### PR TITLE
Making sure boost::filesystem::exists() does not throw

### DIFF
--- a/hpx/util/logging/format/destination/rolling_file.hpp
+++ b/hpx/util/logging/format/destination/rolling_file.hpp
@@ -92,15 +92,18 @@ namespace detail {
             namespace fs = boost::filesystem;
 
             if ( m_flags.initial_erase()) {
-                for ( unsigned idx = 0; idx < m_flags.file_count(); ++idx)
-                    if ( fs::exists( file_name(idx) ))
+                for ( unsigned idx = 0; idx < m_flags.file_count(); ++idx) {
+                    boost::system::error_code ec;
+                    if ( fs::exists( file_name(idx), ec) && ec)
                         fs::remove( file_name(idx) );
+                }
             }
 
             // see what file to start from
             if ( m_flags.start_where_size_not_exceeded() ) {
-                for ( m_cur_idx = 0; m_cur_idx < m_flags.file_count(); ++m_cur_idx )
-                    if ( fs::exists( file_name(m_cur_idx) )) {
+                for ( m_cur_idx = 0; m_cur_idx < m_flags.file_count(); ++m_cur_idx ) {
+                    boost::system::error_code ec;
+                    if ( fs::exists( file_name(m_cur_idx), ec) && ec) {
                         if ( fs::file_size( file_name(m_cur_idx))  < m_flags.max_size_bytes() )
                             // file hasn't reached max size
                             break;
@@ -108,6 +111,7 @@ namespace detail {
                     else
                         // file not found, we'll create it now
                         break;
+                }
 
                 if ( m_cur_idx >= m_flags.file_count())
                     // all files are too full (we'll overwrite the first one)

--- a/src/util/init_ini_data.cpp
+++ b/src/util/init_ini_data.cpp
@@ -35,7 +35,8 @@ namespace hpx { namespace util
     {
         try {
             namespace fs = boost::filesystem;
-            if (!fs::exists(loc))
+            boost::system::error_code ec;
+            if (!fs::exists(loc, ec) || !ec)
                 return false;       // avoid exception on missing file
             ini.read (loc);
         }
@@ -130,7 +131,8 @@ namespace hpx { namespace util
 
         if (!hpx_ini_file.empty()) {
             namespace fs = boost::filesystem;
-            if (!fs::exists(hpx_ini_file)) {
+            boost::system::error_code ec;
+            if (!fs::exists(hpx_ini_file, ec) || !ec) {
                 std::cerr << "hpx::init: command line warning: file specified using "
                              "--hpx::config does not exist ("
                     << hpx_ini_file << ")." << std::endl;
@@ -176,7 +178,8 @@ namespace hpx { namespace util
                 fs::directory_iterator nodir;
                 fs::path this_path (hpx::util::create_path(*it));
 
-                if (!fs::exists(this_path))
+                boost::system::error_code ec;
+                if (!fs::exists(this_path, ec) || !ec)
                     continue;
 
                 for (fs::directory_iterator dir(this_path); dir != nodir; ++dir)
@@ -377,7 +380,8 @@ namespace hpx { namespace util
             fs::directory_iterator nodir;
             fs::path libs_path (hpx::util::create_path(libs));
 
-            if (!fs::exists(libs_path))
+            boost::system::error_code ec;
+            if (!fs::exists(libs_path, ec) || !ec)
                 return plugin_registries;     // given directory doesn't exist
 
             // retrieve/create section [hpx.components]

--- a/src/util/runtime_configuration.cpp
+++ b/src/util/runtime_configuration.cpp
@@ -360,7 +360,7 @@ namespace hpx { namespace util
                     if (p.second) {
                         // have all path elements, now find ini files in there...
                         fs::path this_path (hpx::util::create_path(*p.first));
-                        if (fs::exists(this_path)) {
+                        if (fs::exists(this_path, fsec) || !fsec) {
                             plugin_list_type tmp_regs =
                                 util::init_ini_data_default(
                                     this_path.string(), *this, basenames, modules_);


### PR DESCRIPTION
This fixes #1502: boost::filesystem::exists throws unexpected exception