### PR TITLE
Avoid double-linking Boost on Windows

### DIFF
--- a/tests/unit/threads/CMakeLists.txt
+++ b/tests/unit/threads/CMakeLists.txt
@@ -19,7 +19,11 @@ if(HPX_THREAD_MAINTAIN_LOCAL_STORAGE)
   set(tests ${tests} tss)
 endif()
 
-set(lockfree_fifo_FLAGS NOLIBS DEPENDENCIES ${Boost_LIBRARIES})
+if(NOT MSVC)
+  set(lockfree_fifo_FLAGS NOLIBS DEPENDENCIES ${Boost_LIBRARIES})
+else()
+  set(lockfree_fifo_FLAGS NOLIBS)
+endif()
 
 set(set_thread_state_PARAMETERS THREADS_PER_LOCALITY 4)
 


### PR DESCRIPTION
The `lockfree_fifo` test links both Boost explicitly and does not mitigate
Boost's auto-linking.

This results in symbol conflicts at link time thanks to autolink selecting
static libraries and HPX selecting dynamic libraries. As autolink is more
aligned with the settings the library uses, this commit avoids linking
Boost manually.
