### PR TITLE
Cleaning up schedulers

### DIFF
--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -280,8 +280,8 @@ namespace hpx { namespace threads { namespace detail
             // Get the next HPX thread from the queue
             thread_data_base* thrd = NULL;
 
-            if (scheduler.SchedulingPolicy::get_next_thread(num_thread,
-                    is_running_state(global_state.load()), idle_loop_count, thrd))
+            if (scheduler.SchedulingPolicy::get_next_thread(
+                    num_thread, idle_loop_count, thrd))
             {
                 tfunc_time_wrapper tfunc_time_collector(idle_rate);
 
@@ -404,6 +404,7 @@ namespace hpx { namespace threads { namespace detail
                 if (scheduler.SchedulingPolicy::wait_or_add_new(num_thread,
                         is_running_state(global_state.load()), idle_loop_count))
                 {
+                    // clean up terminated threads one more time before existing
                     if (scheduler.SchedulingPolicy::cleanup_terminated(true))
                         break;
                 }

--- a/hpx/runtime/threads/executors/thread_pool_executors.hpp
+++ b/hpx/runtime/threads/executors/thread_pool_executors.hpp
@@ -108,7 +108,7 @@ namespace hpx { namespace threads { namespace executors
             // resource manager registration
             std::size_t cookie_;
 
-            // store the self reference to the HPX running this scheduler
+            // store the self reference to the HPX thread running this scheduler
             std::vector<threads::thread_self*> self_;
 
             // protect scheduler initialization

--- a/hpx/runtime/threads/policies/hierarchy_scheduler.hpp
+++ b/hpx/runtime/threads/policies/hierarchy_scheduler.hpp
@@ -605,7 +605,7 @@ namespace hpx { namespace threads { namespace policies
 
         /// Return the next thread to be executed, return false if none is
         /// available
-        bool get_next_thread(std::size_t num_thread, bool running,
+        bool get_next_thread(std::size_t num_thread,
             boost::int64_t& idle_loop_count, threads::thread_data_base*& thrd)
         {
             HPX_ASSERT(tree.size());

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -474,7 +474,7 @@ namespace hpx { namespace threads { namespace policies
 
         /// Return the next thread to be executed, return false if none is
         /// available
-        virtual bool get_next_thread(std::size_t num_thread, bool running,
+        virtual bool get_next_thread(std::size_t num_thread,
             boost::int64_t& idle_loop_count, threads::thread_data_base*& thrd)
         {
             std::size_t queues_size = queues_.size();

--- a/hpx/runtime/threads/policies/local_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_queue_scheduler.hpp
@@ -288,7 +288,7 @@ namespace hpx { namespace threads { namespace policies
 
         /// Return the next thread to be executed, return false if none is
         /// available
-        virtual bool get_next_thread(std::size_t num_thread, bool running,
+        virtual bool get_next_thread(std::size_t num_thread,
             boost::int64_t& idle_loop_count, threads::thread_data_base*& thrd)
         {
             std::size_t queues_size = queues_.size();

--- a/hpx/runtime/threads/policies/scheduler_base.hpp
+++ b/hpx/runtime/threads/policies/scheduler_base.hpp
@@ -151,7 +151,7 @@ namespace hpx { namespace threads { namespace policies
             thread_state_enum initial_state, bool run_now, error_code& ec,
             std::size_t num_thread) = 0;
 
-        virtual bool get_next_thread(std::size_t num_thread, bool running,
+        virtual bool get_next_thread(std::size_t num_thread,
             boost::int64_t& idle_loop_count, threads::thread_data_base*& thrd) = 0;
 
         virtual void schedule_thread(threads::thread_data_base* thrd,

--- a/hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp
@@ -48,7 +48,7 @@ namespace hpx { namespace threads { namespace policies
 
         /// Return the next thread to be executed, return false if non is
         /// available
-        bool get_next_thread(std::size_t num_thread, bool running,
+        bool get_next_thread(std::size_t num_thread,
             boost::int64_t& idle_loop_count, threads::thread_data_base*& thrd)
         {
             std::size_t queues_size = this->queues_.size();

--- a/hpx/runtime/threads/policies/thread_queue.hpp
+++ b/hpx/runtime/threads/policies/thread_queue.hpp
@@ -488,13 +488,15 @@ namespace hpx { namespace threads { namespace policies
                 return thread_map_count_ == 0;
 
             if (delete_all) {
+                // do not lock mutex while deleting all threads, do it piece-wise
                 bool thread_map_is_empty = false;
                 while (true)
                 {
                     typename mutex_type::scoped_lock lk(mtx_);
                     if (cleanup_terminated_locked_helper(false))
                     {
-                        thread_map_is_empty = thread_map_.empty();
+                        thread_map_is_empty =
+                            (thread_map_count_ == 0) && (new_tasks_count_ == 0);
                         break;
                     }
                 }
@@ -502,7 +504,8 @@ namespace hpx { namespace threads { namespace policies
             }
 
             typename mutex_type::scoped_lock lk(mtx_);
-            return cleanup_terminated_locked_helper(false) && thread_map_.empty();
+            return cleanup_terminated_locked_helper(false) &&
+                (thread_map_count_ == 0) && (new_tasks_count_ == 0);
         }
 
         // The maximum number of active threads this thread manager should

--- a/src/runtime/threads/executors/thread_pool_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_executors.cpp
@@ -346,8 +346,10 @@ namespace hpx { namespace threads { namespace executors { namespace detail
             on_run_exit on_exit(current_concurrency_, shutdown_sem_,
                 self_[virt_core]);
 
+            // FIXME: turn these values into performance counters
             boost::int64_t executed_threads = 0, executed_thread_phases = 0;
             boost::uint64_t overall_times = 0, thread_times = 0;
+
             threads::detail::scheduling_loop(virt_core, scheduler_,
                 states_[virt_core], executed_threads, executed_thread_phases,
                 overall_times, thread_times, util::function_nonser<void()>(),
@@ -355,12 +357,11 @@ namespace hpx { namespace threads { namespace executors { namespace detail
                     &thread_pool_executor::suspend_back_into_calling_context,
                     this, virt_core));
 
-#ifdef HPX_DEBUG
             // the scheduling_loop is allowed to exit only if no more HPX
             // threads exist
             HPX_ASSERT(!scheduler_.get_thread_count(
-                unknown, thread_priority_default, thread_num));
-#endif
+                unknown, thread_priority_default, virt_core) ||
+                states_[virt_core] == state_terminating);
         }
     }
 

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -145,8 +145,7 @@ namespace hpx { namespace util
             std::size_t num_localities)
         {
             std::size_t batch_localities = env.retrieve_number_of_localities();
-            if (num_localities == 1 &&
-                batch_localities != std::size_t(batch_localities))
+            if (num_localities == 1 && batch_localities != std::size_t(-1))
             {
                 std::size_t cfg_num_localities = cfgmap.get_value<std::size_t>(
                     "hpx.localities", batch_localities);


### PR DESCRIPTION
This PR cleans up some minor left over problems from merging #1573:

- Comment fixes
- Fixing wrong conditional expression caught by @sithhell in #1573 
- Improve consistency of exit condition from schedulers 
- Remove an unneeded parameter from one of the scheduler API functions