### PR TITLE
Properly fix HPX_DEFINE_*_ACTION macros

### DIFF
--- a/hpx/runtime/actions/plain_action.hpp
+++ b/hpx/runtime/actions/plain_action.hpp
@@ -127,14 +127,49 @@ namespace hpx { namespace traits {
 /// to avoid defining the action_type in global namespace. Normally, the use of
 /// the macro \a HPX_PLAIN_ACTION is recommend.
 ///
-#define HPX_DEFINE_PLAIN_ACTION(func, name)                                   \
-    struct name : hpx::actions::make_action<                                  \
-        decltype(&func), &func, name>::type {}                                \
+/// \note The macro \a HPX_DEFINE_PLAIN_ACTION can be used with 1 or 2
+/// arguments. The second argument is optional. The default value for the
+/// second argument (the typename of the defined action) is derived from the
+/// name of the function (as passed as the first argument) by appending '_action'.
+/// The second argument can be omitted only if the first argument with an
+/// appended suffix '_action' resolves to a valid, unqualified C++ type name.
+///
+#define HPX_DEFINE_PLAIN_ACTION(...)                                          \
+    HPX_DEFINE_PLAIN_ACTION_(__VA_ARGS__)                                     \
     /**/
 
 /// \cond NOINTERNAL
 
-#define HPX_DEFINE_PLAIN_DIRECT_ACTION(func, name)                            \
+#define HPX_DEFINE_PLAIN_DIRECT_ACTION(...)                                   \
+    HPX_DEFINE_PLAIN_DIRECT_ACTION_(__VA_ARGS__)                              \
+    /**/
+
+#define HPX_DEFINE_PLAIN_ACTION_(...)                                         \
+    HPX_UTIL_EXPAND_(BOOST_PP_CAT(                                            \
+        HPX_DEFINE_PLAIN_ACTION_, HPX_UTIL_PP_NARG(__VA_ARGS__)               \
+    )(__VA_ARGS__))                                                           \
+    /**/
+
+#define HPX_DEFINE_PLAIN_DIRECT_ACTION_(...)                                  \
+    HPX_UTIL_EXPAND_(BOOST_PP_CAT(                                            \
+        HPX_DEFINE_PLAIN_DIRECT_ACTION_, HPX_UTIL_PP_NARG(__VA_ARGS__)        \
+    )(__VA_ARGS__))                                                           \
+    /**/
+
+#define HPX_DEFINE_PLAIN_ACTION_1(func)                                       \
+    HPX_DEFINE_PLAIN_ACTION_2(func, BOOST_PP_CAT(func, _action))              \
+    /**/
+
+#define HPX_DEFINE_PLAIN_ACTION_2(func, name)                                 \
+    struct name : hpx::actions::make_action<                                  \
+        decltype(&func), &func, name>::type {}                                \
+    /**/
+
+#define HPX_DEFINE_PLAIN_DIRECT_ACTION_1(func)                                \
+    HPX_DEFINE_PLAIN_DIRECT_ACTION_2(func, BOOST_PP_CAT(func, _action))       \
+    /**/
+
+#define HPX_DEFINE_PLAIN_DIRECT_ACTION_2(func, name)                          \
     struct name : hpx::actions::make_direct_action<                           \
         decltype(&func), &func, name>::type {}                                \
     /**/

--- a/tests/regressions/actions/CMakeLists.txt
+++ b/tests/regressions/actions/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(components)
 
 set(tests
     plain_action_1330
+    plain_action_1550
     plain_action_move_semantics
     component_action_move_semantics
    )

--- a/tests/regressions/actions/plain_action_1550.cpp
+++ b/tests/regressions/actions/plain_action_1550.cpp
@@ -1,0 +1,45 @@
+//  Copyright (c) 2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Verify that #1550 was properly fixed (Properly fix HPX_DEFINE_*_ACTION macros)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/actions.hpp>
+#include <hpx/include/async.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+bool called_test_action = false;
+
+namespace mynamespace
+{
+    void test()
+    {
+        called_test_action = true;
+    }
+
+    HPX_DEFINE_PLAIN_ACTION(test);
+}
+
+typedef mynamespace::test_action mynamespace_test_action;
+
+HPX_REGISTER_ACTION(mynamespace_test_action);
+
+int hpx_main(int argc, char* argv[])
+{
+    {
+        typedef mynamespace_test_action func;
+        hpx::async<func>(hpx::find_here()).get();
+    }
+
+    HPX_TEST(called_test_action);
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
- this reverts commit 2bdf6a58fa4c10d404663f47aafd2f523808a52f
- properly fix broken macros
- add missing blurb in documentation