### PR TITLE
Expose internal boost::shared_array to allow user management of array li...

### DIFF
--- a/hpx/util/serialize_buffer.hpp
+++ b/hpx/util/serialize_buffer.hpp
@@ -96,7 +96,8 @@ namespace hpx { namespace util
 
         T* data() { return data_.get(); }
         T const* data() const { return data_.get(); }
-
+        boost::shared_array<T> data_array() const { return data_; }
+ 
         std::size_t size() const { return size_; }
 
     private:
@@ -238,7 +239,8 @@ namespace hpx { namespace util
 
         T* data() { return data_.get(); }
         T const* data() const { return data_.get(); }
-
+        boost::shared_array<T> data_array() const { return data_; }
+ 
         std::size_t size() const { return size_; }
 
     private:


### PR DESCRIPTION
This is useful for me to keep the serialize buffer array alive when my action is executed and returns immediately with a future, but the buffer isn't used immediately and filled in later by another task.
