### PR TITLE
Fixing problems with remove_copy algorithm tests

### DIFF
--- a/tests/unit/parallel/algorithms/remove_copy.cpp
+++ b/tests/unit/parallel/algorithms/remove_copy.cpp
@@ -23,11 +23,11 @@ void test_remove_copy(ExPolicy const& policy, IteratorTag)
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size()/2);
-    auto middle = boost::begin(c) + c.size()/2;
+    auto middle = boost::begin(c) + std::rand() % (c.size()/2);
     std::fill(boost::begin(c), middle, 1);
     std::fill(middle, boost::end(c), 2);
     hpx::parallel::remove_copy(policy, iterator(boost::begin(c)),
-        iterator(boost::end(c)), boost::begin(d) , 2);
+        iterator(boost::end(c)), boost::begin(d), 2);
 
     std::size_t count = 0;
     HPX_TEST(std::equal(boost::begin(c), middle, boost::begin(d),
@@ -47,12 +47,12 @@ void test_remove_copy_async(ExPolicy const& p, IteratorTag)
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size()/2);
-    auto middle = boost::begin(c) + c.size()/2;
+    auto middle = boost::begin(c) + std::rand() % (c.size()/2);
     std::fill(boost::begin(c), middle, 1);
     std::fill(middle, boost::end(c), 2);
     hpx::future<base_iterator> f =
         hpx::parallel::remove_copy(p, iterator(boost::begin(c)),
-            iterator(boost::end(c)), boost::begin(d) , 2);
+            iterator(boost::end(c)), boost::begin(d), 2);
 
     f.wait();
 

--- a/tests/unit/parallel/algorithms/remove_copy_if.cpp
+++ b/tests/unit/parallel/algorithms/remove_copy_if.cpp
@@ -23,8 +23,8 @@ void test_remove_copy_if(ExPolicy const& policy, IteratorTag)
 
     std::vector<int> c(10007);
     std::vector<int> d(c.size());
-    auto middle = boost::begin(c) + c.size()/2;
-    std::iota(boost::begin(c), middle, std::rand());
+    auto middle = boost::begin(c) + std::rand() % (c.size()/2);
+    std::iota(boost::begin(c), middle, static_cast<int>(std::rand() % c.size()));
     std::fill(middle, boost::end(c), -1);
 
     hpx::parallel::remove_copy_if(policy,
@@ -58,8 +58,8 @@ void test_remove_copy_if_async(ExPolicy const& p, IteratorTag)
 
     std::vector<int> c(10007);
     std::vector<int> d(c.size());
-    auto middle = boost::begin(c) + c.size()/2;
-    std::iota(boost::begin(c), middle, std::rand());
+    auto middle = boost::begin(c) + std::rand() % (c.size()/2);
+    std::iota(boost::begin(c), middle, static_cast<int>(std::rand() % c.size()));
     std::fill(middle, boost::end(c), -1);
 
     hpx::future<base_iterator> f =
@@ -97,8 +97,8 @@ void test_remove_copy_if_outiter(ExPolicy const& policy, IteratorTag)
 
     std::vector<int> c(10007);
     std::vector<int> d(0);
-    auto middle = boost::begin(c) + c.size()/2;
-    std::iota(boost::begin(c), middle, std::rand());
+    auto middle = boost::begin(c) + std::rand() % (c.size()/2);
+    std::iota(boost::begin(c), middle, static_cast<int>(std::rand() % c.size()));
     std::fill(middle, boost::end(c), -1);
 
     hpx::parallel::remove_copy_if(policy,
@@ -123,8 +123,8 @@ void test_remove_copy_if_outiter_async(ExPolicy const& p, IteratorTag)
 
     std::vector<int> c(10007);
     std::vector<int> d(0);
-    auto middle = boost::begin(c) + c.size()/2;
-    std::iota(boost::begin(c), middle, std::rand());
+    auto middle = boost::begin(c) + std::rand() % (c.size()/2);
+    std::iota(boost::begin(c), middle, static_cast<int>(std::rand() % c.size()));
     std::fill(middle, boost::end(c), -1);
 
     auto f =


### PR DESCRIPTION
This fixes the occasional test failures we were seeing for the remove_copy_if tests. This also applies similar fly-by changes to the remove_copy test.