### PR TITLE
During serialization memory allocation should honour allocator chunk siz...

### DIFF
--- a/hpx/plugins/parcelport/mpi/receiver.hpp
+++ b/hpx/plugins/parcelport/mpi/receiver.hpp
@@ -12,6 +12,7 @@
 #include <hpx/runtime/parcelset/decode_parcels.hpp>
 
 #include <hpx/util/memory_chunk_pool.hpp>
+#include <hpx/util/memory_chunk_pool_allocator.hpp>
 
 namespace hpx { namespace parcelset { namespace policies { namespace mpi
 {
@@ -22,8 +23,8 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
         typedef hpx::lcos::local::spinlock mutex_type;
         typedef std::list<std::pair<int, header> > header_list;
         typedef std::set<std::pair<int, int> > handles_header_type;
-        typedef util::memory_chunk_pool<> memory_pool_type;
-        typedef util::detail::memory_chunk_pool_allocator<char> allocator_type;
+        typedef util::memory_chunk_pool<mutex_type> memory_pool_type;
+        typedef util::detail::memory_chunk_pool_allocator<char,memory_pool_type> allocator_type;
         typedef
             std::vector<char, allocator_type>
             data_type;

--- a/hpx/runtime/parcelset/encode_parcels.hpp
+++ b/hpx/runtime/parcelset/encode_parcels.hpp
@@ -12,6 +12,7 @@
 
 #include <hpx/runtime/parcelset/parcel_buffer.hpp>
 #include <hpx/util/high_resolution_timer.hpp>
+#include <hpx/traits/is_chunk_allocator.hpp>
 
 #include <boost/integer/endian.hpp>
 
@@ -86,6 +87,9 @@ namespace hpx
             // guard against serialization errors
             try {
                 try {
+                    // Get the chunk size from the allocator if it supports it
+                    size_t chunk_default =
+                        hpx::traits::default_chunk_size<typename Buffer::allocator_type>::call(buffer.data_.get_allocator());
                     // preallocate data
                     for (/**/; parcels_sent != parcels_size; ++parcels_sent)
                     {
@@ -93,8 +97,8 @@ namespace hpx
                             break;
                         arg_size += traits::get_type_size(ps[parcels_sent]);
                     }
-
-                    buffer.data_.reserve(arg_size);
+                    
+                    buffer.data_.reserve(std::max(chunk_default,arg_size));
 
                     // mark start of serialization
                     util::high_resolution_timer timer;

--- a/hpx/traits/is_chunk_allocator.hpp
+++ b/hpx/traits/is_chunk_allocator.hpp
@@ -1,0 +1,32 @@
+//  Copyright (c) 2015 John Biddiscombe
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_TRAITS_IS_CHUNK_ALLOCATOR_MAR_24_2015)
+#define HPX_TRAITS_IS_CHUNK_ALLOCATOR_MAR_24_2015
+
+#include <hpx/config.hpp>
+#include <hpx/traits.hpp>
+#include <type_traits>
+#include <boost/utility/enable_if.hpp>
+
+namespace hpx { namespace traits
+{
+    template <typename A>
+    struct is_chunk_allocator : boost::mpl::false_ {};
+
+    template <typename A, typename Enable = void>
+    struct default_chunk_size
+    {
+        static std::size_t call(A const &a) { return 0; }
+    };
+
+    template <typename A>
+    struct default_chunk_size<A, typename boost::enable_if<is_chunk_allocator<A>>::type>
+    {
+        static std::size_t call(A const &a) { return a.memory_pool_->chunk_size_; }
+    };
+}}
+
+#endif

--- a/hpx/util/memory_chunk_pool.hpp
+++ b/hpx/util/memory_chunk_pool.hpp
@@ -8,19 +8,33 @@
 
 #include <hpx/config.hpp>
 
+#include <hpx/traits/is_chunk_allocator.hpp>
 #include <hpx/util/memory_chunk.hpp>
-
+#include <hpx/util/memory_chunk_pool_allocator.hpp>
+//
 #include <cstdlib>
 #include <vector>
 
+// forward declare pool
 namespace hpx { namespace util
 {
-    namespace detail
-    {
-        template <typename T, typename Mutex = hpx::lcos::local::spinlock>
-        struct memory_chunk_pool_allocator;
-    }
+    template <typename Mutex>
+    struct memory_chunk_pool;
+}}
 
+// specialize chunk pool allocator traits for this memory_chunk_pool
+namespace hpx { namespace traits
+{
+    // if the chunk pool supplies fixed chunks of memory when the alloc
+    // is smaller than some threshold, then the pool must declare
+    // std::size_t chunk_size_
+    template <typename T, typename M>
+    struct is_chunk_allocator<util::detail::memory_chunk_pool_allocator<T,util::memory_chunk_pool<M>,M>>
+      : boost::mpl::true_ {};
+}}
+
+namespace hpx { namespace util
+{
     template <typename Mutex = hpx::lcos::local::spinlock>
     struct memory_chunk_pool : boost::noncopyable
     {
@@ -184,99 +198,6 @@ namespace hpx { namespace util
         std::size_t const backup_threshold_;
     };
 
-    namespace detail
-    {
-        template <typename T, typename Mutex>
-        struct memory_chunk_pool_allocator
-        {
-            typedef std::size_t size_type;
-            typedef std::ptrdiff_t difference_type;
-            typedef T* pointer;
-            typedef const T* const_pointer;
-            typedef T& reference;
-            typedef const T& const_reference;
-            typedef T value_type;
-
-            template <typename U>
-            struct rebind
-            {
-                typedef memory_chunk_pool_allocator<U, Mutex> other;
-            };
-
-            memory_chunk_pool_allocator() throw()
-              : memory_pool_(0)
-            {}
-            memory_chunk_pool_allocator(
-                    util::memory_chunk_pool<Mutex> & mp) throw()
-              : memory_pool_(&mp)
-            {}
-            memory_chunk_pool_allocator(
-                    memory_chunk_pool_allocator const & other) throw()
-              : memory_pool_(other.memory_pool_)
-            {}
-            template <typename U>
-            memory_chunk_pool_allocator(
-                    memory_chunk_pool_allocator<U, Mutex> const & other) throw()
-              : memory_pool_(other.memory_pool_)
-            {}
-
-            pointer address(reference x) const
-            {
-                return &x;
-            }
-
-            const_pointer address(const_reference x) const
-            {
-                return &x;
-            }
-
-            pointer allocate(size_type n, void* /*hint*/ = 0)
-            {
-                HPX_ASSERT(memory_pool_);
-                return reinterpret_cast<T*>(memory_pool_->allocate(sizeof(T) * n));
-            }
-
-            void deallocate(pointer p, size_type n)
-            {
-                HPX_ASSERT(memory_pool_);
-                memory_pool_->deallocate(reinterpret_cast<char*>(p), sizeof(T) * n);
-            }
-
-            size_type max_size() const throw()
-            {
-                return (std::numeric_limits<std::size_t>::max)() / sizeof(T);
-            }
-
-            void construct(pointer p)
-            {
-                new (p) T();
-            }
-
-            template <typename U>
-            void construct(pointer p, U && val)
-            {
-                new (p) typename util::decay<T>::type(std::forward<U>(val));
-            }
-
-            /** Destroy the object referenced by @c p. */
-            void destroy(pointer p)
-            {
-                p->~T();
-            }
-
-            bool operator==(memory_chunk_pool_allocator const & other)
-            {
-                return memory_pool_ == other.memory_pool_;
-            }
-
-            bool operator!=(memory_chunk_pool_allocator const & other)
-            {
-                return memory_pool_ != other.memory_pool_;
-            }
-
-            util::memory_chunk_pool<Mutex> * memory_pool_;
-        };
-    }
 }}
 
 #endif

--- a/hpx/util/memory_chunk_pool_allocator.hpp
+++ b/hpx/util/memory_chunk_pool_allocator.hpp
@@ -1,0 +1,112 @@
+//  Copyright (c) 2013-2014 Thomas Heller
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_UTIL_MEMORY_CHUNK_POOL_ALLOCATOR_HPP
+#define HPX_UTIL_MEMORY_CHUNK_POOL_ALLOCATOR_HPP
+
+#include <hpx/config.hpp>
+
+#include <hpx/traits/is_chunk_allocator.hpp>
+#include <hpx/lcos/local/spinlock.hpp>
+//
+#include <cstdlib>
+#include <vector>
+
+namespace hpx { namespace util { namespace detail
+{
+    template <typename T,
+              typename Pool,
+              typename Mutex = hpx::lcos::local::spinlock>
+    struct memory_chunk_pool_allocator
+    {
+        typedef std::size_t size_type;
+        typedef std::ptrdiff_t difference_type;
+        typedef T* pointer;
+        typedef const T* const_pointer;
+        typedef T& reference;
+        typedef const T& const_reference;
+        typedef T value_type;
+
+        template <typename U>
+        struct rebind
+        {
+            typedef memory_chunk_pool_allocator<U, Pool, Mutex> other;
+        };
+
+        memory_chunk_pool_allocator() throw()
+          : memory_pool_(0)
+        {}
+        memory_chunk_pool_allocator(Pool & mp) throw()
+          : memory_pool_(&mp)
+        {}
+        memory_chunk_pool_allocator(
+                memory_chunk_pool_allocator const & other) throw()
+          : memory_pool_(other.memory_pool_)
+        {}
+        template <typename U>
+        memory_chunk_pool_allocator(
+                memory_chunk_pool_allocator<U, Pool, Mutex> const & other) throw()
+          : memory_pool_(other.memory_pool_)
+        {}
+
+        pointer address(reference x) const
+        {
+            return &x;
+        }
+
+        const_pointer address(const_reference x) const
+        {
+            return &x;
+        }
+
+        pointer allocate(size_type n, void* /*hint*/ = 0)
+        {
+            HPX_ASSERT(memory_pool_);
+            return reinterpret_cast<T*>(memory_pool_->allocate(sizeof(T) * n));
+        }
+
+        void deallocate(pointer p, size_type n)
+        {
+            HPX_ASSERT(memory_pool_);
+            memory_pool_->deallocate(reinterpret_cast<char*>(p), sizeof(T) * n);
+        }
+
+        size_type max_size() const throw()
+        {
+            return (std::numeric_limits<std::size_t>::max)() / sizeof(T);
+        }
+
+        void construct(pointer p)
+        {
+            new (p) T();
+        }
+
+        template <typename U>
+        void construct(pointer p, U && val)
+        {
+            new (p) typename util::decay<T>::type(std::forward<U>(val));
+        }
+
+        /** Destroy the object referenced by @c p. */
+        void destroy(pointer p)
+        {
+            p->~T();
+        }
+
+        bool operator==(memory_chunk_pool_allocator const & other)
+        {
+            return memory_pool_ == other.memory_pool_;
+        }
+
+        bool operator!=(memory_chunk_pool_allocator const & other)
+        {
+            return memory_pool_ != other.memory_pool_;
+        }
+
+        Pool * memory_pool_;
+    };
+}}}
+
+#endif

--- a/plugins/parcelport/mpi/parcelport_mpi.cpp
+++ b/plugins/parcelport/mpi/parcelport_mpi.cpp
@@ -275,7 +275,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
 
     private:
         typedef util::memory_chunk_pool<> memory_pool_type;
-        typedef util::detail::memory_chunk_pool_allocator<char> allocator_type;
+        typedef util::detail::memory_chunk_pool_allocator<char, util::memory_chunk_pool<>> allocator_type;
         typedef
             std::vector<char, allocator_type>
             data_type;


### PR DESCRIPTION
...e

Add a traits type for the memory pool/allocator and separate memory_pool
and allocator classes to make further customization (other parcelports)
cleaner.