### PR TITLE
Rephrase initializers to work with VC++ 2012

### DIFF
--- a/examples/quickstart/pipeline1.cpp
+++ b/examples/quickstart/pipeline1.cpp
@@ -49,13 +49,14 @@ struct pipeline
 
 int main()
 {
-    std::vector<std::string> input = {
+    std::string inputs[] = {
         "Error: foobar",
         "Error. foo",
         " Warning: barbaz",
         "Notice: qux",
         "\tError: abc"
       };
+    std::vector<std::string> input(std::begin(inputs), std::end(inputs));
 
     pipeline::process(input);
 

--- a/tests/unit/parallel/all_of.cpp
+++ b/tests/unit/parallel/all_of.cpp
@@ -19,7 +19,8 @@ void test_all_of(ExPolicy const& policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    for (std::size_t i: { 0, 23, 10007 })
+    std::size_t iseq[] = { 0, 23, 10007 };
+    for (std::size_t i: iseq)
     {
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i);
 
@@ -47,7 +48,8 @@ void test_all_of(hpx::parallel::task_execution_policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    for (std::size_t i: { 0, 23, 10007 })
+    std::size_t iseq[] = { 0, 23, 10007 };
+    for (std::size_t i: iseq)
     {
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i);
 
@@ -130,7 +132,8 @@ void test_all_of_exception(ExPolicy const& policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    for (std::size_t i: { 0, 23, 10007 })
+    std::size_t iseq[] = { 0, 23, 10007 };
+    for (std::size_t i : iseq)
     {
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i);
 
@@ -163,7 +166,8 @@ void test_all_of_exception(hpx::parallel::task_execution_policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    for (std::size_t i: { 0, 23, 10007 })
+    std::size_t iseq[] = { 0, 23, 10007 };
+    for (std::size_t i : iseq)
     {
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i);
 
@@ -226,7 +230,8 @@ void test_all_of_bad_alloc(ExPolicy const& policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    for (std::size_t i: { 0, 23, 10007 })
+    std::size_t iseq[] = { 0, 23, 10007 };
+    for (std::size_t i : iseq)
     {
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i);
 
@@ -258,7 +263,8 @@ void test_all_of_bad_alloc(hpx::parallel::task_execution_policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    for (std::size_t i: { 0, 23, 10007 })
+    std::size_t iseq[] = { 0, 23, 10007 };
+    for (std::size_t i : iseq)
     {
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i);
 

--- a/tests/unit/parallel/any_of.cpp
+++ b/tests/unit/parallel/any_of.cpp
@@ -19,7 +19,8 @@ void test_any_of(ExPolicy const& policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    for (std::size_t i: { 0, 23, 10007 })
+    std::size_t iseq[] = { 0, 23, 10007 };
+    for (std::size_t i: iseq)
     {
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i);
 
@@ -47,7 +48,8 @@ void test_any_of(hpx::parallel::task_execution_policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    for (std::size_t i: { 0, 23, 10007 })
+    std::size_t iseq[] = { 0, 23, 10007 };
+    for (std::size_t i: iseq)
     {
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i);
 
@@ -130,7 +132,8 @@ void test_any_of_exception(ExPolicy const& policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    for (std::size_t i: { 0, 23, 10007 })
+    std::size_t iseq[] = { 0, 23, 10007 };
+    for (std::size_t i: iseq)
     {
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i);
 
@@ -163,7 +166,8 @@ void test_any_of_exception(hpx::parallel::task_execution_policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    for (std::size_t i: { 0, 23, 10007 })
+    std::size_t iseq[] = { 0, 23, 10007 };
+    for (std::size_t i : iseq)
     {
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i);
 
@@ -226,7 +230,8 @@ void test_any_of_bad_alloc(ExPolicy const& policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    for (std::size_t i: { 0, 23, 10007 })
+    std::size_t iseq[] = { 0, 23, 10007 };
+    for (std::size_t i : iseq)
     {
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i);
 
@@ -258,7 +263,8 @@ void test_any_of_bad_alloc(hpx::parallel::task_execution_policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    for (std::size_t i: { 0, 23, 10007 })
+    std::size_t iseq[] = { 0, 23, 10007 };
+    for (std::size_t i : iseq)
     {
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i);
 

--- a/tests/unit/parallel/none_of.cpp
+++ b/tests/unit/parallel/none_of.cpp
@@ -19,7 +19,8 @@ void test_none_of(ExPolicy const& policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    for (std::size_t i: { 0, 1, 3 })
+    std::size_t iseq[] = { 0, 1, 3 };
+    for (std::size_t i: iseq)
     {
         std::vector<std::size_t> c = test::fill_all_any_none(3, i);
 
@@ -47,7 +48,8 @@ void test_none_of(hpx::parallel::task_execution_policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    for (std::size_t i: { 0, 23, 10007 })
+    std::size_t iseq[] = { 0, 23, 10007 };
+    for (std::size_t i : iseq)
     {
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i);
 
@@ -130,7 +132,8 @@ void test_none_of_exception(ExPolicy const& policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    for (std::size_t i: { 0, 23, 10007 })
+    std::size_t iseq[] = { 0, 23, 10007 };
+    for (std::size_t i : iseq)
     {
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i);
 
@@ -163,7 +166,8 @@ void test_none_of_exception(hpx::parallel::task_execution_policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    for (std::size_t i: { 0, 23, 10007 })
+    std::size_t iseq[] = { 0, 23, 10007 };
+    for (std::size_t i : iseq)
     {
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i);
 
@@ -226,7 +230,8 @@ void test_none_of_bad_alloc(ExPolicy const& policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    for (std::size_t i: { 0, 23, 10007 })
+    std::size_t iseq[] = { 0, 23, 10007 };
+    for (std::size_t i : iseq)
     {
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i);
 
@@ -258,7 +263,8 @@ void test_none_of_bad_alloc(hpx::parallel::task_execution_policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    for (std::size_t i: { 0, 23, 10007 })
+    std::size_t iseq[] = { 0, 23, 10007 };
+    for (std::size_t i : iseq)
     {
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i);
 


### PR DESCRIPTION
VS2012 does not grok C++11 initializer lists much at all, so we rewrite
them into temporary arrays that are iterated over or initialized with.
