### PR TITLE
Fix #1691: is_executor template specification fails for inherited executors

### DIFF
--- a/hpx/parallel/executors/detail/thread_executor.hpp
+++ b/hpx/parallel/executors/detail/thread_executor.hpp
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_EXECUTORS_THREAD_EXECUTOR_MAY_15_2015_0546PM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_executor.hpp>
 #include <hpx/parallel/config/inline_namespace.hpp>
 #include <hpx/parallel/executors/executor_traits.hpp>
 #include <hpx/runtime/threads/thread_executor.hpp>
@@ -22,7 +23,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
     namespace detail
     {
         /// \cond NOINTERNAL
-        struct threads_executor
+        struct threads_executor : executor_tag
         {
             threads_executor(threads::executor exec)
               : exec_(exec)
@@ -45,11 +46,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         private:
             threads::executor exec_;
         };
-
-        template <>
-        struct is_executor<threads_executor>
-          : std::true_type
-        {};
         /// \endcond
     }
 }}}

--- a/hpx/parallel/executors/executor_traits.hpp
+++ b/hpx/parallel/executors/executor_traits.hpp
@@ -9,7 +9,7 @@
 #if !defined(HPX_PARALLEL_EXECUTOR_TRAITS_MAY_10_2015_1128AM)
 #define HPX_PARALLEL_EXECUTOR_TRAITS_MAY_10_2015_1128AM
 
-#include <hpx/hpx_fwd.hpp>
+#include <hpx/config.hpp>
 #include <hpx/exception.hpp>
 #include <hpx/async.hpp>
 #include <hpx/traits/is_executor.hpp>

--- a/hpx/parallel/executors/parallel_executor.hpp
+++ b/hpx/parallel/executors/parallel_executor.hpp
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_EXECUTORS_PARALLEL_EXECUTOR_MAY_13_2015_1057AM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_executor.hpp>
 #include <hpx/parallel/config/inline_namespace.hpp>
 #include <hpx/parallel/executors/executor_traits.hpp>
 #include <hpx/runtime/threads/thread_executor.hpp>
@@ -25,7 +26,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
     /// executor prefers continuing with the creating thread first before
     /// executing newly created threads.
     ///
-    struct parallel_executor
+    struct parallel_executor : executor_tag
     {
 #if defined(DOXYGEN)
         /// Create a new parallel executor
@@ -49,16 +50,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         }
         /// \endcond
     };
-
-    namespace detail
-    {
-        /// \cond NOINTERNAL
-        template <>
-        struct is_executor<parallel_executor>
-          : std::true_type
-        {};
-        /// \endcond
-    }
 }}}
 
 #endif

--- a/hpx/parallel/executors/parallel_fork_executor.hpp
+++ b/hpx/parallel/executors/parallel_fork_executor.hpp
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_EXECUTORS_PARALLEL_FORK_EXECUTOR_MAY_15_2015_0402PM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_executor.hpp>
 #include <hpx/parallel/config/inline_namespace.hpp>
 #include <hpx/parallel/executors/executor_traits.hpp>
 #include <hpx/runtime/threads/thread_executor.hpp>
@@ -25,7 +26,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
     /// executor prefers executing newly created threads first before continuing
     /// with the creating thread.
     ///
-    struct parallel_fork_executor
+    struct parallel_fork_executor : executor_tag
     {
 #if defined(DOXYGEN)
         /// Create a new parallel fork executor
@@ -49,16 +50,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         }
         /// \endcond
     };
-
-    namespace detail
-    {
-        /// \cond NOINTERNAL
-        template <>
-        struct is_executor<parallel_fork_executor>
-          : std::true_type
-        {};
-        /// \endcond
-    }
 }}}
 
 #endif

--- a/hpx/parallel/executors/sequential_executor.hpp
+++ b/hpx/parallel/executors/sequential_executor.hpp
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_EXECUTORS_SEQUENTIAL_EXECUTOR_MAY_11_2015_1050AM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_executor.hpp>
 #include <hpx/parallel/config/inline_namespace.hpp>
 #include <hpx/parallel/exception_list.hpp>
 #include <hpx/parallel/executors/executor_traits.hpp>
@@ -32,7 +33,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
     /// which execute in the calling thread. The sequential order is given by
     /// the lexicographical order of indices in the index space.
     ///
-    struct sequential_executor
+    struct sequential_executor : executor_tag
     {
 #if defined(DOXYGEN)
         /// Create a new sequential executor
@@ -117,16 +118,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         }
         /// \endcond
     };
-
-    namespace detail
-    {
-        /// \cond NOINTERNAL
-        template <>
-        struct is_executor<sequential_executor>
-          : std::true_type
-        {};
-        /// \endcond
-    }
 }}}
 
 #endif

--- a/hpx/parallel/executors/service_executors.hpp
+++ b/hpx/parallel/executors/service_executors.hpp
@@ -86,16 +86,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
           : threads_executor(detail::get_service_executor(t))
         {}
     };
-
-    namespace detail
-    {
-        /// \cond NOINTERNAL
-        template <>
-        struct is_executor<service_executor>
-          : std::true_type
-        {};
-        /// \endcond
-    }
 }}}
 
 #endif

--- a/hpx/parallel/executors/thread_pool_executors.hpp
+++ b/hpx/parallel/executors/thread_pool_executors.hpp
@@ -84,30 +84,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         {}
     };
 #endif
-
-    namespace detail
-    {
-        /// \cond NOINTERNAL
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
-        template <>
-        struct is_executor<local_queue_executor>
-          : std::true_type
-        {};
-#endif
-
-        template <>
-        struct is_executor<local_priority_queue_executor>
-          : std::true_type
-        {};
-
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
-        template <>
-        struct is_executor<static_priority_queue_executor>
-          : std::true_type
-        {};
-#endif
-        /// \endcond
-    }
 }}}
 
 #endif

--- a/hpx/traits/is_executor.hpp
+++ b/hpx/traits/is_executor.hpp
@@ -13,13 +13,22 @@
 
 #include <type_traits>
 
+#include <boost/type_traits/is_base_of.hpp>
+
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
 {
+    struct executor_tag {};
+
     namespace detail
     {
         /// \cond NOINTERNAL
         template <typename T>
         struct is_executor
+          : boost::is_base_of<executor_tag, T>
+        {};
+
+        template <>
+        struct is_executor<executor_tag>
           : std::false_type
         {};
         /// \endcond

--- a/tests/regressions/parallel/CMakeLists.txt
+++ b/tests/regressions/parallel/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 Hartmut Kaiser
+# Copyright (c) 2014-2015 Hartmut Kaiser
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -38,3 +38,16 @@ foreach(test ${tests})
   add_hpx_pseudo_dependencies(tests.regressions.parallel_dir.${test}
                               ${test}_test_exe)
 endforeach()
+
+# add subdirectories
+set(subdirs
+    executors
+   )
+
+foreach(subdir ${subdirs})
+  add_hpx_pseudo_target(tests.regressions.parallel_dir.${subdir}_dir)
+  add_subdirectory(${subdir})
+  add_hpx_pseudo_dependencies(
+    tests.regressions.parallel_dir tests.regressions.parallel_dir.${subdir}_dir)
+endforeach()
+

--- a/tests/regressions/parallel/executors/CMakeLists.txt
+++ b/tests/regressions/parallel/executors/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Copyright (c) 2014-2015 Hartmut Kaiser
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests
+    is_executor_1691
+   )
+
+foreach(test ${tests})
+  set(sources
+      ${test}.cpp)
+
+  set(${test}_PARAMETERS THREADS_PER_LOCALITY 4)
+
+  source_group("Source Files" FILES ${sources})
+
+  # add example executable
+  add_hpx_executable(${test}_test
+                     SOURCES ${sources}
+                     ${${test}_FLAGS}
+                     EXCLUDE_FROM_ALL
+                     HPX_PREFIX ${HPX_BUILD_PREFIX}
+                     FOLDER "Tests/Regressions/Parallel/Executors")
+
+  add_hpx_unit_test("parallel" ${test} ${${test}_PARAMETERS})
+
+  # add a custom target for this example
+  add_hpx_pseudo_target(tests.regressions.parallel_dir.executors_dir.${test})
+
+  # make pseudo-targets depend on master pseudo-target
+  add_hpx_pseudo_dependencies(tests.regressions.parallel_dir.executors_dir
+                              tests.regressions.parallel_dir.executors_dir.${test})
+
+  # add dependencies to pseudo-target
+  add_hpx_pseudo_dependencies(tests.regressions.parallel_dir.executors_dir.${test}
+                              ${test}_test_exe)
+endforeach()

--- a/tests/regressions/parallel/executors/is_executor_1691.cpp
+++ b/tests/regressions/parallel/executors/is_executor_1691.cpp
@@ -1,0 +1,33 @@
+//  Copyright (c) 2015 Daniel Bourgeois
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+
+#include <hpx/include/parallel_executors.hpp>
+#include <hpx/include/parallel_algorithm.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+struct my_executor : hpx::parallel::parallel_executor {};
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    using hpx::parallel::for_each;
+    using hpx::parallel::par;
+
+    my_executor exec;
+
+    std::vector<int> v(100);
+
+    for_each(par.on(exec), v.begin(), v.end(), [](int x){ });
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    return hpx::init(argc, argv);
+}


### PR DESCRIPTION
- types derived from parallel::executor_tag are treated as executors by default