### PR TITLE
Fixing 1297

### DIFF
--- a/examples/quickstart/data_actions.cpp
+++ b/examples/quickstart/data_actions.cpp
@@ -21,6 +21,8 @@ struct plain_data
         hpx::components::set_component_type<plain_data<Action> >(type);
     }
 
+    static bool is_target_valid(naming::id_type const& id) { return true; }
+
     /// This is the default hook implementation for decorate_action which
     /// does no hooking at all.
     template <typename F>

--- a/hpx/lcos/base_lco.hpp
+++ b/hpx/lcos/base_lco.hpp
@@ -44,6 +44,12 @@ namespace hpx { namespace lcos
         static components::component_type get_component_type();
         static void set_component_type(components::component_type type);
 
+        // This component type requires valid id for its actions to be invoked
+        static bool is_target_valid(naming::id_type const& id)
+        {
+            return !naming::is_locality(id);
+        }
+
         /// Destructor, needs to be virtual to allow for clean destruction of
         /// derived objects
         virtual ~base_lco();

--- a/hpx/performance_counters/server/base_performance_counter.hpp
+++ b/hpx/performance_counters/server/base_performance_counter.hpp
@@ -138,6 +138,12 @@ namespace hpx { namespace performance_counters { namespace server
         HPX_DEFINE_COMPONENT_ACTION(base_performance_counter,
             stop_nonvirt, stop_action);
 
+        // This component type requires valid id for its actions to be invoked
+        static bool is_target_valid(naming::id_type const& id)
+        {
+            return !naming::is_locality(id);
+        }
+
         /// This is the default hook implementation for decorate_action which
         /// does no hooking at all.
         template <typename F>

--- a/hpx/runtime/actions/component_const_action.hpp
+++ b/hpx/runtime/actions/component_const_action.hpp
@@ -37,10 +37,10 @@ namespace hpx { namespace actions
         typedef action<Component const, result_type, arguments_type, Derived>
             base_type;
 
-        // Only non-localities are valid targets for a component action
+        // Let the component decide whether the id is valid
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
 
     protected:
@@ -241,10 +241,10 @@ namespace hpx { namespace actions
         typedef action<Component const, result_type, arguments_type, Derived>
             base_type;
 
-        // Only non-localities are valid targets for a component action
+        // Let the component decide whether the id is valid
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
 
     protected:

--- a/hpx/runtime/actions/component_const_action_implementations.hpp
+++ b/hpx/runtime/actions/component_const_action_implementations.hpp
@@ -113,10 +113,10 @@ namespace hpx { namespace actions
         typedef action<Component const, result_type, arguments_type, Derived>
             base_type;
 
-        // Only non-localities are valid targets for a component action
+        // Let the component decide whether the id is valid
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
 
     protected:
@@ -327,10 +327,10 @@ namespace hpx { namespace actions
         typedef action<Component const, result_type, arguments_type, Derived>
             base_type;
 
-        // Only non-localities are valid targets for a component action
+        // Let the component decide whether the id is valid
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
 
     protected:

--- a/hpx/runtime/actions/component_non_const_action.hpp
+++ b/hpx/runtime/actions/component_non_const_action.hpp
@@ -37,10 +37,10 @@ namespace hpx { namespace actions
         typedef action<Component, result_type, arguments_type, Derived>
             base_type;
 
-        // Only non-localities are valid targets for a component action
+        // Let the component decide whether the id is valid
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
 
     protected:
@@ -220,10 +220,10 @@ namespace hpx { namespace actions
         typedef action<Component, result_type, arguments_type, Derived>
             base_type;
 
-        // Only non-localities are valid targets for a component action
+        // Let the component decide whether the id is valid
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
 
     protected:

--- a/hpx/runtime/actions/component_non_const_action_implementations.hpp
+++ b/hpx/runtime/actions/component_non_const_action_implementations.hpp
@@ -74,10 +74,10 @@ namespace hpx { namespace actions
         typedef action<Component, result_type, arguments_type, Derived>
             base_type;
 
-        // Only non-localities are valid targets for a component action
+        // Let the component decide whether the id is valid
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
 
     protected:
@@ -286,10 +286,10 @@ namespace hpx { namespace actions
         typedef action<Component, result_type, arguments_type, Derived>
             base_type;
 
-        // Only non-localities are valid targets for a component action
+        // Let the component decide whether the id is valid
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
 
     protected:

--- a/hpx/runtime/actions/preprocessed/component_const_action_implementations_10.hpp
+++ b/hpx/runtime/actions/preprocessed/component_const_action_implementations_10.hpp
@@ -34,7 +34,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -227,7 +227,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -434,7 +434,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -627,7 +627,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -834,7 +834,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1027,7 +1027,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1234,7 +1234,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1427,7 +1427,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1634,7 +1634,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1827,7 +1827,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2034,7 +2034,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2227,7 +2227,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2434,7 +2434,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2627,7 +2627,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2834,7 +2834,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3027,7 +3027,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3234,7 +3234,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3427,7 +3427,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3634,7 +3634,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3827,7 +3827,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         

--- a/hpx/runtime/actions/preprocessed/component_const_action_implementations_15.hpp
+++ b/hpx/runtime/actions/preprocessed/component_const_action_implementations_15.hpp
@@ -34,7 +34,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -227,7 +227,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -434,7 +434,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -627,7 +627,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -834,7 +834,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1027,7 +1027,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1234,7 +1234,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1427,7 +1427,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1634,7 +1634,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1827,7 +1827,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2034,7 +2034,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2227,7 +2227,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2434,7 +2434,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2627,7 +2627,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2834,7 +2834,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3027,7 +3027,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3234,7 +3234,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3427,7 +3427,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3634,7 +3634,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3827,7 +3827,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -4034,7 +4034,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -4227,7 +4227,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -4434,7 +4434,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -4627,7 +4627,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -4834,7 +4834,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -5027,7 +5027,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -5234,7 +5234,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -5427,7 +5427,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -5634,7 +5634,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -5827,7 +5827,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         

--- a/hpx/runtime/actions/preprocessed/component_const_action_implementations_20.hpp
+++ b/hpx/runtime/actions/preprocessed/component_const_action_implementations_20.hpp
@@ -34,7 +34,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -227,7 +227,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -434,7 +434,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -627,7 +627,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -834,7 +834,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1027,7 +1027,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1234,7 +1234,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1427,7 +1427,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1634,7 +1634,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1827,7 +1827,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2034,7 +2034,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2227,7 +2227,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2434,7 +2434,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2627,7 +2627,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2834,7 +2834,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3027,7 +3027,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3234,7 +3234,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3427,7 +3427,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3634,7 +3634,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3827,7 +3827,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -4034,7 +4034,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -4227,7 +4227,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -4434,7 +4434,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -4627,7 +4627,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -4834,7 +4834,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -5027,7 +5027,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -5234,7 +5234,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -5427,7 +5427,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -5634,7 +5634,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -5827,7 +5827,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -6034,7 +6034,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -6227,7 +6227,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -6434,7 +6434,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -6627,7 +6627,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -6834,7 +6834,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -7027,7 +7027,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -7234,7 +7234,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -7427,7 +7427,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -7634,7 +7634,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -7827,7 +7827,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         

--- a/hpx/runtime/actions/preprocessed/component_const_action_implementations_5.hpp
+++ b/hpx/runtime/actions/preprocessed/component_const_action_implementations_5.hpp
@@ -34,7 +34,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -227,7 +227,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -434,7 +434,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -627,7 +627,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -834,7 +834,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1027,7 +1027,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1234,7 +1234,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1427,7 +1427,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1634,7 +1634,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1827,7 +1827,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         

--- a/hpx/runtime/actions/preprocessed/component_non_const_action_implementations_10.hpp
+++ b/hpx/runtime/actions/preprocessed/component_non_const_action_implementations_10.hpp
@@ -33,7 +33,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -224,7 +224,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -431,7 +431,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -622,7 +622,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -829,7 +829,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1020,7 +1020,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1227,7 +1227,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1418,7 +1418,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1625,7 +1625,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1816,7 +1816,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2023,7 +2023,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2214,7 +2214,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2421,7 +2421,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2612,7 +2612,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2819,7 +2819,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3010,7 +3010,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3217,7 +3217,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3408,7 +3408,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3615,7 +3615,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3806,7 +3806,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         

--- a/hpx/runtime/actions/preprocessed/component_non_const_action_implementations_15.hpp
+++ b/hpx/runtime/actions/preprocessed/component_non_const_action_implementations_15.hpp
@@ -33,7 +33,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -224,7 +224,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -431,7 +431,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -622,7 +622,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -829,7 +829,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1020,7 +1020,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1227,7 +1227,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1418,7 +1418,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1625,7 +1625,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1816,7 +1816,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2023,7 +2023,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2214,7 +2214,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2421,7 +2421,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2612,7 +2612,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2819,7 +2819,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3010,7 +3010,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3217,7 +3217,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3408,7 +3408,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3615,7 +3615,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3806,7 +3806,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -4013,7 +4013,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -4204,7 +4204,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -4411,7 +4411,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -4602,7 +4602,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -4809,7 +4809,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -5000,7 +5000,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -5207,7 +5207,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -5398,7 +5398,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -5605,7 +5605,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -5796,7 +5796,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         

--- a/hpx/runtime/actions/preprocessed/component_non_const_action_implementations_20.hpp
+++ b/hpx/runtime/actions/preprocessed/component_non_const_action_implementations_20.hpp
@@ -33,7 +33,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -224,7 +224,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -431,7 +431,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -622,7 +622,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -829,7 +829,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1020,7 +1020,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1227,7 +1227,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1418,7 +1418,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1625,7 +1625,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1816,7 +1816,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2023,7 +2023,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2214,7 +2214,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2421,7 +2421,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2612,7 +2612,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -2819,7 +2819,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3010,7 +3010,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3217,7 +3217,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3408,7 +3408,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3615,7 +3615,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -3806,7 +3806,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -4013,7 +4013,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -4204,7 +4204,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -4411,7 +4411,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -4602,7 +4602,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -4809,7 +4809,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -5000,7 +5000,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -5207,7 +5207,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -5398,7 +5398,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -5605,7 +5605,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -5796,7 +5796,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -6003,7 +6003,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -6194,7 +6194,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -6401,7 +6401,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -6592,7 +6592,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -6799,7 +6799,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -6990,7 +6990,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -7197,7 +7197,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -7388,7 +7388,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -7595,7 +7595,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -7786,7 +7786,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         

--- a/hpx/runtime/actions/preprocessed/component_non_const_action_implementations_5.hpp
+++ b/hpx/runtime/actions/preprocessed/component_non_const_action_implementations_5.hpp
@@ -33,7 +33,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -224,7 +224,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -431,7 +431,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -622,7 +622,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -829,7 +829,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1020,7 +1020,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1227,7 +1227,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1418,7 +1418,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1625,7 +1625,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         
@@ -1816,7 +1816,7 @@ namespace hpx { namespace actions
         
         static bool is_target_valid(naming::id_type const& id)
         {
-            return !naming::is_locality(id);
+            return Component::is_target_valid(id);
         }
     protected:
         

--- a/hpx/runtime/components/server/abstract_component_base.hpp
+++ b/hpx/runtime/components/server/abstract_component_base.hpp
@@ -39,6 +39,12 @@ namespace hpx { namespace components
             hpx::components::set_component_type<outer_wrapping_type>(t);
         }
 
+        // This component type requires valid id for its actions to be invoked
+        static bool is_target_valid(naming::id_type const& id)
+        {
+            return !naming::is_locality(id);
+        }
+
         /// This is the default hook implementation for decorate_action which
         /// does no hooking at all.
         template <typename F>
@@ -81,6 +87,12 @@ namespace hpx { namespace components
         static void set_component_type(component_type t)
         {
             hpx::components::set_component_type<wrapping_type>(t);
+        }
+
+        // This component type requires valid id for its actions to be invoked
+        static bool is_target_valid(naming::id_type const& id)
+        {
+            return !naming::is_locality(id);
         }
 
         /// This is the default hook implementation for decorate_action which
@@ -126,6 +138,12 @@ namespace hpx { namespace components
         static void set_component_type(component_type t)
         {
             hpx::components::set_component_type<outer_wrapping_type>(t);
+        }
+
+        // This component type requires valid id for its actions to be invoked
+        static bool is_target_valid(naming::id_type const& id)
+        {
+            return !naming::is_locality(id);
         }
 
         /// This is the default hook implementation for decorate_action which

--- a/hpx/runtime/components/server/fixed_component_base.hpp
+++ b/hpx/runtime/components/server/fixed_component_base.hpp
@@ -144,6 +144,12 @@ public:
     }
 #endif
 
+    // This component type requires valid id for its actions to be invoked
+    static bool is_target_valid(naming::id_type const& id)
+    {
+        return !naming::is_locality(id);
+    }
+
     // This component type does not support migration.
     static BOOST_CONSTEXPR bool supports_migration() { return false; }
 
@@ -151,6 +157,7 @@ public:
     void pin() {}
     void unpin() {}
     boost::uint32_t pin_count() const { return 0; }
+
     void mark_as_migrated()
     {
         // If this assertion is triggered then this component instance is being

--- a/hpx/runtime/components/server/managed_component_base.hpp
+++ b/hpx/runtime/components/server/managed_component_base.hpp
@@ -288,6 +288,12 @@ namespace hpx { namespace components
             hpx::threads::register_work_plain(data, initial_state); //-V106
         }
 
+        // This component type requires valid id for its actions to be invoked
+        static bool is_target_valid(naming::id_type const& id)
+        {
+            return !naming::is_locality(id);
+        }
+
         // This component type does not support migration.
         static BOOST_CONSTEXPR bool supports_migration() { return false; }
 
@@ -295,6 +301,7 @@ namespace hpx { namespace components
         void pin() {}
         void unpin() {}
         boost::uint32_t pin_count() const { return 0; }
+
         void mark_as_migrated()
         {
             // If this assertion is triggered then this component instance is

--- a/hpx/runtime/components/server/memory.hpp
+++ b/hpx/runtime/components/server/memory.hpp
@@ -133,6 +133,9 @@ namespace hpx { namespace components { namespace server
         HPX_DEFINE_COMPONENT_CONST_DIRECT_ACTION(memory, load128);
 #endif
 
+        // This component type requires valid id for its actions to be invoked
+        static bool is_target_valid(naming::id_type const& id) { return true; }
+
         /// This is the default hook implementation for decorate_action which
         /// does no hooking at all.
         template <typename F>

--- a/hpx/runtime/components/server/memory_block.hpp
+++ b/hpx/runtime/components/server/memory_block.hpp
@@ -418,6 +418,9 @@ namespace hpx { namespace components { namespace server { namespace detail
         HPX_DEFINE_COMPONENT_ACTION(memory_block, checkin);
         HPX_DEFINE_COMPONENT_ACTION(memory_block, clone);
 
+        // This component type requires valid id for its actions to be invoked
+        static bool is_target_valid(naming::id_type const& id) { return true; }
+
         /// This is the default hook implementation for decorate_action which
         /// does no hooking at all.
         template <typename F>

--- a/hpx/runtime/components/server/plain_function.hpp
+++ b/hpx/runtime/components/server/plain_function.hpp
@@ -28,7 +28,13 @@ namespace hpx { namespace components { namespace server
             components::set_component_type<plain_function<Action> >(type);
         }
 
-        /// This is the default hook implementation for decorate_action which 
+        // This component type requires valid id for its actions to be invoked
+        static bool is_target_valid(naming::id_type const& id)
+        {
+            return naming::is_locality(id);
+        }
+
+        /// This is the default hook implementation for decorate_action which
         /// does no hooking at all.
         template <typename F>
         static threads::thread_function_type

--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -129,6 +129,13 @@ namespace hpx { namespace components { namespace server
 
         void tidy();
 
+        // This component type requires valid locality id for its actions to
+        // be invoked
+        static bool is_target_valid(naming::id_type const& id)
+        {
+            return naming::is_locality(id);
+        }
+
         ///////////////////////////////////////////////////////////////////////
         // exposed functionality of this component
 

--- a/hpx/runtime/components/server/simple_component_base.hpp
+++ b/hpx/runtime/components/server/simple_component_base.hpp
@@ -189,6 +189,12 @@ namespace hpx { namespace components
         }
 #endif
 
+        // This component type requires valid id for its actions to be invoked
+        static bool is_target_valid(naming::id_type const& id)
+        {
+            return !naming::is_locality(id);
+        }
+
         // This component type does not support migration.
         static BOOST_CONSTEXPR bool supports_migration() { return false; }
 
@@ -196,6 +202,7 @@ namespace hpx { namespace components
         void pin() {}
         void unpin() {}
         boost::uint32_t pin_count() const { return 0; }
+
         void mark_as_migrated()
         {
             // If this assertion is triggered then this component instance is


### PR DESCRIPTION
This patch adds checking for proper ids to component actions. Formerly this check was implemented for plain action sonly.
