### PR TITLE
Refactoring thread manager, mainly extracting thread pool

### DIFF
--- a/hpx/hpx_fwd.hpp
+++ b/hpx/hpx_fwd.hpp
@@ -253,9 +253,7 @@ namespace hpx
         class HPX_EXPORT thread_data_base;
         class HPX_EXPORT thread_data;
 
-        template <
-            typename SchedulingPolicy,
-            typename NotificationPolicy = threads::policies::callback_notifier>
+        template <typename SchedulingPolicy>
         class HPX_EXPORT threadmanager_impl;
 
         ///////////////////////////////////////////////////////////////////////
@@ -504,9 +502,7 @@ namespace hpx
         std::size_t dflt);
 
     ///////////////////////////////////////////////////////////////////////////
-    template <
-        typename SchedulingPolicy,
-        typename NotificationPolicy = threads::policies::callback_notifier>
+    template <typename SchedulingPolicy>
     class HPX_API_EXPORT runtime_impl;
 
     /// The function \a get_runtime returns a reference to the (thread

--- a/hpx/runtime.hpp
+++ b/hpx/runtime.hpp
@@ -59,7 +59,7 @@ namespace hpx
     int pre_main(runtime_mode);
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename SchedulingPolicy, typename NotificationPolicy>
+    template <typename SchedulingPolicy>
     class HPX_EXPORT runtime_impl;
 
 #if defined(HPX_HAVE_SECURITY)
@@ -72,7 +72,7 @@ namespace hpx
     class HPX_EXPORT runtime
     {
     public:
-      
+
         state get_state() const { return state_.load(); }
 
         /// The \a hpx_main_function_type is the default function type usable

--- a/hpx/runtime/threads/detail/periodic_maintenance.hpp
+++ b/hpx/runtime/threads/detail/periodic_maintenance.hpp
@@ -1,0 +1,96 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_RUNTIME_THREADS_DETAIL_PERIODIC_MAINTENANCE_JAN_11_2015_0626PM)
+#define HPX_RUNTIME_THREADS_DETAIL_PERIODIC_MAINTENANCE_JAN_11_2015_0626PM
+
+#include <hpx/config.hpp>
+#include <hpx/state.hpp>
+#include <hpx/util/io_service_pool.hpp>
+#include <hpx/util/bind.hpp>
+#include <hpx/util/date_time_chrono.hpp>
+
+#include <boost/cstdint.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/ref.hpp>
+#include <boost/asio/basic_deadline_timer.hpp>
+#include <boost/atomic.hpp>
+#include <boost/chrono/system_clocks.hpp>
+
+namespace hpx { namespace threads { namespace detail
+{
+    ///////////////////////////////////////////////////////////////////////////
+    inline bool is_running_state(hpx::state state)
+    {
+        return state == state_running || state == state_suspended;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename SchedulingPolicy>
+    inline void periodic_maintenance_handler(SchedulingPolicy& scheduler,
+        boost::atomic<hpx::state>& global_state, boost::mpl::false_)
+    {
+    }
+
+    template <typename SchedulingPolicy>
+    inline void periodic_maintenance_handler(SchedulingPolicy& scheduler,
+        boost::atomic<hpx::state>& global_state, boost::mpl::true_)
+    {
+        bool running = is_running_state(global_state.load());
+        scheduler.periodic_maintenance(running);
+
+        if (running)
+        {
+            // create timer firing in correspondence with given time
+            typedef boost::asio::basic_deadline_timer<
+                boost::chrono::steady_clock
+              , util::chrono_traits<boost::chrono::steady_clock>
+            > deadline_timer;
+
+            deadline_timer t(
+                get_thread_pool("timer-thread")->get_io_service(),
+                boost::chrono::milliseconds(1000));
+
+            void (*handler)(SchedulingPolicy&, boost::atomic<hpx::state>&, boost::mpl::true_) =
+                &periodic_maintenance_handler<SchedulingPolicy>;
+
+            t.async_wait(boost::bind(handler, boost::ref(scheduler),
+                boost::ref(global_state), boost::mpl::true_()));
+        }
+    }
+
+    template <typename SchedulingPolicy>
+    inline void start_periodic_maintenance(SchedulingPolicy&,
+        boost::atomic<hpx::state>& global_state, boost::mpl::false_)
+    {
+    }
+
+    template <typename SchedulingPolicy>
+    inline void start_periodic_maintenance(SchedulingPolicy& scheduler,
+        boost::atomic<hpx::state>& global_state, boost::mpl::true_)
+    {
+        scheduler.periodic_maintenance(is_running_state(global_state.load()));
+
+        // create timer firing in correspondence with given time
+        typedef boost::asio::basic_deadline_timer<
+            boost::chrono::steady_clock
+          , util::chrono_traits<boost::chrono::steady_clock>
+        > deadline_timer;
+
+        deadline_timer t (
+            get_thread_pool("io-thread")->get_io_service(),
+            boost::chrono::milliseconds(1000));
+
+        void (*handler)(SchedulingPolicy&, boost::atomic<hpx::state>&, boost::mpl::true_) =
+            &periodic_maintenance_handler<SchedulingPolicy>;
+
+        t.async_wait(util::bind(handler, boost::ref(scheduler),
+            boost::ref(global_state), boost::mpl::true_()));
+    }
+}}}
+
+#endif
+
+

--- a/hpx/runtime/threads/detail/thread_pool.hpp
+++ b/hpx/runtime/threads/detail/thread_pool.hpp
@@ -1,0 +1,175 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_RUNTIME_THREADS_DETAIL_THREAD_POOL_JUN_11_2015_1137AM)
+#define HPX_RUNTIME_THREADS_DETAIL_THREAD_POOL_JUN_11_2015_1137AM
+
+#include <hpx/config.hpp>
+#include <hpx/state.hpp>
+#include <hpx/runtime/threads/policies/affinity_data.hpp>
+#include <hpx/runtime/threads/policies/scheduler_base.hpp>
+#include <hpx/util/thread_specific_ptr.hpp>
+#include <hpx/util/date_time_chrono.hpp>
+
+#include <boost/thread/barrier.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/thread/thread.hpp>
+#include <boost/atomic.hpp>
+#include <boost/ptr_container/ptr_vector.hpp>
+#include <boost/cstdint.hpp>
+#include <boost/scoped_ptr.hpp>
+
+#include <vector>
+#include <string>
+
+namespace hpx { namespace threads { namespace detail
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Scheduler> struct init_tss_helper;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // note: this data structure has to be protected from races from the outside
+    template <typename Scheduler>
+    class thread_pool
+    {
+    public:
+        thread_pool(Scheduler& sched,
+            threads::policies::callback_notifier& notifier,
+            char const* pool_name);
+        ~thread_pool();
+
+        std::size_t init(std::size_t num_threads,
+            policies::init_affinity_data const& data);
+
+        bool run(boost::unique_lock<boost::mutex>& l, std::size_t num_threads);
+        void stop(boost::unique_lock<boost::mutex>& l, bool blocking = true);
+        template <typename Lock>
+        void stop_locked(Lock& l, bool blocking = true);
+
+        std::size_t get_worker_thread_num() const;
+        std::size_t get_os_thread_count() const
+        {
+            return threads_.size();
+        }
+        boost::thread& get_os_thread_handle(std::size_t num_thread);
+
+        void create_thread(thread_init_data& data, thread_id_type& id,
+            thread_state_enum initial_state, bool run_now, error_code& ec);
+        void create_work(thread_init_data& data,
+            thread_state_enum initial_state, error_code& ec);
+
+        thread_id_type
+        set_state(util::steady_time_point const& abs_time,
+            thread_id_type const& id, thread_state_enum newstate,
+            thread_state_ex_enum newstate_ex, thread_priority priority,
+            error_code& ec);
+
+        std::size_t get_pu_num(std::size_t num_thread) const;
+        mask_cref_type get_pu_mask(topology const& topology,
+            std::size_t num_thread) const;
+        mask_cref_type get_used_processing_units() const;
+
+        // performance counters
+#ifdef HPX_HAVE_THREAD_CUMULATIVE_COUNTS
+        boost::int64_t get_executed_threads(std::size_t num, bool reset);
+        boost::int64_t get_executed_thread_phases(std::size_t num, bool reset);
+#ifdef HPX_HAVE_THREAD_IDLE_RATES
+        boost::int64_t get_thread_phase_duration(std::size_t num, bool reset);
+        boost::int64_t get_thread_duration(std::size_t num, bool reset);
+        boost::int64_t get_thread_phase_overhead(std::size_t num, bool reset);
+        boost::int64_t get_thread_overhead(std::size_t num, bool reset);
+#endif
+#endif
+
+#ifdef HPX_HAVE_THREAD_IDLE_RATES
+    ///////////////////////////////////////////////////////////////////////////
+    boost::int64_t avg_idle_rate(bool reset);
+    boost::int64_t avg_idle_rate(std::size_t num_thread, bool reset);
+
+#if defined(HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES)
+        boost::int64_t avg_creation_idle_rate(bool reset);
+        boost::int64_t avg_cleanup_idle_rate(bool reset);
+#endif
+#endif
+
+        boost::int64_t get_queue_length(std::size_t num_thread) const;
+
+#ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
+        boost::int64_t get_average_thread_wait_time(
+            std::size_t num_thread) const;
+        boost::int64_t get_average_task_wait_time(
+            std::size_t num_thread) const;
+#endif
+
+#ifdef HPX_HAVE_THREAD_STEALING_COUNTS
+        boost::int64_t get_num_pending_misses(std::size_t num, bool reset);
+        boost::int64_t get_num_pending_accesses(std::size_t num, bool reset);
+
+        boost::int64_t get_num_stolen_from_pending(std::size_t num, bool reset);
+        boost::int64_t get_num_stolen_to_pending(std::size_t num, bool reset);
+        boost::int64_t get_num_stolen_from_staged(std::size_t num, bool reset);
+        boost::int64_t get_num_stolen_to_staged(std::size_t num, bool reset);
+#endif
+
+        boost::int64_t get_thread_count(thread_state_enum state,
+            thread_priority priority, std::size_t num_thread, bool reset) const;
+
+        //
+        void abort_all_suspended_threads();
+        bool cleanup_terminated(bool delete_all);
+
+        hpx::state get_state() const { return state_.load(); }
+
+        void do_some_work(std::size_t num_thread);
+
+        void report_error(std::size_t num, boost::exception_ptr const& e);
+
+    protected:
+        friend struct init_tss_helper<Scheduler>;
+
+        void init_tss(std::size_t num);
+        void deinit_tss();
+
+        void thread_func(std::size_t num_thread, topology const& topology,
+            boost::barrier& startup);
+
+    private:
+        // this thread manager has exactly as many OS-threads as requested
+        boost::ptr_vector<boost::thread> threads_;
+
+        // refer to used scheduler
+        Scheduler& sched_;
+        threads::policies::callback_notifier& notifier_;
+        std::string pool_name_;
+
+        // thread pool state
+        boost::atomic<hpx::state> state_;
+
+        // startup barrier
+        boost::scoped_ptr<boost::barrier> startup_;
+
+        // count number of executed HPX-threads and thread phases (invocations)
+        std::vector<boost::int64_t> executed_threads_;
+        std::vector<boost::int64_t> executed_thread_phases_;
+        boost::atomic<long> thread_count_;
+
+#if defined(HPX_HAVE_THREAD_CUMULATIVE_COUNTS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
+        double timestamp_scale_;    // scale timestamps to nanoseconds
+#endif
+
+        // tfunc_impl timers
+        std::vector<boost::uint64_t> exec_times_, tfunc_times_;
+
+        // Stores the mask identifying all processing units used by this
+        // thread manager.
+        threads::mask_type used_processing_units_;
+
+        // the TSS holds the number associated with a given OS thread
+        struct tls_tag {};
+        static hpx::util::thread_specific_ptr<std::size_t, tls_tag> thread_num_;
+    };
+}}}
+
+#endif

--- a/hpx/runtime/threads/policies/hierarchy_scheduler.hpp
+++ b/hpx/runtime/threads/policies/hierarchy_scheduler.hpp
@@ -349,9 +349,9 @@ namespace hpx { namespace threads { namespace policies
 #endif
 
 #ifdef HPX_HAVE_THREAD_STEALING_COUNTS
-        boost::uint64_t get_num_pending_misses(std::size_t num_thread, bool reset)
+        boost::int64_t get_num_pending_misses(std::size_t num_thread, bool reset)
         {
-            boost::uint64_t num_pending_misses = 0;
+            boost::int64_t num_pending_misses = 0;
             if (num_thread == std::size_t(-1))
             {
                 for (size_type i = 0; i != tree.size(); ++i)
@@ -376,9 +376,9 @@ namespace hpx { namespace threads { namespace policies
             return num_pending_misses;
         }
 
-        boost::uint64_t get_num_pending_accesses(std::size_t num_thread, bool reset)
+        boost::int64_t get_num_pending_accesses(std::size_t num_thread, bool reset)
         {
-            boost::uint64_t num_pending_accesses = 0;
+            boost::int64_t num_pending_accesses = 0;
             if (num_thread == std::size_t(-1))
             {
                 for (size_type i = 0; i != tree.size(); ++i)
@@ -403,9 +403,9 @@ namespace hpx { namespace threads { namespace policies
             return num_pending_accesses;
         }
 
-        boost::uint64_t get_num_stolen_from_pending(std::size_t num_thread, bool reset)
+        boost::int64_t get_num_stolen_from_pending(std::size_t num_thread, bool reset)
         {
-            boost::uint64_t num_stolen_threads = 0;
+            boost::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
             {
                 for (size_type i = 0; i != tree.size(); ++i)
@@ -430,9 +430,9 @@ namespace hpx { namespace threads { namespace policies
             return num_stolen_threads;
         }
 
-        boost::uint64_t get_num_stolen_to_pending(std::size_t num_thread, bool reset)
+        boost::int64_t get_num_stolen_to_pending(std::size_t num_thread, bool reset)
         {
-            boost::uint64_t num_stolen_threads = 0;
+            boost::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
             {
                 for (size_type i = 0; i != tree.size(); ++i)
@@ -457,9 +457,9 @@ namespace hpx { namespace threads { namespace policies
             return num_stolen_threads;
         }
 
-        boost::uint64_t get_num_stolen_from_staged(std::size_t num_thread, bool reset)
+        boost::int64_t get_num_stolen_from_staged(std::size_t num_thread, bool reset)
         {
-            boost::uint64_t num_stolen_threads = 0;
+            boost::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
             {
                 for (size_type i = 0; i != tree.size(); ++i)
@@ -484,9 +484,9 @@ namespace hpx { namespace threads { namespace policies
             return num_stolen_threads;
         }
 
-        boost::uint64_t get_num_stolen_to_staged(std::size_t num_thread, bool reset)
+        boost::int64_t get_num_stolen_to_staged(std::size_t num_thread, bool reset)
         {
-            boost::uint64_t num_stolen_threads = 0;
+            boost::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
             {
                 for (size_type i = 0; i != tree.size(); ++i)

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -180,9 +180,9 @@ namespace hpx { namespace threads { namespace policies
 #endif
 
 #ifdef HPX_HAVE_THREAD_STEALING_COUNTS
-        boost::uint64_t get_num_pending_misses(std::size_t num_thread, bool reset)
+        boost::int64_t get_num_pending_misses(std::size_t num_thread, bool reset)
         {
-            boost::uint64_t num_pending_misses = 0;
+            boost::int64_t num_pending_misses = 0;
             if (num_thread == std::size_t(-1))
             {
                 for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
@@ -215,9 +215,9 @@ namespace hpx { namespace threads { namespace policies
             return num_pending_misses;
         }
 
-        boost::uint64_t get_num_pending_accesses(std::size_t num_thread, bool reset)
+        boost::int64_t get_num_pending_accesses(std::size_t num_thread, bool reset)
         {
-            boost::uint64_t num_pending_accesses = 0;
+            boost::int64_t num_pending_accesses = 0;
             if (num_thread == std::size_t(-1))
             {
                 for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
@@ -250,9 +250,9 @@ namespace hpx { namespace threads { namespace policies
             return num_pending_accesses;
         }
 
-        boost::uint64_t get_num_stolen_from_pending(std::size_t num_thread, bool reset)
+        boost::int64_t get_num_stolen_from_pending(std::size_t num_thread, bool reset)
         {
-            boost::uint64_t num_stolen_threads = 0;
+            boost::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
             {
                 for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
@@ -285,9 +285,9 @@ namespace hpx { namespace threads { namespace policies
             return num_stolen_threads;
         }
 
-        boost::uint64_t get_num_stolen_to_pending(std::size_t num_thread, bool reset)
+        boost::int64_t get_num_stolen_to_pending(std::size_t num_thread, bool reset)
         {
-            boost::uint64_t num_stolen_threads = 0;
+            boost::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
             {
                 for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
@@ -320,9 +320,9 @@ namespace hpx { namespace threads { namespace policies
             return num_stolen_threads;
         }
 
-        boost::uint64_t get_num_stolen_from_staged(std::size_t num_thread, bool reset)
+        boost::int64_t get_num_stolen_from_staged(std::size_t num_thread, bool reset)
         {
-            boost::uint64_t num_stolen_threads = 0;
+            boost::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
             {
                 for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
@@ -355,9 +355,9 @@ namespace hpx { namespace threads { namespace policies
             return num_stolen_threads;
         }
 
-        boost::uint64_t get_num_stolen_to_staged(std::size_t num_thread, bool reset)
+        boost::int64_t get_num_stolen_to_staged(std::size_t num_thread, bool reset)
         {
-            boost::uint64_t num_stolen_threads = 0;
+            boost::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
             {
                 for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)

--- a/hpx/runtime/threads/policies/local_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_queue_scheduler.hpp
@@ -149,9 +149,9 @@ namespace hpx { namespace threads { namespace policies
 #endif
 
 #ifdef HPX_HAVE_THREAD_STEALING_COUNTS
-        boost::uint64_t get_num_pending_misses(std::size_t num_thread, bool reset)
+        boost::int64_t get_num_pending_misses(std::size_t num_thread, bool reset)
         {
-            boost::uint64_t num_pending_misses = 0;
+            boost::int64_t num_pending_misses = 0;
             if (num_thread == std::size_t(-1))
             {
                 for (std::size_t i = 0; i != queues_.size(); ++i)
@@ -166,9 +166,9 @@ namespace hpx { namespace threads { namespace policies
             return num_pending_misses;
         }
 
-        boost::uint64_t get_num_pending_accesses(std::size_t num_thread, bool reset)
+        boost::int64_t get_num_pending_accesses(std::size_t num_thread, bool reset)
         {
-            boost::uint64_t num_pending_accesses = 0;
+            boost::int64_t num_pending_accesses = 0;
             if (num_thread == std::size_t(-1))
             {
                 for (std::size_t i = 0; i != queues_.size(); ++i)
@@ -183,9 +183,9 @@ namespace hpx { namespace threads { namespace policies
             return num_pending_accesses;
         }
 
-        boost::uint64_t get_num_stolen_from_pending(std::size_t num_thread, bool reset)
+        boost::int64_t get_num_stolen_from_pending(std::size_t num_thread, bool reset)
         {
-            boost::uint64_t num_stolen_threads = 0;
+            boost::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
             {
                 for (std::size_t i = 0; i != queues_.size(); ++i)
@@ -197,9 +197,9 @@ namespace hpx { namespace threads { namespace policies
             return num_stolen_threads;
         }
 
-        boost::uint64_t get_num_stolen_to_pending(std::size_t num_thread, bool reset)
+        boost::int64_t get_num_stolen_to_pending(std::size_t num_thread, bool reset)
         {
-            boost::uint64_t num_stolen_threads = 0;
+            boost::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
             {
                 for (std::size_t i = 0; i != queues_.size(); ++i)
@@ -211,9 +211,9 @@ namespace hpx { namespace threads { namespace policies
             return num_stolen_threads;
         }
 
-        boost::uint64_t get_num_stolen_from_staged(std::size_t num_thread, bool reset)
+        boost::int64_t get_num_stolen_from_staged(std::size_t num_thread, bool reset)
         {
-            boost::uint64_t num_stolen_threads = 0;
+            boost::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
             {
                 for (std::size_t i = 0; i != queues_.size(); ++i)
@@ -225,9 +225,9 @@ namespace hpx { namespace threads { namespace policies
             return num_stolen_threads;
         }
 
-        boost::uint64_t get_num_stolen_to_staged(std::size_t num_thread, bool reset)
+        boost::int64_t get_num_stolen_to_staged(std::size_t num_thread, bool reset)
         {
-            boost::uint64_t num_stolen_threads = 0;
+            boost::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
             {
                 for (std::size_t i = 0; i != queues_.size(); ++i)

--- a/hpx/runtime/threads/policies/periodic_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/periodic_priority_queue_scheduler.hpp
@@ -9,6 +9,7 @@
 #define HPX_THREADMANAGER_SCHEDULING_PERIODIC_PRIORITY_QUEUE_HPP
 
 #include <hpx/config.hpp>
+#include <hpx/runtime/threads/detail/periodic_maintenance.hpp>
 #include <hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -34,6 +35,13 @@ namespace hpx { namespace threads { namespace policies
     {
     public:
         typedef boost::mpl::true_ has_periodic_maintenance;
+
+        void start_periodic_maintenance(
+            boost::atomic<hpx::state>& global_state)
+        {
+            threads::detail::start_periodic_maintenance(*this, global_state,
+                has_periodic_maintenance());
+        }
 
         typedef local_priority_queue_scheduler<
             Mutex, PendingQueuing, StagedQueuing, TerminatedQueuing

--- a/hpx/runtime/threads/policies/scheduler_base.hpp
+++ b/hpx/runtime/threads/policies/scheduler_base.hpp
@@ -10,6 +10,7 @@
 #include <hpx/runtime/threads/thread_init_data.hpp>
 #include <hpx/runtime/threads/topology.hpp>
 #include <hpx/runtime/threads/policies/affinity_data.hpp>
+#include <hpx/util/assert.hpp>
 
 #include <boost/noncopyable.hpp>
 #include <boost/thread/mutex.hpp>
@@ -25,16 +26,18 @@ namespace hpx { namespace threads { namespace policies
     {
         struct reset_on_exit
         {
-            reset_on_exit(boost::atomic<bool>& flag)
-              : flag_(flag)
+            reset_on_exit(boost::atomic<boost::int32_t>& counter)
+              : counter_(counter)
             {
-                flag_ = true;
+                ++counter_;
+                HPX_ASSERT(counter_ > 0);
             }
             ~reset_on_exit()
             {
-                flag_ = false;
+                HPX_ASSERT(counter_ > 0);
+                --counter_;
             }
-            boost::atomic<bool>& flag_;
+            boost::atomic<boost::int32_t>& counter_;
         };
     }
 #endif
@@ -49,7 +52,6 @@ namespace hpx { namespace threads { namespace policies
           , affinity_data_(num_threads)
 #if defined(HPX_HAVE_THREAD_MANAGER_IDLE_BACKOFF)
           , wait_count_(0)
-          , waiting_(false)
 #endif
         {}
 
@@ -72,7 +74,8 @@ namespace hpx { namespace threads { namespace policies
             affinity_data_.add_punit(virt_core, thread_num, topology_);
         }
 
-        std::size_t init(init_affinity_data const& data, topology const& topology)
+        std::size_t init(init_affinity_data const& data,
+            topology const& topology)
         {
             return affinity_data_.init(data, topology);
         }
@@ -86,13 +89,11 @@ namespace hpx { namespace threads { namespace policies
             boost::posix_time::millisec period(++wait_count_);
 
             boost::mutex::scoped_lock l(mtx_);
-            policies::detail::reset_on_exit w(waiting_);
             cond_.timed_wait(l, period);
 #else
             boost::chrono::milliseconds period(++wait_count_);
 
             boost::mutex::scoped_lock l(mtx_);
-            policies::detail::reset_on_exit w(waiting_);
             cond_.wait_for(l, period);
 #endif
 #endif
@@ -101,14 +102,15 @@ namespace hpx { namespace threads { namespace policies
         /// This function gets called by the thread-manager whenever new work
         /// has been added, allowing the scheduler to reactivate one or more of
         /// possibly idling OS threads
-        void do_some_work(std::size_t /*num_thread*/)
+        void do_some_work(std::size_t num_thread)
         {
 #if defined(HPX_HAVE_THREAD_MANAGER_IDLE_BACKOFF)
             wait_count_.store(0, boost::memory_order_release);
-            if (waiting_)
-            {
+
+            if (num_thread == std::size_t(-1))
+                cond_.notify_all();
+            else
                 cond_.notify_one();
-            }
 #endif
         }
 
@@ -121,27 +123,29 @@ namespace hpx { namespace threads { namespace policies
 #endif
 
 #ifdef HPX_HAVE_THREAD_STEALING_COUNTS
-        virtual boost::uint64_t get_num_pending_misses(std::size_t num_thread,
+        virtual boost::int64_t get_num_pending_misses(std::size_t num_thread,
             bool reset) = 0;
-        virtual boost::uint64_t get_num_pending_accesses(std::size_t num_thread,
+        virtual boost::int64_t get_num_pending_accesses(std::size_t num_thread,
             bool reset) = 0;
 
-        virtual boost::uint64_t get_num_stolen_from_pending(std::size_t num_thread,
+        virtual boost::int64_t get_num_stolen_from_pending(std::size_t num_thread,
             bool reset) = 0;
-        virtual boost::uint64_t get_num_stolen_to_pending(std::size_t num_thread,
+        virtual boost::int64_t get_num_stolen_to_pending(std::size_t num_thread,
             bool reset) = 0;
-        virtual boost::uint64_t get_num_stolen_from_staged(std::size_t num_thread,
+        virtual boost::int64_t get_num_stolen_from_staged(std::size_t num_thread,
             bool reset) = 0;
-        virtual boost::uint64_t get_num_stolen_to_staged(std::size_t num_thread,
+        virtual boost::int64_t get_num_stolen_to_staged(std::size_t num_thread,
             bool reset) = 0;
 #endif
 
         virtual boost::int64_t get_queue_length(
             std::size_t num_thread = std::size_t(-1)) const = 0;
 
-        virtual boost::int64_t get_thread_count(thread_state_enum state = unknown,
+        virtual boost::int64_t get_thread_count(
+            thread_state_enum state = unknown,
             thread_priority priority = thread_priority_default,
-            std::size_t num_thread = std::size_t(-1), bool reset = false) const = 0;
+            std::size_t num_thread = std::size_t(-1),
+            bool reset = false) const = 0;
 
         virtual void abort_all_suspended_threads() = 0;
 
@@ -169,7 +173,8 @@ namespace hpx { namespace threads { namespace policies
 
         virtual void on_start_thread(std::size_t num_thread) = 0;
         virtual void on_stop_thread(std::size_t num_thread) = 0;
-        virtual void on_error(std::size_t num_thread, boost::exception_ptr const& e) = 0;
+        virtual void on_error(std::size_t num_thread,
+            boost::exception_ptr const& e) = 0;
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
         virtual boost::int64_t get_average_thread_wait_time(
@@ -177,6 +182,10 @@ namespace hpx { namespace threads { namespace policies
         virtual boost::int64_t get_average_task_wait_time(
             std::size_t num_thread = std::size_t(-1)) const = 0;
 #endif
+
+        virtual void start_periodic_maintenance(
+            boost::atomic<hpx::state>& global_state)
+        {}
 
     protected:
         topology const& topology_;
@@ -187,7 +196,6 @@ namespace hpx { namespace threads { namespace policies
         boost::mutex mtx_;
         boost::condition_variable cond_;
         boost::atomic<boost::uint32_t> wait_count_;
-        boost::atomic<bool> waiting_;
 #endif
     };
 }}}

--- a/hpx/runtime/threads/policies/thread_queue.hpp
+++ b/hpx/runtime/threads/policies/thread_queue.hpp
@@ -612,7 +612,7 @@ namespace hpx { namespace threads { namespace policies
 #endif
 
 #ifdef HPX_HAVE_THREAD_STEALING_COUNTS
-        boost::uint64_t get_num_pending_misses(bool reset)
+        boost::int64_t get_num_pending_misses(bool reset)
         {
             return util::get_and_reset_value(pending_misses_, reset);
         }
@@ -622,7 +622,7 @@ namespace hpx { namespace threads { namespace policies
             pending_misses_ += num;
         }
 
-        boost::uint64_t get_num_pending_accesses(bool reset)
+        boost::int64_t get_num_pending_accesses(bool reset)
         {
             return util::get_and_reset_value(pending_accesses_, reset);
         }
@@ -632,7 +632,7 @@ namespace hpx { namespace threads { namespace policies
             pending_accesses_ += num;
         }
 
-        boost::uint64_t get_num_stolen_from_pending(bool reset)
+        boost::int64_t get_num_stolen_from_pending(bool reset)
         {
             return util::get_and_reset_value(stolen_from_pending_, reset);
         }
@@ -642,7 +642,7 @@ namespace hpx { namespace threads { namespace policies
             stolen_from_pending_ += num;
         }
 
-        boost::uint64_t get_num_stolen_from_staged(bool reset)
+        boost::int64_t get_num_stolen_from_staged(bool reset)
         {
             return util::get_and_reset_value(stolen_from_staged_, reset);
         }
@@ -652,7 +652,7 @@ namespace hpx { namespace threads { namespace policies
             stolen_from_staged_ += num;
         }
 
-        boost::uint64_t get_num_stolen_to_pending(bool reset)
+        boost::int64_t get_num_stolen_to_pending(bool reset)
         {
             return util::get_and_reset_value(stolen_to_pending_, reset);
         }
@@ -662,7 +662,7 @@ namespace hpx { namespace threads { namespace policies
             stolen_to_pending_ += num;
         }
 
-        boost::uint64_t get_num_stolen_to_staged(bool reset)
+        boost::int64_t get_num_stolen_to_staged(bool reset)
         {
             return util::get_and_reset_value(stolen_to_staged_, reset);
         }

--- a/hpx/runtime/threads/threadmanager.hpp
+++ b/hpx/runtime/threads/threadmanager.hpp
@@ -49,7 +49,8 @@ namespace hpx { namespace threads
         /// \brief return the number of HPX-threads with the given state
         virtual boost::int64_t get_thread_count(
             thread_state_enum state = unknown,
-            thread_priority priority = thread_priority_default) const = 0;
+            thread_priority priority = thread_priority_default,
+            std::size_t num_thread = std::size_t(-1), bool reset = false) const = 0;
 
         // \brief Abort all threads which are in suspended state. This will set
         //        the state of all suspended threads to \a pending while
@@ -473,15 +474,7 @@ namespace hpx { namespace threads
         virtual executor get_executor(thread_id_type const& id, error_code& ec) const = 0;
 
         ///////////////////////////////////////////////////////////////////////
-        static std::size_t get_worker_thread_num(bool* numa_sensitive = 0);
-
-        void init_tss(std::size_t thread_num, bool numa_sensitive);
-        void deinit_tss();
-
-    private:
-        // the TSS holds the number associated with a given OS thread
-        struct tls_tag {};
-        static hpx::util::thread_specific_ptr<std::size_t, tls_tag> thread_num_;
+        virtual std::size_t get_worker_thread_num(bool* numa_sensitive = 0) = 0;
     };
 }}
 

--- a/hpx/runtime_impl.hpp
+++ b/hpx/runtime_impl.hpp
@@ -38,7 +38,7 @@ namespace hpx
     /// The \a runtime class encapsulates the HPX runtime system in a simple to
     /// use way. It makes sure all required parts of the HPX runtime system are
     /// properly initialized.
-    template <typename SchedulingPolicy, typename NotificationPolicy>
+    template <typename SchedulingPolicy>
     class HPX_EXPORT runtime_impl : public runtime
     {
     private:
@@ -58,7 +58,7 @@ namespace hpx
 
     public:
         typedef SchedulingPolicy scheduling_policy_type;
-        typedef NotificationPolicy notification_policy_type;
+        typedef threads::policies::callback_notifier notification_policy_type;
 
         typedef typename scheduling_policy_type::init_parameter_type
             init_scheduler_type;

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -253,7 +253,7 @@ namespace hpx { namespace detail
         if (NULL != self)
         {
             if (threads::threadmanager_is(state_running))
-                shepherd = threads::threadmanager_base::get_worker_thread_num();
+                shepherd = hpx::get_worker_thread_num();
 
             thread_id = threads::get_self_id();
             thread_name = threads::get_thread_description(thread_id);

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -838,7 +838,7 @@ namespace hpx
             return;
         }
 
-        std::size_t num_thread = hpx::threads::threadmanager_base::get_worker_thread_num();
+        std::size_t num_thread = hpx::get_worker_thread_num();
         hpx::applier::get_applier().get_thread_manager().report_error(num_thread, e);
     }
 

--- a/src/runtime/threads/detail/thread_pool.cpp
+++ b/src/runtime/threads/detail/thread_pool.cpp
@@ -1,0 +1,936 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_fwd.hpp>
+#include <hpx/exception.hpp>
+#include <hpx/runtime/threads/detail/thread_pool.hpp>
+#include <hpx/runtime/threads/detail/create_thread.hpp>
+#include <hpx/runtime/threads/detail/create_work.hpp>
+#include <hpx/runtime/threads/detail/scheduling_loop.hpp>
+#include <hpx/runtime/threads/detail/set_thread_state.hpp>
+#include <hpx/runtime/threads/policies/callback_notifier.hpp>
+#include <hpx/runtime/threads/topology.hpp>
+#include <hpx/util/logging.hpp>
+#include <hpx/util/bind.hpp>
+#include <hpx/lcos/local/no_mutex.hpp>
+#include <hpx/util/scoped_unlock.hpp>
+
+#if defined(HPX_HAVE_THREAD_CUMULATIVE_COUNTS) && \
+    defined(HPX_HAVE_THREAD_IDLE_RATES)
+#include <hpx/util/hardware/timestamp.hpp>
+#include <hpx/util/high_resolution_clock.hpp>
+#endif
+
+#include <boost/ref.hpp>
+#include <boost/exception_ptr.hpp>
+
+#include <cstdint>
+#include <numeric>
+
+namespace hpx { namespace threads { namespace detail
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Scheduler>
+    hpx::util::thread_specific_ptr<
+            std::size_t, typename thread_pool<Scheduler>::tls_tag
+        > thread_pool<Scheduler>::thread_num_;
+
+    template <typename Scheduler>
+    void thread_pool<Scheduler>::init_tss(std::size_t num)
+    {
+        // shouldn't be initialized yet
+        HPX_ASSERT(NULL == thread_pool::thread_num_.get());
+
+        thread_pool::thread_num_.reset(new std::size_t);
+        *thread_pool::thread_num_.get() = num;
+    }
+
+    template <typename Scheduler>
+    void thread_pool<Scheduler>::deinit_tss()
+    {
+        thread_pool::thread_num_.reset();
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Scheduler>
+    thread_pool<Scheduler>::thread_pool(Scheduler& sched,
+            threads::policies::callback_notifier& notifier,
+            char const* pool_name)
+      : sched_(sched),
+        notifier_(notifier),
+        pool_name_(pool_name),
+        state_(state_starting),
+        thread_count_(0),
+        used_processing_units_()
+    {
+#if defined(HPX_HAVE_THREAD_CUMULATIVE_COUNTS) && \
+    defined(HPX_HAVE_THREAD_IDLE_RATES)
+        timestamp_scale_ = 1.0;
+#endif
+    }
+
+    template <typename Scheduler>
+    thread_pool<Scheduler>::~thread_pool()
+    {
+        if (!threads_.empty()) {
+            if (state_.load() == state_running)
+            {
+                lcos::local::no_mutex mtx;
+                lcos::local::no_mutex::scoped_lock l(mtx);
+                stop_locked(l);
+            }
+            threads_.clear();
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Scheduler>
+    std::size_t thread_pool<Scheduler>::init(std::size_t num_threads,
+        policies::init_affinity_data const& data)
+    {
+        topology const& topology_ = get_topology();
+        std::size_t cores_used = sched_.Scheduler::init(data, topology_);
+
+        resize(used_processing_units_, threads::hardware_concurrency());
+        for (std::size_t i = 0; i != num_threads; ++i)
+            used_processing_units_ |= sched_.Scheduler::get_pu_mask(topology_, i);
+
+        return cores_used;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Scheduler>
+    std::size_t thread_pool<Scheduler>::get_pu_num(std::size_t num_thread) const
+    {
+        return sched_.Scheduler::get_pu_num(num_thread);
+    }
+
+    template <typename Scheduler>
+    mask_cref_type thread_pool<Scheduler>::get_pu_mask(
+        topology const& topology, std::size_t num_thread) const
+    {
+        return sched_.Scheduler::get_pu_mask(topology, num_thread);
+    }
+
+    template <typename Scheduler>
+    mask_cref_type thread_pool<Scheduler>::get_used_processing_units() const
+    {
+        return used_processing_units_;
+    }
+
+    template <typename Scheduler>
+    void thread_pool<Scheduler>::do_some_work(std::size_t num_thread)
+    {
+        sched_.Scheduler::do_some_work(num_thread);
+    }
+
+    template <typename Scheduler>
+    void thread_pool<Scheduler>::report_error(std::size_t num,
+        boost::exception_ptr const& e)
+    {
+        state_.store(state_terminating);
+        notifier_.on_error(num, e);
+        sched_.Scheduler::on_error(num, e);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Scheduler>
+    void thread_pool<Scheduler>::create_thread(thread_init_data& data,
+        thread_id_type& id, thread_state_enum initial_state, bool run_now,
+        error_code& ec)
+    {
+        // verify state
+        if ((thread_count_ == 0 && state_.load() != state_running))
+        {
+            // thread-manager is not currently running
+            HPX_THROWS_IF(ec, invalid_status,
+                "thread_pool<Scheduler>::create_thread",
+                "invalid state: thread pool is not running");
+            return;
+        }
+
+        detail::create_thread(&sched_, data, id, initial_state, run_now, ec); //-V601
+    }
+
+    template <typename Scheduler>
+    void thread_pool<Scheduler>::create_work(thread_init_data& data,
+        thread_state_enum initial_state, error_code& ec)
+    {
+        // verify state
+        if ((thread_count_ == 0 && state_.load() != state_running))
+        {
+            // thread-manager is not currently running
+            HPX_THROWS_IF(ec, invalid_status,
+                "thread_pool<Scheduler>::create_work",
+                "invalid state: thread pool is not running");
+            return;
+        }
+
+        detail::create_work(&sched_, data, initial_state, ec); //-V601
+    }
+
+    template <typename Scheduler>
+    thread_id_type thread_pool<Scheduler>::set_state(
+        util::steady_time_point const& abs_time,
+        thread_id_type const& id, thread_state_enum newstate,
+        thread_state_ex_enum newstate_ex, thread_priority priority,
+        error_code& ec)
+    {
+        return detail::set_thread_state_timed(sched_, abs_time, id,
+            newstate, newstate_ex, priority, get_worker_thread_num(), ec);
+    }
+
+    template <typename Scheduler>
+    void thread_pool<Scheduler>::abort_all_suspended_threads()
+    {
+        sched_.Scheduler::abort_all_suspended_threads();
+    }
+
+    template <typename Scheduler>
+    bool thread_pool<Scheduler>::cleanup_terminated(bool delete_all)
+    {
+        return sched_.Scheduler::cleanup_terminated(delete_all);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Scheduler>
+    std::size_t thread_pool<Scheduler>::get_worker_thread_num() const
+    {
+        if (NULL != thread_pool::thread_num_.get())
+            return *thread_pool::thread_num_;
+
+        // some OS threads are not managed by the thread-manager
+        return std::size_t(-1);
+    }
+
+    template <typename Scheduler>
+    boost::thread& thread_pool<Scheduler>::get_os_thread_handle(
+        std::size_t num_thread)
+    {
+        HPX_ASSERT(num_thread < threads_.size());
+        return threads_[threads_.size() - num_thread - 1];
+    }
+
+    template <typename Scheduler>
+    boost::int64_t thread_pool<Scheduler>::get_thread_count(
+        thread_state_enum state, thread_priority priority,
+        std::size_t num, bool reset) const
+    {
+        return sched_.Scheduler::get_thread_count(state, priority, num, reset);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Scheduler>
+    bool thread_pool<Scheduler>::run(boost::unique_lock<boost::mutex>& l,
+        std::size_t num_threads)
+    {
+        LTM_(info)
+            << "thread_pool::run: " << pool_name_
+            << " number of processing units available: " //-V128
+            << threads::hardware_concurrency();
+        LTM_(info)
+            << "thread_pool::run: " << pool_name_
+            << " creating " << num_threads << " OS thread(s)"; //-V128
+
+        if (0 == num_threads) {
+            HPX_THROW_EXCEPTION(bad_parameter,
+                "thread_pool::run", "number of threads is zero");
+        }
+
+#if defined(HPX_HAVE_THREAD_CUMULATIVE_COUNTS) && \
+    defined(HPX_HAVE_THREAD_IDLE_RATES)
+        // scale timestamps to nanoseconds
+        boost::uint64_t base_timestamp = util::hardware::timestamp();
+        boost::uint64_t base_time = util::high_resolution_clock::now();
+        boost::uint64_t curr_timestamp = util::hardware::timestamp();
+        boost::uint64_t curr_time = util::high_resolution_clock::now();
+
+        while ((curr_time - base_time) <= 100000)
+        {
+            curr_timestamp = util::hardware::timestamp();
+            curr_time = util::high_resolution_clock::now();
+        }
+
+        if (curr_timestamp - base_timestamp != 0)
+        {
+            timestamp_scale_ = double(curr_time - base_time) /
+                double(curr_timestamp - base_timestamp);
+        }
+
+        LTM_(info)
+            << "thread_pool::run: " << pool_name_
+            << " timestamp_scale: " << timestamp_scale_; //-V128
+#endif
+
+        if (!threads_.empty() || (state_.load() == state_running))
+            return true;    // do nothing if already running
+
+        executed_threads_.resize(num_threads);
+        executed_thread_phases_.resize(num_threads);
+        tfunc_times_.resize(num_threads);
+        exec_times_.resize(num_threads);
+
+        try {
+            HPX_ASSERT(startup_.get() == 0);
+            startup_.reset(
+                new boost::barrier(static_cast<unsigned>(num_threads+1))
+            );
+
+            // run threads and wait for initialization to complete
+            state_.store(state_running);
+
+            topology const& topology_ = get_topology();
+
+            std::size_t thread_num = num_threads;
+            while (thread_num-- != 0) {
+                threads::mask_cref_type mask =
+                    sched_.Scheduler::get_pu_mask(topology_, thread_num);
+
+                LTM_(info)
+                    << "thread_pool::run: " << pool_name_
+                    << " create OS thread " << thread_num //-V128
+                    << ": will run on processing units within this mask: "
+#if !defined(HPX_WITH_MORE_THAN_64_THREADS) || \
+    (defined(HPX_HAVE_MAX_CPU_COUNT) && HPX_HAVE_MAX_CPU_COUNT <= 64)
+                    << std::hex << "0x" << mask;
+#else
+                    << "0b" << mask;
+#endif
+
+                // create a new thread
+                threads_.push_back(new boost::thread(
+                        util::bind(&thread_pool::thread_func, this, thread_num,
+                            boost::ref(topology_), boost::ref(*startup_))
+                    ));
+
+                // set the new threads affinity (on Windows systems)
+                if (any(mask))
+                {
+                    error_code ec(lightweight);
+                    topology_.set_thread_affinity_mask(threads_.back(), mask, ec);
+                    if (ec)
+                    {
+                        LTM_(warning)
+                            << "thread_pool::run: " << pool_name_
+                            << " setting thread affinity on OS thread " //-V128
+                            << thread_num << " failed with: "
+                            << ec.get_message();
+                    }
+                }
+                else
+                {
+                    LTM_(debug)
+                        << "thread_pool::run: " << pool_name_
+                        << " setting thread affinity on OS thread " //-V128
+                        << thread_num << " was explicitly disabled.";
+                }
+            }
+
+            // the main thread needs to have a unique thread_num
+            init_tss(num_threads);
+            startup_->wait();
+        }
+        catch (std::exception const& e) {
+            LTM_(always)
+                << "thread_pool::run: " << pool_name_
+                << " failed with: " << e.what();
+
+            // trigger the barrier
+            if (startup_.get() != 0)
+            {
+                while (num_threads-- != 0 && !startup_->wait())
+                    ;
+            }
+
+            stop(l);
+            threads_.clear();
+
+            return false;
+        }
+
+        LTM_(info) << "thread_pool::run: " << pool_name_ << " running";
+        return true;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Scheduler>
+    void thread_pool<Scheduler>::stop (
+        boost::unique_lock<boost::mutex>& l, bool blocking)
+    {
+        return stop_locked(l, blocking);
+    }
+
+    template <typename Scheduler>
+    template <typename Lock>
+    void thread_pool<Scheduler>::stop_locked(Lock& l, bool blocking)
+    {
+        LTM_(info)
+            << "thread_pool::stop: " << pool_name_
+            << " blocking(" << std::boolalpha << blocking << ")";
+
+        deinit_tss();
+
+        if (!threads_.empty()) {
+            // set state to stopping
+            state_.store(state_stopping);
+
+            // make sure we're not waiting
+            sched_.Scheduler::do_some_work(std::size_t(-1));
+
+            if (blocking) {
+                for (std::size_t i = 0; i != threads_.size(); ++i)
+                {
+                    // make sure no OS thread is waiting
+                    LTM_(info)
+                        << "thread_pool::stop: " << pool_name_
+                        << " notify_all";
+
+                    sched_.Scheduler::do_some_work(std::size_t(-1));
+
+                    LTM_(info)
+                        << "thread_pool::stop: " << pool_name_
+                        << " join:" << i; //-V128
+
+                    // unlock the lock while joining
+                    util::scoped_unlock<Lock> ul(l);
+                    threads_[i].join();
+                }
+                threads_.clear();
+            }
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    struct manage_active_thread_count
+    {
+        manage_active_thread_count(boost::atomic<long>& counter)
+          : counter_(counter)
+        {
+            ++counter_;
+        }
+        ~manage_active_thread_count()
+        {
+            --counter_;
+        }
+
+        boost::atomic<long>& counter_;
+    };
+
+    template <typename Scheduler>
+    struct init_tss_helper
+    {
+        init_tss_helper(thread_pool<Scheduler>& pool, std::size_t thread_num)
+          : pool_(pool), thread_num_(thread_num)
+        {
+            pool.notifier_.on_start_thread(thread_num);
+            pool.init_tss(thread_num);
+            pool.sched_.Scheduler::on_start_thread(thread_num);
+        }
+        ~init_tss_helper()
+        {
+            pool_.sched_.Scheduler::on_stop_thread(thread_num_);
+            pool_.deinit_tss();
+            pool_.notifier_.on_stop_thread(thread_num_);
+        }
+
+        thread_pool<Scheduler>& pool_;
+        std::size_t thread_num_;
+    };
+
+    template <typename Scheduler>
+    void thread_pool<Scheduler>::thread_func(std::size_t num_thread,
+        topology const& topology, boost::barrier& startup)
+    {
+        // Set the affinity for the current thread.
+        threads::mask_cref_type mask =
+            sched_.Scheduler::get_pu_mask(topology, num_thread);
+
+        if (LHPX_ENABLED(debug))
+            topology.write_to_log();
+
+        error_code ec(lightweight);
+        if (any(mask))
+        {
+            topology.set_thread_affinity_mask(mask, ec);
+            if (ec)
+            {
+                LTM_(warning)
+                    << "thread_pool::thread_func: " << pool_name_
+                    << " setting thread affinity on OS thread " //-V128
+                    << num_thread << " failed with: " << ec.get_message();
+            }
+        }
+        else
+        {
+            LTM_(debug)
+                << "thread_pool::thread_func: " << pool_name_
+                << " setting thread affinity on OS thread " //-V128
+                << num_thread << " was explicitly disabled.";
+        }
+
+        // Setting priority of worker threads to a lower priority, this needs to
+        // be done in order to give the parcel pool threads higher priority
+        if (any(mask & used_processing_units_))
+        {
+            topology.reduce_thread_priority(ec);
+            if (ec)
+            {
+                LTM_(warning)
+                    << "thread_pool::thread_func: " << pool_name_
+                    << " reducing thread priority on OS thread " //-V128
+                    << num_thread << " failed with: " << ec.get_message();
+            }
+        }
+
+        // manage the number of this thread in its TSS
+        init_tss_helper<Scheduler> tss_helper(*this, num_thread);
+
+        // wait for all threads to start up before before starting HPX work
+        startup.wait();
+
+        {
+            LTM_(info)
+                << "thread_pool::thread_func: " << pool_name_
+                << " starting OS thread: " << num_thread; //-V128
+
+            try {
+                try {
+                    manage_active_thread_count count(thread_count_);
+
+                    // run the work queue
+                    hpx::util::coroutines::prepare_main_thread main_thread;
+
+                    // run main Scheduler loop until terminated
+                    detail::scheduling_loop(num_thread, sched_, state_,
+                        executed_threads_[num_thread],
+                        executed_thread_phases_[num_thread],
+                        tfunc_times_[num_thread], exec_times_[num_thread],
+                        util::bind(&policies::scheduler_base::idle_callback,
+                            &sched_, num_thread
+                        ));
+
+                    // the OS thread is allowed to exit only if no more HPX
+                    // threads exist or if some other thread has terminated
+                    HPX_ASSERT(!sched_.Scheduler::get_thread_count(
+                        unknown, thread_priority_default, num_thread) ||
+                        state_ == state_terminating);
+                }
+                catch (hpx::exception const& e) {
+                    LFATAL_
+                        << "thread_pool::thread_func: " << pool_name_
+                        << " thread_num:" << num_thread //-V128
+                        << " : caught hpx::exception: "
+                        << e.what() << ", aborted thread execution";
+
+                    report_error(num_thread, boost::current_exception());
+                    return;
+                }
+                catch (boost::system::system_error const& e) {
+                    LFATAL_
+                        << "thread_pool::thread_func: " << pool_name_
+                        << " thread_num:" << num_thread //-V128
+                        << " : caught boost::system::system_error: "
+                        << e.what() << ", aborted thread execution";
+
+                    report_error(num_thread, boost::current_exception());
+                    return;
+                }
+                catch (std::exception const& e) {
+                    // Repackage exceptions to avoid slicing.
+                    boost::throw_exception(boost::enable_error_info(
+                        hpx::exception(unhandled_exception, e.what())));
+                }
+            }
+            catch (...) {
+                LFATAL_
+                    << "thread_pool::thread_func: " << pool_name_
+                    << " thread_num:" << num_thread //-V128
+                    << " : caught unexpected " //-V128
+                       "exception, aborted thread execution";
+
+                report_error(num_thread, boost::current_exception());
+                return;
+            }
+
+            LTM_(info)
+                << "thread_pool::thread_func: " << pool_name_
+                << " thread_num: " << num_thread
+                << " : ending OS thread, " //-V128
+                   "executed " << executed_threads_[num_thread]
+                << " HPX threads";
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // performance counters
+#ifdef HPX_HAVE_THREAD_CUMULATIVE_COUNTS
+    template <typename Scheduler>
+    boost::int64_t thread_pool<Scheduler>::
+        get_executed_threads(std::size_t num, bool reset)
+    {
+        boost::int64_t result = 0;
+        if (num != std::size_t(-1)) {
+            result = executed_threads_[num];
+            if (reset)
+                executed_threads_[num] = 0;
+            return result;
+        }
+
+        result = std::accumulate(executed_threads_.begin(),
+            executed_threads_.end(), 0LL);
+        if (reset)
+            std::fill(executed_threads_.begin(), executed_threads_.end(), 0LL);
+        return result;
+    }
+
+    template <typename Scheduler>
+    boost::int64_t thread_pool<Scheduler>::
+        get_executed_thread_phases(std::size_t num, bool reset)
+    {
+        boost::int64_t result = 0;
+        if (num != std::size_t(-1)) {
+            result = executed_thread_phases_[num];
+            if (reset)
+                executed_thread_phases_[num] = 0;
+            return result;
+        }
+
+        result = std::accumulate(executed_thread_phases_.begin(),
+            executed_thread_phases_.end(), 0LL);
+        if (reset) {
+            std::fill(executed_thread_phases_.begin(),
+                executed_thread_phases_.end(), 0LL);
+        }
+        return result;
+    }
+
+#ifdef HPX_HAVE_THREAD_IDLE_RATES
+    template <typename Scheduler>
+    boost::int64_t thread_pool<Scheduler>::
+        get_thread_phase_duration(std::size_t num, bool reset)
+    {
+        if (num != std::size_t(-1)) {
+            double exec_total = static_cast<double>(exec_times_[num]);
+            double num_phases = static_cast<double>(executed_thread_phases_[num]);
+
+            if (reset) {
+                executed_thread_phases_[num] = 0;
+                tfunc_times_[num] = boost::uint64_t(-1);
+            }
+            return boost::uint64_t((exec_total * timestamp_scale_)/ num_phases);
+        }
+
+        double exec_total = std::accumulate(exec_times_.begin(),
+            exec_times_.end(), 0.);
+        double num_phases = std::accumulate(executed_thread_phases_.begin(),
+            executed_thread_phases_.end(), 0.);
+
+        if (reset) {
+            std::fill(executed_thread_phases_.begin(),
+                executed_thread_phases_.end(), 0LL);
+            std::fill(tfunc_times_.begin(), tfunc_times_.end(),
+                boost::uint64_t(-1));
+        }
+        return boost::uint64_t((exec_total * timestamp_scale_)/ num_phases);
+    }
+
+    template <typename Scheduler>
+    boost::int64_t thread_pool<Scheduler>::
+        get_thread_duration(std::size_t num, bool reset)
+    {
+        if (num != std::size_t(-1)) {
+            double exec_total = static_cast<double>(exec_times_[num]);
+            double num_threads = static_cast<double>(executed_threads_[num]);
+
+            if (reset) {
+                executed_threads_[num] = 0;
+                tfunc_times_[num] = boost::uint64_t(-1);
+            }
+            return boost::uint64_t((exec_total * timestamp_scale_)/ num_threads);
+        }
+
+        double exec_total = std::accumulate(exec_times_.begin(),
+            exec_times_.end(), 0.);
+        double num_threads = std::accumulate(executed_threads_.begin(),
+            executed_threads_.end(), 0.);
+
+        if (reset) {
+            std::fill(executed_threads_.begin(), executed_threads_.end(), 0LL);
+            std::fill(tfunc_times_.begin(), tfunc_times_.end(),
+                boost::uint64_t(-1));
+        }
+        return boost::uint64_t((exec_total * timestamp_scale_) / num_threads);
+    }
+
+    template <typename Scheduler>
+    boost::int64_t thread_pool<Scheduler>::
+        get_thread_phase_overhead(std::size_t num, bool reset)
+    {
+        if (num != std::size_t(-1)) {
+            double exec_total = static_cast<double>(exec_times_[num]);
+            double tfunc_total = static_cast<double>(tfunc_times_[num]);
+            double num_phases = static_cast<double>(executed_thread_phases_[num]);
+
+            if (reset) {
+                executed_thread_phases_[num] = 0;
+                tfunc_times_[num] = boost::uint64_t(-1);
+            }
+            return boost::uint64_t(((tfunc_total - exec_total) * timestamp_scale_)/
+                    num_phases);
+        }
+
+        double exec_total = std::accumulate(exec_times_.begin(),
+            exec_times_.end(), 0.);
+        double tfunc_total = std::accumulate(tfunc_times_.begin(),
+            tfunc_times_.end(), 0.);
+        double num_phases = std::accumulate(executed_thread_phases_.begin(),
+            executed_thread_phases_.end(), 0.);
+
+        if (reset) {
+            std::fill(executed_thread_phases_.begin(),
+                executed_thread_phases_.end(), 0LL);
+            std::fill(tfunc_times_.begin(), tfunc_times_.end(),
+                boost::uint64_t(-1));
+        }
+        return boost::uint64_t(((tfunc_total - exec_total) * timestamp_scale_)/
+                num_phases);
+    }
+
+    template <typename Scheduler>
+    boost::int64_t thread_pool<Scheduler>::
+        get_thread_overhead(std::size_t num, bool reset)
+    {
+        if (num != std::size_t(-1)) {
+            double exec_total = static_cast<double>(exec_times_[num]);
+            double tfunc_total = static_cast<double>(tfunc_times_[num]);
+            double num_threads = static_cast<double>(executed_threads_[num]);
+
+            if (reset) {
+                executed_threads_[num] = 0;
+                tfunc_times_[num] = boost::uint64_t(-1);
+            }
+            return boost::uint64_t(((tfunc_total - exec_total) *
+                        timestamp_scale_) / num_threads);
+        }
+
+        double exec_total = std::accumulate(exec_times_.begin(),
+            exec_times_.end(), 0.);
+        double tfunc_total = std::accumulate(tfunc_times_.begin(),
+            tfunc_times_.end(), 0.);
+        double num_threads = std::accumulate(executed_threads_.begin(),
+            executed_threads_.end(), 0.);
+
+        if (reset) {
+            std::fill(executed_threads_.begin(), executed_threads_.end(), 0LL);
+            std::fill(tfunc_times_.begin(), tfunc_times_.end(),
+                boost::uint64_t(-1));
+        }
+        return boost::uint64_t(((tfunc_total - exec_total) *
+                        timestamp_scale_) / num_threads);
+    }
+#endif
+#endif
+
+#ifdef HPX_HAVE_THREAD_IDLE_RATES
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Scheduler>
+    boost::int64_t thread_pool<Scheduler>::avg_idle_rate(bool reset)
+    {
+        double const exec_total =
+            std::accumulate(exec_times_.begin(), exec_times_.end(), 0.);
+        double const tfunc_total =
+            std::accumulate(tfunc_times_.begin(), tfunc_times_.end(), 0.);
+
+        if (reset) {
+            std::fill(tfunc_times_.begin(), tfunc_times_.end(),
+                boost::uint64_t(-1));
+        }
+
+        if (std::abs(tfunc_total) < 1e-16)   // avoid division by zero
+            return 10000LL;
+
+        HPX_ASSERT(tfunc_total > exec_total);
+
+        double const percent = 1. - (exec_total / tfunc_total);
+        return boost::int64_t(10000. * percent);    // 0.01 percent
+    }
+
+    template <typename Scheduler>
+    boost::int64_t thread_pool<Scheduler>::avg_idle_rate(
+        std::size_t num_thread, bool reset)
+    {
+        double const exec_time = static_cast<double>(exec_times_[num_thread]);
+        double const tfunc_time = static_cast<double>(tfunc_times_[num_thread]);
+
+        if (reset) {
+            tfunc_times_[num_thread] = boost::uint64_t(-1);
+        }
+
+        if (std::abs(tfunc_time) < 1e-16)   // avoid division by zero
+            return 10000LL;
+
+        HPX_ASSERT(tfunc_time > exec_time);
+
+        double const percent = 1. - (exec_time / tfunc_time);
+        return boost::int64_t(10000. * percent);   // 0.01 percent
+    }
+
+#if defined(HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES)
+    template <typename Scheduler>
+    boost::int64_t thread_pool<Scheduler>::avg_creation_idle_rate(bool reset)
+    {
+        double const creation_total =
+            static_cast<double>(sched_.get_creation_time(reset));
+        double const exec_total =
+            std::accumulate(exec_times_.begin(), exec_times_.end(), 0.);
+        double const tfunc_total =
+            std::accumulate(tfunc_times_.begin(), tfunc_times_.end(), 0.);
+
+        if (reset) {
+            std::fill(tfunc_times_.begin(), tfunc_times_.end(),
+                boost::uint64_t(-1));
+        }
+
+        // avoid division by zero
+        if (std::abs(tfunc_total - exec_total) < 1e-16)
+            return 10000LL;
+
+        HPX_ASSERT(tfunc_total > exec_total);
+
+        double const percent = (creation_total / (tfunc_total - exec_total));
+        return boost::int64_t(10000. * percent);    // 0.01 percent
+    }
+
+    template <typename Scheduler>
+    boost::int64_t thread_pool<Scheduler>::avg_cleanup_idle_rate(bool reset)
+    {
+        double const cleanup_total =
+            static_cast<double>(sched_.get_cleanup_time(reset));
+        double const exec_total =
+            std::accumulate(exec_times_.begin(), exec_times_.end(), 0.);
+        double const tfunc_total =
+            std::accumulate(tfunc_times_.begin(), tfunc_times_.end(), 0.);
+
+        if (reset) {
+            std::fill(tfunc_times_.begin(), tfunc_times_.end(),
+                boost::uint64_t(-1));
+        }
+
+        // avoid division by zero
+        if (std::abs(tfunc_total - exec_total) < 1e-16)
+            return 10000LL;
+
+        HPX_ASSERT(tfunc_total > exec_total);
+
+        double const percent = (cleanup_total / (tfunc_total - exec_total));
+        return boost::int64_t(10000. * percent);    // 0.01 percent
+    }
+#endif
+#endif
+
+    template <typename Scheduler>
+    boost::int64_t thread_pool<Scheduler>::
+        get_queue_length(std::size_t num_thread) const
+    {
+        return sched_.Scheduler::get_queue_length(num_thread);
+    }
+
+#ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
+    template <typename Scheduler>
+    boost::int64_t thread_pool<Scheduler>::
+        get_average_thread_wait_time(std::size_t num_thread) const
+    {
+        return sched_.Scheduler::get_average_thread_wait_time(num_thread);
+    }
+
+    template <typename Scheduler>
+    boost::int64_t thread_pool<Scheduler>::
+        get_average_task_wait_time(std::size_t num_thread) const
+    {
+        return sched_.Scheduler::get_average_task_wait_time(num_thread);
+    }
+#endif
+
+#ifdef HPX_HAVE_THREAD_STEALING_COUNTS
+    template <typename Scheduler>
+    boost::int64_t thread_pool<Scheduler>::
+        get_num_pending_misses(std::size_t num, bool reset)
+    {
+        return sched_.Scheduler::get_num_pending_misses(num, reset);
+    }
+
+    template <typename Scheduler>
+    boost::int64_t thread_pool<Scheduler>::
+        get_num_pending_accesses(std::size_t num, bool reset)
+    {
+        return sched_.Scheduler::get_num_pending_accesses(num, reset);
+    }
+
+    template <typename Scheduler>
+    boost::int64_t thread_pool<Scheduler>::
+        get_num_stolen_from_pending(std::size_t num, bool reset)
+    {
+        return sched_.Scheduler::get_num_stolen_from_pending(num, reset);
+    }
+
+    template <typename Scheduler>
+    boost::int64_t thread_pool<Scheduler>::
+        get_num_stolen_to_pending(std::size_t num, bool reset)
+    {
+        return sched_.Scheduler::get_num_stolen_to_pending(num, reset);
+    }
+
+    template <typename Scheduler>
+    boost::int64_t thread_pool<Scheduler>::
+        get_num_stolen_from_staged(std::size_t num, bool reset)
+    {
+        return sched_.Scheduler::get_num_stolen_from_staged(num, reset);
+    }
+
+    template <typename Scheduler>
+    boost::int64_t thread_pool<Scheduler>::
+        get_num_stolen_to_staged(std::size_t num, bool reset)
+    {
+        return sched_.Scheduler::get_num_stolen_to_staged(num, reset);
+    }
+#endif
+
+}}}
+
+///////////////////////////////////////////////////////////////////////////////
+/// explicit template instantiation for the thread manager of our choice
+#if defined(HPX_HAVE_LOCAL_SCHEDULER)
+#include <hpx/runtime/threads/policies/local_queue_scheduler.hpp>
+template class HPX_EXPORT hpx::threads::detail::thread_pool<
+    hpx::threads::policies::local_queue_scheduler<> >;
+#endif
+
+#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
+#include <hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp>
+template class HPX_EXPORT hpx::threads::detail::thread_pool<
+    hpx::threads::policies::static_priority_queue_scheduler<> >;
+#endif
+
+#include <hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp>
+template class HPX_EXPORT hpx::threads::detail::thread_pool<
+    hpx::threads::policies::local_priority_queue_scheduler<> >;
+
+#if defined(HPX_HAVE_ABP_SCHEDULER)
+template class HPX_EXPORT hpx::threads::detail::thread_pool<
+    hpx::threads::policies::abp_fifo_priority_queue_scheduler>;
+#endif
+
+#if defined(HPX_HAVE_HIERARCHY_SCHEDULER)
+#include <hpx/runtime/threads/policies/hierarchy_scheduler.hpp>
+template class HPX_EXPORT hpx::threads::detail::thread_pool<
+    hpx::threads::policies::hierarchy_scheduler<> >;
+#endif
+
+#if defined(HPX_HAVE_PERIODIC_PRIORITY_SCHEDULER)
+#include <hpx/runtime/threads/policies/periodic_priority_queue_scheduler.hpp>
+template class HPX_EXPORT hpx::threads::detail::thread_pool<
+    hpx::threads::policies::periodic_priority_queue_scheduler<> >;
+#endif
+

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2015 Patricia Grubel
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2015 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach, Katelyn Kufahl
 //  Copyright (c) 2008-2009 Chirag Dekate, Anshul Tandon
 //
@@ -13,9 +13,6 @@
 #include <hpx/runtime/threads/threadmanager_impl.hpp>
 #include <hpx/runtime/threads/thread_data.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
-#include <hpx/runtime/threads/detail/scheduling_loop.hpp>
-#include <hpx/runtime/threads/detail/create_thread.hpp>
-#include <hpx/runtime/threads/detail/create_work.hpp>
 #include <hpx/runtime/threads/detail/set_thread_state.hpp>
 #include <hpx/runtime/threads/executors/generic_thread_pool_executor.hpp>
 #include <hpx/include/performance_counters.hpp>
@@ -130,134 +127,92 @@ namespace hpx { namespace threads
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    threadmanager_impl<SchedulingPolicy, NotificationPolicy>::threadmanager_impl(
+    template <typename SchedulingPolicy>
+    threadmanager_impl<SchedulingPolicy>::threadmanager_impl(
             util::io_service_pool& timer_pool,
             scheduling_policy_type& scheduler,
             notification_policy_type& notifier,
             std::size_t num_threads)
-      : startup_(NULL),
-        num_threads_(num_threads),
-        thread_count_(0),
-#if defined(HPX_HAVE_THREAD_CUMULATIVE_COUNTS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
-        timestamp_scale_(1.),
-#endif
-        state_(state_starting),
+      : num_threads_(num_threads),
         timer_pool_(timer_pool),
         thread_logger_("threadmanager_impl::register_thread"),
         work_logger_("threadmanager_impl::register_work"),
         set_state_logger_("threadmanager_impl::set_state"),
-        scheduler_(scheduler),
-        notifier_(notifier),
-        used_processing_units_()
+        pool_(scheduler, notifier, "main_thread_scheduling_pool"),
+        notifier_(notifier)
     {}
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    threadmanager_impl<SchedulingPolicy, NotificationPolicy>::~threadmanager_impl()
+    template <typename SchedulingPolicy>
+    threadmanager_impl<SchedulingPolicy>::~threadmanager_impl()
     {
-        //LTM_(debug) << "~threadmanager_impl";
-        if (!threads_.empty()) {
-            if (state_.load() == state_running)
-                stop();
-            threads_.clear();
-        }
-        delete startup_;
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    std::size_t threadmanager_impl<SchedulingPolicy, NotificationPolicy>::init(
+    template <typename SchedulingPolicy>
+    std::size_t threadmanager_impl<SchedulingPolicy>::init(
         policies::init_affinity_data const& data)
     {
-        topology const& topology_ = get_topology();
-        std::size_t cores_used = scheduler_.init(data, topology_);
-
-        resize(used_processing_units_, hardware_concurrency());
-        for (std::size_t i = 0; i != num_threads_; ++i)
-            used_processing_units_ |= scheduler_.get_pu_mask(topology_, i);
-
-        return cores_used;
+        return pool_.init(num_threads_, data);
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    boost::int64_t threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
-        get_thread_count(thread_state_enum state, thread_priority priority) const
+    template <typename SchedulingPolicy>
+    boost::int64_t threadmanager_impl<SchedulingPolicy>::
+        get_thread_count(thread_state_enum state, thread_priority priority,
+            std::size_t num_thread, bool reset) const
     {
         mutex_type::scoped_lock lk(mtx_);
-        return scheduler_.get_thread_count(state, priority);
+        return pool_.get_thread_count(state, priority, num_thread, reset);
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    // \brief Abort all threads which are in suspended state. This will set
-    //        the state of all suspended threads to \a pending while
-    //        supplying the wait_abort extended state flag
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    // Abort all threads which are in suspended state. This will set
+    // the state of all suspended threads to \a pending while
+    // supplying the wait_abort extended state flag
+    template <typename SchedulingPolicy>
+    void threadmanager_impl<SchedulingPolicy>::
         abort_all_suspended_threads()
     {
         mutex_type::scoped_lock lk(mtx_);
-        scheduler_.abort_all_suspended_threads();
+        pool_.abort_all_suspended_threads();
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    // \brief Clean up terminated threads. This deletes all threads which
-    //        have been terminated but which are still held in the queue
-    //        of terminated threads. Some schedulers might not do anything
-    //        here.
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    bool threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    // Clean up terminated threads. This deletes all threads which
+    // have been terminated but which are still held in the queue
+    // of terminated threads. Some schedulers might not do anything
+    // here.
+    template <typename SchedulingPolicy>
+    bool threadmanager_impl<SchedulingPolicy>::
         cleanup_terminated(bool delete_all)
     {
         mutex_type::scoped_lock lk(mtx_);
-        return scheduler_.cleanup_terminated(delete_all);
+        return pool_.cleanup_terminated(delete_all);
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    void threadmanager_impl<SchedulingPolicy>::
         register_thread(thread_init_data& data, thread_id_type& id,
             thread_state_enum initial_state, bool run_now, error_code& ec)
     {
         util::block_profiler_wrapper<register_thread_tag> bp(thread_logger_);
-
-        // verify state
-        if ((thread_count_ == 0 && state_ != state_running))
-        {
-            // thread-manager is not currently running
-            HPX_THROWS_IF(ec, invalid_status,
-                "threadmanager_impl::register_thread",
-                "invalid state: thread manager is not running");
-            return;
-        }
-
-        detail::create_thread(&scheduler_, data, id, initial_state, run_now, ec); //-V601
+        pool_.create_thread(data, id, initial_state, run_now, ec);
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void threadmanager_impl<SchedulingPolicy, NotificationPolicy>::register_work(
+    template <typename SchedulingPolicy>
+    void threadmanager_impl<SchedulingPolicy>::register_work(
         thread_init_data& data, thread_state_enum initial_state, error_code& ec)
     {
         util::block_profiler_wrapper<register_work_tag> bp(work_logger_);
-
-        // verify state
-        if ((thread_count_ == 0 && state_ != state_running))
-        {
-            // thread-manager is not currently running
-            HPX_THROWS_IF(ec, invalid_status,
-                "threadmanager_impl::register_work",
-                "invalid state: thread manager is not running");
-            return;
-        }
-
-        detail::create_work(&scheduler_, data, initial_state, ec);
+        pool_.create_work(data, initial_state, ec);
     }
 
     ///////////////////////////////////////////////////////////////////////////
     /// The set_state function is part of the thread related API and allows
     /// to change the state of one of the threads managed by this threadmanager_impl
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    thread_state threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    thread_state threadmanager_impl<SchedulingPolicy>::
         set_state(thread_id_type const& id, thread_state_enum new_state,
             thread_state_ex_enum new_state_ex, thread_priority priority,
             error_code& ec)
@@ -268,8 +223,8 @@ namespace hpx { namespace threads
 
     /// The get_state function is part of the thread related API. It
     /// queries the state of one of the threads known to the threadmanager_impl
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    thread_state threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    thread_state threadmanager_impl<SchedulingPolicy>::
         get_state(thread_id_type const& thrd) const
     {
         return thrd ? thrd->get_state() : thread_state(terminated);
@@ -277,8 +232,8 @@ namespace hpx { namespace threads
 
     /// The get_phase function is part of the thread related API. It
     /// queries the phase of one of the threads known to the threadmanager_impl
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    std::size_t threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    std::size_t threadmanager_impl<SchedulingPolicy>::
         get_phase(thread_id_type const& thrd) const
     {
         return thrd ? thrd->get_thread_phase() : std::size_t(~0);
@@ -286,32 +241,33 @@ namespace hpx { namespace threads
 
     /// The get_priority function is part of the thread related API. It
     /// queries the priority of one of the threads known to the threadmanager_impl
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    thread_priority threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    thread_priority threadmanager_impl<SchedulingPolicy>::
         get_priority(thread_id_type const& thrd) const
     {
         return thrd ? thrd->get_priority() : thread_priority_unknown;
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    std::ptrdiff_t threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    std::ptrdiff_t threadmanager_impl<SchedulingPolicy>::
         get_stack_size(thread_id_type const& thrd) const
     {
-        return thrd ? thrd->get_stack_size() : static_cast<std::ptrdiff_t>(thread_stacksize_unknown);
+        return thrd ? thrd->get_stack_size() :
+            static_cast<std::ptrdiff_t>(thread_stacksize_unknown);
     }
 
     /// The get_description function is part of the thread related API and
     /// allows to query the description of one of the threads known to the
     /// threadmanager_impl
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    char const* threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    char const* threadmanager_impl<SchedulingPolicy>::
         get_description(thread_id_type const& thrd) const
     {
         return thrd ? thrd->get_description() : "<unknown>";
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    char const* threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    char const* threadmanager_impl<SchedulingPolicy>::
         set_description(thread_id_type const& thrd, char const* desc)
     {
         if (HPX_UNLIKELY(!thrd)) {
@@ -326,8 +282,8 @@ namespace hpx { namespace threads
         return NULL;
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    char const* threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    char const* threadmanager_impl<SchedulingPolicy>::
         get_lco_description(thread_id_type const& thrd) const
     {
         if (HPX_UNLIKELY(!thrd)) {
@@ -340,8 +296,8 @@ namespace hpx { namespace threads
         return thrd ? thrd->get_lco_description() : "<unknown>";
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    char const* threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    char const* threadmanager_impl<SchedulingPolicy>::
         set_lco_description(thread_id_type const& thrd, char const* desc)
     {
         if (HPX_UNLIKELY(!thrd)) {
@@ -358,12 +314,12 @@ namespace hpx { namespace threads
 
     ///////////////////////////////////////////////////////////////////////////
 #ifdef HPX_HAVE_THREAD_FULLBACKTRACE_ON_SUSPENSION
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    char const* threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    char const* threadmanager_impl<SchedulingPolicy>::
         get_backtrace(thread_id_type const& thrd) const
 #else
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    util::backtrace const* threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    util::backtrace const* threadmanager_impl<SchedulingPolicy>::
         get_backtrace(thread_id_type const& thrd) const
 #endif
     {
@@ -378,12 +334,12 @@ namespace hpx { namespace threads
     }
 
 #ifdef HPX_HAVE_THREAD_FULLBACKTRACE_ON_SUSPENSION
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    char const* threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    char const* threadmanager_impl<SchedulingPolicy>::
         set_backtrace(thread_id_type const& thrd, char const* bt)
 #else
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    util::backtrace const* threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    util::backtrace const* threadmanager_impl<SchedulingPolicy>::
         set_backtrace(thread_id_type const& thrd, util::backtrace const* bt)
 #endif
     {
@@ -398,8 +354,8 @@ namespace hpx { namespace threads
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    bool threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    bool threadmanager_impl<SchedulingPolicy>::
         get_interruption_enabled(thread_id_type const& thrd, error_code& ec)
     {
         if (HPX_UNLIKELY(!thrd)) {
@@ -415,8 +371,8 @@ namespace hpx { namespace threads
         return thrd ? thrd->interruption_enabled() : false;
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    bool threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    bool threadmanager_impl<SchedulingPolicy>::
         set_interruption_enabled(thread_id_type const& thrd, bool enable, error_code& ec)
     {
         if (HPX_UNLIKELY(!thrd)) {
@@ -433,8 +389,8 @@ namespace hpx { namespace threads
         return false;
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    bool threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    bool threadmanager_impl<SchedulingPolicy>::
         get_interruption_requested(thread_id_type const& thrd, error_code& ec)
     {
         if (HPX_UNLIKELY(!thrd)) {
@@ -450,8 +406,8 @@ namespace hpx { namespace threads
         return thrd ? thrd->interruption_requested() : false;
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    void threadmanager_impl<SchedulingPolicy>::
         interrupt(thread_id_type const& thrd, bool flag, error_code& ec)
     {
         if (HPX_UNLIKELY(!thrd)) {
@@ -474,8 +430,8 @@ namespace hpx { namespace threads
         }
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    void threadmanager_impl<SchedulingPolicy>::
         interruption_point(thread_id_type const& thrd, error_code& ec)
     {
         if (HPX_UNLIKELY(!thrd)) {
@@ -494,8 +450,8 @@ namespace hpx { namespace threads
 
 #ifdef HPX_HAVE_THREAD_LOCAL_STORAGE
     ///////////////////////////////////////////////////////////////////////////
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    std::size_t threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    std::size_t threadmanager_impl<SchedulingPolicy>::
         get_thread_data(thread_id_type const& thrd, error_code& ec) const
     {
         if (HPX_UNLIKELY(!thrd)) {
@@ -508,8 +464,8 @@ namespace hpx { namespace threads
         return thrd ? thrd->get_thread_data() : 0;
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    std::size_t threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    std::size_t threadmanager_impl<SchedulingPolicy>::
         set_thread_data(thread_id_type const& thrd, std::size_t data,
             error_code& ec)
     {
@@ -525,8 +481,8 @@ namespace hpx { namespace threads
 #endif
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    void threadmanager_impl<SchedulingPolicy>::
     run_thread_exit_callbacks(thread_id_type const& thrd, error_code& ec)
     {
         if (HPX_UNLIKELY(!thrd)) {
@@ -543,8 +499,8 @@ namespace hpx { namespace threads
             thrd->run_thread_exit_callbacks();
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    bool threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    bool threadmanager_impl<SchedulingPolicy>::
     add_thread_exit_callback(thread_id_type const& thrd,
         util::function_nonser<void()> const& f, error_code& ec)
     {
@@ -561,8 +517,8 @@ namespace hpx { namespace threads
         return (0 != thrd) ? thrd->add_thread_exit_callback(f) : false;
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    void threadmanager_impl<SchedulingPolicy>::
         free_thread_exit_callbacks(thread_id_type const& thrd, error_code& ec)
     {
         if (HPX_UNLIKELY(!thrd)) {
@@ -580,8 +536,8 @@ namespace hpx { namespace threads
     }
 
     // Return the executor associated with th egiven thread
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    executor threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    executor threadmanager_impl<SchedulingPolicy>::
         get_executor(thread_id_type const& thrd, error_code& ec) const
     {
         if (HPX_UNLIKELY(!thrd)) {
@@ -602,149 +558,22 @@ namespace hpx { namespace threads
     ///////////////////////////////////////////////////////////////////////////
     /// Set a timer to set the state of the given \a thread to the given
     /// new value after it expired (at the given time)
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    thread_id_type threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    thread_id_type threadmanager_impl<SchedulingPolicy>::
         set_state(util::steady_time_point const& abs_time,
             thread_id_type const& id, thread_state_enum newstate,
             thread_state_ex_enum newstate_ex, thread_priority priority,
             error_code& ec)
     {
-        return detail::set_thread_state_timed(scheduler_, abs_time, id,
-            newstate, newstate_ex, priority, get_worker_thread_num(), ec);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    // main function executed by all OS threads managed by this threadmanager_impl
-    template <typename SP, typename NP>
-    struct init_tss_helper
-    {
-        typedef threadmanager_impl<SP, NP> threadmanager_type;
-
-        init_tss_helper(threadmanager_type& tm, std::size_t thread_num,
-                bool numa_sensitive)
-          : tm_(tm)
-        {
-            tm_.init_tss(thread_num, numa_sensitive);
-        }
-        ~init_tss_helper()
-        {
-            tm_.deinit_tss();
-        }
-
-        threadmanager_type& tm_;
-    };
-
-    struct manage_active_thread_count
-    {
-        manage_active_thread_count(boost::atomic<long>& counter)
-          : counter_(counter)
-        {
-            ++counter_;
-        }
-        ~manage_active_thread_count()
-        {
-            --counter_;
-        }
-
-        boost::atomic<long>& counter_;
-    };
-
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
-        tfunc(std::size_t num_thread, topology const& topology_)
-    {
-        // Set the affinity for the current thread.
-        threads::mask_cref_type mask = get_pu_mask(topology_, num_thread);
-
-        if (LHPX_ENABLED(debug))
-            topology_.write_to_log();
-
-        error_code ec(lightweight);
-        if (any(mask))
-        {
-            topology_.set_thread_affinity_mask(mask, ec);
-            if (ec)
-            {
-                LTM_(warning) << "run: setting thread affinity on OS thread " //-V128
-                    << num_thread << " failed with: " << ec.get_message();
-            }
-        }
-        else
-        {
-            LTM_(debug) << "run: setting thread affinity on OS thread " //-V128
-                << num_thread << " was explicitly disabled.";
-        }
-
-        // Setting priority of worker threads to a lower priority, this needs to
-        // be done in order to give the parcel pool threads higher priority
-        if (any(mask & get_used_processing_units()))
-        {
-            topology_.reduce_thread_priority(ec);
-            if (ec)
-            {
-                LTM_(warning) << "run: reducing thread priority on OS thread " //-V128
-                    << num_thread << " failed with: " << ec.get_message();
-            }
-        }
-
-        // manage the number of this thread in its TSS
-        init_tss_helper<SchedulingPolicy, NotificationPolicy>
-            tss_helper(*this, num_thread, scheduler_.numa_sensitive());
-
-        // needs to be done as the first thing, otherwise logging won't work
-        notifier_.on_start_thread(num_thread);       // notify runtime system of started thread
-        scheduler_.on_start_thread(num_thread);
-
-        // wait for all threads to start up before before starting HPX work
-        startup_->wait();
-
-        {
-            LTM_(info) << "tfunc(" << num_thread << "): starting OS thread"; //-V128
-            try {
-                try {
-                    tfunc_impl(num_thread);
-                }
-                catch (hpx::exception const& e) {
-                    LFATAL_ << "tfunc(" << num_thread //-V128
-                            << "): caught hpx::exception: "
-                            << e.what() << ", aborted thread execution";
-                    report_error(num_thread, boost::current_exception());
-                    return;
-                }
-                catch (boost::system::system_error const& e) {
-                    LFATAL_ << "tfunc(" << num_thread //-V128
-                            << "): caught boost::system::system_error: "
-                            << e.what() << ", aborted thread execution";
-                    report_error(num_thread, boost::current_exception());
-                    return;
-                }
-                catch (std::exception const& e) {
-                    // Repackage exceptions to avoid slicing.
-                    boost::throw_exception(boost::enable_error_info(
-                        hpx::exception(unhandled_exception, e.what())));
-                }
-            }
-            catch (...) {
-                LFATAL_ << "tfunc(" << num_thread << "): caught unexpected " //-V128
-                    "exception, aborted thread execution";
-                report_error(num_thread, boost::current_exception());
-                return;
-            }
-
-            LTM_(info) << "tfunc(" << num_thread << "): ending OS thread, " //-V128
-                "executed " << executed_threads_[num_thread] << " HPX threads";
-        }
-
-        notifier_.on_stop_thread(num_thread);
-        scheduler_.on_stop_thread(num_thread);
+        return pool_.set_state(abs_time, id, newstate, newstate_ex, priority, ec);
     }
 
     ///////////////////////////////////////////////////////////////////////////
     // counter creator and discovery functions
 
     // queue length(s) counter creation function
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    naming::gid_type threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    naming::gid_type threadmanager_impl<SchedulingPolicy>::
         queue_length_counter_creator(
             performance_counters::counter_info const& info, error_code& ec)
     {
@@ -762,7 +591,7 @@ namespace hpx { namespace threads
             return naming::invalid_gid;
         }
 
-        typedef scheduling_policy_type spt;
+        typedef detail::thread_pool<scheduling_policy_type> spt;
 
         using util::placeholders::_1;
         if (paths.instancename_ == "total" && paths.instanceindex_ == -1)
@@ -770,17 +599,17 @@ namespace hpx { namespace threads
             // overall counter
             using performance_counters::detail::create_raw_counter;
             util::function_nonser<boost::int64_t()> f =
-                util::bind(&spt::get_queue_length, &scheduler_, -1);
+                util::bind(&spt::get_queue_length, &pool_, -1);
             return create_raw_counter(info, std::move(f), ec);
         }
         else if (paths.instancename_ == "worker-thread" &&
             paths.instanceindex_ >= 0 &&
-            std::size_t(paths.instanceindex_) < threads_.size())
+            std::size_t(paths.instanceindex_) < pool_.get_os_thread_count())
         {
             // specific counter
             using performance_counters::detail::create_raw_counter;
             util::function_nonser<boost::int64_t()> f =
-                util::bind(&spt::get_queue_length, &scheduler_,
+                util::bind(&spt::get_queue_length, &pool_,
                     static_cast<std::size_t>(paths.instanceindex_));
             return create_raw_counter(info, std::move(f), ec);
         }
@@ -792,8 +621,8 @@ namespace hpx { namespace threads
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
     // average pending thread wait time
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    naming::gid_type threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    naming::gid_type threadmanager_impl<SchedulingPolicy>::
         thread_wait_time_counter_creator(
             performance_counters::counter_info const& info, error_code& ec)
     {
@@ -822,7 +651,7 @@ namespace hpx { namespace threads
             // overall counter
             using performance_counters::detail::create_raw_counter;
             util::function_nonser<boost::int64_t()> f =
-                util::bind(&spt::get_average_thread_wait_time, &scheduler_, -1);
+                util::bind(&spt::get_average_thread_wait_time, &pool_, -1);
             return create_raw_counter(info, std::move(f), ec);
         }
         else if (paths.instancename_ == "worker-thread" &&
@@ -834,7 +663,7 @@ namespace hpx { namespace threads
             // specific counter
             using performance_counters::detail::create_raw_counter;
             util::function_nonser<boost::int64_t()> f =
-                util::bind(&spt::get_average_thread_wait_time, &scheduler_,
+                util::bind(&spt::get_average_thread_wait_time, &pool_,
                     static_cast<std::size_t>(paths.instanceindex_));
             return create_raw_counter(info, std::move(f), ec);
         }
@@ -845,8 +674,8 @@ namespace hpx { namespace threads
     }
 
     // average pending task wait time
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    naming::gid_type threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    naming::gid_type threadmanager_impl<SchedulingPolicy>::
         task_wait_time_counter_creator(
             performance_counters::counter_info const& info, error_code& ec)
     {
@@ -875,7 +704,7 @@ namespace hpx { namespace threads
             // overall counter
             using performance_counters::detail::create_raw_counter;
             util::function_nonser<boost::int64_t()> f =
-                util::bind(&spt::get_average_task_wait_time, &scheduler_, -1);
+                util::bind(&spt::get_average_task_wait_time, &pool_, -1);
             return create_raw_counter(info, std::move(f), ec);
         }
         else if (paths.instancename_ == "worker-thread" &&
@@ -887,7 +716,7 @@ namespace hpx { namespace threads
             // specific counter
             using performance_counters::detail::create_raw_counter;
             util::function_nonser<boost::int64_t()> f =
-                util::bind(&spt::get_average_task_wait_time, &scheduler_,
+                util::bind(&spt::get_average_task_wait_time, &pool_,
                     static_cast<std::size_t>(paths.instanceindex_));
             return create_raw_counter(info, std::move(f), ec);
         }
@@ -978,8 +807,8 @@ namespace hpx { namespace threads
 #ifdef HPX_HAVE_THREAD_IDLE_RATES
     ///////////////////////////////////////////////////////////////////////////
     // idle rate counter creation function
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    naming::gid_type threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    naming::gid_type threadmanager_impl<SchedulingPolicy>::
         idle_rate_counter_creator(
             performance_counters::counter_info const& info, error_code& ec)
     {
@@ -1073,8 +902,8 @@ namespace hpx { namespace threads
 
     ///////////////////////////////////////////////////////////////////////////
     // thread counts counter creation function
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    naming::gid_type threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    naming::gid_type threadmanager_impl<SchedulingPolicy>::
         thread_counts_counter_creator(
             performance_counters::counter_info const& info, error_code& ec)
     {
@@ -1092,15 +921,16 @@ namespace hpx { namespace threads
             std::size_t individual_count;
         };
 
-        typedef scheduling_policy_type spt;
+        typedef detail::thread_pool<scheduling_policy_type> spt;
         typedef threadmanager_impl ti;
 
         using util::placeholders::_1;
 
-        std::size_t shepherd_count = threads_.size();
+        std::size_t shepherd_count = pool_.get_os_thread_count();
         creator_data data[] =
         {
-#if defined(HPX_HAVE_THREAD_IDLE_RATES) && defined(HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES)
+#if defined(HPX_HAVE_THREAD_IDLE_RATES) && \
+    defined(HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES)
             // /threads{locality#%d/total}/creation-idle-rate
             // /threads{locality#%d/worker-thread%d}/creation-idle-rate
             { "creation-idle-rate",
@@ -1171,9 +1001,9 @@ namespace hpx { namespace threads
             // /threads{locality#%d/total}/count/instantaneous/all
             // /threads{locality#%d/worker-thread%d}/count/instantaneous/all
             { "count/instantaneous/all",
-              util::bind(&spt::get_thread_count, &scheduler_, unknown,
+              util::bind(&ti::get_thread_count, this, unknown,
                   thread_priority_default, std::size_t(-1), _1),
-              util::bind(&spt::get_thread_count, &scheduler_, unknown,
+              util::bind(&ti::get_thread_count, this, unknown,
                   thread_priority_default,
                   static_cast<std::size_t>(paths.instanceindex_), _1),
               "worker-thread", shepherd_count
@@ -1181,9 +1011,9 @@ namespace hpx { namespace threads
             // /threads{locality#%d/total}/count/instantaneous/active
             // /threads{locality#%d/worker-thread%d}/count/instantaneous/active
             { "count/instantaneous/active",
-              util::bind(&spt::get_thread_count, &scheduler_, active,
+              util::bind(&ti::get_thread_count, this, active,
                   thread_priority_default, std::size_t(-1), _1),
-              util::bind(&spt::get_thread_count, &scheduler_, active,
+              util::bind(&ti::get_thread_count, this, active,
                   thread_priority_default,
                   static_cast<std::size_t>(paths.instanceindex_), _1),
               "worker-thread", shepherd_count
@@ -1191,9 +1021,9 @@ namespace hpx { namespace threads
             // /threads{locality#%d/total}/count/instantaneous/pending
             // /threads{locality#%d/worker-thread%d}/count/instantaneous/pending
             { "count/instantaneous/pending",
-              util::bind(&spt::get_thread_count, &scheduler_, pending,
+              util::bind(&ti::get_thread_count, this, pending,
                   thread_priority_default, std::size_t(-1), _1),
-              util::bind(&spt::get_thread_count, &scheduler_, pending,
+              util::bind(&ti::get_thread_count, this, pending,
                   thread_priority_default,
                   static_cast<std::size_t>(paths.instanceindex_), _1),
               "worker-thread", shepherd_count
@@ -1201,9 +1031,9 @@ namespace hpx { namespace threads
             // /threads{locality#%d/total}/count/instantaneous/suspended
             // /threads{locality#%d/worker-thread%d}/count/instantaneous/suspended
             { "count/instantaneous/suspended",
-              util::bind(&spt::get_thread_count, &scheduler_, suspended,
+              util::bind(&ti::get_thread_count, this, suspended,
                   thread_priority_default, std::size_t(-1), _1),
-              util::bind(&spt::get_thread_count, &scheduler_, suspended,
+              util::bind(&ti::get_thread_count, this, suspended,
                   thread_priority_default,
                   static_cast<std::size_t>(paths.instanceindex_), _1),
               "worker-thread", shepherd_count
@@ -1211,9 +1041,9 @@ namespace hpx { namespace threads
             // /threads(locality#%d/total}/count/instantaneous/terminated
             // /threads(locality#%d/worker-thread%d}/count/instantaneous/terminated
             { "count/instantaneous/terminated",
-              util::bind(&spt::get_thread_count, &scheduler_, terminated,
+              util::bind(&ti::get_thread_count, this, terminated,
                   thread_priority_default, std::size_t(-1), _1),
-              util::bind(&spt::get_thread_count, &scheduler_, terminated,
+              util::bind(&ti::get_thread_count, this, terminated,
                   thread_priority_default,
                   static_cast<std::size_t>(paths.instanceindex_), _1),
               "worker-thread", shepherd_count
@@ -1221,9 +1051,9 @@ namespace hpx { namespace threads
             // /threads{locality#%d/total}/count/instantaneous/staged
             // /threads{locality#%d/worker-thread%d}/count/instantaneous/staged
             { "count/instantaneous/staged",
-              util::bind(&spt::get_thread_count, &scheduler_, staged,
+              util::bind(&ti::get_thread_count, this, staged,
                   thread_priority_default, std::size_t(-1), _1),
-              util::bind(&spt::get_thread_count, &scheduler_, staged,
+              util::bind(&ti::get_thread_count, this, staged,
                   thread_priority_default,
                   static_cast<std::size_t>(paths.instanceindex_), _1),
               "worker-thread", shepherd_count
@@ -1252,54 +1082,54 @@ namespace hpx { namespace threads
             // /threads{locality#%d/total}/count/pending-misses
             // /threads{locality#%d/worker-thread%d}/count/pending-misses
             { "count/pending-misses",
-              util::bind(&spt::get_num_pending_misses, &scheduler_,
+              util::bind(&spt::get_num_pending_misses, &pool_,
                   std::size_t(-1), _1),
-              util::bind(&spt::get_num_pending_misses, &scheduler_,
+              util::bind(&spt::get_num_pending_misses, &pool_,
                   static_cast<std::size_t>(paths.instanceindex_), _1),
               "worker-thread", shepherd_count
             },
             // /threads{locality#%d/total}/count/pending-accesses
             // /threads{locality#%d/worker-thread%d}/count/pending-accesses
             { "count/pending-accesses",
-              util::bind(&spt::get_num_pending_accesses, &scheduler_,
+              util::bind(&spt::get_num_pending_accesses, &pool_,
                   std::size_t(-1), _1),
-              util::bind(&spt::get_num_pending_accesses, &scheduler_,
+              util::bind(&spt::get_num_pending_accesses, &pool_,
                   static_cast<std::size_t>(paths.instanceindex_), _1),
               "worker-thread", shepherd_count
             },
             // /threads{locality#%d/total}/count/stolen-from-pending
             // /threads{locality#%d/worker-thread%d}/count/stolen-from-pending
             { "count/stolen-from-pending",
-              util::bind(&spt::get_num_stolen_from_pending, &scheduler_,
+              util::bind(&spt::get_num_stolen_from_pending, &pool_,
                   std::size_t(-1), _1),
-              util::bind(&spt::get_num_stolen_from_pending, &scheduler_,
+              util::bind(&spt::get_num_stolen_from_pending, &pool_,
                   static_cast<std::size_t>(paths.instanceindex_), _1),
               "worker-thread", shepherd_count
             },
             // /threads{locality#%d/total}/count/stolen-from-staged
             // /threads{locality#%d/worker-thread%d}/count/stolen-from-staged
             { "count/stolen-from-staged",
-              util::bind(&spt::get_num_stolen_from_staged, &scheduler_,
+              util::bind(&spt::get_num_stolen_from_staged, &pool_,
                   std::size_t(-1), _1),
-              util::bind(&spt::get_num_stolen_from_staged, &scheduler_,
+              util::bind(&spt::get_num_stolen_from_staged, &pool_,
                   static_cast<std::size_t>(paths.instanceindex_), _1),
               "worker-thread", shepherd_count
             },
             // /threads{locality#%d/total}/count/stolen-to-pending
             // /threads{locality#%d/worker-thread%d}/count/stolen-to-pending
             { "count/stolen-to-pending",
-              util::bind(&spt::get_num_stolen_to_pending, &scheduler_,
+              util::bind(&spt::get_num_stolen_to_pending, &pool_,
                   std::size_t(-1), _1),
-              util::bind(&spt::get_num_stolen_to_pending, &scheduler_,
+              util::bind(&spt::get_num_stolen_to_pending, &pool_,
                   static_cast<std::size_t>(paths.instanceindex_), _1),
               "worker-thread", shepherd_count
             },
             // /threads{locality#%d/total}/count/stolen-to-staged
             // /threads{locality#%d/worker-thread%d}/count/stolen-to-staged
             { "count/stolen-to-staged",
-              util::bind(&spt::get_num_stolen_to_staged, &scheduler_,
+              util::bind(&spt::get_num_stolen_to_staged, &pool_,
                   std::size_t(-1), _1),
-              util::bind(&spt::get_num_stolen_to_staged, &scheduler_,
+              util::bind(&spt::get_num_stolen_to_staged, &pool_,
                   static_cast<std::size_t>(paths.instanceindex_), _1),
               "worker-thread", shepherd_count
             }
@@ -1323,8 +1153,8 @@ namespace hpx { namespace threads
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    void threadmanager_impl<SchedulingPolicy>::
         register_counter_types()
     {
         typedef threadmanager_impl ti;
@@ -1534,146 +1364,25 @@ namespace hpx { namespace threads
             counter_types, sizeof(counter_types)/sizeof(counter_types[0]));
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
-        idle_callback(std::size_t num_thread)
-    {
-        scheduler_.idle_callback(num_thread);
-    }
-
     ///////////////////////////////////////////////////////////////////////////
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
-        tfunc_impl(std::size_t num_thread)
-    {
-        manage_active_thread_count count(thread_count_);
-
-        // run the work queue
-        hpx::util::coroutines::prepare_main_thread main_thread;
-
-        // run main scheduling loop until terminated
-        detail::scheduling_loop(num_thread, scheduler_, state_,
-            executed_threads_[num_thread], executed_thread_phases_[num_thread],
-            tfunc_times[num_thread], exec_times[num_thread],
-            util::bind(&threadmanager_impl::idle_callback, this, num_thread));
-
-        // the OS thread is allowed to exit only if no more HPX threads exist
-        // or if some other thread has terminated
-        HPX_ASSERT(!scheduler_.get_thread_count(
-            unknown, thread_priority_default, num_thread) ||
-            state_ == state_terminating);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    bool threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    bool threadmanager_impl<SchedulingPolicy>::
         run(std::size_t num_threads)
     {
-        LTM_(info) << "run: number of processing units available: " //-V128
-            << threads::hardware_concurrency();
-        LTM_(info) << "run: creating " << num_threads << " OS thread(s)"; //-V128
-
-        if (0 == num_threads) {
-            HPX_THROW_EXCEPTION(bad_parameter,
-                "threadmanager_impl::run", "number of threads is zero");
-        }
-
-#if defined(HPX_HAVE_THREAD_CUMULATIVE_COUNTS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
-        // scale timestamps to nanoseconds
-        boost::uint64_t base_timestamp = util::hardware::timestamp();
-        boost::uint64_t base_time = util::high_resolution_clock::now();
-        boost::uint64_t curr_timestamp = util::hardware::timestamp();
-        boost::uint64_t curr_time = util::high_resolution_clock::now();
-
-        while ((curr_time - base_time) <= 100000)
-        {
-            curr_timestamp = util::hardware::timestamp();
-            curr_time = util::high_resolution_clock::now();
-        }
-
-        if (curr_timestamp - base_timestamp != 0)
-        {
-            timestamp_scale_ = double(curr_time - base_time) /
-                double(curr_timestamp - base_timestamp);
-        }
-
-        LTM_(info) << "run: timestamp_scale: " << timestamp_scale_; //-V128
-#endif
-
         mutex_type::scoped_lock lk(mtx_);
-        if (!threads_.empty() || (state_.load() == state_running))
+
+        if (pool_.get_os_thread_count() != 0 ||
+            pool_.get_state() == state_running)
+        {
             return true;    // do nothing if already running
+        }
 
         LTM_(info) << "run: running timer pool";
         timer_pool_.run(false);
 
-        executed_threads_.resize(num_threads);
-        executed_thread_phases_.resize(num_threads);
-        tfunc_times.resize(num_threads);
-        exec_times.resize(num_threads);
-
-        try {
-            // run threads and wait for initialization to complete
-            HPX_ASSERT (NULL == startup_);
-            startup_ = new boost::barrier(static_cast<unsigned>(num_threads+1));
-
-            state_.store(state_running);
-
-            topology const& topology_ = get_topology();
-
-            std::size_t thread_num = num_threads;
-
-            while (thread_num-- != 0) {
-                threads::mask_cref_type mask = get_pu_mask(topology_, thread_num);
-
-                LTM_(info) << "run: create OS thread " << thread_num //-V128
-                    << ": will run on processing units within this mask: "
-#if !defined(HPX_WITH_MORE_THAN_64_THREADS) || (defined(HPX_HAVE_MAX_CPU_COUNT) && HPX_HAVE_MAX_CPU_COUNT <= 64)
-                    << std::hex << "0x" << mask;
-#else
-                    << "0b" << mask;
-#endif
-                // create a new thread
-                threads_.push_back(new boost::thread(boost::bind(
-                    &threadmanager_impl::tfunc, this, thread_num,
-                        boost::ref(topology_))));
-
-                // set the new threads affinity (on Windows systems)
-                if (any(mask))
-                {
-                    error_code ec(lightweight);
-                    topology_.set_thread_affinity_mask(threads_.back(), mask, ec);
-                    if (ec)
-                    {
-                        LTM_(warning) << "run: setting thread affinity on OS " //-V128
-                                         "thread " << thread_num << " failed with: "
-                                      << ec.get_message();
-                    }
-                }
-                else
-                {
-                    LTM_(debug) << "run: setting thread affinity on OS thread " //-V128
-                        << thread_num << " was explicitly disabled.";
-                }
-            }
-
-            // start timer pool as well
-            timer_pool_.run(false);
-
-            // the main thread needs to have a unique thread_num
-            init_tss(thread_num, scheduler_.numa_sensitive());
-            startup_->wait();
-        }
-        catch (std::exception const& e) {
-            LTM_(always) << "run: failed with: " << e.what();
-
-            // trigger the barrier
-            while (num_threads-- != 0 && !startup_->wait())
-                ;
-
-            stop();
-            threads_.clear();
-
+        if (!pool_.run(lk, num_threads))
+        {
+            timer_pool_.stop();
             return false;
         }
 
@@ -1681,221 +1390,73 @@ namespace hpx { namespace threads
         return true;
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    void threadmanager_impl<SchedulingPolicy>::
         stop (bool blocking)
     {
         LTM_(info) << "stop: blocking(" << std::boolalpha << blocking << ")";
 
-        deinit_tss();
+        mutex_type::scoped_lock lk(mtx_);
+        pool_.stop(lk, blocking);
 
-        mutex_type::scoped_lock l(mtx_);
-        if (!threads_.empty()) {
-            if (state_.load() == state_running) {
-                state_.store(state_stopping);
-                do_some_work();         // make sure we're not waiting
-            }
-
-            if (blocking) {
-                for (std::size_t i = 0; i != threads_.size(); ++i)
-                {
-                    // make sure no OS thread is waiting
-                    LTM_(info) << "stop: notify_all";
-                    do_some_work();
-
-                    LTM_(info) << "stop(" << i << "): join"; //-V128
-
-                    // unlock the lock while joining
-                    util::scoped_unlock<mutex_type::scoped_lock> ul(l);
-                    threads_[i].join();
-                }
-                threads_.clear();
-
-                LTM_(info) << "stop: stopping timer pool";
-                timer_pool_.stop();             // stop timer pool as well
-                if (blocking) {
-                    timer_pool_.join();
-                    timer_pool_.clear();
-                }
-            }
+        LTM_(info) << "stop: stopping timer pool";
+        timer_pool_.stop();             // stop timer pool as well
+        if (blocking) {
+            timer_pool_.join();
+            timer_pool_.clear();
         }
-        delete startup_;
-        startup_ = NULL;
     }
 
 #ifdef HPX_HAVE_THREAD_CUMULATIVE_COUNTS
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    boost::int64_t threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    boost::int64_t threadmanager_impl<SchedulingPolicy>::
         get_executed_threads(std::size_t num, bool reset)
     {
-        boost::int64_t result = 0;
-        if (num != std::size_t(-1)) {
-            result = executed_threads_[num];
-            if (reset)
-                executed_threads_[num] = 0;
-            return result;
-        }
-
-        result = std::accumulate(executed_threads_.begin(),
-            executed_threads_.end(), 0LL);
-        if (reset)
-            std::fill(executed_threads_.begin(), executed_threads_.end(), 0LL);
-        return result;
+        return pool_.get_executed_threads(num, reset);
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    boost::int64_t threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    boost::int64_t threadmanager_impl<SchedulingPolicy>::
         get_executed_thread_phases(std::size_t num, bool reset)
     {
-        boost::int64_t result = 0;
-        if (num != std::size_t(-1)) {
-            result = executed_thread_phases_[num];
-            if (reset)
-                executed_thread_phases_[num] = 0;
-            return result;
-        }
-
-        result = std::accumulate(executed_thread_phases_.begin(),
-            executed_thread_phases_.end(), 0LL);
-        if (reset) {
-            std::fill(executed_thread_phases_.begin(),
-                executed_thread_phases_.end(), 0LL);
-        }
-        return result;
+        return pool_.get_executed_thread_phases(num, reset);
     }
 
 #ifdef HPX_HAVE_THREAD_IDLE_RATES
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    boost::int64_t threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    boost::int64_t threadmanager_impl<SchedulingPolicy>::
         get_thread_phase_duration(std::size_t num, bool reset)
     {
-        if (num != std::size_t(-1)) {
-            double exec_total = static_cast<double>(exec_times[num]);
-            double num_phases = static_cast<double>(executed_thread_phases_[num]);
-
-            if (reset) {
-                executed_thread_phases_[num] = 0;
-                tfunc_times[num] = boost::uint64_t(-1);
-            }
-            return boost::uint64_t((exec_total * timestamp_scale_)/ num_phases);
-        }
-
-        double exec_total = std::accumulate(exec_times.begin(),
-            exec_times.end(), 0.);
-        double num_phases = std::accumulate(executed_thread_phases_.begin(),
-            executed_thread_phases_.end(), 0.);
-
-        if (reset) {
-            std::fill(executed_thread_phases_.begin(),
-                executed_thread_phases_.end(), 0LL);
-            std::fill(tfunc_times.begin(), tfunc_times.end(),
-                boost::uint64_t(-1));
-        }
-        return boost::uint64_t((exec_total * timestamp_scale_)/ num_phases);
+        return pool_.get_thread_phase_duration(num, reset);
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    boost::int64_t threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    boost::int64_t threadmanager_impl<SchedulingPolicy>::
         get_thread_duration(std::size_t num, bool reset)
     {
-        if (num != std::size_t(-1)) {
-            double exec_total = static_cast<double>(exec_times[num]);
-            double num_threads = static_cast<double>(executed_threads_[num]);
-
-            if (reset) {
-                executed_threads_[num] = 0;
-                tfunc_times[num] = boost::uint64_t(-1);
-            }
-            return boost::uint64_t((exec_total * timestamp_scale_)/ num_threads);
-        }
-
-        double exec_total = std::accumulate(exec_times.begin(),
-            exec_times.end(), 0.);
-        double num_threads = std::accumulate(executed_threads_.begin(),
-            executed_threads_.end(), 0.);
-
-        if (reset) {
-            std::fill(executed_threads_.begin(), executed_threads_.end(), 0LL);
-            std::fill(tfunc_times.begin(), tfunc_times.end(),
-                boost::uint64_t(-1));
-        }
-        return boost::uint64_t((exec_total * timestamp_scale_) / num_threads);
+        return pool_.get_thread_duration(num, reset);
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    boost::int64_t threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    boost::int64_t threadmanager_impl<SchedulingPolicy>::
         get_thread_phase_overhead(std::size_t num, bool reset)
     {
-        if (num != std::size_t(-1)) {
-            double exec_total = static_cast<double>(exec_times[num]);
-            double tfunc_total = static_cast<double>(tfunc_times[num]);
-            double num_phases = static_cast<double>(executed_thread_phases_[num]);
-
-            if (reset) {
-                executed_thread_phases_[num] = 0;
-                tfunc_times[num] = boost::uint64_t(-1);
-            }
-            return boost::uint64_t(((tfunc_total - exec_total) * timestamp_scale_)/
-                    num_phases);
-        }
-
-        double exec_total = std::accumulate(exec_times.begin(),
-            exec_times.end(), 0.);
-        double tfunc_total = std::accumulate(tfunc_times.begin(),
-            tfunc_times.end(), 0.);
-        double num_phases = std::accumulate(executed_thread_phases_.begin(),
-            executed_thread_phases_.end(), 0.);
-
-        if (reset) {
-            std::fill(executed_thread_phases_.begin(),
-                executed_thread_phases_.end(), 0LL);
-            std::fill(tfunc_times.begin(), tfunc_times.end(),
-                boost::uint64_t(-1));
-        }
-        return boost::uint64_t(((tfunc_total - exec_total) * timestamp_scale_)/
-                num_phases);
+        return pool_.get_thread_phase_overhead(num, reset);
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    boost::int64_t threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    boost::int64_t threadmanager_impl<SchedulingPolicy>::
         get_thread_overhead(std::size_t num, bool reset)
     {
-        if (num != std::size_t(-1)) {
-            double exec_total = static_cast<double>(exec_times[num]);
-            double tfunc_total = static_cast<double>(tfunc_times[num]);
-            double num_threads = static_cast<double>(executed_threads_[num]);
-
-            if (reset) {
-                executed_threads_[num] = 0;
-                tfunc_times[num] = boost::uint64_t(-1);
-            }
-            return boost::uint64_t(((tfunc_total - exec_total) *
-                        timestamp_scale_) / num_threads);
-        }
-
-        double exec_total = std::accumulate(exec_times.begin(),
-            exec_times.end(), 0.);
-        double tfunc_total = std::accumulate(tfunc_times.begin(),
-            tfunc_times.end(), 0.);
-        double num_threads = std::accumulate(executed_threads_.begin(),
-            executed_threads_.end(), 0.);
-
-        if (reset) {
-            std::fill(executed_threads_.begin(), executed_threads_.end(), 0LL);
-            std::fill(tfunc_times.begin(), tfunc_times.end(),
-                boost::uint64_t(-1));
-        }
-        return boost::uint64_t(((tfunc_total - exec_total) *
-                        timestamp_scale_) / num_threads);
+        return pool_.get_thread_overhead(num, reset);
     }
-
 #endif
 #endif
 
 #ifdef HPX_HAVE_THREAD_IDLE_RATES
     ///////////////////////////////////////////////////////////////////////////
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    boost::int64_t threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    boost::int64_t threadmanager_impl<SchedulingPolicy>::
         avg_idle_rate(bool reset)
     {
         double const exec_total =
@@ -1917,8 +1478,8 @@ namespace hpx { namespace threads
         return boost::int64_t(10000. * percent);    // 0.01 percent
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    boost::int64_t threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    boost::int64_t threadmanager_impl<SchedulingPolicy>::
         avg_idle_rate(std::size_t num_thread, bool reset)
     {
         double const exec_time = static_cast<double>(exec_times[num_thread]);
@@ -1938,57 +1499,21 @@ namespace hpx { namespace threads
     }
 #endif
 
-#if defined(HPX_HAVE_THREAD_IDLE_RATES) && defined(HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES)
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    boost::int64_t threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+#if defined(HPX_HAVE_THREAD_IDLE_RATES) && \
+    defined(HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES)
+
+    template <typename SchedulingPolicy>
+    boost::int64_t threadmanager_impl<SchedulingPolicy>::
         avg_creation_idle_rate(bool reset)
     {
-        double const creation_total =
-            static_cast<double>(scheduler_.get_creation_time(reset));
-        double const exec_total =
-            std::accumulate(exec_times.begin(), exec_times.end(), 0.);
-        double const tfunc_total =
-            std::accumulate(tfunc_times.begin(), tfunc_times.end(), 0.);
-
-        if (reset) {
-            std::fill(tfunc_times.begin(), tfunc_times.end(),
-                boost::uint64_t(-1));
-        }
-
-        // avoid division by zero
-        if (std::abs(tfunc_total - exec_total) < 1e-16)
-            return 10000LL;
-
-        HPX_ASSERT(tfunc_total > exec_total);
-
-        double const percent = (creation_total / (tfunc_total - exec_total));
-        return boost::int64_t(10000. * percent);    // 0.01 percent
+        return avg_creation_idle_rate(reset);
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    boost::int64_t threadmanager_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    boost::int64_t threadmanager_impl<SchedulingPolicy>::
         avg_cleanup_idle_rate(bool reset)
     {
-        double const cleanup_total =
-            static_cast<double>(scheduler_.get_cleanup_time(reset));
-        double const exec_total =
-            std::accumulate(exec_times.begin(), exec_times.end(), 0.);
-        double const tfunc_total =
-            std::accumulate(tfunc_times.begin(), tfunc_times.end(), 0.);
-
-        if (reset) {
-            std::fill(tfunc_times.begin(), tfunc_times.end(),
-                boost::uint64_t(-1));
-        }
-
-        // avoid division by zero
-        if (std::abs(tfunc_total - exec_total) < 1e-16)
-            return 10000LL;
-
-        HPX_ASSERT(tfunc_total > exec_total);
-
-        double const percent = (cleanup_total / (tfunc_total - exec_total));
-        return boost::int64_t(10000. * percent);    // 0.01 percent
+        return avg_creation_idle_rate(reset);
     }
 #endif
 }}
@@ -2000,39 +1525,33 @@ namespace hpx { namespace threads
 #if defined(HPX_HAVE_LOCAL_SCHEDULER)
 #include <hpx/runtime/threads/policies/local_queue_scheduler.hpp>
 template class HPX_EXPORT hpx::threads::threadmanager_impl<
-    hpx::threads::policies::local_queue_scheduler<>,
-    hpx::threads::policies::callback_notifier>;
+    hpx::threads::policies::local_queue_scheduler<> >;
 #endif
 
 #if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
 #include <hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp>
 template class HPX_EXPORT hpx::threads::threadmanager_impl<
-    hpx::threads::policies::static_priority_queue_scheduler<>,
-    hpx::threads::policies::callback_notifier>;
+    hpx::threads::policies::static_priority_queue_scheduler<> >;
 #endif
 
 #include <hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp>
 template class HPX_EXPORT hpx::threads::threadmanager_impl<
-    hpx::threads::policies::local_priority_queue_scheduler<>,
-    hpx::threads::policies::callback_notifier>;
+    hpx::threads::policies::local_priority_queue_scheduler<> >;
 
 #if defined(HPX_HAVE_ABP_SCHEDULER)
 template class HPX_EXPORT hpx::threads::threadmanager_impl<
-    hpx::threads::policies::abp_fifo_priority_queue_scheduler,
-    hpx::threads::policies::callback_notifier>;
+    hpx::threads::policies::abp_fifo_priority_queue_scheduler>;
 #endif
 
 #if defined(HPX_HAVE_HIERARCHY_SCHEDULER)
 #include <hpx/runtime/threads/policies/hierarchy_scheduler.hpp>
 template class HPX_EXPORT hpx::threads::threadmanager_impl<
-    hpx::threads::policies::hierarchy_scheduler<>,
-    hpx::threads::policies::callback_notifier>;
+    hpx::threads::policies::hierarchy_scheduler<> >;
 #endif
 
 #if defined(HPX_HAVE_PERIODIC_PRIORITY_SCHEDULER)
 #include <hpx/runtime/threads/policies/periodic_priority_queue_scheduler.hpp>
 template class HPX_EXPORT hpx::threads::threadmanager_impl<
-    hpx::threads::policies::periodic_priority_queue_scheduler<>,
-    hpx::threads::policies::callback_notifier>;
+    hpx::threads::policies::periodic_priority_queue_scheduler<> >;
 #endif
 

--- a/src/runtime/threads/threadmanager_base.cpp
+++ b/src/runtime/threads/threadmanager_base.cpp
@@ -13,53 +13,10 @@
 namespace hpx { namespace threads
 {
     ///////////////////////////////////////////////////////////////////////////
-    hpx::util::thread_specific_ptr<std::size_t, threadmanager_base::tls_tag>
-        threadmanager_base::thread_num_;
-
-    void threadmanager_base::init_tss(std::size_t thread_num, bool numa_sensitive)
-    {
-        HPX_ASSERT(NULL == threadmanager_base::thread_num_.get());    // shouldn't be initialized yet
-        threadmanager_base::thread_num_.reset(new std::size_t);
-        if (numa_sensitive) {
-            *threadmanager_base::thread_num_.get() =
-                thread_num | (std::size_t(0x1) << 31);
-        }
-        else {
-            *threadmanager_base::thread_num_.get() = thread_num;
-        }
-    }
-
-    void threadmanager_base::deinit_tss()
-    {
-        threadmanager_base::thread_num_.reset();
-    }
-
-    std::size_t threadmanager_base::get_worker_thread_num(bool* numa_sensitive)
-    {
-        if (NULL != threadmanager_base::thread_num_.get())
-        {
-            std::size_t result = *threadmanager_base::thread_num_;
-            if (std::size_t(-1) != result)
-            {
-                if (numa_sensitive)
-                    *numa_sensitive = (result & (std::size_t(0x1) << 31)) != 0;
-                return result & ~(std::size_t(0x1) << 31);
-            }
-        }
-
-        // some OS threads are not managed by the thread-manager
-        if (numa_sensitive)
-            *numa_sensitive = false;
-        return std::size_t(-1);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
     // Return the number of the NUMA node the current thread is running on
     std::size_t get_numa_node_number()
     {
-        bool numa_sensitive = false;
-        std::size_t thread_num =
-            threadmanager_base::get_worker_thread_num(&numa_sensitive);
+        std::size_t thread_num = hpx::get_worker_thread_num();
         return get_topology().get_numa_node_number(
             get_thread_manager().get_pu_num(thread_num));
     }

--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -115,8 +115,8 @@ namespace hpx {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    runtime_impl<SchedulingPolicy, NotificationPolicy>::runtime_impl(
+    template <typename SchedulingPolicy>
+    runtime_impl<SchedulingPolicy>::runtime_impl(
             util::runtime_configuration & rtcfg,
             runtime_mode locality_mode, std::size_t num_threads,
             init_scheduler_type const& init,
@@ -137,8 +137,8 @@ namespace hpx {
             boost::bind(&runtime_impl::init_tss, This(), "worker-thread", ::_1, ::_2, false),
             boost::bind(&runtime_impl::deinit_tss, This()),
             boost::bind(&runtime_impl::report_error, This(), _1, _2)),
-        thread_manager_(new hpx::threads::threadmanager_impl<
-            SchedulingPolicy, NotificationPolicy>(
+        thread_manager_(
+            new hpx::threads::threadmanager_impl<SchedulingPolicy>(
                 timer_pool_, scheduler_, notifier_, num_threads)),
         parcel_handler_(rtcfg, thread_manager_.get(),
             new parcelset::policies::global_parcelhandler_queue,
@@ -162,10 +162,12 @@ namespace hpx {
 #endif
         // now, launch AGAS and register all nodes, launch all other components
         agas_client_.initialize(
-            parcel_handler_, boost::uint64_t(runtime_support_.get()), boost::uint64_t(memory_.get()));
+            parcel_handler_, boost::uint64_t(runtime_support_.get()),
+            boost::uint64_t(memory_.get()));
         parcel_handler_.initialize(agas_client_);
 
-        applier_.initialize(boost::uint64_t(runtime_support_.get()), boost::uint64_t(memory_.get()));
+        applier_.initialize(boost::uint64_t(runtime_support_.get()),
+        boost::uint64_t(memory_.get()));
 
 #if defined(HPX_HAVE_SECURITY)
         // enable parcel capability checking
@@ -202,8 +204,8 @@ namespace hpx {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    runtime_impl<SchedulingPolicy, NotificationPolicy>::~runtime_impl()
+    template <typename SchedulingPolicy>
+    runtime_impl<SchedulingPolicy>::~runtime_impl()
     {
         LRT_(debug) << "~runtime_impl(entering)";
 
@@ -220,9 +222,9 @@ namespace hpx {
 
     int pre_main(hpx::runtime_mode);
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
+    template <typename SchedulingPolicy>
     threads::thread_state
-    runtime_impl<SchedulingPolicy, NotificationPolicy>::run_helper(
+    runtime_impl<SchedulingPolicy>::run_helper(
         util::function_nonser<runtime::hpx_main_function_type> func, int& result)
     {
         LBT_(info) << "(2nd stage) runtime_impl::run_helper: launching pre_main";
@@ -254,8 +256,8 @@ namespace hpx {
         return threads::thread_state(threads::terminated);
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    int runtime_impl<SchedulingPolicy, NotificationPolicy>::start(
+    template <typename SchedulingPolicy>
+    int runtime_impl<SchedulingPolicy>::start(
         util::function_nonser<hpx_main_function_type> const& func, bool blocking)
     {
 #if defined(_WIN64) && defined(_DEBUG) && !defined(HPX_HAVE_FIBER_BASED_COROUTINES)
@@ -319,16 +321,16 @@ namespace hpx {
         return 0;   // return zero as we don't know the outcome of hpx_main yet
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    int runtime_impl<SchedulingPolicy, NotificationPolicy>::start(bool blocking)
+    template <typename SchedulingPolicy>
+    int runtime_impl<SchedulingPolicy>::start(bool blocking)
     {
         util::function_nonser<hpx_main_function_type> empty_main;
         return start(empty_main, blocking);
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void runtime_impl<SchedulingPolicy, NotificationPolicy>::wait_helper(
+    template <typename SchedulingPolicy>
+    void runtime_impl<SchedulingPolicy>::wait_helper(
         boost::mutex& mtx, boost::condition& cond, bool& running)
     {
         // signal successful initialization
@@ -351,8 +353,8 @@ namespace hpx {
         main_pool_.stop();
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    int runtime_impl<SchedulingPolicy, NotificationPolicy>::wait()
+    template <typename SchedulingPolicy>
+    int runtime_impl<SchedulingPolicy>::wait()
     {
         LRT_(info) << "runtime_impl: about to enter wait state";
 
@@ -362,7 +364,7 @@ namespace hpx {
         bool running = false;
 
         boost::thread t (boost::bind(
-                &runtime_impl<SchedulingPolicy, NotificationPolicy>::wait_helper,
+                &runtime_impl<SchedulingPolicy>::wait_helper,
                 this, boost::ref(mtx), boost::ref(cond), boost::ref(running)
             ));
 
@@ -386,8 +388,8 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // First half of termination process: stop thread manager,
     // schedule a task managed by timer_pool to initiate second part
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void runtime_impl<SchedulingPolicy, NotificationPolicy>::stop(bool blocking)
+    template <typename SchedulingPolicy>
+    void runtime_impl<SchedulingPolicy>::stop(bool blocking)
     {
         LRT_(warning) << "runtime_impl: about to stop services";
 
@@ -424,8 +426,8 @@ namespace hpx {
     // Second step in termination: shut down all services.
     // This gets executed as a task in the timer_pool io_service and not as
     // a HPX thread!
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void runtime_impl<SchedulingPolicy, NotificationPolicy>::stopped(
+    template <typename SchedulingPolicy>
+    void runtime_impl<SchedulingPolicy>::stopped(
         bool blocking, boost::condition& cond, boost::mutex& mtx)
     {
         // wait for thread manager to exit
@@ -442,8 +444,8 @@ namespace hpx {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void runtime_impl<SchedulingPolicy, NotificationPolicy>::report_error(
+    template <typename SchedulingPolicy>
+    void runtime_impl<SchedulingPolicy>::report_error(
         std::size_t num_thread, boost::exception_ptr const& e)
     {
         // Early and late exceptions, errors outside of HPX-threads
@@ -486,17 +488,15 @@ namespace hpx {
             naming::get_id_from_locality_id(HPX_AGAS_BOOTSTRAP_PREFIX));
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void runtime_impl<SchedulingPolicy, NotificationPolicy>::report_error(
+    template <typename SchedulingPolicy>
+    void runtime_impl<SchedulingPolicy>::report_error(
         boost::exception_ptr const& e)
     {
-        std::size_t num_thread =
-            hpx::threads::threadmanager_base::get_worker_thread_num();
-        return report_error(num_thread, e);
+        return report_error(hpx::get_worker_thread_num(), e);
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void runtime_impl<SchedulingPolicy, NotificationPolicy>::rethrow_exception()
+    template <typename SchedulingPolicy>
+    void runtime_impl<SchedulingPolicy>::rethrow_exception()
     {
         if (state_.load() > state_running)
         {
@@ -511,8 +511,8 @@ namespace hpx {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    int runtime_impl<SchedulingPolicy, NotificationPolicy>::run(
+    template <typename SchedulingPolicy>
+    int runtime_impl<SchedulingPolicy>::run(
         util::function_nonser<hpx_main_function_type> const& func)
     {
         // start the main thread function
@@ -529,8 +529,8 @@ namespace hpx {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    int runtime_impl<SchedulingPolicy, NotificationPolicy>::run()
+    template <typename SchedulingPolicy>
+    int runtime_impl<SchedulingPolicy>::run()
     {
         // start the main thread function
         start();
@@ -546,8 +546,8 @@ namespace hpx {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void runtime_impl<SchedulingPolicy, NotificationPolicy>::default_errorsink(
+    template <typename SchedulingPolicy>
+    void runtime_impl<SchedulingPolicy>::default_errorsink(
         std::string const& msg)
     {
         // log the exception information in any case
@@ -557,8 +557,8 @@ namespace hpx {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void runtime_impl<SchedulingPolicy, NotificationPolicy>::init_tss(
+    template <typename SchedulingPolicy>
+    void runtime_impl<SchedulingPolicy>::init_tss(
         char const* context, std::size_t num, char const* postfix,
         bool service_thread)
     {
@@ -612,8 +612,8 @@ namespace hpx {
         }
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void runtime_impl<SchedulingPolicy, NotificationPolicy>::deinit_tss()
+    template <typename SchedulingPolicy>
+    void runtime_impl<SchedulingPolicy>::deinit_tss()
     {
         // initialize coroutines context switcher
         hpx::util::coroutines::thread_shutdown();
@@ -631,51 +631,51 @@ namespace hpx {
         runtime::thread_name_.reset();
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
+    template <typename SchedulingPolicy>
     naming::gid_type
-    runtime_impl<SchedulingPolicy, NotificationPolicy>::get_next_id(std::size_t count)
+    runtime_impl<SchedulingPolicy>::get_next_id(std::size_t count)
     {
         return id_pool_.get_id(count);
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void runtime_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    void runtime_impl<SchedulingPolicy>::
         add_pre_startup_function(util::function_nonser<void()> const& f)
     {
         runtime_support_->add_pre_startup_function(f);
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void runtime_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    void runtime_impl<SchedulingPolicy>::
         add_startup_function(util::function_nonser<void()> const& f)
     {
         runtime_support_->add_startup_function(f);
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void runtime_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    void runtime_impl<SchedulingPolicy>::
         add_pre_shutdown_function(util::function_nonser<void()> const& f)
     {
         runtime_support_->add_pre_shutdown_function(f);
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    void runtime_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    void runtime_impl<SchedulingPolicy>::
         add_shutdown_function(util::function_nonser<void()> const& f)
     {
         runtime_support_->add_shutdown_function(f);
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    bool runtime_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    bool runtime_impl<SchedulingPolicy>::
         keep_factory_alive(components::component_type type)
     {
         return runtime_support_->keep_factory_alive(type);
     }
 
-    template <typename SchedulingPolicy, typename NotificationPolicy>
+    template <typename SchedulingPolicy>
     hpx::util::io_service_pool*
-    runtime_impl<SchedulingPolicy, NotificationPolicy>::
+    runtime_impl<SchedulingPolicy>::
         get_thread_pool(char const* name)
     {
         HPX_ASSERT(name != 0);
@@ -693,8 +693,8 @@ namespace hpx {
     }
 
     /// Register an external OS-thread with HPX
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    bool runtime_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    bool runtime_impl<SchedulingPolicy>::
         register_thread(char const* name, std::size_t num, bool service_thread)
     {
         if (NULL != runtime::thread_name_.get())
@@ -709,8 +709,8 @@ namespace hpx {
     }
 
     /// Unregister an external OS-thread with HPX
-    template <typename SchedulingPolicy, typename NotificationPolicy>
-    bool runtime_impl<SchedulingPolicy, NotificationPolicy>::
+    template <typename SchedulingPolicy>
+    bool runtime_impl<SchedulingPolicy>::
         unregister_thread()
     {
         if (NULL == runtime::thread_name_.get())
@@ -726,39 +726,33 @@ namespace hpx {
 #if defined(HPX_HAVE_LOCAL_SCHEDULER)
 #include <hpx/runtime/threads/policies/local_queue_scheduler.hpp>
 template class HPX_EXPORT hpx::runtime_impl<
-    hpx::threads::policies::local_queue_scheduler<>,
-    hpx::threads::policies::callback_notifier>;
+    hpx::threads::policies::local_queue_scheduler<> >;
 #endif
 
 #if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
 #include <hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp>
 template class HPX_EXPORT hpx::runtime_impl<
-    hpx::threads::policies::static_priority_queue_scheduler<>,
-    hpx::threads::policies::callback_notifier>;
+    hpx::threads::policies::static_priority_queue_scheduler<> >;
 #endif
 
 #include <hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp>
 template class HPX_EXPORT hpx::runtime_impl<
-    hpx::threads::policies::local_priority_queue_scheduler<>,
-    hpx::threads::policies::callback_notifier>;
+    hpx::threads::policies::local_priority_queue_scheduler<> >;
 
 #if defined(HPX_HAVE_ABP_SCHEDULER)
 template class HPX_EXPORT hpx::runtime_impl<
-    hpx::threads::policies::abp_fifo_priority_queue_scheduler,
-    hpx::threads::policies::callback_notifier>;
+    hpx::threads::policies::abp_fifo_priority_queue_scheduler>;
 #endif
 
 #if defined(HPX_HAVE_HIERARCHY_SCHEDULER)
 #include <hpx/runtime/threads/policies/hierarchy_scheduler.hpp>
 template class HPX_EXPORT hpx::runtime_impl<
-    hpx::threads::policies::hierarchy_scheduler<>,
-    hpx::threads::policies::callback_notifier>;
+    hpx::threads::policies::hierarchy_scheduler<> >;
 #endif
 
 #if defined(HPX_HAVE_PERIODIC_PRIORITY_SCHEDULER)
 #include <hpx/runtime/threads/policies/periodic_priority_queue_scheduler.hpp>
 template class HPX_EXPORT hpx::runtime_impl<
-    hpx::threads::policies::periodic_priority_queue_scheduler<>,
-    hpx::threads::policies::callback_notifier>;
+    hpx::threads::policies::periodic_priority_queue_scheduler<> >;
 #endif
 


### PR DESCRIPTION
This patch separates the thread-pool functionality from the thread-manager. This is the first step towards creating an executor which has full control over processing units. The existing executors are built on top of the underlying main scheduler, which causes them to compete for processing time. The new executor will not have that disadvantage.