### PR TITLE
Changed return type of bulk executors and added test

### DIFF
--- a/hpx/parallel/executors/executor_traits.hpp
+++ b/hpx/parallel/executors/executor_traits.hpp
@@ -266,7 +266,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         template <typename Executor>
         std::size_t call_os_thread_count(Executor& exec)
         {
-            return os_thread_count_helper<Executor>::call(0, exec);
+            return os_thread_count_helper::call(0, exec);
         }
         /// \endcond
     }

--- a/hpx/parallel/executors/parallel_executor.hpp
+++ b/hpx/parallel/executors/parallel_executor.hpp
@@ -34,13 +34,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
 
         /// \cond NOINTERNAL
         template <typename F>
-        void apply_execute(F && f)
+        static void apply_execute(F && f)
         {
             hpx::apply(std::forward<F>(f));
         }
 
         template <typename F>
-        hpx::future<typename hpx::util::result_of<
+        static hpx::future<typename hpx::util::result_of<
             typename hpx::util::decay<F>::type()
         >::type>
         async_execute(F && f)

--- a/hpx/parallel/executors/parallel_fork_executor.hpp
+++ b/hpx/parallel/executors/parallel_fork_executor.hpp
@@ -34,13 +34,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
 
         /// \cond NOINTERNAL
         template <typename F>
-        void apply_execute(F && f)
+        static void apply_execute(F && f)
         {
             return hpx::apply(std::forward<F>(f));
         }
 
         template <typename F>
-        hpx::future<typename hpx::util::result_of<
+        static hpx::future<typename hpx::util::result_of<
             typename hpx::util::decay<F>::type()
         >::type>
         async_execute(F && f)

--- a/tests/unit/parallel/executors/CMakeLists.txt
+++ b/tests/unit/parallel/executors/CMakeLists.txt
@@ -4,6 +4,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    created_executor
     minimal_async_executor
     minimal_sync_executor
     parallel_executor

--- a/tests/unit/parallel/executors/CMakeLists.txt
+++ b/tests/unit/parallel/executors/CMakeLists.txt
@@ -4,6 +4,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    bulk_async
     created_executor
     minimal_async_executor
     minimal_sync_executor

--- a/tests/unit/parallel/executors/bulk_async.cpp
+++ b/tests/unit/parallel/executors/bulk_async.cpp
@@ -1,0 +1,74 @@
+//  Copyright (c) 2015 Daniel Bourgeois
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/include/parallel_executors.hpp>
+#include <hpx/parallel/executors/executor_traits.hpp>
+#include <hpx/util/lightweight_test.hpp>
+#include <hpx/util/deferred_call.hpp>
+
+#include <algorithm>
+
+////////////////////////////////////////////////////////////////////////////////
+int bulk_test(hpx::thread::id tid, int value, bool is_par)
+{
+    HPX_TEST(is_par == (tid != hpx::this_thread::get_id()));
+    return value;
+}
+
+template <typename Executor>
+void test_bulk_async(Executor& exec, bool is_par = true)
+{
+    typedef hpx::parallel::executor_traits<Executor> traits;
+
+    hpx::thread::id tid = hpx::this_thread::get_id();
+
+    std::vector<int> v(107);
+    std::iota(std::begin(v), std::end(v), 0);
+
+    using hpx::util::placeholders::_1;
+
+    std::vector<hpx::future<int> > results = traits::async_execute
+    (
+        exec, hpx::util::bind(&bulk_test, tid, _1, is_par), v
+    );
+
+    HPX_TEST(std::equal(std::begin(results), std::end(results), std::begin(v),
+        [](hpx::future<int>& lhs, const int& rhs)
+        {
+            return lhs.get() == rhs;
+        }));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    using namespace hpx::parallel;
+
+    sequential_executor seq_exec;
+    parallel_executor par_exec;
+    parallel_fork_executor par_fork_exec;
+
+    test_bulk_async(seq_exec, false);
+    test_bulk_async(par_exec);
+    test_bulk_async(par_fork_exec);
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // By default this test should run on all available cores
+    std::vector<std::string> cfg;
+    cfg.push_back("hpx.os_threads=" +
+        boost::lexical_cast<std::string>(hpx::threads::hardware_concurrency()));
+
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/parallel/executors/created_executor.cpp
+++ b/tests/unit/parallel/executors/created_executor.cpp
@@ -185,6 +185,7 @@ void sum_test()
     HPX_TEST(f_void_par.get() == sum);
 }
 
+////////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
     unsigned int seed = (unsigned int)std::time(0);

--- a/tests/unit/parallel/executors/created_executor.cpp
+++ b/tests/unit/parallel/executors/created_executor.cpp
@@ -107,7 +107,7 @@ private:
 // Create shape argument for parallel_executor
 std::vector<range> split(iter first, iter last, int parts)
 {
-    typedef typename std::iterator_traits<iter>::difference_type sz_type;
+    typedef std::iterator_traits<iter>::difference_type sz_type;
     sz_type count = std::distance(first, last);
     sz_type increment = count/parts;
     std::vector<range> results;

--- a/tests/unit/parallel/executors/created_executor.cpp
+++ b/tests/unit/parallel/executors/created_executor.cpp
@@ -1,0 +1,224 @@
+//  Copyright (c) 2015 Daniel Bourgeois
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/include/parallel_executors.hpp>
+#include <hpx/parallel/executors/executor_traits.hpp>
+#include <hpx/util/lightweight_test.hpp>
+#include <hpx/util/deferred_call.hpp>
+
+#include <iostream>
+#include <functional>
+#include <algorithm>
+#include <numeric>
+#include <iterator>
+
+using hpx::parallel::parallel_executor;
+using hpx::util::deferred_call
+using iter = std::vector<int>::iterator;
+using std::begin;
+using std::end;
+
+////////////////////////////////////////////////////////////////////////////////
+// A parallel executor that returns void for bulk_execute and hpx::future<void>
+// for bulk_async_execute
+struct void_parallel_executor
+    : public parallel_executor
+{
+    void_parallel_executor() {}
+
+    template <typename F, typename Shape>
+    static hpx::future<void> bulk_async_execute(F && f, Shape const& shape)
+    {
+        std::vector<hpx::future<void> > results;
+        for(auto const& elem: shape)
+        {
+            results.push_back(
+                parallel_executor::async_execute(deferred_call(f, elem))
+            );
+        }
+        return hpx::when_all(results);
+    }
+
+    template <typename F, typename Shape>
+    static void bulk_execute(F && f, Shape const& shape)
+    {
+        return hpx::util::unwrapped(
+            bulk_async_execute(std::forward<F>(f), shape));
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Tests to void_parallel_executor behavior for the bulk executes
+
+void bulk_test(hpx::thread::id tid, int value)
+{
+    HPX_TEST(tid != hpx::this_thread::get_id());
+}
+
+void test_void_bulk_sync()
+{
+    typedef void_parallel_executor executor;
+    typedef hpx::parallel::executor_traits<executor> traits;
+
+    hpx::thread::id tid = hpx::this_thread::get_id();
+
+    std::vector<int> v(107);
+    std::iota(boost::begin(v), boost::end(v), std::rand());
+
+    using hpx::util::placeholders::_1;
+
+    executor exec;
+    traits::execute(exec, hpx::util::bind(&bulk_test, tid, _1), v);
+}
+
+void test_void_bulk_async()
+{
+    typedef void_parallel_executor executor;
+    typedef hpx::parallel::executor_traits<executor> traits;
+
+    hpx::thread::id tid = hpx::this_thread::get_id();
+
+    std::vector<int> v(107);
+    std::iota(boost::begin(v), boost::end(v), std::rand());
+
+    using hpx::util::placeholders::_1;
+
+    executor exec;
+    traits::async_execute(exec, hpx::util::bind(&bulk_test, tid, _1), v).get();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Sum using hpx's parallel_executor and the above void_parallel_executor
+
+struct range
+{
+    range(iter first, iter last): first_(first), last_(last) {}
+    iter begin() const { return first_; }
+    iter end() const { return last_; }
+private:
+    iter first_;
+    iter last_;
+};
+
+// Create shape argument for parallel_executor
+std::vector<range> split(iter first, iter last, int parts)
+{
+    typedef typename std::iterator_traits<iter>::difference_type sz_type;
+    sz_type count = std::distance(first, last);
+    sz_type increment = count/parts;
+    std::vector<range> results;
+    while(first != last)
+    {
+        iter prev = first;
+        std::advance(
+            first,
+            (std::min)(increment, std::distance(first,last))
+        );
+        results.push_back(range(prev, first));
+    }
+    return std::move(results);
+}
+
+// parallel sum using hpx's parallel executor
+int parallel_sum(iter first, iter last, int num_parts)
+{
+    parallel_executor exec;
+    typedef hpx::parallel::executor_traits<parallel_executor> traits;
+
+    std::vector<hpx::future<int> > v =
+        traits::async_execute(exec, [](const range& rng)
+        {
+            return std::accumulate(begin(rng), end(rng), 0);
+        }, split(first, last, num_parts));
+
+    return std::accumulate(begin(v), end(v), 0,
+        [](int a, hpx::future<int>& b)
+        {
+            return a + b.get();
+        });
+}
+
+// parallel sum using void parallel executer
+int void_parallel_sum(iter first, iter last, int num_parts)
+{
+    void_parallel_executor exec;
+    typedef hpx::parallel::executor_traits<void_parallel_executor> traits;
+
+    std::vector<int> temp(num_parts + 1, 0);
+    std::iota(begin(temp), end(temp), 0);
+
+    int section_size = std::distance(first,last)/num_parts;
+
+    hpx::future<void> f = traits::async_execute(exec, [&](const int& i)
+    {
+        iter b = first + i*section_size;
+        iter e = first + (std::min)(int(std::distance(first, last)), (i+1)*section_size);
+        temp[i] = std::accumulate(b, e, 0);
+    }, temp);
+
+    f.get();
+
+    return std::accumulate(begin(temp), end(temp), 0);
+}
+
+void sum_test()
+{
+    std::vector<int> vec(10007);
+    auto random_num = [](){ return std::rand() % 50 - 25; };
+    std::generate(begin(vec), end(vec), random_num);
+
+    int sum = std::accumulate(begin(vec), end(vec), 0);
+    int num_parts = std::rand() % 5 + 3;
+
+    // Return futures holding results of parallel_sum and void_parallel_sum
+    parallel_executor exec;
+    hpx::future<int> f_par = exec.async_execute(deferred_call(
+        parallel_sum, begin(vec), end(vec), num_parts));
+    hpx::future<int> f_void_par = exec.async_execute(deferred_call(
+        void_parallel_sum, begin(vec), end(vec), num_parts));
+
+    HPX_TEST(f_par.get() == sum);
+    HPX_TEST(f_void_par.get() == sum);
+}
+
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int)std::time(0);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    test_void_bulk_sync();
+    test_void_bulk_async();
+    sum_test();
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace boost::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()
+        ("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run")
+        ;
+
+    // By default this test should run on all available cores
+    std::vector<std::string> cfg;
+    cfg.push_back("hpx.os_threads=" +
+        boost::lexical_cast<std::string>(hpx::threads::hardware_concurrency()));
+
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/parallel/executors/created_executor.cpp
+++ b/tests/unit/parallel/executors/created_executor.cpp
@@ -17,7 +17,7 @@
 #include <iterator>
 
 using hpx::parallel::parallel_executor;
-using hpx::util::deferred_call
+using hpx::util::deferred_call;
 using iter = std::vector<int>::iterator;
 using std::begin;
 using std::end;

--- a/tests/unit/parallel/executors/minimal_async_executor.cpp
+++ b/tests/unit/parallel/executors/minimal_async_executor.cpp
@@ -6,6 +6,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/include/parallel_executors.hpp>
+#include <hpx/lcos/wait_all.hpp>
 #include <hpx/util/lightweight_test.hpp>
 #include <hpx/util/decay.hpp>
 
@@ -91,7 +92,8 @@ void test_bulk_async(Executor& exec)
     using hpx::util::placeholders::_1;
 
     typedef hpx::parallel::executor_traits<Executor> traits;
-    traits::async_execute(exec, hpx::util::bind(&async_bulk_test, tid, _1), v).get();
+    hpx::wait_all(traits::async_execute(
+        exec, hpx::util::bind(&async_bulk_test, tid, _1), v));
 }
 
 template <typename Executor>
@@ -200,4 +202,3 @@ int main(int argc, char* argv[])
 
     return hpx::util::report_errors();
 }
-

--- a/tests/unit/parallel/executors/minimal_async_executor.cpp
+++ b/tests/unit/parallel/executors/minimal_async_executor.cpp
@@ -6,7 +6,6 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/include/parallel_executors.hpp>
-#include <hpx/lcos/wait_all.hpp>
 #include <hpx/util/lightweight_test.hpp>
 #include <hpx/util/decay.hpp>
 
@@ -92,8 +91,8 @@ void test_bulk_async(Executor& exec)
     using hpx::util::placeholders::_1;
 
     typedef hpx::parallel::executor_traits<Executor> traits;
-    hpx::wait_all(traits::async_execute(
-        exec, hpx::util::bind(&async_bulk_test, tid, _1), v));
+    hpx::when_all(traits::async_execute(
+        exec, hpx::util::bind(&async_bulk_test, tid, _1), v)).get();
 }
 
 template <typename Executor>
@@ -156,7 +155,7 @@ struct test_async_executor3 : test_async_executor2
 struct test_async_executor4 : test_async_executor2
 {
     template <typename F, typename Shape>
-    hpx::future<void>
+    std::vector<hpx::future<void> >
     bulk_async_execute(F f, Shape const& shape)
     {
         std::vector<hpx::future<void> > results;
@@ -164,7 +163,7 @@ struct test_async_executor4 : test_async_executor2
         {
             results.push_back(hpx::async(hpx::launch::async, f, elem));
         }
-        return hpx::when_all(results);
+        return std::move(results);
     }
 };
 

--- a/tests/unit/parallel/executors/minimal_sync_executor.cpp
+++ b/tests/unit/parallel/executors/minimal_sync_executor.cpp
@@ -6,6 +6,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/include/parallel_executors.hpp>
+#include <hpx/lcos/wait_all.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <algorithm>
@@ -90,7 +91,8 @@ void test_bulk_async(Executor& exec)
     using hpx::util::placeholders::_1;
 
     typedef hpx::parallel::executor_traits<Executor> traits;
-    traits::async_execute(exec, hpx::util::bind(&sync_bulk_test, tid, _1), v).get();
+    hpx::wait_all(traits::async_execute(
+        exec, hpx::util::bind(&sync_bulk_test, tid, _1), v));
 }
 
 template <typename Executor>
@@ -210,4 +212,3 @@ int main(int argc, char* argv[])
 
     return hpx::util::report_errors();
 }
-

--- a/tests/unit/parallel/executors/parallel_executor.cpp
+++ b/tests/unit/parallel/executors/parallel_executor.cpp
@@ -6,6 +6,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/include/parallel_executors.hpp>
+#include <hpx/lcos/wait_all.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <algorithm>
@@ -72,7 +73,8 @@ void test_bulk_async()
     using hpx::util::placeholders::_1;
 
     executor exec;
-    traits::async_execute(exec, hpx::util::bind(&bulk_test, tid, _1), v).get();
+    hpx::wait_all(traits::async_execute(
+        exec, hpx::util::bind(&bulk_test, tid, _1), v));
 }
 
 int hpx_main(int argc, char* argv[])
@@ -98,4 +100,3 @@ int main(int argc, char* argv[])
 
     return hpx::util::report_errors();
 }
-

--- a/tests/unit/parallel/executors/parallel_executor.cpp
+++ b/tests/unit/parallel/executors/parallel_executor.cpp
@@ -6,7 +6,6 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/include/parallel_executors.hpp>
-#include <hpx/lcos/wait_all.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <algorithm>
@@ -73,8 +72,8 @@ void test_bulk_async()
     using hpx::util::placeholders::_1;
 
     executor exec;
-    hpx::wait_all(traits::async_execute(
-        exec, hpx::util::bind(&bulk_test, tid, _1), v));
+    hpx::when_all(traits::async_execute(
+        exec, hpx::util::bind(&bulk_test, tid, _1), v)).get();
 }
 
 int hpx_main(int argc, char* argv[])

--- a/tests/unit/parallel/executors/parallel_fork_executor.cpp
+++ b/tests/unit/parallel/executors/parallel_fork_executor.cpp
@@ -6,6 +6,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/include/parallel_executors.hpp>
+#include <hpx/lcos/wait_all.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <algorithm>
@@ -72,7 +73,8 @@ void test_bulk_async()
     using hpx::util::placeholders::_1;
 
     executor exec;
-    traits::async_execute(exec, hpx::util::bind(&bulk_test, tid, _1), v).get();
+    hpx::wait_all(traits::async_execute(
+        exec, hpx::util::bind(&bulk_test, tid, _1), v));
 }
 
 int hpx_main(int argc, char* argv[])
@@ -98,4 +100,3 @@ int main(int argc, char* argv[])
 
     return hpx::util::report_errors();
 }
-

--- a/tests/unit/parallel/executors/parallel_fork_executor.cpp
+++ b/tests/unit/parallel/executors/parallel_fork_executor.cpp
@@ -6,7 +6,6 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/include/parallel_executors.hpp>
-#include <hpx/lcos/wait_all.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <algorithm>
@@ -73,8 +72,8 @@ void test_bulk_async()
     using hpx::util::placeholders::_1;
 
     executor exec;
-    hpx::wait_all(traits::async_execute(
-        exec, hpx::util::bind(&bulk_test, tid, _1), v));
+    hpx::when_all(traits::async_execute(
+        exec, hpx::util::bind(&bulk_test, tid, _1), v)).get();
 }
 
 int hpx_main(int argc, char* argv[])

--- a/tests/unit/parallel/executors/sequential_executor.cpp
+++ b/tests/unit/parallel/executors/sequential_executor.cpp
@@ -6,6 +6,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/include/parallel_executors.hpp>
+#include <hpx/lcos/wait_all.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <algorithm>
@@ -72,7 +73,8 @@ void test_bulk_async()
     using hpx::util::placeholders::_1;
 
     executor exec;
-    traits::async_execute(exec, hpx::util::bind(&bulk_test, tid, _1), v).get();
+    hpx::wait_all(traits::async_execute(
+        exec, hpx::util::bind(&bulk_test, tid, _1), v));
 }
 
 int hpx_main(int argc, char* argv[])
@@ -98,4 +100,3 @@ int main(int argc, char* argv[])
 
     return hpx::util::report_errors();
 }
-

--- a/tests/unit/parallel/executors/sequential_executor.cpp
+++ b/tests/unit/parallel/executors/sequential_executor.cpp
@@ -6,7 +6,6 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/include/parallel_executors.hpp>
-#include <hpx/lcos/wait_all.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <algorithm>
@@ -73,8 +72,8 @@ void test_bulk_async()
     using hpx::util::placeholders::_1;
 
     executor exec;
-    hpx::wait_all(traits::async_execute(
-        exec, hpx::util::bind(&bulk_test, tid, _1), v));
+    hpx::when_all(traits::async_execute(
+        exec, hpx::util::bind(&bulk_test, tid, _1), v)).get();
 }
 
 int hpx_main(int argc, char* argv[])

--- a/tests/unit/parallel/executors/service_executors.cpp
+++ b/tests/unit/parallel/executors/service_executors.cpp
@@ -6,6 +6,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/parallel/executors/service_executors.hpp>
+#include <hpx/lcos/wait_all.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <algorithm>
@@ -66,7 +67,8 @@ void test_bulk_async(Executor& exec)
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
-    traits::async_execute(exec, hpx::util::bind(&bulk_test, tid, _1), v).get();
+    hpx::wait_all(traits::async_execute(
+        exec, hpx::util::bind(&bulk_test, tid, _1), v));
 }
 
 template <typename Executor>
@@ -113,4 +115,3 @@ int main(int argc, char* argv[])
 
     return hpx::util::report_errors();
 }
-

--- a/tests/unit/parallel/executors/service_executors.cpp
+++ b/tests/unit/parallel/executors/service_executors.cpp
@@ -6,7 +6,6 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/parallel/executors/service_executors.hpp>
-#include <hpx/lcos/wait_all.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <algorithm>
@@ -67,8 +66,8 @@ void test_bulk_async(Executor& exec)
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
-    hpx::wait_all(traits::async_execute(
-        exec, hpx::util::bind(&bulk_test, tid, _1), v));
+    hpx::when_all(traits::async_execute(
+        exec, hpx::util::bind(&bulk_test, tid, _1), v)).get();
 }
 
 template <typename Executor>

--- a/tests/unit/parallel/executors/thread_pool_executors.cpp
+++ b/tests/unit/parallel/executors/thread_pool_executors.cpp
@@ -6,6 +6,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/parallel/executors/thread_pool_executors.hpp>
+#include <hpx/lcos/wait_all.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <algorithm>
@@ -66,7 +67,8 @@ void test_bulk_async(Executor& exec)
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
-    traits::async_execute(exec, hpx::util::bind(&bulk_test, tid, _1), v).get();
+    hpx::wait_all(
+        traits::async_execute(exec, hpx::util::bind(&bulk_test, tid, _1), v));
 }
 
 template <typename Executor>
@@ -117,4 +119,3 @@ int main(int argc, char* argv[])
 
     return hpx::util::report_errors();
 }
-

--- a/tests/unit/parallel/executors/thread_pool_executors.cpp
+++ b/tests/unit/parallel/executors/thread_pool_executors.cpp
@@ -6,7 +6,6 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/parallel/executors/thread_pool_executors.hpp>
-#include <hpx/lcos/wait_all.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <algorithm>
@@ -67,8 +66,8 @@ void test_bulk_async(Executor& exec)
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
-    hpx::wait_all(
-        traits::async_execute(exec, hpx::util::bind(&bulk_test, tid, _1), v));
+    hpx::when_all(traits::async_execute(
+        exec, hpx::util::bind(&bulk_test, tid, _1), v)).get();
 }
 
 template <typename Executor>


### PR DESCRIPTION
The default return type of `bulk_execute` and `bulk_async_execute` was changed from `void` and `hpx::future<void>` to `std::vector<return_of_F_type>` (void if return_of_F_type is void) and `std::vector<hpx::future<return_of_F_type> >` for each of the executors and for the behavior of executor_traits. Note that the return type is forwarded from the executor_type so a user can easily create an executor with the behavior described by n4406. This was tested in created_executor.cpp.

For sequential_executor, I don't think hpx::util::unwrapped is optimal in bulk_execute. Any suggestions? Also, executor tests compiled on my machine but running thread_pool_executors_test failed about half of the time. I got `{what}: assertion 'running()' failed: HPX(assertion_failure)`
