### PR TITLE
Reimplement decay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -791,7 +791,7 @@ hpx_check_for_cxx11_std_unique_ptr(
   REQUIRED "HPX needs support for C++11 std::unique_ptr")
 
 hpx_check_for_cxx11_std_type_traits(
-  DEFINITIONS HPX_HAVE_CXX11_STD_TYPE_TRAITS)
+  REQUIRED "HPX needs support for C++11 basic type traits")
 
 # Check the availability of certain C++14 language features
 hpx_check_for_cxx14_constexpr(

--- a/hpx/util/decay.hpp
+++ b/hpx/util/decay.hpp
@@ -7,36 +7,17 @@
 #ifndef HPX_UTIL_DECAY_HPP
 #define HPX_UTIL_DECAY_HPP
 
-#include <boost/mpl/eval_if.hpp>
-#include <boost/mpl/identity.hpp>
+#include <hpx/config.hpp>
+
 #include <boost/ref.hpp>
-#include <boost/type_traits/config.hpp>
-#include <boost/type_traits/is_array.hpp>
-#include <boost/type_traits/is_function.hpp>
-#include <boost/type_traits/remove_bounds.hpp>
-#include <boost/type_traits/add_pointer.hpp>
-#include <boost/type_traits/remove_cv.hpp>
-#include <boost/type_traits/remove_reference.hpp>
+
+#include <functional>
+#include <type_traits>
 
 namespace hpx { namespace util
 {
     template <typename T>
-    struct decay
-    {
-        typedef typename boost::remove_reference<T>::type Ty;
-
-        typedef
-            typename boost::mpl::eval_if<
-                boost::is_array<Ty>
-              , boost::mpl::identity<typename boost::remove_bounds<Ty>::type *>
-              , typename boost::mpl::eval_if<
-                    boost::is_function<Ty>
-                  , boost::add_pointer<Ty>
-                  , boost::remove_cv<Ty>
-                >
-            >::type
-            type;
-    };
+    struct decay : std::decay<T> {};
 
     namespace detail
     {
@@ -47,7 +28,13 @@ namespace hpx { namespace util
         };
 
         template <typename X>
-        struct decay_unwrap_impl<boost::reference_wrapper<X> >
+        struct decay_unwrap_impl< ::boost::reference_wrapper<X> >
+        {
+            typedef X& type;
+        };
+
+        template <typename X>
+        struct decay_unwrap_impl< ::std::reference_wrapper<X> >
         {
             typedef X& type;
         };


### PR DESCRIPTION
Reimplement decay on top of `std::decay`, add support for decay-unwrapping std::[c]refs