### PR TITLE
Exit application on --hpx:version/-v and --hpx:info 

### DIFF
--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -954,12 +954,16 @@ namespace hpx { namespace util
         rtcfg_.reconfigure(ini_config_);
 
         // print version/copyright information
-        if (vm_.count("hpx:version"))
+        if (vm_.count("hpx:version")) {
             detail::print_version(std::cout);
+            return 1;
+        }
 
         // print configuration information (static and dynamic)
-        if (vm_.count("hpx:info"))
+        if (vm_.count("hpx:info")) {
             detail::print_info(std::cout, *this);
+            return 1;
+        }
 
         // all is good
         return 0;


### PR DESCRIPTION
Exit application on `--hpx:version`/`-v` and `--hpx:info`  after printing the respective information