### PR TITLE
Fixing the MPI parcelport

### DIFF
--- a/hpx/plugins/parcelport/mpi/mpi_environment.hpp
+++ b/hpx/plugins/parcelport/mpi/mpi_environment.hpp
@@ -38,6 +38,7 @@ namespace hpx { namespace util
         {
             scoped_lock();
             ~scoped_lock();
+            void unlock();
             HPX_MOVABLE_BUT_NOT_COPYABLE(scoped_lock);
         };
 
@@ -45,6 +46,7 @@ namespace hpx { namespace util
         {
             scoped_try_lock();
             ~scoped_try_lock();
+            void unlock();
             bool locked;
             HPX_MOVABLE_BUT_NOT_COPYABLE(scoped_try_lock);
         };

--- a/hpx/plugins/parcelport/mpi/receiver.hpp
+++ b/hpx/plugins/parcelport/mpi/receiver.hpp
@@ -158,7 +158,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
             return std::unique_ptr<connection_type>();
         }
 
-        connection_ptr accept_locked(mutex_type::scoped_try_lock & header_lock)
+        connection_ptr accept_locked(boost::unique_lock<mutex_type> & header_lock)
         {
             util::mpi_environment::scoped_try_lock l;
 

--- a/hpx/plugins/parcelport/mpi/receiver.hpp
+++ b/hpx/plugins/parcelport/mpi/receiver.hpp
@@ -9,10 +9,12 @@
 #define HPX_PARCELSET_POLICIES_MPI_RECEIVER_HPP
 
 #include <hpx/plugins/parcelport/mpi/header.hpp>
-#include <hpx/runtime/parcelset/decode_parcels.hpp>
+#include <hpx/plugins/parcelport/mpi/receiver_connection.hpp>
 
 #include <hpx/util/memory_chunk_pool.hpp>
-#include <hpx/util/memory_chunk_pool_allocator.hpp>
+
+#include <list>
+#include <iterator>
 
 namespace hpx { namespace parcelset { namespace policies { namespace mpi
 {
@@ -24,74 +26,15 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
         typedef std::list<std::pair<int, header> > header_list;
         typedef std::set<std::pair<int, int> > handles_header_type;
         typedef util::memory_chunk_pool<mutex_type> memory_pool_type;
-        typedef util::detail::memory_chunk_pool_allocator<
-                char, memory_pool_type
-            > allocator_type;
         typedef
-            std::vector<char, allocator_type>
-            data_type;
-        typedef parcel_buffer<data_type, data_type> buffer_type;
-
-        struct handle_header
-        {
-            handle_header(header_list::iterator it, receiver &receiver,
-                    mutex_type::scoped_lock * l)
-              : receiver_(receiver)
-              , handles_(false)
-              , l_(l)
-            {
-                // as handle_header tries to acquire a mutex as well, we need
-                // to ignore the headers_mtx_ here
-                util::ignore_while_checking<mutex_type::scoped_lock> il(l_);
-                mutex_type::scoped_lock lk(receiver_.handles_header_mtx_);
-                std::pair<int, int> p(it->first, it->second.tag());
-                header_handle_ = receiver_.handles_header_.find(p);
-
-                if(header_handle_ == receiver_.handles_header_.end())
-                {
-                    handles_ = true;
-                    std::pair<handles_header_type::iterator, bool> ins_pair =
-                        receiver_.handles_header_.insert(p);
-                    HPX_ASSERT(ins_pair.second);
-                    header_handle_ = ins_pair.first;
-                }
-            }
-
-            handle_header(handle_header && other)
-              : receiver_(other.receiver_)
-              , handles_(other.handles_)
-              , l_(other.l_)
-              , header_handle_(other.header_handle_)
-            {
-                other.handles_ = false;
-            }
-
-            ~handle_header()
-            {
-                // as handle_header tries to acquire a mutex as well, we need
-                // to ignore the headers_mtx_ here
-                util::ignore_while_checking<mutex_type::scoped_lock> il(l_);
-                mutex_type::scoped_lock lk(receiver_.handles_header_mtx_);
-                if(handles_)
-                {
-                    HPX_ASSERT(header_handle_ != receiver_.handles_header_.end());
-
-                    receiver_.handles_header_.erase(header_handle_);
-                }
-#if defined(HPX_DEBUG) && !defined(BOOST_MSVC)
-                else
-                {
-                    HPX_ASSERT(header_handle_ != receiver_.handles_header_.end());
-                }
+            receiver_connection
+            connection_type;
+#if defined(HPX_INTEL_VERSION) && ((__GNUC__ == 4 && __GNUC_MINOR__ == 4) || HPX_INTEL_VERSION < 1400)
+        typedef boost::shared_ptr<connection_type> connection_ptr;
+#else
+        typedef std::unique_ptr<connection_type> connection_ptr;
 #endif
-            }
-
-            receiver &receiver_;
-            bool handles_;
-            mutex_type::scoped_lock * l_;
-            handles_header_type::iterator header_handle_;
-            HPX_MOVABLE_BUT_NOT_COPYABLE(handle_header);
-        };
+        typedef std::list<connection_ptr> connection_list;
 
         receiver(parcelport & pp, memory_pool_type & chunk_pool
               , std::size_t max_connections)
@@ -106,221 +49,138 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
             new_header();
         }
 
-        struct check_num_connections
+        bool background_work(std::size_t num_thread)
         {
-            check_num_connections(receiver *r)
-             : this_(r)
-             , decrement_(false)
+            // We accept as many connections as we can ...
+            while(true)
             {
-                if(this_->num_connections_ >= this_->max_connections_)
-                    return;
-                decrement_ = true;
-                ++this_->num_connections_;
-            }
-
-            ~check_num_connections()
-            {
-                if(decrement_)
+                connection_ptr rcv = accept();
+                if(rcv)
                 {
-                    --this_->num_connections_;
-                }
-            }
-
-            receiver *this_;
-            bool decrement_;
-        };
-
-        bool receive(bool background = true)
-        {
-            typedef header_list::iterator iterator;
-
-            bool has_work = true;
-            bool did_some_work = false;
-
-            while(has_work)
-            {
-                check_num_connections chk(this);
-                if(!chk.decrement_) break;
-                mutex_type::scoped_lock l(headers_mtx_);
-                accept_locked();
-                iterator it = headers_.begin();
-                while(it != headers_.end())
-                {
-                    handle_header handle(it, *this, &l);
-                    if(handle.handles_)
+                    if(!rcv->receive())
                     {
-
-                        int source = it->first;
-                        header h = it->second;
-                        headers_.erase(it);
-
-                        {
-                            hpx::util::scoped_unlock<mutex_type::scoped_lock> ul(l);
-
-                            std::size_t num_thread(-1);
-                            if(threads::get_self_ptr())
-                                num_thread = hpx::get_worker_thread_num();
-
-                            error_code ec(lightweight);
-                            if(hpx::is_starting())
-                            {
-                                receive_message(source, h, std::move(handle));
-                            }
-                            else
-                            {
-                                hpx::applier::register_thread_nullary(
-                                    util::bind(
-                                        util::one_shot(&receiver::receive_message),
-                                        this, source, h, std::move(handle)),
-                                    "mpi::receiver::receive_message",
-                                    threads::pending, true, threads::thread_priority_boost,
-                                    num_thread, threads::thread_stacksize_default, ec);
-                            }
-                            h.reset();
-                        }
-
-                        if(background)
-                            it = headers_.begin();
-                        else
-                            it = headers_.end();
-
-                        did_some_work = true;
-                    }
-                    else
-                    {
-                        ++it;
+                        boost::unique_lock<mutex_type> l(connections_mtx_);
+                        connections_.push_back(std::move(rcv));
                     }
                 }
-                if(it == headers_.end()) has_work = false;
+                else
+                {
+                    break;
+                }
             }
-            return did_some_work;
+
+            connection_list connections;
+            {
+                boost::unique_lock<mutex_type> l(connections_mtx_);
+                std::swap(connections, connections_);
+            }
+
+            if(!connections.empty())
+            {
+                if(hpx::is_starting())
+                {
+                    receive_messages(std::move(connections));
+                }
+                else
+                {
+//                     error_code ec(lightweight);
+                    hpx::applier::register_thread_nullary(
+                        util::bind(
+                            util::one_shot(&receiver::receive_messages),
+                            this, std::move(connections)),
+                        "mpi::receiver::receive_messages",
+                        threads::pending, true, threads::thread_priority_boost,
+                        num_thread, threads::thread_stacksize_default);
+                }
+                return true;
+            }
+            return false;
         }
 
-        void receive_message(int source, header h, handle_header)
+        void receive_messages(
+            connection_list connections
+        )
         {
-            util::high_resolution_timer timer;
-            MPI_Request request;
-            MPI_Request *wait_request = NULL;
-            // Now do receives ...
-            h.assert_valid();
+            std::size_t k = 0;
+            connection_list::iterator it = connections.begin();
 
-            int tag = h.tag();
-
-            allocator_type alloc(chunk_pool_);
-            buffer_type buffer(alloc);
-
-            performance_counters::parcels::data_point& data = buffer.data_point_;
-            data.time_ = timer.elapsed_nanoseconds();
-            data.bytes_ = static_cast<std::size_t>(h.numbytes());
-
-            buffer.data_.resize(static_cast<std::size_t>(h.size()));
-            buffer.num_chunks_ = h.num_chunks();
-
-            // determine the size of the chunk buffer
-            std::size_t num_zero_copy_chunks =
-                static_cast<std::size_t>(
-                    static_cast<boost::uint32_t>(buffer.num_chunks_.first));
-            std::size_t num_non_zero_copy_chunks =
-                static_cast<std::size_t>(
-                    static_cast<boost::uint32_t>(buffer.num_chunks_.second));
-
-            if(num_zero_copy_chunks != 0)
+            // Handle all receives
+            while(it != connections.end())
             {
-                buffer.transmission_chunks_.resize(
-                    num_zero_copy_chunks + num_non_zero_copy_chunks
-                );
+                connection_type & rcv = **it;
+                if(rcv.receive())
                 {
-                    util::mpi_environment::scoped_lock l;
-                    MPI_Irecv(
-                        buffer.transmission_chunks_.data()
-                      , static_cast<int>(
-                            buffer.transmission_chunks_.size()
-                          * sizeof(buffer_type::transmission_chunk_type)
-                        )
-                      , MPI_BYTE
-                      , source
-                      , tag
-                      , util::mpi_environment::communicator()
-                      , &request
-                    );
-                    wait_request = &request;
+                    it = connections.erase(it);
                 }
-                buffer.chunks_.resize(num_zero_copy_chunks, data_type(alloc));
-            }
-
-            char *piggy_back = h.piggy_back();
-            if(piggy_back)
-            {
-                std::memcpy(&buffer.data_[0], piggy_back, buffer.data_.size());
-            }
-            else
-            {
-                wait_done(wait_request);
+                else
                 {
-                    util::mpi_environment::scoped_lock l;
-                    MPI_Irecv(
-                        buffer.data_.data()
-                      , static_cast<int>(buffer.data_.size())
-                      , MPI_BYTE
-                      , source
-                      , tag
-                      , util::mpi_environment::communicator()
-                      , &request
-                    );
-                    wait_request = &request;
+                    if(k < 32 || k & 1) //-V112
+                    {
+                        if(threads::get_self_ptr())
+                            hpx::this_thread::suspend(hpx::threads::pending,
+                                "mpi::receiver::wait_done");
+                    }
+                    ++k;
+                    ++it;
                 }
             }
 
-            std::size_t chunk_idx = 0;
-            for(data_type & c: buffer.chunks_)
+            if(!connections.empty())
             {
-                wait_done(wait_request);
-                std::size_t chunk_size = buffer.transmission_chunks_[chunk_idx++].second;
-
-                c.resize(chunk_size);
+                boost::unique_lock<mutex_type> l(connections_mtx_);
+                if(connections_.empty())
                 {
-                    util::mpi_environment::scoped_lock l;
-                    MPI_Irecv(
-                        c.data()
-                      , static_cast<int>(c.size())
-                      , MPI_BYTE
-                      , source
-                      , tag
-                      , util::mpi_environment::communicator()
-                      , &request
+                    std::swap(connections, connections_);
+                }
+                else
+                {
+                    connections_.insert(
+                        connections_.end()
+#if defined(HPX_INTEL_VERSION) && ((__GNUC__ == 4 && __GNUC_MINOR__ == 4) || HPX_INTEL_VERSION < 1400)
+                      , connections.begin()
+                      , connections.end()
+#else
+                      , std::make_move_iterator(connections.begin())
+                      , std::make_move_iterator(connections.end())
+#endif
                     );
-                    wait_request = &request;
                 }
             }
-
-            wait_done(wait_request);
-
-            data.time_ = timer.elapsed_nanoseconds() - data.time_;
-
-            decode_parcel(pp_, std::move(buffer));
         }
 
-        void accept()
+        connection_ptr accept()
         {
             mutex_type::scoped_try_lock l(headers_mtx_);
             if(l)
-                accept_locked();
+                return accept_locked(l);
+            return std::unique_ptr<connection_type>();
         }
 
-        void accept_locked()
+        connection_ptr accept_locked(mutex_type::scoped_try_lock & header_lock)
         {
             util::mpi_environment::scoped_try_lock l;
 
+            connection_ptr res;
             if(l.locked)
             {
                 MPI_Status status;
                 if(request_done_locked(hdr_request_, &status))
                 {
                     header h = new_header();
-                    h.assert_valid();
-                    headers_.push_back(std::make_pair(status.MPI_SOURCE, h));
+                    l.unlock();
+                    header_lock.unlock();
+                    res.reset(
+                        new connection_type(
+                            status.MPI_SOURCE
+                          , h
+                          , pp_
+                          , chunk_pool_
+                        )
+                    );
+                    return res;
                 }
             }
+            return res;
         }
 
         header new_header()
@@ -346,7 +206,6 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
         mutex_type headers_mtx_;
         MPI_Request hdr_request_;
         header rcv_header_;
-        std::list<std::pair<int, header> > headers_;
 
         mutex_type handles_header_mtx_;
         handles_header_type handles_header_;
@@ -354,44 +213,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
         mutex_type connections_mtx_;
         std::size_t const max_connections_;
         boost::atomic<std::size_t> num_connections_;
-
-        void wait_done(MPI_Request *& request)
-        {
-            if(request == NULL) return;
-
-            std::size_t k = 0;
-
-            MPI_Status status;
-            while(true)
-            {
-                if(request_done(*request, &status))
-                {
-                    break;
-                }
-
-                if (k < 4) //-V112
-                {
-                }
-                else if(k < 32 || k & 1) //-V112
-                {
-                    if(threads::get_self_ptr())
-                        hpx::this_thread::suspend(hpx::threads::pending,
-                            "mpi::sender::wait_done");
-                }
-                else
-                {
-                    accept();
-                }
-                ++k;
-            }
-            request = NULL;
-        }
-
-        bool request_done(MPI_Request & r, MPI_Status *status)
-        {
-            util::mpi_environment::scoped_lock l;
-            return request_done_locked(r, status);
-        }
+        connection_list connections_;
 
         bool request_done_locked(MPI_Request & r, MPI_Status *status)
         {

--- a/hpx/plugins/parcelport/mpi/receiver_connection.hpp
+++ b/hpx/plugins/parcelport/mpi/receiver_connection.hpp
@@ -1,0 +1,260 @@
+//  Copyright (c) 2014-2015 Thomas Heller
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_PARCELSET_POLICIES_MPI_RECEIVER_CONNECTION_HPP
+#define HPX_PARCELSET_POLICIES_MPI_RECEIVER_CONNECTION_HPP
+
+#include <hpx/plugins/parcelport/mpi/header.hpp>
+#include <hpx/runtime/parcelset/decode_parcels.hpp>
+#include <hpx/runtime/parcelset/parcel_buffer.hpp>
+
+#include <hpx/util/memory_chunk_pool.hpp>
+#include <hpx/util/memory_chunk_pool_allocator.hpp>
+
+#include <vector>
+
+namespace hpx { namespace parcelset { namespace policies { namespace mpi
+{
+    class parcelport;
+
+    struct receiver_connection
+    {
+    private:
+        enum connection_state
+        {
+            initialized
+          , rcvd_transmission_chunks
+          , rcvd_data
+          , rcvd_chunks
+          , sent_release_tag
+        };
+
+        typedef hpx::lcos::local::spinlock mutex_type;
+
+        typedef util::memory_chunk_pool<mutex_type> memory_pool_type;
+        typedef util::detail::memory_chunk_pool_allocator<
+                char, memory_pool_type
+            > allocator_type;
+        typedef
+            std::vector<char, allocator_type>
+            data_type;
+        typedef parcel_buffer<data_type, data_type> buffer_type;
+
+    public:
+        receiver_connection(
+            int src
+          , header h
+          , parcelport & pp
+          , memory_pool_type & chunk_pool
+        )
+          : state_(initialized)
+          , src_(src)
+          , tag_(h.tag())
+          , header_(h)
+          , allocator_(chunk_pool)
+          , buffer_(allocator_)
+          , request_ptr_(0)
+          , chunks_idx_(0)
+          , pp_(pp)
+        {
+            header_.assert_valid();
+
+            performance_counters::parcels::data_point& data = buffer_.data_point_;
+            data.time_ = timer_.elapsed_nanoseconds();
+            data.bytes_ = static_cast<std::size_t>(header_.numbytes());
+
+            buffer_.data_.resize(static_cast<std::size_t>(header_.size()));
+            buffer_.num_chunks_ = header_.num_chunks();
+        }
+
+        bool receive()
+        {
+            switch (state_)
+            {
+                case initialized:
+                    return receive_transmission_chunks();
+                case rcvd_transmission_chunks:
+                    return receive_data();
+                case rcvd_data:
+                    return receive_chunks();
+                case rcvd_chunks:
+                    return send_release_tag();
+                case sent_release_tag:
+                    return done();
+                default:
+                    HPX_ASSERT(false);
+            }
+            return false;
+        }
+
+        bool receive_transmission_chunks()
+        {
+            // determine the size of the chunk buffer
+            std::size_t num_zero_copy_chunks =
+                static_cast<std::size_t>(
+                    static_cast<boost::uint32_t>(buffer_.num_chunks_.first));
+            std::size_t num_non_zero_copy_chunks =
+                static_cast<std::size_t>(
+                    static_cast<boost::uint32_t>(buffer_.num_chunks_.second));
+            buffer_.transmission_chunks_.resize(
+                num_zero_copy_chunks + num_non_zero_copy_chunks
+            );
+            if(num_zero_copy_chunks != 0)
+            {
+                buffer_.chunks_.resize(num_zero_copy_chunks, data_type(allocator_));
+                {
+                    util::mpi_environment::scoped_lock l;
+                    MPI_Irecv(
+                        buffer_.transmission_chunks_.data()
+                      , static_cast<int>(
+                            buffer_.transmission_chunks_.size()
+                          * sizeof(buffer_type::transmission_chunk_type)
+                        )
+                      , MPI_BYTE
+                      , src_
+                      , tag_
+                      , util::mpi_environment::communicator()
+                      , &request_
+                    );
+                    request_ptr_ = &request_;
+                }
+            }
+
+            state_ = rcvd_transmission_chunks;
+
+            return receive_data();
+        }
+
+        bool receive_data()
+        {
+            if(!request_done()) return false;
+
+            char *piggy_back = header_.piggy_back();
+            if(piggy_back)
+            {
+                std::memcpy(&buffer_.data_[0], piggy_back, buffer_.data_.size());
+            }
+            else
+            {
+                util::mpi_environment::scoped_lock l;
+                MPI_Irecv(
+                    buffer_.data_.data()
+                  , static_cast<int>(buffer_.data_.size())
+                  , MPI_BYTE
+                  , src_
+                  , tag_
+                  , util::mpi_environment::communicator()
+                  , &request_
+                );
+                request_ptr_ = &request_;
+            }
+
+            state_ = rcvd_data;
+
+            return receive_chunks();
+        }
+
+        bool receive_chunks()
+        {
+            while(chunks_idx_ < buffer_.chunks_.size())
+            {
+                if(!request_done()) return false;
+
+                std::size_t idx = chunks_idx_++;
+                std::size_t chunk_size = buffer_.transmission_chunks_[idx].second;
+
+                data_type & c = buffer_.chunks_[idx];
+                c.resize(chunk_size);
+                {
+                    util::mpi_environment::scoped_lock l;
+                    MPI_Irecv(
+                        c.data()
+                      , static_cast<int>(c.size())
+                      , MPI_BYTE
+                      , src_
+                      , tag_
+                      , util::mpi_environment::communicator()
+                      , &request_
+                    );
+                    request_ptr_ = &request_;
+                }
+            }
+
+            state_ = rcvd_chunks;
+
+            return send_release_tag();
+        }
+
+        bool send_release_tag()
+        {
+            if(!request_done()) return false;
+
+            performance_counters::parcels::data_point& data = buffer_.data_point_;
+            data.time_ = timer_.elapsed_nanoseconds() - data.time_;
+
+            {
+                util::mpi_environment::scoped_lock l;
+                MPI_Isend(
+                    &tag_
+                  , 1
+                  , MPI_INT
+                  , src_
+                  , 1
+                  , util::mpi_environment::communicator()
+                  , &request_
+                );
+                request_ptr_ = &request_;
+            }
+
+            decode_parcel(pp_, std::move(buffer_));
+
+            state_ = sent_release_tag;
+
+            return done();
+        }
+
+        bool done()
+        {
+            return request_done();
+        }
+
+        bool request_done()
+        {
+            if(request_ptr_ == 0) return true;
+
+            util::mpi_environment::scoped_lock l;
+
+            int completed = 0;
+            MPI_Status status;
+            int ret = 0;
+            ret = MPI_Test(request_ptr_, &completed, &status);
+            HPX_ASSERT(ret == MPI_SUCCESS);
+            if(completed)// && status.MPI_ERROR != MPI_ERR_PENDING)
+            {
+                request_ptr_ = 0;
+                return true;
+            }
+            return false;
+        }
+
+        util::high_resolution_timer timer_;
+
+        connection_state state_;
+
+        int src_;
+        int tag_;
+        header header_;
+        allocator_type allocator_;
+        buffer_type buffer_;
+
+        MPI_Request request_;
+        MPI_Request *request_ptr_;
+        std::size_t chunks_idx_;
+
+        parcelport & pp_;
+    };
+}}}}
+
+#endif

--- a/hpx/plugins/parcelport/mpi/sender.hpp
+++ b/hpx/plugins/parcelport/mpi/sender.hpp
@@ -9,76 +9,40 @@
 
 #include <hpx/lcos/local/spinlock.hpp>
 
-#include <hpx/plugins/parcelport/mpi/header.hpp>
 #include <hpx/plugins/parcelport/mpi/mpi_environment.hpp>
+#include <hpx/plugins/parcelport/mpi/sender_connection.hpp>
+#include <hpx/plugins/parcelport/mpi/tag_provider.hpp>
+
+#include <list>
+#include <iterator>
 
 namespace hpx { namespace parcelset { namespace policies { namespace mpi
 {
-    struct tag_provider
-    {
-        typedef lcos::local::spinlock mutex_type;
-
-        struct tag
-        {
-            tag(tag_provider *provider)
-              : provider_(provider)
-              , tag_(provider_->acquire())
-            {}
-
-            operator int () const
-            {
-                return tag_;
-            }
-
-            ~tag()
-            {
-                provider_->release(tag_);
-            }
-
-            tag_provider *provider_;
-            int tag_;
-        };
-
-        tag_provider()
-          : next_tag_(1)
-        {}
-
-        tag operator()()
-        {
-            return tag(this);
-        }
-
-        int acquire()
-        {
-            mutex_type::scoped_lock l(mtx_);
-            if(free_tags_.empty())
-                return next_tag_++;
-
-            int tag = free_tags_.front();
-            free_tags_.pop_front();
-            return tag;
-        }
-
-        void release(int tag)
-        {
-            if(tag == next_tag_) return;
-
-            mutex_type::scoped_lock l(mtx_);
-            free_tags_.push_back(tag);
-        }
-
-        mutex_type mtx_;
-        int next_tag_;
-        std::deque<int> free_tags_;
-    };
-
+    template <typename Buffer>
     struct sender
     {
+        typedef
+            sender_connection<typename hpx::util::decay<Buffer>::type>
+            connection_type;
+#if defined(HPX_INTEL_VERSION) && ((__GNUC__ == 4 && __GNUC_MINOR__ == 4) || HPX_INTEL_VERSION < 1400)
+        typedef boost::shared_ptr<connection_type> connection_ptr;
+#else
+        typedef std::unique_ptr<connection_type> connection_ptr;
+#endif
+        typedef std::list<connection_ptr> connection_list;
+
         typedef hpx::lcos::local::spinlock mutex_type;
         sender(std::size_t max_connections)
           : max_connections_(max_connections)
           , num_connections_(0)
-        {}
+          , next_free_tag_(-1)
+        {
+        }
+
+        void run()
+        {
+            get_next_free_tag();
+        }
 
         struct check_num_connections
         {
@@ -111,151 +75,179 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
             bool decrement_;
         };
 
-        template <typename Buffer, typename Background>
-        void send(int dest, Buffer & buffer, Background background)
+        template <typename Handler>
+        void send(
+            int dest
+          , parcel && p
+          , Handler && handler
+          , Buffer && buffer
+          , performance_counters::parcels::gatherer & parcels_sent
+        )
         {
             check_num_connections chk(this);
-            tag_provider::tag tag(tag_provider_());
 
-            header h(buffer, tag);
-            h.assert_valid();
-
-            MPI_Request request;
-            MPI_Request *wait_request = NULL;
-            {
-                util::mpi_environment::scoped_lock l;
-                MPI_Isend(
-                    h.data()
-                  , h.data_size_
-                  , MPI_BYTE
+            connection_ptr sender(
+                new connection_type(
+                    tag_provider_.acquire()
                   , dest
-                  , 0
-                  , util::mpi_environment::communicator()
-                  , &request
-                );
-                wait_request = &request;
-            }
+                  , std::move(p)
+                  , std::move(buffer)
+                  , std::forward<Handler>(handler)
+                  , parcels_sent
+                )
+            );
 
-            std::vector<typename Buffer::transmission_chunk_type>& chunks =
-                buffer.transmission_chunks_;
-            if(!chunks.empty())
+            if(!sender->send())
             {
-                wait_done(wait_request, background);
+                boost::unique_lock<mutex_type> l(connections_mtx_);
+                connections_.push_back(std::move(sender));
+            }
+        }
+
+        void send_messages(
+            connection_list connections
+        )
+        {
+            std::size_t k = 0;
+            typename connection_list::iterator it = connections.begin();
+
+            // We try to handle all receives within 1 secone
+            while(it != connections.end())
+            {
+                connection_type & sender = **it;
+                if(sender.send())
                 {
-                    util::mpi_environment::scoped_lock l;
-                    MPI_Isend(
-                        chunks.data()
-                      , static_cast<int>(
-                            chunks.size()
-                          * sizeof(typename Buffer::transmission_chunk_type)
-                        )
-                      , MPI_BYTE
-                      , dest
-                      , tag
-                      , util::mpi_environment::communicator()
-                      , &request
-                    );
-                    wait_request = &request;
+                    it = connections.erase(it);
                 }
-            }
-
-            if(!h.piggy_back())
-            {
-                wait_done(wait_request, background);
+                else
                 {
-                    util::mpi_environment::scoped_lock l;
-                    MPI_Isend(
-                        buffer.data_.data()
-                      , static_cast<int>(buffer.data_.size())
-                      , MPI_BYTE
-                      , dest
-                      , tag
-                      , util::mpi_environment::communicator()
-                      , &request
-                    );
-                    wait_request = &request;
-                }
-            }
-
-            for (serialization::serialization_chunk& c : buffer.chunks_)
-            {
-                if(c.type_ == serialization::chunk_type_pointer)
-                {
-                    wait_done(wait_request, background);
+                    if(k < 32 || k & 1) //-V112
                     {
-                        util::mpi_environment::scoped_lock l;
-                        MPI_Isend(
-                            const_cast<void *>(c.data_.cpos_)
-                          , static_cast<int>(c.size_)
-                          , MPI_BYTE
-                          , dest
-                          , tag
-                          , util::mpi_environment::communicator()
-                          , &request
-                        );
-                        wait_request = &request;
+                        if(threads::get_self_ptr())
+                            hpx::this_thread::suspend(hpx::threads::pending,
+                                "mpi::sender::wait_done");
                     }
+                    ++k;
+                    ++it;
                 }
             }
 
-            wait_done(wait_request, background);
+            if(!connections.empty())
+            {
+                boost::unique_lock<mutex_type> l(connections_mtx_);
+                if(connections_.empty())
+                {
+                    std::swap(connections, connections_);
+                }
+                else
+                {
+                    connections_.insert(
+                        connections_.end()
+#if defined(HPX_INTEL_VERSION) && ((__GNUC__ == 4 && __GNUC_MINOR__ == 4) || HPX_INTEL_VERSION < 1400)
+                      , connections.begin()
+                      , connections.end()
+#else
+                      , std::make_move_iterator(connections.begin())
+                      , std::make_move_iterator(connections.end())
+#endif
+                    );
+                }
+            }
+        }
+
+        bool background_work(std::size_t num_thread)
+        {
+            connection_list connections;
+            {
+                boost::unique_lock<mutex_type> l(connections_mtx_);
+                std::swap(connections, connections_);
+            }
+            bool has_work = false;
+            if(!connections.empty())
+            {
+                if(hpx::is_starting())
+                {
+                    send_messages(std::move(connections));
+                }
+                else
+                {
+//                     error_code ec(lightweight);
+                    hpx::applier::register_thread_nullary(
+                        util::bind(
+                            util::one_shot(&sender::send_messages),
+                            this, std::move(connections)),
+                        "mpi::sender::send_messages",
+                        threads::pending, true, threads::thread_priority_boost,
+                        num_thread, threads::thread_stacksize_default);
+                }
+                has_work = true;
+            }
+            next_free_tag();
+            return has_work;
         }
 
     private:
         tag_provider tag_provider_;
 
+        void next_free_tag()
+        {
+            int next_free = -1;
+            {
+                mutex_type::scoped_try_lock l(next_free_tag_mtx_);
+                if(l)
+                    next_free = next_free_tag_locked();
+            }
+
+            if(next_free != -1)
+            {
+                HPX_ASSERT(next_free > 1);
+                tag_provider_.release(next_free);
+            }
+        }
+
+        int next_free_tag_locked()
+        {
+            util::mpi_environment::scoped_try_lock l;
+
+            if(l.locked)
+            {
+                MPI_Status status;
+                int completed = 0;
+                int ret = 0;
+                ret = MPI_Test(&next_free_tag_request_, &completed, &status);
+                HPX_ASSERT(ret == MPI_SUCCESS);
+                if(completed)// && status->MPI_ERROR != MPI_ERR_PENDING)
+                {
+                    return get_next_free_tag();
+                }
+            }
+            return -1;
+        }
+
+        int get_next_free_tag()
+        {
+            int next_free = next_free_tag_;
+            MPI_Irecv(
+                &next_free_tag_
+              , 1
+              , MPI_INT
+              , MPI_ANY_SOURCE
+              , 1
+              , util::mpi_environment::communicator()
+              , &next_free_tag_request_
+            );
+            return next_free;
+        }
+
         mutex_type connections_mtx_;
         lcos::local::detail::condition_variable connections_cond_;
         std::size_t const max_connections_;
         std::size_t num_connections_;
+        connection_list connections_;
 
-        template <typename Background>
-        void wait_done(MPI_Request *& request, Background const & background)
-        {
-            if(request == NULL) return;
-
-            std::size_t k = 0;
-
-            while(true)
-            {
-                if(request_done(*request))
-                {
-                    break;
-                }
-
-                if (k < 4) //-V112
-                {
-                }
-                else if(k < 32 || k & 1) //-V112
-                {
-                    if(threads::get_self_ptr())
-                        this_thread::suspend(threads::pending,
-                            "mpi::sender::wait_done");
-                }
-                else
-                {
-                    background();
-                }
-                ++k;
-            }
-            request = NULL;
-        }
-
-        bool request_done(MPI_Request & r)
-        {
-            util::mpi_environment::scoped_lock l;
-
-            int completed = 0;
-            MPI_Status status;
-            int ret = 0;
-            ret = MPI_Test(&r, &completed, &status);
-            HPX_ASSERT(ret == MPI_SUCCESS);
-            if(completed)// && status.MPI_ERROR != MPI_ERR_PENDING)
-            {
-                return true;
-            }
-            return false;
-        }
+        mutex_type next_free_tag_mtx_;
+        MPI_Request next_free_tag_request_;
+        int next_free_tag_;
     };
 
 }}}}

--- a/hpx/plugins/parcelport/mpi/sender_connection.hpp
+++ b/hpx/plugins/parcelport/mpi/sender_connection.hpp
@@ -1,0 +1,239 @@
+//  Copyright (c) 2014-2015 Thomas Heller
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_PARCELSET_POLICIES_MPI_SENDER_CONNECTION_HPP
+#define HPX_PARCELSET_POLICIES_MPI_SENDER_CONNECTION_HPP
+
+#include <hpx/plugins/parcelport/mpi/header.hpp>
+
+namespace hpx { namespace parcelset { namespace policies { namespace mpi
+{
+    template <typename Buffer>
+    struct sender_connection
+    {
+    private:
+        typedef util::function_nonser<
+            void(boost::system::error_code const&, parcel const&)
+        > write_handler_type;
+
+        enum connection_state
+        {
+            initialized
+          , sent_header
+          , sent_transmission_chunks
+          , sent_data
+          , sent_chunks
+        };
+
+    public:
+        sender_connection(
+            int tag
+          , int dst
+          , parcel && p
+          , Buffer && buffer
+          , write_handler_type && handler
+          , performance_counters::parcels::gatherer & parcels_sent
+        )
+          : state_(initialized)
+          , tag_(tag)
+          , dst_(dst)
+          , parcel_(std::move(p))
+          , buffer_(std::move(buffer))
+          , handler_(std::move(handler))
+          , header_(buffer_, tag_)
+          , request_ptr_(0)
+          , chunks_idx_(0)
+          , parcels_sent_(parcels_sent)
+        {
+            header_.assert_valid();
+        }
+
+        bool send()
+        {
+            switch(state_)
+            {
+                case initialized:
+                    return send_header();
+                case sent_header:
+                    return send_transmission_chunks();
+                case sent_transmission_chunks:
+                    return send_data();
+                case sent_data:
+                    return send_chunks();
+                case sent_chunks:
+                    return done();
+                default:
+                    HPX_ASSERT(false);
+            }
+
+            return false;
+        }
+
+        bool send_header()
+        {
+            {
+                util::mpi_environment::scoped_lock l;
+                HPX_ASSERT(state_ == initialized);
+                HPX_ASSERT(request_ptr_ == 0);
+                MPI_Isend(
+                    header_.data()
+                  , header_.data_size_
+                  , MPI_BYTE
+                  , dst_
+                  , 0
+                  , util::mpi_environment::communicator()
+                  , &request_
+                );
+                request_ptr_ = &request_;
+            }
+
+            state_ = sent_header;
+            return send_transmission_chunks();
+        }
+
+        bool send_transmission_chunks()
+        {
+            HPX_ASSERT(state_ == sent_header);
+            HPX_ASSERT(request_ptr_ != 0);
+            if(!request_done()) return false;
+
+            HPX_ASSERT(request_ptr_ == 0);
+
+            std::vector<typename Buffer::transmission_chunk_type>& chunks =
+                buffer_.transmission_chunks_;
+            if(!chunks.empty())
+            {
+                util::mpi_environment::scoped_lock l;
+                MPI_Isend(
+                    chunks.data()
+                  , static_cast<int>(
+                        chunks.size()
+                      * sizeof(typename Buffer::transmission_chunk_type)
+                    )
+                  , MPI_BYTE
+                  , dst_
+                  , tag_
+                  , util::mpi_environment::communicator()
+                  , &request_
+                );
+                request_ptr_ = &request_;
+            }
+
+            state_ = sent_transmission_chunks;
+            return send_data();
+        }
+
+        bool send_data()
+        {
+            HPX_ASSERT(state_ == sent_transmission_chunks);
+            if(!request_done()) return false;
+
+            if(!header_.piggy_back())
+            {
+                util::mpi_environment::scoped_lock l;
+                MPI_Isend(
+                    buffer_.data_.data()
+                  , static_cast<int>(buffer_.data_.size())
+                  , MPI_BYTE
+                  , dst_
+                  , tag_
+                  , util::mpi_environment::communicator()
+                  , &request_
+                );
+                request_ptr_ = &request_;
+            }
+            state_ = sent_data;
+
+            return send_chunks();
+        }
+
+        bool send_chunks()
+        {
+            HPX_ASSERT(state_ == sent_data);
+
+            while(chunks_idx_ < buffer_.chunks_.size())
+            {
+                serialization::serialization_chunk& c = buffer_.chunks_[chunks_idx_];
+                if(c.type_ == serialization::chunk_type_pointer)
+                {
+                    if(!request_done()) return false;
+                    else
+                    {
+                        util::mpi_environment::scoped_lock l;
+                        MPI_Isend(
+                            const_cast<void *>(c.data_.cpos_)
+                          , static_cast<int>(c.size_)
+                          , MPI_BYTE
+                          , dst_
+                          , tag_
+                          , util::mpi_environment::communicator()
+                          , &request_
+                        );
+                        request_ptr_ = &request_;
+                    }
+                 }
+
+                chunks_idx_++;
+            }
+
+            if(!request_done()) return false;
+
+            state_ = sent_chunks;
+
+            return done();
+        }
+
+        bool done()
+        {
+            if(!request_done()) return false;
+
+            error_code ec;
+            handler_(ec, parcel_);
+            buffer_.data_point_.time_ =
+                util::high_resolution_clock::now() - buffer_.data_point_.time_;
+            parcels_sent_.add_data(buffer_.data_point_);
+
+            return true;
+        }
+
+        bool request_done()
+        {
+            if(request_ptr_ == 0) return true;
+
+            util::mpi_environment::scoped_lock l;
+
+            int completed = 0;
+            MPI_Status status;
+            int ret = 0;
+            ret = MPI_Test(request_ptr_, &completed, &status);
+            HPX_ASSERT(ret == MPI_SUCCESS);
+            if(completed)// && status.MPI_ERROR != MPI_ERR_PENDING)
+            {
+                request_ptr_ = 0;
+                return true;
+            }
+            return false;
+        }
+
+        connection_state state_;
+        int tag_;
+        int dst_;
+        parcel parcel_;
+        Buffer buffer_;
+        write_handler_type handler_;
+
+        header header_;
+
+        MPI_Request request_;
+        MPI_Request *request_ptr_;
+        std::size_t chunks_idx_;
+        char ack_;
+
+        performance_counters::parcels::gatherer & parcels_sent_;
+    };
+}}}}
+
+#endif
+

--- a/hpx/plugins/parcelport/mpi/tag_provider.hpp
+++ b/hpx/plugins/parcelport/mpi/tag_provider.hpp
@@ -26,7 +26,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
             boost::lock_guard<mutex_type> l(mtx_);
             if(free_tags_.empty())
             {
-                HPX_ASSERT(next_tag_ < std::numeric_limits<int>::max());
+                HPX_ASSERT(next_tag_ < (std::numeric_limits<int>::max)());
                 tag = next_tag_++;
             }
             else

--- a/hpx/plugins/parcelport/mpi/tag_provider.hpp
+++ b/hpx/plugins/parcelport/mpi/tag_provider.hpp
@@ -1,0 +1,58 @@
+//  Copyright (c) 2014-2015 Thomas Heller
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_PARCELSET_POLICIES_MPI_TAG_PROVIDER_HPP
+#define HPX_PARCELSET_POLICIES_MPI_TAG_PROVIDER_HPP
+
+#include <hpx/lcos/local/spinlock.hpp>
+
+#include <deque>
+
+namespace hpx { namespace parcelset { namespace policies { namespace mpi
+{
+    struct tag_provider
+    {
+        typedef lcos::local::spinlock mutex_type;
+
+        tag_provider()
+          : next_tag_(2)
+        {}
+
+        int acquire()
+        {
+            int tag = -1;
+            mutex_type::scoped_lock l(mtx_);
+            if(free_tags_.empty())
+            {
+                HPX_ASSERT(next_tag_ < std::numeric_limits<int>::max());
+                tag = next_tag_++;
+            }
+            else
+            {
+                tag = free_tags_.front();
+                free_tags_.pop_front();
+            }
+            HPX_ASSERT(tag > 1);
+            return tag;
+        }
+
+        void release(int tag)
+        {
+            HPX_ASSERT(tag > 1);
+            mutex_type::scoped_lock l(mtx_);
+            HPX_ASSERT(tag <= next_tag_);
+
+            if(tag == next_tag_) return;
+
+            free_tags_.push_back(tag);
+        }
+
+        mutex_type mtx_;
+        int next_tag_;
+        std::deque<int> free_tags_;
+    };
+}}}}
+
+#endif

--- a/plugins/parcelport/mpi/mpi_environment.cpp
+++ b/plugins/parcelport/mpi/mpi_environment.cpp
@@ -251,6 +251,12 @@ namespace hpx { namespace util
             mtx_.unlock();
     }
 
+    void mpi_environment::scoped_lock::unlock()
+    {
+        if(!multi_threaded())
+            mtx_.unlock();
+    }
+
     mpi_environment::scoped_try_lock::scoped_try_lock()
       : locked(false)
     {
@@ -258,16 +264,21 @@ namespace hpx { namespace util
         {
             locked = mtx_.try_lock();
         }
-        else
-        {
-            locked = true;
-        }
     }
 
     mpi_environment::scoped_try_lock::~scoped_try_lock()
     {
         if(!multi_threaded() && locked)
             mtx_.unlock();
+    }
+
+    void mpi_environment::scoped_try_lock::unlock()
+    {
+        if(!multi_threaded() && locked)
+        {
+            locked = false;
+            mtx_.unlock();
+        }
     }
 }}
 


### PR DESCRIPTION
 - Turning receiving and sending into a asynchronous state machine
 - Adding explicit tag release mechansim once the receiver is completely done
 - Disabling MPI multithreading support by default