### PR TITLE
Various fixes to threads::executors to make custom schedulers work

### DIFF
--- a/hpx/runtime.hpp
+++ b/hpx/runtime.hpp
@@ -294,6 +294,12 @@ namespace hpx
         ///
         virtual bool unregister_thread() = 0;
 
+        /// Generate a new notification policy instance for the given thread
+        /// name prefix
+        typedef threads::policies::callback_notifier notification_policy_type;
+        virtual notification_policy_type
+            get_notification_policy(char const* prefix) = 0;
+
         /// This function creates anew base_lco_factory (if none is available
         /// for the given type yet), registers this factory with the
         /// runtime_support object and asks the factory for it's heap object

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -13,6 +13,9 @@
 #include <hpx/runtime/agas/interface.hpp>
 #include <hpx/util/itt_notify.hpp>
 #include <hpx/util/hardware/timestamp.hpp>
+#include <hpx/util/assert.hpp>
+#include <hpx/util/move.hpp>
+#include <hpx/util/function.hpp>
 
 #include <boost/cstdint.hpp>
 
@@ -200,12 +203,32 @@ namespace hpx { namespace threads { namespace detail
         boost::uint64_t& exec_time_;
     };
 
+    struct scheduling_callbacks
+    {
+        typedef util::function_nonser<void()> callback_type;
+        typedef util::function_nonser<bool()> background_callback_type;
+
+        explicit scheduling_callbacks(
+                callback_type && outer,
+                callback_type && inner = callback_type(),
+                background_callback_type && background =
+                    background_callback_type())
+          : outer_(std::move(outer)),
+            inner_(std::move(inner)),
+            background_(std::move(background))
+        {}
+
+        callback_type outer_;
+        callback_type inner_;
+        background_callback_type background_;
+    };
+
     template <typename SchedulingPolicy>
     void scheduling_loop(std::size_t num_thread, SchedulingPolicy& scheduler,
-        boost::atomic<hpx::state>& global_state, scheduling_counters& counters,
-        util::function_nonser<void()> const& cb_outer = util::function_nonser<void()>(),
-        util::function_nonser<void()> const& cb_inner = util::function_nonser<void()>())
+        scheduling_counters& counters, scheduling_callbacks& callbacks)
     {
+        boost::atomic<hpx::state>& this_state = scheduler.get_state(num_thread);
+
         util::itt::stack_context ctx;        // helper for itt support
         util::itt::domain domain(get_thread_name().data());
 //         util::itt::id threadid(domain, this);
@@ -217,7 +240,7 @@ namespace hpx { namespace threads { namespace detail
         idle_collect_rate idle_rate(counters.tfunc_time_, counters.exec_time_);
         tfunc_time_wrapper tfunc_time_collector(idle_rate);
 
-        scheduler.SchedulingPolicy::start_periodic_maintenance(global_state);
+        scheduler.SchedulingPolicy::start_periodic_maintenance(this_state);
 
         // spin for some time after queues have become empty
         bool may_exit = false;
@@ -307,7 +330,7 @@ namespace hpx { namespace threads { namespace detail
                     if (state_val == pending) {
                         // schedule other work
                         scheduler.SchedulingPolicy::wait_or_add_new(num_thread,
-                            is_running_state(global_state.load()), idle_loop_count);
+                            is_running_state(this_state.load()), idle_loop_count);
 
                         // schedule this thread again, make sure it ends up at
                         // the end of the queue
@@ -349,15 +372,15 @@ namespace hpx { namespace threads { namespace detail
                 ++idle_loop_count;
 
                 if (scheduler.SchedulingPolicy::wait_or_add_new(num_thread,
-                        is_running_state(global_state.load()), idle_loop_count))
+                        is_running_state(this_state.load()), idle_loop_count))
                 {
                     // clean up terminated threads one more time before existing
                     if (scheduler.SchedulingPolicy::cleanup_terminated(true))
                     {
                         // if this is an inner scheduler, exit immediately
-                        if (!cb_inner.empty())
+                        if (!callbacks.inner_.empty())
                         {
-                            global_state.store(state_stopped);
+                            this_state.store(state_stopped);
                             break;
                         }
 
@@ -369,21 +392,19 @@ namespace hpx { namespace threads { namespace detail
                 }
 
                 // do background work in parcel layer and in agas
-                if (hpx::parcelset::do_background_work(num_thread))
-                    idle_loop_count = 0;
-
-                if (0 == num_thread)
+                if (!callbacks.background_.empty())
                 {
-                    hpx::agas::garbage_collect_non_blocking();
+                    if (callbacks.background_())
+                    idle_loop_count = 0;
                 }
 
                 // call back into invoking context
-                if (!cb_inner.empty())
-                    cb_inner();
+                if (!callbacks.inner_.empty())
+                    callbacks.inner_();
             }
 
             // something went badly wrong, give up
-            if (global_state == state_terminating)
+            if (this_state.load() == state_terminating)
                 break;
 
             if (busy_loop_count > HPX_BUSY_LOOP_COUNT_MAX)
@@ -391,19 +412,17 @@ namespace hpx { namespace threads { namespace detail
                 busy_loop_count = 0;
 
                 // do background work in parcel layer and in agas
-                if (hpx::parcelset::do_background_work(num_thread))
-                    idle_loop_count = 0;
-
-                if (0 == num_thread)
+                if (!callbacks.background_.empty())
                 {
-                    hpx::agas::garbage_collect_non_blocking();
+                    if (callbacks.background_())
+                    idle_loop_count = 0;
                 }
             }
             else if (idle_loop_count > HPX_IDLE_LOOP_COUNT_MAX)
             {
                 // call back into invoking context
-                if (!cb_outer.empty())
-                    cb_outer();
+                if (!callbacks.outer_.empty())
+                    callbacks.outer_();
 
                 // clean up terminated threads
                 idle_loop_count = 0;
@@ -413,7 +432,7 @@ namespace hpx { namespace threads { namespace detail
                 {
                     if (scheduler.SchedulingPolicy::cleanup_terminated(true))
                     {
-                        global_state.store(state_stopped);
+                        this_state.store(state_stopped);
                         break;
                     }
                     may_exit = false;

--- a/hpx/runtime/threads/detail/thread_pool.hpp
+++ b/hpx/runtime/threads/detail/thread_pool.hpp
@@ -38,7 +38,7 @@ namespace hpx { namespace threads { namespace detail
     public:
         thread_pool(Scheduler& sched,
             threads::policies::callback_notifier& notifier,
-            char const* pool_name);
+            char const* pool_name, bool do_background_work = false);
         ~thread_pool();
 
         std::size_t init(std::size_t num_threads,
@@ -121,7 +121,10 @@ namespace hpx { namespace threads { namespace detail
         void abort_all_suspended_threads();
         bool cleanup_terminated(bool delete_all);
 
-        hpx::state get_state() const { return state_.load(); }
+        hpx::state get_state() const;
+        hpx::state get_state(std::size_t num_thread) const;
+
+        bool has_reached_state(hpx::state s) const;
 
         void do_some_work(std::size_t num_thread);
 
@@ -145,9 +148,6 @@ namespace hpx { namespace threads { namespace detail
         threads::policies::callback_notifier& notifier_;
         std::string pool_name_;
 
-        // thread pool state
-        boost::atomic<hpx::state> state_;
-
         // startup barrier
         boost::scoped_ptr<boost::barrier> startup_;
 
@@ -166,6 +166,10 @@ namespace hpx { namespace threads { namespace detail
         // Stores the mask identifying all processing units used by this
         // thread manager.
         threads::mask_type used_processing_units_;
+
+        // Instruct pool to allow doing background work (parcelport and garbage
+        // collection)
+        bool do_background_work_;
     };
 }}}
 

--- a/hpx/runtime/threads/executors/this_thread_executors.hpp
+++ b/hpx/runtime/threads/executors/this_thread_executors.hpp
@@ -10,7 +10,6 @@
 
 #if defined(HPX_HAVE_STATIC_SCHEDULER) || defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
 
-#include <hpx/state.hpp>
 #include <hpx/runtime/threads/thread_executor.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 #include <hpx/lcos/local/counting_semaphore.hpp>
@@ -95,7 +94,7 @@ namespace hpx { namespace threads { namespace executors
             // the scheduler used by this executor
             Scheduler scheduler_;
             lcos::local::counting_semaphore shutdown_sem_;
-            boost::atomic<hpx::state> state_;
+
             std::size_t thread_num_;
             std::size_t parent_thread_num_;
             std::size_t orig_thread_num_;

--- a/hpx/runtime/threads/executors/thread_pool_executors.hpp
+++ b/hpx/runtime/threads/executors/thread_pool_executors.hpp
@@ -1,10 +1,10 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2015 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(HPX_RUNTIME_THREADS_EXECUTORS_SERIAL_EXECUTOR_JAN_11_2013_0831PM)
-#define HPX_RUNTIME_THREADS_EXECUTORS_SERIAL_EXECUTOR_JAN_11_2013_0831PM
+#if !defined(HPX_RUNTIME_THREADS_EXECUTORS_POOL_EXECUTORS_JAN_11_2013_0831PM)
+#define HPX_RUNTIME_THREADS_EXECUTORS_POOL_EXECUTORS_JAN_11_2013_0831PM
 
 #include <hpx/hpx_fwd.hpp>
 #include <hpx/state.hpp>
@@ -93,7 +93,6 @@ namespace hpx { namespace threads { namespace executors
             // the scheduler used by this executor
             Scheduler scheduler_;
             lcos::local::counting_semaphore shutdown_sem_;
-            boost::ptr_vector<boost::atomic<hpx::state> > states_;
 
             // collect statistics
             boost::atomic<std::size_t> current_concurrency_;

--- a/hpx/runtime/threads/policies/scheduler_base.hpp
+++ b/hpx/runtime/threads/policies/scheduler_base.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2015 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,17 +6,22 @@
 #if !defined(HPX_THREADMANAGER_SCHEDULING_SCHEDULER_BASE_JUL_14_2013_1132AM)
 #define HPX_THREADMANAGER_SCHEDULING_SCHEDULER_BASE_JUL_14_2013_1132AM
 
-#include <hpx/hpx_fwd.hpp>
+#include <hpx/config.hpp>
+#include <hpx/state.hpp>
 #include <hpx/runtime/threads/thread_init_data.hpp>
 #include <hpx/runtime/threads/topology.hpp>
 #include <hpx/runtime/threads/policies/affinity_data.hpp>
+#include <hpx/runtime/agas/interface.hpp>
 #include <hpx/util/assert.hpp>
 
 #include <boost/noncopyable.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/condition_variable.hpp>
+#include <boost/ptr_container/ptr_vector.hpp>
 
 #include <hpx/config/warnings_prefix.hpp>
+
+#include <boost/atomic.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace threads { namespace policies
@@ -53,7 +58,11 @@ namespace hpx { namespace threads { namespace policies
 #if defined(HPX_HAVE_THREAD_MANAGER_IDLE_BACKOFF)
           , wait_count_(0)
 #endif
-        {}
+        {
+            states_.resize(num_threads);
+            for (std::size_t i = 0; i != num_threads; ++i)
+                states_[i].store(state_initialized);
+        }
 
         virtual ~scheduler_base() {}
 
@@ -99,6 +108,17 @@ namespace hpx { namespace threads { namespace policies
 #endif
         }
 
+        bool background_callback(std::size_t num_thread)
+        {
+            bool result = false;
+            if (hpx::parcelset::do_background_work(num_thread))
+                result = true;
+
+            if (0 == num_thread)
+                hpx::agas::garbage_collect_non_blocking();
+            return result;
+        }
+
         /// This function gets called by the thread-manager whenever new work
         /// has been added, allowing the scheduler to reactivate one or more of
         /// possibly idling OS threads
@@ -112,6 +132,48 @@ namespace hpx { namespace threads { namespace policies
             else
                 cond_.notify_one();
 #endif
+        }
+
+        // allow to access/manipulate states
+        boost::atomic<hpx::state>& get_state(std::size_t num_thread)
+        {
+            HPX_ASSERT(num_thread < states_.size());
+            return states_[num_thread];
+        }
+        boost::atomic<hpx::state> const& get_state(std::size_t num_thread) const
+        {
+            HPX_ASSERT(num_thread < states_.size());
+            return states_[num_thread];
+        }
+
+        void set_all_states(hpx::state s)
+        {
+            typedef boost::atomic<hpx::state> state_type;
+            for (state_type& state : states_)
+                state.store(s);
+        }
+
+        // return whether all states are at least at the given one
+        bool has_reached_state(hpx::state s) const
+        {
+            typedef boost::atomic<hpx::state> state_type;
+            for (state_type const& state : states_)
+            {
+                if (state.load() < s)
+                    return false;
+            }
+            return true;
+        }
+
+        bool is_state(hpx::state s) const
+        {
+            typedef boost::atomic<hpx::state> state_type;
+            for (state_type const& state : states_)
+            {
+                if (state.load() != s)
+                    return false;
+            }
+            return true;
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -197,6 +259,8 @@ namespace hpx { namespace threads { namespace policies
         boost::condition_variable cond_;
         boost::atomic<boost::uint32_t> wait_count_;
 #endif
+
+        boost::ptr_vector<boost::atomic<hpx::state> > states_;
     };
 }}}
 

--- a/hpx/runtime/threads/thread_helpers.hpp
+++ b/hpx/runtime/threads/thread_helpers.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2015 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //  Copyright (c) 2008-2009 Chirag Dekate, Anshul Tandon
 //
@@ -20,6 +20,11 @@
 namespace hpx { namespace threads
 {
     struct thread_init_data;
+
+    namespace executors
+    {
+        struct HPX_EXPORT generic_thread_pool_executor;
+    }
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief  Set the thread state of the \a thread referenced by the
@@ -401,7 +406,7 @@ namespace hpx { namespace threads
 
     HPX_API_EXPORT std::size_t& get_continuation_recursion_count();
 
-    /// Returns a non-null pointer to the executor which was used to create
+    /// Returns a reference to the executor which was used to create
     /// the given thread.
     ///
     /// \throws If <code>&ec != &throws</code>, never throws, but will set \a ec
@@ -414,8 +419,8 @@ namespace hpx { namespace threads
     ///         running, it will throw an \a hpx#exception with an error code of
     ///         \a hpx#invalid_status.
     ///
-    HPX_API_EXPORT threads::executor get_executor(
-        thread_id_type const& id, error_code& ec = throws);
+    HPX_API_EXPORT threads::executors::generic_thread_pool_executor
+        get_executor(thread_id_type const& id, error_code& ec = throws);
 }}
 
 namespace hpx { namespace this_thread
@@ -512,6 +517,22 @@ namespace hpx { namespace this_thread
     {
         return suspend(boost::chrono::milliseconds(ms), description, ec);
     }
+
+    /// Returns a reference to the executor which was used to create the current
+    /// thread.
+    ///
+    /// \throws If <code>&ec != &throws</code>, never throws, but will set \a ec
+    ///         to an appropriate value when an error occurs. Otherwise, this
+    ///         function will throw an \a hpx#exception with an error code of
+    ///         \a hpx#yield_aborted if it is signaled with \a wait_aborted.
+    ///         If called outside of a HPX-thread, this function will throw
+    ///         an \a hpx#exception with an error code of \a hpx::null_thread_id.
+    ///         If this function is called while the thread-manager is not
+    ///         running, it will throw an \a hpx#exception with an error code of
+    ///         \a hpx#invalid_status.
+    ///
+    HPX_EXPORT threads::executors::generic_thread_pool_executor
+        get_executor(error_code& ec = throws);
 }}
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/threads/threadmanager.hpp
+++ b/hpx/runtime/threads/threadmanager.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2015 Hartmut Kaiser
 //  Copyright (c) 2007-2009 Chirag Dekate, Anshul Tandon
 //  Copyright (c)      2011 Bryce Lelbach, Katelyn Kufahl
 //
@@ -17,6 +17,7 @@
 #include <hpx/util/thread_specific_ptr.hpp>
 #include <hpx/runtime/threads/topology.hpp>
 #include <hpx/runtime/threads/thread_executor.hpp>
+#include <hpx/runtime/threads/executors/generic_thread_pool_executor.hpp>
 #include <hpx/runtime/threads/policies/affinity_data.hpp>
 
 #include <hpx/config/warnings_prefix.hpp>
@@ -471,7 +472,8 @@ namespace hpx { namespace threads
         virtual mask_cref_type get_used_processing_units() const = 0;
 
         // Return the executor associated with th egiven thread
-        virtual executor get_executor(thread_id_type const& id, error_code& ec) const = 0;
+        virtual executors::generic_thread_pool_executor
+            get_executor(thread_id_type const& id, error_code& ec) const = 0;
 
         ///////////////////////////////////////////////////////////////////////
         virtual std::size_t get_worker_thread_num(bool* numa_sensitive = 0) = 0;

--- a/hpx/runtime/threads/threadmanager_impl.hpp
+++ b/hpx/runtime/threads/threadmanager_impl.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2015 Hartmut Kaiser
 //  Copyright (c) 2007-2009 Chirag Dekate, Anshul Tandon
 //  Copyright (c)      2011 Bryce Lelbach, Katelyn Kufahl
 //
@@ -36,7 +36,7 @@
 namespace hpx { namespace threads
 {
     ///////////////////////////////////////////////////////////////////////////
-    /// The \a threadmanager class is the central instance of management for
+    /// The \a thread-manager class is the central instance of management for
     /// all (non-depleted) threads
     template <typename SchedulingPolicy>
     class HPX_EXPORT threadmanager_impl : public threadmanager_base
@@ -552,7 +552,8 @@ namespace hpx { namespace threads
         }
 
         // Return the executor associated with the given thread
-        executor get_executor(thread_id_type const& id, error_code& ec) const;
+        executors::generic_thread_pool_executor
+            get_executor(thread_id_type const& id, error_code& ec) const;
 
     private:
         // counter creator functions

--- a/hpx/runtime_impl.hpp
+++ b/hpx/runtime_impl.hpp
@@ -362,6 +362,10 @@ namespace hpx
         /// Unregister an external OS-thread with HPX
         bool unregister_thread();
 
+        /// Generate a new notification policy instance for the given thread
+        /// name prefix
+        notification_policy_type get_notification_policy(char const* prefix);
+
     private:
         void init_tss(char const* context, std::size_t num, char const* postfix,
             bool service_thread);

--- a/src/runtime/threads/detail/thread_num_tss.cpp
+++ b/src/runtime/threads/detail/thread_num_tss.cpp
@@ -22,10 +22,11 @@ namespace hpx { namespace threads { namespace detail
     void thread_num_tss::init_tss(std::size_t num)
     {
         // shouldn't be initialized yet
-        HPX_ASSERT(NULL == thread_num_tss::thread_num_.get());
-
-        thread_num_tss::thread_num_.reset(new std::size_t);
-        *thread_num_tss::thread_num_.get() = num;
+        if (NULL == thread_num_tss::thread_num_.get())
+        {
+            thread_num_tss::thread_num_.reset(new std::size_t);
+            *thread_num_tss::thread_num_.get() = num;
+        }
     }
 
     void thread_num_tss::deinit_tss()

--- a/src/runtime/threads/thread_helpers.cpp
+++ b/src/runtime/threads/thread_helpers.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2015 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -415,7 +415,8 @@ namespace hpx { namespace threads
         return app->get_thread_manager().set_backtrace(id, bt);
     }
 
-    threads::executor get_executor(thread_id_type const& id, error_code& ec)
+    threads::executors::generic_thread_pool_executor
+        get_executor(thread_id_type const& id, error_code& ec)
     {
         hpx::applier::applier* app = hpx::applier::get_applier_ptr();
         if (NULL == app)
@@ -423,7 +424,7 @@ namespace hpx { namespace threads
             HPX_THROWS_IF(ec, invalid_status,
                 "hpx::threads::get_executor",
                 "global applier object is not accessible");
-            return default_executor();
+            return threads::executors::generic_thread_pool_executor(0);
         }
 
         return app->get_thread_manager().get_executor(id, ec);
@@ -594,6 +595,13 @@ namespace hpx { namespace this_thread
             ec = make_success_code();
 
         return statex;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    threads::executors::generic_thread_pool_executor
+        get_executor(error_code& ec)
+    {
+        return threads::get_executor(threads::get_self_id(), ec);
     }
 }}
 

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -139,7 +139,7 @@ namespace hpx { namespace threads
         thread_logger_("threadmanager_impl::register_thread"),
         work_logger_("threadmanager_impl::register_work"),
         set_state_logger_("threadmanager_impl::set_state"),
-        pool_(scheduler, notifier, "main_thread_scheduling_pool"),
+        pool_(scheduler, notifier, "main_thread_scheduling_pool", true),
         notifier_(notifier)
     {}
 
@@ -536,23 +536,21 @@ namespace hpx { namespace threads
             thrd->free_thread_exit_callbacks();
     }
 
-    // Return the executor associated with th egiven thread
+    // Return the executor associated with the given thread
     template <typename SchedulingPolicy>
-    executor threadmanager_impl<SchedulingPolicy>::
+    executors::generic_thread_pool_executor threadmanager_impl<SchedulingPolicy>::
         get_executor(thread_id_type const& thrd, error_code& ec) const
     {
         if (HPX_UNLIKELY(!thrd)) {
             HPX_THROWS_IF(ec, null_thread_id,
                 "threadmanager_impl::get_executor",
                 "NULL thread id encountered");
-            return default_executor();
+            return executors::generic_thread_pool_executor(0);
         }
 
         if (&ec != &throws)
             ec = make_success_code();
 
-        if (0 == thrd)
-            return default_executor();
         return executors::generic_thread_pool_executor(thrd->get_scheduler_base());
     }
 
@@ -1373,7 +1371,7 @@ namespace hpx { namespace threads
         boost::unique_lock<mutex_type> lk(mtx_);
 
         if (pool_.get_os_thread_count() != 0 ||
-            pool_.get_state() == state_running)
+            pool_.has_reached_state(state_running))
         {
             return true;    // do nothing if already running
         }

--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -135,10 +135,8 @@ namespace hpx {
             boost::bind(&runtime_impl::init_tss, This(), "timer-thread", ::_1, ::_2, true),
             boost::bind(&runtime_impl::deinit_tss, This()), "timer_pool"),
         scheduler_(init),
-        notifier_(
-            boost::bind(&runtime_impl::init_tss, This(), "worker-thread", ::_1, ::_2, false),
-            boost::bind(&runtime_impl::deinit_tss, This()),
-            boost::bind(&runtime_impl::report_error, This(), _1, _2)),
+        notifier_(runtime_impl<SchedulingPolicy>::
+            get_notification_policy("worker-thread")),
         thread_manager_(
             new hpx::threads::threadmanager_impl<SchedulingPolicy>(
                 timer_pool_, scheduler_, notifier_, num_threads)),
@@ -559,6 +557,16 @@ namespace hpx {
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    template <typename SchedulingPolicy>
+    threads::policies::callback_notifier runtime_impl<SchedulingPolicy>::
+        get_notification_policy(char const* prefix)
+    {
+        return notification_policy_type(
+            boost::bind(&runtime_impl::init_tss, This(), prefix, ::_1, ::_2, false),
+            boost::bind(&runtime_impl::deinit_tss, This()),
+            boost::bind(&runtime_impl::report_error, This(), _1, _2));
+    }
+
     template <typename SchedulingPolicy>
     void runtime_impl<SchedulingPolicy>::init_tss(
         char const* context, std::size_t num, char const* postfix,


### PR DESCRIPTION
- exposing new API functions supporting executors
- adding third callback to scheduling_loop for background related work