### PR TITLE
missing boost::scoped_ptr includes

### DIFF
--- a/hpx/performance_counters/server/statistics_counter.hpp
+++ b/hpx/performance_counters/server/statistics_counter.hpp
@@ -11,6 +11,8 @@
 #include <hpx/util/interval_timer.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 
+#include <boost/smart_ptr/scoped_ptr.hpp>
+
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/mean.hpp>

--- a/hpx/runtime.hpp
+++ b/hpx/runtime.hpp
@@ -26,6 +26,7 @@
 #include <hpx/config/warnings_prefix.hpp>
 
 #include <boost/foreach.hpp>
+#include <boost/smart_ptr/scoped_ptr.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx


### PR DESCRIPTION
Without these includes, the code doesn't build with latest master of Boost.
