### PR TITLE
Serialization complex

### DIFF
--- a/hpx/runtime/serialization/complex.hpp
+++ b/hpx/runtime/serialization/complex.hpp
@@ -1,0 +1,40 @@
+//  Copyright (c) 2015 Agustin Berge
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_SERIALIZATION_COMPLEX_HPP
+#define HPX_SERIALIZATION_COMPLEX_HPP
+
+#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/traits/is_bitwise_serializable.hpp>
+
+#include <complex>
+
+namespace hpx { namespace serialization
+{
+    template <typename T>
+    void serialize(input_archive& ar, std::complex<T>& c, unsigned)
+    {
+        T real, imag;
+        ar >> real >> imag;
+        c.real(real);
+        c.imag(imag);
+    }
+
+    template <typename T>
+    void serialize(output_archive& ar, std::complex<T>& c, unsigned)
+    {
+        ar << c.real() << c.imag();
+    }
+}}
+
+namespace hpx { namespace traits
+{
+    template <typename T>
+    struct is_bitwise_serializable<std::complex<T> >
+      : is_bitwise_serializable<T>
+    {};
+}}
+
+#endif

--- a/tests/unit/serialization/CMakeLists.txt
+++ b/tests/unit/serialization/CMakeLists.txt
@@ -5,7 +5,9 @@
 
 set(tests
     serialization
+    serialization_array
     serialization_builtins
+    serialization_map
     serialization_smart_ptr
     serialization_vector
     serialize_buffer

--- a/tests/unit/serialization/CMakeLists.txt
+++ b/tests/unit/serialization/CMakeLists.txt
@@ -7,6 +7,7 @@ set(tests
     serialization
     serialization_array
     serialization_builtins
+    serialization_complex
     serialization_map
     serialization_smart_ptr
     serialization_vector

--- a/tests/unit/serialization/serialization_complex.cpp
+++ b/tests/unit/serialization/serialization_complex.cpp
@@ -1,0 +1,68 @@
+//  Copyright (c) 2014 Thomas Heller
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/runtime/serialization/complex.hpp>
+
+#include <hpx/runtime/serialization/input_archive.hpp>
+#include <hpx/runtime/serialization/output_archive.hpp>
+
+#include <hpx/util/lightweight_test.hpp>
+
+#include <vector>
+
+template <typename T>
+struct A
+{
+    A() {}
+
+    A(T t) : t_(t) {}
+    T t_;
+
+    A & operator=(T t) { t_ = t; return *this; }
+
+    template <typename Archive>
+    void serialize(Archive & ar, unsigned)
+    {
+        ar & t_;
+    }
+};
+
+template <class T>
+void test_complex(T real, T imag)
+{
+    {
+        std::vector<char> buffer;
+        hpx::serialization::output_archive oarchive(buffer);
+        std::complex<T> ocomplex(real, imag);
+        oarchive << ocomplex;
+
+        hpx::serialization::input_archive iarchive(buffer);
+        std::complex<T> icomplex;
+        iarchive >> icomplex;
+        HPX_TEST_EQ(ocomplex.real(), icomplex.real());
+        HPX_TEST_EQ(ocomplex.imag(), icomplex.imag());
+    }
+    {
+        std::vector<char> buffer;
+        hpx::serialization::output_archive oarchive(buffer);
+        A<std::complex<T>> ocomplex(std::complex<T>(real, imag));
+        oarchive << ocomplex;
+
+        hpx::serialization::input_archive iarchive(buffer);
+        A<std::complex<T>> icomplex;
+        iarchive >> icomplex;
+        HPX_TEST_EQ(ocomplex.t_.real(), icomplex.t_.real());
+        HPX_TEST_EQ(ocomplex.t_.imag(), icomplex.t_.imag());
+    }
+}
+
+int main()
+{
+    test_complex<float>(100, 100);
+    test_complex<double>(100, 100);
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Add serialization support for `std::complex<T>`

Includes drive-by fix for missing tests in CMake file.