### PR TITLE
Fixing tests for parallel rotate

### DIFF
--- a/tests/unit/parallel/algorithms/rotate.cpp
+++ b/tests/unit/parallel/algorithms/rotate.cpp
@@ -124,7 +124,10 @@ void test_rotate_exception(ExPolicy const& policy, IteratorTag)
     std::iota(boost::begin(c), boost::end(c), std::rand());
 
     base_iterator mid = boost::begin(c);
-    std::advance(mid, std::rand() % c.size()); //-V104
+
+    // move at least one element to guarantee an exception to be thrown
+    std::size_t delta = (std::max)(std::rand() % c.size(), std::size_t(1)); //-V104
+    std::advance(mid, delta);
 
     bool caught_exception = false;
     try {
@@ -158,7 +161,10 @@ void test_rotate_exception_async(ExPolicy const& p, IteratorTag)
     std::iota(boost::begin(c), boost::end(c), std::rand());
 
     base_iterator mid = boost::begin(c);
-    std::advance(mid, std::rand() % c.size()); //-V104
+
+    // move at least one element to guarantee an exception to be thrown
+    std::size_t delta = (std::max)(std::rand() % c.size(), std::size_t(1)); //-V104
+    std::advance(mid, delta);
 
     bool caught_exception = false;
     bool returned_from_algorithm = false;
@@ -228,7 +234,10 @@ void test_rotate_bad_alloc(ExPolicy const& policy, IteratorTag)
     std::iota(boost::begin(c), boost::end(c), std::rand());
 
     base_iterator mid = boost::begin(c);
-    std::advance(mid, std::rand() % c.size()); //-V104
+
+    // move at least one element to guarantee an exception to be thrown
+    std::size_t delta = (std::max)(std::rand() % c.size(), std::size_t(1)); //-V104
+    std::advance(mid, delta);
 
     bool caught_bad_alloc = false;
     try {
@@ -261,7 +270,10 @@ void test_rotate_bad_alloc_async(ExPolicy const& p, IteratorTag)
     std::iota(boost::begin(c), boost::end(c), std::rand());
 
     base_iterator mid = boost::begin(c);
-    std::advance(mid, std::rand() % c.size()); //-V104
+
+    // move at least one element to guarantee an exception to be thrown
+    std::size_t delta = (std::max)(std::rand() % c.size(), std::size_t(1)); //-V104
+    std::advance(mid, delta);
 
     bool caught_bad_alloc = false;
     bool returned_from_algorithm = false;

--- a/tests/unit/parallel/algorithms/rotate_copy.cpp
+++ b/tests/unit/parallel/algorithms/rotate_copy.cpp
@@ -119,7 +119,10 @@ void test_rotate_copy_exception(ExPolicy const& policy, IteratorTag)
     std::iota(boost::begin(c), boost::end(c), std::rand());
 
     base_iterator mid = boost::begin(c);
-    std::advance(mid, std::rand() % c.size()); //-V104
+
+    // move at least one element to guarantee an exception to be thrown
+    std::size_t delta = (std::max)(std::rand() % c.size(), std::size_t(1)); //-V104
+    std::advance(mid, delta);
 
     bool caught_exception = false;
     try {
@@ -155,7 +158,10 @@ void test_rotate_copy_exception_async(ExPolicy const& p, IteratorTag)
     std::iota(boost::begin(c), boost::end(c), std::rand());
 
     base_iterator mid = boost::begin(c);
-    std::advance(mid, std::rand() % c.size()); //-V104
+
+    // move at least one element to guarantee an exception to be thrown
+    std::size_t delta = (std::max)(std::rand() % c.size(), std::size_t(1)); //-V104
+    std::advance(mid, delta);
 
     bool caught_exception = false;
     bool returned_from_algorithm = false;
@@ -227,7 +233,10 @@ void test_rotate_copy_bad_alloc(ExPolicy const& policy, IteratorTag)
     std::iota(boost::begin(c), boost::end(c), std::rand());
 
     base_iterator mid = boost::begin(c);
-    std::advance(mid, std::rand() % c.size()); //-V104
+
+    // move at least one element to guarantee an exception to be thrown
+    std::size_t delta = (std::max)(std::rand() % c.size(), std::size_t(1)); //-V104
+    std::advance(mid, delta);
 
     bool caught_bad_alloc = false;
     try {
@@ -262,7 +271,10 @@ void test_rotate_copy_bad_alloc_async(ExPolicy const& p, IteratorTag)
     std::iota(boost::begin(c), boost::end(c), std::rand());
 
     base_iterator mid = boost::begin(c);
-    std::advance(mid, std::rand() % c.size()); //-V104
+
+    // move at least one element to guarantee an exception to be thrown
+    std::size_t delta = (std::max)(std::rand() % c.size(), std::size_t(1)); //-V104
+    std::advance(mid, delta);
 
     bool caught_bad_alloc = false;
     bool returned_from_algorithm = false;


### PR DESCRIPTION
Parallel rotate sometimes failed to pass because of expected exceptions not being thrown. This patch makes sure exceptions are being thrown always.