### PR TITLE
Only build test thread_pool_executor_1114_test if HPX_LOCAL_SCHEDULER is set

### DIFF
--- a/tests/regressions/threads/CMakeLists.txt
+++ b/tests/regressions/threads/CMakeLists.txt
@@ -9,11 +9,14 @@ set(tests
     resume_priority
     thread_data_1111
     thread_pool_executor_1112
-    thread_pool_executor_1114
     thread_rescheduling
     thread_suspend_pending
     thread_suspend_duration
    )
+
+if(HPX_LOCAL_SCHEDULER)
+  set(tests ${tests} thread_pool_executor_1114)
+endif(HPX_LOCAL_SCHEDULER)
 
 set(block_os_threads_1036_PARAMETERS THREADS_PER_LOCALITY 4)
 set(thread_pool_executor_1112_PARAMETERS THREADS_PER_LOCALITY 4)


### PR DESCRIPTION
Hi,

in the current master with default configuration, "make tests" fails.

This is because "thread_pool_executor_1114" requires local_queue_executor, which is disabled if HPX_LOCAL_SCHEDULER is set to false, which is the default. The error message is:

CMakeFiles/thread_pool_executor_1114_test_exe.dir/thread_pool_executor_1114.cpp.o: In function `hpx_startup::user_main()':
thread_pool_executor_1114.cpp:(.text+0xd9e): undefined reference to`hpx::threads::executors::local_queue_executor::local_queue_executor()'

The proposed fix builds thread_pool_executor_1114 only if HPX_LOCAL_SCHEDULER is set to ON
