### PR TITLE
hpx::lcos::queue exhibits strange behavior

### DIFF
--- a/hpx/lcos/queue.hpp
+++ b/hpx/lcos/queue.hpp
@@ -90,7 +90,7 @@ namespace hpx { namespace lcos
         }
         void set_value(RemoteType && val) //-V659
         {
-            this->base_type::set_value(this->get_gid(), val);
+            this->base_type::set_value(this->get_gid(), std::forward(val));
         }
 
         void abort_pending()

--- a/hpx/lcos/stubs/queue.hpp
+++ b/hpx/lcos/stubs/queue.hpp
@@ -71,7 +71,7 @@ namespace hpx { namespace lcos { namespace stubs
             typedef typename
                 lcos::base_lco_with_value<ValueType, RemoteType>::set_value_action
             action_type;
-            hpx::apply<action_type>(gid, val);
+            hpx::apply<action_type>(gid, std::forward<RemoteType>(val));
         }
 
         static void abort_pending(naming::id_type const& gid,


### PR DESCRIPTION
I am trying to use `hpx::lcos::queue` to distribute values between asynchronous jobs. During compilation I got errors like this:
````
hpx/hpx/runtime/actions/component_action.hpp:65:18: error: rvalue reference to type 'particle<[...]>' cannot bind to lvalue of type 'particle<[...]>'
                (std::forward<Ts>(vs)...);
````
with a help of my mentor we compiled attached fix to these problems.

Sadly `hpx::lcos::queue` still does not seem to be doing what I want it. Usage is as follows:

````c++
#include <hpx/include/lcos.hpp>
#include <hpx/include/parallel_algorithm.hpp>
#include <boost/function.hpp>

template<typename Intermediate, typename Reduction>
struct reduce_helper : boost::function1<void, hpx::future<Intermediate>> {
private:
    boost::function2<Reduction, Reduction, Intermediate> m_reduce;
    mutable hpx::lcos::queue<Reduction> m_queue;

    friend class hpx::serialization::access;

    // When the class Archive corresponds to an output archive, the
    // & operator is defined similar to <<.  Likewise, when the class Archive
    // is a type of input archive the & operator is defined similar to >>.
    template<class Archive>
    void serialize(Archive &ar, const unsigned int version) {
        ar &m_reduce;
        ar &m_queue;
    }

public:

    reduce_helper(boost::function2<Reduction, Reduction, Intermediate> reduce,
                  hpx::lcos::queue<Reduction> queue) : m_reduce(reduce), m_queue(queue) {

    }


    void operator()(hpx::future<Intermediate> next) const {
        Intermediate nextValue = next.get();
        Reduction val = m_reduce(m_queue.get_value_sync(), nextValue);
        m_queue.set_value(val);
    }

};

boost::function1<Reduction, InputData> m_initial;
boost::function2<Reduction, Reduction, Intermediate> m_reduce;
std::vector<hpx::future<Intermediate>> futures = std::vector<hpx::future<Intermediate>>();

// populate futures with futures, assign m_initial and m_reduce with appropriate functors ;-)

hpx::lcos::queue<Reduction> queue = hpx::lcos::queue<Reduction>();
Reduction initial = m_initial(hpx::util::get<1>(left));
queue.set_value(initial);

hpx::lcos::wait_each(reduce_helper<Intermediate, Reduction>(m_reduce, queue), futures);

output_future.get();
output.set_value_sync(hpx::util::get<0>(left), queue.get_value_sync());
````
