### PR TITLE
Adding parallel::replace etc.

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -56,6 +56,7 @@ set(doxygen_dependencies
     "${hpx_SOURCE_DIR}/hpx/parallel/detail/mismatch.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/detail/move.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/detail/reduce.hpp"
+    "${hpx_SOURCE_DIR}/hpx/parallel/detail/replace.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/detail/reverse.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/detail/rotate.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/detail/swap_ranges.hpp"

--- a/docs/hpx.idx
+++ b/docs/hpx.idx
@@ -100,6 +100,12 @@ parallel::move                        "move" "hpx\.parallel\.v1\.move$"
 # hpx/parallel/detail/reduce.hpp
 parallel::reduce                      "reduce" "hpx\.parallel\.v1\.reduce.*"
 
+# hpx/parallel/detail/replace.hpp
+parallel::replace                     "replace" "hpx\.parallel\.v1\.replace$"
+parallel::replace_if                  "replace_if" "hpx\.parallel\.v1\.replace_if.*"
+parallel::replace_copy                "replace_copy" "hpx\.parallel\.v1\.replace_copy$"
+parallel::replace_copy_if             "replace_copy_if" "hpx\.parallel\.v1\.replace_copy_if.*"
+
 # hpx/parallel/detail/reverse.hpp
 parallel::reverse                     "reverse" "hpx\.parallel\.v1\.reverse$"
 parallel::reverse_copy                "reverse_copy" "hpx\.parallel\.v1\.reverse_copy.*"

--- a/hpx/include/parallel_replace.hpp
+++ b/hpx/include/parallel_replace.hpp
@@ -1,0 +1,13 @@
+//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2014 Grant Mercer
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_REPLACE_AUG_18_2014_0148PM)
+#define HPX_PARALLEL_REPLACE_AUG_18_2014_0148PM
+
+#include <hpx/parallel/detail/replace.hpp>
+
+#endif
+

--- a/hpx/parallel/algorithm.hpp
+++ b/hpx/parallel/algorithm.hpp
@@ -22,6 +22,7 @@
 #include <hpx/parallel/detail/generate.hpp>
 #include <hpx/parallel/detail/mismatch.hpp>
 #include <hpx/parallel/detail/move.hpp>
+#include <hpx/parallel/detail/replace.hpp>
 #include <hpx/parallel/detail/reverse.hpp>
 #include <hpx/parallel/detail/rotate.hpp>
 #include <hpx/parallel/detail/swap_ranges.hpp>

--- a/hpx/parallel/detail/find.hpp
+++ b/hpx/parallel/detail/find.hpp
@@ -646,6 +646,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///                     second range (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a replace requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.

--- a/hpx/parallel/detail/replace.hpp
+++ b/hpx/parallel/detail/replace.hpp
@@ -1,0 +1,545 @@
+//  Copyright (c) 2014 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/detail/replace.hpp
+
+#if !defined(HPX_PARALLEL_DETAIL_REPLACE_AUG_18_2014_0136PM)
+#define HPX_PARALLEL_DETAIL_REPLACE_AUG_18_2014_0136PM
+
+#include <hpx/hpx_fwd.hpp>
+#include <hpx/util/move.hpp>
+#include <hpx/util/unused.hpp>
+
+#include <hpx/parallel/config/inline_namespace.hpp>
+#include <hpx/parallel/execution_policy.hpp>
+#include <hpx/parallel/detail/algorithm_result.hpp>
+#include <hpx/parallel/detail/dispatch.hpp>
+#include <hpx/parallel/detail/for_each.hpp>
+#include <hpx/parallel/util/zip_iterator.hpp>
+
+#include <algorithm>
+#include <iterator>
+
+#include <boost/static_assert.hpp>
+#include <boost/utility/enable_if.hpp>
+#include <boost/type_traits/is_base_of.hpp>
+
+namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // replace
+    namespace detail
+    {
+        /// \cond NOINTERNAL
+        struct replace : public detail::algorithm<replace>
+        {
+            replace()
+              : replace::algorithm("replace")
+            {}
+
+            template <typename ExPolicy, typename FwdIter, typename T>
+            static hpx::util::unused_type
+            sequential(ExPolicy const&, FwdIter first, FwdIter last,
+                T const& old_value, T const& new_value)
+            {
+                std::replace(first, last, old_value, new_value);
+                return hpx::util::unused;
+            }
+
+            template <typename ExPolicy, typename FwdIter, typename T>
+            static typename detail::algorithm_result<ExPolicy>::type
+            parallel(ExPolicy const& policy, FwdIter first, FwdIter last,
+                T const& old_value, T const& new_value)
+            {
+                typedef typename detail::algorithm_result<ExPolicy>::type
+                    result_type;
+                typedef typename std::iterator_traits<FwdIter>::value_type type;
+
+                return hpx::util::void_guard<result_type>(),
+                    for_each_n<FwdIter>().call(policy,
+                        first, std::distance(first, last),
+                        [old_value, new_value](type& t) {
+                            if (t == old_value)
+                                t = new_value;
+                        },
+                        boost::mpl::false_());
+            }
+        };
+        /// \endcond
+    }
+
+    /// Replaces all elements satisfying specific criteria with \a new_value
+    /// in the range [first, last).
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam T           The type of the old and new values to replace
+    ///                     (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param old_value    Refers to the old value of the elements to replace.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    ///
+    /// The assignments in the parallel \a replace algorithm invoked with an
+    /// execution policy object of type \a sequential_execution_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a replace algorithm invoked with
+    /// an execution policy object of type \a parallel_execution_policy or
+    /// \a task_execution_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a replace algorithm returns a \a hpx::future<void> if
+    ///           the execution policy is of type \a task_execution_policy and
+    ///           returns \a void otherwise.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename T>
+    inline typename boost::enable_if<
+        is_execution_policy<ExPolicy>,
+        typename detail::algorithm_result<ExPolicy>::type
+    >::type
+    replace(ExPolicy && policy, FwdIter first, FwdIter last,
+        T const& old_value, T const& new_value)
+    {
+        typedef typename std::iterator_traits<FwdIter>::iterator_category
+            iterator_category;
+
+        BOOST_STATIC_ASSERT_MSG(
+            (boost::is_base_of<
+                std::forward_iterator_tag, iterator_category>::value),
+            "Required at least forward iterator.");
+
+        typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
+
+        return detail::replace().call(
+            std::forward<ExPolicy>(policy),
+            first, last, old_value, new_value, is_seq());
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // replace_if
+    namespace detail
+    {
+        /// \cond NOINTERNAL
+        struct replace_if : public detail::algorithm<replace_if>
+        {
+            replace_if()
+              : replace_if::algorithm("replace_if")
+            {}
+
+            template <typename ExPolicy, typename FwdIter, typename F, typename T>
+            static hpx::util::unused_type
+            sequential(ExPolicy const&, FwdIter first, FwdIter last, F && f,
+                T const& new_value)
+            {
+                std::replace_if(first, last, std::forward<F>(f), new_value);
+                return hpx::util::unused;
+            }
+
+            template <typename ExPolicy, typename FwdIter, typename F, typename T>
+            static typename detail::algorithm_result<ExPolicy>::type
+            parallel(ExPolicy const& policy, FwdIter first, FwdIter last,
+                F && f, T const& new_value)
+            {
+                typedef typename detail::algorithm_result<ExPolicy>::type
+                    result_type;
+                typedef typename std::iterator_traits<FwdIter>::value_type type;
+
+                return hpx::util::void_guard<result_type>(),
+                    for_each_n<FwdIter>().call(policy,
+                        first, std::distance(first, last),
+                        [f, new_value](type& t) {
+                            if (f(t))
+                                t = new_value;
+                        },
+                        boost::mpl::false_());
+            }
+        };
+        /// \endcond
+    }
+
+    /// Replaces all elements satisfying specific criteria (for which predicate
+    /// \a f returns true) with \a new_value in the range [first, last).
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first applications of
+    ///         the predicate.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a equal requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    ///                     (deduced).
+    /// \tparam T           The type of the new values to replace (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param f            Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     elements which need to replaced. The
+    ///                     signature of this predicate should be equivalent
+    ///                     to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    ///
+    /// The assignments in the parallel \a replace_if algorithm invoked with an
+    /// execution policy object of type \a sequential_execution_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a replace_if algorithm invoked with
+    /// an execution policy object of type \a parallel_execution_policy or
+    /// \a task_execution_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a replace_if algorithm returns a \a hpx::future<void>
+    ///           if the execution policy is of type \a task_execution_policy
+    ///           and returns \a void otherwise.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename F, typename T>
+    inline typename boost::enable_if<
+        is_execution_policy<ExPolicy>,
+        typename detail::algorithm_result<ExPolicy>::type
+    >::type
+    replace_if(ExPolicy && policy, FwdIter first, FwdIter last,
+        F && f, T const& new_value)
+    {
+        typedef typename std::iterator_traits<FwdIter>::iterator_category
+            iterator_category;
+
+        BOOST_STATIC_ASSERT_MSG(
+            (boost::is_base_of<
+                std::forward_iterator_tag, iterator_category>::value),
+            "Required at least forward iterator.");
+
+        typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
+
+        return detail::replace_if().call(
+            std::forward<ExPolicy>(policy),
+            first, last, std::forward<F>(f), new_value, is_seq());
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // replace_copy
+    namespace detail
+    {
+        /// \cond NOINTERNAL
+        template <typename OutIter>
+        struct replace_copy
+          : public detail::algorithm<replace_copy<OutIter>, OutIter>
+        {
+            replace_copy()
+              : replace_copy::algorithm("replace_copy")
+            {}
+
+            template <typename ExPolicy, typename InIter, typename T>
+            static OutIter
+            sequential(ExPolicy const&, InIter first, InIter last,
+                OutIter dest, T const& old_value, T const& new_value)
+            {
+                return std::replace_copy(first, last, dest, old_value, new_value);
+            }
+
+            template <typename ExPolicy, typename FwdIter, typename T>
+            static typename detail::algorithm_result<ExPolicy, OutIter>::type
+            parallel(ExPolicy const& policy, FwdIter first, FwdIter last,
+                OutIter dest, T const& old_value, T const& new_value)
+            {
+                typedef hpx::util::zip_iterator<FwdIter, OutIter> zip_iterator;
+                typedef typename zip_iterator::reference reference;
+                typedef
+                    typename detail::algorithm_result<ExPolicy, OutIter>::type
+                result_type;
+
+                return get_iter<1, result_type>(
+                    for_each_n<zip_iterator>().call(policy,
+                        hpx::util::make_zip_iterator(first, dest),
+                        std::distance(first, last),
+                        [old_value, new_value](reference t) {
+                            if (old_value == hpx::util::get<0>(t))
+                                hpx::util::get<1>(t) = new_value;
+                            else
+                                hpx::util::get<1>(t) = hpx::util::get<0>(t); //-V573
+                        },
+                        boost::mpl::false_()));
+            }
+        };
+        /// \endcond
+    }
+
+    /// Copies the all elements from the range [first, last) to another range
+    /// beginning at \a dest replacing all elements satisfying a specific
+    /// criteria with \a new_value.
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first applications of
+    ///         the predicate.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam T           The type of the old and new values to replace
+    ///                     (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param old_value    Refers to the old value of the elements to replace.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    ///
+    /// The assignments in the parallel \a replace_copy algorithm invoked
+    /// with an execution policy object of type \a sequential_execution_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a replace_copy algorithm invoked
+    /// with an execution policy object of type \a parallel_execution_policy or
+    /// \a task_execution_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a replace_copy algorithm returns a \a hpx::future<OutIter>
+    ///           if the execution policy is of type \a task_execution_policy
+    ///           and returns \a OutIter otherwise.
+    ///           The \a replace_copy algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    template <typename ExPolicy, typename InIter, typename OutIter, typename T>
+    inline typename boost::enable_if<
+        is_execution_policy<ExPolicy>,
+        typename detail::algorithm_result<ExPolicy, OutIter>::type
+    >::type
+    replace_copy(ExPolicy && policy, InIter first, InIter last, OutIter dest,
+        T const& old_value, T const& new_value)
+    {
+        typedef typename std::iterator_traits<InIter>::iterator_category
+            input_iterator_category;
+        typedef typename std::iterator_traits<OutIter>::iterator_category
+            output_iterator_category;
+
+        BOOST_STATIC_ASSERT_MSG(
+            (boost::is_base_of<
+                std::input_iterator_tag, input_iterator_category>::value),
+            "Required at least forward iterator.");
+
+        BOOST_STATIC_ASSERT_MSG(
+            (boost::mpl::or_<
+                boost::is_base_of<
+                    std::forward_iterator_tag, output_iterator_category>,
+                boost::is_same<
+                    std::output_iterator_tag, output_iterator_category>
+            >::value),
+            "Requires at least output iterator.");
+
+        typedef typename boost::mpl::or_<
+            is_sequential_execution_policy<ExPolicy>,
+            boost::is_same<std::input_iterator_tag, input_iterator_category>,
+            boost::is_same<std::output_iterator_tag, output_iterator_category>
+        >::type is_seq;
+
+        return detail::replace_copy<OutIter>().call(
+            std::forward<ExPolicy>(policy),
+            first, last, dest, old_value, new_value, is_seq());
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // replace_copy_if
+    namespace detail
+    {
+        /// \cond NOINTERNAL
+        template <typename OutIter>
+        struct replace_copy_if
+          : public detail::algorithm<replace_copy_if<OutIter>, OutIter>
+        {
+            replace_copy_if()
+              : replace_copy_if::algorithm("replace_copy_if")
+            {}
+
+            template <typename ExPolicy, typename InIter, typename F, typename T>
+            static OutIter
+            sequential(ExPolicy const&, InIter first, InIter last,
+                OutIter dest, F && f, T const& new_value)
+            {
+                return std::replace_copy_if(first, last, dest,
+                    std::forward<F>(f), new_value);
+            }
+
+            template <typename ExPolicy, typename FwdIter, typename F, typename T>
+            static typename detail::algorithm_result<ExPolicy, OutIter>::type
+            parallel(ExPolicy const& policy, FwdIter first, FwdIter last,
+                OutIter dest, F && f, T const& new_value)
+            {
+                typedef hpx::util::zip_iterator<FwdIter, OutIter> zip_iterator;
+                typedef typename zip_iterator::reference reference;
+                typedef
+                    typename detail::algorithm_result<ExPolicy, OutIter>::type
+                result_type;
+
+                return get_iter<1, result_type>(
+                    for_each_n<zip_iterator>().call(policy,
+                        hpx::util::make_zip_iterator(first, dest),
+                        std::distance(first, last),
+                        [f, new_value](reference t) {
+                            if (f(hpx::util::get<0>(t)))
+                                hpx::util::get<1>(t) = new_value;
+                            else
+                                hpx::util::get<1>(t) = hpx::util::get<0>(t); //-V573
+                        },
+                        boost::mpl::false_()));
+            }
+        };
+        /// \endcond
+    }
+
+    /// Copies the all elements from the range [first, last) to another range
+    /// beginning at \a dest replacing all elements satisfying a specific
+    /// criteria with \a new_value.
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first applications of
+    ///         the predicate.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a equal requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    ///                     (deduced).
+    /// \tparam T           The type of the new values to replace (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param f            Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     elements which need to replaced. The
+    ///                     signature of this predicate should be equivalent
+    ///                     to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    ///
+    /// The assignments in the parallel \a replace_copy_if algorithm invoked
+    /// with an execution policy object of type \a sequential_execution_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a replace_copy_if algorithm invoked
+    /// with an execution policy object of type \a parallel_execution_policy or
+    /// \a task_execution_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a replace_copy_if algorithm returns a \a hpx::future<OutIter>
+    ///           if the execution policy is of type \a task_execution_policy
+    ///           and returns \a OutIter otherwise.
+    ///           The \a replace_copy_if algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    template <typename ExPolicy, typename InIter, typename OutIter, typename F,
+        typename T>
+    inline typename boost::enable_if<
+        is_execution_policy<ExPolicy>,
+        typename detail::algorithm_result<ExPolicy, OutIter>::type
+    >::type
+    replace_copy_if(ExPolicy && policy, InIter first, InIter last, OutIter dest,
+        F && f, T const& new_value)
+    {
+        typedef typename std::iterator_traits<InIter>::iterator_category
+            input_iterator_category;
+        typedef typename std::iterator_traits<OutIter>::iterator_category
+            output_iterator_category;
+
+        BOOST_STATIC_ASSERT_MSG(
+            (boost::is_base_of<
+                std::input_iterator_tag, input_iterator_category>::value),
+            "Required at least forward iterator.");
+
+        BOOST_STATIC_ASSERT_MSG(
+            (boost::mpl::or_<
+                boost::is_base_of<
+                    std::forward_iterator_tag, output_iterator_category>,
+                boost::is_same<
+                    std::output_iterator_tag, output_iterator_category>
+            >::value),
+            "Requires at least output iterator.");
+
+        typedef typename boost::mpl::or_<
+            is_sequential_execution_policy<ExPolicy>,
+            boost::is_same<std::input_iterator_tag, input_iterator_category>,
+            boost::is_same<std::output_iterator_tag, output_iterator_category>
+        >::type is_seq;
+
+        return detail::replace_copy_if<OutIter>().call(
+            std::forward<ExPolicy>(policy),
+            first, last, dest, std::forward<F>(f), new_value, is_seq());
+    }
+}}}
+
+#endif

--- a/tests/unit/parallel/CMakeLists.txt
+++ b/tests/unit/parallel/CMakeLists.txt
@@ -29,6 +29,10 @@ set(tests
     move
     none_of
     reduce_
+    replace
+    replace_if
+    replace_copy
+    replace_copy_if
     reverse
     reverse_copy
     rotate

--- a/tests/unit/parallel/replace.cpp
+++ b/tests/unit/parallel/replace.cpp
@@ -1,0 +1,297 @@
+//  Copyright (c) 2014 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/include/parallel_replace.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_replace(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+    std::copy(boost::begin(c), boost::end(c), boost::begin(d));
+
+    std::size_t idx = std::rand() % c.size();
+
+    hpx::parallel::replace(policy,
+        iterator(boost::begin(c)), iterator(boost::end(c)),
+        c[idx], c[idx]+1);
+
+    std::replace(boost::begin(d), boost::end(d), d[idx], d[idx]+1);
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(boost::begin(c), boost::end(c), boost::begin(d),
+        [&count](std::size_t v1, std::size_t v2) {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d.size());
+}
+
+template <typename IteratorTag>
+void test_replace(hpx::parallel::task_execution_policy, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+    std::copy(boost::begin(c), boost::end(c), boost::begin(d));
+
+    std::size_t idx = std::rand() % c.size();
+
+    hpx::future<void> f =
+        hpx::parallel::replace(hpx::parallel::task,
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            c[idx], c[idx]+1);
+    f.wait();
+
+    std::replace(boost::begin(d), boost::end(d), d[idx], d[idx]+1);
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(boost::begin(c), boost::end(c), boost::begin(d),
+        [&count](std::size_t v1, std::size_t v2) {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d.size());
+}
+
+template <typename IteratorTag>
+void test_replace()
+{
+    using namespace hpx::parallel;
+    test_replace(seq, IteratorTag());
+    test_replace(par, IteratorTag());
+    test_replace(par_vec, IteratorTag());
+    test_replace(task, IteratorTag());
+
+    test_replace(execution_policy(seq), IteratorTag());
+    test_replace(execution_policy(par), IteratorTag());
+    test_replace(execution_policy(par_vec), IteratorTag());
+    test_replace(execution_policy(task), IteratorTag());
+}
+
+void replace_test()
+{
+    test_replace<std::random_access_iterator_tag>();
+    test_replace<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_replace_exception(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_exception = false;
+    try {
+        hpx::parallel::replace(policy,
+            decorated_iterator(
+                boost::begin(c),
+                [](){ throw std::runtime_error("test"); }),
+            decorated_iterator(boost::end(c)),
+            42, 43);
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch (...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename IteratorTag>
+void test_replace_exception(hpx::parallel::task_execution_policy, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_exception = false;
+    try {
+        hpx::future<void> f =
+            hpx::parallel::replace(hpx::parallel::task,
+                decorated_iterator(
+                    boost::begin(c),
+                    [](){ throw std::runtime_error("test"); }),
+                decorated_iterator(boost::end(c)),
+                42, 43);
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<
+            hpx::parallel::task_execution_policy, IteratorTag
+        >::call(hpx::parallel::task, e);
+    }
+    catch (...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename IteratorTag>
+void test_replace_exception()
+{
+    using namespace hpx::parallel;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_replace_exception(seq, IteratorTag());
+    test_replace_exception(par, IteratorTag());
+    test_replace_exception(task, IteratorTag());
+
+    test_replace_exception(execution_policy(seq), IteratorTag());
+    test_replace_exception(execution_policy(par), IteratorTag());
+    test_replace_exception(execution_policy(task), IteratorTag());
+}
+
+void replace_exception_test()
+{
+    test_replace_exception<std::random_access_iterator_tag>();
+    test_replace_exception<std::forward_iterator_tag>();
+}
+
+//////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_replace_bad_alloc(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_bad_alloc = false;
+    try {
+        hpx::parallel::replace(policy,
+            decorated_iterator(
+                boost::begin(c),
+                [](){ throw std::bad_alloc(); }),
+            decorated_iterator(boost::end(c)),
+            42, 43);
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&) {
+        caught_bad_alloc = true;
+    }
+    catch (...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
+template <typename IteratorTag>
+void test_replace_bad_alloc(hpx::parallel::task_execution_policy, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_bad_alloc = false;
+    try {
+        hpx::future<void> f =
+            hpx::parallel::replace(hpx::parallel::task,
+                decorated_iterator(
+                    boost::begin(c),
+                    [](){ throw std::bad_alloc(); }),
+                decorated_iterator(boost::end(c)),
+                42, 43);
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(std::bad_alloc const&) {
+        caught_bad_alloc = true;
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
+template <typename IteratorTag>
+void test_replace_bad_alloc()
+{
+    using namespace hpx::parallel;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_replace_bad_alloc(seq, IteratorTag());
+    test_replace_bad_alloc(par, IteratorTag());
+    test_replace_bad_alloc(task, IteratorTag());
+
+    test_replace_bad_alloc(execution_policy(seq), IteratorTag());
+    test_replace_bad_alloc(execution_policy(par), IteratorTag());
+    test_replace_bad_alloc(execution_policy(task), IteratorTag());
+}
+
+void replace_bad_alloc_test()
+{
+    test_replace_bad_alloc<std::random_access_iterator_tag>();
+    test_replace_bad_alloc<std::forward_iterator_tag>();
+}
+
+int hpx_main()
+{
+    replace_test();
+    replace_exception_test();
+    replace_bad_alloc_test();
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg;
+    cfg.push_back("hpx.os_threads=" +
+        boost::lexical_cast<std::string>(hpx::threads::hardware_concurrency()));
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/parallel/replace_copy.cpp
+++ b/tests/unit/parallel/replace_copy.cpp
@@ -1,0 +1,308 @@
+//  Copyright (c) 2014 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/include/parallel_replace.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_replace_copy(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d1(c.size());
+    std::vector<std::size_t> d2(c.size());
+
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    std::size_t idx = std::rand() % c.size();
+
+    hpx::parallel::replace_copy(policy,
+        iterator(boost::begin(c)), iterator(boost::end(c)),
+        boost::begin(d1), c[idx], c[idx]+1);
+
+    std::replace_copy(boost::begin(c), boost::end(c),
+        boost::begin(d2), c[idx], c[idx]+1);
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(boost::begin(d1), boost::end(d1), boost::begin(d2),
+        [&count](std::size_t v1, std::size_t v2) {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d1.size());
+}
+
+template <typename IteratorTag>
+void test_replace_copy(hpx::parallel::task_execution_policy, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d1(c.size());
+    std::vector<std::size_t> d2(c.size());
+
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    std::size_t idx = std::rand() % c.size();
+
+    hpx::future<void> f =
+        hpx::parallel::replace_copy(hpx::parallel::task,
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            boost::begin(d1), c[idx], c[idx]+1);
+    f.wait();
+
+    std::replace_copy(boost::begin(c), boost::end(c),
+        boost::begin(d2), c[idx], c[idx]+1);
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(boost::begin(d1), boost::end(d1), boost::begin(d2),
+        [&count](std::size_t v1, std::size_t v2) {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d1.size());
+}
+
+template <typename IteratorTag>
+void test_replace_copy()
+{
+    using namespace hpx::parallel;
+    test_replace_copy(seq, IteratorTag());
+    test_replace_copy(par, IteratorTag());
+    test_replace_copy(par_vec, IteratorTag());
+    test_replace_copy(task, IteratorTag());
+
+    test_replace_copy(execution_policy(seq), IteratorTag());
+    test_replace_copy(execution_policy(par), IteratorTag());
+    test_replace_copy(execution_policy(par_vec), IteratorTag());
+    test_replace_copy(execution_policy(task), IteratorTag());
+}
+
+void replace_copy_test()
+{
+    test_replace_copy<std::random_access_iterator_tag>();
+    test_replace_copy<std::forward_iterator_tag>();
+    test_replace_copy<std::input_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_replace_copy_exception(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_exception = false;
+    try {
+        hpx::parallel::replace_copy(policy,
+            decorated_iterator(
+                boost::begin(c),
+                [](){ throw std::runtime_error("test"); }),
+            decorated_iterator(boost::end(c)),
+            boost::begin(d), 42, 43);
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch (...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename IteratorTag>
+void test_replace_copy_exception(hpx::parallel::task_execution_policy, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_exception = false;
+    try {
+        hpx::future<void> f =
+            hpx::parallel::replace_copy(hpx::parallel::task,
+                decorated_iterator(
+                    boost::begin(c),
+                    [](){ throw std::runtime_error("test"); }),
+                decorated_iterator(boost::end(c)),
+                boost::begin(d), 42, 43);
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<
+            hpx::parallel::task_execution_policy, IteratorTag
+        >::call(hpx::parallel::task, e);
+    }
+    catch (...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename IteratorTag>
+void test_replace_copy_exception()
+{
+    using namespace hpx::parallel;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_replace_copy_exception(seq, IteratorTag());
+    test_replace_copy_exception(par, IteratorTag());
+    test_replace_copy_exception(task, IteratorTag());
+
+    test_replace_copy_exception(execution_policy(seq), IteratorTag());
+    test_replace_copy_exception(execution_policy(par), IteratorTag());
+    test_replace_copy_exception(execution_policy(task), IteratorTag());
+}
+
+void replace_copy_exception_test()
+{
+    test_replace_copy_exception<std::random_access_iterator_tag>();
+    test_replace_copy_exception<std::forward_iterator_tag>();
+    test_replace_copy_exception<std::input_iterator_tag>();
+}
+
+//////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_replace_copy_bad_alloc(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_bad_alloc = false;
+    try {
+        hpx::parallel::replace_copy(policy,
+            decorated_iterator(
+                boost::begin(c),
+                [](){ throw std::bad_alloc(); }),
+            decorated_iterator(boost::end(c)),
+            boost::begin(d), 42, 43);
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&) {
+        caught_bad_alloc = true;
+    }
+    catch (...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
+template <typename IteratorTag>
+void test_replace_copy_bad_alloc(hpx::parallel::task_execution_policy, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_bad_alloc = false;
+    try {
+        hpx::future<void> f =
+            hpx::parallel::replace_copy(hpx::parallel::task,
+                decorated_iterator(
+                    boost::begin(c),
+                    [](){ throw std::bad_alloc(); }),
+                decorated_iterator(boost::end(c)),
+                boost::begin(d), 42, 43);
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(std::bad_alloc const&) {
+        caught_bad_alloc = true;
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
+template <typename IteratorTag>
+void test_replace_copy_bad_alloc()
+{
+    using namespace hpx::parallel;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_replace_copy_bad_alloc(seq, IteratorTag());
+    test_replace_copy_bad_alloc(par, IteratorTag());
+    test_replace_copy_bad_alloc(task, IteratorTag());
+
+    test_replace_copy_bad_alloc(execution_policy(seq), IteratorTag());
+    test_replace_copy_bad_alloc(execution_policy(par), IteratorTag());
+    test_replace_copy_bad_alloc(execution_policy(task), IteratorTag());
+}
+
+void replace_copy_bad_alloc_test()
+{
+    test_replace_copy_bad_alloc<std::random_access_iterator_tag>();
+    test_replace_copy_bad_alloc<std::forward_iterator_tag>();
+    test_replace_copy_bad_alloc<std::input_iterator_tag>();
+}
+
+int hpx_main()
+{
+    replace_copy_test();
+    replace_copy_exception_test();
+    replace_copy_bad_alloc_test();
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg;
+    cfg.push_back("hpx.os_threads=" +
+        boost::lexical_cast<std::string>(hpx::threads::hardware_concurrency()));
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/parallel/replace_copy_if.cpp
+++ b/tests/unit/parallel/replace_copy_if.cpp
@@ -1,0 +1,320 @@
+//  Copyright (c) 2014 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/include/parallel_replace.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+struct equal_f
+{
+    equal_f(std::size_t val) : val_(val) {}
+
+    bool operator()(std::size_t lhs) const
+    {
+        return lhs == val_;
+    }
+
+    std::size_t val_;
+};
+
+template <typename ExPolicy, typename IteratorTag>
+void test_replace_copy_if(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d1(c.size());
+    std::vector<std::size_t> d2(c.size());
+
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    std::size_t idx = std::rand() % c.size();
+
+    hpx::parallel::replace_copy_if(policy,
+        iterator(boost::begin(c)), iterator(boost::end(c)),
+        boost::begin(d1), equal_f(c[idx]), c[idx]+1);
+
+    std::replace_copy_if(boost::begin(c), boost::end(c), boost::begin(d2),
+        equal_f(c[idx]), c[idx]+1);
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(boost::begin(d1), boost::end(d1), boost::begin(d2),
+        [&count](std::size_t v1, std::size_t v2) {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d1.size());
+}
+
+template <typename IteratorTag>
+void test_replace_copy_if(hpx::parallel::task_execution_policy, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d1(c.size());
+    std::vector<std::size_t> d2(c.size());
+
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    std::size_t idx = std::rand() % c.size();
+
+    hpx::future<void> f =
+        hpx::parallel::replace_copy_if(hpx::parallel::task,
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            boost::begin(d1), equal_f(c[idx]), c[idx]+1);
+    f.wait();
+
+    std::replace_copy_if(boost::begin(c), boost::end(c),
+        boost::begin(d2), equal_f(c[idx]), c[idx]+1);
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(boost::begin(d1), boost::end(d1), boost::begin(d2),
+        [&count](std::size_t v1, std::size_t v2) {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d1.size());
+}
+
+template <typename IteratorTag>
+void test_replace_copy_if()
+{
+    using namespace hpx::parallel;
+    test_replace_copy_if(seq, IteratorTag());
+    test_replace_copy_if(par, IteratorTag());
+    test_replace_copy_if(par_vec, IteratorTag());
+    test_replace_copy_if(task, IteratorTag());
+
+    test_replace_copy_if(execution_policy(seq), IteratorTag());
+    test_replace_copy_if(execution_policy(par), IteratorTag());
+    test_replace_copy_if(execution_policy(par_vec), IteratorTag());
+    test_replace_copy_if(execution_policy(task), IteratorTag());
+}
+
+void replace_copy_if_test()
+{
+    test_replace_copy_if<std::random_access_iterator_tag>();
+    test_replace_copy_if<std::forward_iterator_tag>();
+    test_replace_copy_if<std::input_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_replace_copy_if_exception(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_exception = false;
+    try {
+        hpx::parallel::replace_copy_if(policy,
+            decorated_iterator(
+                boost::begin(c),
+                [](){ throw std::runtime_error("test"); }),
+            decorated_iterator(boost::end(c)),
+            boost::begin(d), equal_f(42), 43);
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch (...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename IteratorTag>
+void test_replace_copy_if_exception(hpx::parallel::task_execution_policy, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_exception = false;
+    try {
+        hpx::future<void> f =
+            hpx::parallel::replace_copy_if(hpx::parallel::task,
+                decorated_iterator(
+                    boost::begin(c),
+                    [](){ throw std::runtime_error("test"); }),
+                decorated_iterator(boost::end(c)),
+                boost::begin(d), equal_f(42), 43);
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<
+            hpx::parallel::task_execution_policy, IteratorTag
+        >::call(hpx::parallel::task, e);
+    }
+    catch (...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename IteratorTag>
+void test_replace_copy_if_exception()
+{
+    using namespace hpx::parallel;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_replace_copy_if_exception(seq, IteratorTag());
+    test_replace_copy_if_exception(par, IteratorTag());
+    test_replace_copy_if_exception(task, IteratorTag());
+
+    test_replace_copy_if_exception(execution_policy(seq), IteratorTag());
+    test_replace_copy_if_exception(execution_policy(par), IteratorTag());
+    test_replace_copy_if_exception(execution_policy(task), IteratorTag());
+}
+
+void replace_copy_if_exception_test()
+{
+    test_replace_copy_if_exception<std::random_access_iterator_tag>();
+    test_replace_copy_if_exception<std::forward_iterator_tag>();
+    test_replace_copy_if_exception<std::input_iterator_tag>();
+}
+
+//////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_replace_copy_if_bad_alloc(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_bad_alloc = false;
+    try {
+        hpx::parallel::replace_copy_if(policy,
+            decorated_iterator(
+                boost::begin(c),
+                [](){ throw std::bad_alloc(); }),
+            decorated_iterator(boost::end(c)),
+            boost::begin(d), equal_f(42), 43);
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&) {
+        caught_bad_alloc = true;
+    }
+    catch (...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
+template <typename IteratorTag>
+void test_replace_copy_if_bad_alloc(hpx::parallel::task_execution_policy, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_bad_alloc = false;
+    try {
+        hpx::future<void> f =
+            hpx::parallel::replace_copy_if(hpx::parallel::task,
+                decorated_iterator(
+                    boost::begin(c),
+                    [](){ throw std::bad_alloc(); }),
+                decorated_iterator(boost::end(c)),
+                boost::begin(d), equal_f(42), 43);
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(std::bad_alloc const&) {
+        caught_bad_alloc = true;
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
+template <typename IteratorTag>
+void test_replace_copy_if_bad_alloc()
+{
+    using namespace hpx::parallel;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_replace_copy_if_bad_alloc(seq, IteratorTag());
+    test_replace_copy_if_bad_alloc(par, IteratorTag());
+    test_replace_copy_if_bad_alloc(task, IteratorTag());
+
+    test_replace_copy_if_bad_alloc(execution_policy(seq), IteratorTag());
+    test_replace_copy_if_bad_alloc(execution_policy(par), IteratorTag());
+    test_replace_copy_if_bad_alloc(execution_policy(task), IteratorTag());
+}
+
+void replace_copy_if_bad_alloc_test()
+{
+    test_replace_copy_if_bad_alloc<std::random_access_iterator_tag>();
+    test_replace_copy_if_bad_alloc<std::forward_iterator_tag>();
+    test_replace_copy_if_bad_alloc<std::input_iterator_tag>();
+}
+
+int hpx_main()
+{
+    replace_copy_if_test();
+    replace_copy_if_exception_test();
+    replace_copy_if_bad_alloc_test();
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg;
+    cfg.push_back("hpx.os_threads=" +
+        boost::lexical_cast<std::string>(hpx::threads::hardware_concurrency()));
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/parallel/replace_if.cpp
+++ b/tests/unit/parallel/replace_if.cpp
@@ -1,0 +1,309 @@
+//  Copyright (c) 2014 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/include/parallel_replace.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+struct equal_f
+{
+    equal_f(std::size_t val) : val_(val) {}
+
+    bool operator()(std::size_t lhs) const
+    {
+        return lhs == val_;
+    }
+
+    std::size_t val_;
+};
+
+template <typename ExPolicy, typename IteratorTag>
+void test_replace_if(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+    std::copy(boost::begin(c), boost::end(c), boost::begin(d));
+
+    std::size_t idx = std::rand() % c.size();
+
+    hpx::parallel::replace_if(policy,
+        iterator(boost::begin(c)), iterator(boost::end(c)),
+        equal_f(c[idx]), c[idx]+1);
+
+    std::replace_if(boost::begin(d), boost::end(d), equal_f(d[idx]), d[idx]+1);
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(boost::begin(c), boost::end(c), boost::begin(d),
+        [&count](std::size_t v1, std::size_t v2) {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d.size());
+}
+
+template <typename IteratorTag>
+void test_replace_if(hpx::parallel::task_execution_policy, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+    std::copy(boost::begin(c), boost::end(c), boost::begin(d));
+
+    std::size_t idx = std::rand() % c.size();
+
+    hpx::future<void> f =
+        hpx::parallel::replace_if(hpx::parallel::task,
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            equal_f(c[idx]), c[idx]+1);
+    f.wait();
+
+    std::replace_if(boost::begin(d), boost::end(d), equal_f(d[idx]), d[idx]+1);
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(boost::begin(c), boost::end(c), boost::begin(d),
+        [&count](std::size_t v1, std::size_t v2) {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d.size());
+}
+
+template <typename IteratorTag>
+void test_replace_if()
+{
+    using namespace hpx::parallel;
+    test_replace_if(seq, IteratorTag());
+    test_replace_if(par, IteratorTag());
+    test_replace_if(par_vec, IteratorTag());
+    test_replace_if(task, IteratorTag());
+
+    test_replace_if(execution_policy(seq), IteratorTag());
+    test_replace_if(execution_policy(par), IteratorTag());
+    test_replace_if(execution_policy(par_vec), IteratorTag());
+    test_replace_if(execution_policy(task), IteratorTag());
+}
+
+void replace_if_test()
+{
+    test_replace_if<std::random_access_iterator_tag>();
+    test_replace_if<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_replace_if_exception(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_exception = false;
+    try {
+        hpx::parallel::replace_if(policy,
+            decorated_iterator(
+                boost::begin(c),
+                [](){ throw std::runtime_error("test"); }),
+            decorated_iterator(boost::end(c)),
+            equal_f(42), 43);
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch (...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename IteratorTag>
+void test_replace_if_exception(hpx::parallel::task_execution_policy, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_exception = false;
+    try {
+        hpx::future<void> f =
+            hpx::parallel::replace_if(hpx::parallel::task,
+                decorated_iterator(
+                    boost::begin(c),
+                    [](){ throw std::runtime_error("test"); }),
+                decorated_iterator(boost::end(c)),
+                equal_f(42), 43);
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<
+            hpx::parallel::task_execution_policy, IteratorTag
+        >::call(hpx::parallel::task, e);
+    }
+    catch (...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename IteratorTag>
+void test_replace_if_exception()
+{
+    using namespace hpx::parallel;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_replace_if_exception(seq, IteratorTag());
+    test_replace_if_exception(par, IteratorTag());
+    test_replace_if_exception(task, IteratorTag());
+
+    test_replace_if_exception(execution_policy(seq), IteratorTag());
+    test_replace_if_exception(execution_policy(par), IteratorTag());
+    test_replace_if_exception(execution_policy(task), IteratorTag());
+}
+
+void replace_if_exception_test()
+{
+    test_replace_if_exception<std::random_access_iterator_tag>();
+    test_replace_if_exception<std::forward_iterator_tag>();
+}
+
+//////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_replace_if_bad_alloc(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_bad_alloc = false;
+    try {
+        hpx::parallel::replace_if(policy,
+            decorated_iterator(
+                boost::begin(c),
+                [](){ throw std::bad_alloc(); }),
+            decorated_iterator(boost::end(c)),
+            equal_f(42), 43);
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&) {
+        caught_bad_alloc = true;
+    }
+    catch (...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
+template <typename IteratorTag>
+void test_replace_if_bad_alloc(hpx::parallel::task_execution_policy, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_bad_alloc = false;
+    try {
+        hpx::future<void> f =
+            hpx::parallel::replace_if(hpx::parallel::task,
+                decorated_iterator(
+                    boost::begin(c),
+                    [](){ throw std::bad_alloc(); }),
+                decorated_iterator(boost::end(c)),
+                equal_f(42), 43);
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(std::bad_alloc const&) {
+        caught_bad_alloc = true;
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
+template <typename IteratorTag>
+void test_replace_if_bad_alloc()
+{
+    using namespace hpx::parallel;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_replace_if_bad_alloc(seq, IteratorTag());
+    test_replace_if_bad_alloc(par, IteratorTag());
+    test_replace_if_bad_alloc(task, IteratorTag());
+
+    test_replace_if_bad_alloc(execution_policy(seq), IteratorTag());
+    test_replace_if_bad_alloc(execution_policy(par), IteratorTag());
+    test_replace_if_bad_alloc(execution_policy(task), IteratorTag());
+}
+
+void replace_if_bad_alloc_test()
+{
+    test_replace_if_bad_alloc<std::random_access_iterator_tag>();
+    test_replace_if_bad_alloc<std::forward_iterator_tag>();
+}
+
+int hpx_main()
+{
+    replace_if_test();
+    replace_if_exception_test();
+    replace_if_bad_alloc_test();
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg;
+    cfg.push_back("hpx.os_threads=" +
+        boost::lexical_cast<std::string>(hpx::threads::hardware_concurrency()));
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Adding `parallel::replace`, `parallel::replace_if`, `parallel::replace_copy`, and `parallel::replace_copy_if`.
