### PR TITLE
Adding #include - would not compile without this

### DIFF
--- a/hpx/util/batch_environments/pbs_environment.hpp
+++ b/hpx/util/batch_environments/pbs_environment.hpp
@@ -12,6 +12,7 @@
 #include <hpx/util/safe_lexical_cast.hpp>
 
 #include <boost/asio/ip/host_name.hpp>
+#include <boost/format.hpp>
 
 #include <iostream>
 #include <fstream>


### PR DESCRIPTION
Added "#include <boost/format.hpp>" to pbs_environment.hpp, would not compile on my computer without it.