### PR TITLE
Fixing thread pool executor

### DIFF
--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -317,10 +317,11 @@ namespace detail
             boost::unique_lock<mutex_type> l(this->mtx_);
 
             if (is_ready_locked()) {
-                // invoke the callback (continuation) function right away
-                l.unlock();
 
                 HPX_ASSERT(!on_completed_);
+
+                // invoke the callback (continuation) function right away
+                l.unlock();
 
                 data_sink();
             }

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -404,7 +404,8 @@ namespace hpx { namespace threads { namespace detail
                 if (scheduler.SchedulingPolicy::wait_or_add_new(num_thread,
                         is_running_state(global_state.load()), idle_loop_count))
                 {
-                    break;
+                    if (scheduler.SchedulingPolicy::cleanup_terminated(true))
+                        break;
                 }
 
                 // do background work in parcel layer and in agas

--- a/hpx/runtime/threads/executors/thread_pool_executors.hpp
+++ b/hpx/runtime/threads/executors/thread_pool_executors.hpp
@@ -108,6 +108,9 @@ namespace hpx { namespace threads { namespace executors
             // resource manager registration
             std::size_t cookie_;
 
+            // store the self reference to the HPX running this scheduler
+            std::vector<threads::thread_self*> self_;
+
             // protect scheduler initialization
             typedef lcos::local::spinlock mutex_type;
             mutex_type mtx_;

--- a/hpx/runtime/threads/executors/thread_pool_executors.hpp
+++ b/hpx/runtime/threads/executors/thread_pool_executors.hpp
@@ -80,6 +80,9 @@ namespace hpx { namespace threads { namespace executors
             // Remove the given processing unit from the scheduler.
             void remove_processing_unit(std::size_t thread_num, error_code& ec);
 
+            // give invoking context a chance to catch up with its tasks
+            void suspend_back_into_calling_context(std::size_t virt_core);
+
         private:
             // internal run method
             void run(std::size_t virt_core, std::size_t num_thread);
@@ -104,6 +107,10 @@ namespace hpx { namespace threads { namespace executors
 
             // resource manager registration
             std::size_t cookie_;
+
+            // protect scheduler initialization
+            typedef lcos::local::spinlock mutex_type;
+            mutex_type mtx_;
         };
     }
 

--- a/hpx/state.hpp
+++ b/hpx/state.hpp
@@ -24,11 +24,12 @@ namespace hpx
         state_pre_main = 3,
         state_starting = 4,
         state_running = 5,
-        state_pre_shutdown = 6,
-        state_shutdown = 7,
-        state_stopping    = 8,
-        state_terminating = 9,
-        state_stopped = 10,
+        state_suspended = 6,
+        state_pre_shutdown = 7,
+        state_shutdown = 8,
+        state_stopping = 9,
+        state_terminating = 10,
+        state_stopped = 11,
         last_valid_runtime_state = state_stopped
     };
 
@@ -36,7 +37,6 @@ namespace hpx
     {
         // return whether thread manager is in the state described by 'mask'
         HPX_EXPORT bool threadmanager_is(state st);
-
     }
 
     namespace agas

--- a/hpx/util/coroutine/coroutine.hpp
+++ b/hpx/util/coroutine/coroutine.hpp
@@ -269,7 +269,7 @@ namespace hpx { namespace util { namespace coroutines
       HPX_ASSERT(m_pimpl);
       HPX_ASSERT(m_pimpl->is_ready());
 
-      result_type* ptr;
+      result_type* ptr = 0;
       m_pimpl->bind_args(&arg0);
       m_pimpl->bind_result_pointer(&ptr);
 

--- a/hpx/util/coroutine/detail/self.hpp
+++ b/hpx/util/coroutine/detail/self.hpp
@@ -122,6 +122,7 @@ namespace hpx { namespace util { namespace coroutines { namespace detail
       HPX_ASSERT(m_pimpl);
 
       this->m_pimpl->bind_result(&arg0);
+
       {
         reset_self_on_exit on_exit(this);
         this->m_pimpl->yield();

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -194,11 +194,12 @@ namespace hpx
             "state_pre_main",     // 3
             "state_starting",     // 4
             "state_running",      // 5
-            "state_pre_shutdown"  // 6
-            "state_shutdown",     // 7
-            "state_stopping",     // 8
-            "state_terminating",  // 9
-            "state_stopped"       // 10
+            "state_suspended",    // 6
+            "state_pre_shutdown"  // 7
+            "state_shutdown",     // 8
+            "state_stopping",     // 9
+            "state_terminating",  // 10
+            "state_stopped"       // 11
         };
     }
 

--- a/src/runtime/threads/thread_data.cpp
+++ b/src/runtime/threads/thread_data.cpp
@@ -166,6 +166,14 @@ namespace hpx { namespace threads
         return thread_self::impl_type::get_self();
     }
 
+    namespace detail
+    {
+        void set_self_ptr(thread_self* self)
+        {
+            thread_self::impl_type::set_self(self);
+        }
+    }
+
     thread_self::impl_type* get_ctx_ptr()
     {
         return hpx::util::coroutines::detail::coroutine_accessor::get_impl(get_self());

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -145,7 +145,8 @@ namespace hpx { namespace util
             std::size_t num_localities)
         {
             std::size_t batch_localities = env.retrieve_number_of_localities();
-            if (num_localities == 1)
+            if (num_localities == 1 &&
+                batch_localities != std::size_t(batch_localities))
             {
                 std::size_t cfg_num_localities = cfgmap.get_value<std::size_t>(
                     "hpx.localities", batch_localities);

--- a/tests/unit/lcos/promise.cpp
+++ b/tests/unit/lcos/promise.cpp
@@ -201,8 +201,8 @@ int hpx_main(boost::program_options::variables_map&)
         bool caught_exception = false;
 
         try {
+            p.get();      // guarantee for callback to have finished executing
             f.get();      // throws
-            p.get();
             HPX_TEST(false);
         }
         catch (std::exception const& e) {

--- a/tests/unit/threads/CMakeLists.txt
+++ b/tests/unit/threads/CMakeLists.txt
@@ -13,6 +13,7 @@ set(tests
     thread_mf
     thread_stacksize
     thread_suspension_executor
+    thread_yield
    )
 
 if(HPX_HAVE_THREAD_LOCAL_STORAGE)

--- a/tests/unit/threads/thread_suspension_executor.cpp
+++ b/tests/unit/threads/thread_suspension_executor.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2007-2013 Hartmut Kaiser
+// Copyright (C) 2007-2015 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -13,29 +13,78 @@
 #include <boost/assign/std/vector.hpp>
 #include <boost/lexical_cast.hpp>
 
-void test_executor_association()
+#include <vector>
+
+#define NUM_SUSPEND_TESTS 1000
+#define NUM_YIELD_TESTS 1000
+
+///////////////////////////////////////////////////////////////////////////////
+void test_executor_association_yield()
 {
     hpx::threads::thread_id_type id = hpx::threads::get_self_id();
     hpx::threads::executor exec_before = hpx::threads::get_executor(id);
 
-    hpx::this_thread::suspend();
+    for (int i = 0; i != NUM_YIELD_TESTS; ++i)
+    {
+        hpx::this_thread::yield();
 
-    hpx::threads::executor exec_after = hpx::threads::get_executor(id);
-    HPX_TEST_EQ(exec_before, exec_after);
+        hpx::threads::executor exec_after = hpx::threads::get_executor(id);
+        HPX_TEST_EQ(exec_before, exec_after);
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void wakeup_thread(hpx::threads::thread_id_type id)
+{
+    hpx::threads::set_thread_state(id, hpx::threads::pending);
+}
+
+void test_executor_association_suspend()
+{
+    hpx::threads::thread_id_type id = hpx::threads::get_self_id();
+    hpx::threads::executor exec_before = hpx::threads::get_executor(id);
+
+    for (int i = 0; i != NUM_YIELD_TESTS; ++i)
+    {
+        hpx::apply(exec_before, &wakeup_thread, id);
+
+        hpx::this_thread::suspend(hpx::threads::suspended);
+
+        hpx::threads::executor exec_after = hpx::threads::get_executor(id);
+        HPX_TEST_EQ(exec_before, exec_after);
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main()
 {
     {
-        hpx::threads::executors::local_priority_queue_executor exec(1);
-        hpx::async(exec, &test_executor_association).get();
+        hpx::threads::executors::local_priority_queue_executor exec(
+            hpx::get_os_thread_count());
+
+        std::vector<hpx::future<void> > result;
+        for (std::size_t i = 0; i != hpx::get_os_thread_count(); ++i)
+        {
+            hpx::apply(exec, &test_executor_association_yield);
+            hpx::apply(exec, &test_executor_association_suspend);
+        }
+
+        // destructor synchronizes will all running tasks
     }
 
     {
-        hpx::threads::executors::local_priority_queue_executor exec(1);
-        hpx::apply(exec, &test_executor_association);
+        hpx::threads::executors::local_priority_queue_executor exec(
+            hpx::get_os_thread_count());
+
+        std::vector<hpx::future<void> > result;
+        for (std::size_t i = 0; i != hpx::get_os_thread_count(); ++i)
+        {
+            result.push_back(hpx::async(exec, &test_executor_association_yield));
+            result.push_back(hpx::async(exec, &test_executor_association_suspend));
+        }
+        hpx::wait_all();
     }
+
     return hpx::finalize();
 }
 

--- a/tests/unit/threads/thread_yield.cpp
+++ b/tests/unit/threads/thread_yield.cpp
@@ -1,0 +1,51 @@
+// Copyright (C) 2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/threadmanager.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <vector>
+#include <string>
+
+#include <boost/lexical_cast.hpp>
+
+#define NUM_YIELD_TESTS 1000
+
+///////////////////////////////////////////////////////////////////////////////
+void test_yield()
+{
+    for (std::size_t i = 0; i != NUM_YIELD_TESTS; ++i)
+        hpx::this_thread::yield();
+}
+
+int hpx_main()
+{
+    std::size_t num_cores = hpx::get_os_thread_count();
+
+    std::vector<hpx::future<void> > finished;
+    finished.reserve(num_cores);
+
+    for (std::size_t i = 0; i != num_cores; ++i)
+        finished.push_back(hpx::async(&test_yield));
+
+    hpx::wait_all(finished);
+
+    return hpx::finalize();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char* argv[])
+{
+    // By default this test should run on all available cores
+    std::vector<std::string> cfg;
+    cfg.push_back("hpx.os_threads=" +
+        boost::lexical_cast<std::string>(hpx::threads::hardware_concurrency()));
+
+    HPX_TEST_EQ(hpx::init(argc, argv, cfg), 0);
+    return hpx::util::report_errors();
+}
+


### PR DESCRIPTION
This patch fixes the problems with the thread pool executors. It also includes 2 fly-by changes

- to the shared state of `hpx::future`, fixing a benign data race
- to the promise test

It also includes a new test and an extension to an existing test