### PR TITLE
Increase timeout for CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -36,7 +36,8 @@ dependencies:
         # image, expanding it by about 500 MB.
         # docker-compile.pl is a dirty workaround, and shall be removed ASAP.
         - cp tools/docker/Dockerfile tools/docker/.dockerignore .
-        - ./tools/docker/docker-compile.pl ${TARGET_IMAGE_NAME}
+        - ./tools/docker/docker-compile.pl ${TARGET_IMAGE_NAME}:
+            timeout: 1200   # increase timeout to avoid failure
 
 test:
     override:


### PR DESCRIPTION
Increase timeout for one of the commands executed by CircleCI as it is failing occasionally