### PR TITLE
Adding declaration num_of_cores

### DIFF
--- a/hpx/runtime/threads/policies/windows_topology.hpp
+++ b/hpx/runtime/threads/policies/windows_topology.hpp
@@ -82,6 +82,7 @@ struct windows_topology : topology
         if (&ec != &throws)
             ec = make_success_code();
 
+        std::size_t const num_of_cores = hardware_concurrency();
         // the machine mask is the bitor of all masks in the system
         mask_type mask = 0;
         for (std::size_t i = 0; i < num_of_cores; ++i)


### PR DESCRIPTION
Would not build for certain configurations of VS without the declaration
