### PR TITLE
Changed return type of bulk executors and added test

### DIFF
--- a/hpx/parallel/executors/executor_traits.hpp
+++ b/hpx/parallel/executors/executor_traits.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2015 Daniel Bourgeois
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -176,16 +177,20 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         {
             template <typename Executor, typename F, typename S>
             static auto call(wrap_int, Executor& exec, F && f, S const& shape)
-                ->  typename future_type<Executor, void>::type
+                -> std::vector<
+                    decltype(exec.async_execute(
+                        util::deferred_call(f, *std::begin(shape))))
+                    >
             {
-                std::vector<hpx::future<void> > results;
+                std::vector<decltype(exec.async_execute(
+                    util::deferred_call(f, *std::begin(shape))))> results;
                 for (auto const& elem: shape)
                 {
                     results.push_back(
                         exec.async_execute(util::deferred_call(f, elem))
                     );
                 }
-                return hpx::when_all(results);
+                return std::move(results);
             }
 
             template <typename Executor, typename F, typename S>
@@ -197,8 +202,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         };
 
         template <typename Executor, typename F, typename S>
-        typename future_type<Executor, void>::type
-        call_bulk_async_execute(Executor& exec, F && f, S const& shape)
+        auto call_bulk_async_execute(Executor& exec, F && f, S const& shape)
+            -> decltype(bulk_async_execute_helper::call(
+                0, exec, std::forward<F>(f), shape))
         {
             return bulk_async_execute_helper::call(
                 0, exec, std::forward<F>(f), shape);
@@ -209,16 +215,19 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         {
             template <typename Executor, typename F, typename S>
             static auto call(wrap_int, Executor& exec, F && f, S const& shape)
-                ->  void
+                ->  decltype(hpx::util::unwrapped(exec.async_execute(
+                        util::deferred_call(f, *std::begin(shape)))))
+                //returns void if F returns void
             {
-                std::vector<hpx::future<void> > results;
+                std::vector<decltype(exec.async_execute(
+                    util::deferred_call(f, *std::begin(shape))))> results;
                 for (auto const& elem: shape)
                 {
                     results.push_back(
                         exec.async_execute(util::deferred_call(f, elem))
                     );
                 }
-                hpx::when_all(results).get();
+                return hpx::util::unwrapped(results);
             }
 
             template <typename Executor, typename F, typename S>
@@ -230,7 +239,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         };
 
         template <typename Executor, typename F, typename S>
-        void call_bulk_execute(Executor& exec, F && f, S const& shape)
+        auto call_bulk_execute(Executor& exec, F && f, S const& shape)
+            -> decltype(bulk_execute_helper::call(
+                0, exec, std::forward<F>(f), shape))
         {
             return bulk_execute_helper::call(0, exec, std::forward<F>(f), shape);
         }
@@ -254,7 +265,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         template <typename Executor>
         std::size_t call_os_thread_count(Executor& exec)
         {
-            return os_thread_count_helper::call(0, exec);
+            return os_thread_count_helper<Executor>::call(0, exec);
         }
         /// \endcond
     }
@@ -373,8 +384,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         ///       otherwise hpx::async(f).get()
         ///
         template <typename F>
-        static
-        typename hpx::util::result_of<
+        static typename hpx::util::result_of<
             typename hpx::util::decay<F>::type()
         >::type
         execute(executor_type& exec, F && f)
@@ -400,15 +410,19 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         /// \param shape [in] The shape objects which defines the iteration
         ///              boundaries for the arguments to be passed to \a f.
         ///
-        /// \returns A future object representing which becomes ready once all
-        ///          scheduled functions have finished executing.
+        /// \returns The return type of \a executor_type::async_execute if
+        ///          defined by \a executor_type. Otherwise a vector
+        ///          of futures holding the returned value of each invocation
+        ///          of \a f.
         ///
         /// \note This calls exec.async_execute(f, shape) if it exists;
         ///       otherwise it executes hpx::async(f, i) as often as needed.
         ///
         template <typename F, typename Shape>
-        static typename future<void>::type
+        static auto
         async_execute(executor_type& exec, F && f, Shape const& shape)
+            -> decltype(detail::call_bulk_async_execute(
+                exec, std::forward<F>(f), shape))
         {
             return detail::call_bulk_async_execute(
                 exec, std::forward<F>(f), shape);
@@ -433,11 +447,19 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         /// \param shape [in] The shape objects which defines the iteration
         ///              boundaries for the arguments to be passed to \a f.
         ///
+        /// \returns The return type of \a executor_type::execute if defined
+        ///          by \a executor_type. Otherwise a vector holding the
+        ///          returned value of each invocation of \a f except when
+        ///          \a f returns void, which case void is returned.
+        ///
         /// \note This calls exec.execute(f, shape) if it exists;
         ///       otherwise it executes hpx::async(f, i) as often as needed.
         ///
         template <typename F, typename Shape>
-        static void execute(executor_type& exec, F && f, Shape const& shape)
+        static auto
+        execute(executor_type& exec, F && f, Shape const& shape)
+            -> decltype(detail::call_bulk_execute(
+                exec, std::forward<F>(f), shape))
         {
             return detail::call_bulk_execute(exec, std::forward<F>(f), shape);
         }

--- a/hpx/parallel/executors/parallel_executor.hpp
+++ b/hpx/parallel/executors/parallel_executor.hpp
@@ -34,13 +34,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
 
         /// \cond NOINTERNAL
         template <typename F>
-        void apply_execute(F && f)
+        static void apply_execute(F && f)
         {
             hpx::apply(std::forward<F>(f));
         }
 
         template <typename F>
-        hpx::future<typename hpx::util::result_of<
+        static hpx::future<typename hpx::util::result_of<
             typename hpx::util::decay<F>::type()
         >::type>
         async_execute(F && f)

--- a/hpx/parallel/executors/parallel_fork_executor.hpp
+++ b/hpx/parallel/executors/parallel_fork_executor.hpp
@@ -34,13 +34,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
 
         /// \cond NOINTERNAL
         template <typename F>
-        void apply_execute(F && f)
+        static void apply_execute(F && f)
         {
             return hpx::apply(std::forward<F>(f));
         }
 
         template <typename F>
-        hpx::future<typename hpx::util::result_of<
+        static hpx::future<typename hpx::util::result_of<
             typename hpx::util::decay<F>::type()
         >::type>
         async_execute(F && f)

--- a/hpx/parallel/executors/sequential_executor.hpp
+++ b/hpx/parallel/executors/sequential_executor.hpp
@@ -71,11 +71,24 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         }
 
         template <typename F, typename Shape>
-        static void bulk_execute(F && f, Shape const& shape)
+        static auto bulk_execute(F && f, Shape const& shape)
+            -> decltype(hpx::util::unwrapped(
+                bulk_async_execute(std::forward<F>(f), shape)))
         {
+            return hpx::util::unwrapped(
+                bulk_async_execute(std::forward<F>(f), shape));
+        }
+
+        template <typename F, typename Shape>
+        static auto bulk_async_execute(F && f, Shape const& shape)
+            -> std::vector<decltype(
+                    hpx::async(hpx::launch::sync, f, *std::begin(shape)))>
+        {
+            std::vector<decltype(
+                hpx::async(hpx::launch::sync, f, *std::begin(shape)))> results;
             try {
                 for (auto const& elem: shape)
-                    f(elem);
+                    results.push_back(hpx::async(hpx::launch::sync, f, elem));
             }
             catch (std::bad_alloc const& ba) {
                 boost::throw_exception(ba);
@@ -85,15 +98,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
                     exception_list(boost::current_exception())
                 );
             }
-        }
-
-        template <typename F, typename Shape>
-        static hpx::future<void>
-        bulk_async_execute(F && f, Shape const& shape)
-        {
-            return hpx::async(hpx::launch::sync,
-                &sequential_executor::bulk_execute<F, Shape>,
-                std::forward<F>(f), shape);
+            return std::move(results);
         }
 
         std::size_t os_thread_count()

--- a/tests/unit/parallel/executors/CMakeLists.txt
+++ b/tests/unit/parallel/executors/CMakeLists.txt
@@ -4,6 +4,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    created_executor
     minimal_async_executor
     minimal_sync_executor
     parallel_executor

--- a/tests/unit/parallel/executors/created_executor.cpp
+++ b/tests/unit/parallel/executors/created_executor.cpp
@@ -1,0 +1,224 @@
+//  Copyright (c) 2015 Daniel Bourgeois
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/include/parallel_executors.hpp>
+#include <hpx/parallel/executors/executor_traits.hpp>
+#include <hpx/util/lightweight_test.hpp>
+#include <hpx/util/deferred_call.hpp>
+
+#include <iostream>
+#include <functional>
+#include <algorithm>
+#include <numeric>
+#include <iterator>
+
+using hpx::parallel::parallel_executor;
+using hpx::util::deferred_call
+using iter = std::vector<int>::iterator;
+using std::begin;
+using std::end;
+
+////////////////////////////////////////////////////////////////////////////////
+// A parallel executor that returns void for bulk_execute and hpx::future<void>
+// for bulk_async_execute
+struct void_parallel_executor
+    : public parallel_executor
+{
+    void_parallel_executor() {}
+
+    template <typename F, typename Shape>
+    static hpx::future<void> bulk_async_execute(F && f, Shape const& shape)
+    {
+        std::vector<hpx::future<void> > results;
+        for(auto const& elem: shape)
+        {
+            results.push_back(
+                parallel_executor::async_execute(deferred_call(f, elem))
+            );
+        }
+        return hpx::when_all(results);
+    }
+
+    template <typename F, typename Shape>
+    static void bulk_execute(F && f, Shape const& shape)
+    {
+        return hpx::util::unwrapped(
+            bulk_async_execute(std::forward<F>(f), shape));
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Tests to void_parallel_executor behavior for the bulk executes
+
+void bulk_test(hpx::thread::id tid, int value)
+{
+    HPX_TEST(tid != hpx::this_thread::get_id());
+}
+
+void test_void_bulk_sync()
+{
+    typedef void_parallel_executor executor;
+    typedef hpx::parallel::executor_traits<executor> traits;
+
+    hpx::thread::id tid = hpx::this_thread::get_id();
+
+    std::vector<int> v(107);
+    std::iota(boost::begin(v), boost::end(v), std::rand());
+
+    using hpx::util::placeholders::_1;
+
+    executor exec;
+    traits::execute(exec, hpx::util::bind(&bulk_test, tid, _1), v);
+}
+
+void test_void_bulk_async()
+{
+    typedef void_parallel_executor executor;
+    typedef hpx::parallel::executor_traits<executor> traits;
+
+    hpx::thread::id tid = hpx::this_thread::get_id();
+
+    std::vector<int> v(107);
+    std::iota(boost::begin(v), boost::end(v), std::rand());
+
+    using hpx::util::placeholders::_1;
+
+    executor exec;
+    traits::async_execute(exec, hpx::util::bind(&bulk_test, tid, _1), v).get();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Sum using hpx's parallel_executor and the above void_parallel_executor
+
+struct range
+{
+    range(iter first, iter last): first_(first), last_(last) {}
+    iter begin() const { return first_; }
+    iter end() const { return last_; }
+private:
+    iter first_;
+    iter last_;
+};
+
+// Create shape argument for parallel_executor
+std::vector<range> split(iter first, iter last, int parts)
+{
+    typedef typename std::iterator_traits<iter>::difference_type sz_type;
+    sz_type count = std::distance(first, last);
+    sz_type increment = count/parts;
+    std::vector<range> results;
+    while(first != last)
+    {
+        iter prev = first;
+        std::advance(
+            first,
+            (std::min)(increment, std::distance(first,last))
+        );
+        results.push_back(range(prev, first));
+    }
+    return std::move(results);
+}
+
+// parallel sum using hpx's parallel executor
+int parallel_sum(iter first, iter last, int num_parts)
+{
+    parallel_executor exec;
+    typedef hpx::parallel::executor_traits<parallel_executor> traits;
+
+    std::vector<hpx::future<int> > v =
+        traits::async_execute(exec, [](const range& rng)
+        {
+            return std::accumulate(begin(rng), end(rng), 0);
+        }, split(first, last, num_parts));
+
+    return std::accumulate(begin(v), end(v), 0,
+        [](int a, hpx::future<int>& b)
+        {
+            return a + b.get();
+        });
+}
+
+// parallel sum using void parallel executer
+int void_parallel_sum(iter first, iter last, int num_parts)
+{
+    void_parallel_executor exec;
+    typedef hpx::parallel::executor_traits<void_parallel_executor> traits;
+
+    std::vector<int> temp(num_parts + 1, 0);
+    std::iota(begin(temp), end(temp), 0);
+
+    int section_size = std::distance(first,last)/num_parts;
+
+    hpx::future<void> f = traits::async_execute(exec, [&](const int& i)
+    {
+        iter b = first + i*section_size;
+        iter e = first + (std::min)(int(std::distance(first, last)), (i+1)*section_size);
+        temp[i] = std::accumulate(b, e, 0);
+    }, temp);
+
+    f.get();
+
+    return std::accumulate(begin(temp), end(temp), 0);
+}
+
+void sum_test()
+{
+    std::vector<int> vec(10007);
+    auto random_num = [](){ return std::rand() % 50 - 25; };
+    std::generate(begin(vec), end(vec), random_num);
+
+    int sum = std::accumulate(begin(vec), end(vec), 0);
+    int num_parts = std::rand() % 5 + 3;
+
+    // Return futures holding results of parallel_sum and void_parallel_sum
+    parallel_executor exec;
+    hpx::future<int> f_par = exec.async_execute(deferred_call(
+        parallel_sum, begin(vec), end(vec), num_parts));
+    hpx::future<int> f_void_par = exec.async_execute(deferred_call(
+        void_parallel_sum, begin(vec), end(vec), num_parts));
+
+    HPX_TEST(f_par.get() == sum);
+    HPX_TEST(f_void_par.get() == sum);
+}
+
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int)std::time(0);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    test_void_bulk_sync();
+    test_void_bulk_async();
+    sum_test();
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace boost::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()
+        ("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run")
+        ;
+
+    // By default this test should run on all available cores
+    std::vector<std::string> cfg;
+    cfg.push_back("hpx.os_threads=" +
+        boost::lexical_cast<std::string>(hpx::threads::hardware_concurrency()));
+
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/parallel/executors/minimal_async_executor.cpp
+++ b/tests/unit/parallel/executors/minimal_async_executor.cpp
@@ -6,6 +6,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/include/parallel_executors.hpp>
+#include <hpx/lcos/wait_all.hpp>
 #include <hpx/util/lightweight_test.hpp>
 #include <hpx/util/decay.hpp>
 
@@ -91,7 +92,8 @@ void test_bulk_async(Executor& exec)
     using hpx::util::placeholders::_1;
 
     typedef hpx::parallel::executor_traits<Executor> traits;
-    traits::async_execute(exec, hpx::util::bind(&async_bulk_test, tid, _1), v).get();
+    hpx::wait_all(traits::async_execute(
+        exec, hpx::util::bind(&async_bulk_test, tid, _1), v));
 }
 
 template <typename Executor>
@@ -200,4 +202,3 @@ int main(int argc, char* argv[])
 
     return hpx::util::report_errors();
 }
-

--- a/tests/unit/parallel/executors/minimal_sync_executor.cpp
+++ b/tests/unit/parallel/executors/minimal_sync_executor.cpp
@@ -6,6 +6,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/include/parallel_executors.hpp>
+#include <hpx/lcos/wait_all.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <algorithm>
@@ -90,7 +91,8 @@ void test_bulk_async(Executor& exec)
     using hpx::util::placeholders::_1;
 
     typedef hpx::parallel::executor_traits<Executor> traits;
-    traits::async_execute(exec, hpx::util::bind(&sync_bulk_test, tid, _1), v).get();
+    hpx::wait_all(traits::async_execute(
+        exec, hpx::util::bind(&sync_bulk_test, tid, _1), v));
 }
 
 template <typename Executor>
@@ -210,4 +212,3 @@ int main(int argc, char* argv[])
 
     return hpx::util::report_errors();
 }
-

--- a/tests/unit/parallel/executors/parallel_executor.cpp
+++ b/tests/unit/parallel/executors/parallel_executor.cpp
@@ -6,6 +6,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/include/parallel_executors.hpp>
+#include <hpx/lcos/wait_all.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <algorithm>
@@ -72,7 +73,8 @@ void test_bulk_async()
     using hpx::util::placeholders::_1;
 
     executor exec;
-    traits::async_execute(exec, hpx::util::bind(&bulk_test, tid, _1), v).get();
+    hpx::wait_all(traits::async_execute(
+        exec, hpx::util::bind(&bulk_test, tid, _1), v));
 }
 
 int hpx_main(int argc, char* argv[])
@@ -98,4 +100,3 @@ int main(int argc, char* argv[])
 
     return hpx::util::report_errors();
 }
-

--- a/tests/unit/parallel/executors/parallel_fork_executor.cpp
+++ b/tests/unit/parallel/executors/parallel_fork_executor.cpp
@@ -6,6 +6,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/include/parallel_executors.hpp>
+#include <hpx/lcos/wait_all.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <algorithm>
@@ -72,7 +73,8 @@ void test_bulk_async()
     using hpx::util::placeholders::_1;
 
     executor exec;
-    traits::async_execute(exec, hpx::util::bind(&bulk_test, tid, _1), v).get();
+    hpx::wait_all(traits::async_execute(
+        exec, hpx::util::bind(&bulk_test, tid, _1), v));
 }
 
 int hpx_main(int argc, char* argv[])
@@ -98,4 +100,3 @@ int main(int argc, char* argv[])
 
     return hpx::util::report_errors();
 }
-

--- a/tests/unit/parallel/executors/sequential_executor.cpp
+++ b/tests/unit/parallel/executors/sequential_executor.cpp
@@ -6,6 +6,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/include/parallel_executors.hpp>
+#include <hpx/lcos/wait_all.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <algorithm>
@@ -72,7 +73,8 @@ void test_bulk_async()
     using hpx::util::placeholders::_1;
 
     executor exec;
-    traits::async_execute(exec, hpx::util::bind(&bulk_test, tid, _1), v).get();
+    hpx::wait_all(traits::async_execute(
+        exec, hpx::util::bind(&bulk_test, tid, _1), v));
 }
 
 int hpx_main(int argc, char* argv[])
@@ -98,4 +100,3 @@ int main(int argc, char* argv[])
 
     return hpx::util::report_errors();
 }
-

--- a/tests/unit/parallel/executors/service_executors.cpp
+++ b/tests/unit/parallel/executors/service_executors.cpp
@@ -6,6 +6,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/parallel/executors/service_executors.hpp>
+#include <hpx/lcos/wait_all.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <algorithm>
@@ -66,7 +67,8 @@ void test_bulk_async(Executor& exec)
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
-    traits::async_execute(exec, hpx::util::bind(&bulk_test, tid, _1), v).get();
+    hpx::wait_all(traits::async_execute(
+        exec, hpx::util::bind(&bulk_test, tid, _1), v));
 }
 
 template <typename Executor>
@@ -113,4 +115,3 @@ int main(int argc, char* argv[])
 
     return hpx::util::report_errors();
 }
-

--- a/tests/unit/parallel/executors/thread_pool_executors.cpp
+++ b/tests/unit/parallel/executors/thread_pool_executors.cpp
@@ -6,6 +6,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/parallel/executors/thread_pool_executors.hpp>
+#include <hpx/lcos/wait_all.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <algorithm>
@@ -66,7 +67,8 @@ void test_bulk_async(Executor& exec)
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
-    traits::async_execute(exec, hpx::util::bind(&bulk_test, tid, _1), v).get();
+    hpx::wait_all(
+        traits::async_execute(exec, hpx::util::bind(&bulk_test, tid, _1), v));
 }
 
 template <typename Executor>
@@ -117,4 +119,3 @@ int main(int argc, char* argv[])
 
     return hpx::util::report_errors();
 }
-


### PR DESCRIPTION
The default return type of `bulk_execute` and `bulk_async_execute` was changed from `void` and `hpx::future<void>` to `std::vector<return_of_F_type>` (void if return_of_F_type is void) and `std::vector<hpx::future<return_of_F_type> >` for each of the executors and for the behavior  of executor_traits. Note that the return type is forwarded from the executor_type so a user can easily create an executor with the behavior described by n4406. This was tested in created_executor.cpp. 

For sequential_executor, I don't think `hpx::util::unwrapped` is optimal in `bulk_execute`. Any suggestions? Also, all tests compiled on my machine but thread_pool_executors_test failed. I got `{what}: assertion 'running()' failed: HPX(assertion_failure)`