### PR TITLE
Executor algorithms

### DIFF
--- a/hpx/parallel/algorithms/detail/dispatch.hpp
+++ b/hpx/parallel/algorithms/detail/dispatch.hpp
@@ -15,6 +15,7 @@
 #include <hpx/util/invoke.hpp>
 #include <hpx/util/invoke_fused.hpp>
 #include <hpx/util/tuple.hpp>
+#include <hpx/util/void_guard.hpp>
 #include <hpx/parallel/exception_list.hpp>
 #include <hpx/parallel/execution_policy.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
@@ -59,6 +60,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
           : name_(name)
         {}
 
+        ///////////////////////////////////////////////////////////////////////
         template <typename ExPolicy, typename... Args>
         typename parallel::util::detail::algorithm_result<
             ExPolicy, local_result_type
@@ -68,31 +70,56 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
             try {
                 return parallel::util::detail::algorithm_result<
                         ExPolicy, local_result_type
-                    >::get(Derived::sequential(policy, std::forward<Args>(args)...));
+                    >::get(Derived::sequential(policy,
+                        std::forward<Args>(args)...));
             }
             catch (...) {
                 detail::handle_exception<ExPolicy, local_result_type>::call();
             }
         }
 
-        template <typename... Args>
+        ///////////////////////////////////////////////////////////////////////
+        template <typename ExPolicy, typename... Args>
         typename parallel::util::detail::algorithm_result<
-            sequential_task_execution_policy, local_result_type
+            ExPolicy, local_result_type
         >::type
-        operator()(sequential_task_execution_policy policy,
-            Args&&... args) const
+        operator()(ExPolicy policy, Args&&... args) const
         {
             try {
                 return parallel::util::detail::algorithm_result<
-                        sequential_task_execution_policy, local_result_type
-                    >::get(Derived::sequential(policy, std::forward<Args>(args)...));
+                        ExPolicy, local_result_type
+                    >::get(Derived::sequential(policy,
+                        std::forward<Args>(args)...));
             }
             catch (...) {
                 return detail::handle_exception<
-                        sequential_task_execution_policy, local_result_type
+                        ExPolicy, local_result_type
                     >::call();
             }
         }
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename ExPolicy, typename... Args>
+        typename parallel::util::detail::algorithm_result<
+            ExPolicy, local_result_type
+        >::type
+        call_sequential(ExPolicy policy, Args&&... args) const
+        {
+            try {
+                hpx::future<local_result_type> result =
+                    hpx::async(derived(), policy, std::forward<Args>(args)...);
+
+                return parallel::util::detail::algorithm_result<
+                        ExPolicy, local_result_type
+                    >::get(std::move(result));
+            }
+            catch (...) {
+                return detail::handle_exception<
+                        ExPolicy, local_result_type
+                    >::call();
+            }
+        }
+
 
         template <typename... Args>
         typename parallel::util::detail::algorithm_result<
@@ -101,21 +128,20 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         call(sequential_task_execution_policy policy, boost::mpl::true_,
             Args&&... args) const
         {
-            try {
-                hpx::future<local_result_type> result =
-                    hpx::async(derived(), policy, std::forward<Args>(args)...);
-
-                return parallel::util::detail::algorithm_result<
-                        sequential_task_execution_policy, local_result_type
-                    >::get(std::move(result));
-            }
-            catch (...) {
-                return detail::handle_exception<
-                        sequential_task_execution_policy, local_result_type
-                    >::call();
-            }
+            return call_sequential(policy, std::forward<Args>(args)...);
         }
 
+        template <typename Executor, typename... Args>
+        typename parallel::util::detail::algorithm_result<
+            sequential_task_execution_policy_shim<Executor>, local_result_type
+        >::type
+        call(sequential_task_execution_policy_shim<Executor> policy,
+            boost::mpl::true_, Args&&... args) const
+        {
+            return call_sequential(policy, std::forward<Args>(args)...);
+        }
+
+        ///////////////////////////////////////////////////////////////////////
         template <typename... Args>
         typename parallel::util::detail::algorithm_result<
             parallel_task_execution_policy, local_result_type
@@ -123,17 +149,17 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         call(parallel_task_execution_policy policy, boost::mpl::true_,
             Args&&... args) const
         {
-            try {
-                return parallel::util::detail::algorithm_result<
-                        parallel_task_execution_policy, local_result_type
-                    >::get(Derived::sequential(policy,
-                        std::forward<Args>(args)...));
-            }
-            catch (...) {
-                return detail::handle_exception<
-                        parallel_task_execution_policy, local_result_type
-                    >::call();
-            }
+            return call_sequential(policy, std::forward<Args>(args)...);
+        }
+
+        template <typename Executor, typename... Args>
+        typename parallel::util::detail::algorithm_result<
+            parallel_task_execution_policy_shim<Executor>, local_result_type
+        >::type
+        call(parallel_task_execution_policy_shim<Executor> policy,
+            boost::mpl::true_, Args&&... args) const
+        {
+            return call_sequential(policy, std::forward<Args>(args)...);
         }
 
         template <typename ExPolicy, typename... Args>

--- a/hpx/parallel/algorithms/detail/dispatch.hpp
+++ b/hpx/parallel/algorithms/detail/dispatch.hpp
@@ -15,7 +15,6 @@
 #include <hpx/util/invoke.hpp>
 #include <hpx/util/invoke_fused.hpp>
 #include <hpx/util/tuple.hpp>
-#include <hpx/util/void_guard.hpp>
 #include <hpx/parallel/exception_list.hpp>
 #include <hpx/parallel/execution_policy.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>

--- a/hpx/parallel/algorithms/detail/dispatch.hpp
+++ b/hpx/parallel/algorithms/detail/dispatch.hpp
@@ -63,7 +63,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         typename parallel::util::detail::algorithm_result<
             ExPolicy, local_result_type
         >::type
-        call(ExPolicy const& policy, boost::mpl::true_, Args&&... args) const
+        call(ExPolicy policy, boost::mpl::true_, Args&&... args) const
         {
             try {
                 return parallel::util::detail::algorithm_result<
@@ -79,7 +79,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         typename parallel::util::detail::algorithm_result<
             sequential_task_execution_policy, local_result_type
         >::type
-        operator()(sequential_task_execution_policy const& policy,
+        operator()(sequential_task_execution_policy policy,
             Args&&... args) const
         {
             try {
@@ -98,7 +98,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         typename parallel::util::detail::algorithm_result<
             sequential_task_execution_policy, local_result_type
         >::type
-        call(sequential_task_execution_policy const& policy, boost::mpl::true_,
+        call(sequential_task_execution_policy policy, boost::mpl::true_,
             Args&&... args) const
         {
             try {
@@ -120,7 +120,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         typename parallel::util::detail::algorithm_result<
             parallel_task_execution_policy, local_result_type
         >::type
-        call(parallel_task_execution_policy const& policy, boost::mpl::true_,
+        call(parallel_task_execution_policy policy, boost::mpl::true_,
             Args&&... args) const
         {
             try {
@@ -140,7 +140,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         typename parallel::util::detail::algorithm_result<
             ExPolicy, local_result_type
         >::type
-        call(ExPolicy const& policy, boost::mpl::false_, Args&&... args) const
+        call(ExPolicy policy, boost::mpl::false_, Args&&... args) const
         {
             return Derived::parallel(policy, std::forward<Args>(args)...);
         }
@@ -148,7 +148,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         ///////////////////////////////////////////////////////////////////////////
         template <typename... Args>
         local_result_type
-        call(parallel::execution_policy const& policy, boost::mpl::false_,
+        call(parallel::execution_policy policy, boost::mpl::false_,
             Args&&... args) const
         {
             // this implementation is not nice, however we don't have variadic
@@ -196,7 +196,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
 
         template <typename... Args>
         local_result_type
-        call(parallel::execution_policy const& policy, boost::mpl::true_,
+        call(parallel::execution_policy policy, boost::mpl::true_,
             Args&&... args) const
         {
             return call(seq, boost::mpl::true_(), std::forward<Args>(args)...);

--- a/hpx/parallel/algorithms/for_each.hpp
+++ b/hpx/parallel/algorithms/for_each.hpp
@@ -46,7 +46,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
             template <typename ExPolicy, typename F>
             static Iter
-            sequential(ExPolicy const&, Iter first, std::size_t count, F && f)
+            sequential(ExPolicy, Iter first, std::size_t count, F && f)
             {
                 return util::loop_n(first, count,
                     [f](Iter const& curr)
@@ -57,7 +57,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
             template <typename ExPolicy, typename F>
             static typename util::detail::algorithm_result<ExPolicy, Iter>::type
-            parallel(ExPolicy const& policy, Iter first, std::size_t count,
+            parallel(ExPolicy policy, Iter first, std::size_t count,
                 F && f)
             {
                 if (count != 0)
@@ -195,7 +195,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
             template <typename ExPolicy, typename InIter, typename F>
             static hpx::util::unused_type
-            sequential(ExPolicy const&, InIter first, InIter last, F && f)
+            sequential(ExPolicy, InIter first, InIter last, F && f)
             {
                 std::for_each(first, last, std::forward<F>(f));
                 return hpx::util::unused;
@@ -203,7 +203,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
             template <typename ExPolicy, typename FwdIter, typename F>
             static typename util::detail::algorithm_result<ExPolicy>::type
-            parallel(ExPolicy const& policy, FwdIter first, FwdIter last, F && f)
+            parallel(ExPolicy policy, FwdIter first, FwdIter last, F && f)
             {
                 typedef
                     typename util::detail::algorithm_result<ExPolicy>::type

--- a/hpx/parallel/exception_list.hpp
+++ b/hpx/parallel/exception_list.hpp
@@ -15,8 +15,14 @@
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
+    ///////////////////////////////////////////////////////////////////////////
+    // forward declarations, see execution_policy.hpp
     struct sequential_task_execution_policy;
+    template <typename Executor> struct sequential_task_execution_policy_shim;
+
     struct parallel_task_execution_policy;
+    template <typename Executor> struct parallel_task_execution_policy_shim;
+
     struct parallel_vector_execution_policy;
 
     namespace detail
@@ -25,6 +31,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         template <typename ExPolicy, typename Result = void>
         struct handle_exception
         {
+            typedef void type;
+
             HPX_ATTRIBUTE_NORETURN static void call()
             {
                 try {
@@ -44,6 +52,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         template <typename Result>
         struct handle_exception<sequential_task_execution_policy, Result>
         {
+            typedef future<Result> type;
+
             static future<Result> call()
             {
                 try {
@@ -60,14 +70,24 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     }
                 }
                 catch (...) {
-                    return hpx::make_exceptional_future<Result>(boost::current_exception());
+                    return hpx::make_exceptional_future<Result>(
+                        boost::current_exception());
                 }
             }
         };
 
+        template <typename Executor, typename Result>
+        struct handle_exception<
+                sequential_task_execution_policy_shim<Executor>, Result>
+          : handle_exception<sequential_task_execution_policy, Result>
+        {};
+
+        ///////////////////////////////////////////////////////////////////////
         template <typename Result>
         struct handle_exception<parallel_task_execution_policy, Result>
         {
+            typedef future<Result> type;
+
             static future<Result> call()
             {
                 try {
@@ -84,14 +104,24 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     }
                 }
                 catch (...) {
-                    return hpx::make_exceptional_future<Result>(boost::current_exception());
+                    return hpx::make_exceptional_future<Result>(
+                        boost::current_exception());
                 }
             }
         };
 
+        template <typename Executor, typename Result>
+        struct handle_exception<
+                parallel_task_execution_policy_shim<Executor>, Result>
+          : handle_exception<parallel_task_execution_policy, Result>
+        {};
+
+        ///////////////////////////////////////////////////////////////////////
         template <typename Result>
         struct handle_exception<parallel_vector_execution_policy, Result>
         {
+            typedef void type;
+
             HPX_ATTRIBUTE_NORETURN static void call()
             {
                 // any exceptions thrown by algorithms executed with the

--- a/hpx/parallel/execution_policy.hpp
+++ b/hpx/parallel/execution_policy.hpp
@@ -200,34 +200,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             return *this;
         }
 
-        /// Create a new sequential_task_execution_policy_shim from the given
-        /// executor
-        ///
-        /// \tparam Executor    The type of the executor to associate with this
-        ///                     execution policy.
-        ///
-        /// \param exec         [in] The executor to use for the
-        ///                     execution of the parallel algorithm the
-        ///                     returned execution policy is used with.
-        ///
-        /// \note Requires: is_executor<Executor>::value is true
-        ///
-        /// \returns The new parallel_task_execution_policy
-        ///
-        template <typename Executor_>
-        typename rebind_executor<
-            sequential_task_execution_policy, Executor_
-        >::type
-        on(Executor_& exec) const
-        {
-            BOOST_STATIC_ASSERT(is_executor<Executor_>::value);
-
-            typedef typename rebind_executor<
-                sequential_task_execution_policy, Executor_
-            >::type rebound_type;
-            return rebound_type(exec);
-        }
-
         /// Return the associated executor object.
         Executor& executor() { return exec_; }
         /// Return the associated executor object.
@@ -362,32 +334,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             return sequential_task_execution_policy_shim<Executor>(exec_);
         }
 
-        /// Create a new sequential_execution_policy_shim from the given
-        /// executor
-        ///
-        /// \tparam Executor    The type of the executor to associate with this
-        ///                     execution policy.
-        ///
-        /// \param exec         [in] The executor to use for the
-        ///                     execution of the parallel algorithm the
-        ///                     returned execution policy is used with.
-        ///
-        /// \note Requires: is_executor<Executor>::value is true
-        ///
-        /// \returns The new parallel_task_execution_policy
-        ///
-        template <typename Executor_>
-        typename rebind_executor<sequential_execution_policy, Executor_>::type
-        on(Executor_& exec) const
-        {
-            BOOST_STATIC_ASSERT(is_executor<Executor_>::value);
-
-            typedef typename rebind_executor<
-                sequential_execution_policy, Executor_
-            >::type rebound_type;
-            return rebound_type(exec);
-        }
-
         /// Return the associated executor object.
         Executor& executor() { return exec_; }
         /// Return the associated executor object.
@@ -395,6 +341,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
     private:
         /// \cond NOINTERNAL
+        friend struct sequential_execution_policy;
+
         sequential_execution_policy_shim(Executor& exec)
           : exec_(exec)
         {}
@@ -568,34 +516,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             return *this;
         }
 
-        /// Create a new sequential_task_execution_policy from the given
-        /// executor
-        ///
-        /// \tparam Executor    The type of the executor to associate with this
-        ///                     execution policy.
-        ///
-        /// \param exec         [in] The executor to use for the
-        ///                     execution of the parallel algorithm the
-        ///                     returned execution policy is used with.
-        ///
-        /// \note Requires: is_executor<Executor>::value is true
-        ///
-        /// \returns The new parallel_task_execution_policy
-        ///
-        template <typename Executor_>
-        typename rebind_executor<
-            parallel_task_execution_policy, Executor_
-        >::type
-        on(Executor_& exec) const
-        {
-            BOOST_STATIC_ASSERT(is_executor<Executor_>::value);
-
-            typedef typename rebind_executor<
-                parallel_task_execution_policy, Executor_
-            >::type rebound_type;
-            return rebound_type(exec, this->get_chunk_size());
-        }
-
         /// Return the associated executor object.
         Executor& executor() { return exec_; }
         /// Return the associated executor object.
@@ -762,27 +682,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             /// The type of the rebound execution policy
             typedef parallel_execution_policy_shim<Executor_> type;
         };
-
-        /// Create a new parallel_execution_policy referencing an executor and
-        /// a chunk size.
-        ///
-        /// \param exec         [in] The executor to use for the execution of
-        ///                     the parallel algorithm the returned execution
-        ///                     policy is used with
-        ///
-        /// \returns The new parallel_execution_policy
-        ///
-        template <typename Executor_>
-        typename rebind_executor<parallel_execution_policy, Executor_>::type
-        on(Executor_& exec) const
-        {
-            BOOST_STATIC_ASSERT(is_executor<Executor_>::value);
-
-            typedef typename rebind_executor<
-                parallel_execution_policy, Executor_
-            >::type rebound_type;
-            return rebound_type(exec, this->get_chunk_size());
-        }
 
         /// Create a new parallel_execution_policy_shim referencing a chunk size.
         ///

--- a/hpx/parallel/execution_policy.hpp
+++ b/hpx/parallel/execution_policy.hpp
@@ -1081,10 +1081,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     private:
         boost::shared_ptr<detail::execution_policy_base> inner_;
 
-        execution_policy(execution_policy const& rhs)
-          : inner_(rhs.inner_)
-        {}
-
     public:
         /// Effects: Constructs an execution_policy object with a copy of
         ///          exec's state
@@ -1106,6 +1102,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         /// \param policy Specifies the inner execution policy
         execution_policy(execution_policy && policy)
           : inner_(std::move(policy.inner_))
+        {}
+
+        execution_policy(execution_policy const& rhs)
+          : inner_(rhs.inner_)
         {}
 
         /// Extension: Create a new execution_policy holding the current policy

--- a/hpx/parallel/executors/sequential_executor.hpp
+++ b/hpx/parallel/executors/sequential_executor.hpp
@@ -73,7 +73,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         >::type>
         async_execute(F && f)
         {
-            return hpx::async(hpx::launch::deferred, std::forward<F>(f));
+            return hpx::async(launch::deferred, std::forward<F>(f));
         }
 
         template <typename F, typename Shape>

--- a/hpx/parallel/util/foreach_partitioner.hpp
+++ b/hpx/parallel/util/foreach_partitioner.hpp
@@ -35,7 +35,7 @@ namespace hpx { namespace parallel { namespace util
         struct foreach_n_static_partitioner
         {
             template <typename FwdIter, typename F1>
-            static FwdIter call(ExPolicy const& policy, FwdIter first,
+            static FwdIter call(ExPolicy policy, FwdIter first,
                 std::size_t count, F1 && f1, std::size_t chunk_size)
             {
                 std::vector<hpx::future<Result> > workitems;
@@ -83,7 +83,7 @@ namespace hpx { namespace parallel { namespace util
         struct foreach_n_static_partitioner<parallel_task_execution_policy, Result>
         {
             template <typename ExPolicy, typename FwdIter, typename F1>
-            static hpx::future<FwdIter> call(ExPolicy const& policy,
+            static hpx::future<FwdIter> call(ExPolicy policy,
                 FwdIter first, std::size_t count, F1 && f1,
                 std::size_t chunk_size)
             {
@@ -152,7 +152,7 @@ namespace hpx { namespace parallel { namespace util
             parallel::traits::static_partitioner_tag>
         {
             template <typename FwdIter, typename F1>
-            static FwdIter call(ExPolicy const& policy, FwdIter first,
+            static FwdIter call(ExPolicy policy, FwdIter first,
                 std::size_t count, F1 && f1, std::size_t chunk_size = 0)
             {
                 return foreach_n_static_partitioner<ExPolicy, Result>::call(
@@ -165,7 +165,7 @@ namespace hpx { namespace parallel { namespace util
                 parallel::traits::static_partitioner_tag>
         {
             template <typename ExPolicy, typename FwdIter, typename F1>
-            static hpx::future<FwdIter> call(ExPolicy const& policy,
+            static hpx::future<FwdIter> call(ExPolicy policy,
                 FwdIter first, std::size_t count, F1 && f1,
                 std::size_t chunk_size = 0)
             {
@@ -174,10 +174,28 @@ namespace hpx { namespace parallel { namespace util
             }
         };
 
-        template <typename Executor, typename Result, typename Tag>
+        template <typename Executor, typename Result>
         struct foreach_n_partitioner<
-                parallel_task_execution_policy_shim<Executor>, Result, Tag>
-          : foreach_n_partitioner<parallel_task_execution_policy, Result, Tag>
+                parallel_task_execution_policy_shim<Executor>, Result,
+                parallel::traits::static_partitioner_tag>
+          : foreach_n_partitioner<parallel_task_execution_policy, Result,
+                parallel::traits::static_partitioner_tag>
+        {};
+
+        template <typename Executor, typename Result>
+        struct foreach_n_partitioner<
+                parallel_task_execution_policy_shim<Executor>, Result,
+                parallel::traits::auto_partitioner_tag>
+          : foreach_n_partitioner<parallel_task_execution_policy, Result,
+                parallel::traits::auto_partitioner_tag>
+        {};
+
+        template <typename Executor, typename Result>
+        struct foreach_n_partitioner<
+                parallel_task_execution_policy_shim<Executor>, Result,
+                parallel::traits::default_partitioner_tag>
+          : foreach_n_partitioner<parallel_task_execution_policy, Result,
+                parallel::traits::static_partitioner_tag>
         {};
 
         ///////////////////////////////////////////////////////////////////////

--- a/tests/unit/parallel/algorithms/CMakeLists.txt
+++ b/tests/unit/parallel/algorithms/CMakeLists.txt
@@ -25,6 +25,7 @@ set(tests
     findif
     findifnot
     foreach
+    foreach_executors
     foreachn
     generate
     generaten

--- a/tests/unit/parallel/algorithms/foreach.cpp
+++ b/tests/unit/parallel/algorithms/foreach.cpp
@@ -5,68 +5,10 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/include/parallel_for_each.hpp>
-#include <hpx/util/lightweight_test.hpp>
 
-#include <boost/range/functions.hpp>
-
-#include "test_utils.hpp"
+#include "foreach_tests.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
-template <typename ExPolicy, typename IteratorTag>
-void test_for_each(ExPolicy && policy, IteratorTag)
-{
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
-
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    std::vector<std::size_t> c(10007);
-    std::iota(boost::begin(c), boost::end(c), std::rand());
-
-    hpx::parallel::for_each(std::forward<ExPolicy>(policy),
-        iterator(boost::begin(c)), iterator(boost::end(c)),
-        [](std::size_t& v) {
-            v = 42;
-        });
-
-    // verify values
-    std::size_t count = 0;
-    std::for_each(boost::begin(c), boost::end(c),
-        [&count](std::size_t v) -> void {
-            HPX_TEST_EQ(v, std::size_t(42));
-            ++count;
-        });
-    HPX_TEST_EQ(count, c.size());
-}
-
-template <typename ExPolicy, typename IteratorTag>
-void test_for_each_async(ExPolicy && p, IteratorTag)
-{
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    std::vector<std::size_t> c(10007);
-    std::iota(boost::begin(c), boost::end(c), std::rand());
-
-    hpx::future<void> f =
-        hpx::parallel::for_each(std::forward<ExPolicy>(p),
-            iterator(boost::begin(c)), iterator(boost::end(c)),
-            [](std::size_t& v) {
-                v = 42;
-            });
-    f.wait();
-
-    // verify values
-    std::size_t count = 0;
-    std::for_each(boost::begin(c), boost::end(c),
-        [&count](std::size_t v) -> void {
-            HPX_TEST_EQ(v, std::size_t(42));
-            ++count;
-        });
-    HPX_TEST_EQ(count, c.size());
-}
-
 template <typename IteratorTag>
 void test_for_each()
 {
@@ -87,30 +29,6 @@ void test_for_each()
     test_for_each(execution_policy(par(task)), IteratorTag());
 }
 
-// template <typename IteratorTag>
-// void test_for_each_exec()
-// {
-//     using namespace hpx::parallel;
-//
-//     {
-//         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_for_each(par(exec), IteratorTag());
-//     }
-//     {
-//         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_for_each(task(exec), IteratorTag());
-//     }
-//
-//     {
-//         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_for_each(execution_policy(par(exec)), IteratorTag());
-//     }
-//     {
-//         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_for_each(execution_policy(task(exec)), IteratorTag());
-//     }
-// }
-
 void for_each_test()
 {
     test_for_each<std::random_access_iterator_tag>();
@@ -123,69 +41,6 @@ void for_each_test()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-template <typename ExPolicy, typename IteratorTag>
-void test_for_each_exception(ExPolicy && policy, IteratorTag)
-{
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
-
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    std::vector<std::size_t> c(10007);
-    std::iota(boost::begin(c), boost::end(c), std::rand());
-
-    bool caught_exception = false;
-    try {
-        hpx::parallel::for_each(std::forward<ExPolicy>(policy),
-            iterator(boost::begin(c)), iterator(boost::end(c)),
-            [](std::size_t& v) { throw std::runtime_error("test"); });
-
-        HPX_TEST(false);
-    }
-    catch(hpx::exception_list const& e) {
-        caught_exception = true;
-        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
-    }
-    catch(...) {
-        HPX_TEST(false);
-    }
-
-    HPX_TEST(caught_exception);
-}
-
-template <typename ExPolicy, typename IteratorTag>
-void test_for_each_exception_async(ExPolicy && p, IteratorTag)
-{
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    std::vector<std::size_t> c(10007);
-    std::iota(boost::begin(c), boost::end(c), std::rand());
-
-    bool caught_exception = false;
-    bool returned_from_algorithm = false;
-    try {
-        hpx::future<void> f =
-            hpx::parallel::for_each(std::forward<ExPolicy>(p),
-                iterator(boost::begin(c)), iterator(boost::end(c)),
-                [](std::size_t& v) { throw std::runtime_error("test"); });
-        returned_from_algorithm = true;
-        f.get();
-
-        HPX_TEST(false);
-    }
-    catch(hpx::exception_list const& e) {
-        caught_exception = true;
-        test::test_num_exceptions<ExPolicy, IteratorTag>::call(p, e);
-    }
-    catch(...) {
-        HPX_TEST(false);
-    }
-
-    HPX_TEST(caught_exception);
-    HPX_TEST(returned_from_algorithm);
-}
-
 template <typename IteratorTag>
 void test_for_each_exception()
 {
@@ -214,67 +69,6 @@ void for_each_exception_test()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-template <typename ExPolicy, typename IteratorTag>
-void test_for_each_bad_alloc(ExPolicy && policy, IteratorTag)
-{
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
-
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    std::vector<std::size_t> c(10007);
-    std::iota(boost::begin(c), boost::end(c), std::rand());
-
-    bool caught_exception = false;
-    try {
-        hpx::parallel::for_each(std::forward<ExPolicy>(policy),
-            iterator(boost::begin(c)), iterator(boost::end(c)),
-            [](std::size_t& v) { throw std::bad_alloc(); });
-
-        HPX_TEST(false);
-    }
-    catch(std::bad_alloc const&) {
-        caught_exception = true;
-    }
-    catch(...) {
-        HPX_TEST(false);
-    }
-
-    HPX_TEST(caught_exception);
-}
-
-template <typename ExPolicy, typename IteratorTag>
-void test_for_each_bad_alloc_async(ExPolicy && p, IteratorTag)
-{
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    std::vector<std::size_t> c(10007);
-    std::iota(boost::begin(c), boost::end(c), std::rand());
-
-    bool caught_exception = false;
-    bool returned_from_algorithm = false;
-    try {
-        hpx::future<void> f =
-            hpx::parallel::for_each(std::forward<ExPolicy>(p),
-                iterator(boost::begin(c)), iterator(boost::end(c)),
-                [](std::size_t& v) { throw std::bad_alloc(); });
-        returned_from_algorithm = true;
-        f.get();
-
-        HPX_TEST(false);
-    }
-    catch(std::bad_alloc const&) {
-        caught_exception = true;
-    }
-    catch(...) {
-        HPX_TEST(false);
-    }
-
-    HPX_TEST(caught_exception);
-    HPX_TEST(returned_from_algorithm);
-}
-
 template <typename IteratorTag>
 void test_for_each_bad_alloc()
 {
@@ -302,50 +96,6 @@ void for_each_bad_alloc_test()
     test_for_each_bad_alloc<std::input_iterator_tag>();
 }
 
-////////////////////////////////////////////////////////////////////////////////
-template <typename ExPolicy>
-void test_executors(ExPolicy && policy)
-{
-    using iterator_tag = std::random_access_iterator_tag;
-
-    test_for_each(std::forward<ExPolicy>(policy), iterator_tag());
-    test_for_each_exception(std::forward<ExPolicy>(policy), iterator_tag());
-    test_for_each_bad_alloc(std::forward<ExPolicy>(policy), iterator_tag());
-}
-
-template <typename ExPolicy>
-void test_executors_async(ExPolicy && p)
-{
-    using iterator_tag = std::random_access_iterator_tag;
-
-    test_for_each_async(std::forward<ExPolicy>(p), iterator_tag());
-    test_for_each_exception_async(
-        std::forward<ExPolicy>(p), iterator_tag());
-    test_for_each_bad_alloc_async(
-        std::forward<ExPolicy>(p), iterator_tag());
-}
-
-void for_each_executors_test()
-{
-    using namespace hpx::parallel;
-    {
-        parallel_executor exec;
-
-        test_executors(par.on(exec));
-        test_executors_async(par(task).on(exec));
-    }
-
-    {
-        sequential_executor exec;
-
-        test_executors(seq.on(exec));
-        test_executors_async(seq(task).on(exec));
-
-        test_executors(par.on(exec));
-        test_executors_async(par(task).on(exec));
-    }
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
@@ -359,7 +109,6 @@ int hpx_main(boost::program_options::variables_map& vm)
     for_each_test();
     for_each_exception_test();
     for_each_bad_alloc_test();
-    for_each_executors_test();
     return hpx::finalize();
 }
 

--- a/tests/unit/parallel/algorithms/foreach_executors.cpp
+++ b/tests/unit/parallel/algorithms/foreach_executors.cpp
@@ -14,9 +14,9 @@ void test_executors(ExPolicy && policy)
 {
     using iterator_tag = std::random_access_iterator_tag;
 
+    test_for_each_exception(policy, iterator_tag());
+    test_for_each_bad_alloc(policy, iterator_tag());
     test_for_each(std::forward<ExPolicy>(policy), iterator_tag());
-    test_for_each_exception(std::forward<ExPolicy>(policy), iterator_tag());
-    test_for_each_bad_alloc(std::forward<ExPolicy>(policy), iterator_tag());
 }
 
 template <typename ExPolicy>
@@ -24,11 +24,9 @@ void test_executors_async(ExPolicy && p)
 {
     using iterator_tag = std::random_access_iterator_tag;
 
+    test_for_each_exception_async(p, iterator_tag());
+    test_for_each_bad_alloc_async(p, iterator_tag());
     test_for_each_async(std::forward<ExPolicy>(p), iterator_tag());
-    test_for_each_exception_async(
-        std::forward<ExPolicy>(p), iterator_tag());
-    test_for_each_bad_alloc_async(
-        std::forward<ExPolicy>(p), iterator_tag());
 }
 
 void for_each_executors_test()

--- a/tests/unit/parallel/algorithms/foreach_executors.cpp
+++ b/tests/unit/parallel/algorithms/foreach_executors.cpp
@@ -1,0 +1,117 @@
+//  Copyright (c) 2015 Daniel Bourgeois
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+
+#include "foreach_tests.hpp"
+
+// template <typename IteratorTag>
+// void test_for_each_exec()
+// {
+//     using namespace hpx::parallel;
+//
+//     {
+//         hpx::threads::executors::local_priority_queue_executor exec;
+//         test_for_each(par(exec), IteratorTag());
+//     }
+//     {
+//         hpx::threads::executors::local_priority_queue_executor exec;
+//         test_for_each(task(exec), IteratorTag());
+//     }
+//
+//     {
+//         hpx::threads::executors::local_priority_queue_executor exec;
+//         test_for_each(execution_policy(par(exec)), IteratorTag());
+//     }
+//     {
+//         hpx::threads::executors::local_priority_queue_executor exec;
+//         test_for_each(execution_policy(task(exec)), IteratorTag());
+//     }
+// }
+
+
+////////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy>
+void test_executors(ExPolicy && policy)
+{
+    using iterator_tag = std::random_access_iterator_tag;
+
+    test_for_each(std::forward<ExPolicy>(policy), iterator_tag());
+    test_for_each_exception(std::forward<ExPolicy>(policy), iterator_tag());
+    test_for_each_bad_alloc(std::forward<ExPolicy>(policy), iterator_tag());
+}
+
+template <typename ExPolicy>
+void test_executors_async(ExPolicy && p)
+{
+    using iterator_tag = std::random_access_iterator_tag;
+
+    test_for_each_async(std::forward<ExPolicy>(p), iterator_tag());
+    test_for_each_exception_async(
+        std::forward<ExPolicy>(p), iterator_tag());
+    test_for_each_bad_alloc_async(
+        std::forward<ExPolicy>(p), iterator_tag());
+}
+
+void for_each_executors_test()
+{
+    using namespace hpx::parallel;
+    {
+        parallel_executor exec;
+
+        test_executors(par.on(exec));
+        test_executors_async(par(task).on(exec));
+    }
+
+    {
+        sequential_executor exec;
+
+        test_executors(seq.on(exec));
+//ERROR FROM BELOW, not handline errors correctly
+        test_executors_async(seq(task).on(exec));
+
+        test_executors(par.on(exec));
+        test_executors_async(par(task).on(exec));
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int)std::time(0);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    for_each_executors_test();
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace boost::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()
+        ("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run")
+        ;
+
+    // By default this test should run on all available cores
+    std::vector<std::string> cfg;
+    cfg.push_back("hpx.os_threads=" +
+        boost::lexical_cast<std::string>(hpx::threads::hardware_concurrency()));
+
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/parallel/algorithms/foreach_executors.cpp
+++ b/tests/unit/parallel/algorithms/foreach_executors.cpp
@@ -8,31 +8,6 @@
 
 #include "foreach_tests.hpp"
 
-// template <typename IteratorTag>
-// void test_for_each_exec()
-// {
-//     using namespace hpx::parallel;
-//
-//     {
-//         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_for_each(par(exec), IteratorTag());
-//     }
-//     {
-//         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_for_each(task(exec), IteratorTag());
-//     }
-//
-//     {
-//         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_for_each(execution_policy(par(exec)), IteratorTag());
-//     }
-//     {
-//         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_for_each(execution_policy(task(exec)), IteratorTag());
-//     }
-// }
-
-
 ////////////////////////////////////////////////////////////////////////////////
 template <typename ExPolicy>
 void test_executors(ExPolicy && policy)
@@ -59,6 +34,7 @@ void test_executors_async(ExPolicy && p)
 void for_each_executors_test()
 {
     using namespace hpx::parallel;
+
     {
         parallel_executor exec;
 
@@ -70,7 +46,6 @@ void for_each_executors_test()
         sequential_executor exec;
 
         test_executors(seq.on(exec));
-//ERROR FROM BELOW, not handline errors correctly
         test_executors_async(seq(task).on(exec));
 
         test_executors(par.on(exec));

--- a/tests/unit/parallel/algorithms/foreach_tests.hpp
+++ b/tests/unit/parallel/algorithms/foreach_tests.hpp
@@ -1,0 +1,197 @@
+//  Copyright (c) 2014 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_TEST_FOREACH_MAY26_15_1414)
+#define HPX_PARALLEL_TEST_FOREACH_MAY26_15_1414
+
+#include <hpx/include/parallel_for_each.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <boost/range/functions.hpp>
+
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_for_each(ExPolicy && policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    hpx::parallel::for_each(std::forward<ExPolicy>(policy),
+        iterator(boost::begin(c)), iterator(boost::end(c)),
+        [](std::size_t& v) {
+            v = 42;
+        });
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(boost::begin(c), boost::end(c),
+        [&count](std::size_t v) -> void {
+            HPX_TEST_EQ(v, std::size_t(42));
+            ++count;
+        });
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_for_each_async(ExPolicy && p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    hpx::future<void> f =
+        hpx::parallel::for_each(std::forward<ExPolicy>(p),
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            [](std::size_t& v) {
+                v = 42;
+            });
+    f.wait();
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(boost::begin(c), boost::end(c),
+        [&count](std::size_t v) -> void {
+            HPX_TEST_EQ(v, std::size_t(42));
+            ++count;
+        });
+    HPX_TEST_EQ(count, c.size());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_for_each_exception(ExPolicy policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_exception = false;
+    try {
+        hpx::parallel::for_each(policy,
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            [](std::size_t& v) { throw std::runtime_error("test"); });
+
+        HPX_TEST(false);
+    }
+    catch(hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_for_each_exception_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try {
+        hpx::future<void> f =
+            hpx::parallel::for_each(p,
+                iterator(boost::begin(c)), iterator(boost::end(c)),
+                [](std::size_t& v) { throw std::runtime_error("test"); });
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(p, e);
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_for_each_bad_alloc(ExPolicy policy, IteratorTag)
+{
+    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_exception = false;
+    try {
+        hpx::parallel::for_each(policy,
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            [](std::size_t& v) { throw std::bad_alloc(); });
+
+        HPX_TEST(false);
+    }
+    catch(std::bad_alloc const&) {
+        caught_exception = true;
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_for_each_bad_alloc_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try {
+        hpx::future<void> f =
+            hpx::parallel::for_each(p,
+                iterator(boost::begin(c)), iterator(boost::end(c)),
+                [](std::size_t& v) { throw std::bad_alloc(); });
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(std::bad_alloc const&) {
+        caught_exception = true;
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+#endif


### PR DESCRIPTION
-Integrated for_each with executors
-removed .on() functionality from 'shims'