### PR TITLE
Extended Non-intrusive Serialization to Ease Usage for Library Developers

### DIFF
--- a/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
+++ b/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
@@ -206,8 +206,8 @@ namespace hpx { namespace serialization { namespace detail
 /**/
 #define HPX_SERIALIZATION_REGISTER_CLASS_NAME_TEMPLATE(Parameters, Template, Name) \
     namespace hpx { namespace serialization { namespace detail {              \
-        Parameters                                                            \
-        struct get_serialization_name<Template>                               \
+        HPX_UTIL_STRIP(Parameters)                                            \
+        struct get_serialization_name<HPX_UTIL_STRIP(Template)>               \
         {                                                                     \
             char const* operator()()                                          \
             {                                                                 \
@@ -223,8 +223,8 @@ namespace hpx { namespace serialization { namespace detail
     HPX_SERIALIZATION_REGISTER_CLASS_NAME_TEMPLATE(                           \
         Parameters, Template,                                                 \
         hpx::util::type_id<HPX_UTIL_STRIP(Template) >::typeid_.type_id())     \
-    Parameters hpx::serialization::detail::register_class<Template>           \
-        Template::hpx_register_class_instance;                                \
+    HPX_UTIL_STRIP(Parameters) hpx::serialization::detail::register_class<HPX_UTIL_STRIP(Template)> \
+        HPX_UTIL_STRIP(Template)::hpx_register_class_instance;                \
 /**/
 #define HPX_SERIALIZATION_POLYMORPHIC_TEMPLATE_SEMIINTRUSIVE(Template)        \
     static hpx::serialization::detail::register_class<Template>               \

--- a/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
+++ b/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
@@ -207,7 +207,7 @@ namespace hpx { namespace serialization { namespace detail
 #define HPX_SERIALIZATION_REGISTER_CLASS_NAME_TEMPLATE(                       \
         Parameters, Template, Name)                                           \
     namespace hpx { namespace serialization { namespace detail {              \
-        HPX_UTIL_STRIP(Parameters)                                            \
+        HPX_UTIL_STRIP(Parameters) HPX_ALWAYS_EXPORT                          \
         struct get_serialization_name<HPX_UTIL_STRIP(Template)>               \
         {                                                                     \
             char const* operator()()                                          \

--- a/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
+++ b/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
@@ -204,7 +204,8 @@ namespace hpx { namespace serialization { namespace detail
     template hpx::serialization::detail::register_class<Class>                \
         hpx::serialization::detail::register_class<Class>::instance;          \
 /**/
-#define HPX_SERIALIZATION_REGISTER_CLASS_NAME_TEMPLATE(Parameters, Template, Name) \
+#define HPX_SERIALIZATION_REGISTER_CLASS_NAME_TEMPLATE(                       \
+        Parameters, Template, Name)                                           \
     namespace hpx { namespace serialization { namespace detail {              \
         HPX_UTIL_STRIP(Parameters)                                            \
         struct get_serialization_name<HPX_UTIL_STRIP(Template)>               \
@@ -223,7 +224,8 @@ namespace hpx { namespace serialization { namespace detail
     HPX_SERIALIZATION_REGISTER_CLASS_NAME_TEMPLATE(                           \
         Parameters, Template,                                                 \
         hpx::util::type_id<HPX_UTIL_STRIP(Template) >::typeid_.type_id())     \
-    HPX_UTIL_STRIP(Parameters) hpx::serialization::detail::register_class<HPX_UTIL_STRIP(Template)> \
+    HPX_UTIL_STRIP(Parameters) hpx::serialization::detail::register_class<    \
+        HPX_UTIL_STRIP(Template)>                                             \
         HPX_UTIL_STRIP(Template)::hpx_register_class_instance;                \
 /**/
 #define HPX_SERIALIZATION_POLYMORPHIC_TEMPLATE_SEMIINTRUSIVE(Template)        \
@@ -231,7 +233,8 @@ namespace hpx { namespace serialization { namespace detail
     hpx_register_class_instance;                                              \
                                                                               \
     virtual hpx::serialization::detail::register_class<Template>&             \
-    hpx_get_register_class_instance(hpx::serialization::detail::register_class<Template>*) const \
+    hpx_get_register_class_instance(                                          \
+        hpx::serialization::detail::register_class<Template>*) const          \
     {                                                                         \
         return hpx_register_class_instance;                                   \
     }                                                                         \

--- a/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
+++ b/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
@@ -179,8 +179,8 @@ namespace hpx { namespace serialization { namespace detail
 
 #define HPX_SERIALIZATION_REGISTER_CLASS_DECLARATION(Class)                   \
     namespace hpx { namespace serialization { namespace detail {              \
-        template <> HPX_ALWAYS_EXPORT                                         \
-        struct get_serialization_name<Class>;                                 \
+        template <>                                                           \
+        struct HPX_ALWAYS_EXPORT get_serialization_name<Class>;               \
     }}}                                                                       \
     namespace hpx { namespace traits {                                        \
         template <>                                                           \
@@ -189,11 +189,11 @@ namespace hpx { namespace serialization { namespace detail
         {};                                                                   \
     }}                                                                        \
     HPX_TRAITS_NONINTRUSIVE_POLYMORPHIC(Class);                               \
-
+/**/
 #define HPX_SERIALIZATION_REGISTER_CLASS_NAME(Class, Name)                    \
     namespace hpx { namespace serialization { namespace detail {              \
-        template <> HPX_ALWAYS_EXPORT                                         \
-        struct get_serialization_name<Class>                                  \
+        template <>                                                           \
+        struct HPX_ALWAYS_EXPORT get_serialization_name<Class>                \
         {                                                                     \
             char const* operator()()                                          \
             {                                                                 \
@@ -207,8 +207,9 @@ namespace hpx { namespace serialization { namespace detail
 #define HPX_SERIALIZATION_REGISTER_CLASS_NAME_TEMPLATE(                       \
         Parameters, Template, Name)                                           \
     namespace hpx { namespace serialization { namespace detail {              \
-        HPX_UTIL_STRIP(Parameters) HPX_ALWAYS_EXPORT                          \
-        struct get_serialization_name<HPX_UTIL_STRIP(Template)>               \
+        HPX_UTIL_STRIP(Parameters)                                            \
+        struct HPX_ALWAYS_EXPORT get_serialization_name<HPX_UTIL_STRIP(       \
+            Template)>                                                        \
         {                                                                     \
             char const* operator()()                                          \
             {                                                                 \

--- a/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
+++ b/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
@@ -204,7 +204,36 @@ namespace hpx { namespace serialization { namespace detail
     template hpx::serialization::detail::register_class<Class>                \
         hpx::serialization::detail::register_class<Class>::instance;          \
 /**/
+#define HPX_SERIALIZATION_REGISTER_CLASS_NAME_TEMPLATE(Parameters, Template, Name) \
+    namespace hpx { namespace serialization { namespace detail {              \
+        Parameters                                                            \
+        struct get_serialization_name<Template>                               \
+        {                                                                     \
+            char const* operator()()                                          \
+            {                                                                 \
+                return Name;                                                  \
+            }                                                                 \
+        };                                                                    \
+    }}}                                                                       \
+/**/
 #define HPX_SERIALIZATION_REGISTER_CLASS(Class)                               \
     HPX_SERIALIZATION_REGISTER_CLASS_NAME(Class, BOOST_PP_STRINGIZE(Class))   \
-
+/**/
+#define HPX_SERIALIZATION_REGISTER_CLASS_TEMPLATE(Parameters, Template)       \
+    HPX_SERIALIZATION_REGISTER_CLASS_NAME_TEMPLATE(                           \
+        Parameters, Template,                                                 \
+        hpx::util::type_id<HPX_UTIL_STRIP(Template) >::typeid_.type_id())     \
+    Parameters hpx::serialization::detail::register_class<Template>           \
+        Template::hpx_register_class_instance;                                \
+/**/
+#define HPX_SERIALIZATION_POLYMORPHIC_TEMPLATE_SEMIINTRUSIVE(Template)        \
+    static hpx::serialization::detail::register_class<Template>               \
+    hpx_register_class_instance;                                              \
+                                                                              \
+    virtual hpx::serialization::detail::register_class<Template>&             \
+    hpx_get_register_class_instance(hpx::serialization::detail::register_class<Template>*) const \
+    {                                                                         \
+        return hpx_register_class_instance;                                   \
+    }                                                                         \
+/**/
 #endif

--- a/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
+++ b/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2014 Thomas Heller
 //  Copyright (c) 2015 Anton Bikineev
+//  Copyright (c) 2015 Andreas Schaefer
 //
 //  Distributed under the Boost Software License, Version 1.0.
 //  See accompanying file LICENSE_1_0.txt or copy at
@@ -27,22 +28,25 @@
 namespace hpx { namespace serialization { namespace detail
 {
         template <typename T>
-        char const* get_serialization_name()
+        struct get_serialization_name
 #ifdef HPX_DISABLE_AUTOMATIC_SERIALIZATION_REGISTRATION
         ;
 #else
         {
-            /// If you encounter this assert while compiling code, that means that
-            /// you have a HPX_REGISTER_ACTION macro somewhere in a source file,
-            /// but the header in which the action is defined misses a
-            /// HPX_REGISTER_ACTION_DECLARATION
-            BOOST_MPL_ASSERT_MSG(
-                traits::needs_automatic_registration<T>::value
-              , HPX_REGISTER_ACTION_DECLARATION_MISSING
-              , (T)
-            );
-            return util::type_id<T>::typeid_.type_id();
-        }
+            const char *operator()()
+            {
+                /// If you encounter this assert while compiling code, that means that
+                /// you have a HPX_REGISTER_ACTION macro somewhere in a source file,
+                /// but the header in which the action is defined misses a
+                /// HPX_REGISTER_ACTION_DECLARATION
+                BOOST_MPL_ASSERT_MSG(
+                    traits::needs_automatic_registration<T>::value
+                  , HPX_REGISTER_ACTION_DECLARATION_MISSING
+                  , (T)
+                );
+                return util::type_id<T>::typeid_.type_id();
+            }
+        };
 #endif
 
     struct function_bunch_type
@@ -158,7 +162,7 @@ namespace hpx { namespace serialization { namespace detail
             polymorphic_nonintrusive_factory::instance().
                 register_class(
                     typeid(Derived),
-                    get_serialization_name<Derived>(),
+                    get_serialization_name<Derived>()(),
                     bunch
                 );
         }
@@ -176,7 +180,7 @@ namespace hpx { namespace serialization { namespace detail
 #define HPX_SERIALIZATION_REGISTER_CLASS_DECLARATION(Class)                   \
     namespace hpx { namespace serialization { namespace detail {              \
         template <> HPX_ALWAYS_EXPORT                                         \
-        char const* get_serialization_name<Class>();                          \
+        struct get_serialization_name<Class>;                                 \
     }}}                                                                       \
     namespace hpx { namespace traits {                                        \
         template <>                                                           \
@@ -189,10 +193,13 @@ namespace hpx { namespace serialization { namespace detail
 #define HPX_SERIALIZATION_REGISTER_CLASS_NAME(Class, Name)                    \
     namespace hpx { namespace serialization { namespace detail {              \
         template <> HPX_ALWAYS_EXPORT                                         \
-        char const* get_serialization_name<Class>()                           \
+        struct get_serialization_name<Class>                                  \
         {                                                                     \
-            return Name;                                                      \
-        }                                                                     \
+            char const* operator()()                                          \
+            {                                                                 \
+                return Name;                                                  \
+            }                                                                 \
+        };                                                                    \
     }}}                                                                       \
     template hpx::serialization::detail::register_class<Class>                \
         hpx::serialization::detail::register_class<Class>::instance;          \

--- a/tests/unit/serialization/polymorphic/CMakeLists.txt
+++ b/tests/unit/serialization/polymorphic/CMakeLists.txt
@@ -8,6 +8,8 @@ set(tests
     serialization_polymorphic_pointer
     serialization_polymorphic_nonintrusive
     serialization_polymorphic_nonintrusive_abstract
+    serialization_polymorphic_semiintrusive_template
+    serialization_polymorphic_template
     serialization_smart_ptr_polymorphic
     serialization_smart_ptr_polymorphic_nonintrusive
 )

--- a/tests/unit/serialization/polymorphic/serialization_polymorphic_semiintrusive_template.cpp
+++ b/tests/unit/serialization/polymorphic/serialization_polymorphic_semiintrusive_template.cpp
@@ -1,0 +1,99 @@
+//  Copyright (c) 2014-2015 Anton Bikineev
+//  Copyright (c) 2015 Andreas Schaefer
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <iostream>
+#include <vector>
+
+#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/runtime/serialization/base_object.hpp>
+#include <hpx/runtime/serialization/shared_ptr.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <boost/shared_ptr.hpp>
+#include <boost/make_shared.hpp>
+
+template <class T>
+struct A
+{
+    int a = 0;
+
+    explicit A(int a):
+        a(a)
+    {}
+
+    A() = default;
+
+    virtual void foo() const = 0;
+
+};
+
+HPX_TRAITS_NONINTRUSIVE_POLYMORPHIC_TEMPLATE(template<class T>, A<T>)
+
+template <class T>
+struct B: A<T>
+{
+    int b = 0;
+
+    explicit B(int b):
+        A<T>(b-1),
+        b(b)
+    {}
+
+    B() = default;
+
+    virtual void foo() const{}
+
+    HPX_SERIALIZATION_POLYMORPHIC_TEMPLATE_SEMIINTRUSIVE(B);
+};
+
+HPX_TRAITS_NONINTRUSIVE_POLYMORPHIC_TEMPLATE(template<class T>, B<T>)
+HPX_SERIALIZATION_REGISTER_CLASS_TEMPLATE(template<class T>, B<T>)
+
+namespace hpx { namespace serialization {
+
+    template <class Archive, class T>
+    void serialize(Archive& archive, A<T>& s, unsigned)
+    {
+      archive & s.a;
+    }
+
+    template <class Archive, class T>
+    void serialize(Archive& archive, B<T>& s, unsigned)
+    {
+      archive & hpx::serialization::base_object<A<T> >(s);
+      archive & s.b;
+    }
+
+} }
+
+int main()
+{
+  std::vector<char> vector;
+  {
+    hpx::serialization::output_archive archive{vector};
+    boost::shared_ptr<A<int> > b = boost::make_shared<B<int> >(-4);
+    boost::shared_ptr<A<char> > c = boost::make_shared<B<char> >(44);
+    boost::shared_ptr<A<double> > d = boost::make_shared<B<double> >(99);
+    archive << b << c << d;
+  }
+
+  {
+    hpx::serialization::input_archive archive{vector};
+    boost::shared_ptr<A<int> > b;
+    boost::shared_ptr<A<char> > c;
+    boost::shared_ptr<A<double> > d;
+    archive >> b >> c >> d;
+    HPX_TEST_EQ(b->a, -5);
+    HPX_TEST_EQ(boost::static_pointer_cast<B<int> >(b)->b, -4);
+
+    HPX_TEST_EQ(c->a, 43);
+    HPX_TEST_EQ(boost::static_pointer_cast<B<char> >(c)->b, 44);
+
+    HPX_TEST_EQ(d->a, 98);
+    HPX_TEST_EQ(boost::static_pointer_cast<B<double> >(d)->b, 99);
+  }
+
+}

--- a/tests/unit/serialization/polymorphic/serialization_polymorphic_semiintrusive_template.cpp
+++ b/tests/unit/serialization/polymorphic/serialization_polymorphic_semiintrusive_template.cpp
@@ -78,22 +78,22 @@ namespace hpx { namespace serialization {
     template <class Archive, class T>
     void serialize(Archive& archive, A<T>& s, unsigned)
     {
-      archive & s.a;
+        archive & s.a;
     }
 
     template <class Archive, class T>
     void serialize(Archive& archive, B<T>& s, unsigned)
     {
-      archive & hpx::serialization::base_object<A<T> >(s);
-      archive & s.b;
+        archive & hpx::serialization::base_object<A<T> >(s);
+        archive & s.b;
     }
 
     template <class Archive, class S, class T>
     void serialize(Archive& archive, C<S, T>& s, unsigned)
     {
-      archive & hpx::serialization::base_object<A<T> >(s);
-      archive & s.b;
-      archive & s.c;
+        archive & hpx::serialization::base_object<A<T> >(s);
+        archive & s.b;
+        archive & s.c;
     }
 
 } }
@@ -102,35 +102,35 @@ int main()
 {
   std::vector<char> vector;
   {
-    hpx::serialization::output_archive archive{vector};
-    boost::shared_ptr<A<int> > b = boost::make_shared<B<int> >(-4);
-    boost::shared_ptr<A<char> > c = boost::make_shared<B<char> >(44);
-    boost::shared_ptr<A<double> > d = boost::make_shared<B<double> >(99);
-    boost::shared_ptr<A<float> > e = boost::make_shared<C<short, float> >(222);
-    archive << b << c << d << e;
+      hpx::serialization::output_archive archive{vector};
+      boost::shared_ptr<A<int> > b = boost::make_shared<B<int> >(-4);
+      boost::shared_ptr<A<char> > c = boost::make_shared<B<char> >(44);
+      boost::shared_ptr<A<double> > d = boost::make_shared<B<double> >(99);
+      boost::shared_ptr<A<float> > e = boost::make_shared<C<short, float> >(222);
+      archive << b << c << d << e;
   }
 
   {
-    hpx::serialization::input_archive archive{vector};
-    boost::shared_ptr<A<int> > b;
-    boost::shared_ptr<A<char> > c;
-    boost::shared_ptr<A<double> > d;
-    boost::shared_ptr<A<float> > e;
+      hpx::serialization::input_archive archive{vector};
+      boost::shared_ptr<A<int> > b;
+      boost::shared_ptr<A<char> > c;
+      boost::shared_ptr<A<double> > d;
+      boost::shared_ptr<A<float> > e;
 
-    archive >> b >> c >> d >> e;
+      archive >> b >> c >> d >> e;
 
-    HPX_TEST_EQ(b->a, -5);
-    HPX_TEST_EQ(boost::static_pointer_cast<B<int> >(b)->b, -4);
+      HPX_TEST_EQ(b->a, -5);
+      HPX_TEST_EQ(boost::static_pointer_cast<B<int> >(b)->b, -4);
 
-    HPX_TEST_EQ(c->a, 43);
-    HPX_TEST_EQ(boost::static_pointer_cast<B<char> >(c)->b, 44);
+      HPX_TEST_EQ(c->a, 43);
+      HPX_TEST_EQ(boost::static_pointer_cast<B<char> >(c)->b, 44);
 
-    HPX_TEST_EQ(d->a, 98);
-    HPX_TEST_EQ(boost::static_pointer_cast<B<double> >(d)->b, 99);
+      HPX_TEST_EQ(d->a, 98);
+      HPX_TEST_EQ(boost::static_pointer_cast<B<double> >(d)->b, 99);
 
-    HPX_TEST_EQ(e->a, 221);
-    HPX_TEST_EQ((boost::static_pointer_cast<C<short, float> >(e)->b), 222);
-    HPX_TEST_EQ((boost::static_pointer_cast<C<short, float> >(e)->c), 223);
+      HPX_TEST_EQ(e->a, 221);
+      HPX_TEST_EQ((boost::static_pointer_cast<C<short, float> >(e)->b), 222);
+      HPX_TEST_EQ((boost::static_pointer_cast<C<short, float> >(e)->c), 223);
   }
 
 }

--- a/tests/unit/serialization/polymorphic/serialization_polymorphic_template.cpp
+++ b/tests/unit/serialization/polymorphic/serialization_polymorphic_template.cpp
@@ -9,6 +9,7 @@
 #include <hpx/runtime/serialization/serialize.hpp>
 #include <hpx/runtime/serialization/base_object.hpp>
 #include <hpx/runtime/serialization/shared_ptr.hpp>
+#include <hpx/util/lightweight_test.hpp>
 
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
@@ -75,10 +76,12 @@ int main()
     boost::shared_ptr<A<int> > b;
     boost::shared_ptr<A<char> > c;
     archive >> b >> c;
-    std::cout << "b: " << boost::static_pointer_cast<B<int> >(b)->a << ", "
-        << boost::static_pointer_cast<B<int> >(b)->b << std::endl;
-    std::cout << "c: " << boost::static_pointer_cast<B<char> >(c)->a << ", "
-        << boost::static_pointer_cast<B<char> >(c)->b << std::endl;
+
+    HPX_TEST_EQ(boost::static_pointer_cast<B<int> >(b)->a, 1);
+    HPX_TEST_EQ(boost::static_pointer_cast<B<int> >(b)->b, 2);
+
+    HPX_TEST_EQ(boost::static_pointer_cast<B<char> >(c)->a, 7);
+    HPX_TEST_EQ(boost::static_pointer_cast<B<char> >(c)->b, 8);
   }
 
 }


### PR DESCRIPTION
The intrusive serialization factory requires a class to ship a serialize() function. This is not always desirable, e.g. if this function is automatically generated externally. The non-intrusive serialization factory requires users to manually register all template instantiations, which is impossible to guarantee in the context of generic libraries (or: a user burden, but that's essentially the same).

The new "semi-intrusive" code adds infrastructure to relieve library developers from having to manually register all template instantiations. This requires a minute change (intrusion) to registered templates, but serialize() can still be put outside.
