### PR TITLE
Remove unnecessary null pointer checks.

### DIFF
--- a/hpx/util/coroutine/detail/context_base.hpp
+++ b/hpx/util/coroutine/detail/context_base.hpp
@@ -177,8 +177,7 @@ namespace hpx { namespace util { namespace coroutines { namespace detail
       m_phase = 0;
 #endif
 #if HPX_THREAD_MAINTAIN_THREAD_DATA
-      if (m_thread_data)
-        delete_tss_storage(m_thread_data);
+      delete_tss_storage(m_thread_data);
 #endif
     }
 

--- a/hpx/util/merging_map.hpp
+++ b/hpx/util/merging_map.hpp
@@ -207,11 +207,8 @@ struct merging_map : boost::noncopyable
             pointer p
             ) const
         {
-            if (p)
-            {
-                delete p;
-                p = 0;
-            }
+            delete p;
+            p = 0;
         }
     };
 

--- a/hpx/util/thread_specific_ptr.hpp
+++ b/hpx/util/thread_specific_ptr.hpp
@@ -62,9 +62,7 @@ namespace hpx { namespace util
             T* new_value = 0
             )
         {
-            if (0 != ptr_) //-V809
-                delete ptr_;
-
+            delete ptr_;
             ptr_ = new_value;
         }
 


### PR DESCRIPTION
Explicit null pointer checks are performed at a few source code places before pointers are passed to the C++ delete operator. This is unnecessary because [the delete operator will care for such parameter validation already](http://www.parashift.com/c++-faq/delete-handles-null.html).
