### PR TITLE
Adding async_cb, async_continue_cb, and async_colocated_cb. 

### DIFF
--- a/hpx/async.hpp
+++ b/hpx/async.hpp
@@ -8,8 +8,8 @@
 
 #include <hpx/hpx_fwd.hpp>
 #include <hpx/lcos/async.hpp>
-#include <hpx/lcos/async_colocated.hpp>
 #include <hpx/lcos/async_continue.hpp>
+#include <hpx/lcos/async_colocated.hpp>
 #include <hpx/lcos/local/packaged_task.hpp>
 #include <hpx/util/bind_action.hpp>
 #include <hpx/util/deferred_call.hpp>

--- a/hpx/hpx_fwd.hpp
+++ b/hpx/hpx_fwd.hpp
@@ -1686,6 +1686,7 @@ namespace hpx
 #include <hpx/runtime/set_parcel_write_handler.hpp>
 
 #include <hpx/lcos/async_fwd.hpp>
+#include <hpx/lcos/async_callback_fwd.hpp>
 
 #endif
 

--- a/hpx/include/async.hpp
+++ b/hpx/include/async.hpp
@@ -7,6 +7,9 @@
 #define HPX_ASYNC_APR_15_2012_0442PM
 
 #include <hpx/async.hpp>
+#include <hpx/lcos/async_callback.hpp>
+#include <hpx/lcos/async_continue_callback.hpp>
+#include <hpx/lcos/async_colocated_callback.hpp>
 
 #endif
 

--- a/hpx/lcos/async_callback.hpp
+++ b/hpx/lcos/async_callback.hpp
@@ -1,0 +1,161 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_LCOS_ASYNC_CALLBACK_MAR_30_2015_1119AM)
+#define HPX_LCOS_ASYNC_CALLBACK_MAR_30_2015_1119AM
+
+#include <hpx/hpx_fwd.hpp>
+#include <hpx/traits/component_type_is_compatible.hpp>
+#include <hpx/runtime/actions/action_support.hpp>
+#include <hpx/lcos/packaged_action.hpp>
+#include <hpx/lcos/future.hpp>
+#include <hpx/lcos/async.hpp>
+
+namespace hpx
+{
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Action, typename Result>
+        struct sync_local_invoke_cb
+        {
+            template <typename Callback, typename ...Ts>
+            BOOST_FORCEINLINE static lcos::future<Result> call(
+                naming::id_type const& gid, naming::address const&,
+                Callback&& cb, Ts&&... vs)
+            {
+                lcos::packaged_action<Action, Result> p;
+                p.apply_cb(launch::sync, gid, std::forward<Callback>(cb),
+                    std::forward<Ts>(vs)...);
+                return p.get_future();
+            }
+        };
+
+        template <typename Action, typename R>
+        struct sync_local_invoke_cb<Action, lcos::future<R> >
+        {
+            template <typename Callback, typename ...Ts>
+            BOOST_FORCEINLINE static lcos::future<R> call(
+                boost::mpl::true_, naming::id_type const&,
+                naming::address const& addr, Callback&& cb, Ts&&... vs)
+            {
+                HPX_ASSERT(traits::component_type_is_compatible<
+                    typename Action::component_type>::call(addr));
+                lcos::future<R> f = Action::execute_function(addr.address_,
+                    std::forward<Ts>(vs)...);
+
+                // invoke callback
+                cb(boost::system::error_code(), parcelset::parcel());
+
+                return f;
+            }
+        };
+
+    }
+
+    template <typename Action, typename Callback, typename ...Ts>
+    lcos::future<
+        typename traits::promise_local_result<
+            typename hpx::actions::extract_action<Action>::remote_result_type
+        >::type>
+    async_cb(BOOST_SCOPED_ENUM(launch) policy, naming::id_type const& gid,
+        Callback&& cb, Ts&&... vs)
+    {
+        typedef typename hpx::actions::extract_action<Action>::type action_type;
+        typedef typename traits::promise_local_result<
+            typename action_type::remote_result_type
+        >::type result_type;
+
+        naming::address addr;
+        if (agas::is_local_address_cached(gid, addr) && policy == launch::sync)
+        {
+            return detail::sync_local_invoke_cb<action_type, result_type>::
+                call(gid, addr, std::forward<Callback>(cb),
+                    std::forward<Ts>(vs)...);
+        }
+
+        lcos::packaged_action<action_type, result_type> p;
+
+        bool target_is_managed = false;
+        if (policy == launch::sync || detail::has_async_policy(policy))
+        {
+            if (addr) {
+                p.apply_cb(policy, std::move(addr), gid,
+                    std::forward<Callback>(cb), std::forward<Ts>(vs)...);
+            }
+            else if (gid.get_management_type() == naming::id_type::managed) {
+                p.apply_cb(policy,
+                    naming::id_type(gid.get_gid(), naming::id_type::unmanaged),
+                    std::forward<Callback>(cb), std::forward<Ts>(vs)...);
+                target_is_managed = true;
+            }
+            else {
+                p.apply_cb(policy, gid, std::forward<Callback>(cb),
+                    std::forward<Ts>(vs)...);
+            }
+        }
+
+        // keep id alive, if needed - this allows to send the destination as an
+        // unmanaged id
+        future<result_type> f = p.get_future();
+
+        if (target_is_managed)
+        {
+            typedef typename lcos::detail::shared_state_ptr_for<
+                future<result_type>
+            >::type shared_state_ptr;
+
+            shared_state_ptr const& state = lcos::detail::get_shared_state(f);
+            state->set_on_completed(detail::keep_id_alive(gid));
+        }
+
+        return std::move(f);
+    }
+
+    template <typename Action, typename Callback, typename ...Ts>
+    lcos::future<
+        typename traits::promise_local_result<
+            typename hpx::actions::extract_action<Action>::remote_result_type
+        >::type>
+    async_cb(naming::id_type const& gid, Callback&& cb, Ts&&... vs)
+    {
+        return async_cb<Action>(launch::all, gid, std::forward<Callback>(cb),
+            std::forward<Ts>(vs)...);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <
+        typename Component, typename Signature, typename Derived,
+        typename Callback, typename ...Ts>
+    lcos::future<
+        typename traits::promise_local_result<
+            typename hpx::actions::extract_action<Derived>::remote_result_type
+        >::type>
+    async_cb(BOOST_SCOPED_ENUM(launch) policy,
+        hpx::actions::basic_action<Component, Signature, Derived> const& /*act*/,
+        naming::id_type const& gid, Callback&& cb, Ts&&... vs)
+    {
+        return async_cb<Derived>(policy, gid, std::forward<Callback>(cb),
+            std::forward<Ts>(vs)...);
+    }
+
+    template <
+        typename Component, typename Signature, typename Derived,
+        typename Callback, typename ...Ts>
+    lcos::future<
+        typename traits::promise_local_result<
+            typename hpx::actions::extract_action<Derived>::remote_result_type
+        >::type>
+    async_cb(
+        hpx::actions::basic_action<Component, Signature, Derived> const& /*act*/,
+        naming::id_type const& gid, Callback&& cb, Ts&&... vs)
+    {
+        return async_cb<Derived>(launch::all, gid, std::forward<Callback>(cb),
+            std::forward<Ts>(vs)...);
+    }
+}
+
+#endif

--- a/hpx/lcos/async_callback_fwd.hpp
+++ b/hpx/lcos/async_callback_fwd.hpp
@@ -1,0 +1,53 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_LCOS_ASYNC_CALLBACK_FWD_MAR_30_2015_1122AM)
+#define HPX_LCOS_ASYNC_CALLBACK_FWD_MAR_30_2015_1122AM
+
+#include <hpx/lcos/async_fwd.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Action, typename Callback, typename ...Ts>
+    lcos::future<
+        typename traits::promise_local_result<
+            typename hpx::actions::extract_action<Action>::remote_result_type
+        >::type>
+    async_cb(BOOST_SCOPED_ENUM(launch) policy, naming::id_type const& gid,
+        Callback&& cb, Ts&&... vs);
+
+    template <typename Action, typename Callback, typename ...Ts>
+    lcos::future<
+        typename traits::promise_local_result<
+            typename hpx::actions::extract_action<Action>::remote_result_type
+        >::type>
+    async_cb(naming::id_type const& gid, Callback&& cb, Ts&&... vs);
+
+    template <
+        typename Component, typename Signature, typename Derived,
+        typename Callback, typename ...Ts>
+    lcos::future<
+        typename traits::promise_local_result<
+            typename hpx::actions::extract_action<Derived>::remote_result_type
+        >::type>
+    async_cb(
+        hpx::actions::basic_action<Component, Signature, Derived> const& /*act*/,
+        naming::id_type const& gid, Callback&& cb, Ts&&... vs);
+
+    template <
+        typename Component, typename Signature, typename Derived,
+        typename Callback, typename ...Ts>
+    lcos::future<
+        typename traits::promise_local_result<
+            typename hpx::actions::extract_action<Derived>::remote_result_type
+        >::type>
+    async_cb(BOOST_SCOPED_ENUM(launch) policy,
+        hpx::actions::basic_action<Component, Signature, Derived> const& /*act*/,
+        naming::id_type const& gid, Callback&& cb, Ts&&... vs);
+}
+
+#endif

--- a/hpx/lcos/async_colocated_callback.hpp
+++ b/hpx/lcos/async_colocated_callback.hpp
@@ -1,0 +1,60 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_LCOS_ASYNC_COLOCATED_CALLBACK_MAR_30_2015_1146AM)
+#define HPX_LCOS_ASYNC_COLOCATED_CALLBACK_MAR_30_2015_1146AM
+
+#include <hpx/lcos/async_colocated.hpp>
+
+namespace hpx
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Action, typename Callback, typename ...Ts>
+    lcos::future<
+        typename traits::promise_local_result<
+            typename hpx::actions::extract_action<Action>::remote_result_type
+        >::type>
+    async_colocated_cb(naming::id_type const& gid, Callback&& cb, Ts&&... vs)
+    {
+        // Attach the requested action as a continuation to a resolve_async
+        // call on the locality responsible for the target gid.
+        agas::request req(agas::primary_ns_resolve_gid, gid.get_gid());
+        naming::id_type service_target(
+            agas::stubs::primary_namespace::get_service_instance(gid.get_gid())
+          , naming::id_type::unmanaged);
+
+        typedef
+            typename hpx::actions::extract_action<Action>::remote_result_type
+        remote_result_type;
+        typedef agas::server::primary_namespace::service_action action_type;
+
+        using util::placeholders::_2;
+        return detail::async_continue_r_cb<action_type, remote_result_type>(
+            util::functional::async_continuation(
+                util::bind<Action>(
+                    util::bind(util::functional::extract_locality(), _2, gid)
+                  , std::forward<Ts>(vs)...)
+                ),
+            service_target, std::forward<Callback>(cb), req);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <
+        typename Component, typename Signature, typename Derived,
+        typename Callback, typename ...Ts>
+    lcos::future<
+        typename traits::promise_local_result<
+            typename hpx::actions::extract_action<Derived>::remote_result_type
+        >::type>
+    async_colocated_cb(
+        hpx::actions::basic_action<Component, Signature, Derived> /*act*/
+      , naming::id_type const& gid, Callback&& cb, Ts&&... vs)
+    {
+        return async_colocated_cb<Derived>(gid, std::forward<Callback>(cb),
+            std::forward<Ts>(vs)...);
+    }
+}
+
+#endif

--- a/hpx/lcos/async_colocated_callback_fwd.hpp
+++ b/hpx/lcos/async_colocated_callback_fwd.hpp
@@ -1,0 +1,34 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_LCOS_ASYNC_COLOCATED_CALLBACK_FWD_MAR_30_2015_1145PM)
+#define HPX_LCOS_ASYNC_COLOCATED_CALLBACK_FWD_MAR_30_2015_1145PM
+
+#include <hpx/lcos/async_colocated_fwd.hpp>
+
+namespace hpx
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Action, typename Callback, typename ...Ts>
+    lcos::future<
+        typename traits::promise_local_result<
+            typename hpx::actions::extract_action<Action>::remote_result_type
+        >::type>
+    async_colocated_cb(naming::id_type const& gid, Callback&& cb, Ts&&... vs);
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <
+        typename Component, typename Signature, typename Derived,
+        typename Callback, typename ...Ts>
+    lcos::future<
+        typename traits::promise_local_result<
+            typename hpx::actions::extract_action<Derived>::remote_result_type
+        >::type>
+    async_colocated_cb(
+        hpx::actions::basic_action<Component, Signature, Derived> /*act*/
+      , naming::id_type const& gid, Callback&& cb, Ts&&... vs);
+}
+
+#endif

--- a/hpx/lcos/async_continue_callback.hpp
+++ b/hpx/lcos/async_continue_callback.hpp
@@ -1,0 +1,90 @@
+//  Copyright (c) 2007-2013 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+///////////////////////////////////////////////////////////////////////////////
+
+#if !defined(HPX_LCOS_ASYNC_CONTINUE_CALLBACK_MAR_30_2015_1132AM)
+#define HPX_LCOS_ASYNC_CONTINUE_CALLBACK_MAR_30_2015_1132AM
+
+#include <hpx/lcos/async_continue.hpp>
+
+namespace hpx
+{
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        template <
+            typename Action, typename RemoteResult
+          , typename Cont, typename Callback, typename ...Ts>
+        lcos::future<
+            typename traits::promise_local_result<
+                typename result_of_async_continue<Action, Cont>::type
+            >::type
+        >
+        async_continue_r_cb(Cont&& cont, naming::id_type const& gid,
+            Callback&& cb, Ts&&... vs)
+        {
+            typedef
+                typename traits::promise_local_result<
+                    typename result_of_async_continue<Action, Cont>::type
+                >::type
+            result_type;
+
+            typedef
+                typename hpx::actions::extract_action<
+                    Action
+                >::result_type
+            continuation_result_type;
+
+            lcos::promise<result_type, RemoteResult> p;
+            apply_cb<Action>(
+                new hpx::actions::typed_continuation<continuation_result_type>(
+                    p.get_gid(), std::forward<Cont>(cont))
+              , gid, std::forward<Callback>(cb), std::forward<Ts>(vs)...);
+            return p.get_future();
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Action, typename Cont, typename Callback, typename ...Ts>
+    lcos::future<
+        typename traits::promise_local_result<
+            typename detail::result_of_async_continue<Action, Cont>::type
+        >::type
+    >
+    async_continue_cb(Cont&& cont, naming::id_type const& gid, Callback&& cb,
+        Ts&&... vs)
+    {
+        typedef
+            typename traits::promise_local_result<
+                typename detail::result_of_async_continue<Action, Cont>::type
+            >::type
+        result_type;
+
+        return detail::async_continue_r_cb<Action, result_type>(
+            std::forward<Cont>(cont), gid, std::forward<Callback>(cb),
+            std::forward<Ts>(vs)...);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <
+        typename Component, typename Signature, typename Derived,
+        typename Cont, typename Callback, typename ...Ts>
+    lcos::future<
+         typename traits::promise_local_result<
+            typename detail::result_of_async_continue<Derived, Cont>::type
+        >::type
+    >
+    async_continue_cb(
+        hpx::actions::basic_action<Component, Signature, Derived> /*act*/
+      , Cont&& cont, naming::id_type const& gid, Callback&& cb, Ts&&... vs)
+    {
+        return async_continue_cb<Derived>(
+            std::forward<Cont>(cont), gid, std::forward<Callback>(cb),
+            std::forward<Ts>(vs)...);
+    }
+}
+
+#endif

--- a/hpx/lcos/async_continue_callback_fwd.hpp
+++ b/hpx/lcos/async_continue_callback_fwd.hpp
@@ -1,0 +1,52 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_LCOS_ASYNC_CONTINUE_CALLBACK_FWD_MAR_30_2015_1130AM)
+#define HPX_LCOS_ASYNC_CONTINUE_CALLBACK_FWD_MAR_30_2015_1130AM
+
+#include <hpx/lcos/async_continue_fwd.hpp>
+
+namespace hpx
+{
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        template <
+            typename Action, typename RemoteResult,
+            typename Cont, typename Callback, typename ...Ts>
+        lcos::future<
+            typename traits::promise_local_result<
+                typename result_of_async_continue<Action, Cont>::type
+            >::type
+        >
+        async_continue_r_cb(Cont&& cont, naming::id_type const& gid,
+            Callback&& cb, Ts&&... vs);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Action, typename Cont, typename Callback, typename ...Ts>
+    lcos::future<
+        typename traits::promise_local_result<
+            typename detail::result_of_async_continue<Action, Cont>::type
+        >::type
+    >
+    async_continue_cb(Cont&& cont, naming::id_type const& gid, Callback&& cb,
+        Ts&&... vs);
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <
+        typename Component, typename Signature, typename Derived,
+        typename Cont, typename Callback, typename ...Ts>
+    lcos::future<
+        typename traits::promise_local_result<
+            typename detail::result_of_async_continue<Derived, Cont>::type
+        >::type
+    >
+    async_continue_cb(
+        hpx::actions::basic_action<Component, Signature, Derived> /*act*/
+      , Cont&& cont, naming::id_type const& gid, Callback&& cb, Ts&&... vs);
+}
+
+#endif

--- a/hpx/lcos/packaged_action.hpp
+++ b/hpx/lcos/packaged_action.hpp
@@ -83,6 +83,24 @@ namespace hpx { namespace lcos
             }
         }
 
+        template <typename Callback>
+        static void parcel_write_handler_cb(Callback const& cb,
+            boost::intrusive_ptr<typename base_type::wrapping_type> impl,
+            boost::system::error_code const& ec, parcelset::parcel const& p)
+        {
+            // any error in the parcel layer will be stored in the future object
+            if (ec) {
+                boost::exception_ptr exception =
+                    hpx::detail::get_exception(hpx::exception(ec),
+                        "packaged_action::parcel_write_handler",
+                        __FILE__, __LINE__, parcelset::dump_parcel(p));
+                (*impl)->set_exception(exception);
+            }
+
+            // invoke user supplied callback
+            cb(ec, p);
+        }
+
     public:
         /// Construct a (non-functional) instance of an \a packaged_action. To use
         /// this instance its member function \a apply needs to be directly
@@ -124,6 +142,38 @@ namespace hpx { namespace lcos
                 std::forward<Ts>(vs)...);
         }
 
+        template <typename Callback, typename ...Ts>
+        void apply_cb(BOOST_SCOPED_ENUM(launch) policy,
+            naming::id_type const& gid, Callback && cb, Ts&&... vs)
+        {
+            util::block_profiler_wrapper<profiler_tag> bp(apply_logger_);
+
+            typedef typename util::decay<Callback>::type callback_type;
+
+            hpx::apply_c_cb<action_type>(this->get_gid(), gid,
+                util::bind(
+                    &packaged_action::parcel_write_handler_cb<callback_type>,
+                    std::forward<Callback>(cb), this->impl_,
+                    util::placeholders::_1, util::placeholders::_2),
+                std::forward<Ts>(vs)...);
+        }
+
+        template <typename Callback, typename ...Ts>
+        void apply_cb(BOOST_SCOPED_ENUM(launch) policy, naming::address&& addr,
+            naming::id_type const& gid, Callback && cb, Ts&&... vs)
+        {
+            util::block_profiler_wrapper<profiler_tag> bp(apply_logger_);
+
+            typedef typename util::decay<Callback>::type callback_type;
+
+            hpx::apply_c_cb<action_type>(this->get_gid(), std::move(addr), gid,
+                util::bind(
+                    &packaged_action::parcel_write_handler_cb<callback_type>,
+                    std::forward<Callback>(cb), this->impl_,
+                    util::placeholders::_1, util::placeholders::_2),
+                std::forward<Ts>(vs)...);
+        }
+
         template <typename ...Ts>
         void apply_p(BOOST_SCOPED_ENUM(launch) policy, naming::id_type const& gid,
             threads::thread_priority priority, Ts&&... vs)
@@ -147,6 +197,40 @@ namespace hpx { namespace lcos
                 gid, priority,
                 util::bind(&packaged_action::parcel_write_handler,
                     this->impl_, util::placeholders::_1, util::placeholders::_2),
+                std::forward<Ts>(vs)...);
+        }
+
+        template <typename Callback, typename ...Ts>
+        void apply_p_cb(BOOST_SCOPED_ENUM(launch) policy, naming::id_type const& gid,
+            threads::thread_priority priority, Callback && cb, Ts&&... vs)
+        {
+            util::block_profiler_wrapper<profiler_tag> bp(apply_logger_);
+
+            typedef typename util::decay<Callback>::type callback_type;
+
+            hpx::apply_c_p_cb<action_type>(this->get_gid(), gid, priority,
+                util::bind(
+                    &packaged_action::parcel_write_handler_cb<callback_type>,
+                    std::forward<Callback>(cb), this->impl_,
+                    util::placeholders::_1, util::placeholders::_2),
+                std::forward<Ts>(vs)...);
+        }
+
+        template <typename Callback, typename ...Ts>
+        void apply_p_cb(BOOST_SCOPED_ENUM(launch) policy, naming::address&& addr,
+            naming::id_type const& gid, threads::thread_priority priority,
+            Callback && cb, Ts&&... vs)
+        {
+            util::block_profiler_wrapper<profiler_tag> bp(apply_logger_);
+
+            typedef typename util::decay<Callback>::type callback_type;
+
+            hpx::apply_c_p_cb<action_type>(this->get_gid(), std::move(addr),
+                gid, priority,
+                util::bind(
+                    &packaged_action::parcel_write_handler_cb<callback_type>,
+                    std::forward<Callback>(cb), this->impl_,
+                    util::placeholders::_1, util::placeholders::_2),
                 std::forward<Ts>(vs)...);
         }
 
@@ -220,6 +304,24 @@ namespace hpx { namespace lcos
             }
         }
 
+        template <typename Callback>
+        static void parcel_write_handler_cb(Callback const& cb,
+            boost::intrusive_ptr<typename base_type::wrapping_type> impl,
+            boost::system::error_code const& ec, parcelset::parcel const& p)
+        {
+            // any error in the parcel layer will be stored in the future object
+            if (ec) {
+                boost::exception_ptr exception =
+                    hpx::detail::get_exception(hpx::exception(ec),
+                        "packaged_action::parcel_write_handler",
+                        __FILE__, __LINE__, parcelset::dump_parcel(p));
+                (*impl)->set_exception(exception);
+            }
+
+            // invoke user supplied callback
+            cb(ec, p);
+        }
+
     public:
         /// Construct a (non-functional) instance of an \a packaged_action. To use
         /// this instance its member function \a apply needs to be directly
@@ -282,6 +384,69 @@ namespace hpx { namespace lcos
                     std::move(addr), this->get_gid(), gid,
                     util::bind(&packaged_action::parcel_write_handler,
                         this->impl_, util::placeholders::_1, util::placeholders::_2),
+                    std::forward<Ts>(vs)...);
+            }
+        }
+
+        template <typename Callback, typename ...Ts>
+        void apply_cb(BOOST_SCOPED_ENUM(launch) /*policy*/,
+            naming::id_type const& gid, Callback && cb, Ts&&... vs)
+        {
+            util::block_profiler_wrapper<profiler_tag> bp(apply_logger_);
+
+            naming::address addr;
+            if (agas::is_local_address_cached(gid, addr)) {
+                // local, direct execution
+                HPX_ASSERT(traits::component_type_is_compatible<
+                    typename Action::component_type>::call(addr));
+
+                (*this->impl_)->set_data(action_type::execute_function(
+                    addr.address_, std::forward<Ts>(vs)...));
+
+                // invoke callback
+                cb(boost::system::error_code(), parcelset::parcel());
+            }
+            else {
+                // remote execution
+                typedef typename util::decay<Callback>::type callback_type;
+
+                hpx::applier::detail::apply_c_cb<action_type>(
+                    std::move(addr), this->get_gid(), gid,
+                    util::bind(
+                        &packaged_action::parcel_write_handler_cb<callback_type>,
+                        std::forward<Callback>(cb), this->impl_,
+                        util::placeholders::_1, util::placeholders::_2),
+                    std::forward<Ts>(vs)...);
+            }
+        }
+
+        template <typename Callback, typename ...Ts>
+        void apply_cb(BOOST_SCOPED_ENUM(launch) /*policy*/, naming::address&& addr,
+            naming::id_type const& gid, Ts&&... vs)
+        {
+            util::block_profiler_wrapper<profiler_tag> bp(apply_logger_);
+
+            if (addr.locality_ == hpx::get_locality()) {
+                // local, direct execution
+                HPX_ASSERT(traits::component_type_is_compatible<
+                    typename Action::component_type>::call(addr));
+
+                (*this->impl_)->set_data(action_type::execute_function(
+                    addr.address_, std::forward<Ts>(vs)...));
+
+                // invoke callback
+                cb(boost::system::error_code(), parcelset::parcel());
+            }
+            else {
+                // remote execution
+                typedef typename util::decay<Callback>::type callback_type;
+
+                hpx::applier::detail::apply_c_cb<action_type>(
+                    std::move(addr), this->get_gid(), gid,
+                    util::bind(
+                        &packaged_action::parcel_write_handler_cb<callback_type>,
+                        std::forward<Callback>(cb), this->impl_,
+                        util::placeholders::_1, util::placeholders::_2),
                     std::forward<Ts>(vs)...);
             }
         }

--- a/tests/unit/lcos/CMakeLists.txt
+++ b/tests/unit/lcos/CMakeLists.txt
@@ -9,8 +9,10 @@ set(tests
     apply_local
     apply_remote
     async_continue
+    async_continue_cb
     async_local
     async_remote
+    async_cb_remote
     broadcast
     broadcast_apply
     composable_guard

--- a/tests/unit/lcos/async_cb_remote.cpp
+++ b/tests/unit/lcos/async_cb_remote.cpp
@@ -1,0 +1,212 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/components.hpp>
+#include <hpx/include/async.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+boost::int32_t increment(boost::int32_t i)
+{
+    return i + 1;
+}
+HPX_PLAIN_ACTION(increment);
+
+boost::int32_t increment_with_future(hpx::shared_future<boost::int32_t> fi)
+{
+    return fi.get() + 1;
+}
+HPX_PLAIN_ACTION(increment_with_future);
+
+///////////////////////////////////////////////////////////////////////////////
+struct decrement_server
+  : hpx::components::managed_component_base<decrement_server>
+{
+    boost::int32_t call(boost::int32_t i) const
+    {
+        return i - 1;
+    }
+
+    HPX_DEFINE_COMPONENT_ACTION(decrement_server, call);
+};
+
+typedef hpx::components::managed_component<decrement_server> server_type;
+HPX_REGISTER_MINIMAL_COMPONENT_FACTORY(server_type, decrement_server);
+
+typedef decrement_server::call_action call_action;
+HPX_REGISTER_ACTION_DECLARATION(call_action);
+HPX_REGISTER_ACTION(call_action);
+
+///////////////////////////////////////////////////////////////////////////////
+boost::atomic<int> callback_called(0);
+
+void cb(boost::system::error_code const& ec,
+    hpx::parcelset::parcel const& p)
+{
+    ++callback_called;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_remote_async_cb(hpx::id_type const& target)
+{
+    {
+        increment_action inc;
+
+        callback_called.store(0);
+        hpx::future<boost::int32_t> f1 = hpx::async_cb(inc, target, &cb, 42);
+        HPX_TEST_EQ(f1.get(), 43);
+        HPX_TEST_EQ(callback_called.load(), 1);
+
+        callback_called.store(0);
+        hpx::future<boost::int32_t> f2 =
+            hpx::async_cb(hpx::launch::all, inc, target, &cb, 42);
+        HPX_TEST_EQ(f2.get(), 43);
+        HPX_TEST_EQ(callback_called.load(), 1);
+    }
+
+    {
+        increment_with_future_action inc;
+
+        hpx::promise<boost::int32_t> p;
+        hpx::shared_future<boost::int32_t> f = p.get_future();
+
+        callback_called.store(0);
+        hpx::future<boost::int32_t> f1 = hpx::async_cb(inc, target, &cb, f);
+        hpx::future<boost::int32_t> f2 =
+            hpx::async_cb(hpx::launch::all, inc, target, &cb, f);
+
+        p.set_value(42);
+        HPX_TEST_EQ(f1.get(), 43);
+        HPX_TEST_EQ(f2.get(), 43);
+        HPX_TEST_EQ(callback_called.load(), 2);
+    }
+
+//     {
+//         increment_action inc;
+//
+//         callback_called.store(0);
+//         hpx::future<boost::int32_t> f1 =
+//             hpx::async_cb(hpx::util::bind(inc, target, 42), &cb);
+//         HPX_TEST_EQ(f1.get(), 43);
+//         HPX_TEST_EQ(callback_called.load(), 1);
+//     }
+
+    {
+        callback_called.store(0);
+        hpx::future<boost::int32_t> f1 =
+            hpx::async_cb<increment_action>(target, &cb, 42);
+        HPX_TEST_EQ(f1.get(), 43);
+        HPX_TEST_EQ(callback_called.load(), 1);
+
+        callback_called.store(0);
+        hpx::future<boost::int32_t> f2 =
+            hpx::async_cb<increment_action>(hpx::launch::all, target, &cb, 42);
+        HPX_TEST_EQ(f2.get(), 43);
+        HPX_TEST_EQ(callback_called.load(), 1);
+    }
+
+    {
+        hpx::future<hpx::id_type> dec_f =
+            hpx::components::new_<decrement_server>(target);
+        hpx::id_type dec = dec_f.get();
+
+        call_action call;
+
+        callback_called.store(0);
+        hpx::future<boost::int32_t> f1 = hpx::async_cb(call, dec, &cb, 42);
+        HPX_TEST_EQ(f1.get(), 41);
+        HPX_TEST_EQ(callback_called.load(), 1);
+
+        callback_called.store(0);
+        hpx::future<boost::int32_t> f2 =
+            hpx::async_cb(hpx::launch::all, call, dec, &cb, 42);
+        HPX_TEST_EQ(f2.get(), 41);
+        HPX_TEST_EQ(callback_called.load(), 1);
+    }
+
+//     {
+//         hpx::future<hpx::id_type> dec_f =
+//             hpx::components::new_<decrement_server>(target);
+//         hpx::id_type dec = dec_f.get();
+//
+//         call_action call;
+//
+//         callback_called.store(0);
+//         hpx::future<boost::int32_t> f1 =
+//             hpx::async_cb(hpx::util::bind(call, dec, 42), &cb);
+//         HPX_TEST_EQ(f1.get(), 41);
+//         HPX_TEST_EQ(callback_called.load(), 1);
+//
+//         using hpx::util::placeholders::_1;
+//         using hpx::util::placeholders::_2;
+//
+//         callback_called.store(0);
+//         hpx::future<boost::int32_t> f2 =
+//             hpx::async_cb(hpx::util::bind(call, _1, 42), dec, &cb);
+//         HPX_TEST_EQ(f2.get(), 41);
+//         HPX_TEST_EQ(callback_called.load(), 1);
+
+//         callback_called.store(0);
+//         hpx::future<boost::int32_t> f3 =
+//             hpx::async_cb(hpx::util::bind(call, _1, _2), dec, &cb, 42);
+//         HPX_TEST_EQ(f3.get(), 41);
+//         HPX_TEST_EQ(callback_called.load(), 1);
+//     }
+
+    {
+        hpx::future<hpx::id_type> dec_f =
+            hpx::components::new_<decrement_server>(target);
+        hpx::id_type dec = dec_f.get();
+
+        callback_called.store(0);
+        hpx::future<boost::int32_t> f1 =
+            hpx::async_cb<call_action>(dec, &cb, 42);
+        HPX_TEST_EQ(f1.get(), 41);
+        HPX_TEST_EQ(callback_called.load(), 1);
+
+        callback_called.store(0);
+        hpx::future<boost::int32_t> f2 =
+            hpx::async_cb<call_action>(hpx::launch::all, dec, &cb, 42);
+        HPX_TEST_EQ(f2.get(), 41);
+        HPX_TEST_EQ(callback_called.load(), 1);
+    }
+
+    {
+        increment_with_future_action inc;
+        hpx::shared_future<boost::int32_t> f =
+            hpx::async(hpx::launch::deferred, hpx::util::bind(&increment, 42));
+
+        callback_called.store(0);
+        hpx::future<boost::int32_t> f1 = hpx::async_cb(inc, target, &cb, f);
+        hpx::future<boost::int32_t> f2 =
+            hpx::async_cb(hpx::launch::all, inc, target, &cb, f);
+
+        HPX_TEST_EQ(f1.get(), 44);
+        HPX_TEST_EQ(f2.get(), 44);
+        HPX_TEST_EQ(callback_called.load(), 2);
+    }
+}
+
+int hpx_main()
+{
+    std::vector<hpx::id_type> localities = hpx::find_all_localities();
+    BOOST_FOREACH(hpx::id_type const& id, localities)
+    {
+        test_remote_async_cb(id);
+    }
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}
+

--- a/tests/unit/lcos/async_continue_cb.cpp
+++ b/tests/unit/lcos/async_continue_cb.cpp
@@ -1,0 +1,193 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/apply.hpp>
+#include <hpx/include/async.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+boost::int32_t increment(boost::int32_t i)
+{
+    return i + 1;
+}
+HPX_PLAIN_ACTION(increment);  // defines increment_action
+
+boost::int32_t increment_with_future(hpx::shared_future<boost::int32_t> fi)
+{
+    return fi.get() + 1;
+}
+HPX_PLAIN_ACTION(increment_with_future);
+
+///////////////////////////////////////////////////////////////////////////////
+boost::int32_t mult2(boost::int32_t i)
+{
+    return i * 2;
+}
+HPX_PLAIN_ACTION(mult2);      // defines mult2_action
+
+///////////////////////////////////////////////////////////////////////////////
+boost::atomic<int> callback_called(0);
+
+void cb(boost::system::error_code const& ec,
+    hpx::parcelset::parcel const& p)
+{
+    ++callback_called;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main()
+{
+    using hpx::make_continuation;
+
+    increment_action inc;
+    increment_with_future_action inc_f;
+    mult2_action mult;
+
+    // test locally, fully equivalent to plain hpx::async
+    {
+        callback_called.store(0);
+        hpx::future<int> f1 = hpx::async_continue_cb(
+            inc, make_continuation(), hpx::find_here(), &cb, 42);
+        HPX_TEST_EQ(f1.get(), 43);
+        HPX_TEST_EQ(callback_called.load(), 1);
+
+        hpx::promise<boost::int32_t> p;
+        hpx::shared_future<boost::int32_t> f = p.get_future();
+
+        callback_called.store(0);
+        hpx::future<int> f2 = hpx::async_continue_cb(
+            inc_f, make_continuation(), hpx::find_here(), &cb, f);
+
+        p.set_value(42);
+        HPX_TEST_EQ(f2.get(), 43);
+        HPX_TEST_EQ(callback_called.load(), 1);
+    }
+
+    // test remotely, if possible, fully equivalent to plain hpx::async
+    std::vector<hpx::id_type> localities = hpx::find_remote_localities();
+    if (!localities.empty())
+    {
+        callback_called.store(0);
+        hpx::future<int> f1 = hpx::async_continue_cb(
+            inc, make_continuation(), localities[0], &cb, 42);
+        HPX_TEST_EQ(f1.get(), 43);
+        HPX_TEST_EQ(callback_called.load(), 1);
+
+        hpx::promise<boost::int32_t> p;
+        hpx::shared_future<boost::int32_t> f = p.get_future();
+
+        callback_called.store(0);
+        hpx::future<int> f2 = hpx::async_continue_cb(
+            inc_f, make_continuation(), localities[0], &cb, f);
+
+        p.set_value(42);
+        HPX_TEST_EQ(f2.get(), 43);
+        HPX_TEST_EQ(callback_called.load(), 1);
+    }
+
+    // test chaining locally
+    {
+        callback_called.store(0);
+        hpx::future<int> f = hpx::async_continue_cb(
+            inc, make_continuation(mult), hpx::find_here(), &cb, 42);
+        HPX_TEST_EQ(f.get(), 86);
+        HPX_TEST_EQ(callback_called.load(), 1);
+
+        callback_called.store(0);
+        f = hpx::async_continue_cb(inc,
+            make_continuation(mult, make_continuation()), hpx::find_here(),
+            &cb, 42);
+        HPX_TEST_EQ(f.get(), 86);
+        HPX_TEST_EQ(callback_called.load(), 1);
+
+        callback_called.store(0);
+        f = hpx::async_continue_cb(inc,
+            make_continuation(mult, make_continuation(inc)), hpx::find_here(),
+            &cb, 42);
+        HPX_TEST_EQ(f.get(), 87);
+        HPX_TEST_EQ(callback_called.load(), 1);
+
+        callback_called.store(0);
+        f = hpx::async_continue_cb(inc,
+            make_continuation(mult, make_continuation(inc, make_continuation())),
+            hpx::find_here(), &cb, 42);
+        HPX_TEST_EQ(f.get(), 87);
+        HPX_TEST_EQ(callback_called.load(), 1);
+    }
+
+    // test chaining remotely, if possible
+    if (!localities.empty())
+    {
+        callback_called.store(0);
+        hpx::future<int> f = hpx::async_continue_cb(inc,
+            make_continuation(mult, localities[0]), localities[0], &cb, 42);
+        HPX_TEST_EQ(f.get(), 86);
+        HPX_TEST_EQ(callback_called.load(), 1);
+
+        callback_called.store(0);
+        f = hpx::async_continue_cb(inc,
+            make_continuation(mult, localities[0], make_continuation()),
+            localities[0], &cb, 42);
+        HPX_TEST_EQ(f.get(), 86);
+        HPX_TEST_EQ(callback_called.load(), 1);
+
+        callback_called.store(0);
+        f = hpx::async_continue_cb(inc,
+            make_continuation(mult, localities[0],
+                make_continuation(inc)), localities[0], &cb, 42);
+        HPX_TEST_EQ(f.get(), 87);
+        HPX_TEST_EQ(callback_called.load(), 1);
+
+        callback_called.store(0);
+        f = hpx::async_continue_cb(inc,
+            make_continuation(mult, localities[0],
+                make_continuation(inc, make_continuation())), localities[0],
+            &cb, 42);
+        HPX_TEST_EQ(f.get(), 87);
+        HPX_TEST_EQ(callback_called.load(), 1);
+
+        callback_called.store(0);
+        f = hpx::async_continue_cb(inc,
+            make_continuation(mult, localities[0],
+                make_continuation(inc, localities[0])), localities[0], &cb, 42);
+        HPX_TEST_EQ(f.get(), 87);
+        HPX_TEST_EQ(callback_called.load(), 1);
+
+        callback_called.store(0);
+        f = hpx::async_continue_cb(inc,
+            make_continuation(mult, localities[0],
+                make_continuation(inc, localities[0], make_continuation())),
+                localities[0], &cb, 42);
+        HPX_TEST_EQ(f.get(), 87);
+        HPX_TEST_EQ(callback_called.load(), 1);
+
+        callback_called.store(0);
+        f = hpx::async_continue_cb(inc,
+            make_continuation(mult), localities[0], &cb, 42);
+        HPX_TEST_EQ(f.get(), 86);
+        HPX_TEST_EQ(callback_called.load(), 1);
+
+        callback_called.store(0);
+        f = hpx::async_continue_cb(inc,
+            make_continuation(mult, make_continuation()), localities[0],
+            &cb, 42);
+        HPX_TEST_EQ(f.get(), 86);
+        HPX_TEST_EQ(callback_called.load(), 1);
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}
+


### PR DESCRIPTION
These versions are available for actions only, not for purely local operations.

This is per our discussion on IRC this morning. The new overloads will help to manage the lifetime for arguments which are zero-copied. The callback will be invoked once it is safe to overwrite the memory of the arguments.

I decided to stick with callback functions instead of the suggested additional future to minimize the overheads introduced by this change. If a future is required/desired the user can easily pass a packaged_task (or similar) as the callback function object.