### PR TITLE
Removed future get_status()

### DIFF
--- a/hpx/components/dataflow/dataflow_base_impl.hpp
+++ b/hpx/components/dataflow/dataflow_base_impl.hpp
@@ -33,7 +33,7 @@ namespace hpx { namespace lcos { namespace detail
                 hpx::lcos::base_lco::connect_action
                 action_type;
 
-            HPX_ASSERT(gid_promise.get_status() != hpx::lcos::future_status::uninitialized);
+            HPX_ASSERT(gid_promise.valid());
 
             hpx::apply<action_type>(gid_promise.get(), id);
         }

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -415,12 +415,6 @@ namespace detail
             return state_ != empty && data_.stores_error();
         }
 
-        BOOST_SCOPED_ENUM(future_status) get_status() const
-        {
-            typename mutex_type::scoped_lock l(mtx_);
-            return state_ != empty ? future_status::ready : future_status::deferred; //-V110
-        }
-
     protected:
         mutable mutex_type mtx_;
         data_type data_;                            // protected data

--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -529,15 +529,6 @@ namespace hpx { namespace lcos { namespace detail
             return shared_state_ != 0 && shared_state_->has_exception();
         }
 
-        // Returns the future status
-        BOOST_SCOPED_ENUM(future_status) get_status() const
-        {
-            if (!shared_state_)
-                return future_status::uninitialized;
-
-            return shared_state_->get_status();
-        }
-
         // Effects:
         //   - Blocks until the future is ready.
         // Returns: The stored exception_ptr if has_exception(), a null
@@ -967,7 +958,6 @@ namespace hpx { namespace lcos
         using base_type::is_ready;
         using base_type::has_value;
         using base_type::has_exception;
-        using base_type::get_status;
 
         template <typename F>
         typename boost::lazy_disable_if<
@@ -1197,7 +1187,6 @@ namespace hpx { namespace lcos
         using base_type::is_ready;
         using base_type::has_value;
         using base_type::has_exception;
-        using base_type::get_status;
 
         using base_type::then;
 

--- a/tests/unit/lcos/future.cpp
+++ b/tests/unit/lcos/future.cpp
@@ -75,7 +75,6 @@ void test_store_value_from_thread()
     HPX_TEST(fi2.is_ready());
     HPX_TEST(fi2.has_value());
     HPX_TEST(!fi2.has_exception());
-    HPX_TEST(fi2.get_status() == hpx::lcos::future_status::ready);
     int j = fi2.get();
     HPX_TEST_EQ(j, 42);
     t.join();
@@ -92,7 +91,6 @@ void test_store_exception()
     HPX_TEST(fi3.is_ready());
     HPX_TEST(!fi3.has_value());
     HPX_TEST(fi3.has_exception());
-    HPX_TEST(fi3.get_status() ==  hpx::lcos::future_status::ready);
     try {
         fi3.get();
         HPX_TEST(false);
@@ -110,7 +108,6 @@ void test_initial_state()
     HPX_TEST(!fi.is_ready());
     HPX_TEST(!fi.has_value());
     HPX_TEST(!fi.has_exception());
-    HPX_TEST(fi.get_status() == hpx::lcos::future_status::uninitialized);
     int i;
     try {
         i = fi.get();
@@ -134,8 +131,7 @@ void test_waiting_future()
     HPX_TEST(!fi.is_ready());
     HPX_TEST(!fi.has_value());
     HPX_TEST(!fi.has_exception());
-    HPX_TEST(fi.get_status() == hpx::lcos::future_status::deferred);
-    
+
     // fulfill the promise so the destructor of promise is happy.
     pi.set_value(0);
 }
@@ -170,7 +166,6 @@ void test_set_value_updates_future_status()
     HPX_TEST(fi.is_ready());
     HPX_TEST(fi.has_value());
     HPX_TEST(!fi.has_exception());
-    HPX_TEST(fi.get_status() == hpx::lcos::future_status::ready);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -186,7 +181,6 @@ void test_set_value_can_be_retrieved()
     HPX_TEST(fi.is_ready());
     HPX_TEST(fi.has_value());
     HPX_TEST(!fi.has_exception());
-    HPX_TEST(fi.get_status() == hpx::lcos::future_status::ready);
     int i = fi.get();
     HPX_TEST_EQ(i, 42);
 }
@@ -204,7 +198,6 @@ void test_set_value_can_be_moved()
     HPX_TEST(fi.is_ready());
     HPX_TEST(fi.has_value());
     HPX_TEST(!fi.has_exception());
-    HPX_TEST(fi.get_status() == hpx::lcos::future_status::ready);
     int i=0;
     HPX_TEST(i = fi.get());
     HPX_TEST_EQ(i, 42);
@@ -219,7 +212,6 @@ void test_future_from_packaged_task_is_waiting()
     HPX_TEST(!fi.is_ready());
     HPX_TEST(!fi.has_value());
     HPX_TEST(!fi.has_exception());
-    HPX_TEST(fi.get_status() == hpx::lcos::future_status::deferred);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -233,7 +225,6 @@ void test_invoking_a_packaged_task_populates_future()
     HPX_TEST(fi.is_ready());
     HPX_TEST(fi.has_value());
     HPX_TEST(!fi.has_exception());
-    HPX_TEST(fi.get_status() == hpx::lcos::future_status::ready);
 
     int i = fi.get();
     HPX_TEST_EQ(i, 42);
@@ -289,7 +280,6 @@ void test_task_stores_exception_if_function_throws()
     HPX_TEST(fi.is_ready());
     HPX_TEST(!fi.has_value());
     HPX_TEST(fi.has_exception());
-    HPX_TEST(fi.get_status()==hpx::lcos::future_status::ready);
     try {
         fi.get();
         HPX_TEST(false);
@@ -311,7 +301,6 @@ void test_void_promise()
     HPX_TEST(f.is_ready());
     HPX_TEST(f.has_value());
     HPX_TEST(!f.has_exception());
-    HPX_TEST(f.get_status() == hpx::lcos::future_status::ready);
 }
 
 void test_reference_promise()
@@ -323,7 +312,6 @@ void test_reference_promise()
     HPX_TEST(f.is_ready());
     HPX_TEST(f.has_value());
     HPX_TEST(!f.has_exception());
-    HPX_TEST(f.get_status() == hpx::lcos::future_status::ready);
     HPX_TEST_EQ(&f.get(), &i);
 }
 
@@ -341,7 +329,6 @@ void test_task_returning_void()
     HPX_TEST(fi.is_ready());
     HPX_TEST(fi.has_value());
     HPX_TEST(!fi.has_exception());
-    HPX_TEST(fi.get_status() == hpx::lcos::future_status::ready);
 }
 
 int global_ref_target = 0;
@@ -361,7 +348,6 @@ void test_task_returning_reference()
     HPX_TEST(fi.is_ready());
     HPX_TEST(fi.has_value());
     HPX_TEST(!fi.has_exception());
-    HPX_TEST(fi.get_status() == hpx::lcos::future_status::ready);
     int& i = fi.get();
     HPX_TEST_EQ(&i, &global_ref_target);
 }
@@ -629,7 +615,7 @@ void test_wait_for_either_of_two_futures_2()
     HPX_STD_TUPLE<
         hpx::lcos::future<int>
       , hpx::lcos::future<int> > t = r.get();
-    
+
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
 
@@ -650,7 +636,7 @@ void test_wait_for_either_of_two_futures_list_1()
     hpx::lcos::future<std::vector<hpx::lcos::future<int> > > r =
         hpx::when_any(futures);
     std::vector<hpx::lcos::future<int> > t = r.get();
-    
+
     HPX_TEST(!futures[0].valid());
     HPX_TEST(!futures[1].valid());
 
@@ -866,7 +852,7 @@ void test_wait_for_either_of_four_futures_2()
       , hpx::lcos::future<int>
       , hpx::lcos::future<int>
       , hpx::lcos::future<int> > t = r.get();
-    
+
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
     HPX_TEST(!f3.valid());
@@ -900,7 +886,7 @@ void test_wait_for_either_of_four_futures_3()
       , hpx::lcos::future<int>
       , hpx::lcos::future<int>
       , hpx::lcos::future<int> > t = r.get();
-    
+
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
     HPX_TEST(!f3.valid());
@@ -934,7 +920,7 @@ void test_wait_for_either_of_four_futures_4()
       , hpx::lcos::future<int>
       , hpx::lcos::future<int>
       , hpx::lcos::future<int> > t = r.get();
-    
+
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
     HPX_TEST(!f3.valid());
@@ -969,7 +955,7 @@ void test_wait_for_either_of_five_futures_1_from_list()
     hpx::lcos::future<std::vector<hpx::lcos::future<int> > > r =
         hpx::when_any(futures);
     std::vector<hpx::lcos::future<int> > t = r.get();
-    
+
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
     HPX_TEST(!f3.valid());
@@ -1005,7 +991,7 @@ void test_wait_for_either_of_five_futures_1_from_list_iterators()
     hpx::lcos::future<std::vector<hpx::lcos::future<int> > > r =
         hpx::when_any(futures.begin(), futures.end());
     std::vector<hpx::lcos::future<int> > t = r.get();
-    
+
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
     HPX_TEST(!f3.valid());
@@ -1041,7 +1027,7 @@ void test_wait_swapped_for_either_of_five_futures_1_from_list()
     hpx::lcos::future<std::vector<hpx::lcos::future<int> > > r =
         hpx::when_any_swapped(futures);
     std::vector<hpx::lcos::future<int> > t = r.get();
-    
+
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
     HPX_TEST(!f3.valid());
@@ -1077,7 +1063,7 @@ void test_wait_swapped_for_either_of_five_futures_1_from_list_iterators()
     hpx::lcos::future<std::vector<hpx::lcos::future<int> > > r =
         hpx::when_any_swapped(futures.begin(), futures.end());
     std::vector<hpx::lcos::future<int> > t = r.get();
-    
+
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
     HPX_TEST(!f3.valid());
@@ -1116,7 +1102,7 @@ void test_wait_for_either_of_five_futures_1()
       , hpx::lcos::future<int>
       , hpx::lcos::future<int>
       , hpx::lcos::future<int> > t = r.get();
-    
+
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
     HPX_TEST(!f3.valid());
@@ -1155,7 +1141,7 @@ void test_wait_for_either_of_five_futures_2()
       , hpx::lcos::future<int>
       , hpx::lcos::future<int>
       , hpx::lcos::future<int> > t = r.get();
-    
+
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
     HPX_TEST(!f3.valid());
@@ -1194,7 +1180,7 @@ void test_wait_for_either_of_five_futures_3()
       , hpx::lcos::future<int>
       , hpx::lcos::future<int>
       , hpx::lcos::future<int> > t = r.get();
-    
+
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
     HPX_TEST(!f3.valid());
@@ -1233,7 +1219,7 @@ void test_wait_for_either_of_five_futures_4()
       , hpx::lcos::future<int>
       , hpx::lcos::future<int>
       , hpx::lcos::future<int> > t = r.get();
-    
+
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
     HPX_TEST(!f3.valid());
@@ -1272,7 +1258,7 @@ void test_wait_for_either_of_five_futures_5()
       , hpx::lcos::future<int>
       , hpx::lcos::future<int>
       , hpx::lcos::future<int> > t = r.get();
-    
+
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
     HPX_TEST(!f3.valid());

--- a/tests/unit/lcos/shared_future.cpp
+++ b/tests/unit/lcos/shared_future.cpp
@@ -55,7 +55,6 @@ void test_store_value_from_thread()
     HPX_TEST(fi2.is_ready());
     HPX_TEST(fi2.has_value());
     HPX_TEST(!fi2.has_exception());
-    HPX_TEST(fi2.get_status() == hpx::lcos::future_status::ready);
     t.join();
 }
 
@@ -76,7 +75,6 @@ void test_store_exception()
     HPX_TEST(fi3.is_ready());
     HPX_TEST(!fi3.has_value());
     HPX_TEST(fi3.has_exception());
-    HPX_TEST(fi3.get_status() ==  hpx::lcos::future_status::ready);
     t.join();
 }
 
@@ -87,7 +85,6 @@ void test_initial_state()
     HPX_TEST(!fi.is_ready());
     HPX_TEST(!fi.has_value());
     HPX_TEST(!fi.has_exception());
-    HPX_TEST(fi.get_status() == hpx::lcos::future_status::uninitialized);
     int i;
     try {
         i = fi.get();
@@ -111,8 +108,7 @@ void test_waiting_future()
     HPX_TEST(!fi.is_ready());
     HPX_TEST(!fi.has_value());
     HPX_TEST(!fi.has_exception());
-    HPX_TEST(fi.get_status() == hpx::lcos::future_status::deferred);
-    
+
     // fulfill the promise so the destructor of promise is happy.
     pi.set_value(0);
 }
@@ -147,7 +143,6 @@ void test_set_value_updates_future_status()
     HPX_TEST(fi.is_ready());
     HPX_TEST(fi.has_value());
     HPX_TEST(!fi.has_exception());
-    HPX_TEST(fi.get_status() == hpx::lcos::future_status::ready);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -164,7 +159,6 @@ void test_set_value_can_be_retrieved()
     HPX_TEST(fi.is_ready());
     HPX_TEST(fi.has_value());
     HPX_TEST(!fi.has_exception());
-    HPX_TEST(fi.get_status() == hpx::lcos::future_status::ready);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -182,7 +176,6 @@ void test_set_value_can_be_moved()
     HPX_TEST(fi.is_ready());
     HPX_TEST(fi.has_value());
     HPX_TEST(!fi.has_exception());
-    HPX_TEST(fi.get_status() == hpx::lcos::future_status::ready);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -194,7 +187,6 @@ void test_future_from_packaged_task_is_waiting()
     HPX_TEST(!fi.is_ready());
     HPX_TEST(!fi.has_value());
     HPX_TEST(!fi.has_exception());
-    HPX_TEST(fi.get_status() == hpx::lcos::future_status::deferred);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -208,7 +200,6 @@ void test_invoking_a_packaged_task_populates_future()
     HPX_TEST(fi.is_ready());
     HPX_TEST(fi.has_value());
     HPX_TEST(!fi.has_exception());
-    HPX_TEST(fi.get_status() == hpx::lcos::future_status::ready);
 
     int i = fi.get();
     HPX_TEST_EQ(i, 42);
@@ -264,7 +255,6 @@ void test_task_stores_exception_if_function_throws()
     HPX_TEST(fi.is_ready());
     HPX_TEST(!fi.has_value());
     HPX_TEST(fi.has_exception());
-    HPX_TEST(fi.get_status()==hpx::lcos::future_status::ready);
     try {
         fi.get();
         HPX_TEST(false);
@@ -286,7 +276,6 @@ void test_void_promise()
     HPX_TEST(f.is_ready());
     HPX_TEST(f.has_value());
     HPX_TEST(!f.has_exception());
-    HPX_TEST(f.get_status() == hpx::lcos::future_status::ready);
 }
 
 void test_reference_promise()
@@ -298,7 +287,6 @@ void test_reference_promise()
     HPX_TEST(f.is_ready());
     HPX_TEST(f.has_value());
     HPX_TEST(!f.has_exception());
-    HPX_TEST(f.get_status() == hpx::lcos::future_status::ready);
     HPX_TEST_EQ(&f.get(), &i);
 }
 
@@ -316,7 +304,6 @@ void test_task_returning_void()
     HPX_TEST(fi.is_ready());
     HPX_TEST(fi.has_value());
     HPX_TEST(!fi.has_exception());
-    HPX_TEST(fi.get_status() == hpx::lcos::future_status::ready);
 }
 
 int global_ref_target = 0;
@@ -336,7 +323,6 @@ void test_task_returning_reference()
     HPX_TEST(fi.is_ready());
     HPX_TEST(fi.has_value());
     HPX_TEST(!fi.has_exception());
-    HPX_TEST(fi.get_status() == hpx::lcos::future_status::ready);
     int& i = fi.get();
     HPX_TEST_EQ(&i, &global_ref_target);
 }
@@ -347,14 +333,12 @@ void test_shared_future()
     hpx::lcos::shared_future<int> fi = pt.get_future();
 
     hpx::lcos::shared_future<int> sf(boost::move(fi));
-    HPX_TEST(fi.get_status() == hpx::lcos::future_status::uninitialized);
 
     pt();
 
     HPX_TEST(sf.is_ready());
     HPX_TEST(sf.has_value());
     HPX_TEST(!sf.has_exception());
-    HPX_TEST(sf.get_status() == hpx::lcos::future_status::ready);
 
     int i = sf.get();
     HPX_TEST_EQ(i, 42);
@@ -370,16 +354,15 @@ void test_copies_of_shared_future_become_ready_together()
     hpx::lcos::shared_future<int> sf3;
 
     sf3 = sf1;
-    HPX_TEST(sf1.get_status() == hpx::lcos::future_status::deferred);
-    HPX_TEST(sf2.get_status() == hpx::lcos::future_status::deferred);
-    HPX_TEST(sf3.get_status() == hpx::lcos::future_status::deferred);
+    HPX_TEST(!sf1.is_ready());
+    HPX_TEST(!sf2.is_ready());
+    HPX_TEST(!sf3.is_ready());
 
     pt();
 
     HPX_TEST(sf1.is_ready());
     HPX_TEST(sf1.has_value());
     HPX_TEST(!sf1.has_exception());
-    HPX_TEST(sf1.get_status() == hpx::lcos::future_status::ready);
     int i = sf1.get();
     HPX_TEST_EQ(i, 42);
 
@@ -387,7 +370,6 @@ void test_copies_of_shared_future_become_ready_together()
     HPX_TEST(sf2.is_ready());
     HPX_TEST(sf2.has_value());
     HPX_TEST(!sf2.has_exception());
-    HPX_TEST(sf2.get_status() == hpx::lcos::future_status::ready);
     i = sf2.get();
     HPX_TEST_EQ(i, 42);
 
@@ -395,7 +377,6 @@ void test_copies_of_shared_future_become_ready_together()
     HPX_TEST(sf3.is_ready());
     HPX_TEST(sf3.has_value());
     HPX_TEST(!sf3.has_exception());
-    HPX_TEST(sf3.get_status() == hpx::lcos::future_status::ready);
     i = sf3.get();
     HPX_TEST_EQ(i, 42);
 }
@@ -407,12 +388,11 @@ void test_shared_future_can_be_move_assigned_from_shared_future()
 
     hpx::lcos::shared_future<int> sf;
     sf = boost::move(fi);
-    HPX_TEST(fi.get_status() == hpx::lcos::future_status::uninitialized);
+    HPX_TEST(!fi.valid());
 
     HPX_TEST(!sf.is_ready());
     HPX_TEST(!sf.has_value());
     HPX_TEST(!sf.has_exception());
-    HPX_TEST(sf.get_status() == hpx::lcos::future_status::deferred);
 }
 
 void test_shared_future_void()
@@ -421,14 +401,13 @@ void test_shared_future_void()
     hpx::lcos::shared_future<void> fi = pt.get_future();
 
     hpx::lcos::shared_future<void> sf(boost::move(fi));
-    HPX_TEST(fi.get_status() == hpx::lcos::future_status::uninitialized);
+    HPX_TEST(!fi.valid());
 
     pt();
 
     HPX_TEST(sf.is_ready());
     HPX_TEST(sf.has_value());
     HPX_TEST(!sf.has_exception());
-    HPX_TEST(sf.get_status() == hpx::lcos::future_status::ready);
     sf.get();
 }
 
@@ -441,7 +420,6 @@ void test_shared_future_ref()
     HPX_TEST(f.is_ready());
     HPX_TEST(f.has_value());
     HPX_TEST(!f.has_exception());
-    HPX_TEST(f.get_status() == hpx::lcos::future_status::ready);
     HPX_TEST_EQ(&f.get(), &i);
 }
 


### PR DESCRIPTION
The `get_status()` member function of futures provides no new functionality, and it uses `deferred` in a way that conflicts with the definition in the standard and everywhere else within HPX.
