### PR TITLE
Inclusive scan

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -74,6 +74,7 @@ set(doxygen_dependencies
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/search.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/swap_ranges.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/transform.hpp"
+    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/transform_exclusive_scan.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/transform_reduce.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/uninitialized_copy.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/uninitialized_fill.hpp"

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -63,6 +63,7 @@ set(doxygen_dependencies
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/find.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/for_each.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/generate.hpp"
+    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/inclusive_scan.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/minmax.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/mismatch.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/move.hpp"

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -58,6 +58,7 @@ set(doxygen_dependencies
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/copy.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/count.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/equal.hpp"
+    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/exclusive_scan.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/fill.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/find.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/for_each.hpp"

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -75,6 +75,7 @@ set(doxygen_dependencies
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/swap_ranges.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/transform.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/transform_exclusive_scan.hpp"
+    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/transform_inclusive_scan.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/transform_reduce.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/uninitialized_copy.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/uninitialized_fill.hpp"

--- a/docs/hpx.idx
+++ b/docs/hpx.idx
@@ -146,6 +146,9 @@ parallel::task_canceled_exception     "task_canceled_exception" "hpx\.parallel\.
 # hpx/parallel/algorithms/transform.hpp
 parallel::transform                   "transform" "hpx\.parallel\.v1\.transform.*"
 
+# hpx/parallel/algorithms/transform_exclusive_scan.hpp
+parallel::transform_exclusive_scan    "transform_exclusive_scan" "hpx\.parallel\.v1\.transform_exclusive_scan.*"
+
 # hpx/parallel/algorithms/transform_reduce.hpp
 parallel::transform_reduce            "transform_reduce" "hpx\.parallel\.v1\.transform_reduce.*"
 

--- a/docs/hpx.idx
+++ b/docs/hpx.idx
@@ -149,6 +149,9 @@ parallel::transform                   "transform" "hpx\.parallel\.v1\.transform.
 # hpx/parallel/algorithms/transform_exclusive_scan.hpp
 parallel::transform_exclusive_scan    "transform_exclusive_scan" "hpx\.parallel\.v1\.transform_exclusive_scan.*"
 
+# hpx/parallel/algorithms/transform_inclusive_scan.hpp
+parallel::transform_inclusive_scan    "transform_inclusive_scan" "hpx\.parallel\.v1\.transform_inclusive_scan.*"
+
 # hpx/parallel/algorithms/transform_reduce.hpp
 parallel::transform_reduce            "transform_reduce" "hpx\.parallel\.v1\.transform_reduce.*"
 

--- a/docs/hpx.idx
+++ b/docs/hpx.idx
@@ -1,4 +1,4 @@
-#   Copyright (c) 2001-2014 Hartmut Kaiser
+#   Copyright (c) 2001-2015 Hartmut Kaiser
 #
 #   Distributed under the Boost Software License, Version 1.0. (See accompanying
 #   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -76,6 +76,9 @@ parallel::count_if                    "count_if" "hpx\.parallel\.v1\.count_if.*"
 
 # hpx/parallel/algorithms/equal.hpp
 parallel::equal                       "equal" "hpx\.parallel\.v1\.equal_id.*"
+
+# hpx/parallel/algorithms/exclusive_scan.hpp
+parallel::exclusive_scan              "exclusive_scan" "hpx\.parallel\.v1\.exclusive_scan.*"
 
 # hpx/parallel/algorithms/fill.hpp
 parallel::fill                        "fill" "hpx\.parallel\.v1\.fill$"

--- a/docs/hpx.idx
+++ b/docs/hpx.idx
@@ -99,6 +99,9 @@ parallel::for_each_n                  "for_each_n" "hpx\.parallel\.v1\.for_each_
 parallel::generate                    "generate" "hpx\.parallel\.v1\.generate$"
 parallel::generate_n                  "generate_n" "hpx\.parallel\.v1\.generate_n.*"
 
+# hpx/parallel/algorithms/inclusive_scan.hpp
+parallel::inclusive_scan              "inclusive_scan" "hpx\.parallel\.v1\.inclusive_scan.*"
+
 # hpx/parallel/algorithms/minmax.hpp
 parallel::max_element                 "max_element" "hpx\.parallel\.v1\.max_element.*"
 parallel::min_element                 "min_element" "hpx\.parallel\.v1\.min_element.*"

--- a/hpx/include/parallel_algorithm.hpp
+++ b/hpx/include/parallel_algorithm.hpp
@@ -6,7 +6,6 @@
 #if !defined(HPX_ALGORITHM_MAY_27_2014_0905PM)
 #define HPX_ALGORITHM_MAY_27_2014_0905PM
 
-#include <hpx/hpx_fwd.hpp>
 #include <hpx/parallel/algorithm.hpp>
 
 #endif

--- a/hpx/include/parallel_numeric.hpp
+++ b/hpx/include/parallel_numeric.hpp
@@ -6,7 +6,6 @@
 #if !defined(HPX_NUMERIC_JUN_02_2014_1153AM)
 #define HPX_NUMERIC_JUN_02_2014_1153AM
 
-#include <hpx/hpx_fwd.hpp>
 #include <hpx/parallel/numeric.hpp>
 
 #endif

--- a/hpx/include/parallel_scan.hpp
+++ b/hpx/include/parallel_scan.hpp
@@ -7,6 +7,7 @@
 #define HPX_PARALLEL_SCAN_DEC_30_2014_1257PM
 
 #include <hpx/parallel/algorithms/exclusive_scan.hpp>
+#include <hpx/parallel/algorithms/inclusive_scan.hpp>
 
 #endif
 

--- a/hpx/include/parallel_scan.hpp
+++ b/hpx/include/parallel_scan.hpp
@@ -1,0 +1,12 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_SCAN_DEC_30_2014_1257PM)
+#define HPX_PARALLEL_SCAN_DEC_30_2014_1257PM
+
+#include <hpx/parallel/algorithms/exclusive_scan.hpp>
+
+#endif
+

--- a/hpx/include/parallel_transform_scan.hpp
+++ b/hpx/include/parallel_transform_scan.hpp
@@ -7,6 +7,7 @@
 #define HPX_PARALLEL_TRANSFORM_SCAN_JAN_04_2014_0413PM
 
 #include <hpx/parallel/algorithms/transform_exclusive_scan.hpp>
+#include <hpx/parallel/algorithms/transform_inclusive_scan.hpp>
 
 #endif
 

--- a/hpx/include/parallel_transform_scan.hpp
+++ b/hpx/include/parallel_transform_scan.hpp
@@ -1,0 +1,12 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_TRANSFORM_SCAN_JAN_04_2014_0413PM)
+#define HPX_PARALLEL_TRANSFORM_SCAN_JAN_04_2014_0413PM
+
+#include <hpx/parallel/algorithms/transform_exclusive_scan.hpp>
+
+#endif
+

--- a/hpx/parallel/algorithm.hpp
+++ b/hpx/parallel/algorithm.hpp
@@ -9,7 +9,7 @@
 
 #include <hpx/hpx_fwd.hpp>
 
-/// See N4071: 1.3/3
+/// See N4310: 1.3/3
 #include <algorithm>
 
 #include <hpx/parallel/algorithms/adjacent_find.hpp>

--- a/hpx/parallel/algorithms/adjacent_find.hpp
+++ b/hpx/parallel/algorithms/adjacent_find.hpp
@@ -158,9 +158,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef is_sequential_execution_policy<ExPolicy> is_seq;
 
         return detail::adjacent_find<FwdIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, detail::equal_to(),
-            is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, detail::equal_to());
     }
 
     /// Searches the range [first, last) for two consecutive identical elements.
@@ -244,8 +243,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef is_sequential_execution_policy<ExPolicy> is_seq;
 
         return detail::adjacent_find<FwdIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, op, is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, op);
     }
 }}}
 

--- a/hpx/parallel/algorithms/all_any_none.hpp
+++ b/hpx/parallel/algorithms/all_any_none.hpp
@@ -161,8 +161,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::none_of().call(
-            std::forward<ExPolicy>(policy),
-            first, last, std::forward<F>(f), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, std::forward<F>(f));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -297,8 +297,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::any_of().call(
-            std::forward<ExPolicy>(policy),
-            first, last, std::forward<F>(f), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, std::forward<F>(f));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -433,8 +433,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::all_of().call(
-            std::forward<ExPolicy>(policy),
-            first, last, std::forward<F>(f), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, std::forward<F>(f));
     }
 }}}
 

--- a/hpx/parallel/algorithms/copy.hpp
+++ b/hpx/parallel/algorithms/copy.hpp
@@ -58,13 +58,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 result_type;
 
                 return get_iter<1, result_type>(
-                    for_each_n<zip_iterator>().call(policy,
+                    for_each_n<zip_iterator>().call(
+                        policy, boost::mpl::false_(),
                         hpx::util::make_zip_iterator(first, dest),
                         std::distance(first, last),
                         [](reference t) {
                             hpx::util::get<1>(t) = hpx::util::get<0>(t); //-V573
-                        },
-                        boost::mpl::false_()));
+                        }));
             }
         };
         /// \endcond
@@ -147,8 +147,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::copy<OutIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, dest, is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, dest);
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -183,13 +183,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 result_type;
 
                 return get_iter<1, result_type>(
-                    for_each_n<zip_iterator>().call(policy,
+                    for_each_n<zip_iterator>().call(
+                        policy, boost::mpl::false_(),
                         hpx::util::make_zip_iterator(first, dest),
                         count,
                         [](reference t) {
                             hpx::util::get<1>(t) = hpx::util::get<0>(t); //-V573
-                        },
-                        boost::mpl::false_()));
+                        }));
             }
         };
         /// \endcond
@@ -283,8 +283,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::copy_n<OutIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, std::size_t(count), dest, is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, std::size_t(count), dest);
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -530,8 +530,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::copy_if<OutIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, dest, std::forward<F>(f), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, dest, std::forward<F>(f));
     }
 }}}
 

--- a/hpx/parallel/algorithms/count.hpp
+++ b/hpx/parallel/algorithms/count.hpp
@@ -100,7 +100,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 difference_type;
 
             return detail::count<difference_type>().call(
-                std::forward<ExPolicy>(policy), first, last, value, is_seq());
+                std::forward<ExPolicy>(policy), is_seq(), first, last, value);
         }
 
         // forward declare the segmented version of this algorithm
@@ -252,8 +252,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 difference_type;
 
             return detail::count_if<difference_type>().call(
-                std::forward<ExPolicy>(policy),
-                first, last, std::forward<F>(f), is_seq());
+                std::forward<ExPolicy>(policy), is_seq(),
+                first, last, std::forward<F>(f));
         }
 
         // forward declare the segmented version of this algorithm

--- a/hpx/parallel/algorithms/detail/dispatch.hpp
+++ b/hpx/parallel/algorithms/detail/dispatch.hpp
@@ -1,9 +1,7 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2015 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-
-#ifndef BOOST_PP_IS_ITERATING
 
 #if !defined(HPX_PARALLEL_DISPATCH_JUN_25_2014_1145PM)
 #define HPX_PARALLEL_DISPATCH_JUN_25_2014_1145PM
@@ -19,103 +17,163 @@
 #include <hpx/util/invoke_fused.hpp>
 #include <hpx/util/tuple.hpp>
 
-#include <boost/preprocessor/repeat.hpp>
-#include <boost/preprocessor/iterate.hpp>
-#include <boost/preprocessor/repetition/enum_params.hpp>
-#include <boost/preprocessor/repetition/enum_binary_params.hpp>
-
 #include <boost/mpl/bool.hpp>
 #include <boost/serialization/serialization.hpp>
 
 #include <string>
 
-///////////////////////////////////////////////////////////////////////////////
-#define HPX_PARALLEL_DISPATCH(policy, ...)                                    \
-    switch(detail::which(policy))                                             \
-    {                                                                         \
-    case detail::execution_policy_enum::sequential:                           \
-        return call(*policy.get<sequential_execution_policy>(), __VA_ARGS__,  \
-            boost::mpl::true_());                                             \
-                                                                              \
-    case detail::execution_policy_enum::sequential_task:                      \
-        return call(seq, __VA_ARGS__, boost::mpl::true_());                   \
-                                                                              \
-    case detail::execution_policy_enum::parallel:                             \
-        return call(*policy.get<parallel_execution_policy>(), __VA_ARGS__,    \
-            boost::mpl::false_());                                            \
-                                                                              \
-    case detail::execution_policy_enum::parallel_task:                        \
-        {                                                                     \
-            parallel_task_execution_policy const& t =                         \
-                *policy.get<parallel_task_execution_policy>();                \
-            return call(par(t.get_executor(), t.get_chunk_size()),            \
-                __VA_ARGS__, boost::mpl::false_());                           \
-        }                                                                     \
-                                                                              \
-    case detail::execution_policy_enum::parallel_vector:                      \
-        return call(*policy.get<parallel_vector_execution_policy>(),          \
-            __VA_ARGS__, boost::mpl::false_());                               \
-                                                                              \
-    default:                                                                  \
-        HPX_THROW_EXCEPTION(hpx::bad_parameter,                               \
-            std::string("hpx::parallel::") + name_,                           \
-            "Not supported execution policy");                                \
-    }                                                                         \
-    /**/
-
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
 {
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename Derived, typename Tuple>
-    struct async_fused_wrapper
-    {
-        typedef typename parallel::v1::detail::algorithm_result<
-            sequential_task_execution_policy, typename Derived::result_type
-        >::type result_type;
-
-        async_fused_wrapper(Tuple && t)
-          : t_(std::move(t))
-        {}
-
-        BOOST_FORCEINLINE result_type operator()() const
-        {
-            return hpx::util::invoke_fused_r<result_type>(
-                Derived(), std::move(t_));
-        }
-
-        typename hpx::util::tuple_decay<Tuple>::type t_;
-    };
-
-    template <typename Derived, typename Tuple>
-    BOOST_FORCEINLINE async_fused_wrapper<
-        Derived
-      , typename hpx::util::decay<Tuple>::type
-    >
-    get_async_fused_wrapper(Tuple && t)
-    {
-        typedef async_fused_wrapper<
-            Derived
-          , typename hpx::util::decay<Tuple>::type
-        > invoker_type;
-
-        return invoker_type(std::forward<Tuple>(t));
-    }
-
     ///////////////////////////////////////////////////////////////////////////
     template <typename Derived, typename Result = void>
     struct algorithm
     {
+    private:
+        Derived const& derived() const
+        {
+            return static_cast<Derived const&>(*this);
+        }
+
+    public:
         typedef Result result_type;
 
-#define BOOST_PP_ITERATION_PARAMS_1                                           \
-    (3, (2, 6, "hpx/parallel/algorithms/detail/dispatch.hpp"))                \
-    /**/
+        explicit algorithm(char const* const name)
+          : name_(name)
+        {}
 
-#include BOOST_PP_ITERATE()
+        template <typename ExPolicy, typename... Args>
+        typename parallel::v1::detail::algorithm_result<
+            ExPolicy, result_type
+        >::type
+        call(ExPolicy const& policy, boost::mpl::true_, Args&&... args) const
+        {
+            try {
+                return parallel::v1::detail::algorithm_result<
+                        ExPolicy, result_type
+                    >::get(Derived::sequential(policy, std::forward<Args>(args)...));
+            }
+            catch (...) {
+                parallel::v1::detail::handle_exception<ExPolicy>::call();
+            }
+        }
 
-        explicit algorithm(char const* const name) : name_(name) {}
+        template <typename... Args>
+        typename parallel::v1::detail::algorithm_result<
+            sequential_task_execution_policy, result_type
+        >::type
+        operator()(sequential_task_execution_policy const& policy,
+            Args&&... args) const
+        {
+            try {
+                return parallel::v1::detail::algorithm_result<
+                        sequential_task_execution_policy, result_type
+                    >::get(Derived::sequential(policy, std::forward<Args>(args)...));
+            }
+            catch (...) {
+                return parallel::v1::detail::handle_exception<
+                        sequential_task_execution_policy, result_type
+                    >::call();
+            }
+        }
 
+        template <typename... Args>
+        typename parallel::v1::detail::algorithm_result<
+            sequential_task_execution_policy, result_type
+        >::type
+        call(sequential_task_execution_policy const& policy, boost::mpl::true_,
+            Args&&... args) const
+        {
+            try {
+                hpx::future<result_type> result =
+                    hpx::async(derived(), policy, std::forward<Args>(args)...);
+
+                return parallel::v1::detail::algorithm_result<
+                        sequential_task_execution_policy, result_type
+                    >::get(std::move(result));
+            }
+            catch (...) {
+                return parallel::v1::detail::handle_exception<
+                        sequential_task_execution_policy, result_type
+                    >::call();
+            }
+        }
+
+        template <typename... Args>
+        typename parallel::v1::detail::algorithm_result<
+            parallel_task_execution_policy, result_type
+        >::type
+        call(parallel_task_execution_policy const& policy, boost::mpl::true_,
+            Args&&... args) const
+        {
+            try {
+                return parallel::v1::detail::algorithm_result<
+                        parallel_task_execution_policy, result_type
+                    >::get(Derived::sequential(policy, std::forward<Args>(args)...));
+            }
+            catch (...) {
+                return parallel::v1::detail::handle_exception<
+                        parallel_task_execution_policy, result_type
+                    >::call();
+            }
+        }
+
+        template <typename ExPolicy, typename... Args>
+        typename parallel::v1::detail::algorithm_result<ExPolicy, result_type>::type
+        call(ExPolicy const& policy, boost::mpl::false_, Args&&... args) const
+        {
+            return Derived::parallel(policy, std::forward<Args>(args)...);
+        }
+
+        ///////////////////////////////////////////////////////////////////////////
+        template <typename... Args>
+        result_type
+        call(parallel::v1::execution_policy const& policy, boost::mpl::false_,
+            Args&&... args) const
+        {
+            switch(detail::which(policy))
+            {
+            case detail::execution_policy_enum::sequential:
+                return call(*policy.get<sequential_execution_policy>(),
+                    boost::mpl::true_(), std::forward<Args>(args)...);
+
+            case detail::execution_policy_enum::sequential_task:
+                return call(seq, boost::mpl::true_(), std::forward<Args>(args)...);
+
+            case detail::execution_policy_enum::parallel:
+                return call(*policy.get<parallel_execution_policy>(),
+                    boost::mpl::false_(), std::forward<Args>(args)...);
+
+            case detail::execution_policy_enum::parallel_task:
+                {
+                    parallel_task_execution_policy const& t =
+                        *policy.get<parallel_task_execution_policy>();
+                    return call(par(t.get_executor(), t.get_chunk_size()),
+                        boost::mpl::false_(), std::forward<Args>(args)...);
+                }
+
+            case detail::execution_policy_enum::parallel_vector:
+                return call(*policy.get<parallel_vector_execution_policy>(),
+                    boost::mpl::false_(), std::forward<Args>(args)...);
+
+            default:
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    std::string("hpx::parallel::") + name_,
+                    "Not supported execution policy");
+            }
+        }
+
+        template <typename... Args>
+        result_type
+        call(parallel::v1::execution_policy const& policy, boost::mpl::true_,
+            Args&&... args) const
+        {
+            return call(seq, boost::mpl::true_(), std::forward<Args>(args)...);
+        }
+
+    private:
         char const* const name_;
+
+        friend class boost::serialization::access;
 
         template <typename Archive>
         void serialize(Archive& ar, unsigned int)
@@ -123,125 +181,5 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         }
     };
 }}}}
-
-#undef HPX_PARALLEL_DISPATCH
-
-#endif
-
-///////////////////////////////////////////////////////////////////////////////
-//  Preprocessor vertical repetition code
-///////////////////////////////////////////////////////////////////////////////
-#else // defined(BOOST_PP_IS_ITERATING)
-
-#define N BOOST_PP_ITERATION()
-
-    template <typename ExPolicy, BOOST_PP_ENUM_PARAMS(N, typename Arg)>
-    typename parallel::v1::detail::algorithm_result<
-        ExPolicy, result_type
-    >::type
-    call(ExPolicy const& policy, HPX_ENUM_FWD_ARGS(N, Arg, arg),
-        boost::mpl::true_) const
-    {
-        try {
-            return parallel::v1::detail::algorithm_result<
-                    ExPolicy, result_type
-                >::get(Derived::sequential(
-                    policy, HPX_ENUM_FORWARD_ARGS(N, Arg, arg)));
-        }
-        catch (...) {
-            parallel::v1::detail::handle_exception<ExPolicy>::call();
-        }
-    }
-
-    template <BOOST_PP_ENUM_PARAMS(N, typename Arg)>
-    typename parallel::v1::detail::algorithm_result<
-        sequential_task_execution_policy, result_type
-    >::type
-    operator()(sequential_task_execution_policy const& policy,
-        HPX_ENUM_FWD_ARGS(N, Arg, arg)) const
-    {
-        try {
-            return parallel::v1::detail::algorithm_result<
-                    sequential_task_execution_policy, result_type
-                >::get(Derived::sequential(
-                    policy, HPX_ENUM_FORWARD_ARGS(N, Arg, arg)));
-        }
-        catch (...) {
-            return parallel::v1::detail::handle_exception<
-                    sequential_task_execution_policy, result_type
-                >::call();
-        }
-    }
-
-    template <BOOST_PP_ENUM_PARAMS(N, typename Arg)>
-    typename parallel::v1::detail::algorithm_result<
-        sequential_task_execution_policy, result_type
-    >::type
-    call(sequential_task_execution_policy const& policy,
-        HPX_ENUM_FWD_ARGS(N, Arg, arg), boost::mpl::true_) const
-    {
-        try {
-            hpx::future<result_type> result =
-                hpx::async(get_async_fused_wrapper<Derived>(
-                    hpx::util::forward_as_tuple(policy,
-                        HPX_ENUM_FORWARD_ARGS(N, Arg, arg))
-                ));
-
-            return parallel::v1::detail::algorithm_result<
-                    sequential_task_execution_policy, result_type
-                >::get(std::move(result));
-        }
-        catch (...) {
-            return parallel::v1::detail::handle_exception<
-                    sequential_task_execution_policy, result_type
-                >::call();
-        }
-    }
-
-    template <BOOST_PP_ENUM_PARAMS(N, typename Arg)>
-    typename parallel::v1::detail::algorithm_result<
-        parallel_task_execution_policy, result_type
-    >::type
-    call(parallel_task_execution_policy const& policy,
-        HPX_ENUM_FWD_ARGS(N, Arg, arg), boost::mpl::true_) const
-    {
-        try {
-            return parallel::v1::detail::algorithm_result<
-                    parallel_task_execution_policy, result_type
-                >::get(Derived::sequential(
-                    policy, HPX_ENUM_FORWARD_ARGS(N, Arg, arg)));
-        }
-        catch (...) {
-            return parallel::v1::detail::handle_exception<
-                    parallel_task_execution_policy, result_type
-                >::call();
-        }
-    }
-
-    template <typename ExPolicy, BOOST_PP_ENUM_PARAMS(N, typename Arg)>
-    typename parallel::v1::detail::algorithm_result<ExPolicy, result_type>::type
-    call(ExPolicy const& policy, HPX_ENUM_FWD_ARGS(N, Arg, arg),
-        boost::mpl::false_) const
-    {
-        return Derived::parallel(policy, HPX_ENUM_FORWARD_ARGS(N, Arg, arg));
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    template <BOOST_PP_ENUM_PARAMS(N, typename Arg)>
-    result_type call(parallel::v1::execution_policy const& policy,
-        HPX_ENUM_FWD_ARGS(N, Arg, arg), boost::mpl::false_) const
-    {
-        HPX_PARALLEL_DISPATCH(policy, HPX_ENUM_FORWARD_ARGS(N, Arg, arg));
-    }
-
-    template <BOOST_PP_ENUM_PARAMS(N, typename Arg)>
-    result_type call(parallel::v1::execution_policy const& policy,
-         HPX_ENUM_FWD_ARGS(N, Arg, arg), boost::mpl::true_) const
-    {
-        return call(seq, HPX_ENUM_FORWARD_ARGS(N, Arg, arg),
-            boost::mpl::true_());
-    }
-
-#undef N
 
 #endif

--- a/hpx/parallel/algorithms/detail/dispatch.hpp
+++ b/hpx/parallel/algorithms/detail/dispatch.hpp
@@ -108,7 +108,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         typedef Result result_type;
 
 #define BOOST_PP_ITERATION_PARAMS_1                                           \
-    (3, (2, 5, "hpx/parallel/algorithms/detail/dispatch.hpp"))                \
+    (3, (2, 6, "hpx/parallel/algorithms/detail/dispatch.hpp"))                \
     /**/
 
 #include BOOST_PP_ITERATE()

--- a/hpx/parallel/algorithms/equal.hpp
+++ b/hpx/parallel/algorithms/equal.hpp
@@ -208,8 +208,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::equal_binary().call(
-            std::forward<ExPolicy>(policy),
-            first1, last1, first2, last2, detail::equal_to(), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first1, last1, first2, last2, detail::equal_to());
     }
 
     /// Returns true if the range [first1, last1) is equal to the range
@@ -311,8 +311,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::equal_binary().call(
-            std::forward<ExPolicy>(policy),
-            first1, last1, first2, last2, std::forward<F>(f), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first1, last1, first2, last2, std::forward<F>(f));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -457,8 +457,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::equal().call(
-            std::forward<ExPolicy>(policy),
-            first1, last1, first2, detail::equal_to(), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first1, last1, first2, detail::equal_to());
     }
 
     /// Returns true if the range [first1, last1) is equal to the range
@@ -556,8 +556,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::equal().call(
-            std::forward<ExPolicy>(policy),
-            first1, last1, first2, std::forward<F>(f), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first1, last1, first2, std::forward<F>(f));
     }
 }}}
 

--- a/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -282,9 +282,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::exclusive_scan<OutIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, dest, std::move(init), std::forward<Op>(op),
-            is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, dest, std::move(init), std::forward<Op>(op));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -378,9 +377,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::exclusive_scan<OutIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, dest, std::move(init), std::plus<T>(),
-            is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, dest, std::move(init), std::plus<T>());
     }
 }}}
 

--- a/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -86,7 +86,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                                     op(*get<0>(d.get_iterator_tuple()), v);
                             });
                     },
-                    [=](std::vector<future<void> > && r) mutable -> OutIter
+                    [dest, count, data](
+                        std::vector<future<void> > && r) mutable -> OutIter
                     {
                         std::advance(dest, count);
                         return dest;

--- a/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -1,0 +1,381 @@
+//  Copyright (c) 2014-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/algorithms/exclusive_scan.hpp
+
+#if !defined(HPX_PARALLEL_ALGORITHM_EXCLUSIVE_SCAN_DEC_30_2014_1236PM)
+#define HPX_PARALLEL_ALGORITHM_EXCLUSIVE_SCAN_DEC_30_2014_1236PM
+
+#include <hpx/hpx_fwd.hpp>
+#include <hpx/util/move.hpp>
+
+#include <hpx/parallel/config/inline_namespace.hpp>
+#include <hpx/parallel/execution_policy.hpp>
+#include <hpx/parallel/algorithms/detail/algorithm_result.hpp>
+#include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/util/partitioner.hpp>
+#include <hpx/parallel/util/scan_partitioner.hpp>
+#include <hpx/parallel/util/loop.hpp>
+
+#include <algorithm>
+#include <numeric>
+#include <iterator>
+
+#include <boost/static_assert.hpp>
+#include <boost/utility/enable_if.hpp>
+#include <boost/type_traits/is_base_of.hpp>
+
+namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // exclusive_scan
+    namespace detail
+    {
+        /// \cond NOINTERNAL
+
+        // Our own version of the sequential exclusive_scan.
+        template <typename InIter, typename OutIter, typename T, typename Op>
+        OutIter sequential_exclusive_scan(InIter first, InIter last,
+            OutIter dest, T init, Op && op)
+        {
+            for (/**/; first != last; (void) ++first, ++dest)
+            {
+                *dest = init;
+                init = op(init, *first);
+            }
+            return dest;
+        }
+
+        template <typename InIter, typename OutIter, typename T, typename Op>
+        T sequential_exclusive_scan_n(InIter first, std::size_t count,
+            OutIter dest, T init, Op && op)
+        {
+            for (/**/; count-- != 0; (void) ++first, ++dest)
+            {
+                *dest = init;
+                init = op(init, *first);
+            }
+            return init;
+        }
+
+        template <typename ExPolicy, typename T, typename OutIter, typename Op>
+        typename detail::algorithm_result<ExPolicy, OutIter>::type
+        exclusive_scan_helper(ExPolicy const& policy,
+            std::vector<hpx::shared_future<T> >&& r,
+            boost::shared_array<T> data, std::size_t count,
+            OutIter dest, Op && op, std::vector<std::size_t> const& chunk_sizes)
+        {
+            typedef hpx::util::zip_iterator<T*, OutIter> zip_iterator;
+            typedef typename zip_iterator::reference reference;
+
+            using hpx::util::make_zip_iterator;
+            return
+                util::partitioner<ExPolicy, OutIter, void>::call_with_data(
+                    policy, make_zip_iterator(data.get(), dest), count,
+                    [=](hpx::shared_future<T>&& val,
+                        zip_iterator part_begin, std::size_t part_size)
+                    {
+                        T const& v = val.get();
+                        parallel::util::loop_n(part_begin, part_size,
+                            [&](zip_iterator d)
+                            {
+                                using hpx::util::get;
+                                *get<1>(d.get_iterator_tuple()) =
+                                    op(*get<0>(d.get_iterator_tuple()), v);
+                            });
+                    },
+                    [=](std::vector<future<void> > && r) mutable -> OutIter
+                    {
+                        std::advance(dest, count);
+                        return dest;
+                    },
+                    chunk_sizes, std::move(r)
+                );
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename OutIter>
+        struct exclusive_scan
+          : public detail::algorithm<exclusive_scan<OutIter>, OutIter>
+        {
+            exclusive_scan()
+              : exclusive_scan::algorithm("exclusive_scan")
+            {}
+
+            template <typename ExPolicy, typename InIter, typename T, typename Op>
+            static OutIter
+            sequential(ExPolicy const&, InIter first, InIter last,
+                OutIter dest, T && init, Op && op)
+            {
+                return sequential_exclusive_scan(first, last, dest,
+                    std::forward<T>(init), std::forward<Op>(op));
+            }
+
+            template <typename ExPolicy, typename FwdIter, typename T, typename Op>
+            static typename detail::algorithm_result<ExPolicy, OutIter>::type
+            parallel(ExPolicy const& policy, FwdIter first, FwdIter last,
+                 OutIter dest, T && init, Op && op)
+            {
+                typedef detail::algorithm_result<ExPolicy, OutIter> result;
+                typedef hpx::util::zip_iterator<FwdIter, T*> zip_iterator;
+
+                if (first == last)
+                    return result::get(std::move(dest));
+
+                std::size_t count = std::distance(first, last);
+                std::size_t chunk_size = 0;
+
+                boost::shared_array<T> data(new T[count]);
+
+                // The overall scan algorithm is performed by executing 2
+                // subsequent parallel steps. The first calculates the scan
+                // results for each partition and the second produces the
+                // overall result
+
+                using hpx::util::make_zip_iterator;
+                return
+                    util::scan_partitioner<ExPolicy, OutIter, T>::call(
+                        policy, make_zip_iterator(first, data.get()), count, init,
+                        // step 1 performs first part of scan algorithm
+                        [=](zip_iterator part_begin, std::size_t part_size) -> T
+                        {
+                            using hpx::util::get;
+                            return sequential_exclusive_scan_n(
+                                get<0>(part_begin.get_iterator_tuple()), part_size,
+                                get<1>(part_begin.get_iterator_tuple()), init, op);
+                        },
+                        // step 2 propagates the partition results from left
+                        // to right
+                        hpx::util::unwrapped(
+                            [=](T const& prev, T const& curr) -> T
+                            {
+                                return op(prev, curr);
+                            }),
+                        // step 3 runs the remaining operation
+                        [=](std::vector<hpx::shared_future<T> >&& r,
+                            std::vector<std::size_t> const& chunk_sizes)
+                        {
+                            // run the final copy step and produce the required
+                            // result
+                            return exclusive_scan_helper(policy, std::move(r),
+                                data, count, dest, op, chunk_sizes);
+                        }
+                    );
+            }
+        };
+        /// \endcond
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, *first, ..., *(first + (i - result) - 1)).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param init         The initial value for the generalized sum.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm invoked
+    /// with an execution policy object of type \a sequential_execution_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm invoked
+    /// with an execution policy object of type \a parallel_execution_policy
+    /// or \a parallel_task_execution_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a copy_n algorithm returns a \a hpx::future<OutIter> if
+    ///           the execution policy is of type
+    ///           \a sequential_task_execution_policy or
+    ///           \a parallel_task_execution_policy and
+    ///           returns \a OutIter otherwise.
+    ///           The \a exclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK), GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The behavior of exclusive_scan may be non-deterministic for
+    /// a non-associative predicate.
+    ///
+    template <typename ExPolicy, typename InIter, typename OutIter, typename T,
+        typename Op>
+    inline typename boost::enable_if<
+        is_execution_policy<ExPolicy>,
+        typename detail::algorithm_result<ExPolicy, OutIter>::type
+    >::type
+    exclusive_scan(ExPolicy&& policy, InIter first, InIter last, OutIter dest,
+        T init, Op && op)
+    {
+        typedef typename std::iterator_traits<InIter>::iterator_category
+            iterator_category;
+        typedef typename std::iterator_traits<OutIter>::iterator_category
+            output_iterator_category;
+
+        BOOST_STATIC_ASSERT_MSG(
+            (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
+            "Requires at least input iterator.");
+
+        BOOST_STATIC_ASSERT_MSG(
+            (boost::mpl::or_<
+                boost::is_base_of<
+                    std::forward_iterator_tag, output_iterator_category>,
+                boost::is_same<
+                    std::output_iterator_tag, output_iterator_category>
+            >::value),
+            "Requires at least output iterator.");
+
+        typedef typename boost::mpl::or_<
+            is_sequential_execution_policy<ExPolicy>,
+            boost::is_same<std::input_iterator_tag, iterator_category>,
+            boost::is_same<std::output_iterator_tag, output_iterator_category>
+        >::type is_seq;
+
+        return detail::exclusive_scan<OutIter>().call(
+            std::forward<ExPolicy>(policy),
+            first, last, dest, std::move(init), std::forward<Op>(op),
+            is_seq());
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, init, *first, ..., *(first + (i - result) - 1))
+    /// where \a op is std::plus<T>.
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a std::plus<T>.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param init         The initial value for the generalized sum.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm invoked
+    /// with an execution policy object of type \a sequential_execution_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm invoked
+    /// with an execution policy object of type \a parallel_execution_policy
+    /// or \a parallel_task_execution_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a copy_n algorithm returns a \a hpx::future<OutIter> if
+    ///           the execution policy is of type
+    ///           \a sequential_task_execution_policy or
+    ///           \a parallel_task_execution_policy and
+    ///           returns \a OutIter otherwise.
+    ///           The \a exclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK), GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///         * op is std::plus<T>
+    ///
+    template <typename ExPolicy, typename InIter, typename OutIter, typename T>
+    inline typename boost::enable_if<
+        is_execution_policy<ExPolicy>,
+        typename detail::algorithm_result<ExPolicy, OutIter>::type
+    >::type
+    exclusive_scan(ExPolicy&& policy, InIter first, InIter last, OutIter dest,
+        T init)
+    {
+        typedef typename std::iterator_traits<InIter>::iterator_category
+            iterator_category;
+        typedef typename std::iterator_traits<OutIter>::iterator_category
+            output_iterator_category;
+
+        BOOST_STATIC_ASSERT_MSG(
+            (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
+            "Requires at least input iterator.");
+
+        BOOST_STATIC_ASSERT_MSG(
+            (boost::mpl::or_<
+                boost::is_base_of<
+                    std::forward_iterator_tag, output_iterator_category>,
+                boost::is_same<
+                    std::output_iterator_tag, output_iterator_category>
+            >::value),
+            "Requires at least output iterator.");
+
+        typedef typename boost::mpl::or_<
+            is_sequential_execution_policy<ExPolicy>,
+            boost::is_same<std::input_iterator_tag, iterator_category>,
+            boost::is_same<std::output_iterator_tag, output_iterator_category>
+        >::type is_seq;
+
+        return detail::exclusive_scan<OutIter>().call(
+            std::forward<ExPolicy>(policy),
+            first, last, dest, std::move(init), std::plus<T>(),
+            is_seq());
+    }
+}}}
+
+#endif

--- a/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -240,7 +240,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///
     /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
     ///         * a1 when N is 1
-    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK), GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK), GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
     ///           where 1 < K+1 = M <= N.
     ///
     /// The difference between \a exclusive_scan and \a inclusive_scan is that
@@ -337,11 +337,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           to the element in the destination range, one past the last
     ///           element copied.
     ///
-    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
     ///         * a1 when N is 1
-    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK), GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK) + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
     ///           where 1 < K+1 = M <= N.
-    ///         * op is std::plus<T>
     ///
     /// The difference between \a exclusive_scan and \a inclusive_scan is that
     /// \a inclusive_scan includes the ith input element in the ith sum.

--- a/hpx/parallel/algorithms/fill.hpp
+++ b/hpx/parallel/algorithms/fill.hpp
@@ -62,11 +62,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 return hpx::util::void_guard<result_type>(),
                     for_each_n<FwdIter>().call(
-                        policy, first, std::distance(first, last),
+                        policy, boost::mpl::false_(),
+                        first, std::distance(first, last),
                         [val](type& v) {
                             v = val;
-                        },
-                        boost::mpl::false_());
+                        });
             }
         };
         /// \endcond
@@ -128,8 +128,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
 
         return detail::fill().call(
-            std::forward<ExPolicy>(policy),
-            first, last, value, is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, value);
     }
     ///////////////////////////////////////////////////////////////////////////
     // fill_n
@@ -160,11 +160,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 return
                     for_each_n<OutIter>().call(
-                        policy, first, count,
+                        policy, boost::mpl::false_(), first, count,
                         [val](type& v) {
                             v = val;
-                        },
-                        boost::mpl::false_());
+                        });
             }
         };
         /// \endcond
@@ -244,8 +243,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::fill_n<OutIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, std::size_t(count), value, is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, std::size_t(count), value);
     }
 }}}
 

--- a/hpx/parallel/algorithms/find.hpp
+++ b/hpx/parallel/algorithms/find.hpp
@@ -149,8 +149,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::find<InIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, val, is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, val);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -290,8 +290,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::find_if<InIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, std::forward<F>(f), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, std::forward<F>(f));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -436,8 +436,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::find_if_not<InIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, std::forward<F>(f), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, std::forward<F>(f));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -615,9 +615,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef is_sequential_execution_policy<ExPolicy> is_seq;
 
         return detail::find_end<FwdIter1>().call(
-            std::forward<ExPolicy>(policy),
-            first1, last1, first2, last2, detail::equal_to(),
-            is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first1, last1, first2, last2, detail::equal_to());
     }
 
     /// Returns the last subsequence of elements [first2, last2) found in the range
@@ -721,8 +720,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef is_sequential_execution_policy<ExPolicy> is_seq;
 
         return detail::find_end<FwdIter1>().call(
-            std::forward<ExPolicy>(policy),
-            first1, last1, first2, last2, std::forward<F>(f), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first1, last1, first2, last2, std::forward<F>(f));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -893,9 +892,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::find_first_of<InIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, s_first, s_last,
-            detail::equal_to(), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, s_first, s_last, detail::equal_to());
     }
 
     /// Searches the range [first, last) for any elements in the range [s_first, s_last).
@@ -1000,8 +998,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::find_first_of<InIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, s_first, s_last, std::forward<Pred>(op), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, s_first, s_last, std::forward<Pred>(op));
     }
 }}}
 

--- a/hpx/parallel/algorithms/for_each.hpp
+++ b/hpx/parallel/algorithms/for_each.hpp
@@ -177,8 +177,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::for_each_n<InIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, std::size_t(count), std::forward<F>(f), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, std::size_t(count), std::forward<F>(f));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -210,8 +210,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 return hpx::util::void_guard<result_type>(),
                     detail::for_each_n<FwdIter>().call(
-                        policy, first, std::distance(first, last),
-                        std::forward<F>(f), boost::mpl::false_());
+                        policy, boost::mpl::false_(),
+                        first, std::distance(first, last), std::forward<F>(f));
             }
         };
 
@@ -234,8 +234,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 return detail::algorithm_result<ExPolicy>::get();
 
             return for_each().call(
-                std::forward<ExPolicy>(policy),
-                first, last, std::forward<F>(f), is_seq());
+                std::forward<ExPolicy>(policy), is_seq(),
+                first, last, std::forward<F>(f));
         }
 
         // forward declare the segmented version of this algorithm

--- a/hpx/parallel/algorithms/generate.hpp
+++ b/hpx/parallel/algorithms/generate.hpp
@@ -53,11 +53,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 return hpx::util::void_guard<result_type>(),
                     for_each_n<FwdIter>().call(
-                        policy, first, std::distance(first, last),
+                        policy, boost::mpl::false_(),
+                        first, std::distance(first, last),
                         [f](type& v) {
                             v = f();
-                        },
-                        boost::mpl::false_());
+                        });
             }
         };
         /// \endcond
@@ -129,8 +129,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
 
         return detail::generate().call(
-            std::forward<ExPolicy>(policy),
-            first, last, std::forward<F>(f), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, std::forward<F>(f));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -161,11 +161,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 return
                     for_each_n<OutIter>().call(
-                        policy, first, count,
+                        policy, boost::mpl::false_(), first, count,
                         [f](type& v) {
                             v = f();
-                        },
-                        boost::mpl::false_());
+                        });
             }
         };
         /// \endcond
@@ -251,9 +250,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::generate_n<OutIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, std::size_t(count), std::forward<F>(f),
-            is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, std::size_t(count), std::forward<F>(f));
     }
 }}}
 

--- a/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -240,7 +240,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///
     /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
     ///         * a1 when N is 1
-    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK), GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK), GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
     ///           where 1 < K+1 = M <= N.
     ///
     /// The difference between \a exclusive_scan and \a inclusive_scan is that
@@ -337,11 +337,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           to the element in the destination range, one past the last
     ///           element copied.
     ///
-    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
     ///         * a1 when N is 1
-    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK), GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK) + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
     ///           where 1 < K+1 = M <= N.
-    ///         * op is std::plus<T>
     ///
     /// The difference between \a exclusive_scan and \a inclusive_scan is that
     /// \a inclusive_scan includes the ith input element in the ith sum.
@@ -431,11 +430,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           to the element in the destination range, one past the last
     ///           element copied.
     ///
-    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
     ///         * a1 when N is 1
-    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK), GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK) + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
     ///           where 1 < K+1 = M <= N.
-    ///         * op is std::plus<T>
     ///
     /// The difference between \a exclusive_scan and \a inclusive_scan is that
     /// \a inclusive_scan includes the ith input element in the ith sum.

--- a/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -282,9 +282,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::inclusive_scan<OutIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, dest, std::move(init), std::forward<Op>(op),
-            is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, dest, std::move(init), std::forward<Op>(op));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -378,9 +377,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::inclusive_scan<OutIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, dest, std::move(init), std::plus<T>(),
-            is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, dest, std::move(init), std::plus<T>());
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -472,9 +470,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter>::value_type value_type;
 
         return detail::inclusive_scan<OutIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, dest, value_type(), std::plus<value_type>(),
-            is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, dest, value_type(), std::plus<value_type>());
     }
 }}}
 

--- a/hpx/parallel/algorithms/minmax.hpp
+++ b/hpx/parallel/algorithms/minmax.hpp
@@ -188,8 +188,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
 
         return detail::min_element<FwdIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, std::forward<F>(f), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, std::forward<F>(f));
     }
 
     /// Finds the smallest element in the range [first, last) using the given
@@ -254,8 +254,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
 
         return detail::min_element<FwdIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, std::less<value_type>(), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, std::less<value_type>());
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -418,8 +418,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
 
         return detail::max_element<FwdIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, std::forward<F>(f), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, std::forward<F>(f));
     }
 
     /// Finds the greatest element in the range [first, last) using the given
@@ -484,8 +484,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
 
         return detail::max_element<FwdIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, std::less<value_type>(), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, std::less<value_type>());
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -666,8 +666,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
 
         return detail::minmax_element<FwdIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, std::forward<F>(f), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, std::forward<F>(f));
     }
 
     /// Finds the greatest element in the range [first, last) using the given
@@ -737,8 +737,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
 
         return detail::minmax_element<FwdIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, std::less<value_type>(), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, std::less<value_type>());
     }
 }}}
 

--- a/hpx/parallel/algorithms/mismatch.hpp
+++ b/hpx/parallel/algorithms/mismatch.hpp
@@ -213,8 +213,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::pair<InIter1, InIter2> result_type;
         return detail::mismatch_binary<result_type>().call(
-            std::forward<ExPolicy>(policy),
-            first1, last1, first2, last2, detail::equal_to(), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first1, last1, first2, last2, detail::equal_to());
     }
 
     /// Returns true if the range [first1, last1) is mismatch to the range
@@ -321,8 +321,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::pair<InIter1, InIter2> result_type;
         return detail::mismatch_binary<result_type>().call(
-            std::forward<ExPolicy>(policy),
-            first1, last1, first2, last2, std::forward<F>(f), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first1, last1, first2, last2, std::forward<F>(f));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -474,8 +474,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::pair<InIter1, InIter2> result_type;
         return detail::mismatch<result_type>().call(
-            std::forward<ExPolicy>(policy),
-            first1, last1, first2, detail::equal_to(), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first1, last1, first2, detail::equal_to());
     }
 
     /// Returns std::pair with iterators to the first two non-equivalent
@@ -573,8 +573,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::pair<InIter1, InIter2> result_type;
         return detail::mismatch<result_type>().call(
-            std::forward<ExPolicy>(policy),
-            first1, last1, first2, std::forward<F>(f), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first1, last1, first2, std::forward<F>(f));
     }
 }}}
 

--- a/hpx/parallel/algorithms/move.hpp
+++ b/hpx/parallel/algorithms/move.hpp
@@ -58,13 +58,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 result_type;
 
                 return get_iter<1, result_type>(
-                    for_each_n<zip_iterator>().call(policy,
+                    for_each_n<zip_iterator>().call(
+                        policy, boost::mpl::false_(),
                         hpx::util::make_zip_iterator(first, dest),
                         std::distance(first, last),
                         [](reference t) {
-                            hpx::util::get<1>(t) = std::move(hpx::util::get<0>(t)); //-V573
-                        },
-                        boost::mpl::false_()));
+                            using hpx::util::get;
+                            get<1>(t) = std::move(get<0>(t)); //-V573
+                        }));
             }
         };
         /// \endcond
@@ -150,8 +151,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::move<OutIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, dest, is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, dest);
     }
 }}}
 

--- a/hpx/parallel/algorithms/reduce.hpp
+++ b/hpx/parallel/algorithms/reduce.hpp
@@ -171,8 +171,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::reduce<T>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, std::move(init), std::forward<F>(f), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, std::move(init), std::forward<F>(f));
     }
 
     /// Returns GENERALIZED_SUM(+, init, *first, ..., *(first + (last - first) - 1)).
@@ -248,8 +248,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::reduce<T>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, std::move(init), std::plus<T>(), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, std::move(init), std::plus<T>());
     }
 
     /// Returns GENERALIZED_SUM(+, T(), *first, ..., *(first + (last - first) - 1)).
@@ -328,8 +328,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::reduce<value_type>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, value_type(), std::plus<value_type>(), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, value_type(), std::plus<value_type>());
     }
 }}}
 

--- a/hpx/parallel/algorithms/remote/dispatch.hpp
+++ b/hpx/parallel/algorithms/remote/dispatch.hpp
@@ -1,9 +1,7 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2015 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-
-#ifndef BOOST_PP_IS_ITERATING
 
 #if !defined(HPX_PARALLEL_ALGORITHM_REMOTE_DISPATCH_OCT_15_2014_0938PM)
 #define HPX_PARALLEL_ALGORITHM_REMOTE_DISPATCH_OCT_15_2014_0938PM
@@ -18,144 +16,92 @@
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/util/detail/handle_remote_exceptions.hpp>
 
-#include <boost/preprocessor/repeat.hpp>
-#include <boost/preprocessor/iterate.hpp>
-#include <boost/preprocessor/repetition/enum_params.hpp>
-#include <boost/preprocessor/repetition/enum_binary_params.hpp>
-
-///////////////////////////////////////////////////////////////////////////////
-#define HPX_DISPATCH_DECAY_ARG(Z, N, D)                                       \
-    typename hpx::util::decay<BOOST_PP_CAT(D, N)>::type                       \
-    /**/
-#define HPX_DISPATCH_ARG(Z, N, D) BOOST_PP_CAT(D, N) const&                   \
-    /**/
-#define HPX_MAP_TO_LOCAL_ITERATOR(Z, N, D)                                    \
-    ::hpx::traits::segmented_local_iterator_traits<                           \
-        BOOST_PP_CAT(Arg, N)>::base(BOOST_PP_CAT(arg, N))                     \
-    /**/
-
-#define BOOST_PP_ITERATION_PARAMS_1                                           \
-    (3, (2, 5, "hpx/parallel/algorithms/remote/dispatch.hpp"))                \
-    /**/
-
-#include BOOST_PP_ITERATE()
-
-#undef HPX_MAP_TO_LOCAL_ITERATOR
-#undef HPX_DISPATCH_ARG
-#undef HPX_DISPATCH_DECAY_ARG
-
-#endif
-
-///////////////////////////////////////////////////////////////////////////////
-//  Preprocessor vertical repetition code
-///////////////////////////////////////////////////////////////////////////////
-#else // defined(BOOST_PP_IS_ITERATING)
-
-#define N BOOST_PP_ITERATION()
-
 namespace hpx { namespace parallel { namespace util { namespace remote
 {
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Algo, typename ExPolicy,
-        BOOST_PP_ENUM_PARAMS(N, typename Arg)>
-    struct BOOST_PP_CAT(dispatcher, N)
+    template <typename Algo, typename ExPolicy, typename... Args>
+    struct dispatcher
     {
         static typename parallel::v1::detail::algorithm_result<
-            ExPolicy, typename Algo::result_type
+            ExPolicy, typename hpx::util::decay<Algo>::type::result_type
         >::type
-        sequential(Algo const& algo, ExPolicy const& policy,
-            BOOST_PP_ENUM_BINARY_PARAMS(N, Arg, const& arg))
+        sequential(Algo const& algo, ExPolicy const& policy, Args const&... args)
         {
-            return algo.call(policy,
-                BOOST_PP_ENUM(N, HPX_MAP_TO_LOCAL_ITERATOR, _),
-                boost::mpl::true_());
+            using hpx::traits::segmented_local_iterator_traits;
+            return algo.call(policy, boost::mpl::true_(),
+                segmented_local_iterator_traits<Args>::base(args)...);
         }
 
         static typename parallel::v1::detail::algorithm_result<
-            ExPolicy, typename Algo::result_type
+            ExPolicy, typename hpx::util::decay<Algo>::type::result_type
         >::type
-        parallel(Algo const& algo, ExPolicy const& policy,
-            BOOST_PP_ENUM_BINARY_PARAMS(N, Arg, const& arg))
+        parallel(Algo const& algo, ExPolicy const& policy, Args const&... args)
         {
-            return algo.call(policy,
-                BOOST_PP_ENUM(N, HPX_MAP_TO_LOCAL_ITERATOR, _),
-                boost::mpl::false_());
+            using hpx::traits::segmented_local_iterator_traits;
+            return algo.call(policy, boost::mpl::false_(),
+                segmented_local_iterator_traits<Args>::base(args)...);
         }
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    template <
-        typename Algo, typename ExPolicy, typename IsSeq, typename R,
-        BOOST_PP_ENUM_PARAMS(N, typename Arg)>
-    struct BOOST_PP_CAT(algorithm_invoker_action, N);
+    template <typename Algo, typename ExPolicy, typename IsSeq, typename F>
+    struct algorithm_invoker_action;
 
     // sequential
-    template <typename Algo, typename ExPolicy, typename R,
-        BOOST_PP_ENUM_PARAMS(N, typename Arg)>
-    struct BOOST_PP_CAT(algorithm_invoker_action, N)<
-                Algo, ExPolicy, boost::mpl::true_, R,
-                BOOST_PP_ENUM_PARAMS(N, Arg)>
+    template <typename Algo, typename ExPolicy, typename R, typename... Args>
+    struct algorithm_invoker_action<
+                Algo, ExPolicy, boost::mpl::true_, R(Args const& ...)>
         : hpx::actions::make_action<
-            R (*)(Algo const&, ExPolicy const&,
-                BOOST_PP_ENUM(N, HPX_DISPATCH_ARG, Arg)),
-            &BOOST_PP_CAT(dispatcher, N)<
-                    Algo, ExPolicy, BOOST_PP_ENUM_PARAMS(N, Arg)
-                >::sequential,
-            BOOST_PP_CAT(algorithm_invoker_action, N)<
-                Algo, ExPolicy, boost::mpl::true_, R,
-                BOOST_PP_ENUM_PARAMS(N, Arg)>
+            R (*)(Algo const&, ExPolicy const&, Args const&...),
+            &dispatcher<Algo, ExPolicy, Args...>::sequential,
+            algorithm_invoker_action<
+                Algo, ExPolicy, boost::mpl::true_, R(Args const& ...)>
         >
     {};
 
     // parallel
-    template <typename Algo, typename ExPolicy, typename R,
-        BOOST_PP_ENUM_PARAMS(N, typename Arg)>
-    struct BOOST_PP_CAT(algorithm_invoker_action, N)<
-                Algo, ExPolicy, boost::mpl::false_, R,
-                BOOST_PP_ENUM_PARAMS(N, Arg)>
+    template <typename Algo, typename ExPolicy, typename R, typename... Args>
+    struct algorithm_invoker_action<
+                Algo, ExPolicy, boost::mpl::false_, R(Args const& ...)>
         : hpx::actions::make_action<
-            R (*)(Algo const&, ExPolicy const&,
-                BOOST_PP_ENUM(N, HPX_DISPATCH_ARG, Arg)),
-            &BOOST_PP_CAT(dispatcher, N)<
-                    Algo, ExPolicy, BOOST_PP_ENUM_PARAMS(N, Arg)
-                >::parallel,
-            BOOST_PP_CAT(algorithm_invoker_action, N)<
-                Algo, ExPolicy, boost::mpl::false_, R,
-                BOOST_PP_ENUM_PARAMS(N, Arg)>
+            R (*)(Algo const&, ExPolicy const&, Args const&...),
+            &dispatcher<Algo, ExPolicy, Args...>::parallel,
+            algorithm_invoker_action<
+                Algo, ExPolicy, boost::mpl::false_, R(Args const& ...)>
         >
     {};
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Algo, typename ExPolicy, typename IsSeq,
-        BOOST_PP_ENUM_PARAMS(N, typename Arg)>
+    template <typename Algo, typename ExPolicy, typename IsSeq, typename... Args>
     BOOST_FORCEINLINE
-    future<typename Algo::result_type>
-    dispatch_async(id_type const& id, Algo && algo,
-        ExPolicy const& policy, IsSeq, HPX_ENUM_FWD_ARGS(N, Arg, arg))
+    future<typename hpx::util::decay<Algo>::type::result_type>
+    dispatch_async(id_type const& id, Algo && algo, ExPolicy const& policy,
+        IsSeq, Args&&... args)
     {
-        BOOST_PP_CAT(algorithm_invoker_action, N)<
-            typename hpx::util::decay<Algo>::type, ExPolicy, IsSeq,
-            typename parallel::v1::detail::algorithm_result<
-                ExPolicy, typename Algo::result_type
-            >::type,
-            BOOST_PP_ENUM(N, HPX_DISPATCH_DECAY_ARG, Arg)
+        typedef typename hpx::util::decay<Algo>::type algo_type;
+        typedef typename parallel::v1::detail::algorithm_result<
+                ExPolicy, typename algo_type::result_type
+            >::type result_type;
+
+        algorithm_invoker_action<
+            algo_type, ExPolicy, IsSeq,
+            result_type(typename hpx::util::decay<Args>::type const&...)
         > act;
 
         return hpx::async_colocated(act, id, std::forward<Algo>(algo), policy,
-            HPX_ENUM_FORWARD_ARGS(N, Arg, arg));
+            std::forward<Args>(args)...);
     }
 
-    template <typename Algo, typename ExPolicy, typename IsSeq,
-        BOOST_PP_ENUM_PARAMS(N, typename Arg)>
+    template <typename Algo, typename ExPolicy, typename IsSeq, typename... Args>
     BOOST_FORCEINLINE
-    typename Algo::result_type
+    typename hpx::util::decay<Algo>::type::result_type
     dispatch(id_type const& id, Algo && algo, ExPolicy const& policy,
-        IsSeq is_seq, HPX_ENUM_FWD_ARGS(N, Arg, arg))
+        IsSeq is_seq, Args&&... args)
     {
         // synchronously invoke remote operation
-        future<typename Algo::result_type> f =
+        future<typename hpx::util::decay<Algo>::type::result_type> f =
             dispatch_async(id, std::forward<Algo>(algo), policy, is_seq,
-                HPX_ENUM_FORWARD_ARGS(N, Arg, arg));
+                std::forward<Args>(args)...);
         f.wait();
 
         // handle any remote exceptions
@@ -175,10 +121,8 @@ namespace hpx { namespace parallel { namespace util { namespace remote
 
 HPX_REGISTER_PLAIN_ACTION_TEMPLATE(
     (template <typename Algo, typename ExPolicy, typename IsSeq, typename R,
-        BOOST_PP_ENUM_PARAMS(N, typename Arg)>),
-    (hpx::parallel::util::remote::BOOST_PP_CAT(algorithm_invoker_action, N)<
-        Algo, ExPolicy, IsSeq, R, BOOST_PP_ENUM_PARAMS(N, Arg)>))
-
-#undef N
+        typename... Args>),
+    (hpx::parallel::util::remote::algorithm_invoker_action<
+        Algo, ExPolicy, IsSeq, R(Args const&...)>))
 
 #endif

--- a/hpx/parallel/algorithms/replace.hpp
+++ b/hpx/parallel/algorithms/replace.hpp
@@ -58,13 +58,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 typedef typename std::iterator_traits<FwdIter>::value_type type;
 
                 return hpx::util::void_guard<result_type>(),
-                    for_each_n<FwdIter>().call(policy,
+                    for_each_n<FwdIter>().call(
+                        policy, boost::mpl::false_(),
                         first, std::distance(first, last),
                         [old_value, new_value](type& t) {
                             if (t == old_value)
                                 t = new_value;
-                        },
-                        boost::mpl::false_());
+                        });
             }
         };
         /// \endcond
@@ -129,8 +129,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
 
         return detail::replace().call(
-            std::forward<ExPolicy>(policy),
-            first, last, old_value, new_value, is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, old_value, new_value);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -163,13 +163,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 typedef typename std::iterator_traits<FwdIter>::value_type type;
 
                 return hpx::util::void_guard<result_type>(),
-                    for_each_n<FwdIter>().call(policy,
+                    for_each_n<FwdIter>().call(
+                        policy, boost::mpl::false_(),
                         first, std::distance(first, last),
                         [f, new_value](type& t) {
                             if (f(t))
                                 t = new_value;
-                        },
-                        boost::mpl::false_());
+                        });
             }
         };
         /// \endcond
@@ -253,8 +253,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
 
         return detail::replace_if().call(
-            std::forward<ExPolicy>(policy),
-            first, last, std::forward<F>(f), new_value, is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, std::forward<F>(f), new_value);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -290,16 +290,17 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 result_type;
 
                 return get_iter<1, result_type>(
-                    for_each_n<zip_iterator>().call(policy,
+                    for_each_n<zip_iterator>().call(
+                        policy, boost::mpl::false_(),
                         hpx::util::make_zip_iterator(first, dest),
                         std::distance(first, last),
                         [old_value, new_value](reference t) {
-                            if (old_value == hpx::util::get<0>(t))
-                                hpx::util::get<1>(t) = new_value;
+                            using hpx::util::get;
+                            if (old_value == get<0>(t))
+                                get<1>(t) = new_value;
                             else
-                                hpx::util::get<1>(t) = hpx::util::get<0>(t); //-V573
-                        },
-                        boost::mpl::false_()));
+                                get<1>(t) = get<0>(t); //-V573
+                        }));
             }
         };
         /// \endcond
@@ -389,8 +390,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::replace_copy<OutIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, dest, old_value, new_value, is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, dest, old_value, new_value);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -427,16 +428,17 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 result_type;
 
                 return get_iter<1, result_type>(
-                    for_each_n<zip_iterator>().call(policy,
+                    for_each_n<zip_iterator>().call(
+                        policy, boost::mpl::false_(),
                         hpx::util::make_zip_iterator(first, dest),
                         std::distance(first, last),
                         [f, new_value](reference t) {
-                            if (f(hpx::util::get<0>(t)))
-                                hpx::util::get<1>(t) = new_value;
+                            using hpx::util::get;
+                            if (f(get<0>(t)))
+                                get<1>(t) = new_value;
                             else
-                                hpx::util::get<1>(t) = hpx::util::get<0>(t); //-V573
-                        },
-                        boost::mpl::false_()));
+                                get<1>(t) = get<0>(t); //-V573
+                        }));
             }
         };
         /// \endcond
@@ -545,8 +547,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::replace_copy_if<OutIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, dest, std::forward<F>(f), new_value, is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, dest, std::forward<F>(f), new_value);
     }
 }}}
 

--- a/hpx/parallel/algorithms/reverse.hpp
+++ b/hpx/parallel/algorithms/reverse.hpp
@@ -60,15 +60,15 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     result_type;
 
                 return hpx::util::void_guard<result_type>(),
-                    for_each_n<zip_iterator>().call(policy,
+                    for_each_n<zip_iterator>().call(
+                        policy, boost::mpl::false_(),
                         hpx::util::make_zip_iterator(
                             first, destination_iterator(last)),
                         std::distance(first, last) / 2,
                         [](reference t) {
                             using hpx::util::get;
                             std::swap(get<0>(t), get<1>(t));
-                        },
-                        boost::mpl::false_());
+                        });
             }
         };
         /// \endcond
@@ -129,7 +129,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
 
         return detail::reverse().call(
-            std::forward<ExPolicy>(policy), first, last, is_seq());
+            std::forward<ExPolicy>(policy), is_seq(), first, last);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -161,8 +161,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 typedef std::reverse_iterator<BidirIter> iterator;
 
                 return detail::copy<OutputIter>().call(
-                    policy, iterator(last), iterator(first), dest_first,
-                    boost::mpl::false_());
+                    policy, boost::mpl::false_(),
+                    iterator(last), iterator(first), dest_first);
             }
         };
         /// \endcond
@@ -251,8 +251,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::reverse_copy<OutputIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, dest_first, is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, dest_first);
     }
 }}}
 

--- a/hpx/parallel/algorithms/rotate.hpp
+++ b/hpx/parallel/algorithms/rotate.hpp
@@ -75,7 +75,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             return lcos::local::dataflow(
                 hpx::util::unwrapped([=]() mutable -> hpx::future<FwdIter>
                 {
-                    hpx::future<void> f = r.call(p, first, last, non_seq());
+                    hpx::future<void> f = r.call(p, non_seq(), first, last);
                     std::advance(first, std::distance(new_first, last));
                     return f.then(
                         [first] (hpx::future<void> &&) -> FwdIter
@@ -83,8 +83,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                             return first;
                         });
                 }),
-                r.call(p, first, new_first, non_seq()),
-                r.call(p, new_first, last, non_seq()));
+                r.call(p, non_seq(), first, new_first),
+                r.call(p, non_seq(), new_first, last));
         }
 
         template <typename FwdIter>

--- a/hpx/parallel/algorithms/rotate.hpp
+++ b/hpx/parallel/algorithms/rotate.hpp
@@ -178,7 +178,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::rotate<FwdIter>().call(
-            std::forward<ExPolicy>(policy), first, new_first, last, is_seq());
+            std::forward<ExPolicy>(policy), is_seq(), first, new_first, last);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -196,13 +196,15 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             parallel_task_execution_policy p =
                 par(task, policy.get_executor(), policy.get_chunk_size());
 
-            hpx::future<OutIter> f = detail::copy<OutIter>().call(p, new_first,
-                last, dest_first, non_seq());
+            hpx::future<OutIter> f =
+                detail::copy<OutIter>().call(p, non_seq(),
+                    new_first, last, dest_first);
 
             return f.then(
-                [=](hpx::future<OutIter> && it) {
-                    return detail::copy<OutIter>().call(p, first,
-                        new_first, it.get(), non_seq());
+                [=](hpx::future<OutIter> && it)
+                {
+                    return detail::copy<OutIter>().call(
+                        p, non_seq(), first, new_first, it.get());
                 });
         }
 
@@ -312,8 +314,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::rotate_copy<OutIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, new_first, last, dest_first, is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, new_first, last, dest_first);
     }
 }}}
 

--- a/hpx/parallel/algorithms/search.hpp
+++ b/hpx/parallel/algorithms/search.hpp
@@ -202,9 +202,8 @@ namespace hpx {namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::search<FwdIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, s_first, s_last,
-            detail::equal_to(), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, s_first, s_last, detail::equal_to());
     }
 
     /// Searches the range [first, last) for any elements in the range [s_first, s_last).
@@ -294,9 +293,8 @@ namespace hpx {namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::search<FwdIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, s_first, s_last,
-            op, is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, s_first, s_last, std::forward<Pred>(op));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -467,9 +465,8 @@ namespace hpx {namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::search_n<FwdIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, count, s_first, s_last,
-            detail::equal_to(), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, count, s_first, s_last, detail::equal_to());
     }
 
     /// Searches the range [first, last) for any elements in the range [s_first, s_last).
@@ -559,9 +556,8 @@ namespace hpx {namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::search_n<FwdIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, count, s_first, s_last,
-            op, is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, count, s_first, s_last, std::forward<Pred>(op));
     }
 }}}
 

--- a/hpx/parallel/algorithms/swap_ranges.hpp
+++ b/hpx/parallel/algorithms/swap_ranges.hpp
@@ -61,13 +61,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 result_type;
 
                 return get_iter<1, result_type>(
-                    for_each_n<zip_iterator>().call(policy,
+                    for_each_n<zip_iterator>().call(
+                        policy, boost::mpl::false_(),
                         hpx::util::make_zip_iterator(first1, first2),
                         std::distance(first1, last1),
                         [](reference t) {
-                            std::swap(hpx::util::get<0>(t), hpx::util::get<1>(t));
-                        },
-                        boost::mpl::false_()));
+                            using hpx::util::get;
+                            std::swap(get<0>(t), get<1>(t));
+                        }));
             }
         };
         /// \endcond
@@ -143,8 +144,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
         return detail::swap_ranges<ForwardIter2>().call(
-            std::forward<ExPolicy>(policy),
-            first1, last1, first2, is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first1, last1, first2);
     }
 }}}
 

--- a/hpx/parallel/algorithms/transform.hpp
+++ b/hpx/parallel/algorithms/transform.hpp
@@ -59,13 +59,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 result_type;
 
                 return get_iter<1, result_type>(
-                    for_each_n<zip_iterator>().call(policy,
+                    for_each_n<zip_iterator>().call(
+                        policy, boost::mpl::false_(),
                         hpx::util::make_zip_iterator(first, dest),
                         std::distance(first, last),
                         [f](reference t) {
-                            hpx::util::get<1>(t) = f(hpx::util::get<0>(t)); //-V573
-                        },
-                        boost::mpl::false_()));
+                            using hpx::util::get;
+                            get<1>(t) = f(get<0>(t)); //-V573
+                        }));
             }
         };
         /// \endcond
@@ -152,8 +153,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::transform<OutIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, dest, std::forward<F>(f), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, dest, std::forward<F>(f));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -192,14 +193,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 result_type;
 
                 return get_iter<2, result_type>(
-                    for_each_n<zip_iterator>().call(policy,
+                    for_each_n<zip_iterator>().call(
+                        policy, boost::mpl::false_(),
                         hpx::util::make_zip_iterator(first1, first2, dest),
                         std::distance(first1, last1),
                         [f](reference t) {
-                            hpx::util::get<2>(t) = //-V573
-                                f(hpx::util::get<0>(t), hpx::util::get<1>(t));
-                        },
-                        boost::mpl::false_()));
+                            hpx::util::get;
+                            get<2>(t) = f(get<0>(t), get<1>(t)); //-V573
+                        }));
             }
         };
         /// \endcond
@@ -301,8 +302,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::transform_binary<OutIter>().call(
-            std::forward<ExPolicy>(policy),
-            first1, last1, first2, dest, std::forward<F>(f), is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first1, last1, first2, dest, std::forward<F>(f));
     }
 }}}
 

--- a/hpx/parallel/algorithms/transform.hpp
+++ b/hpx/parallel/algorithms/transform.hpp
@@ -198,7 +198,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         hpx::util::make_zip_iterator(first1, first2, dest),
                         std::distance(first1, last1),
                         [f](reference t) {
-                            hpx::util::get;
+                            using hpx::util::get;
                             get<2>(t) = f(get<0>(t), get<1>(t)); //-V573
                         }));
             }

--- a/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -1,0 +1,278 @@
+//  Copyright (c) 2014-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/algorithms/transform_transform_exclusive_scan.hpp
+
+#if !defined(HPX_PARALLEL_ALGORITHM_TRANSFORM_TRANSFORM_EXCLUSIVE_SCAN_JAN_04_2015_0354PM)
+#define HPX_PARALLEL_ALGORITHM_TRANSFORM_TRANSFORM_EXCLUSIVE_SCAN_JAN_04_2015_0354PM
+
+#include <hpx/hpx_fwd.hpp>
+#include <hpx/util/move.hpp>
+
+#include <hpx/parallel/config/inline_namespace.hpp>
+#include <hpx/parallel/execution_policy.hpp>
+#include <hpx/parallel/algorithms/detail/algorithm_result.hpp>
+#include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/algorithms/exclusive_scan.hpp>
+#include <hpx/parallel/util/partitioner.hpp>
+#include <hpx/parallel/util/scan_partitioner.hpp>
+#include <hpx/parallel/util/loop.hpp>
+
+#include <algorithm>
+#include <numeric>
+#include <iterator>
+
+#include <boost/static_assert.hpp>
+#include <boost/utility/enable_if.hpp>
+#include <boost/type_traits/is_base_of.hpp>
+
+namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // transform_exclusive_scan
+    namespace detail
+    {
+        /// \cond NOINTERNAL
+
+        // Our own version of the sequential transform_exclusive_scan.
+        template <typename InIter, typename OutIter, typename Conv, typename T,
+            typename Op>
+        OutIter sequential_transform_exclusive_scan(InIter first, InIter last,
+            OutIter dest, Conv && conv, T init, Op && op)
+        {
+            for (/**/; first != last; (void) ++first, ++dest)
+            {
+                *dest = init;
+                init = op(init, conv(*first));
+            }
+            return dest;
+        }
+
+        template <typename InIter, typename OutIter, typename Conv, typename T,
+            typename Op>
+        T sequential_transform_exclusive_scan_n(InIter first, std::size_t count,
+            OutIter dest, Conv && conv, T init, Op && op)
+        {
+            for (/**/; count-- != 0; (void) ++first, ++dest)
+            {
+                *dest = init;
+                init = op(init, conv(*first));
+            }
+            return init;
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename OutIter>
+        struct transform_exclusive_scan
+          : public detail::algorithm<transform_exclusive_scan<OutIter>, OutIter>
+        {
+            transform_exclusive_scan()
+              : transform_exclusive_scan::algorithm("transform_exclusive_scan")
+            {}
+
+            template <typename ExPolicy, typename InIter, typename Conv,
+                typename T, typename Op>
+            static OutIter
+            sequential(ExPolicy const&, InIter first, InIter last,
+                OutIter dest, Conv && conv, T && init, Op && op)
+            {
+                return sequential_transform_exclusive_scan(first, last, dest,
+                    std::forward<Conv>(conv), std::forward<T>(init),
+                    std::forward<Op>(op));
+            }
+
+            template <typename ExPolicy, typename FwdIter, typename Conv,
+                typename T, typename Op>
+            static typename detail::algorithm_result<ExPolicy, OutIter>::type
+            parallel(ExPolicy const& policy, FwdIter first, FwdIter last,
+                 OutIter dest, Conv && conv, T && init, Op && op)
+            {
+                typedef detail::algorithm_result<ExPolicy, OutIter> result;
+                typedef hpx::util::zip_iterator<FwdIter, T*> zip_iterator;
+
+                if (first == last)
+                    return result::get(std::move(dest));
+
+                std::size_t count = std::distance(first, last);
+                std::size_t chunk_size = 0;
+
+                boost::shared_array<T> data(new T[count]);
+
+                // The overall scan algorithm is performed by executing 2
+                // subsequent parallel steps. The first calculates the scan
+                // results for each partition and the second produces the
+                // overall result
+
+                using hpx::util::make_zip_iterator;
+                return
+                    util::scan_partitioner<ExPolicy, OutIter, T>::call(
+                        policy, make_zip_iterator(first, data.get()), count, init,
+                        // step 1 performs first part of scan algorithm
+                        [=](zip_iterator part_begin, std::size_t part_size) -> T
+                        {
+                            using hpx::util::get;
+                            return sequential_transform_exclusive_scan_n(
+                                get<0>(part_begin.get_iterator_tuple()), part_size,
+                                get<1>(part_begin.get_iterator_tuple()),
+                                conv, init, op);
+                        },
+                        // step 2 propagates the partition results from left
+                        // to right
+                        hpx::util::unwrapped(
+                            [=](T const& prev, T const& curr) -> T
+                            {
+                                return op(prev, curr);
+                            }),
+                        // step 3 runs the remaining operation
+                        [=](std::vector<hpx::shared_future<T> >&& r,
+                            std::vector<std::size_t> const& chunk_sizes)
+                        {
+                            // run the final copy step and produce the required
+                            // result
+                            return exclusive_scan_helper(policy, std::move(r),
+                                data, count, dest, op, chunk_sizes);
+                        }
+                    );
+            }
+        };
+        /// \endcond
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, conv(*first), ..., conv(*(first + (i - result) - 1))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicates \a op and \a conv.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Conv        The type of the unary function object used for
+    ///                     the conversion operation.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param conv         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     R fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a InIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///                     The type \a R must be such that an object of this
+    ///                     type can be implicitly converted to \a T.
+    /// \param init         The initial value for the generalized sum.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a transform_exclusive_scan algorithm
+    /// invoked with an execution policy object of type \a sequential_execution_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a transform_exclusive_scan algorithm
+    /// invoked with an execution policy object of type \a parallel_execution_policy
+    /// or \a parallel_task_execution_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a copy_n algorithm returns a \a hpx::future<OutIter> if
+    ///           the execution policy is of type
+    ///           \a sequential_task_execution_policy or
+    ///           \a parallel_task_execution_policy and
+    ///           returns \a OutIter otherwise.
+    ///           The \a transform_exclusive_scan algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK), GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
+    /// modify elements in the ranges [first,last) or [result,result + (last - first)).
+    ///
+    /// The behavior of transform_exclusive_scan may be non-deterministic for
+    /// a non-associative predicate.
+    ///
+    template <typename ExPolicy, typename InIter, typename OutIter,
+        typename Conv, typename T, typename Op>
+    inline typename boost::enable_if<
+        is_execution_policy<ExPolicy>,
+        typename detail::algorithm_result<ExPolicy, OutIter>::type
+    >::type
+    transform_exclusive_scan(ExPolicy&& policy, InIter first, InIter last,
+        OutIter dest, Conv && conv, T init, Op && op)
+    {
+        typedef typename std::iterator_traits<InIter>::iterator_category
+            iterator_category;
+        typedef typename std::iterator_traits<OutIter>::iterator_category
+            output_iterator_category;
+
+        BOOST_STATIC_ASSERT_MSG(
+            (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
+            "Requires at least input iterator.");
+
+        BOOST_STATIC_ASSERT_MSG(
+            (boost::mpl::or_<
+                boost::is_base_of<
+                    std::forward_iterator_tag, output_iterator_category>,
+                boost::is_same<
+                    std::output_iterator_tag, output_iterator_category>
+            >::value),
+            "Requires at least output iterator.");
+
+        typedef typename boost::mpl::or_<
+            is_sequential_execution_policy<ExPolicy>,
+            boost::is_same<std::input_iterator_tag, iterator_category>,
+            boost::is_same<std::output_iterator_tag, output_iterator_category>
+        >::type is_seq;
+
+        return detail::transform_exclusive_scan<OutIter>().call(
+            std::forward<ExPolicy>(policy),
+            first, last, dest, std::forward<Conv>(conv), std::move(init),
+            std::forward<Op>(op), is_seq());
+    }
+}}}
+
+#endif

--- a/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -269,9 +269,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::transform_exclusive_scan<OutIter>().call(
-            std::forward<ExPolicy>(policy),
+            std::forward<ExPolicy>(policy), is_seq(),
             first, last, dest, std::forward<Conv>(conv), std::move(init),
-            std::forward<Op>(op), is_seq());
+            std::forward<Op>(op));
     }
 }}}
 

--- a/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -3,10 +3,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-/// \file parallel/algorithms/transform_exclusive_scan.hpp
+/// \file parallel/algorithms/transform_inclusive_scan.hpp
 
-#if !defined(HPX_PARALLEL_ALGORITHM_TRANSFORM_EXCLUSIVE_SCAN_JAN_04_2015_0354PM)
-#define HPX_PARALLEL_ALGORITHM_TRANSFORM_EXCLUSIVE_SCAN_JAN_04_2015_0354PM
+#if !defined(HPX_PARALLEL_ALGORITHM_TRANSFORM_INCLUSIVE_SCAN_JAN_04_2015_0556PM)
+#define HPX_PARALLEL_ALGORITHM_TRANSFORM_INCLUSIVE_SCAN_JAN_04_2015_0556PM
 
 #include <hpx/hpx_fwd.hpp>
 #include <hpx/util/move.hpp>
@@ -15,7 +15,7 @@
 #include <hpx/parallel/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/algorithm_result.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
-#include <hpx/parallel/algorithms/exclusive_scan.hpp>
+#include <hpx/parallel/algorithms/inclusive_scan.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/scan_partitioner.hpp>
 #include <hpx/parallel/util/loop.hpp>
@@ -31,45 +31,46 @@
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
     ///////////////////////////////////////////////////////////////////////////
-    // transform_exclusive_scan
+    // transform_inclusive_scan
     namespace detail
     {
         /// \cond NOINTERNAL
 
-        // Our own version of the sequential transform_exclusive_scan.
+        ///////////////////////////////////////////////////////////////////////
+        // Our own version of the sequential transform_inclusive_scan.
         template <typename InIter, typename OutIter, typename Conv, typename T,
             typename Op>
-        OutIter sequential_transform_exclusive_scan(InIter first, InIter last,
+        OutIter sequential_transform_inclusive_scan(InIter first, InIter last,
             OutIter dest, Conv && conv, T init, Op && op)
         {
             for (/**/; first != last; (void) ++first, ++dest)
             {
-                *dest = init;
                 init = op(init, conv(*first));
+                *dest = init;
             }
             return dest;
         }
 
         template <typename InIter, typename OutIter, typename Conv, typename T,
             typename Op>
-        T sequential_transform_exclusive_scan_n(InIter first, std::size_t count,
+        T sequential_transform_inclusive_scan_n(InIter first, std::size_t count,
             OutIter dest, Conv && conv, T init, Op && op)
         {
             for (/**/; count-- != 0; (void) ++first, ++dest)
             {
-                *dest = init;
                 init = op(init, conv(*first));
+                *dest = init;
             }
             return init;
         }
 
         ///////////////////////////////////////////////////////////////////////
         template <typename OutIter>
-        struct transform_exclusive_scan
-          : public detail::algorithm<transform_exclusive_scan<OutIter>, OutIter>
+        struct transform_inclusive_scan
+          : public detail::algorithm<transform_inclusive_scan<OutIter>, OutIter>
         {
-            transform_exclusive_scan()
-              : transform_exclusive_scan::algorithm("transform_exclusive_scan")
+            transform_inclusive_scan()
+              : transform_inclusive_scan::algorithm("transform_inclusive_scan")
             {}
 
             template <typename ExPolicy, typename InIter, typename Conv,
@@ -78,7 +79,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             sequential(ExPolicy const&, InIter first, InIter last,
                 OutIter dest, Conv && conv, T && init, Op && op)
             {
-                return sequential_transform_exclusive_scan(first, last, dest,
+                return sequential_transform_inclusive_scan(first, last, dest,
                     std::forward<Conv>(conv), std::forward<T>(init),
                     std::forward<Op>(op));
             }
@@ -113,7 +114,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         [=](zip_iterator part_begin, std::size_t part_size) -> T
                         {
                             using hpx::util::get;
-                            return sequential_transform_exclusive_scan_n(
+                            return sequential_transform_inclusive_scan_n(
                                 get<0>(part_begin.get_iterator_tuple()), part_size,
                                 get<1>(part_begin.get_iterator_tuple()),
                                 conv, init, op);
@@ -131,7 +132,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         {
                             // run the final copy step and produce the required
                             // result
-                            return exclusive_scan_helper(policy, std::move(r),
+                            return inclusive_scan_helper(policy, std::move(r),
                                 data, count, dest, op, chunk_sizes);
                         }
                     );
@@ -143,10 +144,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
     /// the value of
-    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, conv(*first), ..., conv(*(first + (i - result) - 1))).
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, init, conv(*first), ..., conv(*(first + (i - result)))).
     ///
     /// \note   Complexity: O(\a last - \a first) applications of the
-    ///         predicates \a op and \a conv.
+    ///         predicate \a op.
     ///
     /// \tparam ExPolicy    The type of the execution policy to use (deduced).
     ///                     It describes the manner in which the execution
@@ -205,12 +206,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///                     sequence can be implicitly converted to any
     ///                     of those types.
     ///
-    /// The reduce operations in the parallel \a transform_exclusive_scan algorithm
-    /// invoked with an execution policy object of type \a sequential_execution_policy
+    /// The reduce operations in the parallel \a transform_inclusive_scan algorithm invoked
+    /// with an execution policy object of type \a sequential_execution_policy
     /// execute in sequential order in the calling thread.
     ///
-    /// The reduce operations in the parallel \a transform_exclusive_scan algorithm
-    /// invoked with an execution policy object of type \a parallel_execution_policy
+    /// The reduce operations in the parallel \a transform_inclusive_scan algorithm invoked
+    /// with an execution policy object of type \a parallel_execution_policy
     /// or \a parallel_task_execution_policy are permitted to execute in an unordered
     /// fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
@@ -220,20 +221,22 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           \a sequential_task_execution_policy or
     ///           \a parallel_task_execution_policy and
     ///           returns \a OutIter otherwise.
-    ///           The \a transform_exclusive_scan algorithm returns the output
-    ///           iterator to the element in the destination range, one past
-    ///           the last element copied.
+    ///           The \a transform_inclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
     ///
     /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
     ///         * a1 when N is 1
-    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK), GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK), GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
     ///           where 1 < K+1 = M <= N.
     ///
     /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
     /// modify elements in the ranges [first,last) or [result,result + (last - first)).
     ///
-    /// The behavior of transform_exclusive_scan may be non-deterministic for
-    /// a non-associative predicate.
+    /// The difference between \a exclusive_scan and \a transform_inclusive_scan is that
+    /// \a transform_inclusive_scan includes the ith input element in the ith sum. If
+    /// \a op is not mathematically associative, the behavior of
+    /// \a transform_inclusive_scan may be non-deterministic.
     ///
     template <typename ExPolicy, typename InIter, typename OutIter,
         typename Conv, typename T, typename Op>
@@ -241,7 +244,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         is_execution_policy<ExPolicy>,
         typename detail::algorithm_result<ExPolicy, OutIter>::type
     >::type
-    transform_exclusive_scan(ExPolicy&& policy, InIter first, InIter last,
+    transform_inclusive_scan(ExPolicy&& policy, InIter first, InIter last,
         OutIter dest, Conv && conv, T init, Op && op)
     {
         typedef typename std::iterator_traits<InIter>::iterator_category
@@ -268,9 +271,144 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             boost::is_same<std::output_iterator_tag, output_iterator_category>
         >::type is_seq;
 
-        return detail::transform_exclusive_scan<OutIter>().call(
+        return detail::transform_inclusive_scan<OutIter>().call(
             std::forward<ExPolicy>(policy),
             first, last, dest, std::forward<Conv>(conv), std::move(init),
+            std::forward<Op>(op), is_seq());
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, conv(*first), ..., conv(*(first + (i - result)))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Conv        The type of the unary function object used for
+    ///                     the conversion operation.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param conv         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     R fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a InIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///                     The type \a R must be such that an object of this
+    ///                     type can be implicitly converted to \a T.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a transform_inclusive_scan algorithm invoked
+    /// with an execution policy object of type \a sequential_execution_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a transform_inclusive_scan algorithm invoked
+    /// with an execution policy object of type \a parallel_execution_policy
+    /// or \a parallel_task_execution_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a copy_n algorithm returns a \a hpx::future<OutIter> if
+    ///           the execution policy is of type
+    ///           \a sequential_task_execution_policy or
+    ///           \a parallel_task_execution_policy and
+    ///           returns \a OutIter otherwise.
+    ///           The \a transform_inclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK), GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
+    /// modify elements in the ranges [first,last) or [result,result + (last - first)).
+    ///
+    /// The difference between \a exclusive_scan and \a transform_inclusive_scan is that
+    /// \a transform_inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename ExPolicy, typename InIter, typename OutIter,
+        typename Conv, typename Op>
+    inline typename boost::enable_if<
+        is_execution_policy<ExPolicy>,
+        typename detail::algorithm_result<ExPolicy, OutIter>::type
+    >::type
+    transform_inclusive_scan(ExPolicy&& policy, InIter first, InIter last,
+        OutIter dest, Conv && conv, Op && op)
+    {
+        typedef typename std::iterator_traits<InIter>::iterator_category
+            iterator_category;
+        typedef typename std::iterator_traits<OutIter>::iterator_category
+            output_iterator_category;
+
+        BOOST_STATIC_ASSERT_MSG(
+            (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
+            "Requires at least input iterator.");
+
+        BOOST_STATIC_ASSERT_MSG(
+            (boost::mpl::or_<
+                boost::is_base_of<
+                    std::forward_iterator_tag, output_iterator_category>,
+                boost::is_same<
+                    std::output_iterator_tag, output_iterator_category>
+            >::value),
+            "Requires at least output iterator.");
+
+        typedef typename boost::mpl::or_<
+            is_sequential_execution_policy<ExPolicy>,
+            boost::is_same<std::input_iterator_tag, iterator_category>,
+            boost::is_same<std::output_iterator_tag, output_iterator_category>
+        >::type is_seq;
+
+        typedef typename std::iterator_traits<InIter>::value_type value_type;
+
+        return detail::transform_inclusive_scan<OutIter>().call(
+            std::forward<ExPolicy>(policy),
+            first, last, dest, std::forward<Conv>(conv), value_type(),
             std::forward<Op>(op), is_seq());
     }
 }}}

--- a/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -272,9 +272,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::transform_inclusive_scan<OutIter>().call(
-            std::forward<ExPolicy>(policy),
+            std::forward<ExPolicy>(policy), is_seq(),
             first, last, dest, std::forward<Conv>(conv), std::move(init),
-            std::forward<Op>(op), is_seq());
+            std::forward<Op>(op));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -407,9 +407,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter>::value_type value_type;
 
         return detail::transform_inclusive_scan<OutIter>().call(
-            std::forward<ExPolicy>(policy),
+            std::forward<ExPolicy>(policy), is_seq(),
             first, last, dest, std::forward<Conv>(conv), value_type(),
-            std::forward<Op>(op), is_seq());
+            std::forward<Op>(op));
     }
 }}}
 

--- a/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/hpx/parallel/algorithms/transform_reduce.hpp
@@ -118,10 +118,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typedef typename hpx::util::decay<T>::type init_type;
 
             return transform_reduce<init_type>().call(
-                std::forward<ExPolicy>(policy), first, last,
-                std::forward<T>(init),
-                std::forward<Reduce>(red_op), std::forward<Convert>(conv_op),
-                is_seq());
+                std::forward<ExPolicy>(policy), is_seq(),
+                first, last, std::forward<T>(init),
+                std::forward<Reduce>(red_op), std::forward<Convert>(conv_op));
         }
 
         // forward declare the segmented version of this algorithm

--- a/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/hpx/parallel/algorithms/transform_reduce.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2015 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -95,13 +95,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             }
         };
 
-        template <typename ExPolicy, typename InIter, typename T, typename Reduce,
-            typename Convert>
+        template <typename ExPolicy, typename InIter, typename T,
+            typename Reduce, typename Convert>
         inline typename detail::algorithm_result<
             ExPolicy, typename hpx::util::decay<T>::type
         >::type
-        transform_reduce_(ExPolicy&& policy, InIter first, InIter last, T && init,
-            Reduce && red_op, Convert && conv_op, boost::mpl::false_)
+        transform_reduce_(ExPolicy&& policy, InIter first, InIter last,
+            T && init, Reduce && red_op, Convert && conv_op, boost::mpl::false_)
         {
             typedef typename std::iterator_traits<InIter>::iterator_category
                 iterator_category;
@@ -125,8 +125,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         }
 
         // forward declare the segmented version of this algorithm
-        template <typename ExPolicy, typename InIter, typename T, typename Reduce,
-            typename Convert>
+        template <typename ExPolicy, typename InIter, typename T,
+            typename Reduce, typename Convert>
         typename detail::algorithm_result<
             ExPolicy, typename hpx::util::decay<T>::type
         >::type
@@ -154,6 +154,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///                     requirements of \a CopyConstructible.
     /// \tparam T           The type of the value to be used as initial (and
     ///                     intermediate) values (deduced).
+    /// \tparam Reduce      The type of the binary function object used for
+    ///                     the reduction operation.
+    /// \tparam Convert     The type of the unary function object used to
+    ///                     transform the elements of the input sequence before
+    ///                     invoking the reduce function.
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.

--- a/hpx/parallel/algorithms/uninitialized_copy.hpp
+++ b/hpx/parallel/algorithms/uninitialized_copy.hpp
@@ -207,8 +207,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::uninitialized_copy<FwdIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, last, dest, is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, dest);
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -331,8 +331,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::uninitialized_copy_n<FwdIter>().call(
-            std::forward<ExPolicy>(policy),
-            first, std::size_t(count), dest, is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, std::size_t(count), dest);
     }
 }}}
 

--- a/hpx/parallel/algorithms/uninitialized_fill.hpp
+++ b/hpx/parallel/algorithms/uninitialized_fill.hpp
@@ -187,8 +187,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type is_seq;
 
         return detail::uninitialized_fill().call(
-            std::forward<ExPolicy>(policy),
-            first, last, value, is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, last, value);
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -290,8 +290,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
 
         return detail::uninitialized_fill_n().call(
-            std::forward<ExPolicy>(policy),
-            first, std::size_t(count), value, is_seq());
+            std::forward<ExPolicy>(policy), is_seq(),
+            first, std::size_t(count), value);
     }
 }}}
 

--- a/hpx/parallel/numeric.hpp
+++ b/hpx/parallel/numeric.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2015 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -8,10 +8,11 @@
 
 #include <hpx/hpx_fwd.hpp>
 
-/// See N4071: 1.3/3
+/// See N4310: 1.3/3
 #include <numeric>
 
 #include <hpx/parallel/algorithms/reduce.hpp>
+#include <hpx/parallel/algorithms/exclusive_scan.hpp>
 #include <hpx/parallel/algorithms/transform_reduce.hpp>
 
 #endif

--- a/hpx/parallel/numeric.hpp
+++ b/hpx/parallel/numeric.hpp
@@ -15,6 +15,7 @@
 #include <hpx/parallel/algorithms/exclusive_scan.hpp>
 #include <hpx/parallel/algorithms/inclusive_scan.hpp>
 #include <hpx/parallel/algorithms/transform_exclusive_scan.hpp>
+#include <hpx/parallel/algorithms/transform_inclusive_scan.hpp>
 #include <hpx/parallel/algorithms/transform_reduce.hpp>
 
 #endif

--- a/hpx/parallel/numeric.hpp
+++ b/hpx/parallel/numeric.hpp
@@ -14,6 +14,7 @@
 #include <hpx/parallel/algorithms/reduce.hpp>
 #include <hpx/parallel/algorithms/exclusive_scan.hpp>
 #include <hpx/parallel/algorithms/inclusive_scan.hpp>
+#include <hpx/parallel/algorithms/transform_exclusive_scan.hpp>
 #include <hpx/parallel/algorithms/transform_reduce.hpp>
 
 #endif

--- a/hpx/parallel/numeric.hpp
+++ b/hpx/parallel/numeric.hpp
@@ -13,6 +13,7 @@
 
 #include <hpx/parallel/algorithms/reduce.hpp>
 #include <hpx/parallel/algorithms/exclusive_scan.hpp>
+#include <hpx/parallel/algorithms/inclusive_scan.hpp>
 #include <hpx/parallel/algorithms/transform_reduce.hpp>
 
 #endif

--- a/hpx/parallel/util/detail/chunk_size.hpp
+++ b/hpx/parallel/util/detail/chunk_size.hpp
@@ -15,8 +15,9 @@
 namespace hpx { namespace parallel { namespace util { namespace detail
 {
     ///////////////////////////////////////////////////////////////////////////
-    template <typename R, typename F, typename FwdIter>
-    void add_ready_future(std::vector<hpx::future<R> >& workitems,
+    template <typename F, typename Future, typename FwdIter>
+        // requires traits::is_future<Future>
+    void add_ready_future(std::vector<Future>& workitems,
         F && f, FwdIter first, std::size_t count)
     {
         workitems.push_back(hpx::make_ready_future(f(first, count)));
@@ -27,12 +28,22 @@ namespace hpx { namespace parallel { namespace util { namespace detail
         F && f, FwdIter first, std::size_t count)
     {
         f(first, count);
+        workitems.push_back(hpx::make_ready_future());
+    }
+
+    template <typename F, typename FwdIter>
+    void add_ready_future(std::vector<hpx::shared_future<void> >&,
+        F && f, FwdIter first, std::size_t count)
+    {
+        f(first, count);
+        workitems.push_back(hpx::make_ready_future());
     }
 
     // estimate a chunk size based on number of cores used
-    template <typename Result, typename F1, typename FwdIter>
+    template <typename Future, typename F1, typename FwdIter>
+        // requires traits::is_future<Future>
     std::size_t auto_chunk_size(
-        std::vector<hpx::future<Result> >& workitems,
+        std::vector<Future>& workitems,
         F1 && f1, FwdIter& first, std::size_t& count)
     {
         std::size_t test_chunk_size = count / 100;
@@ -50,10 +61,11 @@ namespace hpx { namespace parallel { namespace util { namespace detail
         return t == 0 ? 0 : (std::min)(count, (std::size_t)(80000 / t));
     }
 
-    template <typename ExPolicy, typename Result, typename F1,
+    template <typename ExPolicy, typename Future, typename F1,
         typename FwdIter>
+        // requires traits::is_future<Future>
     std::size_t get_static_chunk_size(ExPolicy const& policy,
-        std::vector<hpx::future<Result> >& workitems,
+        std::vector<Future>& workitems,
         F1 && f1, FwdIter& first, std::size_t& count,
         std::size_t chunk_size)
     {
@@ -75,8 +87,9 @@ namespace hpx { namespace parallel { namespace util { namespace detail
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename R, typename F, typename FwdIter>
-    void add_ready_future_idx(std::vector<hpx::future<R> >& workitems,
+    template <typename Future, typename F, typename FwdIter>
+        // requires traits::is_future<Future>
+    void add_ready_future_idx(std::vector<Future>& workitems,
         F && f, std::size_t base_idx, FwdIter first, std::size_t count)
     {
         workitems.push_back(
@@ -84,17 +97,27 @@ namespace hpx { namespace parallel { namespace util { namespace detail
     }
 
     template <typename F, typename FwdIter>
-    void add_ready_future_idx(std::vector<hpx::future<void> >&,
+    void add_ready_future_idx(std::vector<hpx::future<void> >& workitems,
         F && f, std::size_t base_idx, FwdIter first, std::size_t count)
     {
         f(base_idx, first, count);
+        workitems.push_back(hpx::make_ready_future());
+    }
+
+    template <typename F, typename FwdIter>
+    void add_ready_future_idx(std::vector<hpx::shared_future<void> >& workitems,
+        F && f, std::size_t base_idx, FwdIter first, std::size_t count)
+    {
+        f(base_idx, first, count);
+        workitems.push_back(hpx::make_ready_future());
     }
 
     // estimate a chunk size based on number of cores used, take into
     // account base index
-    template <typename Result, typename F1, typename FwdIter>
+    template <typename Future, typename F1, typename FwdIter>
+        // requires traits::is_future<Future>
     std::size_t auto_chunk_size_idx(
-        std::vector<hpx::future<Result> >& workitems, F1 && f1,
+        std::vector<Future>& workitems, F1 && f1,
         std::size_t& base_idx, FwdIter& first, std::size_t& count)
     {
         std::size_t test_chunk_size = count / 100;
@@ -113,10 +136,11 @@ namespace hpx { namespace parallel { namespace util { namespace detail
         return t == 0 ? 0 : (std::min)(count, (std::size_t)(80000 / t));
     }
 
-    template <typename ExPolicy, typename Result, typename F1,
+    template <typename ExPolicy, typename Future, typename F1,
         typename FwdIter>
+        // requires traits::is_future<Future>
     std::size_t get_static_chunk_size_idx(ExPolicy const& policy,
-        std::vector<hpx::future<Result> >& workitems,
+        std::vector<Future>& workitems,
         F1 && f1, std::size_t& base_idx, FwdIter& first,
         std::size_t& count, std::size_t chunk_size)
     {

--- a/hpx/parallel/util/detail/chunk_size.hpp
+++ b/hpx/parallel/util/detail/chunk_size.hpp
@@ -24,7 +24,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail
     }
 
     template <typename F, typename FwdIter>
-    void add_ready_future(std::vector<hpx::future<void> >&,
+    void add_ready_future(std::vector<hpx::future<void> >& workitems,
         F && f, FwdIter first, std::size_t count)
     {
         f(first, count);
@@ -32,7 +32,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail
     }
 
     template <typename F, typename FwdIter>
-    void add_ready_future(std::vector<hpx::shared_future<void> >&,
+    void add_ready_future(std::vector<hpx::shared_future<void> >& workitems,
         F && f, FwdIter first, std::size_t count)
     {
         f(first, count);

--- a/hpx/parallel/util/detail/handle_local_exceptions.hpp
+++ b/hpx/parallel/util/detail/handle_local_exceptions.hpp
@@ -50,6 +50,20 @@ namespace hpx { namespace parallel { namespace util { namespace detail
                 boost::throw_exception(exception_list(std::move(errors)));
         }
 
+        template <typename T>
+        static void call(std::vector<hpx::shared_future<T> > const& workitems,
+            std::list<boost::exception_ptr>& errors)
+        {
+            for (hpx::shared_future<T> const& f: workitems)
+            {
+                if (f.has_exception())
+                    call(f.get_exception_ptr(), errors);
+            }
+
+            if (!errors.empty())
+                boost::throw_exception(exception_list(std::move(errors)));
+        }
+
         template <typename T, typename Cleanup>
         static void call(std::vector<hpx::future<T> >& workitems,
             std::list<boost::exception_ptr>& errors, Cleanup && cleanup)
@@ -108,6 +122,17 @@ namespace hpx { namespace parallel { namespace util { namespace detail
             std::list<boost::exception_ptr>&)
         {
             for (hpx::future<T> const& f: workitems)
+            {
+                if (f.has_exception())
+                    hpx::terminate();
+            }
+        }
+
+        template <typename T>
+        static void call(std::vector<hpx::shared_future<T> > const& workitems,
+            std::list<boost::exception_ptr>&)
+        {
+            for (hpx::shared_future<T> const& f: workitems)
             {
                 if (f.has_exception())
                     hpx::terminate();

--- a/hpx/parallel/util/partitioner.hpp
+++ b/hpx/parallel/util/partitioner.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2015 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -12,11 +12,12 @@
 #include <hpx/lcos/wait_all.hpp>
 #include <hpx/lcos/local/dataflow.hpp>
 #include <hpx/util/bind.hpp>
+#include <hpx/util/decay.hpp>
+
 #include <hpx/parallel/execution_policy.hpp>
 #include <hpx/parallel/util/detail/chunk_size.hpp>
 #include <hpx/parallel/util/detail/handle_local_exceptions.hpp>
 #include <hpx/parallel/traits/extract_partitioner.hpp>
-#include <hpx/util/decay.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace parallel { namespace util
@@ -84,46 +85,58 @@ namespace hpx { namespace parallel { namespace util
             }
 
             template <typename FwdIter, typename F1, typename F2, typename Data>
+                // requires is_container<Data>
             static R call_with_data(ExPolicy const& policy, FwdIter first,
-                std::size_t count, F1 && f1, F2 && f2, std::size_t chunk_size,
-                Data && data)
+                std::size_t count, F1 && f1, F2 && f2,
+                std::vector<std::size_t> const& chunk_sizes, Data && data)
             {
+                HPX_ASSERT(boost::size(data) >= chunk_sizes.size());
+
                 typename hpx::util::decay<Data>::type::const_iterator data_it =
                     boost::begin(data);
+                typename std::vector<std::size_t>::const_iterator chunk_size_it =
+                    boost::begin(chunk_sizes);
 
                 std::vector<hpx::future<Result> > workitems;
                 std::list<boost::exception_ptr> errors;
 
                 try {
-                    workitems.reserve(count / chunk_size + 1);
+                    workitems.reserve(chunk_sizes.size());
 
                     threads::executor exec = policy.get_executor();
-                    while (count > chunk_size)
+                    while (count > *chunk_size_it)
                     {
+                        std::size_t chunk = *chunk_size_it;
                         if (exec)
                         {
-                            workitems.push_back(hpx::async(exec, f1, *data_it,
-                                first, chunk_size));
-                            ++data_it;
+                            workitems.push_back(hpx::async(exec,
+                                f1, *data_it, first, chunk));
                         }
                         else
                         {
-                            workitems.push_back(hpx::async(hpx::launch::fork, f1,
-                                *data_it, first, chunk_size));
-                            ++data_it;
+                            workitems.push_back(hpx::async(hpx::launch::fork,
+                                f1, *data_it, first, chunk));
                         }
-                        count -= chunk_size;
-                        std::advance(first, chunk_size);
+
+                        count -= chunk;
+                        std::advance(first, chunk);
+
+                        ++data_it;
+                        ++chunk_size_it;
                     }
 
                     // execute last chunk directly
-                    if (count != 0)
+                    if (*chunk_size_it != 0)
                     {
                         workitems.push_back(hpx::async(hpx::launch::sync,
-                            std::forward<F1>(f1), *data_it++,
-                            first, count));
-                        std::advance(first, count);
+                            std::forward<F1>(f1), *data_it,
+                            first, *chunk_size_it));
+                        std::advance(first, *chunk_size_it);
                     }
+#if defined(HPX_DEBUG)
+                    ++chunk_size_it;
+                    HPX_ASSERT(chunk_size_it == chunk_sizes.end());
+#endif
                 }
                 catch (...) {
                     detail::handle_local_exceptions<ExPolicy>::call(
@@ -197,68 +210,6 @@ namespace hpx { namespace parallel { namespace util
         template <typename R, typename Result>
         struct static_partitioner<parallel_task_execution_policy, R, Result>
         {
-            template <typename FwdIter, typename F1, typename F2, typename Data>
-            static R call_with_data(
-                parallel_task_execution_policy const& policy, FwdIter first,
-                std::size_t count, F1 && f1, F2 && f2, std::size_t chunk_size,
-                Data && data)
-            {
-                typename hpx::util::decay<Data>::type::const_iterator data_it = boost::begin(data);
-
-                std::vector<hpx::future<Result> > workitems;
-                std::list<boost::exception_ptr> errors;
-
-                try {
-                    workitems.reserve(count / chunk_size + 1);
-
-                    threads::executor exec = policy.get_executor();
-                    while (count > chunk_size)
-                    {
-                        if (exec)
-                        {
-                            workitems.push_back(hpx::async(exec, f1, *data_it,
-                                first, chunk_size));
-                            ++data_it;
-                        }
-                        else
-                        {
-                            workitems.push_back(hpx::async(hpx::launch::fork, f1,
-                                *data_it, first, chunk_size));
-                            ++data_it;
-                        }
-                        count -= chunk_size;
-                        std::advance(first, chunk_size);
-                    }
-
-                    // execute last chunk directly
-                    if (count != 0)
-                    {
-                        workitems.push_back(hpx::async(hpx::launch::sync,
-                            std::forward<F1>(f1), *data_it++,
-                            first, count));
-                        std::advance(first, count);
-                    }
-                }
-                catch (std::bad_alloc const&) {
-                    return hpx::make_exceptional_future<R>(
-                        boost::current_exception());
-                }
-                catch (...) {
-                    errors.push_back(boost::current_exception());
-                }
-
-                // wait for all tasks to finish
-                return hpx::lcos::local::dataflow(
-                    [f2, errors](std::vector<hpx::future<Result> > && r) mutable -> R
-                    {
-                        detail::handle_local_exceptions<
-                                parallel_task_execution_policy
-                            >::call(r, errors);
-                        return f2(std::move(r));
-                    },
-                    std::move(workitems));
-            }
-
             template <typename FwdIter, typename F1, typename F2>
             static hpx::future<R> call(
                 parallel_task_execution_policy const& policy,
@@ -330,53 +281,50 @@ namespace hpx { namespace parallel { namespace util
 
             template <typename FwdIter, typename F1, typename F2,
                 typename Data>
+                // requires is_container<Data>
             static hpx::future<R> call_with_data(
                 parallel_task_execution_policy const& policy,
                 FwdIter first, std::size_t count, F1 && f1, F2 && f2,
-                std::size_t chunk_size, Data && data)
+                std::vector<std::size_t> const& chunk_sizes, Data && data)
             {
+                HPX_ASSERT(boost::size(data) >= chunk_sizes.size());
+
                 typename hpx::util::decay<Data>::type::const_iterator data_it =
                     boost::begin(data);
+                typename std::vector<std::size_t>::const_iterator chunk_size_it =
+                    boost::begin(chunk_sizes);
 
                 std::vector<hpx::future<Result> > workitems;
                 std::list<boost::exception_ptr> errors;
 
                 try {
                     // schedule every chunk on a separate thread
-                    workitems.reserve(count / chunk_size + 1);
+                    workitems.reserve(chunk_sizes.size());
 
                     threads::executor exec = policy.get_executor();
-                    while (count > chunk_size)
+                    while (chunk_size_it != chunk_sizes.end())
                     {
-                        if (exec)
+                        std::size_t chunk = *chunk_size_it;
+                        if (chunk != 0)
                         {
-                            workitems.push_back(hpx::async(exec, f1, *data_it++,
-                                first, chunk_size));
+                            if (exec)
+                            {
+                                workitems.push_back(hpx::async(exec,
+                                    f1, *data_it, first, chunk));
+                            }
+                            else
+                            {
+                                workitems.push_back(hpx::async(hpx::launch::fork,
+                                    f1, *data_it, first, chunk));
+                            }
+                            count -= chunk;
+                            std::advance(first, chunk);
                         }
-                        else
-                        {
-                            workitems.push_back(hpx::async(hpx::launch::fork,
-                                f1, *data_it++, first, chunk_size));
-                        }
-                        count -= chunk_size;
-                        std::advance(first, chunk_size);
+                        ++data_it;
+                        ++chunk_size_it;
                     }
 
-                    // add last chunk
-                    if (count != 0)
-                    {
-                        if (exec)
-                        {
-                            workitems.push_back(hpx::async(exec, f1,
-                                *data_it++, first, count));
-                        }
-                        else
-                        {
-                            workitems.push_back(hpx::async(hpx::launch::fork,
-                                f1, *data_it++, first, count));
-                        }
-                        std::advance(first, count);
-                    }
+                    HPX_ASSERT(count == 0);
                 }
                 catch (std::bad_alloc const&) {
                     return hpx::make_exceptional_future<R>(
@@ -486,32 +434,34 @@ namespace hpx { namespace parallel { namespace util
         {
             template <typename FwdIter, typename F1, typename F2>
             static R call(ExPolicy const& policy, FwdIter first,
-                std::size_t count, F1 && f1, F2 && f2)
+                std::size_t count, F1 && f1, F2 && f2,
+                std::size_t chunk_size = 0)
             {
                 return static_partitioner<ExPolicy, R, Result>::call(
                     policy, first, count,
-                    std::forward<F1>(f1), std::forward<F2>(f2), 0);
+                    std::forward<F1>(f1), std::forward<F2>(f2), chunk_size);
             }
 
             template <typename FwdIter, typename F1, typename F2,
                 typename Data>
             static R call_with_data(ExPolicy const& policy, FwdIter first,
-                std::size_t count, F1 && f1, F2 && f2, std::size_t chunk_size,
-                Data && data)
+                std::size_t count, F1 && f1, F2 && f2,
+                std::vector<std::size_t> const& chunk_sizes, Data && data)
             {
                 return static_partitioner<ExPolicy, R, Result>::call_with_data(
                     policy, first, count,
-                    std::forward<F1>(f1), std::forward<F2>(f2), chunk_size,
+                    std::forward<F1>(f1), std::forward<F2>(f2), chunk_sizes,
                     std::forward<Data>(data));
             }
 
             template <typename FwdIter, typename F1, typename F2>
             static R call_with_index(ExPolicy const& policy, FwdIter first,
-                std::size_t count, F1 && f1, F2 && f2)
+                std::size_t count, F1 && f1, F2 && f2,
+                std::size_t chunk_size = 0)
             {
                 return static_partitioner<ExPolicy, R, Result>::call_with_index(
                     policy, first, count,
-                    std::forward<F1>(f1), std::forward<F2>(f2), 0);
+                    std::forward<F1>(f1), std::forward<F2>(f2), chunk_size);
             }
         };
 
@@ -522,12 +472,13 @@ namespace hpx { namespace parallel { namespace util
             template <typename FwdIter, typename F1, typename F2>
             static hpx::future<R> call(
                 parallel_task_execution_policy const& policy,
-                FwdIter first, std::size_t count, F1 && f1, F2 && f2)
+                FwdIter first, std::size_t count, F1 && f1, F2 && f2,
+                std::size_t chunk_size = 0)
             {
                 return static_partitioner<
                         parallel_task_execution_policy, R, Result
                     >::call(policy, first, count,
-                        std::forward<F1>(f1), std::forward<F2>(f2), 0);
+                        std::forward<F1>(f1), std::forward<F2>(f2), chunk_size);
             }
 
             template <typename FwdIter, typename F1, typename F2,
@@ -535,24 +486,25 @@ namespace hpx { namespace parallel { namespace util
             static hpx::future<R> call_with_data(
                 parallel_task_execution_policy const& policy,
                 FwdIter first, std::size_t count, F1 && f1, F2 && f2,
-                std::size_t chunk_size, Data && data)
+                std::vector<std::size_t> const& chunk_sizes, Data && data)
             {
                 return static_partitioner<
                     parallel_task_execution_policy, R, Result
                 >::call_with_data(policy, first, count,
                     std::forward<F1>(f1), std::forward<F2>(f2),
-                    chunk_size, std::forward<Data>(data));
+                    chunk_sizes, std::forward<Data>(data));
             }
 
             template <typename FwdIter, typename F1, typename F2>
             static hpx::future<R> call_with_index(
                 parallel_task_execution_policy const& policy,
-                FwdIter first, std::size_t count, F1 && f1, F2 && f2)
+                FwdIter first, std::size_t count, F1 && f1, F2 && f2,
+                std::size_t chunk_size = 0)
             {
                 return static_partitioner<
                         parallel_task_execution_policy, R, Result
                     >::call_with_index(policy, first, count,
-                        std::forward<F1>(f1), std::forward<F2>(f2), 0);
+                        std::forward<F1>(f1), std::forward<F2>(f2), chunk_size);
             }
         };
 

--- a/hpx/parallel/util/scan_partitioner.hpp
+++ b/hpx/parallel/util/scan_partitioner.hpp
@@ -152,7 +152,7 @@ namespace hpx { namespace parallel { namespace util
                     threads::executor exec = policy.get_executor();
                     while (count != 0)
                     {
-                        std::size_t chunk = (std::min)(count, chunk_size);
+                        std::size_t chunk = (std::min)(chunk_size, count);
                         if (exec)
                         {
                             workitems.push_back(

--- a/hpx/parallel/util/scan_partitioner.hpp
+++ b/hpx/parallel/util/scan_partitioner.hpp
@@ -1,0 +1,269 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_UTIL_SCAN_PARTITIONER_DEC_30_2014_0227PM)
+#define HPX_PARALLEL_UTIL_SCAN_PARTITIONER_DEC_30_2014_0227PM
+
+#include <hpx/hpx_fwd.hpp>
+#include <hpx/async.hpp>
+#include <hpx/exception_list.hpp>
+#include <hpx/lcos/wait_all.hpp>
+#include <hpx/lcos/local/dataflow.hpp>
+#include <hpx/util/bind.hpp>
+#include <hpx/util/decay.hpp>
+
+#include <hpx/parallel/execution_policy.hpp>
+#include <hpx/parallel/util/detail/chunk_size.hpp>
+#include <hpx/parallel/util/detail/handle_local_exceptions.hpp>
+#include <hpx/parallel/traits/extract_partitioner.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace parallel { namespace util
+{
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        ///////////////////////////////////////////////////////////////////////
+        // The static partitioner simply spawns one chunk of iterations for
+        // each available core.
+        template <typename ExPolicy, typename R, typename Result = void>
+        struct static_scan_partitioner
+        {
+            template <typename FwdIter, typename T,
+                typename F1, typename F2, typename F3>
+            static R call(ExPolicy const& policy, FwdIter first,
+                std::size_t count_, T && init, F1 && f1, F2 && f2, F3 && f3,
+                std::size_t chunk_size)
+            {
+                std::vector<hpx::shared_future<Result> > workitems;
+                std::vector<std::size_t> chunk_sizes;
+
+                std::list<boost::exception_ptr> errors;
+
+                try {
+                    // pre-initialize first intermediate result
+                    workitems.push_back(make_ready_future(std::forward<T>(init)));
+
+                    // estimate a chunk size based on number of cores used
+                    std::size_t count = count_;
+                    chunk_size = get_static_chunk_size(policy, workitems, f1,
+                        first, count, chunk_size);
+
+                    HPX_ASSERT(workitems.size() == 2);
+
+                    // schedule every chunk on a separate thread
+                    workitems.reserve(count_ / chunk_size + 2);
+                    chunk_sizes.reserve(workitems.capacity());
+
+                    chunk_sizes.push_back(count_ - count);
+
+                    // pre-initialize second intermediate result
+                    workitems[1] = lcos::local::dataflow(hpx::launch::sync,
+                        f2, workitems[0], workitems[1]);
+
+                    // Schedule first step of scan algorithm, step 2 is
+                    // performed as soon as the current partition and the
+                    // partition to the left is ready.
+                    threads::executor exec = policy.get_executor();
+                    while (count != 0)
+                    {
+                        std::size_t chunk = (std::min)(chunk_size, count);
+                        if (exec)
+                        {
+                            workitems.push_back(
+                                lcos::local::dataflow(
+                                    hpx::launch::sync, f2,
+                                    workitems.back(),
+                                    hpx::async(exec, f1, first, chunk)
+                                ));
+                        }
+                        else
+                        {
+                            workitems.push_back(
+                                lcos::local::dataflow(
+                                    hpx::launch::sync, f2,
+                                    workitems.back(),
+                                    hpx::async(hpx::launch::fork,
+                                        f1, first, chunk)
+                                ));
+                        }
+
+                        chunk_sizes.push_back(chunk);
+                        count -= chunk;
+                        std::advance(first, chunk);
+                    }
+                }
+                catch (...) {
+                    detail::handle_local_exceptions<ExPolicy>::call(
+                        boost::current_exception(), errors);
+                }
+
+                // wait for all tasks to finish
+                hpx::wait_all(workitems);
+                detail::handle_local_exceptions<
+                    ExPolicy>::call(workitems, errors);
+
+                // Execute step 3 of the scan algorithm
+                return f3(std::move(workitems), chunk_sizes);
+            }
+        };
+
+        template <typename R, typename Result>
+        struct static_scan_partitioner<parallel_task_execution_policy, R, Result>
+        {
+            template <typename FwdIter, typename T,
+                typename F1, typename F2, typename F3>
+            static hpx::future<R> call(
+                parallel_task_execution_policy const& policy,
+                FwdIter first, std::size_t count_, T && init,
+                F1 && f1, F2 && f2, F3 && f3, std::size_t chunk_size)
+            {
+                std::vector<hpx::shared_future<Result> > workitems;
+                std::vector<std::size_t> chunk_sizes;
+
+                std::list<boost::exception_ptr> errors;
+
+                try {
+                    // pre-initialize first intermediate result
+                    workitems.push_back(make_ready_future(std::forward<T>(init)));
+
+                    // estimate a chunk size based on number of cores used
+                    std::size_t count = count_;
+                    chunk_size = get_static_chunk_size(policy, workitems, f1,
+                        first, count, chunk_size);
+
+                    HPX_ASSERT(workitems.size() == 2);
+
+                    // schedule every chunk on a separate thread
+                    workitems.reserve(count_ / chunk_size + 2);
+                    chunk_sizes.reserve(workitems.capacity());
+
+                    chunk_sizes.push_back(count_ - count);
+
+                    // pre-initialize second intermediate result
+                    workitems[1] = lcos::local::dataflow(hpx::launch::sync,
+                        f2, workitems[0], workitems[1]);
+
+                    // Schedule first step of scan algorithm, step 2 is
+                    // performed as soon as the current partition and the
+                    // partition to the left is ready.
+                    threads::executor exec = policy.get_executor();
+                    while (count != 0)
+                    {
+                        std::size_t chunk = (std::min)(count, chunk_size);
+                        if (exec)
+                        {
+                            workitems.push_back(
+                                lcos::local::dataflow(
+                                    hpx::launch::sync, f2,
+                                    workitems.back(),
+                                    hpx::async(exec, f1, first, chunk)
+                                ));
+                        }
+                        else
+                        {
+                            workitems.push_back(
+                                lcos::local::dataflow(
+                                    hpx::launch::sync, f2,
+                                    workitems.back(),
+                                    hpx::async(hpx::launch::fork,
+                                        f1, first, chunk)
+                                ));
+                        }
+
+                        chunk_sizes.push_back(chunk);
+                        count -= chunk;
+                        std::advance(first, chunk);
+                    }
+                }
+                catch (std::bad_alloc const&) {
+                    return hpx::make_exceptional_future<R>(
+                        boost::current_exception());
+                }
+                catch (...) {
+                    errors.push_back(boost::current_exception());
+                }
+
+                // wait for all tasks to finish
+                return lcos::local::dataflow(
+                    [=](std::vector<hpx::shared_future<Result> >&& r) mutable
+                    {
+                        detail::handle_local_exceptions<
+                                parallel_task_execution_policy
+                            >::call(r, errors);
+
+                        // Execute step 3 of the scan algorithm
+                        return f3(std::move(r), chunk_sizes);
+                    },
+                    std::move(workitems));
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        // ExPolicy: execution policy
+        // R:        overall result type
+        // Result:   intermediate result type of first step
+        // PartTag:  select appropriate partitioner
+        template <typename ExPolicy, typename R, typename Result, typename PartTag>
+        struct scan_partitioner;
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename ExPolicy, typename R, typename Result>
+        struct scan_partitioner<ExPolicy, R, Result,
+            parallel::traits::static_partitioner_tag>
+        {
+            template <typename FwdIter, typename T,
+                typename F1, typename F2, typename F3>
+            static R call(ExPolicy const& policy, FwdIter first,
+                std::size_t count, T && init, F1 && f1, F2 && f2, F3 && f3,
+                std::size_t chunk_size = 0)
+            {
+                return static_scan_partitioner<ExPolicy, R, Result>::call(
+                    policy, first, count, std::forward<T>(init),
+                    std::forward<F1>(f1), std::forward<F2>(f2),
+                    std::forward<F3>(f3), chunk_size);
+            }
+        };
+
+        template <typename R, typename Result>
+        struct scan_partitioner<parallel_task_execution_policy, R, Result,
+            parallel::traits::static_partitioner_tag>
+        {
+            template <typename FwdIter, typename T,
+                typename F1, typename F2, typename F3>
+            static hpx::future<R> call(
+                parallel_task_execution_policy const& policy, FwdIter first,
+                std::size_t count, T && init, F1 && f1, F2 && f2, F3 && f3,
+                std::size_t chunk_size = 0)
+            {
+                return static_scan_partitioner<
+                        parallel_task_execution_policy, R, Result
+                    >::call(policy, first, count, std::forward<T>(init),
+                        std::forward<F1>(f1), std::forward<F2>(f2),
+                        std::forward<F3>(f3), chunk_size);
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename ExPolicy, typename R, typename Result>
+        struct scan_partitioner<ExPolicy, R, Result,
+                parallel::traits::default_partitioner_tag>
+          : scan_partitioner<ExPolicy, R, Result,
+                parallel::traits::static_partitioner_tag>
+        {};
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename ExPolicy, typename R = void, typename Result = R,
+        typename PartTag = typename parallel::traits::extract_partitioner<
+            typename hpx::util::decay<ExPolicy>::type
+        >::type>
+    struct scan_partitioner
+      : detail::scan_partitioner<
+            typename hpx::util::decay<ExPolicy>::type, R, Result, PartTag>
+    {};
+}}}
+
+#endif

--- a/tests/unit/parallel/CMakeLists.txt
+++ b/tests/unit/parallel/CMakeLists.txt
@@ -51,6 +51,7 @@ set(tests
     task_region
     transform
     transform_binary
+    transform_exclusive_scan
     transform_reduce
     uninitialized_copy
     uninitialized_copyn

--- a/tests/unit/parallel/CMakeLists.txt
+++ b/tests/unit/parallel/CMakeLists.txt
@@ -15,6 +15,7 @@ set(tests
     countif
     equal
     equal_binary
+    exclusive_scan
     fill
     filln
     find

--- a/tests/unit/parallel/CMakeLists.txt
+++ b/tests/unit/parallel/CMakeLists.txt
@@ -52,6 +52,7 @@ set(tests
     transform
     transform_binary
     transform_exclusive_scan
+    transform_inclusive_scan
     transform_reduce
     uninitialized_copy
     uninitialized_copyn

--- a/tests/unit/parallel/CMakeLists.txt
+++ b/tests/unit/parallel/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 Hartmut Kaiser
+# Copyright (c) 2014-2015 Hartmut Kaiser
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -28,6 +28,7 @@ set(tests
     foreachn
     generate
     generaten
+    inclusive_scan
     max_element
     min_element
     minmax_element

--- a/tests/unit/parallel/exclusive_scan.cpp
+++ b/tests/unit/parallel/exclusive_scan.cpp
@@ -1,0 +1,425 @@
+//  Copyright (c) 2014-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/include/parallel_scan.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include "test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_exclusive_scan1(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    auto op =
+        [val](std::size_t v1, std::size_t v2) {
+            return v1 + v2;
+        };
+
+    hpx::parallel::exclusive_scan(policy,
+        iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d),
+        val, op);
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::detail::sequential_exclusive_scan(
+        boost::begin(c), boost::end(c), boost::begin(e), val, op);
+
+    HPX_TEST(std::equal(boost::begin(d), boost::end(d), boost::begin(e)));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_exclusive_scan1_async(ExPolicy const& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    auto op =
+        [val](std::size_t v1, std::size_t v2) {
+            return v1 + v2;
+        };
+
+    hpx::future<void> f =
+        hpx::parallel::exclusive_scan(p,
+            iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d),
+            val, op);
+    f.wait();
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::detail::sequential_exclusive_scan(
+        boost::begin(c), boost::end(c), boost::begin(e), val, op);
+
+    HPX_TEST(std::equal(boost::begin(d), boost::end(d), boost::begin(e)));
+}
+
+template <typename IteratorTag>
+void test_exclusive_scan1()
+{
+    using namespace hpx::parallel;
+
+    test_exclusive_scan1(seq, IteratorTag());
+    test_exclusive_scan1(par, IteratorTag());
+    test_exclusive_scan1(par_vec, IteratorTag());
+
+    test_exclusive_scan1_async(seq(task), IteratorTag());
+    test_exclusive_scan1_async(par(task), IteratorTag());
+
+    test_exclusive_scan1(execution_policy(seq), IteratorTag());
+    test_exclusive_scan1(execution_policy(par), IteratorTag());
+    test_exclusive_scan1(execution_policy(par_vec), IteratorTag());
+
+    test_exclusive_scan1(execution_policy(seq(task)), IteratorTag());
+    test_exclusive_scan1(execution_policy(par(task)), IteratorTag());
+}
+
+void exclusive_scan_test1()
+{
+    test_exclusive_scan1<std::random_access_iterator_tag>();
+    test_exclusive_scan1<std::forward_iterator_tag>();
+    test_exclusive_scan1<std::input_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_exclusive_scan2(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    hpx::parallel::exclusive_scan(policy,
+        iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d),
+        val);
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::detail::sequential_exclusive_scan(
+        boost::begin(c), boost::end(c), boost::begin(e), val,
+        std::plus<std::size_t>());
+
+    HPX_TEST(std::equal(boost::begin(d), boost::end(d), boost::begin(e)));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_exclusive_scan2_async(ExPolicy const& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    hpx::future<void> f =
+        hpx::parallel::exclusive_scan(p,
+            iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d),
+            val);
+    f.wait();
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::detail::sequential_exclusive_scan(
+        boost::begin(c), boost::end(c), boost::begin(e), val,
+        std::plus<std::size_t>());
+
+    HPX_TEST(std::equal(boost::begin(d), boost::end(d), boost::begin(e)));
+}
+
+template <typename IteratorTag>
+void test_exclusive_scan2()
+{
+    using namespace hpx::parallel;
+
+    test_exclusive_scan2(seq, IteratorTag());
+    test_exclusive_scan2(par, IteratorTag());
+    test_exclusive_scan2(par_vec, IteratorTag());
+
+    test_exclusive_scan2_async(seq(task), IteratorTag());
+    test_exclusive_scan2_async(par(task), IteratorTag());
+
+    test_exclusive_scan2(execution_policy(seq), IteratorTag());
+    test_exclusive_scan2(execution_policy(par), IteratorTag());
+    test_exclusive_scan2(execution_policy(par_vec), IteratorTag());
+
+    test_exclusive_scan2(execution_policy(seq(task)), IteratorTag());
+    test_exclusive_scan2(execution_policy(par(task)), IteratorTag());
+}
+
+void exclusive_scan_test2()
+{
+    test_exclusive_scan2<std::random_access_iterator_tag>();
+    test_exclusive_scan2<std::forward_iterator_tag>();
+    test_exclusive_scan2<std::input_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_exclusive_scan_exception(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    bool caught_exception = false;
+    try {
+        hpx::parallel::exclusive_scan(policy,
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            boost::begin(d), std::size_t(0),
+            [](std::size_t v1, std::size_t v2)
+            {
+                return throw std::runtime_error("test"), v1 + v2;
+            });
+
+        HPX_TEST(false);
+    }
+    catch(hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_exclusive_scan_exception_async(ExPolicy const& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try {
+        hpx::future<void> f =
+            hpx::parallel::exclusive_scan(p,
+                iterator(boost::begin(c)), iterator(boost::end(c)),
+                boost::begin(d), std::size_t(0),
+                [](std::size_t v1, std::size_t v2)
+                {
+                    return throw std::runtime_error("test"), v1 + v2;
+                });
+
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(p, e);
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+template <typename IteratorTag>
+void test_exclusive_scan_exception()
+{
+    using namespace hpx::parallel;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_exclusive_scan_exception(seq, IteratorTag());
+    test_exclusive_scan_exception(par, IteratorTag());
+
+    test_exclusive_scan_exception_async(seq(task), IteratorTag());
+    test_exclusive_scan_exception_async(par(task), IteratorTag());
+
+    test_exclusive_scan_exception(execution_policy(seq), IteratorTag());
+    test_exclusive_scan_exception(execution_policy(par), IteratorTag());
+
+    test_exclusive_scan_exception(execution_policy(seq(task)), IteratorTag());
+    test_exclusive_scan_exception(execution_policy(par(task)), IteratorTag());
+}
+
+void exclusive_scan_exception_test()
+{
+    test_exclusive_scan_exception<std::random_access_iterator_tag>();
+    test_exclusive_scan_exception<std::forward_iterator_tag>();
+    test_exclusive_scan_exception<std::input_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_exclusive_scan_bad_alloc(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    bool caught_exception = false;
+    try {
+        hpx::parallel::exclusive_scan(policy,
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            boost::begin(d), std::size_t(0),
+            [](std::size_t v1, std::size_t v2)
+            {
+                return throw std::bad_alloc(), v1 + v2;
+            });
+
+        HPX_TEST(false);
+    }
+    catch(std::bad_alloc const&) {
+        caught_exception = true;
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_exclusive_scan_bad_alloc_async(ExPolicy const& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try {
+        hpx::future<void> f =
+            hpx::parallel::exclusive_scan(p,
+                iterator(boost::begin(c)), iterator(boost::end(c)),
+                boost::begin(d), std::size_t(0),
+                [](std::size_t v1, std::size_t v2)
+                {
+                    return throw std::bad_alloc(), v1 + v2;
+                });
+
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(std::bad_alloc const&) {
+        caught_exception = true;
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+template <typename IteratorTag>
+void test_exclusive_scan_bad_alloc()
+{
+    using namespace hpx::parallel;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_exclusive_scan_bad_alloc(seq, IteratorTag());
+    test_exclusive_scan_bad_alloc(par, IteratorTag());
+
+    test_exclusive_scan_bad_alloc_async(seq(task), IteratorTag());
+    test_exclusive_scan_bad_alloc_async(par(task), IteratorTag());
+
+    test_exclusive_scan_bad_alloc(execution_policy(seq), IteratorTag());
+    test_exclusive_scan_bad_alloc(execution_policy(par), IteratorTag());
+
+    test_exclusive_scan_bad_alloc(execution_policy(seq(task)), IteratorTag());
+    test_exclusive_scan_bad_alloc(execution_policy(par(task)), IteratorTag());
+}
+
+void exclusive_scan_bad_alloc_test()
+{
+    test_exclusive_scan_bad_alloc<std::random_access_iterator_tag>();
+    test_exclusive_scan_bad_alloc<std::forward_iterator_tag>();
+    test_exclusive_scan_bad_alloc<std::input_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int)std::time(0);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    exclusive_scan_test1();
+    exclusive_scan_test2();
+
+    exclusive_scan_exception_test();
+    exclusive_scan_bad_alloc_test();
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace boost::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()
+        ("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run")
+        ;
+    // By default this test should run on all available cores
+    std::vector<std::string> cfg;
+    cfg.push_back("hpx.os_threads=" +
+        boost::lexical_cast<std::string>(hpx::threads::hardware_concurrency()));
+
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/parallel/inclusive_scan.cpp
+++ b/tests/unit/parallel/inclusive_scan.cpp
@@ -1,0 +1,504 @@
+//  Copyright (c) 2014-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/include/parallel_scan.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include "test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_inclusive_scan1(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    auto op =
+        [val](std::size_t v1, std::size_t v2) {
+            return v1 + v2;
+        };
+
+    hpx::parallel::inclusive_scan(policy,
+        iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d),
+        val, op);
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::detail::sequential_inclusive_scan(
+        boost::begin(c), boost::end(c), boost::begin(e), val, op);
+
+    HPX_TEST(std::equal(boost::begin(d), boost::end(d), boost::begin(e)));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_inclusive_scan1_async(ExPolicy const& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    auto op =
+        [val](std::size_t v1, std::size_t v2) {
+            return v1 + v2;
+        };
+
+    hpx::future<void> f =
+        hpx::parallel::inclusive_scan(p,
+            iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d),
+            val, op);
+    f.wait();
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::detail::sequential_inclusive_scan(
+        boost::begin(c), boost::end(c), boost::begin(e), val, op);
+
+    HPX_TEST(std::equal(boost::begin(d), boost::end(d), boost::begin(e)));
+}
+
+template <typename IteratorTag>
+void test_inclusive_scan1()
+{
+    using namespace hpx::parallel;
+
+    test_inclusive_scan1(seq, IteratorTag());
+    test_inclusive_scan1(par, IteratorTag());
+    test_inclusive_scan1(par_vec, IteratorTag());
+
+    test_inclusive_scan1_async(seq(task), IteratorTag());
+    test_inclusive_scan1_async(par(task), IteratorTag());
+
+    test_inclusive_scan1(execution_policy(seq), IteratorTag());
+    test_inclusive_scan1(execution_policy(par), IteratorTag());
+    test_inclusive_scan1(execution_policy(par_vec), IteratorTag());
+
+    test_inclusive_scan1(execution_policy(seq(task)), IteratorTag());
+    test_inclusive_scan1(execution_policy(par(task)), IteratorTag());
+}
+
+void inclusive_scan_test1()
+{
+    test_inclusive_scan1<std::random_access_iterator_tag>();
+    test_inclusive_scan1<std::forward_iterator_tag>();
+    test_inclusive_scan1<std::input_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_inclusive_scan2(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    hpx::parallel::inclusive_scan(policy,
+        iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d),
+        val);
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::detail::sequential_inclusive_scan(
+        boost::begin(c), boost::end(c), boost::begin(e), val,
+        std::plus<std::size_t>());
+
+    HPX_TEST(std::equal(boost::begin(d), boost::end(d), boost::begin(e)));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_inclusive_scan2_async(ExPolicy const& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    hpx::future<void> f =
+        hpx::parallel::inclusive_scan(p,
+            iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d),
+            val);
+    f.wait();
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::detail::sequential_inclusive_scan(
+        boost::begin(c), boost::end(c), boost::begin(e), val,
+        std::plus<std::size_t>());
+
+    HPX_TEST(std::equal(boost::begin(d), boost::end(d), boost::begin(e)));
+}
+
+template <typename IteratorTag>
+void test_inclusive_scan2()
+{
+    using namespace hpx::parallel;
+
+    test_inclusive_scan2(seq, IteratorTag());
+    test_inclusive_scan2(par, IteratorTag());
+    test_inclusive_scan2(par_vec, IteratorTag());
+
+    test_inclusive_scan2_async(seq(task), IteratorTag());
+    test_inclusive_scan2_async(par(task), IteratorTag());
+
+    test_inclusive_scan2(execution_policy(seq), IteratorTag());
+    test_inclusive_scan2(execution_policy(par), IteratorTag());
+    test_inclusive_scan2(execution_policy(par_vec), IteratorTag());
+
+    test_inclusive_scan2(execution_policy(seq(task)), IteratorTag());
+    test_inclusive_scan2(execution_policy(par(task)), IteratorTag());
+}
+
+void inclusive_scan_test2()
+{
+    test_inclusive_scan2<std::random_access_iterator_tag>();
+    test_inclusive_scan2<std::forward_iterator_tag>();
+    test_inclusive_scan2<std::input_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_inclusive_scan3(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    hpx::parallel::inclusive_scan(policy,
+        iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d));
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::detail::sequential_inclusive_scan(
+        boost::begin(c), boost::end(c), boost::begin(e), std::size_t(),
+        std::plus<std::size_t>());
+
+    HPX_TEST(std::equal(boost::begin(d), boost::end(d), boost::begin(e)));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_inclusive_scan3_async(ExPolicy const& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    hpx::future<void> f =
+        hpx::parallel::inclusive_scan(p,
+            iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d));
+    f.wait();
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::detail::sequential_inclusive_scan(
+        boost::begin(c), boost::end(c), boost::begin(e), std::size_t(),
+        std::plus<std::size_t>());
+
+    HPX_TEST(std::equal(boost::begin(d), boost::end(d), boost::begin(e)));
+}
+
+template <typename IteratorTag>
+void test_inclusive_scan3()
+{
+    using namespace hpx::parallel;
+
+    test_inclusive_scan3(seq, IteratorTag());
+    test_inclusive_scan3(par, IteratorTag());
+    test_inclusive_scan3(par_vec, IteratorTag());
+
+    test_inclusive_scan3_async(seq(task), IteratorTag());
+    test_inclusive_scan3_async(par(task), IteratorTag());
+
+    test_inclusive_scan3(execution_policy(seq), IteratorTag());
+    test_inclusive_scan3(execution_policy(par), IteratorTag());
+    test_inclusive_scan3(execution_policy(par_vec), IteratorTag());
+
+    test_inclusive_scan3(execution_policy(seq(task)), IteratorTag());
+    test_inclusive_scan3(execution_policy(par(task)), IteratorTag());
+}
+
+void inclusive_scan_test3()
+{
+    test_inclusive_scan3<std::random_access_iterator_tag>();
+    test_inclusive_scan3<std::forward_iterator_tag>();
+    test_inclusive_scan3<std::input_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_inclusive_scan_exception(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    bool caught_exception = false;
+    try {
+        hpx::parallel::inclusive_scan(policy,
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            boost::begin(d), std::size_t(0),
+            [](std::size_t v1, std::size_t v2)
+            {
+                return throw std::runtime_error("test"), v1 + v2;
+            });
+
+        HPX_TEST(false);
+    }
+    catch(hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_inclusive_scan_exception_async(ExPolicy const& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try {
+        hpx::future<void> f =
+            hpx::parallel::inclusive_scan(p,
+                iterator(boost::begin(c)), iterator(boost::end(c)),
+                boost::begin(d), std::size_t(0),
+                [](std::size_t v1, std::size_t v2)
+                {
+                    return throw std::runtime_error("test"), v1 + v2;
+                });
+
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(p, e);
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+template <typename IteratorTag>
+void test_inclusive_scan_exception()
+{
+    using namespace hpx::parallel;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_inclusive_scan_exception(seq, IteratorTag());
+    test_inclusive_scan_exception(par, IteratorTag());
+
+    test_inclusive_scan_exception_async(seq(task), IteratorTag());
+    test_inclusive_scan_exception_async(par(task), IteratorTag());
+
+    test_inclusive_scan_exception(execution_policy(seq), IteratorTag());
+    test_inclusive_scan_exception(execution_policy(par), IteratorTag());
+
+    test_inclusive_scan_exception(execution_policy(seq(task)), IteratorTag());
+    test_inclusive_scan_exception(execution_policy(par(task)), IteratorTag());
+}
+
+void inclusive_scan_exception_test()
+{
+    test_inclusive_scan_exception<std::random_access_iterator_tag>();
+    test_inclusive_scan_exception<std::forward_iterator_tag>();
+    test_inclusive_scan_exception<std::input_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_inclusive_scan_bad_alloc(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    bool caught_exception = false;
+    try {
+        hpx::parallel::inclusive_scan(policy,
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            boost::begin(d), std::size_t(0),
+            [](std::size_t v1, std::size_t v2)
+            {
+                return throw std::bad_alloc(), v1 + v2;
+            });
+
+        HPX_TEST(false);
+    }
+    catch(std::bad_alloc const&) {
+        caught_exception = true;
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_inclusive_scan_bad_alloc_async(ExPolicy const& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try {
+        hpx::future<void> f =
+            hpx::parallel::inclusive_scan(p,
+                iterator(boost::begin(c)), iterator(boost::end(c)),
+                boost::begin(d), std::size_t(0),
+                [](std::size_t v1, std::size_t v2)
+                {
+                    return throw std::bad_alloc(), v1 + v2;
+                });
+
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(std::bad_alloc const&) {
+        caught_exception = true;
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+template <typename IteratorTag>
+void test_inclusive_scan_bad_alloc()
+{
+    using namespace hpx::parallel;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_inclusive_scan_bad_alloc(seq, IteratorTag());
+    test_inclusive_scan_bad_alloc(par, IteratorTag());
+
+    test_inclusive_scan_bad_alloc_async(seq(task), IteratorTag());
+    test_inclusive_scan_bad_alloc_async(par(task), IteratorTag());
+
+    test_inclusive_scan_bad_alloc(execution_policy(seq), IteratorTag());
+    test_inclusive_scan_bad_alloc(execution_policy(par), IteratorTag());
+
+    test_inclusive_scan_bad_alloc(execution_policy(seq(task)), IteratorTag());
+    test_inclusive_scan_bad_alloc(execution_policy(par(task)), IteratorTag());
+}
+
+void inclusive_scan_bad_alloc_test()
+{
+    test_inclusive_scan_bad_alloc<std::random_access_iterator_tag>();
+    test_inclusive_scan_bad_alloc<std::forward_iterator_tag>();
+    test_inclusive_scan_bad_alloc<std::input_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int)std::time(0);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    inclusive_scan_test1();
+    inclusive_scan_test2();
+    inclusive_scan_test3();
+
+    inclusive_scan_exception_test();
+    inclusive_scan_bad_alloc_test();
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace boost::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()
+        ("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run")
+        ;
+    // By default this test should run on all available cores
+    std::vector<std::string> cfg;
+    cfg.push_back("hpx.os_threads=" +
+        boost::lexical_cast<std::string>(hpx::threads::hardware_concurrency()));
+
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/parallel/transform_exclusive_scan.cpp
+++ b/tests/unit/parallel/transform_exclusive_scan.cpp
@@ -1,0 +1,348 @@
+//  Copyright (c) 2014-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/include/parallel_transform_scan.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include "test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_exclusive_scan(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    auto op = [val](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto conv = [](std::size_t val) { return 2*val; };
+
+    hpx::parallel::transform_exclusive_scan(policy,
+        iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d),
+        conv, val, op);
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::detail::sequential_transform_exclusive_scan(
+        boost::begin(c), boost::end(c), boost::begin(e), conv, val, op);
+
+    HPX_TEST(std::equal(boost::begin(d), boost::end(d), boost::begin(e)));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_exclusive_scan_async(ExPolicy const& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    auto op = [val](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto conv = [](std::size_t val) { return 2*val; };
+
+    hpx::future<void> f =
+        hpx::parallel::transform_exclusive_scan(p,
+            iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d),
+            conv, val, op);
+    f.wait();
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::detail::sequential_transform_exclusive_scan(
+        boost::begin(c), boost::end(c), boost::begin(e), conv, val, op);
+
+    HPX_TEST(std::equal(boost::begin(d), boost::end(d), boost::begin(e)));
+}
+
+template <typename IteratorTag>
+void test_transform_exclusive_scan()
+{
+    using namespace hpx::parallel;
+
+    test_transform_exclusive_scan(seq, IteratorTag());
+    test_transform_exclusive_scan(par, IteratorTag());
+    test_transform_exclusive_scan(par_vec, IteratorTag());
+
+    test_transform_exclusive_scan_async(seq(task), IteratorTag());
+    test_transform_exclusive_scan_async(par(task), IteratorTag());
+
+    test_transform_exclusive_scan(execution_policy(seq), IteratorTag());
+    test_transform_exclusive_scan(execution_policy(par), IteratorTag());
+    test_transform_exclusive_scan(execution_policy(par_vec), IteratorTag());
+
+    test_transform_exclusive_scan(execution_policy(seq(task)), IteratorTag());
+    test_transform_exclusive_scan(execution_policy(par(task)), IteratorTag());
+}
+
+void transform_exclusive_scan_test()
+{
+    test_transform_exclusive_scan<std::random_access_iterator_tag>();
+    test_transform_exclusive_scan<std::forward_iterator_tag>();
+    test_transform_exclusive_scan<std::input_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_exclusive_scan_exception(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    bool caught_exception = false;
+    try {
+        hpx::parallel::transform_exclusive_scan(policy,
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            boost::begin(d),
+            [](std::size_t val) { return val; },
+            std::size_t(0),
+            [](std::size_t v1, std::size_t v2)
+            {
+                return throw std::runtime_error("test"), v1 + v2;
+            });
+
+        HPX_TEST(false);
+    }
+    catch(hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_exclusive_scan_exception_async(ExPolicy const& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try {
+        hpx::future<void> f =
+            hpx::parallel::transform_exclusive_scan(p,
+                iterator(boost::begin(c)), iterator(boost::end(c)),
+                boost::begin(d),
+                [](std::size_t val) { return val; },
+                std::size_t(0),
+                [](std::size_t v1, std::size_t v2)
+                {
+                    return throw std::runtime_error("test"), v1 + v2;
+                });
+
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(p, e);
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+template <typename IteratorTag>
+void test_transform_exclusive_scan_exception()
+{
+    using namespace hpx::parallel;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_transform_exclusive_scan_exception(seq, IteratorTag());
+    test_transform_exclusive_scan_exception(par, IteratorTag());
+
+    test_transform_exclusive_scan_exception_async(seq(task), IteratorTag());
+    test_transform_exclusive_scan_exception_async(par(task), IteratorTag());
+
+    test_transform_exclusive_scan_exception(execution_policy(seq), IteratorTag());
+    test_transform_exclusive_scan_exception(execution_policy(par), IteratorTag());
+
+    test_transform_exclusive_scan_exception(execution_policy(seq(task)), IteratorTag());
+    test_transform_exclusive_scan_exception(execution_policy(par(task)), IteratorTag());
+}
+
+void transform_exclusive_scan_exception_test()
+{
+    test_transform_exclusive_scan_exception<std::random_access_iterator_tag>();
+    test_transform_exclusive_scan_exception<std::forward_iterator_tag>();
+    test_transform_exclusive_scan_exception<std::input_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_exclusive_scan_bad_alloc(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    bool caught_exception = false;
+    try {
+        hpx::parallel::transform_exclusive_scan(policy,
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            boost::begin(d),
+            [](std::size_t val) { return val; },
+            std::size_t(0),
+            [](std::size_t v1, std::size_t v2)
+            {
+                return throw std::bad_alloc(), v1 + v2;
+            });
+
+        HPX_TEST(false);
+    }
+    catch(std::bad_alloc const&) {
+        caught_exception = true;
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_exclusive_scan_bad_alloc_async(ExPolicy const& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try {
+        hpx::future<void> f =
+            hpx::parallel::transform_exclusive_scan(p,
+                iterator(boost::begin(c)), iterator(boost::end(c)),
+                boost::begin(d),
+                [](std::size_t val) { return val; },
+                std::size_t(0),
+                [](std::size_t v1, std::size_t v2)
+                {
+                    return throw std::bad_alloc(), v1 + v2;
+                });
+
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(std::bad_alloc const&) {
+        caught_exception = true;
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+template <typename IteratorTag>
+void test_transform_exclusive_scan_bad_alloc()
+{
+    using namespace hpx::parallel;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_transform_exclusive_scan_bad_alloc(seq, IteratorTag());
+    test_transform_exclusive_scan_bad_alloc(par, IteratorTag());
+
+    test_transform_exclusive_scan_bad_alloc_async(seq(task), IteratorTag());
+    test_transform_exclusive_scan_bad_alloc_async(par(task), IteratorTag());
+
+    test_transform_exclusive_scan_bad_alloc(execution_policy(seq), IteratorTag());
+    test_transform_exclusive_scan_bad_alloc(execution_policy(par), IteratorTag());
+
+    test_transform_exclusive_scan_bad_alloc(execution_policy(seq(task)), IteratorTag());
+    test_transform_exclusive_scan_bad_alloc(execution_policy(par(task)), IteratorTag());
+}
+
+void transform_exclusive_scan_bad_alloc_test()
+{
+    test_transform_exclusive_scan_bad_alloc<std::random_access_iterator_tag>();
+    test_transform_exclusive_scan_bad_alloc<std::forward_iterator_tag>();
+    test_transform_exclusive_scan_bad_alloc<std::input_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int)std::time(0);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    transform_exclusive_scan_test();
+
+    transform_exclusive_scan_exception_test();
+    transform_exclusive_scan_bad_alloc_test();
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace boost::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()
+        ("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run")
+        ;
+    // By default this test should run on all available cores
+    std::vector<std::string> cfg;
+    cfg.push_back("hpx.os_threads=" +
+        boost::lexical_cast<std::string>(hpx::threads::hardware_concurrency()));
+
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/parallel/transform_inclusive_scan.cpp
+++ b/tests/unit/parallel/transform_inclusive_scan.cpp
@@ -1,0 +1,433 @@
+//  Copyright (c) 2014-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/include/parallel_transform_scan.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include "test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_inclusive_scan1(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    auto op = [val](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto conv = [](std::size_t val) { return 2*val; };
+
+    hpx::parallel::transform_inclusive_scan(policy,
+        iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d),
+        conv, val, op);
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::detail::sequential_transform_inclusive_scan(
+        boost::begin(c), boost::end(c), boost::begin(e), conv, val, op);
+
+    HPX_TEST(std::equal(boost::begin(d), boost::end(d), boost::begin(e)));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_inclusive_scan1_async(ExPolicy const& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    auto op = [val](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto conv = [](std::size_t val) { return 2*val; };
+
+    hpx::future<void> f =
+        hpx::parallel::transform_inclusive_scan(p,
+            iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d),
+            conv, val, op);
+    f.wait();
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::detail::sequential_transform_inclusive_scan(
+        boost::begin(c), boost::end(c), boost::begin(e), conv, val, op);
+
+    HPX_TEST(std::equal(boost::begin(d), boost::end(d), boost::begin(e)));
+}
+
+template <typename IteratorTag>
+void test_transform_inclusive_scan1()
+{
+    using namespace hpx::parallel;
+
+    test_transform_inclusive_scan1(seq, IteratorTag());
+    test_transform_inclusive_scan1(par, IteratorTag());
+    test_transform_inclusive_scan1(par_vec, IteratorTag());
+
+    test_transform_inclusive_scan1_async(seq(task), IteratorTag());
+    test_transform_inclusive_scan1_async(par(task), IteratorTag());
+
+    test_transform_inclusive_scan1(execution_policy(seq), IteratorTag());
+    test_transform_inclusive_scan1(execution_policy(par), IteratorTag());
+    test_transform_inclusive_scan1(execution_policy(par_vec), IteratorTag());
+
+    test_transform_inclusive_scan1(execution_policy(seq(task)), IteratorTag());
+    test_transform_inclusive_scan1(execution_policy(par(task)), IteratorTag());
+}
+
+void transform_inclusive_scan_test1()
+{
+    test_transform_inclusive_scan1<std::random_access_iterator_tag>();
+    test_transform_inclusive_scan1<std::forward_iterator_tag>();
+    test_transform_inclusive_scan1<std::input_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_inclusive_scan2(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    auto op = [val](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto conv = [](std::size_t val) { return 2*val; };
+
+    hpx::parallel::transform_inclusive_scan(policy,
+        iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d),
+        conv, op);
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::detail::sequential_transform_inclusive_scan(
+        boost::begin(c), boost::end(c), boost::begin(e), conv, std::size_t(), op);
+
+    HPX_TEST(std::equal(boost::begin(d), boost::end(d), boost::begin(e)));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_inclusive_scan2_async(ExPolicy const& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    auto op = [val](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto conv = [](std::size_t val) { return 2*val; };
+
+    hpx::future<void> f =
+        hpx::parallel::transform_inclusive_scan(p,
+            iterator(boost::begin(c)), iterator(boost::end(c)), boost::begin(d),
+            conv, op);
+    f.wait();
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::detail::sequential_transform_inclusive_scan(
+        boost::begin(c), boost::end(c), boost::begin(e), conv, std::size_t(), op);
+
+    HPX_TEST(std::equal(boost::begin(d), boost::end(d), boost::begin(e)));
+}
+
+template <typename IteratorTag>
+void test_transform_inclusive_scan2()
+{
+    using namespace hpx::parallel;
+
+    test_transform_inclusive_scan2(seq, IteratorTag());
+    test_transform_inclusive_scan2(par, IteratorTag());
+    test_transform_inclusive_scan2(par_vec, IteratorTag());
+
+    test_transform_inclusive_scan2_async(seq(task), IteratorTag());
+    test_transform_inclusive_scan2_async(par(task), IteratorTag());
+
+    test_transform_inclusive_scan2(execution_policy(seq), IteratorTag());
+    test_transform_inclusive_scan2(execution_policy(par), IteratorTag());
+    test_transform_inclusive_scan2(execution_policy(par_vec), IteratorTag());
+
+    test_transform_inclusive_scan2(execution_policy(seq(task)), IteratorTag());
+    test_transform_inclusive_scan2(execution_policy(par(task)), IteratorTag());
+}
+
+void transform_inclusive_scan_test2()
+{
+    test_transform_inclusive_scan2<std::random_access_iterator_tag>();
+    test_transform_inclusive_scan2<std::forward_iterator_tag>();
+    test_transform_inclusive_scan2<std::input_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_inclusive_scan_exception(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    bool caught_exception = false;
+    try {
+        hpx::parallel::transform_inclusive_scan(policy,
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            boost::begin(d),
+            [](std::size_t val) { return val; },
+            std::size_t(0),
+            [](std::size_t v1, std::size_t v2)
+            {
+                return throw std::runtime_error("test"), v1 + v2;
+            });
+
+        HPX_TEST(false);
+    }
+    catch(hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_inclusive_scan_exception_async(ExPolicy const& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try {
+        hpx::future<void> f =
+            hpx::parallel::transform_inclusive_scan(p,
+                iterator(boost::begin(c)), iterator(boost::end(c)),
+                boost::begin(d),
+                [](std::size_t val) { return val; },
+                std::size_t(0),
+                [](std::size_t v1, std::size_t v2)
+                {
+                    return throw std::runtime_error("test"), v1 + v2;
+                });
+
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(p, e);
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+template <typename IteratorTag>
+void test_transform_inclusive_scan_exception()
+{
+    using namespace hpx::parallel;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_transform_inclusive_scan_exception(seq, IteratorTag());
+    test_transform_inclusive_scan_exception(par, IteratorTag());
+
+    test_transform_inclusive_scan_exception_async(seq(task), IteratorTag());
+    test_transform_inclusive_scan_exception_async(par(task), IteratorTag());
+
+    test_transform_inclusive_scan_exception(execution_policy(seq), IteratorTag());
+    test_transform_inclusive_scan_exception(execution_policy(par), IteratorTag());
+
+    test_transform_inclusive_scan_exception(execution_policy(seq(task)), IteratorTag());
+    test_transform_inclusive_scan_exception(execution_policy(par(task)), IteratorTag());
+}
+
+void transform_inclusive_scan_exception_test()
+{
+    test_transform_inclusive_scan_exception<std::random_access_iterator_tag>();
+    test_transform_inclusive_scan_exception<std::forward_iterator_tag>();
+    test_transform_inclusive_scan_exception<std::input_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_inclusive_scan_bad_alloc(ExPolicy const& policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    bool caught_exception = false;
+    try {
+        hpx::parallel::transform_inclusive_scan(policy,
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            boost::begin(d),
+            [](std::size_t val) { return val; },
+            std::size_t(0),
+            [](std::size_t v1, std::size_t v2)
+            {
+                return throw std::bad_alloc(), v1 + v2;
+            });
+
+        HPX_TEST(false);
+    }
+    catch(std::bad_alloc const&) {
+        caught_exception = true;
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_inclusive_scan_bad_alloc_async(ExPolicy const& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try {
+        hpx::future<void> f =
+            hpx::parallel::transform_inclusive_scan(p,
+                iterator(boost::begin(c)), iterator(boost::end(c)),
+                boost::begin(d),
+                [](std::size_t val) { return val; },
+                std::size_t(0),
+                [](std::size_t v1, std::size_t v2)
+                {
+                    return throw std::bad_alloc(), v1 + v2;
+                });
+
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(std::bad_alloc const&) {
+        caught_exception = true;
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+template <typename IteratorTag>
+void test_transform_inclusive_scan_bad_alloc()
+{
+    using namespace hpx::parallel;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_transform_inclusive_scan_bad_alloc(seq, IteratorTag());
+    test_transform_inclusive_scan_bad_alloc(par, IteratorTag());
+
+    test_transform_inclusive_scan_bad_alloc_async(seq(task), IteratorTag());
+    test_transform_inclusive_scan_bad_alloc_async(par(task), IteratorTag());
+
+    test_transform_inclusive_scan_bad_alloc(execution_policy(seq), IteratorTag());
+    test_transform_inclusive_scan_bad_alloc(execution_policy(par), IteratorTag());
+
+    test_transform_inclusive_scan_bad_alloc(execution_policy(seq(task)), IteratorTag());
+    test_transform_inclusive_scan_bad_alloc(execution_policy(par(task)), IteratorTag());
+}
+
+void transform_inclusive_scan_bad_alloc_test()
+{
+    test_transform_inclusive_scan_bad_alloc<std::random_access_iterator_tag>();
+    test_transform_inclusive_scan_bad_alloc<std::forward_iterator_tag>();
+    test_transform_inclusive_scan_bad_alloc<std::input_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int)std::time(0);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    transform_inclusive_scan_test1();
+    transform_inclusive_scan_test2();
+
+    transform_inclusive_scan_exception_test();
+    transform_inclusive_scan_bad_alloc_test();
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace boost::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()
+        ("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run")
+        ;
+    // By default this test should run on all available cores
+    std::vector<std::string> cfg;
+    cfg.push_back("hpx.os_threads=" +
+        boost::lexical_cast<std::string>(hpx::threads::hardware_concurrency()));
+
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Adding  `exclusive_scan` and `inclusive_scan` algorithm. This also adds `transform_exclusive_scan` and `transform_inclusive_scan`. Irt also changes the implementation of `parallel::dispatch` and `parallel::remote::dispatch` to use variadics.