### PR TITLE
Converting partitioners to use bulk async execute

### DIFF
--- a/hpx/parallel/algorithms/is_sorted.hpp
+++ b/hpx/parallel/algorithms/is_sorted.hpp
@@ -66,7 +66,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 util::cancellation_token<> tok;
                 return util::partitioner<ExPolicy, bool>::call(
-                    policy, first, count ,
+                    policy, first, count,
                     [tok, pred, last](FwdIter part_begin,
                     std::size_t part_size) mutable -> bool
                     {

--- a/hpx/parallel/util/detail/chunk_size.hpp
+++ b/hpx/parallel/util/detail/chunk_size.hpp
@@ -93,22 +93,22 @@ namespace hpx { namespace parallel { namespace util { namespace detail
     template <typename ExPolicy, typename Future, typename F1,
         typename FwdIter>
         // requires traits::is_future<Future>
-    std::vector<std::pair<FwdIter, std::size_t > > get_static_shape(
-        ExPolicy policy, std::vector<Future>& workitems,
+    std::vector<hpx::util::tuple<FwdIter, std::size_t> > get_static_shape(
+        ExPolicy policy, std::vector<Future>& inititems,
         F1 && f1, FwdIter& first, std::size_t& count,
         std::size_t chunk_size)
     {
-        chunk_size = get_static_chunk_size(policy, workitems,
+        chunk_size = get_static_chunk_size(policy, inititems,
             std::forward<F1>(f1), first, count, chunk_size);
 
-        std::vector<std::pair<FwdIter, std::size_t> > shape;
-        shape.reserve(count);
+        std::vector<hpx::util::tuple<FwdIter, std::size_t> > shape;
+        shape.reserve(count / chunk_size + 1);
 
         while (count != 0)
         {
             std::size_t chunk = (std::min)(chunk_size, count);
 
-            shape.push_back(std::make_pair(first, chunk));
+            shape.push_back(hpx::util::make_tuple(first, chunk));
 
             count -= chunk;
             std::advance(first, chunk);
@@ -193,6 +193,38 @@ namespace hpx { namespace parallel { namespace util { namespace detail
             }
         }
         return chunk_size;
+    }
+
+    template <typename ExPolicy, typename Future, typename F1,
+        typename FwdIter>
+        // requires traits::is_future<Future>
+    std::vector<hpx::util::tuple<std::size_t, FwdIter, std::size_t > >
+        get_static_shape_idx(ExPolicy policy,
+        std::vector<Future>& inititems, F1 && f1,
+        std::size_t& base_idx, FwdIter& first, std::size_t& count,
+        std::size_t chunk_size)
+    {
+        typedef typename hpx::util::tuple<std::size_t, FwdIter, std::size_t>
+            tuple;
+
+        chunk_size = get_static_chunk_size_idx(policy, inititems,
+            std::forward<F1>(f1), base_idx, first, count, chunk_size);
+
+        std::vector<tuple> shape;
+        shape.reserve(count / chunk_size + 1);
+
+        while (count != 0)
+        {
+            std::size_t chunk = (std::min)(chunk_size, count);
+
+            shape.push_back(hpx::util::make_tuple(base_idx, first, chunk));
+
+            count -= chunk;
+            std::advance(first, chunk);
+            base_idx += chunk;
+        }
+
+        return shape;
     }
 }}}}
 

--- a/hpx/parallel/util/foreach_partitioner.hpp
+++ b/hpx/parallel/util/foreach_partitioner.hpp
@@ -14,6 +14,8 @@
 #include <hpx/util/bind.hpp>
 #include <hpx/util/decay.hpp>
 #include <hpx/util/deferred_call.hpp>
+#include <hpx/util/invoke_fused.hpp>
+#include <hpx/util/tuple.hpp>
 
 #include <hpx/parallel/executors/executor_traits.hpp>
 #include <hpx/parallel/execution_policy.hpp>
@@ -41,27 +43,29 @@ namespace hpx { namespace parallel { namespace util
                 typedef typename ExPolicy::executor_type executor_type;
                 typedef typename hpx::parallel::executor_traits<executor_type>
                     executor_traits;
+                typedef typename hpx::util::tuple<FwdIter, std::size_t> tuple;
 
                 FwdIter last = first;
                 std::advance(last, count);
 
                 std::vector<hpx::future<Result> > inititems, workitems;
                 std::list<boost::exception_ptr> errors;
+                std::vector<tuple> shape;
 
                 try {
                     // estimates a chunk size based on number of cores used
-                    std::vector<std::pair<FwdIter, std::size_t> > shape =
-                        get_static_shape(policy, inititems, f1,
-                            first, count, chunk_size);
-
-                    auto f = [f1](std::pair<FwdIter, std::size_t> const& elem)
-                    {
-                        return f1(elem.first, elem.second);
-                    };
+                    shape = get_static_shape(policy, inititems, f1,
+                        first, count, chunk_size);
 
                     workitems.reserve(shape.size());
+
+                    using hpx::util::bind;
+                    using hpx::util::functional::invoke_fused;
+                    using hpx::util::placeholders::_1;
                     workitems = executor_traits::async_execute(
-                        policy.executor(), f, shape);
+                        policy.executor(),
+                        bind(invoke_fused(), std::forward<F1>(f1), _1),
+                        shape);
                 }
                 catch (...) {
                     detail::handle_local_exceptions<ExPolicy>::call(
@@ -94,27 +98,29 @@ namespace hpx { namespace parallel { namespace util
                 typedef typename ExPolicy::executor_type executor_type;
                 typedef typename hpx::parallel::executor_traits<executor_type>
                     executor_traits;
+                typedef typename hpx::util::tuple<FwdIter, std::size_t> tuple;
 
                 FwdIter last = first;
                 std::advance(last, count);
 
                 std::vector<hpx::future<Result> > inititems, workitems;
                 std::list<boost::exception_ptr> errors;
+                std::vector<tuple> shape;
 
                 try {
                     // estimates a chunk size based on number of cores used
-                    std::vector<std::pair<FwdIter, std::size_t> > shape =
-                        get_static_shape(policy, inititems, f1,
-                            first, count, chunk_size);
-
-                    auto f = [f1](std::pair<FwdIter, std::size_t> const& elem)
-                    {
-                        return f1(elem.first, elem.second);
-                    };
+                    shape = get_static_shape(policy, inititems, f1,
+                        first, count, chunk_size);
 
                     workitems.reserve(shape.size());
+
+                    using hpx::util::bind;
+                    using hpx::util::functional::invoke_fused;
+                    using hpx::util::placeholders::_1;
                     workitems = executor_traits::async_execute(
-                        policy.executor(), f, shape);
+                        policy.executor(),
+                        bind(invoke_fused(), std::forward<F1>(f1), _1),
+                        shape);
                 }
                 catch (std::bad_alloc const&) {
                     return hpx::make_exceptional_future<FwdIter>(

--- a/hpx/parallel/util/partitioner.hpp
+++ b/hpx/parallel/util/partitioner.hpp
@@ -14,6 +14,8 @@
 #include <hpx/util/bind.hpp>
 #include <hpx/util/decay.hpp>
 #include <hpx/util/deferred_call.hpp>
+#include <hpx/util/invoke_fused.hpp>
+#include <hpx/util/tuple.hpp>
 
 #include <hpx/parallel/executors/executor_traits.hpp>
 #include <hpx/parallel/execution_policy.hpp>
@@ -22,6 +24,7 @@
 #include <hpx/parallel/traits/extract_partitioner.hpp>
 
 #include <boost/range/functions.hpp>
+#include <iterator>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace parallel { namespace util
@@ -39,31 +42,34 @@ namespace hpx { namespace parallel { namespace util
             static R call(ExPolicy policy, FwdIter first,
                 std::size_t count, F1 && f1, F2 && f2, std::size_t chunk_size)
             {
-                std::vector<hpx::future<Result> > workitems;
+                typedef typename ExPolicy::executor_type executor_type;
+                typedef typename hpx::parallel::executor_traits<executor_type>
+                    executor_traits;
+                typedef typename hpx::util::tuple<FwdIter, std::size_t>
+                    tuple_type;
+
+                std::vector<hpx::future<Result> > inititems;
                 std::list<boost::exception_ptr> errors;
+                std::vector<tuple_type> shape;
 
                 try {
                     // estimate a chunk size based on number of cores used
-                    chunk_size = get_static_chunk_size(policy, workitems, f1,
-                        first, count, chunk_size);
+                    shape = get_static_shape(policy, inititems, f1, first,
+                        count, chunk_size);
 
-                    // schedule every chunk on a separate thread
-                    workitems.reserve(count / chunk_size + 1);
-                    while(count != 0)
-                    {
-                        std::size_t chunk = (std::min)(count, chunk_size);
+                    std::vector<hpx::future<Result> > workitems;
+                    workitems.reserve(shape.size());
 
-                        typedef typename ExPolicy::executor_type executor_type;
-                        workitems.push_back(
-                            executor_traits<executor_type>::async_execute(
-                                policy.executor(),
-                                hpx::util::deferred_call(f1, first, chunk)
-                            )
-                        );
+                    using hpx::util::bind;
+                    using hpx::util::functional::invoke_fused;
+                    using hpx::util::placeholders::_1;
+                    workitems = executor_traits::async_execute(
+                        policy.executor(),
+                        bind(invoke_fused(), std::forward<F1>(f1), _1),
+                        shape);
 
-                        count -= chunk;
-                        std::advance(first, chunk);
-                    }
+                    std::move(workitems.begin(), workitems.end(),
+                        std::back_inserter(inititems));
                 }
                 catch (...) {
                     detail::handle_local_exceptions<ExPolicy>::call(
@@ -71,11 +77,12 @@ namespace hpx { namespace parallel { namespace util
                 }
 
                 // wait for all tasks to finish
-                hpx::wait_all(workitems);
-                detail::handle_local_exceptions<ExPolicy>::call(
-                    workitems, errors);
+                hpx::wait_all(inititems);
 
-                return f2(std::move(workitems));
+                detail::handle_local_exceptions<ExPolicy>::call(
+                    inititems, errors);
+
+                return f2(std::move(inititems));
             }
 
             template <typename FwdIter, typename F1, typename F2, typename Data>
@@ -86,30 +93,33 @@ namespace hpx { namespace parallel { namespace util
             {
                 HPX_ASSERT(boost::size(data) >= boost::size(chunk_sizes));
 
-                typename hpx::util::decay<Data>::type::const_iterator data_it =
-                    boost::begin(data);
+                typedef typename ExPolicy::executor_type executor_type;
+                typedef typename hpx::parallel::executor_traits<executor_type>
+                    executor_traits;
+                typedef typename hpx::util::decay<Data>::type data_type;
+
+                typename data_type::const_iterator data_it = boost::begin(data);
                 typename std::vector<std::size_t>::const_iterator chunk_size_it =
                     boost::begin(chunk_sizes);
 
+                typedef typename hpx::util::tuple<
+                        typename data_type::value_type, FwdIter, std::size_t
+                    > tuple_type;
+
                 std::vector<hpx::future<Result> > workitems;
                 std::list<boost::exception_ptr> errors;
+                std::vector<tuple_type> shape;
 
                 try {
                     // schedule every chunk on a separate thread
-                    workitems.reserve(chunk_sizes.size());
+                    shape.reserve(chunk_sizes.size());
                     while(count != 0)
                     {
                         std::size_t chunk = (std::min)(count, *chunk_size_it);
                         HPX_ASSERT(chunk != 0);
 
-
-                        typedef typename ExPolicy::executor_type executor_type;
-                        workitems.push_back(
-                            executor_traits<executor_type>::async_execute(
-                                policy.executor(),
-                                hpx::util::deferred_call(f1, *data_it, first, chunk)
-                            )
-                        );
+                        shape.push_back(hpx::util::make_tuple(
+                            *data_it, first, chunk));
 
                         count -= chunk;
                         std::advance(first, chunk);
@@ -119,6 +129,15 @@ namespace hpx { namespace parallel { namespace util
                     }
 
                     HPX_ASSERT(chunk_size_it == chunk_sizes.end());
+                    workitems.reserve(chunk_sizes.size());
+
+                    using hpx::util::bind;
+                    using hpx::util::functional::invoke_fused;
+                    using hpx::util::placeholders::_1;
+                    workitems = executor_traits::async_execute(
+                        policy.executor(),
+                        bind(invoke_fused(), std::forward<F1>(f1), _1),
+                        shape);
                 }
                 catch (...) {
                     detail::handle_local_exceptions<ExPolicy>::call(
@@ -137,33 +156,35 @@ namespace hpx { namespace parallel { namespace util
             static R call_with_index(ExPolicy policy, FwdIter first,
                 std::size_t count, F1 && f1, F2 && f2, std::size_t chunk_size)
             {
-                std::vector<hpx::future<Result> > workitems;
+                typedef typename ExPolicy::executor_type executor_type;
+                typedef typename hpx::parallel::executor_traits<executor_type>
+                    executor_traits;
+                typedef hpx::util::tuple<std::size_t, FwdIter, std::size_t>
+                    tuple_type;
+
+                std::vector<hpx::future<Result> > inititems;
                 std::list<boost::exception_ptr> errors;
+                std::vector<tuple_type> shape;
 
                 try {
                     // estimate a chunk size based on number of cores used
                     std::size_t base_idx = 0;
-                    chunk_size = get_static_chunk_size_idx(policy, workitems,
-                        f1, base_idx, first, count, chunk_size);
+                    shape = get_static_shape_idx(policy, inititems, f1,
+                        base_idx, first, count, chunk_size);
 
-                    // schedule every chunk on a separate thread
-                    workitems.reserve(count / chunk_size + 1);
-                    while(count != 0)
-                    {
-                        std::size_t chunk = (std::min)(count, chunk_size);
+                    std::vector<hpx::future<Result> > workitems;
+                    workitems.reserve(shape.size());
 
-                        typedef typename ExPolicy::executor_type executor_type;
-                        workitems.push_back(
-                            executor_traits<executor_type>::async_execute(
-                                policy.executor(),
-                                hpx::util::deferred_call(f1, base_idx, first, chunk)
-                            )
-                        );
+                    using hpx::util::bind;
+                    using hpx::util::functional::invoke_fused;
+                    using hpx::util::placeholders::_1;
+                    workitems = executor_traits::async_execute(
+                        policy.executor(),
+                        bind(invoke_fused(), std::forward<F1>(f1), _1),
+                        shape);
 
-                        count -= chunk;
-                        std::advance(first, chunk);
-                        base_idx += chunk;
-                    }
+                    std::move(workitems.begin(), workitems.end(),
+                        std::back_inserter(inititems));
                 }
                 catch (...) {
                     detail::handle_local_exceptions<ExPolicy>::call(
@@ -171,11 +192,11 @@ namespace hpx { namespace parallel { namespace util
                 }
 
                 // wait for all tasks to finish
-                hpx::wait_all(workitems);
+                hpx::wait_all(inititems);
                 detail::handle_local_exceptions<ExPolicy>::call(
-                    workitems, errors);
+                    inititems, errors);
 
-                return f2(std::move(workitems));
+                return f2(std::move(inititems));
             }
         };
 
@@ -187,31 +208,34 @@ namespace hpx { namespace parallel { namespace util
                 FwdIter first, std::size_t count, F1 && f1, F2 && f2,
                 std::size_t chunk_size)
             {
-                std::vector<hpx::future<Result> > workitems;
+                typedef typename ExPolicy::executor_type executor_type;
+                typedef typename hpx::parallel::executor_traits<executor_type>
+                    executor_traits;
+                typedef typename hpx::util::tuple<FwdIter, std::size_t>
+                    tuple_type;
+
+                std::vector<hpx::future<Result> > inititems;
                 std::list<boost::exception_ptr> errors;
+                std::vector<tuple_type> shape;
 
                 try {
                     // estimate a chunk size based on number of cores used
-                    chunk_size = get_static_chunk_size(policy, workitems, f1,
-                        first, count, chunk_size);
+                    shape = get_static_shape(policy, inititems, f1, first,
+                        count, chunk_size);
 
-                    // schedule every chunk on a separate thread
-                    workitems.reserve(count / chunk_size + 1);
-                    while(count != 0)
-                    {
-                        std::size_t chunk = (std::min)(count, chunk_size);
+                    std::vector<hpx::future<Result> > workitems;
+                    workitems.reserve(shape.size());
 
-                        typedef typename ExPolicy::executor_type executor_type;
-                        workitems.push_back(
-                            executor_traits<executor_type>::async_execute(
-                                policy.executor(),
-                                hpx::util::deferred_call(f1, first, chunk)
-                            )
-                        );
+                    using hpx::util::bind;
+                    using hpx::util::functional::invoke_fused;
+                    using hpx::util::placeholders::_1;
+                    workitems = executor_traits::async_execute(
+                        policy.executor(),
+                        bind(invoke_fused(), std::forward<F1>(f1), _1),
+                        shape);
 
-                        count -= chunk;
-                        std::advance(first, chunk);
-                    }
+                    std::move(workitems.begin(), workitems.end(),
+                        std::back_inserter(inititems));
                 }
                 catch (std::bad_alloc const&) {
                     return hpx::make_exceptional_future<R>(
@@ -228,7 +252,7 @@ namespace hpx { namespace parallel { namespace util
                         detail::handle_local_exceptions<ExPolicy>::call(r, errors);
                         return f2(std::move(r));
                     },
-                    std::move(workitems));
+                    std::move(inititems));
             }
 
             template <typename ExPolicy, typename FwdIter, typename F1,
@@ -240,29 +264,33 @@ namespace hpx { namespace parallel { namespace util
             {
                 HPX_ASSERT(boost::size(data) >= boost::size(chunk_sizes));
 
-                typename hpx::util::decay<Data>::type::const_iterator data_it =
-                    boost::begin(data);
+                typedef typename ExPolicy::executor_type executor_type;
+                typedef typename hpx::parallel::executor_traits<executor_type>
+                    executor_traits;
+                typedef typename hpx::util::decay<Data>::type data_type;
+
+                typename data_type::const_iterator data_it = boost::begin(data);
                 typename std::vector<std::size_t>::const_iterator chunk_size_it =
                     boost::begin(chunk_sizes);
 
+                typedef typename hpx::util::tuple<
+                        typename data_type::value_type, FwdIter, std::size_t
+                    > tuple_type;
+
                 std::vector<hpx::future<Result> > workitems;
                 std::list<boost::exception_ptr> errors;
+                std::vector<tuple_type> shape;
 
                 try {
                     // schedule every chunk on a separate thread
-                    workitems.reserve(chunk_sizes.size());
-                    while (count != 0)
+                    shape.reserve(chunk_sizes.size());
+                    while(count != 0)
                     {
-                        std::size_t chunk = *chunk_size_it;
-                        HPX_ASSERT(chunk != 0 && count >= chunk);
+                        std::size_t chunk = (std::min)(count, *chunk_size_it);
+                        HPX_ASSERT(chunk != 0);
 
-                        typedef typename ExPolicy::executor_type executor_type;
-                        workitems.push_back(
-                            executor_traits<executor_type>::async_execute(
-                                policy.executor(),
-                                hpx::util::deferred_call(f1, *data_it, first, chunk)
-                            )
-                        );
+                        shape.push_back(hpx::util::make_tuple(
+                            *data_it, first, chunk));
 
                         count -= chunk;
                         std::advance(first, chunk);
@@ -272,6 +300,15 @@ namespace hpx { namespace parallel { namespace util
                     }
 
                     HPX_ASSERT(chunk_size_it == chunk_sizes.end());
+                    workitems.reserve(chunk_sizes.size());
+
+                    using hpx::util::bind;
+                    using hpx::util::functional::invoke_fused;
+                    using hpx::util::placeholders::_1;
+                    workitems = executor_traits::async_execute(
+                        policy.executor(),
+                        bind(invoke_fused(), std::forward<F1>(f1), _1),
+                        shape);
                 }
                 catch (std::bad_alloc const&) {
                     return hpx::make_exceptional_future<R>(
@@ -297,33 +334,35 @@ namespace hpx { namespace parallel { namespace util
                 FwdIter first, std::size_t count, F1 && f1, F2 && f2,
                 std::size_t chunk_size)
             {
-                std::vector<hpx::future<Result> > workitems;
+                typedef typename ExPolicy::executor_type executor_type;
+                typedef typename hpx::parallel::executor_traits<executor_type>
+                    executor_traits;
+                typedef hpx::util::tuple<std::size_t, FwdIter, std::size_t>
+                    tuple_type;
+
+                std::vector<hpx::future<Result> > inititems;
                 std::list<boost::exception_ptr> errors;
+                std::vector<tuple_type> shape;
 
                 try {
                     // estimate a chunk size based on number of cores used
                     std::size_t base_idx = 0;
-                    chunk_size = get_static_chunk_size_idx(policy, workitems,
-                        f1, base_idx, first, count, chunk_size);
+                    shape = get_static_shape_idx(policy, inititems, f1,
+                        base_idx, first, count, chunk_size);
 
-                    // schedule every chunk on a separate thread
-                    workitems.reserve(count / chunk_size + 1);
-                    while(count != 0)
-                    {
-                        std::size_t chunk = (std::min)(count, chunk_size);
+                    std::vector<hpx::future<Result> > workitems;
+                    workitems.reserve(shape.size());
 
-                        typedef typename ExPolicy::executor_type executor_type;
-                        workitems.push_back(
-                            executor_traits<executor_type>::async_execute(
-                                policy.executor(),
-                                hpx::util::deferred_call(f1, base_idx, first, chunk)
-                            )
-                        );
+                    using hpx::util::bind;
+                    using hpx::util::functional::invoke_fused;
+                    using hpx::util::placeholders::_1;
+                    workitems = executor_traits::async_execute(
+                        policy.executor(),
+                        bind(invoke_fused(), std::forward<F1>(f1), _1),
+                        shape);
 
-                        count -= chunk;
-                        std::advance(first, chunk);
-                        base_idx += chunk;
-                    }
+                    std::move(workitems.begin(), workitems.end(),
+                        std::back_inserter(inititems));
                 }
                 catch (std::bad_alloc const&) {
                     return hpx::make_exceptional_future<R>(
@@ -341,7 +380,7 @@ namespace hpx { namespace parallel { namespace util
                         detail::handle_local_exceptions<ExPolicy>::call(r, errors);
                         return f2(std::move(r));
                     },
-                    std::move(workitems));
+                    std::move(inititems));
             }
         };
 

--- a/hpx/parallel/util/partitioner_with_cleanup.hpp
+++ b/hpx/parallel/util/partitioner_with_cleanup.hpp
@@ -42,31 +42,34 @@ namespace hpx { namespace parallel { namespace util
                 std::size_t count, F1 && f1, F2 && f2, F3 && f3,
                 std::size_t chunk_size)
             {
-                std::vector<hpx::future<Result> > workitems;
+                typedef typename ExPolicy::executor_type executor_type;
+                typedef typename hpx::parallel::executor_traits<executor_type>
+                    executor_traits;
+                typedef typename hpx::util::tuple<FwdIter, std::size_t>
+                    tuple_type;
+
+                std::vector<hpx::future<Result> > inititems;
                 std::list<boost::exception_ptr> errors;
+                std::vector<tuple_type> shape;
 
                 try {
                     // estimate a chunk size based on number of cores used
-                    chunk_size = get_static_chunk_size(policy, workitems, f1,
-                        first, count, chunk_size);
+                    shape = get_static_shape(policy, inititems, f1, first,
+                        count, chunk_size);
 
-                    // schedule every chunk on a separate thread
-                    workitems.reserve(count / chunk_size + 1);
-                    while (count != 0)
-                    {
-                        std::size_t chunk = (std::min)(chunk_size, count);
+                    std::vector<hpx::future<Result> > workitems;
+                    workitems.reserve(shape.size());
 
-                        typedef typename ExPolicy::executor_type executor_type;
-                        workitems.push_back(
-                            executor_traits<executor_type>::async_execute(
-                                policy.executor(),
-                                hpx::util::deferred_call(f1, first, chunk)
-                            )
-                        );
+                    using hpx::util::bind;
+                    using hpx::util::functional::invoke_fused;
+                    using hpx::util::placeholders::_1;
+                    workitems = executor_traits::async_execute(
+                        policy.executor(),
+                        bind(invoke_fused(), std::forward<F1>(f1), _1),
+                        shape);
 
-                        count -= chunk;
-                        std::advance(first, chunk);
-                    }
+                    std::move(workitems.begin(), workitems.end(),
+                        std::back_inserter(inititems));
                 }
                 catch (...) {
                     detail::handle_local_exceptions<ExPolicy>::call(
@@ -74,11 +77,11 @@ namespace hpx { namespace parallel { namespace util
                 }
 
                 // wait for all tasks to finish
-                hpx::wait_all(workitems);
+                hpx::wait_all(inititems);
                 detail::handle_local_exceptions<ExPolicy>::call(
-                    workitems, errors, std::forward<F3>(f3));
+                    inititems, errors, std::forward<F3>(f3));
 
-                return f2(std::move(workitems));
+                return f2(std::move(inititems));
             }
 
             template <typename FwdIter, typename F1, typename F2, typename F3>
@@ -86,33 +89,35 @@ namespace hpx { namespace parallel { namespace util
                 std::size_t count, F1 && f1, F2 && f2, F3 && f3,
                 std::size_t chunk_size)
             {
-                std::vector<hpx::future<Result> > workitems;
+                typedef typename ExPolicy::executor_type executor_type;
+                typedef typename hpx::parallel::executor_traits<executor_type>
+                    executor_traits;
+                typedef hpx::util::tuple<std::size_t, FwdIter, std::size_t>
+                    tuple_type;
+
+                std::vector<hpx::future<Result> > inititems;
                 std::list<boost::exception_ptr> errors;
+                std::vector<tuple_type> shape;
 
                 try {
                     // estimate a chunk size based on number of cores used
                     std::size_t base_idx = 0;
-                    chunk_size = get_static_chunk_size_idx(policy, workitems,
-                        f1, base_idx, first, count, chunk_size);
+                    shape = get_static_shape_idx(policy, inititems, f1,
+                        base_idx, first, count, chunk_size);
 
-                    // schedule every chunk on a separate thread
-                    workitems.reserve(count / chunk_size + 1);
-                    while (count != 0)
-                    {
-                        std::size_t chunk = (std::min)(chunk_size, count);
+                    std::vector<hpx::future<Result> > workitems;
+                    workitems.reserve(shape.size());
 
-                        typedef typename ExPolicy::executor_type executor_type;
-                        workitems.push_back(
-                            executor_traits<executor_type>::async_execute(
-                                policy.executor(),
-                                hpx::util::deferred_call(f1, base_idx, first, chunk)
-                            )
-                        );
+                    using hpx::util::bind;
+                    using hpx::util::functional::invoke_fused;
+                    using hpx::util::placeholders::_1;
+                    workitems = executor_traits::async_execute(
+                        policy.executor(),
+                        bind(invoke_fused(), std::forward<F1>(f1), _1),
+                        shape);
 
-                        count -= chunk;
-                        std::advance(first, chunk);
-                        base_idx += chunk;
-                    }
+                    std::move(workitems.begin(), workitems.end(),
+                        std::back_inserter(inititems));
                 }
                 catch (...) {
                     detail::handle_local_exceptions<ExPolicy>::call(
@@ -120,11 +125,11 @@ namespace hpx { namespace parallel { namespace util
                 }
 
                 // wait for all tasks to finish
-                hpx::wait_all(workitems);
+                hpx::wait_all(inititems);
                 detail::handle_local_exceptions<ExPolicy>::call(
-                    workitems, errors, std::forward<F3>(f3));
+                    inititems, errors, std::forward<F3>(f3));
 
-                return f2(std::move(workitems));
+                return f2(std::move(inititems));
             }
         };
 
@@ -138,31 +143,34 @@ namespace hpx { namespace parallel { namespace util
                 FwdIter first, std::size_t count, F1 && f1, F2 && f2, F3 && f3,
                 std::size_t chunk_size)
             {
-                std::vector<hpx::future<Result> > workitems;
+                typedef typename ExPolicy::executor_type executor_type;
+                typedef typename hpx::parallel::executor_traits<executor_type>
+                    executor_traits;
+                typedef typename hpx::util::tuple<FwdIter, std::size_t>
+                    tuple_type;
+
+                std::vector<hpx::future<Result> > inititems;
                 std::list<boost::exception_ptr> errors;
+                std::vector<tuple_type> shape;
 
                 try {
                     // estimate a chunk size based on number of cores used
-                    chunk_size = get_static_chunk_size(policy, workitems, f1,
-                        first, count, chunk_size);
+                    shape = get_static_shape(policy, inititems, f1, first,
+                        count, chunk_size);
 
-                    // schedule every chunk on a separate thread
-                    workitems.reserve(count / chunk_size + 1);
-                    while (count != 0)
-                    {
-                        std::size_t chunk = (std::min)(chunk_size, count);
+                    std::vector<hpx::future<Result> > workitems;
+                    workitems.reserve(shape.size());
 
-                        typedef typename ExPolicy::executor_type executor_type;
-                        workitems.push_back(
-                            executor_traits<executor_type>::async_execute(
-                                policy.executor(),
-                                hpx::util::deferred_call(f1, first, chunk)
-                            )
-                        );
+                    using hpx::util::bind;
+                    using hpx::util::functional::invoke_fused;
+                    using hpx::util::placeholders::_1;
+                    workitems = executor_traits::async_execute(
+                        policy.executor(),
+                        bind(invoke_fused(), std::forward<F1>(f1), _1),
+                        shape);
 
-                        count -= chunk;
-                        std::advance(first, chunk);
-                    }
+                    std::move(workitems.begin(), workitems.end(),
+                        std::back_inserter(inititems));
                 }
                 catch (std::bad_alloc const&) {
                     return hpx::make_exceptional_future<R>(
@@ -181,7 +189,7 @@ namespace hpx { namespace parallel { namespace util
                             r, errors, std::forward<F3>(f3));
                         return f2(std::move(r));
                     },
-                    std::move(workitems));
+                    std::move(inititems));
             }
 
             template <typename ExPolicy, typename FwdIter, typename F1,
@@ -190,33 +198,35 @@ namespace hpx { namespace parallel { namespace util
                 FwdIter first, std::size_t count, F1 && f1, F2 && f2, F3 && f3,
                 std::size_t chunk_size)
             {
-                std::vector<hpx::future<Result> > workitems;
+                typedef typename ExPolicy::executor_type executor_type;
+                typedef typename hpx::parallel::executor_traits<executor_type>
+                    executor_traits;
+                typedef hpx::util::tuple<std::size_t, FwdIter, std::size_t>
+                    tuple_type;
+
+                std::vector<hpx::future<Result> > inititems;
                 std::list<boost::exception_ptr> errors;
+                std::vector<tuple_type> shape;
 
                 try {
                     // estimate a chunk size based on number of cores used
                     std::size_t base_idx = 0;
-                    chunk_size = get_static_chunk_size_idx(policy, workitems,
-                        f1, base_idx, first, count, chunk_size);
+                    shape = get_static_shape_idx(policy, inititems, f1,
+                        base_idx, first, count, chunk_size);
 
-                    // schedule every chunk on a separate thread
-                    workitems.reserve(count / chunk_size + 1);
-                    while (count != 0)
-                    {
-                        std::size_t chunk = (std::min)(chunk_size, count);
+                    std::vector<hpx::future<Result> > workitems;
+                    workitems.reserve(shape.size());
 
-                        typedef typename ExPolicy::executor_type executor_type;
-                        workitems.push_back(
-                            executor_traits<executor_type>::async_execute(
-                                policy.executor(),
-                                hpx::util::deferred_call(f1, base_idx, first, chunk)
-                            )
-                        );
+                    using hpx::util::bind;
+                    using hpx::util::functional::invoke_fused;
+                    using hpx::util::placeholders::_1;
+                    workitems = executor_traits::async_execute(
+                        policy.executor(),
+                        bind(invoke_fused(), std::forward<F1>(f1), _1),
+                        shape);
 
-                        count -= chunk;
-                        std::advance(first, chunk);
-                        base_idx += chunk;
-                    }
+                    std::move(workitems.begin(), workitems.end(),
+                        std::back_inserter(inititems));
                 }
                 catch (std::bad_alloc const&) {
                     return hpx::make_exceptional_future<R>(
@@ -235,7 +245,7 @@ namespace hpx { namespace parallel { namespace util
                             r, errors, std::forward<F3>(f3));
                         return f2(std::move(r));
                     },
-                    std::move(workitems));
+                    std::move(inititems));
             }
         };
 

--- a/hpx/util/invoke_fused.hpp
+++ b/hpx/util/invoke_fused.hpp
@@ -117,6 +117,33 @@ namespace hpx { namespace util
             typename detail::make_index_pack<sizeof...(Ts)>::type(),
             std::forward<F>(f), std::move(args));
     }
+
+    namespace functional
+    {
+        struct invoke_fused
+        {
+            template <typename F, typename Tuple>
+            typename invoke_fused_result_of<F(Tuple)>::type
+            operator()(F && f, Tuple && args)
+            {
+                return util::invoke_fused(
+                    std::forward<F>(f),
+                    std::forward<Tuple>(args));
+            }
+        };
+
+        template <typename R>
+        struct invoke_fused_r
+        {
+            template <typename F, typename Tuple>
+            R operator()(F && f, Tuple && args)
+            {
+                return util::invoke_fused_r<R>(
+                    std::forward<F>(f),
+                    std::forward<Tuple>(args));
+            }
+        };
+    }
 }}
 
 #endif


### PR DESCRIPTION
The partitioner was changed to make use of the bulk overload of
async execute for the parallel algorithms and functional components
of invoke fused was added.
Other:
- chunk_size.hpp reserves different size for shape function and
  shape is now a vector of tuples
- partitioner and foreach partioner takes advantage of
  bind(invoked, function, _1)