### PR TITLE
Fixed algorithms relying on copy_if implementation

### DIFF
--- a/hpx/parallel/algorithms/copy.hpp
+++ b/hpx/parallel/algorithms/copy.hpp
@@ -399,6 +399,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                         typedef util::partitioner<ExPolicy, Iter, void>
                             partitioner_type;
+
+                        // capturing 'flags' below keeps the array alive
                         return partitioner_type::call_with_data(
                             policy,
                             hpx::util::make_zip_iterator(first, flags.get()),

--- a/hpx/parallel/algorithms/copy.hpp
+++ b/hpx/parallel/algorithms/copy.hpp
@@ -403,7 +403,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                             policy,
                             hpx::util::make_zip_iterator(first, flags.get()),
                             count,
-                            [dest](hpx::shared_future<std::size_t>&& pos,
+                            [dest, flags](
+                                hpx::shared_future<std::size_t>&& pos,
                                 zip_iterator part_begin, std::size_t part_count)
                             {
                                 Iter iter = dest;

--- a/tests/regressions/parallel/scan_shortlength.cpp
+++ b/tests/regressions/parallel/scan_shortlength.cpp
@@ -113,10 +113,10 @@ void test_async_one(std::vector<int> const& a)
 
     Fut_Iter f_copy_if =
         copy_if(par(task), a.begin(), a.end(), b.begin(),
-        [](int bar){ return bar % 2 == 1; });
+            [](int bar){ return bar % 2 == 1; });
     Fut_Iter f_remove_copy_if =
         remove_copy_if(par(task), a.begin(), a.end(), c.begin(),
-        [](int bar){ return bar % 2 != 1; });
+            [](int bar){ return bar % 2 != 1; });
     Fut_Iter f_remove_copy =
         remove_copy(par(task), a.begin(), a.end(), d.begin(), 0);
 


### PR DESCRIPTION
This mainly fixes the failing `scan_shortlength` test