### PR TITLE
Fix more unused variable warnings

### DIFF
--- a/hpx/hpx_init_impl.hpp
+++ b/hpx/hpx_init_impl.hpp
@@ -182,7 +182,7 @@ namespace hpx
     /// console mode or worker mode depending on the command line settings).
     namespace detail
     {
-        inline int init_helper(boost::program_options::variables_map& vm,
+        inline int init_helper(boost::program_options::variables_map& /*vm*/,
             HPX_STD_FUNCTION<int(int, char**)> const& f, int argc, char** argv)
         {
             return f(argc, argv);
@@ -190,7 +190,7 @@ namespace hpx
     }
 
     inline int init(HPX_STD_FUNCTION<int(int, char**)> const& f,
-        std::string const& app_name, int argc, char** argv, hpx::runtime_mode mode)
+        std::string const& /*app_name*/, int argc, char** argv, hpx::runtime_mode mode)
     {
         using boost::program_options::options_description;
         options_description desc_commandline(

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -280,7 +280,7 @@ namespace detail
 
         /// Reset the promise to allow to restart an asynchronous
         /// operation. Allows any subsequent set_data operation to succeed.
-        void reset(error_code& ec = throws)
+        void reset(error_code& /*ec*/ = throws)
         {
             typename mutex_type::scoped_lock l(this->mtx_);
             state_ = empty;
@@ -534,13 +534,13 @@ namespace detail
         }
 
         virtual BOOST_SCOPED_ENUM(future_status)
-        wait_for(boost::posix_time::time_duration const& p, error_code& ec = throws)
+        wait_for(boost::posix_time::time_duration const& /*p*/, error_code& /*ec*/ = throws)
         {
             return future_status::deferred; //-V110
         }
 
         virtual BOOST_SCOPED_ENUM(future_status)
-        wait_until(boost::posix_time::ptime const& at, error_code& ec = throws)
+        wait_until(boost::posix_time::ptime const& /*at*/, error_code& /*ec*/ = throws)
         {
             return future_status::deferred; //-V110
         };

--- a/hpx/runtime/components/server/wrapper_heap.hpp
+++ b/hpx/runtime/components/server/wrapper_heap.hpp
@@ -312,7 +312,7 @@ namespace hpx { namespace components { namespace detail
         }
 
     protected:
-        bool test_release(scoped_lock& lk)
+        bool test_release(scoped_lock& /*lk*/)
         {
             if (pool_ == NULL || free_size_ < size_ || first_free_ < pool_+size_)
                 return false;

--- a/hpx/traits/action_may_require_id_splitting.hpp
+++ b/hpx/traits/action_may_require_id_splitting.hpp
@@ -18,7 +18,7 @@ namespace hpx { namespace traits
     {
         // return a new instance of a serialization filter
         template <typename Arguments>
-        static bool call(Arguments const& act)
+        static bool call(Arguments const& /*act*/)
         {
             // by default actions are assumed to require id-splitting
             return true;

--- a/hpx/traits/action_serialization_filter.hpp
+++ b/hpx/traits/action_serialization_filter.hpp
@@ -18,7 +18,7 @@ namespace hpx { namespace traits
     struct action_serialization_filter
     {
         // return a new instance of a serialization filter
-        static util::binary_filter* call(parcelset::parcel const& p)
+        static util::binary_filter* call(parcelset::parcel const& /*p*/)
         {
             return 0;   // by default actions don't have a serialization filter
         }

--- a/hpx/traits/type_size.hpp
+++ b/hpx/traits/type_size.hpp
@@ -30,7 +30,7 @@ namespace hpx { namespace traits
     {
         typedef void uses_sizeof;
 
-        static BOOST_FORCEINLINE std::size_t call(T const& t)
+        static BOOST_FORCEINLINE std::size_t call(T const&)
         {
             return sizeof(T);
         }

--- a/hpx/util/assert_owns_lock.hpp
+++ b/hpx/util/assert_owns_lock.hpp
@@ -16,23 +16,35 @@
 namespace hpx { namespace util { namespace detail
 {
     template <typename Lock>
-    void assert_owns_lock(Lock& l, int)
+    void assert_owns_lock(Lock& /*l*/, int)
     {}
     
     template <typename Mutex>
+#if defined(HPX_DISABLE_ASSERTS) || defined(BOOST_DISABLE_ASSERTS) || defined(NDEBUG)
+    void assert_owns_lock(boost::unique_lock<Mutex>& /*l*/, long)
+#else
     void assert_owns_lock(boost::unique_lock<Mutex>& l, long)
+#endif
     {
         HPX_ASSERT(l.owns_lock());
     }
     
     template <typename Mutex>
+#if defined(HPX_DISABLE_ASSERTS) || defined(BOOST_DISABLE_ASSERTS) || defined(NDEBUG)
+    void assert_owns_lock(boost::shared_lock<Mutex>& /*l*/, long)
+#else
     void assert_owns_lock(boost::shared_lock<Mutex>& l, long)
+#endif
     {
         HPX_ASSERT(l.owns_lock());
     }
     
     template <typename Mutex>
+#if defined(HPX_DISABLE_ASSERTS) || defined(BOOST_DISABLE_ASSERTS) || defined(NDEBUG)
+    void assert_owns_lock(boost::upgrade_lock<Mutex>& /*l*/, long)
+#else
     void assert_owns_lock(boost::upgrade_lock<Mutex>& l, long)
+#endif
     {
         HPX_ASSERT(l.owns_lock());
     }
@@ -40,7 +52,11 @@ namespace hpx { namespace util { namespace detail
 #   if !defined(BOOST_NO_CXX11_DECLTYPE_N3276) && !defined(BOOST_NO_SFINAE_EXPR)
     template <typename Lock>
     decltype(boost::declval<Lock>().owns_lock())
+#if defined(HPX_DISABLE_ASSERTS) || defined(BOOST_DISABLE_ASSERTS) || defined(NDEBUG)
+    assert_owns_lock(Lock& /*l*/, long)
+#else
     assert_owns_lock(Lock& l, long)
+#endif
     {
         HPX_ASSERT(l.owns_lock());
         return true;

--- a/hpx/util/bind.hpp
+++ b/hpx/util/bind.hpp
@@ -55,7 +55,7 @@ namespace hpx { namespace util
 
             template <typename UnboundArgs>
             static BOOST_FORCEINLINE
-            type call(T& t, UnboundArgs && unbound_args)
+            type call(T& t, UnboundArgs && /*unbound_args*/)
             {
                     return t;
             }
@@ -68,7 +68,7 @@ namespace hpx { namespace util
 
             template <typename UnboundArgs>
             static BOOST_FORCEINLINE
-            type call(T& t, UnboundArgs && unbound_args)
+            type call(T& t, UnboundArgs && /*unbound_args*/)
             {
                 return std::move(t);
             }

--- a/hpx/util/detail/serialization_registration.hpp
+++ b/hpx/util/detail/serialization_registration.hpp
@@ -55,7 +55,7 @@ namespace hpx { namespace util { namespace detail
         return static_cast<char>(number_tmp - 10 + 'A');
     }
 
-#if defined(HPX_DISABLE_ASSERTS)
+#if defined(HPX_DISABLE_ASSERTS) || defined(BOOST_DISABLE_ASSERTS) || defined(NDEBUG)
     inline void convert_byte(boost::uint8_t b, char*& buffer, char const* /*end*/)
 #else
     inline void convert_byte(boost::uint8_t b, char*& buffer, char const* end)

--- a/hpx/util/register_locks.hpp
+++ b/hpx/util/register_locks.hpp
@@ -43,10 +43,10 @@ namespace hpx { namespace util
     inline void enable_lock_detection()
     {
     }
-    inline void ignore_lock(void const* lock)
+    inline void ignore_lock(void const* /*lock*/)
     {
     }
-    inline void reset_ignored(void const* lock)
+    inline void reset_ignored(void const* /*lock*/)
     {
     }
 #endif


### PR DESCRIPTION
Those changes prevent more unused variable warnings to occur, in particular when building with -DNDEBUG, which disables asserts.
