### PR TITLE
Fixing array access

### DIFF
--- a/hpx/runtime/serialization/vector.hpp
+++ b/hpx/runtime/serialization/vector.hpp
@@ -67,7 +67,7 @@ namespace hpx { namespace serialization
         // normal load ... no chance of doing bitwise here ...
         for(size_type i = 0; i != size; ++i)
         {
-            bool b = v[i];
+            bool b = false;
             ar >> b;
             v.push_back(b);
         }

--- a/hpx/util/filesystem_compatibility.hpp
+++ b/hpx/util/filesystem_compatibility.hpp
@@ -36,7 +36,7 @@ namespace hpx { namespace util
 
     inline boost::filesystem::path create_path(std::string const& p)
     {
-        char back = p[p.length()-1];
+        char back = p.empty() ? 0 : p[p.length()-1];
 #if BOOST_FILESYSTEM_VERSION >= 3
         return boost::filesystem::path(back == ':' ? p.substr(0, p.size()-1) : p);
 #else


### PR DESCRIPTION
When running the test suite with C++ standard library debug mode enabled, a few problems occured. The commits in this PR fixes them.