### PR TITLE
Segmented copy

### DIFF
--- a/hpx/parallel/execution_policy.hpp
+++ b/hpx/parallel/execution_policy.hpp
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_EXECUTION_POLICY_MAY_27_2014_0908PM
 
 #include <hpx/hpx_fwd.hpp>
+#include <hpx/exception.hpp>
 #include <hpx/util/decay.hpp>
 #include <hpx/runtime/threads/thread_executor.hpp>
 #include <hpx/parallel/config/inline_namespace.hpp>
@@ -27,6 +28,19 @@
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
     ///////////////////////////////////////////////////////////////////////////
+    /// \cond NOINTERNAL
+    struct task_execution_policy_tag
+    {
+        task_execution_policy_tag() {}
+    };
+    /// \endcond
+
+    /// The execution policy tag \a task can be used to create a execution
+    /// policy which forces the given algorithm to be executed in an
+    /// asynchronous way.
+    static task_execution_policy_tag const task;
+
+    ///////////////////////////////////////////////////////////////////////////
     /// Extension: The class sequential_task_execution_policy is an execution
     /// policy type used as a unique type to disambiguate parallel algorithm
     /// overloading and indicate that a parallel algorithm's execution may be
@@ -38,6 +52,19 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     struct sequential_task_execution_policy
     {
         sequential_task_execution_policy() {}
+
+        /// Create a new sequential_task_execution_policy from itself
+        ///
+        /// \param tag          [in] Specify that the corresponding asynchronous
+        ///                     execution policy should be used
+        ///
+        /// \returns The new sequential_task_execution_policy
+        ///
+        sequential_task_execution_policy operator()(
+            task_execution_policy_tag tag) const
+        {
+            return *this;
+        }
     };
 
     /// Default sequential task execution policy object.
@@ -103,6 +130,19 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             return parallel_task_execution_policy(exec_, chunk_size);
         }
 
+        /// Create a new parallel_task_execution_policy from itself
+        ///
+        /// \param tag          [in] Specify that the corresponding asynchronous
+        ///                     execution policy should be used
+        ///
+        /// \returns The new parallel_task_execution_policy
+        ///
+        parallel_task_execution_policy operator()(
+            task_execution_policy_tag tag) const
+        {
+            return *this;
+        }
+
         /// \cond NOINTERNAL
         threads::executor get_executor() const { return exec_; }
         std::size_t get_chunk_size() const { return chunk_size_; }
@@ -130,19 +170,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
     /// Default parallel task execution policy object.
     static parallel_task_execution_policy const par_task;
-
-    ///////////////////////////////////////////////////////////////////////////
-    /// \cond NOINTERNAL
-    struct task_execution_policy_tag
-    {
-        task_execution_policy_tag() {}
-    };
-    /// \endcond
-
-    /// The execution policy tag \a task can be used to create a execution
-    /// policy which forces the given algorithm to be executed in an
-    /// asynchronous way.
-    static task_execution_policy_tag const task;
 
     ///////////////////////////////////////////////////////////////////////////
     /// The class parallel_execution_policy is an execution policy type used
@@ -336,6 +363,19 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         static threads::executor get_executor() { return threads::executor(); }
         static std::size_t get_chunk_size() { return 0; }
         /// \endcond
+
+        /// Create a new parallel_vector_execution_policy from itself
+        ///
+        /// \param tag [in] Specify that the corresponding asynchronous
+        ///            execution policy should be used
+        ///
+        /// \returns The new parallel_vector_execution_policy
+        ///
+        parallel_vector_execution_policy operator()(
+            task_execution_policy_tag tag) const
+        {
+            return *this;
+        }
     };
 
     /// Default vector execution policy object.
@@ -530,6 +570,26 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     {};
 
     ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        /// \cond NOINTERNAL
+        namespace execution_policy_enum
+        {
+            enum {
+                unknown = -1,
+                sequential = 0,
+                sequential_task = 1,
+                parallel = 2,
+                parallel_task = 3,
+                parallel_vector = 4
+            };
+        }
+
+        int which(class parallel::execution_policy const& policy);
+        /// \endcond
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     ///
     /// An execution policy is an object that expresses the requirements on the
     /// ordering of functions invoked as a consequence of the invocation of a
@@ -572,6 +632,38 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             type_(policy.type_)
         {
             policy.type_ = 0;
+        }
+
+        /// Extension: Create a new execution_policy holding the current policy
+        /// made asynchronous.
+        ///
+        /// \param tag  [in] Specify that the corresponding asynchronous
+        ///             execution policy should be used
+        ///
+        /// \returns The new execution_policy
+        ///
+        execution_policy operator()(task_execution_policy_tag tag) const
+        {
+            switch(detail::which(*this))
+            {
+            case detail::execution_policy_enum::sequential:
+                return (*get<sequential_execution_policy>())(task);
+
+            case detail::execution_policy_enum::parallel:
+                return (*get<parallel_execution_policy>())(task);
+
+            case detail::execution_policy_enum::parallel_vector:
+                return (*get<parallel_vector_execution_policy>())(task);
+
+            case detail::execution_policy_enum::sequential_task:
+            case detail::execution_policy_enum::parallel_task:
+                return *this;
+
+            default:
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "hpx::parallel::execution_policy::operator()(task)",
+                    "The given execution policy is not supported");
+            }
         }
 
         /// Effects: Assigns a copy of exec's state to *this
@@ -655,18 +747,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     namespace detail
     {
         /// \cond NOINTERNAL
-        namespace execution_policy_enum
-        {
-            enum {
-                unknown = -1,
-                sequential = 0,
-                sequential_task = 1,
-                parallel = 2,
-                parallel_task = 3,
-                parallel_vector = 4
-            };
-        }
-
         inline int which(execution_policy const& policy)
         {
             std::type_info const& t = policy.type();

--- a/hpx/parallel/execution_policy.hpp
+++ b/hpx/parallel/execution_policy.hpp
@@ -609,6 +609,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         boost::shared_ptr<void> inner_;
         std::type_info const* type_;
 
+        execution_policy(execution_policy const& rhs)
+          : inner_(rhs.inner_),
+            type_(rhs.type_)
+        {}
+
     public:
         /// Effects: Constructs an execution_policy object with a copy of
         ///          exec's state

--- a/hpx/traits/segmented_iterator_traits.hpp
+++ b/hpx/traits/segmented_iterator_traits.hpp
@@ -12,12 +12,14 @@
 
 namespace hpx { namespace traits
 {
+    ///////////////////////////////////////////////////////////////////////////
     template <typename Iterator, typename Enable>
     struct segmented_iterator_traits
     {
         typedef boost::mpl::false_ is_segmented_iterator;
     };
 
+    ///////////////////////////////////////////////////////////////////////////
     // traits allowing to distinguish iterators which have a purely local
     // representation
     template <typename Iterator, typename Enable>
@@ -29,7 +31,12 @@ namespace hpx { namespace traits
         typedef Iterator local_iterator;
         typedef Iterator local_raw_iterator;
 
-        static local_raw_iterator const& base(local_iterator const& it)
+        static local_raw_iterator const& local(local_iterator const& it)
+        {
+            return it;
+        }
+
+        static local_iterator const& remote(local_raw_iterator const& it)
         {
             return it;
         }

--- a/hpx/traits/segmented_iterator_traits.hpp
+++ b/hpx/traits/segmented_iterator_traits.hpp
@@ -40,6 +40,16 @@ namespace hpx { namespace traits
         {
             return it;
         }
+
+        static local_raw_iterator local(local_iterator&& it)
+        {
+            return std::move(it);
+        }
+
+        static local_iterator remote(local_raw_iterator&& it)
+        {
+            return std::move(it);
+        }
     };
 }}
 

--- a/hpx/util/zip_iterator.hpp
+++ b/hpx/util/zip_iterator.hpp
@@ -556,7 +556,7 @@ namespace hpx { namespace traits
         };
 
         ///////////////////////////////////////////////////////////////////////
-        struct get_base_iterator
+        struct get_raw_iterator
         {
             template <typename Iterator>
             struct apply
@@ -573,10 +573,35 @@ namespace hpx { namespace traits
                 };
 
                 template <typename SegIter>
-                typename result<get_base_iterator(SegIter)>::type
+                typename result<get_raw_iterator(SegIter)>::type
                 operator()(SegIter iter) const
                 {
-                    return iter.base_iterator();
+                    return iter.local();
+                };
+            };
+        };
+
+        struct get_remote_iterator
+        {
+            template <typename Iterator>
+            struct apply
+            {
+                template <typename T>
+                struct result;
+
+                template <typename This, typename SegIter>
+                struct result<This(SegIter)>
+                {
+                    typedef typename segmented_iterator_traits<
+                            Iterator
+                        >::local_iterator type;
+                };
+
+                template <typename SegIter>
+                typename result<get_remote_iterator(SegIter)>::type
+                operator()(SegIter iter) const
+                {
+                    return iter.remote();
                 };
             };
         };
@@ -752,11 +777,20 @@ namespace hpx { namespace traits
             > local_raw_iterator;
 
         // Extract base iterator from local_iterator
-        static local_raw_iterator base(local_iterator const& iter)
+        static local_raw_iterator local(local_iterator const& iter)
         {
             return local_raw_iterator(
                 functional::lift_zipped_iterators<
-                        functional::get_base_iterator, iterator
+                        functional::get_raw_iterator, iterator
+                    >::call(iter));
+        }
+
+        // Construct remote local_iterator from local_raw_iterator
+        static local_iterator remote(local_raw_iterator const& iter)
+        {
+            return local_iterator(
+                functional::lift_zipped_iterators<
+                        functional::get_remote_iterator, iterator
                     >::call(iter));
         }
     };


### PR DESCRIPTION
This adds the implementation of the segmented `parallel::copy` algorithm. It includes a couple of refinements to the iterators as exposed by `hpx::vector`.