### PR TITLE
Enabling usage of moveonly types for component construction

### DIFF
--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -528,9 +528,13 @@ namespace hpx { namespace components { namespace server
             util::unlock_guard<boost::unique_lock<component_map_mutex_type> > ul(l);
 
             typedef typename Component::wrapping_type wrapping_type;
+
+            // Note, T and Ts can't be (non-const) references, and parameters
+            // should be moved to allow for move-only constructor argument
+            // types.
             id = factory->create_with_args(
                     detail::construct_function<wrapping_type>(
-                        std::forward<T>(v), std::forward<Ts>(vs)...));
+                        std::move(v), std::move(vs)...));
         }
         LRT_(info) << "successfully created component " << id
             << " of type: " << components::get_component_type_name(type);
@@ -634,9 +638,12 @@ namespace hpx { namespace components { namespace server
             {
                 typedef typename Component::wrapping_type wrapping_type;
 
+                // Note, T and Ts can't be (non-const) references, and parameters
+                // should be moved to allow for move-only constructor argument
+                // types.
                 ids.push_back(factory->create_with_args(
                     detail::construct_function<wrapping_type>(
-                        std::forward<T>(v), std::forward<Ts>(vs)...)));
+                        std::move(v), std::move(vs)...)));
             }
         }
         LRT_(info) << "successfully created " << count //-V128

--- a/hpx/runtime/components/stubs/runtime_support.hpp
+++ b/hpx/runtime/components/stubs/runtime_support.hpp
@@ -337,13 +337,15 @@ namespace hpx { namespace components { namespace stubs
         /// \brief Retrieve configuration information
         static lcos::future<util::section> get_config_async(
             naming::id_type const& targetgid);
-        static void get_config(naming::id_type const& targetgid, util::section& ini);
+        static void get_config(naming::id_type const& targetgid,
+            util::section& ini);
 
         ///////////////////////////////////////////////////////////////////////
         /// \brief Retrieve instance count for given component type
         static lcos::future<boost::int32_t > get_instance_count_async(
             naming::id_type const& targetgid, components::component_type type);
-        static boost::int32_t  get_instance_count(naming::id_type const& targetgid,
+        static boost::int32_t  get_instance_count(
+            naming::id_type const& targetgid,
             components::component_type type);
 
         ///////////////////////////////////////////////////////////////////////

--- a/tests/regressions/CMakeLists.txt
+++ b/tests/regressions/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (c) 2011-2012 Bryce Adelstein-Lelbach
-# Copyright (c) 2007-2014 Hartmut Kaiser
+# Copyright (c) 2007-2015 Hartmut Kaiser
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,13 +9,14 @@ set(subdirs
     actions
     build
     block_matrix
+    components
     iostreams
     lcos
+    parallel
     performance_counters
     threads
     traits
     util
-    parallel
    )
 
 if(HPX_HAVE_CXX11_LAMBDAS)

--- a/tests/regressions/components/CMakeLists.txt
+++ b/tests/regressions/components/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Copyright (c) 2007-2016 Hartmut Kaiser
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests
+    moveonly_constructor_arguments_1405
+   )
+
+foreach(test ${tests})
+  set(sources
+      ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  # add example executable
+  add_hpx_executable(${test}_test
+                     SOURCES ${sources}
+                     ${${test}_FLAGS}
+                     EXCLUDE_FROM_ALL
+                     HPX_PREFIX ${HPX_BUILD_PREFIX}
+                     FOLDER "Tests/Regressions/Components")
+
+  add_hpx_regression_test("components_dir" ${test} ${${test}_PARAMETERS})
+
+  # add a custom target for this test
+  add_hpx_pseudo_target(tests.regressions.components_dir.${test})
+
+  # make pseudo-targets depend on master pseudo-target
+  add_hpx_pseudo_dependencies(tests.regressions.components_dir
+                              tests.regressions.components_dir.${test})
+
+  # add dependencies to pseudo-target
+  add_hpx_pseudo_dependencies(tests.regressions.components_dir.${test}
+                              ${test}_test_exe)
+endforeach()
+

--- a/tests/regressions/components/moveonly_constructor_arguments_1405.cpp
+++ b/tests/regressions/components/moveonly_constructor_arguments_1405.cpp
@@ -1,0 +1,79 @@
+//  Copyright (c) 2007-2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// verify #1405 is fixed (Allow component constructors to take movable
+// only types)
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+struct moveonly
+{
+private:
+    HPX_MOVABLE_BUT_NOT_COPYABLE(moveonly);
+
+public:
+    moveonly() {}
+
+    moveonly(moveonly&&) {}
+    moveonly& operator=(moveonly&&) { return *this; }
+};
+
+struct moveable
+{
+    moveable() {}
+
+    moveable(moveable&&) {}
+    moveable& operator=(moveable&&) { return *this; }
+
+    moveable(moveable const&) {}
+    moveable& operator=(moveable const&) { return *this; }
+};
+
+boost::atomic<int> constructed_from_moveonly(0);
+boost::atomic<int> constructed_from_moveable(0);
+
+///////////////////////////////////////////////////////////////////////////////
+struct test_server
+  : hpx::components::managed_component_base<test_server>
+{
+    test_server() {}
+
+    test_server(moveonly && arg)
+    {
+        ++constructed_from_moveonly;
+    }
+    test_server(moveable const& arg)
+    {
+        ++constructed_from_moveable;
+    }
+};
+
+typedef hpx::components::managed_component<test_server> server_type;
+HPX_REGISTER_COMPONENT(server_type, test_server);
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char** argv_init)
+{
+    hpx::new_<test_server>(hpx::find_here(), moveonly()).get();
+    HPX_TEST_EQ(constructed_from_moveonly.load(), 1);
+
+    moveable o;
+    hpx::new_<test_server>(hpx::find_here(), o).get();
+    HPX_TEST_EQ(constructed_from_moveable.load(), 1);
+
+    hpx::new_<test_server>(hpx::find_here(), moveable()).get();
+    HPX_TEST_EQ(constructed_from_moveable.load(), 2);
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
This pull request fixes #1405: Allow component constructors to take movable only types. 