### PR TITLE
Removing various distribution policies for hpx::vector

### DIFF
--- a/hpx/components/vector/distribution_policy.hpp
+++ b/hpx/components/vector/distribution_policy.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014 Bibek Ghimire
+//  Copyright (c) 2014-2015 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -18,39 +19,30 @@
 namespace hpx
 {
     ///////////////////////////////////////////////////////////////////////////
-    BOOST_SCOPED_ENUM_START(vector_distribution_policy)
-    {
-        block         = 0,      ///< block distribution policy
-        cyclic        = 1,      ///< cyclic distribution policy
-        block_cyclic  = 2       ///< block-cyclic distribution policy
-    };
-    BOOST_SCOPED_ENUM_END
-
-    ///////////////////////////////////////////////////////////////////////////
     // This class specifies the block chunking policy parameters to use for the
     // partitioning of the data in a hpx::vector
-    struct block_distribution_policy
+    struct distribution_policy
     {
     public:
-        block_distribution_policy()
+        distribution_policy()
           : num_partitions_(1)
         {}
 
-        block_distribution_policy operator()(std::size_t num_partitions) const
+        distribution_policy operator()(std::size_t num_partitions) const
         {
-            return block_distribution_policy(num_partitions, localities_);
+            return distribution_policy(num_partitions, localities_);
         }
 
-        block_distribution_policy operator()(
+        distribution_policy operator()(
             std::vector<id_type> const& localities) const
         {
-            return block_distribution_policy(num_partitions_, localities);
+            return distribution_policy(num_partitions_, localities);
         }
 
-        block_distribution_policy operator()(std::size_t num_partitions,
+        distribution_policy operator()(std::size_t num_partitions,
             std::vector<id_type> const& localities) const
         {
-            return block_distribution_policy(num_partitions, localities);
+            return distribution_policy(num_partitions, localities);
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -59,19 +51,9 @@ namespace hpx
             return localities_;
         }
 
-        std::size_t get_block_size() const
-        {
-            return std::size_t(-1);
-        }
-
         std::size_t get_num_partitions() const
         {
             return num_partitions_;
-        }
-
-        BOOST_SCOPED_ENUM(vector_distribution_policy) get_policy_type() const
-        {
-            return vector_distribution_policy::block;
         }
 
     private:
@@ -83,7 +65,7 @@ namespace hpx
             ar & localities_ & num_partitions_;
         }
 
-        block_distribution_policy(std::size_t num_partitions,
+        distribution_policy(std::size_t num_partitions,
              std::vector<id_type> const& localities)
           : localities_(localities),
             num_partitions_(num_partitions)
@@ -91,175 +73,10 @@ namespace hpx
 
     private:
         std::vector<id_type> localities_;   // localities to create chunks on
-        std::size_t num_partitions_;            // number of chunks to create
+        std::size_t num_partitions_;        // number of chunks to create
     };
 
-    static block_distribution_policy const block;
-
-    ///////////////////////////////////////////////////////////////////////////
-    // This class specifies the cyclic chunking policy parameters to use for
-    // the partitioning of the data in a hpx::vector
-    struct cyclic_distribution_policy
-    {
-    public:
-        cyclic_distribution_policy()
-          : num_partitions_(1)
-        {}
-
-        cyclic_distribution_policy operator()(std::size_t num_partitions) const
-        {
-            return cyclic_distribution_policy(num_partitions, localities_);
-        }
-
-        cyclic_distribution_policy operator()(
-            std::vector<id_type> const& localities) const
-        {
-            return cyclic_distribution_policy(num_partitions_, localities);
-        }
-
-        cyclic_distribution_policy operator()(std::size_t num_partitions,
-            std::vector<id_type> const& localities) const
-        {
-            return cyclic_distribution_policy(num_partitions, localities);
-        }
-
-        std::vector<id_type> const& get_localities() const
-        {
-            return localities_;
-        }
-
-        std::size_t get_block_size() const
-        {
-            return std::size_t(-1);
-        }
-
-        std::size_t get_num_partitions() const
-        {
-            return num_partitions_;
-        }
-
-        BOOST_SCOPED_ENUM(vector_distribution_policy) get_policy_type() const
-        {
-            return vector_distribution_policy::cyclic;
-        }
-
-    private:
-        friend class boost::serialization::access;
-
-        template<class Archive>
-        void serialize(Archive & ar, const unsigned int version)
-        {
-            ar & localities_ & num_partitions_;
-        }
-
-        cyclic_distribution_policy(std::size_t num_partitions,
-                std::vector<id_type> const& localities)
-          : localities_(localities),
-            num_partitions_(num_partitions)
-        {}
-
-    private:
-        std::vector<id_type> localities_;
-        std::size_t num_partitions_;
-    };
-
-    static cyclic_distribution_policy const cyclic;
-
-    ///////////////////////////////////////////////////////////////////////////
-    // This class specifies the block-cyclic chunking policy parameters to
-    // use for the partitioning of the data in a hpx::vector
-    struct block_cyclic_distribution_policy
-    {
-    public:
-        block_cyclic_distribution_policy()
-          : num_partitions_(1),
-            block_size_(std::size_t(-1))
-        {}
-
-        block_cyclic_distribution_policy operator()(std::size_t num_partitions) const
-        {
-            return block_cyclic_distribution_policy(
-                num_partitions, localities_, block_size_);
-        }
-
-        block_cyclic_distribution_policy operator()(std::size_t num_partitions,
-            std::vector<id_type> const& localities) const
-        {
-            return block_cyclic_distribution_policy(
-                num_partitions, localities, block_size_);
-        }
-
-        block_cyclic_distribution_policy operator()(std::size_t num_partitions,
-            std::vector<id_type> const& localities, std::size_t block_size) const
-        {
-            return block_cyclic_distribution_policy(
-                num_partitions, localities, block_size);
-        }
-
-        block_cyclic_distribution_policy operator()(
-            std::vector<id_type> const& localities, std::size_t block_size) const
-        {
-            return block_cyclic_distribution_policy(
-                num_partitions_, localities, block_size);
-        }
-
-        block_cyclic_distribution_policy operator()(
-            std::vector<id_type> const& localities) const
-        {
-            return block_cyclic_distribution_policy(
-                num_partitions_, localities, block_size_);
-        }
-
-        block_cyclic_distribution_policy operator()(std::size_t num_partitions,
-            std::size_t block_size) const
-        {
-            return block_cyclic_distribution_policy(
-                num_partitions, localities_, block_size);
-        }
-
-        std::vector<id_type> const& get_localities() const
-        {
-            return localities_;
-        }
-
-        std::size_t get_num_partitions() const
-        {
-            return num_partitions_;
-        }
-
-        BOOST_SCOPED_ENUM(vector_distribution_policy) get_policy_type() const
-        {
-            return vector_distribution_policy::block_cyclic;
-        }
-
-        std::size_t get_block_size() const
-        {
-            return block_size_;
-        }
-
-    private:
-        friend class boost::serialization::access;
-
-        template <typename Archive>
-        void serialize(Archive & ar, const unsigned int version)
-        {
-            ar & localities_ & num_partitions_ & block_size_;
-        }
-
-        block_cyclic_distribution_policy(std::size_t num_partitions,
-                std::vector<id_type> const& localities, std::size_t block_size)
-          : localities_(localities),
-            num_partitions_(num_partitions),
-            block_size_(block_size)
-        {}
-
-    private:
-        std::vector<id_type> localities_;   // localities to create chunks on
-        std::size_t num_partitions_;            // number of chunks to create
-        std::size_t block_size_;            // size of a cyclic block
-    };
-
-    static block_cyclic_distribution_policy const block_cyclic;
+    static distribution_policy const layout;
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail
@@ -271,17 +88,7 @@ namespace hpx
         {};
 
         template <>
-        struct is_vector_distribution_policy<block_distribution_policy>
-          : boost::mpl::true_
-        {};
-
-        template <>
-        struct is_vector_distribution_policy<cyclic_distribution_policy>
-          : boost::mpl::true_
-        {};
-
-        template <>
-        struct is_vector_distribution_policy<block_cyclic_distribution_policy>
+        struct is_vector_distribution_policy<distribution_policy>
           : boost::mpl::true_
         {};
         // \endcond

--- a/tests/performance/local/vector_foreach.cpp
+++ b/tests/performance/local/vector_foreach.cpp
@@ -95,23 +95,23 @@ int hpx_main(boost::program_options::variables_map& vm)
         }
 
         {
-            hpx::vector<int> v(vector_size, hpx::block(2));
+            hpx::vector<int> v(vector_size, hpx::layout(2));
 
-            hpx::cout << "hpx::vector<int>(seq, block(2)): "
+            hpx::cout << "hpx::vector<int>(seq, layout(2)): "
                 << foreach_vector(hpx::parallel::seq, v)/double(seq_ref)
                 << "\n";
-            hpx::cout << "hpx::vector<int>(par, block(2)): "
+            hpx::cout << "hpx::vector<int>(par, layout(2)): "
                 << foreach_vector(hpx::parallel::par(chunk_size), v)/double(par_ref) //-V106
                 << "\n";
         }
 
         {
-            hpx::vector<int> v(vector_size, hpx::block(10));
+            hpx::vector<int> v(vector_size, hpx::layout(10));
 
-            hpx::cout << "hpx::vector<int>(seq, block(10)): "
+            hpx::cout << "hpx::vector<int>(seq, layout(10)): "
                 << foreach_vector(hpx::parallel::seq, v)/double(seq_ref)
                 << "\n";
-            hpx::cout << "hpx::vector<int>(par, block(10)): "
+            hpx::cout << "hpx::vector<int>(par, layout(10)): "
                 << foreach_vector(hpx::parallel::par(chunk_size), v)/double(par_ref) //-V106
                 << "\n";
         }

--- a/tests/unit/components/vector.cpp
+++ b/tests/unit/components/vector.cpp
@@ -345,29 +345,11 @@ void trivial_tests()
 
     trivial_test_without_policy<T>(length, "test1");
 
-    trivial_test_with_policy<T>(length, 1, hpx::block, "test1");
-    trivial_test_with_policy<T>(length, 3, hpx::block(3), "test2");
-    trivial_test_with_policy<T>(length, 3, hpx::block(3, localities), "test3");
+    trivial_test_with_policy<T>(length, 1, hpx::layout, "test1");
+    trivial_test_with_policy<T>(length, 3, hpx::layout(3), "test2");
+    trivial_test_with_policy<T>(length, 3, hpx::layout(3, localities), "test3");
     trivial_test_with_policy<T>(length, localities.size(),
-        hpx::block(localities), "test4");
-
-    trivial_test_with_policy<T>(length, 1, hpx::cyclic, "test5");
-    trivial_test_with_policy<T>(length, 3, hpx::cyclic(3), "test6");
-    trivial_test_with_policy<T>(length, 3, hpx::cyclic(3, localities), "test7");
-    trivial_test_with_policy<T>(length, localities.size(),
-        hpx::cyclic(localities), "test8");
-
-    trivial_test_with_policy<T>(length, 1, hpx::block_cyclic, "test9");
-    trivial_test_with_policy<T>(length, 3, hpx::block_cyclic(3), "test10");
-    trivial_test_with_policy<T>(length, 3,
-        hpx::block_cyclic(3, localities), "test11");
-    trivial_test_with_policy<T>(length, localities.size(),
-        hpx::block_cyclic(localities), "test12");
-    trivial_test_with_policy<T>(length, 4, hpx::block_cyclic(4, 3), "test13"); //-V112
-    trivial_test_with_policy<T>(length, 4, //-V112
-        hpx::block_cyclic(4, localities, 3), "test14"); //-V112
-    trivial_test_with_policy<T>(length, localities.size(),
-        hpx::block_cyclic(localities, 3), "test15");
+        hpx::layout(localities), "test4");
 }
 
 int main()

--- a/tests/unit/components/vector_copy.cpp
+++ b/tests/unit/components/vector_copy.cpp
@@ -32,7 +32,6 @@ void compare_vectors(hpx::vector<T> const& v1, hpx::vector<T> const& v2,
     typedef typename hpx::vector<T>::const_iterator const_iterator;
 
     HPX_TEST_EQ(v1.size(), v2.size());
-    HPX_TEST(v1.get_policy() == v2.get_policy());
 
     const_iterator it1 = v1.begin(), it2 = v2.begin();
     const_iterator end1 = v1.end(), end2 = v2.end();
@@ -74,7 +73,6 @@ void copy_tests_with_policy(std::size_t size, std::size_t localities,
     hpx::vector<T> v1(size, policy);
 
     hpx::vector<T> v2(v1);
-    HPX_TEST(v2.get_policy() == policy.get_policy_type());
     compare_vectors(v1, v2);
 
     fill_vector(v2, T(43));
@@ -82,7 +80,6 @@ void copy_tests_with_policy(std::size_t size, std::size_t localities,
 
     hpx::vector<T> v3;
     v3 = v1;
-    HPX_TEST(v3.get_policy() == policy.get_policy_type());
     compare_vectors(v1, v3);
 
     fill_vector(v3, T(43));
@@ -111,29 +108,11 @@ void copy_tests()
         copy_tests(v);
     }
 
-    copy_tests_with_policy<T>(length, 1, hpx::block);
-    copy_tests_with_policy<T>(length, 3, hpx::block(3));
-    copy_tests_with_policy<T>(length, 3, hpx::block(3, localities));
+    copy_tests_with_policy<T>(length, 1, hpx::layout);
+    copy_tests_with_policy<T>(length, 3, hpx::layout(3));
+    copy_tests_with_policy<T>(length, 3, hpx::layout(3, localities));
     copy_tests_with_policy<T>(length, localities.size(),
-        hpx::block(localities));
-
-    copy_tests_with_policy<T>(length, 1, hpx::cyclic);
-    copy_tests_with_policy<T>(length, 3, hpx::cyclic(3));
-    copy_tests_with_policy<T>(length, 3, hpx::cyclic(3, localities));
-    copy_tests_with_policy<T>(length, localities.size(),
-        hpx::cyclic(localities));
-
-    copy_tests_with_policy<T>(length, 1, hpx::block_cyclic);
-    copy_tests_with_policy<T>(length, 3, hpx::block_cyclic(3));
-    copy_tests_with_policy<T>(length, 3,
-        hpx::block_cyclic(3, localities));
-    copy_tests_with_policy<T>(length, localities.size(),
-        hpx::block_cyclic(localities));
-    copy_tests_with_policy<T>(length, 4, hpx::block_cyclic(4, 3)); //-V112
-    copy_tests_with_policy<T>(length, 4, //-V112
-        hpx::block_cyclic(4, localities, 3)); //-V112
-    copy_tests_with_policy<T>(length, localities.size(),
-        hpx::block_cyclic(localities, 3));
+        hpx::layout(localities));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/components/vector_handle_values.cpp
+++ b/tests/unit/components/vector_handle_values.cpp
@@ -140,29 +140,11 @@ void handle_values_tests()
         handle_values_tests(v);
     }
 
-    handle_values_tests_with_policy<T>(length, 1, hpx::block);
-    handle_values_tests_with_policy<T>(length, 3, hpx::block(3));
-    handle_values_tests_with_policy<T>(length, 3, hpx::block(3, localities));
+    handle_values_tests_with_policy<T>(length, 1, hpx::layout);
+    handle_values_tests_with_policy<T>(length, 3, hpx::layout(3));
+    handle_values_tests_with_policy<T>(length, 3, hpx::layout(3, localities));
     handle_values_tests_with_policy<T>(length, localities.size(),
-        hpx::block(localities));
-
-    handle_values_tests_with_policy<T>(length, 1, hpx::cyclic);
-    handle_values_tests_with_policy<T>(length, 3, hpx::cyclic(3));
-    handle_values_tests_with_policy<T>(length, 3, hpx::cyclic(3, localities));
-    handle_values_tests_with_policy<T>(length, localities.size(),
-        hpx::cyclic(localities));
-
-    handle_values_tests_with_policy<T>(length, 1, hpx::block_cyclic);
-    handle_values_tests_with_policy<T>(length, 3, hpx::block_cyclic(3));
-    handle_values_tests_with_policy<T>(length, 3,
-        hpx::block_cyclic(3, localities));
-    handle_values_tests_with_policy<T>(length, localities.size(),
-        hpx::block_cyclic(localities));
-    handle_values_tests_with_policy<T>(length, 4, hpx::block_cyclic(4, 3)); //-V112
-    handle_values_tests_with_policy<T>(length, 4, //-V112
-        hpx::block_cyclic(4, localities, 3)); //-V112
-    handle_values_tests_with_policy<T>(length, localities.size(),
-        hpx::block_cyclic(localities, 3));
+        hpx::layout(localities));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/components/vector_move.cpp
+++ b/tests/unit/components/vector_move.cpp
@@ -32,7 +32,6 @@ void compare_vectors(hpx::vector<T> const& v1, hpx::vector<T> const& v2,
     typedef typename hpx::vector<T>::const_iterator const_iterator;
 
     HPX_TEST_EQ(v1.size(), v2.size());
-    HPX_TEST(v1.get_policy() == v2.get_policy());
 
     const_iterator it1 = v1.begin(), it2 = v2.begin();
     const_iterator end1 = v1.end(), end2 = v2.end();
@@ -81,11 +80,9 @@ void move_tests_with_policy(std::size_t size, std::size_t localities,
     hpx::vector<T> v1(size, policy);
 
     hpx::vector<T> v2(v1);
-    HPX_TEST(v2.get_policy() == policy.get_policy_type());
     compare_vectors(v1, v2);
 
     hpx::vector<T> v3(std::move(v2));
-    HPX_TEST(v3.get_policy() == policy.get_policy_type());
     compare_vectors(v1, v3);
 
     fill_vector(v3, T(43));
@@ -93,12 +90,10 @@ void move_tests_with_policy(std::size_t size, std::size_t localities,
 
     hpx::vector<T> v4;
     v4 = v1;
-    HPX_TEST(v4.get_policy() == policy.get_policy_type());
     compare_vectors(v1, v4);
 
     hpx::vector<T> v5;
     v5 = std::move(v4);
-    HPX_TEST(v5.get_policy() == policy.get_policy_type());
     compare_vectors(v1, v5);
 
     fill_vector(v5, T(43));
@@ -127,29 +122,11 @@ void move_tests()
         move_tests(v);
     }
 
-    move_tests_with_policy<T>(length, 1, hpx::block);
-    move_tests_with_policy<T>(length, 3, hpx::block(3));
-    move_tests_with_policy<T>(length, 3, hpx::block(3, localities));
+    move_tests_with_policy<T>(length, 1, hpx::layout);
+    move_tests_with_policy<T>(length, 3, hpx::layout(3));
+    move_tests_with_policy<T>(length, 3, hpx::layout(3, localities));
     move_tests_with_policy<T>(length, localities.size(),
-        hpx::block(localities));
-
-    move_tests_with_policy<T>(length, 1, hpx::cyclic);
-    move_tests_with_policy<T>(length, 3, hpx::cyclic(3));
-    move_tests_with_policy<T>(length, 3, hpx::cyclic(3, localities));
-    move_tests_with_policy<T>(length, localities.size(),
-        hpx::cyclic(localities));
-
-    move_tests_with_policy<T>(length, 1, hpx::block_cyclic);
-    move_tests_with_policy<T>(length, 3, hpx::block_cyclic(3));
-    move_tests_with_policy<T>(length, 3,
-        hpx::block_cyclic(3, localities));
-    move_tests_with_policy<T>(length, localities.size(),
-        hpx::block_cyclic(localities));
-    move_tests_with_policy<T>(length, 4, hpx::block_cyclic(4, 3)); //-V112
-    move_tests_with_policy<T>(length, 4, //-V112
-        hpx::block_cyclic(4, localities, 3)); //-V112
-    move_tests_with_policy<T>(length, localities.size(),
-        hpx::block_cyclic(localities, 3));
+        hpx::layout(localities));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/components/vector_transform_reduce.cpp
+++ b/tests/unit/components/vector_transform_reduce.cpp
@@ -90,8 +90,8 @@ void transform_reduce_tests()
     }
 
     {
-        hpx::vector<T> xvalues(num, T(1), hpx::block(2));
-        hpx::vector<T> yvalues(num, T(1), hpx::block(2));
+        hpx::vector<T> xvalues(num, T(1), hpx::layout(2));
+        hpx::vector<T> yvalues(num, T(1), hpx::layout(2));
 
         transform_reduce_tests(num, xvalues, yvalues);
     }


### PR DESCRIPTION
The distribution policies we've had were not compatible with the iterator model we use. We have to come back to the possibility of having index manipulation schemes at some point. For now, let's remove the half-working attempt of introducing those.