### PR TITLE
changed header of printout to be compatible with python csv module

### DIFF
--- a/examples/1d_stencil/print_time_results.hpp
+++ b/examples/1d_stencil/print_time_results.hpp
@@ -25,13 +25,8 @@ void print_time_results(
     )
 {
     if (header)
-<<<<<<< HEAD
         std::cout << "OS_Threads,Execution_Time_sec,"
                 "Points_per_Partition,Partitions,Time_Steps\n"
-=======
-        std::cout << "OS-threads, Execution-Time(seconds),"
-                " Points/Partition, Partitions, Time-Steps\n"
->>>>>>> master
              << hpx::flush;
 
     std::string const threads_str = boost::str(boost::format("%lu,") % num_os_threads);
@@ -53,13 +48,8 @@ void print_time_results(
     )
 {
     if (header)
-<<<<<<< HEAD
         std::cout << "OS_Threads,Execution_Time_sec,"
                 "Grid_Points,Time_Steps\n"
-=======
-        std::cout << "OS-threads, Execution-Time(seconds),"
-                " Grid-Points, Time-Steps\n"
->>>>>>> master
              << hpx::flush;
 
     std::string const threads_str = boost::str(boost::format("%lu,") % num_os_threads);


### PR DESCRIPTION
Changed header for python csv module which will only accept letters, numbers and '_' . Also, it doesn't like spaces before the header column labels.
