### PR TITLE
When serializing, pass archive flags to traits::get_type_size

### DIFF
--- a/hpx/runtime/actions/action_support.hpp
+++ b/hpx/runtime/actions/action_support.hpp
@@ -269,7 +269,8 @@ namespace hpx { namespace actions
         virtual threads::thread_stacksize get_thread_stacksize() const = 0;
 
         /// Return the size of action arguments in bytes
-        virtual std::size_t get_type_size() const = 0;
+        /// flags should contain serialization options which affect the space required
+        virtual std::size_t get_type_size(int flags) const = 0;
 
         /// Return whether the embedded action may require id-splitting
         virtual bool may_require_id_splitting() const = 0;

--- a/hpx/runtime/actions/transfer_action.hpp
+++ b/hpx/runtime/actions/transfer_action.hpp
@@ -253,9 +253,10 @@ namespace hpx { namespace actions
         }
 
         /// Return the size of action arguments in bytes
-        std::size_t get_type_size() const
+        /// flags should contain serialization options which affect the space required
+        std::size_t get_type_size(int flags) const
         {
-            return traits::type_size<arguments_type>::call(arguments_);
+            return traits::type_size<arguments_type>::call(arguments_, flags);
         }
 
         /// Return whether the embedded action may require id-splitting

--- a/hpx/runtime/parcelset/encode_parcels.hpp
+++ b/hpx/runtime/parcelset/encode_parcels.hpp
@@ -99,7 +99,7 @@ namespace hpx
                     {
                         if (arg_size >= max_outbound_size)
                             break;
-                        arg_size += traits::get_type_size(ps[parcels_sent]);
+                        arg_size += traits::get_type_size(ps[parcels_sent], archive_flags_);
                     }
 
                     buffer.data_.reserve((std::max)(chunk_default, arg_size));

--- a/hpx/runtime/parcelset/parcel.hpp
+++ b/hpx/runtime/parcelset/parcel.hpp
@@ -100,7 +100,7 @@ namespace hpx { namespace parcelset
             virtual naming::gid_type get_parcel_id() const = 0;
             virtual void set_parcel_id(naming::gid_type const& id) = 0;
 
-            virtual std::size_t get_type_size() const = 0;
+            virtual std::size_t get_type_size(int flags) const = 0;
 
             virtual bool may_require_id_splitting() const = 0;
 
@@ -322,9 +322,9 @@ namespace hpx { namespace parcelset
                 data_.parcel_id_ = id;
             }
 
-            std::size_t get_type_size() const
+            std::size_t get_type_size(int flags) const
             {
-                return sizeof(parcel_buffer) + this->get_action()->get_type_size();
+                return sizeof(parcel_buffer) + this->get_action()->get_type_size(flags);
             }
 
             bool may_require_id_splitting() const
@@ -509,12 +509,12 @@ namespace hpx { namespace parcelset
                 data_.parcel_id_ = id;
             }
 
-            std::size_t get_type_size() const
+            std::size_t get_type_size(int flags) const
             {
                 return sizeof(parcel_buffer) +
-                    traits::type_size<std::vector<naming::id_type> >::call(dests_) +
-                    traits::type_size<std::vector<naming::address> >::call(addrs_) +
-                    this->get_action()->get_type_size();      // action
+                    traits::type_size<std::vector<naming::id_type> >::call(dests_, flags) +
+                    traits::type_size<std::vector<naming::address> >::call(addrs_, flags) +
+                    this->get_action()->get_type_size(flags);      // action
             }
 
             void save(util::portable_binary_oarchive& ar) const;
@@ -717,9 +717,9 @@ namespace hpx { namespace parcelset
             return data_->get_message_handler(ph, loc, *this);
         }
 
-        std::size_t get_type_size() const
+        std::size_t get_type_size(int flags) const
         {
-            return data_->get_type_size();
+            return data_->get_type_size(flags);
         }
 
         bool may_require_id_splitting() const
@@ -766,9 +766,9 @@ namespace hpx { namespace traits
     template <>
     struct type_size<hpx::parcelset::parcel>
     {
-        static std::size_t call(hpx::parcelset::parcel const& p)
+        static std::size_t call(hpx::parcelset::parcel const& p, int flags)
         {
-            return sizeof(hpx::parcelset::parcel) + p.get_type_size();
+            return sizeof(hpx::parcelset::parcel) + p.get_type_size(flags);
         }
     };
 

--- a/hpx/traits/type_size.hpp
+++ b/hpx/traits/type_size.hpp
@@ -29,8 +29,8 @@ namespace hpx { namespace traits
     struct type_size
     {
         typedef void uses_sizeof;
-
-        static BOOST_FORCEINLINE std::size_t call(T const&)
+        // flags are used for serialization options which may affect final encoded size
+        static BOOST_FORCEINLINE std::size_t call(T const&, int)
         {
             return sizeof(T);
         }
@@ -74,28 +74,28 @@ namespace hpx { namespace traits
         typename boost::enable_if<traits::detail::is_container<T> >::type>
     {
         template <typename T_>
-        static BOOST_FORCEINLINE std::size_t call(T_ const& v, boost::mpl::false_)
+        static BOOST_FORCEINLINE std::size_t call(T_ const& v, int flags, boost::mpl::false_)
         {
             std::size_t sum = sizeof(T_);
             typename T_::const_iterator end = v.end();
             for (typename T_::const_iterator it = v.begin(); it != end; ++it)
-                sum += type_size<typename T_::value_type>::call(*it);
+                sum += type_size<typename T_::value_type>::call(*it, flags);
             return sum;
         }
 
         template <typename T_>
-        static BOOST_FORCEINLINE std::size_t call(T_ const& v, boost::mpl::true_)
+        static BOOST_FORCEINLINE std::size_t call(T_ const& v, int, boost::mpl::true_)
         {
             return sizeof(T_) + v.size() * sizeof(typename T_::value_type); //-V119
         }
 
-        static BOOST_FORCEINLINE std::size_t call(T const& v)
+        static BOOST_FORCEINLINE std::size_t call(T const& v, int flags)
         {
             typedef boost::mpl::bool_<
                 traits::detail::has_uses_sizeof<
                     traits::type_size<typename T::value_type>
                 >::value> predicate;
-            return call(v, predicate());
+            return call(v, flags, predicate());
         }
     };
 
@@ -108,9 +108,9 @@ namespace hpx { namespace traits
             typedef std::size_t result_type;
 
             template <typename T>
-            BOOST_FORCEINLINE std::size_t operator()(std::size_t size, T const& t) const
+            BOOST_FORCEINLINE std::size_t operator()(std::size_t size, T const& t, int flags) const
             {
-                return size + type_size<T>::call(t);
+                return size + type_size<T>::call(t, flags);
             }
         };
     }
@@ -119,10 +119,12 @@ namespace hpx { namespace traits
     struct type_size<T,
         typename boost::enable_if<boost::fusion::traits::is_sequence<T> >::type>
     {
-        static BOOST_FORCEINLINE std::size_t call(T const& v)
+        static BOOST_FORCEINLINE std::size_t call(T const& v, int flags)
         {
             std::size_t sum = sizeof(T);
-            return boost::fusion::accumulate(v, sum, traits::detail::get_size());
+            return boost::fusion::accumulate(v, sum,
+                util::bind(traits::detail::get_size(),
+                util::placeholders::_1, util::placeholders::_2, flags));
         }
     };
 
@@ -130,9 +132,9 @@ namespace hpx { namespace traits
     template <typename T>
     struct type_size<boost::shared_ptr<T> >
     {
-        static BOOST_FORCEINLINE std::size_t call(boost::shared_ptr<T> const& p)
+        static BOOST_FORCEINLINE std::size_t call(boost::shared_ptr<T> const& p, int flags)
         {
-            return type_size<T>::call(*p);
+            return type_size<T>::call(*p, flags);
         }
     };
 
@@ -140,17 +142,17 @@ namespace hpx { namespace traits
     template <typename T>
     struct type_size<boost::intrusive_ptr<T> >
     {
-        static BOOST_FORCEINLINE std::size_t call(boost::intrusive_ptr<T> const& p)
+        static BOOST_FORCEINLINE std::size_t call(boost::intrusive_ptr<T> const& p, int flags)
         {
-            return type_size<T>::call(*p);
+            return type_size<T>::call(*p, flags);
         }
     };
 
     //////////////////////////////////////////////////////////////////////////
     template <typename T>
-    BOOST_FORCEINLINE std::size_t get_type_size(T const& t)
+    BOOST_FORCEINLINE std::size_t get_type_size(T const& t, int flags)
     {
-        return type_size<T>::call(t);
+        return type_size<T>::call(t, flags);
     }
 }}
 

--- a/hpx/util/serialize_buffer.hpp
+++ b/hpx/util/serialize_buffer.hpp
@@ -548,9 +548,15 @@ namespace hpx { namespace traits
     template <typename T, typename Allocator>
     struct type_size<util::serialize_buffer<T, Allocator> >
     {
-        static std::size_t call(util::serialize_buffer<T, Allocator> const& b)
+        static std::size_t call(util::serialize_buffer<T, Allocator> const& b, int flags)
         {
-            return b.size() * sizeof(T) + sizeof(std::size_t) + sizeof(Allocator); //-V119
+            if (flags & hpx::util::disable_data_chunking) {
+                return b.size() * sizeof(T) + sizeof(std::size_t) + sizeof(Allocator); //-V119
+            }
+            else {
+                // size required to specify a new pointer chunk is coming (needs checking)
+                return 8;
+            }
         }
     };
 }}

--- a/tests/performance/local/serialization_overhead.cpp
+++ b/tests/performance/local/serialization_overhead.cpp
@@ -101,7 +101,7 @@ double benchmark_serialization(std::size_t data_size, std::size_t iterations,
 
     for (std::size_t i = 0; i != iterations; ++i)
     {
-        std::size_t arg_size = hpx::traits::get_type_size(outp);
+        std::size_t arg_size = hpx::traits::get_type_size(outp, out_archive_flags);
         std::vector<char> out_buffer;
 
         out_buffer.resize(arg_size + HPX_PARCEL_SERIALIZATION_OVERHEAD);

--- a/tests/unit/util/zero_copy_serialization.cpp
+++ b/tests/unit/util/zero_copy_serialization.cpp
@@ -77,7 +77,7 @@ void test_parcel_serialization(hpx::parcelset::parcel outp,
     int in_archive_flags, int out_archive_flags, bool zero_copy)
 {
     // serialize data
-    std::size_t arg_size = hpx::traits::get_type_size(outp);
+    std::size_t arg_size = hpx::traits::get_type_size(outp, out_archive_flags);
     std::vector<char> out_buffer;
     std::vector<hpx::util::serialization_chunk> out_chunks;
     boost::uint32_t dest_locality_id = outp.get_destination_locality_id();


### PR DESCRIPTION
This allows specializations for classes like serialization_buffer
to return a different size depending on whether zero_copy is
enabled or not.