### PR TITLE
Improve use of locks

### DIFF
--- a/examples/1d_hydro/1d_hydro_upwind.cpp
+++ b/examples/1d_hydro/1d_hydro_upwind.cpp
@@ -20,6 +20,7 @@
 
 #include <boost/format.hpp>
 #include <boost/math/constants/constants.hpp>
+#include <boost/thread/locks.hpp>
 
 using hpx::naming::id_type;
 using hpx::naming::invalid_id;
@@ -98,7 +99,7 @@ struct cell{
   {
     // first, we lock both the mutex of this cell, and the mutex of the other
     // cell
-    //    hpx::lcos::local::mutex::scoped_lock this_lock(mtx), other_lock(other.mtx);
+    //    boost::lock_guard<hpx::lcos::local::mutex> this_lock(mtx), other_lock(other.mtx);
 
     rho = other.rho;
     mom = other.mom;
@@ -229,7 +230,7 @@ double timestep_size(boost::uint64_t timestep)
 {
   // locking
 
-  hpx::lcos::local::mutex::scoped_lock l(grid.time_array.at(timestep).mtx);
+  boost::lock_guard<hpx::lcos::local::mutex> l(grid.time_array.at(timestep).mtx);
 
   // if it has already been calculated, then just return the value
   if (grid.time_array.at(timestep).computed)
@@ -329,7 +330,7 @@ double timestep_size(boost::uint64_t timestep)
 
 cell compute(boost::uint64_t timestep, boost::uint64_t location)
 {
-    hpx::lcos::local::mutex::scoped_lock l(grid.time_array.at(timestep).fluid.at(location).mtx);
+    boost::lock_guard<hpx::lcos::local::mutex> l(grid.time_array.at(timestep).fluid.at(location).mtx);
 
   // if it is already computed then just return the value
     if (grid.time_array.at(timestep).fluid.at(location).computed == true)

--- a/examples/1d_stencil/1d_stencil_8.cpp
+++ b/examples/1d_stencil/1d_stencil_8.cpp
@@ -46,7 +46,7 @@ public:
 
     ~partition_allocator()
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
         while (!heap_.empty())
         {
             T* p = heap_.top();
@@ -57,7 +57,7 @@ public:
 
     T* allocate(std::size_t n)
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
         if (heap_.empty())
             return new T[n];
 
@@ -68,7 +68,7 @@ public:
 
     void deallocate(T* p)
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
         if (max_size_ == static_cast<std::size_t>(-1) || heap_.size() < max_size_)
             heap_.push(p);
         else

--- a/examples/accumulator/accumulators/server/template_function_accumulator.hpp
+++ b/examples/accumulator/accumulators/server/template_function_accumulator.hpp
@@ -52,7 +52,7 @@ namespace examples { namespace server
         void reset()
         {
             // Atomically set value_ to 0.
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             value_ = 0;
         }
 
@@ -61,7 +61,7 @@ namespace examples { namespace server
         void add(T arg)
         {
             // Atomically add value_ to arg, and store the result in value_.
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             value_ += boost::lexical_cast<double>(arg);
         }
 
@@ -69,7 +69,7 @@ namespace examples { namespace server
         double query() const
         {
             // Get the value of value_.
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             return value_;
         }
 

--- a/examples/allgather/ag/server/allgather.cpp
+++ b/examples/allgather/ag/server/allgather.cpp
@@ -14,6 +14,7 @@
 #include <boost/ref.hpp>
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/thread/locks.hpp>
 
 #include <iostream>
 #include <fstream>
@@ -23,14 +24,14 @@ namespace ag { namespace server
 {
     void allgather::init(std::size_t item,std::size_t np)
     {
-      //hpx::util::spinlock::scoped_lock l(mtx_);
+      //boost::lock_guard<hpx::util::spinlock> l(mtx_);
       item_ = item;
       value_ = item*3.14159;
     }
 
     void allgather::compute(std::vector<hpx::naming::id_type> const& point_components)
     {
-     // hpx::util::spinlock::scoped_lock l(mtx_);
+     // boost::lock_guard<hpx::util::spinlock> l(mtx_);
       typedef std::vector<hpx::lcos::future< double > > lazy_results_type;
       lazy_results_type lazy_results;
 
@@ -46,7 +47,7 @@ namespace ag { namespace server
     double allgather::get_item() const
     {
       //std::cout << " Get_item " << item_ << std::endl;
-      //hpx::util::spinlock::scoped_lock l(mtx_);
+      //boost::lock_guard<hpx::util::spinlock> l(mtx_);
       return value_;
     }
 

--- a/examples/allgather/ag/server/allgather.hpp
+++ b/examples/allgather/ag/server/allgather.hpp
@@ -11,7 +11,7 @@
 
 #include <hpx/runtime/components/server/managed_component_base.hpp>
 #include <hpx/runtime/actions/component_action.hpp>
-#include <hpx/util/scoped_unlock.hpp>
+#include <hpx/util/unlock_guard.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace ag { namespace server

--- a/examples/allgather/ag/server/allgather_and_gate.cpp
+++ b/examples/allgather/ag/server/allgather_and_gate.cpp
@@ -16,6 +16,7 @@
 #include <boost/ref.hpp>
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/thread/locks.hpp>
 
 #include <iostream>
 #include <fstream>
@@ -26,7 +27,7 @@ namespace ag { namespace server
     void allgather_and_gate::init(
         std::vector<hpx::naming::id_type> const& components, std::size_t rank)
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
 
         rank_ = rank;
         components_ = components;
@@ -77,7 +78,7 @@ namespace ag { namespace server
         gate_.synchronize(generation, "allgather_and_gate::set_data");
 
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
 
             if (which >= n_.size())
             {
@@ -95,7 +96,7 @@ namespace ag { namespace server
 
     void allgather_and_gate::print()
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
 
         std::cout << " location: " << rank_ << " n size : " << n_.size() << std::endl;
         for (std::size_t i = 0; i < n_.size(); ++i)

--- a/examples/balancing/hpx_thread_phase.cpp
+++ b/examples/balancing/hpx_thread_phase.cpp
@@ -56,7 +56,7 @@ void lock_and_wait(
     while (true)
     {
         // Try to acquire the mutex.
-        mutex::scoped_try_lock l(m);
+        boost::unique_lock<mutex> l(m, boost::try_to_lock);
 
         if (l.owns_lock())
         {

--- a/examples/cancelable_action/cancelable_action/server/cancelable_action.hpp
+++ b/examples/cancelable_action/cancelable_action/server/cancelable_action.hpp
@@ -11,6 +11,8 @@
 #include <hpx/include/actions.hpp>
 #include <hpx/include/threads.hpp>
 
+#include <boost/thread/locks.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace examples { namespace server
 {
@@ -34,12 +36,12 @@ namespace examples { namespace server
             reset_id(cancelable_action& this_)
               : outer_(this_)
             {
-                mutex_type::scoped_lock l(outer_.mtx_);
+                boost::lock_guard<mutex_type> l(outer_.mtx_);
                 outer_.id_ = hpx::this_thread::get_id();
             }
             ~reset_id()
             {
-                mutex_type::scoped_lock l(outer_.mtx_);
+                boost::lock_guard<mutex_type> l(outer_.mtx_);
                 outer_.id_ = hpx::thread::id();    // invalidate thread id
             }
 
@@ -65,7 +67,7 @@ namespace examples { namespace server
         // Cancel the lengthy action above
         void cancel_it()
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             if (id_ != hpx::thread::id()) {
                 hpx::thread::interrupt(id_);
                 id_ = hpx::thread::id();        // invalidate thread id

--- a/examples/diskperf/diskperf_ofs_pxfs_action.cpp
+++ b/examples/diskperf/diskperf_ofs_pxfs_action.cpp
@@ -17,16 +17,16 @@
 #include <hpx/include/runtime.hpp>
 #include <hpx/include/serialization.hpp>
 
+#include <boost/cstdint.hpp>
+#include <boost/format.hpp>
+#include <boost/shared_array.hpp>
+#include <boost/thread/locks.hpp>
+
 #include <fstream>
 #include <cstdlib>
 #include <ctime>
 #include <sys/times.h>
 #include <vector>
-
-#include <boost/cstdint.hpp>
-#include <boost/format.hpp>
-#include <boost/shared_array.hpp>
-
 
 using boost::program_options::variables_map;
 using boost::program_options::options_description;
@@ -502,7 +502,7 @@ int hpx_main(variables_map& vm)
         hpx::lcos::local::spinlock mtx;
         hpx::lcos::wait_each(futures,
                 hpx::util::unwrapped([&](RESULT r) {
-                    hpx::lcos::local::spinlock::scoped_lock lk(mtx);
+                    boost::lock_guard<hpx::lcos::local::spinlock> lk(mtx);
                     result_vector.push_back(r);
                 }));
 

--- a/examples/performance_counters/sine/server/sine.cpp
+++ b/examples/performance_counters/sine/server/sine.cpp
@@ -9,6 +9,8 @@
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/util/high_resolution_clock.hpp>
 
+#include <boost/thread/locks.hpp>
+
 #include "sine.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -50,7 +52,7 @@ namespace performance_counters { namespace sine { namespace server
 
         // gather the current value
         {
-            mutex_type::scoped_lock mtx(mtx_);
+            boost::lock_guard<mutex_type> mtx(mtx_);
             value.value_ = boost::int64_t(current_value_ * scaling);
             if (reset)
                 current_value_ = 0;
@@ -73,7 +75,7 @@ namespace performance_counters { namespace sine { namespace server
 
     bool sine_counter::evaluate()
     {
-        mutex_type::scoped_lock mtx(mtx_);
+        boost::lock_guard<mutex_type> mtx(mtx_);
         evaluated_at_ = static_cast<boost::int64_t>(hpx::get_system_uptime());
         current_value_ = std::sin(evaluated_at_ / 1e10);
         return true;

--- a/examples/qt/widget.cpp
+++ b/examples/qt/widget.cpp
@@ -6,6 +6,8 @@
 #include <hpx/config.hpp>
 #include <hpx/apply.hpp>
 
+#include <boost/thread/locks.hpp>
+
 #include "widget.hpp"
 
 #include <QtGui/QLabel>
@@ -45,7 +47,7 @@ widget::widget(boost::function<void(widget *, std::size_t)> callback, QWidget *p
 
 void widget::add_label(std::size_t i, double t)
 {
-    hpx::lcos::local::spinlock::scoped_lock l(mutex);
+    boost::lock_guard<hpx::lcos::local::spinlock> l(mutex);
     QString txt("Thread ");
     txt.append(QString::number(i))
        .append(" finished in ")

--- a/examples/quickstart/1d_wave_equation.cpp
+++ b/examples/quickstart/1d_wave_equation.cpp
@@ -28,6 +28,7 @@
 
 #include <boost/format.hpp>
 #include <boost/math/constants/constants.hpp>
+#include <boost/thread/locks.hpp>
 
 using boost::program_options::variables_map;
 using boost::program_options::options_description;
@@ -128,7 +129,7 @@ double calculate_u_tplus_x_1st(double u_t_xplus, double u_t_x,
 
 double wave(boost::uint64_t t, boost::uint64_t x)
 {
-  hpx::lcos::local::mutex::scoped_lock l(u[t][x].mtx);
+  boost::lock_guard<hpx::lcos::local::mutex> l(u[t][x].mtx);
   //  cout << (boost::format("calling wave... t=%1% x=%2%\n") % t % x) << flush;
   if (u[t][x].computed)
     {

--- a/examples/quickstart/hello_world.cpp
+++ b/examples/quickstart/hello_world.cpp
@@ -14,12 +14,13 @@
 #include <hpx/include/components.hpp>
 #include <hpx/include/iostreams.hpp>
 
+#include <boost/ref.hpp>
+#include <boost/format.hpp>
+#include <boost/thread/locks.hpp>
+
 #include <vector>
 #include <list>
 #include <set>
-
-#include <boost/ref.hpp>
-#include <boost/format.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 // The purpose of this example is to execute a HPX-thread printing "Hello world"
@@ -110,7 +111,7 @@ void hello_world_foreman()
             hpx::util::unwrapped([&](std::size_t t) {
                 if (std::size_t(-1) != t)
                 {
-                    hpx::lcos::local::spinlock::scoped_lock lk(mtx);
+                    boost::lock_guard<hpx::lcos::local::spinlock> lk(mtx);
                     attendance.erase(t);
                 }
             }),

--- a/examples/random_mem_access/random_mem_access/server/random_mem_access.hpp
+++ b/examples/random_mem_access/random_mem_access/server/random_mem_access.hpp
@@ -53,7 +53,7 @@ namespace hpx { namespace components { namespace server
         /// Initialize the accumulator
         void init(int i)
         {
-            hpx::lcos::local::mutex::scoped_lock l(mtx_);
+            boost::lock_guard<hpx::lcos::local::mutex> l(mtx_);
 
             std::ostringstream oss;
             oss << "[L" << prefix_ << "/" << this << "]"
@@ -67,7 +67,7 @@ namespace hpx { namespace components { namespace server
         /// Add the given number to the accumulator
         void add()
         {
-            hpx::lcos::local::mutex::scoped_lock l(mtx_);
+            boost::lock_guard<hpx::lcos::local::mutex> l(mtx_);
 
             std::ostringstream oss;
             oss << "[L" << prefix_ << "/" << this << "]"
@@ -81,7 +81,7 @@ namespace hpx { namespace components { namespace server
         /// Return the current value to the caller
         int query()
         {
-            hpx::lcos::local::mutex::scoped_lock l(mtx_);
+            boost::lock_guard<hpx::lcos::local::mutex> l(mtx_);
 
             std::ostringstream oss;
             oss << "[L" << prefix_ << "/" << this << "]"
@@ -94,7 +94,7 @@ namespace hpx { namespace components { namespace server
         /// Print the current value of the accumulator
         void print()
         {
-            hpx::lcos::local::mutex::scoped_lock l(mtx_);
+            boost::lock_guard<hpx::lcos::local::mutex> l(mtx_);
 
             std::ostringstream oss;
             oss << "[L" << prefix_ << "/" << this << "]"

--- a/examples/throttle/throttle/server/throttle.cpp
+++ b/examples/throttle/throttle/server/throttle.cpp
@@ -84,7 +84,7 @@ namespace throttle { namespace server
     // do the requested throttling
     void throttle::throttle_controller(std::size_t shepherd)
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::unique_lock<mutex_type> l(mtx_);
         if (!blocked_os_threads_[shepherd])
             return;     // nothing more to do
 
@@ -93,7 +93,7 @@ namespace throttle { namespace server
             boost::system_time xt(boost::get_system_time() +
                 boost::posix_time::milliseconds(100));
 
-            hpx::util::scoped_unlock<mutex_type::scoped_lock> ul(l);
+            hpx::util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
             boost::thread::sleep(xt);
         }
 

--- a/examples/throttle/throttle/server/throttle.cpp
+++ b/examples/throttle/throttle/server/throttle.cpp
@@ -7,12 +7,12 @@
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/runtime/components/component_factory.hpp>
 #include <hpx/runtime.hpp>
-#include <hpx/util/scoped_unlock.hpp>
-
 #include <hpx/util/assert.hpp>
+#include <hpx/util/scoped_unlock.hpp>
 
 #include <boost/bind.hpp>
 #include <boost/thread.hpp>
+#include <boost/thread/locks.hpp>
 
 #include "throttle.hpp"
 
@@ -43,7 +43,7 @@ namespace throttle { namespace server
             return;
         }
 
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
 
         if (shepherd >= blocked_os_threads_.size()) {
             HPX_THROW_EXCEPTION(hpx::bad_parameter, "throttle::suspend",
@@ -59,7 +59,7 @@ namespace throttle { namespace server
 
     void throttle::resume(std::size_t shepherd)
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
 
         if (shepherd >= blocked_os_threads_.size()) {
             HPX_THROW_EXCEPTION(hpx::bad_parameter, "throttle::resume",
@@ -71,7 +71,7 @@ namespace throttle { namespace server
 
     bool throttle::is_suspended(std::size_t shepherd) const
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
 
         if (shepherd >= blocked_os_threads_.size()) {
             HPX_THROW_EXCEPTION(hpx::bad_parameter, "throttle::is_suspended",

--- a/examples/throttle/throttle/server/throttle.cpp
+++ b/examples/throttle/throttle/server/throttle.cpp
@@ -8,7 +8,7 @@
 #include <hpx/runtime/components/component_factory.hpp>
 #include <hpx/runtime.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/scoped_unlock.hpp>
+#include <hpx/util/unlock_guard.hpp>
 
 #include <boost/bind.hpp>
 #include <boost/thread.hpp>
@@ -93,7 +93,7 @@ namespace throttle { namespace server
             boost::system_time xt(boost::get_system_time() +
                 boost::posix_time::milliseconds(100));
 
-            hpx::util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+            hpx::util::unlock_guard<boost::unique_lock<mutex_type> > ul(l);
             boost::thread::sleep(xt);
         }
 

--- a/examples/tuplespace/central_tuplespace/server/simple_central_tuplespace.hpp
+++ b/examples/tuplespace/central_tuplespace/server/simple_central_tuplespace.hpp
@@ -14,6 +14,8 @@
 #include <hpx/util/high_resolution_timer.hpp>
 #include <hpx/include/local_lcos.hpp>
 
+#include <boost/thread/locks.hpp>
+
 #include "tuples_warehouse.hpp"
 
 // #define TS_DEBUG
@@ -92,7 +94,7 @@ namespace examples { namespace server
                 }
 
                 {
-                    mutex_type::scoped_lock l(mtx_);
+                    boost::lock_guard<mutex_type> l(mtx_);
 
                     tuples_.insert(tp);
                 }
@@ -115,7 +117,7 @@ namespace examples { namespace server
                     }
 
                     {
-                        mutex_type::scoped_lock l(mtx_);
+                        boost::lock_guard<mutex_type> l(mtx_);
 
                         result = tuples_.match(tp);
                     }
@@ -146,7 +148,7 @@ namespace examples { namespace server
                     }
 
                     {
-                        mutex_type::scoped_lock l(mtx_);
+                        boost::lock_guard<mutex_type> l(mtx_);
 
                         result = tuples_.match_and_erase(tp);
                     }

--- a/hpx/components/iostreams/ostream.hpp
+++ b/hpx/components/iostreams/ostream.hpp
@@ -8,22 +8,22 @@
 #define HPX_97FC0FA2_E773_4F83_8477_806EC68C2253
 
 #include <hpx/hpx_fwd.hpp>
-#include <hpx/lcos/local/recursive_mutex.hpp>
-
-#include <iterator>
-#include <ios>
-#include <iostream>
-
-#include <boost/swap.hpp>
-#include <boost/noncopyable.hpp>
-#include <boost/iostreams/stream.hpp>
-#include <boost/atomic.hpp>
-
 #include <hpx/state.hpp>
 #include <hpx/include/client.hpp>
 #include <hpx/components/iostreams/manipulators.hpp>
 #include <hpx/components/iostreams/stubs/output_stream.hpp>
 #include <hpx/util/move.hpp>
+#include <hpx/lcos/local/recursive_mutex.hpp>
+
+#include <boost/swap.hpp>
+#include <boost/noncopyable.hpp>
+#include <boost/iostreams/stream.hpp>
+#include <boost/atomic.hpp>
+#include <boost/thread/locks.hpp>
+
+#include <iterator>
+#include <ios>
+#include <iostream>
 
 namespace hpx { namespace iostreams
 {
@@ -288,14 +288,14 @@ namespace hpx { namespace iostreams
         template <typename T>
         ostream& operator<<(T const& subject)
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             return streaming_operator_lazy(subject);
         }
 
         ///////////////////////////////////////////////////////////////////////
         ostream& operator<<(std_stream_type& (*manip_fun)(std_stream_type&))
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             return streaming_operator_lazy(manip_fun);
         }
     };

--- a/hpx/components/iostreams/ostream.hpp
+++ b/hpx/components/iostreams/ostream.hpp
@@ -209,7 +209,7 @@ namespace hpx { namespace iostreams
 
         bool flush()
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             if (!this->detail::buffer::empty())
             {
                 // Create the next buffer, returns the previous buffer
@@ -240,7 +240,7 @@ namespace hpx { namespace iostreams
         // reset this object during runtime system shutdown
         void uninitialize()
         {
-            mutex_type::scoped_lock l(mtx_, boost::try_to_lock);
+            boost::unique_lock<mutex_type> l(mtx_, boost::try_to_lock);
             if (l)
             {
                 streaming_operator_sync(hpx::async_flush, l);   // unlocks l
@@ -259,28 +259,28 @@ namespace hpx { namespace iostreams
         // hpx::flush manipulator
         ostream& operator<<(hpx::iostreams::flush_type const& m)
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             return streaming_operator_sync(m, l);
         }
 
         // hpx::endl manipulator
         ostream& operator<<(hpx::iostreams::endl_type const& m)
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             return streaming_operator_sync(m, l);
         }
 
         // hpx::async_flush manipulator
         ostream& operator<<(hpx::iostreams::async_flush_type const& m)
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             return streaming_operator_async(m, l);
         }
 
         // hpx::async_endl manipulator
         ostream& operator<<(hpx::iostreams::async_endl_type const& m)
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             return streaming_operator_async(m, l);
         }
 

--- a/hpx/components/iostreams/server/buffer.hpp
+++ b/hpx/components/iostreams/server/buffer.hpp
@@ -9,11 +9,12 @@
 #include <hpx/hpx_fwd.hpp>
 #include <hpx/util/spinlock.hpp>
 #include <hpx/util/move.hpp>
-
-#include <vector>
+#include <hpx/runtime/serialization/serialize.hpp>
 
 #include <boost/shared_ptr.hpp>
-#include <hpx/runtime/serialization/serialize.hpp>
+#include <boost/thread/locks.hpp>
+
+#include <vector>
 
 namespace hpx { namespace iostreams { namespace detail
 {
@@ -57,13 +58,13 @@ namespace hpx { namespace iostreams { namespace detail
 
         bool empty() const
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             return !data_.get() || data_->empty();
         }
 
         buffer init()
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
 
             buffer b;
             boost::swap(b.data_, data_);
@@ -73,7 +74,7 @@ namespace hpx { namespace iostreams { namespace detail
         template <typename Char>
         std::streamsize write(Char const* s, std::streamsize n)
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             std::copy(s, s + n, std::back_inserter(*data_));
             return n;
         }
@@ -88,7 +89,7 @@ namespace hpx { namespace iostreams { namespace detail
                 data_.reset();
                 l.unlock();
 
-                typename Mutex::scoped_lock ll(mtx);
+                boost::lock_guard<Mutex> ll(mtx);
                 f(*data);
             }
         }

--- a/hpx/components/iostreams/server/buffer.hpp
+++ b/hpx/components/iostreams/server/buffer.hpp
@@ -82,7 +82,7 @@ namespace hpx { namespace iostreams { namespace detail
         template <typename Mutex>
         void write(write_function_type const& f, Mutex& mtx)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             if (data_.get() && !data_->empty())
             {
                 boost::shared_ptr<std::vector<char> > data(data_);

--- a/hpx/components/iostreams/server/order_output.hpp
+++ b/hpx/components/iostreams/server/order_output.hpp
@@ -8,7 +8,7 @@
 
 #include <hpx/hpx_fwd.hpp>
 #include <hpx/components/iostreams/server/buffer.hpp>
-#include <hpx/util/scoped_unlock.hpp>
+#include <hpx/util/unlock_guard.hpp>
 
 #include <boost/cstdint.hpp>
 #include <boost/thread/locks.hpp>
@@ -36,7 +36,7 @@ namespace hpx { namespace iostreams { namespace detail
                 if (!in.empty())
                 {
                     // output the line as requested
-                    util::scoped_unlock<boost::unique_lock<Mutex> > ul(l);
+                    util::unlock_guard<boost::unique_lock<Mutex> > ul(l);
                     in.write(write_f, mtx);
                 }
                 ++data.first;
@@ -49,7 +49,7 @@ namespace hpx { namespace iostreams { namespace detail
                     if (!next_in.empty())
                     {
                         // output the next line
-                        util::scoped_unlock<boost::unique_lock<Mutex> > ul(l);
+                        util::unlock_guard<boost::unique_lock<Mutex> > ul(l);
                         next_in.write(write_f, mtx);
                     }
                     data.second.erase(next);

--- a/hpx/components/iostreams/server/order_output.hpp
+++ b/hpx/components/iostreams/server/order_output.hpp
@@ -10,9 +10,10 @@
 #include <hpx/components/iostreams/server/buffer.hpp>
 #include <hpx/util/scoped_unlock.hpp>
 
-#include <map>
-
 #include <boost/cstdint.hpp>
+#include <boost/thread/locks.hpp>
+
+#include <map>
 
 namespace hpx { namespace iostreams { namespace detail
 {
@@ -26,7 +27,7 @@ namespace hpx { namespace iostreams { namespace detail
         void output(boost::uint32_t locality_id, boost::uint64_t count,
             detail::buffer in, F const& write_f, Mutex& mtx)
         {
-            typename Mutex::scoped_lock l(mtx);
+            boost::unique_lock<Mutex> l(mtx);
             data_type& data = output_data_map_[locality_id];
 
             if (count == data.first)
@@ -35,7 +36,7 @@ namespace hpx { namespace iostreams { namespace detail
                 if (!in.empty())
                 {
                     // output the line as requested
-                    util::scoped_unlock<typename Mutex::scoped_lock> ul(l);
+                    util::scoped_unlock<boost::unique_lock<Mutex> > ul(l);
                     in.write(write_f, mtx);
                 }
                 ++data.first;
@@ -48,7 +49,7 @@ namespace hpx { namespace iostreams { namespace detail
                     if (!next_in.empty())
                     {
                         // output the next line
-                        util::scoped_unlock<typename Mutex::scoped_lock> ul(l);
+                        util::scoped_unlock<boost::unique_lock<Mutex> > ul(l);
                         next_in.write(write_f, mtx);
                     }
                     data.second.erase(next);

--- a/hpx/exception_list.hpp
+++ b/hpx/exception_list.hpp
@@ -8,13 +8,15 @@
 #if !defined(HPX_EXCEPTION_LIST_OCT_06_2008_0942AM)
 #define HPX_EXCEPTION_LIST_OCT_06_2008_0942AM
 
-#include <list>
-#include <string>
-
 #include <hpx/exception.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 #include <hpx/util/move.hpp>
 #include <hpx/util/scoped_unlock.hpp>
+
+#include <boost/thread/locks.hpp>
+
+#include <list>
+#include <string>
 
 #include <hpx/config/warnings_prefix.hpp>
 
@@ -65,7 +67,7 @@ namespace hpx
         /// \note Complexity: Constant time.
         std::size_t size() const BOOST_NOEXCEPT
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             return exceptions_.size();
         }
 
@@ -73,14 +75,14 @@ namespace hpx
         /// within the exception_list.
         exception_list_type::const_iterator begin() const BOOST_NOEXCEPT
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             return exceptions_.begin();
         }
 
         /// An iterator which is the past-the-end value for the exception_list.
         exception_list_type::const_iterator end() const BOOST_NOEXCEPT
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             return exceptions_.end();
         }
 

--- a/hpx/exception_list.hpp
+++ b/hpx/exception_list.hpp
@@ -11,7 +11,7 @@
 #include <hpx/exception.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 #include <hpx/util/move.hpp>
-#include <hpx/util/scoped_unlock.hpp>
+#include <hpx/util/unlock_guard.hpp>
 
 #include <boost/thread/locks.hpp>
 

--- a/hpx/lcos/detail/full_empty_entry.hpp
+++ b/hpx/lcos/detail/full_empty_entry.hpp
@@ -11,7 +11,7 @@
 #include <hpx/util/move.hpp>
 #include <hpx/lcos/local/no_mutex.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
-#include <hpx/util/scoped_unlock.hpp>
+#include <hpx/util/unlock_guard.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
 
 #include <boost/aligned_storage.hpp>
@@ -204,7 +204,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 {
                     // yield this thread
-                    util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+                    util::unlock_guard<boost::unique_lock<mutex_type> > ul(l);
                     this_thread::suspend(threads::suspended,
                         "full_empty_entry::enqueue_full_full", ec);
                     if (ec) return;
@@ -240,7 +240,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 {
                     // yield this thread
-                    util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+                    util::unlock_guard<boost::unique_lock<mutex_type> > ul(l);
                     this_thread::suspend(threads::suspended,
                         "full_empty_entry::enqueue_full_full", ec);
                     if (ec) return;
@@ -274,7 +274,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 {
                     // yield this thread
-                    util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+                    util::unlock_guard<boost::unique_lock<mutex_type> > ul(l);
                     this_thread::suspend(threads::suspended,
                         "full_empty_entry::enqueue_full_full", ec);
                     if (ec) return;
@@ -316,7 +316,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 {
                     // yield this thread
-                    util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+                    util::unlock_guard<boost::unique_lock<mutex_type> > ul(l);
                     this_thread::suspend(threads::suspended,
                         "full_empty_entry::enqueue_full_empty", ec);
                     if (ec) return;
@@ -351,7 +351,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 {
                     // yield this thread
-                    util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+                    util::unlock_guard<boost::unique_lock<mutex_type> > ul(l);
                     this_thread::suspend(threads::suspended,
                         "full_empty_entry::enqueue_full_empty", ec);
                     if (ec) return;
@@ -385,7 +385,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 {
                     // yield this thread
-                    util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+                    util::unlock_guard<boost::unique_lock<mutex_type> > ul(l);
                     this_thread::suspend(threads::suspended,
                         "full_empty_entry::enqueue_if_full", ec);
                     if (ec) return;
@@ -421,7 +421,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 {
                     // yield this thread
-                    util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+                    util::unlock_guard<boost::unique_lock<mutex_type> > ul(l);
                     this_thread::suspend(threads::suspended,
                         "full_empty_entry::enqueue_if_full", ec);
                     if (ec) return;
@@ -687,7 +687,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 {
                     // yield this thread
-                    util::scoped_unlock<Lock> ul(l);
+                    util::unlock_guard<Lock> ul(l);
                     this_thread::suspend(threads::suspended,
                         "full_empty_entry::enqueue_full_full", ec);
                     if (ec) return;
@@ -722,7 +722,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 {
                     // yield this thread
-                    util::scoped_unlock<Lock> ul(l);
+                    util::unlock_guard<Lock> ul(l);
                     this_thread::suspend(threads::suspended,
                         "full_empty_entry::enqueue_full_full", ec);
                     if (ec) return;
@@ -754,7 +754,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 {
                     // yield this thread
-                    util::scoped_unlock<Lock> ul(l);
+                    util::unlock_guard<Lock> ul(l);
                     this_thread::suspend(threads::suspended,
                         "full_empty_entry::enqueue_full_full", ec);
                     if (ec) return;
@@ -795,7 +795,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 {
                     // yield this thread
-                    util::scoped_unlock<Lock> ul(l);
+                    util::unlock_guard<Lock> ul(l);
                     this_thread::suspend(threads::suspended,
                         "full_empty_entry::enqueue_full_empty", ec);
                     if (ec) return;
@@ -829,7 +829,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 {
                     // yield this thread
-                    util::scoped_unlock<Lock> ul(l);
+                    util::unlock_guard<Lock> ul(l);
                     this_thread::suspend(threads::suspended,
                         "full_empty_entry::enqueue_full_empty", ec);
                     if (ec) return;
@@ -861,7 +861,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 {
                     // yield this thread
-                    util::scoped_unlock<Lock> ul(l);
+                    util::unlock_guard<Lock> ul(l);
                     this_thread::suspend(threads::suspended,
                         "full_empty_entry::enqueue_if_full", ec);
                     if (ec) return;
@@ -896,7 +896,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 {
                     // yield this thread
-                    util::scoped_unlock<Lock> ul(l);
+                    util::unlock_guard<Lock> ul(l);
                     this_thread::suspend(threads::suspended,
                         "full_empty_entry::enqueue_if_full", ec);
                     if (ec) return;

--- a/hpx/lcos/detail/full_empty_entry.hpp
+++ b/hpx/lcos/detail/full_empty_entry.hpp
@@ -187,7 +187,7 @@ namespace hpx { namespace lcos { namespace detail
         template <typename T>
         void enqueue_full_full(T& dest, error_code& ec = throws)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
 
             // block if this entry is empty
             if (state_ == empty) {
@@ -204,7 +204,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 {
                     // yield this thread
-                    util::scoped_unlock<typename mutex_type::scoped_lock> ul(l);
+                    util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
                     this_thread::suspend(threads::suspended,
                         "full_empty_entry::enqueue_full_full", ec);
                     if (ec) return;
@@ -223,7 +223,7 @@ namespace hpx { namespace lcos { namespace detail
         // same as above, but for entries without associated data
         void enqueue_full_full(error_code& ec = throws)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
 
             // block if this entry is empty
             if (state_ == empty) {
@@ -240,7 +240,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 {
                     // yield this thread
-                    util::scoped_unlock<typename mutex_type::scoped_lock> ul(l);
+                    util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
                     this_thread::suspend(threads::suspended,
                         "full_empty_entry::enqueue_full_full", ec);
                     if (ec) return;
@@ -257,7 +257,7 @@ namespace hpx { namespace lcos { namespace detail
         template <typename T>
         void enqueue_full_full_move(T& dest, error_code& ec = throws)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
 
             // block if this entry is empty
             if (state_ == empty) {
@@ -274,7 +274,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 {
                     // yield this thread
-                    util::scoped_unlock<typename mutex_type::scoped_lock> ul(l);
+                    util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
                     this_thread::suspend(threads::suspended,
                         "full_empty_entry::enqueue_full_full", ec);
                     if (ec) return;
@@ -301,7 +301,7 @@ namespace hpx { namespace lcos { namespace detail
         template <typename T>
         void enqueue_full_empty(T& dest, error_code& ec = throws)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
 
             // block if this entry is empty
             if (state_ == empty) {
@@ -316,7 +316,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 {
                     // yield this thread
-                    util::scoped_unlock<typename mutex_type::scoped_lock> ul(l);
+                    util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
                     this_thread::suspend(threads::suspended,
                         "full_empty_entry::enqueue_full_empty", ec);
                     if (ec) return;
@@ -336,7 +336,7 @@ namespace hpx { namespace lcos { namespace detail
         // same as above, but for entries without associated data
         void enqueue_full_empty(error_code& ec = throws)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
 
             // block if this entry is empty
             if (state_ == empty) {
@@ -351,7 +351,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 {
                     // yield this thread
-                    util::scoped_unlock<typename mutex_type::scoped_lock> ul(l);
+                    util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
                     this_thread::suspend(threads::suspended,
                         "full_empty_entry::enqueue_full_empty", ec);
                     if (ec) return;
@@ -370,7 +370,7 @@ namespace hpx { namespace lcos { namespace detail
         template <typename T>
         void enqueue_if_full(T && src, error_code& ec = throws)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
 
             // block if this entry is already full
             if (state_ == full) {
@@ -385,7 +385,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 {
                     // yield this thread
-                    util::scoped_unlock<typename mutex_type::scoped_lock> ul(l);
+                    util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
                     this_thread::suspend(threads::suspended,
                         "full_empty_entry::enqueue_if_full", ec);
                     if (ec) return;
@@ -406,7 +406,7 @@ namespace hpx { namespace lcos { namespace detail
         // same as above, but for entries without associated data
         void enqueue_if_full(error_code& ec = throws)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
 
             // block if this entry is already full
             if (state_ == full) {
@@ -421,7 +421,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 {
                     // yield this thread
-                    util::scoped_unlock<typename mutex_type::scoped_lock> ul(l);
+                    util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
                     this_thread::suspend(threads::suspended,
                         "full_empty_entry::enqueue_if_full", ec);
                     if (ec) return;

--- a/hpx/lcos/detail/full_empty_entry.hpp
+++ b/hpx/lcos/detail/full_empty_entry.hpp
@@ -18,6 +18,7 @@
 #include <boost/type_traits/alignment_of.hpp>
 #include <boost/type_traits/add_pointer.hpp>
 #include <boost/intrusive/slist.hpp>
+#include <boost/thread/locks.hpp>
 
 #include <memory>
 #include <sstream>
@@ -101,7 +102,7 @@ namespace hpx { namespace lcos { namespace detail
 
         void log_non_empty_queue(char const* const desc, queue_type& queue)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             while (!queue.empty()) {
                 threads::thread_id_type id = queue.front().id_;
                 queue.front().id_ = threads::invalid_thread_id;
@@ -154,28 +155,28 @@ namespace hpx { namespace lcos { namespace detail
         // returns whether this entry is currently empty
         bool is_empty() const
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             return state_ == empty;
         }
 
         // sets this entry to empty
         bool set_empty(error_code& ec = throws)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             return set_empty_locked(ec);
         }
 
         // sets this entry to full
         bool set_full(error_code& ec = throws)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             return set_full_locked(ec);
         }
 
         template <typename F>
         bool peek(F f) const
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             if (state_ == empty)
                 return false;
             return f(data_);      // pass the data to the provided function
@@ -440,7 +441,7 @@ namespace hpx { namespace lcos { namespace detail
         template <typename T>
         void set_and_fill(T && src, error_code& ec = throws)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
 
             // set the data
             data_ = std::forward<T>(src);
@@ -452,7 +453,7 @@ namespace hpx { namespace lcos { namespace detail
         // same as above, but for entries without associated data
         void set_and_fill(error_code& ec = throws)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
 
             // make sure the entry is full
             set_full_locked(ec);    // state_ = full
@@ -461,7 +462,7 @@ namespace hpx { namespace lcos { namespace detail
         // returns whether this entry is still in use
         bool is_used() const
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             return is_used_locked();
         }
 

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -556,12 +556,12 @@ namespace detail
 
         threads::thread_id_type get_id() const
         {
-            typename mutex_type::scoped_lock l(this->mtx_);
+            boost::lock_guard<mutex_type> l(this->mtx_);
             return id_;
         }
         void set_id(threads::thread_id_type id)
         {
-            typename mutex_type::scoped_lock l(this->mtx_);
+            boost::lock_guard<mutex_type> l(this->mtx_);
             id_ = id;
         }
 
@@ -611,13 +611,13 @@ namespace detail
     private:
         bool started_test() const
         {
-            typename mutex_type::scoped_lock l(this->mtx_);
+            boost::lock_guard<mutex_type> l(this->mtx_);
             return started_;
         }
 
         bool started_test_and_set()
         {
-            typename mutex_type::scoped_lock l(this->mtx_);
+            boost::lock_guard<mutex_type> l(this->mtx_);
             if (started_)
                 return true;
 
@@ -627,7 +627,7 @@ namespace detail
 
         void check_started()
         {
-            typename mutex_type::scoped_lock l(this->mtx_);
+            boost::lock_guard<mutex_type> l(this->mtx_);
             if (started_) {
                 HPX_THROW_EXCEPTION(task_already_started,
                     "task_base::check_started",

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -724,7 +724,7 @@ namespace detail
 
         void cancel()
         {
-            typename mutex_type::scoped_lock l(this->mtx_);
+            boost::unique_lock<mutex_type> l(this->mtx_);
             try {
                 if (!this->started_)
                     boost::throw_exception(hpx::thread_interrupted());

--- a/hpx/lcos/gather.hpp
+++ b/hpx/lcos/gather.hpp
@@ -32,6 +32,7 @@ namespace hpx { namespace lcos
 #include <hpx/util/unwrapped.hpp>
 
 #include <boost/preprocessor/cat.hpp>
+#include <boost/thread/locks.hpp>
 
 #include <vector>
 
@@ -65,7 +66,7 @@ namespace hpx { namespace lcos
 
             hpx::future<std::vector<T> > get_result(std::size_t which, T && t)
             {
-                typename mutex_type::scoped_lock l(mtx_);
+                boost::unique_lock<mutex_type> l(mtx_);
 
                 using util::placeholders::_1;
                 hpx::future<std::vector<T> > f = gate_.get_future().then(
@@ -78,7 +79,7 @@ namespace hpx { namespace lcos
 
             void set_result(std::size_t which, T && t)
             {
-                typename mutex_type::scoped_lock l(mtx_);
+                boost::unique_lock<mutex_type> l(mtx_);
                 set_result_locked(which, std::move(t), l);
             }
 

--- a/hpx/lcos/local/and_gate.hpp
+++ b/hpx/lcos/local/and_gate.hpp
@@ -225,7 +225,7 @@ namespace hpx { namespace lcos { namespace local
                     &base_and_gate::test_condition, this, generation_value));
 
                 {
-                    hpx::util::scoped_unlock<Lock> ul(l);
+                    hpx::util::unlock_guard<Lock> ul(l);
                     f.get();
                 }   // make sure lock gets re-acquired
             }

--- a/hpx/lcos/local/and_gate.hpp
+++ b/hpx/lcos/local/and_gate.hpp
@@ -108,7 +108,7 @@ namespace hpx { namespace lcos { namespace local
         template <typename OuterLock>
         bool set(std::size_t which, OuterLock & outer_lock, error_code& ec = throws)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             if (which >= received_segments_.size())
             {
                 // out of bounds index
@@ -152,7 +152,7 @@ namespace hpx { namespace lcos { namespace local
         bool set(std::size_t which, error_code& ec = throws)
         {
             no_mutex mtx;
-            no_mutex::scoped_lock lk(mtx);
+            boost::unique_lock<no_mutex> lk(mtx);
             return set(which, lk, ec);
         }
 
@@ -195,7 +195,7 @@ namespace hpx { namespace lcos { namespace local
             char const* function_name = "base_and_gate<>::synchronize",
             error_code& ec= throws)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             synchronize(generation_value, l, function_name, ec);
         }
 

--- a/hpx/lcos/local/and_gate.hpp
+++ b/hpx/lcos/local/and_gate.hpp
@@ -13,9 +13,10 @@
 #include <hpx/util/assert.hpp>
 
 #include <boost/dynamic_bitset.hpp>
-#include <utility>
+#include <boost/thread/locks.hpp>
 
 #include <list>
+#include <utility>
 
 namespace hpx { namespace lcos { namespace local
 {
@@ -52,7 +53,7 @@ namespace hpx { namespace lcos { namespace local
         {
             if (this != &rhs)
             {
-                typename mutex_type::scoped_lock l(rhs.mtx_);
+                boost::lock_guard<mutex_type> l(rhs.mtx_);
                 received_segments_ = std::move(rhs.received_segments_);
                 promise_ = std::move(rhs.promise_);
                 generation_ = rhs.generation_;
@@ -81,7 +82,7 @@ namespace hpx { namespace lcos { namespace local
         future<void> get_future(std::size_t count = std::size_t(~0U),
             std::size_t* generation_value = 0, error_code& ec = hpx::throws)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
 
             // by default we use as many segments as specified during construction
             if (count == std::size_t(~0U))
@@ -235,7 +236,7 @@ namespace hpx { namespace lcos { namespace local
     public:
         std::size_t next_generation()
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             HPX_ASSERT(generation_ != std::size_t(-1));
             std::size_t retval = ++generation_;
 
@@ -246,7 +247,7 @@ namespace hpx { namespace lcos { namespace local
 
         std::size_t generation() const
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             return generation_;
         }
 

--- a/hpx/lcos/local/and_gate.hpp
+++ b/hpx/lcos/local/and_gate.hpp
@@ -11,6 +11,7 @@
 #include <hpx/lcos/local/conditional_trigger.hpp>
 #include <hpx/lcos/local/no_mutex.hpp>
 #include <hpx/util/assert.hpp>
+#include <hpx/util/assert_owns_lock.hpp>
 
 #include <boost/dynamic_bitset.hpp>
 #include <boost/thread/locks.hpp>
@@ -205,7 +206,7 @@ namespace hpx { namespace lcos { namespace local
             char const* function_name = "base_and_gate<>::synchronize",
             error_code& ec= throws)
         {
-            HPX_ASSERT(l.owns_lock());
+            HPX_ASSERT_OWNS_LOCK(l);
 
             if (generation_value < generation_)
             {

--- a/hpx/lcos/local/channel.hpp
+++ b/hpx/lcos/local/channel.hpp
@@ -12,6 +12,8 @@
 #include <hpx/lcos/detail/future_data.hpp>
 #include <hpx/lcos/local/packaged_continuation.hpp>
 
+#include <boost/thread/locks.hpp>
+
 namespace hpx { namespace lcos { namespace detail
 {
 
@@ -29,7 +31,7 @@ struct channel_future_data : future_data<Result>
         // yields control if needed
         data_type d;
         {
-            typename mutex_type::scoped_lock l(this->mtx_);
+            boost::unique_lock<mutex_type> l(this->mtx_);
             // moves the data from the store
             this->data_.read_and_empty(d, l, ec);
             if (ec) return result_type();

--- a/hpx/lcos/local/condition_variable.hpp
+++ b/hpx/lcos/local/condition_variable.hpp
@@ -10,7 +10,7 @@
 #include <hpx/config.hpp>
 #include <hpx/lcos/local/detail/condition_variable.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
-#include <hpx/util/scoped_unlock.hpp>
+#include <hpx/util/unlock_guard.hpp>
 #include <hpx/util/date_time_chrono.hpp>
 
 #include <boost/detail/scoped_enum_emulation.hpp>
@@ -48,7 +48,7 @@ namespace hpx { namespace lcos { namespace local
         {
             util::ignore_all_while_checking ignore_lock;
             boost::unique_lock<mutex_type> l(mtx_);
-            util::scoped_unlock<Lock> unlock(lock);
+            util::unlock_guard<Lock> unlock(lock);
 
             cond_.wait(l, ec);
 
@@ -71,7 +71,7 @@ namespace hpx { namespace lcos { namespace local
         {
             util::ignore_all_while_checking ignore_lock;
             boost::unique_lock<mutex_type> l(mtx_);
-            util::scoped_unlock<Lock> unlock(lock);
+            util::unlock_guard<Lock> unlock(lock);
 
             threads::thread_state_ex_enum const reason =
                 cond_.wait_until(l, abs_time, ec);

--- a/hpx/lcos/local/detail/condition_variable.hpp
+++ b/hpx/lcos/local/detail/condition_variable.hpp
@@ -10,7 +10,7 @@
 #include <hpx/config.hpp>
 #include <hpx/lcos/local/no_mutex.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/scoped_unlock.hpp>
+#include <hpx/util/unlock_guard.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
 
 #include <boost/intrusive/slist.hpp>
@@ -238,7 +238,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail
             threads::thread_state_ex_enum reason = threads::wait_unknown;
             {
                 // yield this thread
-                util::scoped_unlock<boost::unique_lock<Mutex> > unlock(lock);
+                util::unlock_guard<boost::unique_lock<Mutex> > unlock(lock);
                 reason = this_thread::suspend(threads::suspended, description, ec);
                 if (ec) return threads::wait_unknown;
             }
@@ -271,7 +271,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail
             threads::thread_state_ex_enum reason = threads::wait_unknown;
             {
                 // yield this thread
-                util::scoped_unlock<boost::unique_lock<Mutex> > unlock(lock);
+                util::unlock_guard<boost::unique_lock<Mutex> > unlock(lock);
                 reason = this_thread::suspend(abs_time, description, ec);
                 if (ec) return threads::wait_unknown;
             }

--- a/hpx/lcos/local/mutex.hpp
+++ b/hpx/lcos/local/mutex.hpp
@@ -16,7 +16,7 @@
 #include <hpx/util/date_time_chrono.hpp>
 #include <hpx/util/itt_notify.hpp>
 #include <hpx/util/register_locks.hpp>
-#include <hpx/util/scoped_unlock.hpp>
+#include <hpx/util/unlock_guard.hpp>
 
 #include <boost/intrusive/slist.hpp>
 #include <boost/thread/locks.hpp>

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -377,7 +377,7 @@ namespace hpx { namespace lcos { namespace detail
 
         void cancel()
         {
-            typename mutex_type::scoped_lock l(this->mtx_);
+            boost::unique_lock<mutex_type> l(this->mtx_);
             try {
                 if (!this->started_)
                     boost::throw_exception(hpx::thread_interrupted());

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -21,6 +21,8 @@
 #include <boost/make_shared.hpp>
 #include <boost/intrusive_ptr.hpp>
 #include <boost/type_traits/remove_reference.hpp>
+#include <boost/thread/locks.hpp>
+
 #include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -167,12 +169,12 @@ namespace hpx { namespace lcos { namespace detail
     protected:
         threads::thread_id_type get_id() const
         {
-            typename mutex_type::scoped_lock l(this->mtx_);
+            boost::lock_guard<mutex_type> l(this->mtx_);
             return id_;
         }
         void set_id(threads::thread_id_type const& id)
         {
-            typename mutex_type::scoped_lock l(this->mtx_);
+            boost::lock_guard<mutex_type> l(this->mtx_);
             id_ = id;
         }
 
@@ -213,7 +215,7 @@ namespace hpx { namespace lcos { namespace detail
             >::type const& f, error_code& ec)
         {
             {
-                typename mutex_type::scoped_lock l(this->mtx_);
+                boost::lock_guard<mutex_type> l(this->mtx_);
                 if (started_) {
                     HPX_THROWS_IF(ec, task_already_started,
                         "continuation::run",
@@ -257,7 +259,7 @@ namespace hpx { namespace lcos { namespace detail
             error_code& ec)
         {
             {
-                typename mutex_type::scoped_lock l(this->mtx_);
+                boost::lock_guard<mutex_type> l(this->mtx_);
                 if (started_) {
                     HPX_THROWS_IF(ec, task_already_started,
                         "continuation::async",
@@ -287,7 +289,7 @@ namespace hpx { namespace lcos { namespace detail
             threads::executor& sched, error_code& ec)
         {
             {
-                typename mutex_type::scoped_lock l(this->mtx_);
+                boost::lock_guard<mutex_type> l(this->mtx_);
                 if (started_) {
                     HPX_THROWS_IF(ec, task_already_started,
                         "continuation::async",
@@ -318,7 +320,7 @@ namespace hpx { namespace lcos { namespace detail
             Executor& exec, error_code& ec)
         {
             {
-                typename mutex_type::scoped_lock l(this->mtx_);
+                boost::lock_guard<mutex_type> l(this->mtx_);
                 if (started_) {
                     HPX_THROWS_IF(ec, task_already_started,
                         "continuation::async_exec",

--- a/hpx/lcos/local/receive_buffer.hpp
+++ b/hpx/lcos/local/receive_buffer.hpp
@@ -14,11 +14,12 @@
 #include <hpx/util/assert.hpp>
 #include <hpx/util/move.hpp>
 
-#include <utility>
-#include <map>
-
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
+#include <boost/thread/locks.hpp>
+
+#include <utility>
+#include <map>
 
 namespace hpx { namespace lcos { namespace local
 {
@@ -100,7 +101,7 @@ namespace hpx { namespace lcos { namespace local
 
         hpx::future<T> receive(std::size_t step)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
 
             iterator it = get_buffer_entry(step);
             HPX_ASSERT(it != buffer_map_.end());
@@ -123,7 +124,7 @@ namespace hpx { namespace lcos { namespace local
             boost::shared_ptr<entry_data> entry;
 
             {
-                typename mutex_type::scoped_lock l(mtx_);
+                boost::lock_guard<mutex_type> l(mtx_);
 
                 iterator it = get_buffer_entry(step);
                 HPX_ASSERT(it != buffer_map_.end());
@@ -250,7 +251,7 @@ namespace hpx { namespace lcos { namespace local
 
         hpx::future<void> receive(std::size_t step)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
 
             iterator it = get_buffer_entry(step);
             HPX_ASSERT(it != buffer_map_.end());
@@ -273,7 +274,7 @@ namespace hpx { namespace lcos { namespace local
             boost::shared_ptr<entry_data> entry;
 
             {
-                typename mutex_type::scoped_lock l(mtx_);
+                boost::lock_guard<mutex_type> l(mtx_);
 
                 iterator it = get_buffer_entry(step);
                 HPX_ASSERT(it != buffer_map_.end());

--- a/hpx/lcos/local/trigger.hpp
+++ b/hpx/lcos/local/trigger.hpp
@@ -145,7 +145,7 @@ namespace hpx { namespace lcos { namespace local
             char const* function_name = "base_and_gate<>::synchronize",
             error_code& ec= throws)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
             synchronize(generation_value, l, function_name, ec);
         }
 

--- a/hpx/lcos/local/trigger.hpp
+++ b/hpx/lcos/local/trigger.hpp
@@ -11,6 +11,7 @@
 #include <hpx/lcos/local/conditional_trigger.hpp>
 #include <hpx/lcos/local/no_mutex.hpp>
 #include <hpx/util/assert.hpp>
+#include <hpx/util/assert_owns_lock.hpp>
 
 #include <boost/thread/locks.hpp>
 
@@ -155,7 +156,7 @@ namespace hpx { namespace lcos { namespace local
             char const* function_name = "base_and_gate<>::synchronize",
             error_code& ec= throws)
         {
-            HPX_ASSERT(l.owns_lock());
+            HPX_ASSERT_OWNS_LOCK(l);
 
             if (generation_value < generation_)
             {

--- a/hpx/lcos/local/trigger.hpp
+++ b/hpx/lcos/local/trigger.hpp
@@ -12,6 +12,8 @@
 #include <hpx/lcos/local/no_mutex.hpp>
 #include <hpx/util/assert.hpp>
 
+#include <boost/thread/locks.hpp>
+
 #include <utility>
 
 namespace hpx { namespace lcos { namespace local
@@ -45,7 +47,7 @@ namespace hpx { namespace lcos { namespace local
         {
             if (this != &rhs)
             {
-                typename mutex_type::scoped_lock l(rhs.mtx_);
+                boost::lock_guard<mutex_type> l(rhs.mtx_);
                 promise_ = std::move(rhs.promise_);
                 generation_ = rhs.generation_;
                 rhs.generation_ = std::size_t(-1);
@@ -73,7 +75,7 @@ namespace hpx { namespace lcos { namespace local
         future<void> get_future(std::size_t* generation_value = 0,
             error_code& ec = hpx::throws)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
 
             HPX_ASSERT(generation_ != std::size_t(-1));
             ++generation_;
@@ -90,7 +92,7 @@ namespace hpx { namespace lcos { namespace local
         /// \brief Trigger this object.
         bool set(error_code& ec = throws)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
 
             if (&ec != &throws)
                 ec = make_success_code();
@@ -184,7 +186,7 @@ namespace hpx { namespace lcos { namespace local
     public:
         std::size_t next_generation()
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             HPX_ASSERT(generation_ != std::size_t(-1));
             std::size_t retval = ++generation_;
 
@@ -195,7 +197,7 @@ namespace hpx { namespace lcos { namespace local
 
         std::size_t generation() const
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             return generation_;
         }
 

--- a/hpx/lcos/local/trigger.hpp
+++ b/hpx/lcos/local/trigger.hpp
@@ -175,7 +175,7 @@ namespace hpx { namespace lcos { namespace local
                         &base_trigger::test_condition, this, generation_value));
 
                 {
-                    hpx::util::scoped_unlock<Lock> ul(l);
+                    hpx::util::unlock_guard<Lock> ul(l);
                     f.get();
                 }   // make sure lock gets re-acquired
             }

--- a/hpx/lcos/server/object_semaphore.hpp
+++ b/hpx/lcos/server/object_semaphore.hpp
@@ -7,8 +7,6 @@
 #if !defined(HPX_1A262552_0D65_4C7D_887E_D11B02AAAC7E)
 #define HPX_1A262552_0D65_4C7D_887E_D11B02AAAC7E
 
-#include <boost/intrusive/slist.hpp>
-
 #include <hpx/hpx_fwd.hpp>
 #include <hpx/exception.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
@@ -17,6 +15,9 @@
 #include <hpx/runtime/components/server/managed_component_base.hpp>
 #include <hpx/runtime/applier/trigger.hpp>
 #include <hpx/lcos/base_lco.hpp>
+
+#include <boost/intrusive/slist.hpp>
+#include <boost/thread/locks.hpp>
 
 #include <memory>
 
@@ -157,7 +158,7 @@ struct object_semaphore
 
     void abort_pending(error ec)
     { // {{{
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
 
         LLCO_(info)
             << "object_semaphore::abort_pending: thread_queue is not empty, "
@@ -193,7 +194,7 @@ struct object_semaphore
             lcos::template base_lco_with_value<ValueType>::get_value_action
         action_type;
 
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
 
         typename thread_queue_type::const_iterator it = thread_queue_.begin()
                                                  , end = thread_queue_.end();

--- a/hpx/lcos/server/object_semaphore.hpp
+++ b/hpx/lcos/server/object_semaphore.hpp
@@ -11,7 +11,7 @@
 #include <hpx/exception.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/scoped_unlock.hpp>
+#include <hpx/util/unlock_guard.hpp>
 #include <hpx/runtime/components/component_type.hpp>
 #include <hpx/runtime/components/server/managed_component_base.hpp>
 #include <hpx/runtime/applier/trigger.hpp>
@@ -114,7 +114,7 @@ struct object_semaphore
             thread_queue_.pop_front();
 
             {
-                util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+                util::unlock_guard<boost::unique_lock<mutex_type> > ul(l);
 
                 // set the LCO's result
                 applier::trigger(id, std::move(value));

--- a/hpx/lcos/when_some.hpp
+++ b/hpx/lcos/when_some.hpp
@@ -241,6 +241,7 @@ namespace hpx
 #include <boost/fusion/include/for_each.hpp>
 #include <boost/fusion/include/is_sequence.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/thread/locks.hpp>
 #include <boost/utility/enable_if.hpp>
 
 #include <algorithm>
@@ -407,7 +408,7 @@ namespace hpx { namespace lcos
                 if (new_count <= needed_count_)
                 {
                     {
-                        typename mutex_type::scoped_lock l(this->mtx_);
+                        boost::lock_guard<mutex_type> l(this->mtx_);
                         lazy_values_.indices.push_back(idx);
                     }
                     if (new_count == needed_count_) {

--- a/hpx/parallel/task_block.hpp
+++ b/hpx/parallel/task_block.hpp
@@ -28,6 +28,7 @@
 #include <boost/utility/addressof.hpp>      // boost::addressof
 
 #include <boost/static_assert.hpp>
+#include <boost/thread/locks.hpp>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
 {
@@ -175,7 +176,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
             parallel::exception_list errors;
 
             {
-                mutex_type::scoped_lock l(mtx_);
+                boost::lock_guard<mutex_type> l(mtx_);
                 std::swap(tasks_, tasks);
                 std::swap(errors_, errors);
             }
@@ -256,7 +257,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
                 executor_traits<executor_type>::async_execute(
                     policy_.executor(), std::move(f));
 
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             tasks_.push_back(std::move(result));
         }
 

--- a/hpx/parallel/task_block.hpp
+++ b/hpx/parallel/task_block.hpp
@@ -15,7 +15,7 @@
 #include <hpx/lcos/local/spinlock.hpp>
 #include <hpx/lcos/future.hpp>
 #include <hpx/lcos/when_all.hpp>
-#include <hpx/util/scoped_unlock.hpp>
+#include <hpx/util/unlock_guard.hpp>
 #include <hpx/util/decay.hpp>
 #include <hpx/async.hpp>
 

--- a/hpx/performance_counters/parcels/gatherer.hpp
+++ b/hpx/performance_counters/parcels/gatherer.hpp
@@ -15,6 +15,7 @@
 
 #include <boost/config.hpp>
 #include <boost/cstdint.hpp>
+#include <boost/thread/locks.hpp>
 
 namespace hpx { namespace performance_counters { namespace parcels
 {
@@ -68,7 +69,7 @@ namespace hpx { namespace performance_counters { namespace parcels
 
     inline void gatherer::add_data(data_point const& x)
     {
-        mutex_type::scoped_lock mtx(acc_mtx);
+        boost::lock_guard<mutex_type> l(acc_mtx);
 
         overall_bytes_ += x.bytes_;
         overall_time_ += x.time_;
@@ -84,51 +85,51 @@ namespace hpx { namespace performance_counters { namespace parcels
 
     inline boost::int64_t gatherer::num_parcels(bool reset)
     {
-        mutex_type::scoped_lock mtx(acc_mtx);
+        boost::lock_guard<mutex_type> l(acc_mtx);
         return util::get_and_reset_value(num_parcels_, reset);
     }
 
     inline boost::int64_t gatherer::num_messages(bool reset)
     {
-        mutex_type::scoped_lock mtx(acc_mtx);
+        boost::lock_guard<mutex_type> l(acc_mtx);
         return util::get_and_reset_value(num_messages_, reset);
     }
 
     inline boost::int64_t gatherer::total_time(bool reset)
     {
-        mutex_type::scoped_lock mtx(acc_mtx);
+        boost::lock_guard<mutex_type> l(acc_mtx);
         return util::get_and_reset_value(overall_time_, reset);
     }
 
     inline boost::int64_t gatherer::total_serialization_time(bool reset)
     {
-        mutex_type::scoped_lock mtx(acc_mtx);
+        boost::lock_guard<mutex_type> l(acc_mtx);
         return util::get_and_reset_value(serialization_time_, reset);
     }
 
 #if defined(HPX_HAVE_SECURITY)
     inline boost::int64_t gatherer::total_security_time(bool reset)
     {
-        mutex_type::scoped_lock mtx(acc_mtx);
+        boost::lock_guard<mutex_type> l(acc_mtx);
         return util::get_and_reset_value(security_time_, reset);
     }
 #endif
 
     inline boost::int64_t gatherer::total_bytes(bool reset)
     {
-        mutex_type::scoped_lock mtx(acc_mtx);
+        boost::lock_guard<mutex_type> l(acc_mtx);
         return util::get_and_reset_value(overall_bytes_, reset);
     }
 
     inline boost::int64_t gatherer::total_raw_bytes(bool reset)
     {
-        mutex_type::scoped_lock mtx(acc_mtx);
+        boost::lock_guard<mutex_type> l(acc_mtx);
         return util::get_and_reset_value(overall_raw_bytes_, reset);
     }
 
     inline boost::int64_t gatherer::total_buffer_allocate_time(bool reset)
     {
-        mutex_type::scoped_lock mtx(acc_mtx);
+        boost::lock_guard<mutex_type> l(acc_mtx);
         return util::get_and_reset_value(buffer_allocate_time_, reset);
     }
 }}}

--- a/hpx/plugins/parcel/coalescing_message_handler.hpp
+++ b/hpx/plugins/parcel/coalescing_message_handler.hpp
@@ -18,6 +18,7 @@
 #include <hpx/plugins/parcel/message_buffer.hpp>
 
 #include <boost/preprocessor/stringize.hpp>
+#include <boost/thread/locks.hpp>
 
 #include <hpx/config/warnings_prefix.hpp>
 
@@ -46,7 +47,7 @@ namespace hpx { namespace plugins { namespace parcel
 
     protected:
         bool timer_flush();
-        bool flush(mutex_type::scoped_lock& l, bool stop_buffering);
+        bool flush(boost::unique_lock<mutex_type>& l, bool stop_buffering);
 
     private:
         mutable mutex_type mtx_;

--- a/hpx/plugins/parcelport/ibverbs/receiver.hpp
+++ b/hpx/plugins/parcelport/ibverbs/receiver.hpp
@@ -24,6 +24,7 @@
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/thread/locks.hpp>
 
 namespace hpx { namespace parcelset { namespace policies { namespace ibverbs
 {
@@ -93,7 +94,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace ibverbs
         {
             next_function_type f = 0;
             {
-                hpx::lcos::local::spinlock::scoped_lock l(mtx_);
+                boost::lock_guard<hpx::lcos::local::spinlock> l(mtx_);
                 f = next_;
             }
             if(f != 0)
@@ -181,7 +182,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace ibverbs
 
         bool next(next_function_type f)
         {
-            hpx::lcos::local::spinlock::scoped_lock l(mtx_);
+            boost::lock_guard<hpx::lcos::local::spinlock> l(mtx_);
             next_ = f;
             return false;
         }

--- a/hpx/plugins/parcelport/ibverbs/sender.hpp
+++ b/hpx/plugins/parcelport/ibverbs/sender.hpp
@@ -17,6 +17,7 @@
 #include <hpx/util/high_resolution_timer.hpp>
 
 #include <boost/asio/placeholders.hpp>
+#include <boost/thread/locks.hpp>
 
 namespace hpx { namespace parcelset { namespace policies { namespace ibverbs
 {
@@ -110,7 +111,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace ibverbs
         {
             next_function_type f = 0;
             {
-                hpx::lcos::local::spinlock::scoped_lock l(mtx_);
+                boost::lock_guard<hpx::lcos::local::spinlock> l(mtx_);
                 f = next_;
             }
             if(f != 0)
@@ -227,7 +228,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace ibverbs
 
         bool next(next_function_type f)
         {
-            hpx::lcos::local::spinlock::scoped_lock l(mtx_);
+            boost::lock_guard<hpx::lcos::local::spinlock> l(mtx_);
             next_ = f;
             return false;
         }

--- a/hpx/plugins/parcelport/ipc/data_buffer_cache.hpp
+++ b/hpx/plugins/parcelport/ipc/data_buffer_cache.hpp
@@ -20,6 +20,7 @@
 
 #include <boost/tuple/tuple.hpp>
 #include <boost/noncopyable.hpp>
+#include <boost/thread/locks.hpp>
 
 #include <map>
 #include <list>
@@ -52,7 +53,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace ipc
 
         bool get(key_type const& size, connection_type& conn)
         {
-            mutex_type::scoped_lock lock(mtx_);
+            boost::lock_guard<mutex_type> lock(mtx_);
 
             // Check if a matching entry exists ...
             cache_type::iterator const it = cache_.lower_bound(size);
@@ -76,7 +77,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace ipc
         // add the given data_buffer to the cache, evict old entries if needed
         void add(key_type const& size, connection_type const& conn)
         {
-            mutex_type::scoped_lock lock(mtx_);
+            boost::lock_guard<mutex_type> lock(mtx_);
 
             if (key_tracker_.empty()) {
                 HPX_ASSERT(cache_.empty());
@@ -113,13 +114,13 @@ namespace hpx { namespace parcelset { namespace policies { namespace ipc
 
         bool full() const
         {
-            mutex_type::scoped_lock lock(mtx_);
+            boost::lock_guard<mutex_type> lock(mtx_);
             return (cache_.size() >= max_cache_size_);
         }
 
         void clear()
         {
-            mutex_type::scoped_lock lock(mtx_);
+            boost::lock_guard<mutex_type> lock(mtx_);
             key_tracker_.clear();
             cache_.clear();
 

--- a/hpx/plugins/parcelport/mpi/receiver.hpp
+++ b/hpx/plugins/parcelport/mpi/receiver.hpp
@@ -43,7 +43,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
                 // as handle_header tries to acquire a mutex as well, we need
                 // to ignore the headers_mtx_ here
                 util::ignore_while_checking<mutex_type::scoped_lock> il(l_);
-                mutex_type::scoped_lock lk(receiver_.handles_header_mtx_);
+                boost::lock_guard<mutex_type> lk(receiver_.handles_header_mtx_);
                 std::pair<int, int> p(it->first, it->second.tag());
                 header_handle_ = receiver_.handles_header_.find(p);
 
@@ -71,7 +71,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
                 // as handle_header tries to acquire a mutex as well, we need
                 // to ignore the headers_mtx_ here
                 util::ignore_while_checking<mutex_type::scoped_lock> il(l_);
-                mutex_type::scoped_lock lk(receiver_.handles_header_mtx_);
+                boost::lock_guard<mutex_type> lk(receiver_.handles_header_mtx_);
                 if(handles_)
                 {
                     HPX_ASSERT(header_handle_ != receiver_.handles_header_.end());

--- a/hpx/plugins/parcelport/mpi/receiver.hpp
+++ b/hpx/plugins/parcelport/mpi/receiver.hpp
@@ -14,6 +14,8 @@
 #include <hpx/util/memory_chunk_pool.hpp>
 #include <hpx/util/memory_chunk_pool_allocator.hpp>
 
+#include <boost/thread/locks.hpp>
+
 namespace hpx { namespace parcelset { namespace policies { namespace mpi
 {
     class parcelport;
@@ -35,14 +37,14 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
         struct handle_header
         {
             handle_header(header_list::iterator it, receiver &receiver,
-                    mutex_type::scoped_lock * l)
+                    boost::unique_lock<mutex_type> * l)
               : receiver_(receiver)
               , handles_(false)
               , l_(l)
             {
                 // as handle_header tries to acquire a mutex as well, we need
                 // to ignore the headers_mtx_ here
-                util::ignore_while_checking<mutex_type::scoped_lock> il(l_);
+                util::ignore_while_checking<boost::unique_lock<mutex_type> > il(l_);
                 boost::lock_guard<mutex_type> lk(receiver_.handles_header_mtx_);
                 std::pair<int, int> p(it->first, it->second.tag());
                 header_handle_ = receiver_.handles_header_.find(p);
@@ -70,7 +72,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
             {
                 // as handle_header tries to acquire a mutex as well, we need
                 // to ignore the headers_mtx_ here
-                util::ignore_while_checking<mutex_type::scoped_lock> il(l_);
+                util::ignore_while_checking<boost::unique_lock<mutex_type> > il(l_);
                 boost::lock_guard<mutex_type> lk(receiver_.handles_header_mtx_);
                 if(handles_)
                 {
@@ -88,7 +90,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
 
             receiver &receiver_;
             bool handles_;
-            mutex_type::scoped_lock * l_;
+            boost::unique_lock<mutex_type> * l_;
             handles_header_type::iterator header_handle_;
             HPX_MOVABLE_BUT_NOT_COPYABLE(handle_header);
         };
@@ -141,7 +143,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
             {
                 check_num_connections chk(this);
                 if(!chk.decrement_) break;
-                mutex_type::scoped_lock l(headers_mtx_);
+                boost::unique_lock<mutex_type> l(headers_mtx_);
                 accept_locked();
                 iterator it = headers_.begin();
                 while(it != headers_.end())
@@ -155,7 +157,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
                         headers_.erase(it);
 
                         {
-                            hpx::util::scoped_unlock<mutex_type::scoped_lock> ul(l);
+                            hpx::util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
 
                             std::size_t num_thread(-1);
                             if(threads::get_self_ptr())

--- a/hpx/plugins/parcelport/mpi/receiver.hpp
+++ b/hpx/plugins/parcelport/mpi/receiver.hpp
@@ -157,7 +157,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
                         headers_.erase(it);
 
                         {
-                            hpx::util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+                            hpx::util::unlock_guard<boost::unique_lock<mutex_type> > ul(l);
 
                             std::size_t num_thread(-1);
                             if(threads::get_self_ptr())

--- a/hpx/plugins/parcelport/mpi/receiver.hpp
+++ b/hpx/plugins/parcelport/mpi/receiver.hpp
@@ -304,8 +304,8 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
 
         void accept()
         {
-            mutex_type::scoped_try_lock l(headers_mtx_);
-            if(l)
+            boost::unique_lock<mutex_type> l(headers_mtx_, boost::try_to_lock);
+            if(l.owns_lock())
                 accept_locked();
         }
 

--- a/hpx/plugins/parcelport/mpi/sender.hpp
+++ b/hpx/plugins/parcelport/mpi/sender.hpp
@@ -12,6 +12,8 @@
 #include <hpx/plugins/parcelport/mpi/header.hpp>
 #include <hpx/plugins/parcelport/mpi/mpi_environment.hpp>
 
+#include <boost/thread/locks.hpp>
+
 namespace hpx { namespace parcelset { namespace policies { namespace mpi
 {
     struct tag_provider
@@ -50,7 +52,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
 
         int acquire()
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             if(free_tags_.empty())
                 return next_tag_++;
 
@@ -63,7 +65,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
         {
             if(tag == next_tag_) return;
 
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             free_tags_.push_back(tag);
         }
 

--- a/hpx/plugins/parcelport/tcp/receiver.hpp
+++ b/hpx/plugins/parcelport/tcp/receiver.hpp
@@ -30,6 +30,7 @@
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/tuple/tuple.hpp>
+#include <boost/thread/locks.hpp>
 
 #include <sstream>
 #include <vector>
@@ -111,7 +112,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
 
         void shutdown()
         {
-            mutex_type::scoped_lock lk(mtx_);
+            boost::lock_guard<mutex_type> lk(mtx_);
             // gracefully and portably shutdown the socket
             boost::system::error_code ec;
             if (socket_.is_open()) {

--- a/hpx/plugins/parcelport/tcp/receiver.hpp
+++ b/hpx/plugins/parcelport/tcp/receiver.hpp
@@ -83,7 +83,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
                 sizeof(buffer_.num_chunks_)));
 
             {
-                mutex_type::scoped_lock lk(mtx_);
+                boost::unique_lock<mutex_type> lk(mtx_);
                 if(!socket_.is_open())
                 {
                     lk.unlock();
@@ -197,7 +197,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
                 }
 
                 {
-                    mutex_type::scoped_lock lk(mtx_);
+                    boost::unique_lock<mutex_type> lk(mtx_);
                     if(!socket_.is_open())
                     {
                         lk.unlock();
@@ -253,7 +253,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
                     = &receiver::handle_read_data<Handler>;
 
                 {
-                    mutex_type::scoped_lock lk(mtx_);
+                    boost::unique_lock<mutex_type> lk(mtx_);
                     if(!socket_.is_open())
                     {
                         lk.unlock();
@@ -301,7 +301,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
 
                 ack_ = true;
                 {
-                    mutex_type::scoped_lock lk(mtx_);
+                    boost::unique_lock<mutex_type> lk(mtx_);
                     if(!socket_.is_open())
                     {
                         lk.unlock();

--- a/hpx/runtime.hpp
+++ b/hpx/runtime.hpp
@@ -25,11 +25,12 @@
 #include <hpx/components/security/certificate_store.hpp>
 #endif
 
-#include <hpx/config/warnings_prefix.hpp>
-
 #include <boost/smart_ptr/scoped_ptr.hpp>
+#include <boost/thread/locks.hpp>
 
 #include <memory>
+
+#include <hpx/config/warnings_prefix.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx
@@ -93,7 +94,7 @@ namespace hpx
         /// \brief Manage list of functions to call on exit
         void on_exit(util::function_nonser<void()> const& f)
         {
-            boost::mutex::scoped_lock l(mtx_);
+            boost::lock_guard<boost::mutex> l(mtx_);
             on_exit_functions_.push_back(f);
         }
 
@@ -110,7 +111,7 @@ namespace hpx
 
             typedef util::function_nonser<void()> value_type;
 
-            boost::mutex::scoped_lock l(mtx_);
+            boost::lock_guard<boost::mutex> l(mtx_);
             for (value_type const& f : on_exit_functions_)
                 f();
         }
@@ -424,7 +425,7 @@ namespace hpx {
     bool runtime::verify_parcel_suffix(Buffer const& data,
         naming::gid_type& parcel_id, error_code& ec) const
     {
-        lcos::local::spinlock::scoped_lock l(security_mtx_);
+        boost::lock_guard<lcos::local::spinlock> l(security_mtx_);
         return components::security::verify(*cert_store(ec), data, parcel_id);
     }
 }

--- a/hpx/runtime/agas/addressing_service.hpp
+++ b/hpx/runtime/agas/addressing_service.hpp
@@ -11,16 +11,6 @@
 
 #include <hpx/config.hpp>
 
-#include <vector>
-
-#include <boost/make_shared.hpp>
-#include <boost/cache/entries/lfu_entry.hpp>
-#include <boost/cache/local_cache.hpp>
-#include <boost/cache/statistics/local_full_statistics.hpp>
-#include <boost/cstdint.hpp>
-#include <boost/noncopyable.hpp>
-#include <boost/dynamic_bitset.hpp>
-
 #include <hpx/exception.hpp>
 #include <hpx/hpx_fwd.hpp>
 #include <hpx/state.hpp>
@@ -30,7 +20,17 @@
 #include <hpx/runtime/naming/address.hpp>
 #include <hpx/runtime/naming/name.hpp>
 
+#include <boost/make_shared.hpp>
+#include <boost/cache/entries/lfu_entry.hpp>
+#include <boost/cache/local_cache.hpp>
+#include <boost/cache/statistics/local_full_statistics.hpp>
+#include <boost/cstdint.hpp>
+#include <boost/noncopyable.hpp>
+#include <boost/dynamic_bitset.hpp>
+#include <boost/thread/locks.hpp>
+
 #include <map>
+#include <vector>
 
 // TODO: split into a base class and two implementations (one for bootstrap,
 // one for hosted).
@@ -242,25 +242,25 @@ protected:
 private:
     /// Assumes that \a refcnt_requests_mtx_ is locked.
     void send_refcnt_requests(
-        mutex_type::scoped_lock& l
+        boost::unique_lock<mutex_type>& l
       , error_code& ec = throws
         );
 
     /// Assumes that \a refcnt_requests_mtx_ is locked.
     void send_refcnt_requests_non_blocking(
-        mutex_type::scoped_lock& l
+        boost::unique_lock<mutex_type>& l
       , error_code& ec
         );
 
     /// Assumes that \a refcnt_requests_mtx_ is locked.
     std::vector<hpx::future<std::vector<response> > >
     send_refcnt_requests_async(
-        mutex_type::scoped_lock& l
+        boost::unique_lock<mutex_type>& l
         );
 
     /// Assumes that \a refcnt_requests_mtx_ is locked.
     void send_refcnt_requests_sync(
-        mutex_type::scoped_lock& l
+        boost::unique_lock<mutex_type>& l
       , error_code& ec
         );
 

--- a/hpx/runtime/agas/server/primary_namespace.hpp
+++ b/hpx/runtime/agas/server/primary_namespace.hpp
@@ -22,16 +22,17 @@
 #include <hpx/util/high_resolution_clock.hpp>
 #include <hpx/lcos/local/condition_variable.hpp>
 
-#include <map>
-
+#include <boost/atomic.hpp>
 #include <boost/format.hpp>
 #include <boost/fusion/include/at_c.hpp>
 #include <boost/fusion/include/vector.hpp>
-#include <boost/atomic.hpp>
+#include <boost/thread/locks.hpp>
 
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION < 408000
 #include <boost/shared_ptr.hpp>
 #endif
+
+#include <map>
 
 namespace hpx { namespace agas
 {
@@ -241,7 +242,7 @@ struct HPX_EXPORT primary_namespace
       , refcnt_table_type::iterator upper_it
       , naming::gid_type const& lower
       , naming::gid_type const& upper
-      , mutex_type::scoped_lock& l
+      , boost::unique_lock<mutex_type>& l
       , const char* func_name
         );
 #endif
@@ -256,7 +257,7 @@ struct HPX_EXPORT primary_namespace
 
     // helper function
     void wait_for_migration_locked(
-        mutex_type::scoped_lock& l
+        boost::unique_lock<mutex_type>& l
       , naming::gid_type id
       , error_code& ec);
 
@@ -385,7 +386,7 @@ struct HPX_EXPORT primary_namespace
     };
 
     void resolve_free_list(
-        mutex_type::scoped_lock& l
+        boost::unique_lock<mutex_type>& l
       , std::list<refcnt_table_type::iterator> const& free_list
       , std::list<free_entry>& free_entry_list
       , naming::gid_type const& lower

--- a/hpx/runtime/components/server/console_error_sink_singleton.hpp
+++ b/hpx/runtime/components/server/console_error_sink_singleton.hpp
@@ -16,6 +16,7 @@
 #include <boost/noncopyable.hpp>
 #include <boost/signals2.hpp>
 #include <boost/thread.hpp>
+#include <boost/thread/locks.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace components { namespace server
@@ -32,13 +33,13 @@ namespace hpx { namespace components { namespace server
         template <typename F, typename Connection>
         bool register_error_sink(F sink, Connection& conn)
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             return (conn = dispatcher_.connect(sink)).connected();
         }
 
         void operator()(std::string const& msg)
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             dispatcher_(msg);
         }
 

--- a/hpx/runtime/components/server/locking_hook.hpp
+++ b/hpx/runtime/components/server/locking_hook.hpp
@@ -14,6 +14,8 @@
 #include <hpx/util/register_locks.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 
+#include <boost/thread/locks.hpp>
+
 namespace hpx { namespace components
 {
     /// This hook can be inserted into the derivation chain of any component
@@ -69,7 +71,7 @@ namespace hpx { namespace components
             threads::thread_state_enum result = threads::unknown;
 
             // now lock the mutex and execute the action
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
 
             // We can safely ignore this lock while checking as it is
             // guaranteed to be unlocked before the thread is suspended.
@@ -77,7 +79,7 @@ namespace hpx { namespace components
             // If this lock is not ignored it will cause false positives as the
             // check for held locks is performed before this lock is unlocked.
             util::ignore_while_checking<
-                    typename mutex_type::scoped_lock
+                    boost::unique_lock<mutex_type>
                 > ignore_lock(&l);
 
             {

--- a/hpx/runtime/components/server/locking_hook.hpp
+++ b/hpx/runtime/components/server/locking_hook.hpp
@@ -8,7 +8,7 @@
 
 #include <hpx/hpx_fwd.hpp>
 #include <hpx/runtime/get_lva.hpp>
-#include <hpx/util/scoped_unlock.hpp>
+#include <hpx/util/unlock_guard.hpp>
 #include <hpx/util/move.hpp>
 #include <hpx/util/coroutine/coroutine.hpp>
 #include <hpx/util/register_locks.hpp>
@@ -122,7 +122,7 @@ namespace hpx { namespace components
             threads::thread_state_ex_enum result = threads::wait_unknown;
 
             {
-                util::scoped_unlock<mutex_type> ul(mtx_);
+                util::unlock_guard<mutex_type> ul(mtx_);
                 result = threads::get_self().yield_impl(state);
             }
 

--- a/hpx/runtime/components/server/migration_support.hpp
+++ b/hpx/runtime/components/server/migration_support.hpp
@@ -9,6 +9,8 @@
 #include <hpx/hpx_fwd.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 
+#include <boost/thread/locks.hpp>
+
 namespace hpx { namespace components
 {
     /// This hook has to be inserted into the derivation chain of any component
@@ -42,24 +44,24 @@ namespace hpx { namespace components
         // Pinning functionality
         void pin()
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             ++pin_count_;
         }
         void unpin()
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             HPX_ASSERT(pin_count_ != 0);
             if (pin_count_ != ~0x0u)
                 --pin_count_;
         }
         boost::uint32_t pin_count() const
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             return pin_count_;
         }
         void mark_as_migrated()
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             HPX_ASSERT(1 == pin_count_);
             pin_count_ = ~0x0u;
         }

--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -29,6 +29,7 @@
 
 #include <boost/thread.hpp>
 #include <boost/thread/condition.hpp>
+#include <boost/thread/locks.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/program_options/options_description.hpp>
 #include <boost/atomic.hpp>
@@ -285,25 +286,25 @@ namespace hpx { namespace components { namespace server
 
         void add_pre_startup_function(util::function_nonser<void()> const& f)
         {
-            lcos::local::spinlock::scoped_lock l(globals_mtx_);
+            boost::lock_guard<lcos::local::spinlock> l(globals_mtx_);
             pre_startup_functions_.push_back(f);
         }
 
         void add_startup_function(util::function_nonser<void()> const& f)
         {
-            lcos::local::spinlock::scoped_lock l(globals_mtx_);
+            boost::lock_guard<lcos::local::spinlock> l(globals_mtx_);
             startup_functions_.push_back(f);
         }
 
         void add_pre_shutdown_function(util::function_nonser<void()> const& f)
         {
-            lcos::local::spinlock::scoped_lock l(globals_mtx_);
+            boost::lock_guard<lcos::local::spinlock> l(globals_mtx_);
             pre_shutdown_functions_.push_back(f);
         }
 
         void add_shutdown_function(util::function_nonser<void()> const& f)
         {
-            lcos::local::spinlock::scoped_lock l(globals_mtx_);
+            boost::lock_guard<lcos::local::spinlock> l(globals_mtx_);
             shutdown_functions_.push_back(f);
         }
 

--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -479,7 +479,7 @@ namespace hpx { namespace components { namespace server
         naming::gid_type id;
         boost::shared_ptr<component_factory_base> factory((*it).second.first);
         {
-            util::scoped_unlock<boost::unique_lock<component_map_mutex_type> > ul(l);
+            util::unlock_guard<boost::unique_lock<component_map_mutex_type> > ul(l);
             id = factory->create();
         }
         LRT_(info) << "successfully created component " << id
@@ -524,7 +524,7 @@ namespace hpx { namespace components { namespace server
         naming::gid_type id;
         boost::shared_ptr<component_factory_base> factory((*it).second.first);
         {
-            util::scoped_unlock<boost::unique_lock<component_map_mutex_type> > ul(l);
+            util::unlock_guard<boost::unique_lock<component_map_mutex_type> > ul(l);
 
             typedef typename Component::wrapping_type wrapping_type;
             id = factory->create_with_args(
@@ -576,7 +576,7 @@ namespace hpx { namespace components { namespace server
 
         boost::shared_ptr<component_factory_base> factory((*it).second.first);
         {
-            util::scoped_unlock<boost::unique_lock<component_map_mutex_type> > ul(l);
+            util::unlock_guard<boost::unique_lock<component_map_mutex_type> > ul(l);
             for (std::size_t i = 0; i != count; ++i)
             {
                 ids.push_back(factory->create());
@@ -628,7 +628,7 @@ namespace hpx { namespace components { namespace server
 
         boost::shared_ptr<component_factory_base> factory((*it).second.first);
         {
-            util::scoped_unlock<boost::unique_lock<component_map_mutex_type> > ul(l);
+            util::unlock_guard<boost::unique_lock<component_map_mutex_type> > ul(l);
             for (std::size_t i = 0; i != count; ++i)
             {
                 typedef typename Component::wrapping_type wrapping_type;
@@ -682,7 +682,7 @@ namespace hpx { namespace components { namespace server
         naming::gid_type id;
         boost::shared_ptr<component_factory_base> factory((*it).second.first);
         {
-            util::scoped_unlock<boost::unique_lock<component_map_mutex_type> > ul(l);
+            util::unlock_guard<boost::unique_lock<component_map_mutex_type> > ul(l);
 
             typedef typename Component::wrapping_type wrapping_type;
             if (!local_op) {
@@ -742,7 +742,7 @@ namespace hpx { namespace components { namespace server
         naming::gid_type id;
         boost::shared_ptr<component_factory_base> factory((*it).second.first);
         {
-            util::scoped_unlock<boost::unique_lock<component_map_mutex_type> > ul(l);
+            util::unlock_guard<boost::unique_lock<component_map_mutex_type> > ul(l);
 
             typedef typename Component::wrapping_type wrapping_type;
             id = factory->create_with_args(migrated_id,

--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -450,7 +450,7 @@ namespace hpx { namespace components { namespace server
             components::get_component_type<
                 typename Component::wrapped_type>();
 
-        component_map_mutex_type::scoped_lock l(cm_mtx_);
+        boost::unique_lock<component_map_mutex_type> l(cm_mtx_);
         component_map_type::const_iterator it = components_.find(type);
         if (it == components_.end()) {
             std::ostringstream strm;
@@ -479,7 +479,7 @@ namespace hpx { namespace components { namespace server
         naming::gid_type id;
         boost::shared_ptr<component_factory_base> factory((*it).second.first);
         {
-            util::scoped_unlock<component_map_mutex_type::scoped_lock> ul(l);
+            util::scoped_unlock<boost::unique_lock<component_map_mutex_type> > ul(l);
             id = factory->create();
         }
         LRT_(info) << "successfully created component " << id
@@ -495,7 +495,7 @@ namespace hpx { namespace components { namespace server
             components::get_component_type<
                 typename Component::wrapped_type>();
 
-        component_map_mutex_type::scoped_lock l(cm_mtx_);
+        boost::unique_lock<component_map_mutex_type> l(cm_mtx_);
         component_map_type::const_iterator it = components_.find(type);
         if (it == components_.end()) {
             std::ostringstream strm;
@@ -524,7 +524,7 @@ namespace hpx { namespace components { namespace server
         naming::gid_type id;
         boost::shared_ptr<component_factory_base> factory((*it).second.first);
         {
-            util::scoped_unlock<component_map_mutex_type::scoped_lock> ul(l);
+            util::scoped_unlock<boost::unique_lock<component_map_mutex_type> > ul(l);
 
             typedef typename Component::wrapping_type wrapping_type;
             id = factory->create_with_args(
@@ -545,7 +545,7 @@ namespace hpx { namespace components { namespace server
             components::get_component_type<
                 typename Component::wrapped_type>();
 
-        component_map_mutex_type::scoped_lock l(cm_mtx_);
+        boost::unique_lock<component_map_mutex_type> l(cm_mtx_);
         component_map_type::const_iterator it = components_.find(type);
         if (it == components_.end()) {
             std::ostringstream strm;
@@ -576,7 +576,7 @@ namespace hpx { namespace components { namespace server
 
         boost::shared_ptr<component_factory_base> factory((*it).second.first);
         {
-            util::scoped_unlock<component_map_mutex_type::scoped_lock> ul(l);
+            util::scoped_unlock<boost::unique_lock<component_map_mutex_type> > ul(l);
             for (std::size_t i = 0; i != count; ++i)
             {
                 ids.push_back(factory->create());
@@ -597,7 +597,7 @@ namespace hpx { namespace components { namespace server
             components::get_component_type<
                 typename Component::wrapped_type>();
 
-        component_map_mutex_type::scoped_lock l(cm_mtx_);
+        boost::unique_lock<component_map_mutex_type> l(cm_mtx_);
         component_map_type::const_iterator it = components_.find(type);
         if (it == components_.end()) {
             std::ostringstream strm;
@@ -628,7 +628,7 @@ namespace hpx { namespace components { namespace server
 
         boost::shared_ptr<component_factory_base> factory((*it).second.first);
         {
-            util::scoped_unlock<component_map_mutex_type::scoped_lock> ul(l);
+            util::scoped_unlock<boost::unique_lock<component_map_mutex_type> > ul(l);
             for (std::size_t i = 0; i != count; ++i)
             {
                 typedef typename Component::wrapping_type wrapping_type;
@@ -653,7 +653,7 @@ namespace hpx { namespace components { namespace server
             components::get_component_type<
                 typename Component::wrapped_type>();
 
-        component_map_mutex_type::scoped_lock l(cm_mtx_);
+        boost::unique_lock<component_map_mutex_type> l(cm_mtx_);
         component_map_type::const_iterator it = components_.find(type);
         if (it == components_.end()) {
             std::ostringstream strm;
@@ -682,7 +682,7 @@ namespace hpx { namespace components { namespace server
         naming::gid_type id;
         boost::shared_ptr<component_factory_base> factory((*it).second.first);
         {
-            util::scoped_unlock<component_map_mutex_type::scoped_lock> ul(l);
+            util::scoped_unlock<boost::unique_lock<component_map_mutex_type> > ul(l);
 
             typedef typename Component::wrapping_type wrapping_type;
             if (!local_op) {
@@ -709,7 +709,7 @@ namespace hpx { namespace components { namespace server
             components::get_component_type<
                 typename Component::wrapped_type>();
 
-        component_map_mutex_type::scoped_lock l(cm_mtx_);
+        boost::unique_lock<component_map_mutex_type> l(cm_mtx_);
         component_map_type::const_iterator it = components_.find(type);
         if (it == components_.end()) {
             std::ostringstream strm;
@@ -742,7 +742,7 @@ namespace hpx { namespace components { namespace server
         naming::gid_type id;
         boost::shared_ptr<component_factory_base> factory((*it).second.first);
         {
-            util::scoped_unlock<component_map_mutex_type::scoped_lock> ul(l);
+            util::scoped_unlock<boost::unique_lock<component_map_mutex_type> > ul(l);
 
             typedef typename Component::wrapping_type wrapping_type;
             id = factory->create_with_args(migrated_id,

--- a/hpx/runtime/components/server/wrapper_heap.hpp
+++ b/hpx/runtime/components/server/wrapper_heap.hpp
@@ -25,7 +25,7 @@
 #include <hpx/util/generate_unique_ids.hpp>
 #include <hpx/util/itt_notify.hpp>
 #include <hpx/util/logging.hpp>
-#include <hpx/util/scoped_unlock.hpp>
+#include <hpx/util/unlock_guard.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace components { namespace detail
@@ -261,7 +261,7 @@ namespace hpx { namespace components { namespace detail
                 {
                     // this is the first call to get_gid() for this heap - allocate
                     // a sufficiently large range of global ids
-                    util::scoped_unlock<scoped_lock> ul(l);
+                    util::unlock_guard<scoped_lock> ul(l);
                     base_gid = ids.get_id(step_);
 
                     // register the global ids and the base address of this heap
@@ -284,7 +284,7 @@ namespace hpx { namespace components { namespace detail
                 else
                 {
                     // unbind the range which is not needed anymore
-                    util::scoped_unlock<scoped_lock> ul(l);
+                    util::unlock_guard<scoped_lock> ul(l);
                     applier::unbind_range_local(base_gid, step_);
                 }
             }
@@ -323,7 +323,7 @@ namespace hpx { namespace components { namespace detail
                 naming::gid_type base_gid = base_gid_;
                 base_gid_ = naming::invalid_gid;
 
-                util::scoped_unlock<scoped_lock> ull(lk);
+                util::unlock_guard<scoped_lock> ull(lk);
                 applier::unbind_range_local(base_gid, step_);
             }
 

--- a/hpx/runtime/components/server/wrapper_heap_list.hpp
+++ b/hpx/runtime/components/server/wrapper_heap_list.hpp
@@ -38,7 +38,7 @@ namespace hpx { namespace components { namespace detail
             {
                 if ((*it)->did_alloc(p))
                 {
-                    util::scoped_unlock<typename base_type::unique_lock_type> ul(guard);
+                    util::unlock_guard<typename base_type::unique_lock_type> ul(guard);
                     return (*it)->get_gid(id_range_, p, type_);
                 }
             }

--- a/hpx/runtime/parcelset/parcelhandler.hpp
+++ b/hpx/runtime/parcelset/parcelhandler.hpp
@@ -433,7 +433,7 @@ namespace hpx { namespace parcelset
         {
             write_handler_type f;
             {
-                mutex_type::scoped_lock l(mtx_);
+                boost::lock_guard<mutex_type> l(mtx_);
                 f = write_handler_;
             }
             f(ec, p);
@@ -441,7 +441,7 @@ namespace hpx { namespace parcelset
 
         write_handler_type set_write_handler(write_handler_type f)
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             std::swap(f, write_handler_);
             return f;
         }

--- a/hpx/runtime/parcelset/parcelport.hpp
+++ b/hpx/runtime/parcelset/parcelport.hpp
@@ -19,6 +19,7 @@
 #include <hpx/lcos/local/spinlock.hpp>
 
 #include <boost/enable_shared_from_this.hpp>
+#include <boost/thread/locks.hpp>
 
 #include <map>
 #include <set>
@@ -311,7 +312,7 @@ namespace hpx { namespace parcelset
 
         boost::uint64_t get_pending_parcels_count(bool /*reset*/)
         {
-            lcos::local::spinlock::scoped_lock l(mtx_);
+            boost::lock_guard<lcos::local::spinlock> l(mtx_);
             return pending_parcels_.size();
         }
 

--- a/hpx/runtime/parcelset/parcelport_impl.hpp
+++ b/hpx/runtime/parcelset/parcelport_impl.hpp
@@ -612,8 +612,8 @@ namespace hpx { namespace parcelset
             std::vector<locality> destinations;
 
             {
-                lcos::local::spinlock::scoped_try_lock l(mtx_);
-                if(l)
+                boost::unique_lock<lcos::local::spinlock> l(mtx_, boost::try_to_lock);
+                if(l.owns_lock())
                 {
                     if (parcel_destinations_.empty())
                         return true;
@@ -657,8 +657,8 @@ namespace hpx { namespace parcelset
                 // need to force a new connection to avoid deadlocks.
                 bool force_connection = false;
                 {
-                    mutex_type::scoped_try_lock l(sender_threads_mtx_);
-                    if(l)
+                    boost::unique_lock<mutex_type> l(sender_threads_mtx_, boost::try_to_lock);
+                    if(l.owns_lock())
                     {
                         std::vector<threads::thread_id_type> threads;
                         threads.reserve(sender_threads_.size());

--- a/hpx/runtime/parcelset/parcelport_impl.hpp
+++ b/hpx/runtime/parcelset/parcelport_impl.hpp
@@ -490,11 +490,13 @@ namespace hpx { namespace parcelset
         {
             typedef pending_parcels_map::mapped_type mapped_type;
 
-            lcos::local::spinlock::scoped_lock l(mtx_);
+            boost::unique_lock<lcos::local::spinlock> l(mtx_);
             // We ignore the lock here. It might happen that while enqueuing,
             // we need to acquire a lock. This should not cause any problems
             // (famous last words)
-            util::ignore_while_checking<lcos::local::spinlock::scoped_lock> il(&l);
+            util::ignore_while_checking<
+                boost::unique_lock<lcos::local::spinlock>
+            > il(&l);
 
             mapped_type& e = pending_parcels_[locality_id];
             e.first.push_back(std::move(p));
@@ -509,11 +511,13 @@ namespace hpx { namespace parcelset
         {
             typedef pending_parcels_map::mapped_type mapped_type;
 
-            lcos::local::spinlock::scoped_lock l(mtx_);
+            boost::unique_lock<lcos::local::spinlock> l(mtx_);
             // We ignore the lock here. It might happen that while enqueuing,
             // we need to acquire a lock. This should not cause any problems
             // (famous last words)
-            util::ignore_while_checking<lcos::local::spinlock::scoped_lock> il(&l);
+            util::ignore_while_checking<
+                boost::unique_lock<lcos::local::spinlock>
+            > il(&l);
 
             HPX_ASSERT(parcels.size() == handlers.size());
 

--- a/hpx/runtime/parcelset/parcelport_impl.hpp
+++ b/hpx/runtime/parcelset/parcelport_impl.hpp
@@ -19,6 +19,8 @@
 #include <hpx/util/runtime_configuration.hpp>
 #include <hpx/util/safe_lexical_cast.hpp>
 
+#include <boost/thread/locks.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx
 {
@@ -554,7 +556,7 @@ namespace hpx { namespace parcelset
                 return false;
 
             {
-                lcos::local::spinlock::scoped_lock l(mtx_);
+                boost::lock_guard<lcos::local::spinlock> l(mtx_);
 
                 iterator it = pending_parcels_.find(locality_id);
 
@@ -723,7 +725,7 @@ namespace hpx { namespace parcelset
                             thread_num, threads::thread_stacksize_default
                         );
                     {
-                        mutex_type::scoped_lock l(sender_threads_mtx_);
+                        boost::lock_guard<mutex_type> l(sender_threads_mtx_);
                         HPX_ASSERT(new_send_thread != threads::invalid_thread_id);
                         sender_threads_.insert(new_send_thread);
                     }
@@ -734,7 +736,7 @@ namespace hpx { namespace parcelset
                     new_send_thread = threads::get_self_id();
                     if(new_send_thread != threads::invalid_thread_id)
                     {
-                        mutex_type::scoped_lock l(sender_threads_mtx_);
+                        boost::lock_guard<mutex_type> l(sender_threads_mtx_);
                         sender_threads_.insert(new_send_thread);
                     }
                     send_pending_parcels(
@@ -761,7 +763,7 @@ namespace hpx { namespace parcelset
             client_connection->set_state(parcelport_connection::state_scheduled_thread);
 #endif
             {
-                lcos::local::spinlock::scoped_lock l(mtx_);
+                boost::lock_guard<lcos::local::spinlock> l(mtx_);
 
                 HPX_ASSERT(locality_id == sender_connection->destination());
                 if (!ec)
@@ -849,7 +851,7 @@ namespace hpx { namespace parcelset
             threads::thread_id_type this_thread = threads::get_self_id();
             if(this_thread != threads::invalid_thread_id)
             {
-                mutex_type::scoped_lock l(sender_threads_mtx_);
+                boost::lock_guard<lcos::local::spinlock> l(sender_threads_mtx_);
                 std::set<threads::thread_id_type>::iterator it
                     = sender_threads_.find(this_thread);
                 HPX_ASSERT(it != sender_threads_.end());

--- a/hpx/runtime/parcelset/policies/global_parcelhandler_queue.hpp
+++ b/hpx/runtime/parcelset/policies/global_parcelhandler_queue.hpp
@@ -16,6 +16,8 @@
 #include <hpx/lcos/local/spinlock.hpp>
 #include <hpx/util/assert.hpp>
 
+#include <boost/thread/locks.hpp>
+
 namespace hpx { namespace parcelset { namespace policies
 {
     ///////////////////////////////////////////////////////////////////////////
@@ -38,7 +40,7 @@ namespace hpx { namespace parcelset { namespace policies
 
             // Add parcel to queue.
             {
-                mutex_type::scoped_lock l(mtx_);
+                boost::lock_guard<mutex_type> l(mtx_);
                 std::pair<parcel_map_type::iterator, bool> ret =
                     parcels_.insert(parcel_map_type::value_type(id, p));
 
@@ -60,7 +62,7 @@ namespace hpx { namespace parcelset { namespace policies
         bool get_parcel(parcel& p)
         {
             // Remove the first parcel from queue.
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
 
             if (!parcels_.empty()) {
                 parcel_map_type::iterator front = parcels_.begin();
@@ -75,7 +77,7 @@ namespace hpx { namespace parcelset { namespace policies
         bool get_parcel(parcel& p, naming::gid_type const& parcel_id)
         {
             // Remove the requested parcel from queue.
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
 
             parcel_map_type::iterator it = parcels_.find(parcel_id);
             if (it != parcels_.end()) {
@@ -106,7 +108,7 @@ namespace hpx { namespace parcelset { namespace policies
 
         std::size_t get_queue_length() const
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             return parcels_.size();
         }
 

--- a/hpx/runtime/threads/policies/scheduler_base.hpp
+++ b/hpx/runtime/threads/policies/scheduler_base.hpp
@@ -88,12 +88,12 @@ namespace hpx { namespace threads { namespace policies
 #if BOOST_VERSION < 105000
             boost::posix_time::millisec period(++wait_count_);
 
-            boost::mutex::scoped_lock l(mtx_);
+            boost::unique_lock<boost::mutex> l(mtx_);
             cond_.timed_wait(l, period);
 #else
             boost::chrono::milliseconds period(++wait_count_);
 
-            boost::mutex::scoped_lock l(mtx_);
+            boost::unique_lock<boost::mutex> l(mtx_);
             cond_.wait_for(l, period);
 #endif
 #endif

--- a/hpx/runtime/threads/policies/thread_queue.hpp
+++ b/hpx/runtime/threads/policies/thread_queue.hpp
@@ -210,7 +210,7 @@ namespace hpx { namespace threads { namespace policies
 
             else
             {
-                hpx::util::scoped_unlock<Lock> ull(lk);
+                hpx::util::unlock_guard<Lock> ull(lk);
 
                 // Allocate a new thread object.
                 if (data.stacksize != 0)

--- a/hpx/runtime/threads/policies/thread_queue.hpp
+++ b/hpx/runtime/threads/policies/thread_queue.hpp
@@ -23,8 +23,9 @@
 #   include <hpx/util/tick_counter.hpp>
 #endif
 
-#include <boost/thread/mutex.hpp>
 #include <boost/thread/condition.hpp>
+#include <boost/thread/locks.hpp>
+#include <boost/thread/mutex.hpp>
 #include <boost/atomic.hpp>
 #include <boost/unordered_set.hpp>
 
@@ -492,7 +493,7 @@ namespace hpx { namespace threads { namespace policies
                 bool thread_map_is_empty = false;
                 while (true)
                 {
-                    typename mutex_type::scoped_lock lk(mtx_);
+                    boost::lock_guard<mutex_type> lk(mtx_);
                     if (cleanup_terminated_locked_helper(false))
                     {
                         thread_map_is_empty =
@@ -503,7 +504,7 @@ namespace hpx { namespace threads { namespace policies
                 return thread_map_is_empty;
             }
 
-            typename mutex_type::scoped_lock lk(mtx_);
+            boost::lock_guard<mutex_type> lk(mtx_);
             return cleanup_terminated_locked_helper(false) &&
                 (thread_map_count_ == 0) && (new_tasks_count_ == 0);
         }
@@ -877,7 +878,7 @@ namespace hpx { namespace threads { namespace policies
                 return thread_map_count_ + new_tasks_count_ - terminated_items_count_;
 
             // acquire lock only if absolutely necessary
-            typename mutex_type::scoped_lock lk(mtx_);
+            boost::lock_guard<mutex_type> lk(mtx_);
 
             boost::int64_t num_threads = 0;
             thread_map_type::const_iterator end = thread_map_.end();
@@ -893,7 +894,7 @@ namespace hpx { namespace threads { namespace policies
         ///////////////////////////////////////////////////////////////////////
         void abort_all_suspended_threads()
         {
-            typename mutex_type::scoped_lock lk(mtx_);
+            boost::lock_guard<mutex_type> lk(mtx_);
             thread_map_type::iterator end =  thread_map_.end();
             for (thread_map_type::iterator it = thread_map_.begin();
                  it != end; ++it)
@@ -961,7 +962,7 @@ namespace hpx { namespace threads { namespace policies
             return false;
 #else
             if (minimal_deadlock_detection) {
-                typename mutex_type::scoped_lock lk(mtx_);
+                boost::lock_guard<mutex_type> lk(mtx_);
                 return detail::dump_suspended_threads(num_thread, thread_map_
                   , idle_loop_count, running);
             }

--- a/hpx/runtime/threads/thread.hpp
+++ b/hpx/runtime/threads/thread.hpp
@@ -11,6 +11,7 @@
 #include <hpx/util/move.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 
+#include <boost/thread/locks.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/utility/enable_if.hpp>
 
@@ -58,14 +59,14 @@ namespace hpx
         void swap(thread&) BOOST_NOEXCEPT;
         bool joinable() const BOOST_NOEXCEPT
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             return joinable_locked();
         }
 
         void join();
         void detach()
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             detach_locked();
         }
 
@@ -73,7 +74,7 @@ namespace hpx
 
         native_handle_type native_handle() const
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             return id_;
         }
 

--- a/hpx/runtime/threads/threadmanager_impl.hpp
+++ b/hpx/runtime/threads/threadmanager_impl.hpp
@@ -27,6 +27,7 @@
 #include <boost/ptr_container/ptr_vector.hpp>
 #include <boost/thread.hpp>
 #include <boost/thread/condition.hpp>
+#include <boost/thread/locks.hpp>
 
 #include <vector>
 #include <memory>
@@ -251,13 +252,13 @@ namespace hpx { namespace threads
         /// is running.
         std::size_t get_os_thread_count() const
         {
-            mutex_type::scoped_lock lk(mtx_);
+            boost::lock_guard<mutex_type> lk(mtx_);
             return pool_.get_os_thread_count();
         }
 
         boost::thread& get_os_thread_handle(std::size_t num_thread)
         {
-            mutex_type::scoped_lock lk(mtx_);
+            boost::lock_guard<mutex_type> lk(mtx_);
             return pool_.get_os_thread_handle(num_thread);
         }
 

--- a/hpx/util/assert_owns_lock.hpp
+++ b/hpx/util/assert_owns_lock.hpp
@@ -16,23 +16,23 @@
 namespace hpx { namespace util { namespace detail
 {
     template <typename Lock>
-    void assert_owns_lock(Lock&, int) {}
+    void assert_owns_lock(Lock const&, int) {}
 
 #if !defined(HPX_DISABLE_ASSERTS) && !defined(BOOST_DISABLE_ASSERTS) && !defined(NDEBUG)
     template <typename Mutex>
-    void assert_owns_lock(boost::unique_lock<Mutex>& l, long)
+    void assert_owns_lock(boost::unique_lock<Mutex> const& l, long)
     {
         HPX_ASSERT(l.owns_lock());
     }
 
     template <typename Mutex>
-    void assert_owns_lock(boost::shared_lock<Mutex>& l, long)
+    void assert_owns_lock(boost::shared_lock<Mutex> const& l, long)
     {
         HPX_ASSERT(l.owns_lock());
     }
 
     template <typename Mutex>
-    void assert_owns_lock(boost::upgrade_lock<Mutex>& l, long)
+    void assert_owns_lock(boost::upgrade_lock<Mutex> const& l, long)
     {
         HPX_ASSERT(l.owns_lock());
     }
@@ -40,7 +40,7 @@ namespace hpx { namespace util { namespace detail
 #   if !defined(BOOST_NO_CXX11_DECLTYPE_N3276) && !defined(BOOST_NO_SFINAE_EXPR)
     template <typename Lock>
     decltype(boost::declval<Lock>().owns_lock())
-    assert_owns_lock(Lock& l, long)
+    assert_owns_lock(Lock const& l, long)
     {
         HPX_ASSERT(l.owns_lock());
         return true;
@@ -52,7 +52,7 @@ namespace hpx { namespace util { namespace detail
 #   if !defined(BOOST_NO_CXX11_DECLTYPE_N3276) && !defined(BOOST_NO_SFINAE_EXPR)
     template <typename Lock>
     decltype(boost::declval<Lock>().owns_lock())
-    assert_owns_lock(Lock&, long)
+    assert_owns_lock(Lock const&, long)
     {
         return true;
     }

--- a/hpx/util/connection_cache.hpp
+++ b/hpx/util/connection_cache.hpp
@@ -28,9 +28,10 @@
 #include <stdexcept>
 #include <string>
 
+#include <boost/cstdint.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread.hpp>
-#include <boost/cstdint.hpp>
+#include <boost/thread/locks.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace util
@@ -177,7 +178,7 @@ namespace hpx { namespace util
         ///          \a reclaim().
         connection_type get(key_type const& l)
         {
-            mutex_type::scoped_lock lock(mtx_);
+            boost::lock_guard<mutex_type> lock(mtx_);
 
             // Check if this key already exists in the cache.
             typename cache_type::iterator const it = cache_.find(l);
@@ -234,7 +235,7 @@ namespace hpx { namespace util
         bool get_or_reserve(key_type const& l, connection_type& conn,
             bool force_insert = false)
         {
-            mutex_type::scoped_lock lock(mtx_);
+            boost::lock_guard<mutex_type> lock(mtx_);
 
             typename cache_type::iterator const it = cache_.find(l);
 
@@ -350,7 +351,7 @@ namespace hpx { namespace util
         ///       a prior call to \a get() or \a get_or_reserve().
         void reclaim(key_type const& l, connection_type const& conn)
         {
-            mutex_type::scoped_lock lock(mtx_);
+            boost::lock_guard<mutex_type> lock(mtx_);
 
             // Search for an entry for this key.
             typename cache_type::iterator const ct = cache_.find(l);
@@ -405,7 +406,7 @@ namespace hpx { namespace util
         /// than the maximum number of overall connections, and false otherwise.
         bool full() const
         {
-            mutex_type::scoped_lock lock(mtx_);
+            boost::lock_guard<mutex_type> lock(mtx_);
             return (connections_ >= max_connections_);
         }
 
@@ -413,7 +414,7 @@ namespace hpx { namespace util
         /// than the maximum connection count per locality, and false otherwise.
         bool full(key_type const& l) const
         {
-            mutex_type::scoped_lock lock(mtx_);
+            boost::lock_guard<mutex_type> lock(mtx_);
 
             if (!cache_.count(l))
                 return false || (connections_ >= max_connections_);
@@ -431,7 +432,7 @@ namespace hpx { namespace util
         ///       invariants.
         void clear()
         {
-            mutex_type::scoped_lock lock(mtx_);
+            boost::lock_guard<mutex_type> lock(mtx_);
             key_tracker_.clear();
             cache_.clear();
             connections_ = 0;
@@ -455,7 +456,7 @@ namespace hpx { namespace util
         ///       invariants.
         void clear(key_type const& l)
         {
-            mutex_type::scoped_lock lock(mtx_);
+            boost::lock_guard<mutex_type> lock(mtx_);
 
             // Check if this key already exists in the cache.
             typename cache_type::iterator it = cache_.find(l);
@@ -482,7 +483,7 @@ namespace hpx { namespace util
         /// all associated counts.
         void clear(key_type const& l, connection_type const& conn)
         {
-            mutex_type::scoped_lock lock(mtx_);
+            boost::lock_guard<mutex_type> lock(mtx_);
 
             // Check if this key already exists in the cache.
             typename cache_type::iterator const it = cache_.find(l);
@@ -506,31 +507,31 @@ namespace hpx { namespace util
         // access statistics
         boost::int64_t get_cache_insertions(bool reset)
         {
-            mutex_type::scoped_lock lock(mtx_);
+            boost::lock_guard<mutex_type> lock(mtx_);
             return util::get_and_reset_value(insertions_, reset);
         }
 
         boost::int64_t get_cache_evictions(bool reset)
         {
-            mutex_type::scoped_lock lock(mtx_);
+            boost::lock_guard<mutex_type> lock(mtx_);
             return util::get_and_reset_value(evictions_, reset);
         }
 
         boost::int64_t get_cache_hits(bool reset)
         {
-            mutex_type::scoped_lock lock(mtx_);
+            boost::lock_guard<mutex_type> lock(mtx_);
             return util::get_and_reset_value(hits_, reset);
         }
 
         boost::int64_t get_cache_misses(bool reset)
         {
-            mutex_type::scoped_lock lock(mtx_);
+            boost::lock_guard<mutex_type> lock(mtx_);
             return util::get_and_reset_value(misses_, reset);
         }
 
         boost::int64_t get_cache_reclaims(bool reset)
         {
-            mutex_type::scoped_lock lock(mtx_);
+            boost::lock_guard<mutex_type> lock(mtx_);
             return util::get_and_reset_value(reclaims_, reset);
         }
 

--- a/hpx/util/generate_unique_ids.hpp
+++ b/hpx/util/generate_unique_ids.hpp
@@ -13,8 +13,9 @@
 #include <hpx/util/assert.hpp>
 #include <hpx/util/spinlock.hpp>
 
-#include <boost/thread.hpp>
 #include <boost/cstdint.hpp>
+#include <boost/thread.hpp>
+#include <boost/thread.hpp>
 
 #if defined(BOOST_MSVC)
 #pragma warning(push)
@@ -43,12 +44,11 @@ namespace hpx { namespace util
         /// Generate next unique component id
         naming::gid_type get_id(std::size_t count = 1);
 
-        /// Not thread-safe
         void set_range(
             naming::gid_type const& lower
           , naming::gid_type const& upper)
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             lower_ = lower;
             upper_ = upper;
         }

--- a/hpx/util/interval_timer.hpp
+++ b/hpx/util/interval_timer.hpp
@@ -64,7 +64,7 @@ namespace hpx { namespace util
 
     protected:
         // schedule a high priority task after a given time interval
-        void schedule_thread(mutex_type::scoped_lock & l);
+        void schedule_thread(boost::unique_lock<mutex_type> & l);
 
         threads::thread_state_enum
             evaluate(threads::thread_state_ex_enum statex);

--- a/hpx/util/interval_timer.hpp
+++ b/hpx/util/interval_timer.hpp
@@ -9,6 +9,8 @@
 #include <hpx/hpx_fwd.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 
+#include <boost/thread/locks.hpp>
+
 #include <string>
 #include <vector>
 
@@ -45,18 +47,18 @@ namespace hpx { namespace util
 
         boost::int64_t get_interval() const
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             return microsecs_;
         }
 
         void slow_down(boost::int64_t max_interval)
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             microsecs_ = (std::min)((110 * microsecs_) / 100, max_interval);
         }
         void speed_up(boost::int64_t min_interval)
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             microsecs_ = (std::max)((90 * microsecs_) / 100, min_interval);
         }
 

--- a/hpx/util/lightweight_test.hpp
+++ b/hpx/util/lightweight_test.hpp
@@ -18,6 +18,7 @@
 #include <boost/config.hpp>
 #include <boost/current_function.hpp>
 #include <boost/preprocessor/stringize.hpp>
+#include <boost/thread/locks.hpp>
 
 // Use smart_ptr's spinlock header because this header is used by the CMake
 // config tests, and therefore we can't include other hpx headers in this file.
@@ -86,7 +87,7 @@ struct fixture
     {
         if (!t)
         {
-            mutex_type::scoped_lock l(mutex_);
+            boost::lock_guard<mutex_type> l(mutex_);
             boost::io::ios_flags_saver ifs(stream_);
             stream_
                 << file << "(" << line << "): "
@@ -104,7 +105,7 @@ struct fixture
     {
         if (!(t == u))
         {
-            mutex_type::scoped_lock l(mutex_);
+            boost::lock_guard<mutex_type> l(mutex_);
             boost::io::ios_flags_saver ifs(stream_);
             stream_
                 << file << "(" << line << "): " << msg
@@ -123,7 +124,7 @@ struct fixture
     {
         if (!(t != u))
         {
-            mutex_type::scoped_lock l(mutex_);
+            boost::lock_guard<mutex_type> l(mutex_);
             boost::io::ios_flags_saver ifs(stream_);
             stream_
                 << file << "(" << line << "): " << msg
@@ -141,7 +142,7 @@ struct fixture
     {
         if (!(t < u))
         {
-            mutex_type::scoped_lock l(mutex_);
+            boost::lock_guard<mutex_type> l(mutex_);
             boost::io::ios_flags_saver ifs(stream_);
             stream_
                 << file << "(" << line << "): " << msg
@@ -160,7 +161,7 @@ struct fixture
     {
         if (!(t <= u))
         {
-            mutex_type::scoped_lock l(mutex_);
+            boost::lock_guard<mutex_type> l(mutex_);
             boost::io::ios_flags_saver ifs(stream_);
             stream_
                 << file << "(" << line << "): " << msg
@@ -179,7 +180,7 @@ struct fixture
     {
         if (!(t >= u && t <= v))
         {
-            mutex_type::scoped_lock l(mutex_);
+            boost::lock_guard<mutex_type> l(mutex_);
             boost::io::ios_flags_saver ifs(stream_);
             if (!(t >= u))
             {

--- a/hpx/util/logging/format/destination/file.hpp
+++ b/hpx/util/logging/format/destination/file.hpp
@@ -29,10 +29,11 @@
 #include <hpx/util/logging/detail/fwd.hpp>
 #include <hpx/util/logging/detail/manipulator.hpp>
 #include <hpx/util/logging/format/destination/convert_destination.hpp>
-
-#include <fstream>
 #include <boost/config.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/thread/locks.hpp>
+
+#include <fstream>
 
 namespace hpx { namespace util { namespace logging { namespace destination {
 
@@ -114,7 +115,7 @@ struct file_t : is_generic, non_const_context<detail::file_info>
     template <class msg_type>
     void operator()(const msg_type & msg) const
     {
-        typename mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
 
         if (!non_const_context_base::context().out)
             non_const_context_base::context().open();   // make sure file is opened

--- a/hpx/util/memory_chunk.hpp
+++ b/hpx/util/memory_chunk.hpp
@@ -7,8 +7,9 @@
 #define HPX_UTIL_MEMORY_CHUNK_HPP
 
 #include <hpx/config.hpp>
-
 #include <hpx/lcos/local/spinlock.hpp>
+
+#include <boost/thread/locks.hpp>
 
 namespace hpx { namespace util
 {
@@ -77,7 +78,7 @@ namespace hpx { namespace util
 
         bool full() const
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             check_invariants_locked();
             if(allocated_ == chunk_size_)
             {
@@ -88,7 +89,7 @@ namespace hpx { namespace util
 
         bool contains(char * p) const
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             return contains_locked(p);
         }
 
@@ -105,7 +106,7 @@ namespace hpx { namespace util
         void check_invariants(char * p = 0, std::size_t size = 0) const
         {
 #ifdef HPX_DEBUG
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             check_invariants_locked(p, size);
 #endif
         }
@@ -142,7 +143,7 @@ namespace hpx { namespace util
 
         char *allocate(size_type size)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             check_invariants_locked();
 
             if(!data_) charge();
@@ -193,7 +194,7 @@ namespace hpx { namespace util
 
         bool deallocate(char * p, size_type size)
         {
-            typename mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             HPX_ASSERT(data_);
             if(!contains_locked(p))
                 return false;

--- a/hpx/util/memory_chunk_pool.hpp
+++ b/hpx/util/memory_chunk_pool.hpp
@@ -12,6 +12,8 @@
 #include <hpx/traits/is_chunk_allocator.hpp>
 #include <hpx/util/memory_chunk.hpp>
 #include <hpx/util/memory_chunk_pool_allocator.hpp>
+
+#include <boost/thread/locks.hpp>
 //
 #include <cstdlib>
 #include <vector>
@@ -124,7 +126,7 @@ namespace hpx { namespace util
             }
 
             {
-                typename mutex_type::scoped_lock l(backup_chunks_mtx_);
+                boost::lock_guard<mutex_type> l(backup_chunks_mtx_);
                 typename backup_chunks_type::iterator it =
                     backup_chunks_.lower_bound(size);
 
@@ -177,7 +179,7 @@ namespace hpx { namespace util
             }
             else
             {
-                typename mutex_type::scoped_lock l(backup_chunks_mtx_);
+                boost::lock_guard<mutex_type> l(backup_chunks_mtx_);
                 if(backup_size_ <= backup_threshold_)
                 {
                     backup_size_ += size;

--- a/hpx/util/one_size_heap_list.hpp
+++ b/hpx/util/one_size_heap_list.hpp
@@ -123,7 +123,7 @@ namespace hpx { namespace util
                         bool allocated = false;
 
                         {
-                            util::scoped_unlock<unique_lock_type> ul(guard);
+                            util::unlock_guard<unique_lock_type> ul(guard);
                             allocated = heap->alloc(&p, count);
                         }
 
@@ -169,7 +169,7 @@ namespace hpx { namespace util
                 bool result = false;
 
                 {
-                    util::scoped_unlock<unique_lock_type> ul(guard);
+                    util::unlock_guard<unique_lock_type> ul(guard);
                     result = heap->alloc(&p, count);
                 }
 
@@ -272,7 +272,7 @@ namespace hpx { namespace util
                 bool did_allocate = false;
 
                 {
-                    util::scoped_unlock<unique_lock_type> ull(ul);
+                    util::unlock_guard<unique_lock_type> ull(ul);
                     did_allocate = heap->did_alloc(p);
                     if (did_allocate)
                         heap->free(p, count);
@@ -303,7 +303,7 @@ namespace hpx { namespace util
                 bool did_allocate = false;
 
                 {
-                    util::scoped_unlock<unique_lock_type> ull(ul);
+                    util::unlock_guard<unique_lock_type> ull(ul);
                     did_allocate = heap->did_alloc(p);
                 }
 

--- a/hpx/util/plugin/detail/dll_dlopen.hpp
+++ b/hpx/util/plugin/detail/dll_dlopen.hpp
@@ -18,6 +18,7 @@
 #include <boost/type_traits/remove_pointer.hpp>
 #include <boost/type_traits/is_pointer.hpp>
 #include <boost/thread.hpp>
+#include <boost/thread/locks.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/convenience.hpp>
 #include <boost/throw_exception.hpp>
@@ -114,7 +115,7 @@ namespace hpx { namespace util { namespace plugin {
                 if (NULL != h_)
                 {
                     dll::initialize_mutex();
-                    boost::mutex::scoped_lock lock(dll::mutex_instance());
+                    boost::lock_guard<boost::mutex> lock(dll::mutex_instance());
 
                     dll::deinit_library(h_);
                     dlerror();
@@ -207,7 +208,7 @@ namespace hpx { namespace util { namespace plugin {
             if (ec) return std::pair<SymbolType, Deleter>();
 
             initialize_mutex();
-            boost::mutex::scoped_lock lock(mutex_instance());
+            boost::lock_guard<boost::mutex> lock(mutex_instance());
 
             BOOST_STATIC_ASSERT(boost::is_pointer<SymbolType>::value);
 
@@ -270,7 +271,7 @@ namespace hpx { namespace util { namespace plugin {
         {
             if (!dll_handle || force) {
                 initialize_mutex();
-                boost::mutex::scoped_lock lock(mutex_instance());
+                boost::lock_guard<boost::mutex> lock(mutex_instance());
 
                 ::dlerror();                // Clear the error state.
                 dll_handle = MyLoadLibrary((dll_name.empty() ? NULL : dll_name.c_str()));
@@ -352,7 +353,7 @@ namespace hpx { namespace util { namespace plugin {
             if (NULL != dll_handle)
             {
                 initialize_mutex();
-                boost::mutex::scoped_lock lock(mutex_instance());
+                boost::lock_guard<boost::mutex> lock(mutex_instance());
 
                 deinit_library(dll_handle);
                 dlerror();

--- a/hpx/util/unlock_guard.hpp
+++ b/hpx/util/unlock_guard.hpp
@@ -1,0 +1,43 @@
+//  Copyright (c) 2007-2008 Chirag Dekate, Hartmut Kaiser
+//  Copyright (c) 2015 Agustin Berge
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_UTIL_UNLOCK_GUARD_HPP
+#define HPX_UTIL_UNLOCK_GUARD_HPP
+
+#include <hpx/config.hpp>
+#include <hpx/config/emulate_deleted.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace util
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // This is a helper structure to make sure a lock gets unlocked and locked
+    // again in a scope.
+    template <typename Mutex>
+    class unlock_guard
+    {
+        HPX_NON_COPYABLE(unlock_guard);
+
+    public:
+        typedef Mutex mutex_type;
+
+        explicit unlock_guard(Mutex& m)
+          : m_(m)
+        {
+            m_.unlock();
+        }
+
+        ~unlock_guard()
+        {
+            m_.lock();
+        }
+
+    private:
+        Mutex& m_;
+    };
+}}
+
+#endif

--- a/plugins/parcel/coalescing/coalescing_message_handler.cpp
+++ b/plugins/parcel/coalescing/coalescing_message_handler.cpp
@@ -12,6 +12,7 @@
 #include <hpx/plugins/parcel/coalescing_message_handler.hpp>
 
 #include <boost/lexical_cast.hpp>
+#include <boost/thread/locks.hpp>
 
 namespace hpx { namespace traits
 {
@@ -80,7 +81,7 @@ namespace hpx { namespace plugins { namespace parcel
         parcelset::locality const & dest, parcelset::parcel& p,
         write_handler_type const& f)
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::unique_lock<mutex_type> l(mtx_);
         if (stopped_) {
             l.unlock();
 

--- a/plugins/parcel/coalescing/coalescing_message_handler.cpp
+++ b/plugins/parcel/coalescing/coalescing_message_handler.cpp
@@ -119,7 +119,7 @@ namespace hpx { namespace plugins { namespace parcel
     bool coalescing_message_handler::timer_flush()
     {
         // adjust timer if needed
-        mutex_type::scoped_lock l(mtx_);
+        boost::unique_lock<mutex_type> l(mtx_);
         if (!buffer_.empty())
             flush(l, false);
 
@@ -129,13 +129,16 @@ namespace hpx { namespace plugins { namespace parcel
 
     bool coalescing_message_handler::flush(bool stop_buffering)
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::unique_lock<mutex_type> l(mtx_);
         return flush(l, stop_buffering);
     }
 
-    bool coalescing_message_handler::flush(mutex_type::scoped_lock& l,
+    bool coalescing_message_handler::flush(
+        boost::unique_lock<mutex_type>& l,
         bool stop_buffering)
     {
+        HPX_ASSERT(l.owns_lock());
+
         if (!stopped_ && stop_buffering) {
             stopped_ = true;
             l.unlock();

--- a/plugins/parcelport/ipc/connection_handler_ipc.cpp
+++ b/plugins/parcelport/ipc/connection_handler_ipc.cpp
@@ -20,6 +20,7 @@
 #include <boost/asio/placeholders.hpp>
 #include <boost/assign/std/vector.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/thread/locks.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx
@@ -141,7 +142,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace ipc
     {
         {
             // cancel all pending read operations, close those sockets
-            lcos::local::spinlock::scoped_lock l(mtx_);
+            boost::lock_guard<hpx::lcos::local::spinlock> l(mtx_);
             for (boost::shared_ptr<receiver> const& c : accepted_connections_)
             {
                 boost::system::error_code ec;
@@ -259,7 +260,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace ipc
 
             {
                 // keep track of all the accepted connections
-                lcos::local::spinlock::scoped_lock l(mtx_);
+                boost::lock_guard<hpx::lcos::local::spinlock> l(mtx_);
                 accepted_connections_.insert(c);
             }
 
@@ -270,7 +271,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace ipc
         }
         else {
             // remove this connection from the list of known connections
-            lcos::local::spinlock::scoped_lock l(mtx_);
+            boost::lock_guard<hpx::lcos::local::spinlock> l(mtx_);
             accepted_connections_.erase(receiver_conn);
         }
     }
@@ -293,7 +294,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace ipc
 //         if (e != boost::asio::error::eof)
         {
             // remove this connection from the list of known connections
-            lcos::local::spinlock::scoped_lock l(mtx_);
+            boost::lock_guard<hpx::lcos::local::spinlock> l(mtx_);
             accepted_connections_.erase(receiver_conn);
         }
     }

--- a/plugins/parcelport/tcp/connection_handler_tcp.cpp
+++ b/plugins/parcelport/tcp/connection_handler_tcp.cpp
@@ -20,6 +20,7 @@
 #include <boost/io/ios_state.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/thread/locks.hpp>
 
 namespace hpx { namespace parcelset { namespace policies { namespace tcp
 {
@@ -113,7 +114,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
     {
         {
             // cancel all pending read operations, close those sockets
-            lcos::local::spinlock::scoped_lock l(connections_mtx_);
+            boost::lock_guard<lcos::local::spinlock> l(connections_mtx_);
             for (boost::shared_ptr<receiver> const& c : accepted_connections_)
             {
                 c->shutdown();
@@ -211,7 +212,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
 
 #if defined(HPX_HOLDON_TO_OUTGOING_CONNECTIONS)
         {
-            lcos::local::spinlock::scoped_lock lock(connections_mtx_);
+            boost::lock_guard<lcos::local::spinlock> lock(connections_mtx_);
             write_connections_.insert(sender_connection);
         }
 #endif
@@ -279,7 +280,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
 
             {
                 // keep track of all accepted connections
-                lcos::local::spinlock::scoped_lock l(connections_mtx_);
+                boost::lock_guard<lcos::local::spinlock> l(connections_mtx_);
                 accepted_connections_.insert(c);
             }
 
@@ -298,7 +299,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
         else
         {
             // remove this connection from the list of known connections
-            lcos::local::spinlock::scoped_lock l(mtx_);
+            boost::lock_guard<lcos::local::spinlock> l(mtx_);
             accepted_connections_.erase(receiver_conn);
         }
     }
@@ -321,7 +322,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
 //         if (e != boost::asio::error::eof)
         {
             // remove this connection from the list of known connections
-            lcos::local::spinlock::scoped_lock l(connections_mtx_);
+            boost::lock_guard<lcos::local::spinlock> l(connections_mtx_);
             accepted_connections_.erase(receiver_conn);
         }
     }

--- a/src/exception_list.cpp
+++ b/src/exception_list.cpp
@@ -130,7 +130,7 @@ namespace hpx
         {
             hpx::exception ex;
             {
-                util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+                util::unlock_guard<boost::unique_lock<mutex_type> > ul(l);
                 ex = hpx::exception(hpx::get_error(e));
             }
 

--- a/src/exception_list.cpp
+++ b/src/exception_list.cpp
@@ -125,12 +125,12 @@ namespace hpx
 
     void exception_list::add(boost::exception_ptr const& e)
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::unique_lock<mutex_type> l(mtx_);
         if (exceptions_.empty())
         {
             hpx::exception ex;
             {
-                util::scoped_unlock<mutex_type::scoped_lock> ul(l);
+                util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
                 ex = hpx::exception(hpx::get_error(e));
             }
 

--- a/src/exception_list.cpp
+++ b/src/exception_list.cpp
@@ -6,6 +6,8 @@
 #include <hpx/hpx_fwd.hpp>
 #include <hpx/exception_list.hpp>
 
+#include <boost/thread/locks.hpp>
+
 #include <set>
 
 namespace hpx
@@ -93,7 +95,7 @@ namespace hpx
     ///////////////////////////////////////////////////////////////////////////
     boost::system::error_code exception_list::get_error() const
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
         if (exceptions_.empty())
             return hpx::no_success;
         return hpx::get_error(exceptions_.front());
@@ -101,7 +103,7 @@ namespace hpx
 
     std::string exception_list::get_message() const
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
         if (exceptions_.empty())
             return "";
 

--- a/src/performance_counters/server/arithmetics_counter.cpp
+++ b/src/performance_counters/server/arithmetics_counter.cpp
@@ -14,6 +14,7 @@
 #include <hpx/performance_counters/server/arithmetics_counter.hpp>
 
 #include <boost/algorithm/string.hpp>
+#include <boost/thread/locks.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace performance_counters { namespace server
@@ -75,7 +76,7 @@ namespace hpx { namespace performance_counters { namespace server
         // lock here to avoid checking out multiple reference counted GIDs
         // from AGAS
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
 
             for (std::size_t i = 0; i != base_counter_names_.size(); ++i)
             {
@@ -125,7 +126,7 @@ namespace hpx { namespace performance_counters { namespace server
     template <typename Operation>
     bool arithmetics_counter<Operation>::start()
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
         for (std::size_t i = 0; i != base_counter_names_.size(); ++i)
         {
             if (!base_counter_ids_[i] &&
@@ -156,7 +157,7 @@ namespace hpx { namespace performance_counters { namespace server
     template <typename Operation>
     bool arithmetics_counter<Operation>::stop()
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
         for (std::size_t i = 0; i != base_counter_names_.size(); ++i)
         {
             if (!base_counter_ids_[i] &&
@@ -187,7 +188,7 @@ namespace hpx { namespace performance_counters { namespace server
     template <typename Operation>
     void arithmetics_counter<Operation>::reset_counter_value()
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
         for (std::size_t i = 0; i != base_counter_names_.size(); ++i)
         {
             if (!base_counter_ids_[i] &&

--- a/src/performance_counters/server/statistics_counter.cpp
+++ b/src/performance_counters/server/statistics_counter.cpp
@@ -15,6 +15,7 @@
 
 #include <boost/version.hpp>
 #include <boost/chrono/chrono.hpp>
+#include <boost/thread/locks.hpp>
 
 #define BOOST_SPIRIT_USE_PHOENIX_V3
 #include <boost/spirit/include/qi_char.hpp>
@@ -55,7 +56,7 @@ namespace hpx { namespace performance_counters { namespace server
     hpx::performance_counters::counter_value
         statistics_counter<Statistic>::get_counter_value(bool reset)
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
 
         hpx::performance_counters::counter_value value;
 
@@ -96,7 +97,7 @@ namespace hpx { namespace performance_counters { namespace server
             return false;
         }
         else {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             (*value_)(static_cast<double>(base_value.value_));          // accumulate new value
         }
         return true;
@@ -107,7 +108,7 @@ namespace hpx { namespace performance_counters { namespace server
     {
         // lock here to avoid checking out multiple reference counted GIDs
         // from AGAS
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
 
         if (!base_counter_id_) {
             // get or create the base counter
@@ -158,7 +159,7 @@ namespace hpx { namespace performance_counters { namespace server
                 counter_value base_value;
                 if (evaluate_base_counter(base_value))
                 {
-                    mutex_type::scoped_lock l(mtx_);
+                    boost::lock_guard<mutex_type> l(mtx_);
                     (*value_)(static_cast<double>(base_value.value_));
                     prev_value_ = base_value;
                 }
@@ -187,7 +188,7 @@ namespace hpx { namespace performance_counters { namespace server
     template <typename Statistic>
     void statistics_counter<Statistic>::reset_counter_value()
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
 
         value_.reset(detail::counter_type_from_statistic<Statistic>::create(
             parameter2_)); // reset accumulator

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -542,7 +542,7 @@ parcelset::endpoints_type const & addressing_service::resolve_locality(
   , error_code& ec
     )
 { // {{{
-    mutex_type::scoped_lock l(resolved_localities_mtx_);
+    boost::unique_lock<mutex_type> l(resolved_localities_mtx_);
     resolved_localities_type::iterator it = resolved_localities_.find(gid);
     if(it == resolved_localities_.end())
     {
@@ -565,7 +565,7 @@ parcelset::endpoints_type const & addressing_service::resolve_locality(
         else
         {
             {
-                hpx::util::scoped_unlock<mutex_type::scoped_lock> ul(l);
+                hpx::util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
                 future<parcelset::endpoints_type> endpoints_future =
                     hosted->locality_ns_.service_async<parcelset::endpoints_type>(
                         req
@@ -1979,7 +1979,7 @@ void addressing_service::decref(
 
     try {
         naming::gid_type raw = naming::detail::get_stripped_gid(gid);
-        mutex_type::scoped_lock l(refcnt_requests_mtx_);
+        boost::unique_lock<mutex_type> l(refcnt_requests_mtx_);
 
         // Match the decref request with entries in the incref table
         typedef refcnt_requests_type::iterator iterator;

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -565,7 +565,7 @@ parcelset::endpoints_type const & addressing_service::resolve_locality(
         else
         {
             {
-                hpx::util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+                hpx::util::unlock_guard<boost::unique_lock<mutex_type> > ul(l);
                 future<parcelset::endpoints_type> endpoints_future =
                     hosted->locality_ns_.service_async<parcelset::endpoints_type>(
                         req

--- a/src/runtime/agas/big_boot_barrier.cpp
+++ b/src/runtime/agas/big_boot_barrier.cpp
@@ -41,6 +41,7 @@
 #include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/thread/locks.hpp>
 
 #include <sstream>
 
@@ -966,7 +967,7 @@ void big_boot_barrier::wait_hosted(
 
 void big_boot_barrier::notify()
 {
-    boost::mutex::scoped_lock lk(mtx, boost::adopt_lock);
+    boost::lock_guard<boost::mutex> lk(mtx, boost::adopt_lock);
     --connected;
     cond.notify_all();
 }

--- a/src/runtime/agas/big_boot_barrier.cpp
+++ b/src/runtime/agas/big_boot_barrier.cpp
@@ -811,7 +811,7 @@ void notify_worker_security(notification_header_security const& header)
 ///////////////////////////////////////////////////////////////////////////////
 void big_boot_barrier::spin()
 {
-    boost::mutex::scoped_lock lock(mtx);
+    boost::unique_lock<boost::mutex> lock(mtx);
     while (connected)
         cond.wait(lock);
 }

--- a/src/runtime/agas/server/component_namespace_server.cpp
+++ b/src/runtime/agas/server/component_namespace_server.cpp
@@ -14,6 +14,8 @@
 #include <hpx/include/performance_counters.hpp>
 #include <hpx/util/get_and_reset_value.hpp>
 
+#include <boost/thread/locks.hpp>
+
 // TODO: Remove the use of the name "prefix"
 
 namespace hpx { namespace agas
@@ -452,7 +454,7 @@ response component_namespace::resolve_id(
     if (key != components::get_base_type(key))
         key = components::get_derived_type(key);
 
-    mutex_type::scoped_lock l(mutex_);
+    boost::lock_guard<mutex_type> l(mutex_);
 
     factory_table_type::const_iterator it = factories_.find(key)
                                      , end = factories_.end();
@@ -502,7 +504,7 @@ response component_namespace::unbind(
     // parameters
     std::string key = req.get_name();
 
-    mutex_type::scoped_lock l(mutex_);
+    boost::lock_guard<mutex_type> l(mutex_);
 
     component_id_table_type::left_map::iterator it = component_ids_.left.find(key);
 
@@ -542,7 +544,7 @@ response component_namespace::iterate_types(
 { // {{{ iterate implementation
     iterate_types_function_type f = req.get_iterate_types_function();
 
-    mutex_type::scoped_lock l(mutex_);
+    boost::lock_guard<mutex_type> l(mutex_);
 
     for (component_id_table_type::left_map::iterator it = component_ids_.left.begin()
                                          , end = component_ids_.left.end();
@@ -579,7 +581,7 @@ response component_namespace::get_component_type_name(
 { // {{{ get_component_type_name implementation
     components::component_type t = req.get_component_type();
 
-    mutex_type::scoped_lock l(mutex_);
+    boost::lock_guard<mutex_type> l(mutex_);
 
     std::string result;
 
@@ -629,7 +631,7 @@ response component_namespace::get_num_localities(
     if (key != components::get_base_type(key))
         key = components::get_derived_type(key);
 
-    mutex_type::scoped_lock l(mutex_);
+    boost::lock_guard<mutex_type> l(mutex_);
 
     factory_table_type::const_iterator it = factories_.find(key)
                                      , end = factories_.end();

--- a/src/runtime/agas/server/component_namespace_server.cpp
+++ b/src/runtime/agas/server/component_namespace_server.cpp
@@ -303,7 +303,7 @@ response component_namespace::bind_prefix(
     std::string key = req.get_name();
     boost::uint32_t prefix = req.get_locality_id();
 
-    mutex_type::scoped_lock l(mutex_);
+    boost::unique_lock<mutex_type> l(mutex_);
 
     component_id_table_type::left_map::iterator cit = component_ids_.left.find(key)
                                     , cend = component_ids_.left.end();
@@ -405,7 +405,7 @@ response component_namespace::bind_name(
     // parameters
     std::string key = req.get_name();
 
-    mutex_type::scoped_lock l(mutex_);
+    boost::unique_lock<mutex_type> l(mutex_);
 
     component_id_table_type::left_map::iterator it = component_ids_.left.find(key)
                                     , end = component_ids_.left.end();

--- a/src/runtime/agas/server/locality_namespace_server.cpp
+++ b/src/runtime/agas/server/locality_namespace_server.cpp
@@ -311,7 +311,7 @@ response locality_namespace::allocate(
     boost::uint32_t const num_threads = req.get_num_threads();
     naming::gid_type const suggested_prefix = req.get_suggested_prefix();
 
-    mutex_type::scoped_lock l(mutex_);
+    boost::unique_lock<mutex_type> l(mutex_);
 
 #if defined(HPX_DEBUG)
     for (partition_table_type::value_type const& partition : partitions_)
@@ -436,7 +436,7 @@ response locality_namespace::free(
     naming::gid_type locality = req.get_gid();
     boost::uint32_t prefix = naming::get_locality_id_from_gid(locality);
 
-    mutex_type::scoped_lock l(mutex_);
+    boost::unique_lock<mutex_type> l(mutex_);
 
     partition_table_type::iterator pit = partitions_.find(prefix)
                                  , pend = partitions_.end();

--- a/src/runtime/agas/server/locality_namespace_server.cpp
+++ b/src/runtime/agas/server/locality_namespace_server.cpp
@@ -19,6 +19,7 @@
 #include <list>
 
 #include <boost/fusion/include/at_c.hpp>
+#include <boost/thread/locks.hpp>
 
 namespace hpx { namespace agas
 {
@@ -412,7 +413,7 @@ response locality_namespace::resolve_locality(
     using boost::fusion::at_c;
     boost::uint32_t prefix = naming::get_locality_id_from_gid(req.get_gid());
 
-    mutex_type::scoped_lock l(mutex_);
+    boost::lock_guard<mutex_type> l(mutex_);
     partition_table_type::iterator it = partitions_.find(prefix);
 
     if(it != partitions_.end())
@@ -495,7 +496,7 @@ response locality_namespace::localities(
 { // {{{ localities implementation
     using boost::fusion::at_c;
 
-    mutex_type::scoped_lock l(mutex_);
+    boost::lock_guard<mutex_type> l(mutex_);
 
     std::vector<boost::uint32_t> p;
 
@@ -522,7 +523,7 @@ response locality_namespace::resolved_localities(
 { // {{{ localities implementation
     using boost::fusion::at_c;
 
-    mutex_type::scoped_lock l(mutex_);
+    boost::lock_guard<mutex_type> l(mutex_);
 
     std::map<naming::gid_type, parcelset::endpoints_type> localities;
 
@@ -554,7 +555,7 @@ response locality_namespace::get_num_localities(
   , error_code& ec
     )
 { // {{{ get_num_localities implementation
-    mutex_type::scoped_lock l(mutex_);
+    boost::lock_guard<mutex_type> l(mutex_);
 
     boost::uint32_t num_localities =
         static_cast<boost::uint32_t>(partitions_.size());
@@ -574,7 +575,7 @@ response locality_namespace::get_num_threads(
   , error_code& ec
     )
 { // {{{ get_num_threads implementation
-    mutex_type::scoped_lock l(mutex_);
+    boost::lock_guard<mutex_type> l(mutex_);
 
     std::vector<boost::uint32_t> num_threads;
 

--- a/src/runtime/agas/server/primary_namespace_server.cpp
+++ b/src/runtime/agas/server/primary_namespace_server.cpp
@@ -378,7 +378,7 @@ response primary_namespace::begin_migration(
 
     naming::gid_type id = req.get_gid();
 
-    mutex_type::scoped_lock l(mutex_);
+    boost::unique_lock<mutex_type> l(mutex_);
 
     resolved_type r = resolve_gid_locked(id, ec);
     if (at_c<0>(r) == naming::invalid_gid)
@@ -468,7 +468,7 @@ response primary_namespace::bind_gid(
 
     naming::detail::strip_internal_bits_from_gid(id);
 
-    mutex_type::scoped_lock l(mutex_);
+    boost::unique_lock<mutex_type> l(mutex_);
 
     gva_table_type::iterator it = gvas_.lower_bound(id)
                            , begin = gvas_.begin()
@@ -680,7 +680,7 @@ response primary_namespace::unbind_gid(
     naming::gid_type id = req.get_gid();
     naming::detail::strip_internal_bits_from_gid(id);
 
-    mutex_type::scoped_lock l(mutex_);
+    boost::unique_lock<mutex_type> l(mutex_);
 
     gva_table_type::iterator it = gvas_.find(id)
                            , end = gvas_.end();

--- a/src/runtime/agas/server/primary_namespace_server.cpp
+++ b/src/runtime/agas/server/primary_namespace_server.cpp
@@ -420,7 +420,7 @@ response primary_namespace::end_migration(
 {
     naming::gid_type id = req.get_gid();
 
-    mutex_type::scoped_lock l(mutex_);
+    boost::lock_guard<mutex_type> l(mutex_);
 
     migration_table_type::iterator it = migrating_objects_.find(id);
     if (it == migrating_objects_.end())

--- a/src/runtime/agas/server/route.cpp
+++ b/src/runtime/agas/server/route.cpp
@@ -32,7 +32,7 @@ namespace hpx { namespace agas { namespace server
         // resolve destination addresses, we should be able to resolve all of
         // them, otherwise it's an error
         {
-            mutex_type::scoped_lock l(mutex_);
+            boost::unique_lock<mutex_type> l(mutex_);
 
             cache_addresses.reserve(size);
             for (std::size_t i = 0; i != size; ++i)

--- a/src/runtime/agas/server/symbol_namespace_server.cpp
+++ b/src/runtime/agas/server/symbol_namespace_server.cpp
@@ -297,7 +297,7 @@ response symbol_namespace::bind(
     std::string key = req.get_name();
     naming::gid_type gid = req.get_gid();
 
-    mutex_type::scoped_lock l(mutex_);
+    boost::unique_lock<mutex_type> l(mutex_);
 
     gid_table_type::iterator it = gids_.find(key);
     gid_table_type::iterator end = gids_.end();
@@ -393,7 +393,7 @@ response symbol_namespace::bind(
             boost::shared_ptr<naming::gid_type> current_gid = gid_it->second;
 
             {
-                util::scoped_unlock<mutex_type::scoped_lock> ul(l);
+                util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
 
                 // split the credit as the receiving end will expect to keep the
                 // object alive
@@ -426,7 +426,7 @@ response symbol_namespace::resolve(
     // parameters
     std::string key = req.get_name();
 
-    mutex_type::scoped_lock l(mutex_);
+    boost::unique_lock<mutex_type> l(mutex_);
 
     gid_table_type::iterator it = gids_.find(key);
     gid_table_type::iterator end = gids_.end();
@@ -508,7 +508,7 @@ response symbol_namespace::iterate(
 { // {{{ iterate implementation
     iterate_names_function_type f = req.get_iterate_names_function();
 
-    mutex_type::scoped_lock l(mutex_);
+    boost::unique_lock<mutex_type> l(mutex_);
 
     for (gid_table_type::iterator it = gids_.begin(); it != gids_.end(); ++it)
     {
@@ -516,7 +516,7 @@ response symbol_namespace::iterate(
         naming::gid_type gid = *(it->second);
 
         {
-            util::scoped_unlock<mutex_type::scoped_lock> ul(l);
+            util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
             f(key, gid);
         }
 
@@ -550,7 +550,7 @@ response symbol_namespace::on_event(
         return response(symbol_ns_on_event, no_success);
     }
 
-    mutex_type::scoped_lock l(mutex_);
+    boost::unique_lock<mutex_type> l(mutex_);
 
     bool handled = false;
     if (call_for_past_events)
@@ -564,7 +564,7 @@ response symbol_namespace::on_event(
             // split the credit as the receiving end will expect to keep the
             // object alive
             {
-                util::scoped_unlock<mutex_type::scoped_lock> ul(l);
+                util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
                 naming::gid_type new_gid = naming::detail::split_gid_if_needed(
                     *current_gid);
 

--- a/src/runtime/agas/server/symbol_namespace_server.cpp
+++ b/src/runtime/agas/server/symbol_namespace_server.cpp
@@ -16,6 +16,7 @@
 #include <hpx/util/get_and_reset_value.hpp>
 
 #include <boost/make_shared.hpp>
+#include <boost/thread/locks.hpp>
 
 namespace hpx { namespace agas
 {
@@ -468,7 +469,7 @@ response symbol_namespace::unbind(
     // parameters
     std::string key = req.get_name();
 
-    mutex_type::scoped_lock l(mutex_);
+    boost::lock_guard<mutex_type> l(mutex_);
 
     gid_table_type::iterator it = gids_.find(key);
     gid_table_type::iterator end = gids_.end();

--- a/src/runtime/agas/server/symbol_namespace_server.cpp
+++ b/src/runtime/agas/server/symbol_namespace_server.cpp
@@ -393,7 +393,7 @@ response symbol_namespace::bind(
             boost::shared_ptr<naming::gid_type> current_gid = gid_it->second;
 
             {
-                util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+                util::unlock_guard<boost::unique_lock<mutex_type> > ul(l);
 
                 // split the credit as the receiving end will expect to keep the
                 // object alive
@@ -516,7 +516,7 @@ response symbol_namespace::iterate(
         naming::gid_type gid = *(it->second);
 
         {
-            util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+            util::unlock_guard<boost::unique_lock<mutex_type> > ul(l);
             f(key, gid);
         }
 
@@ -564,7 +564,7 @@ response symbol_namespace::on_event(
             // split the credit as the receiving end will expect to keep the
             // object alive
             {
-                util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+                util::unlock_guard<boost::unique_lock<mutex_type> > ul(l);
                 naming::gid_type new_gid = naming::detail::split_gid_if_needed(
                     *current_gid);
 

--- a/src/runtime/components/console_logging.cpp
+++ b/src/runtime/components/console_logging.cpp
@@ -19,6 +19,7 @@
 #include <hpx/util/reinitializable_static.hpp>
 
 #include <boost/fusion/include/at_c.hpp>
+#include <boost/thread/locks.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace components
@@ -108,7 +109,7 @@ namespace hpx { namespace components
             // queue up the new message and log it with the rest of it
             messages_type msgs;
             {
-                queue_mutex_type::scoped_lock l(queue_mtx_);
+                boost::lock_guard<queue_mutex_type> l(queue_mtx_);
                 queue_.push_back(msg);
                 queue_.swap(msgs);
             }
@@ -124,7 +125,7 @@ namespace hpx { namespace components
             std::size_t size = 0;
 
             {
-                queue_mutex_type::scoped_lock l(queue_mtx_);
+                boost::lock_guard<queue_mutex_type> l(queue_mtx_);
                 queue_.push_back(msg);
                 size = queue_.size();
             }
@@ -143,7 +144,7 @@ namespace hpx { namespace components
             if (!naming::get_agas_client().is_console())
             {
                 // queue it for delivery to the console
-                queue_mutex_type::scoped_lock l(queue_mtx_);
+                boost::lock_guard<queue_mutex_type> l(queue_mtx_);
                 queue_.push_back(msg);
             }
             else
@@ -166,7 +167,7 @@ namespace hpx { namespace components
         {
             messages_type msgs;
             {
-                queue_mutex_type::scoped_lock l(queue_mtx_);
+                boost::lock_guard<queue_mutex_type> l(queue_mtx_);
                 if (queue_.empty())
                     return;         // some other thread did the deed
                 queue_.swap(msgs);
@@ -219,7 +220,7 @@ namespace hpx { namespace components
 
         try {
             {
-                queue_mutex_type::scoped_lock l(queue_mtx_);
+                boost::lock_guard<queue_mutex_type> l(queue_mtx_);
                 if (queue_.empty())
                     return;         // some other thread did the deed
             }
@@ -229,7 +230,7 @@ namespace hpx { namespace components
 
             messages_type msgs;
             {
-                queue_mutex_type::scoped_lock l(queue_mtx_);
+                boost::lock_guard<queue_mutex_type> l(queue_mtx_);
                 if (queue_.empty())
                     return;         // some other thread did the deed
                 queue_.swap(msgs);

--- a/src/runtime/components/console_logging.cpp
+++ b/src/runtime/components/console_logging.cpp
@@ -188,7 +188,7 @@ namespace hpx { namespace components
             {
                 naming::gid_type raw_prefix;
                 {
-                    util::scoped_unlock<boost::unique_lock<prefix_mutex_type> > ul(l);
+                    util::unlock_guard<boost::unique_lock<prefix_mutex_type> > ul(l);
                     naming::get_agas_client().get_console_locality(raw_prefix);
                 }
 

--- a/src/runtime/components/console_logging.cpp
+++ b/src/runtime/components/console_logging.cpp
@@ -182,13 +182,13 @@ namespace hpx { namespace components
         // Resolve the console prefix if it's still invalid.
         if (HPX_UNLIKELY(naming::invalid_id == prefix_))
         {
-            prefix_mutex_type::scoped_try_lock l(prefix_mtx_);
+            boost::unique_lock<prefix_mutex_type> l(prefix_mtx_, boost::try_to_lock);
 
             if (l.owns_lock() && (naming::invalid_id == prefix_))
             {
                 naming::gid_type raw_prefix;
                 {
-                    util::scoped_unlock<prefix_mutex_type::scoped_try_lock> ul(l);
+                    util::scoped_unlock<boost::unique_lock<prefix_mutex_type> > ul(l);
                     naming::get_agas_client().get_console_locality(raw_prefix);
                 }
 

--- a/src/runtime/components/server/console_logging_server.cpp
+++ b/src/runtime/components/server/console_logging_server.cpp
@@ -14,11 +14,12 @@
 #include <hpx/runtime/components/server/console_logging.hpp>
 #include <hpx/runtime/serialization/serialize_sequence.hpp>
 
-#include <boost/fusion/include/at_c.hpp>
-#include <boost/lexical_cast.hpp>
-
 #include <hpx/util/logging/format/named_write_fwd.hpp>
 #include <hpx/util/logging/format_fwd.hpp>
+
+#include <boost/fusion/include/at_c.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/thread/locks.hpp>
 
 #include <vector>
 #include <iostream>
@@ -51,7 +52,7 @@ namespace hpx { namespace components { namespace server
     // implementation of console based logging
     void console_logging(messages_type const& msgs)
     {
-        util::spinlock::scoped_lock l(util::detail::get_log_lock());
+        boost::lock_guard<util::spinlock> l(util::detail::get_log_lock());
 
         using boost::fusion::at_c;
 

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -268,7 +268,7 @@ namespace hpx { namespace components { namespace server
         components::component_type type, std::size_t count)
     {
         // locate the factory for the requested component type
-        component_map_mutex_type::scoped_lock l(cm_mtx_);
+        boost::unique_lock<component_map_mutex_type> l(cm_mtx_);
 
         std::vector<naming::gid_type> ids;
 
@@ -307,7 +307,7 @@ namespace hpx { namespace components { namespace server
         runtime_support::get_promise_heap(components::component_type type)
     {
         // locate the factory for the requested component type
-        component_map_mutex_type::scoped_lock l(cm_mtx_);
+        boost::unique_lock<component_map_mutex_type> l(cm_mtx_);
 
         component_map_type::iterator it = components_.find(type);
         if (it == components_.end())
@@ -409,7 +409,7 @@ namespace hpx { namespace components { namespace server
         boost::shared_ptr<component_factory_base> factory;
 
         {
-            component_map_mutex_type::scoped_lock l(cm_mtx_);
+            boost::unique_lock<component_map_mutex_type> l(cm_mtx_);
             component_map_type::const_iterator it = components_.find(g.type);
             if (it == components_.end()) {
                 // we don't know anything about this component
@@ -958,7 +958,7 @@ namespace hpx { namespace components { namespace server
     ///////////////////////////////////////////////////////////////////////////
     boost::int32_t runtime_support::get_instance_count(components::component_type type)
     {
-        component_map_mutex_type::scoped_lock l(cm_mtx_);
+        boost::unique_lock<component_map_mutex_type> l(cm_mtx_);
 
         component_map_type::const_iterator it = components_.find(type);
         if (it == components_.end() || !(*it).second.first) {
@@ -1032,7 +1032,7 @@ namespace hpx { namespace components { namespace server
     void runtime_support::stop(double timeout,
         naming::id_type const& respond_to, bool remove_from_remote_caches)
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::unique_lock<mutex_type> l(mtx_);
         if (!stopped_) {
             // push pending logs
             components::cleanup_logging();
@@ -2163,7 +2163,7 @@ namespace hpx { namespace components { namespace server
     {
         components::security::capability caps;
 
-        component_map_mutex_type::scoped_lock l(cm_mtx_);
+        boost::unique_lock<component_map_mutex_type> l(cm_mtx_);
         component_map_type::const_iterator it = components_.find(type);
         if (it == components_.end()) {
             std::ostringstream strm;
@@ -2195,7 +2195,7 @@ namespace hpx { namespace components { namespace server
 
         boost::shared_ptr<component_factory_base> factory((*it).second.first);
         {
-            util::scoped_unlock<component_map_mutex_type::scoped_lock> ul(l);
+            util::scoped_unlock<boost::unique_lock<component_map_mutex_type> > ul(l);
             caps = factory->get_required_capabilities();
         }
         return caps;

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -993,7 +993,7 @@ namespace hpx { namespace components { namespace server
     ///////////////////////////////////////////////////////////////////////////
     void runtime_support::run()
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::unique_lock<mutex_type> l(mtx_);
         stopped_ = false;
         terminated_ = false;
         shutdown_all_invoked_.store(false);
@@ -1001,7 +1001,7 @@ namespace hpx { namespace components { namespace server
 
     void runtime_support::wait()
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::unique_lock<mutex_type> l(mtx_);
         while (!stopped_) {
             LRT_(info) << "runtime_support: about to enter wait state";
             wait_condition_.wait(l);
@@ -1112,7 +1112,7 @@ namespace hpx { namespace components { namespace server
 
     void runtime_support::notify_waiting_main()
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::unique_lock<mutex_type> l(mtx_);
         if (!stopped_) {
             stopped_ = true;
             wait_condition_.notify_all();

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -51,6 +51,7 @@
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/convenience.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
+#include <boost/thread/locks.hpp>
 
 #include <algorithm>
 #include <set>
@@ -560,7 +561,7 @@ namespace hpx { namespace components { namespace server
     void runtime_support::dijkstra_make_black()
     {
         // Rule 1: A machine sending a message makes itself black.
-        dijkstra_mtx_type::scoped_lock l(dijkstra_mtx_);
+        boost::lock_guard<dijkstra_mtx_type> l(dijkstra_mtx_);
         dijkstra_color_ = true;
     }
 
@@ -599,7 +600,7 @@ namespace hpx { namespace components { namespace server
         // Rule 2: When machine nr.i + 1 propagates the probe, it hands over a
         // black token to machine nr.i if it is black itself, whereas while
         // being white it leaves the color of the token unchanged.
-        dijkstra_mtx_type::scoped_lock l(dijkstra_mtx_);
+        boost::lock_guard<dijkstra_mtx_type> l(dijkstra_mtx_);
         bool dijkstra_token = dijkstra_color_;
 
         // Rule 5: Upon transmission of the token to machine nr.i, machine
@@ -684,7 +685,7 @@ namespace hpx { namespace components { namespace server
         // black token to machine nr.i if it is black itself, whereas while
         // being white it leaves the color of the token unchanged.
         {
-            dijkstra_mtx_type::scoped_lock l(dijkstra_mtx_);
+            boost::lock_guard<dijkstra_mtx_type> l(dijkstra_mtx_);
             if (dijkstra_color_)
                 dijkstra_token = dijkstra_color_;
 
@@ -715,7 +716,7 @@ namespace hpx { namespace components { namespace server
             // we received the token after a full circle
             if (dijkstra_token)
             {
-                dijkstra_mtx_type::scoped_lock l(dijkstra_mtx_);
+                boost::lock_guard<dijkstra_mtx_type> l(dijkstra_mtx_);
                 dijkstra_color_ = true;     // unsuccessful termination
             }
 
@@ -926,7 +927,7 @@ namespace hpx { namespace components { namespace server
     ///////////////////////////////////////////////////////////////////////////
     void runtime_support::tidy()
     {
-        component_map_mutex_type::scoped_lock l(cm_mtx_);
+        boost::lock_guard<component_map_mutex_type> l(cm_mtx_);
 
         // Only after releasing the components we are allowed to release
         // the modules. This is done in reverse order of loading.
@@ -1122,7 +1123,7 @@ namespace hpx { namespace components { namespace server
     // this will be called after the thread manager has exited
     void runtime_support::stopped()
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
         if (!terminated_) {
             terminated_ = true;
             stop_condition_.notify_all();   // finished cleanup/termination
@@ -1199,7 +1200,7 @@ namespace hpx { namespace components { namespace server
     ///////////////////////////////////////////////////////////////////////////
     bool runtime_support::keep_factory_alive(component_type type)
     {
-        component_map_mutex_type::scoped_lock l(cm_mtx_);
+        boost::lock_guard<component_map_mutex_type> l(cm_mtx_);
 
         // Only after releasing the components we are allowed to release
         // the modules. This is done in reverse order of loading.
@@ -1395,7 +1396,7 @@ namespace hpx { namespace components { namespace server
                 }
 
                 // store component factory and module for later use
-                component_map_mutex_type::scoped_lock l(cm_mtx_);
+                boost::lock_guard<component_map_mutex_type> l(cm_mtx_);
 
                 component_factory_type data(factory, isenabled);
                 std::pair<component_map_type::iterator, bool> p =
@@ -1922,7 +1923,7 @@ namespace hpx { namespace components { namespace server
                 }
 
                 // store component factory and module for later use
-                component_map_mutex_type::scoped_lock l(cm_mtx_);
+                boost::lock_guard<component_map_mutex_type> l(cm_mtx_);
 
                 component_factory_type data(factory, d, isenabled);
                 std::pair<component_map_type::iterator, bool> p =

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -11,7 +11,7 @@
 #include <hpx/util/ini.hpp>
 #include <hpx/util/logging.hpp>
 #include <hpx/util/filesystem_compatibility.hpp>
-#include <hpx/util/scoped_unlock.hpp>
+#include <hpx/util/unlock_guard.hpp>
 
 #include <hpx/runtime/agas/interface.hpp>
 #include <hpx/runtime/threads/threadmanager.hpp>
@@ -636,7 +636,7 @@ namespace hpx { namespace components { namespace server
                 dijkstra_termination_action act;
                 bool termination_aborted = false;
                 {
-                    util::scoped_unlock<dijkstra_mtx_type::scoped_lock> ul(l);
+                    util::unlock_guard<dijkstra_mtx_type::scoped_lock> ul(l);
                     termination_aborted = lcos::reduce(act,
                         locality_ids, std_logical_or_type()).get()
                 }
@@ -760,7 +760,7 @@ namespace hpx { namespace components { namespace server
                 dijkstra_color_ = false;        // start off with white
 
                 {
-                    util::scoped_unlock<dijkstra_mtx_type::scoped_lock> ul(l);
+                    util::unlock_guard<dijkstra_mtx_type::scoped_lock> ul(l);
                     send_dijkstra_termination_token(target_id - 1,
                         initiating_locality_id, num_localities, false);
                 }
@@ -1021,7 +1021,7 @@ namespace hpx { namespace components { namespace server
 
         // give the scheduler some time to work on remaining tasks
         {
-            util::scoped_unlock<Lock> ul(l);
+            util::unlock_guard<Lock> ul(l);
             self->yield(threads::pending);
         }
 
@@ -2195,7 +2195,7 @@ namespace hpx { namespace components { namespace server
 
         boost::shared_ptr<component_factory_base> factory((*it).second.first);
         {
-            util::scoped_unlock<boost::unique_lock<component_map_mutex_type> > ul(l);
+            util::unlock_guard<boost::unique_lock<component_map_mutex_type> > ul(l);
             caps = factory->get_required_capabilities();
         }
         return caps;

--- a/src/runtime/naming/name.cpp
+++ b/src/runtime/naming/name.cpp
@@ -273,7 +273,7 @@ namespace hpx { namespace naming
                 if(src_log2credits == 1)
                 {
 
-                    util::scoped_unlock<scoped_lock> ul(l);
+                    util::unlock_guard<scoped_lock> ul(l);
                     boost::int64_t new_credit = (HPX_GLOBALCREDIT_INITIAL - 1) * 2;
                     agas::incref(new_gid, new_credit);
                 }
@@ -315,7 +315,7 @@ namespace hpx { namespace naming
                     if(overflow_credit > 0)
                     {
                         HPX_ASSERT(overflow_credit <= HPX_GLOBALCREDIT_INITIAL-1);
-                        util::scoped_unlock<scoped_lock> ul(l);
+                        util::unlock_guard<scoped_lock> ul(l);
                         agas::decref(new_gid, overflow_credit);
                     }
                 }

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -29,6 +29,7 @@
 #include <boost/asio/io_service.hpp>
 #include <boost/thread.hpp>
 #include <boost/format.hpp>
+#include <boost/thread/locks.hpp>
 
 #include <algorithm>
 #include <sstream>
@@ -506,14 +507,14 @@ namespace hpx { namespace parcelset
         std::size_t num_messages, std::size_t interval,
         locality const& loc, error_code& ec)
     {
-        mutex_type::scoped_lock l(handlers_mtx_);
+        boost::unique_lock<mutex_type> l(handlers_mtx_);
         handler_key_type key(loc, action);
         message_handler_map::iterator it = handlers_.find(key);
         if (it == handlers_.end()) {
             boost::shared_ptr<policies::message_handler> p;
 
             {
-                util::scoped_unlock<mutex_type::scoped_lock> ul(l);
+                util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
                 p.reset(hpx::create_message_handler(message_handler_type,
                     action, find_parcelport(loc.type()), num_messages, interval, ec));
             }

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -250,9 +250,9 @@ namespace hpx { namespace parcelset
         // flush all parcel buffers
         if(0 == num_thread)
         {
-            mutex_type::scoped_try_lock l(handlers_mtx_);
+            boost::unique_lock<mutex_type> l(handlers_mtx_, boost::try_to_lock);
 
-            if(l)
+            if(l.owns_lock())
             {
                 message_handler_map::iterator end = handlers_.end();
                 for (message_handler_map::iterator it = handlers_.begin();
@@ -261,7 +261,7 @@ namespace hpx { namespace parcelset
                     if ((*it).second)
                     {
                         boost::shared_ptr<policies::message_handler> p((*it).second);
-                        util::scoped_unlock<mutex_type::scoped_try_lock> ul(l);
+                        util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
                         did_some_work = p->flush(stop_buffering) || did_some_work;
                     }
                 }

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -261,7 +261,7 @@ namespace hpx { namespace parcelset
                     if ((*it).second)
                     {
                         boost::shared_ptr<policies::message_handler> p((*it).second);
-                        util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+                        util::unlock_guard<boost::unique_lock<mutex_type> > ul(l);
                         did_some_work = p->flush(stop_buffering) || did_some_work;
                     }
                 }
@@ -514,7 +514,7 @@ namespace hpx { namespace parcelset
             boost::shared_ptr<policies::message_handler> p;
 
             {
-                util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+                util::unlock_guard<boost::unique_lock<mutex_type> > ul(l);
                 p.reset(hpx::create_message_handler(message_handler_type,
                     action, find_parcelport(loc.type()), num_messages, interval, ec));
             }

--- a/src/runtime/threads/detail/thread_pool.cpp
+++ b/src/runtime/threads/detail/thread_pool.cpp
@@ -15,7 +15,7 @@
 #include <hpx/util/logging.hpp>
 #include <hpx/util/bind.hpp>
 #include <hpx/lcos/local/no_mutex.hpp>
-#include <hpx/util/scoped_unlock.hpp>
+#include <hpx/util/unlock_guard.hpp>
 
 #if defined(HPX_HAVE_THREAD_CUMULATIVE_COUNTS) && \
     defined(HPX_HAVE_THREAD_IDLE_RATES)
@@ -398,7 +398,7 @@ namespace hpx { namespace threads { namespace detail
                         << " join:" << i; //-V128
 
                     // unlock the lock while joining
-                    util::scoped_unlock<Lock> ul(l);
+                    util::unlock_guard<Lock> ul(l);
                     threads_[i].join();
                 }
                 threads_.clear();

--- a/src/runtime/threads/detail/thread_pool.cpp
+++ b/src/runtime/threads/detail/thread_pool.cpp
@@ -78,7 +78,7 @@ namespace hpx { namespace threads { namespace detail
             if (state_.load() == state_running)
             {
                 lcos::local::no_mutex mtx;
-                lcos::local::no_mutex::scoped_lock l(mtx);
+                boost::unique_lock<lcos::local::no_mutex> l(mtx);
                 stop_locked(l);
             }
             threads_.clear();
@@ -226,6 +226,8 @@ namespace hpx { namespace threads { namespace detail
     bool thread_pool<Scheduler>::run(boost::unique_lock<boost::mutex>& l,
         std::size_t num_threads)
     {
+        HPX_ASSERT(l.owns_lock());
+
         LTM_(info) //-V128
             << "thread_pool::run: " << pool_name_
             << " number of processing units available: " //-V128
@@ -359,6 +361,8 @@ namespace hpx { namespace threads { namespace detail
     void thread_pool<Scheduler>::stop (
         boost::unique_lock<boost::mutex>& l, bool blocking)
     {
+        HPX_ASSERT(l.owns_lock());
+
         return stop_locked(l, blocking);
     }
 

--- a/src/runtime/threads/executors/thread_pool_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_executors.cpp
@@ -16,6 +16,8 @@
 #include <hpx/util/assert.hpp>
 #include <hpx/util/bind.hpp>
 
+#include <boost/thread/locks.hpp>
+
 namespace hpx { namespace threads { namespace detail
 {
     // The function \a set_self_ptr sets a pointer to the (OS thread
@@ -336,7 +338,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
             ++max_current_concurrency_;
 
             {
-                typename mutex_type::scoped_lock l(mtx_);
+                boost::lock_guard<mutex_type> l(mtx_);
                 scheduler_.add_punit(virt_core, thread_num);
                 scheduler_.on_start_thread(virt_core);
             }

--- a/src/runtime/threads/resource_manager.cpp
+++ b/src/runtime/threads/resource_manager.cpp
@@ -9,6 +9,8 @@
 #include <hpx/lcos/local/once.hpp>
 #include <hpx/util/reinitializable_static.hpp>
 
+#include <boost/thread/locks.hpp>
+
 namespace hpx { namespace threads
 {
     ///////////////////////////////////////////////////////////////////////////
@@ -46,7 +48,7 @@ namespace hpx { namespace threads
         if (ec1) max_punits = get_os_thread_count();
 
         // lock the resource manager from this point on
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
 
         // allocate initial resources for the given executor
         std::vector<std::pair<std::size_t, std::size_t> > cores =
@@ -142,7 +144,7 @@ namespace hpx { namespace threads
     // Stop the executor identified with the given cookie
     void resource_manager::stop_executor(std::size_t cookie, error_code& ec)
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
         proxies_map_type::iterator it = proxies_.find(cookie);
         if (it == proxies_.end()) {
             HPX_THROWS_IF(ec, bad_parameter, "resource_manager::detach",
@@ -161,7 +163,7 @@ namespace hpx { namespace threads
     // Detach the executor identified with the given cookie
     void resource_manager::detach(std::size_t cookie, error_code& ec)
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
         proxies_map_type::iterator it = proxies_.find(cookie);
         if (it == proxies_.end()) {
             HPX_THROWS_IF(ec, bad_parameter, "resource_manager::detach",

--- a/src/runtime/threads/thread.cpp
+++ b/src/runtime/threads/thread.cpp
@@ -185,7 +185,7 @@ namespace hpx
                 util::bind(&resume_thread, this_id)))
         {
             // wait for thread to be terminated
-            util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+            util::unlock_guard<boost::unique_lock<mutex_type> > ul(l);
             this_thread::suspend(threads::suspended, "thread::join");
         }
 

--- a/src/runtime/threads/thread.cpp
+++ b/src/runtime/threads/thread.cpp
@@ -13,6 +13,8 @@
 #include <hpx/lcos/future.hpp>
 #include <hpx/util/register_locks.hpp>
 
+#include <boost/thread/locks.hpp>
+
 #if defined(__ANDROID__) || defined(ANDROID)
 #include <cpu-features.h>
 #endif
@@ -42,15 +44,15 @@ namespace hpx
     thread::thread(thread && rhs) BOOST_NOEXCEPT
       : id_(threads::invalid_thread_id)   // the rhs needs to end up with an invalid_id
     {
-        mutex_type::scoped_lock l(rhs.mtx_);
+        boost::lock_guard<mutex_type> l(rhs.mtx_);
         id_ = rhs.id_;
         rhs.id_ = threads::invalid_thread_id;
     }
 
     thread& thread::operator=(thread && rhs) BOOST_NOEXCEPT
     {
-        mutex_type::scoped_lock l(mtx_);
-        mutex_type::scoped_lock l2(rhs.mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
+        boost::lock_guard<mutex_type> l2(rhs.mtx_);
         // If our current thread is joinable, terminate
         if (joinable_locked())
         {
@@ -70,15 +72,15 @@ namespace hpx
         }
         threads::thread_id_type id = threads::invalid_thread_id;
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             std::swap(id_, id);
         }
     }
 
     void thread::swap(thread& rhs) BOOST_NOEXCEPT
     {
-        mutex_type::scoped_lock l(mtx_);
-        mutex_type::scoped_lock l2(rhs.mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
+        boost::lock_guard<mutex_type> l2(rhs.mtx_);
         std::swap(id_, rhs.id_);
     }
 
@@ -255,7 +257,7 @@ namespace hpx
 
             void cancel()
             {
-                mutex_type::scoped_lock l(this->mtx_);
+                boost::lock_guard<mutex_type> l(this->mtx_);
                 if (!this->is_ready()) {
                     threads::interrupt_thread(id_);
                     this->set_error(thread_cancelled,
@@ -269,7 +271,7 @@ namespace hpx
             void thread_exit_function()
             {
                 // might have been finished or canceled
-                mutex_type::scoped_lock l(this->mtx_);
+                boost::lock_guard<mutex_type> l(this->mtx_);
                 if (!this->is_ready())
                     this->set_data(result_type());
                 id_ = threads::invalid_thread_id;

--- a/src/runtime/threads/thread.cpp
+++ b/src/runtime/threads/thread.cpp
@@ -163,7 +163,7 @@ namespace hpx
 
     void thread::join()
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::unique_lock<mutex_type> l(mtx_);
 
         if(!joinable_locked())
         {
@@ -185,7 +185,7 @@ namespace hpx
                 util::bind(&resume_thread, this_id)))
         {
             // wait for thread to be terminated
-            util::scoped_unlock<mutex_type::scoped_lock> ul(l);
+            util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
             this_thread::suspend(threads::suspended, "thread::join");
         }
 

--- a/src/runtime/threads/thread_data.cpp
+++ b/src/runtime/threads/thread_data.cpp
@@ -95,7 +95,7 @@ namespace hpx { namespace threads
         while(!exit_funcs_.empty())
         {
             {
-                hpx::util::scoped_unlock<mutex_type::scoped_lock> ul(l);
+                hpx::util::unlock_guard<mutex_type::scoped_lock> ul(l);
                 if(!exit_funcs_.back().empty())
                     exit_funcs_.back()();
             }

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -19,7 +19,7 @@
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/scoped_unlock.hpp>
+#include <hpx/util/unlock_guard.hpp>
 #include <hpx/util/logging.hpp>
 #include <hpx/util/block_profiler.hpp>
 #include <hpx/util/itt_notify.hpp>

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -30,6 +30,7 @@
 #include <boost/bind.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/format.hpp>
+#include <boost/thread/locks.hpp>
 
 #include <numeric>
 #include <sstream>
@@ -160,7 +161,7 @@ namespace hpx { namespace threads
         get_thread_count(thread_state_enum state, thread_priority priority,
             std::size_t num_thread, bool reset) const
     {
-        mutex_type::scoped_lock lk(mtx_);
+        boost::lock_guard<mutex_type> lk(mtx_);
         return pool_.get_thread_count(state, priority, num_thread, reset);
     }
 
@@ -172,7 +173,7 @@ namespace hpx { namespace threads
     void threadmanager_impl<SchedulingPolicy>::
         abort_all_suspended_threads()
     {
-        mutex_type::scoped_lock lk(mtx_);
+        boost::lock_guard<mutex_type> lk(mtx_);
         pool_.abort_all_suspended_threads();
     }
 
@@ -185,7 +186,7 @@ namespace hpx { namespace threads
     bool threadmanager_impl<SchedulingPolicy>::
         cleanup_terminated(bool delete_all)
     {
-        mutex_type::scoped_lock lk(mtx_);
+        boost::lock_guard<mutex_type> lk(mtx_);
         return pool_.cleanup_terminated(delete_all);
     }
 

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -1370,7 +1370,7 @@ namespace hpx { namespace threads
     bool threadmanager_impl<SchedulingPolicy>::
         run(std::size_t num_threads)
     {
-        mutex_type::scoped_lock lk(mtx_);
+        boost::unique_lock<mutex_type> lk(mtx_);
 
         if (pool_.get_os_thread_count() != 0 ||
             pool_.get_state() == state_running)
@@ -1397,7 +1397,7 @@ namespace hpx { namespace threads
     {
         LTM_(info) << "stop: blocking(" << std::boolalpha << blocking << ")";
 
-        mutex_type::scoped_lock lk(mtx_);
+        boost::unique_lock<mutex_type> lk(mtx_);
         pool_.stop(lk, blocking);
 
         LTM_(info) << "stop: stopping timer pool";

--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -5,9 +5,6 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_fwd.hpp>
-#include <boost/config.hpp>
-#include <boost/thread.hpp>
-#include <boost/bind.hpp>
 
 #include <hpx/state.hpp>
 #include <hpx/exception.hpp>
@@ -24,6 +21,11 @@
 #include <hpx/runtime/threads/threadmanager_impl.hpp>
 #include <hpx/include/performance_counters.hpp>
 #include <hpx/runtime/agas/big_boot_barrier.hpp>
+
+#include <boost/config.hpp>
+#include <boost/bind.hpp>
+#include <boost/thread.hpp>
+#include <boost/thread/locks.hpp>
 
 #include <iostream>
 #include <sstream>
@@ -335,7 +337,7 @@ namespace hpx {
     {
         // signal successful initialization
         {
-            boost::mutex::scoped_lock lk(mtx);
+            boost::lock_guard<boost::mutex> lk(mtx);
             running = true;
             cond.notify_all();
         }
@@ -439,7 +441,7 @@ namespace hpx {
 
         LRT_(info) << "runtime_impl: stopped all services";
 
-        boost::mutex::scoped_lock l(mtx);
+        boost::lock_guard<boost::mutex> l(mtx);
         cond.notify_all();                  // we're done now
     }
 
@@ -456,7 +458,7 @@ namespace hpx {
 
             // store the exception to be able to rethrow it later
             {
-                boost::mutex::scoped_lock l(mtx_);
+                boost::lock_guard<boost::mutex> l(mtx_);
                 exception_ = e;
             }
 
@@ -500,7 +502,7 @@ namespace hpx {
     {
         if (state_.load() > state_running)
         {
-            boost::mutex::scoped_lock l(mtx_);
+            boost::lock_guard<boost::mutex> l(mtx_);
             if (exception_)
             {
                 boost::exception_ptr e = exception_;

--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -372,7 +372,7 @@ namespace hpx {
 
         // wait for the thread to run
         {
-            boost::mutex::scoped_lock lk(mtx);
+            boost::unique_lock<boost::mutex> lk(mtx);
             while (!running)
                 cond.wait(lk);
         }
@@ -410,7 +410,7 @@ namespace hpx {
         // manager
         boost::mutex mtx;
         boost::condition cond;
-        boost::mutex::scoped_lock l(mtx);
+        boost::unique_lock<boost::mutex> l(mtx);
 
         boost::thread t(boost::bind(&runtime_impl::stopped, this, blocking,
             boost::ref(cond), boost::ref(mtx)));

--- a/src/util/generate_unique_ids.cpp
+++ b/src/util/generate_unique_ids.cpp
@@ -22,7 +22,7 @@ namespace hpx { namespace util
     naming::gid_type unique_id_ranges::get_id(std::size_t count)
     {
         // create a new id
-        mutex_type::scoped_lock l(mtx_);
+        boost::unique_lock<mutex_type> l(mtx_);
 
         // ensure next_id doesn't overflow
         while (!lower_ || (lower_ + count) > upper_)
@@ -33,7 +33,7 @@ namespace hpx { namespace util
             std::size_t count_ = (std::max)(std::size_t(range_delta), count);
 
             {
-                scoped_unlock<mutex_type::scoped_lock> ul(l);
+                scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
                 lower = hpx::agas::get_next_id(count_);
             }
 

--- a/src/util/generate_unique_ids.cpp
+++ b/src/util/generate_unique_ids.cpp
@@ -11,7 +11,7 @@
 #include <hpx/util/assert.hpp>
 #include <hpx/util/generate_unique_ids.hpp>
 #include <hpx/util/spinlock_pool.hpp>
-#include <hpx/util/scoped_unlock.hpp>
+#include <hpx/util/unlock_guard.hpp>
 #include <hpx/util/logging.hpp>
 
 #include <boost/swap.hpp>
@@ -33,7 +33,7 @@ namespace hpx { namespace util
             std::size_t count_ = (std::max)(std::size_t(range_delta), count);
 
             {
-                scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+                unlock_guard<boost::unique_lock<mutex_type> > ul(l);
                 lower = hpx::agas::get_next_id(count_);
             }
 

--- a/src/util/interval_timer.cpp
+++ b/src/util/interval_timer.cpp
@@ -184,8 +184,10 @@ namespace hpx { namespace util
     }
 
     // schedule a high priority task after a given time interval
-    void interval_timer::schedule_thread(mutex_type::scoped_lock & l)
+    void interval_timer::schedule_thread(boost::unique_lock<mutex_type> & l)
     {
+        HPX_ASSERT(l.owns_lock());
+
         using namespace hpx::threads;
 
         error_code ec;
@@ -197,7 +199,7 @@ namespace hpx { namespace util
             // the allocators use hpx::lcos::local::spinlock. Unlocking the
             // lock here would be the right thing but leads to crashes and hangs
             // at shutdown.
-            //util::scoped_unlock<mutex_type::scoped_lock> ul(l);
+            //util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
             id = hpx::applier::register_thread_plain(
                 boost::bind(&interval_timer::evaluate, this, _1),
                 description_.c_str(), threads::suspended, true,

--- a/src/util/interval_timer.cpp
+++ b/src/util/interval_timer.cpp
@@ -41,7 +41,7 @@ namespace hpx { namespace util
 
     bool interval_timer::start(bool evaluate_)
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::unique_lock<mutex_type> l(mtx_);
         if (is_terminated_)
             return false;
 
@@ -49,7 +49,7 @@ namespace hpx { namespace util
             if (first_start_) {
                 first_start_ = false;
 
-                util::scoped_unlock<mutex_type::scoped_lock> ul(l);
+                util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
                 if (pre_shutdown_)
                     register_pre_shutdown_function(boost::bind(&interval_timer::terminate, this));
                 else
@@ -76,7 +76,7 @@ namespace hpx { namespace util
         if (!is_started_)
             return start(evaluate_);
 
-        mutex_type::scoped_lock l(mtx_);
+        boost::unique_lock<mutex_type> l(mtx_);
 
         if (is_terminated_)
             return false;
@@ -122,7 +122,7 @@ namespace hpx { namespace util
 
     void interval_timer::terminate()
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::unique_lock<mutex_type> l(mtx_);
         if (!is_terminated_) {
             is_terminated_ = true;
             stop_locked();
@@ -148,7 +148,7 @@ namespace hpx { namespace util
         threads::thread_state_ex_enum statex)
     {
         try {
-            mutex_type::scoped_lock l(mtx_);
+            boost::unique_lock<mutex_type> l(mtx_);
 
             if (is_stopped_ || is_terminated_ ||
                 statex == threads::wait_abort || 0 == microsecs_)
@@ -165,7 +165,7 @@ namespace hpx { namespace util
             bool result = false;
 
             {
-                util::scoped_unlock<mutex_type::scoped_lock> ul(l);
+                util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
                 result = f_();            // invoke the supplied function
             }
 

--- a/src/util/interval_timer.cpp
+++ b/src/util/interval_timer.cpp
@@ -8,7 +8,7 @@
 #include <hpx/runtime/applier/applier.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
 #include <hpx/util/interval_timer.hpp>
-#include <hpx/util/scoped_unlock.hpp>
+#include <hpx/util/unlock_guard.hpp>
 
 #include <boost/bind.hpp>
 #include <boost/thread/locks.hpp>
@@ -49,7 +49,7 @@ namespace hpx { namespace util
             if (first_start_) {
                 first_start_ = false;
 
-                util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+                util::unlock_guard<boost::unique_lock<mutex_type> > ul(l);
                 if (pre_shutdown_)
                     register_pre_shutdown_function(boost::bind(&interval_timer::terminate, this));
                 else
@@ -165,7 +165,7 @@ namespace hpx { namespace util
             bool result = false;
 
             {
-                util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+                util::unlock_guard<boost::unique_lock<mutex_type> > ul(l);
                 result = f_();            // invoke the supplied function
             }
 
@@ -199,7 +199,7 @@ namespace hpx { namespace util
             // the allocators use hpx::lcos::local::spinlock. Unlocking the
             // lock here would be the right thing but leads to crashes and hangs
             // at shutdown.
-            //util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+            //util::unlock_guard<boost::unique_lock<mutex_type> > ul(l);
             id = hpx::applier::register_thread_plain(
                 boost::bind(&interval_timer::evaluate, this, _1),
                 description_.c_str(), threads::suspended, true,

--- a/src/util/interval_timer.cpp
+++ b/src/util/interval_timer.cpp
@@ -11,6 +11,7 @@
 #include <hpx/util/scoped_unlock.hpp>
 
 #include <boost/bind.hpp>
+#include <boost/thread/locks.hpp>
 
 namespace hpx { namespace util
 {
@@ -96,7 +97,7 @@ namespace hpx { namespace util
 
     bool interval_timer::stop()
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::lock_guard<mutex_type> l(mtx_);
         is_stopped_ = true;
         return stop_locked();
     }

--- a/src/util/io_service_pool.cpp
+++ b/src/util/io_service_pool.cpp
@@ -9,8 +9,6 @@
 
 #include <hpx/hpx_fwd.hpp>
 
-#include <stdexcept>
-
 #include <hpx/exception.hpp>
 #include <hpx/util/io_service_pool.hpp>
 
@@ -18,6 +16,9 @@
 #include <boost/thread.hpp>
 #include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/thread/locks.hpp>
+
+#include <stdexcept>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace util
@@ -70,7 +71,7 @@ namespace hpx { namespace util
 
     io_service_pool::~io_service_pool()
     {
-        boost::mutex::scoped_lock l(mtx_);
+        boost::lock_guard<boost::mutex> l(mtx_);
         stop_locked();
         join_locked();
         clear_locked();
@@ -90,7 +91,7 @@ namespace hpx { namespace util
 
     bool io_service_pool::run(bool join_threads)
     {
-        boost::mutex::scoped_lock l(mtx_);
+        boost::lock_guard<boost::mutex> l(mtx_);
 
         // Create a pool of threads to run all of the io_services.
         if (!threads_.empty())   // should be called only once
@@ -143,7 +144,7 @@ namespace hpx { namespace util
 
     void io_service_pool::join()
     {
-        boost::mutex::scoped_lock l(mtx_);
+        boost::lock_guard<boost::mutex> l(mtx_);
         join_locked();
     }
 
@@ -157,7 +158,7 @@ namespace hpx { namespace util
 
     void io_service_pool::stop()
     {
-        boost::mutex::scoped_lock l(mtx_);
+        boost::lock_guard<boost::mutex> l(mtx_);
         stop_locked();
     }
 
@@ -179,7 +180,7 @@ namespace hpx { namespace util
 
     void io_service_pool::clear()
     {
-        boost::mutex::scoped_lock l(mtx_);
+        boost::lock_guard<boost::mutex> l(mtx_);
         clear_locked();
     }
 
@@ -195,14 +196,14 @@ namespace hpx { namespace util
 
     bool io_service_pool::stopped()
     {
-        boost::mutex::scoped_lock l(mtx_);
+        boost::lock_guard<boost::mutex> l(mtx_);
         return stopped_;
     }
 
     boost::asio::io_service& io_service_pool::get_io_service(int index)
     {
         // use this function for single group io_service pools only
-        boost::mutex::scoped_lock l(mtx_);
+        boost::lock_guard<boost::mutex> l(mtx_);
 
         if (index == -1) {
             if (++next_io_service_ == pool_size_)

--- a/src/util/query_counters.cpp
+++ b/src/util/query_counters.cpp
@@ -16,6 +16,7 @@
 #include <hpx/lcos/wait_all.hpp>
 
 #include <boost/format.hpp>
+#include <boost/thread/locks.hpp>
 
 #include <iostream>
 #include <fstream>
@@ -151,7 +152,7 @@ namespace hpx { namespace util
     {
         std::vector<naming::id_type> ids;
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             // give up control over all performance counters
             std::swap(ids, ids_);
         }
@@ -162,7 +163,7 @@ namespace hpx { namespace util
     {
         bool has_been_started = false;
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             has_been_started = !ids_.empty();
         }
 
@@ -207,7 +208,7 @@ namespace hpx { namespace util
     {
         bool has_been_started = false;
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             has_been_started = !ids_.empty();
         }
 
@@ -252,7 +253,7 @@ namespace hpx { namespace util
     {
         bool has_been_started = false;
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             has_been_started = !ids_.empty();
         }
 
@@ -306,7 +307,7 @@ namespace hpx { namespace util
         bool has_been_started = false;
         bool destination_is_cout = false;
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             has_been_started = !ids_.empty();
             destination_is_cout = destination_ == "cout";
         }
@@ -322,7 +323,7 @@ namespace hpx { namespace util
 
         std::vector<id_type> ids;
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             ids = ids_;
         }
 

--- a/src/util/query_counters.cpp
+++ b/src/util/query_counters.cpp
@@ -86,7 +86,7 @@ namespace hpx { namespace util
 
                 // find matching counter type
                 {
-                    hpx::util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
+                    hpx::util::unlock_guard<boost::unique_lock<mutex_type> > ul(l);
                     performance_counters::discover_counter_type(name, func,
                         performance_counters::discover_counters_full);
                 }

--- a/src/util/query_counters.cpp
+++ b/src/util/query_counters.cpp
@@ -63,7 +63,7 @@ namespace hpx { namespace util
 
     void query_counters::find_counters()
     {
-        mutex_type::scoped_lock l(mtx_);
+        boost::unique_lock<mutex_type> l(mtx_);
 
         std::vector<std::string> names;
         std::swap(names, names_);
@@ -86,7 +86,7 @@ namespace hpx { namespace util
 
                 // find matching counter type
                 {
-                    hpx::util::scoped_unlock<mutex_type::scoped_lock> ul(l);
+                    hpx::util::scoped_unlock<boost::unique_lock<mutex_type> > ul(l);
                     performance_counters::discover_counter_type(name, func,
                         performance_counters::discover_counters_full);
                 }

--- a/src/util/static_reinit.cpp
+++ b/src/util/static_reinit.cpp
@@ -9,6 +9,8 @@
 #include <hpx/util/static.hpp>
 #include <hpx/util/spinlock.hpp>
 
+#include <boost/thread/locks.hpp>
+
 namespace hpx { namespace util
 {
     ///////////////////////////////////////////////////////////////////////////
@@ -28,13 +30,13 @@ namespace hpx { namespace util
         void register_functions(construct_type const& construct,
             destruct_type const& destruct)
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             funcs_.push_back(value_type(construct, destruct));
         }
 
         void construct_all()
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             for (value_type const& val : funcs_)
             {
                 val.first();
@@ -43,7 +45,7 @@ namespace hpx { namespace util
 
         void destruct_all()
         {
-            mutex_type::scoped_lock l(mtx_);
+            boost::lock_guard<mutex_type> l(mtx_);
             for (value_type const& val : funcs_)
             {
                 val.second();

--- a/src/util/thread_mapper.cpp
+++ b/src/util/thread_mapper.cpp
@@ -10,6 +10,7 @@
 #include <cstring>
 
 #include <boost/format.hpp>
+#include <boost/thread/locks.hpp>
 
 #if defined(__linux__)
 #include <sys/syscall.h>
@@ -48,7 +49,7 @@ namespace hpx { namespace util
 
     thread_mapper::~thread_mapper()
     {
-        mutex_type::scoped_lock m(mtx_);
+        boost::lock_guard<mutex_type> m(mtx_);
 
         for (boost::uint32_t i = 0; i < thread_info_.size(); i++) //-V104
             thread_info_[i].cleanup_(i); //-V108
@@ -56,7 +57,7 @@ namespace hpx { namespace util
 
     boost::uint32_t thread_mapper::register_thread(char const *l)
     {
-        mutex_type::scoped_lock m(mtx_);
+        boost::lock_guard<mutex_type> m(mtx_);
 
         boost::thread::id id = boost::this_thread::get_id();
         thread_map_type::iterator it = thread_map_.find(id);
@@ -79,7 +80,7 @@ namespace hpx { namespace util
 
     bool thread_mapper::unregister_thread()
     {
-        mutex_type::scoped_lock m(mtx_);
+        boost::lock_guard<mutex_type> m(mtx_);
 
         boost::thread::id id = boost::this_thread::get_id();
         thread_map_type::iterator it = thread_map_.find(id);
@@ -89,7 +90,7 @@ namespace hpx { namespace util
     bool thread_mapper::register_callback(boost::uint32_t tix,
         callback_type const& cb)
     {
-        mutex_type::scoped_lock m(mtx_);
+        boost::lock_guard<mutex_type> m(mtx_);
 
         if (tix >= thread_info_.size()) return false; //-V104
         thread_info_[tix].cleanup_ = cb; //-V108
@@ -98,7 +99,7 @@ namespace hpx { namespace util
 
     bool thread_mapper::revoke_callback(boost::uint32_t tix)
     {
-        mutex_type::scoped_lock m(mtx_);
+        boost::lock_guard<mutex_type> m(mtx_);
 
         if (tix >= thread_info_.size()) return false; //-V104
         thread_info_[tix].cleanup_ = boost::ref(null_cb); //-V108
@@ -107,14 +108,14 @@ namespace hpx { namespace util
 
     long int thread_mapper::get_thread_id(boost::uint32_t tix) const
     {
-        mutex_type::scoped_lock m(mtx_);
+        boost::lock_guard<mutex_type> m(mtx_);
 
         return (tix < thread_info_.size())? thread_info_[tix].tid_: invalid_tid; //-V104 //-V108
     }
 
     std::string const& thread_mapper::get_thread_label(boost::uint32_t tix) const
     {
-        mutex_type::scoped_lock m(mtx_);
+        boost::lock_guard<mutex_type> m(mtx_);
 
         label_map_type::right_map::const_iterator it = label_map_.right.find(tix);
         return (it == label_map_.right.end())? invalid_label: it->second;
@@ -122,7 +123,7 @@ namespace hpx { namespace util
 
     boost::uint32_t thread_mapper::get_thread_index(std::string const& label) const
     {
-        mutex_type::scoped_lock m(mtx_);
+        boost::lock_guard<mutex_type> m(mtx_);
 
         label_map_type::left_map::const_iterator it = label_map_.left.find(label);
         return (it == label_map_.left.end())? invalid_index: it->second;
@@ -130,7 +131,7 @@ namespace hpx { namespace util
 
     boost::uint32_t thread_mapper::get_thread_count() const
     {
-        mutex_type::scoped_lock m(mtx_);
+        boost::lock_guard<mutex_type> m(mtx_);
 
         return static_cast<boost::uint32_t>(thread_info_.size());
     }

--- a/tests/performance/local/spinlock_overhead2.cpp
+++ b/tests/performance/local/spinlock_overhead2.cpp
@@ -15,12 +15,13 @@
 #include <hpx/include/async.hpp>
 #include <hpx/include/iostreams.hpp>
 
-#include <stdexcept>
-
 #include <boost/format.hpp>
 #include <boost/bind.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/chrono/duration.hpp>
+#include <boost/thread/locks.hpp>
+
+#include <stdexcept>
 
 using boost::program_options::variables_map;
 using boost::program_options::options_description;
@@ -181,9 +182,6 @@ namespace test
             HPX_ITT_SYNC_RELEASED(this);
             hpx::util::unregister_lock(this);
         }
-
-        typedef boost::unique_lock<local_spinlock> scoped_lock;
-        typedef boost::detail::try_lock_wrapper<local_spinlock> scoped_try_lock;
     };
 }
 
@@ -195,7 +193,7 @@ double null_function(std::size_t i)
     double d = 0.;
     std::size_t idx = i % N;
     {
-        test::local_spinlock::scoped_lock l(mtx[idx]);
+        boost::lock_guard<test::local_spinlock> l(mtx[idx]);
         d = global_init[idx];
     }
     for (double j = 0; j < num_iterations; ++j)
@@ -203,7 +201,7 @@ double null_function(std::size_t i)
         d += 1 / (2. * j + 1);
     }
     {
-        test::local_spinlock::scoped_lock l(mtx[idx]);
+        boost::lock_guard<test::local_spinlock> l(mtx[idx]);
         global_init[idx] = d;
     }
     return d;

--- a/tests/performance/network/network_storage/network_storage.cpp
+++ b/tests/performance/network/network_storage/network_storage.cpp
@@ -11,6 +11,7 @@
 #include <boost/atomic.hpp>
 #include <boost/array.hpp>
 #include <boost/random.hpp>
+#include <boost/thread/locks.hpp>
 
 #include <algorithm>
 #include <iostream>
@@ -329,7 +330,7 @@ int RemoveCompletions()
     while(FuturesActive)
     {
         {
-            hpx::lcos::local::spinlock::scoped_lock lk(FuturesMutex);
+            boost::lock_guard<hpx::lcos::local::spinlock> lk(FuturesMutex);
             for(std::vector<hpx::future<int> > &futvec : ActiveFutures) {
                 for(std::vector<hpx::future<int> >::iterator fut = futvec.begin();
                     fut != futvec.end(); /**/)
@@ -454,7 +455,7 @@ void test_write(
                 );
 #ifdef USE_CLEANING_THREAD
                 ++FuturesWaiting[send_rank];
-                hpx::lcos::local::spinlock::scoped_lock lk(FuturesMutex);
+                boost::lock_guard<hpx::lcos::local::spinlock> lk(FuturesMutex);
 #endif
                 ActiveFutures[send_rank].push_back(
                     hpx::async(actWrite, locality,
@@ -619,7 +620,7 @@ void test_read(
             {
 #ifdef USE_CLEANING_THREAD
                 ++FuturesWaiting[send_rank];
-                hpx::lcos::local::spinlock::scoped_lock lk(FuturesMutex);
+                boost::lock_guard<hpx::lcos::local::spinlock> lk(FuturesMutex);
 #endif
                 using hpx::util::placeholders::_1;
                 std::size_t buffer_address = reinterpret_cast<std::size_t>(general_buffer.data());

--- a/tests/performance/network/osu/broadcast.hpp
+++ b/tests/performance/network/osu/broadcast.hpp
@@ -5,6 +5,8 @@
 
 #include <hpx/util/bind_action.hpp>
 
+#include <boost/thread/locks.hpp>
+
 #define HPX_DEFINE_COMPONENT_BROADCAST(NAME, TYPE)                              \
     void BOOST_PP_CAT(NAME, _)(TYPE const & value)                              \
     {                                                                           \
@@ -83,7 +85,7 @@ namespace hpx { namespace lcos
             else
             {
                 {
-                    mutex_type::scoped_lock lk(mtx);
+                    boost::lock_guard<mutex_type> lk(mtx);
                     bcast_future = bcast_gate.get_future(1);
 
                     ready_promise.set_value();
@@ -98,7 +100,7 @@ namespace hpx { namespace lcos
         {
             hpx::wait_all(ready_future);
             {
-                mutex_type::scoped_lock lk(mtx);
+                boost::lock_guard<mutex_type> lk(mtx);
                 recv_value = v;
                 bcast_gate.set(0);
                 ready_future = ready_promise.get_future();

--- a/tests/unit/lcos/apply_colocated.cpp
+++ b/tests/unit/lcos/apply_colocated.cpp
@@ -9,6 +9,8 @@
 #include <hpx/include/components.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/thread/locks.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////
 bool on_shutdown_executed = false;
 boost::uint32_t locality_id = boost::uint32_t(-1);
@@ -18,7 +20,7 @@ hpx::util::spinlock result_mutex;
 
 void receive_result(boost::int32_t i)
 {
-    hpx::util::spinlock::scoped_lock l(result_mutex);
+    boost::lock_guard<hpx::util::spinlock> l(result_mutex);
     if (i > final_result)
         final_result = i;
 }
@@ -59,7 +61,7 @@ HPX_REGISTER_ACTION(call_action);
 ///////////////////////////////////////////////////////////////////////////////
 void on_shutdown()
 {
-    hpx::util::spinlock::scoped_lock l(result_mutex);
+    boost::lock_guard<hpx::util::spinlock> l(result_mutex);
     HPX_TEST_EQ(final_result, 3);
 
     on_shutdown_executed = true;

--- a/tests/unit/lcos/apply_local.cpp
+++ b/tests/unit/lcos/apply_local.cpp
@@ -124,7 +124,7 @@ int hpx_main()
 #   endif
 
     hpx::lcos::local::no_mutex result_mutex;
-    hpx::lcos::local::no_mutex::scoped_lock l(result_mutex);
+    boost::unique_lock<hpx::lcos::local::no_mutex> l(result_mutex);
 #   if !defined(BOOST_NO_CXX11_LAMBDAS) && !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS)
     result_cv.wait_for(l, boost::chrono::seconds(1),
         hpx::util::bind(std::equal_to<boost::int32_t>(), boost::ref(accumulator), 18));

--- a/tests/unit/lcos/apply_local_executor.cpp
+++ b/tests/unit/lcos/apply_local_executor.cpp
@@ -124,7 +124,7 @@ void test_apply_with_executor(Executor& exec)
     }
 
     hpx::lcos::local::no_mutex result_mutex;
-    hpx::lcos::local::no_mutex::scoped_lock l(result_mutex);
+    boost::unique_lock<hpx::lcos::local::no_mutex> l(result_mutex);
     result_cv.wait_for(l, boost::chrono::seconds(1),
         hpx::util::bind(std::equal_to<boost::int32_t>(),
             boost::ref(accumulator), 18));

--- a/tests/unit/lcos/apply_remote.cpp
+++ b/tests/unit/lcos/apply_remote.cpp
@@ -9,6 +9,8 @@
 #include <hpx/include/components.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/thread/locks.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////
 bool root_locality = false;
 boost::int32_t final_result;
@@ -16,7 +18,7 @@ hpx::util::spinlock result_mutex;
 
 void receive_result(boost::int32_t i)
 {
-    hpx::util::spinlock::scoped_lock l(result_mutex);
+    boost::lock_guard<hpx::util::spinlock> l(result_mutex);
     if (i > final_result)
         final_result = i;
 }

--- a/tests/unit/lcos/condition_variable.cpp
+++ b/tests/unit/lcos/condition_variable.cpp
@@ -506,7 +506,7 @@ void test_condition_waits()
         HPX_TEST(lock ? true : false);
 
         {
-            hpx::util::scoped_unlock<unique_lock> ul(lock);
+            hpx::util::unlock_guard<unique_lock> ul(lock);
             hpx::this_thread::sleep_for(boost::chrono::milliseconds(1));
         }
 
@@ -518,7 +518,7 @@ void test_condition_waits()
         HPX_TEST_EQ(data.awoken, 1);
 
         {
-            hpx::util::scoped_unlock<unique_lock> ul(lock);
+            hpx::util::unlock_guard<unique_lock> ul(lock);
             hpx::this_thread::sleep_for(boost::chrono::milliseconds(1));
         }
 
@@ -530,7 +530,7 @@ void test_condition_waits()
         HPX_TEST_EQ(data.awoken, 2);
 
         {
-            hpx::util::scoped_unlock<unique_lock> ul(lock);
+            hpx::util::unlock_guard<unique_lock> ul(lock);
             hpx::this_thread::sleep_for(boost::chrono::milliseconds(1));
         }
 
@@ -542,7 +542,7 @@ void test_condition_waits()
         HPX_TEST_EQ(data.awoken, 3);
 
         {
-            hpx::util::scoped_unlock<unique_lock> ul(lock);
+            hpx::util::unlock_guard<unique_lock> ul(lock);
             hpx::this_thread::sleep_for(boost::chrono::milliseconds(1));
         }
 
@@ -555,7 +555,7 @@ void test_condition_waits()
 
 
         {
-            hpx::util::scoped_unlock<unique_lock> ul(lock);
+            hpx::util::unlock_guard<unique_lock> ul(lock);
             hpx::this_thread::sleep_for(boost::chrono::milliseconds(1));
         }
 

--- a/tests/unit/threads/thread.cpp
+++ b/tests/unit/threads/thread.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/assign/std/vector.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/thread/locks.hpp>
 
 using boost::program_options::variables_map;
 using boost::program_options::options_description;
@@ -122,7 +123,7 @@ void interruption_point_thread(hpx::lcos::local::barrier* b,
     hpx::lcos::local::spinlock* m, bool* failed)
 {
     try {
-        hpx::lcos::local::spinlock::scoped_lock lk(*m);
+        boost::lock_guard<hpx::lcos::local::spinlock> lk(*m);
         hpx::this_thread::interruption_point();
         *failed = true;
     }
@@ -162,7 +163,7 @@ void disabled_interruption_point_thread(hpx::lcos::local::spinlock* m,
 {
     hpx::this_thread::disable_interruption dc;
     try {
-        hpx::lcos::local::spinlock::scoped_lock lk(*m);
+        boost::lock_guard<hpx::lcos::local::spinlock> lk(*m);
         hpx::this_thread::interruption_point();
         *failed = false;
     }
@@ -240,7 +241,7 @@ void test_creation_through_reference_wrapper()
 //
 //     void operator()()
 //     {
-//         boost::mutex::scoped_lock lk(mut);
+//         boost::lock_guard<boost::mutex> lk(mut);
 //         while(!done)
 //         {
 //             cond.wait(lk);
@@ -261,7 +262,7 @@ void test_creation_through_reference_wrapper()
 //     HPX_TEST(!joined);
 //     HPX_TEST(thrd.joinable());
 //     {
-//         boost::mutex::scoped_lock lk(f.mut);
+//         boost::lock_guard<boost::mutex> lk(f.mut);
 //         f.done=true;
 //         f.cond.notify_one();
 //     }

--- a/tests/unit/threads/thread.cpp
+++ b/tests/unit/threads/thread.cpp
@@ -139,7 +139,7 @@ void do_test_thread_interrupts_at_interruption_point()
     hpx::lcos::local::spinlock m;
     hpx::lcos::local::barrier b(2);
     bool failed = false;
-    hpx::lcos::local::spinlock::scoped_lock lk(m);
+    boost::unique_lock<hpx::lcos::local::spinlock> lk(m);
     hpx::thread thrd(&interruption_point_thread, &b, &m, &failed);
     thrd.interrupt();
     lk.unlock();
@@ -179,7 +179,7 @@ void do_test_thread_no_interrupt_if_interrupts_disabled_at_interruption_point()
     hpx::lcos::local::spinlock m;
     hpx::lcos::local::barrier b(2);
     bool failed = true;
-    hpx::lcos::local::spinlock::scoped_lock lk(m);
+    boost::unique_lock<hpx::lcos::local::spinlock> lk(m);
     hpx::thread thrd(&disabled_interruption_point_thread, &m, &b, &failed);
     thrd.interrupt();
     lk.unlock();


### PR DESCRIPTION
Replace several misleading uses of `scoped_lock` by appropriate lock types.

Possible future directions include:
- Fixing lockable types that don't actually model _[Basic]Lockable_
- Deprecating/removing the rejected nested `scoped_xxx` typedefs, or otherwise making them scoped
- Expose lock ownership transfer in interfaces (don't steal ownership from lvalues)
- Providing implementations of standard generic lock types (for "cosmetic" reasons)
- Augmenting `ASSERT_OWNS_LOCK`, lock registering machinery, and others to work with `std::` lock types if available