### PR TITLE
Fixed problems with performance counters in distributed

### DIFF
--- a/docs/manual/existing_performance_counters.qbk
+++ b/docs/manual/existing_performance_counters.qbk
@@ -18,25 +18,36 @@ system and application performance.
     [[Counter Type] [Counter Instance Formatting] [Parameters] [Description]]
     [   [`/agas/count/<agas_service>`
 
-          where:[br] `<agas_service>` is one of the following:
-            `allocate`, `bind`, `bind_gid`, `bind_name`, `bind_prefix`,
-            `increment_credit`, `decrement_credit`, `free`, `get_component_typename`,
-            `iterate_names`, `iterate_types`, `localities`,
-            `num_localities`, `num_localities_type`, `num_threads`, `resolve`,
-            `resolve_gid`, `resolve_id`, `resolve_locality`, `resolved_localities`,
-            `route`, `unbind`, `unbind_gid`, `unbind_name`
-            `begin_migration`, `end_migration`.
+          where:[br] `<agas_service>` is one of the following:[br]
+            /primary namespace services/: `route`, `bind_gid`, `resolve_gid`,
+            `unbind_gid`, `increment_credit`, `decrement_credit`, `allocate`,
+            `begin_migration`, `end_migration`
+            [br]
+
+            /component namespace services/: `bind_prefix`, `bind_name`,
+            `resolve_id`, `unbind_name`, `iterate_types`, `get_component_typename`,
+            `num_localities_type`
+            [br]
+
+            /locality namespace services/: `free`, `localities`, `num_localities`,
+            `num_threads`, `resolve_locality`, `resolved_localities`
+            [br]
+
+            /symbol namespace services/: `bind`, `resolve`, `unbind`,
+            `iterate_names`, `on_symbol_namespace_event`
         ]
         [`<agas_instance>/total`
 
           where:[br] `<agas_instance>` is the name of the AGAS service to query.
           Currently, this value will be `locality#0`, where `0` is the root locality
-          (the id of the locality hosting the AGAS service). Except for `<agas_service>`
+          (the id of the locality hosting the AGAS service).
+
+          The value for `*` can be any locality id for the following `<agas_service>`:
           `route`, `bind_gid`, `resolve_gid`, `unbind_gid`, `increment_credit`,
-          `decrement_credit`, `bind`, `resolve`, `unbind`, and `iterate_names`
-          for which the value for `*` can be any locality id (only the primary and
-          symbol AGAS service components live on all localities, whereas all other AGAS services
-          are available on `locality#0` only).
+          `decrement_credit`,`bind`, `resolve`, `unbind`, and `iterate_names`
+          (only the primary and symbol AGAS service components live on all
+          localities, whereas all other AGAS services are available on
+          `locality#0` only).
         ]
         [None]
         [Returns the total number of invocations of the specified AGAS service
@@ -62,25 +73,36 @@ system and application performance.
     ]
     [   [`/agas/time/<agas_service>`
 
-          where:[br] `<agas_service>` is one of the following:
-            `allocate`, `bind`, `bind_gid`, `bind_name`, `bind_prefix`,
-            `increment_credit`, `decrement_credit`, `free`, `get_component_typename`,
-            `iterate_names`, `iterate_types`, `localities`,
-            `num_localities`, `num_localities_type`, `num_threads`, `resolve`,
-            `resolve_gid`, `resolve_id`, `resolve_locality`, `resolved_localities`,
-            `route`, `unbind`, `unbind_gid`, `unbind_name`,
-            `begin_migration`, `end_migration`.
+          where:[br] `<agas_service>` is one of the following:[br]
+            /primary namespace services/: `route`, `bind_gid`, `resolve_gid`,
+            `unbind_gid`, `increment_credit`, `decrement_credit`, `allocate`,
+            `begin_migration`, `end_migration`
+            [br]
+
+            /component namespace services/: `bind_prefix`, `bind_name`,
+            `resolve_id`, `unbind_name`, `iterate_types`, `get_component_typename`,
+            `num_localities_type`
+            [br]
+
+            /locality namespace services/: `free`, `localities`, `num_localities`,
+            `num_threads`, `resolve_locality`, `resolved_localities`
+            [br]
+
+            /symbol namespace services/: `bind`, `resolve`, `unbind`,
+            `iterate_names`, `on_symbol_namespace_event`
         ]
         [`<agas_instance>/total`
 
           where:[br] `<agas_instance>` is the name of the AGAS service to query.
           Currently, this value will be `locality#0`, where `0` is the root locality
-          (the id of the locality hosting the AGAS service). Except for `<agas_service>`
+          (the id of the locality hosting the AGAS service).
+
+          The value for `*` can be any locality id for the following `<agas_service>`:
           `route`, `bind_gid`, `resolve_gid`, `unbind_gid`, `increment_credit`,
           `decrement_credit`,`bind`, `resolve`, `unbind`, and `iterate_names`
-          for which the value for `*` can be any locality id (only the primary and symbol AGAS
-          service components live on all localities, whereas all other AGAS services
-          are available on `locality#0` only).
+          (only the primary and symbol AGAS service components live on all
+          localities, whereas all other AGAS services are available on
+          `locality#0` only).
         ]
         [None]
         [Returns the overall execution time of the specified AGAS service
@@ -107,7 +129,7 @@ system and application performance.
     [   [`/agas/count/<cache_statistics>`
 
           where:[br] `<cache_statistics>` is one of the following:
-          `cache-evictions`, `cache-hits`, `cache-inserts`, `cache-misses`
+          `cache/evictions`, `cache/hits`, `cache/inserts`, `cache/misses`
         ]
         [`locality#*/total`
 
@@ -123,8 +145,8 @@ system and application performance.
     [   [`/agas/count/<full_cache_statistics>`
 
           where:[br] `<full_cache_statistics>` is one of the following:
-          `cache_get_entry`, `cache_insert_entry`, `cache_update_entry`,
-          `cache_erase_entry`
+          `cache/get_entry`, `cache/insert_entry`, `cache/update_entry`,
+          `cache/erase_entry`
         ]
         [`locality#*/total`
 
@@ -139,8 +161,8 @@ system and application performance.
     [   [`/agas/time/<full_cache_statistics>`
 
           where:[br] `<full_cache_statistics>` is one of the following:
-          `cache_get_entry`, `cache_insert_entry`, `cache_update_entry`,
-          `cache_erase_entry`
+          `cache/get_entry`, `cache/insert_entry`, `cache/update_entry`,
+          `cache/erase_entry`
         ]
         [`locality#*/total`
 
@@ -423,8 +445,8 @@ system and application performance.
     [   [`/parcelport/count/<connection_type>/<cache_statistics>`
 
           where:[br] `<cache_statistics>` is one of the following:
-          `cache-insertions`, `cache-evictions`, `cache-hits`, `cache-misses`,
-          `cache-misses`[br]
+          `cache/insertions`, `cache/evictions`, `cache/hits`, `cache/misses`,
+          `cache/misses`[br]
           `<connection_type>` is one of the following: `tcp`, `ipc`, `ibverbs`, `mpi`
         ]
         [`locality#*/total`
@@ -436,8 +458,8 @@ system and application performance.
         [None]
         [Returns the overall number cache events (evictions, hits, inserts,
          misses, and reclaims) for the connection cache of the given connection
-         type on the given locality (see `<cache_statistics>`, e.g. `cache-insertions`,
-         `cache-evictions`, `cache-hits`, `cache-misses`, or `cache-reclaims`).
+         type on the given locality (see `<cache_statistics>`, e.g. `cache/insertions`,
+         `cache/evictions`, `cache/hits`, `cache/misses`, or `cache/reclaims`).
 
          The performance counters for the connection type `ipc` are available
          only if the compile time constant `HPX_PARCELPORT_IPC` was
@@ -658,7 +680,7 @@ system and application performance.
           where:[br]
           `locality#*` is defining the locality for which the
           current number of threads with the given state should be queried for.
-          The locality id (given by `*`) is a (zero based) number identifying 
+          The locality id (given by `*`) is a (zero based) number identifying
           the locality.
 
           `worker-thread#*` is defining the worker thread for which the
@@ -691,7 +713,7 @@ system and application performance.
           where:[br]
           `locality#*` is defining the locality for which the
           average wait time of __hpx__-threads (pending) or thread descriptions
-          (staged) with the given state should be queried for.  The locality 
+          (staged) with the given state should be queried for.  The locality
           id (given by `*`) is a (zero based) number identifying the locality.
 
           `worker-thread#*` is defining the worker thread for which the
@@ -751,8 +773,8 @@ system and application performance.
 
           where:[br]
           `locality#*` is defining the locality for which the average
-          creation idle rate of all (or one) worker threads should be queried 
-          for. The locality id (given by `*`) is a (zero based) number 
+          creation idle rate of all (or one) worker threads should be queried
+          for. The locality id (given by `*`) is a (zero based) number
           identifying the locality.
 
           `worker-thread#*` is defining the worker thread for which the
@@ -778,8 +800,8 @@ system and application performance.
 
           where:[br]
           `locality#*` is defining the locality for which the average
-          cleanup idle rate of all (or one) worker threads should be queried 
-          for. The locality id (given by `*`) is a (zero based) number 
+          cleanup idle rate of all (or one) worker threads should be queried
+          for. The locality id (given by `*`) is a (zero based) number
           identifying the locality.
 
           `worker-thread#*` is defining the worker thread for which the
@@ -916,14 +938,14 @@ system and application performance.
           where:[br]
           `locality#*` is defining the locality for which the number of
           __hpx__-threads stolen from the staged queue of all (or one) worker
-          threads should be queried for. The locality id (given by `*`) 
+          threads should be queried for. The locality id (given by `*`)
           is a (zero based) number identifying the locality.
 
           `worker-thread#*` is defining the worker thread for which the
-          number of __hpx__-threads stolen from the staged queue should be queried 
-          for. The worker thread number (given by the `*`) is a (zero based) 
-          number identifying the worker thread. The number of available worker 
-          threads is usually specified on the command line for the application 
+          number of __hpx__-threads stolen from the staged queue should be queried
+          for. The worker thread number (given by the `*`) is a (zero based)
+          number identifying the worker thread. The number of available worker
+          threads is usually specified on the command line for the application
           using the option [hpx_cmdline `--hpx:threads`].
         ]
         [None]
@@ -942,14 +964,14 @@ system and application performance.
           where:[br]
           `locality#*` is defining the locality for which the number of
           __hpx__-threads stolen to the pending queue of all (or one) worker
-          threads should be queried for. The locality id (given by `*`) 
+          threads should be queried for. The locality id (given by `*`)
           is a (zero based) number identifying the locality.
 
           `worker-thread#*` is defining the worker thread for which the
-          number of __hpx__-threads stolen to the pending queue should be queried 
-          for. The worker thread number (given by the `*`) is a (zero based) 
-          number identifying the worker thread. The number of available worker 
-          threads is usually specified on the command line for the application 
+          number of __hpx__-threads stolen to the pending queue should be queried
+          for. The worker thread number (given by the `*`) is a (zero based)
+          number identifying the worker thread. The number of available worker
+          threads is usually specified on the command line for the application
           using the option [hpx_cmdline `--hpx:threads`].
         ]
         [None]
@@ -968,12 +990,12 @@ system and application performance.
           where:[br]
           `locality#*` is defining the locality for which the number of
           __hpx__-threads stolen to the staged queue of all (or one) worker
-          threads should be queried for. The locality id (given by `*`) 
+          threads should be queried for. The locality id (given by `*`)
           is a (zero based) number identifying the locality.
 
           `worker-thread#*` is defining the worker thread for which the
-          number of __hpx__-threads stolen to the staged queue should be queried 
-          for. The worker thread number (given by the `*`) is a (zero based) 
+          number of __hpx__-threads stolen to the staged queue should be queried
+          for. The worker thread number (given by the `*`) is a (zero based)
           worker thread number (given by the `*`) is a (zero based) number
           identifying the worker thread. The number of available worker threads
           is usually specified on the command line for the application using the

--- a/hpx/runtime/agas/server/component_namespace.hpp
+++ b/hpx/runtime/agas/server/component_namespace.hpp
@@ -189,6 +189,9 @@ struct HPX_EXPORT component_namespace
     static void register_counter_types(
         error_code& ec = throws
         );
+    static void register_global_counter_types(
+        error_code& ec = throws
+        );
 
     void register_server_instance(
         char const* servicename

--- a/hpx/runtime/agas/server/locality_namespace.hpp
+++ b/hpx/runtime/agas/server/locality_namespace.hpp
@@ -187,6 +187,9 @@ struct HPX_EXPORT locality_namespace
     static void register_counter_types(
         error_code& ec = throws
         );
+    static void register_global_counter_types(
+        error_code& ec = throws
+        );
 
     void register_server_instance(
         char const* servicename

--- a/hpx/runtime/agas/server/primary_namespace.hpp
+++ b/hpx/runtime/agas/server/primary_namespace.hpp
@@ -305,6 +305,9 @@ struct HPX_EXPORT primary_namespace
     static void register_counter_types(
         error_code& ec = throws
         );
+    static void register_global_counter_types(
+        error_code& ec = throws
+        );
 
     void register_server_instance(
         char const* servicename

--- a/hpx/runtime/agas/server/symbol_namespace.hpp
+++ b/hpx/runtime/agas/server/symbol_namespace.hpp
@@ -174,6 +174,9 @@ struct HPX_EXPORT symbol_namespace
     static void register_counter_types(
         error_code& ec = throws
         );
+    static void register_global_counter_types(
+        error_code& ec = throws
+        );
 
     void register_server_instance(
         char const* servicename

--- a/src/performance_counters/counter_creators.cpp
+++ b/src/performance_counters/counter_creators.cpp
@@ -95,6 +95,13 @@ namespace hpx { namespace performance_counters
             get_counter_path_elements(info.fullname_, p, ec);
         if (!status_is_valid(status)) return false;
 
+        // restrict to locality zero
+        if (p.parentinstancename_ == "locality#*")
+        {
+            p.parentinstancename_ = "locality";
+            p.parentinstanceindex_ = 0;
+        }
+
         if (mode == discover_counters_minimal ||
             p.parentinstancename_.empty() || p.instancename_.empty())
         {
@@ -109,14 +116,11 @@ namespace hpx { namespace performance_counters
                 p.instancename_ = "total";
                 p.instanceindex_ = -1;
             }
+        }
 
-            status = get_counter_name(p, i.fullname_, ec);
-            if (!status_is_valid(status) || !f(i, ec) || ec)
-                return false;
-        }
-        else if (!f(i, ec) || ec) {
+        status = get_counter_name(p, i.fullname_, ec);
+        if (!status_is_valid(status) || !f(i, ec) || ec)
             return false;
-        }
 
         if (&ec != &throws)
             ec = make_success_code();

--- a/src/performance_counters/registry.cpp
+++ b/src/performance_counters/registry.cpp
@@ -199,9 +199,11 @@ namespace hpx { namespace performance_counters
                     types += "  " + (*it).first + "\n";
                 }
 
-                HPX_THROWS_IF(ec, bad_parameter, "registry::discover_counter_type",
-                    boost::str(boost::format("unknown counter type: %s, known counter types: \n%s") %
-                        type_name % types));
+                HPX_THROWS_IF(ec, bad_parameter,
+                    "registry::discover_counter_type",
+                    boost::str(boost::format(
+                        "unknown counter type: %s, known counter "
+                        "types: \n%s") % type_name % types));
                 return status_counter_type_unknown;
             }
 
@@ -263,8 +265,9 @@ namespace hpx { namespace performance_counters
                 }
 
                 HPX_THROWS_IF(ec, bad_parameter, "registry::discover_counter_type",
-                    boost::str(boost::format("counter type: %s does not match any known type"
-                        ", known counter types: \n%s") % type_name % types));
+                    boost::str(boost::format(
+                        "counter type %s does not match any known type, "
+                        "known counter types: \n%s") % type_name % types));
                 return status_counter_type_unknown;
             }
         }
@@ -315,14 +318,29 @@ namespace hpx { namespace performance_counters
 
         counter_type_map_type::const_iterator it = locate_counter_type(type_name);
         if (it == countertypes_.end()) {
-            HPX_THROWS_IF(ec, bad_parameter, "registry::get_counter_create_function",
-                "counter type is not defined");
+            // compose a list of known counter types
+            std::string types;
+            counter_type_map_type::const_iterator end = countertypes_.end();
+            for (counter_type_map_type::const_iterator it = countertypes_.begin();
+                    it != end; ++it)
+            {
+                types += "  " + (*it).first + "\n";
+            }
+
+            HPX_THROWS_IF(ec, bad_parameter,
+                "registry::get_counter_create_function",
+                boost::str(boost::format(
+                    "counter type %s is not defined, known counter "
+                    "types: \n%s") % type_name % types));
             return status_counter_type_unknown;
         }
 
         if ((*it).second.create_counter_.empty()) {
-            HPX_THROWS_IF(ec, bad_parameter, "registry::get_counter_create_function",
-                "counter type has no associated create function");
+            HPX_THROWS_IF(ec, bad_parameter,
+                "registry::get_counter_create_function",
+                boost::str(boost::format(
+                    "counter type %s has no associated create "
+                    "function") % type_name));
             return status_invalid_data;
         }
 
@@ -345,14 +363,19 @@ namespace hpx { namespace performance_counters
 
         counter_type_map_type::const_iterator it = locate_counter_type(type_name);
         if (it == countertypes_.end()) {
-            HPX_THROWS_IF(ec, bad_parameter, "registry::get_counter_discovery_function",
-                "counter type is not defined");
+            HPX_THROWS_IF(ec, bad_parameter,
+                "registry::get_counter_discovery_function",
+                boost::str(boost::format(
+                    "counter type %s is not defined") % type_name));
             return status_counter_type_unknown;
         }
 
         if ((*it).second.discover_counters_.empty()) {
-            HPX_THROWS_IF(ec, bad_parameter, "registry::get_counter_discovery_function",
-                "counter type has no associated discovery function");
+            HPX_THROWS_IF(ec, bad_parameter,
+                "registry::get_counter_discovery_function",
+                boost::str(boost::format(
+                    "counter type %s has no associated discovery "
+                    "function") % type_name));
             return status_invalid_data;
         }
 

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -48,9 +48,13 @@ struct addressing_service::bootstrap_data_type
     void register_counter_types()
     {
         server::locality_namespace::register_counter_types();
+        server::locality_namespace::register_global_counter_types();
         server::primary_namespace::register_counter_types();
+        server::primary_namespace::register_global_counter_types();
         server::component_namespace::register_counter_types();
+        server::component_namespace::register_global_counter_types();
         server::symbol_namespace::register_counter_types();
+        server::symbol_namespace::register_global_counter_types();
     }
 
     void register_server_instance(char const* servicename)
@@ -85,7 +89,9 @@ struct addressing_service::hosted_data_type
     void register_counter_types()
     {
         server::primary_namespace::register_counter_types();
+        server::primary_namespace::register_global_counter_types();
         server::symbol_namespace::register_counter_types();
+        server::symbol_namespace::register_global_counter_types();
     }
 
     void register_server_instance(char const* servicename
@@ -2691,7 +2697,7 @@ void addressing_service::register_counter_types()
 
     performance_counters::generic_counter_type_data const counter_types[] =
     {
-        { "/agas/count/cache-hits", performance_counters::counter_raw,
+        { "/agas/count/cache/hits", performance_counters::counter_raw,
           "returns the number of cache hits while accessing the AGAS cache",
           HPX_PERFORMANCE_COUNTER_V1,
           boost::bind(&performance_counters::locality_raw_counter_creator,
@@ -2699,7 +2705,7 @@ void addressing_service::register_counter_types()
           &performance_counters::locality_counter_discoverer,
           ""
         },
-        { "/agas/count/cache-misses", performance_counters::counter_raw,
+        { "/agas/count/cache/misses", performance_counters::counter_raw,
           "returns the number of cache misses while accessing the AGAS cache",
           HPX_PERFORMANCE_COUNTER_V1,
           boost::bind(&performance_counters::locality_raw_counter_creator,
@@ -2707,7 +2713,7 @@ void addressing_service::register_counter_types()
           &performance_counters::locality_counter_discoverer,
           ""
         },
-        { "/agas/count/cache-evictions", performance_counters::counter_raw,
+        { "/agas/count/cache/evictions", performance_counters::counter_raw,
           "returns the number of cache evictions from the AGAS cache",
           HPX_PERFORMANCE_COUNTER_V1,
           boost::bind(&performance_counters::locality_raw_counter_creator,
@@ -2715,7 +2721,7 @@ void addressing_service::register_counter_types()
           &performance_counters::locality_counter_discoverer,
           ""
         },
-        { "/agas/count/cache-insertions", performance_counters::counter_raw,
+        { "/agas/count/cache/insertions", performance_counters::counter_raw,
           "returns the number of cache insertions into the AGAS cache",
           HPX_PERFORMANCE_COUNTER_V1,
           boost::bind(&performance_counters::locality_raw_counter_creator,
@@ -2724,7 +2730,7 @@ void addressing_service::register_counter_types()
           ""
         },
 
-        { "/agas/count/cache_get_entry", performance_counters::counter_raw,
+        { "/agas/count/cache/get_entry", performance_counters::counter_raw,
           "returns the number of invocations of get_entry function of the "
                 "AGAS cache",
           HPX_PERFORMANCE_COUNTER_V1,
@@ -2733,7 +2739,7 @@ void addressing_service::register_counter_types()
           &performance_counters::locality_counter_discoverer,
           ""
         },
-        { "/agas/count/cache_insert_entry", performance_counters::counter_raw,
+        { "/agas/count/cache/insert_entry", performance_counters::counter_raw,
           "returns the number of invocations of insert_entry function of the "
                 "AGAS cache",
           HPX_PERFORMANCE_COUNTER_V1,
@@ -2742,7 +2748,7 @@ void addressing_service::register_counter_types()
           &performance_counters::locality_counter_discoverer,
           ""
         },
-        { "/agas/count/cache_update_entry", performance_counters::counter_raw,
+        { "/agas/count/cache/update_entry", performance_counters::counter_raw,
           "returns the number of invocations of update_entry function of the "
                 "AGAS cache",
           HPX_PERFORMANCE_COUNTER_V1,
@@ -2751,7 +2757,7 @@ void addressing_service::register_counter_types()
           &performance_counters::locality_counter_discoverer,
           ""
         },
-        { "/agas/count/cache_erase_entry", performance_counters::counter_raw,
+        { "/agas/count/cache/erase_entry", performance_counters::counter_raw,
           "returns the number of invocations of erase_entry function of the "
                 "AGAS cache",
           HPX_PERFORMANCE_COUNTER_V1,
@@ -2761,7 +2767,7 @@ void addressing_service::register_counter_types()
           ""
         },
 
-        { "/agas/time/cache_get_entry", performance_counters::counter_raw,
+        { "/agas/time/cache/get_entry", performance_counters::counter_raw,
           "returns the the overall time spent executing of the get_entry API "
                 "function of the AGAS cache",
           HPX_PERFORMANCE_COUNTER_V1,
@@ -2770,7 +2776,7 @@ void addressing_service::register_counter_types()
           &performance_counters::locality_counter_discoverer,
           "ns"
         },
-        { "/agas/time/cache_insert_entry", performance_counters::counter_raw,
+        { "/agas/time/cache/insert_entry", performance_counters::counter_raw,
           "returns the the overall time spent executing of the insert_entry API "
               "function of the AGAS cache",
           HPX_PERFORMANCE_COUNTER_V1,
@@ -2779,7 +2785,7 @@ void addressing_service::register_counter_types()
           &performance_counters::locality_counter_discoverer,
           "ns"
         },
-        { "/agas/time/cache_update_entry", performance_counters::counter_raw,
+        { "/agas/time/cache/update_entry", performance_counters::counter_raw,
           "returns the the overall time spent executing of the update_entry API "
                 "function of the AGAS cache",
           HPX_PERFORMANCE_COUNTER_V1,
@@ -2788,7 +2794,7 @@ void addressing_service::register_counter_types()
           &performance_counters::locality_counter_discoverer,
           "ns"
         },
-        { "/agas/time/cache_erase_entry", performance_counters::counter_raw,
+        { "/agas/time/cache/erase_entry", performance_counters::counter_raw,
           "returns the the overall time spent executing of the erase_entry API "
                 "function of the AGAS cache",
           HPX_PERFORMANCE_COUNTER_V1,

--- a/src/runtime/agas/server/component_namespace_server.cpp
+++ b/src/runtime/agas/server/component_namespace_server.cpp
@@ -179,27 +179,59 @@ void component_namespace::register_counter_types(
           i != detail::num_component_namespace_services;
           ++i)
     {
+        // global counters are handled elsewhere
+        if (detail::component_namespace_services[i].code_ == component_ns_statistics_counter)
+            continue;
+
         std::string name(detail::component_namespace_services[i].name_);
         std::string help;
         std::string::size_type p = name.find_last_of('/');
-        if (p != std::string::npos) {
-            if (detail::component_namespace_services[i].target_ == detail::counter_target_count)
-                help = boost::str(help_count % name.substr(p+1));
-            else
-                help = boost::str(help_time % name.substr(p+1));
-        }
-        else {
-            HPX_ASSERT(detail::component_namespace_services[i].code_ ==
-                component_ns_statistics_counter);
-            name = component_namespace_service_name + name;
-            if (detail::component_namespace_services[i].target_ == detail::counter_target_count)
-                help = "returns the overall number of invocations of all component AGAS services";
-            else
-                help = "returns the overall execution time of all component AGAS services";
-        }
+        HPX_ASSERT(p != std::string::npos);
+
+        if (detail::component_namespace_services[i].target_ == detail::counter_target_count)
+            help = boost::str(help_count % name.substr(p+1));
+        else
+            help = boost::str(help_time % name.substr(p+1));
 
         performance_counters::install_counter_type(
             agas::performance_counter_basename + name
+          , performance_counters::counter_raw
+          , help
+          , creator
+          , &performance_counters::locality0_counter_discoverer
+          , HPX_PERFORMANCE_COUNTER_V1
+          , detail::component_namespace_services[i].uom_
+          , ec
+          );
+        if (ec) return;
+    }
+}
+
+void component_namespace::register_global_counter_types(
+    error_code& ec
+    )
+{
+    performance_counters::create_counter_func creator(
+        boost::bind(&performance_counters::agas_raw_counter_creator, _1, _2
+      , agas::server::component_namespace_service_name));
+
+    for (std::size_t i = 0;
+          i != detail::num_component_namespace_services;
+          ++i)
+    {
+        // local counters are handled elsewhere
+        if (detail::component_namespace_services[i].code_ != component_ns_statistics_counter)
+            continue;
+
+        std::string help;
+        if (detail::component_namespace_services[i].target_ == detail::counter_target_count)
+            help = "returns the overall number of invocations of all component AGAS services";
+        else
+            help = "returns the overall execution time of all component AGAS services";
+
+        performance_counters::install_counter_type(
+            std::string(agas::performance_counter_basename) +
+                detail::component_namespace_services[i].name_
           , performance_counters::counter_raw
           , help
           , creator

--- a/src/runtime/agas/server/locality_namespace_server.cpp
+++ b/src/runtime/agas/server/locality_namespace_server.cpp
@@ -183,27 +183,59 @@ void locality_namespace::register_counter_types(
           i != detail::num_locality_namespace_services;
           ++i)
     {
+        // global counters are handled elsewhere
+        if (detail::locality_namespace_services[i].code_ == locality_ns_statistics_counter)
+            continue;
+
         std::string name(detail::locality_namespace_services[i].name_);
         std::string help;
         std::string::size_type p = name.find_last_of('/');
-        if (p != std::string::npos) {
-            if (detail::locality_namespace_services[i].target_ == detail::counter_target_count)
-                help = boost::str(help_count % name.substr(p+1));
-            else
-                help = boost::str(help_time % name.substr(p+1));
-        }
-        else {
-            HPX_ASSERT(detail::locality_namespace_services[i].code_ ==
-                locality_ns_statistics_counter);
-            name = locality_namespace_service_name + name;
-            if (detail::locality_namespace_services[i].target_ == detail::counter_target_count)
-                help = "returns the overall number of invocations of all locality AGAS services";
-            else
-                help = "returns the overall execution time of all locality AGAS services";
-        }
+        HPX_ASSERT(p != std::string::npos);
+
+        if (detail::locality_namespace_services[i].target_ == detail::counter_target_count)
+            help = boost::str(help_count % name.substr(p+1));
+        else
+            help = boost::str(help_time % name.substr(p+1));
 
         performance_counters::install_counter_type(
             agas::performance_counter_basename + name
+          , performance_counters::counter_raw
+          , help
+          , creator
+          , &performance_counters::locality0_counter_discoverer
+          , HPX_PERFORMANCE_COUNTER_V1
+          , detail::locality_namespace_services[i].uom_
+          , ec
+          );
+        if (ec) return;
+    }
+}
+
+void locality_namespace::register_global_counter_types(
+    error_code& ec
+    )
+{
+    performance_counters::create_counter_func creator(
+        boost::bind(&performance_counters::agas_raw_counter_creator, _1, _2
+      , agas::server::locality_namespace_service_name));
+
+    for (std::size_t i = 0;
+          i != detail::num_locality_namespace_services;
+          ++i)
+    {
+        // local counters are handled elsewhere
+        if (detail::locality_namespace_services[i].code_ != locality_ns_statistics_counter)
+            continue;
+
+        std::string help;
+        if (detail::locality_namespace_services[i].target_ == detail::counter_target_count)
+            help = "returns the overall number of invocations of all locality AGAS services";
+        else
+            help = "returns the overall execution time of all locality AGAS services";
+
+        performance_counters::install_counter_type(
+            std::string(agas::performance_counter_basename) +
+                detail::locality_namespace_services[i].name_
           , performance_counters::counter_raw
           , help
           , creator

--- a/src/runtime/agas/server/primary_namespace_server.cpp
+++ b/src/runtime/agas/server/primary_namespace_server.cpp
@@ -204,27 +204,59 @@ void primary_namespace::register_counter_types(
           i != detail::num_primary_namespace_services;
           ++i)
     {
+        // global counters are handled elsewhere
+        if (detail::primary_namespace_services[i].code_ == primary_ns_statistics_counter)
+            continue;
+
         std::string name(detail::primary_namespace_services[i].name_);
         std::string help;
         std::string::size_type p = name.find_last_of('/');
-        if (p != std::string::npos) {
-            if (detail::primary_namespace_services[i].target_ == detail::counter_target_count)
-                help = boost::str(help_count % name.substr(p+1));
-            else
-                help = boost::str(help_time % name.substr(p+1));
-        }
-        else {
-            HPX_ASSERT(detail::primary_namespace_services[i].code_ ==
-                primary_ns_statistics_counter);
-            name = primary_namespace_service_name + name;
-            if (detail::primary_namespace_services[i].target_ == detail::counter_target_count)
-                help = "returns the overall number of invocations of all primary AGAS services";
-            else
-                help = "returns the overall execution time of all primary AGAS services";
-        }
+        HPX_ASSERT(p != std::string::npos);
+
+        if (detail::primary_namespace_services[i].target_ == detail::counter_target_count)
+            help = boost::str(help_count % name.substr(p+1));
+        else
+            help = boost::str(help_time % name.substr(p+1));
 
         performance_counters::install_counter_type(
             agas::performance_counter_basename + name
+          , performance_counters::counter_raw
+          , help
+          , creator
+          , &performance_counters::locality_counter_discoverer
+          , HPX_PERFORMANCE_COUNTER_V1
+          , detail::primary_namespace_services[i].uom_
+          , ec
+          );
+        if (ec) return;
+    }
+}
+
+void primary_namespace::register_global_counter_types(
+    error_code& ec
+    )
+{
+    performance_counters::create_counter_func creator(
+        boost::bind(&performance_counters::agas_raw_counter_creator, _1, _2
+      , agas::server::primary_namespace_service_name));
+
+    for (std::size_t i = 0;
+          i != detail::num_primary_namespace_services;
+          ++i)
+    {
+        // local counters are handled elsewhere
+        if (detail::primary_namespace_services[i].code_ != primary_ns_statistics_counter)
+            continue;
+
+        std::string help;
+        if (detail::primary_namespace_services[i].target_ == detail::counter_target_count)
+            help = "returns the overall number of invocations of all primary AGAS services";
+        else
+            help = "returns the overall execution time of all primary AGAS services";
+
+        performance_counters::install_counter_type(
+            std::string(agas::performance_counter_basename) +
+                detail::primary_namespace_services[i].name_
           , performance_counters::counter_raw
           , help
           , creator

--- a/src/runtime/agas/server/symbol_namespace_server.cpp
+++ b/src/runtime/agas/server/symbol_namespace_server.cpp
@@ -164,27 +164,59 @@ void symbol_namespace::register_counter_types(
           i != detail::num_symbol_namespace_services;
           ++i)
     {
+        // global counters are handled elsewhere
+        if (detail::symbol_namespace_services[i].code_ == symbol_ns_statistics_counter)
+            continue;
+
         std::string name(detail::symbol_namespace_services[i].name_);
         std::string help;
         std::string::size_type p = name.find_last_of('/');
-        if (p != std::string::npos) {
-            if (detail::symbol_namespace_services[i].target_ == detail::counter_target_count)
-                help = boost::str(help_count % name.substr(p+1));
-            else
-                help = boost::str(help_time % name.substr(p+1));
-        }
-        else {
-            HPX_ASSERT(detail::symbol_namespace_services[i].code_ ==
-                symbol_ns_statistics_counter);
-            name = symbol_namespace_service_name + name;
-            if (detail::symbol_namespace_services[i].target_ == detail::counter_target_count)
-                help = "returns the overall number of invocations of all symbol AGAS services";
-            else
-                help = "returns the overall execution time of all symbol AGAS services";
-        }
+        HPX_ASSERT(p != std::string::npos);
+
+        if (detail::symbol_namespace_services[i].target_ == detail::counter_target_count)
+            help = boost::str(help_count % name.substr(p+1));
+        else
+            help = boost::str(help_time % name.substr(p+1));
 
         performance_counters::install_counter_type(
             agas::performance_counter_basename + name
+          , performance_counters::counter_raw
+          , help
+          , creator
+          , &performance_counters::locality_counter_discoverer
+          , HPX_PERFORMANCE_COUNTER_V1
+          , detail::symbol_namespace_services[i].uom_
+          , ec
+          );
+        if (ec) return;
+    }
+}
+
+void symbol_namespace::register_global_counter_types(
+    error_code& ec
+    )
+{
+    performance_counters::create_counter_func creator(
+        boost::bind(&performance_counters::agas_raw_counter_creator, _1, _2
+      , agas::server::symbol_namespace_service_name));
+
+    for (std::size_t i = 0;
+          i != detail::num_symbol_namespace_services;
+          ++i)
+    {
+        // local counters are handled elsewhere
+        if (detail::symbol_namespace_services[i].code_ != symbol_ns_statistics_counter)
+            continue;
+
+        std::string help;
+        if (detail::symbol_namespace_services[i].target_ == detail::counter_target_count)
+            help = "returns the overall number of invocations of all symbol AGAS services";
+        else
+            help = "returns the overall execution time of all symbol AGAS services";
+
+        performance_counters::install_counter_type(
+            std::string(agas::performance_counter_basename) +
+                detail::symbol_namespace_services[i].name_
           , performance_counters::counter_raw
           , help
           , creator


### PR DESCRIPTION
this also unifies certain performance counter names (related to the AGAS cache) and improves error reporting for missing performance counters