### PR TITLE
Removing obsolete Boost.Serialization macros. 

### DIFF
--- a/hpx/config/export_definitions.hpp
+++ b/hpx/config/export_definitions.hpp
@@ -77,12 +77,4 @@
 # define HPX_ALWAYS_EXPORT       HPX_SYMBOL_IMPORT
 #endif
 
-// Boost.Serialization fails to export some symbols correctly on gcc with hidden visibility if
-// we don't manually define these macros
-#if !defined(BOOST_MSVC) && !defined(BOOST_INTEL_WIN) && defined(HPX_SERIALIZATION_EXPORTS)
-#  define BOOST_ARCHIVE_DECL(T) HPX_ALWAYS_EXPORT T
-#  define BOOST_WARCHIVE_DECL(T) HPX_ALWAYS_EXPORT T
-#  define BOOST_ARCHIVE_OR_WARCHIVE_DECL(T) HPX_ALWAYS_EXPORT T
-#endif
-
 #endif

--- a/hpx/runtime/serialization/basic_archive.hpp
+++ b/hpx/runtime/serialization/basic_archive.hpp
@@ -44,7 +44,7 @@ namespace hpx { namespace serialization
     }
 
     template <typename Archive>
-    struct basic_archive
+    struct HPX_EXPORT basic_archive
     {
         static const boost::uint64_t npos = -1;
 

--- a/hpx/runtime/serialization/input_archive.hpp
+++ b/hpx/runtime/serialization/input_archive.hpp
@@ -23,7 +23,7 @@
 
 namespace hpx { namespace serialization
 {
-    struct HPX_ALWAYS_EXPORT input_archive
+    struct HPX_EXPORT input_archive
       : basic_archive<input_archive>
     {
         typedef basic_archive<input_archive> base_type;

--- a/hpx/runtime/serialization/output_archive.hpp
+++ b/hpx/runtime/serialization/output_archive.hpp
@@ -22,7 +22,7 @@
 
 namespace hpx { namespace serialization
 {
-    struct HPX_ALWAYS_EXPORT output_archive
+    struct HPX_EXPORT output_archive
       : basic_archive<output_archive>
     {
         typedef basic_archive<output_archive> base_type;


### PR DESCRIPTION
Also properly export serialization archives