### PR TITLE
Fixed running multiple localities without localities parameter 

### DIFF
--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -496,6 +496,10 @@ namespace hpx { namespace util
                     mode_ = hpx::runtime_mode_console;
                 }
                 else {
+                    // don't use port zero for non-console localities
+                    if (hpx_port == 0 && node != 0)
+                        hpx_port = HPX_INITIAL_IP_PORT;
+
                     // each node gets an unique port
                     hpx_port = static_cast<boost::uint16_t>(hpx_port + node);
                     mode_ = hpx::runtime_mode_worker;


### PR DESCRIPTION
This fixes #1606: Running without localities parameter binds to bogus port range