### PR TITLE
Removing type_size trait, replacing it with special archive type

### DIFF
--- a/docs/manual/commandline.qbk
+++ b/docs/manual/commandline.qbk
@@ -106,10 +106,16 @@ described in the table below:
     [[`--hpx:list-component-types`][list all dynamic component types after startup]]
     [[`--hpx:dump-config-initial`][print the initial runtime configuration]]
     [[`--hpx:dump-config`]      [print the final runtime configuration]]
-    [[`--hpx:debug-hpx-log`]    [enable all messages on the __hpx__ log channel and send all
-                                 __hpx__ logs to the target destination]]
-    [[`--hpx:debug-agas-log`]   [enable all messages on the AGAS log channel and send all
-                                 AGAS logs to the target destination]]
+    [[`--hpx:debug-hpx-log [arg]`]    [enable all messages on the __hpx__ log
+                                       channel and send all __hpx__ logs to the
+                                       target destination (default: cout)]]
+    [[`--hpx:debug-agas-log [arg]`]   [enable all messages on the AGAS log channel
+                                       and send all AGAS logs to the target
+                                       destination (default: cout)]]
+    [[`--hpx:debug-parcel-log [arg]`] [enable all messages on the parcel transport
+                                       log channel and send all parcel transport
+                                       logs to the target destination (default:
+                                       cout)]]
     [[`--hpx:debug-clp`]        [debug command line processing]]
     [[`--hpx:attach-debugger arg`] [wait for a debugger to be attached, possible arg values:
                                     startup or exception (default: startup)]]

--- a/hpx/hpx_fwd.hpp
+++ b/hpx/hpx_fwd.hpp
@@ -534,8 +534,9 @@ namespace hpx
         destination_hpx = 0,
         destination_timing = 1,
         destination_agas = 2,
-        destination_app = 3,
-        destination_debuglog = 4
+        destination_parcel = 3,
+        destination_app = 4,
+        destination_debuglog = 5
     };
 
     /// \namespace components

--- a/hpx/runtime/naming/name.hpp
+++ b/hpx/runtime/naming/name.hpp
@@ -806,7 +806,7 @@ namespace hpx { namespace naming
         private:
             // credit management (called during serialization), this function
             // has to be 'const' as save() above has to be 'const'.
-            naming::gid_type preprocess_gid(boost::uint32_t dest_locality_id) const;
+            naming::gid_type preprocess_gid() const;
 
             // reference counting
             friend HPX_EXPORT void intrusive_ptr_add_ref(id_type_impl* p);

--- a/hpx/runtime/parcelset/encode_parcels.hpp
+++ b/hpx/runtime/parcelset/encode_parcels.hpp
@@ -22,51 +22,105 @@ namespace hpx
 {
     namespace parcelset
     {
-        template <typename Buffer>
-        void encode_finalize(Buffer & buffer, std::size_t arg_size)
+        namespace detail
         {
-            buffer.size_ = buffer.data_.size();
-            buffer.data_size_ = arg_size;
-
-            performance_counters::parcels::data_point& data = buffer.data_point_;
-            data.bytes_ = arg_size;
-            data.raw_bytes_ = buffer.data_.size();
-
-            // prepare chunk data for transmission, the transmission_chunks data
-            // first holds all zero-copy, then all non-zero-copy chunk infos
-            typedef typename Buffer::transmission_chunk_type
-                transmission_chunk_type;
-            typedef typename Buffer::count_chunks_type
-                count_chunks_type;
-
-            std::vector<transmission_chunk_type>& chunks =
-                buffer.transmission_chunks_;
-
-            chunks.clear();
-            chunks.reserve(buffer.chunks_.size());
-
-            std::size_t index = 0;
-            for (serialization::serialization_chunk& c : buffer.chunks_)
+            ///////////////////////////////////////////////////////////////////
+            inline char
+            to_digit(int number)
             {
-                if (c.type_ == serialization::chunk_type_pointer)
-                    chunks.push_back(transmission_chunk_type(index, c.size_));
-                ++index;
+                char number_tmp = static_cast<char>(number);
+                if (number >= 0 && number <= 9)
+                {
+                    return static_cast<char>(number_tmp + '0');
+                }
+                return static_cast<char>(number_tmp - 10 + 'A');
             }
 
-            buffer.num_chunks_ = count_chunks_type(
-                static_cast<boost::uint32_t>(chunks.size()),
-                static_cast<boost::uint32_t>(buffer.chunks_.size() - chunks.size())
-            );
+            inline void
+            convert_byte(boost::uint8_t b, char* buffer, char const* end)
+            {
+                *buffer++ = to_digit((b & 0xF0) >> 4);
+                *buffer++ = to_digit(b & 0x0F);
+            }
 
-            if (!chunks.empty()) {
-                // the remaining number of chunks are non-zero-copy
-                for (serialization::serialization_chunk& c : buffer.chunks_)
+            template <typename Buffer>
+            std::string binary_archive_content(Buffer const& buffer)
+            {
+                std::string result;
+                if (LPT_ENABLED(debug))
                 {
-                    if (c.type_ == serialization::chunk_type_index) {
-                        chunks.push_back(
-                            transmission_chunk_type(c.data_.index_, c.size_));
+                    result.reserve(buffer.data_.size() * 2 + 1);
+                    for (boost::uint8_t byte: buffer.data_)
+                    {
+                        char b[3] = { 0 };
+                        convert_byte(byte, &b[0], &b[3]);
+                        result += b;
                     }
                 }
+                return result;
+            }
+
+            template <typename Buffer>
+            void encode_finalize(Buffer & buffer, std::size_t arg_size)
+            {
+                buffer.size_ = buffer.data_.size();
+                buffer.data_size_ = arg_size;
+
+                LPT_(debug) << binary_archive_content(buffer);
+
+                performance_counters::parcels::data_point& data = buffer.data_point_;
+                data.bytes_ = arg_size;
+                data.raw_bytes_ = buffer.data_.size();
+
+                // prepare chunk data for transmission, the transmission_chunks data
+                // first holds all zero-copy, then all non-zero-copy chunk infos
+                typedef typename Buffer::transmission_chunk_type
+                    transmission_chunk_type;
+                typedef typename Buffer::count_chunks_type
+                    count_chunks_type;
+
+                std::vector<transmission_chunk_type>& chunks =
+                    buffer.transmission_chunks_;
+
+                chunks.clear();
+                chunks.reserve(buffer.chunks_.size());
+
+                std::size_t index = 0;
+                for (serialization::serialization_chunk& c : buffer.chunks_)
+                {
+                    if (c.type_ == serialization::chunk_type_pointer)
+                        chunks.push_back(transmission_chunk_type(index, c.size_));
+                    ++index;
+                }
+
+                buffer.num_chunks_ = count_chunks_type(
+                    static_cast<boost::uint32_t>(chunks.size()),
+                    static_cast<boost::uint32_t>(buffer.chunks_.size() - chunks.size())
+                );
+
+                if (!chunks.empty()) {
+                    // the remaining number of chunks are non-zero-copy
+                    for (serialization::serialization_chunk& c : buffer.chunks_)
+                    {
+                        if (c.type_ == serialization::chunk_type_index) {
+                            chunks.push_back(
+                                transmission_chunk_type(c.data_.index_, c.size_));
+                        }
+                    }
+                }
+            }
+
+            inline std::size_t
+            get_archive_size(parcel const& p, boost::uint32_t flags,
+                boost::uint32_t dest_locality_id,
+                std::vector<serialization::serialization_chunk>* chunks)
+            {
+                // gather the required size for the archive
+                hpx::serialization::detail::size_gatherer_container gather_size;
+                hpx::serialization::output_archive archive(
+                    gather_size, flags, dest_locality_id, chunks);
+                archive << p;
+                return gather_size.size();
             }
         }
 
@@ -78,7 +132,8 @@ namespace hpx
             HPX_ASSERT(buffer.data_.empty());
             // collect argument sizes from parcels
             std::size_t arg_size = 0;
-            boost::uint32_t dest_locality_id = ps[0].get_destination_locality_id();
+            boost::uint32_t dest_locality_id =
+                ps[0].get_destination_locality_id();
 
             std::size_t parcels_sent = 0;
 
@@ -89,6 +144,13 @@ namespace hpx
             // guard against serialization errors
             try {
                 try {
+                    std::unique_ptr<serialization::binary_filter> filter(
+                        ps[0].get_serialization_filter());
+
+                    int archive_flags = archive_flags_;
+                    if (filter.get() != 0)
+                        archive_flags |= serialization::enable_compression;
+
                     // Get the chunk size from the allocator if it supports it
                     size_t chunk_default = hpx::traits::default_chunk_size<
                             typename Buffer::allocator_type
@@ -99,7 +161,8 @@ namespace hpx
                     {
                         if (arg_size >= max_outbound_size)
                             break;
-                        arg_size += traits::get_type_size(ps[parcels_sent], archive_flags_);
+                        arg_size += detail::get_archive_size(ps[parcels_sent],
+                            archive_flags, dest_locality_id, &buffer.chunks_);
                     }
 
                     buffer.data_.reserve((std::max)(chunk_default, arg_size));
@@ -109,14 +172,8 @@ namespace hpx
 
                     {
                         // Serialize the data
-                        std::unique_ptr<serialization::binary_filter> filter(
-                            ps[0].get_serialization_filter());
-
-                        int archive_flags = archive_flags_;
-                        if (filter.get() != 0) {
+                        if (filter.get() != 0)
                             filter->set_max_length(buffer.data_.capacity());
-                            archive_flags |= serialization::enable_compression;
-                        }
 
                         serialization::output_archive archive(
                             buffer.data_
@@ -129,7 +186,10 @@ namespace hpx
                             archive << parcels_sent;
 
                         for(std::size_t i = 0; i != parcels_sent; ++i)
+                        {
+                            LPT_(debug) << ps[i];
                             archive << ps[i];
+                        }
 
                         arg_size = archive.bytes_written();
                     }
@@ -179,7 +239,7 @@ namespace hpx
             }
 
             buffer.data_point_.num_parcels_ = parcels_sent;
-            encode_finalize(buffer, arg_size);
+            detail::encode_finalize(buffer, arg_size);
 
             return parcels_sent;
         }

--- a/hpx/runtime/serialization/basic_archive.hpp
+++ b/hpx/runtime/serialization/basic_archive.hpp
@@ -99,6 +99,14 @@ namespace hpx { namespace serialization
             return flags_;
         }
 
+        // Archives can be used to do 'fake' serialization, in which case no
+        // data is being stored/restored and no side effects should be
+        // performed during serialization/de-serialization.
+        bool is_saving() const
+        {
+            return false;
+        }
+
         boost::uint32_t flags_;
         std::size_t size_;
     };

--- a/hpx/runtime/serialization/container.hpp
+++ b/hpx/runtime/serialization/container.hpp
@@ -17,6 +17,7 @@ namespace hpx { namespace serialization
     {
         virtual ~erased_output_container() {}
 
+        virtual bool is_saving() const { return false; }
         virtual void set_filter(binary_filter* filter) = 0;
         virtual void save_binary(void const* address, std::size_t count) = 0;
         virtual void save_binary_chunk(void const* address, std::size_t count) = 0;
@@ -26,6 +27,7 @@ namespace hpx { namespace serialization
     {
         virtual ~erased_input_container() {}
 
+        virtual bool is_saving() const { return false; }
         virtual void set_filter(binary_filter* filter) = 0;
         virtual void load_binary(void * address, std::size_t count) = 0;
         virtual void load_binary_chunk(void * address, std::size_t count) = 0;

--- a/hpx/runtime/serialization/detail/size_gatherer_container.hpp
+++ b/hpx/runtime/serialization/detail/size_gatherer_container.hpp
@@ -29,7 +29,7 @@ namespace hpx { namespace serialization { namespace detail
     template <>
     struct access_data<size_gatherer_container>
     {
-        static bool is_saving() { return true; }
+        static bool is_saving() { return false; }
 
         static void
         write(size_gatherer_container& cont, std::size_t count,

--- a/hpx/runtime/serialization/detail/size_gatherer_container.hpp
+++ b/hpx/runtime/serialization/detail/size_gatherer_container.hpp
@@ -1,0 +1,49 @@
+//  Copyright (c) 2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_SERIALIZATION_SIZE_GATHERER_CONTAINER_MAY_27_2015_0818AM)
+#define HPX_SERIALIZATION_SIZE_GATHERER_CONTAINER_MAY_27_2015_0818AM
+
+// This 'container' is used to gather the required archive size for a given
+// type before it is serialized.
+
+namespace hpx { namespace serialization { namespace detail
+{
+    template <typename Container>
+    struct access_data;
+
+    class size_gatherer_container
+    {
+    public:
+        size_gatherer_container() : size_(0) {}
+
+        std::size_t size() const { return size_; }
+        void resize(std::size_t size) { size_ = size; }
+
+    private:
+        std::size_t size_;
+    };
+
+    template <>
+    struct access_data<size_gatherer_container>
+    {
+        static bool is_saving() { return true; }
+
+        static void
+        write(size_gatherer_container& cont, std::size_t count,
+            std::size_t current, void const* address)
+        {
+        }
+
+        static bool
+        flush(binary_filter* filter, size_gatherer_container& cont,
+            std::size_t current, std::size_t size, std::size_t written)
+        {
+            return true;
+        }
+    };
+}}}
+
+#endif

--- a/hpx/runtime/serialization/output_archive.hpp
+++ b/hpx/runtime/serialization/output_archive.hpp
@@ -59,6 +59,11 @@ namespace hpx { namespace serialization
             }
         }
 
+        bool is_saving() const
+        {
+            return buffer_->is_saving();
+        }
+
         template <typename T>
         void invoke_impl(T const & t)
         {

--- a/hpx/runtime/serialization/serialize.hpp
+++ b/hpx/runtime/serialization/serialize.hpp
@@ -10,6 +10,7 @@
 #include <hpx/runtime/serialization/access.hpp>
 #include <hpx/runtime/serialization/input_archive.hpp>
 #include <hpx/runtime/serialization/output_archive.hpp>
+#include <hpx/runtime/serialization/detail/size_gatherer_container.hpp>
 
 namespace hpx { namespace serialization
 {

--- a/hpx/util/logging.hpp
+++ b/hpx/util/logging.hpp
@@ -41,6 +41,20 @@ namespace hpx { namespace util
     /**/
 
     ///////////////////////////////////////////////////////////////////////////
+    HPX_EXPORT HPX_DECLARE_LOG_FILTER(parcel_level, filter_type)
+    HPX_EXPORT HPX_DECLARE_LOG(parcel_logger, logger_type)
+
+    #define LPT_(lvl)                                                         \
+        HPX_LOG_USE_LOG_IF_LEVEL(hpx::util::parcel_logger(),                  \
+            hpx::util::parcel_level(), lvl)                                   \
+        << hpx::util::levelname(::hpx::util::logging::level::lvl) << " "      \
+    /**/
+
+    #define LPT_ENABLED(lvl)                                                  \
+        hpx::util::parcel_level()->is_enabled(::hpx::util::logging::level::lvl)\
+    /**/
+
+    ///////////////////////////////////////////////////////////////////////////
     HPX_EXPORT HPX_DECLARE_LOG_FILTER(timing_level, filter_type)
     HPX_EXPORT HPX_DECLARE_LOG(timing_logger, logger_type)
 
@@ -129,6 +143,10 @@ namespace hpx { namespace util
     HPX_EXPORT HPX_DECLARE_LOG(agas_console_logger, logger_type)
 
     ///////////////////////////////////////////////////////////////////////////
+    HPX_EXPORT HPX_DECLARE_LOG_FILTER(parcel_console_level, filter_type)
+    HPX_EXPORT HPX_DECLARE_LOG(parcel_console_logger, logger_type)
+
+    ///////////////////////////////////////////////////////////////////////////
     HPX_EXPORT HPX_DECLARE_LOG_FILTER(timing_console_level, filter_type)
     HPX_EXPORT HPX_DECLARE_LOG(timing_console_logger, logger_type)
 
@@ -151,6 +169,13 @@ namespace hpx { namespace util
     HPX_LOG_USE_LOG(hpx::util::agas_console_logger(),                         \
         read_msg().gather().out(),                                            \
         hpx::util::agas_console_level()->is_enabled(                          \
+            static_cast<hpx::util::logging::level::type>(lvl)))               \
+/**/
+
+#define LPT_CONSOLE_(lvl)                                                     \
+    HPX_LOG_USE_LOG(hpx::util::parcel_console_logger(),                       \
+        read_msg().gather().out(),                                            \
+        hpx::util::parcel_console_level()->is_enabled(                        \
             static_cast<hpx::util::logging::level::type>(lvl)))               \
 /**/
 
@@ -201,6 +226,7 @@ namespace hpx { namespace util { namespace detail
     inline dummy_log_impl& operator<<(dummy_log_impl& l, T) { return l; }
 
     #define LAGAS_(lvl)           if(true) {} else hpx::util::detail::dummy_log
+    #define LPT_(lvl)             if(true) {} else hpx::util::detail::dummy_log
     #define LTIM_(lvl)            if(true) {} else hpx::util::detail::dummy_log
     #define LHPX_(lvl, cat)       if(true) {} else hpx::util::detail::dummy_log
     #define LAPP_(lvl)            if(true) {} else hpx::util::detail::dummy_log
@@ -209,12 +235,14 @@ namespace hpx { namespace util { namespace detail
     #define LFATAL_               if(true) {} else hpx::util::detail::dummy_log
 
     #define LAGAS_CONSOLE_(lvl)   if(true) {} else hpx::util::detail::dummy_log
+    #define LPT_CONSOLE_(lvl)     if(true) {} else hpx::util::detail::dummy_log
     #define LTIM_CONSOLE_(lvl)    if(true) {} else hpx::util::detail::dummy_log
     #define LHPX_CONSOLE_(lvl)    if(true) {} else hpx::util::detail::dummy_log
     #define LAPP_CONSOLE_(lvl)    if(true) {} else hpx::util::detail::dummy_log
     #define LDEB_CONSOLE_         if(true) {} else hpx::util::detail::dummy_log
 
     #define LAGAS_ENABLED(lvl)    (false)
+    #define LPT_ENABLED(lvl)      (false)
     #define LTIM_ENABLED(lvl)     (false)
     #define LHPX_ENABLED(lvl)     (false)
     #define LAPP_ENABLED(lvl)     (false)
@@ -229,7 +257,6 @@ namespace hpx { namespace util { namespace detail
 #define LRT_(lvl)   LHPX_(lvl, "  [RT] ")   /* runtime support */
 #define LOSH_(lvl)  LHPX_(lvl, " [OSH] ")   /* one size heap */
 #define LERR_(lvl)  LHPX_(lvl, " [ERR] ")   /* exceptions */
-#define LPT_(lvl)   LHPX_(lvl, "  [PT] ")   /* parcel transport */
 #define LLCO_(lvl)  LHPX_(lvl, " [LCO] ")   /* lcos */
 #define LPCS_(lvl)  LHPX_(lvl, " [PCS] ")   /* performance counters */
 #define LAS_(lvl)   LHPX_(lvl, "  [AS] ")   /* addressing service */

--- a/src/runtime/actions/action_manager.cpp
+++ b/src/runtime/actions/action_manager.cpp
@@ -41,13 +41,13 @@ namespace hpx { namespace actions
         // Give up if we're shutting down.
         if (threads::threadmanager_is(state_stopping))
         {
-            LPT_(debug) << "action_manager: fetch_parcel: dropping late "
-                            "parcel " << p;
+//             LPT_(debug) << "action_manager: fetch_parcel: dropping late "
+//                             "parcel " << p;
             return;
         }
 
         // write this parcel to the log
-        LPT_(debug) << "action_manager: fetch_parcel: " << p;
+//         LPT_(debug) << "action_manager: fetch_parcel: " << p;
 
         appl_.schedule_action(p);
     }

--- a/src/runtime/components/console_logging.cpp
+++ b/src/runtime/components/console_logging.cpp
@@ -48,6 +48,10 @@ namespace hpx { namespace components
                 LAGAS_CONSOLE_(at_c<1>(msg)) << fail_msg << at_c<2>(msg);
                 break;
 
+            case destination_parcel:
+                LPT_CONSOLE_(at_c<1>(msg)) << fail_msg << at_c<2>(msg);
+                break;
+
             case destination_app:
                 LAPP_CONSOLE_(at_c<1>(msg)) << fail_msg << at_c<2>(msg);
                 break;

--- a/src/runtime/components/server/console_logging_server.cpp
+++ b/src/runtime/components/server/console_logging_server.cpp
@@ -73,6 +73,10 @@ namespace hpx { namespace components { namespace server
                 LAGAS_CONSOLE_(level) << s;
                 break;
 
+            case destination_parcel:
+                LPT_CONSOLE_(level) << s;
+                break;
+
             case destination_app:
                 LAPP_CONSOLE_(level) << s;
                 break;

--- a/src/runtime/naming/name.cpp
+++ b/src/runtime/naming/name.cpp
@@ -210,8 +210,7 @@ namespace hpx { namespace naming
 
         ///////////////////////////////////////////////////////////////////////
         // prepare the given id, note: this function modifies the passed id
-        naming::gid_type id_type_impl::preprocess_gid(
-            boost::uint32_t dest_locality_id) const
+        naming::gid_type id_type_impl::preprocess_gid() const
         {
             // unmanaged gids do not require any special handling
             if (unmanaged == type_)
@@ -407,15 +406,22 @@ namespace hpx { namespace naming
         // serialization
         void id_type_impl::save(serialization::output_archive& ar) const
         {
-            boost::uint32_t dest_locality_id = ar.get_dest_locality_id();
+            // Avoid performing side effects if the archive is not saving the
+            // data.
+            if (ar.is_saving())
+            {
+                id_type_management type = type_;
+                if (managed_move_credit == type)
+                    type = managed;
 
-            id_type_management type = type_;
-            if (managed_move_credit == type)
-                type = managed;
-
-            gid_serialization_data data{
-                preprocess_gid(dest_locality_id), type};
-            ar << data;
+                gid_serialization_data data { preprocess_gid(), type };
+                ar << data;
+            }
+            else
+            {
+                gid_serialization_data data { *this, type_ };
+                ar << data;
+            }
         }
 
         void id_type_impl::load(serialization::input_archive& ar)
@@ -426,7 +432,8 @@ namespace hpx { namespace naming
             static_cast<gid_type&>(*this) = data.gid_;
             type_ = static_cast<id_type_management>(data.type_);
 
-            if (detail::unmanaged != type_ && detail::managed != type_) {
+            if (detail::unmanaged != type_ && detail::managed != type_)
+            {
                 HPX_THROW_EXCEPTION(version_too_new, "id_type::load",
                     "trying to load id_type with unknown deleter");
             }

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -87,7 +87,7 @@ namespace hpx { namespace parcelset
         // Give up if we're shutting down.
         if (threads::threadmanager_is(state_stopping))
         {
-            LPT_(debug) << "parcel_sink: dropping late parcel";
+//             LPT_(debug) << "parcel_sink: dropping late parcel";
             return;
         }
 

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -641,6 +641,17 @@ namespace hpx { namespace util
             ini_config += "hpx.logging.agas.level=5";
         }
 
+        if (vm.count("hpx:debug-parcel-log")) {
+            ini_config += "hpx.logging.console.parcel.destination=" +
+                detail::convert_to_log_file(
+                    vm["hpx:debug-parcel-log"].as<std::string>());
+            ini_config += "hpx.logging.parcel.destination=" +
+                detail::convert_to_log_file(
+                    vm["hpx:debug-parcel-log"].as<std::string>());
+            ini_config += "hpx.logging.console.parcel.level=5";
+            ini_config += "hpx.logging.parcel.level=5";
+        }
+
         // Set number of cores and OS threads in configuration.
         ini_config += "hpx.os_threads=" +
             boost::lexical_cast<std::string>(num_threads_);

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -449,6 +449,59 @@ namespace hpx { namespace util
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    // this is required in order to use the logging library
+    HPX_DEFINE_LOG_FILTER_WITH_ARGS(parcel_level, filter_type,
+        hpx::util::logging::level::disable_all)
+    HPX_DEFINE_LOG(parcel_logger, logger_type)
+
+    // initialize logging for the parcel transport
+    void init_parcel_log(util::section const& ini, bool isconsole)
+    {
+        std::string loglevel, logdest, logformat;
+
+        if (ini.has_section("hpx.logging.parcel")) {
+            util::section const* logini = ini.get_section("hpx.logging.parcel");
+            HPX_ASSERT(NULL != logini);
+
+            std::string empty;
+            loglevel = logini->get_entry("level", empty);
+            if (!loglevel.empty()) {
+                logdest = logini->get_entry("destination", empty);
+                logformat = detail::unescape(logini->get_entry("format", empty));
+            }
+        }
+
+        unsigned lvl = hpx::util::logging::level::disable_all;
+        if (!loglevel.empty())
+            lvl = detail::get_log_level(loglevel);
+
+        if (hpx::util::logging::level::disable_all != lvl)
+        {
+           logger_writer_type& writer = parcel_logger()->writer();
+
+#if defined(ANDROID) || defined(__ANDROID__)
+            if (logdest.empty())      // ensure minimal defaults
+                logdest = isconsole ? "android_log" : "console";
+            parcel_logger()->writer().add_destination("android_log",
+                android_log("hpx.parcel"));
+#else
+            if (logdest.empty())      // ensure minimal defaults
+                logdest = isconsole ? "cerr" : "console";
+#endif
+            if (logformat.empty())
+                logformat = "|\\n";
+
+            writer.add_destination("console",
+                console(lvl, destination_parcel)); //-V106
+            writer.write(logformat, logdest);
+            detail::define_formatters(writer);
+
+            parcel_logger()->mark_as_initialized();
+            parcel_level()->set_enabled(lvl);
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     // this is required in order to use the logging library for timings
     HPX_DEFINE_LOG_FILTER_WITH_ARGS(timing_level, filter_type,
         hpx::util::logging::level::disable_all)
@@ -741,6 +794,55 @@ namespace hpx { namespace util
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    HPX_DEFINE_LOG_FILTER_WITH_ARGS(parcel_console_level, filter_type,
+        hpx::util::logging::level::disable_all)
+    HPX_DEFINE_LOG(parcel_console_logger, logger_type)
+
+    // initialize logging for the parcel transport
+    void init_parcel_console_log(util::section const& ini)
+    {
+        std::string loglevel, logdest, logformat;
+
+        if (ini.has_section("hpx.logging.console.parcel")) {
+            util::section const* logini =
+                ini.get_section("hpx.logging.console.parcel");
+            HPX_ASSERT(NULL != logini);
+
+            std::string empty;
+            loglevel = logini->get_entry("level", empty);
+            if (!loglevel.empty()) {
+                logdest = logini->get_entry("destination", empty);
+                logformat = detail::unescape(logini->get_entry("format", empty));
+            }
+        }
+
+        unsigned lvl = hpx::util::logging::level::disable_all;
+        if (!loglevel.empty())
+            lvl = detail::get_log_level(loglevel, true);
+
+        if (hpx::util::logging::level::disable_all != lvl)
+        {
+            logger_writer_type& writer = parcel_console_logger()->writer();
+
+#if defined(ANDROID) || defined(__ANDROID__)
+            if (logdest.empty())      // ensure minimal defaults
+                logdest = "android_log";
+            writer.add_destination("android_log", android_log("hpx.parcel"));
+#else
+            if (logdest.empty())      // ensure minimal defaults
+                logdest = "cerr";
+#endif
+            if (logformat.empty())
+                logformat = "|\\n";
+
+            writer.write(logformat, logdest);
+
+            parcel_console_logger()->mark_as_initialized();
+            parcel_console_level()->set_enabled(lvl);
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     HPX_DEFINE_LOG_FILTER_WITH_ARGS(timing_console_level, filter_type,
         hpx::util::logging::level::disable_all)
     HPX_DEFINE_LOG(timing_console_logger, logger_type)
@@ -1011,6 +1113,25 @@ namespace hpx { namespace util { namespace detail
 #endif
                 "format = ${HPX_CONSOLE_AGAS_LOGFORMAT:|}",
 
+                // logging related to the parcel transport
+                "[hpx.logging.parcel]",
+                "level = ${HPX_PARCEL_LOGLEVEL:-1}",
+                "destination = ${HPX_PARCEL_LOGDESTINATION:file(hpx.parcel.$[system.pid].log)}",
+                "format = ${HPX_PARCEL_LOGFORMAT:"
+                    "(T%locality%/%hpxthread%.%hpxphase%/%hpxcomponent%) "
+                    "P%parentloc%/%hpxparent%.%hpxparentphase% %time%(" HPX_TIMEFORMAT
+                    ") [%idx%][  PT] |\\n}",
+
+                // console logging related to the parcel transport
+                "[hpx.logging.console.parcel]",
+                "level = ${HPX_PARCEL_LOGLEVEL:$[hpx.logging.parcel.level]}",
+#if defined(ANDROID) || defined(__ANDROID__)
+                "destination = ${HPX_CONSOLE_PARCEL_LOGDESTINATION:android_log}",
+#else
+                "destination = ${HPX_CONSOLE_PARCEL_LOGDESTINATION:file(hpx.parcel.$[system.pid].log)}",
+#endif
+                "format = ${HPX_CONSOLE_PARCEL_LOGFORMAT:|}",
+
                 // logging related to applications
                 "[hpx.logging.application]",
                 "level = ${HPX_APP_LOGLEVEL:-1}",
@@ -1071,6 +1192,7 @@ namespace hpx { namespace util { namespace detail
     {
         // initialize normal logs
         init_agas_log(ini, isconsole);
+        init_parcel_log(ini, isconsole);
         init_timing_log(ini, isconsole);
         init_hpx_logs(ini, isconsole);
         init_app_logs(ini, isconsole);
@@ -1078,6 +1200,7 @@ namespace hpx { namespace util { namespace detail
 
         // initialize console logs
         init_agas_console_log(ini);
+        init_parcel_console_log(ini);
         init_timing_console_log(ini);
         init_hpx_console_log(ini);
         init_app_console_log(ini);

--- a/src/util/parse_command_line.cpp
+++ b/src/util/parse_command_line.cpp
@@ -482,6 +482,9 @@ namespace hpx { namespace util
                 ("hpx:debug-agas-log", value<std::string>()->implicit_value("cout"),
                   "enable all messages on the AGAS log channel and send all "
                   "AGAS logs to the target destination")
+                ("hpx:debug-parcel-log", value<std::string>()->implicit_value("cout"),
+                  "enable all messages on the parcel transport log channel and send all "
+                  "parcel transport logs to the target destination")
                 // enable debug output from command line handling
                 ("hpx:debug-clp", "debug command line processing")
 #if defined(_POSIX_VERSION) || defined(BOOST_WINDOWS)


### PR DESCRIPTION
This additionally 

- fixes the issues showing up after merging #1557 (avoid side effects like id-splitting during fake serialization)
- add parcel logging (command line option `--hpx:debug-parcel-log[=<file>]`, binary parcel content dump, etc.)