### PR TITLE
Partially re-apply changes from limit_dataflow_recursion branch

### DIFF
--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -259,7 +259,7 @@ namespace detail
         {
             // set the received result, reset error status
             try {
-               typedef typename util::decay<T>::type naked_type;
+                typedef typename util::decay<T>::type naked_type;
 
                 typedef traits::get_remote_result<
                     result_type, naked_type
@@ -431,7 +431,7 @@ namespace detail
             error_code ec;
             threads::thread_id_type id = threads::register_thread_nullary(
                 util::bind(util::one_shot(&timed_future_data::set_data),
-                    this_, std::forward<Result_>(init)),
+                    std::move(this_), std::forward<Result_>(init)),
                 "timed_future_data<Result>::timed_future_data",
                 threads::suspended, true, threads::thread_priority_normal,
                 std::size_t(-1), threads::thread_stacksize_default, ec);
@@ -571,20 +571,20 @@ namespace detail
                 hpx::threads::get_self_id());
 
             if (sched_) {
-                sched_->add(util::bind(&task_base::run_impl, this_),
+                sched_->add(util::bind(&task_base::run_impl, std::move(this_)),
                     desc ? desc : "task_base::apply", threads::pending, false,
                     stacksize, ec);
             }
             else if (policy == launch::fork) {
                 threads::register_thread_plain(
-                    util::bind(&task_base::run_impl, this_),
+                    util::bind(&task_base::run_impl, std::move(this_)),
                     desc ? desc : "task_base::apply", threads::pending, false,
                     threads::thread_priority_boost, get_worker_thread_num(),
                     stacksize, ec);
             }
             else {
                 threads::register_thread_plain(
-                    util::bind(&task_base::run_impl, this_),
+                    util::bind(&task_base::run_impl, std::move(this_)),
                     desc ? desc : "task_base::apply", threads::pending, false,
                     priority, std::size_t(-1), stacksize, ec);
             }

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -409,8 +409,9 @@ namespace hpx { namespace lcos { namespace detail
             // bind an on_completed handler to this future which will invoke
             // the continuation
             boost::intrusive_ptr<continuation> this_(this);
-            void (continuation::*cb)(shared_state_ptr const&, threads::executor&) =
-                &continuation::async;
+            void (continuation::*cb)(
+                    shared_state_ptr const&, threads::executor&
+                ) = &continuation::async;
 
             shared_state_ptr const& state =
                 lcos::detail::get_shared_state(future);

--- a/hpx/lcos/wait_some.hpp
+++ b/hpx/lcos/wait_some.hpp
@@ -191,19 +191,25 @@ namespace hpx { namespace lcos
             template <typename SharedState>
             void operator()(SharedState& shared_state) const
             {
-                std::size_t counter = wait_.count_.load(boost::memory_order_seq_cst);
-                if (counter < wait_.needed_count_ && !shared_state->is_ready()) {
+                std::size_t counter =
+                    wait_.count_.load(boost::memory_order_seq_cst);
+                if (counter < wait_.needed_count_ && !shared_state->is_ready())
+                {
                     // handle future only if not enough futures are ready yet
                     // also, do not touch any futures which are already ready
 
                     shared_state->execute_deferred();
-                    shared_state->set_on_completed(Callback(callback_));
-                }
-                else {
-                    if (wait_.count_.fetch_add(1) + 1 == wait_.needed_count_)
+
+                    // execute_deferred might have made the future ready
+                    if (!shared_state->is_ready())
                     {
-                        wait_.goal_reached_on_calling_thread_ = true;
+                        shared_state->set_on_completed(Callback(callback_));
+                        return;
                     }
+                }
+                if (wait_.count_.fetch_add(1) + 1 == wait_.needed_count_)
+                {
+                    wait_.goal_reached_on_calling_thread_ = true;
                 }
             }
 

--- a/hpx/lcos/when_all.hpp
+++ b/hpx/lcos/when_all.hpp
@@ -220,28 +220,36 @@ namespace hpx { namespace lcos
             template <typename TupleIter, typename Iter>
             void await_range(TupleIter iter, Iter next, Iter end)
             {
+                typedef typename std::iterator_traits<Iter>::value_type
+                    future_type;
+                typedef typename traits::future_traits<future_type>::type
+                    future_result_type;
+
+                void (when_all_frame::*f)(TupleIter, Iter, Iter) =
+                    &when_all_frame::await_range;
+
                 for (/**/; next != end; ++next)
                 {
-                    if (!next->is_ready())
+                    boost::intrusive_ptr<
+                        lcos::detail::future_data<future_result_type>
+                    > next_future_data = lcos::detail::get_shared_state(*next);
+
+                    if (!next_future_data->is_ready())
                     {
-                        void (when_all_frame::*f)(TupleIter, Iter, Iter) =
-                            &when_all_frame::await_range;
-
-                        typedef typename std::iterator_traits<Iter>::value_type
-                            future_type;
-                        typedef typename traits::future_traits<future_type>::type
-                            future_result_type;
-
-                        boost::intrusive_ptr<
-                            lcos::detail::future_data<future_result_type>
-                        > next_future_data = lcos::detail::get_shared_state(*next);
-
-                        boost::intrusive_ptr<when_all_frame> this_(this);
                         next_future_data->execute_deferred();
-                        next_future_data->set_on_completed(util::bind(
-                            f, this_, std::move(iter),
-                            std::move(next), std::move(end)));
-                        return;
+
+                        // execute_deferred might have made the future ready
+                        if (!next_future_data->is_ready())
+                        {
+                            // Attach a continuation to this future which will
+                            // re-evaluate it and continue to the next element
+                            // in the sequence (if any).
+                            boost::intrusive_ptr<when_all_frame> this_(this);
+                            next_future_data->set_on_completed(util::bind(
+                                f, std::move(this_), std::move(iter),
+                                std::move(next), std::move(end)));
+                            return;
+                        }
                     }
                 }
 
@@ -274,27 +282,34 @@ namespace hpx { namespace lcos
                 using boost::mpl::true_;
 
                 future_type& f_ = boost::fusion::deref(iter);
-                if (!f_.is_ready())
+
+                typedef typename traits::future_traits<future_type>::type
+                    future_result_type;
+
+                boost::intrusive_ptr<
+                    lcos::detail::future_data<future_result_type>
+                > next_future_data = lcos::detail::get_shared_state(f_);
+
+                if (!next_future_data->is_ready())
                 {
-                    // Attach a continuation to this future which will
-                    // re-evaluate it and continue to the next argument
-                    // (if any).
-                    void (when_all_frame::*f)(TupleIter, true_, false_) =
-                        &when_all_frame::await_next;
-
-                    typedef typename traits::future_traits<future_type>::type
-                        future_result_type;
-
-                    boost::intrusive_ptr<
-                        lcos::detail::future_data<future_result_type>
-                    > next_future_data = lcos::detail::get_shared_state(f_);
-
-                    boost::intrusive_ptr<when_all_frame> this_(this);
                     next_future_data->execute_deferred();
-                    next_future_data->set_on_completed(hpx::util::bind(
-                        f, this_, std::move(iter), true_(), false_()));
 
-                    return;
+                    // execute_deferred might have made the future ready
+                    if (!next_future_data->is_ready())
+                    {
+                        // Attach a continuation to this future which will
+                        // re-evaluate it and continue to the next argument
+                        // (if any).
+                        void (when_all_frame::*f)(TupleIter, true_, false_) =
+                            &when_all_frame::await_next;
+
+                        boost::intrusive_ptr<when_all_frame> this_(this);
+                        next_future_data->set_on_completed(
+                            hpx::util::bind(
+                                f, std::move(this_), std::move(iter),
+                                true_(), false_()));
+                        return;
+                    }
                 }
 
                 typedef typename boost::fusion::result_of::next<TupleIter>::type

--- a/hpx/lcos/when_any.hpp
+++ b/hpx/lcos/when_any.hpp
@@ -216,28 +216,41 @@ namespace hpx { namespace lcos
             template <typename Future>
             void operator()(Future& future) const
             {
-                std::size_t index = when_.index_.load(boost::memory_order_seq_cst);
-                if (index == when_any_result<Sequence>::index_error()) {
-                    if (!future.is_ready()) {
-                        // handle future only if not enough futures are ready yet
-                        // also, do not touch any futures which are already ready
+                std::size_t index =
+                    when_.index_.load(boost::memory_order_seq_cst);
+                if (index == when_any_result<Sequence>::index_error())
+                {
+                    typedef typename lcos::detail::shared_state_ptr_for<
+                            Future
+                        >::type shared_state_ptr;
 
-                        typedef
-                            typename lcos::detail::shared_state_ptr_for<Future>::type
-                            shared_state_ptr;
+                    shared_state_ptr const& shared_state =
+                        lcos::detail::get_shared_state(future);
 
-                        shared_state_ptr const& shared_state =
-                            lcos::detail::get_shared_state(future);
+                    if (!shared_state->is_ready())
+                    {
+                        // handle future only if not enough futures are ready
+                        // yet also, do not touch any futures which are already
+                        // ready
+
                         shared_state->execute_deferred();
-                        shared_state->set_on_completed(util::bind(
-                            &when_any<Sequence>::on_future_ready, when_.shared_from_this(),
-                            idx_, threads::get_self_id()));
-                    }
-                    else {
-                        if (when_.index_.compare_exchange_strong(index, idx_))
+
+                        // execute_deferred might have made the future ready
+                        if (!shared_state->is_ready())
                         {
-                            when_.goal_reached_on_calling_thread_ = true;
+                            shared_state->set_on_completed(
+                                util::bind(
+                                    &when_any<Sequence>::on_future_ready,
+                                    when_.shared_from_this(),
+                                    idx_, threads::get_self_id()));
+                            ++idx_;
+                            return;
                         }
+                    }
+
+                    if (when_.index_.compare_exchange_strong(index, idx_))
+                    {
+                        when_.goal_reached_on_calling_thread_ = true;
                     }
                 }
                 ++idx_;

--- a/hpx/lcos/when_each.hpp
+++ b/hpx/lcos/when_each.hpp
@@ -156,29 +156,37 @@ namespace hpx { namespace lcos
             template <typename TupleIter, typename Iter>
             void await_range(TupleIter iter, Iter next, Iter end)
             {
+                typedef typename std::iterator_traits<Iter>::value_type
+                    future_type;
+                typedef typename traits::future_traits<future_type>::type
+                    future_result_type;
+
+                void (when_each_frame::*f)(TupleIter, Iter, Iter) =
+                    &when_each_frame::await_range;
+
                 for(/**/; next != end; ++next)
                 {
-                    if(!next->is_ready())
+                    boost::intrusive_ptr<
+                        lcos::detail::future_data<future_result_type>
+                    > next_future_data = lcos::detail::get_shared_state(*next);
+
+                    if (!next_future_data->is_ready())
                     {
-                        void (when_each_frame::*f)(TupleIter, Iter, Iter) =
-                            &when_each_frame::await_range;
-
-                        typedef typename std::iterator_traits<Iter>::value_type
-                            future_type;
-
-                        typedef typename traits::future_traits<future_type>::type
-                            future_result_type;
-
-                        boost::intrusive_ptr<
-                            lcos::detail::future_data<future_result_type>
-                        > next_future_data = lcos::detail::get_shared_state(*next);
-
-                        boost::intrusive_ptr<when_each_frame> this_(this);
                         next_future_data->execute_deferred();
-                        next_future_data->set_on_completed(util::bind(
-                            f, this_, std::move(iter),
-                            std::move(next), std::move(end)));
-                        return;
+
+                        // execute_deferred might have made the future ready
+                        if (!next_future_data->is_ready())
+                        {
+                            // Attach a continuation to this future which will
+                            // re-evaluate it and continue to the next argument
+                            // (if any).
+                            boost::intrusive_ptr<when_each_frame> this_(this);
+                            next_future_data->set_on_completed(
+                                util::bind(
+                                    f, std::move(this_), std::move(iter),
+                                    std::move(next), std::move(end)));
+                            return;
+                        }
                     }
 
                     f_(std::move(*next));
@@ -215,32 +223,38 @@ namespace hpx { namespace lcos
                 typedef typename util::decay_unwrap<
                     typename boost::fusion::result_of::deref<TupleIter>::type
                 >::type future_type;
+                typedef typename traits::future_traits<future_type>::type
+                    future_result_type;
 
                 using boost::mpl::false_;
                 using boost::mpl::true_;
 
                 future_type& fut = boost::fusion::deref(iter);
-                if (!fut.is_ready())
+
+                boost::intrusive_ptr<
+                    lcos::detail::future_data<future_result_type>
+                > next_future_data = lcos::detail::get_shared_state(fut);
+
+                if (!next_future_data->is_ready())
                 {
-                    // Attach a continuation to this future which will
-                    // re-evaluate it and continue to the next argument
-                    // (if any).
-                    void (when_each_frame::*f)(TupleIter, true_, false_) =
-                        &when_each_frame::await_next;
 
-                    typedef typename traits::future_traits<future_type>::type
-                        future_result_type;
-
-                    boost::intrusive_ptr<
-                        lcos::detail::future_data<future_result_type>
-                    > next_future_data = lcos::detail::get_shared_state(fut);
-
-                    boost::intrusive_ptr<when_each_frame> this_(this);
                     next_future_data->execute_deferred();
-                    next_future_data->set_on_completed(hpx::util::bind(
-                        f, this_, std::move(iter), true_(), false_()));
 
-                    return;
+                    // execute_deferred might have made the future ready
+                    if (!next_future_data->is_ready())
+                    {
+                        // Attach a continuation to this future which will
+                        // re-evaluate it and continue to the next argument
+                        // (if any).
+                        void (when_each_frame::*f)(TupleIter, true_, false_) =
+                            &when_each_frame::await_next;
+                        boost::intrusive_ptr<when_each_frame> this_(this);
+                        next_future_data->set_on_completed(
+                            hpx::util::bind(
+                                f, std::move(this_), std::move(iter),
+                                true_(), false_()));
+                        return;
+                    }
                 }
 
                 f_(std::move(fut));

--- a/hpx/lcos/when_some.hpp
+++ b/hpx/lcos/when_some.hpp
@@ -309,30 +309,40 @@ namespace hpx { namespace lcos
             template <typename Future>
             void operator()(Future& future) const
             {
-                std::size_t counter = when_.count_.load(boost::memory_order_seq_cst);
+                std::size_t counter =
+                    when_.count_.load(boost::memory_order_seq_cst);
                 if (counter < when_.needed_count_) {
                     if (!future.is_ready()) {
-                        // handle future only if not enough futures are ready yet
-                        // also, do not touch any futures which are already ready
+                        // handle future only if not enough futures are ready
+                        // yet also, do not touch any futures which are already
+                        // ready
 
-                        typedef
-                            typename lcos::detail::shared_state_ptr_for<Future>::type
-                            shared_state_ptr;
+                        typedef typename lcos::detail::shared_state_ptr_for<
+                                Future
+                            >::type shared_state_ptr;
 
                         shared_state_ptr const& shared_state =
                             lcos::detail::get_shared_state(future);
 
                         shared_state->execute_deferred();
-                        shared_state->set_on_completed(util::bind(
-                            &when_some<Sequence>::on_future_ready, when_.shared_from_this(),
-                            idx_, threads::get_self_id()));
-                    }
-                    else {
-                        when_.lazy_values_.indices.push_back(idx_);
-                        if (when_.count_.fetch_add(1) + 1 == when_.needed_count_)
+
+                        // execute_deferred might have made the future ready
+                        if (!shared_state->is_ready())
                         {
-                            when_.goal_reached_on_calling_thread_ = true;
+                            shared_state->set_on_completed(
+                                util::bind(
+                                    &when_some<Sequence>::on_future_ready,
+                                    when_.shared_from_this(),
+                                    idx_, threads::get_self_id()));
+                            ++idx_;
+                            return;
                         }
+                    }
+
+                    when_.lazy_values_.indices.push_back(idx_);
+                    if (when_.count_.fetch_add(1) + 1 == when_.needed_count_)
+                    {
+                        when_.goal_reached_on_calling_thread_ = true;
                     }
                 }
                 ++idx_;


### PR DESCRIPTION
This reapplies changes which have been reverted by merging #1634. This is mainly to better handle continuations on deferred futures. This should also fix the sequential_executor test failures.