### PR TITLE
resolved warning in CMake 3.1 and newer

### DIFF
--- a/cmake/HPX_SetupTarget.cmake
+++ b/cmake/HPX_SetupTarget.cmake
@@ -5,6 +5,8 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+cmake_policy(SET CMP0054 NEW)
+
 function(hpx_setup_target target)
   # retrieve arguments
   set(options EXPORT NOHPX_INIT INSTALL NOLIBS PLUGIN)

--- a/hpx/lcos/when_all.hpp
+++ b/hpx/lcos/when_all.hpp
@@ -335,8 +335,6 @@ namespace hpx { namespace lcos
     lcos::future<std::vector<Future> > //-V659
     when_all(std::vector<Future>&& values)
     {
-        typedef std::vector<Future> result_type;
-
         typedef detail::when_all_frame<
                 hpx::util::tuple<std::vector<Future> >
             > frame_type;


### PR DESCRIPTION
With CMake 3.1.0 I get the following warning when building a code that uses HPX:

     CMake Warning (dev) at /home/gentryx/local_install/lib/cmake/hpx/HPX_SetupTarget.cmake:134 (if):
       Policy CMP0054 is not set: Only interpret if() arguments as variables or
      keywords when unquoted.  Run "cmake --help-policy CMP0054" for policy
      details.  Use the cmake_policy command to set the policy and suppress this
      warning.

      Quoted variables like "COMPONENT" will no longer be dereferenced when the
      policy is set to NEW.  Since the policy is not set the OLD behavior will be
      used.
    Call Stack (most recent call first):
      /home/gentryx/local_install/lib/cmake/hpx/HPX_AddExecutable.cmake:143 (hpx_setup_target)
      src/examples/gameoflife_hpx/CMakeLists.txt:6 (add_hpx_executable)
    This warning is for project developers.  Use -Wno-dev to suppress it.

This commit resolves aforementioned ambiguity.
