### PR TITLE
Making detail::condition_variable safe to use

### DIFF
--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -22,6 +22,7 @@
 #include <boost/intrusive_ptr.hpp>
 #include <boost/detail/atomic_count.hpp>
 #include <boost/detail/scoped_enum_emulation.hpp>
+#include <boost/thread/lock_types.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace lcos
@@ -224,7 +225,7 @@ namespace detail
         {
             completed_callback_type on_completed;
             {
-                typename mutex_type::scoped_lock l(this->mtx_);
+                boost::unique_lock<mutex_type> l(this->mtx_);
 
                 // check whether the data already has been set
                 if (is_ready_locked()) {
@@ -301,7 +302,7 @@ namespace detail
         /// operation. Allows any subsequent set_data operation to succeed.
         void reset(error_code& /*ec*/ = throws)
         {
-            typename mutex_type::scoped_lock l(this->mtx_);
+            boost::unique_lock<mutex_type> l(this->mtx_);
             state_ = empty;
 
             // release any stored data and callback functions
@@ -318,7 +319,7 @@ namespace detail
         {
             if (!data_sink) return;
 
-            typename mutex_type::scoped_lock l(this->mtx_);
+            boost::unique_lock<mutex_type> l(this->mtx_);
 
             if (is_ready_locked()) {
                 // invoke the callback (continuation) function right away
@@ -337,7 +338,7 @@ namespace detail
 
         virtual void wait(error_code& ec = throws)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
 
             // block if this entry is empty
             if (state_ == empty) {
@@ -355,7 +356,7 @@ namespace detail
         wait_until(boost::chrono::steady_clock::time_point const& abs_time,
             error_code& ec = throws)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
 
             // block if this entry is empty
             if (state_ == empty) {
@@ -380,7 +381,7 @@ namespace detail
         /// \a future.
         bool is_ready() const
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             return is_ready_locked();
         }
 
@@ -391,13 +392,13 @@ namespace detail
 
         bool has_value() const
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             return state_ != empty && data_.stores_value();
         }
 
         bool has_exception() const
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             return state_ != empty && data_.stores_error();
         }
 

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -244,12 +244,7 @@ namespace detail
                 state_ = full;
 
                 // handle all threads waiting for the block to become full
-                cond_.notify_all(l, ec);
-
-                // Note: cond_.notify_all() may cause this shared state to be
-                // destroyed. This is, however, safe as the scoped lock above
-                // will not touch the wrapped mutex if it was unlocked inside
-                // notify_all().
+                cond_.notify_all(std::move(l), ec);
             }
 
             // invoke the callback (continuation) function

--- a/hpx/lcos/local/barrier.hpp
+++ b/hpx/lcos/local/barrier.hpp
@@ -9,6 +9,8 @@
 #include <hpx/lcos/local/detail/condition_variable.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 
+#include <boost/thread/lock_types.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace lcos { namespace local
 {
@@ -36,7 +38,7 @@ namespace hpx { namespace lcos { namespace local
         /// entered this function.
         void wait()
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             if (cond_.size(l) < number_of_threads_-1) {
                 cond_.wait(l, "barrier::wait");
             }

--- a/hpx/lcos/local/barrier.hpp
+++ b/hpx/lcos/local/barrier.hpp
@@ -44,7 +44,7 @@ namespace hpx { namespace lcos { namespace local
             }
             else {
                 // release the threads
-                cond_.notify_all(l);
+                cond_.notify_all(std::move(l));
             }
         }
 

--- a/hpx/lcos/local/condition_variable.hpp
+++ b/hpx/lcos/local/condition_variable.hpp
@@ -14,6 +14,7 @@
 #include <hpx/util/date_time_chrono.hpp>
 
 #include <boost/detail/scoped_enum_emulation.hpp>
+#include <boost/thread/lock_types.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace lcos { namespace local
@@ -32,13 +33,13 @@ namespace hpx { namespace lcos { namespace local
     public:
         void notify_one(error_code& ec = throws)
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             cond_.notify_one(l, ec);
         }
 
         void notify_all(error_code& ec = throws)
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             cond_.notify_all(l, ec);
         }
 
@@ -46,7 +47,7 @@ namespace hpx { namespace lcos { namespace local
         void wait(Lock& lock, error_code& ec = throws)
         {
             util::ignore_all_while_checking ignore_lock;
-            mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             util::scoped_unlock<Lock> unlock(lock);
 
             cond_.wait(l, ec);
@@ -69,7 +70,7 @@ namespace hpx { namespace lcos { namespace local
             error_code& ec = throws)
         {
             util::ignore_all_while_checking ignore_lock;
-            mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             util::scoped_unlock<Lock> unlock(lock);
 
             threads::thread_state_ex_enum const reason =

--- a/hpx/lcos/local/condition_variable.hpp
+++ b/hpx/lcos/local/condition_variable.hpp
@@ -34,13 +34,13 @@ namespace hpx { namespace lcos { namespace local
         void notify_one(error_code& ec = throws)
         {
             boost::unique_lock<mutex_type> l(mtx_);
-            cond_.notify_one(l, ec);
+            cond_.notify_one(std::move(l), ec);
         }
 
         void notify_all(error_code& ec = throws)
         {
             boost::unique_lock<mutex_type> l(mtx_);
-            cond_.notify_all(l, ec);
+            cond_.notify_all(std::move(l), ec);
         }
 
         template <class Lock>

--- a/hpx/lcos/local/counting_semaphore.hpp
+++ b/hpx/lcos/local/counting_semaphore.hpp
@@ -13,6 +13,7 @@
 #include <hpx/util/assert.hpp>
 
 #include <boost/cstdint.hpp>
+#include <boost/thread/lock_types.hpp>
 
 #if defined(BOOST_MSVC)
 #pragma warning(push)
@@ -67,7 +68,7 @@ namespace hpx { namespace lcos { namespace local
             ///                 yielded.
             void wait(boost::int64_t count = 1)
             {
-                typename mutex_type::scoped_lock l(mtx_);
+                boost::unique_lock<mutex_type> l(mtx_);
                 wait_locked(count, l);
             }
 
@@ -84,7 +85,7 @@ namespace hpx { namespace lcos { namespace local
             ///                 are available at this point in time.
             bool try_wait(boost::int64_t count = 1)
             {
-                typename mutex_type::scoped_lock l(mtx_);
+                boost::unique_lock<mutex_type> l(mtx_);
                 if (!(value_ < count)) {
                     // enter wait_locked only if there are sufficient credits
                     // available
@@ -99,21 +100,23 @@ namespace hpx { namespace lcos { namespace local
             ///
             void signal(boost::int64_t count = 1)
             {
-                typename mutex_type::scoped_lock l(mtx_);
+                boost::unique_lock<mutex_type> l(mtx_);
                 signal_locked(count, l);
             }
 
             boost::int64_t signal_all()
             {
-                typename mutex_type::scoped_lock l(mtx_);
+                boost::unique_lock<mutex_type> l(mtx_);
                 boost::int64_t count = static_cast<boost::int64_t>(cond_.size(l));
                 signal_locked(count, l);
                 return count;
             }
 
-            template <typename Lock>
-            void wait_locked(boost::int64_t count, Lock& l)
+            void wait_locked(boost::int64_t count,
+                boost::unique_lock<mutex_type>& l)
             {
+                HPX_ASSERT(l.owns_lock());
+
                 while (value_ < count)
                 {
                     cond_.wait(l, "counting_semaphore::wait_locked");
@@ -122,9 +125,11 @@ namespace hpx { namespace lcos { namespace local
             }
 
         private:
-            template <typename Lock>
-            void signal_locked(boost::int64_t count, Lock& l)
+            void signal_locked(boost::int64_t count,
+                boost::unique_lock<mutex_type>& l)
             {
+                HPX_ASSERT(l.owns_lock());
+
                 // release no more threads than we get resources
                 value_ += count;
                 for (boost::int64_t i = 0; value_ >= 0 && i < count; ++i)

--- a/hpx/lcos/local/detail/condition_variable.hpp
+++ b/hpx/lcos/local/detail/condition_variable.hpp
@@ -9,12 +9,13 @@
 
 #include <hpx/config.hpp>
 #include <hpx/lcos/local/no_mutex.hpp>
-#include <hpx/util/assert_owns_lock.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/util/scoped_unlock.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
 
 #include <boost/intrusive/slist.hpp>
 #include <boost/noncopyable.hpp>
+#include <boost/thread/lock_types.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace lcos { namespace local { namespace detail
@@ -79,22 +80,23 @@ namespace hpx { namespace lcos { namespace local { namespace detail
                        "aborting threads";
 
                 local::no_mutex no_mtx;
-                abort_all(no_mtx);
+                boost::unique_lock<local::no_mutex> lock(no_mtx);
+                abort_all(lock);
             }
         }
 
-        template <typename Lock>
-        bool empty(Lock& lock) const
+        template <typename Mutex>
+        bool empty(boost::unique_lock<Mutex>& lock) const
         {
-            HPX_ASSERT_OWNS_LOCK(lock);
+            HPX_ASSERT(lock.owns_lock());
 
             return queue_.empty();
         }
 
-        template <typename Lock>
-        std::size_t size(Lock& lock) const
+        template <typename Mutex>
+        std::size_t size(boost::unique_lock<Mutex>& lock) const
         {
-            HPX_ASSERT_OWNS_LOCK(lock);
+            HPX_ASSERT(lock.owns_lock());
 
             return queue_.size();
         }
@@ -102,10 +104,10 @@ namespace hpx { namespace lcos { namespace local { namespace detail
         // Return false if no more threads are waiting. If it returns false
         // the lock is left unlocked, otherwise it will be relocked before
         // returning.
-        template <typename Lock>
-        bool notify_one(Lock& lock, error_code& ec = throws)
+        template <typename Mutex>
+        bool notify_one(boost::unique_lock<Mutex>& lock, error_code& ec = throws)
         {
-            HPX_ASSERT_OWNS_LOCK(lock);
+            HPX_ASSERT(lock.owns_lock());
 
             if (!queue_.empty())
             {
@@ -122,7 +124,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail
 
                 if (!queue_.empty())
                 {
-                    util::scoped_unlock<Lock> unlock(lock);
+                    util::scoped_unlock<boost::unique_lock<Mutex> > unlock(lock);
 
                     threads::set_thread_state(threads::thread_id_type(
                         reinterpret_cast<threads::thread_data_base*>(id)),
@@ -148,10 +150,10 @@ namespace hpx { namespace lcos { namespace local { namespace detail
         }
 
         // This leaves the lock unlocked
-        template <typename Lock>
-        void notify_all(Lock& lock, error_code& ec = throws)
+        template <typename Mutex>
+        void notify_all(boost::unique_lock<Mutex>& lock, error_code& ec = throws)
         {
-            HPX_ASSERT_OWNS_LOCK(lock);
+            HPX_ASSERT(lock.owns_lock());
 
             // swap the list
             queue_type queue;
@@ -179,10 +181,10 @@ namespace hpx { namespace lcos { namespace local { namespace detail
             }
         }
 
-        template <typename Lock>
-        void abort_all(Lock& lock) // leaves the lock unlocked
+        template <typename Mutex>
+        void abort_all(boost::unique_lock<Mutex>& lock) // leaves the lock unlocked
         {
-            HPX_ASSERT_OWNS_LOCK(lock);
+            HPX_ASSERT(lock.owns_lock());
 
             // swap the list
             queue_type queue;
@@ -218,12 +220,13 @@ namespace hpx { namespace lcos { namespace local { namespace detail
             }
         }
 
-        template <typename Lock>
+        template <typename Mutex>
         threads::thread_state_ex_enum
-        wait(Lock& lock, char const* description, error_code& ec = throws)
+        wait(boost::unique_lock<Mutex>& lock,
+            char const* description, error_code& ec = throws)
         {
             HPX_ASSERT(threads::get_self_ptr() != 0);
-            HPX_ASSERT_OWNS_LOCK(lock);
+            HPX_ASSERT(lock.owns_lock());
 
             // enqueue the request and block this thread
             queue_entry f(threads::get_self_id().get());
@@ -233,7 +236,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail
             threads::thread_state_ex_enum reason = threads::wait_unknown;
             {
                 // yield this thread
-                util::scoped_unlock<Lock> unlock(lock);
+                util::scoped_unlock<boost::unique_lock<Mutex> > unlock(lock);
                 reason = this_thread::suspend(threads::suspended, description, ec);
                 if (ec) return threads::wait_unknown;
             }
@@ -242,20 +245,21 @@ namespace hpx { namespace lcos { namespace local { namespace detail
                 threads::wait_timeout : reason;
         }
 
-        template <typename Lock>
+        template <typename Mutex>
         threads::thread_state_ex_enum
-        wait(Lock& lock, error_code& ec = throws)
+        wait(boost::unique_lock<Mutex>& lock, error_code& ec = throws)
         {
             return wait(lock, "condition_variable::wait", ec);
         }
 
-        template <typename Lock>
+        template <typename Mutex>
         threads::thread_state_ex_enum
-        wait_until(Lock& lock, util::steady_time_point const& abs_time,
+        wait_until(boost::unique_lock<Mutex>& lock,
+            util::steady_time_point const& abs_time,
             char const* description, error_code& ec = throws)
         {
             HPX_ASSERT(threads::get_self_ptr() != 0);
-            HPX_ASSERT_OWNS_LOCK(lock);
+            HPX_ASSERT(lock.owns_lock());
 
             // enqueue the request and block this thread
             queue_entry f(threads::get_self_id().get());
@@ -265,7 +269,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail
             threads::thread_state_ex_enum reason = threads::wait_unknown;
             {
                 // yield this thread
-                util::scoped_unlock<Lock> unlock(lock);
+                util::scoped_unlock<boost::unique_lock<Mutex> > unlock(lock);
                 reason = this_thread::suspend(abs_time, description, ec);
                 if (ec) return threads::wait_unknown;
             }
@@ -274,26 +278,29 @@ namespace hpx { namespace lcos { namespace local { namespace detail
                 threads::wait_timeout : reason;
         }
 
-        template <typename Lock>
+        template <typename Mutex>
         threads::thread_state_ex_enum
-        wait_until(Lock& lock, util::steady_time_point const& abs_time,
+        wait_until(boost::unique_lock<Mutex>& lock,
+            util::steady_time_point const& abs_time,
             error_code& ec = throws)
         {
             return wait_until(lock, abs_time,
                 "condition_variable::wait_until", ec);
         }
 
-        template <typename Lock>
+        template <typename Mutex>
         threads::thread_state_ex_enum
-        wait_for(Lock& lock, util::steady_duration const& rel_time,
+        wait_for(boost::unique_lock<Mutex>& lock,
+            util::steady_duration const& rel_time,
             char const* description, error_code& ec = throws)
         {
             return wait_until(lock, rel_time.from_now(), description, ec);
         }
 
-        template <typename Lock>
+        template <typename Mutex>
         threads::thread_state_ex_enum
-        wait_for(Lock& lock, util::steady_duration const& rel_time,
+        wait_for(boost::unique_lock<Mutex>& lock,
+            util::steady_duration const& rel_time,
             error_code& ec = throws)
         {
             return wait_until(lock, rel_time.from_now(),

--- a/hpx/lcos/local/event.hpp
+++ b/hpx/lcos/local/event.hpp
@@ -63,7 +63,7 @@ namespace hpx { namespace lcos { namespace local
                 event_.store(true, boost::memory_order_release);
 
                 boost::unique_lock<mutex_type> l(mtx_);
-                set_locked(l);
+                set_locked(std::move(l));
             }
 
             /// \brief Reset the event
@@ -83,12 +83,12 @@ namespace hpx { namespace lcos { namespace local
                 }
             }
 
-            void set_locked(boost::unique_lock<mutex_type>& l)
+            void set_locked(boost::unique_lock<mutex_type> l)
             {
                 HPX_ASSERT(l.owns_lock());
 
                 // release the threads
-                cond_.notify_all(l);
+                cond_.notify_all(std::move(l));
             }
 
             mutex_type mtx_;      ///< This mutex protects the queue.

--- a/hpx/lcos/local/event.hpp
+++ b/hpx/lcos/local/event.hpp
@@ -14,6 +14,7 @@
 
 #include <boost/atomic.hpp>
 #include <boost/cstdint.hpp>
+#include <boost/thread/lock_types.hpp>
 
 #if defined(BOOST_MSVC)
 #pragma warning(push)
@@ -52,7 +53,7 @@ namespace hpx { namespace lcos { namespace local
                 if (event_.load(boost::memory_order_acquire))
                     return;
 
-                typename mutex_type::scoped_lock l(mtx_);
+                boost::unique_lock<mutex_type> l(mtx_);
                 wait_locked(l);
             }
 
@@ -61,7 +62,7 @@ namespace hpx { namespace lcos { namespace local
             {
                 event_.store(true, boost::memory_order_release);
 
-                typename mutex_type::scoped_lock l(mtx_);
+                boost::unique_lock<mutex_type> l(mtx_);
                 set_locked(l);
             }
 
@@ -72,7 +73,7 @@ namespace hpx { namespace lcos { namespace local
             }
 
         private:
-            void wait_locked(typename mutex_type::scoped_lock& l)
+            void wait_locked(boost::unique_lock<mutex_type>& l)
             {
                 HPX_ASSERT(l.owns_lock());
 
@@ -82,7 +83,7 @@ namespace hpx { namespace lcos { namespace local
                 }
             }
 
-            void set_locked(typename mutex_type::scoped_lock& l)
+            void set_locked(boost::unique_lock<mutex_type>& l)
             {
                 HPX_ASSERT(l.owns_lock());
 

--- a/hpx/lcos/local/latch.hpp
+++ b/hpx/lcos/local/latch.hpp
@@ -98,7 +98,7 @@ namespace hpx { namespace lcos { namespace local
             HPX_ASSERT(counter_ > 0);
 
             if (--counter_ == 0)
-                cond_.notify_all(l);    // release the threads
+                cond_.notify_all(std::move(l));    // release the threads
             else
                 cond_.wait(l, "hpx::local::latch::count_down_and_wait");
         }
@@ -120,7 +120,7 @@ namespace hpx { namespace lcos { namespace local
             HPX_ASSERT(counter_ >= n);
 
             if ((counter_ -= n) == 0)
-                cond_.notify_all(l);    // release the threads
+                cond_.notify_all(std::move(l));    // release the threads
         }
 
         /// Returns: counter_ == 0. Does not block.
@@ -149,7 +149,7 @@ namespace hpx { namespace lcos { namespace local
         void abort_all()
         {
             boost::unique_lock<mutex_type> l(mtx_);
-            cond_.abort_all(l);
+            cond_.abort_all(std::move(l));
         }
 
     private:

--- a/hpx/lcos/local/latch.hpp
+++ b/hpx/lcos/local/latch.hpp
@@ -11,6 +11,8 @@
 #include <hpx/lcos/local/detail/condition_variable.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 
+#include <boost/thread/lock_types.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace lcos { namespace local
 {
@@ -76,7 +78,7 @@ namespace hpx { namespace lcos { namespace local
         ///       destructor. This may require additional coordination.
         ~latch ()
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             HPX_ASSERT(counter_ == 0);
         }
 
@@ -92,7 +94,7 @@ namespace hpx { namespace lcos { namespace local
         ///
         void count_down_and_wait()
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             HPX_ASSERT(counter_ > 0);
 
             if (--counter_ == 0)
@@ -114,7 +116,7 @@ namespace hpx { namespace lcos { namespace local
         {
             HPX_ASSERT(n >= 0);
 
-            mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             HPX_ASSERT(counter_ >= n);
 
             if ((counter_ -= n) == 0)
@@ -127,7 +129,7 @@ namespace hpx { namespace lcos { namespace local
         ///
         bool is_ready() const BOOST_NOEXCEPT
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             return counter_ == 0;
         }
 
@@ -139,14 +141,14 @@ namespace hpx { namespace lcos { namespace local
         ///
         void wait() const
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             if (counter_ > 0)
                 cond_.wait(l, "hpx::local::latch::wait");
         }
 
         void abort_all()
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             cond_.abort_all(l);
         }
 

--- a/hpx/lcos/local/mutex.hpp
+++ b/hpx/lcos/local/mutex.hpp
@@ -51,7 +51,7 @@ namespace hpx { namespace lcos { namespace local
             HPX_ASSERT(threads::get_self_ptr() != 0);
 
             HPX_ITT_SYNC_PREPARE(this);
-            mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
 
             threads::thread_id_repr_type self_id = threads::get_self_id().get();
             if(owner_id_ == self_id)
@@ -84,7 +84,7 @@ namespace hpx { namespace lcos { namespace local
             HPX_ASSERT(threads::get_self_ptr() != 0);
 
             HPX_ITT_SYNC_PREPARE(this);
-            mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
 
             if (owner_id_ != threads::invalid_thread_id_repr)
             {
@@ -110,7 +110,7 @@ namespace hpx { namespace lcos { namespace local
             HPX_ASSERT(threads::get_self_ptr() != 0);
 
             HPX_ITT_SYNC_PREPARE(this);
-            mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
 
             threads::thread_id_repr_type self_id = threads::get_self_id().get();
             if (owner_id_ != threads::invalid_thread_id_repr)
@@ -161,7 +161,7 @@ namespace hpx { namespace lcos { namespace local
             HPX_ASSERT(threads::get_self_ptr() != 0);
 
             HPX_ITT_SYNC_RELEASING(this);
-            mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
 
             threads::thread_id_repr_type self_id = threads::get_self_id().get();
             if (HPX_UNLIKELY(owner_id_ != self_id))

--- a/hpx/lcos/local/mutex.hpp
+++ b/hpx/lcos/local/mutex.hpp
@@ -177,7 +177,7 @@ namespace hpx { namespace lcos { namespace local
             HPX_ITT_SYNC_RELEASED(this);
             owner_id_ = threads::invalid_thread_id_repr;
 
-            cond_.notify_one(l, ec);
+            cond_.notify_one(std::move(l), ec);
         }
 
     private:

--- a/hpx/lcos/local/shared_mutex.hpp
+++ b/hpx/lcos/local/shared_mutex.hpp
@@ -11,6 +11,8 @@
 #include <hpx/lcos/local/counting_semaphore.hpp>
 #include <hpx/lcos/local/no_mutex.hpp>
 
+#include <boost/thread/lock_types.hpp>
+
 namespace hpx { namespace lcos { namespace local
 {
     namespace detail
@@ -50,7 +52,7 @@ namespace hpx { namespace lcos { namespace local
 
             void lock_shared()
             {
-                typename mutex_type::scoped_lock lk(state_change);
+                boost::unique_lock<mutex_type> lk(state_change);
 
                 while (state.exclusive || state.exclusive_waiting_blocked)
                 {
@@ -62,7 +64,7 @@ namespace hpx { namespace lcos { namespace local
 
             bool try_lock_shared()
             {
-                typename mutex_type::scoped_lock lk(state_change);
+                boost::unique_lock<mutex_type> lk(state_change);
 
                 if (state.exclusive || state.exclusive_waiting_blocked)
                     return false;
@@ -76,7 +78,7 @@ namespace hpx { namespace lcos { namespace local
 
             void unlock_shared()
             {
-                typename mutex_type::scoped_lock lk(state_change);
+                boost::unique_lock<mutex_type> lk(state_change);
 
                 bool const last_reader = !--state.shared_count;
 
@@ -100,7 +102,7 @@ namespace hpx { namespace lcos { namespace local
 
             void lock()
             {
-                typename mutex_type::scoped_lock lk(state_change);
+                boost::unique_lock<mutex_type> lk(state_change);
 
                 while (state.shared_count || state.exclusive)
                 {
@@ -113,7 +115,7 @@ namespace hpx { namespace lcos { namespace local
 
             bool try_lock()
             {
-                typename mutex_type::scoped_lock lk(state_change);
+                boost::unique_lock<mutex_type> lk(state_change);
 
                 if (state.shared_count || state.exclusive)
                     return false;
@@ -127,7 +129,7 @@ namespace hpx { namespace lcos { namespace local
 
             void unlock()
             {
-                typename mutex_type::scoped_lock lk(state_change);
+                boost::unique_lock<mutex_type> lk(state_change);
                 state.exclusive = false;
                 state.exclusive_waiting_blocked = false;
                 release_waiters();
@@ -135,7 +137,7 @@ namespace hpx { namespace lcos { namespace local
 
             void lock_upgrade()
             {
-                typename mutex_type::scoped_lock lk(state_change);
+                boost::unique_lock<mutex_type> lk(state_change);
 
                 while (state.exclusive || state.exclusive_waiting_blocked || state.upgrade)
                 {
@@ -148,7 +150,7 @@ namespace hpx { namespace lcos { namespace local
 
             bool try_lock_upgrade()
             {
-                typename mutex_type::scoped_lock lk(state_change);
+                boost::unique_lock<mutex_type> lk(state_change);
 
                 if (state.exclusive || state.exclusive_waiting_blocked || state.upgrade)
                     return false;
@@ -163,7 +165,7 @@ namespace hpx { namespace lcos { namespace local
 
             void unlock_upgrade()
             {
-                typename mutex_type::scoped_lock lk(state_change);
+                boost::unique_lock<mutex_type> lk(state_change);
                 state.upgrade = false;
                 bool const last_reader = !--state.shared_count;
 
@@ -176,7 +178,7 @@ namespace hpx { namespace lcos { namespace local
 
             void unlock_upgrade_and_lock()
             {
-                typename mutex_type::scoped_lock lk(state_change);
+                boost::unique_lock<mutex_type> lk(state_change);
                 --state.shared_count;
 
                 while (state.shared_count)
@@ -190,7 +192,7 @@ namespace hpx { namespace lcos { namespace local
 
             void unlock_and_lock_upgrade()
             {
-                typename mutex_type::scoped_lock lk(state_change);
+                boost::unique_lock<mutex_type> lk(state_change);
                 state.exclusive = false;
                 state.upgrade = true;
                 ++state.shared_count;
@@ -200,7 +202,7 @@ namespace hpx { namespace lcos { namespace local
 
             void unlock_and_lock_shared()
             {
-                typename mutex_type::scoped_lock lk(state_change);
+                boost::unique_lock<mutex_type> lk(state_change);
                 state.exclusive = false;
                 ++state.shared_count;
                 state.exclusive_waiting_blocked = false;
@@ -209,7 +211,7 @@ namespace hpx { namespace lcos { namespace local
 
             bool try_unlock_shared_and_lock()
             {
-                typename mutex_type::scoped_lock lk(state_change);
+                boost::unique_lock<mutex_type> lk(state_change);
                 if(    !state.exclusive
                     && !state.exclusive_waiting_blocked
                     && !state.upgrade
@@ -224,7 +226,7 @@ namespace hpx { namespace lcos { namespace local
 
             void unlock_upgrade_and_lock_shared()
             {
-                typename mutex_type::scoped_lock lk(state_change);
+                boost::unique_lock<mutex_type> lk(state_change);
                 state.upgrade = false;
                 state.exclusive_waiting_blocked = false;
                 release_waiters();

--- a/hpx/lcos/server/barrier.hpp
+++ b/hpx/lcos/server/barrier.hpp
@@ -14,6 +14,8 @@
 #include <hpx/runtime/components/component_type.hpp>
 #include <hpx/runtime/components/server/managed_component_base.hpp>
 
+#include <boost/thread/lock_types.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace lcos { namespace server
 {
@@ -65,7 +67,7 @@ namespace hpx { namespace lcos { namespace server
         /// entered this function.
         void set_event()
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             if (cond_.size(l) < number_of_threads_-1) {
                 cond_.wait(l, "barrier::set_event");
             }
@@ -84,7 +86,7 @@ namespace hpx { namespace lcos { namespace server
         void set_exception(boost::exception_ptr const& e)
         {
             try {
-                mutex_type::scoped_lock l(mtx_);
+                boost::unique_lock<mutex_type> l(mtx_);
                 cond_.abort_all(l);
 
                 boost::rethrow_exception(e);

--- a/hpx/lcos/server/barrier.hpp
+++ b/hpx/lcos/server/barrier.hpp
@@ -72,7 +72,7 @@ namespace hpx { namespace lcos { namespace server
                 cond_.wait(l, "barrier::set_event");
             }
             else {
-                cond_.notify_all(l);
+                cond_.notify_all(std::move(l));
             }
         }
 
@@ -87,7 +87,7 @@ namespace hpx { namespace lcos { namespace server
         {
             try {
                 boost::unique_lock<mutex_type> l(mtx_);
-                cond_.abort_all(l);
+                cond_.abort_all(std::move(l));
 
                 boost::rethrow_exception(e);
             }

--- a/hpx/lcos/server/queue.hpp
+++ b/hpx/lcos/server/queue.hpp
@@ -109,7 +109,7 @@ namespace hpx { namespace lcos { namespace server
             node.release();
 
             // resume the first thread waiting to pick up that value
-            cond_.notify_one(l);
+            cond_.notify_one(std::move(l));
         }
 
         /// The \a function set_exception is called whenever a
@@ -120,7 +120,7 @@ namespace hpx { namespace lcos { namespace server
         void set_exception(boost::exception_ptr const& /*e*/)
         {
             boost::unique_lock<mutex_type> l(mtx_);
-            cond_.abort_all(l);
+            cond_.abort_all(std::move(l));
         }
 
         // Retrieve the next value from the queue (pop value from front of

--- a/hpx/plugins/parcelport/mpi/sender.hpp
+++ b/hpx/plugins/parcelport/mpi/sender.hpp
@@ -103,7 +103,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
                 {
                     boost::unique_lock<mutex_type> l(this_->connections_mtx_);
                     --this_->num_connections_;
-                    this_->connections_cond_.notify_all(l);
+                    this_->connections_cond_.notify_all(std::move(l));
                 }
             }
 

--- a/hpx/plugins/parcelport/mpi/sender.hpp
+++ b/hpx/plugins/parcelport/mpi/sender.hpp
@@ -88,7 +88,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
             {
                 if(!threads::get_self_ptr()) return;
 
-                mutex_type::scoped_lock l(this_->connections_mtx_);
+                boost::unique_lock<mutex_type> l(this_->connections_mtx_);
                 while(this_->num_connections_ >= this_->max_connections_)
                 {
                     this_->connections_cond_.wait(l);
@@ -101,7 +101,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
             {
                 if(decrement_)
                 {
-                    mutex_type::scoped_lock l(this_->connections_mtx_);
+                    boost::unique_lock<mutex_type> l(this_->connections_mtx_);
                     --this_->num_connections_;
                     this_->connections_cond_.notify_all(l);
                 }


### PR DESCRIPTION
Minor redesign of how locks are handled by `detail::condition_variable`:

- Makes use of locks safe under destruction (after #1488).
- Makes lock status and ownership explicit in code.