### PR TITLE
Towards safer migration

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -50,6 +50,8 @@ set(doxygen_dependencies
     "${hpx_SOURCE_DIR}/hpx/error.hpp"
     "${hpx_SOURCE_DIR}/hpx/exception.hpp"
     "${hpx_SOURCE_DIR}/hpx/exception_list.hpp"
+    "${hpx_SOURCE_DIR}/hpx/components/component_storage/migrate_from_storage.hpp"
+    "${hpx_SOURCE_DIR}/hpx/components/component_storage/migrate_to_storage.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/execution_policy.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/algorithm.hpp"
     "${hpx_SOURCE_DIR}/hpx/parallel/task_region.hpp"

--- a/docs/hpx.idx
+++ b/docs/hpx.idx
@@ -46,6 +46,12 @@ find_ids_from_basename                "" "hpx\.find_ids_from_basename.*"
 register_id_with_basename             "" "hpx\.register_id_with_basename.*"
 unregister_id_with_basename           "" "hpx\.unregister_id_with_basename.*"
 
+# hpx/components/component_storage/migrate_from_storage.hpp
+migrate_from_storage                  "" "hpx\.components\.migrate_from_s.*"
+
+# hpx/components/component_storage/migrate_to_storage.hpp
+migrate_to_storage                    "" "hpx\.components\.migrate_to_s.*"
+
 # hpx/parallel/execution_policy.hpp
 parallel::execution_policy                 "execution_policy"               "hpx\.parallel\.v1\.execution_policy.*"
 parallel::parallel_execution_policy        "parallel_execution_policy"      "hpx\.parallel\.v1\.parallel_exec.*"
@@ -175,7 +181,7 @@ new_colocated                         "" "hpx\.components\.new_colocated.*"
 copy                                  "" "hpx\.components\.copy.*"
 
 # hpx/runtime/components/migrate_component.hpp
-migrate                               "" "hpx\.components\.migrate.*"
+migrate                               "" "hpx\.components\.migrate_id.*"
 
 # hpx/exception.hpp
 HPX_THROW_EXCEPTION                   "" "HPX_THROW_EXCEPTION"

--- a/docs/manual/existing_performance_counters.qbk
+++ b/docs/manual/existing_performance_counters.qbk
@@ -24,7 +24,8 @@ system and application performance.
             `iterate_names`, `iterate_types`, `localities`,
             `num_localities`, `num_localities_type`, `num_threads`, `resolve`,
             `resolve_gid`, `resolve_id`, `resolve_locality`, `resolved_localities`,
-            `route`, `unbind`, `unbind_gid`, `unbind_name`.
+            `route`, `unbind`, `unbind_gid`, `unbind_name`
+            `start_migration`, `end_migration`.
         ]
         [`<agas_instance>/total`
 
@@ -67,7 +68,8 @@ system and application performance.
             `iterate_names`, `iterate_types`, `localities`,
             `num_localities`, `num_localities_type`, `num_threads`, `resolve`,
             `resolve_gid`, `resolve_id`, `resolve_locality`, `resolved_localities`,
-            `route`, `unbind`, `unbind_gid`, `unbind_name`.
+            `route`, `unbind`, `unbind_gid`, `unbind_name`,
+            `start_migration`, `end_migration`.
         ]
         [`<agas_instance>/total`
 
@@ -552,10 +554,10 @@ system and application performance.
          instance name is `total` the counter returns the average time spent on
          overhead while executing one __hpx__-thread for all worker threads (cores)
          on that locality. If the instance name is `worker-thread#*` the counter
-         will return the average time spent on overhead executing 
-         one __hpx__-thread for all worker threads separately.  
-         This counter is available only if the configuration time constants 
-         `HPX_THREAD_MAINTAIN_CUMULATIVE_COUNTS` (default: ON) and 
+         will return the average time spent on overhead executing
+         one __hpx__-thread for all worker threads separately.
+         This counter is available only if the configuration time constants
+         `HPX_THREAD_MAINTAIN_CUMULATIVE_COUNTS` (default: ON) and
          `HPX_THREAD_MAINTAIN_IDLE_RATES` are set to `ON` (default: OFF).]
     ]
     [   [`/threads/count/cumulative-phases`]
@@ -640,8 +642,8 @@ system and application performance.
         phase (invocation) for all worker threads (cores) on that locality.
         If the instance name is `worker-thread#*` the counter will return
         the average time spent on overhead executing one __hpx__-thread phase
-        for all worker threads separately.  This counter is available only 
-        if the configuration time constants 
+        for all worker threads separately.  This counter is available only
+        if the configuration time constants
         `HPX_THREAD_MAINTAIN_CUMULATIVE_COUNTS` (default: ON) and
         `HPX_THREAD_MAINTAIN_IDLE_RATES` are set to `ON` (default: OFF).]
     ]

--- a/docs/manual/existing_performance_counters.qbk
+++ b/docs/manual/existing_performance_counters.qbk
@@ -25,7 +25,7 @@ system and application performance.
             `num_localities`, `num_localities_type`, `num_threads`, `resolve`,
             `resolve_gid`, `resolve_id`, `resolve_locality`, `resolved_localities`,
             `route`, `unbind`, `unbind_gid`, `unbind_name`
-            `start_migration`, `end_migration`.
+            `begin_migration`, `end_migration`.
         ]
         [`<agas_instance>/total`
 
@@ -69,7 +69,7 @@ system and application performance.
             `num_localities`, `num_localities_type`, `num_threads`, `resolve`,
             `resolve_gid`, `resolve_id`, `resolve_locality`, `resolved_localities`,
             `route`, `unbind`, `unbind_gid`, `unbind_name`,
-            `start_migration`, `end_migration`.
+            `begin_migration`, `end_migration`.
         ]
         [`<agas_instance>/total`
 

--- a/hpx/components/component_storage/migrate_from_storage.hpp
+++ b/hpx/components/component_storage/migrate_from_storage.hpp
@@ -3,6 +3,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+/// \file migrate_from_storage.hpp
+
 #if !defined(HPX_MIGRATE_FROM_STORAGE_FEB_09_2015_0329PM)
 #define HPX_MIGRATE_FROM_STORAGE_FEB_09_2015_0329PM
 
@@ -21,13 +23,11 @@ namespace hpx { namespace components
     ///
     /// The function \a migrate_from_storage<Component> will migrate the
     /// component referenced by \a to_resurrect from the storage facility
-    /// specified with \a source_storage. It returns a future referring to
-    /// the migrated component instance. The component instance is resurrected
-    /// on the locality specified by \a target_locality.
+    /// specified where the object is currently stored on. It returns a future
+    /// referring to the migrated component instance. The component instance
+    /// is resurrected on the locality specified by \a target_locality.
     ///
     /// \param to_resurrect    [in] The global id of the component to migrate.
-    /// \param source_storage  [in] The id of the storage facility to migrate
-    ///                        this object from.
     /// \param target          [in] The optional locality to resurrect the
     ///                        object on. By default the object is resurrected
     ///                        on the locality it was located on last.
@@ -47,28 +47,11 @@ namespace hpx { namespace components
     >::type
 #endif
     migrate_from_storage(naming::id_type const& to_resurrect,
-        naming::id_type const& source_storage,
         naming::id_type const& target = naming::invalid_id)
     {
-        typedef server::migrate_from_storage_here_action<Component>
+        typedef server::trigger_migrate_from_storage_here_action<Component>
             action_type;
-        return async_colocated<action_type>(source_storage, source_storage,
-            to_resurrect, target);
-    }
-
-    template <typename Component>
-#if defined(DOXYGEN)
-    future<naming::id_type>
-#else
-    inline typename std::enable_if<
-        traits::is_component<Component>::value, future<naming::id_type>
-    >::type
-#endif
-    migrate_from_storage(naming::id_type const& to_resurrect,
-        hpx::components::component_storage const& source_storage,
-        naming::id_type const& target = naming::invalid_id)
-    {
-        return migrate_from_storage<Component>(source_storage.get_gid(),
+        return async<action_type>(naming::get_locality_from_id(to_resurrect),
             to_resurrect, target);
     }
 }}

--- a/hpx/components/component_storage/migrate_to_storage.hpp
+++ b/hpx/components/component_storage/migrate_to_storage.hpp
@@ -3,6 +3,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+/// \file migrate_to_storage.hpp
+
 #if !defined(HPX_MIGRATE_TO_STORAGE_FEB_04_2015_1245PM)
 #define HPX_MIGRATE_TO_STORAGE_FEB_04_2015_1245PM
 
@@ -44,10 +46,10 @@ namespace hpx { namespace components
     migrate_to_storage(naming::id_type const& to_migrate,
         naming::id_type const& target_storage)
     {
-        typedef server::migrate_to_storage_here_action<Component>
+        typedef server::trigger_migrate_to_storage_here_action<Component>
             action_type;
-        return async_colocated<action_type>(to_migrate, to_migrate,
-            target_storage);
+        return async<action_type>(naming::get_locality_from_id(to_migrate),
+            to_migrate, target_storage);
     }
 
     /// Migrate the given component to the specified target storage

--- a/hpx/components/component_storage/server/migrate_from_storage.hpp
+++ b/hpx/components/component_storage/server/migrate_from_storage.hpp
@@ -140,7 +140,7 @@ namespace hpx { namespace components { namespace server
             return make_ready_future(naming::invalid_id);
         }
 
-        return agas::begin_migration(to_resurrect)
+        return agas::begin_migration(to_resurrect, target_locality)
             .then(
                 [to_resurrect, target_locality](
                     future<std::pair<naming::id_type, naming::address> > && f)

--- a/hpx/components/component_storage/server/migrate_to_storage.hpp
+++ b/hpx/components/component_storage/server/migrate_to_storage.hpp
@@ -175,7 +175,7 @@ namespace hpx { namespace components { namespace server
             return make_ready_future(naming::invalid_id);
         }
 
-        return agas::begin_migration(to_migrate)
+        return agas::begin_migration(to_migrate, target_storage)
             .then(
                 [to_migrate, target_storage](
                     future<std::pair<naming::id_type, naming::address> > && f)

--- a/hpx/components/component_storage/server/migrate_to_storage.hpp
+++ b/hpx/components/component_storage/server/migrate_to_storage.hpp
@@ -17,6 +17,38 @@
 namespace hpx { namespace components { namespace server
 {
     ///////////////////////////////////////////////////////////////////////////
+    // Migrate given component to the component storage
+    //
+    // Object migration is performed in several steps:
+    //
+    // 1) The migration is triggered by invoking the
+    //    trigger_migrate_to_storage_here_action
+    //    on the locality which is responsible for managing the address
+    //    resolution for the object which has to be migrated.
+    // 2) The trigger_migrate_to_storage_here_action performs 3 steps:
+    //    a) Invoke agas::begin_migration, which marks the global id in AGAS,
+    //       deferring all address resolution requests until end_migration is
+    //       called.
+    //    b) Invoke the actual migration operation (see step 3)
+    //    c) Invoke end_migration, which un-marks the global id and releases
+    //       all pending address resolution requests. Those requests now return
+    //       the new object location.
+    // 3) The actual migration (migrate_to_storage_here_action) is executed on
+    //    the locality where the object is currently located. This involves
+    //    several steps as well:
+    //    a) Retrieve the (shared-) pointer to the object, this pins the
+    //       object. The object is unpinned by the deleter associated with the
+    //       shared pointer.
+    //    b) Serialize the object to create a byte stream representing the
+    //       state of the object.
+    //    c) Invoke the action component_storage::migrate_to_here_action on the
+    //       storage object which should receive the data. This passes
+    //       along the serialized data and updates the association of the
+    //       object's global id with the new local virtual address in AGAS.
+    //    d) Mark the old object (through the original shared pointer) as
+    //       migrated which will delete it once the shared pointer goes out of
+    //       scope.
+    //
     namespace detail
     {
         // clean up (source) memory of migrated object
@@ -33,13 +65,12 @@ namespace hpx { namespace components { namespace server
         // trigger the actual migration to storage
         template <typename Component>
         future<naming::id_type> migrate_to_storage_here_postproc(
-            future<boost::shared_ptr<Component> > f,
+            boost::shared_ptr<Component> const& ptr,
             naming::id_type const& to_migrate,
             naming::id_type const& target_storage)
         {
             using components::stubs::runtime_support;
 
-            boost::shared_ptr<Component> ptr = f.get();
             boost::uint32_t pin_count = ptr->pin_count();
 
             if (pin_count == ~0x0u)
@@ -73,18 +104,22 @@ namespace hpx { namespace components { namespace server
 
             typedef typename server::component_storage::migrate_to_here_action
                 action_type;
+
             return hpx::async<action_type>(
-                    target_storage, std::move(data), to_migrate, addr
-                ).then(util::bind(
+                    target_storage, std::move(data), to_migrate, addr)
+                .then(util::bind(
                     &migrate_to_storage_here_cleanup<Component>,
-                    util::placeholders::_1, ptr, to_migrate)
-                );
+                    util::placeholders::_1, ptr, to_migrate));
         }
     }
 
+    ///////////////////////////////////////////////////////////////////////////
+    // This will be executed on the locality where the object lives which is
+    // to be migrated
     template <typename Component>
     future<naming::id_type> migrate_to_storage_here(
         naming::id_type const& to_migrate,
+        naming::address const& addr,
         naming::id_type const& target_storage)
     {
         if (!Component::supports_migration())
@@ -96,24 +131,90 @@ namespace hpx { namespace components { namespace server
             return make_ready_future(naming::invalid_id);
         }
 
-        return hpx::detail::get_ptr_for_migration<Component>(to_migrate)
-            .then(util::bind(&detail::migrate_to_storage_here_postproc<Component>,
-                util::placeholders::_1, to_migrate, target_storage));
+        // retrieve pointer to object (must be local)
+        boost::shared_ptr<Component> ptr =
+            hpx::detail::get_ptr_for_migration<Component>(addr, to_migrate);
+
+        // perform actual migration by sending data over to target locality
+        return detail::migrate_to_storage_here_postproc<Component>(
+            ptr, to_migrate, target_storage);
     }
 
     template <typename Component>
     struct migrate_to_storage_here_action
       : ::hpx::actions::action<
             future<naming::id_type> (*)(naming::id_type const&,
-                naming::id_type const&)
+                naming::address const&, naming::id_type const&)
           , &migrate_to_storage_here<Component>
           , migrate_to_storage_here_action<Component> >
+    {};
+
+    ///////////////////////////////////////////////////////////////////////////
+    // This is executed on the locality responsible for managing the address
+    // resolution for the given object.
+    template <typename Component>
+    future<naming::id_type> trigger_migrate_to_storage_here(
+        naming::id_type const& to_migrate,
+        naming::id_type const& target_storage)
+    {
+        if (!Component::supports_migration())
+        {
+            HPX_THROW_EXCEPTION(invalid_status,
+                "hpx::components::server::trigger_migrate_to_storage_here",
+                "attempting to migrate an instance of a component which "
+                "does not support migration");
+            return make_ready_future(naming::invalid_id);
+        }
+
+        if (naming::get_locality_id_from_id(to_migrate) != get_locality_id())
+        {
+            HPX_THROW_EXCEPTION(invalid_status,
+                "hpx::components::server::trigger_migrate_to_storage_here",
+                "this function has to be executed on the locality responsible "
+                "for managing the address of the given object");
+            return make_ready_future(naming::invalid_id);
+        }
+
+        return agas::begin_migration(to_migrate)
+            .then(
+                [to_migrate, target_storage](
+                    future<std::pair<naming::id_type, naming::address> > && f)
+                        -> future<naming::id_type>
+                {
+                    // rethrow errors
+                    std::pair<naming::id_type, naming::address> r = f.get();
+
+                    // perform actual object migration
+                    typedef server::migrate_to_storage_here_action<Component>
+                        action_type;
+                    return async<action_type>(r.first, to_migrate, r.second,
+                        target_storage);
+                })
+            .then(
+                [to_migrate](future<naming::id_type> && f) -> naming::id_type
+                {
+                    agas::end_migration(to_migrate).get();
+                    return f.get();
+                });
+    }
+
+    template <typename Component>
+    struct trigger_migrate_to_storage_here_action
+      : ::hpx::actions::action<
+            future<naming::id_type> (*)(naming::id_type const&,
+                naming::id_type const&)
+          , &trigger_migrate_to_storage_here<Component>
+          , trigger_migrate_to_storage_here_action<Component> >
     {};
 }}}
 
 HPX_REGISTER_PLAIN_ACTION_TEMPLATE(
     (template <typename Component>),
     (hpx::components::server::migrate_to_storage_here_action<Component>))
+
+HPX_REGISTER_PLAIN_ACTION_TEMPLATE(
+    (template <typename Component>),
+    (hpx::components::server::trigger_migrate_to_storage_here_action<Component>))
 
 #endif
 

--- a/hpx/error.hpp
+++ b/hpx/error.hpp
@@ -79,9 +79,9 @@ namespace hpx
         bad_function_call = 52,                     ///< equivalent of std::bad_function_call
         task_canceled_exception = 53,               ///< parallel::v2::task_canceled_exception
         task_region_not_active = 54,                ///< task_region is not active
-	out_of_range = 55,			    ///< Equivalent to std::out_of_range
-	length_error = 56,			    ///< Equivalent to std::length_error
-	invalid_vector_error = 57,		    ///< An error occurred when Invalid hpx::vector is created [Invalid Conditions: num_chunk !> 0 || chunk_size !> 0 ]
+    out_of_range = 55,			    ///< Equivalent to std::out_of_range
+    length_error = 56,			    ///< Equivalent to std::length_error
+    invalid_vector_error = 57,		    ///< An error occurred when Invalid hpx::vector is created [Invalid Conditions: num_chunk !> 0 || chunk_size !> 0 ]
 
         /// \cond NOINTERNAL
         last_error,
@@ -147,9 +147,9 @@ namespace hpx
         /* 52 */ "bad_function_call",
         /* 53 */ "task_canceled_exception",
         /* 54 */ "task_region_not_active",
-	/* 55 */ "out_of_range",
-	/* 56 */ "length_error",
-	/* 57 */ "invalid_vector_error",
+    /* 55 */ "out_of_range",
+    /* 56 */ "length_error",
+    /* 57 */ "invalid_vector_error",
 
         /*    */ ""
     };

--- a/hpx/runtime/agas/addressing_service.hpp
+++ b/hpx/runtime/agas/addressing_service.hpp
@@ -78,6 +78,7 @@ struct HPX_EXPORT addressing_service : boost::noncopyable
     > gva_cache_type;
     // }}}
 
+    typedef std::map<naming::gid_type, naming::gid_type> migrated_objects_table_type;
     typedef std::map<naming::gid_type, boost::int64_t> refcnt_requests_type;
 
     struct bootstrap_data_type;
@@ -85,6 +86,7 @@ struct HPX_EXPORT addressing_service : boost::noncopyable
 
     mutable cache_mutex_type gva_cache_mtx_;
     boost::shared_ptr<gva_cache_type> gva_cache_;
+    migrated_objects_table_type migrated_objects_table_;
 
     mutable mutex_type console_cache_mtx_;
     boost::uint32_t console_cache_;
@@ -136,7 +138,8 @@ struct HPX_EXPORT addressing_service : boost::noncopyable
         destroy_big_boot_barrier();
     }
 
-    void initialize(parcelset::parcelhandler& ph, boost::uint64_t rts_lva, boost::uint64_t mem_lva);
+    void initialize(parcelset::parcelhandler& ph, boost::uint64_t rts_lva,
+        boost::uint64_t mem_lva);
 
     void adjust_local_cache_size();
 
@@ -229,7 +232,12 @@ protected:
         future<response> f
       , naming::gid_type const& id
       , gva const& g
-    );
+        );
+
+    /// Maintain list of migrated objects
+    bool was_object_migrated_locked(
+        naming::gid_type const& id
+        );
 
 private:
     /// Assumes that \a refcnt_requests_mtx_ is locked.
@@ -1422,11 +1430,18 @@ public:
       , error_code& ec = throws
         );
 
-    // start/stop migration of an object
+    /// start/stop migration of an object
+    ///
     /// \returns Current locality and address of the object to migrate
     hpx::future<std::pair<naming::id_type, naming::address> >
-        begin_migration_async(naming::id_type const& id);
+        begin_migration_async(
+            naming::id_type const& id
+          , naming::id_type const& target_locality
+            );
     hpx::future<bool> end_migration_async(naming::id_type const& id);
+
+    /// Maintain list of migrated objects
+    bool was_object_migrated(naming::id_type const* ids, std::size_t size);
 };
 
 }}

--- a/hpx/runtime/agas/addressing_service.hpp
+++ b/hpx/runtime/agas/addressing_service.hpp
@@ -1424,7 +1424,9 @@ public:
 
     // start/stop migration of an object
 #if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION >= 408000
-    hpx::future<bool> start_migration_async(naming::id_type const& id);
+    /// \returns Current locality and address of the object to migrate
+    hpx::future<std::pair<naming::id_type, naming::address> >
+        begin_migration_async(naming::id_type const& id);
     hpx::future<bool> end_migration_async(naming::id_type const& id);
 #endif
 };

--- a/hpx/runtime/agas/addressing_service.hpp
+++ b/hpx/runtime/agas/addressing_service.hpp
@@ -1423,12 +1423,10 @@ public:
         );
 
     // start/stop migration of an object
-#if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION >= 408000
     /// \returns Current locality and address of the object to migrate
     hpx::future<std::pair<naming::id_type, naming::address> >
         begin_migration_async(naming::id_type const& id);
     hpx::future<bool> end_migration_async(naming::id_type const& id);
-#endif
 };
 
 }}

--- a/hpx/runtime/agas/addressing_service.hpp
+++ b/hpx/runtime/agas/addressing_service.hpp
@@ -1403,6 +1403,13 @@ public:
         error_code& ec = throws
         );
 
+    /// \warning This function is for internal use only. It is dangerous and
+    ///          may break your code if you use it.
+    void remove_cache_entry(
+        naming::gid_type const& gid
+      , error_code& ec = throws
+        );
+
     // Disable refcnt caching during shutdown
     void start_shutdown(
         error_code& ec = throws
@@ -1414,6 +1421,12 @@ public:
       , naming::gid_type& counter
       , error_code& ec = throws
         );
+
+    // start/stop migration of an object
+#if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION >= 408000
+    hpx::future<bool> start_migration_async(naming::id_type const& id);
+    hpx::future<bool> end_migration_async(naming::id_type const& id);
+#endif
 };
 
 }}

--- a/hpx/runtime/agas/interface.hpp
+++ b/hpx/runtime/agas/interface.hpp
@@ -305,7 +305,9 @@ HPX_API_EXPORT hpx::future<hpx::id_type> on_symbol_namespace_event(
 
 ///////////////////////////////////////////////////////////////////////////////
 HPX_API_EXPORT hpx::future<std::pair<naming::id_type, naming::address> >
-    begin_migration(naming::id_type const& id);
+    begin_migration(
+        naming::id_type const& id,
+        naming::id_type const& target_locality);
 HPX_API_EXPORT hpx::future<bool> end_migration(naming::id_type const& id);
 
 }}

--- a/hpx/runtime/agas/interface.hpp
+++ b/hpx/runtime/agas/interface.hpp
@@ -304,7 +304,8 @@ HPX_API_EXPORT hpx::future<hpx::id_type> on_symbol_namespace_event(
     bool call_for_past_events);
 
 ///////////////////////////////////////////////////////////////////////////////
-HPX_API_EXPORT hpx::future<bool> start_migration(naming::id_type const& id);
+HPX_API_EXPORT hpx::future<std::pair<naming::id_type, naming::address> >
+    begin_migration(naming::id_type const& id);
 HPX_API_EXPORT hpx::future<bool> end_migration(naming::id_type const& id);
 
 }}

--- a/hpx/runtime/agas/interface.hpp
+++ b/hpx/runtime/agas/interface.hpp
@@ -302,6 +302,11 @@ HPX_API_EXPORT naming::id_type get_colocation_id_sync(
 HPX_API_EXPORT hpx::future<hpx::id_type> on_symbol_namespace_event(
     std::string const& name, agas::namespace_action_code evt,
     bool call_for_past_events);
+
+///////////////////////////////////////////////////////////////////////////////
+HPX_API_EXPORT hpx::future<bool> start_migration(naming::id_type const& id);
+HPX_API_EXPORT hpx::future<bool> end_migration(naming::id_type const& id);
+
 }}
 
 #endif // HPX_A55506A4_4AC7_4FD0_AB0D_ED0D1368FCC5

--- a/hpx/runtime/agas/namespace_action_code.hpp
+++ b/hpx/runtime/agas/namespace_action_code.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
-//  Copyright (c) 2012-2014 Hartmut Kaiser
+//  Copyright (c) 2012-2015 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -42,7 +42,9 @@ enum namespace_action_code
     primary_ns_increment_credit             = BOOST_BINARY_U(1000110),
     primary_ns_decrement_credit             = BOOST_BINARY_U(1000111),
     primary_ns_allocate                     = BOOST_BINARY_U(1001000),
-    primary_ns_statistics_counter           = BOOST_BINARY_U(1001001),
+    primary_ns_start_migration              = BOOST_BINARY_U(1001001),
+    primary_ns_end_migration                = BOOST_BINARY_U(1001010),
+    primary_ns_statistics_counter           = BOOST_BINARY_U(1001011),
 
     component_ns_service                    = BOOST_BINARY_U(0100000),
     component_ns_bulk_service               = BOOST_BINARY_U(0100001),
@@ -303,6 +305,16 @@ namespace detail
           , counter_target_count
           , primary_ns_allocate
           , primary_ns_statistics_counter }
+      , {   "count/start_migration"
+          , ""
+          , counter_target_count
+          , primary_ns_start_migration
+          , primary_ns_statistics_counter }
+      , {   "count/end_migration"
+          , ""
+          , counter_target_count
+          , primary_ns_end_migration
+          , primary_ns_statistics_counter }
       // counters exposing API timings
       , {   "time/route"
           , "ns"
@@ -338,6 +350,16 @@ namespace detail
           , "ns"
           , counter_target_time
           , primary_ns_allocate
+          , primary_ns_statistics_counter }
+      , {   "time/start_migration"
+          , "ns"
+          , counter_target_time
+          , primary_ns_start_migration
+          , primary_ns_statistics_counter }
+      , {   "time/end_migration"
+          , "ns"
+          , counter_target_time
+          , primary_ns_end_migration
           , primary_ns_statistics_counter }
     };
     static std::size_t const num_primary_namespace_services =

--- a/hpx/runtime/agas/namespace_action_code.hpp
+++ b/hpx/runtime/agas/namespace_action_code.hpp
@@ -42,7 +42,7 @@ enum namespace_action_code
     primary_ns_increment_credit             = BOOST_BINARY_U(1000110),
     primary_ns_decrement_credit             = BOOST_BINARY_U(1000111),
     primary_ns_allocate                     = BOOST_BINARY_U(1001000),
-    primary_ns_start_migration              = BOOST_BINARY_U(1001001),
+    primary_ns_begin_migration              = BOOST_BINARY_U(1001001),
     primary_ns_end_migration                = BOOST_BINARY_U(1001010),
     primary_ns_statistics_counter           = BOOST_BINARY_U(1001011),
 
@@ -305,10 +305,10 @@ namespace detail
           , counter_target_count
           , primary_ns_allocate
           , primary_ns_statistics_counter }
-      , {   "count/start_migration"
+      , {   "count/begin_migration"
           , ""
           , counter_target_count
-          , primary_ns_start_migration
+          , primary_ns_begin_migration
           , primary_ns_statistics_counter }
       , {   "count/end_migration"
           , ""
@@ -351,10 +351,10 @@ namespace detail
           , counter_target_time
           , primary_ns_allocate
           , primary_ns_statistics_counter }
-      , {   "time/start_migration"
+      , {   "time/begin_migration"
           , "ns"
           , counter_target_time
-          , primary_ns_start_migration
+          , primary_ns_begin_migration
           , primary_ns_statistics_counter }
       , {   "time/end_migration"
           , "ns"

--- a/hpx/runtime/agas/response.hpp
+++ b/hpx/runtime/agas/response.hpp
@@ -264,18 +264,6 @@ struct get_remote_result<naming::id_type, agas::response>
     }
 };
 
-// TODO: verification of namespace_action_code
-template <>
-struct get_remote_result<bool, agas::response>
-{
-    static bool call(
-        agas::response const& rep
-        )
-    {
-        return success == rep.get_status();
-    }
-};
-
 template <>
 struct get_remote_result<boost::uint32_t, agas::response>
 {
@@ -320,6 +308,31 @@ struct get_remote_result<boost::int64_t, agas::response>
             "get_remote_result<boost::int64_t, agas::response>::call",
             "unexpected action code in result conversion");
         return 0;
+    }
+};
+
+template <>
+struct get_remote_result<bool, agas::response>
+{
+    static bool call(
+        agas::response const& rep
+        )
+    {
+        switch(rep.get_action_code()) {
+        case agas::symbol_ns_bind:
+        case agas::symbol_ns_on_event:
+        case agas::primary_ns_start_migration:
+        case agas::primary_ns_end_migration:
+            return rep.get_status() == success;
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(bad_parameter,
+            "get_remote_result<void, agas::response>::call",
+            "unexpected action code in result conversion");
+        return false;
     }
 };
 

--- a/hpx/runtime/agas/response.hpp
+++ b/hpx/runtime/agas/response.hpp
@@ -51,7 +51,7 @@ struct HPX_EXPORT response
         namespace_action_code type_
       , naming::gid_type const& gidbase_
       , gva const& gva_
-      , naming::gid_type locality_
+      , naming::gid_type const& locality_
       , error status_ = success
         );
 
@@ -159,6 +159,10 @@ struct HPX_EXPORT response
         ) const;
 
     boost::uint32_t get_locality_id(
+        error_code& ec = throws
+        ) const;
+
+    naming::gid_type response::get_locality(
         error_code& ec = throws
         ) const;
 
@@ -321,7 +325,6 @@ struct get_remote_result<bool, agas::response>
         switch(rep.get_action_code()) {
         case agas::symbol_ns_bind:
         case agas::symbol_ns_on_event:
-        case agas::primary_ns_start_migration:
         case agas::primary_ns_end_migration:
             return rep.get_status() == success;
 
@@ -350,10 +353,39 @@ struct get_remote_result<std::vector<boost::uint32_t>, agas::response>
         default:
             break;
         }
+
         HPX_THROW_EXCEPTION(bad_parameter,
             "get_remote_result<std::vector<boost::uint32_t>, agas::response>::call",
             "unexpected action code in result conversion");
         return std::vector<boost::uint32_t>();
+    }
+};
+
+template <>
+struct get_remote_result<std::pair<naming::id_type, naming::address>, agas::response>
+{
+    static std::pair<naming::id_type, naming::address> call(
+        agas::response const& rep
+        )
+    {
+        switch(rep.get_action_code()) {
+        case agas::primary_ns_begin_migration:
+            {
+                agas::gva g = rep.get_gva();
+
+                naming::address addr(g.prefix, g.type, g.lva());
+                naming::id_type loc(rep.get_locality(), id_type::unmanaged);
+                return std::pair<naming::id_type, naming::address>(loc, addr);
+            }
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(bad_parameter,
+            "get_remote_result<std::pair<naming::id_type, naming::address>, agas::response>::call",
+            "unexpected action code in result conversion");
+        return std::pair<naming::id_type, naming::address>();
     }
 };
 

--- a/hpx/runtime/agas/response.hpp
+++ b/hpx/runtime/agas/response.hpp
@@ -162,7 +162,7 @@ struct HPX_EXPORT response
         error_code& ec = throws
         ) const;
 
-    naming::gid_type response::get_locality(
+    naming::gid_type get_locality(
         error_code& ec = throws
         ) const;
 

--- a/hpx/runtime/agas/server/primary_namespace.hpp
+++ b/hpx/runtime/agas/server/primary_namespace.hpp
@@ -167,7 +167,7 @@ struct HPX_EXPORT primary_namespace
         boost::int64_t get_increment_credit_count(bool);
         boost::int64_t get_decrement_credit_count(bool);
         boost::int64_t get_allocate_count(bool);
-        boost::int64_t get_start_migration_count(bool);
+        boost::int64_t get_begin_migration_count(bool);
         boost::int64_t get_end_migration_count(bool);
         boost::int64_t get_overall_count(bool);
 
@@ -178,7 +178,7 @@ struct HPX_EXPORT primary_namespace
         boost::int64_t get_increment_credit_time(bool);
         boost::int64_t get_decrement_credit_time(bool);
         boost::int64_t get_allocate_time(bool);
-        boost::int64_t get_start_migration_time(bool);
+        boost::int64_t get_begin_migration_time(bool);
         boost::int64_t get_end_migration_time(bool);
         boost::int64_t get_overall_time(bool);
 
@@ -190,7 +190,7 @@ struct HPX_EXPORT primary_namespace
         void increment_increment_credit_count();
         void increment_decrement_credit_count();
         void increment_allocate_count();
-        void increment_start_migration_count();
+        void increment_begin_migration_count();
         void increment_end_migration_count();
 
     private:
@@ -205,7 +205,7 @@ struct HPX_EXPORT primary_namespace
         api_counter_data increment_credit_;     // primary_ns_increment_credit
         api_counter_data decrement_credit_;     // primary_ns_decrement_credit
         api_counter_data allocate_;             // primary_ns_allocate
-        api_counter_data start_migration_;      // primary_ns_start_migration
+        api_counter_data begin_migration_;      // primary_ns_begin_migration
         api_counter_data end_migration_;        // primary_ns_end_migration
     };
     counter_data counter_data_;
@@ -243,14 +243,14 @@ struct HPX_EXPORT primary_namespace
 #endif
 
 #if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION >= 408000
-    response start_migration(
+    response begin_migration(
         request const& req
       , error_code& ec);
     response end_migration(
         request const& req
       , error_code& ec);
 
-    void wait_for_migration(
+    void wait_for_migration_locked(
         mutex_type::scoped_lock& l
       , naming::gid_type id
       , error_code& ec);
@@ -416,7 +416,7 @@ struct HPX_EXPORT primary_namespace
       , namespace_increment_credit              = primary_ns_increment_credit
       , namespace_decrement_credit              = primary_ns_decrement_credit
       , namespace_allocate                      = primary_ns_allocate
-      , namespace_start_migration               = primary_ns_start_migration
+      , namespace_begin_migration               = primary_ns_begin_migration
       , namespace_end_migration                 = primary_ns_end_migration
       , namespace_statistics_counter            = primary_ns_statistics_counter
     }; // }}}

--- a/hpx/runtime/agas/server/primary_namespace.hpp
+++ b/hpx/runtime/agas/server/primary_namespace.hpp
@@ -243,6 +243,7 @@ struct HPX_EXPORT primary_namespace
 #endif
 
 #if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION >= 408000
+    // API
     response begin_migration(
         request const& req
       , error_code& ec);
@@ -250,6 +251,7 @@ struct HPX_EXPORT primary_namespace
         request const& req
       , error_code& ec);
 
+    // helper function
     void wait_for_migration_locked(
         mutex_type::scoped_lock& l
       , naming::gid_type id

--- a/hpx/runtime/components/migrate_component.hpp
+++ b/hpx/runtime/components/migrate_component.hpp
@@ -48,9 +48,9 @@ namespace hpx { namespace components
     migrate(naming::id_type const& to_migrate,
         naming::id_type const& target_locality)
     {
-        typedef server::migrate_component_action<Component> action_type;
-        return async_colocated<action_type>(to_migrate, to_migrate,
-            target_locality);
+        typedef server::trigger_migrate_component_action<Component> action_type;
+        return async<action_type>(naming::get_locality_from_id(to_migrate),
+            to_migrate, target_locality);
     }
 
     /// Migrate the given component to the specified target locality

--- a/hpx/runtime/components/server/migrate_component.hpp
+++ b/hpx/runtime/components/server/migrate_component.hpp
@@ -53,7 +53,7 @@ namespace hpx { namespace components { namespace server
         // clean up (source) memory of migrated object
         template <typename Component>
         naming::id_type migrate_component_cleanup(
-            future<naming::id_type> f,
+            future<naming::id_type> && f,
             boost::shared_ptr<Component> ptr,
             naming::id_type const& to_migrate)
         {

--- a/hpx/runtime/components/server/migrate_component.hpp
+++ b/hpx/runtime/components/server/migrate_component.hpp
@@ -166,7 +166,7 @@ namespace hpx { namespace components { namespace server
             return make_ready_future(naming::invalid_id);
         }
 
-        return agas::begin_migration(to_migrate)
+        return agas::begin_migration(to_migrate, target_locality)
             .then(
                 [to_migrate, target_locality](
                     future<std::pair<naming::id_type, naming::address> > && f)

--- a/hpx/runtime/parcelset/parcelhandler.hpp
+++ b/hpx/runtime/parcelset/parcelhandler.hpp
@@ -39,11 +39,12 @@ namespace hpx { namespace parcelset
     /// parcel-handlers may be connected to a single parcelport.
     class HPX_EXPORT parcelhandler : boost::noncopyable
     {
-    private:
+    public:
         // default callback for put_parcel
         void default_write_handler(boost::system::error_code const&,
             parcel const& p);
 
+    private:
         void parcel_sink(parcel const& p);
 
         threads::thread_state_enum decode_parcel(

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -3053,25 +3053,29 @@ void addressing_service::send_refcnt_requests_sync(
 }
 
 #if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION >= 408000
-hpx::future<bool> addressing_service::start_migration_async(
+hpx::future<std::pair<naming::id_type, naming::address> >
+addressing_service::begin_migration_async(
     naming::id_type const& id
     )
 {
+    typedef std::pair<naming::id_type, naming::address> result_type;
+
     if (!id)
     {
         HPX_THROW_EXCEPTION(bad_parameter,
-            "addressing_service::start_migration_async",
+            "addressing_service::begin_migration_async",
             "invalid reference id");
-        return make_ready_future(false);
+        return make_ready_future(result_type(naming::invalid_id, naming::address()));
     }
 
-    agas::request req(agas::primary_ns_start_migration, id.get_gid());
+    agas::request req(agas::primary_ns_begin_migration, id.get_gid());
     naming::id_type service_target(
         agas::stubs::primary_namespace::get_service_instance(id.get_gid())
       , naming::id_type::unmanaged);
 
-    return stubs::primary_namespace::service_async<bool>(
-        service_target, req);
+    return stubs::primary_namespace::service_async<
+            std::pair<naming::id_type, naming::address>
+        >(service_target, req);
 }
 
 hpx::future<bool> addressing_service::end_migration_async(
@@ -3081,7 +3085,7 @@ hpx::future<bool> addressing_service::end_migration_async(
     if (!id)
     {
         HPX_THROW_EXCEPTION(bad_parameter,
-            "addressing_service::start_migration_async",
+            "addressing_service::end_migration_async",
             "invalid reference id");
         return make_ready_future(false);
     }

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -3052,7 +3052,6 @@ void addressing_service::send_refcnt_requests_sync(
         ec = make_success_code();
 }
 
-#if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION >= 408000
 hpx::future<std::pair<naming::id_type, naming::address> >
 addressing_service::begin_migration_async(
     naming::id_type const& id
@@ -3098,7 +3097,6 @@ hpx::future<bool> addressing_service::end_migration_async(
     return stubs::primary_namespace::service_async<bool>(
         service_target, req);
 }
-#endif
 
 }}
 

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -1440,6 +1440,10 @@ bool addressing_service::resolve_cached(
 
     cache_mutex_type::scoped_lock lock(gva_cache_mtx_);
 
+    // force routing if target object was migrated
+    if (was_object_migrated_locked(id))
+        return false;
+
     // Check if the entry is currently in the cache
     if (gva_cache_->get_entry(k, idbase, e))
     {
@@ -1537,7 +1541,7 @@ hpx::future<naming::id_type> addressing_service::get_colocation_id_async(
     agas::request req(agas::primary_ns_resolve_gid, id.get_gid());
     naming::id_type service_target(
         agas::stubs::primary_namespace::get_service_instance(id.get_gid())
-        , naming::id_type::unmanaged);
+      , naming::id_type::unmanaged);
 
     return stubs::primary_namespace::service_async<naming::id_type>(
         service_target, req);
@@ -1569,7 +1573,6 @@ naming::address addressing_service::resolve_full_postproc(
     addr.locality_ = g.prefix;
     addr.type_ = g.type;
     addr.address_ = g.lva();
-
 
     if(range_caching_)
     {
@@ -1688,7 +1691,6 @@ bool addressing_service::resolve_full_local(
             addr.type_ = g.type;
             addr.address_ = g.lva();
 
-
             if(range_caching_)
             {
                 // Put the range into the cache.
@@ -1791,13 +1793,18 @@ void addressing_service::route(
             naming::id_type const route_target(
                 bootstrap_primary_namespace_gid(), naming::id_type::unmanaged);
 
-            parcelset::parcel route_p(route_target, primary_ns_addr_
+            parcelset::parcel route_p(
+                route_target, primary_ns_addr_
               , new hpx::actions::transfer_action<action_type>(action_priority_,
                     req));
 
             // send to the main AGAS instance for routing
             hpx::applier::get_applier().get_parcel_handler().put_parcel(route_p, f);
             return;
+        }
+        else
+        {
+            HPX_ASSERT(false);      // should not happen
         }
     }
 
@@ -2255,6 +2262,21 @@ void addressing_service::insert_cache_entry(
 
         cache_mutex_type::scoped_lock lock(gva_cache_mtx_);
 
+// Removing entries from the table of migrated object is not safe as there is
+// no other way to reliably tell whether an object is still here or not (other
+// localities might have stale AGAS cache entries).
+//
+//         // remove the object from the table of migrated objects if the object's
+//         // new locality is the same as the locality where the object was
+//         // migrated to.
+//         migrated_objects_table_type::iterator mo_it =
+//             migrated_objects_table_.find(gid);
+//         if (mo_it != migrated_objects_table_.end() &&
+//             (!mo_it->second || mo_it->second == g.prefix))
+//         {
+//             migrated_objects_table_.erase(mo_it);
+//         }
+
         const gva_cache_key key(gid, count);
 
         if (!gva_cache_->insert(key, g))
@@ -2328,13 +2350,19 @@ void addressing_service::update_cache_entry(
 
         cache_mutex_type::scoped_lock lock(gva_cache_mtx_);
 
-        // update cache only if it's currently not locked
-//         cache_mutex_type::scoped_try_lock lock(gva_cache_mtx_);
-//         if (!lock)
+// Removing entries from the table of migrated object is not safe as there is
+// no other way to reliably tell whether an object is still here or not (other
+// localities might have stale AGAS cache entries).
+//
+//         // remove the object from the table of migrated objects if the object's
+//         // new locality is the same as the locality where the object was
+//         // migrated to.
+//         migrated_objects_table_type::iterator mo_it =
+//             migrated_objects_table_.find(gid);
+//         if (mo_it != migrated_objects_table_.end() &&
+//             (!mo_it->second || mo_it->second == g.prefix))
 //         {
-//             if (&ec != &throws)
-//                 ec = make_success_code();
-//             return;
+//             migrated_objects_table_.erase(mo_it);
 //         }
 
         const gva_cache_key key(gid, count);
@@ -3055,6 +3083,7 @@ void addressing_service::send_refcnt_requests_sync(
 hpx::future<std::pair<naming::id_type, naming::address> >
 addressing_service::begin_migration_async(
     naming::id_type const& id
+  , naming::id_type const& target_locality
     )
 {
     typedef std::pair<naming::id_type, naming::address> result_type;
@@ -3067,9 +3096,28 @@ addressing_service::begin_migration_async(
         return make_ready_future(result_type(naming::invalid_id, naming::address()));
     }
 
-    agas::request req(agas::primary_ns_begin_migration, id.get_gid());
+    naming::gid_type gid = id.get_gid();
+
+    // insert the object's new locality into the map of migrated objects
+    {
+        cache_mutex_type::scoped_lock lock(gva_cache_mtx_);
+        if (target_locality)
+        {
+            migrated_objects_table_.insert(
+                migrated_objects_table_type::value_type(
+                    gid, target_locality.get_gid()));
+        }
+        else
+        {
+            migrated_objects_table_.insert(
+                migrated_objects_table_type::value_type(
+                    gid, naming::invalid_gid));
+        }
+    }
+
+    agas::request req(agas::primary_ns_begin_migration, gid);
     naming::id_type service_target(
-        agas::stubs::primary_namespace::get_service_instance(id.get_gid())
+        agas::stubs::primary_namespace::get_service_instance(gid)
       , naming::id_type::unmanaged);
 
     return stubs::primary_namespace::service_async<
@@ -3096,6 +3144,31 @@ hpx::future<bool> addressing_service::end_migration_async(
 
     return stubs::primary_namespace::service_async<bool>(
         service_target, req);
+}
+
+bool addressing_service::was_object_migrated_locked(
+    naming::gid_type const& id
+    )
+{
+    return
+        migrated_objects_table_.find(id) !=
+        migrated_objects_table_.end();
+}
+
+bool addressing_service::was_object_migrated(
+    naming::id_type const* ids
+  , std::size_t size)
+{
+#if !defined(HPX_SUPPORT_MULTIPLE_PARCEL_DESTINATIONS)
+    HPX_ASSERT(1 == size);
+
+    cache_mutex_type::scoped_lock lock(gva_cache_mtx_);
+    return was_object_migrated_locked(ids[0].get_gid());
+#else
+    // #FIXME: it's not really clear how to handle this situation
+    HPX_ASSERT(false);
+    return false;
+#endif
 }
 
 }}

--- a/src/runtime/agas/interface.cpp
+++ b/src/runtime/agas/interface.cpp
@@ -492,10 +492,11 @@ hpx::future<hpx::id_type> on_symbol_namespace_event(
 
 ///////////////////////////////////////////////////////////////////////////////
 hpx::future<std::pair<naming::id_type, naming::address> >
-    begin_migration(naming::id_type const& id)
+    begin_migration(naming::id_type const& id,
+        naming::id_type const& target_locality)
 {
     naming::resolver_client& resolver = naming::get_agas_client();
-    return resolver.begin_migration_async(id);
+    return resolver.begin_migration_async(id, target_locality);
 }
 
 hpx::future<bool> end_migration(naming::id_type const& id)

--- a/src/runtime/agas/interface.cpp
+++ b/src/runtime/agas/interface.cpp
@@ -490,5 +490,18 @@ hpx::future<hpx::id_type> on_symbol_namespace_event(
     return resolver.on_symbol_namespace_event(name, evt, call_for_past_events);
 }
 
+///////////////////////////////////////////////////////////////////////////////
+hpx::future<bool> start_migration(naming::id_type const& id)
+{
+    naming::resolver_client& resolver = naming::get_agas_client();
+    return resolver.start_migration_async(id);
+}
+
+hpx::future<bool> end_migration(naming::id_type const& id)
+{
+    naming::resolver_client& resolver = naming::get_agas_client();
+    return resolver.end_migration_async(id);
+}
+
 }}
 

--- a/src/runtime/agas/interface.cpp
+++ b/src/runtime/agas/interface.cpp
@@ -491,10 +491,11 @@ hpx::future<hpx::id_type> on_symbol_namespace_event(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::future<bool> start_migration(naming::id_type const& id)
+hpx::future<std::pair<naming::id_type, naming::address> >
+    begin_migration(naming::id_type const& id)
 {
     naming::resolver_client& resolver = naming::get_agas_client();
-    return resolver.start_migration_async(id);
+    return resolver.begin_migration_async(id);
 }
 
 hpx::future<bool> end_migration(naming::id_type const& id)

--- a/src/runtime/agas/request.cpp
+++ b/src/runtime/agas/request.cpp
@@ -108,6 +108,8 @@ namespace hpx { namespace agas
             // primary_ns_change_credit_one
             // primary_ns_free
             // primary_ns_resolve_locality
+            // primary_ns_start_migration
+            // primary_ns_end_migration
           , util::tuple<
                 naming::gid_type // gid
             >

--- a/src/runtime/agas/request.cpp
+++ b/src/runtime/agas/request.cpp
@@ -108,7 +108,7 @@ namespace hpx { namespace agas
             // primary_ns_change_credit_one
             // primary_ns_free
             // primary_ns_resolve_locality
-            // primary_ns_start_migration
+            // primary_ns_begin_migration
             // primary_ns_end_migration
           , util::tuple<
                 naming::gid_type // gid

--- a/src/runtime/agas/response.cpp
+++ b/src/runtime/agas/response.cpp
@@ -88,6 +88,7 @@ namespace hpx { namespace agas
             >
             // 0x1
             // primary_ns_resolve_gid
+            // locality_ns_begin_migration
           , util::tuple<
                 naming::gid_type // idbase
               , gva              // gva
@@ -238,14 +239,16 @@ namespace hpx { namespace agas
         namespace_action_code type_
       , naming::gid_type const& gidbase_
       , gva const& gva_
-      , naming::gid_type locality_
+      , naming::gid_type const& locality_
       , error status_
         )
       : mc(type_)
       , status(status_)
       , data(new response_data(util::make_tuple(gidbase_, gva_, locality_)))
     {
-        HPX_ASSERT(type_ == primary_ns_resolve_gid);
+        HPX_ASSERT(
+            type_ == primary_ns_resolve_gid ||
+            type_ == primary_ns_begin_migration);
     }
 
     response::response(
@@ -494,6 +497,24 @@ namespace hpx { namespace agas
                     "response::get_locality_id",
                     "invalid operation for request type");
                 return naming::invalid_locality_id;
+            }
+        }
+    }
+
+    naming::gid_type response::get_locality(
+        error_code& ec
+        ) const
+    {
+        switch (data->which())
+        {
+            case response_data::subtype_gid_gva_prefix:
+                return data->get_data<response_data::subtype_gid_gva_prefix, 2>(ec);
+
+            default: {
+                HPX_THROWS_IF(ec, bad_parameter,
+                    "response::get_locality",
+                    "invalid operation for request type");
+                return naming::invalid_gid;
             }
         }
     }

--- a/src/runtime/agas/server/component_namespace_server.cpp
+++ b/src/runtime/agas/server/component_namespace_server.cpp
@@ -130,6 +130,8 @@ response component_namespace::service(
         case primary_ns_increment_credit:
         case primary_ns_decrement_credit:
         case primary_ns_allocate:
+        case primary_ns_start_migration:
+        case primary_ns_end_migration:
         {
             LAGAS_(warning) <<
                 "component_namespace::service, redirecting request to "

--- a/src/runtime/agas/server/component_namespace_server.cpp
+++ b/src/runtime/agas/server/component_namespace_server.cpp
@@ -130,7 +130,7 @@ response component_namespace::service(
         case primary_ns_increment_credit:
         case primary_ns_decrement_credit:
         case primary_ns_allocate:
-        case primary_ns_start_migration:
+        case primary_ns_begin_migration:
         case primary_ns_end_migration:
         {
             LAGAS_(warning) <<

--- a/src/runtime/agas/server/locality_namespace_server.cpp
+++ b/src/runtime/agas/server/locality_namespace_server.cpp
@@ -120,7 +120,7 @@ response locality_namespace::service(
         case primary_ns_increment_credit:
         case primary_ns_decrement_credit:
         case primary_ns_allocate:
-        case primary_ns_start_migration:
+        case primary_ns_begin_migration:
         case primary_ns_end_migration:
         {
             LAGAS_(warning) <<

--- a/src/runtime/agas/server/locality_namespace_server.cpp
+++ b/src/runtime/agas/server/locality_namespace_server.cpp
@@ -120,6 +120,8 @@ response locality_namespace::service(
         case primary_ns_increment_credit:
         case primary_ns_decrement_credit:
         case primary_ns_allocate:
+        case primary_ns_start_migration:
+        case primary_ns_end_migration:
         {
             LAGAS_(warning) <<
                 "locality_namespace::service, redirecting request to "

--- a/src/runtime/agas/server/primary_namespace_server.cpp
+++ b/src/runtime/agas/server/primary_namespace_server.cpp
@@ -119,8 +119,8 @@ response primary_namespace::service(
                     counter_data_
                   , counter_data_.begin_migration_.time_
                 );
-                counter_data_.increment_allocate_count();
-                return begin_migration(req, ec);
+                counter_data_.increment_begin_migration_count();
+                return this->primary_namespace::begin_migration(req, ec);
             }
         case primary_ns_end_migration:
             {
@@ -128,8 +128,8 @@ response primary_namespace::service(
                     counter_data_
                   , counter_data_.end_migration_.time_
                 );
-                counter_data_.increment_allocate_count();
-                return end_migration(req, ec);
+                counter_data_.increment_end_migration_count();
+                return this->primary_namespace::end_migration(req, ec);
             }
         case primary_ns_statistics_counter:
             return statistics_counter(req, ec);

--- a/src/runtime/agas/server/route.cpp
+++ b/src/runtime/agas/server/route.cpp
@@ -39,7 +39,13 @@ namespace hpx { namespace agas { namespace server
             {
                 if (!addrs[i])
                 {
-                    cache_addresses.push_back(resolve_gid_locked(ids[i].get_gid(), ec));
+                    naming::gid_type gid(ids[i].get_gid());
+
+#if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION >= 408000
+                    // wait for any migration to be completed
+                    wait_for_migration(l, gid, ec);
+#endif
+                    cache_addresses.push_back(resolve_gid_locked(gid, ec));
                     resolved_type const& r = cache_addresses.back();
 
                     if (ec || boost::fusion::at_c<0>(r) == naming::invalid_gid)

--- a/src/runtime/agas/server/route.cpp
+++ b/src/runtime/agas/server/route.cpp
@@ -41,10 +41,9 @@ namespace hpx { namespace agas { namespace server
                 {
                     naming::gid_type gid(ids[i].get_gid());
 
-#if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION >= 408000
                     // wait for any migration to be completed
                     wait_for_migration_locked(l, gid, ec);
-#endif
+
                     cache_addresses.push_back(resolve_gid_locked(gid, ec));
                     resolved_type const& r = cache_addresses.back();
 

--- a/src/runtime/agas/server/route.cpp
+++ b/src/runtime/agas/server/route.cpp
@@ -43,7 +43,7 @@ namespace hpx { namespace agas { namespace server
 
 #if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION >= 408000
                     // wait for any migration to be completed
-                    wait_for_migration(l, gid, ec);
+                    wait_for_migration_locked(l, gid, ec);
 #endif
                     cache_addresses.push_back(resolve_gid_locked(gid, ec));
                     resolved_type const& r = cache_addresses.back();

--- a/src/runtime/agas/server/symbol_namespace_server.cpp
+++ b/src/runtime/agas/server/symbol_namespace_server.cpp
@@ -111,7 +111,7 @@ response symbol_namespace::service(
         case primary_ns_increment_credit:
         case primary_ns_decrement_credit:
         case primary_ns_allocate:
-        case primary_ns_start_migration:
+        case primary_ns_begin_migration:
         case primary_ns_end_migration:
         {
             LAGAS_(warning) <<

--- a/src/runtime/agas/server/symbol_namespace_server.cpp
+++ b/src/runtime/agas/server/symbol_namespace_server.cpp
@@ -111,6 +111,8 @@ response symbol_namespace::service(
         case primary_ns_increment_credit:
         case primary_ns_decrement_credit:
         case primary_ns_allocate:
+        case primary_ns_start_migration:
+        case primary_ns_end_migration:
         {
             LAGAS_(warning) <<
                 "symbol_namespace::service, redirecting request to "

--- a/src/runtime/agas/stubs/component_namespace_stubs.cpp
+++ b/src/runtime/agas/stubs/component_namespace_stubs.cpp
@@ -1,5 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
+//  Copyright (c) 2012-2015 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -35,6 +36,12 @@ template lcos::future<response> component_namespace::service_async<response>(
     );
 
 template lcos::future<boost::uint32_t> component_namespace::service_async<boost::uint32_t>(
+    naming::id_type const& gid
+  , request const& req
+  , threads::thread_priority priority
+    );
+
+template lcos::future<bool> component_namespace::service_async<bool>(
     naming::id_type const& gid
   , request const& req
   , threads::thread_priority priority

--- a/src/runtime/agas/stubs/primary_namespace_stubs.cpp
+++ b/src/runtime/agas/stubs/primary_namespace_stubs.cpp
@@ -55,6 +55,13 @@ template lcos::future<naming::id_type>
       , threads::thread_priority priority
         );
 
+template lcos::future<std::pair<naming::id_type, naming::address> >
+    primary_namespace::service_async<std::pair<naming::id_type, naming::address> >(
+    naming::id_type const& gid
+  , request const& req
+  , threads::thread_priority priority
+    );
+
 void primary_namespace::service_non_blocking(
     naming::id_type const& gid
   , request const& req

--- a/src/runtime/applier/applier.cpp
+++ b/src/runtime/applier/applier.cpp
@@ -24,6 +24,11 @@
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace detail
+{
+    void dijkstra_make_black();     // forward declaration only
+}}
+
 namespace hpx { namespace applier
 {
     ///////////////////////////////////////////////////////////////////////////
@@ -407,9 +412,45 @@ namespace hpx { namespace applier
         applier::applier_.reset();
     }
 
+    namespace detail
+    {
+        // The original parcel-sent handler is wrapped to keep the parcel alive
+        // until after the data has been reliably sent (which is needed for zero
+        // copy serialization).
+        void parcel_sent_handler(parcelset::parcelhandler& ph,
+            boost::system::error_code const& ec,
+            parcelset::parcel const& p)
+        {
+            // invoke the original handler
+            ph.default_write_handler(ec, p);
+
+            // inform termination detection of a sent message
+            if (!p.does_termination_detection())
+                hpx::detail::dijkstra_make_black();
+        }
+    }
+
     // schedule threads based on given parcel
     void applier::schedule_action(parcelset::parcel const& p)
     {
+        // fetch the set of destinations
+#if !defined(HPX_SUPPORT_MULTIPLE_PARCEL_DESTINATIONS)
+        std::size_t const size = 1ul;
+#else
+        std::size_t const size = p.size();
+#endif
+        naming::id_type const* ids = p.get_destinations();
+        naming::address const* addrs = p.get_destination_addrs();
+
+        // make sure the target has not been migrated away
+        naming::resolver_client& client = hpx::naming::get_agas_client();
+        if (client.was_object_migrated(ids, size))
+        {
+            client.route(p, util::bind(&detail::parcel_sent_handler,
+                std::ref(parcel_handler_), util::placeholders::_1, p));
+            return;
+        }
+
         // decode the action-type in the parcel
         actions::continuation_type cont = p.get_continuation();
         actions::action_type act = p.get_action();
@@ -438,11 +479,6 @@ namespace hpx { namespace applier
 #endif
         int comptype = act->get_component_type();
         naming::gid_type dest = p.get_destination_locality();
-
-        // fetch the set of destinations
-        std::size_t size = p.size();
-        naming::id_type const* ids = p.get_destinations();
-        naming::address const* addrs = p.get_destination_addrs();
 
         // if the parcel carries a continuation it should be directed to a
         // single destination

--- a/tests/unit/components/migrate_component_to_storage.cpp
+++ b/tests/unit/components/migrate_component_to_storage.cpp
@@ -10,8 +10,6 @@
 #include <hpx/include/component_storage.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
-#include <boost/atomic/atomic.hpp>
-
 ///////////////////////////////////////////////////////////////////////////////
 struct test_server
   : hpx::components::migration_support<

--- a/tests/unit/components/migrate_component_to_storage.cpp
+++ b/tests/unit/components/migrate_component_to_storage.cpp
@@ -100,14 +100,62 @@ bool test_migrate_component_to_storage(hpx::id_type const& source,
     HPX_TEST_EQ(storage.size_sync(), std::size_t(1));
 
     {
-        test_client t1(hpx::components::migrate_from_storage<test_server>(
-            oldid, storage));
+        test_client t1(hpx::components::migrate_from_storage<test_server>(oldid));
 
         // the id of the newly resurrected object should be the same as the old id
         HPX_TEST_EQ(oldid, t1.get_gid());
 
         // the new object should live on the (original) source locality
         HPX_TEST_EQ(t1.call(), source);
+
+        HPX_TEST_EQ(storage.size_sync(), std::size_t(0));
+    }
+
+    return true;
+}
+
+bool test_migrate_component_to_storage(hpx::id_type const& source,
+    hpx::id_type const& target, hpx::components::component_storage storage,
+    hpx::id_type::management_type t)
+{
+    hpx::id_type oldid;
+
+    {
+        // create component on given locality
+        test_client t1(source);
+        HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_gid());
+
+        // the new object should live on the source locality
+        HPX_TEST_EQ(t1.call(), source);
+
+        // remember the original id for later resurrection
+        oldid = hpx::id_type(t1.get_gid().get_gid(), t);
+
+        try {
+            // migrate of t1 to the target storage
+            test_client t2(hpx::components::migrate_to_storage(t1, storage));
+            HPX_TEST_EQ(hpx::naming::invalid_id, t2.get_gid());
+        }
+        catch (hpx::exception const&) {
+            return false;
+        }
+
+        HPX_TEST_EQ(storage.size_sync(), std::size_t(1));
+
+        // make sure all local references go out of scope if t == unmanaged
+    }
+
+    HPX_TEST_EQ(storage.size_sync(), std::size_t(1));
+
+    {
+        test_client t1(hpx::components::migrate_from_storage<test_server>(
+            oldid, target));
+
+        // the id of the newly resurrected object should be the same as the old id
+        HPX_TEST_EQ(oldid, t1.get_gid());
+
+        // the new object should now live on the target locality
+        HPX_TEST_EQ(t1.call(), target);
 
         HPX_TEST_EQ(storage.size_sync(), std::size_t(0));
     }
@@ -164,25 +212,32 @@ bool test_migrate_component_from_storage(hpx::id_type const& source,
 ///////////////////////////////////////////////////////////////////////////////
 void test_storage(hpx::id_type const& here, hpx::id_type const& there)
 {
-    {
-        // create a new storage instance
-        hpx::components::component_storage storage(here);
-        HPX_TEST_NEQ(hpx::naming::invalid_id, storage.get_gid());
+    // create a new storage instance
+    hpx::components::component_storage storage(here);
+    HPX_TEST_NEQ(hpx::naming::invalid_id, storage.get_gid());
 
-        HPX_TEST(test_migrate_component_to_storage(here, storage, hpx::id_type::unmanaged));
-        HPX_TEST(test_migrate_component_to_storage(here, storage, hpx::id_type::managed));
+    HPX_TEST(test_migrate_component_to_storage(here, storage,
+        hpx::id_type::unmanaged));
+    HPX_TEST(test_migrate_component_to_storage(here, storage,
+        hpx::id_type::managed));
 
-        HPX_TEST(test_migrate_component_from_storage(here, storage));
-    }
+    HPX_TEST(test_migrate_component_to_storage(here, there, storage,
+        hpx::id_type::unmanaged));
+    HPX_TEST(test_migrate_component_to_storage(here, there, storage,
+        hpx::id_type::managed));
+
+//     HPX_TEST(test_migrate_component_from_storage(here, storage));
 }
 
 int main()
 {
-    std::vector<hpx::id_type> localities = hpx::find_all_localities();
-    for(hpx::id_type const& id: localities)
+    test_storage(hpx::find_here(), hpx::find_here());
+
+    for (hpx::id_type const& id: hpx::find_remote_localities())
     {
         test_storage(hpx::find_here(), id);
         test_storage(id, hpx::find_here());
+        test_storage(id, id);
     }
 
     return hpx::util::report_errors();


### PR DESCRIPTION
This PR adds a new AGAS API: `hpx::agas::begin_migration` and `hpx::agas::end_migration`. These functions make sure that no address resolution proceeds while a migration operation is in flight. All address resolution requests will be deferred until `end_migration` is called.

This PR also adapts the existing API functions `hpx::components::migrate`, `hpx::components::migrate_to_storage`, and `hpx::components::migrate_from_storage` to use the new AGAS API.

Overall, this is the first step to make the process of migrating objects transparent to the user (see #559).