### PR TITLE
Executor traits result types

### DIFF
--- a/hpx/parallel/executors/executor_traits.hpp
+++ b/hpx/parallel/executors/executor_traits.hpp
@@ -191,14 +191,15 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         struct bulk_async_execute_helper
         {
             template <typename Executor, typename F, typename S>
-            static std::vector<hpx::future<
-                    typename bulk_async_execute_result<F, S>::type
-                > >
+            static std::vector<typename future_type<
+                    Executor, typename bulk_async_execute_result<F, S>::type
+                >::type>
             call(wrap_int, Executor& exec, F && f, S const& shape)
             {
-                std::vector<hpx::future<
+                std::vector<typename future_type<
+                        Executor,
                         typename bulk_async_execute_result<F, S>::type
-                    > > results;
+                    >::type> results;
 
                 for (auto const& elem: shape)
                 {
@@ -219,9 +220,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         };
 
         template <typename Executor, typename F, typename S>
-        auto call_bulk_async_execute(Executor& exec, F && f, S const& shape)
-            ->  decltype(bulk_async_execute_helper::call(
-                    0, exec, std::forward<F>(f), shape))
+        std::vector<typename future_type<
+                Executor, typename bulk_async_execute_result<F, S>::type
+            >::type>
+        call_bulk_async_execute(Executor& exec, F && f, S const& shape)
         {
             return bulk_async_execute_helper::call(
                 0, exec, std::forward<F>(f), shape);
@@ -254,9 +256,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
             static typename detail::bulk_execute_result<F, S>::type
             call(wrap_int, Executor& exec, F && f, S const& shape)
             {
-                std::vector<hpx::future<
+                std::vector<typename future_type<
+                        Executor,
                         typename bulk_async_execute_result<F, S>::type
-                    > > results;
+                    >::type> results;
 
                 for (auto const& elem: shape)
                 {
@@ -277,9 +280,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         };
 
         template <typename Executor, typename F, typename S>
-        auto call_bulk_execute(Executor& exec, F && f, S const& shape)
-            ->  decltype(bulk_execute_helper::call(
-                    0, exec, std::forward<F>(f), shape))
+        typename detail::bulk_execute_result<F, S>::type
+        call_bulk_execute(Executor& exec, F && f, S const& shape)
         {
             return bulk_execute_helper::call(0, exec, std::forward<F>(f), shape);
         }
@@ -458,10 +460,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         ///       otherwise it executes hpx::async(f, i) as often as needed.
         ///
         template <typename F, typename Shape>
-        static auto
+        static std::vector<typename future<
+            typename detail::bulk_async_execute_result<F, Shape>::type
+        >::type>
         async_execute(executor_type& exec, F && f, Shape const& shape)
-            ->  decltype(detail::call_bulk_async_execute(
-                    exec, std::forward<F>(f), shape))
         {
             return detail::call_bulk_async_execute(
                 exec, std::forward<F>(f), shape);
@@ -495,10 +497,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         ///       otherwise it executes hpx::async(f, i) as often as needed.
         ///
         template <typename F, typename Shape>
-        static auto
+        static typename detail::bulk_execute_result<F, Shape>::type
         execute(executor_type& exec, F && f, Shape const& shape)
-            -> decltype(detail::call_bulk_execute(
-                exec, std::forward<F>(f), shape))
         {
             return detail::call_bulk_execute(exec, std::forward<F>(f), shape);
         }


### PR DESCRIPTION
This fixes compilation problems in executor_traits for older compilers.