### PR TITLE
Supressing cmake 3.0 policy warning for CMP0026

### DIFF
--- a/cmake/HPX_IsTarget.cmake
+++ b/cmake/HPX_IsTarget.cmake
@@ -6,7 +6,17 @@
 set(HPX_ISTARGET_LOADED TRUE)
 
 macro(hpx_is_target variable target)
+
+  if(POLICY CMP0026)
+    cmake_policy(PUSH)
+    cmake_policy(SET CMP0026 OLD)
+  endif()
+
   get_target_property(is_target ${target} LOCATION)
+
+  if(POLICY CMP0026)
+    cmake_policy(POP)
+  endif()
 
   if(${is_target} STREQUAL "is_target-NOTFOUND")
     set(${variable} FALSE)

--- a/cmake/HPX_TargetPaths.cmake
+++ b/cmake/HPX_TargetPaths.cmake
@@ -19,7 +19,17 @@ macro(hpx_get_target_location variable target)
     set(location LOCATION)
   endif()
 
+  if(POLICY CMP0026)
+    cmake_policy(PUSH)
+    cmake_policy(SET CMP0026 OLD)
+  endif()
+
   get_target_property(${variable} ${target} ${location})
+
+  if(POLICY CMP0026)
+    cmake_policy(POP)
+  endif()
+
 endmacro()
 
 macro(hpx_get_target_file variable target)


### PR DESCRIPTION
This change suppresses the cmake policy warning for policy CMP0026 emitted by cmake V3.0. The docs say that the old style

```
  get_target_property(<var> ${target} LOCATION)
```

should be replaced by using 

```
$<TARGET_FILE> 
```

(see http://www.cmake.org/cmake/help/v3.0/policy/CMP0026.html). However it is not clear from the docs how this can be done. 
