### PR TITLE
Fix doc string for config option HPX_WITH_EXAMPLES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ endif()
 
 ################################################################################
 
-hpx_option(HPX_WITH_EXAMPLES BOOL "Build the HPX examples (default OFF)" ON CATEGORY "Build Targets")
+hpx_option(HPX_WITH_EXAMPLES BOOL "Build the HPX examples (default ON)" ON CATEGORY "Build Targets")
 hpx_option(HPX_WITH_TESTS BOOL "Build the HPX tests (default ON)" ON CATEGORY "Build Targets")
 hpx_option(HPX_WITH_TESTS_BENCHMARKS BOOL "Build HPX benchmark tests (default: ON)" ON ADVANCED CATEGORY "Build Targets")
 hpx_option(HPX_WITH_TESTS_REGRESSIONS BOOL "Build HPX regression tests (default: ON)" ON ADVANCED CATEGORY "Build Targets")


### PR DESCRIPTION
@sithhell Not sure if your change of the default option value was intentional (see https://github.com/STEllAR-GROUP/hpx/commit/34a0e3fe5151ec9a05be7489bc4cf1eae1cccf9a), please comment