### PR TITLE
Serialization variant hpp

### DIFF
--- a/hpx/components/containers/unordered/unordered_map.hpp
+++ b/hpx/components/containers/unordered/unordered_map.hpp
@@ -239,7 +239,10 @@ namespace hpx
 
     private:
         typedef hpx::components::client_base<
-                unordered_map, server::unordered_map_config_data
+                unordered_map,
+                hpx::components::server::distributed_metadata_base<
+                    server::unordered_map_config_data
+                >
             > base_type;
         typedef detail::unordered_base<Hash, KeyEqual> hash_base_type;
 

--- a/hpx/runtime/serialization/serialization_fwd.hpp
+++ b/hpx/runtime/serialization/serialization_fwd.hpp
@@ -8,6 +8,7 @@
 #define HPX_SERIALIZATION_FWD_HPP
 
 #include <hpx/config.hpp>
+#include <hpx/util/detail/pp_strip_parens.hpp>
 
 #if defined(HPX_INTEL_VERSION) && ((__GNUC__ == 4 && __GNUC_MINOR__ == 4) || HPX_INTEL_VERSION < 1400)
 #include <boost/shared_ptr.hpp>
@@ -73,6 +74,23 @@ namespace hpx { namespace serialization
     void serialize(hpx::serialization::output_archive & ar, T & t, unsigned)        \
     {                                                                               \
         save(ar, const_cast<boost::add_const<T>::type &>(t), 0);                    \
+    }                                                                               \
+/**/
+#define HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE(TEMPLATE, ARGS)                       \
+    HPX_UTIL_STRIP(TEMPLATE)                                                        \
+    BOOST_FORCEINLINE                                                               \
+    void serialize(hpx::serialization::input_archive & ar,                          \
+            HPX_UTIL_STRIP(ARGS) & t, unsigned)                                     \
+    {                                                                               \
+        load(ar, t, 0);                                                             \
+    }                                                                               \
+    HPX_UTIL_STRIP(TEMPLATE)                                                        \
+    BOOST_FORCEINLINE                                                               \
+    void serialize(hpx::serialization::output_archive & ar,                         \
+            HPX_UTIL_STRIP(ARGS) & t, unsigned)                                     \
+    {                                                                               \
+        save(ar, const_cast<typename boost::add_const                               \
+                <HPX_UTIL_STRIP(ARGS)>::type &>(t), 0);                             \
     }                                                                               \
 /**/
 

--- a/hpx/runtime/serialization/variant.hpp
+++ b/hpx/runtime/serialization/variant.hpp
@@ -1,3 +1,6 @@
+//  copyright (c) 2005
+//  troy d. straszheim <troy@resophonic.com>
+//  http://www.resophonic.com
 //  Copyright (c) 2015 Anton Bikineev
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,94 +9,115 @@
 #ifndef HPX_SERIALIZATION_VARIANT_HPP
 #define HPX_SERIALIZATION_VARIANT_HPP
 
-#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/runtime/serialization/serialization_fwd.hpp>
+#include <hpx/exception.hpp>
+
+#include <boost/mpl/front.hpp>
+#include <boost/mpl/pop_front.hpp>
+#include <boost/mpl/eval_if.hpp>
+#include <boost/mpl/identity.hpp>
+#include <boost/mpl/size.hpp>
+#include <boost/mpl/empty.hpp>
 
 #include <boost/variant.hpp>
 
 namespace hpx { namespace serialization
 {
-    namespace detail
+    struct variant_save_visitor :
+        boost::static_visitor<>
     {
-        struct variant_save_visitor: boost::static_visitor<>
+        variant_save_visitor(output_archive& ar) :
+            m_ar(ar)
+        {}
+
+        template<class T>
+        void operator()(T const & value) const
         {
-            variant_save_visitor(output_archive& ar)
-              : ar(ar)
-            {}
+            m_ar << value;
+        }
+    private:
+        output_archive & m_ar;
+    };
 
-            template <class T>
-            void operator()(const T& value) const
-            {
-                ar << value;
-            }
+    template<class S>
+    struct variant_impl {
 
-        private:
-            output_archive& ar;
+        struct load_null {
+            template<class V>
+            static void invoke(
+                input_archive& /*ar*/,
+                int /*which*/,
+                V & /*v*/
+            ){}
         };
 
-        template <class... Args>
-        struct load_helper_t{};
-
-#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || \
-    defined(BOOST_VARIANT_DO_NOT_USE_VARIADIC_TEMPLATES) // intr. only in 1.56
-        // overload for non-variadic version of variant library
-        template <class Variant, class... Tail>
-        BOOST_FORCEINLINE void load_helper(input_archive&, Variant&,
-                int, load_helper_t<boost::detail::variant::void_, Tail...>)
-        {
-            HPX_ASSERT(false);
-        }
-#else
-        // overload for variadic version of variant library
-        template <class Variant>
-        BOOST_FORCEINLINE void load_helper(input_archive&, Variant&,
-                int, load_helper_t<>)
-        {
-            HPX_ASSERT(false);
-        }
-#endif
-        template <class Variant, class Head, class... Tail>
-        BOOST_FORCEINLINE void load_helper(input_archive& ar, Variant& var,
-                int which, load_helper_t<Head, Tail...>)
-        {
-            if (which == 0)
-            {
-                Head value; // default ctor concept
-                ar >> value;
-                var = value;
+        struct load_impl {
+            template<class V>
+            static void invoke(
+                input_archive& ar,
+                int which,
+                V & v
+            ){
+                if(which == 0){
+                    // note: A non-intrusive implementation (such as this one)
+                    // necessary has to copy the value.  This wouldn't be necessary
+                    // with an implementation that de-serialized to the address of the
+                    // aligned storage included in the variant.
+                    typedef typename boost::mpl::front<S>::type head_type;
+                    head_type value;
+                    ar >> value;
+                    v = value;
+                    return;
+                }
+                typedef typename boost::mpl::pop_front<S>::type type;
+                variant_impl<type>::load(ar, which - 1, v);
             }
-            else
-            {
-                load_helper(ar, var, which - 1, load_helper_t<Tail...>());
-            }
-        }
-    }
+        };
 
-    template <class... Args>
-    void save(output_archive& ar, const boost::variant<Args...>& variant, unsigned)
+        template<class V>
+        static void load(
+            input_archive& ar,
+            int which,
+            V & v
+        ){
+            typedef typename boost::mpl::eval_if<boost::mpl::empty<S>,
+                boost::mpl::identity<load_null>,
+                boost::mpl::identity<load_impl>
+            >::type typex;
+            typex::invoke(ar, which, v);
+        }
+
+    };
+
+    template<BOOST_VARIANT_ENUM_PARAMS(class T)>
+    void save(output_archive& ar,
+            boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)> const & v, unsigned)
     {
-        int which = variant.which();
+        int which = v.which();
         ar << which;
-        detail::variant_save_visitor visitor(ar);
-        variant.apply_visitor(visitor);
+        variant_save_visitor visitor(ar);
+        v.apply_visitor(visitor);
     }
 
-    template <class... Args>
-    void load(input_archive& ar, boost::variant<Args...>& variant, unsigned)
+    template<BOOST_VARIANT_ENUM_PARAMS(class T)>
+    void load(input_archive& ar,
+            boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>& v, unsigned)
     {
         int which;
+        typedef typename boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>::types types;
         ar >> which;
-        if (static_cast<std::size_t>(which) >= sizeof...(Args))
-        {
+        if(which >=  boost::mpl::size<types>::value)
+            // this might happen if a type was removed from the list of variant types
             HPX_THROW_EXCEPTION(serialization_error
-              , "load variant"
-              , "which of loaded variant is greater then saved one");
-        }
-
-        detail::load_helper(ar, variant, which, detail::load_helper_t<Args...>());
+              , "load<Archive, Variant, version>"
+              , "type was removed from the list of variant types");
+        variant_impl<types>::load(ar, which, v);
     }
 
-    HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE((template <class... Args>),
-            (boost::variant<Args...>));
-}}
+    HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE((template <BOOST_VARIANT_ENUM_PARAMS(class T)>),
+            (boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>));
 
-#endif
+} // namespace serialization
+} // namespace boost
+
+#endif //HPX_SERIALIZATION_VARIANT_HPP

--- a/hpx/runtime/serialization/variant.hpp
+++ b/hpx/runtime/serialization/variant.hpp
@@ -33,7 +33,8 @@ namespace hpx { namespace serialization
         template <class... Args>
         struct load_helper_t{};
 
-#if defined(BOOST_VARIANT_DO_NOT_USE_VARIADIC_TEMPLATES)
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || \
+    defined(BOOST_VARIANT_DO_NOT_USE_VARIADIC_TEMPLATES) // intr. only in 1.56
         // overload for non-variadic version of variant library
         template <class Variant, class... Tail>
         BOOST_FORCEINLINE void load_helper(input_archive&, Variant&,

--- a/hpx/runtime/serialization/variant.hpp
+++ b/hpx/runtime/serialization/variant.hpp
@@ -21,7 +21,7 @@ namespace hpx { namespace serialization
             {}
 
             template <class T>
-            void operator()(const T& value)
+            void operator()(const T& value) const
             {
                 ar << value;
             }
@@ -33,9 +33,18 @@ namespace hpx { namespace serialization
         template <class... Args>
         struct load_helper_t{};
 
+        // overload for non-variadic version of variant library
         template <class Variant, class... Tail>
-        BOOST_FORCEINLINE void load_helper(input_archive& ar, Variant& var,
-                int which, load_helper_t<boost::detail::variant::void_, Tail...>)
+        BOOST_FORCEINLINE void load_helper(input_archive&, Variant&,
+                int, load_helper_t<boost::detail::variant::void_, Tail...>)
+        {
+            HPX_ASSERT(false);
+        }
+
+        // overload for variadic version of variant library
+        template <class Variant>
+        BOOST_FORCEINLINE void load_helper(input_archive&, Variant&,
+                int, load_helper_t<>)
         {
             HPX_ASSERT(false);
         }

--- a/hpx/runtime/serialization/variant.hpp
+++ b/hpx/runtime/serialization/variant.hpp
@@ -1,0 +1,67 @@
+//  Copyright (c) 2015 Anton Bikineev
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_SERIALIZATION_VARIANT_HPP
+#define HPX_SERIALIZATION_VARIANT_HPP
+
+#include <hpx/runtime/serialization/serialize.hpp>
+
+#include <boost/variant.hpp>
+
+namespace hpx { namespace serialization
+{
+    namespace detail
+    {
+        struct variant_save_visitor: boost::static_visitor<>
+        {
+            variant_save_visitor(output_archive& ar)
+              : ar(ar)
+            {}
+
+            template <class T>
+            void operator()(const T& value)
+            {
+                ar << value;
+            }
+
+        private:
+            output_archive& ar;
+        };
+
+        template <class... Args>
+        struct load_helper_t{};
+
+        template <class Variant, class Head, class... Args>
+        BOOST_FORCEINLINE void load_helper(input_archive& ar, Variant& var,
+                load_helper_t<Head, boost::detail::variant::void_, Args...>)
+        {
+            Head value; //default ctor concept
+            ar >> value;
+            var = value;
+        }
+
+        template <class Variant, class Head1, class Head2, class... Tail>
+        BOOST_FORCEINLINE void load_helper(input_archive& ar, Variant& var,
+                load_helper_t<Head1, Head2, Tail...>)
+        {
+            load_helper(ar, var, load_helper_t<Head2, Tail...>());
+        }
+    }
+
+    template <class... Args>
+    void serialize(output_archive& ar, boost::variant<Args...>& variant, unsigned)
+    {
+        detail::variant_save_visitor visitor(ar);
+        variant.apply_visitor(visitor);
+    }
+
+    template <class... Args>
+    void serialize(input_archive& ar, boost::variant<Args...>& variant, unsigned)
+    {
+        detail::load_helper(ar, variant, detail::load_helper_t<Args...>());
+    }
+}}
+
+#endif

--- a/hpx/runtime/serialization/variant.hpp
+++ b/hpx/runtime/serialization/variant.hpp
@@ -80,7 +80,7 @@ namespace hpx { namespace serialization
     {
         int which;
         ar >> which;
-        if (which >= sizeof...(Args))
+        if (static_cast<std::size_t>(which) >= sizeof...(Args))
         {
             HPX_THROW_EXCEPTION(serialization_error
               , "load variant"

--- a/hpx/runtime/serialization/variant.hpp
+++ b/hpx/runtime/serialization/variant.hpp
@@ -41,7 +41,7 @@ namespace hpx { namespace serialization
         {
             HPX_ASSERT(false);
         }
-#elif
+#else
         // overload for variadic version of variant library
         template <class Variant>
         BOOST_FORCEINLINE void load_helper(input_archive&, Variant&,

--- a/hpx/runtime/serialization/variant.hpp
+++ b/hpx/runtime/serialization/variant.hpp
@@ -33,6 +33,7 @@ namespace hpx { namespace serialization
         template <class... Args>
         struct load_helper_t{};
 
+#if defined(BOOST_VARIANT_DO_NOT_USE_VARIADIC_TEMPLATES)
         // overload for non-variadic version of variant library
         template <class Variant, class... Tail>
         BOOST_FORCEINLINE void load_helper(input_archive&, Variant&,
@@ -40,7 +41,7 @@ namespace hpx { namespace serialization
         {
             HPX_ASSERT(false);
         }
-
+#elif
         // overload for variadic version of variant library
         template <class Variant>
         BOOST_FORCEINLINE void load_helper(input_archive&, Variant&,
@@ -48,7 +49,7 @@ namespace hpx { namespace serialization
         {
             HPX_ASSERT(false);
         }
-
+#endif
         template <class Variant, class Head, class... Tail>
         BOOST_FORCEINLINE void load_helper(input_archive& ar, Variant& var,
                 int which, load_helper_t<Head, Tail...>)

--- a/hpx/runtime/serialization/variant.hpp
+++ b/hpx/runtime/serialization/variant.hpp
@@ -80,6 +80,13 @@ namespace hpx { namespace serialization
     {
         int which;
         ar >> which;
+        if (which >= sizeof...(Args))
+        {
+            HPX_THROW_EXCEPTION(serialization_error
+              , "load variant"
+              , "which of loaded variant is greater then saved one");
+        }
+
         detail::load_helper(ar, variant, which, detail::load_helper_t<Args...>());
     }
 

--- a/tests/unit/serialization/CMakeLists.txt
+++ b/tests/unit/serialization/CMakeLists.txt
@@ -8,6 +8,7 @@ set(tests
     serialization_builtins
     serialization_smart_ptr
     serialization_vector
+    serialization_variant
     serialize_buffer
     zero_copy_serialization
 )

--- a/tests/unit/serialization/serialization_variant.cpp
+++ b/tests/unit/serialization/serialization_variant.cpp
@@ -46,7 +46,7 @@ int main()
     hpx::serialization::output_archive oar(buf);
     hpx::serialization::input_archive iar(buf);
 
-    boost::variant<int, std::string, double, A<int> > ovar = std::string{"dfsdf"};
+    boost::variant<int, std::string, double, A<int> > ovar = std::string("dfsdf");
     boost::variant<int, std::string, double, A<int> > ivar;
     oar << ovar;
     iar >> ivar;

--- a/tests/unit/serialization/serialization_variant.cpp
+++ b/tests/unit/serialization/serialization_variant.cpp
@@ -1,0 +1,87 @@
+//  Copyright (c) 2015 Anton Bikineev
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/runtime/serialization/string.hpp>
+#include <hpx/runtime/serialization/variant.hpp>
+
+#include <hpx/runtime/serialization/input_archive.hpp>
+#include <hpx/runtime/serialization/output_archive.hpp>
+
+#include <hpx/util/lightweight_test.hpp>
+
+template <typename T>
+struct A
+{
+    A() {}
+
+    A(T t) : t_(t) {}
+    T t_;
+
+    A & operator=(T t) { t_ = t; return *this; }
+
+    friend bool operator==(A a, A b)
+    {
+        return a.t_ == b.t_;
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, A a)
+    {
+        os << a;
+        return os;
+    }
+
+    template <typename Archive>
+    void serialize(Archive & ar, unsigned)
+    {
+        ar & t_;
+    }
+};
+
+int main()
+{
+    std::vector<char> buf;
+    hpx::serialization::output_archive oar(buf);
+    hpx::serialization::input_archive iar(buf);
+
+    boost::variant<int, std::string, double, A<int> > ovar = std::string{"dfsdf"};
+    boost::variant<int, std::string, double, A<int> > ivar;
+    oar << ovar;
+    iar >> ivar;
+
+    HPX_TEST_EQ(ivar.which(), ovar.which());
+    HPX_TEST_EQ(ivar, ovar);
+
+    ovar = 2.5;
+    oar << ovar;
+    iar >> ivar;
+
+    HPX_TEST_EQ(ivar.which(), ovar.which());
+    HPX_TEST_EQ(ivar, ovar);
+
+    ovar = 1;
+    oar << ovar;
+    iar >> ivar;
+
+    HPX_TEST_EQ(ivar.which(), ovar.which());
+    HPX_TEST_EQ(ivar, ovar);
+
+    ovar = A<int>(2);
+    oar << ovar;
+    iar >> ivar;
+
+    HPX_TEST_EQ(ivar.which(), ovar.which());
+    HPX_TEST_EQ(ivar, ovar);
+
+    const boost::variant<std::string> sovar = std::string("string");
+    boost::variant<std::string> sivar;
+    oar << sovar;
+    iar >> sivar;
+
+    HPX_TEST_EQ(sivar.which(), sovar.which());
+    HPX_TEST_EQ(sivar, sovar);
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Drawbacks:
1) requires n+1 instantiations of load_helper (n - amount of template parameters for variant)
2) all types in variant should be serializable;
3) all types should have default ctor.