### PR TITLE
Fixing problems with the Intel compiler using a GCC 4.4 std library

### DIFF
--- a/hpx/runtime/components/new.hpp
+++ b/hpx/runtime/components/new.hpp
@@ -254,7 +254,7 @@ namespace hpx { namespace components
                         std::forward<Ts>(vs)...);
 
                 return f.then(launch::sync,
-                    [count](hpx::future<std::vector<bulk_locality_result> > && f)
+                    [count](hpx::future<std::vector<bulk_locality_result> > && f) -> std::vector<hpx::id_type>
                     {
                         std::vector<hpx::id_type> result;
                         result.reserve(count);

--- a/hpx/runtime/serialization/detail/pointer.hpp
+++ b/hpx/runtime/serialization/detail/pointer.hpp
@@ -56,7 +56,7 @@ namespace hpx { namespace serialization
                     register_pointer(
                           ar
                         , pos
-                        , std::unique_ptr<detail::ptr_helper>(
+                        , ptr_helper_ptr(
                               new detail::erase_ptr_helper<Pointer>(std::move(t), ptr)
                           )
                     );
@@ -74,7 +74,7 @@ namespace hpx { namespace serialization
                     register_pointer(
                         ar
                       , pos
-                      , std::unique_ptr<detail::ptr_helper>(
+                      , ptr_helper_ptr(
                             new detail::erase_ptr_helper<Pointer>(std::move(t), ptr)
                         )
                     );
@@ -92,7 +92,7 @@ namespace hpx { namespace serialization
                     register_pointer(
                         ar
                       , pos
-                      , std::unique_ptr<detail::ptr_helper>(
+                      , ptr_helper_ptr(
                             new detail::erase_ptr_helper<Pointer>(std::move(t), ptr)
                         )
                     );

--- a/hpx/runtime/serialization/input_archive.hpp
+++ b/hpx/runtime/serialization/input_archive.hpp
@@ -29,7 +29,7 @@ namespace hpx { namespace serialization
         typedef basic_archive<input_archive> base_type;
 
         typedef
-            std::map<boost::uint64_t, std::unique_ptr<detail::ptr_helper> >
+            std::map<boost::uint64_t, detail::ptr_helper_ptr>
             pointer_tracker;
 
         template <typename Container>
@@ -210,7 +210,7 @@ namespace hpx { namespace serialization
             return size_;
         }
 
-        void register_pointer(boost::uint64_t pos, std::unique_ptr<detail::ptr_helper> helper)
+        void register_pointer(boost::uint64_t pos, detail::ptr_helper_ptr helper)
         {
             HPX_ASSERT(pointer_tracker_.find(pos) == pointer_tracker_.end());
 
@@ -232,7 +232,7 @@ namespace hpx { namespace serialization
     };
 
     BOOST_FORCEINLINE
-    void register_pointer(input_archive & ar, boost::uint64_t pos, std::unique_ptr<detail::ptr_helper> helper)
+    void register_pointer(input_archive & ar, boost::uint64_t pos, detail::ptr_helper_ptr helper)
     {
         ar.register_pointer(pos, std::move(helper));
     }

--- a/hpx/runtime/serialization/serialization_fwd.hpp
+++ b/hpx/runtime/serialization/serialization_fwd.hpp
@@ -16,7 +16,7 @@ namespace hpx { namespace serialization
     namespace detail
     {
         struct ptr_helper;
-#ifdef HPX_INTEL_VERSION && __GNUC__ == 4 && __GNUC_MINOR__ == 4
+#ifdef HPX_INTEL_VERSION && ((__GNUC__ == 4 && __GNUC_MINOR__ == 4) || HPX_INTEL_VERSION < 1400)
         typedef boost::shared_ptr<ptr_helper> ptr_helper_ptr;
 #else
         typedef std::unique_ptr<ptr_helper> ptr_helper_ptr;

--- a/hpx/runtime/serialization/serialization_fwd.hpp
+++ b/hpx/runtime/serialization/serialization_fwd.hpp
@@ -16,7 +16,7 @@ namespace hpx { namespace serialization
     namespace detail
     {
         struct ptr_helper;
-#ifdef HPX_INTEL_VERSION && ((__GNUC__ == 4 && __GNUC_MINOR__ == 4) || HPX_INTEL_VERSION < 1400)
+#if define(HPX_INTEL_VERSION) && ((__GNUC__ == 4 && __GNUC_MINOR__ == 4) || HPX_INTEL_VERSION < 1400)
         typedef boost::shared_ptr<ptr_helper> ptr_helper_ptr;
 #else
         typedef std::unique_ptr<ptr_helper> ptr_helper_ptr;

--- a/hpx/runtime/serialization/serialization_fwd.hpp
+++ b/hpx/runtime/serialization/serialization_fwd.hpp
@@ -16,13 +16,18 @@ namespace hpx { namespace serialization
     namespace detail
     {
         struct ptr_helper;
+#ifdef HPX_INTEL_VERSION && __GNUC__ == 4 && __GNUC_MINOR__ == 4
+        typedef boost::shared_ptr<ptr_helper> ptr_helper_ptr;
+#else
+        typedef std::unique_ptr<ptr_helper> ptr_helper_ptr;
+#endif
     }
 
     struct input_archive;
     struct output_archive;
 
     BOOST_FORCEINLINE
-    void register_pointer(input_archive & ar, boost::uint64_t pos, std::unique_ptr<detail::ptr_helper> helper);
+    void register_pointer(input_archive & ar, boost::uint64_t pos, detail::ptr_helper_ptr helper);
 
     template <typename Helper>
     Helper & tracked_pointer(input_archive & ar, boost::uint64_t pos);

--- a/hpx/runtime/serialization/serialization_fwd.hpp
+++ b/hpx/runtime/serialization/serialization_fwd.hpp
@@ -9,7 +9,11 @@
 
 #include <hpx/config.hpp>
 
+#if defined(HPX_INTEL_VERSION) && ((__GNUC__ == 4 && __GNUC_MINOR__ == 4) || HPX_INTEL_VERSION < 1400)
+#include <boost/shared_ptr.hpp>
+#else
 #include <memory>
+#endif
 
 namespace hpx { namespace serialization
 {

--- a/hpx/runtime/serialization/serialization_fwd.hpp
+++ b/hpx/runtime/serialization/serialization_fwd.hpp
@@ -16,7 +16,7 @@ namespace hpx { namespace serialization
     namespace detail
     {
         struct ptr_helper;
-#if define(HPX_INTEL_VERSION) && ((__GNUC__ == 4 && __GNUC_MINOR__ == 4) || HPX_INTEL_VERSION < 1400)
+#if defined(HPX_INTEL_VERSION) && ((__GNUC__ == 4 && __GNUC_MINOR__ == 4) || HPX_INTEL_VERSION < 1400)
         typedef boost::shared_ptr<ptr_helper> ptr_helper_ptr;
 #else
         typedef std::unique_ptr<ptr_helper> ptr_helper_ptr;

--- a/tests/unit/util/stencil3_iterator.cpp
+++ b/tests/unit/util/stencil3_iterator.cpp
@@ -162,9 +162,8 @@ namespace test
             typedef hpx::util::tuple<value_type, element_type, value_type> type;
         };
 
-        template <typename F_>
-        custom_stencil_transformer(F_ && f)
-          : f_(std::forward<F_>(f))
+        custom_stencil_transformer(F f)
+          : f_(std::move(f))
         {}
 
         // it will dereference tuple(it-1, it, it+1)
@@ -195,7 +194,7 @@ void test_stencil3_iterator_custom()
     std::vector<int> values(10);
     std::iota(std::begin(values), std::end(values), 0);
 
-    auto t = test::make_custom_stencil_transformer([](int i) { return 2*i; });
+    auto t = test::make_custom_stencil_transformer([](int i) -> int { return 2*i; };);
     auto r = test::make_stencil3_range(values.begin()+1, values.end()-1, t);
 
     typedef std::iterator_traits<decltype(r.first)>::reference reference;


### PR DESCRIPTION
This PR solves a problem with using the intel compiler series with a standard library provided by gcc 4.4.x standard libraries.