### PR TITLE
Adding additional parameter to create_thread

### DIFF
--- a/hpx/exception.hpp
+++ b/hpx/exception.hpp
@@ -55,7 +55,7 @@ namespace hpx
             std::string message(int value) const
             {
                 if (value >= success && value < last_error)
-                    return std::string("HPX(") + error_names[value] + ")";
+                    return std::string("HPX(") + error_names[value] + ")"; //-V108
 
                 return "HPX(unknown_error)";
             }

--- a/hpx/runtime/threads/detail/create_thread.hpp
+++ b/hpx/runtime/threads/detail/create_thread.hpp
@@ -15,9 +15,10 @@
 
 namespace hpx { namespace threads { namespace detail
 {
-    inline threads::thread_id_type create_thread(
-        policies::scheduler_base* scheduler,
-        thread_init_data& data, thread_state_enum initial_state = pending,
+    inline void create_thread(
+        policies::scheduler_base* scheduler, thread_init_data& data,
+        threads::thread_id_type& id,
+        thread_state_enum initial_state = pending,
         bool run_now = true, error_code& ec = throws)
     {
         // verify parameters
@@ -34,7 +35,7 @@ namespace hpx { namespace threads { namespace detail
                 HPX_THROWS_IF(ec, bad_parameter,
                     "threads::detail::create_thread",
                     hpx::util::osstream_get_string(strm));
-                return invalid_thread_id;
+                return;
             }
         }
 
@@ -43,7 +44,7 @@ namespace hpx { namespace threads { namespace detail
         {
             HPX_THROWS_IF(ec, bad_parameter,
                 "threads::detail::create_thread", "description is NULL");
-            return invalid_thread_id;
+            return;
         }
 #endif
 
@@ -72,10 +73,10 @@ namespace hpx { namespace threads { namespace detail
         }
 
         // create the new thread
-        thread_id_type newid = scheduler->create_thread(
-            data, initial_state, run_now, ec, data.num_os_thread);
+        scheduler->create_thread(data, &id, initial_state, run_now, ec,
+            data.num_os_thread);
 
-        LTM_(info) << "register_thread(" << newid << "): initial_state("
+        LTM_(info) << "register_thread(" << id << "): initial_state("
                    << get_thread_state_name(initial_state) << "), "
                    << "run_now(" << (run_now ? "true" : "false")
 #ifdef HPX_THREAD_MAINTAIN_DESCRIPTION
@@ -85,7 +86,6 @@ namespace hpx { namespace threads { namespace detail
 
         // potentially wake up waiting thread
         scheduler->do_some_work(data.num_os_thread);
-        return newid;
     }
 }}}
 

--- a/hpx/runtime/threads/detail/create_work.hpp
+++ b/hpx/runtime/threads/detail/create_work.hpp
@@ -86,11 +86,11 @@ namespace hpx { namespace threads { namespace detail
             thread_priority_boost == data.priority)
         {
             // For critical priority threads, create the thread immediately.
-            scheduler->create_thread(data, initial_state, true, ec, data.num_os_thread);
+            scheduler->create_thread(data, 0, initial_state, true, ec, data.num_os_thread);
         }
         else {
             // Create a task description for the new thread.
-            scheduler->create_thread(data, initial_state, false, ec, data.num_os_thread);
+            scheduler->create_thread(data, 0, initial_state, false, ec, data.num_os_thread);
         }
     }
 }}}

--- a/hpx/runtime/threads/detail/set_thread_state.hpp
+++ b/hpx/runtime/threads/detail/set_thread_state.hpp
@@ -303,7 +303,9 @@ namespace hpx { namespace threads { namespace detail
                 thrd, newstate, newstate_ex, priority,
                 self_id, triggered),
             "wake_timer", 0, priority);
-        thread_id_type wake_id = create_thread(&scheduler, data, suspended);
+
+        thread_id_type wake_id = invalid_thread_id;
+        create_thread(&scheduler, data, wake_id, suspended);
 
         // create timer firing in correspondence with given time
         boost::asio::deadline_timer t (
@@ -354,7 +356,9 @@ namespace hpx { namespace threads { namespace detail
                 priority),
             "at_timer (expire at)", 0, priority, thread_num);
 
-        return create_thread(&scheduler, data, pending, true, ec); //-V601
+        thread_id_type newid = invalid_thread_id;
+        create_thread(&scheduler, data, newid, pending, true, ec); //-V601
+        return newid;
     }
 
     template <typename SchedulingPolicy>
@@ -390,7 +394,9 @@ namespace hpx { namespace threads { namespace detail
                 priority),
             "at_timer (from now)", 0, priority, thread_num);
 
-        return create_thread(&scheduler, data, pending, true, ec); //-V601
+        thread_id_type newid = invalid_thread_id;
+        create_thread(&scheduler, data, newid, pending, true, ec); //-V601
+        return newid;
     }
 
     template <typename SchedulingPolicy>

--- a/hpx/runtime/threads/policies/hierarchy_scheduler.hpp
+++ b/hpx/runtime/threads/policies/hierarchy_scheduler.hpp
@@ -468,13 +468,13 @@ namespace hpx { namespace threads { namespace policies
         // create a new thread and schedule it if the initial state is equal to
         // pending
         // TODO: add recycling
-        thread_id_type create_thread(thread_init_data& data,
+        void create_thread(thread_init_data& data, thread_id_type* id,
             thread_state_enum initial_state, bool run_now, error_code& ec,
             std::size_t num_thread)
         {
             HPX_ASSERT(tree.size());
             HPX_ASSERT(tree.back().size());
-            return tree.back()[0]->create_thread(data, initial_state,
+            tree.back()[0]->create_thread(data, id, initial_state,
                 run_now, ec);
         }
 

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -340,7 +340,7 @@ namespace hpx { namespace threads { namespace policies
         ///////////////////////////////////////////////////////////////////////
         // create a new thread and schedule it if the initial state is equal to
         // pending
-        thread_id_type create_thread(thread_init_data& data,
+        void create_thread(thread_init_data& data, thread_id_type* id,
             thread_state_enum initial_state, bool run_now, error_code& ec,
             std::size_t num_thread)
         {
@@ -365,24 +365,27 @@ namespace hpx { namespace threads { namespace policies
             // now create the thread
             if (data.priority == thread_priority_critical) {
                 std::size_t num = num_thread % high_priority_queues_.size();
-                return high_priority_queues_[num]->create_thread(data,
+                high_priority_queues_[num]->create_thread(data, id,
                     initial_state, run_now, ec);
+                return;
             }
 
             if (data.priority == thread_priority_boost) {
                 data.priority = thread_priority_normal;
                 std::size_t num = num_thread % high_priority_queues_.size();
-                return high_priority_queues_[num]->create_thread(data,
+                high_priority_queues_[num]->create_thread(data, id,
                     initial_state, run_now, ec);
+                return;
             }
 
             if (data.priority == thread_priority_low) {
-                return low_priority_queue_.create_thread(data, initial_state,
+                low_priority_queue_.create_thread(data, id, initial_state,
                     run_now, ec);
+                return;
             }
 
             HPX_ASSERT(num_thread < queue_size);
-            return queues_[num_thread]->create_thread(data, initial_state,
+            queues_[num_thread]->create_thread(data, id, initial_state,
                 run_now, ec);
         }
 
@@ -435,7 +438,7 @@ namespace hpx { namespace threads { namespace policies
 
                     HPX_ASSERT(idx != num_thread);
 
-                    if (!test(this_numa_domain, idx) && !test(numa_domain, idx)) //-V560 //-V600
+                    if (!test(this_numa_domain, idx) && !test(numa_domain, idx)) //-V560 //-V600 //-V111
                         continue;
 
                     if (idx < high_priority_queues_.size())
@@ -817,7 +820,7 @@ namespace hpx { namespace threads { namespace policies
                 // the same NUMA node
 
 #if !defined(HPX_NATIVE_MIC)        // we know that the MIC has one NUMA domain only
-                if (test(steals_in_numa_domain_, num_thread)) //-V600
+                if (test(steals_in_numa_domain_, num_thread)) //-V600 //-V111
 #endif
                 {
                     mask_cref_type numa_domain_mask =
@@ -862,7 +865,7 @@ namespace hpx { namespace threads { namespace policies
 
 #if !defined(HPX_NATIVE_MIC)        // we know that the MIC has one NUMA domain only
                 // if nothing found, ask everybody else
-                if (test(steals_outside_numa_domain_, num_thread)) //-V600
+                if (test(steals_outside_numa_domain_, num_thread)) //-V600 //-V111
                 {
                     mask_cref_type numa_domain_mask =
                         outside_numa_domain_masks_[num_thread];

--- a/hpx/runtime/threads/policies/local_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_queue_scheduler.hpp
@@ -259,7 +259,7 @@ namespace hpx { namespace threads { namespace policies
         ///////////////////////////////////////////////////////////////////////
         // create a new thread and schedule it if the initial state is equal to
         // pending
-        thread_id_type create_thread(thread_init_data& data,
+        void create_thread(thread_init_data& data, thread_id_type* id,
             thread_state_enum initial_state, bool run_now, error_code& ec,
             std::size_t num_thread)
         {
@@ -282,7 +282,7 @@ namespace hpx { namespace threads { namespace policies
                 num_thread %= queue_size;
 
             HPX_ASSERT(num_thread < queue_size);
-            return queues_[num_thread]->create_thread(data, initial_state,
+            queues_[num_thread]->create_thread(data, id, initial_state,
                 run_now, ec);
         }
 
@@ -325,7 +325,7 @@ namespace hpx { namespace threads { namespace policies
 
                     HPX_ASSERT(idx != num_thread);
 
-                    if (!test(this_numa_domain, idx) && !test(numa_domain, idx)) //-V560 //-V600
+                    if (!test(this_numa_domain, idx) && !test(numa_domain, idx)) //-V560 //-V600 //-V111
                         continue;
 
                     thread_queue_type* q = queues_[idx];
@@ -545,7 +545,7 @@ namespace hpx { namespace threads { namespace policies
                 // steal work items: first try to steal from other cores in
                 // the same NUMA node
 #if !defined(HPX_NATIVE_MIC)        // we know that the MIC has one NUMA domain only
-                if (test(steals_in_numa_domain_, num_thread)) //-V600
+                if (test(steals_in_numa_domain_, num_thread)) //-V600 //-V111
 #endif
                 {
                     mask_cref_type numa_domain_mask =
@@ -573,7 +573,7 @@ namespace hpx { namespace threads { namespace policies
 
 #ifndef HPX_NATIVE_MIC        // we know that the MIC has one NUMA domain only
                 // if nothing found, ask everybody else
-                if (test(steals_outside_numa_domain_, num_thread)) { //-V600
+                if (test(steals_outside_numa_domain_, num_thread)) { //-V600 //-V111
                     mask_cref_type numa_domain_mask =
                         outside_numa_domain_masks_[num_thread];
                     for (std::size_t i = 1; i != queues_size; ++i)

--- a/hpx/runtime/threads/policies/scheduler_base.hpp
+++ b/hpx/runtime/threads/policies/scheduler_base.hpp
@@ -147,7 +147,7 @@ namespace hpx { namespace threads { namespace policies
 
         virtual bool cleanup_terminated(bool delete_all = false) = 0;
 
-        virtual thread_id_type create_thread(thread_init_data& data,
+        virtual void create_thread(thread_init_data& data, thread_id_type* id,
             thread_state_enum initial_state, bool run_now, error_code& ec,
             std::size_t num_thread) = 0;
 

--- a/hpx/runtime/threads/threadmanager.hpp
+++ b/hpx/runtime/threads/threadmanager.hpp
@@ -274,6 +274,9 @@ namespace hpx { namespace threads
         /// \param func   [in] The function or function object to execute as
         ///               the thread's function. This must have a signature as
         ///               defined by \a thread_function_type.
+        /// \param id     [out] This parameter will hold the id of the created
+        ///               thread. This id is guaranteed to be validly
+        ///               initialized before the thread function is executed.
         /// \param description [in] The value of this parameter allows to
         ///               specify a description of the thread to create. This
         ///               information is used for logging purposes mainly, but
@@ -294,11 +297,8 @@ namespace hpx { namespace threads
         ///               parameter \a run_now or the function \a
         ///               threadmanager#do_some_work is called). This parameter
         ///               is optional and defaults to \a true.
-        ///
-        /// \returns      The function returns the thread id of the newly
-        ///               created thread.
-        virtual thread_id_type
-        register_thread(thread_init_data& data,
+        virtual void
+        register_thread(thread_init_data& data, thread_id_type& id,
             thread_state_enum initial_state = pending,
             bool run_now = true, error_code& ec = throws) = 0;
 

--- a/hpx/runtime/threads/threadmanager_impl.hpp
+++ b/hpx/runtime/threads/threadmanager_impl.hpp
@@ -100,6 +100,9 @@ namespace hpx { namespace threads
         /// \param func   [in] The function or function object to execute as
         ///               the thread's function. This must have a signature as
         ///               defined by \a thread_function_type.
+        /// \param id     [out] This parameter will hold the id of the created
+        ///               thread. This id is guaranteed to be validly
+        ///               initialized before the thread function is executed.
         /// \param description [in] The value of this parameter allows to
         ///               specify a description of the thread to create. This
         ///               information is used for logging purposes mainly, but
@@ -120,10 +123,7 @@ namespace hpx { namespace threads
         ///               parameter \a run_now or the function \a
         ///               threadmanager#do_some_work is called). This parameter
         ///               is optional and defaults to \a true.
-        ///
-        /// \returns      The function returns the thread id of the newly
-        ///               created thread.
-        thread_id_type register_thread(thread_init_data& data,
+        void register_thread(thread_init_data& data, thread_id_type& id,
             thread_state_enum initial_state = pending,
             bool run_now = true, error_code& ec = throws);
 

--- a/src/runtime/applier/applier.cpp
+++ b/src/runtime/applier/applier.cpp
@@ -75,8 +75,10 @@ namespace hpx { namespace applier
             util::bind(util::one_shot(&thread_function_nullary), std::move(func)),
             desc ? desc : "<unknown>", 0, priority, os_thread,
             threads::get_stack_size(stacksize));
-        return app->get_thread_manager().
-            register_thread(data, state, run_now, ec);
+
+        threads::thread_id_type id = threads::invalid_thread_id;
+        app->get_thread_manager().register_thread(data, id, state, run_now, ec);
+        return id;
     }
 
     threads::thread_id_type register_thread(
@@ -98,8 +100,10 @@ namespace hpx { namespace applier
             util::bind(util::one_shot(&thread_function), std::move(func)),
             desc ? desc : "<unknown>", 0, priority, os_thread,
             threads::get_stack_size(stacksize));
-        return app->get_thread_manager().
-            register_thread(data, state, run_now, ec);
+
+        threads::thread_id_type id = threads::invalid_thread_id;
+        app->get_thread_manager().register_thread(data, id, state, run_now, ec);
+        return id;
     }
 
     threads::thread_id_type register_non_suspendable_thread(
@@ -121,8 +125,10 @@ namespace hpx { namespace applier
             util::bind(util::one_shot(&thread_function), std::move(func)),
             desc ? desc : "<unknown>", 0, priority, os_thread,
             threads::get_stack_size(threads::thread_stacksize_nostack));
-        return app->get_thread_manager().
-            register_thread(data, state, run_now, ec);
+
+        threads::thread_id_type id = threads::invalid_thread_id;
+        app->get_thread_manager().register_thread(data, id, state, run_now, ec);
+        return id;
     }
 
     threads::thread_id_type register_thread_plain(
@@ -143,8 +149,10 @@ namespace hpx { namespace applier
         threads::thread_init_data data(
             std::move(func), desc ? desc : "<unknown>", 0, priority,
             os_thread, threads::get_stack_size(stacksize));
-        return app->get_thread_manager().
-            register_thread(data, state, run_now, ec);
+
+        threads::thread_id_type id = threads::invalid_thread_id;
+        app->get_thread_manager().register_thread(data, id, state, run_now, ec);
+        return id;
     }
 
     threads::thread_id_type register_thread_plain(
@@ -160,8 +168,9 @@ namespace hpx { namespace applier
             return threads::invalid_thread_id;
         }
 
-        return app->get_thread_manager().
-            register_thread(data, state, run_now, ec);
+        threads::thread_id_type id = threads::invalid_thread_id;
+        app->get_thread_manager().register_thread(data, id, state, run_now, ec);
+        return id;
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/runtime/threads/executors/generic_thread_pool_executor.cpp
+++ b/src/runtime/threads/executors/generic_thread_pool_executor.cpp
@@ -49,7 +49,8 @@ namespace hpx { namespace threads { namespace executors { namespace detail
             std::move(f)), desc);
         data.stacksize = threads::get_stack_size(stacksize);
 
-        threads::detail::create_thread(scheduler_base_, data,
+        threads::thread_id_type id = threads::invalid_thread_id;
+        threads::detail::create_thread(scheduler_base_, data, id,
             initial_state, run_now, ec);
         if (ec) return;
 

--- a/src/runtime/threads/executors/thread_pool_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_executors.cpp
@@ -175,7 +175,9 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         // update statistics
         ++tasks_scheduled_;
 
-        threads::detail::create_thread(&scheduler_, data, initial_state, run_now, ec); //-V601
+        threads::thread_id_type id = threads::invalid_thread_id;
+        threads::detail::create_thread(&scheduler_, data, id, initial_state, //-V601
+            run_now, ec);
         if (ec) {
             --tasks_scheduled_;
             return;
@@ -200,8 +202,9 @@ namespace hpx { namespace threads { namespace executors { namespace detail
             this, std::move(f)), desc);
         data.stacksize = threads::get_stack_size(stacksize);
 
-        thread_id_type id = threads::detail::create_thread( //-V601
-            &scheduler_, data, suspended, true, ec);
+        threads::thread_id_type id = threads::invalid_thread_id;
+        threads::detail::create_thread( //-V601
+            &scheduler_, data, id, suspended, true, ec);
         if (ec) return;
         HPX_ASSERT(invalid_thread_id != id);    // would throw otherwise
 
@@ -234,8 +237,9 @@ namespace hpx { namespace threads { namespace executors { namespace detail
             this, std::move(f)), desc);
         data.stacksize = threads::get_stack_size(stacksize);
 
-        thread_id_type id = threads::detail::create_thread( //-V601
-            &scheduler_, data, suspended, true, ec);
+        threads::thread_id_type id = threads::invalid_thread_id;
+        threads::detail::create_thread( //-V601
+            &scheduler_, data, id, suspended, true, ec);
         if (ec) return;
         HPX_ASSERT(invalid_thread_id != id);    // would throw otherwise
 

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -211,9 +211,9 @@ namespace hpx { namespace threads
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename SchedulingPolicy, typename NotificationPolicy>
-    thread_id_type threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
-        register_thread(thread_init_data& data, thread_state_enum initial_state,
-            bool run_now, error_code& ec)
+    void threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+        register_thread(thread_init_data& data, thread_id_type& id,
+            thread_state_enum initial_state, bool run_now, error_code& ec)
     {
         util::block_profiler_wrapper<register_thread_tag> bp(thread_logger_);
 
@@ -224,10 +224,10 @@ namespace hpx { namespace threads
             HPX_THROWS_IF(ec, invalid_status,
                 "threadmanager_impl::register_thread",
                 "invalid state: thread manager is not running");
-            return invalid_thread_id;
+            return;
         }
 
-        return detail::create_thread(&scheduler_, data, initial_state, run_now, ec); //-V601
+        detail::create_thread(&scheduler_, data, id, initial_state, run_now, ec); //-V601
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -259,7 +259,7 @@ namespace hpx { namespace threads
             thread_state_ex_enum new_state_ex, thread_priority priority,
             error_code& ec)
     {
-        return detail::set_thread_state(id, new_state,
+        return detail::set_thread_state(id, new_state, //-V107
             new_state_ex, priority, get_worker_thread_num(), ec);
     }
 

--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -310,7 +310,9 @@ namespace hpx {
                 boost::ref(result_)),
             "run_helper", 0, threads::thread_priority_normal, std::size_t(-1),
             threads::get_stack_size(threads::thread_stacksize_large));
-        thread_manager_->register_thread(data);
+
+        threads::thread_id_type id = threads:: invalid_thread_id;
+        thread_manager_->register_thread(data, id);
         this->runtime::starting();
         // }}}
 

--- a/tests/unit/threads/thread.cpp
+++ b/tests/unit/threads/thread.cpp
@@ -85,7 +85,7 @@ void test_sleep()
 
     // Ensure it's in a range instead of checking actual equality due to time
     // lapse
-    HPX_TEST(in_range(now, boost::chrono::seconds(4)));
+    HPX_TEST(in_range(now, boost::chrono::seconds(4))); //-V112
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Adding additional parameter to create thread to be able to synchronize properly with the start of the thread function (this fixes #1253: hpx::thread defects)
