### PR TITLE
 Modified Scan Partitioner for Algorithms

### DIFF
--- a/hpx/parallel/algorithms/copy.hpp
+++ b/hpx/parallel/algorithms/copy.hpp
@@ -9,7 +9,7 @@
 #if !defined(HPX_PARALLEL_DETAIL_COPY_MAY_30_2014_0317PM)
 #define HPX_PARALLEL_DETAIL_COPY_MAY_30_2014_0317PM
 
-#include <hpx/config.hpp>
+#include <hpx/hpx_fwd.hpp>
 #include <hpx/parallel/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/predicates.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
@@ -27,7 +27,6 @@
 #include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
-#include <boost/shared_array.hpp>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -333,105 +332,73 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
               : copy_if::algorithm("copy_if")
             {}
 
-            template <typename ExPolicy, typename InIter, typename F>
+            template <typename ExPolicy, typename InIter, typename Pred>
             static Iter
             sequential(ExPolicy, InIter first, InIter last, Iter dest,
-                F && f)
+                Pred && pred)
             {
-                return std::copy_if(first, last, dest, std::forward<F>(f));
+                return std::copy_if(first, last, dest,
+                    std::forward<Pred>(pred));
             }
 
-            template <typename ExPolicy, typename FwdIter, typename F>
+            template <typename ExPolicy, typename FwdIter, typename Pred>
             static typename util::detail::algorithm_result<ExPolicy, Iter>::type
             parallel(ExPolicy policy, FwdIter first, FwdIter last,
-                Iter dest, F && f)
+                Iter dest, Pred && pred)
             {
-                typedef hpx::util::zip_iterator<FwdIter, char*> zip_iterator;
+                typedef hpx::util::zip_iterator<FwdIter, bool*> zip_iterator;
                 typedef util::detail::algorithm_result<ExPolicy, Iter> result;
                 typedef typename std::iterator_traits<FwdIter>::difference_type
                     difference_type;
-                typedef typename util::detail::algorithm_result<
-                        ExPolicy, Iter
-                    >::type result_type;
 
                 if (first == last)
                     return result::get(std::move(dest));
 
                 difference_type count = std::distance(first, last);
 
-                boost::shared_array<char> flags(new char[count]);
+                boost::shared_array<bool> flags(new bool[count]);
                 std::size_t init = 0;
 
+                using hpx::util::get;
+                using hpx::util::make_zip_iterator;
                 typedef util::scan_partitioner<ExPolicy, Iter, std::size_t>
                     scan_partitioner_type;
                 return scan_partitioner_type::call(
-                    policy,
-                    hpx::util::make_zip_iterator(first, flags.get()),
-                    count,
-                    init,
-                    // Flag the elements to be copied
-                    [f](zip_iterator part_begin, std::size_t part_size)
+                    policy, make_zip_iterator(first, flags.get()),
+                    count, init,
+                    [pred](zip_iterator part_begin, std::size_t part_size)
                         -> std::size_t
                     {
                         std::size_t curr = 0;
                         util::loop_n(part_begin, part_size,
-                            [&f, &curr](zip_iterator d) mutable
+                            [&pred, &curr](zip_iterator it) mutable
                             {
-                                using hpx::util::get;
-                                get<1>(*d) = (f(get<0>(*d)) != 0) ? 1 : 0;
-                                curr += get<1>(*d);
+                                if(pred(get<0>(*it)))
+                                {
+                                    get<1>(*it) = true;
+                                    ++curr;
+                                } // else get<1>(*it) will be false;
                             });
                         return curr;
                     },
-                    // Determine how far to advance the  dest iterator for each
-                    // partition
-                    hpx::util::unwrapped(
-                        [](std::size_t const& prev, std::size_t const& curr)
-                        {
-                            return prev + curr;
-                        }),
-                    // Copy the elements into dest in parallel
-                    [=](std::vector<hpx::shared_future<std::size_t> >&& r,
-                        std::vector<std::size_t> const& chunk_sizes) mutable
-                            -> result_type
+                    hpx::util::unwrapped(std::plus<std::size_t>()),
+                    [dest, flags](zip_iterator part_begin, std::size_t part_size,
+                        hpx::shared_future<std::size_t> f_accu) mutable
                     {
-                        HPX_ASSERT(!r.empty());
-                        std::size_t last_index = r[r.size()-1].get();
-
-                        typedef util::partitioner<ExPolicy, Iter, void>
-                            partitioner_type;
-
-                        // capturing 'flags' below keeps the array alive
-                        return partitioner_type::call_with_data(
-                            policy,
-                            hpx::util::make_zip_iterator(first, flags.get()),
-                            count,
-                            [dest, flags](
-                                hpx::shared_future<std::size_t>&& pos,
-                                zip_iterator part_begin, std::size_t part_count)
+                        std::advance(dest, f_accu.get());
+                        util::loop_n(part_begin, part_size,
+                            [&dest](zip_iterator it) mutable
                             {
-                                Iter iter = dest;
-                                std::size_t next_pos = pos.get();
-                                std::advance(iter, next_pos);
-                                util::loop_n(part_begin, part_count,
-                                    [&iter](zip_iterator d)
-                                    {
-                                        using hpx::util::get;
-                                        if(get<1>(*d))
-                                            *iter++ = get<0>(*d);
-                                    });
-                            },
-                            [=](std::vector<hpx::future<void> >&&) mutable
-                                -> Iter
-                            {
-                                std::advance(dest, last_index);
-                                return dest;
-                            },
-                            chunk_sizes,
-                            std::move(r)
-                        );
-                    }
-                );
+                                if(get<1>(*it))
+                                    *dest++ = get<0>(*it);
+                            });
+                    },
+                    [dest, flags](std::vector<hpx::shared_future<std::size_t> > items,
+                        std::vector<hpx::future<void> >) mutable
+                    {
+                        std::advance(dest, items.back().get());
+                        return dest;
+                    });
             }
         };
         /// \endcond

--- a/hpx/parallel/algorithms/copy.hpp
+++ b/hpx/parallel/algorithms/copy.hpp
@@ -27,6 +27,7 @@
 #include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
+#include <boost/shared_array.hpp>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {

--- a/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -55,6 +55,20 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             return dest;
         }
 
+        template <typename InIter, typename OutIter, typename T, typename Op>
+        T sequential_exclusive_scan_n(InIter first, std::size_t count,
+            OutIter dest, T init, Op && op)
+        {
+            T temp = init;
+            for (/* */; count-- != 0; (void) ++first, ++dest)
+            {
+                init  = op(init, *first);
+                *dest = temp;
+                temp  = init;
+            }
+            return init;
+        }
+
         ///////////////////////////////////////////////////////////////////////
         template <typename OutIter>
         struct exclusive_scan
@@ -80,69 +94,63 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             parallel(ExPolicy policy, FwdIter first, FwdIter last,
                  OutIter dest, T && init, Op && op)
             {
-                typedef util::detail::algorithm_result<
-                        ExPolicy, OutIter
-                    > result;
-                typedef hpx::util::zip_iterator<FwdIter, T*> zip_iterator;
+                typedef util::detail::algorithm_result<ExPolicy, OutIter>
+                    result;
+                typedef hpx::util::zip_iterator<FwdIter, OutIter> zip_iterator;
+                typedef typename std::iterator_traits<FwdIter>::difference_type
+                    difference_type;
 
                 if (first == last)
                     return result::get(std::move(dest));
 
-                typedef typename std::iterator_traits<FwdIter>::difference_type
-                    difference_type;
-                difference_type count = std::distance(first, last) - 1;
+                difference_type count = std::distance(first, last);
 
-                if (count == 0) {
-                  *dest = init;
-                  return result::get(std::move(dest));
-                }
+                OutIter final_dest = dest;
+                std::advance(final_dest, count);
 
-                // The scan may use the same array for output as input
-                // don't write initial value until after sum to avoid trampling on input
-                OutIter iout = dest++;
-                T temp = init;
+                // The overall scan algorithm is performed by executing 3
+                // steps. The first calculates the scan results for each
+                // partition. The second accumulates the result from left to
+                // right to be used by the third step--which operates on the
+                // same partitions the first step operated on.
 
-
-                boost::shared_array<T> data(new T[count]);
-
-                // The overall scan algorithm is performed by executing 2
-                // subsequent parallel steps. The first calculates the scan
-                // results for each partition and the second produces the
-                // overall result
+                using hpx::util::get;
                 using hpx::util::make_zip_iterator;
-                auto ret =
-                    util::scan_partitioner<ExPolicy, OutIter, T>::call(
-                        policy, make_zip_iterator(first, data.get()), count, init,
-                        // step 1 performs first part of scan algorithm
-                        [=](zip_iterator part_begin, std::size_t part_size) -> T
-                        {
-                            using hpx::util::get;
-                            T part_init = get<0>(*part_begin);
-                            get<1>(*part_begin++) = part_init;
-                            return sequential_inclusive_scan_n(
-                                get<0>(part_begin.get_iterator_tuple()), part_size-1,
-                                get<1>(part_begin.get_iterator_tuple()), part_init, op);
-                        },
-                        // step 2 propagates the partition results from left
-                        // to right
-                        hpx::util::unwrapped(
-                            [=](T const& prev, T const& curr) -> T
+                return util::scan_partitioner<ExPolicy, OutIter, T>::call(
+                    policy, make_zip_iterator(first, dest), count, init,
+                    // step 1 performs first part of scan algorithm
+                    [op](zip_iterator part_begin, std::size_t part_size) -> T
+                    {
+                        T part_init = get<0>(*part_begin++);
+                        return sequential_exclusive_scan_n(
+                            get<0>(part_begin.get_iterator_tuple()),
+                            part_size - 1,
+                            get<1>(part_begin.get_iterator_tuple()),
+                            part_init, op);
+                    },
+                    // step 2 propagates the partition results from left
+                    // to right
+                    hpx::util::unwrapped(op),
+                    // step 3 runs final accumulation on each partition
+                    [op](zip_iterator part_begin, std::size_t part_size,
+                        hpx::shared_future<T> f_accu)
+                    {
+                        T val = f_accu.get();
+                        OutIter dst = get<1>(part_begin.get_iterator_tuple());
+                        *dst++ = val;
+                        util::loop_n(dst, part_size - 1,
+                            [&op, &val](OutIter it)
                             {
-                                return op(prev, curr);
-                            }),
-                        // step 3 runs the remaining operation
-                        [=](std::vector<hpx::shared_future<T> >&& r,
-                            std::vector<std::size_t> const& chunk_sizes)
-                        {
-                            // run the final copy step and produce the required
-                            // result
-                            return scan_copy_helper(policy, std::move(r),
-                                data, count, dest, op, chunk_sizes);
-                        }
-                    );
-                // write output initial value
-                *iout = temp;
-                return ret;
+                                *it = op(*it, val);
+                            });
+                    },
+                    // use this return value
+                    [final_dest](std::vector<hpx::shared_future<T> >,
+                        std::vector<hpx::future<void> >)
+                    {
+                        return final_dest;
+                    });
+
             }
         };
         /// \endcond

--- a/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -29,7 +29,6 @@
 #include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
-#include <boost/shared_array.hpp>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {

--- a/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -65,43 +65,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         }
 
         ///////////////////////////////////////////////////////////////////////
-        template <typename ExPolicy, typename T, typename OutIter, typename Op>
-        typename util::detail::algorithm_result<ExPolicy, OutIter>::type
-        scan_copy_helper(ExPolicy policy,
-            std::vector<hpx::shared_future<T> >&& r,
-            boost::shared_array<T> data, std::size_t count,
-            OutIter dest, Op && op, std::vector<std::size_t> const& chunk_sizes)
-        {
-            typedef hpx::util::zip_iterator<T*, OutIter> zip_iterator;
-            typedef typename zip_iterator::reference reference;
-
-            using hpx::util::make_zip_iterator;
-            return
-                util::partitioner<ExPolicy, OutIter, void>::call_with_data(
-                    policy, make_zip_iterator(data.get(), dest), count,
-                    [=](hpx::shared_future<T>&& val,
-                        zip_iterator part_begin, std::size_t part_size)
-                    {
-                        T const& v = val.get();
-                        parallel::util::loop_n(part_begin, part_size,
-                            [&](zip_iterator d)
-                            {
-                                using hpx::util::get;
-                                *get<1>(d.get_iterator_tuple()) =
-                                    op(*get<0>(d.get_iterator_tuple()), v);
-                            });
-                    },
-                    [dest, count, data](
-                        std::vector<future<void> > && r) mutable -> OutIter
-                    {
-                        std::advance(dest, count);
-                        return dest;
-                    },
-                    chunk_sizes, std::move(r)
-                );
-        }
-
-        ///////////////////////////////////////////////////////////////////////
         template <typename OutIter>
         struct inclusive_scan
           : public detail::algorithm<inclusive_scan<OutIter>, OutIter>
@@ -126,8 +89,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             parallel(ExPolicy policy, FwdIter first, FwdIter last,
                  OutIter dest, T && init, Op && op)
             {
-                typedef util::detail::algorithm_result<ExPolicy, OutIter> result;
-                typedef hpx::util::zip_iterator<FwdIter, T*> zip_iterator;
+                typedef util::detail::algorithm_result<ExPolicy, OutIter>
+                    result;
+                typedef hpx::util::zip_iterator<FwdIter, OutIter> zip_iterator;
                 typedef typename std::iterator_traits<FwdIter>::difference_type
                     difference_type;
 
@@ -135,44 +99,52 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     return result::get(std::move(dest));
 
                 difference_type count = std::distance(first, last);
-                boost::shared_array<T> data(new T[count]);
 
-                // The overall scan algorithm is performed by executing 2
-                // subsequent parallel steps. The first calculates the scan
-                // results for each partition and the second produces the
-                // overall result
+                OutIter final_dest = dest;
+                std::advance(final_dest, count);
 
+                // The overall scan algorithm is performed by executing 3
+                // steps. The first calculates the scan results for each
+                // partition. The second accumulates the result from left to
+                // right to be used by the third step--which operates on the
+                // same partitions the first step operated on.
+
+                using hpx::util::get;
                 using hpx::util::make_zip_iterator;
-                return
-                    util::scan_partitioner<ExPolicy, OutIter, T>::call(
-                        policy, make_zip_iterator(first, data.get()), count, init,
-                        // step 1 performs first part of scan algorithm
-                        [=](zip_iterator part_begin, std::size_t part_size) -> T
-                        {
-                            using hpx::util::get;
-                            T part_init = get<0>(*part_begin);
-                            get<1>(*part_begin++) = part_init;
-                            return sequential_inclusive_scan_n(
-                                get<0>(part_begin.get_iterator_tuple()), part_size-1,
-                                get<1>(part_begin.get_iterator_tuple()), part_init, op);
-                        },
-                        // step 2 propagates the partition results from left
-                        // to right
-                        hpx::util::unwrapped(
-                            [=](T const& prev, T const& curr) -> T
+                return util::scan_partitioner<ExPolicy, OutIter, T>::call(
+                    policy, make_zip_iterator(first, dest), count, init,
+                    // step 1 performs first part of scan algorithm
+                    [op](zip_iterator part_begin, std::size_t part_size) -> T
+                    {
+                        T part_init = get<0>(*part_begin);
+                        get<1>(*part_begin++) = part_init;
+                        return sequential_inclusive_scan_n(
+                            get<0>(part_begin.get_iterator_tuple()),
+                            part_size-1,
+                            get<1>(part_begin.get_iterator_tuple()),
+                            part_init, op);
+                    },
+                    // step 2 propagates the partition results from left
+                    // to right
+                    hpx::util::unwrapped(op),
+                    // step 3 runs final accumulation on each partition
+                    [op](zip_iterator part_begin, std::size_t part_size,
+                        hpx::shared_future<T> f_accu)
+                    {
+                        T val = f_accu.get();
+                        OutIter dst = get<1>(part_begin.get_iterator_tuple());
+                        util::loop_n(dst, part_size,
+                            [&op, &val](OutIter it)
                             {
-                                return op(prev, curr);
-                            }),
-                        // step 3 runs the remaining operation
-                        [=](std::vector<hpx::shared_future<T> >&& r,
-                            std::vector<std::size_t> const& chunk_sizes)
-                        {
-                            // run the final copy step and produce the required
-                            // result
-                            return scan_copy_helper(policy, std::move(r),
-                                data, count, dest, op, chunk_sizes);
-                        }
-                    );
+                                *it = op(*it, val);
+                            });
+                    },
+                    // use this return value
+                    [final_dest](std::vector<hpx::shared_future<T> >,
+                        std::vector<hpx::future<void> >)
+                    {
+                        return final_dest;
+                    });
             }
         };
         /// \endcond

--- a/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -28,7 +28,6 @@
 #include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
-#include <boost/shared_array.hpp>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {

--- a/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -93,7 +93,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                  OutIter dest, Conv && conv, T && init, Op && op)
             {
                 typedef util::detail::algorithm_result<ExPolicy, OutIter> result;
-                typedef hpx::util::zip_iterator<FwdIter, T*> zip_iterator;
+                typedef hpx::util::zip_iterator<FwdIter, OutIter> zip_iterator;
                 typedef typename std::iterator_traits<FwdIter>::difference_type
                     difference_type;
 
@@ -101,46 +101,52 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     return result::get(std::move(dest));
 
                 difference_type count = std::distance(first, last);
-                boost::shared_array<T> data(new T[count]);
+
+                OutIter final_dest = dest;
+                std::advance(final_dest, count);
 
                 // The overall scan algorithm is performed by executing 2
                 // subsequent parallel steps. The first calculates the scan
                 // results for each partition and the second produces the
                 // overall result
 
+                using hpx::util::get;
                 using hpx::util::make_zip_iterator;
-                return
-                    util::scan_partitioner<ExPolicy, OutIter, T>::call(
-                        policy, make_zip_iterator(first, data.get()), count, init,
-                        // step 1 performs first part of scan algorithm
-                        [=](zip_iterator part_begin, std::size_t part_size) -> T
+                return util::scan_partitioner<ExPolicy, OutIter, T>::call(
+                    policy, make_zip_iterator(first, dest), count, init,
+                    // step 1 performs first part of scan algorithm
+                    [op, conv](zip_iterator part_begin, std::size_t part_size)
+                        -> T
+                    {
+                        T part_init = conv(get<0>(*part_begin));
+                        get<1>(*part_begin++) = part_init;
+                        return sequential_transform_inclusive_scan_n(
+                            get<0>(part_begin.get_iterator_tuple()),
+                            part_size-1,
+                            get<1>(part_begin.get_iterator_tuple()),
+                            conv, part_init, op);
+                    },
+                    // step 2 propagates the partition results from left
+                    // to right
+                    hpx::util::unwrapped(op),
+                    // step 3 runs final accumulation on each partition
+                    [op](zip_iterator part_begin, std::size_t part_size,
+                        hpx::shared_future<T> f_accu)
+                    {
+                        T val = f_accu.get();
+                        OutIter dst = get<1>(part_begin.get_iterator_tuple());
+                        util::loop_n(dst, part_size,
+                            [&op, &val](OutIter it)
                         {
-                            using hpx::util::get;
-                            T part_init = conv(get<0>(*part_begin));
-                            get<1>(*part_begin++) = part_init;
-                            return sequential_transform_inclusive_scan_n(
-                                get<0>(part_begin.get_iterator_tuple()), part_size-1,
-                                get<1>(part_begin.get_iterator_tuple()), conv,
-                                part_init, op);
-                        },
-                        // step 2 propagates the partition results from left
-                        // to right
-                        hpx::util::unwrapped(
-                            [=](T const& prev, T const& curr) -> T
-                            {
-                                return op(prev, curr);
-                            }),
-                        // step 3 runs the remaining operation
-                        [=](std::vector<hpx::shared_future<T> >&& r,
-                            std::vector<std::size_t> const& chunk_sizes)
-                                -> typename result::type
-                        {
-                            // run the final copy step and produce the required
-                            // result
-                            return scan_copy_helper(policy, std::move(r),
-                                data, count, dest, op, chunk_sizes);
-                        }
-                    );
+                            *it = op(*it, val);
+                        });
+                    },
+                    // use this return value
+                    [final_dest](std::vector<hpx::shared_future<T> >,
+                        std::vector<hpx::future<void> >)
+                    {
+                        return final_dest;
+                    });
             }
         };
         /// \endcond

--- a/hpx/parallel/util/scan_partitioner.hpp
+++ b/hpx/parallel/util/scan_partitioner.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2015 Daniel Bourgeois
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -33,17 +34,31 @@ namespace hpx { namespace parallel { namespace util
         ///////////////////////////////////////////////////////////////////////
         // The static partitioner simply spawns one chunk of iterations for
         // each available core.
-        template <typename ExPolicy, typename R, typename Result = void>
+        template <typename ExPolicy, typename R, typename Result1,
+            typename Result2>
         struct static_scan_partitioner
         {
             template <typename FwdIter, typename T,
-                typename F1, typename F2, typename F3>
+                typename F1, typename F2, typename F3, typename F4>
             static R call(ExPolicy policy, FwdIter first,
-                std::size_t count_, T && init, F1 && f1, F2 && f2, F3 && f3,
-                std::size_t chunk_size)
+                std::size_t count, T && init, F1 && f1, F2 && f2, F3 && f3,
+                F4 && f4, std::size_t chunk_size)
             {
-                std::vector<hpx::shared_future<Result> > workitems;
-                std::vector<std::size_t> chunk_sizes;
+                typedef typename ExPolicy::executor_type executor_type;
+                typedef typename hpx::parallel::executor_traits<executor_type>
+                    executor_traits;
+                typedef typename hpx::util::tuple<
+                        FwdIter, std::size_t
+                    > tuple_type;
+
+                using hpx::util::get;
+                using hpx::util::placeholders::_1;
+                using lcos::local::dataflow;
+                using hpx::util::deferred_call;
+
+                std::vector<hpx::shared_future<Result1> > workitems;
+                std::vector<hpx::future<Result2> > finalitems;
+                std::vector<tuple_type> shape;
 
                 std::list<boost::exception_ptr> errors;
 
@@ -51,52 +66,68 @@ namespace hpx { namespace parallel { namespace util
                     // pre-initialize first intermediate result
                     workitems.push_back(make_ready_future(std::forward<T>(init)));
 
-                    // estimate a chunk size based on number of cores used
-                    std::size_t count = count_;
                     HPX_ASSERT(count > 0);
+                    FwdIter first_ = first;
+                    std::size_t test_chunk_size = count / 100;
 
-                    chunk_size = get_static_chunk_size(policy, workitems, f1,
-                        first, count, chunk_size);
+                    // estimate a chunk size based on number of cores used
+                    shape = get_static_shape(policy, workitems, f1,
+                        first, count, chunk_size
+                    );
 
                     // schedule every chunk on a separate thread
-                    workitems.reserve(count_ / chunk_size + 2);
-                    chunk_sizes.reserve(workitems.capacity());
+                    workitems.reserve(shape.size() + 1);
+                    finalitems.reserve(shape.size());
 
                     // If the size of count was enough to warrant testing for a
-                    // chunk_size, add to chunk_sizes and pre-initialize second
-                    // intermediate result.
+                    // chunk, pre-initialize second intermediate result and
+                    // start f3.
                     if (workitems.size() == 2)
                     {
-                        chunk_sizes.push_back(count_ - count);
-                        workitems[1] = lcos::local::dataflow(hpx::launch::sync,
-                            f2, workitems[0], workitems[1]);
+                        HPX_ASSERT(workitems.size() < 3);
+
+                        workitems[1] = dataflow(hpx::launch::sync,
+                            f2, workitems[0], workitems[1]
+                        );
+
+                        finalitems.push_back(dataflow(
+                            policy.executor(),
+                            hpx::util::bind(
+                                f3, first_, test_chunk_size, _1),
+                            workitems[0], workitems[1])
+                        );
                     }
 
-                    std::size_t parts = 0;
+                    std::size_t parts = workitems.size();
 
                     // Schedule first step of scan algorithm, step 2 is
                     // performed as soon as the current partition and the
                     // partition to the left is ready.
-                    while (count != 0)
+                    for(auto const& elem: shape)
                     {
-                        std::size_t chunk = (std::min)(chunk_size, count);
-                        BOOST_SCOPED_ENUM(hpx::launch) p = (++parts & 0x7) ?
+                        BOOST_SCOPED_ENUM(hpx::launch) p = (parts & 0x7) ?
                             hpx::launch::sync : hpx::launch::async;
 
-                        typedef typename ExPolicy::executor_type executor_type;
                         workitems.push_back(
-                            lcos::local::dataflow(
+                            dataflow(
                                 p, f2, workitems.back(),
-                                executor_traits<executor_type>::async_execute(
+                                executor_traits::async_execute(
                                     policy.executor(),
-                                    hpx::util::deferred_call(f1, first, chunk)
+                                    deferred_call(f1, get<0>(elem), get<1>(elem))
                                 )
                             )
                         );
 
-                        chunk_sizes.push_back(chunk);
-                        count -= chunk;
-                        std::advance(first, chunk);
+                        finalitems.push_back(
+                            dataflow(
+                                policy.executor(),
+                                hpx::util::bind(
+                                    f3, get<0>(elem), get<1>(elem), _1),
+                                workitems[parts - 1], workitems[parts]
+                            )
+                        );
+
+                        ++parts;
                     }
                 }
                 catch (...) {
@@ -104,27 +135,42 @@ namespace hpx { namespace parallel { namespace util
                         boost::current_exception(), errors);
                 }
 
-                // wait for all tasks to finish
-                hpx::wait_all(workitems);
+                hpx::wait_all(finalitems, workitems);
+
                 detail::handle_local_exceptions<
                     ExPolicy>::call(workitems, errors);
+                detail::handle_local_exceptions<
+                    ExPolicy>::call(finalitems, errors);
 
-                // Execute step 3 of the scan algorithm
-                return f3(std::move(workitems), chunk_sizes);
+                return f4(std::move(workitems), std::move(finalitems));
             }
         };
 
-        template <typename R, typename Result>
-        struct static_scan_partitioner<parallel_task_execution_policy, R, Result>
+        template <typename R, typename Result1, typename Result2>
+        struct static_scan_partitioner<
+            parallel_task_execution_policy, R, Result1, Result2>
         {
             template <typename ExPolicy, typename FwdIter, typename T,
-                typename F1, typename F2, typename F3>
+                typename F1, typename F2, typename F3, typename F4>
             static hpx::future<R> call(ExPolicy policy,
-                FwdIter first, std::size_t count_, T && init,
-                F1 && f1, F2 && f2, F3 && f3, std::size_t chunk_size)
+                FwdIter first, std::size_t count, T && init, F1 && f1,
+                F2 && f2, F3 && f3, F4 && f4, std::size_t chunk_size)
             {
-                std::vector<hpx::shared_future<Result> > workitems;
-                std::vector<std::size_t> chunk_sizes;
+                typedef typename ExPolicy::executor_type executor_type;
+                typedef typename hpx::parallel::executor_traits<executor_type>
+                    executor_traits;
+                typedef typename hpx::util::tuple<
+                        FwdIter, std::size_t
+                    > tuple_type;
+
+                using hpx::util::get;
+                using hpx::util::placeholders::_1;
+                using lcos::local::dataflow;
+                using hpx::util::deferred_call;
+
+                std::vector<hpx::shared_future<Result1> > workitems;
+                std::vector<hpx::future<Result2> > finalitems;
+                std::vector<tuple_type> shape;
 
                 std::list<boost::exception_ptr> errors;
 
@@ -132,52 +178,68 @@ namespace hpx { namespace parallel { namespace util
                     // pre-initialize first intermediate result
                     workitems.push_back(make_ready_future(std::forward<T>(init)));
 
-                    // estimate a chunk size based on number of cores used
-                    std::size_t count = count_;
                     HPX_ASSERT(count > 0);
+                    FwdIter first_ = first;
+                    std::size_t test_chunk_size = count / 100;
 
-                    chunk_size = get_static_chunk_size(policy, workitems, f1,
-                        first, count, chunk_size);
+                    // estimate a chunk size based on number of cores used
+                    shape = get_static_shape(policy, workitems, f1,
+                        first, count, chunk_size
+                    );
 
                     // schedule every chunk on a separate thread
-                    workitems.reserve(count_ / chunk_size + 2);
-                    chunk_sizes.reserve(workitems.capacity());
+                    workitems.reserve(shape.size() + 1);
+                    finalitems.reserve(shape.size());
 
                     // If the size of count was enough to warrant testing for a
-                    // chunk_size, add to chunk_sizes and pre-initialize second
-                    // intermediate result.
+                    // chunk, pre-initialize second intermediate result and
+                    // start f3.
                     if (workitems.size() == 2)
                     {
-                        chunk_sizes.push_back(count_ - count);
-                        workitems[1] = lcos::local::dataflow(hpx::launch::sync,
-                            f2, workitems[0], workitems[1]);
+                        HPX_ASSERT(workitems.size() < 3);
+
+                        workitems[1] = dataflow(hpx::launch::sync,
+                            f2, workitems[0], workitems[1]
+                        );
+
+                        finalitems.push_back(dataflow(
+                            policy.executor(),
+                            hpx::util::bind(
+                                f3, first_, test_chunk_size, _1),
+                            workitems[0], workitems[1])
+                        );
                     }
 
-                    std::size_t parts = 0;
+                    std::size_t parts = workitems.size();
 
                     // Schedule first step of scan algorithm, step 2 is
                     // performed as soon as the current partition and the
                     // partition to the left is ready.
-                    while (count != 0)
+                    for(auto const& elem: shape)
                     {
-                        std::size_t chunk = (std::min)(chunk_size, count);
-                        BOOST_SCOPED_ENUM(hpx::launch) p = (++parts & 0x7) ?
+                        BOOST_SCOPED_ENUM(hpx::launch) p = (parts & 0x7) ?
                             hpx::launch::sync : hpx::launch::async;
 
-                        typedef typename ExPolicy::executor_type executor_type;
                         workitems.push_back(
-                            lcos::local::dataflow(
+                            dataflow(
                                 p, f2, workitems.back(),
-                                executor_traits<executor_type>::async_execute(
+                                executor_traits::async_execute(
                                     policy.executor(),
-                                    hpx::util::deferred_call(f1, first, chunk)
+                                    deferred_call(f1, get<0>(elem), get<1>(elem))
                                 )
                             )
                         );
 
-                        chunk_sizes.push_back(chunk);
-                        count -= chunk;
-                        std::advance(first, chunk);
+                        finalitems.push_back(
+                            dataflow(
+                                policy.executor(),
+                                hpx::util::bind(
+                                    f3, get<0>(elem), get<1>(elem), _1),
+                                workitems[parts - 1], workitems[parts]
+                            )
+                        );
+
+                        ++parts;
                     }
                 }
                 catch (std::bad_alloc const&) {
@@ -188,113 +250,129 @@ namespace hpx { namespace parallel { namespace util
                     errors.push_back(boost::current_exception());
                 }
 
-                typedef typename parallel::util::detail::algorithm_result<
-                        ExPolicy, R>::type result_type;
-
                 // wait for all tasks to finish
-                return lcos::local::dataflow(
-                    [=](std::vector<hpx::shared_future<Result> >&& r) mutable
-                      -> result_type
+                return dataflow(
+                    [=](std::vector<hpx::shared_future<Result1> >&& witems,
+                        std::vector<hpx::future<Result2> >&& fitems) mutable
+                      -> R
                     {
-                        detail::handle_local_exceptions<ExPolicy>::call(r, errors);
+                        detail::handle_local_exceptions<ExPolicy
+                            >::call(witems, errors);
+                        detail::handle_local_exceptions<ExPolicy
+                            >::call(fitems, errors);
 
-                        // Execute step 3 of the scan algorithm
-                        return f3(std::move(r), chunk_sizes);
+                        return f4(std::move(witems), std::move(fitems));
                     },
-                    std::move(workitems));
+                    std::move(workitems), std::move(finalitems));
             }
         };
 
-        template <typename Executor, typename R, typename Result>
+        template <typename Executor, typename R, typename Result1,
+            typename Result2>
         struct static_scan_partitioner<
-                parallel_task_execution_policy_shim<Executor>, R, Result>
-          : static_scan_partitioner<parallel_task_execution_policy, R, Result>
+                parallel_task_execution_policy_shim<Executor>, R, Result1,
+                    Result2>
+          : static_scan_partitioner<parallel_task_execution_policy, R,
+              Result1, Result2>
         {};
 
         ///////////////////////////////////////////////////////////////////////
         // ExPolicy: execution policy
         // R:        overall result type
-        // Result:   intermediate result type of first step
+        // Result1:  intermediate result type of first and second step
+        // Result2:  intermediate result of the third step
         // PartTag:  select appropriate partitioner
-        template <typename ExPolicy, typename R, typename Result, typename Tag>
+        template <typename ExPolicy, typename R, typename Result1,
+            typename Result2, typename Tag>
         struct scan_partitioner;
 
         ///////////////////////////////////////////////////////////////////////
-        template <typename ExPolicy, typename R, typename Result>
-        struct scan_partitioner<ExPolicy, R, Result,
+        template <typename ExPolicy, typename R, typename Result1,
+            typename Result2>
+        struct scan_partitioner<ExPolicy, R, Result1, Result2,
             parallel::traits::static_partitioner_tag>
         {
             template <typename FwdIter, typename T,
-                typename F1, typename F2, typename F3>
+                typename F1, typename F2, typename F3, typename F4>
             static R call(ExPolicy policy, FwdIter first,
                 std::size_t count, T && init, F1 && f1, F2 && f2, F3 && f3,
-                std::size_t chunk_size = 0)
+                F4 && f4, std::size_t chunk_size = 0)
             {
-                return static_scan_partitioner<ExPolicy, R, Result>::call(
-                    policy, first, count, std::forward<T>(init),
-                    std::forward<F1>(f1), std::forward<F2>(f2),
-                    std::forward<F3>(f3), chunk_size);
+                return static_scan_partitioner<
+                    ExPolicy, R, Result1, Result2>::call(
+                        policy, first, count, std::forward<T>(init),
+                        std::forward<F1>(f1), std::forward<F2>(f2),
+                        std::forward<F3>(f3), std::forward<F4>(f4),
+                        chunk_size);
             }
         };
 
-        template <typename R, typename Result>
-        struct scan_partitioner<parallel_task_execution_policy, R, Result,
-            parallel::traits::static_partitioner_tag>
+        template <typename R, typename Result1, typename Result2>
+        struct scan_partitioner<parallel_task_execution_policy, R, Result1,
+            Result2, parallel::traits::static_partitioner_tag>
         {
             template <typename ExPolicy, typename FwdIter, typename T,
-                typename F1, typename F2, typename F3>
+                typename F1, typename F2, typename F3, typename F4>
             static hpx::future<R> call(ExPolicy policy, FwdIter first,
                 std::size_t count, T && init, F1 && f1, F2 && f2, F3 && f3,
-                std::size_t chunk_size = 0)
+                F4 && f4, std::size_t chunk_size = 0)
             {
-                return static_scan_partitioner<ExPolicy, R, Result>::call(
-                    policy, first, count, std::forward<T>(init),
-                    std::forward<F1>(f1), std::forward<F2>(f2),
-                    std::forward<F3>(f3), chunk_size);
+                return static_scan_partitioner<
+                    ExPolicy, R, Result1, Result2>::call(
+                        policy, first, count, std::forward<T>(init),
+                        std::forward<F1>(f1), std::forward<F2>(f2),
+                        std::forward<F3>(f3), std::forward<F4>(f4),
+                        chunk_size);
             }
         };
 
-        template <typename Executor, typename R, typename Result>
+        template <typename Executor, typename R, typename Result1,
+            typename Result2>
         struct scan_partitioner<
-                parallel_task_execution_policy_shim<Executor>, R, Result,
-                parallel::traits::static_partitioner_tag>
-          : scan_partitioner<parallel_task_execution_policy, R, Result,
-                parallel::traits::static_partitioner_tag>
+                parallel_task_execution_policy_shim<Executor>, R, Result1,
+                Result2, parallel::traits::static_partitioner_tag>
+          : scan_partitioner<parallel_task_execution_policy, R, Result1,
+                Result2, parallel::traits::static_partitioner_tag>
         {};
 
-        template <typename Executor, typename R, typename Result>
+        template <typename Executor, typename R, typename Result1,
+            typename Result2>
         struct scan_partitioner<
-                parallel_task_execution_policy_shim<Executor>, R, Result,
-                parallel::traits::auto_partitioner_tag>
-          : scan_partitioner<parallel_task_execution_policy, R, Result,
-                parallel::traits::auto_partitioner_tag>
+                parallel_task_execution_policy_shim<Executor>, R, Result1,
+                Result2, parallel::traits::auto_partitioner_tag>
+          : scan_partitioner<parallel_task_execution_policy, R, Result1,
+                Result2, parallel::traits::auto_partitioner_tag>
         {};
 
-        template <typename Executor, typename R, typename Result>
+        template <typename Executor, typename R, typename Result1,
+            typename Result2>
         struct scan_partitioner<
-                parallel_task_execution_policy_shim<Executor>, R, Result,
-                parallel::traits::default_partitioner_tag>
-          : scan_partitioner<parallel_task_execution_policy, R, Result,
-                parallel::traits::static_partitioner_tag>
+                parallel_task_execution_policy_shim<Executor>, R, Result1,
+                Result2, parallel::traits::default_partitioner_tag>
+          : scan_partitioner<parallel_task_execution_policy, R, Result1,
+                Result2, parallel::traits::static_partitioner_tag>
         {};
 
         ///////////////////////////////////////////////////////////////////////
-        template <typename ExPolicy, typename R, typename Result>
-        struct scan_partitioner<ExPolicy, R, Result,
-                parallel::traits::default_partitioner_tag>
-          : scan_partitioner<ExPolicy, R, Result,
-                parallel::traits::static_partitioner_tag>
+        template <typename ExPolicy, typename R, typename Result1,
+            typename Result2>
+        struct scan_partitioner<ExPolicy, R, Result1,
+                Result2, parallel::traits::default_partitioner_tag>
+          : scan_partitioner<ExPolicy, R, Result1,
+                Result2, parallel::traits::static_partitioner_tag>
         {};
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename ExPolicy, typename R = void, typename Result = R,
+    template <typename ExPolicy, typename R = void, typename Result1 = R,
+        typename Result2 = void,
         typename PartTag = typename parallel::traits::extract_partitioner<
             typename hpx::util::decay<ExPolicy>::type
         >::type>
     struct scan_partitioner
       : detail::scan_partitioner<
-            typename hpx::util::decay<ExPolicy>::type, R, Result, PartTag>
+            typename hpx::util::decay<ExPolicy>::type, R, Result1,
+            Result2, PartTag>
     {};
 }}}
 


### PR DESCRIPTION
With these changes, the scan partitioner now takes four functions.
The first two functions are the same as previously, they operate on a
partition and then accumulate the result. The third function now
operates on each partitioner with it's corresponding accumulated result
instead of being called once. The fourth function is just to create a
result type.

Changes accomplish the following:
 - Reduce overhead of calling another partitioner inside of
   scan_partitioner
 - Allow third step to be called as soon as possible instead of waiting
   for all of the accumulated items to be finished
-  allow scan algorithms to not need a temporary data structure
 - allow transform_exclusive_scan to operate in place