### PR TITLE
fix problem building documentation with xsltproc >= 1.1.27

### DIFF
--- a/external/boostbook/xsl/annotation.xsl
+++ b/external/boostbook/xsl/annotation.xsl
@@ -20,7 +20,7 @@
   <xsl:key name="macros" match="macro" use="@name"/>
   <xsl:key name="headers" match="header" use="@name"/>
   <xsl:key name="globals" match="namespace/data-member|header/data-member" use="@name"/>
-  <xsl:key name="named-entities" match="class|struct|union|concept|function|overloaded-function|macro|library|namespace/data-member|header/data-member|*[attribute::id]" use="translate(@name|@id, $uppercase-letters, $lowercase-letters)"/>
+  <xsl:key name="named-entities" match="class|struct|union|concept|function|overloaded-function|macro|library|namespace/data-member|header/data-member|*[attribute::id]" use="translate(@name|@id, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')"/>
 
   <xsl:template match="function|overloaded-function" mode="generate.id">
     <xsl:call-template name="fully-qualified-id">


### PR DESCRIPTION
It seems variables must not be used in the "use" attribute for an xsl:key. See also 
https://bugzilla.gnome.org/show_bug.cgi?id=705865
xsltproc 1.1.27 and later seem to enforce this. This prevents Ubuntu 13.04 users to build the HPX documentation.

A quickfix is to replace the variables with their content, which is done with this patch.

The boost people did the exact same thing (replacing the variables with their content), see:
http://svn.boost.org/svn/boost/trunk/tools/boostbook/xsl/annotation.xsl

Getting the latest version from boost would be a cleaner solution. But as I cannot oversee possible side effects I propose this simple fix.
