### PR TITLE
Modified foreach partitioner to use bulk execute

### DIFF
--- a/hpx/parallel/util/detail/chunk_size.hpp
+++ b/hpx/parallel/util/detail/chunk_size.hpp
@@ -90,6 +90,32 @@ namespace hpx { namespace parallel { namespace util { namespace detail
         return chunk_size;
     }
 
+    template <typename ExPolicy, typename Future, typename F1,
+        typename FwdIter>
+        // requires traits::is_future<Future>
+    std::vector<std::pair<FwdIter, std::size_t > > get_static_shape(
+        ExPolicy policy, std::vector<Future>& workitems,
+        F1 && f1, FwdIter& first, std::size_t& count,
+        std::size_t chunk_size)
+    {
+        chunk_size = get_static_chunk_size(policy, workitems,
+            std::forward<F1>(f1), first, count, chunk_size);
+
+        std::vector<std::pair<FwdIter, std::size_t> > shape;
+
+        while (count != 0)
+        {
+            std::size_t chunk = (std::min)(chunk_size, count);
+
+            shape.push_back(std::make_pair(first, chunk));
+
+            count -= chunk;
+            std::advance(first, chunk);
+        }
+
+        return shape;
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename Future, typename F, typename FwdIter>
         // requires traits::is_future<Future>


### PR DESCRIPTION
Changed foreach partitioner to make use of bulk async execute. Since
each policy has an associated executor, the partitioners should make
use of the executors bulk functionality.

This starts to solve the bullet point "make use of executor traits'
bulk functionality in each of the partitioners" from issue #1544