### PR TITLE
Reorder includes to ensure ws2 includes early

### DIFF
--- a/tests/performance/function_object_wrapper_overhead.cpp
+++ b/tests/performance/function_object_wrapper_overhead.cpp
@@ -4,11 +4,11 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "worker_timed.hpp"
-
 #include <hpx/hpx_fwd.hpp>
 #include <hpx/util/function.hpp>
 #include <hpx/util/high_resolution_timer.hpp>
+
+#include "worker_timed.hpp"
 
 #include <functional>
 

--- a/tests/performance/hpx_heterogeneous_timed_task_spawn.cpp
+++ b/tests/performance/hpx_heterogeneous_timed_task_spawn.cpp
@@ -4,11 +4,11 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "worker_timed.hpp"
-
 #include <hpx/hpx_init.hpp>
 #include <hpx/util/high_resolution_timer.hpp>
 #include <hpx/include/iostreams.hpp>
+
+#include "worker_timed.hpp"
 
 #include <stdexcept>
 

--- a/tests/performance/hpx_homogeneous_timed_task_spawn.cpp
+++ b/tests/performance/hpx_homogeneous_timed_task_spawn.cpp
@@ -9,8 +9,8 @@
 // FIXME: Calling the tasks "workers" overloads the term worker-thread (which 
 // refers to OS-threads).
 
-#include <hpx/config.hpp>
 #include <hpx/hpx_init.hpp>
+#include <hpx/config.hpp>
 #include <hpx/runtime.hpp>
 #include <hpx/runtime/threads/threadmanager.hpp>
 #include <hpx/util/high_resolution_timer.hpp>

--- a/tests/performance/hpx_homogeneous_timed_task_spawn_executors.cpp
+++ b/tests/performance/hpx_homogeneous_timed_task_spawn_executors.cpp
@@ -4,12 +4,12 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "worker_timed.hpp"
-
 #include <hpx/hpx_init.hpp>
 #include <hpx/util/high_resolution_timer.hpp>
 #include <hpx/include/iostreams.hpp>
 #include <hpx/include/thread_executors.hpp>
+
+#include "worker_timed.hpp"
 
 #include <stdexcept>
 


### PR DESCRIPTION
If the header order is wrong (hpx_init too late) windows.h ends up being
included before ws2_32.h, which causes several conflicts inside of
Winsock2, blocking the compilation.
