### PR TITLE
Change project name to HPX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 ################################################################################
 # project metadata
 ################################################################################
-project(hpx CXX C)
+project(HPX CXX C)
 
 set(HPX_MAJOR_VERSION 0)
 set(HPX_MINOR_VERSION 9)
@@ -50,6 +50,7 @@ set(HPX_PATCH_LEVEL   11)
 set(HPX_VERSION "${HPX_MAJOR_VERSION}.${HPX_MINOR_VERSION}.${HPX_PATCH_LEVEL}")
 set(HPX_LIBRARY_VERSION "${HPX_VERSION}")
 set(HPX_SOVERSION ${HPX_MAJOR_VERSION})
+set(HPX_PACKAGE_NAME HPX)
 
 if(MSVC)
   set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -58,7 +59,7 @@ endif()
 ################################################################################
 # CMake configuration
 ################################################################################
-set(CMAKE_MODULE_PATH "${hpx_SOURCE_DIR}/cmake")
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 # We safe the passed compiler flag to a special variable. This is needed for our
 # build system unit tests. Some flags might influence the created symbols (
@@ -542,7 +543,7 @@ endif()
 ################################################################################
 # Set basic search paths for HPX
 ################################################################################
-include_directories("${hpx_SOURCE_DIR}" "${CMAKE_BINARY_DIR}")
+include_directories("${PROJECT_SOURCE_DIR}" "${CMAKE_BINARY_DIR}")
 link_directories(${CMAKE_BINARY_DIR}/lib)
 
 ################################################################################
@@ -1258,18 +1259,18 @@ endforeach()
 
 # Generate a defines.hpp to be used in the build directory ...
 set(HPX_DEFINES_PREFIX ${HPX_BUILD_PREFIX})
-configure_file("${hpx_SOURCE_DIR}/cmake/templates/config_defines.hpp.in"
+configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config_defines.hpp.in"
                "${CMAKE_BINARY_DIR}/hpx/config/defines.hpp"
                @ONLY)
 
 # Generate a defines.hpp to be used in the install directory ...
 set(HPX_DEFINES_PREFIX ${HPX_PREFIX})
-configure_file("${hpx_SOURCE_DIR}/cmake/templates/config_defines.hpp.in"
+configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config_defines.hpp.in"
                "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/hpx/config/defines.hpp"
                @ONLY)
 
 # Configure hpxrun.py
-configure_file("${hpx_SOURCE_DIR}/cmake/templates/hpxrun.py.in"
+configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/hpxrun.py.in"
                "${CMAKE_BINARY_DIR}/bin/hpxrun.py"
                @ONLY)
 
@@ -1339,7 +1340,7 @@ install( # install all hpx tests source files
 
 install( # Install all HPX cmake utility files
   DIRECTORY cmake/
-  DESTINATION ${LIB}/cmake/hpx
+  DESTINATION ${LIB}/cmake/${HPX_PACKAGE_NAME}
   COMPONENT core
   PATTERN ".cmake.in" EXCLUDE
   PATTERN ".git" EXCLUDE)
@@ -1437,7 +1438,7 @@ if(Boost_VERSION LESS 105300)
 endif()
 
 install(
-  FILES "${hpx_SOURCE_DIR}/LICENSE_1_0.txt"
+  FILES "${PROJECT_SOURCE_DIR}/LICENSE_1_0.txt"
   DESTINATION share/hpx-${HPX_VERSION}
   COMPONENT license)
 
@@ -1456,19 +1457,19 @@ if(HPX_WITH_DOCUMENTATION)
     PATTERN "*images*" EXCLUDE)
 
   install(
-    FILES "${hpx_SOURCE_DIR}/docs/index.html"
+    FILES "${PROJECT_SOURCE_DIR}/docs/index.html"
     DESTINATION share/hpx-${HPX_VERSION}/
     COMPONENT docs)
 
   install(
-    DIRECTORY "${hpx_SOURCE_DIR}/docs/html/src/"
+    DIRECTORY "${PROJECT_SOURCE_DIR}/docs/html/src/"
     DESTINATION share/hpx-${HPX_VERSION}/docs/html/src
     COMPONENT docs
     FILES_MATCHING PATTERN "*.css"
     PATTERN ".git" EXCLUDE)
 
   install(
-    DIRECTORY "${hpx_SOURCE_DIR}/docs/html/images/"
+    DIRECTORY "${PROJECT_SOURCE_DIR}/docs/html/images/"
     DESTINATION share/hpx-${HPX_VERSION}/docs/html/images
     COMPONENT docs
     FILES_MATCHING PATTERN "*.png"

--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -20,7 +20,7 @@ macro(add_hpx_config_test variable)
       if(${variable}_ROOT)
         set(test_source "${${variable}_ROOT}/share/hpx-${HPX_VERSION}/${${variable}_SOURCE}")
       else()
-        set(test_source "${hpx_SOURCE_DIR}/${${variable}_SOURCE}")
+        set(test_source "${PROJECT_SOURCE_DIR}/${${variable}_SOURCE}")
       endif()
     else()
       set(test_source

--- a/cmake/HPX_Documentation.cmake
+++ b/cmake/HPX_Documentation.cmake
@@ -35,8 +35,8 @@ if(HPX_WITH_DOCUMENTATION)
 endif()
 
 
-set(BOOSTBOOK_DTD_PATH "${hpx_SOURCE_DIR}/external/boostbook/dtd/")
-set(BOOSTBOOK_XSL_PATH "${hpx_SOURCE_DIR}/external/boostbook/xsl/")
+set(BOOSTBOOK_DTD_PATH "${PROJECT_SOURCE_DIR}/external/boostbook/dtd/")
+set(BOOSTBOOK_XSL_PATH "${PROJECT_SOURCE_DIR}/external/boostbook/xsl/")
 
 # Generate catalog file for XSLT processing
 macro(hpx_write_boostbook_catalog file)
@@ -70,11 +70,11 @@ macro(hpx_write_boostbook_catalog file)
     #"  />\n"
     "   <rewriteURI\n"
     "    uriStartString=\"http://www.boost.org/tools/boostbook/dtd/\"\n"
-    "    rewritePrefix=\"file:///${hpx_SOURCE_DIR}/external/boostbook/dtd/\"\n"
+    "    rewritePrefix=\"file:///${PROJECT_SOURCE_DIR}/external/boostbook/dtd/\"\n"
     "  />\n"
     "  <rewriteURI\n"
     "    uriStartString=\"http://www.boost.org/tools/boostbook/xsl/\"\n"
-    "    rewritePrefix=\"file:///${hpx_SOURCE_DIR}/external/boostbook/xsl/\"\n"
+    "    rewritePrefix=\"file:///${PROJECT_SOURCE_DIR}/external/boostbook/xsl/\"\n"
     "  />\n"
     "</catalog>\n"
   )
@@ -173,10 +173,10 @@ macro(hpx_docbook_to_xslfo name)
     PARAMETERS
       paper.type=USLetter
       admon.graphics.extension=.png
-      img.src.path=${hpx_SOURCE_DIR}/docs/html/
-      boost.graphics.root=${hpx_SOURCE_DIR}/docs/html/images/
-      admon.graphics.path=${hpx_SOURCE_DIR}/docs/html/images/
-      callout.graphics.path=${hpx_SOURCE_DIR}/docs/html/images/
+      img.src.path=${PROJECT_SOURCE_DIR}/docs/html/
+      boost.graphics.root=${PROJECT_SOURCE_DIR}/docs/html/images/
+      admon.graphics.path=${PROJECT_SOURCE_DIR}/docs/html/images/
+      callout.graphics.path=${PROJECT_SOURCE_DIR}/docs/html/images/
       ${${name}_XSLTPROC_ARGS}
     CATALOG ${${name}_CATALOG}
     DEPENDS ${${name}_DEPENDENCIES}

--- a/cmake/HPX_GeneratePackage.cmake
+++ b/cmake/HPX_GeneratePackage.cmake
@@ -8,17 +8,17 @@ include(CMakePackageConfigHelpers)
 set(CMAKE_DIR "cmake-${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" CACHE STRING "directory (in share), where to put FindHPX cmake module")
 
 write_basic_package_version_file(
-  "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/hpx/HPXConfigVersion.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}/${HPX_PACKAGE_NAME}ConfigVersion.cmake"
   VERSION ${HPX_VERSION}
   COMPATIBILITY AnyNewerVersion
 )
 
 export(TARGETS ${HPX_EXPORT_TARGETS}
-  FILE "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/hpx/HPXTargets.cmake"
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}/HPXTargets.cmake"
 #  NAMESPACE hpx::
 )
 
-export(PACKAGE hpx)
+export(PACKAGE ${HPX_PACKAGE_NAME})
 
 # Generate library list for pkg config ...
 set(_is_debug FALSE)
@@ -54,7 +54,7 @@ endforeach()
 get_directory_property(_INCLUDE_DIRS INCLUDE_DIRECTORIES)
 foreach(dir ${_INCLUDE_DIRS})
   string(REPLACE "++" "\\+\\+" binarydir_escaped ${CMAKE_BINARY_DIR})
-  string(REPLACE "++" "\\+\\+" sourcedir_escaped ${hpx_SOURCE_DIR})
+  string(REPLACE "++" "\\+\\+" sourcedir_escaped ${PROJECT_SOURCE_DIR})
   if((NOT dir MATCHES "^${binarydir_escaped}.*")
     AND (NOT dir MATCHES "^${sourcedir_escaped}.*"))
     set(_NEEDED_INCLUDE_DIRS "${_NEEDED_INCLUDE_DIRS} -I${dir}")
@@ -75,8 +75,8 @@ set(HPX_CMAKE_CONF_INCLUDE_DIRS
   "${_NEEDED_CMAKE_INCLUDE_DIRS}"
 )
 set(HPX_CONF_PREFIX ${CMAKE_INSTALL_PREFIX})
-configure_file(cmake/templates/HPXConfig.cmake.in
-  "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/HPXConfig.cmake"
+configure_file(cmake/templates/${HPX_PACKAGE_NAME}Config.cmake.in
+  "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/${HPX_PACKAGE_NAME}Config.cmake"
   ESCAPE_QUOTES @ONLY)
 configure_file(cmake/templates/hpx_application.pc.in
   "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/hpx_application.pc"
@@ -105,8 +105,8 @@ set(HPX_CMAKE_CONF_INCLUDE_DIRS
   ${_NEEDED_CMAKE_BUILD_DIR_INCLUDE_DIRS}
   ${_NEEDED_CMAKE_INCLUDE_DIRS}
 )
-configure_file(cmake/templates/HPXConfig.cmake.in
-  "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/hpx/HPXConfig.cmake"
+configure_file(cmake/templates/${HPX_PACKAGE_NAME}Config.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}/${HPX_PACKAGE_NAME}Config.cmake"
   ESCAPE_QUOTES @ONLY)
 configure_file(cmake/templates/hpx_application.pc.in
   "${CMAKE_CURRENT_BINARY_DIR}/lib/pkgconfig/hpx_application.pc"
@@ -126,29 +126,29 @@ configure_file(cmake/templates/hpxcxx.in
   @ONLY)
 
 # Configure macros for the install dir ...
-set(HPX_CMAKE_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/lib/cmake/hpx")
+set(HPX_CMAKE_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/lib/cmake/${HPX_PACKAGE_NAME}")
 configure_file(cmake/templates/HPXMacros.cmake.in
   "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/HPXMacros.cmake"
   ESCAPE_QUOTES @ONLY)
 # ... and the build dir
-set(HPX_CMAKE_MODULE_PATH "${hpx_SOURCE_DIR}/cmake")
+set(HPX_CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 configure_file(cmake/templates/HPXMacros.cmake.in
-  "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/hpx/HPXMacros.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}/HPXMacros.cmake"
   ESCAPE_QUOTES @ONLY)
 
 install(
   EXPORT HPXTargets
   FILE HPXTargets.cmake
 #  NAMESPACE hpx::
-  DESTINATION ${LIB}/cmake/hpx
+  DESTINATION ${LIB}/cmake/${HPX_PACKAGE_NAME}
 )
 
 install(
   FILES
-    "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/HPXConfig.cmake"
+    "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/${HPX_PACKAGE_NAME}Config.cmake"
     "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/HPXMacros.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/hpx/HPXConfigVersion.cmake"
-    DESTINATION ${LIB}/cmake/hpx
+    "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}/${HPX_PACKAGE_NAME}ConfigVersion.cmake"
+    DESTINATION ${LIB}/cmake/${HPX_PACKAGE_NAME}
   COMPONENT cmake
 )
 

--- a/cmake/HPX_GitCommit.cmake
+++ b/cmake/HPX_GitCommit.cmake
@@ -9,8 +9,8 @@ find_package(Git)
 
 if(GIT_FOUND)
   execute_process(
-    COMMAND "${GIT_EXECUTABLE}" "log" "--pretty=%H" "-1" "${hpx_SOURCE_DIR}"
-    WORKING_DIRECTORY "${hpx_SOURCE_DIR}"
+    COMMAND "${GIT_EXECUTABLE}" "log" "--pretty=%H" "-1" "${PROJECT_SOURCE_DIR}"
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
     OUTPUT_VARIABLE HPX_WITH_GIT_COMMIT ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif()
 

--- a/cmake/HPX_SetupBoost.cmake
+++ b/cmake/HPX_SetupBoost.cmake
@@ -86,8 +86,8 @@ endif()
 # If the found Boost installation is < 1.53, we need to include our packaged
 # atomic library
 if(Boost_VERSION LESS 105300)
-  set(Boost_INCLUDE_DIRS ${Boost_INCLUDE_DIRS} "${hpx_SOURCE_DIR}/external/atomic")
-  set(Boost_INCLUDE_DIRS ${Boost_INCLUDE_DIRS} "${hpx_SOURCE_DIR}/external/lockfree")
+  set(Boost_INCLUDE_DIRS ${Boost_INCLUDE_DIRS} "${PROJECT_SOURCE_DIR}/external/atomic")
+  set(Boost_INCLUDE_DIRS ${Boost_INCLUDE_DIRS} "${PROJECT_SOURCE_DIR}/external/lockfree")
 else()
   find_package(Boost 1.53 QUIET REQUIRED COMPONENTS atomic)
   if(Boost_ATOMIC_FOUND)
@@ -98,14 +98,14 @@ else()
 endif()
 
 set(Boost_LIBRARIES ${Boost_TMP_LIBRARIES})
-set(Boost_INCLUDE_DIRS ${Boost_INCLUDE_DIRS} ${hpx_SOURCE_DIR}/external/cache)
-set(Boost_INCLUDE_DIRS ${Boost_INCLUDE_DIRS} ${hpx_SOURCE_DIR}/external/endian)
+set(Boost_INCLUDE_DIRS ${Boost_INCLUDE_DIRS} ${PROJECT_SOURCE_DIR}/external/cache)
+set(Boost_INCLUDE_DIRS ${Boost_INCLUDE_DIRS} ${PROJECT_SOURCE_DIR}/external/endian)
 
 # If we compile natively for the MIC, we need some workarounds for certain
 # Boost headers
 # FIXME: push changes upstream
 if(HPX_PLATFORM_UC STREQUAL "XEONPHI")
-  set(Boost_INCLUDE_DIRS ${hpx_SOURCE_DIR}/external/asio ${Boost_INCLUDE_DIRS})
+  set(Boost_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/external/asio ${Boost_INCLUDE_DIRS})
 endif()
 
 # Boost preprocessor definitions

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -5,39 +5,39 @@
 
 hpx_write_boostbook_catalog("${CMAKE_CURRENT_BINARY_DIR}/boostbook_catalog.xml")
 
-file(GLOB base_files "${hpx_SOURCE_DIR}/docs/*.qbk")
-file(GLOB manual_files "${hpx_SOURCE_DIR}/docs/manual/*.qbk")
-file(GLOB build_system_files "${hpx_SOURCE_DIR}/docs/manual/build_system/*.qbk")
-file(GLOB_RECURSE tutorial_files "${hpx_SOURCE_DIR}/docs/tutorial/*.qbk")
-file(GLOB_RECURSE index_files "${hpx_SOURCE_DIR}/docs/*.idx")
+file(GLOB base_files "${PROJECT_SOURCE_DIR}/docs/*.qbk")
+file(GLOB manual_files "${PROJECT_SOURCE_DIR}/docs/manual/*.qbk")
+file(GLOB build_system_files "${PROJECT_SOURCE_DIR}/docs/manual/build_system/*.qbk")
+file(GLOB_RECURSE tutorial_files "${PROJECT_SOURCE_DIR}/docs/tutorial/*.qbk")
+file(GLOB_RECURSE index_files "${PROJECT_SOURCE_DIR}/docs/*.idx")
 
 set(documentation_files
     ${manual_files} ${build_system_files} ${tutorial_files}
     ${base_files} ${index_files})
 
 set(documentation_dependencies
-    "${hpx_SOURCE_DIR}/examples/1d_stencil/1d_stencil_1.cpp"
-    "${hpx_SOURCE_DIR}/examples/1d_stencil/1d_stencil_2.cpp"
-    "${hpx_SOURCE_DIR}/examples/1d_stencil/1d_stencil_3.cpp"
-    "${hpx_SOURCE_DIR}/examples/1d_stencil/1d_stencil_4.cpp"
-    "${hpx_SOURCE_DIR}/examples/1d_stencil/1d_stencil_5.cpp"
-    "${hpx_SOURCE_DIR}/examples/1d_stencil/1d_stencil_6.cpp"
-    "${hpx_SOURCE_DIR}/examples/1d_stencil/1d_stencil_7.cpp"
-    "${hpx_SOURCE_DIR}/examples/1d_stencil/1d_stencil_8.cpp"
-    "${hpx_SOURCE_DIR}/examples/quickstart/hello_world.cpp"
-    "${hpx_SOURCE_DIR}/examples/quickstart/simplest_hello_world.cpp"
-    "${hpx_SOURCE_DIR}/examples/quickstart/error_handling.cpp"
-    "${hpx_SOURCE_DIR}/examples/accumulator/accumulators/server/managed_accumulator.hpp"
-    "${hpx_SOURCE_DIR}/examples/accumulator/accumulators/stubs/managed_accumulator.hpp"
-    "${hpx_SOURCE_DIR}/examples/accumulator/accumulators/managed_accumulator.hpp"
-    "${hpx_SOURCE_DIR}/examples/accumulator/accumulators/managed_accumulator.cpp"
-    "${hpx_SOURCE_DIR}/examples/accumulator/managed_accumulator_client.cpp"
-    "${hpx_SOURCE_DIR}/examples/hello_world_component/hello_world_component.hpp"
-    "${hpx_SOURCE_DIR}/examples/hello_world_component/hello_world_component.cpp"
-    "${hpx_SOURCE_DIR}/examples/performance_counters/simplest_performance_counter.cpp"
-    "${hpx_SOURCE_DIR}/examples/performance_counters/sine/server/sine.hpp"
-    "${hpx_SOURCE_DIR}/hpx/performance_counters/performance_counter.hpp"
-    "${hpx_SOURCE_DIR}/hpx/performance_counters/base_performance_counter.hpp")
+    "${PROJECT_SOURCE_DIR}/examples/1d_stencil/1d_stencil_1.cpp"
+    "${PROJECT_SOURCE_DIR}/examples/1d_stencil/1d_stencil_2.cpp"
+    "${PROJECT_SOURCE_DIR}/examples/1d_stencil/1d_stencil_3.cpp"
+    "${PROJECT_SOURCE_DIR}/examples/1d_stencil/1d_stencil_4.cpp"
+    "${PROJECT_SOURCE_DIR}/examples/1d_stencil/1d_stencil_5.cpp"
+    "${PROJECT_SOURCE_DIR}/examples/1d_stencil/1d_stencil_6.cpp"
+    "${PROJECT_SOURCE_DIR}/examples/1d_stencil/1d_stencil_7.cpp"
+    "${PROJECT_SOURCE_DIR}/examples/1d_stencil/1d_stencil_8.cpp"
+    "${PROJECT_SOURCE_DIR}/examples/quickstart/hello_world.cpp"
+    "${PROJECT_SOURCE_DIR}/examples/quickstart/simplest_hello_world.cpp"
+    "${PROJECT_SOURCE_DIR}/examples/quickstart/error_handling.cpp"
+    "${PROJECT_SOURCE_DIR}/examples/accumulator/accumulators/server/managed_accumulator.hpp"
+    "${PROJECT_SOURCE_DIR}/examples/accumulator/accumulators/stubs/managed_accumulator.hpp"
+    "${PROJECT_SOURCE_DIR}/examples/accumulator/accumulators/managed_accumulator.hpp"
+    "${PROJECT_SOURCE_DIR}/examples/accumulator/accumulators/managed_accumulator.cpp"
+    "${PROJECT_SOURCE_DIR}/examples/accumulator/managed_accumulator_client.cpp"
+    "${PROJECT_SOURCE_DIR}/examples/hello_world_component/hello_world_component.hpp"
+    "${PROJECT_SOURCE_DIR}/examples/hello_world_component/hello_world_component.cpp"
+    "${PROJECT_SOURCE_DIR}/examples/performance_counters/simplest_performance_counter.cpp"
+    "${PROJECT_SOURCE_DIR}/examples/performance_counters/sine/server/sine.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/performance_counters/performance_counter.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/performance_counters/base_performance_counter.hpp")
 
 set(all_documentation_dependencies
     ${documentation_files}
@@ -45,88 +45,88 @@ set(all_documentation_dependencies
 
 # Add all files here which should be passed to doxygen
 set(doxygen_dependencies
-    "${hpx_SOURCE_DIR}/hpx/hpx_fwd.hpp"
-    "${hpx_SOURCE_DIR}/hpx/hpx_init.hpp"
-    "${hpx_SOURCE_DIR}/hpx/hpx_start.hpp"
-    "${hpx_SOURCE_DIR}/hpx/hpx_finalize.hpp"
-    "${hpx_SOURCE_DIR}/hpx/error.hpp"
-    "${hpx_SOURCE_DIR}/hpx/exception.hpp"
-    "${hpx_SOURCE_DIR}/hpx/exception_list.hpp"
-    "${hpx_SOURCE_DIR}/hpx/components/component_storage/migrate_from_storage.hpp"
-    "${hpx_SOURCE_DIR}/hpx/components/component_storage/migrate_to_storage.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/execution_policy.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithm.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/task_block.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/adjacent_difference.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/adjacent_find.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/all_any_none.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/copy.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/count.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/equal.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/exclusive_scan.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/fill.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/find.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/for_each.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/generate.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/includes.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/inclusive_scan.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/inner_product.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/is_partitioned.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/is_sorted.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/lexicographical_compare.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/minmax.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/mismatch.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/move.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/reduce.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/remove_copy.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/replace.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/reverse.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/rotate.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/search.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/set_difference.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/set_intersection.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/set_symmetric_difference.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/set_union.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/swap_ranges.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/transform.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/transform_exclusive_scan.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/transform_inclusive_scan.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/transform_reduce.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/uninitialized_copy.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/algorithms/uninitialized_fill.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/executors/executor_traits.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/executors/sequential_executor.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/executors/parallel_executor.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/executors/parallel_fork_executor.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/executors/service_executors.hpp"
-    "${hpx_SOURCE_DIR}/hpx/parallel/executors/thread_pool_executors.hpp"
-    "${hpx_SOURCE_DIR}/hpx/runtime/get_ptr.hpp"
-    "${hpx_SOURCE_DIR}/hpx/runtime/get_locality_name.hpp"
-    "${hpx_SOURCE_DIR}/hpx/runtime/set_parcel_write_handler.hpp"
-    "${hpx_SOURCE_DIR}/hpx/runtime/trigger_lco.hpp"
-    "${hpx_SOURCE_DIR}/hpx/runtime/actions/basic_action.hpp"
-    "${hpx_SOURCE_DIR}/hpx/runtime/actions/component_action.hpp"
-    "${hpx_SOURCE_DIR}/hpx/runtime/actions/plain_action.hpp"
-    "${hpx_SOURCE_DIR}/hpx/runtime/components/binpacking_distribution_policy.hpp"
-    "${hpx_SOURCE_DIR}/hpx/runtime/components/colocating_distribution_policy.hpp"
-    "${hpx_SOURCE_DIR}/hpx/runtime/components/component_factory.hpp"
-    "${hpx_SOURCE_DIR}/hpx/runtime/components/copy_component.hpp"
-    "${hpx_SOURCE_DIR}/hpx/runtime/components/default_distribution_policy.hpp"
-    "${hpx_SOURCE_DIR}/hpx/runtime/components/migrate_component.hpp"
-    "${hpx_SOURCE_DIR}/hpx/runtime/components/new.hpp"
-    "${hpx_SOURCE_DIR}/hpx/runtime/naming/unmanaged.hpp"
-    "${hpx_SOURCE_DIR}/hpx/lcos/broadcast.hpp"
-    "${hpx_SOURCE_DIR}/hpx/lcos/fold.hpp"
-    "${hpx_SOURCE_DIR}/hpx/lcos/reduce.hpp"
-    "${hpx_SOURCE_DIR}/hpx/lcos/wait_all.hpp"
-    "${hpx_SOURCE_DIR}/hpx/lcos/when_all.hpp"
-    "${hpx_SOURCE_DIR}/hpx/lcos/wait_any.hpp"
-    "${hpx_SOURCE_DIR}/hpx/lcos/when_any.hpp"
-    "${hpx_SOURCE_DIR}/hpx/lcos/wait_some.hpp"
-    "${hpx_SOURCE_DIR}/hpx/lcos/when_some.hpp"
-    "${hpx_SOURCE_DIR}/hpx/lcos/wait_each.hpp"
-    "${hpx_SOURCE_DIR}/hpx/lcos/when_each.hpp"
-    "${hpx_SOURCE_DIR}/hpx/performance_counters/manage_counter_type.hpp")
+    "${PROJECT_SOURCE_DIR}/hpx/hpx_fwd.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/hpx_init.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/hpx_start.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/hpx_finalize.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/error.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/exception.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/exception_list.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/components/component_storage/migrate_from_storage.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/components/component_storage/migrate_to_storage.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/execution_policy.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithm.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/task_block.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/adjacent_difference.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/adjacent_find.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/all_any_none.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/copy.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/count.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/equal.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/exclusive_scan.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/fill.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/find.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/for_each.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/generate.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/includes.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/inclusive_scan.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/inner_product.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/is_partitioned.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/is_sorted.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/lexicographical_compare.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/minmax.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/mismatch.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/move.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/reduce.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/remove_copy.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/replace.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/reverse.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/rotate.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/search.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/set_difference.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/set_intersection.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/set_symmetric_difference.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/set_union.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/swap_ranges.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/transform.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/transform_exclusive_scan.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/transform_inclusive_scan.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/transform_reduce.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/uninitialized_copy.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/uninitialized_fill.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/executors/executor_traits.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/executors/sequential_executor.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/executors/parallel_executor.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/executors/parallel_fork_executor.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/executors/service_executors.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/executors/thread_pool_executors.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/runtime/get_ptr.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/runtime/get_locality_name.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/runtime/set_parcel_write_handler.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/runtime/trigger_lco.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/runtime/actions/basic_action.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/runtime/actions/component_action.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/runtime/actions/plain_action.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/runtime/components/binpacking_distribution_policy.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/runtime/components/colocating_distribution_policy.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/runtime/components/component_factory.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/runtime/components/copy_component.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/runtime/components/default_distribution_policy.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/runtime/components/migrate_component.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/runtime/components/new.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/runtime/naming/unmanaged.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/lcos/broadcast.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/lcos/fold.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/lcos/reduce.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/lcos/wait_all.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/lcos/when_all.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/lcos/wait_any.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/lcos/when_any.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/lcos/wait_some.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/lcos/when_some.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/lcos/wait_each.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/lcos/when_each.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/performance_counters/manage_counter_type.hpp")
 
 
 foreach(doxygen_input ${doxygen_dependencies})
@@ -166,7 +166,7 @@ foreach(doxygen_input ${doxygen_dependencies})
 endforeach()
 
 hpx_info("Creating Doxyfile: ${CMAKE_CURRENT_BINARY_DIR}/hpx_autodoc.doxy")
-configure_file("${hpx_SOURCE_DIR}/cmake/templates/autodoc.doxy.in"
+configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/autodoc.doxy.in"
                 "${CMAKE_CURRENT_BINARY_DIR}/hpx_autodoc.doxy"
                 @ONLY)
 
@@ -236,12 +236,12 @@ foreach(_cat ${HPX_OPTION_CATEGORIES})
 endforeach()
 
 configure_file(
-  "${hpx_SOURCE_DIR}/cmake/templates/cmake_variables.qbk.in"
-  "${hpx_SOURCE_DIR}/docs/manual/build_system/cmake_variables.qbk"
+  "${PROJECT_SOURCE_DIR}/cmake/templates/cmake_variables.qbk.in"
+  "${PROJECT_SOURCE_DIR}/docs/manual/build_system/cmake_variables.qbk"
   @ONLY
 )
 
-set(toolchains_base_dir ${hpx_SOURCE_DIR}/cmake/toolchains/)
+set(toolchains_base_dir ${PROJECT_SOURCE_DIR}/cmake/toolchains/)
 file(GLOB _toolchain_files ${toolchains_base_dir} ${toolchains_base_dir}*.cmake)
 
 set(HPX_CMAKE_TOOLCHAINS_LIST "")
@@ -262,8 +262,8 @@ endforeach()
 
 
 configure_file(
-  "${hpx_SOURCE_DIR}/cmake/templates/cmake_toolchains.qbk.in"
-  "${hpx_SOURCE_DIR}/docs/manual/build_system/cmake_toolchains.qbk"
+  "${PROJECT_SOURCE_DIR}/cmake/templates/cmake_toolchains.qbk.in"
+  "${PROJECT_SOURCE_DIR}/docs/manual/build_system/cmake_toolchains.qbk"
   @ONLY
 )
 
@@ -272,8 +272,8 @@ hpx_quickbook_to_html(hpx
   INDEX hpx.idx
   DEPENDENCIES
     ${all_documentation_dependencies}
-    "${hpx_SOURCE_DIR}/docs/manual/build_system/cmake_variables.qbk"
-    "${hpx_SOURCE_DIR}/docs/manual/build_system/cmake_toolchains.qbk"
+    "${PROJECT_SOURCE_DIR}/docs/manual/build_system/cmake_variables.qbk"
+    "${PROJECT_SOURCE_DIR}/docs/manual/build_system/cmake_toolchains.qbk"
   CATALOG "${CMAKE_CURRENT_BINARY_DIR}/boostbook_catalog.xml"
   XSLTPROC_ARGS chunk.section.depth=4
                 chunk.first.sections=1
@@ -327,17 +327,17 @@ set(DOCS_OUTPUT_DIR "${CMAKE_BINARY_DIR}/share/hpx-${HPX_VERSION}/docs/html")
 execute_process(COMMAND "${CMAKE_COMMAND}" -E make_directory "${DOCS_OUTPUT_DIR}" )
 execute_process(COMMAND "${CMAKE_COMMAND}" -E make_directory "${DOCS_OUTPUT_DIR}/code" )
 execute_process(
-  COMMAND "${CMAKE_COMMAND}" -E create_symlink "${hpx_SOURCE_DIR}/docs/html/src" "${DOCS_OUTPUT_DIR}/src")
+  COMMAND "${CMAKE_COMMAND}" -E create_symlink "${PROJECT_SOURCE_DIR}/docs/html/src" "${DOCS_OUTPUT_DIR}/src")
 execute_process(
-  COMMAND "${CMAKE_COMMAND}" -E create_symlink "${hpx_SOURCE_DIR}/docs/html/images" "${DOCS_OUTPUT_DIR}/images")
+  COMMAND "${CMAKE_COMMAND}" -E create_symlink "${PROJECT_SOURCE_DIR}/docs/html/images" "${DOCS_OUTPUT_DIR}/images")
 execute_process(
-  COMMAND "${CMAKE_COMMAND}" -E create_symlink "${hpx_SOURCE_DIR}/hpx" "${DOCS_OUTPUT_DIR}/code/hpx")
+  COMMAND "${CMAKE_COMMAND}" -E create_symlink "${PROJECT_SOURCE_DIR}/hpx" "${DOCS_OUTPUT_DIR}/code/hpx")
 execute_process(
-  COMMAND "${CMAKE_COMMAND}" -E create_symlink "${hpx_SOURCE_DIR}/src" "${DOCS_OUTPUT_DIR}/code/src")
+  COMMAND "${CMAKE_COMMAND}" -E create_symlink "${PROJECT_SOURCE_DIR}/src" "${DOCS_OUTPUT_DIR}/code/src")
 execute_process(
-  COMMAND "${CMAKE_COMMAND}" -E create_symlink "${hpx_SOURCE_DIR}/examples" "${DOCS_OUTPUT_DIR}/code/examples")
+  COMMAND "${CMAKE_COMMAND}" -E create_symlink "${PROJECT_SOURCE_DIR}/examples" "${DOCS_OUTPUT_DIR}/code/examples")
 execute_process(
-  COMMAND "${CMAKE_COMMAND}" -E create_symlink "${hpx_SOURCE_DIR}/tests" "${DOCS_OUTPUT_DIR}/code/tests")
+  COMMAND "${CMAKE_COMMAND}" -E create_symlink "${PROJECT_SOURCE_DIR}/tests" "${DOCS_OUTPUT_DIR}/code/tests")
 
 source_group(Documentation FILES ${base_files})
 source_group("Documentation\\Manual" FILES ${manual_files})

--- a/docs/manual/build_system/using_hpx_cmake.qbk
+++ b/docs/manual/build_system/using_hpx_cmake.qbk
@@ -35,21 +35,36 @@ The basic structure to include __hpx__ into your CMakeLists.txt is shown here:
     find_package(HPX)
 ``
 
-In order to have CMake find HPX, it needs to be told. The easiest is to add
-the HPX_DIR cmake variable pointing to the directory containing the HPXConfig.cmake
-script which gets picked up by cmake and sets up all the necessary macros needed
-to use HPX in your project. Pass it on the command line while invoking cmake
-(where [^$HPX_LOCATION] is the build directory or [^CMAKE_INSTALL_PREFIX] you
-used while building __hpx__):
+In order to have CMake find __hpx__, it needs to be told where to look for the
+`HPXConfig.cmake` file that is generated when HPX is built or installed,
+it is used by `find_package(HPX)` to set up all the necessary macros needed to 
+use __hpx__ in your project. The ways to achieve this are
 
+* set the `HPX_DIR` cmake variable to point to the directory containing the `HPXConfig.cmake`
+script on the command line when you invoke cmake, 
 ``
-    cmake -DHPX_DIR=$HPX_LOCATION/lib/cmake/hpx ...
+    cmake -DHPX_DIR=$HPX_LOCATION/lib/cmake/HPX ...
 ``
+where [^$HPX_LOCATION] is the build directory or [^CMAKE_INSTALL_PREFIX] you used when 
+building/configuring __hpx__
 
-Alternatively, if you wish to require __hpx__ for your project, replace the
+* set the `CMAKE_PREFIX_PATH` variable to the root directory of your __hpx__ build or install
+location on the command line when you invoke cmake,
+``
+    cmake -DCMAKE_PREFIX_PATH=$HPX_LOCATION ...
+``
+the difference between `CMAKE_PREFIX_PATH` and `HPX_DIR` is that cmake will add common postfixes
+such as `lib/cmake/<project>` to the `CMAKE_PREFIX_PATH` and search in these locations too.
+Note that if your project uses __hpx__ as well as other cmake managed projects, the paths to the 
+locations of these multiple projects may be concatenated in the `CMAKE_PREFIX_PATH`.
+
+* The variables above may be set in the CMake GUI or curses ccmake interface
+instead of the command line.
+
+Additionally, if you wish to require __hpx__ for your project, replace the
 `find_package(HPX)` line with `find_package(HPX REQUIRED)`.
 
-You can check if HPX was succesfully found with the `HPX_FOUND` CMake variable.
+You can check if __hpx__ was succesfully found with the `HPX_FOUND` CMake variable.
 
 The simplst way to add the __hpx__ component is to use the `add_hpx_component`
 macro and add it to the `CMakeLists.txt` file:

--- a/docs/whats_new.qbk
+++ b/docs/whats_new.qbk
@@ -54,6 +54,9 @@
 
 [heading Breaking Changes]
 
+* The CMake project name has changed from 'hpx' to 'HPX' for consistency and 
+  compatibilty with naming conventions and other CMake projects. Generated
+  config files go into <prefix>/lib/cmake/HPX and not <prefix>/lib/cmake/hpx.
 * The macro `HPX_REGISTER_MINIMAL_COMPONENT_FACTORY` has been deprecated. Please
   use [macroref HPX_REGISTER_COMPONENT `HPX_REGISTER_COMPONENT`] instead.
   The old macro will be removed in the next release.

--- a/examples/performance_counters/sine/CMakeLists.txt
+++ b/examples/performance_counters/sine/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(root "${hpx_SOURCE_DIR}/examples/performance_counters/sine")
+set(root "${PROJECT_SOURCE_DIR}/examples/performance_counters/sine")
 
 ###############################################################################
 # add component

--- a/plugins/binary_filter/bzip2/CMakeLists.txt
+++ b/plugins/binary_filter/bzip2/CMakeLists.txt
@@ -26,8 +26,8 @@ macro(add_bzip2_module)
 
     add_hpx_library(compress_bzip2
       PLUGIN
-      SOURCES "${hpx_SOURCE_DIR}/plugins/binary_filter/bzip2/bzip2_serialization_filter.cpp"
-      HEADERS "${hpx_SOURCE_DIR}/hpx/plugins/binary_filter/bzip2_serialization_filter.hpp"
+      SOURCES "${PROJECT_SOURCE_DIR}/plugins/binary_filter/bzip2/bzip2_serialization_filter.cpp"
+      HEADERS "${PROJECT_SOURCE_DIR}/hpx/plugins/binary_filter/bzip2_serialization_filter.hpp"
       FOLDER "Core/Plugins/Compression"
       DEPENDENCIES ${BZIP2_LIBRARIES})
 

--- a/plugins/binary_filter/snappy/CMakeLists.txt
+++ b/plugins/binary_filter/snappy/CMakeLists.txt
@@ -22,8 +22,8 @@ macro(add_snappy_module)
 
     add_hpx_library(compress_snappy
       PLUGIN
-      SOURCES "${hpx_SOURCE_DIR}/plugins/binary_filter/snappy/snappy_serialization_filter.cpp"
-      HEADERS "${hpx_SOURCE_DIR}/hpx/plugins/binary_filter/snappy_serialization_filter.hpp"
+      SOURCES "${PROJECT_SOURCE_DIR}/plugins/binary_filter/snappy/snappy_serialization_filter.cpp"
+      HEADERS "${PROJECT_SOURCE_DIR}/hpx/plugins/binary_filter/snappy_serialization_filter.hpp"
       FOLDER "Core/Plugins/Compression"
       DEPENDENCIES ${SNAPPY_LIBRARY})
 

--- a/plugins/binary_filter/zlib/CMakeLists.txt
+++ b/plugins/binary_filter/zlib/CMakeLists.txt
@@ -26,8 +26,8 @@ macro(add_zlib_module)
 
     add_hpx_library(compress_zlib
       PLUGIN
-      SOURCES "${hpx_SOURCE_DIR}/plugins/binary_filter/zlib/zlib_serialization_filter.cpp"
-      HEADERS "${hpx_SOURCE_DIR}/hpx/plugins/binary_filter/zlib_serialization_filter.hpp"
+      SOURCES "${PROJECT_SOURCE_DIR}/plugins/binary_filter/zlib/zlib_serialization_filter.cpp"
+      HEADERS "${PROJECT_SOURCE_DIR}/hpx/plugins/binary_filter/zlib_serialization_filter.hpp"
       FOLDER "Core/Plugins/Compression"
       DEPENDENCIES ${ZLIB_LIBRARIES})
 

--- a/plugins/parcel/coalescing/CMakeLists.txt
+++ b/plugins/parcel/coalescing/CMakeLists.txt
@@ -9,10 +9,10 @@ macro(add_coalescing_module)
   hpx_debug("add_coalescing_module")
   add_hpx_library(parcel_coalescing
       PLUGIN
-      SOURCES "${hpx_SOURCE_DIR}/plugins/parcel/coalescing/coalescing_message_handler.cpp"
+      SOURCES "${PROJECT_SOURCE_DIR}/plugins/parcel/coalescing/coalescing_message_handler.cpp"
       HEADERS
-            "${hpx_SOURCE_DIR}/hpx/plugins/parcel/coalescing_message_handler.hpp"
-            "${hpx_SOURCE_DIR}/hpx/plugins/parcel/message_buffer.hpp"
+            "${PROJECT_SOURCE_DIR}/hpx/plugins/parcel/coalescing_message_handler.hpp"
+            "${PROJECT_SOURCE_DIR}/hpx/plugins/parcel/message_buffer.hpp"
       FOLDER "Core/Plugins/MessageHandler"
       )
 

--- a/plugins/parcelport/CMakeLists.txt
+++ b/plugins/parcelport/CMakeLists.txt
@@ -35,12 +35,12 @@ macro(add_parcelport name)
     add_hpx_source_group(
       NAME hpx
       CLASS "Header Files"
-      ROOT "${hpx_SOURCE_DIR}/hpx"
+      ROOT "${PROJECT_SOURCE_DIR}/hpx"
       TARGETS ${${name}_HEADERS})
     add_hpx_source_group(
       NAME hpx
       CLASS "Source Files"
-      ROOT "${hpx_SOURCE_DIR}"
+      ROOT "${PROJECT_SOURCE_DIR}"
       TARGETS ${${name}_SOURCES})
 
     set(HPX_STATIC_PARCELPORT_PLUGINS
@@ -110,7 +110,7 @@ macro(add_parcelport_modules)
         "${_parcelport_init}        HPX_ASSERT(parcelport_${parcelport}_factory_base_ptr);\n        parcelport_${parcelport}_factory_base_ptr->force_init();\n")
   endforeach()
 
-  configure_file("${hpx_SOURCE_DIR}/cmake/templates/static_parcelports.hpp.in"
+  configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/static_parcelports.hpp.in"
                  "${CMAKE_BINARY_DIR}/hpx/runtime/parcelset/static_parcelports.hpp"
                  @ONLY)
 endmacro()

--- a/plugins/parcelport/ibverbs/CMakeLists.txt
+++ b/plugins/parcelport/ibverbs/CMakeLists.txt
@@ -30,22 +30,22 @@ if(HPX_WITH_PARCELPORT_IBVERBS)
   macro(add_parcelport_ibverbs_module)
     hpx_debug("add_parcelport_ibverbs_module")
     add_parcelport(ibverbs
-        SOURCES "${hpx_SOURCE_DIR}/plugins/parcelport/ibverbs/connection_handler_ibverbs.cpp"
-                "${hpx_SOURCE_DIR}/plugins/parcelport/ibverbs/parcelport_ibverbs.cpp"
+        SOURCES "${PROJECT_SOURCE_DIR}/plugins/parcelport/ibverbs/connection_handler_ibverbs.cpp"
+                "${PROJECT_SOURCE_DIR}/plugins/parcelport/ibverbs/parcelport_ibverbs.cpp"
         HEADERS
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/acceptor.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/allocator.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/client.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/connection_handler.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/context.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/data_buffer.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/helper.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/ibverbs_errors.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/locality.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/messages.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/receiver.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/sender.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/server.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/acceptor.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/allocator.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/client.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/connection_handler.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/context.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/data_buffer.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/helper.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/ibverbs_errors.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/locality.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/messages.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/receiver.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/sender.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ibverbs/server.hpp"
         DEPENDENCIES
               ${IBVERBS_LIBRARIES}
               ${RDMACM_LIBRARIES}

--- a/plugins/parcelport/ipc/CMakeLists.txt
+++ b/plugins/parcelport/ipc/CMakeLists.txt
@@ -15,19 +15,19 @@ if(HPX_WITH_PARCELPORT_IPC)
   macro(add_parcelport_ipc_module)
     hpx_debug("add_parcelport_ipc_module")
     add_parcelport(ipc
-        SOURCES "${hpx_SOURCE_DIR}/plugins/parcelport/ipc/connection_handler_ipc.cpp"
-                "${hpx_SOURCE_DIR}/plugins/parcelport/ipc/parcelport_ipc.cpp"
+        SOURCES "${PROJECT_SOURCE_DIR}/plugins/parcelport/ipc/connection_handler_ipc.cpp"
+                "${PROJECT_SOURCE_DIR}/plugins/parcelport/ipc/parcelport_ipc.cpp"
         HEADERS
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ipc/acceptor.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ipc/connection_handler.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ipc/data_buffer_cache.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ipc/data_buffer.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ipc/data_window.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ipc/interprocess_errors.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ipc/locality.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ipc/message.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ipc/receiver.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/ipc/sender.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ipc/acceptor.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ipc/connection_handler.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ipc/data_buffer_cache.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ipc/data_buffer.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ipc/data_window.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ipc/interprocess_errors.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ipc/locality.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ipc/message.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ipc/receiver.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/ipc/sender.hpp"
         FOLDER "Core/Plugins/Parcelport/Tcp"
         )
   endmacro()

--- a/plugins/parcelport/mpi/CMakeLists.txt
+++ b/plugins/parcelport/mpi/CMakeLists.txt
@@ -59,14 +59,14 @@ if(HPX_WITH_PARCELPORT_MPI)
     add_parcelport(mpi
       STATIC
       SOURCES
-        "${hpx_SOURCE_DIR}/plugins/parcelport/mpi/mpi_environment.cpp"
-        "${hpx_SOURCE_DIR}/plugins/parcelport/mpi/parcelport_mpi.cpp"
+        "${PROJECT_SOURCE_DIR}/plugins/parcelport/mpi/mpi_environment.cpp"
+        "${PROJECT_SOURCE_DIR}/plugins/parcelport/mpi/parcelport_mpi.cpp"
       HEADERS
-        "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/mpi/header.hpp"
-        "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/mpi/locality.hpp"
-        "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/mpi/mpi_environment.hpp"
-        "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/mpi/sender.hpp"
-        "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/mpi/receiver.hpp"
+        "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/mpi/header.hpp"
+        "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/mpi/locality.hpp"
+        "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/mpi/mpi_environment.hpp"
+        "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/mpi/sender.hpp"
+        "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/mpi/receiver.hpp"
       DEPENDENCIES
         ${_mpi_libraries}
       FOLDER "Core/Plugins/Parcelport/MPI")

--- a/plugins/parcelport/tcp/CMakeLists.txt
+++ b/plugins/parcelport/tcp/CMakeLists.txt
@@ -14,13 +14,13 @@ if(HPX_WITH_PARCELPORT_TCP)
     add_parcelport(
         tcp
         STATIC
-        SOURCES "${hpx_SOURCE_DIR}/plugins/parcelport/tcp/connection_handler_tcp.cpp"
-                "${hpx_SOURCE_DIR}/plugins/parcelport/tcp/parcelport_tcp.cpp"
+        SOURCES "${PROJECT_SOURCE_DIR}/plugins/parcelport/tcp/connection_handler_tcp.cpp"
+                "${PROJECT_SOURCE_DIR}/plugins/parcelport/tcp/parcelport_tcp.cpp"
         HEADERS
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/tcp/connection_handler.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/tcp/locality.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/tcp/receiver.hpp"
-              "${hpx_SOURCE_DIR}/hpx/plugins/parcelport/tcp/sender.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/tcp/connection_handler.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/tcp/locality.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/tcp/receiver.hpp"
+              "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/tcp/sender.hpp"
         FOLDER "Core/Plugins/Parcelport/Tcp"
         )
   endmacro()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,40 +19,40 @@ endforeach()
 
 # libhpx sources
 add_hpx_library_sources(hpx
-  GLOB GLOBS "${hpx_SOURCE_DIR}/src/*.cpp"
+  GLOB GLOBS "${PROJECT_SOURCE_DIR}/src/*.cpp"
   EXCLUDE "(.*(hpx_main|hpx_user).*[.]cpp)|main.cpp")
 add_hpx_library_sources(hpx
-  GLOB GLOBS "${hpx_SOURCE_DIR}/src/pre_main.cpp"
+  GLOB GLOBS "${PROJECT_SOURCE_DIR}/src/pre_main.cpp"
   APPEND)
 add_hpx_library_sources(hpx
-  GLOB_RECURSE GLOBS "${hpx_SOURCE_DIR}/src/runtime/*.cpp"
+  GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/src/runtime/*.cpp"
   APPEND)
 add_hpx_library_sources(hpx
-  GLOB_RECURSE GLOBS "${hpx_SOURCE_DIR}/src/performance_counters/*.cpp"
+  GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/src/performance_counters/*.cpp"
   APPEND)
 add_hpx_library_sources(hpx
-  GLOB_RECURSE GLOBS "${hpx_SOURCE_DIR}/src/util/*.cpp"
+  GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/src/util/*.cpp"
   APPEND)
 add_hpx_library_sources(hpx
-  GLOB_RECURSE GLOBS "${hpx_SOURCE_DIR}/src/lcos/*.cpp"
+  GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/src/lcos/*.cpp"
   APPEND)
 
 
 # libhpx_init sources
 add_hpx_library_sources(hpx_init
-  GLOB GLOBS "${hpx_SOURCE_DIR}/src/hpx_*.cpp"
+  GLOB GLOBS "${PROJECT_SOURCE_DIR}/src/hpx_*.cpp"
   EXCLUDE "hpx_init[.]cpp")
 add_hpx_library_sources(hpx_init
-  GLOB GLOBS "${hpx_SOURCE_DIR}/src/util/lightweight_test.cpp"
+  GLOB GLOBS "${PROJECT_SOURCE_DIR}/src/util/lightweight_test.cpp"
   APPEND)
 add_hpx_library_sources(hpx_init
-  GLOB GLOBS "${hpx_SOURCE_DIR}/src/main.cpp" APPEND)
+  GLOB GLOBS "${PROJECT_SOURCE_DIR}/src/main.cpp" APPEND)
 
 set(hpx_external_SOURCES "" CACHE INTERNAL "Sources for libhpx_external." FORCE)
 
 if(MSVC)
   if(HPX_WITH_SWAP_CONTEXT_EMULATION)
-    set(switch_to_fiber_source "${hpx_SOURCE_DIR}/src/util/coroutine/switch_to_fiber.asm")
+    set(switch_to_fiber_source "${PROJECT_SOURCE_DIR}/src/util/coroutine/switch_to_fiber.asm")
     add_hpx_library_sources(hpx_external_objects
       GLOB GLOBS "${switch_to_fiber_source}")
     add_custom_command(
@@ -74,78 +74,78 @@ endif()
 
 # libhpx headers
 add_hpx_library_headers(hpx
-  GLOB GLOBS "${hpx_SOURCE_DIR}/hpx/*.hpp"
+  GLOB GLOBS "${PROJECT_SOURCE_DIR}/hpx/*.hpp"
   EXCLUDE ".*hpx_main.*[.]hpp")
 add_hpx_library_headers(hpx
-  GLOB GLOBS "${hpx_SOURCE_DIR}/hpx/preprocessed/*.hpp"
+  GLOB GLOBS "${PROJECT_SOURCE_DIR}/hpx/preprocessed/*.hpp"
   APPEND)
 add_hpx_library_headers(hpx
-  GLOB_RECURSE GLOBS "${hpx_SOURCE_DIR}/hpx/runtime/*.hpp"
+  GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/hpx/runtime/*.hpp"
   APPEND)
 add_hpx_library_headers(hpx
-  GLOB_RECURSE GLOBS "${hpx_SOURCE_DIR}/hpx/config/*.hpp"
+  GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/hpx/config/*.hpp"
   APPEND)
 add_hpx_library_headers(hpx
-  GLOB_RECURSE GLOBS "${hpx_SOURCE_DIR}/hpx/include/*.hpp"
+  GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/hpx/include/*.hpp"
   APPEND)
 add_hpx_library_headers(hpx
-  GLOB_RECURSE GLOBS "${hpx_SOURCE_DIR}/hpx/lcos/*.hpp"
+  GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/hpx/lcos/*.hpp"
   APPEND)
 add_hpx_library_headers(hpx
-  GLOB_RECURSE GLOBS "${hpx_SOURCE_DIR}/hpx/performance_counters/*.hpp"
+  GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/hpx/performance_counters/*.hpp"
   APPEND)
 add_hpx_library_headers(hpx
-  GLOB_RECURSE GLOBS "${hpx_SOURCE_DIR}/hpx/traits/*.hpp"
+  GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/hpx/traits/*.hpp"
   APPEND)
 add_hpx_library_headers(hpx
-  GLOB_RECURSE GLOBS "${hpx_SOURCE_DIR}/hpx/util/*.h*"
+  GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/hpx/util/*.h*"
   EXCLUDE "(.*_binary_.*|[io]chunk_.*)[.]hpp"
   APPEND)
 add_hpx_library_headers(hpx
-  GLOB GLOBS "${hpx_SOURCE_DIR}/hpx/plugins/*.hpp"
+  GLOB GLOBS "${PROJECT_SOURCE_DIR}/hpx/plugins/*.hpp"
   APPEND)
 add_hpx_library_headers(hpx
-  GLOB_RECURSE GLOBS "${hpx_SOURCE_DIR}/hpx/parallel/*.hpp"
+  GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/hpx/parallel/*.hpp"
   APPEND)
 
 if(HPX_WITH_STATIC_LINKING)
   add_hpx_library_headers(hpx
-    GLOB GLOBS "${hpx_SOURCE_DIR}/hpx/components/*.hpp"
+    GLOB GLOBS "${PROJECT_SOURCE_DIR}/hpx/components/*.hpp"
     APPEND)
 endif()
 
 # libhpx_init headers
 add_hpx_library_headers(hpx_init
-  GLOB GLOBS "${hpx_SOURCE_DIR}/hpx/hpx_main*.hpp")
+  GLOB GLOBS "${PROJECT_SOURCE_DIR}/hpx/hpx_main*.hpp")
 
 ################################################################################
 # make source groups
 add_hpx_source_group(
   NAME hpx CLASS "Source Files"
-  ROOT "${hpx_SOURCE_DIR}/src"
+  ROOT "${PROJECT_SOURCE_DIR}/src"
   TARGETS ${hpx_SOURCES})
 
 add_hpx_source_group(
   NAME hpx CLASS "External Source Files"
-  ROOT "${hpx_SOURCE_DIR}/external"
+  ROOT "${PROJECT_SOURCE_DIR}/external"
   TARGETS ${hpx_external_SOURCES})
 
 add_hpx_source_group(
   NAME hpx
   CLASS "Header Files"
-  ROOT "${hpx_SOURCE_DIR}/hpx"
+  ROOT "${PROJECT_SOURCE_DIR}/hpx"
   TARGETS ${hpx_HEADERS})
 
 add_hpx_source_group(
   NAME hpx_init
   CLASS "Source Files"
-  ROOT "${hpx_SOURCE_DIR}/src"
+  ROOT "${PROJECT_SOURCE_DIR}/src"
   TARGETS ${hpx_init_SOURCES})
 
 add_hpx_source_group(
   NAME hpx_init
   CLASS "Header Files"
-  ROOT "${hpx_SOURCE_DIR}/hpx"
+  ROOT "${PROJECT_SOURCE_DIR}/hpx"
   TARGETS ${hpx_init_HEADERS})
 
 if(NOT HPX_WITH_STATIC_LINKING)

--- a/src/components/component_storage/CMakeLists.txt
+++ b/src/components/component_storage/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(root "${hpx_SOURCE_DIR}/hpx/components/component_storage")
+set(root "${PROJECT_SOURCE_DIR}/hpx/components/component_storage")
 
 add_definitions(-DHPX_MIGRATE_TO_STORAGE_MODULE_EXPORTS)
 

--- a/src/components/containers/unordered/CMakeLists.txt
+++ b/src/components/containers/unordered/CMakeLists.txt
@@ -4,7 +4,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 ###############################################################################
-set(root "${hpx_SOURCE_DIR}/hpx/components/containers/unordered")
+set(root "${PROJECT_SOURCE_DIR}/hpx/components/containers/unordered")
 
 add_hpx_component(unordered
   FOLDER "Core/Components/Containers"

--- a/src/components/containers/vector/CMakeLists.txt
+++ b/src/components/containers/vector/CMakeLists.txt
@@ -4,7 +4,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 ###############################################################################
-set(root "${hpx_SOURCE_DIR}/hpx/components/containers/vector")
+set(root "${PROJECT_SOURCE_DIR}/hpx/components/containers/vector")
 
 add_hpx_component(vector
   FOLDER "Core/Components/Containers"

--- a/src/components/iostreams/CMakeLists.txt
+++ b/src/components/iostreams/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(root "${hpx_SOURCE_DIR}/hpx/components/iostreams")
+set(root "${PROJECT_SOURCE_DIR}/hpx/components/iostreams")
 
 add_definitions(-DHPX_IOSTREAMS_MODULE_EXPORTS)
 

--- a/src/components/memory/CMakeLists.txt
+++ b/src/components/memory/CMakeLists.txt
@@ -4,7 +4,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 ###############################################################################
-set(root "${hpx_SOURCE_DIR}/hpx/components/memory")
+set(root "${PROJECT_SOURCE_DIR}/hpx/components/memory")
 
 if(HPX_WITH_DEFAULT_TARGETS)
   add_hpx_component(memory

--- a/src/components/papi_counters/CMakeLists.txt
+++ b/src/components/papi_counters/CMakeLists.txt
@@ -5,7 +5,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(root "${hpx_SOURCE_DIR}/hpx/components/papi_counters")
+set(root "${PROJECT_SOURCE_DIR}/hpx/components/papi_counters")
 
 ################################################################################
 # PAPI event counters

--- a/src/components/security/CMakeLists.txt
+++ b/src/components/security/CMakeLists.txt
@@ -6,7 +6,7 @@
 ###############################################################################
 if(HPX_WITH_SECURITY)
 
-  set(root "${hpx_SOURCE_DIR}/hpx/components/security")
+  set(root "${PROJECT_SOURCE_DIR}/hpx/components/security")
 
   add_hpx_component(security
     FOLDER "Core/Components"

--- a/tests/performance/network/network_storage/CMakeLists.txt
+++ b/tests/performance/network/network_storage/CMakeLists.txt
@@ -25,7 +25,7 @@ add_hpx_pseudo_dependencies(
 
 hpx_option(HPX_WITH_BENCHMARK_SCRIPTS_PATH PATH
   "Directory to place batch scripts in"
-  "${hpx_BINARY_DIR}/scripts"
+  "${PROJECT_BINARY_DIR}/scripts"
   ADVANCED)
 
 # our windows batch script needs to know the lib path for boost/hpx

--- a/tests/unit/agas/components/CMakeLists.txt
+++ b/tests/unit/agas/components/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(root "${hpx_SOURCE_DIR}/tests/unit/agas/components")
+set(root "${PROJECT_SOURCE_DIR}/tests/unit/agas/components")
 
 add_hpx_component(simple_refcnt_checker
   DEPENDENCIES iostreams_component

--- a/tests/unit/build/CMakeLists.txt
+++ b/tests/unit/build/CMakeLists.txt
@@ -27,7 +27,7 @@ macro(create_cmake_test name hpx_dir)
   add_custom_target(${name}.make_configure
     COMMAND
       "${CMAKE_COMMAND}" -E chdir "${build_dir}" "${CMAKE_COMMAND}"
-      "${hpx_SOURCE_DIR}/tests/unit/build/src"
+      "${PROJECT_SOURCE_DIR}/tests/unit/build/src"
       -DHPX_DIR=${hpx_dir}
       ${ADDITIONAL_CMAKE_OPTIONS}
       -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
@@ -67,8 +67,8 @@ macro(create_pkgconfig_test name hpx_dir)
   add_custom_target(${name}.make_compile
     COMMAND
       "${CMAKE_COMMAND}" -E chdir "${build_dir}" make
-      -f "${hpx_SOURCE_DIR}/tests/unit/build/src/Makefile"
-      SRC_DIR=${hpx_SOURCE_DIR}/tests/unit/build/src
+      -f "${PROJECT_SOURCE_DIR}/tests/unit/build/src/Makefile"
+      SRC_DIR=${PROJECT_SOURCE_DIR}/tests/unit/build/src
       HPX_DIR=${hpx_dir}
       CXX=${CMAKE_CXX_COMPILER}
       CXX_FLAGS=${CMAKE_CXX_FLAGS_SAFE}
@@ -89,11 +89,11 @@ endmacro()
 
 create_cmake_test(
   cmake_build_dir_test
-  "${CMAKE_BINARY_DIR}/lib/cmake/hpx")
+  "${CMAKE_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}")
 
 create_cmake_test(
   cmake_install_dir_test
-  "${CMAKE_INSTALL_PREFIX}/lib/cmake/hpx"
+  "${CMAKE_INSTALL_PREFIX}/lib/cmake/${HPX_PACKAGE_NAME}"
 )
 
 find_package(PkgConfig)


### PR DESCRIPTION
Lots of CMake changes:
  Use HPX_PACKAGE_NAME for install paths where appropriate
  Replace hpx_SOURCE_DIR with PROJECT_SOURCE_DIR
  Replace hpx_BINARY_DIR with PROJECT_BINARY_DIR

This should allow one to change the project name and have most
install/find rules remain working.

A number of hardcoded filenames of type hpx_XXXX have been left unchanged