### PR TITLE
Fix unwrapped issue with future ranges of void type

### DIFF
--- a/hpx/util/unwrapped.hpp
+++ b/hpx/util/unwrapped.hpp
@@ -237,9 +237,15 @@ namespace hpx { namespace util
         struct unwrapped_impl_result<
             F, T, TD,
             typename boost::enable_if<traits::is_future_range<TD> >::type
-        > : util::invoke_fused_result_of<
-                F(util::tuple<typename unwrap_impl<TD>::type>)
-            >
+        > : boost::mpl::if_<
+                typename unwrap_impl<TD>::is_void
+              , util::invoke_fused_result_of<
+                    F(util::tuple<>)
+                >
+              , util::invoke_fused_result_of<
+                    F(util::tuple<typename unwrap_impl<TD>::type>)
+                >
+            >::type
         {};
 
         template <typename F, typename T, typename TD>

--- a/tests/regressions/util/CMakeLists.txt
+++ b/tests/regressions/util/CMakeLists.txt
@@ -12,6 +12,7 @@ set(tests
     protect_with_nullary_pfo
     serialize_buffer_1069
     tuple_serialization_803
+    unwrapped_1528
     zero_copy_parcels_1001
    )
 

--- a/tests/regressions/util/unwrapped_1528.cpp
+++ b/tests/regressions/util/unwrapped_1528.cpp
@@ -1,0 +1,17 @@
+//  Copyright (c) 2015 Agustin Berge
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/lcos/future.hpp>
+#include <hpx/util/unwrapped.hpp>
+
+#include <vector>
+
+void noop(){}
+
+int main()
+{
+    std::vector<hpx::future<void>> fs;
+    hpx::util::unwrapped(&noop)(fs);
+}


### PR DESCRIPTION
The implementation tried to instantiate `tuple<void>`, which was a synonym for `tuple<>` under the faux variadic implementation but is a hard error with true variadics. Fixes #1528