### PR TITLE
Changed readme to no longer specify using MSVC 2010 compiler

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -248,14 +248,13 @@ Windows
    "Where to build the binaries:", enter the full path to the build folder you
    created in step 2.
 
-4) Add CMake variable definitions (if any) by clicking the "Add Entry" button.
-   Most probably you will need to at least add the directories where `Boost <http://www.boost.org>`_
+4) Add CMake variable definitions (if any) by clicking the "Add Entry" button and selecting type 
+   "String". Most probably you will need to at least add the directories where `Boost <http://www.boost.org>`_
    is located as BOOST_ROOT and where `Hwloc <http://www.open-mpi.org/projects/hwloc/>`_ is
    located as HWLOC_ROOT.
 
 5) Press the "Configure" button. A window will pop up asking you which compiler
-   to use. Select the x64 Visual Studio 10 compiler (x64 Visual Studio 2012 is
-   supported as well). Note that while it is possible to build HPX for x86
+   to use. Select the x64 Visual Studio 2012 compiler. Note that while it is possible to build HPX for x86
    we don't recommend doing so as 32 bit runs are severely restricted by a 32 bit
    Windows system limitation affecting the number of HPX threads you can create.
 


### PR DESCRIPTION
Due to recent issues regarding the compilation of certain HPX classes on 2010, I changed the README to reflect the minimum working version that can be used for building HPX. 

Clarified on the type of the CMake variable definition in the GUI to string.
