### PR TITLE
Add this_thread_executors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,7 +371,7 @@ hpx_option(HPX_WITH_SWAP_CONTEXT_EMULATION BOOL
 # Scheduler configuration
 ################################################################################
 hpx_option(HPX_WITH_THREAD_SCHEDULERS STRING
-  "Which thread schedulers are build. Options are: all, abp-priority, local, static-priority, hierarchy, and periodic-priority. For multiple enabled schedulers, separate with a semicolon (default: all)"
+  "Which thread schedulers are build. Options are: all, abp-priority, local, static-priority, static, hierarchy, and periodic-priority. For multiple enabled schedulers, separate with a semicolon (default: all)"
   "all"
   CATEGORY "Thread Manager" ADVANCED)
 
@@ -392,6 +392,10 @@ foreach(_scheduler ${HPX_WITH_THREAD_SCHEDULERS_UC})
   if(_scheduler STREQUAL "STATIC-PRIORITY" OR _all)
     hpx_add_config_define(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     set(HPX_HAVE_STATIC_PRIORITY_SCHEDULER ON CACHE INTERNAL "")
+  endif()
+  if(_scheduler STREQUAL "STATIC" OR _all)
+    hpx_add_config_define(HPX_HAVE_STATIC_SCHEDULER)
+    set(HPX_HAVE_STATIC_SCHEDULER ON CACHE INTERNAL "")
   endif()
   if(_scheduler STREQUAL "HIERARCHY" OR _all)
     hpx_add_config_define(HPX_HAVE_HIERARCHY_SCHEDULER)

--- a/docs/manual/scheduling_policies.qbk
+++ b/docs/manual/scheduling_policies.qbk
@@ -40,7 +40,7 @@ This scheduler is enabled at build time by default and will be available always.
 
 [heading Static Priority Scheduling Policy]
 
-* invoke using: [hpx_cmdline `--hpx:queuing=static`] (or `-qs`)
+* invoke using: [hpx_cmdline `--hpx:queuing=static-priority`] (or `-qs`)
 * flag to turn on for build: `HPX_THREAD_SCHEDULERS=all` or
   `HPX_THREAD_SCHEDULERS=static-priority`
 
@@ -56,6 +56,16 @@ robin fashion. There is no thread stealing in this policy.
 
 The local scheduling policy maintains one queue per OS thread from which each
 OS thread pulls its tasks (user threads).
+
+[heading Static Scheduling Policy]
+
+* invoke using: [hpx_cmdline `--hpx:queuing=static`]
+* flag to turn on for build: `HPX_THREAD_SCHEDULERS=all` or
+  `HPX_THREAD_SCHEDULERS=static`
+
+The static scheduling policy maintains one queue per OS thread from which each
+OS thread pulls its tasks (user threads). Threads are distributed in a round
+robin fashion. There is no thread stealing in this policy.
 
 [heading Priority ABP Scheduling Policy]
 

--- a/hpx/hpx_fwd.hpp
+++ b/hpx/hpx_fwd.hpp
@@ -183,6 +183,7 @@ namespace hpx
             struct lockfree_fifo;
             struct lockfree_lifo;
 
+            // multi priority scheduler with work-stealing
             template <typename Mutex = boost::mutex
                     , typename PendingQueuing = lockfree_fifo
                     , typename StagedQueuing = lockfree_fifo
@@ -190,6 +191,7 @@ namespace hpx
                      >
             class HPX_EXPORT local_priority_queue_scheduler;
 
+            // single priority scheduler with work-stealing
             template <typename Mutex = boost::mutex
                     , typename PendingQueuing = lockfree_fifo
                     , typename StagedQueuing = lockfree_fifo
@@ -207,12 +209,23 @@ namespace hpx
 #endif
 
 #if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
+            // multi priority scheduler with no work-stealing
             template <typename Mutex = boost::mutex
                     , typename PendingQueuing = lockfree_fifo
                     , typename StagedQueuing = lockfree_fifo
                     , typename TerminatedQueuing = lockfree_lifo
                      >
             class HPX_EXPORT static_priority_queue_scheduler;
+#endif
+
+#if defined(HPX_HAVE_STATIC_SCHEDULER)
+            // single priority scheduler with no work-stealing
+            template <typename Mutex = boost::mutex
+                    , typename PendingQueuing = lockfree_fifo
+                    , typename StagedQueuing = lockfree_fifo
+                    , typename TerminatedQueuing = lockfree_lifo
+                     >
+            class HPX_EXPORT static_queue_scheduler;
 #endif
 
 #if defined(HPX_HAVE_HIERARCHY_SCHEDULER)

--- a/hpx/parallel/executors.hpp
+++ b/hpx/parallel/executors.hpp
@@ -10,5 +10,7 @@
 #include <hpx/parallel/executors/parallel_executor.hpp>
 #include <hpx/parallel/executors/parallel_fork_executor.hpp>
 #include <hpx/parallel/executors/sequential_executor.hpp>
+#include <hpx/parallel/executors/thread_pool_executors.hpp>
+#include <hpx/parallel/executors/this_thread_executors.hpp>
 
 #endif

--- a/hpx/parallel/executors/detail/thread_executor.hpp
+++ b/hpx/parallel/executors/detail/thread_executor.hpp
@@ -42,6 +42,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
                 return hpx::get_os_thread_count(exec_);
             }
 
+            bool has_pending_closures() const
+            {
+                return exec_.num_pending_closures() != 0;
+            }
+
         private:
             threads::executor exec_;
         };

--- a/hpx/parallel/executors/executor_traits.hpp
+++ b/hpx/parallel/executors/executor_traits.hpp
@@ -319,7 +319,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
             template <typename Executor>
             static auto call(wrap_int, Executor& exec) -> bool
             {
-                return hpx::get_os_thread_count();
+                return false;   // assume stateless scheduling
             }
 
             template <typename Executor>

--- a/hpx/parallel/executors/executor_traits.hpp
+++ b/hpx/parallel/executors/executor_traits.hpp
@@ -312,6 +312,29 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         {
             return os_thread_count_helper::call(0, exec);
         }
+
+        ///////////////////////////////////////////////////////////////////////
+        struct has_pending_closures_helper
+        {
+            template <typename Executor>
+            static auto call(wrap_int, Executor& exec) -> bool
+            {
+                return hpx::get_os_thread_count();
+            }
+
+            template <typename Executor>
+            static auto call(int, Executor& exec)
+                ->  decltype(exec.has_pending_closures())
+            {
+                return exec.has_pending_closures();
+            }
+        };
+
+        template <typename Executor>
+        bool call_has_pending_closures(Executor& exec)
+        {
+            return has_pending_closures_helper::call(0, exec);
+        }
         /// \endcond
     }
 
@@ -519,6 +542,19 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         static std::size_t os_thread_count(executor_type const& exec)
         {
             return detail::call_os_thread_count(exec);
+        }
+
+        /// Retrieve whether this executor has operations pending or not.
+        ///
+        /// \param exec  [in] The executor object to use for scheduling of the
+        ///              function \a f.
+        ///
+        /// \note If the executor does not expose this information, this call
+        ///       will always return \a false
+        ///
+        static bool has_pending_closures(executor_type& exec)
+        {
+            return detail::call_has_pending_closures(exec);
         }
     };
 

--- a/hpx/parallel/executors/this_thread_executors.hpp
+++ b/hpx/parallel/executors/this_thread_executors.hpp
@@ -26,13 +26,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
       : detail::threads_executor
 #endif
     {
-        /// Creates a new local_queue_executor
-        ///
-        /// \param max_punits   [in] The maximum number of processing units to
-        ///                     associate with the newly created executor.
-        /// \param min_punits   [in] The minimum number of processing units to
-        ///                     associate with the newly created executor
-        ///                     (default: 1).
+        /// Creates a new this_thread_local_queue_executor
         ///
         explicit this_thread_local_queue_executor()
           : threads_executor(
@@ -47,13 +41,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
       : detail::threads_executor
 #endif
     {
-        /// Creates a new static_priority_queue_executor
-        ///
-        /// \param max_punits   [in] The maximum number of processing units to
-        ///                     associate with the newly created executor.
-        /// \param min_punits   [in] The minimum number of processing units to
-        ///                     associate with the newly created executor
-        ///                     (default: 1).
+        /// Creates a new this_thread_static_priority_queue_executor
         ///
         explicit this_thread_static_priority_queue_executor()
           : threads_executor(

--- a/hpx/parallel/executors/this_thread_executors.hpp
+++ b/hpx/parallel/executors/this_thread_executors.hpp
@@ -20,17 +20,17 @@
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
 {
     ///////////////////////////////////////////////////////////////////////////
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
-    struct this_thread_local_queue_executor
+#if defined(HPX_HAVE_STATIC_SCHEDULER)
+    struct this_thread_static_queue_executor
 #if !defined(DOXYGEN)
       : detail::threads_executor
 #endif
     {
-        /// Creates a new this_thread_local_queue_executor
+        /// Creates a new local_queue_executor
         ///
-        explicit this_thread_local_queue_executor()
+        explicit this_thread_static_queue_executor()
           : threads_executor(
-                threads::executors::this_thread_local_queue_executor())
+                threads::executors::this_thread_static_queue_executor())
         {}
     };
 #endif
@@ -41,7 +41,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
       : detail::threads_executor
 #endif
     {
-        /// Creates a new this_thread_static_priority_queue_executor
+        /// Creates a new static_priority_queue_executor
         ///
         explicit this_thread_static_priority_queue_executor()
           : threads_executor(
@@ -53,9 +53,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
     namespace detail
     {
         /// \cond NOINTERNAL
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
+#if defined(HPX_HAVE_STATIC_SCHEDULER)
         template <>
-        struct is_executor<this_thread_local_queue_executor>
+        struct is_executor<this_thread_static_queue_executor>
           : std::true_type
         {};
 #endif

--- a/hpx/parallel/executors/this_thread_executors.hpp
+++ b/hpx/parallel/executors/this_thread_executors.hpp
@@ -1,0 +1,85 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/executors/thread_pool_executors.hpp
+
+#if !defined(HPX_PARALLEL_EXECUTORS_THIS_THREAD_EXECUTORS_JUL_16_2015_0809PM)
+#define HPX_PARALLEL_EXECUTORS_THIS_THREAD_EXECUTORS_JUL_16_2015_0809PM
+
+#include <hpx/config.hpp>
+#include <hpx/parallel/config/inline_namespace.hpp>
+#include <hpx/parallel/executors/executor_traits.hpp>
+#include <hpx/parallel/executors/detail/thread_executor.hpp>
+#include <hpx/runtime/threads/executors/this_thread_executors.hpp>
+#include <hpx/util/move.hpp>
+
+#include <type_traits>
+
+namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
+{
+    ///////////////////////////////////////////////////////////////////////////
+#if defined(HPX_HAVE_LOCAL_SCHEDULER)
+    struct this_thread_local_queue_executor
+#if !defined(DOXYGEN)
+      : detail::threads_executor
+#endif
+    {
+        /// Creates a new local_queue_executor
+        ///
+        /// \param max_punits   [in] The maximum number of processing units to
+        ///                     associate with the newly created executor.
+        /// \param min_punits   [in] The minimum number of processing units to
+        ///                     associate with the newly created executor
+        ///                     (default: 1).
+        ///
+        explicit this_thread_local_queue_executor()
+          : threads_executor(
+                threads::executors::this_thread_local_queue_executor())
+        {}
+    };
+#endif
+
+#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
+    struct this_thread_static_priority_queue_executor
+#if !defined(DOXYGEN)
+      : detail::threads_executor
+#endif
+    {
+        /// Creates a new static_priority_queue_executor
+        ///
+        /// \param max_punits   [in] The maximum number of processing units to
+        ///                     associate with the newly created executor.
+        /// \param min_punits   [in] The minimum number of processing units to
+        ///                     associate with the newly created executor
+        ///                     (default: 1).
+        ///
+        explicit this_thread_static_priority_queue_executor()
+          : threads_executor(
+                threads::executors::this_thread_static_priority_queue_executor())
+        {}
+    };
+#endif
+
+    namespace detail
+    {
+        /// \cond NOINTERNAL
+#if defined(HPX_HAVE_LOCAL_SCHEDULER)
+        template <>
+        struct is_executor<this_thread_local_queue_executor>
+          : std::true_type
+        {};
+#endif
+
+#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
+        template <>
+        struct is_executor<this_thread_static_priority_queue_executor>
+          : std::true_type
+        {};
+#endif
+        /// \endcond
+    }
+}}}
+
+#endif

--- a/hpx/parallel/executors/thread_pool_executors.hpp
+++ b/hpx/parallel/executors/thread_pool_executors.hpp
@@ -42,6 +42,28 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
     };
 #endif
 
+#if defined(HPX_HAVE_STATIC_SCHEDULER)
+    struct static_queue_executor
+#if !defined(DOXYGEN)
+      : detail::threads_executor
+#endif
+    {
+        /// Creates a new static_queue_executor
+        ///
+        /// \param max_punits   [in] The maximum number of processing units to
+        ///                     associate with the newly created executor.
+        /// \param min_punits   [in] The minimum number of processing units to
+        ///                     associate with the newly created executor
+        ///                     (default: 1).
+        ///
+        explicit static_queue_executor(std::size_t max_punits,
+                std::size_t min_punits = 1)
+          : threads_executor(threads::executors::static_queue_executor(
+                max_punits, min_punits))
+        {}
+    };
+#endif
+
     ///////////////////////////////////////////////////////////////////////////
     struct local_priority_queue_executor
 #if !defined(DOXYGEN)
@@ -91,6 +113,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
 #if defined(HPX_HAVE_LOCAL_SCHEDULER)
         template <>
         struct is_executor<local_queue_executor>
+          : std::true_type
+        {};
+#endif
+
+#if defined(HPX_HAVE_STATIC_SCHEDULER)
+        template <>
+        struct is_executor<static_queue_executor>
           : std::true_type
         {};
 #endif

--- a/hpx/runtime/threads/detail/thread_num_tss.hpp
+++ b/hpx/runtime/threads/detail/thread_num_tss.hpp
@@ -1,0 +1,57 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_RUNTIME_THREADS_DETAIL_THREAD_NUM_TSS_JUL_17_2015_0811PM)
+#define HPX_RUNTIME_THREADS_DETAIL_THREAD_NUM_TSS_JUL_17_2015_0811PM
+
+#include <hpx/config.hpp>
+#include <hpx/util/thread_specific_ptr.hpp>
+
+#include <cstdarg>
+
+namespace hpx { namespace threads { namespace detail
+{
+    ///////////////////////////////////////////////////////////////////////////
+    class thread_num_tss
+    {
+    public:
+        std::size_t set_tss_threadnum(std::size_t num);
+        void init_tss(std::size_t num);
+        void deinit_tss();
+
+        std::size_t get_worker_thread_num() const;
+
+    private:
+        // the TSS holds the number associated with a given OS thread
+        struct tls_tag {};
+        static hpx::util::thread_specific_ptr<std::size_t, tls_tag> thread_num_;
+    };
+
+    // the TSS holds the number associated with a given OS thread
+    extern thread_num_tss thread_num_tss_;
+
+    ///////////////////////////////////////////////////////////////////////////
+    struct reset_tss_helper
+    {
+        reset_tss_helper(std::size_t thread_num)
+          : thread_num_(thread_num_tss_.set_tss_threadnum(thread_num))
+        {}
+
+        ~reset_tss_helper()
+        {
+            thread_num_tss_.set_tss_threadnum(thread_num_);
+        }
+
+        std::size_t previous_thread_num() const
+        {
+            return thread_num_;
+        }
+
+    private:
+        std::size_t thread_num_;
+    };
+}}}
+
+#endif

--- a/hpx/runtime/threads/detail/thread_pool.hpp
+++ b/hpx/runtime/threads/detail/thread_pool.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/state.hpp>
+#include <hpx/runtime/threads/detail/thread_num_tss.hpp>
 #include <hpx/runtime/threads/policies/affinity_data.hpp>
 #include <hpx/runtime/threads/policies/scheduler_base.hpp>
 #include <hpx/util/thread_specific_ptr.hpp>
@@ -165,10 +166,6 @@ namespace hpx { namespace threads { namespace detail
         // Stores the mask identifying all processing units used by this
         // thread manager.
         threads::mask_type used_processing_units_;
-
-        // the TSS holds the number associated with a given OS thread
-        struct tls_tag {};
-        static hpx::util::thread_specific_ptr<std::size_t, tls_tag> thread_num_;
     };
 }}}
 

--- a/hpx/runtime/threads/executors/manage_thread_executor.hpp
+++ b/hpx/runtime/threads/executors/manage_thread_executor.hpp
@@ -1,0 +1,59 @@
+//  Copyright (c) 2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_RUNTIME_THREADS_EXECUTORS_MANAGE_THREAD_EXECUTOR_JUL_16_2015_0745PM)
+#define HPX_RUNTIME_THREADS_EXECUTORS_MANAGE_THREAD_EXECUTOR_JUL_16_2015_0745PM
+
+#include <hpx/config.hpp>
+#include <hpx/error.hpp>
+#include <hpx/runtime/threads/thread_executor.hpp>
+
+#include <cstdarg>
+
+namespace hpx { namespace threads { namespace executors { namespace detail
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename ExecutorImpl>
+    class manage_thread_executor
+      : public threads::detail::manage_executor
+    {
+    public:
+        manage_thread_executor(ExecutorImpl& sched)
+          : sched_(sched)
+        {}
+
+    protected:
+        // Return the requested policy element.
+        std::size_t get_policy_element(threads::detail::executor_parameter p,
+            error_code& ec) const
+        {
+            return sched_.get_policy_element(p, ec);
+        }
+
+        // Return statistics collected by this scheduler
+        void get_statistics(executor_statistics& stats, error_code& ec) const
+        {
+            sched_.get_statistics(stats, ec);
+        }
+
+        // Provide the given processing unit to the scheduler.
+        void add_processing_unit(std::size_t virt_core, std::size_t thread_num,
+            error_code& ec)
+        {
+            sched_.add_processing_unit(virt_core, thread_num, ec);
+        }
+
+        // Remove the given processing unit from the scheduler.
+        void remove_processing_unit(std::size_t thread_num, error_code& ec)
+        {
+            sched_.remove_processing_unit(thread_num, ec);
+        }
+
+    private:
+        ExecutorImpl& sched_;
+    };
+}}}}
+
+#endif

--- a/hpx/runtime/threads/executors/this_thread_executors.hpp
+++ b/hpx/runtime/threads/executors/this_thread_executors.hpp
@@ -83,11 +83,11 @@ namespace hpx { namespace threads { namespace executors
             void remove_processing_unit(std::size_t thread_num, error_code& ec);
 
             // give invoking context a chance to catch up with its tasks
-            void suspend_back_into_calling_context(std::size_t virt_core);
+            void suspend_back_into_calling_context();
 
         private:
             // internal run method
-            void run(std::size_t virt_core, std::size_t num_thread);
+            void run();
 
             threads::thread_state_enum thread_function_nullary(
                 closure_type func);
@@ -97,6 +97,7 @@ namespace hpx { namespace threads { namespace executors
             lcos::local::counting_semaphore shutdown_sem_;
             boost::atomic<hpx::state> state_;
             std::size_t thread_num_;
+            std::size_t parent_thread_num_;
 
             // collect statistics
             boost::atomic<boost::uint64_t> tasks_scheduled_;

--- a/hpx/runtime/threads/executors/this_thread_executors.hpp
+++ b/hpx/runtime/threads/executors/this_thread_executors.hpp
@@ -8,7 +8,7 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_LOCAL_SCHEDULER) || defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
+#if defined(HPX_HAVE_STATIC_SCHEDULER) || defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
 
 #include <hpx/state.hpp>
 #include <hpx/runtime/threads/thread_executor.hpp>
@@ -117,11 +117,11 @@ namespace hpx { namespace threads { namespace executors
 #endif
 
     ///////////////////////////////////////////////////////////////////////////
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
-    struct HPX_EXPORT this_thread_local_queue_executor
+#if defined(HPX_HAVE_STATIC_SCHEDULER)
+    struct HPX_EXPORT this_thread_static_queue_executor
       : public scheduled_executor
     {
-        this_thread_local_queue_executor();
+        this_thread_static_queue_executor();
     };
 #endif
 

--- a/hpx/runtime/threads/executors/thread_pool_executors.hpp
+++ b/hpx/runtime/threads/executors/thread_pool_executors.hpp
@@ -128,6 +128,16 @@ namespace hpx { namespace threads { namespace executors
     };
 #endif
 
+#if defined(HPX_HAVE_STATIC_SCHEDULER)
+    struct HPX_EXPORT static_queue_executor : public scheduled_executor
+    {
+        static_queue_executor();
+
+        explicit static_queue_executor(std::size_t max_punits,
+            std::size_t min_punits = 1);
+    };
+#endif
+
     struct HPX_EXPORT local_priority_queue_executor : public scheduled_executor
     {
         local_priority_queue_executor();

--- a/hpx/runtime/threads/policies/schedulers.hpp
+++ b/hpx/runtime/threads/policies/schedulers.hpp
@@ -11,6 +11,9 @@
 #if defined(HPX_HAVE_LOCAL_SCHEDULER)
 #include <hpx/runtime/threads/policies/local_queue_scheduler.hpp>
 #endif
+#if defined(HPX_HAVE_STATIC_SCHEDULER)
+#include <hpx/runtime/threads/policies/static_queue_scheduler.hpp>
+#endif
 #include <hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp>
 #if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
 #include <hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp>

--- a/hpx/runtime/threads/policies/static_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/static_queue_scheduler.hpp
@@ -1,87 +1,89 @@
-//  Copyright (c)      2013 Thomas Heller
 //  Copyright (c) 2007-2014 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(HPX_THREADMANAGER_SCHEDULING_STATIC_PRIOTITY_QUEUE_HPP)
-#define HPX_THREADMANAGER_SCHEDULING_STATIC_PRIOTITY_QUEUE_HPP
+#if !defined(HPX_THREADMANAGER_SCHEDULING_STATIC_QUEUE_JUL_22_2015_0103PM)
+#define HPX_THREADMANAGER_SCHEDULING_STATIC_QUEUE_JUL_22_2015_0103PM
+
+#include <vector>
+#include <memory>
 
 #include <hpx/config.hpp>
-#include <hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp>
+#include <hpx/exception.hpp>
+#include <hpx/util/logging.hpp>
+#include <hpx/runtime/threads/thread_data.hpp>
+#include <hpx/runtime/threads/topology.hpp>
+#include <hpx/runtime/threads/policies/thread_queue.hpp>
+#include <hpx/runtime/threads/policies/affinity_data.hpp>
+#include <hpx/runtime/threads/policies/scheduler_base.hpp>
+#include <hpx/runtime/threads/policies/local_queue_scheduler.hpp>
+
+#include <boost/noncopyable.hpp>
+#include <boost/atomic.hpp>
+#include <boost/mpl/bool.hpp>
+
+#include <hpx/config/warnings_prefix.hpp>
+
+// TODO: add branch prediction and function heat
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace threads { namespace policies
 {
+#ifdef HPX_THREAD_MINIMAL_DEADLOCK_DETECTION
     ///////////////////////////////////////////////////////////////////////////
-    /// The static_priority_queue_scheduler maintains exactly one queue of work
+    // We globally control whether to do minimal deadlock detection using this
+    // global bool variable. It will be set once by the runtime configuration
+    // startup code
+    extern bool minimal_deadlock_detection;
+#endif
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// The local_queue_scheduler maintains exactly one queue of work
     /// items (threads) per OS thread, where this OS thread pulls its next work
-    /// from. Additionally it maintains separate queues: several for high
-    /// priority threads and one for low priority threads.
-    /// High priority threads are executed by the first N OS threads before any
-    /// other work is executed. Low priority threads are executed by the last
-    /// OS thread whenever no other work is available.
-    /// This scheduler does not do any work stealing.
+    /// from.
     template <typename Mutex
             , typename PendingQueuing
             , typename StagedQueuing
             , typename TerminatedQueuing
              >
-    class static_priority_queue_scheduler
-        : public local_priority_queue_scheduler<
+    class static_queue_scheduler
+        : public local_queue_scheduler<
             Mutex, PendingQueuing, StagedQueuing, TerminatedQueuing
           >
     {
     public:
-        typedef local_priority_queue_scheduler<
+        typedef local_queue_scheduler<
             Mutex, PendingQueuing, StagedQueuing, TerminatedQueuing
         > base_type;
 
-        typedef typename base_type::init_parameter_type
-            init_parameter_type;
-
-        static_priority_queue_scheduler(init_parameter_type const& init,
+        static_queue_scheduler(
+                typename base_type::init_parameter_type const& init,
                 bool deferred_initialization = true)
           : base_type(init, deferred_initialization)
         {}
 
-        /// Return the next thread to be executed, return false if non is
+        /// Return the next thread to be executed, return false if none is
         /// available
-        bool get_next_thread(std::size_t num_thread,
+        virtual bool get_next_thread(std::size_t num_thread,
             boost::int64_t& idle_loop_count, threads::thread_data_base*& thrd)
         {
-            std::size_t queues_size = this->queues_.size();
-
             typedef typename base_type::thread_queue_type thread_queue_type;
 
-            if (num_thread < this->high_priority_queues_.size())
-            {
-                thread_queue_type* q = this->high_priority_queues_[num_thread];
-
-                q->increment_num_pending_accesses();
-                if (q->get_next_thread(thrd))
-                    return true;
-                q->increment_num_pending_misses();
-            }
+            std::size_t queues_size = this->queues_.size();
 
             {
                 HPX_ASSERT(num_thread < queues_size);
+
                 thread_queue_type* q = this->queues_[num_thread];
+                bool result = q->get_next_thread(thrd);
 
                 q->increment_num_pending_accesses();
-                if (q->get_next_thread(thrd))
+                if (result)
                     return true;
                 q->increment_num_pending_misses();
-
-                // Give up, we should have work to convert.
-                if (q->get_staged_queue_length(boost::memory_order_relaxed) != 0)
-                    return false;
             }
-
-            // Limit access to the low priority queue to one worker thread
-            if ((queues_size - 1) == num_thread)
-                return this->low_priority_queue_.get_next_thread(thrd);
 
             return false;
         }
@@ -90,20 +92,14 @@ namespace hpx { namespace threads { namespace policies
         /// manager to allow for maintenance tasks to be executed in the
         /// scheduler. Returns true if the OS thread calling this function
         /// has to be terminated (i.e. no more work has to be done).
-        bool wait_or_add_new(std::size_t num_thread, bool running,
+        virtual bool wait_or_add_new(std::size_t num_thread, bool running,
             boost::int64_t& idle_loop_count)
         {
-            HPX_ASSERT(num_thread < this->queues_.size());
+            std::size_t queues_size = this->queues_.size();
+            HPX_ASSERT(num_thread < queues_size);
 
             std::size_t added = 0;
             bool result = true;
-
-            if (num_thread < this->high_priority_queues_.size())
-            {
-                result = this->high_priority_queues_[num_thread]->
-                    wait_or_add_new(running, idle_loop_count, added) && result;
-                if (0 != added) return result;
-            }
 
             result = this->queues_[num_thread]->wait_or_add_new(running,
                 idle_loop_count, added) && result;
@@ -116,7 +112,7 @@ namespace hpx { namespace threads { namespace policies
                 bool suspended_only = true;
 
                 for (std::size_t i = 0;
-                     suspended_only && i != this->queues_.size(); ++i)
+                     suspended_only && i != queues_size; ++i)
                 {
                     suspended_only = this->queues_[i]->dump_suspended_threads(
                         i, idle_loop_count, running);
@@ -136,10 +132,6 @@ namespace hpx { namespace threads { namespace policies
                 }
             }
 #endif
-
-            result = this->low_priority_queue_.wait_or_add_new(running,
-                idle_loop_count, added) && result;
-            if (0 != added) return result;
 
             return result;
         }

--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -649,7 +649,7 @@ namespace hpx
         // local static scheduler with priority queue (one queue for each OS
         // threads plus one separate queue for high priority HPX-threads). Doesn't
         // steal.
-        int run_static(startup_function_type const& startup,
+        int run_static_priority(startup_function_type const& startup,
             shutdown_function_type const& shutdown,
             util::command_line_handling& cfg, bool blocking)
         {
@@ -730,6 +730,102 @@ namespace hpx
                 local_queue_policy;
             local_queue_policy::init_parameter_type init(
                 cfg.num_threads_, num_high_priority_queues, 1000);
+            threads::policies::init_affinity_data affinity_init(
+                pu_offset, pu_step, affinity_domain, affinity_desc);
+
+            // Build and configure this runtime instance.
+            typedef hpx::runtime_impl<local_queue_policy> runtime_type;
+            std::unique_ptr<hpx::runtime> rt(
+                new runtime_type(cfg.rtcfg_, cfg.mode_, cfg.num_threads_, init,
+                    affinity_init));
+
+            if (blocking) {
+                return run(*rt, cfg.hpx_main_f_, cfg.vm_, cfg.mode_, startup,
+                    shutdown);
+            }
+
+            // non-blocking version
+            start(*rt, cfg.hpx_main_f_, cfg.vm_, cfg.mode_, startup, shutdown);
+
+            rt.release();          // pointer to runtime is stored in TLS
+            return 0;
+        }
+#endif
+
+#if defined(HPX_HAVE_STATIC_SCHEDULER)
+        ///////////////////////////////////////////////////////////////////////
+        // local static scheduler with priority queue (one queue for each OS
+        // threads plus one separate queue for high priority HPX-threads). Doesn't
+        // steal.
+        int run_static(startup_function_type const& startup,
+            shutdown_function_type const& shutdown,
+            util::command_line_handling& cfg, bool blocking)
+        {
+            ensure_high_priority_compatibility(cfg.vm_);
+            ensure_hierarchy_arity_compatibility(cfg.vm_);
+
+            std::size_t pu_offset = std::size_t(-1);
+            std::size_t pu_step = 1;
+            std::string affinity_domain("pu");
+            std::string affinity_desc;
+
+#if defined(HPX_HAVE_HWLOC) || defined(BOOST_WINDOWS)
+            if (cfg.vm_.count("hpx:pu-offset")) {
+                pu_offset = cfg.vm_["hpx:pu-offset"].as<std::size_t>();
+                if (pu_offset >= hpx::threads::hardware_concurrency()) {
+                    throw detail::command_line_error("Invalid command line option "
+                        "--hpx:pu-offset, value must be smaller than number of "
+                        "available processing units.");
+                }
+            }
+
+            if (cfg.vm_.count("hpx:pu-step")) {
+                pu_step = cfg.vm_["hpx:pu-step"].as<std::size_t>();
+                if (pu_step == 0 || pu_step >= hpx::threads::hardware_concurrency()) {
+                    throw detail::command_line_error("Invalid command line option "
+                        "--hpx:pu-step, value must be non-zero smaller than number of "
+                        "available processing units.");
+                }
+            }
+#endif
+#if defined(HPX_HAVE_HWLOC)
+            if (cfg.vm_.count("hpx:affinity")) {
+                affinity_domain = cfg.vm_["hpx:affinity"].as<std::string>();
+                if (0 != std::string("pu").find(affinity_domain) &&
+                    0 != std::string("core").find(affinity_domain) &&
+                    0 != std::string("numa").find(affinity_domain) &&
+                    0 != std::string("machine").find(affinity_domain))
+                {
+                    throw detail::command_line_error("Invalid command line option "
+                        "--hpx:affinity, value must be one of: pu, core, numa, "
+                        "or machine.");
+                }
+            }
+            if (cfg.vm_.count("hpx:bind")) {
+                if (cfg.vm_.count("hpx:pu-offset") ||
+                    cfg.vm_.count("hpx:pu-step") ||
+                    cfg.vm_.count("hpx:affinity"))
+                {
+                    throw detail::command_line_error("Command line option --hpx:bind "
+                        "should not be used with --hpx:pu-step, --hpx:pu-offset, "
+                        "or --hpx:affinity.");
+                }
+
+                std::vector<std::string> bind_affinity =
+                    cfg.vm_["hpx:bind"].as<std::vector<std::string> >();
+                for (std::string const& s : bind_affinity)
+                {
+                    if (!affinity_desc.empty())
+                        affinity_desc += ";";
+                    affinity_desc += s;
+                }
+            }
+#endif
+            // scheduling policy
+            typedef hpx::threads::policies::static_queue_scheduler<>
+                local_queue_policy;
+            local_queue_policy::init_parameter_type init(
+                cfg.num_threads_, 1000);
             threads::policies::init_affinity_data affinity_init(
                 pu_offset, pu_step, affinity_domain, affinity_desc);
 
@@ -1062,15 +1158,27 @@ namespace hpx
                         "'cmake -DHPX_THREAD_SCHEDULERS=local'.");
 #endif
                 }
-                else if (0 == std::string("static").find(cfg.queuing_)) {
+                else if (0 == std::string("static-priority").find(cfg.queuing_)) {
 #if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
+                    cfg.queuing_ = "static-priority";
+                    result = detail::run_static_priority(startup, shutdown,
+                        cfg, blocking);
+#else
+                    throw detail::command_line_error("Command line option "
+                        "--hpx:queuing=static-priority "
+                        "is not configured in this build. Please rebuild with "
+                        "'cmake -DHPX_THREAD_SCHEDULERS=static-priority'.");
+#endif
+                }
+                else if (0 == std::string("static").find(cfg.queuing_)) {
+#if defined(HPX_HAVE_STATIC_SCHEDULER)
                     cfg.queuing_ = "static";
                     result = detail::run_static(startup, shutdown, cfg, blocking);
 #else
                     throw detail::command_line_error("Command line option "
                         "--hpx:queuing=static "
                         "is not configured in this build. Please rebuild with "
-                        "'cmake -DHPX_THREAD_SCHEDULERS=static-priority'.");
+                        "'cmake -DHPX_THREAD_SCHEDULERS=static'.");
 #endif
                 }
                 else if (0 == std::string("local-priority").find(cfg.queuing_)) {

--- a/src/runtime/threads/detail/thread_num_tss.cpp
+++ b/src/runtime/threads/detail/thread_num_tss.cpp
@@ -1,0 +1,53 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_fwd.hpp>
+#include <hpx/runtime/threads/detail/thread_num_tss.hpp>
+#include <hpx/util/assert.hpp>
+
+#include <utility>
+
+namespace hpx { namespace threads { namespace detail
+{
+    // the TSS holds the number associated with a given OS thread
+    thread_num_tss thread_num_tss_;
+
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::util::thread_specific_ptr<
+            std::size_t, thread_num_tss::tls_tag
+        > thread_num_tss::thread_num_;
+
+    void thread_num_tss::init_tss(std::size_t num)
+    {
+        // shouldn't be initialized yet
+        HPX_ASSERT(NULL == thread_num_tss::thread_num_.get());
+
+        thread_num_tss::thread_num_.reset(new std::size_t);
+        *thread_num_tss::thread_num_.get() = num;
+    }
+
+    void thread_num_tss::deinit_tss()
+    {
+        thread_num_tss::thread_num_.reset();
+    }
+
+    std::size_t thread_num_tss::set_tss_threadnum(std::size_t num)
+    {
+        // should have been initialized
+        HPX_ASSERT(NULL != thread_num_tss::thread_num_.get());
+
+        std::swap(*thread_num_tss::thread_num_.get(), num);
+        return num;
+    }
+
+    std::size_t thread_num_tss::get_worker_thread_num() const
+    {
+        if (NULL != thread_num_tss::thread_num_.get())
+            return *thread_num_tss::thread_num_;
+
+        // some OS threads are not managed by the thread-manager
+        return std::size_t(-1);
+    }
+}}}

--- a/src/runtime/threads/detail/thread_pool.cpp
+++ b/src/runtime/threads/detail/thread_pool.cpp
@@ -503,10 +503,13 @@ namespace hpx { namespace threads { namespace detail
                     hpx::util::coroutines::prepare_main_thread main_thread;
 
                     // run main Scheduler loop until terminated
-                    detail::scheduling_loop(num_thread, sched_, state_,
+                    detail::scheduling_counters counters(
                         executed_threads_[num_thread],
                         executed_thread_phases_[num_thread],
-                        tfunc_times_[num_thread], exec_times_[num_thread],
+                        tfunc_times_[num_thread], exec_times_[num_thread]);
+
+                    detail::scheduling_loop(
+                        num_thread, sched_, state_, counters,
                         util::bind(&policies::scheduler_base::idle_callback,
                             &sched_, num_thread
                         ));

--- a/src/runtime/threads/detail/thread_pool.cpp
+++ b/src/runtime/threads/detail/thread_pool.cpp
@@ -897,6 +897,12 @@ template class HPX_EXPORT hpx::threads::detail::thread_pool<
     hpx::threads::policies::local_queue_scheduler<> >;
 #endif
 
+#if defined(HPX_HAVE_STATIC_SCHEDULER)
+#include <hpx/runtime/threads/policies/static_queue_scheduler.hpp>
+template class HPX_EXPORT hpx::threads::detail::thread_pool<
+    hpx::threads::policies::static_queue_scheduler<> >;
+#endif
+
 #if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
 #include <hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp>
 template class HPX_EXPORT hpx::threads::detail::thread_pool<

--- a/src/runtime/threads/detail/thread_pool.cpp
+++ b/src/runtime/threads/detail/thread_pool.cpp
@@ -33,24 +33,15 @@ namespace hpx { namespace threads { namespace detail
 {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Scheduler>
-    hpx::util::thread_specific_ptr<
-            std::size_t, typename thread_pool<Scheduler>::tls_tag
-        > thread_pool<Scheduler>::thread_num_;
-
-    template <typename Scheduler>
     void thread_pool<Scheduler>::init_tss(std::size_t num)
     {
-        // shouldn't be initialized yet
-        HPX_ASSERT(NULL == thread_pool::thread_num_.get());
-
-        thread_pool::thread_num_.reset(new std::size_t);
-        *thread_pool::thread_num_.get() = num;
+        thread_num_tss_.init_tss(num);
     }
 
     template <typename Scheduler>
     void thread_pool<Scheduler>::deinit_tss()
     {
-        thread_pool::thread_num_.reset();
+        thread_num_tss_.deinit_tss();
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -198,11 +189,7 @@ namespace hpx { namespace threads { namespace detail
     template <typename Scheduler>
     std::size_t thread_pool<Scheduler>::get_worker_thread_num() const
     {
-        if (NULL != thread_pool::thread_num_.get())
-            return *thread_pool::thread_num_;
-
-        // some OS threads are not managed by the thread-manager
-        return std::size_t(-1);
+        return thread_num_tss_.get_worker_thread_num();
     }
 
     template <typename Scheduler>

--- a/src/runtime/threads/executors/this_thread_executors.cpp
+++ b/src/runtime/threads/executors/this_thread_executors.cpp
@@ -5,11 +5,11 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_LOCAL_SCHEDULER) || defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
+#if defined(HPX_HAVE_STATIC_SCHEDULER) || defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
 
 #include <hpx/runtime/threads/resource_manager.hpp>
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
-#include <hpx/runtime/threads/policies/local_queue_scheduler.hpp>
+#if defined(HPX_HAVE_STATIC_SCHEDULER)
+#include <hpx/runtime/threads/policies/static_queue_scheduler.hpp>
 #endif
 #if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
 #include <hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp>
@@ -384,11 +384,11 @@ namespace hpx { namespace threads { namespace executors { namespace detail
 
 namespace hpx { namespace threads { namespace executors
 {
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
+#if defined(HPX_HAVE_STATIC_SCHEDULER)
     ///////////////////////////////////////////////////////////////////////////
-    this_thread_local_queue_executor::this_thread_local_queue_executor()
+    this_thread_static_queue_executor::this_thread_static_queue_executor()
       : scheduled_executor(new detail::this_thread_executor<
-            policies::local_queue_scheduler<> >())
+            policies::static_queue_scheduler<> >())
     {}
 #endif
 

--- a/src/runtime/threads/executors/this_thread_executors.cpp
+++ b/src/runtime/threads/executors/this_thread_executors.cpp
@@ -3,19 +3,21 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/hpx_fwd.hpp>
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_LOCAL_SCHEDULER) || defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
+
 #include <hpx/runtime/threads/resource_manager.hpp>
 #if defined(HPX_HAVE_LOCAL_SCHEDULER)
 #include <hpx/runtime/threads/policies/local_queue_scheduler.hpp>
 #endif
-#include <hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp>
 #if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
 #include <hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp>
 #endif
 #include <hpx/runtime/threads/detail/scheduling_loop.hpp>
 #include <hpx/runtime/threads/detail/create_thread.hpp>
 #include <hpx/runtime/threads/detail/set_thread_state.hpp>
-#include <hpx/runtime/threads/executors/thread_pool_executors.hpp>
+#include <hpx/runtime/threads/executors/this_thread_executors.hpp>
 #include <hpx/runtime/threads/executors/manage_thread_executor.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/bind.hpp>
@@ -31,60 +33,26 @@ namespace hpx { namespace threads { namespace executors { namespace detail
 {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Scheduler>
-    thread_pool_executor<Scheduler>::thread_pool_executor(std::size_t max_punits,
-            std::size_t min_punits)
-      : scheduler_(max_punits, false), shutdown_sem_(0),
-        states_(max_punits),
-        current_concurrency_(0), max_current_concurrency_(0),
-        tasks_scheduled_(0), tasks_completed_(0),
-        max_punits_(max_punits), min_punits_(min_punits), cookie_(0),
-        self_(max_punits)
+    this_thread_executor<Scheduler>::this_thread_executor()
+      : scheduler_(1, false), shutdown_sem_(0),
+        state_(state_initialized), thread_num_(std::size_t(-1)),
+        tasks_scheduled_(0), tasks_completed_(0), cookie_(0),
+        self_(0)
     {
-        if (max_punits < min_punits)
-        {
-            HPX_THROW_EXCEPTION(bad_parameter,
-                "thread_pool_executor<Scheduler>::thread_pool_executor",
-                "max_punit shouldn't be smaller than min_punit");
-            return;
-        }
-        if (max_punits > hpx::get_os_thread_count())
-        {
-            HPX_THROW_EXCEPTION(bad_parameter,
-                "thread_pool_executor<Scheduler>::thread_pool_executor",
-                "max_punit shouldn't be larger than number of available "
-                "OS-threads");
-            return;
-        }
-
-        states_.resize(max_punits);
-        for (std::size_t i = 0; i != max_punits; ++i)
-            states_[i].store(state_initialized);
-
         // Inform the resource manager about this new executor. This causes the
         // resource manager to interact with this executor using the
         // manage_executor interface.
         resource_manager& rm = resource_manager::get();
         cookie_ = rm.initial_allocation(
-            new manage_thread_executor<thread_pool_executor>(*this));
-    }
-
-    inline bool starting_up(boost::ptr_vector<boost::atomic<hpx::state> >& states)
-    {
-        typedef boost::atomic<hpx::state> state_type;
-        for (state_type& state : states)
-        {
-            if (state.load() < state_running)
-                return true;
-        }
-        return false;
+            new manage_thread_executor<this_thread_executor>(*this));
     }
 
     template <typename Scheduler>
-    thread_pool_executor<Scheduler>::~thread_pool_executor()
+    this_thread_executor<Scheduler>::~this_thread_executor()
     {
         // if we're still starting up, give this executor a chance of executing
         // its tasks
-        while (starting_up(states_))
+        while (state_.load() < state_running)
             this_thread::suspend();
 
         // Inform the resource manager that this executor is about to be
@@ -94,7 +62,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         rm.stop_executor(cookie_);
 
         // wait for executor to finish executing
-        shutdown_sem_.wait(max_current_concurrency_.load());
+        shutdown_sem_.wait(1);
 
         // detach this executor from resource manager
         rm.detach(cookie_);     // this releases proxy (manage_thread_executor)
@@ -102,23 +70,17 @@ namespace hpx { namespace threads { namespace executors { namespace detail
 #if defined(HPX_DEBUG)
         // all resources should have been stopped at this point (or have never
         // been initialized)
-        for (std::size_t i = 0; i != states_.size(); ++i)
-        {
-            hpx::state s = states_[i].load();
-            HPX_ASSERT(s == state_initialized || s == state_stopped);
-        }
+        hpx::state s = state_.load();
+        HPX_ASSERT(s == state_initialized || s == state_stopped);
 
         // all scheduled tasks should have completed executing
         HPX_ASSERT(tasks_completed_ == tasks_scheduled_);
-
-        // all driver threads should have stopped executing
-        HPX_ASSERT(current_concurrency_ == 0);
 #endif
     }
 
     template <typename Scheduler>
     threads::thread_state_enum
-    thread_pool_executor<Scheduler>::thread_function_nullary(
+    this_thread_executor<Scheduler>::thread_function_nullary(
         closure_type func)
     {
         // execute the actual thread function
@@ -139,14 +101,19 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     // Depending on the subclass implementation, this may block in some
     // situations.
     template <typename Scheduler>
-    void thread_pool_executor<Scheduler>::add(
-        closure_type && f,
+    void this_thread_executor<Scheduler>::add(closure_type && f,
         char const* desc, threads::thread_state_enum initial_state,
         bool run_now, threads::thread_stacksize stacksize, error_code& ec)
     {
+        HPX_ASSERT(std::size_t(-1) != thread_num_);
+
+        // if the scheduler was stopped, we need to restart it
+        state expected = state_stopped;
+        state_.compare_exchange_strong(expected, state_starting);
+
         // create a new thread
         thread_init_data data(util::bind(
-            util::one_shot(&thread_pool_executor::thread_function_nullary),
+            util::one_shot(&this_thread_executor::thread_function_nullary),
             this, std::move(f)), desc);
         data.stacksize = threads::get_stack_size(stacksize);
 
@@ -161,6 +128,9 @@ namespace hpx { namespace threads { namespace executors { namespace detail
             return;
         }
 
+        // execute scheduler directly, if necessary
+        run(0, thread_num_);
+
         if (&ec != &throws)
             ec = make_success_code();
     }
@@ -169,14 +139,20 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     // than time abs_time. This call never blocks, and may violate
     // bounds on the executor's queue size.
     template <typename Scheduler>
-    void thread_pool_executor<Scheduler>::add_at(
+    void this_thread_executor<Scheduler>::add_at(
         boost::chrono::steady_clock::time_point const& abs_time,
         closure_type && f, char const* desc,
         threads::thread_stacksize stacksize, error_code& ec)
     {
+        HPX_ASSERT(std::size_t(-1) != thread_num_);
+
+        // if the scheduler was stopped, we need to restart it
+        state expected = state_stopped;
+        state_.compare_exchange_strong(expected, state_starting);
+
         // create a new suspended thread
         thread_init_data data(util::bind(
-            util::one_shot(&thread_pool_executor::thread_function_nullary),
+            util::one_shot(&this_thread_executor::thread_function_nullary),
             this, std::move(f)), desc);
         data.stacksize = threads::get_stack_size(stacksize);
 
@@ -196,6 +172,9 @@ namespace hpx { namespace threads { namespace executors { namespace detail
             return;
         }
 
+        // execute scheduler directly, if necessary
+        run(0, thread_num_);
+
         if (&ec != &throws)
             ec = make_success_code();
     }
@@ -204,7 +183,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     // than time rel_time from now. This call never blocks, and may
     // violate bounds on the executor's queue size.
     template <typename Scheduler>
-    void thread_pool_executor<Scheduler>::add_after(
+    void this_thread_executor<Scheduler>::add_after(
         boost::chrono::steady_clock::duration const& rel_time,
         closure_type && f, char const* desc,
         threads::thread_stacksize stacksize, error_code& ec)
@@ -215,12 +194,12 @@ namespace hpx { namespace threads { namespace executors { namespace detail
 
     // Return an estimate of the number of waiting tasks.
     template <typename Scheduler>
-    boost::uint64_t thread_pool_executor<Scheduler>::num_pending_closures(
+    boost::uint64_t this_thread_executor<Scheduler>::num_pending_closures(
         error_code& ec) const
     {
         if (&ec != &throws)
             ec = make_success_code();
-        return scheduler_.get_queue_length();
+        return (state_.load() < state_stopped) ? 1 : 0;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -237,22 +216,25 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     };
 
     template <typename Scheduler>
-    void thread_pool_executor<Scheduler>::suspend_back_into_calling_context(
+    void this_thread_executor<Scheduler>::suspend_back_into_calling_context(
         std::size_t virt_core)
     {
-        // give invoking context a chance to catch up with its tasks, but only
-        // if this scheduler is currently in running state
-        state expected = state_running;
-        if (states_[virt_core].compare_exchange_strong(expected, state_suspended))
+        HPX_ASSERT(0 == virt_core);
+
+        // Give invoking context a chance to catch up with its tasks, but only
+        // if this scheduler is currently in running state (this scheduler is
+        // always in stopping state as it has to exit as early as possible).
+        state expected = state_stopping;
+        if (state_.compare_exchange_strong(expected, state_suspended))
         {
             {
-                on_self_reset on_exit(self_[virt_core]);
+                on_self_reset on_exit(self_);
                 this_thread::suspend();
             }
 
             // reset state to running if current state is still suspended
             expected = state_suspended;
-            states_[virt_core].compare_exchange_strong(expected, state_running);
+            state_.compare_exchange_strong(expected, state_stopping);
         }
         else
         {
@@ -263,52 +245,49 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     ///////////////////////////////////////////////////////////////////////////
     struct on_run_exit
     {
-        on_run_exit(boost::atomic<std::size_t>& current_concurrency,
-                lcos::local::counting_semaphore& shutdown_sem,
+        on_run_exit(lcos::local::counting_semaphore& shutdown_sem,
                 threads::thread_self* self)
-          : current_concurrency_(current_concurrency),
-            shutdown_sem_(shutdown_sem),
+          : shutdown_sem_(shutdown_sem),
             self_(self)
         {
             threads::detail::set_self_ptr(0);
-            ++current_concurrency_;
         }
 
         ~on_run_exit()
         {
-            --current_concurrency_;
             threads::detail::set_self_ptr(self_);
             shutdown_sem_.signal();
         }
 
-        boost::atomic<std::size_t>& current_concurrency_;
         lcos::local::counting_semaphore& shutdown_sem_;
         threads::thread_self* self_;
     };
 
     // execute all work
     template <typename Scheduler>
-    void thread_pool_executor<Scheduler>::run(std::size_t virt_core,
+    void this_thread_executor<Scheduler>::run(std::size_t virt_core,
         std::size_t thread_num)
     {
-        // Set the state to 'state_running' only if it's still in 'state_starting'
-        // state, otherwise our destructor is currently being executed, which
-        // means we need to still execute all threads.
-        state expected = state_starting;
-        if (states_[virt_core].compare_exchange_strong(expected, state_running))
-        {
-            ++max_current_concurrency_;
+        HPX_ASSERT(0 == virt_core);
 
+        // We want to exit this scheduling loop as early as possible, thus
+        // we use 'state_stopping' instead of 'state_running'.
+
+        // Set the state to 'state_stopping' only if it's still in
+        // 'state_starting' state, otherwise our destructor is currently being
+        // executed, which means we need to still execute all threads.
+        state expected = state_starting;
+        if (state_.compare_exchange_strong(expected, state_stopping))
+        {
             {
                 typename mutex_type::scoped_lock l(mtx_);
                 scheduler_.add_punit(virt_core, thread_num);
                 scheduler_.on_start_thread(virt_core);
             }
 
-            self_[virt_core] = threads::get_self_ptr();
+            self_ = threads::get_self_ptr();
 
-            on_run_exit on_exit(current_concurrency_, shutdown_sem_,
-                self_[virt_core]);
+            on_run_exit on_exit(shutdown_sem_, self_);
 
             // FIXME: turn these values into performance counters
             boost::int64_t executed_threads = 0, executed_thread_phases = 0;
@@ -319,22 +298,22 @@ namespace hpx { namespace threads { namespace executors { namespace detail
                 overall_times, thread_times);
 
             threads::detail::scheduling_loop(virt_core, scheduler_,
-                states_[virt_core], counters, util::function_nonser<void()>(),
+                state_, counters, util::function_nonser<void()>(),
                 util::bind( //-V107
-                    &thread_pool_executor::suspend_back_into_calling_context,
+                    &this_thread_executor::suspend_back_into_calling_context,
                     this, virt_core));
 
             // the scheduling_loop is allowed to exit only if no more HPX
             // threads exist
             HPX_ASSERT(!scheduler_.get_thread_count(
                 unknown, thread_priority_default, virt_core) ||
-                states_[virt_core] == state_terminating);
+                state_ == state_terminating);
         }
     }
 
     // Return statistics collected by this scheduler
     template <typename Scheduler>
-    void thread_pool_executor<Scheduler>::get_statistics(
+    void this_thread_executor<Scheduler>::get_statistics(
         executor_statistics& stats, error_code& ec) const
     {
         if (&ec != &throws)
@@ -347,107 +326,74 @@ namespace hpx { namespace threads { namespace executors { namespace detail
 
     // Return the requested policy element
     template <typename Scheduler>
-    std::size_t thread_pool_executor<Scheduler>::get_policy_element(
+    std::size_t this_thread_executor<Scheduler>::get_policy_element(
         threads::detail::executor_parameter p, error_code& ec) const
     {
         switch(p) {
         case threads::detail::min_concurrency:
-            return min_punits_;
-
         case threads::detail::max_concurrency:
-            return max_punits_;
-
         case threads::detail::current_concurrency:
-            return current_concurrency_ ?
-                static_cast<std::size_t>(current_concurrency_)
-              : min_punits_;
+            return 1;
 
         default:
             break;
         }
 
         HPX_THROWS_IF(ec, bad_parameter,
-            "thread_pool_executor::get_policy_element",
+            "this_thread_executor::get_policy_element",
             "requested value of invalid policy element");
         return std::size_t(-1);
     }
 
     // Provide the given processing unit to the scheduler.
     template <typename Scheduler>
-    void thread_pool_executor<Scheduler>::add_processing_unit(
+    void this_thread_executor<Scheduler>::add_processing_unit(
         std::size_t virt_core, std::size_t thread_num, error_code& ec)
     {
+        HPX_ASSERT(0 == virt_core);
+        HPX_ASSERT(std::size_t(-1) == thread_num_);
+
+        thread_num_ = thread_num;
+
         state expected = state_initialized;
-        if (states_[virt_core].compare_exchange_strong(expected, state_starting))
-        {
-            register_thread_nullary(
-                util::bind(
-                    util::one_shot(&thread_pool_executor::run),
-                    this, virt_core, thread_num
-                ),
-                "thread_pool_executor thread", threads::pending, true,
-                threads::thread_priority_normal, thread_num,
-                threads::thread_stacksize_default, ec);
-        }
+        bool result = state_.compare_exchange_strong(expected, state_starting);
+        HPX_ASSERT(result);
     }
 
     // Remove the given processing unit from the scheduler.
     template <typename Scheduler>
-    void thread_pool_executor<Scheduler>::remove_processing_unit(
+    void this_thread_executor<Scheduler>::remove_processing_unit(
         std::size_t virt_core, error_code& ec)
     {
+        HPX_ASSERT(0 == virt_core);
+        HPX_ASSERT(std::size_t(-1) != thread_num_);
+
         // inform the scheduler to stop the virtual core
-        state oldstate = states_[virt_core].exchange(state_stopped);
-        HPX_ASSERT(oldstate == state_running || oldstate == state_suspended ||
-            oldstate == state_stopped);
+        state oldstate = state_.exchange(state_stopped);
+        HPX_ASSERT(oldstate == state_suspended || oldstate == state_stopped);
+
+        thread_num_ = std::size_t(-1);
     }
 }}}}
+
+#endif
 
 namespace hpx { namespace threads { namespace executors
 {
 #if defined(HPX_HAVE_LOCAL_SCHEDULER)
     ///////////////////////////////////////////////////////////////////////////
-    local_queue_executor::local_queue_executor()
-      : scheduled_executor(new detail::thread_pool_executor<
-            policies::local_queue_scheduler<> >(
-                get_os_thread_count(), 1))
-    {}
-
-    local_queue_executor::local_queue_executor(
-            std::size_t max_punits, std::size_t min_punits)
-      : scheduled_executor(new detail::thread_pool_executor<
-            policies::local_queue_scheduler<> >(
-                max_punits, min_punits))
+    this_thread_local_queue_executor::this_thread_local_queue_executor()
+      : scheduled_executor(new detail::this_thread_executor<
+            policies::local_queue_scheduler<> >())
     {}
 #endif
 
-    ///////////////////////////////////////////////////////////////////////////
-    local_priority_queue_executor::local_priority_queue_executor()
-      : scheduled_executor(new detail::thread_pool_executor<
-            policies::local_priority_queue_scheduler<> >(
-                get_os_thread_count(), 1))
-    {}
-
-    local_priority_queue_executor::local_priority_queue_executor(
-            std::size_t max_punits, std::size_t min_punits)
-      : scheduled_executor(new detail::thread_pool_executor<
-            policies::local_priority_queue_scheduler<> >(
-                max_punits, min_punits))
-    {}
-
 #if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     ///////////////////////////////////////////////////////////////////////////
-    static_priority_queue_executor::static_priority_queue_executor()
-      : scheduled_executor(new detail::thread_pool_executor<
-            policies::static_priority_queue_scheduler<> >(
-                get_os_thread_count(), 1))
-    {}
-
-    static_priority_queue_executor::static_priority_queue_executor(
-            std::size_t max_punits, std::size_t min_punits)
-      : scheduled_executor(new detail::thread_pool_executor<
-            policies::static_priority_queue_scheduler<> >(
-                max_punits, min_punits))
+    this_thread_static_priority_queue_executor::
+            this_thread_static_priority_queue_executor()
+      : scheduled_executor(new detail::this_thread_executor<
+            policies::static_priority_queue_scheduler<> >())
     {}
 #endif
 }}}

--- a/src/runtime/threads/executors/thread_pool_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_executors.cpp
@@ -8,6 +8,9 @@
 #if defined(HPX_HAVE_LOCAL_SCHEDULER)
 #include <hpx/runtime/threads/policies/local_queue_scheduler.hpp>
 #endif
+#if defined(HPX_HAVE_STATIC_SCHEDULER)
+#include <hpx/runtime/threads/policies/static_queue_scheduler.hpp>
+#endif
 #include <hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp>
 #if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
 #include <hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp>
@@ -417,6 +420,22 @@ namespace hpx { namespace threads { namespace executors
             std::size_t max_punits, std::size_t min_punits)
       : scheduled_executor(new detail::thread_pool_executor<
             policies::local_queue_scheduler<> >(
+                max_punits, min_punits))
+    {}
+#endif
+
+#if defined(HPX_HAVE_STATIC_SCHEDULER)
+    ///////////////////////////////////////////////////////////////////////////
+    static_queue_executor::static_queue_executor()
+      : scheduled_executor(new detail::thread_pool_executor<
+            policies::static_queue_scheduler<> >(
+                get_os_thread_count(), 1))
+    {}
+
+    static_queue_executor::static_queue_executor(
+            std::size_t max_punits, std::size_t min_punits)
+      : scheduled_executor(new detail::thread_pool_executor<
+            policies::static_queue_scheduler<> >(
                 max_punits, min_punits))
     {}
 #endif

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -1497,6 +1497,12 @@ template class HPX_EXPORT hpx::threads::threadmanager_impl<
     hpx::threads::policies::local_queue_scheduler<> >;
 #endif
 
+#if defined(HPX_HAVE_STATIC_SCHEDULER)
+#include <hpx/runtime/threads/policies/static_queue_scheduler.hpp>
+template class HPX_EXPORT hpx::threads::threadmanager_impl<
+    hpx::threads::policies::static_queue_scheduler<> >;
+#endif
+
 #if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
 #include <hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp>
 template class HPX_EXPORT hpx::threads::threadmanager_impl<

--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -729,6 +729,12 @@ template class HPX_EXPORT hpx::runtime_impl<
     hpx::threads::policies::local_queue_scheduler<> >;
 #endif
 
+#if defined(HPX_HAVE_STATIC_SCHEDULER)
+#include <hpx/runtime/threads/policies/static_queue_scheduler.hpp>
+template class HPX_EXPORT hpx::runtime_impl<
+    hpx::threads::policies::static_queue_scheduler<> >;
+#endif
+
 #if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
 #include <hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp>
 template class HPX_EXPORT hpx::runtime_impl<

--- a/src/util/parse_command_line.cpp
+++ b/src/util/parse_command_line.cpp
@@ -409,19 +409,22 @@ namespace hpx { namespace util
                   "the first processing unit this instance of HPX should be "
                   "run on (default: 0), valid for "
                   "--hpx:queuing=local, --hpx:queuing=abp-priority, "
-                  "--hpx:queuing=static and --hpx:queuing=local-priority only")
+                  "--hpx:queuing=static, --hpx:queuing=static-priority, "
+                  "and --hpx:queuing=local-priority only")
                 ("hpx:pu-step", value<std::size_t>(),
                   "the step between used processing unit numbers for this "
                   "instance of HPX (default: 1), valid for "
                   "--hpx:queuing=local, --hpx:queuing=abp-priority, "
-                  "--hpx:queuing=static and --hpx:queuing=local-priority only")
+                  "--hpx:queuing=static, --hpx:queuing=static-priority "
+                  "and --hpx:queuing=local-priority only")
 #endif
 #if defined(HPX_HAVE_HWLOC)
                 ("hpx:affinity", value<std::string>(),
                   "the affinity domain the OS threads will be confined to, "
                   "possible values: pu, core, numa, machine (default: pu), valid for "
                   "--hpx:queuing=local, --hpx:queuing=abp-priority, "
-                  "--hpx:queuing=static and --hpx:queuing=local-priority only")
+                  "--hpx:queuing=static, --hpx:queuing=static-priority "
+                  " and --hpx:queuing=local-priority only")
                 ("hpx:bind", value<std::vector<std::string> >()->composing(),
                   "the detailed affinity description for the OS threads, see "
                   "the documentation for a detailed description of possible "
@@ -443,8 +446,8 @@ namespace hpx { namespace util
                 ("hpx:queuing", value<std::string>(),
                   "the queue scheduling policy to use, options are "
                   "'local', 'local-priority', 'abp-priority', "
-                  "'hierarchy', 'static', and 'periodic-priority' "
-                  "(default: 'local-priority'; "
+                  "'hierarchy', 'static', 'static-priority', and "
+                  "'periodic-priority' (default: 'local-priority'; "
                   "all option values can be abbreviated)")
                 ("hpx:hierarchy-arity", value<std::size_t>(),
                   "the arity of the of the thread queue tree, valid for "
@@ -452,7 +455,8 @@ namespace hpx { namespace util
                 ("hpx:high-priority-threads", value<std::size_t>(),
                   "the number of operating system threads maintaining a high "
                   "priority queue (default: number of OS threads), valid for "
-                  "--hpx:queuing=local-priority and --hpx:queuing=abp-priority only)")
+                  "--hpx:queuing=local-priority,--hpx:queuing=static-priority, "
+                  " and --hpx:queuing=abp-priority only)")
                 ("hpx:numa-sensitive",
                   "makes the local-priority scheduler NUMA sensitive")
             ;

--- a/tests/unit/parallel/executors/CMakeLists.txt
+++ b/tests/unit/parallel/executors/CMakeLists.txt
@@ -12,6 +12,7 @@ set(tests
     parallel_fork_executor
     sequential_executor
     service_executors
+    this_thread_executors
     thread_pool_executors
    )
 

--- a/tests/unit/parallel/executors/this_thread_executors.cpp
+++ b/tests/unit/parallel/executors/this_thread_executors.cpp
@@ -1,0 +1,108 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/parallel/executors/this_thread_executors.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <algorithm>
+#include <cstdlib>
+#include <vector>
+
+#include <boost/range/functions.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+boost::thread::id test() { return boost::this_thread::get_id(); }
+
+template <typename Executor>
+void test_sync(Executor& exec)
+{
+    typedef hpx::parallel::executor_traits<Executor> traits;
+
+    HPX_TEST(traits::execute(exec, &test) == boost::this_thread::get_id());
+}
+
+template <typename Executor>
+void test_async(Executor& exec)
+{
+    typedef hpx::parallel::executor_traits<Executor> traits;
+
+    HPX_TEST(
+        traits::async_execute(exec, &test).get() ==
+        boost::this_thread::get_id());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void bulk_test(boost::thread::id tid, int value)
+{
+    HPX_TEST(tid == boost::this_thread::get_id());
+}
+
+template <typename Executor>
+void test_bulk_sync(Executor& exec)
+{
+    typedef hpx::parallel::executor_traits<Executor> traits;
+
+    boost::thread::id tid = boost::this_thread::get_id();
+
+    std::vector<int> v(107);
+    std::iota(boost::begin(v), boost::end(v), std::rand());
+
+    using hpx::util::placeholders::_1;
+    traits::execute(exec, hpx::util::bind(&bulk_test, tid, _1), v);
+}
+
+template <typename Executor>
+void test_bulk_async(Executor& exec)
+{
+    typedef hpx::parallel::executor_traits<Executor> traits;
+
+    boost::thread::id tid = boost::this_thread::get_id();
+
+    std::vector<int> v(107);
+    std::iota(boost::begin(v), boost::end(v), std::rand());
+
+    using hpx::util::placeholders::_1;
+    hpx::when_all(traits::async_execute(
+        exec, hpx::util::bind(&bulk_test, tid, _1), v)).get();
+}
+
+template <typename Executor>
+void test_this_thread_executor(Executor& exec)
+{
+    test_sync(exec);
+    test_async(exec);
+    test_bulk_sync(exec);
+    test_bulk_async(exec);
+}
+
+int hpx_main(int argc, char* argv[])
+{
+#if defined(HPX_HAVE_LOCAL_SCHEDULER)
+    {
+        hpx::parallel::this_thread_local_queue_executor exec;
+        test_this_thread_executor(exec);
+    }
+#endif
+
+#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
+    {
+        hpx::parallel::this_thread_static_priority_queue_executor exec;
+        test_this_thread_executor(exec);
+    }
+#endif
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/parallel/executors/this_thread_executors.cpp
+++ b/tests/unit/parallel/executors/this_thread_executors.cpp
@@ -81,9 +81,9 @@ void test_this_thread_executor(Executor& exec)
 
 int hpx_main(int argc, char* argv[])
 {
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
+#if defined(HPX_HAVE_STATIC_SCHEDULER)
     {
-        hpx::parallel::this_thread_local_queue_executor exec;
+        hpx::parallel::this_thread_static_queue_executor exec;
         test_this_thread_executor(exec);
     }
 #endif

--- a/tests/unit/parallel/executors/this_thread_executors.cpp
+++ b/tests/unit/parallel/executors/this_thread_executors.cpp
@@ -15,14 +15,14 @@
 #include <boost/range/functions.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-boost::thread::id test() { return boost::this_thread::get_id(); }
+std::size_t test() { return hpx::get_worker_thread_num(); }
 
 template <typename Executor>
 void test_sync(Executor& exec)
 {
     typedef hpx::parallel::executor_traits<Executor> traits;
 
-    HPX_TEST(traits::execute(exec, &test) == boost::this_thread::get_id());
+    HPX_TEST(traits::execute(exec, &test) == hpx::get_worker_thread_num());
 }
 
 template <typename Executor>
@@ -32,13 +32,13 @@ void test_async(Executor& exec)
 
     HPX_TEST(
         traits::async_execute(exec, &test).get() ==
-        boost::this_thread::get_id());
+        hpx::get_worker_thread_num());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void bulk_test(boost::thread::id tid, int value)
+void bulk_test(std::size_t tid, int value)
 {
-    HPX_TEST(tid == boost::this_thread::get_id());
+    HPX_TEST(tid == hpx::get_worker_thread_num());
 }
 
 template <typename Executor>
@@ -46,7 +46,7 @@ void test_bulk_sync(Executor& exec)
 {
     typedef hpx::parallel::executor_traits<Executor> traits;
 
-    boost::thread::id tid = boost::this_thread::get_id();
+    std::size_t tid = hpx::get_worker_thread_num();
 
     std::vector<int> v(107);
     std::iota(boost::begin(v), boost::end(v), std::rand());
@@ -60,7 +60,7 @@ void test_bulk_async(Executor& exec)
 {
     typedef hpx::parallel::executor_traits<Executor> traits;
 
-    boost::thread::id tid = boost::this_thread::get_id();
+    std::size_t tid = hpx::get_worker_thread_num();
 
     std::vector<int> v(107);
     std::iota(boost::begin(v), boost::end(v), std::rand());

--- a/tests/unit/parallel/executors/thread_pool_executors.cpp
+++ b/tests/unit/parallel/executors/thread_pool_executors.cpp
@@ -83,9 +83,9 @@ int hpx_main(int argc, char* argv[])
 {
     std::size_t num_threads = hpx::get_os_thread_count();
 
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
+#if defined(HPX_HAVE_STATIC_SCHEDULER)
     {
-        hpx::parallel::local_queue_executor exec(num_threads);
+        hpx::parallel::static_queue_executor exec(num_threads);
         test_thread_pool_executor(exec);
     }
 #endif


### PR DESCRIPTION
- also add executor_traits<>:;has_pending_closures()
- refactoring interface of scheduling_loop
- exit scheduling loop without delay if called from inner scheduler (fixes performance regression)
- add missing #includes