### PR TITLE
serialization of arrays didn't work with non-pod types. fixed.

### DIFF
--- a/hpx/runtime/serialization/array.hpp
+++ b/hpx/runtime/serialization/array.hpp
@@ -44,24 +44,8 @@ namespace hpx { namespace serialization
         template <class Archive>
         void serialize_optimized(Archive& ar, unsigned int v, boost::mpl::false_)
         {
-#ifdef BOOST_BIG_ENDIAN
-            if (ar.endian_little())
-            {
-                for (std::size_t i = 0; i != m_element_count; ++i)
-                    ar & m_t[i];
-            }
-#else
-            if (ar.endian_big())
-            {
-                for (std::size_t i = 0; i != m_element_count; ++i)
-                    ar & m_t[i];
-            }
-#endif
-            else
-            {
-                // this behaviour has been kept from old version with portable boost archives
-                serialize_optimized(ar, v, boost::mpl::true_());
-            }
+            for (std::size_t i = 0; i != m_element_count; ++i)
+                ar & m_t[i];
         }
 
         void serialize_optimized(output_archive& ar, unsigned int, boost::mpl::true_)

--- a/hpx/runtime/serialization/array.hpp
+++ b/hpx/runtime/serialization/array.hpp
@@ -66,7 +66,13 @@ namespace hpx { namespace serialization
             typedef typename hpx::traits::is_bitwise_serializable<T>::type
                 use_optimized;
 
-            if (ar.disable_array_optimization())
+#ifdef BOOST_BIG_ENDIAN
+            bool archive_endianess_differs = ar.endian_little();
+#else
+            bool archive_endianess_differs = ar.endian_big();
+#endif
+
+            if (ar.disable_array_optimization() || archive_endianess_differs)
                 serialize_optimized(ar, v, boost::mpl::false_());
             else
                 serialize_optimized(ar, v, use_optimized());

--- a/tests/unit/serialization/serialization_array.cpp
+++ b/tests/unit/serialization/serialization_array.cpp
@@ -176,14 +176,14 @@ void test_multi_array(T first)
                 HPX_TEST_EQ(oarray[i][j][k], iarray[i][j][k]);
 }
 
-template <typename T, std::size_t SIZE>
+template <typename T, std::size_t N>
 void test_plain_array()
 {
     std::vector<char> buffer;
-    T iarray[SIZE];
-    T oarray[SIZE];
+    T iarray[N];
+    T oarray[N];
 
-    for(std::size_t i = 0; i < SIZE; ++i) {
+    for(std::size_t i = 0; i < N; ++i) {
         iarray[i] = i * i;
         oarray[i] = -1;
     }
@@ -194,19 +194,19 @@ void test_plain_array()
     hpx::serialization::input_archive iarchive(buffer);
     iarchive >> oarray;
 
-    for(std::size_t i = 0; i < SIZE; ++i) {
+    for(std::size_t i = 0; i < N; ++i) {
         HPX_TEST_EQ(oarray[i], iarray[i]);
     }
 }
 
-template <typename T, std::size_t SIZE>
+template <typename T, std::size_t N>
 void test_array_of_vectors()
 {
     std::vector<char> buffer;
-    std::vector<T> iarray[SIZE];
-    std::vector<T> oarray[SIZE];
+    std::vector<T> iarray[N];
+    std::vector<T> oarray[N];
 
-    for(std::size_t i = 0; i < SIZE; ++i) {
+    for(std::size_t i = 0; i < N; ++i) {
         for (std::size_t j = 0; j < i; ++j) {
             iarray[i].push_back(i * i);
         }
@@ -218,7 +218,7 @@ void test_array_of_vectors()
     hpx::serialization::input_archive iarchive(buffer);
     iarchive >> oarray;
 
-    for(std::size_t i = 0; i < SIZE; ++i) {
+    for(std::size_t i = 0; i < N; ++i) {
         HPX_TEST_EQ(oarray[i].size(), iarray[i].size());
 
         for (std::size_t j = 0; j < i; ++j) {

--- a/tests/unit/serialization/serialization_array.cpp
+++ b/tests/unit/serialization/serialization_array.cpp
@@ -199,6 +199,35 @@ void test_plain_array()
     }
 }
 
+template <typename T, std::size_t SIZE>
+void test_array_of_vectors()
+{
+    std::vector<char> buffer;
+    std::vector<T> iarray[SIZE];
+    std::vector<T> oarray[SIZE];
+
+    for(std::size_t i = 0; i < SIZE; ++i) {
+        for (std::size_t j = 0; j < i; ++j) {
+            iarray[i].push_back(i * i);
+        }
+    }
+
+    hpx::serialization::output_archive oarchive(buffer);
+    oarchive << iarray;
+
+    hpx::serialization::input_archive iarchive(buffer);
+    iarchive >> oarray;
+
+    for(std::size_t i = 0; i < SIZE; ++i) {
+        HPX_TEST_EQ(oarray[i].size(), iarray[i].size());
+
+        for (std::size_t j = 0; j < i; ++j) {
+            HPX_TEST_EQ(oarray[i][j], iarray[i][j]);
+        }
+    }
+}
+
+
 int main()
 {
     test<char>((std::numeric_limits<char>::min)(), (std::numeric_limits<char>::max)());
@@ -226,5 +255,9 @@ int main()
 
     test_plain_array<double, 20>();
     test_plain_array<int, 200>();
+
+    test_array_of_vectors<double, 20>();
+    test_array_of_vectors<int, 200>();
+
     return hpx::util::report_errors();
 }


### PR DESCRIPTION
I did pull out some code of which the first half (related to Endianess) did just look wrong and the other half didn't work properly.