### PR TITLE
List serialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -758,7 +758,7 @@ hpx_check_for_cxx11_alias_templates(
   DEFINITIONS HPX_HAVE_CXX11_ALIAS_TEMPLATES)
 
 hpx_check_for_cxx11_auto(
-  DEFINITIONS HPX_HAVE_CXX11_AUTO)
+  REQUIRED "HPX needs support for C++11 auto")
 
 hpx_check_for_cxx11_constexpr(
   DEFINITIONS HPX_HAVE_CXX11_CONSTEXPR)

--- a/hpx/runtime/serialization/list.hpp
+++ b/hpx/runtime/serialization/list.hpp
@@ -1,0 +1,45 @@
+//  Copyright (c) 2015 Thomas Heller
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_SERIALIZATION_LIST_HPP
+#define HPX_SERIALIZATION_LIST_HPP
+
+#include <hpx/runtime/serialization/serialize.hpp>
+
+#include <list>
+
+namespace hpx { namespace serialization
+{
+    template <typename T, typename Allocator>
+    void serialize(input_archive & ar, std::list<T, Allocator> & ls, unsigned)
+    {
+        // normal load ...
+        typedef typename std::list<T, Allocator>::size_type size_type;
+        size_type size;
+        ar >> size; //-V128
+        if(size == 0) return;
+
+        ls.resize(size);
+        for(auto & li: ls)
+        {
+            ar >> li;
+        }
+    }
+
+    template <typename T, typename Allocator>
+    void serialize(output_archive & ar, std::list<T, Allocator> & ls, unsigned)
+    {
+        // normal save ...
+        ar << ls.size(); //-V128
+        if(ls.empty()) return;
+
+        for(auto const & li: ls)
+        {
+            ar << li;
+        }
+    }
+}}
+
+#endif

--- a/hpx/runtime/serialization/vector.hpp
+++ b/hpx/runtime/serialization/vector.hpp
@@ -18,13 +18,13 @@ namespace hpx { namespace serialization
     void load_impl(input_archive & ar, std::vector<T, Allocator> & vs, boost::mpl::false_)
     {
         // normal load ...
-        typedef typename std::vector<T>::size_type size_type;
+        typedef typename std::vector<T, Allocator>::size_type size_type;
         size_type size;
         ar >> size; //-V128
         if(size == 0) return;
 
         vs.resize(size);
-        typedef typename std::vector<T>::value_type value_type;
+        typedef typename std::vector<T, Allocator>::value_type value_type;
         for(size_type i = 0; i != size; ++i)
         {
             ar >> vs[i];
@@ -41,8 +41,8 @@ namespace hpx { namespace serialization
         else
         {
             // bitwise load ...
-            typedef typename std::vector<T>::value_type value_type;
-            typedef typename std::vector<T>::size_type size_type;
+            typedef typename std::vector<T, Allocator>::value_type value_type;
+            typedef typename std::vector<T, Allocator>::size_type size_type;
             size_type size;
             ar >> size; //-V128
             if(size == 0) return;
@@ -55,7 +55,7 @@ namespace hpx { namespace serialization
     template <typename Allocator>
     void serialize(input_archive & ar, std::vector<bool, Allocator> & v, unsigned)
     {
-        typedef typename std::vector<bool>::size_type size_type;
+        typedef typename std::vector<bool, Allocator>::size_type size_type;
         size_type size = 0;
         ar >> size; //-V128
         if(size == 0) return;
@@ -78,7 +78,7 @@ namespace hpx { namespace serialization
             ar
           , v
           , typename traits::is_bitwise_serializable<
-                typename std::vector<T>::value_type
+                typename std::vector<T, Allocator>::value_type
             >::type()
         );
     }
@@ -88,7 +88,7 @@ namespace hpx { namespace serialization
     void save_impl(output_archive & ar, std::vector<T, Allocator> & vs, boost::mpl::false_)
     {
         // normal save ...
-        typedef typename std::vector<T>::value_type value_type;
+        typedef typename std::vector<T, Allocator>::value_type value_type;
         for(const value_type & v : vs)
         {
             ar << v;
@@ -105,7 +105,7 @@ namespace hpx { namespace serialization
         else
         {
             // bitwise save ...
-            typedef typename std::vector<T>::value_type value_type;
+            typedef typename std::vector<T, Allocator>::value_type value_type;
             save_binary(ar, &v[0], v.size() * sizeof(value_type));
         }
     }
@@ -113,7 +113,7 @@ namespace hpx { namespace serialization
     template <typename Allocator>
     void serialize(output_archive & ar, std::vector<bool, Allocator> & v, unsigned)
     {
-        typedef typename std::vector<bool>::size_type size_type;
+        typedef typename std::vector<bool, Allocator>::size_type size_type;
         ar << v.size(); //-V128
         if(v.empty()) return;
         // normal save ... no chance of doing bitwise here ...
@@ -133,7 +133,7 @@ namespace hpx { namespace serialization
             ar
           , v
           , typename traits::is_bitwise_serializable<
-                typename std::vector<T>::value_type
+                typename std::vector<T, Allocator>::value_type
             >::type()
         );
     }

--- a/tests/unit/serialization/CMakeLists.txt
+++ b/tests/unit/serialization/CMakeLists.txt
@@ -8,6 +8,7 @@ set(tests
     serialization_builtins
     serialization_complex
     serialization_custom_constructor
+    serialization_list
     serialization_map
     serialization_set
     serialization_simple

--- a/tests/unit/serialization/serialization_list.cpp
+++ b/tests/unit/serialization/serialization_list.cpp
@@ -1,0 +1,192 @@
+//  Copyright (c) 2014 Thomas Heller
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/runtime/serialization/list.hpp>
+
+#include <hpx/runtime/serialization/input_archive.hpp>
+#include <hpx/runtime/serialization/output_archive.hpp>
+
+#include <hpx/util/lightweight_test.hpp>
+
+template <typename T>
+struct A
+{
+    A() {}
+
+    A(T t) : t_(t) {}
+    T t_;
+
+    A & operator=(T t) { t_ = t; return *this; }
+
+    template <typename Archive>
+    void serialize(Archive & ar, unsigned)
+    {
+        ar & t_;
+    }
+};
+
+void test_bool()
+{
+    {
+        std::vector<char> buffer;
+        hpx::serialization::output_archive oarchive(buffer);
+
+        std::list<bool> os;
+        os.push_back(true);
+        os.push_back(false);
+        os.push_back(false);
+        os.push_back(true);
+        oarchive << os;
+
+        hpx::serialization::input_archive iarchive(buffer);
+        std::list<bool> is;
+        iarchive >> is;
+        HPX_TEST_EQ(os.size(), is.size());
+        auto ot = os.begin();
+        auto it = is.begin();
+        for(std::size_t i = 0; i < os.size(); ++i)
+        {
+            HPX_TEST_EQ(*ot, *it);
+        }
+    }
+    {
+        std::vector<char> buffer;
+        hpx::serialization::output_archive oarchive(buffer);
+
+        std::list<A<bool> > os;
+        os.push_back(true);
+        os.push_back(false);
+        os.push_back(false);
+        os.push_back(true);
+        oarchive << os;
+
+        hpx::serialization::input_archive iarchive(buffer);
+        std::list<A<bool> > is;
+        iarchive >> is;
+        HPX_TEST_EQ(os.size(), is.size());
+        auto ot = os.begin();
+        auto it = is.begin();
+        for(std::size_t i = 0; i < os.size(); ++i)
+        {
+            HPX_TEST_EQ(ot->t_, it->t_);
+        }
+    }
+}
+
+template <typename T>
+void test(T min, T max)
+{
+    {
+        std::vector<char> buffer;
+        hpx::serialization::output_archive oarchive(buffer);
+        std::list<T> os;
+        for(T c = min; c < max; ++c)
+        {
+            os.push_back(c);
+        }
+        oarchive << os;
+        hpx::serialization::input_archive iarchive(buffer);
+        std::list<T> is;
+        iarchive >> is;
+        HPX_TEST_EQ(os.size(), is.size());
+        auto ot = os.begin();
+        auto it = is.begin();
+        for(std::size_t i = 0; i < os.size(); ++i)
+        {
+            HPX_TEST_EQ(*ot, *it);
+        }
+    }
+    {
+        std::vector<char> buffer;
+        hpx::serialization::output_archive oarchive(buffer);
+        std::list<A<T> > os;
+        for(T c = min; c < max; ++c)
+        {
+            os.push_back(c);
+        }
+        oarchive << os;
+        hpx::serialization::input_archive iarchive(buffer);
+        std::list<A<T> > is;
+        iarchive >> is;
+        HPX_TEST_EQ(os.size(), is.size());
+        auto ot = os.begin();
+        auto it = is.begin();
+        for(std::size_t i = 0; i < os.size(); ++i)
+        {
+            HPX_TEST_EQ(ot->t_, it->t_);
+        }
+    }
+}
+
+template <typename T>
+void test_fp(T min, T max)
+{
+    {
+        std::vector<char> buffer;
+        hpx::serialization::output_archive oarchive(buffer);
+        std::list<T> os;
+        for(T c = min; c < max; c += static_cast<T>(0.5))
+        {
+            os.push_back(c);
+        }
+        oarchive << os;
+        hpx::serialization::input_archive iarchive(buffer);
+        std::list<T> is;
+        iarchive >> is;
+        HPX_TEST_EQ(os.size(), is.size());
+        auto ot = os.begin();
+        auto it = is.begin();
+        for(std::size_t i = 0; i < os.size(); ++i)
+        {
+            HPX_TEST_EQ(*ot, *it);
+        }
+    }
+    {
+        std::vector<char> buffer;
+        hpx::serialization::output_archive oarchive(buffer);
+        std::list<A<T> > os;
+        for(T c = min; c < max; c += static_cast<T>(0.5))
+        {
+            os.push_back(c);
+        }
+        oarchive << os;
+        hpx::serialization::input_archive iarchive(buffer);
+        std::list<A<T> > is;
+        iarchive >> is;
+        HPX_TEST_EQ(os.size(), is.size());
+        auto ot = os.begin();
+        auto it = is.begin();
+        for(std::size_t i = 0; i < os.size(); ++i)
+        {
+            HPX_TEST_EQ(ot->t_, it->t_);
+        }
+    }
+}
+
+int main()
+{
+    test_bool();
+    test<char>((std::numeric_limits<char>::min)(), (std::numeric_limits<char>::max)());
+    test<int>((std::numeric_limits<int>::min)(), (std::numeric_limits<int>::min)() + 100);
+    test<int>((std::numeric_limits<int>::max)() - 100, (std::numeric_limits<int>::max)());
+    test<int>(-100, 100);
+    test<unsigned>((std::numeric_limits<unsigned>::min)(), (std::numeric_limits<unsigned>::min)() + 100);
+    test<unsigned>((std::numeric_limits<unsigned>::max)() - 100, (std::numeric_limits<unsigned>::max)());
+    test<long>((std::numeric_limits<long>::min)(), (std::numeric_limits<long>::min)() + 100);
+    test<long>((std::numeric_limits<long>::max)() - 100, (std::numeric_limits<long>::max)());
+    test<long>(-100, 100);
+    test<unsigned long>((std::numeric_limits<unsigned long>::min)(), (std::numeric_limits<unsigned long>::min)() + 100);
+    test<unsigned long>((std::numeric_limits<unsigned long>::max)() - 100, (std::numeric_limits<unsigned long>::max)());
+    test_fp<float>((std::numeric_limits<float>::min)(), (std::numeric_limits<float>::min)() + 100);
+    test_fp<float>((std::numeric_limits<float>::max)() - 100, (std::numeric_limits<float>::max)()); //it's incorrect
+    // because floatmax() - 100 causes cancellations error, digits are not affected
+    test_fp<float>(-100, 100);
+    test<double>((std::numeric_limits<double>::min)(), (std::numeric_limits<double>::min)() + 100);
+    test<double>((std::numeric_limits<double>::max)() - 100, (std::numeric_limits<double>::max)()); //it's the same
+    test<double>(-100, 100);
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
This patch adds serialization support for std::list.

A small flyby change has been included which fixes vector serialization to properly honor the Allocator template during it's serialization.