### PR TITLE
removed harmful std::moves from return statements

### DIFF
--- a/hpx/lcos/async.hpp
+++ b/hpx/lcos/async.hpp
@@ -123,7 +123,7 @@ namespace hpx
             state->set_on_completed(detail::keep_id_alive(gid));
         }
 
-        return std::move(f);
+        return f;
     }
 
     template <typename Action, typename ...Ts>

--- a/hpx/lcos/async_callback.hpp
+++ b/hpx/lcos/async_callback.hpp
@@ -112,7 +112,7 @@ namespace hpx
             state->set_on_completed(detail::keep_id_alive(gid));
         }
 
-        return std::move(f);
+        return f;
     }
 
     template <typename Action, typename Callback, typename ...Ts>

--- a/hpx/lcos/broadcast.hpp
+++ b/hpx/lcos/broadcast.hpp
@@ -517,7 +517,7 @@ namespace hpx { namespace lcos
                 std::move(t.begin(), t.end(), std::back_inserter(res));
             }
 
-            return std::move(res);
+            return res;
         }
 
         ///////////////////////////////////////////////////////////////////////

--- a/hpx/lcos/local/channel.hpp
+++ b/hpx/lcos/local/channel.hpp
@@ -142,14 +142,14 @@ struct channel
     {
         HPX_ASSERT(data_);
         T tmp = data_->get_data(ec);
-        return std::move(tmp);
+        return tmp;
     }
 
     T move(hpx::error_code& ec = hpx::throws) const
     {
         HPX_ASSERT(data_);
         T tmp = data_->move_data(ec);
-        return std::move(tmp);
+        return tmp;
     }
 
     void post(T && result)

--- a/hpx/lcos/local/conditional_trigger.hpp
+++ b/hpx/lcos/local/conditional_trigger.hpp
@@ -51,7 +51,7 @@ namespace hpx { namespace lcos { namespace local
 
             set(ec);      // trigger as soon as possible
 
-            return std::move(f);
+            return f;
         }
 
         void reset()

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -397,7 +397,7 @@ namespace hpx { namespace lcos { namespace detail
         typename shared_state_ptr<result_type>::type p(
             new shared_state(std::forward<F>(f)));
         static_cast<shared_state*>(p.get())->attach(future, policy);
-        return std::move(p);
+        return p;
     }
 
     template <typename ContResult, typename Future, typename F>
@@ -414,7 +414,7 @@ namespace hpx { namespace lcos { namespace detail
         typename shared_state_ptr<result_type>::type p(
             new shared_state(std::forward<F>(f)));
         static_cast<shared_state*>(p.get())->attach(future, sched);
-        return std::move(p);
+        return p;
     }
 }}}
 
@@ -512,7 +512,7 @@ namespace hpx { namespace lcos { namespace detail
         // create a continuation
         typename shared_state_ptr<result_type>::type p(new shared_state());
         static_cast<shared_state*>(p.get())->attach(future);
-        return std::move(p);
+        return p;
     }
 }}}
 
@@ -565,7 +565,7 @@ namespace hpx { namespace lcos { namespace detail
         // create a continuation
         typename shared_state_ptr<void>::type p(new void_shared_state());
         static_cast<void_shared_state*>(p.get())->attach(future);
-        return std::move(p);
+        return p;
     }
 }}}
 

--- a/hpx/lcos/reduce.hpp
+++ b/hpx/lcos/reduce.hpp
@@ -281,7 +281,7 @@ namespace hpx { namespace lcos
                 for (std::size_t i = 2; i != fres.size(); ++i)
                     res = reduce_op_(res, fres[i].get());
 
-                return std::move(res);
+                return res;
             }
 
             ReduceOp const& reduce_op_;

--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -590,7 +590,7 @@ namespace hpx { namespace components { namespace server
                    << " component(s) of type: "
                    << components::get_component_type_name(type);
 
-        return std::move(ids);
+        return ids;
     }
 
     template <typename Component, typename T, typename ...Ts>
@@ -646,7 +646,7 @@ namespace hpx { namespace components { namespace server
                    << " component(s) of type: "
                    << components::get_component_type_name(type);
 
-        return std::move(ids);
+        return ids;
     }
 
     template <typename Component>

--- a/hpx/traits/acquire_future.hpp
+++ b/hpx/traits/acquire_future.hpp
@@ -147,7 +147,7 @@ namespace hpx { namespace traits
             std::transform(boost::begin(futures), boost::end(futures),
                 std::back_inserter(values), acquire_future_disp());
 
-            return std::move(values);
+            return values;
         }
     };
 }}

--- a/hpx/util/coroutine/detail/self.hpp
+++ b/hpx/util/coroutine/detail/self.hpp
@@ -136,14 +136,14 @@ namespace hpx { namespace util { namespace coroutines { namespace detail
     {
         yield_decorator_type tmp(std::forward<F>(f));
         std::swap(tmp, yield_decorator_);
-        return std::move(tmp);
+        return tmp;
     }
 
     yield_decorator_type decorate_yield(yield_decorator_type const& f)
     {
         yield_decorator_type tmp(f);
         std::swap(tmp, yield_decorator_);
-        return std::move(tmp);
+        return tmp;
     }
 
     yield_decorator_type decorate_yield(yield_decorator_type && f)
@@ -156,7 +156,7 @@ namespace hpx { namespace util { namespace coroutines { namespace detail
     {
         yield_decorator_type tmp;
         std::swap(tmp, yield_decorator_);
-        return std::move(tmp);
+        return tmp;
     }
 
     HPX_ATTRIBUTE_NORETURN void exit() {

--- a/hpx/util/unwrapped.hpp
+++ b/hpx/util/unwrapped.hpp
@@ -410,7 +410,7 @@ namespace hpx { namespace util
         detail::unwrapped_impl<typename util::decay<F>::type >
             res(std::forward<F>(f));
 
-        return std::move(res);
+        return res;
     }
 
     template <typename ...Ts>

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -2073,7 +2073,7 @@ lcos::future<bool> addressing_service::register_name_async(
         );
     }
 
-    return std::move(f);
+    return f;
 } // }}}
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
These std::moves prevent compiler from using NRVO.
In case it's difficult for compiler to use RVO (e.g. several return statements), move constructor will be used anyways.