### PR TITLE
 Modifying parallel search algorithm for zero length searches

### DIFF
--- a/hpx/parallel/algorithms/search.hpp
+++ b/hpx/parallel/algorithms/search.hpp
@@ -66,7 +66,7 @@ namespace hpx {namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 s_difference_type diff = std::distance(s_first, s_last);
                 if (diff <= 0)
-		  return result::get(std::move(first));
+                    return result::get(std::move(first));
 
                 difference_type count = std::distance(first, last);
                 if (diff > count)

--- a/hpx/parallel/algorithms/search.hpp
+++ b/hpx/parallel/algorithms/search.hpp
@@ -66,7 +66,7 @@ namespace hpx {namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 s_difference_type diff = std::distance(s_first, s_last);
                 if (diff <= 0)
-                    return result::get(std::move(last));
+		  return result::get(std::move(first));
 
                 difference_type count = std::distance(first, last);
                 if (diff > count)

--- a/hpx/parallel/util/loop.hpp
+++ b/hpx/parallel/util/loop.hpp
@@ -77,7 +77,7 @@ namespace hpx { namespace parallel { namespace util
             template <typename Iter, typename F>
             static Iter call(Iter it, std::size_t count, F && f)
             {
-                for (/**/; count != 0; --count, ++it)
+                for (/**/; count != 0; (void) --count, ++it)
                     f(it);
                 return it;
             }
@@ -86,7 +86,7 @@ namespace hpx { namespace parallel { namespace util
             static Iter call(Iter it, std::size_t count, CancelToken& tok,
                 F && f)
             {
-                for (/**/; count != 0; --count, ++it)
+                for (/**/; count != 0; (void) --count, ++it)
                 {
                     if (tok.was_cancelled())
                         break;
@@ -148,7 +148,7 @@ namespace hpx { namespace parallel { namespace util
             {
                 FwdIter base = dest;
                 try {
-                    for (/**/; it != last;  ++it, ++dest)
+                    for (/**/; it != last; (void) ++it, ++dest)
                         f(it, dest);
                     return dest;
                 }
@@ -196,7 +196,7 @@ namespace hpx { namespace parallel { namespace util
             {
                 FwdIter base = it;
                 try {
-                    for (/**/; count != 0; --count, ++it)
+                    for (/**/; count != 0; (void) --count, ++it)
                         f(it);
                     return it;
                 }
@@ -214,7 +214,7 @@ namespace hpx { namespace parallel { namespace util
             {
                 FwdIter base = dest;
                 try {
-                    for (/**/; count != 0; --count, ++it, ++dest)
+                    for (/**/; count != 0; (void) --count, ++it, ++dest)
                         f(it, dest);
                     return dest;
                 }
@@ -233,7 +233,7 @@ namespace hpx { namespace parallel { namespace util
             {
                 FwdIter base = it;
                 try {
-                    for (/**/; count != 0; --count, ++it)
+                    for (/**/; count != 0; (void) --count, ++it)
                     {
                         if (tok.was_cancelled())
                             break;
@@ -256,7 +256,7 @@ namespace hpx { namespace parallel { namespace util
             {
                 FwdIter base = dest;
                 try {
-                    for (/**/; count != 0; --count, ++it, ++dest)
+                    for (/**/; count != 0; (void) --count, ++it, ++dest)
                     {
                         if (tok.was_cancelled())
                             break;
@@ -329,7 +329,7 @@ namespace hpx { namespace parallel { namespace util
             static Iter
             call(std::size_t base_idx, Iter it, std::size_t count, F && f)
             {
-                for (/**/; count != 0; --count, ++it, ++base_idx)
+                for (/**/; count != 0; (void) --count, ++it, ++base_idx)
                     f(*it, base_idx);
 
                 return it;
@@ -340,7 +340,7 @@ namespace hpx { namespace parallel { namespace util
             call(std::size_t base_idx, Iter it, std::size_t count,
                 CancelToken& tok, F && f)
             {
-                for (/**/; count != 0; --count, ++it, ++base_idx)
+                for (/**/; count != 0; (void) --count, ++it, ++base_idx)
                 {
                     if (tok.was_cancelled(base_idx))
                         break;
@@ -382,7 +382,7 @@ namespace hpx { namespace parallel { namespace util
             template <typename Iter, typename T, typename Pred>
             static T call(Iter it, std::size_t count, T init, Pred && f)
             {
-                for (/**/; count != 0; --count, ++it)
+                for (/**/; count != 0; (void) --count, ++it)
                     init = f(init, *it);
                 return init;
             }

--- a/hpx/parallel/util/loop.hpp
+++ b/hpx/parallel/util/loop.hpp
@@ -77,7 +77,7 @@ namespace hpx { namespace parallel { namespace util
             template <typename Iter, typename F>
             static Iter call(Iter it, std::size_t count, F && f)
             {
-                for (/**/; count != 0; (void) --count, ++it)
+                for (/**/; count != 0; --count, ++it)
                     f(it);
                 return it;
             }
@@ -86,7 +86,7 @@ namespace hpx { namespace parallel { namespace util
             static Iter call(Iter it, std::size_t count, CancelToken& tok,
                 F && f)
             {
-                for (/**/; count != 0; (void) --count, ++it)
+                for (/**/; count != 0; --count, ++it)
                 {
                     if (tok.was_cancelled())
                         break;
@@ -148,7 +148,7 @@ namespace hpx { namespace parallel { namespace util
             {
                 FwdIter base = dest;
                 try {
-                    for (/**/; it != last; (void) ++it, ++dest)
+                    for (/**/; it != last;  ++it, ++dest)
                         f(it, dest);
                     return dest;
                 }
@@ -196,7 +196,7 @@ namespace hpx { namespace parallel { namespace util
             {
                 FwdIter base = it;
                 try {
-                    for (/**/; count != 0; (void) --count, ++it)
+                    for (/**/; count != 0; --count, ++it)
                         f(it);
                     return it;
                 }
@@ -214,7 +214,7 @@ namespace hpx { namespace parallel { namespace util
             {
                 FwdIter base = dest;
                 try {
-                    for (/**/; count != 0; (void) --count, ++it, ++dest)
+                    for (/**/; count != 0; --count, ++it, ++dest)
                         f(it, dest);
                     return dest;
                 }
@@ -233,7 +233,7 @@ namespace hpx { namespace parallel { namespace util
             {
                 FwdIter base = it;
                 try {
-                    for (/**/; count != 0; (void) --count, ++it)
+                    for (/**/; count != 0; --count, ++it)
                     {
                         if (tok.was_cancelled())
                             break;
@@ -256,7 +256,7 @@ namespace hpx { namespace parallel { namespace util
             {
                 FwdIter base = dest;
                 try {
-                    for (/**/; count != 0; (void) --count, ++it, ++dest)
+                    for (/**/; count != 0; --count, ++it, ++dest)
                     {
                         if (tok.was_cancelled())
                             break;
@@ -329,7 +329,7 @@ namespace hpx { namespace parallel { namespace util
             static Iter
             call(std::size_t base_idx, Iter it, std::size_t count, F && f)
             {
-                for (/**/; count != 0; (void) --count, ++it, ++base_idx)
+                for (/**/; count != 0; --count, ++it, ++base_idx)
                     f(*it, base_idx);
 
                 return it;
@@ -340,7 +340,7 @@ namespace hpx { namespace parallel { namespace util
             call(std::size_t base_idx, Iter it, std::size_t count,
                 CancelToken& tok, F && f)
             {
-                for (/**/; count != 0; (void) --count, ++it, ++base_idx)
+                for (/**/; count != 0; --count, ++it, ++base_idx)
                 {
                     if (tok.was_cancelled(base_idx))
                         break;
@@ -382,7 +382,7 @@ namespace hpx { namespace parallel { namespace util
             template <typename Iter, typename T, typename Pred>
             static T call(Iter it, std::size_t count, T init, Pred && f)
             {
-                for (/**/; count != 0; (void) --count, ++it)
+                for (/**/; count != 0; --count, ++it)
                     init = f(init, *it);
                 return init;
             }

--- a/tests/regressions/CMakeLists.txt
+++ b/tests/regressions/CMakeLists.txt
@@ -14,6 +14,7 @@ set(subdirs
     threads
     traits
     util
+    parallel
    )
 
 if(HPX_HAVE_CXX11_LAMBDAS)

--- a/tests/regressions/parallel/CMakeLists.txt
+++ b/tests/regressions/parallel/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 set(tests
     minimal_findend
+    search_zerolength
    )
 
 foreach(test ${tests})

--- a/tests/regressions/parallel/search_zerolength.cpp
+++ b/tests/regressions/parallel/search_zerolength.cpp
@@ -10,38 +10,38 @@
 
 void search_zero_dist_test()
 {
-  using hpx::parallel::execution_policy;
-  using hpx::parallel::seq;
-  using hpx::parallel::par;
-  using hpx::parallel::search;
-  using hpx::parallel::task;
+    using hpx::parallel::execution_policy;
+    using hpx::parallel::seq;
+    using hpx::parallel::par;
+    using hpx::parallel::search;
+    using hpx::parallel::task;
 
-  typedef std::vector<int>::iterator iterator;
+    typedef std::vector<int>::iterator iterator;
 
-  std::vector<int> c(10007);
-  std::iota(c.begin(), c.end(), 1);
-  std::vector<int> h(0);
+    std::vector<int> c(10007);
+    std::iota(c.begin(), c.end(), 1);
+    std::vector<int> h(0);
 
-  hpx::future<iterator> fut_seq = 
-    search(seq(task), c.begin(), c.end(), h.begin(), h.end());
-  hpx::future<iterator> fut_par = 
-    search(par(task), c.begin(), c.end(), h.begin(), h.end());
-  
-  HPX_TEST(fut_seq.get() == c.begin());
-  HPX_TEST(fut_par.get() == c.begin());
-}  
+    hpx::future<iterator> fut_seq = search(seq(task), c.begin(), c.end(),
+        h.begin(), h.end());
+    hpx::future<iterator> fut_par = search(par(task), c.begin(), c.end(),
+        h.begin(), h.end());
+
+    HPX_TEST(fut_seq.get() == c.begin());
+    HPX_TEST(fut_par.get() == c.begin());
+}
 
 int hpx_main()
 {
-  search_zero_dist_test();
-  return hpx::finalize();
+    search_zero_dist_test();
+    return hpx::finalize();
 }
 
 int main(int argc, char* argv[])
 {
     std::vector<std::string> cfg;
-    cfg.push_back("hpx.os_threads=" +
-        boost::lexical_cast<std::string>(hpx::threads::hardware_concurrency()));
+    cfg.push_back("hpx.os_threads=" + boost::lexical_cast<std::string>
+                  (hpx::threads::hardware_concurrency()));
 
     HPX_TEST_EQ_MSG(hpx::init(argc, argv, cfg), 0,
         "HPX main exted with non-zero status");

--- a/tests/regressions/parallel/search_zerolength.cpp
+++ b/tests/regressions/parallel/search_zerolength.cpp
@@ -1,0 +1,50 @@
+//  Copyright (c) 2015 Daniel Bourgeois
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/include/parallel_search.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+void search_zero_dist_test()
+{
+  using hpx::parallel::execution_policy;
+  using hpx::parallel::seq;
+  using hpx::parallel::par;
+  using hpx::parallel::search;
+  using hpx::parallel::task;
+
+  typedef std::vector<int>::iterator iterator;
+
+  std::vector<int> c(10007);
+  std::iota(c.begin(), c.end(), 1);
+  std::vector<int> h(0);
+
+  hpx::future<iterator> fut_seq = 
+    search(seq(task), c.begin(), c.end(), h.begin(), h.end());
+  hpx::future<iterator> fut_par = 
+    search(par(task), c.begin(), c.end(), h.begin(), h.end());
+  
+  HPX_TEST(fut_seq.get() == c.begin());
+  HPX_TEST(fut_par.get() == c.begin());
+}  
+
+int hpx_main()
+{
+  search_zero_dist_test();
+  return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg;
+    cfg.push_back("hpx.os_threads=" +
+        boost::lexical_cast<std::string>(hpx::threads::hardware_concurrency()));
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, cfg), 0,
+        "HPX main exted with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Changed search.hpp to return the first iterator if the search iterators are the same.