### PR TITLE
Fix potential zero-copy for primarynamespace::bulk_service_async et.al.

### DIFF
--- a/hpx/runtime/agas/primary_namespace.hpp
+++ b/hpx/runtime/agas/primary_namespace.hpp
@@ -46,23 +46,6 @@ struct primary_namespace
     {
         this->base_type::service_non_blocking(this->get_gid(), req, priority);
     }
-
-//     std::vector<response> bulk_service(
-//         std::vector<request> const& reqs
-//       , threads::thread_priority priority = threads::thread_priority_default
-//       , error_code& ec = throws
-//         )
-//     {
-//         return this->base_type::bulk_service(this->get_gid(), reqs, priority, ec);
-//     }
-
-//     void bulk_service_non_blocking(
-//         std::vector<request> const& reqs
-//       , threads::thread_priority priority = threads::thread_priority_default
-//         )
-//     {
-//         this->base_type::bulk_service_non_blocking(this->get_gid(), reqs, priority);
-//     }
 };
 
 }}

--- a/hpx/runtime/agas/primary_namespace.hpp
+++ b/hpx/runtime/agas/primary_namespace.hpp
@@ -47,22 +47,22 @@ struct primary_namespace
         this->base_type::service_non_blocking(this->get_gid(), req, priority);
     }
 
-    std::vector<response> bulk_service(
-        std::vector<request> const& reqs
-      , threads::thread_priority priority = threads::thread_priority_default
-      , error_code& ec = throws
-        )
-    {
-        return this->base_type::bulk_service(this->get_gid(), reqs, priority, ec);
-    }
+//     std::vector<response> bulk_service(
+//         std::vector<request> const& reqs
+//       , threads::thread_priority priority = threads::thread_priority_default
+//       , error_code& ec = throws
+//         )
+//     {
+//         return this->base_type::bulk_service(this->get_gid(), reqs, priority, ec);
+//     }
 
-    void bulk_service_non_blocking(
-        std::vector<request> const& reqs
-      , threads::thread_priority priority = threads::thread_priority_default
-        )
-    {
-        this->base_type::bulk_service_non_blocking(this->get_gid(), reqs, priority);
-    }
+//     void bulk_service_non_blocking(
+//         std::vector<request> const& reqs
+//       , threads::thread_priority priority = threads::thread_priority_default
+//         )
+//     {
+//         this->base_type::bulk_service_non_blocking(this->get_gid(), reqs, priority);
+//     }
 };
 
 }}

--- a/hpx/runtime/agas/stubs/primary_namespace.hpp
+++ b/hpx/runtime/agas/stubs/primary_namespace.hpp
@@ -21,6 +21,10 @@ struct HPX_EXPORT primary_namespace
     typedef server::primary_namespace server_type;
     typedef server::primary_namespace server_component_type;
 
+    typedef util::function_nonser<
+            void(boost::system::error_code const&, parcelset::parcel const&)
+        > parcel_sent_func;
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename Result>
     static lcos::future<Result> service_async(
@@ -41,8 +45,7 @@ struct HPX_EXPORT primary_namespace
     static void service_non_blocking(
         naming::id_type const& gid
       , request const& req
-      , util::function_nonser<void(boost::system::error_code const&,
-            parcelset::parcel const&)> const& f
+      , parcel_sent_func const& cb
       , threads::thread_priority priority = threads::thread_priority_default
         );
 
@@ -60,6 +63,7 @@ struct HPX_EXPORT primary_namespace
     static lcos::future<std::vector<response> > bulk_service_async(
         naming::id_type const& gid
       , std::vector<request> const& reqs
+      , parcel_sent_func const& cb
       , threads::thread_priority priority = threads::thread_priority_default
         );
 
@@ -69,6 +73,7 @@ struct HPX_EXPORT primary_namespace
     static void bulk_service_non_blocking(
         naming::id_type const& gid
       , std::vector<request> const& reqs
+      , parcel_sent_func const& cb
       , threads::thread_priority priority = threads::thread_priority_default
         );
 
@@ -77,10 +82,7 @@ struct HPX_EXPORT primary_namespace
       , std::vector<request> const& reqs
       , threads::thread_priority priority = threads::thread_priority_default
       , error_code& ec = throws
-        )
-    {
-        return bulk_service_async(gid, reqs, priority).get(ec);
-    }
+        );
 
     static naming::gid_type get_service_instance(naming::gid_type const& dest)
     {


### PR DESCRIPTION
This fixes one instance where zero-copy serialization was interfering with a plain async invocation.