### PR TITLE
Added support for 128bit number serialization

### DIFF
--- a/hpx/runtime/serialization/input_archive.hpp
+++ b/hpx/runtime/serialization/input_archive.hpp
@@ -147,6 +147,18 @@ namespace hpx { namespace serialization
             val = static_cast<T>(ul);
         }
 
+#if defined(BOOST_HAS_INT128)
+        void load_integral(boost::int128_type& t, boost::mpl::false_)
+        {
+            load_integral_impl(t);
+        }
+
+        void load_integral(boost::uint128_type& t, boost::mpl::true_)
+        {
+            load_integral_impl(t);
+        }
+#endif
+
         void load(float & f)
         {
             load_binary(&f, sizeof(float));
@@ -168,25 +180,11 @@ namespace hpx { namespace serialization
             HPX_ASSERT(0 == static_cast<int>(b) || 1 == static_cast<int>(b));
         }
 
-        void load_integral_impl(boost::int64_t & l)
+        template <class Promoted>
+        void load_integral_impl(Promoted& l)
         {
-            const std::size_t size = sizeof(boost::int64_t);
+            const std::size_t size = sizeof(Promoted);
             char* cptr = reinterpret_cast<char *>(&l); //-V206
-            load_binary(cptr, static_cast<std::size_t>(size));
-
-#ifdef BOOST_BIG_ENDIAN
-            if (endian_little())
-                reverse_bytes(size, cptr);
-#else
-            if (endian_big())
-                reverse_bytes(size, cptr);
-#endif
-        }
-
-        void load_integral_impl(boost::uint64_t & ul)
-        {
-            const std::size_t size = sizeof(boost::uint64_t);
-            char* cptr = reinterpret_cast<char *>(&ul); //-V206
             load_binary(cptr, static_cast<std::size_t>(size));
 
 #ifdef BOOST_BIG_ENDIAN

--- a/hpx/runtime/serialization/output_archive.hpp
+++ b/hpx/runtime/serialization/output_archive.hpp
@@ -144,6 +144,18 @@ namespace hpx { namespace serialization
             save_integral_impl(static_cast<boost::uint64_t>(val));
         }
 
+#if defined(BOOST_HAS_INT128)
+        void save_integral(boost::int128_type t, boost::mpl::false_)
+        {
+            save_integral_impl(t);
+        }
+
+        void save_integral(boost::uint128_type t, boost::mpl::true_)
+        {
+            save_integral_impl(t);
+        }
+#endif
+
         void save(float f)
         {
             save_binary(&f, sizeof(float));
@@ -165,26 +177,11 @@ namespace hpx { namespace serialization
             save_binary(&b, sizeof(bool));
         }
 
-        void save_integral_impl(boost::int64_t l)
+        template <class Promoted>
+        void save_integral_impl(Promoted l)
         {
-            const std::size_t size = sizeof(boost::int64_t);
+            const std::size_t size = sizeof(Promoted);
             char* cptr = reinterpret_cast<char *>(&l); //-V206
-#ifdef BOOST_BIG_ENDIAN
-            if(endian_little())
-                reverse_bytes(size, cptr);
-#else
-            if(endian_big())
-                reverse_bytes(size, cptr);
-#endif
-
-            save_binary(cptr, size);
-        }
-
-        void save_integral_impl(boost::uint64_t ul)
-        {
-            const std::size_t size = sizeof(boost::uint64_t);
-            char* cptr = reinterpret_cast<char*>(&ul); //-V206
-
 #ifdef BOOST_BIG_ENDIAN
             if(endian_little())
                 reverse_bytes(size, cptr);

--- a/tests/unit/serialization/serialization_builtins.cpp
+++ b/tests/unit/serialization/serialization_builtins.cpp
@@ -8,7 +8,7 @@
 #include <hpx/runtime/serialization/input_archive.hpp>
 #include <hpx/runtime/serialization/output_archive.hpp>
 
-#include <hpx/util/lightweight_test.hpp>
+#include <boost/cstdint.hpp>
 
 template <typename T>
 struct A
@@ -26,6 +26,28 @@ struct A
         ar & t_;
     }
 };
+
+#if defined(BOOST_HAS_INT128)
+std::ostream& operator<<(std::ostream& s, boost::int128_type i)
+{
+    boost::int64_t low = i;
+    i >>= 64;
+    boost::int64_t high = i;
+    s << std::hex << "high: i" << high << "; low: " << low;
+    return s;
+}
+
+std::ostream& operator<<(std::ostream& s, boost::uint128_type i)
+{
+    boost::uint64_t low = i;
+    i >>= 64;
+    boost::uint64_t high = i;
+    s << std::hex << "high: i" << high << "; low: " << low;
+    return s;
+}
+#endif
+
+#include <hpx/util/lightweight_test.hpp>
 
 void test_bool()
 {
@@ -153,6 +175,10 @@ int main()
     test<long>(-100, 100);
     test<unsigned long>((std::numeric_limits<unsigned long>::min)(), (std::numeric_limits<unsigned long>::min)() + 100);
     test<unsigned long>((std::numeric_limits<unsigned long>::max)() - 100, (std::numeric_limits<unsigned long>::max)());
+#if defined(BOOST_HAS_INT128)
+    test<boost::int128_type>((std::numeric_limits<boost::int128_type>::max)() - 100, (std::numeric_limits<boost::int128_type>::max)());
+    test<boost::uint128_type>((std::numeric_limits<boost::uint128_type>::max)() - 100, (std::numeric_limits<boost::uint128_type>::max)());
+#endif
     test_fp<float>((std::numeric_limits<float>::min)(), (std::numeric_limits<float>::min)() + 100);
     test_fp<float>(-100, 100);
     test<double>((std::numeric_limits<double>::min)(), (std::numeric_limits<double>::min)() + 100);


### PR DESCRIPTION
There still might be some problems when compiling the test in case some platforms don't support numeric_limits for 128bit types