### PR TITLE
Always stripping HPX command line arguments before executing start function

### DIFF
--- a/hpx/hpx_init_impl.hpp
+++ b/hpx/hpx_init_impl.hpp
@@ -208,22 +208,24 @@ namespace hpx
         return init(f, desc_commandline, argc, argv, empty, empty, mode);
     }
 
+    /// \cond NOINTERNAL
+    namespace detail
+    {
+        HPX_EXPORT int init_helper(
+            boost::program_options::variables_map& /*vm*/,
+            util::function_nonser<int(int, char**)> const& f);
+    }
+    /// \endcond
+
     /// \brief Main entry point for launching the HPX runtime system.
     ///
     /// This is a simplified main entry point, which can be used to set up the
     /// runtime for an HPX application (the runtime system will be set up in
     /// console mode or worker mode depending on the command line settings).
-    namespace detail
-    {
-        inline int init_helper(boost::program_options::variables_map& /*vm*/,
-            util::function_nonser<int(int, char**)> const& f, int argc, char** argv)
-        {
-            return f(argc, argv);
-        }
-    }
-
-    inline int init(util::function_nonser<int(int, char**)> const& f,
-        std::string const& /*app_name*/, int argc, char** argv, hpx::runtime_mode mode)
+    inline int
+    init(util::function_nonser<int(int, char**)> const& f,
+        std::string const& /*app_name*/, int argc, char** argv,
+        hpx::runtime_mode mode)
     {
         using boost::program_options::options_description;
         options_description desc_commandline(
@@ -233,7 +235,7 @@ namespace hpx
         util::function_nonser<void()> const empty;
 
         return init(
-            util::bind(detail::init_helper, util::placeholders::_1, f, argc, argv),
+            util::bind(detail::init_helper, util::placeholders::_1, f),
             desc_commandline, argc, argv, cfg, empty, empty, mode);
     }
 }

--- a/tests/regressions/CMakeLists.txt
+++ b/tests/regressions/CMakeLists.txt
@@ -28,11 +28,13 @@ foreach(subdir ${subdirs})
 endforeach()
 
 set(tests
+    commandline_options_1437
     id_type_ref_counting_1032
     multiple_init
     unhandled_exception_582
    )
 
+set(commandline_options_1437_PARAMETERS THREADS_PER_LOCALITY 2)
 set(id_type_ref_counting_1032_PARAMETERS THREADS_PER_LOCALITY 1)
 set(unhandled_exception_582_PARAMETERS THREADS_PER_LOCALITY 1)
 

--- a/tests/regressions/commandline_options_1437.cpp
+++ b/tests/regressions/commandline_options_1437.cpp
@@ -1,0 +1,31 @@
+//  Copyright (c) 2015 Andreas Schaefer`
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Demonstrating #1437: hpx::init() should strip HPX-related flags from argv
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+bool invoked_main = false;
+
+int my_hpx_main(int argc, char **argv)
+{
+    // all HPX command line arguments should have been stripped here
+    HPX_TEST(argc == 1);
+
+    invoked_main = true;
+    return hpx::finalize();
+}
+
+int main(int argc, char **argv)
+{
+    HPX_TEST(argc > 1);
+
+    HPX_TEST_EQ(hpx::init(&my_hpx_main, "testapp", argc, argv), 0);
+    HPX_TEST(invoked_main);
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
This will fix #1437: hpx::init() should strip HPX-related flags from argv