### PR TITLE
Adding configuration option disabling/enabling all message handlers 

### DIFF
--- a/docs/manual/config_defaults.qbk
+++ b/docs/manual/config_defaults.qbk
@@ -235,6 +235,7 @@ sections, one for each component.
     zero_copy_optimization = ${HPX_PARCEL_ZERO_COPY_OPTIMIZATION:$[hpx.parcel.array_optimization]}
     async_serialization = ${HPX_PARCEL_ASYNC_SERIALIZATION:1}
     enable_security = ${HPX_PARCEL_ENABLE_SECURITY:0}
+    message_handlers = ${HPX_PARCEL_MESSAGE_HANDLERS:0}
 ``
 [c++]
 
@@ -287,6 +288,9 @@ sections, one for each component.
       default is `1`.]]
     [[`hpx.parcel.enable_security`]
      [This property defines whether this locality is encrypting parcels. The
+      default is `0`.]]
+    [[`hpx.parcel.message_handlers`]
+     [This property defines whether message handlers are loaded. The
       default is `0`.]]
 ]
 

--- a/hpx/runtime/parcelset/parcelhandler.hpp
+++ b/hpx/runtime/parcelset/parcelhandler.hpp
@@ -506,6 +506,7 @@ namespace hpx { namespace parcelset
         /// Store message handlers for actions
         mutex_type handlers_mtx_;
         message_handler_map handlers_;
+        bool const load_message_handlers_;
 
         /// Count number of (outbound) parcels routed
         boost::atomic<boost::int64_t> count_routed_;

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -103,6 +103,9 @@ namespace hpx { namespace parcelset
         parcels_(policy),
         use_alternative_parcelports_(false),
         enable_parcel_handling_(true),
+        load_message_handlers_(
+            util::get_entry_as<int>(cfg, "hpx.parcel.message_handlers", "0") != 0
+        ),
         count_routed_(0),
         write_handler_(&parcelhandler::default_write_handler)
     {
@@ -424,8 +427,8 @@ namespace hpx { namespace parcelset
 
         // If we were able to resolve the address(es) locally we send the
         // parcel directly to the destination.
-        if (resolved_locally) {
-
+        if (resolved_locally)
+        {
             // re-wrap the given parcel-sent handler
             using util::placeholders::_1;
             write_handler_type wrapped_f =
@@ -435,12 +438,16 @@ namespace hpx { namespace parcelset
             // encapsulated action
             typedef std::pair<boost::shared_ptr<parcelport>, locality> destination_pair;
             destination_pair dest = find_appropriate_destination(addrs[0].locality_);
-            policies::message_handler* mh =
-                p.get_message_handler(this, dest.second);
 
-            if (mh) {
-                mh->put_parcel(dest.second, p, wrapped_f);
-                return;
+            if (load_message_handlers_)
+            {
+                policies::message_handler* mh =
+                    p.get_message_handler(this, dest.second);
+
+                if (mh) {
+                    mh->put_parcel(dest.second, p, wrapped_f);
+                    return;
+                }
             }
 
             dest.first->put_parcel(dest.second, p, wrapped_f);
@@ -1183,7 +1190,8 @@ namespace hpx { namespace parcelset
             "zero_copy_optimization = ${HPX_PARCEL_ZERO_COPY_OPTIMIZATION:"
                 "$[hpx.parcel.array_optimization]}",
             "enable_security = ${HPX_PARCEL_ENABLE_SECURITY:0}",
-            "async_serialization = ${HPX_PARCEL_ASYNC_SERIALIZATION:1}"
+            "async_serialization = ${HPX_PARCEL_ASYNC_SERIALIZATION:1}",
+            "message_handlers = ${HPX_PARCEL_MESSAGE_HANDLERS:0}"
             ;
 
         for (plugins::parcelport_factory_base* factory : get_parcelport_factories())


### PR DESCRIPTION
By default message handlers are now disabled (use `-Ihpx.parcel.message_handlers=1` to enable)