### PR TITLE
clean up pkg-config files

### DIFF
--- a/cmake/templates/hpx_application.pc.in
+++ b/cmake/templates/hpx_application.pc.in
@@ -3,14 +3,14 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-prefix=@HPX_PREFIX@
+prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib/hpx
+libdir=${exec_prefix}/@LIB@/hpx
 includedir=${exec_prefix}/include
 
 Name: hpx_application
 Description: High Performance ParalleX (application configuration)
 Version: @HPX_VERSION@
-Libs: -Wl,-rpath,@external_rpath@ @CMAKE_CXX_FLAGS@ @external_link_flags@ -lhpx -lhpx_init -lhpx_serialization @external_libraries_name@
-Cflags: @CMAKE_CXX_FLAGS@ @external_definitions@ @external_include_flags@ -DHPX_APPLICATION_EXPORTS -DHPX_ENABLE_ASSERT_HANDLER
-
+Libs: -L${libdir} -lhpx -lhpx_init -lhpx_serialization
+Libs.private: @external_libraries_name@
+Cflags: @external_definitions@ @external_include_flags@ -DHPX_APPLICATION_EXPORTS -DHPX_ENABLE_ASSERT_HANDLER

--- a/cmake/templates/hpx_application_debug.pc.in
+++ b/cmake/templates/hpx_application_debug.pc.in
@@ -3,14 +3,15 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-prefix=@HPX_PREFIX@
+prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib/hpx
+libdir=${exec_prefix}/@LIB@/hpx
 includedir=${exec_prefix}/include
 
 Name: hpx_application
 Description: High Performance ParalleX (application configuration) - debug build
 Version: @HPX_VERSION@
-Libs: -Wl,-rpath,@external_rpath@ @CMAKE_CXX_FLAGS@ @external_link_flags@ -lhpxd -lhpx_initd -lhpx_serializationd @external_libraries_name@
-Cflags: @CMAKE_CXX_FLAGS@ @external_definitions@ @external_include_flags@ -DHPX_APPLICATION_EXPORTS -DHPX_ENABLE_ASSERT_HANDLER
+Libs: -L${libdir} -lhpxd -lhpx_initd -lhpx_serializationd
+Libs.private: @external_libraries_name@
+Cflags: @external_definitions@ @external_include_flags@ -DHPX_APPLICATION_EXPORTS -DHPX_ENABLE_ASSERT_HANDLER
 

--- a/cmake/templates/hpx_component.pc.in
+++ b/cmake/templates/hpx_component.pc.in
@@ -3,14 +3,14 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-prefix=@HPX_PREFIX@
+prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib/hpx
+libdir=${exec_prefix}/@LIB@/hpx
 includedir=${exec_prefix}/include
 
 Name: hpx_component
 Description: High Performance ParalleX (application configuration)
 Version: @HPX_VERSION@
-Libs: -Wl,-rpath,@external_rpath@ @CMAKE_CXX_FLAGS@ -fPIC -shared @external_link_flags@ -lhpx -lhpx_serialization
-Cflags: @CMAKE_CXX_FLAGS@ @external_definitions@ @external_include_flags@ -DHPX_COMPONENT_EXPORTS -DHPX_ENABLE_ASSERT_HANDLER
+Libs: -L${libdir} -lhpx -lhpx_serialization
+Cflags: @external_definitions@ @external_include_flags@ -DHPX_COMPONENT_EXPORTS -DHPX_ENABLE_ASSERT_HANDLER
 

--- a/cmake/templates/hpx_component_debug.pc.in
+++ b/cmake/templates/hpx_component_debug.pc.in
@@ -3,14 +3,14 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-prefix=@HPX_PREFIX@
+prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib/hpx
+libdir=${exec_prefix}/@LIB@/hpx
 includedir=${exec_prefix}/include
 
 Name: hpx_component
 Description: High Performance ParalleX (application configuration) - debug build
 Version: @HPX_VERSION@
-Libs: -Wl,-rpath,@external_rpath@ @CMAKE_CXX_FLAGS@ -fPIC -shared @external_link_flags@ -lhpxd -lhpx_serializationd
-Cflags: @CMAKE_CXX_FLAGS@ @external_definitions@ @external_include_flags@ -DHPX_COMPONENT_EXPORTS -DHPX_ENABLE_ASSERT_HANDLER
+Libs: -L${libdir} -lhpxd -lhpx_serializationd
+Cflags: @external_definitions@ @external_include_flags@ -DHPX_COMPONENT_EXPORTS -DHPX_ENABLE_ASSERT_HANDLER
 


### PR DESCRIPTION
- prefix contained build dir
- rpath are Linux-specific and should not be in there
- CFlags should only contain needed cflags, no optimizations
  or CMAKE_CXX_FLAGS
- external libs should go in libs.private and not libs
- lib -> @LIB@
