### PR TITLE
Correct directory for dispatch_gcc46.hpp iteration

### DIFF
--- a/hpx/parallel/segmented_algorithms/detail/dispatch_gcc46.hpp
+++ b/hpx/parallel/segmented_algorithms/detail/dispatch_gcc46.hpp
@@ -14,7 +14,7 @@
 #include <boost/preprocessor/repetition/enum_binary_params.hpp>
 
 #define BOOST_PP_ITERATION_PARAMS_1                                           \
-    (3, (2, 6, "hpx/parallel/algorithms/remote/dispatch_gcc46.hpp"))          \
+    (3, (2, 6, "hpx/parallel/segmented_algorithms/detail/dispatch_gcc46.hpp"))\
     /**/
 
 #define HPX_DISPATCH_CONST_ARG(Z, N, D) BOOST_PP_CAT(D, N) const&             \


### PR DESCRIPTION
The path for dispatch_gcc46.hpp while PP iterating is incorrect and
appears to be a legacy location for the file. The filename is adjusted
to refer to the new location.