### PR TITLE
When using runtime_mode_connect, find the correct localhost public ip…

### DIFF
--- a/hpx/util/asio_util.hpp
+++ b/hpx/util/asio_util.hpp
@@ -27,6 +27,10 @@ namespace hpx { namespace util
     resolve_hostname(std::string const& hostname, boost::uint16_t port,
         boost::asio::io_service& io_service);
 
+    ///////////////////////////////////////////////////////////////////////////
+    // return the public IP address of the local node
+    HPX_API_EXPORT std::string resolve_public_ip_address();
+
     ///////////////////////////////////////////////////////////////////////
     // Addresses are supposed to have the format <hostname>[:port]
     HPX_API_EXPORT bool split_ip_address(std::string const& v,

--- a/src/util/asio_util.cpp
+++ b/src/util/asio_util.cpp
@@ -92,6 +92,37 @@ namespace hpx { namespace util
         return tcp::endpoint();
     }
 
+    ///////////////////////////////////////////////////////////////////////////
+    // return the public IP address of the local node
+    std::string
+    resolve_public_ip_address()
+    {
+        using boost::asio::ip::tcp;
+
+        // collect errors here
+        exception_list errors;
+
+        try {
+            boost::asio::io_service io_service;
+            tcp::resolver resolver(io_service);
+            tcp::resolver::query query(boost::asio::ip::host_name(), "");
+            tcp::resolver::iterator it = resolver.resolve(query);
+            tcp::endpoint endpoint = *it;
+            return endpoint.address().to_string();
+        }
+        catch (boost::system::system_error const&) {
+            errors.add(boost::current_exception());
+        }
+
+        // report errors
+        std::ostringstream strm;
+        strm << errors.get_message()
+                << " (while trying to resolve public ip address)";
+        HPX_THROW_EXCEPTION(network_error, "util::resolve_public_ip_address",
+            strm.str());
+        return "";
+    }
+
     ///////////////////////////////////////////////////////////////////////
     // Addresses are supposed to have the format <hostname>[:port]
     bool split_ip_address(std::string const& v, std::string& host,

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -537,6 +537,10 @@ namespace hpx { namespace util
             }
         }
 
+        if (vm.count("hpx:connect") && hpx_host==std::string("127.0.0.1")) {
+            hpx_host = hpx::util::resolve_public_ip_address();
+        }
+
         queuing_ = "local-priority";
         if (vm.count("hpx:queuing"))
             queuing_ = vm["hpx:queuing"].as<std::string>();
@@ -985,4 +989,3 @@ namespace hpx { namespace util
         return 0;
     }
 }}
-


### PR DESCRIPTION
… address

If using --hpx::connect, the worker needs to know the public ip address
of itself so that it can send it to the hpx:agas root where it is used
for communication. If the user does not specify the hpx parcel address
then 127.0.0.1 is assumed, but this only works for localities ilaunched
on the same node.

This patch finds the public ip address and uses that instead.

It may still fail if multiple ip addresses exist for the node,
but it is a better guess than before - providing those ip addresses
support tcp connections then all should be ok.

This is particularly useful when the worker is spawned using

    srun app <params> --hpx:hpx=xx.xx.xx.xx:port

where the user does not know which node srun will spawn the worker on
so cannot easily put the correct ip address on the command line.