### PR TITLE
Silence several warnings

### DIFF
--- a/examples/1d_hydro/1d_hydro_upwind.cpp
+++ b/examples/1d_hydro/1d_hydro_upwind.cpp
@@ -183,18 +183,12 @@ struct time_element{
 class One_Dimension_Grid
 {
 public:
-    One_Dimension_Grid():number_t_steps(0),number_of_cells(0),time_array(0)
-    {}
-    One_Dimension_Grid(boost::uint64_t num_cells,boost::uint64_t num_time_steps):number_t_steps(num_time_steps),number_of_cells(num_cells)
+    One_Dimension_Grid():time_array(0)
     {}
     // ~One_Dimension_Grid();
     void remove_bottom_time_step();//takes the timesteps position in the vector
     void addNewTimeStep();
 
-private:
-
-   boost::uint64_t number_t_steps;
-   boost::uint64_t number_of_cells;
 public:
    std::vector<time_element> time_array;//pointer to the Grid we will create whden the user starts a simulation
 
@@ -364,8 +358,8 @@ cell compute(boost::uint64_t timestep, boost::uint64_t location)
   //now we have to actually compute some values.
 
   //these are the dependencies, or "stencil"
-  if(timestep<0)
-        return grid.time_array.at(timestep).fluid.at(location);
+  //if(timestep<0) // unsigned comparision always false
+  //      return grid.time_array.at(timestep).fluid.at(location);
 
   compute_future nleft = async<compute_action>(here,timestep-1,location-1);
   compute_future nmiddle = async<compute_action>(here,timestep-1,location);

--- a/examples/quickstart/timed_futures.cpp
+++ b/examples/quickstart/timed_futures.cpp
@@ -41,7 +41,6 @@ int return_int_at_time()
 
     // Schedule a wakeup 2 seconds from now.
     using namespace boost::posix_time;
-    int arg = 42;
     hpx::future<int> f = hpx::make_ready_future_at(
         microsec_clock::universal_time() + seconds(2), 42);
 

--- a/examples/throttle/spin.cpp
+++ b/examples/throttle/spin.cpp
@@ -27,8 +27,6 @@ using hpx::naming::get_locality_id_from_gid;
 int hpx_main(variables_map& vm)
 {
     {
-        resolver_client& agas_client = get_agas_client();
-
         std::cout << "commands: localities, help, quit\n";
 
         while (true)

--- a/tests/performance/network/osu/osu_bw.cpp
+++ b/tests/performance/network/osu/osu_bw.cpp
@@ -59,6 +59,7 @@ double ireceive(hpx::naming::id_type dest, std::size_t size, std::size_t window_
 
     // align used buffers on page boundaries
     unsigned long align_size = getpagesize();
+    (void)align_size;
     BOOST_ASSERT(align_size <= MAX_ALIGNMENT);
 
     char *send_buffer = new char[size];

--- a/tests/regressions/block_matrix/block_matrix.cc
+++ b/tests/regressions/block_matrix/block_matrix.cc
@@ -40,6 +40,7 @@ std::ptrdiff_t structure_t::find(std::ptrdiff_t i) const
   auto loopinv = [&]() { return b0>=0 && b1<B && b0<=b1; };
   auto loopvar = [&]() { return b1 - b0; };
   assert(loopinv());
+  (void)loopinv;
   std::ptrdiff_t old_loopvar = loopvar();
   while (b0 < b1 && i>=begin[b0] && i<end[b1]) {
     std::ptrdiff_t b = (b0 + b1)/2;

--- a/tests/regressions/util/protect_with_nullary_pfo.cpp
+++ b/tests/regressions/util/protect_with_nullary_pfo.cpp
@@ -65,6 +65,7 @@ int hpx_main()
 
     v2.reserve(v1.size());
     iterator_type itr_o = v2.begin();
+    (void)itr_o;
     
     std::size_t i = 0;
     BOOST_FOREACH(std::size_t const & v, my_range)

--- a/tests/unit/lcos/async_local.cpp
+++ b/tests/unit/lcos/async_local.cpp
@@ -80,10 +80,6 @@ struct do_nothing_member
     }
 };
 
-#ifndef BOOST_NO_CXX11_LAMBDAS
-auto increment_lambda = [](boost::int32_t i){ return i + 1; };
-#endif /*BOOST_NO_CXX11_LAMBDAS*/
-
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main()
 {

--- a/tests/unit/parallel/copy.cpp
+++ b/tests/unit/parallel/copy.cpp
@@ -22,7 +22,7 @@ void test_copy(ExPolicy const& policy, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
     std::iota(boost::begin(c), boost::end(c), std::rand());
-    base_iterator res = hpx::parallel::copy(policy,
+    hpx::parallel::copy(policy,
         iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d));
 
     std::size_t count = 0;
@@ -71,7 +71,7 @@ void test_copy_outiter(ExPolicy const& policy, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(0);
     std::iota(boost::begin(c), boost::end(c), std::rand());
-    auto res = hpx::parallel::copy(policy,
+    hpx::parallel::copy(policy,
         iterator(boost::begin(c)), iterator(boost::end(c)), std::back_inserter(d));
 
     std::size_t count = 0;
@@ -158,7 +158,7 @@ void test_copy_exception(ExPolicy const& policy, IteratorTag)
 
     bool caught_exception = false;
     try {
-        base_iterator outiter = hpx::parallel::copy(policy,
+        hpx::parallel::copy(policy,
             decorated_iterator(
                 boost::begin(c),
                 [](){ throw std::runtime_error("test"); }),
@@ -253,7 +253,7 @@ void test_copy_bad_alloc(ExPolicy const& policy, IteratorTag)
 
     bool caught_bad_alloc = false;
     try {
-        base_iterator outiter = hpx::parallel::copy(policy,
+        hpx::parallel::copy(policy,
             decorated_iterator(
                 boost::begin(c),
                 [](){ throw std::bad_alloc(); }),

--- a/tests/unit/parallel/copyif.cpp
+++ b/tests/unit/parallel/copyif.cpp
@@ -25,7 +25,7 @@ void test_copy_if(ExPolicy const& policy, IteratorTag)
     std::iota(boost::begin(c), middle, std::rand());
     std::fill(middle, boost::end(c), -1);
 
-    base_iterator outiter = hpx::parallel::copy_if(policy,
+    hpx::parallel::copy_if(policy,
         iterator(boost::begin(c)), iterator(boost::end(c)),
         boost::begin(d), [](int i){return !(i<0);});
 
@@ -99,7 +99,7 @@ void test_copy_if_outiter(ExPolicy const& policy, IteratorTag)
     std::iota(boost::begin(c), middle, std::rand());
     std::fill(middle, boost::end(c), -1);
 
-    auto outiter = hpx::parallel::copy_if(policy,
+    hpx::parallel::copy_if(policy,
         iterator(boost::begin(c)), iterator(boost::end(c)),
         std::back_inserter(d), [](int i){return !(i<0);});
 
@@ -191,7 +191,7 @@ void test_copy_if_exception(ExPolicy const& policy, IteratorTag)
 
     bool caught_exception = false;
     try {
-        base_iterator outiter = hpx::parallel::copy_if(policy,
+        hpx::parallel::copy_if(policy,
             iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d),
             [](std::size_t v) {
                 throw std::runtime_error("test");
@@ -285,7 +285,7 @@ void test_copy_if_bad_alloc(ExPolicy const& policy, IteratorTag)
 
     bool caught_bad_alloc = false;
     try {
-        base_iterator outiter = hpx::parallel::copy_if(policy,
+        hpx::parallel::copy_if(policy,
             iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d),
             [](std::size_t v) {
                 throw std::bad_alloc();

--- a/tests/unit/parallel/copyn.cpp
+++ b/tests/unit/parallel/copyn.cpp
@@ -23,7 +23,7 @@ void test_copy_n(ExPolicy const& policy, IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::iota(boost::begin(c), boost::end(c), std::rand());
 
-    base_iterator outiter = hpx::parallel::copy_n(policy,
+    hpx::parallel::copy_n(policy,
         iterator(boost::begin(c)), c.size(), boost::begin(d));
 
     std::size_t count = 0;
@@ -73,7 +73,7 @@ void test_copy_n_outiter(ExPolicy const& policy, IteratorTag)
     std::vector<std::size_t> d(0);
     std::iota(boost::begin(c), boost::end(c), std::rand());
 
-    auto outiter = hpx::parallel::copy_n(policy,
+    hpx::parallel::copy_n(policy,
         iterator(boost::begin(c)), c.size(), std::back_inserter(d));
 
     std::size_t count = 0;
@@ -163,7 +163,7 @@ void test_copy_n_exception(ExPolicy const& policy, IteratorTag)
 
     bool caught_exception = false;
     try {
-        base_iterator outiter = hpx::parallel::copy_n(policy,
+        hpx::parallel::copy_n(policy,
             decorated_iterator(
                 boost::begin(c),
                 [](){throw std::runtime_error("test");}
@@ -260,7 +260,7 @@ void test_copy_n_bad_alloc(ExPolicy const& policy, IteratorTag)
 
     bool caught_bad_alloc = false;
     try {
-        base_iterator outiter = hpx::parallel::copy_n(policy,
+        hpx::parallel::copy_n(policy,
             decorated_iterator(
                 boost::begin(c),
                 [](){throw std::bad_alloc();}

--- a/tests/unit/parallel/foreachn.cpp
+++ b/tests/unit/parallel/foreachn.cpp
@@ -104,7 +104,7 @@ void test_for_each_n_exception(ExPolicy const& policy, IteratorTag)
 
     bool caught_exception = false;
     try {
-        iterator result = hpx::parallel::for_each_n(policy,
+        hpx::parallel::for_each_n(policy,
             iterator(boost::begin(c)), c.size(),
             [](std::size_t& v) {
                 throw std::runtime_error("test");
@@ -194,7 +194,7 @@ void test_for_each_n_bad_alloc(ExPolicy const& policy, IteratorTag)
 
     bool caught_bad_alloc = false;
     try {
-        iterator result = hpx::parallel::for_each_n(policy,
+        hpx::parallel::for_each_n(policy,
             iterator(boost::begin(c)), c.size(),
             [](std::size_t& v) {
                 throw std::bad_alloc();

--- a/tests/unit/parallel/move.cpp
+++ b/tests/unit/parallel/move.cpp
@@ -24,7 +24,7 @@ void test_move(ExPolicy const& policy, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
     std::iota(boost::begin(c), boost::end(c), std::rand());
-    base_iterator res = hpx::parallel::move(policy,
+    hpx::parallel::move(policy,
         iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d));
 
     //copy contents of d back into c for testing
@@ -85,7 +85,7 @@ void test_outiter_move(ExPolicy const& policy, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(0);
     std::iota(boost::begin(c), boost::end(c), std::rand());
-    outiterator res = hpx::parallel::move(policy,
+    hpx::parallel::move(policy,
         iterator(boost::begin(c)), iterator(boost::end(c)), std::back_inserter(d));
 
     //copy contents of d back into c for testing
@@ -185,7 +185,7 @@ void test_move_exception(ExPolicy const& policy, IteratorTag)
 
     bool caught_exception = false;
     try {
-        base_iterator outiter = hpx::parallel::move(policy,
+        hpx::parallel::move(policy,
             decorated_iterator(
                 boost::begin(c),
                 [](){ throw std::runtime_error("test"); }),
@@ -282,7 +282,7 @@ void test_move_bad_alloc(ExPolicy const& policy, IteratorTag)
 
     bool caught_bad_alloc = false;
     try {
-        base_iterator outiter = hpx::parallel::move(policy,
+        hpx::parallel::move(policy,
             decorated_iterator(
                 boost::begin(c),
                 [](){ throw std::bad_alloc(); }),

--- a/tests/unit/parallel/swapranges.cpp
+++ b/tests/unit/parallel/swapranges.cpp
@@ -24,7 +24,7 @@ void test_swap_ranges(ExPolicy const& policy, IteratorTag)
     std::iota(boost::begin(c), boost::end(c), std::rand());
     std::fill(boost::begin(d), boost::end(d), std::rand());
 
-    base_iterator res = hpx::parallel::swap_ranges(policy,
+    hpx::parallel::swap_ranges(policy,
         iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d));
 
     //equal begins at one, therefore counter is started at 1
@@ -120,7 +120,7 @@ void test_swap_ranges_exception(ExPolicy const& policy, IteratorTag)
 
     bool caught_exception = false;
     try {
-        base_iterator outiter = hpx::parallel::swap_ranges(policy,
+        hpx::parallel::swap_ranges(policy,
             decorated_iterator(
                 boost::begin(c),
                 [](){ throw std::runtime_error("test"); }),
@@ -216,7 +216,7 @@ void test_swap_ranges_bad_alloc(ExPolicy const& policy, IteratorTag)
 
     bool caught_bad_alloc = false;
     try {
-        base_iterator outiter = hpx::parallel::swap_ranges(policy,
+        hpx::parallel::swap_ranges(policy,
             decorated_iterator(
                 boost::begin(c),
                 [](){ throw std::bad_alloc(); }),

--- a/tests/unit/parallel/transform.cpp
+++ b/tests/unit/parallel/transform.cpp
@@ -23,7 +23,7 @@ void test_transform(ExPolicy const& policy, IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::iota(boost::begin(c), boost::end(c), std::rand());
 
-    base_iterator outiter = hpx::parallel::transform(policy,
+    hpx::parallel::transform(policy,
         iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d),
         [](std::size_t v) {
             return v + 1;
@@ -107,7 +107,7 @@ void test_transform_exception(ExPolicy const& policy, IteratorTag)
 
     bool caught_exception = false;
     try {
-        base_iterator outiter = hpx::parallel::transform(policy,
+        hpx::parallel::transform(policy,
             iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d),
             [](std::size_t v) {
                 throw std::runtime_error("test");
@@ -202,7 +202,7 @@ void test_transform_bad_alloc(ExPolicy const& policy, IteratorTag)
 
     bool caught_bad_alloc = false;
     try {
-        base_iterator outiter = hpx::parallel::transform(policy,
+        hpx::parallel::transform(policy,
             iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d),
             [](std::size_t v) {
                 throw std::bad_alloc();

--- a/tests/unit/parallel/transform_binary.cpp
+++ b/tests/unit/parallel/transform_binary.cpp
@@ -30,7 +30,7 @@ void test_transform_binary(ExPolicy const& policy, IteratorTag)
             return v1 + v2;
         };
 
-    base_iterator outiter = hpx::parallel::transform(policy,
+    hpx::parallel::transform(policy,
         iterator(boost::begin(c1)), iterator(boost::end(c1)),
         boost::begin(c2), boost::begin(d1), add);
 
@@ -127,7 +127,7 @@ void test_transform_binary_exception(ExPolicy const& policy, IteratorTag)
 
     bool caught_exception = false;
     try {
-        base_iterator outiter = hpx::parallel::transform(policy,
+        hpx::parallel::transform(policy,
             iterator(boost::begin(c1)), iterator(boost::end(c1)),
             boost::begin(c2), boost::begin(d1),
             [](std::size_t v1, std::size_t v2) {
@@ -227,7 +227,7 @@ void test_transform_binary_bad_alloc(ExPolicy const& policy, IteratorTag)
 
     bool caught_bad_alloc = false;
     try {
-        base_iterator outiter = hpx::parallel::transform(policy,
+        hpx::parallel::transform(policy,
             iterator(boost::begin(c1)), iterator(boost::end(c1)),
             boost::begin(c2), boost::begin(d1),
             [](std::size_t v1, std::size_t v2) {

--- a/tests/unit/threads/thread_affinity.cpp
+++ b/tests/unit/threads/thread_affinity.cpp
@@ -36,15 +36,15 @@ std::size_t thread_affinity_worker(std::size_t desired)
     // Returns the OS-thread number of the worker that is running this
     // PX-thread.
     std::size_t current = hpx::get_worker_thread_num();
-    bool numa_sensitive = hpx::is_scheduler_numa_sensitive();
-
     if (current == desired)
     {
+#if defined(HPX_HAVE_HWLOC)
+        bool numa_sensitive = hpx::is_scheduler_numa_sensitive();
+
         // extract the desired affinity mask
         hpx::threads::topology const& t = hpx::get_runtime().get_topology();
         hpx::threads::mask_type desired_mask = t.get_thread_affinity_mask(current, numa_sensitive);
 
-#if defined(HPX_HAVE_HWLOC)
         std::size_t idx = hpx::threads::find_first(desired_mask);
 
         hwloc_topology_t topo;


### PR DESCRIPTION
Some warnings have been lingering around for a long time, and some
warnings are new. In order to actually spot new problems in the stream
of noise, the code is audited and mitigated where it's spurious
warnings.

The warnings addressed are mostly unused fields, unused variables and
tautological compares.
