### PR TITLE
Allowing to specify whether to send credits along with message 

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -101,6 +101,7 @@ set(doxygen_dependencies
     "${hpx_SOURCE_DIR}/hpx/runtime/get_ptr.hpp"
     "${hpx_SOURCE_DIR}/hpx/runtime/get_locality_name.hpp"
     "${hpx_SOURCE_DIR}/hpx/runtime/set_parcel_write_handler.hpp"
+    "${hpx_SOURCE_DIR}/hpx/runtime/trigger_lco.hpp"
     "${hpx_SOURCE_DIR}/hpx/runtime/actions/basic_action.hpp"
     "${hpx_SOURCE_DIR}/hpx/runtime/actions/component_action.hpp"
     "${hpx_SOURCE_DIR}/hpx/runtime/actions/plain_action.hpp"

--- a/hpx/hpx_fwd.hpp
+++ b/hpx/hpx_fwd.hpp
@@ -1475,88 +1475,6 @@ namespace hpx
         naming::id_type const& id);
 
     ///////////////////////////////////////////////////////////////////////////
-    /// \brief Trigger the LCO referenced by the given id
-    ///
-    /// \param id [in] This represents the id of the LCO which should be
-    ///                triggered.
-    /// \param move_credits [in] If this is set to \a true then it is ok to
-    ///                     send all credits in \a id along with the generated
-    ///                     message. The default value is \a true.
-    HPX_API_EXPORT void trigger_lco_event(naming::id_type const& id,
-        bool move_credits = true);
-
-    /// \brief Trigger the LCO referenced by the given id
-    ///
-    /// \param id   [in] This represents the id of the LCO which should be
-    ///                  triggered.
-    /// \param cont [in] This represents the LCO to trigger after completion.
-    /// \param move_credits [in] If this is set to \a true then it is ok to
-    ///                     send all credits in \a id along with the generated
-    ///                     message. The default value is \a true.
-    HPX_API_EXPORT void trigger_lco_event(naming::id_type const& id,
-        naming::id_type const& cont, bool move_credits = true);
-
-    /// \brief Set the result value for the LCO referenced by the given id
-    ///
-    /// \param id [in] This represents the id of the LCO which should
-    ///                receive the given value.
-    /// \param t  [in] This is the value which should be sent to the LCO.
-    /// \param move_credits [in] If this is set to \a true then it is ok to
-    ///                     send all credits in \a id along with the generated
-    ///                     message. The default value is \a true.
-    template <typename T>
-    void set_lco_value(naming::id_type const& id, T && t,
-        bool move_credits = true);
-
-    /// \brief Set the result value for the LCO referenced by the given id
-    ///
-    /// \param id   [in] This represents the id of the LCO which should
-    ///                  receive the given value.
-    /// \param t    [in] This is the value which should be sent to the LCO.
-    /// \param cont [in] This represents the LCO to trigger after completion.
-    /// \param move_credits [in] If this is set to \a true then it is ok to
-    ///                     send all credits in \a id along with the generated
-    ///                     message. The default value is \a true.
-    template <typename T>
-    void set_lco_value(naming::id_type const& id, T && t,
-        naming::id_type const& cont, bool move_credits = true);
-
-    /// \brief Set the error state for the LCO referenced by the given id
-    ///
-    /// \param id [in] This represents the id of the LCO which should
-    ///                receive the error value.
-    /// \param e  [in] This is the error value which should be sent to
-    ///                the LCO.
-    /// \param move_credits [in] If this is set to \a true then it is ok to
-    ///                     send all credits in \a id along with the generated
-    ///                     message. The default value is \a true.
-    HPX_API_EXPORT void set_lco_error(naming::id_type const& id,
-        boost::exception_ptr const& e, bool move_credits = true);
-
-    /// \copydoc hpx::set_lco_error(naming::id_type const& id, boost::exception_ptr const& e, bool move_credits)
-    HPX_API_EXPORT void set_lco_error(naming::id_type const& id,
-        boost::exception_ptr && e, bool move_credits = true);
-
-    /// \brief Set the error state for the LCO referenced by the given id
-    ///
-    /// \param id   [in] This represents the id of the LCO which should
-    ///                  receive the error value.
-    /// \param e    [in] This is the error value which should be sent to
-    ///                  the LCO.
-    /// \param cont [in] This represents the LCO to trigger after completion.
-    /// \param move_credits [in] If this is set to \a true then it is ok to
-    ///                     send all credits in \a id along with the generated
-    ///                     message. The default value is \a true.
-    HPX_API_EXPORT void set_lco_error(naming::id_type const& id,
-        boost::exception_ptr const& e, naming::id_type const& cont,
-        bool move_credits);
-
-    /// \copydoc hpx::set_lco_error(naming::id_type const& id, boost::exception_ptr const& e, naming::id_type const& cont, bool move_credits)
-    HPX_API_EXPORT void set_lco_error(naming::id_type const& id,
-        boost::exception_ptr && e, naming::id_type const& cont,
-        bool move_credits);
-
-    ///////////////////////////////////////////////////////////////////////////
     /// \brief Start all active performance counters, optionally naming the
     ///        section of code
     ///
@@ -1715,6 +1633,7 @@ namespace hpx
 }
 
 // Including declarations of various API function declarations
+#include <hpx/runtime/trigger_lco.hpp>
 #include <hpx/runtime/get_locality_name.hpp>
 #include <hpx/runtime/set_parcel_write_handler.hpp>
 

--- a/hpx/hpx_fwd.hpp
+++ b/hpx/hpx_fwd.hpp
@@ -1483,23 +1483,34 @@ namespace hpx
     ///
     /// \param id [in] This represents the id of the LCO which should be
     ///                triggered.
-    HPX_API_EXPORT void trigger_lco_event(naming::id_type const& id);
+    /// \param move_credits [in] If this is set to \a true then it is ok to
+    ///                     send all credits in \a id along with the generated
+    ///                     message. The default value is \a true.
+    HPX_API_EXPORT void trigger_lco_event(naming::id_type const& id,
+        bool move_credits = true);
 
     /// \brief Trigger the LCO referenced by the given id
     ///
     /// \param id   [in] This represents the id of the LCO which should be
     ///                  triggered.
     /// \param cont [in] This represents the LCO to trigger after completion.
+    /// \param move_credits [in] If this is set to \a true then it is ok to
+    ///                     send all credits in \a id along with the generated
+    ///                     message. The default value is \a true.
     HPX_API_EXPORT void trigger_lco_event(naming::id_type const& id,
-        naming::id_type const& cont);
+        naming::id_type const& cont, bool move_credits = true);
 
     /// \brief Set the result value for the LCO referenced by the given id
     ///
     /// \param id [in] This represents the id of the LCO which should
     ///                receive the given value.
     /// \param t  [in] This is the value which should be sent to the LCO.
+    /// \param move_credits [in] If this is set to \a true then it is ok to
+    ///                     send all credits in \a id along with the generated
+    ///                     message. The default value is \a true.
     template <typename T>
-    void set_lco_value(naming::id_type const& id, T && t);
+    void set_lco_value(naming::id_type const& id, T && t,
+        bool move_credits = true);
 
     /// \brief Set the result value for the LCO referenced by the given id
     ///
@@ -1507,9 +1518,12 @@ namespace hpx
     ///                  receive the given value.
     /// \param t    [in] This is the value which should be sent to the LCO.
     /// \param cont [in] This represents the LCO to trigger after completion.
+    /// \param move_credits [in] If this is set to \a true then it is ok to
+    ///                     send all credits in \a id along with the generated
+    ///                     message. The default value is \a true.
     template <typename T>
     void set_lco_value(naming::id_type const& id, T && t,
-        naming::id_type const& cont);
+        naming::id_type const& cont, bool move_credits = true);
 
     /// \brief Set the error state for the LCO referenced by the given id
     ///
@@ -1517,12 +1531,15 @@ namespace hpx
     ///                receive the error value.
     /// \param e  [in] This is the error value which should be sent to
     ///                the LCO.
+    /// \param move_credits [in] If this is set to \a true then it is ok to
+    ///                     send all credits in \a id along with the generated
+    ///                     message. The default value is \a true.
     HPX_API_EXPORT void set_lco_error(naming::id_type const& id,
-        boost::exception_ptr const& e);
+        boost::exception_ptr const& e, bool move_credits = true);
 
-    /// \copydoc hpx::set_lco_error(naming::id_type const& id, boost::exception_ptr const& e)
+    /// \copydoc hpx::set_lco_error(naming::id_type const& id, boost::exception_ptr const& e, bool move_credits)
     HPX_API_EXPORT void set_lco_error(naming::id_type const& id,
-        boost::exception_ptr && e);
+        boost::exception_ptr && e, bool move_credits = true);
 
     /// \brief Set the error state for the LCO referenced by the given id
     ///
@@ -1531,12 +1548,17 @@ namespace hpx
     /// \param e    [in] This is the error value which should be sent to
     ///                  the LCO.
     /// \param cont [in] This represents the LCO to trigger after completion.
+    /// \param move_credits [in] If this is set to \a true then it is ok to
+    ///                     send all credits in \a id along with the generated
+    ///                     message. The default value is \a true.
     HPX_API_EXPORT void set_lco_error(naming::id_type const& id,
-        boost::exception_ptr const& e, naming::id_type const& cont);
+        boost::exception_ptr const& e, naming::id_type const& cont,
+        bool move_credits);
 
-    /// \copydoc hpx::set_lco_error(naming::id_type const& id, boost::exception_ptr const& e, naming::id_type const& cont)
+    /// \copydoc hpx::set_lco_error(naming::id_type const& id, boost::exception_ptr const& e, naming::id_type const& cont, bool move_credits)
     HPX_API_EXPORT void set_lco_error(naming::id_type const& id,
-        boost::exception_ptr && e, naming::id_type const& cont);
+        boost::exception_ptr && e, naming::id_type const& cont,
+        bool move_credits);
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Start all active performance counters, optionally naming the

--- a/hpx/runtime/actions/continuation.hpp
+++ b/hpx/runtime/actions/continuation.hpp
@@ -80,26 +80,46 @@ namespace hpx
     //////////////////////////////////////////////////////////////////////////
     // handling special case of triggering an LCO
     template <typename T>
-    void set_lco_value(naming::id_type const& id, T && t)
+    void set_lco_value(naming::id_type const& id, T && t, bool move_credits)
     {
         typename lcos::base_lco_with_value<
             typename boost::remove_reference<T>::type
         >::set_value_action set;
-        apply(set, id, util::detail::make_temporary<T>(t));
+        if (move_credits)
+        {
+            naming::id_type target(id.get_gid(), id_type::managed_move_credit);
+            id.make_unmanaged();
+
+            apply(set, target, util::detail::make_temporary<T>(t));
+        }
+        else
+        {
+            apply(set, id, util::detail::make_temporary<T>(t));
+        }
     }
 
     template <typename T>
     void set_lco_value(naming::id_type const& id, T && t,
-        naming::id_type const& cont)
+        naming::id_type const& cont, bool move_credits)
     {
         typename lcos::base_lco_with_value<
             typename boost::remove_reference<T>::type
         >::set_value_action set;
-        apply_c(set, cont, id, util::detail::make_temporary<T>(t));
+        if (move_credits)
+        {
+            naming::id_type target(id.get_gid(), id_type::managed_move_credit);
+            id.make_unmanaged();
+
+            apply_c(set, cont, target, util::detail::make_temporary<T>(t));
+        }
+        else
+        {
+            apply_c(set, cont, id, util::detail::make_temporary<T>(t));
+        }
     }
 
     HPX_API_EXPORT void set_lco_error(naming::id_type const& id,
-        boost::exception_ptr const& e);
+        boost::exception_ptr const& e, bool move_credits);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/trigger_lco.hpp
+++ b/hpx/runtime/trigger_lco.hpp
@@ -1,0 +1,102 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file hpx/runtime/trigger_lco.hpp
+
+#if !defined(HPX_RUNTIME_TRIGGER_LCO_JUN_22_2015_0618PM)
+#define HPX_RUNTIME_TRIGGER_LCO_JUN_22_2015_0618PM
+
+#include <hpx/config.hpp>
+#include <hpx/config/export_definitions.hpp>
+#include <hpx/runtime/naming/name.hpp>
+
+#include <boost/exception_ptr.hpp>
+
+namespace hpx
+{
+    ///////////////////////////////////////////////////////////////////////////
+    /// \brief Trigger the LCO referenced by the given id
+    ///
+    /// \param id [in] This represents the id of the LCO which should be
+    ///                triggered.
+    /// \param move_credits [in] If this is set to \a true then it is ok to
+    ///                     send all credits in \a id along with the generated
+    ///                     message. The default value is \a true.
+    HPX_API_EXPORT void trigger_lco_event(naming::id_type const& id,
+        bool move_credits = true);
+
+    /// \brief Trigger the LCO referenced by the given id
+    ///
+    /// \param id   [in] This represents the id of the LCO which should be
+    ///                  triggered.
+    /// \param cont [in] This represents the LCO to trigger after completion.
+    /// \param move_credits [in] If this is set to \a true then it is ok to
+    ///                     send all credits in \a id along with the generated
+    ///                     message. The default value is \a true.
+    HPX_API_EXPORT void trigger_lco_event(naming::id_type const& id,
+        naming::id_type const& cont, bool move_credits = true);
+
+    /// \brief Set the result value for the LCO referenced by the given id
+    ///
+    /// \param id [in] This represents the id of the LCO which should
+    ///                receive the given value.
+    /// \param t  [in] This is the value which should be sent to the LCO.
+    /// \param move_credits [in] If this is set to \a true then it is ok to
+    ///                     send all credits in \a id along with the generated
+    ///                     message. The default value is \a true.
+    template <typename T>
+    void set_lco_value(naming::id_type const& id, T && t,
+        bool move_credits = true);
+
+    /// \brief Set the result value for the LCO referenced by the given id
+    ///
+    /// \param id   [in] This represents the id of the LCO which should
+    ///                  receive the given value.
+    /// \param t    [in] This is the value which should be sent to the LCO.
+    /// \param cont [in] This represents the LCO to trigger after completion.
+    /// \param move_credits [in] If this is set to \a true then it is ok to
+    ///                     send all credits in \a id along with the generated
+    ///                     message. The default value is \a true.
+    template <typename T>
+    void set_lco_value(naming::id_type const& id, T && t,
+        naming::id_type const& cont, bool move_credits = true);
+
+    /// \brief Set the error state for the LCO referenced by the given id
+    ///
+    /// \param id [in] This represents the id of the LCO which should
+    ///                receive the error value.
+    /// \param e  [in] This is the error value which should be sent to
+    ///                the LCO.
+    /// \param move_credits [in] If this is set to \a true then it is ok to
+    ///                     send all credits in \a id along with the generated
+    ///                     message. The default value is \a true.
+    HPX_API_EXPORT void set_lco_error(naming::id_type const& id,
+        boost::exception_ptr const& e, bool move_credits = true);
+
+    /// \copydoc hpx::set_lco_error(naming::id_type const& id, boost::exception_ptr const& e, bool move_credits)
+    HPX_API_EXPORT void set_lco_error(naming::id_type const& id,
+        boost::exception_ptr && e, bool move_credits = true);
+
+    /// \brief Set the error state for the LCO referenced by the given id
+    ///
+    /// \param id   [in] This represents the id of the LCO which should
+    ///                  receive the error value.
+    /// \param e    [in] This is the error value which should be sent to
+    ///                  the LCO.
+    /// \param cont [in] This represents the LCO to trigger after completion.
+    /// \param move_credits [in] If this is set to \a true then it is ok to
+    ///                     send all credits in \a id along with the generated
+    ///                     message. The default value is \a true.
+    HPX_API_EXPORT void set_lco_error(naming::id_type const& id,
+        boost::exception_ptr const& e, naming::id_type const& cont,
+        bool move_credits = true);
+
+    /// \copydoc hpx::set_lco_error(naming::id_type const& id, boost::exception_ptr const& e, naming::id_type const& cont, bool move_credits)
+    HPX_API_EXPORT void set_lco_error(naming::id_type const& id,
+        boost::exception_ptr && e, naming::id_type const& cont,
+        bool move_credits = true);
+}
+
+#endif

--- a/src/runtime/actions/continuation.cpp
+++ b/src/runtime/actions/continuation.cpp
@@ -12,61 +12,106 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx
 {
-    void trigger_lco_event(naming::id_type const& id)
+    void trigger_lco_event(naming::id_type const& id, bool move_credits)
     {
-        naming::id_type target(id.get_gid(), id_type::managed_move_credit);
-        id.make_unmanaged();
-
         lcos::base_lco::set_event_action set;
-        apply(set, target);
+        if (move_credits)
+        {
+            naming::id_type target(id.get_gid(), id_type::managed_move_credit);
+            id.make_unmanaged();
+
+            apply(set, target);
+        }
+        else
+        {
+            apply(set, id);
+        }
     }
 
-    void trigger_lco_event(naming::id_type const& id, naming::id_type const& cont)
+    void trigger_lco_event(naming::id_type const& id,
+        naming::id_type const& cont, bool move_credits)
     {
-        naming::id_type target(id.get_gid(), id_type::managed_move_credit);
-        id.make_unmanaged();
-
         lcos::base_lco::set_event_action set;
-        apply_c(set, cont, target);
+        if (move_credits)
+        {
+            naming::id_type target(id.get_gid(), id_type::managed_move_credit);
+            id.make_unmanaged();
+
+            apply_c(set, cont, target);
+        }
+        else
+        {
+            apply_c(set, cont, id);
+        }
     }
 
-    void set_lco_error(naming::id_type const& id, boost::exception_ptr const& e)
+    void set_lco_error(naming::id_type const& id,
+        boost::exception_ptr const& e, bool move_credits)
     {
-        naming::id_type target(id.get_gid(), id_type::managed_move_credit);
-        id.make_unmanaged();
-
         lcos::base_lco::set_exception_action set;
-        apply(set, target, e);
+        if (move_credits)
+        {
+            naming::id_type target(id.get_gid(), id_type::managed_move_credit);
+            id.make_unmanaged();
+
+            apply(set, target, e);
+        }
+        else
+        {
+            apply(set, id, e);
+        }
     }
 
     void set_lco_error(naming::id_type const& id, //-V659
-        boost::exception_ptr && e)
+        boost::exception_ptr && e, bool move_credits)
     {
-        naming::id_type target(id.get_gid(), id_type::managed_move_credit);
-        id.make_unmanaged();
-
         lcos::base_lco::set_exception_action set;
-        apply(set, target, std::move(e));
+        if (move_credits)
+        {
+            naming::id_type target(id.get_gid(), id_type::managed_move_credit);
+            id.make_unmanaged();
+
+            apply(set, target, std::move(e));
+        }
+        else
+        {
+            apply(set, id, std::move(e));
+        }
     }
 
     void set_lco_error(naming::id_type const& id, boost::exception_ptr const& e,
-        naming::id_type const& cont)
+        naming::id_type const& cont, bool move_credits)
     {
-        naming::id_type target(id.get_gid(), id_type::managed_move_credit);
-        id.make_unmanaged();
-
         lcos::base_lco::set_exception_action set;
-        apply_c(set, cont, target, e);
+        if (move_credits)
+        {
+            naming::id_type target(id.get_gid(), id_type::managed_move_credit);
+            id.make_unmanaged();
+
+            apply_c(set, cont, target, e);
+        }
+        else
+        {
+            apply_c(set, cont, id, e);
+        }
     }
 
     void set_lco_error(naming::id_type const& id, //-V659
-        boost::exception_ptr && e, naming::id_type const& cont)
+        boost::exception_ptr && e, naming::id_type const& cont,
+        bool move_credits)
     {
-        naming::id_type target(id.get_gid(), id_type::managed_move_credit);
-        id.make_unmanaged();
-
         lcos::base_lco::set_exception_action set;
-        apply_c(set, cont, target, std::move(e));
+        if (move_credits)
+        {
+            naming::id_type target(id.get_gid(), id_type::managed_move_credit);
+            id.make_unmanaged();
+
+            apply_c(set, cont, target, std::move(e));
+        }
+        else
+        {
+            apply_c(set, cont, id, std::move(e));
+        }
     }
 }
 


### PR DESCRIPTION
Allowing to specify whether to send credits along with message  back to the future.
This has shown to fix the HPXCL problems (see comments on https://github.com/STEllAR-GROUP/hpx/commit/42d15d3f378d39ff833344d4ef9b89452ab4db58)