### PR TITLE
Sync docs and comments with code in hello_world example

### DIFF
--- a/docs/tutorial/examples.qbk
+++ b/docs/tutorial/examples.qbk
@@ -257,9 +257,9 @@ beginning with `main()`:
 
 In this excerpt of the code we again see the use of futures. This time
 the futures are stored in a vector so that they can easily be accessed.
-[funcref hpx::lcos::wait]`()` is a family of functions that wait on for an `std::vector<>`
+[funcref hpx::lcos::wait_all]`()` is a family of functions that wait on for an `std::vector<>`
 of futures to become ready. In this piece of code, we are using the synchronous
-version of [funcref hpx::lcos::wait]`()`, which takes one argument (the `std::vector<>` of
+version of [funcref hpx::lcos::wait_all]`()`, which takes one argument (the `std::vector<>` of
 futures to wait on). This function will not return until all the futures in the
 vector have been executed.
 
@@ -283,19 +283,19 @@ the action above:
 [hello_world_foreman]
 
 Now, before we discuss `hello_world_foreman()`, let's talk about the
-[funcref hpx::lcos::wait]`()` function. [funcref hpx::lcos::wait]`()` provides a way to make sure
+[funcref hpx::lcos::wait_each]`()` function. [funcref hpx::lcos::wait_each]`()` provides a way to make sure
 that all of the futures have finished being calculated without having to call
-[memberref hpx::lcos::future::get]`()` for each one. The version of [funcref hpx::lcos::wait]`()` used here performs an
+[memberref hpx::lcos::future::get]`()` for each one. The version of [funcref hpx::lcos::wait_each]`()` used here performs a
 non-blocking wait, which acts on an `std::vector<>`. It queries the state of
 the futures, waiting for them to finish. Whenever a future becomes marked as
-ready, [funcref hpx::lcos::wait]`()` invokes a callback function provided by the user,
+ready, [funcref hpx::lcos::wait_each]`()` invokes a callback function provided by the user,
 supplying the callback function with the index of the future in the
 `std::vector<>` and the result of the future.
 
 In `hello_world_foreman()`, an `std::set<>` called `attendance` keeps track of
 which OS-threads have printed out the hello world message. When the OS-thread
 prints out the statement, the future is marked as ready, and
-[funcref hpx::lcos::wait]`()` invokes the callback function, in this case a C+11 lambda.
+[funcref hpx::lcos::wait_each]`()` invokes the callback function, in this case a C++11 lambda.
 This lambda erases the OS-threads id from the set `attendance`, thus letting
 `hello_world_foreman()` know which OS-threads still need to print out hello
 world. However, if the future returns a value of -1, the future executed on an
@@ -306,7 +306,7 @@ the OS-thread id in `attendance`.
 Finally, let us look at `hello_world_worker()`. Here, `hello_world_worker()`
 checks to see if it is on the target OS-thread. If it is executing on the
 correct OS-thread, it prints out the hello world message and returns the
-OS-thread id to [funcref hpx::lcos::wait]`()` in `hello_world_foreman()`. If it is
+OS-thread id to [funcref hpx::lcos::wait_each]`()` in `hello_world_foreman()`. If it is
 not executing on the correct OS-thread, it returns a value of -1, which causes
 `hello_world_foreman()` to leave the OS-thread id in `attendance`.
 

--- a/examples/quickstart/hello_world.cpp
+++ b/examples/quickstart/hello_world.cpp
@@ -102,10 +102,10 @@ void hello_world_foreman()
         }
 
         // Wait for all of the futures to finish. The callback version of the
-        // hpx::lcos::wait function takes two arguments: a vector of futures,
+        // hpx::lcos::wait_each function takes two arguments: a vector of futures,
         // and a binary callback.  The callback takes two arguments; the first
         // is the index of the future in the vector, and the second is the
-        // return value of the future. hpx::lcos::wait doesn't return until
+        // return value of the future. hpx::lcos::wait_each doesn't return until
         // all the futures in the vector have returned.
         hpx::lcos::local::spinlock mtx;
         hpx::lcos::wait_each(futures,
@@ -149,8 +149,8 @@ int main()
         futures.push_back(hpx::async<action_type>(node));
     }
 
-    // The non-callback version of hpx::lcos::wait takes a single parameter,
-    // a future of vectors to wait on. hpx::wait_all only returns when
+    // The non-callback version of hpx::lcos::wait_all takes a single parameter,
+    // a vector of futures to wait on. hpx::wait_all only returns when
     // all of the futures have finished.
     hpx::wait_all(futures);
     return 0;


### PR DESCRIPTION
The [hello_world.cpp](https://github.com/STEllAR-GROUP/hpx/blob/cfea04731607675f2bdea2bfc719af9d79a6a0af/examples/quickstart/hello_world.cpp) in [tutorial](http://stellar-group.github.io/hpx/docs/html/hpx/tutorial/examples/hello_world.html) uses `wait_all()` and `wait_each()`
functions, but the documentation and the comments state that `wait()`
function is used. This is not true since 50be59f8 and fca92db6.
