### PR TITLE
Typos in docs

### DIFF
--- a/docs/tutorial/examples.qbk
+++ b/docs/tutorial/examples.qbk
@@ -158,7 +158,7 @@ functions which are not associated with any particular object (we will discuss
 other types of actions in the __accumulator_example__).
 In this block of code the function `fibonacci()` is declared. After the
 declaration, the function is wrapped in an action in the declaration
-[macroref HPX_PLAIN_ACTION `HPX_PLAIN_ACTION`]. This function takes two aruments: the name of the
+[macroref HPX_PLAIN_ACTION `HPX_PLAIN_ACTION`]. This function takes two arguments: the name of the
 function that is to be wrapped and the name of the action that you are
 creating.
 

--- a/docs/tutorial/introduction.qbk
+++ b/docs/tutorial/introduction.qbk
@@ -246,7 +246,7 @@ several (very often all) threads (when using __openmp__) or processes (__mpi__).
 For instance, an implicit global barrier is inserted after each loop parallelized
 using __openmp__ as the system synchronizes the threads used to execute the
 different iterations in parallel. In __mpi__ each of the communication steps
-imposes an explicit barrier onto the execution flow as (often all) nodes have be
+imposes an explicit barrier onto the execution flow as (often all) nodes have to be
 synchronized. Each of those barriers acts as an eye of the needle the overall
 execution is forced to be squeezed through. Even minimal fluctuations in the
 execution times of the parallel threads (jobs) causes them to wait. Additionally
@@ -266,7 +266,7 @@ There are certain attempts today to get back to those ideas and to incorporate
 them with modern architectures. For instance, a lot of work is being done in
 the area of constructing dataflow oriented execution trees. Our results show
 that employing dataflow techniques in combination with the other ideas, as
-outlined herein, considerabley improves scalability for many problems.
+outlined herein, considerably improves scalability for many problems.
 
 [heading:locality_control Adaptive Locality Control instead of Static Data Distribution]
 


### PR DESCRIPTION
A couple of typos in introductory sections of the documentation.
