### PR TITLE
Some ambiguous calls of map::erase have been prevented by adding additional check in locality constructor.

### DIFF
--- a/hpx/runtime/parcelset/locality.hpp
+++ b/hpx/runtime/parcelset/locality.hpp
@@ -79,7 +79,7 @@ namespace hpx { namespace parcelset
                 >
             >::type* = 0
         )
-          : impl_(new typename util::decay<impl<Impl> >::type(std::forward<Impl>(i)))
+          : impl_(new impl<typename util::decay<Impl>::type>(std::forward<Impl>(i)))
         {}
 
         locality(locality const & other)


### PR DESCRIPTION
Just struggled with a problem while building with clang-3.5:
![screen shot 2014-12-18 at 8 45 18 pm](https://cloud.githubusercontent.com/assets/5951678/5492918/d166c8f0-86f6-11e4-85f8-95216777bdcc.png)

This issue is described here:
http://cplusplus.github.io/LWG/lwg-active.html#2059
