### PR TITLE
Avoid CMake name clash for Boost.Thread library

### DIFF
--- a/cmake/HPX_SetupBoost.cmake
+++ b/cmake/HPX_SetupBoost.cmake
@@ -28,11 +28,11 @@ endif()
 
 set(Boost_TMP_LIBRARIES ${Boost_LIBRARIES})
 if(UNIX AND NOT CYGWIN)
-  find_library(BOOST_THREAD_LIBRARY NAMES pthread DOC "The threading library used by boost.thread")
-  if(NOT BOOST_THREAD_LIBRARY AND (HPX_PLATFORM_UC STREQUAL "XEONPHI"))
-    set(BOOST_THREAD_LIBRARY "-pthread")
+  find_library(BOOST_UNDERLYING_THREAD_LIBRARY NAMES pthread DOC "The threading library used by boost.thread")
+  if(NOT BOOST_UNDERLYING_THREAD_LIBRARY AND (HPX_PLATFORM_UC STREQUAL "XEONPHI"))
+    set(BOOST_UNDERLYING_THREAD_LIBRARY "-pthread")
   endif()
-  set(Boost_TMP_LIBRARIES ${Boost_TMP_LIBRARIES} ${BOOST_THREAD_LIBRARY})
+  set(Boost_TMP_LIBRARIES ${Boost_TMP_LIBRARIES} ${BOOST_UNDERLYING_THREAD_LIBRARY})
 endif()
 
 # Set configuration option to use Boost.Context or not. This depends on the Boost


### PR DESCRIPTION
FindBoost uses `Boost_THREAD_LIBRARY` to denote the library filename to
link when using Boost.Thread.

HPX_SetupBoost.cmake used `BOOST_THREAD_LIBRARY` as the target to detect
the underlying platform threading library used by Boost.Thread. As
find_library avoids the search if the cache variable exists, this search
was always a no-op.

The temporary name is now instead `BOOST_UNDERLYING_THREAD_LIBRARY`.
