### PR TITLE
Mark decltype support as required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -730,7 +730,11 @@ hpx_check_for_cxx11_constexpr(
   DEFINITIONS HPX_HAVE_CXX11_CONSTEXPR)
 
 hpx_check_for_cxx11_decltype(
-  DEFINITIONS HPX_HAVE_CXX11_DECLTYPE BOOST_RESULT_OF_USE_DECLTYPE)
+  REQUIRED "HPX needs support for C++11 decltype")
+hpx_add_config_define(BOOST_RESULT_OF_USE_DECLTYPE)
+
+hpx_check_for_cxx11_decltype_n3276(
+  DEFINITIONS HPX_HAVE_CXX11_DECLTYPE_N3276)
 
 hpx_check_for_cxx11_defaulted_functions(
   DEFINITIONS HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS)

--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -140,6 +140,13 @@ macro(hpx_check_for_cxx11_decltype)
 endmacro()
 
 ###############################################################################
+macro(hpx_check_for_cxx11_decltype_n3276)
+  add_hpx_config_test(HPX_WITH_CXX11_DECLTYPE_N3276
+    SOURCE cmake/tests/cxx11_decltype_n3276.cpp
+    FILE ${ARGN})
+endmacro()
+
+###############################################################################
 macro(hpx_check_for_cxx11_defaulted_functions)
   add_hpx_config_test(HPX_WITH_CXX11_DEFAULTED_FUNCTIONS
     SOURCE cmake/tests/cxx11_defaulted_functions.cpp

--- a/cmake/tests/cxx11_decltype_n3276.cpp
+++ b/cmake/tests/cxx11_decltype_n3276.cpp
@@ -1,0 +1,24 @@
+////////////////////////////////////////////////////////////////////////////////
+//  Copyright (c) 2008 Beman Dawes
+//  Copyright (c) 2015 Agustin Berge
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename T> struct is_int { static const bool value = false; };
+template <> struct is_int<int> { static const bool value = true; };
+
+template <typename T>
+struct instantiation_guard
+{
+    int check_not_instantiated[!is_int<T>::value ? 1 : -1];
+};
+
+template <typename T>
+instantiation_guard<T> f(T) { return instantiation_guard<T>{}; }
+
+int main()
+{
+    typedef decltype(f(0)) result_type;
+}


### PR DESCRIPTION
Add config macro for optional N3276 decltype support