### PR TITLE
Renaming vector

### DIFF
--- a/examples/transpose/CMakeLists.txt
+++ b/examples/transpose/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 Hartmut Kaiser
+# Copyright (c) 2014-2015 Hartmut Kaiser
 # Copyright (c) 2011 Bryce Lelbach
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -18,6 +18,8 @@ if(HPX_WITH_AWAIT)
     ${example_programs}
     transpose_await)
 endif()
+
+set(transpose_serial_vector_FLAGS DEPENDENCIES partitioned_vector_component)
 
 foreach(example_program ${example_programs})
 

--- a/examples/transpose/transpose_serial_vector.cpp
+++ b/examples/transpose/transpose_serial_vector.cpp
@@ -6,7 +6,7 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/include/vector.hpp>
+#include <hpx/include/partitioned_vector.hpp>
 
 #include <algorithm>
 #include <vector>
@@ -16,9 +16,10 @@
 
 bool verbose = false;
 
-double test_results(boost::uint64_t order, hpx::vector<double> const & trans);
+double test_results(boost::uint64_t order,
+    hpx::partitioned_vector<double> const & trans);
 
-HPX_REGISTER_VECTOR(double);
+HPX_REGISTER_PARTITIONED_VECTOR(double);
 
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
@@ -35,8 +36,8 @@ int hpx_main(boost::program_options::variables_map& vm)
     boost::uint64_t bytes =
         static_cast<boost::uint64_t>(2.0 * sizeof(double) * order * order);
 
-    hpx::vector<double> A(order * order);
-    hpx::vector<double> B(order * order);
+    hpx::partitioned_vector<double> A(order * order);
+    hpx::partitioned_vector<double> B(order * order);
 
     std::cout
         << "Serial Matrix transpose: B = A^T\n"
@@ -160,7 +161,8 @@ int main(int argc, char* argv[])
     return hpx::init(desc_commandline, argc, argv, cfg);
 }
 
-double test_results(boost::uint64_t order, hpx::vector<double> const & trans)
+double test_results(boost::uint64_t order,
+    hpx::partitioned_vector<double> const & trans)
 {
     double errsq = 0.0;
 

--- a/hpx/components/containers/container_distribution_policy.hpp
+++ b/hpx/components/containers/container_distribution_policy.hpp
@@ -21,8 +21,9 @@ namespace hpx
 {
     ///////////////////////////////////////////////////////////////////////////
     // This class specifies the block chunking policy parameters to use for the
-    // partitioning of the data in a hpx::vector
-    struct container_distribution_policy : components::default_distribution_policy
+    // partitioning of the data in a hpx::partitioned_vector
+    struct container_distribution_policy
+      : components::default_distribution_policy
     {
     public:
         container_distribution_policy()

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp
@@ -4,13 +4,11 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-/// \file partition_vector_component.hpp
+/// \file hpx/components/partitioned_vector/partitioned_vector_component.hpp
 
-#ifndef HPX_PARTITION_VECTOR_COMPONENT_HPP
-#define HPX_PARTITION_VECTOR_COMPONENT_HPP
+#ifndef HPX_PARTITIONED_VECTOR_COMPONENT_HPP
+#define HPX_PARTITIONED_VECTOR_COMPONENT_HPP
 
-/// \file hpx/components/vector/partition_vector_component.hpp
-///
 /// \brief The partition_vector as the hpx component is defined here.
 ///
 /// The partition_vector is the wrapper to the stl vector class except all API's
@@ -37,9 +35,9 @@ namespace hpx { namespace server
     /// This contain the implementation of the partition_vector's component
     /// functionality.
     template <typename T>
-    class partition_vector
+    class partitioned_vector
       : public components::locking_hook<
-            components::simple_component_base<partition_vector<T> > >
+            components::simple_component_base<partitioned_vector<T> > >
     {
     public:
         typedef std::vector<T> data_type;
@@ -49,7 +47,7 @@ namespace hpx { namespace server
         typedef typename data_type::const_iterator const_iterator_type;
 
         typedef components::locking_hook<
-                components::simple_component_base<partition_vector<T> > >
+                components::simple_component_base<partitioned_vector<T> > >
             base_type;
 
     private:
@@ -61,12 +59,12 @@ namespace hpx { namespace server
         ///////////////////////////////////////////////////////////////////////
 
         /// \brief Default Constructor which create partition_vector with size 0.
-        partition_vector()
+        partitioned_vector()
         {
             HPX_ASSERT(false);  // shouldn't ever be called
         }
 
-        explicit partition_vector(size_type partition_size)
+        explicit partitioned_vector(size_type partition_size)
           : partition_vector_(partition_size)
         {}
 
@@ -76,17 +74,17 @@ namespace hpx { namespace server
         /// param partition_size The size of vector
         /// param val Default value for the elements in partition_vector
         ///
-        partition_vector(size_type partition_size, T const& val)
+        partitioned_vector(size_type partition_size, T const& val)
           : partition_vector_(partition_size, val)
         {}
 
         // support components::copy
-        partition_vector(partition_vector const& rhs)
+        partitioned_vector(partitioned_vector const& rhs)
           : base_type(rhs),
             partition_vector_(rhs.partition_vector_)
         {}
 
-        partition_vector& operator=(partition_vector const& rhs)
+        partitioned_vector& operator=(partitioned_vector const& rhs)
         {
             if (this != &rhs)
             {
@@ -96,12 +94,12 @@ namespace hpx { namespace server
             return *this;
         }
 
-        partition_vector(partition_vector && rhs)
+        partitioned_vector(partitioned_vector && rhs)
           : base_type(std::move(rhs)),
             partition_vector_(std::move(rhs.partition_vector_))
         {}
 
-        partition_vector& operator=(partition_vector && rhs)
+        partitioned_vector& operator=(partitioned_vector && rhs)
         {
             if (this != &rhs)
             {
@@ -340,18 +338,18 @@ namespace hpx { namespace server
         }
 
         /// Macros to define HPX component actions for all exported functions.
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_vector, size);
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, size);
 
 //         HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_vector, max_size);
 
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_vector, resize);
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, resize);
 
 //         HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_vector, capacity);
 //         HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_vector, empty);
 //         HPX_DEFINE_COMPONENT_ACTION(partition_vector, reserve);
 
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_vector, get_value);
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_vector, get_values);
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, get_value);
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, get_values);
 
 //         HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_vector, front);
 //         HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_vector, back);
@@ -359,8 +357,8 @@ namespace hpx { namespace server
 //         HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_vector, push_back);
 //         HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_vector, pop_back);
 
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_vector, set_value);
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_vector, set_values);
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, set_value);
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, set_values);
 
 //         HPX_DEFINE_COMPONENT_ACTION(partition_vector, clear);
     };
@@ -381,26 +379,26 @@ namespace hpx { namespace server
 /**/
 #define HPX_REGISTER_VECTOR_DECLARATION_2(type, name)                         \
     HPX_REGISTER_ACTION_DECLARATION(                                          \
-        hpx::server::partition_vector<type>::get_value_action,                \
+        hpx::server::partitioned_vector<type>::get_value_action,              \
         BOOST_PP_CAT(__vector_get_value_action_, name));                      \
     HPX_REGISTER_ACTION_DECLARATION(                                          \
-        hpx::server::partition_vector<type>::get_values_action,               \
+        hpx::server::partitioned_vector<type>::get_values_action,             \
         BOOST_PP_CAT(__vector_get_values_action_, name));                     \
     HPX_REGISTER_ACTION_DECLARATION(                                          \
-        hpx::server::partition_vector<type>::set_value_action,                \
+        hpx::server::partitioned_vector<type>::set_value_action,              \
         BOOST_PP_CAT(__vector_set_value_action_, name));                      \
     HPX_REGISTER_ACTION_DECLARATION(                                          \
-        hpx::server::partition_vector<type>::set_values_action,               \
+        hpx::server::partitioned_vector<type>::set_values_action,             \
         BOOST_PP_CAT(__vector_set_values_action_, name));                     \
     HPX_REGISTER_ACTION_DECLARATION(                                          \
-        hpx::server::partition_vector<type>::size_action,                     \
+        hpx::server::partitioned_vector<type>::size_action,                   \
         BOOST_PP_CAT(__vector_size_action_, name));                           \
     HPX_REGISTER_ACTION_DECLARATION(                                          \
-        hpx::server::partition_vector<type>::resize_action,                   \
+        hpx::server::partitioned_vector<type>::resize_action,                 \
         BOOST_PP_CAT(__vector_resize_action_, name));                         \
 /**/
 
-#define HPX_REGISTER_VECTOR(...)                                              \
+#define HPX_REGISTER_PARTITIONED_VECTOR(...)                                  \
     HPX_REGISTER_VECTOR_(__VA_ARGS__)                                         \
 /**/
 #define HPX_REGISTER_VECTOR_(...)                                             \
@@ -414,25 +412,25 @@ namespace hpx { namespace server
 /**/
 #define HPX_REGISTER_VECTOR_2(type, name)                                     \
     HPX_REGISTER_ACTION(                                                      \
-        ::hpx::server::partition_vector<type>::get_value_action,              \
+        ::hpx::server::partitioned_vector<type>::get_value_action,            \
         BOOST_PP_CAT(__vector_get_value_action_, name));                      \
     HPX_REGISTER_ACTION(                                                      \
-        ::hpx::server::partition_vector<type>::get_values_action,             \
+        ::hpx::server::partitioned_vector<type>::get_values_action,           \
         BOOST_PP_CAT(__vector_get_values_action_, name));                     \
     HPX_REGISTER_ACTION(                                                      \
-        ::hpx::server::partition_vector<type>::set_value_action,              \
+        ::hpx::server::partitioned_vector<type>::set_value_action,            \
         BOOST_PP_CAT(__vector_set_value_action_, name));                      \
     HPX_REGISTER_ACTION(                                                      \
-        ::hpx::server::partition_vector<type>::set_values_action,             \
+        ::hpx::server::partitioned_vector<type>::set_values_action,           \
         BOOST_PP_CAT(__vector_set_values_action_, name));                     \
     HPX_REGISTER_ACTION(                                                      \
-        hpx::server::partition_vector<type>::size_action,                     \
+        hpx::server::partitioned_vector<type>::size_action,                   \
         BOOST_PP_CAT(__vector_size_action_, name));                           \
     HPX_REGISTER_ACTION(                                                      \
-        hpx::server::partition_vector<type>::resize_action,                   \
+        hpx::server::partitioned_vector<type>::resize_action,                 \
         BOOST_PP_CAT(__vector_resize_action_, name));                         \
     typedef ::hpx::components::simple_component<                              \
-        ::hpx::server::partition_vector<type>                                 \
+        ::hpx::server::partitioned_vector<type>                               \
     > BOOST_PP_CAT(__vector_, name);                                          \
     HPX_REGISTER_COMPONENT(BOOST_PP_CAT(__vector_, name))                     \
 /**/
@@ -443,13 +441,13 @@ namespace hpx
     template <typename T>
     class partition_vector
       : public components::client_base<
-            partition_vector<T>, server::partition_vector<T>
+            partition_vector<T>, server::partitioned_vector<T>
         >
     {
     private:
-        typedef hpx::server::partition_vector<T> server_type;
+        typedef hpx::server::partitioned_vector<T> server_type;
         typedef hpx::components::client_base<
-                partition_vector<T>, server::partition_vector<T>
+                partition_vector<T>, server::partitioned_vector<T>
             > base_type;
 
     public:
@@ -464,10 +462,11 @@ namespace hpx
         {}
 
         // Return the pinned pointer to the underlying component
-        boost::shared_ptr<server::partition_vector<T> > get_ptr() const
+        boost::shared_ptr<server::partitioned_vector<T> > get_ptr() const
         {
             error_code ec(lightweight);
-            return hpx::get_ptr<server::partition_vector<T> >(this->get_id()).get(ec);
+            return hpx::get_ptr<server::partitioned_vector<T> >(
+                this->get_id()).get(ec);
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -606,7 +605,8 @@ namespace hpx
         ///
         /// \return This returns the value as the hpx::future
         ///
-        future<std::vector<T> > get_values(std::vector<std::size_t> const& pos) const
+        future<std::vector<T> >
+        get_values(std::vector<std::size_t> const& pos) const
         {
             HPX_ASSERT(this->get_id());
             return hpx::async<typename server_type::get_values_action>(

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_segmented_iterator.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_segmented_iterator.hpp
@@ -531,7 +531,8 @@ namespace hpx
             > base_type;
 
     public:
-        const_segment_vector_iterator(BaseIter const& it, partitioned_vector<T> const* data = 0)
+        const_segment_vector_iterator(BaseIter const& it,
+                partitioned_vector<T> const* data = 0)
           : base_type(it), data_(data)
         {}
 
@@ -654,7 +655,8 @@ namespace hpx
     public:
         typedef std::size_t size_type;
         typedef typename partitioned_vector<T>::segment_iterator segment_iterator;
-        typedef typename partitioned_vector<T>::local_segment_iterator local_segment_iterator;
+        typedef typename partitioned_vector<T>::local_segment_iterator
+            local_segment_iterator;
         typedef typename partitioned_vector<T>::local_iterator local_iterator;
 
         // constructors
@@ -735,7 +737,8 @@ namespace hpx
     public:
         typedef std::size_t size_type;
         typedef typename partitioned_vector<T>::const_segment_iterator segment_iterator;
-        typedef typename partitioned_vector<T>::const_local_segment_iterator local_segment_iterator;
+        typedef typename partitioned_vector<T>::const_local_segment_iterator
+            local_segment_iterator;
         typedef typename partitioned_vector<T>::const_local_iterator local_iterator;
 
         // constructors

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_segmented_iterator.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_segmented_iterator.hpp
@@ -4,11 +4,11 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http:// ww.boost.org/LICENSE_1_0.txt)
 
-#ifndef HPX_VECTOR_SEGMENTED_ITERATOR_HPP
-#define HPX_VECTOR_SEGMENTED_ITERATOR_HPP
+#ifndef HPX_PARTITIONED_VECTOR_SEGMENTED_ITERATOR_HPP
+#define HPX_PARTITIONED_VECTOR_SEGMENTED_ITERATOR_HPP
 
-/// \file hpx/components/vector/segmented_iterator.hpp
-/// \brief This file contains the implementation of iterators for hpx::vector.
+/// \file hpx/components/partitioned_vector/partitioned_vector_segmented_iterator.hpp
+/// \brief This file contains the implementation of iterators for hpx::partitioned_vector.
 
  // The idea for these iterators is taken from
  // http://afstern.org/matt/segmented.pdf.
@@ -18,7 +18,7 @@
 #include <hpx/include/traits.hpp>
 #include <hpx/include/serialization.hpp>
 
-#include <hpx/components/containers/vector/partition_vector_component.hpp>
+#include <hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp>
 
 #include <cstdint>
 #include <iterator>
@@ -33,7 +33,7 @@
 namespace hpx
 {
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T> class vector;       // forward declaration
+    template <typename T> class partitioned_vector;       // forward declaration
 
     template <typename T> class local_vector_iterator;
     template <typename T> class const_local_vector_iterator;
@@ -56,7 +56,7 @@ namespace hpx
 
     namespace server
     {
-        template <typename T> class partition_vector;
+        template <typename T> class partitioned_vector;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -78,7 +78,7 @@ namespace hpx
         typedef const_local_vector_iterator<T> local_const_iterator;
 
         local_raw_vector_iterator(base_iterator const& it,
-                boost::shared_ptr<server::partition_vector<T> > const& data)
+                boost::shared_ptr<server::partitioned_vector<T> > const& data)
           : base_type(it), data_(data)
         {}
 
@@ -98,7 +98,7 @@ namespace hpx
         }
 
     private:
-        boost::shared_ptr<server::partition_vector<T> > data_;
+        boost::shared_ptr<server::partitioned_vector<T> > data_;
     };
 
     template <typename T, typename BaseIter>
@@ -118,7 +118,7 @@ namespace hpx
         typedef const_local_vector_iterator<T> local_const_iterator;
 
         const_local_raw_vector_iterator(base_iterator const& it,
-                boost::shared_ptr<server::partition_vector<T> > const& data)
+                boost::shared_ptr<server::partitioned_vector<T> > const& data)
           : base_type(it), data_(data)
         {}
 
@@ -138,7 +138,7 @@ namespace hpx
         }
 
     private:
-        boost::shared_ptr<server::partition_vector<T> > data_;
+        boost::shared_ptr<server::partitioned_vector<T> > data_;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -206,7 +206,7 @@ namespace hpx
         template <typename T>
         struct vector_value_proxy
         {
-            vector_value_proxy(hpx::vector<T>& v, std::size_t index)
+            vector_value_proxy(hpx::partitioned_vector<T>& v, std::size_t index)
               : v_(v), index_(index)
             {}
 
@@ -222,7 +222,7 @@ namespace hpx
                 return *this;
             }
 
-            vector<T>& v_;
+            partitioned_vector<T>& v_;
             std::size_t index_;
         };
     }
@@ -253,7 +253,7 @@ namespace hpx
 
         local_vector_iterator(partition_vector<T> partition,
                 size_type local_index,
-                boost::shared_ptr<server::partition_vector<T> > const& data)
+                boost::shared_ptr<server::partitioned_vector<T> > const& data)
           : partition_(partition),
             local_index_(local_index),
             data_(data)
@@ -337,11 +337,11 @@ namespace hpx
 
         size_type get_local_index() const { return local_index_; }
 
-        boost::shared_ptr<server::partition_vector<T> >& get_data()
+        boost::shared_ptr<server::partitioned_vector<T> >& get_data()
         {
             return data_;
         }
-        boost::shared_ptr<server::partition_vector<T> > const& get_data() const
+        boost::shared_ptr<server::partitioned_vector<T> > const& get_data() const
         {
             return data_;
         }
@@ -354,7 +354,7 @@ namespace hpx
         size_type local_index_;
 
         // caching address of component
-        boost::shared_ptr<server::partition_vector<T> > data_;
+        boost::shared_ptr<server::partitioned_vector<T> > data_;
     };
 
     template <typename T>
@@ -382,7 +382,7 @@ namespace hpx
 
         const_local_vector_iterator(partition_vector<T> partition,
                 size_type local_index,
-                boost::shared_ptr<server::partition_vector<T> > const& data)
+                boost::shared_ptr<server::partitioned_vector<T> > const& data)
           : partition_(partition),
             local_index_(local_index),
             data_(data)
@@ -468,11 +468,11 @@ namespace hpx
         partition_vector<T> const& get_partition() const { return partition_; }
         size_type get_local_index() const { return local_index_; }
 
-        boost::shared_ptr<server::partition_vector<T> >& get_data()
+        boost::shared_ptr<server::partitioned_vector<T> >& get_data()
         {
             return data_;
         }
-        boost::shared_ptr<server::partition_vector<T> > const& get_data() const
+        boost::shared_ptr<server::partitioned_vector<T> > const& get_data() const
         {
             return data_;
         }
@@ -485,7 +485,7 @@ namespace hpx
         size_type local_index_;
 
         // caching address of component
-        boost::shared_ptr<server::partition_vector<T> > data_;
+        boost::shared_ptr<server::partitioned_vector<T> > data_;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -502,12 +502,12 @@ namespace hpx
             > base_type;
 
     public:
-        segment_vector_iterator(BaseIter const& it, vector<T>* data = 0)
+        segment_vector_iterator(BaseIter const& it, partitioned_vector<T>* data = 0)
           : base_type(it), data_(data)
         {}
 
-        vector<T>* get_data() { return data_; }
-        vector<T> const* get_data() const { return data_; }
+        partitioned_vector<T>* get_data() { return data_; }
+        partitioned_vector<T> const* get_data() const { return data_; }
 
         bool is_at_end() const
         {
@@ -516,7 +516,7 @@ namespace hpx
         }
 
     private:
-        vector<T>* data_;
+        partitioned_vector<T>* data_;
     };
 
     template <typename T, typename BaseIter>
@@ -531,11 +531,11 @@ namespace hpx
             > base_type;
 
     public:
-        const_segment_vector_iterator(BaseIter const& it, vector<T> const* data = 0)
+        const_segment_vector_iterator(BaseIter const& it, partitioned_vector<T> const* data = 0)
           : base_type(it), data_(data)
         {}
 
-        vector<T> const* get_data() const { return data_; }
+        partitioned_vector<T> const* get_data() const { return data_; }
 
         bool is_at_end() const
         {
@@ -544,7 +544,7 @@ namespace hpx
         }
 
     private:
-        vector<T> const* data_;
+        partitioned_vector<T> const* data_;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -631,7 +631,7 @@ namespace hpx
         }
 
     private:
-        boost::shared_ptr<server::partition_vector<T> > data_;
+        boost::shared_ptr<server::partitioned_vector<T> > data_;
         predicate predicate_;
         BaseIter end_;
     };
@@ -653,21 +653,21 @@ namespace hpx
 
     public:
         typedef std::size_t size_type;
-        typedef typename vector<T>::segment_iterator segment_iterator;
-        typedef typename vector<T>::local_segment_iterator local_segment_iterator;
-        typedef typename vector<T>::local_iterator local_iterator;
+        typedef typename partitioned_vector<T>::segment_iterator segment_iterator;
+        typedef typename partitioned_vector<T>::local_segment_iterator local_segment_iterator;
+        typedef typename partitioned_vector<T>::local_iterator local_iterator;
 
         // constructors
         vector_iterator()
           : data_(0), global_index_(size_type(-1))
         {}
 
-        vector_iterator(vector<T>* data, size_type global_index)
+        vector_iterator(partitioned_vector<T>* data, size_type global_index)
           : data_(data), global_index_(global_index)
         {}
 
-        vector<T>* get_data() { return data_; }
-        vector<T> const* get_data() const { return data_; }
+        partitioned_vector<T>* get_data() { return data_; }
+        partitioned_vector<T> const* get_data() const { return data_; }
 
         size_type get_global_index() const { return global_index_; }
 
@@ -712,7 +712,7 @@ namespace hpx
 
     protected:
         // refer to the vector
-        vector<T>* data_;
+        partitioned_vector<T>* data_;
 
         // global position in the referenced vector
         size_type global_index_;
@@ -734,20 +734,20 @@ namespace hpx
 
     public:
         typedef std::size_t size_type;
-        typedef typename vector<T>::const_segment_iterator segment_iterator;
-        typedef typename vector<T>::const_local_segment_iterator local_segment_iterator;
-        typedef typename vector<T>::const_local_iterator local_iterator;
+        typedef typename partitioned_vector<T>::const_segment_iterator segment_iterator;
+        typedef typename partitioned_vector<T>::const_local_segment_iterator local_segment_iterator;
+        typedef typename partitioned_vector<T>::const_local_iterator local_iterator;
 
         // constructors
         const_vector_iterator()
           : data_(0), global_index_(size_type(-1))
         {}
 
-        const_vector_iterator(vector<T> const* data, size_type global_index)
+        const_vector_iterator(partitioned_vector<T> const* data, size_type global_index)
           : data_(data), global_index_(global_index)
         {}
 
-        vector<T> const* get_data() const { return data_; }
+        partitioned_vector<T> const* get_data() const { return data_; }
         size_type get_global_index() const { return global_index_; }
 
     protected:
@@ -791,7 +791,7 @@ namespace hpx
 
     protected:
         // refer to the vector
-        vector<T> const* data_;
+        partitioned_vector<T> const* data_;
 
         // global position in the referenced vector
         size_type global_index_;
@@ -834,7 +834,7 @@ namespace hpx { namespace traits
         static iterator compose(segment_iterator seg_iter,
             local_iterator local_iter)
         {
-            vector<T>* data = seg_iter.get_data();
+            partitioned_vector<T>* data = seg_iter.get_data();
             std::size_t index = local_iter.get_local_index();
             return iterator(data, data->get_global_index(seg_iter, index));
         }
@@ -921,7 +921,7 @@ namespace hpx { namespace traits
         static iterator compose(segment_iterator const& seg_iter,
             local_iterator const& local_iter)
         {
-            vector<T> const* data = seg_iter.get_data();
+            partitioned_vector<T> const* data = seg_iter.get_data();
             std::size_t index = local_iter.get_local_index();
             return iterator(data, data->get_global_index(seg_iter, index));
         }

--- a/hpx/include/partitioned_vector.hpp
+++ b/hpx/include/partitioned_vector.hpp
@@ -3,10 +3,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(HPX_VECTOR_NOV_02_2014_0636PM)
-#define HPX_VECTOR_NOV_02_2014_0636PM
+#if !defined(HPX_PARTITIONED_VECTOR_NOV_02_2014_0636PM)
+#define HPX_PARTITIONED_VECTOR_NOV_02_2014_0636PM
 
-#include <hpx/components/containers/vector/vector.hpp>
+#include <hpx/components/containers/partitioned_vector/partitioned_vector.hpp>
 
 #endif
 

--- a/src/components/containers/CMakeLists.txt
+++ b/src/components/containers/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 set(subdirs
     unordered
-    vector
+    partitioned_vector
    )
 
 foreach(subdir ${subdirs})

--- a/src/components/containers/partitioned_vector/CMakeLists.txt
+++ b/src/components/containers/partitioned_vector/CMakeLists.txt
@@ -4,13 +4,14 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 ###############################################################################
-set(root "${PROJECT_SOURCE_DIR}/hpx/components/containers/vector")
+set(root "${PROJECT_SOURCE_DIR}/hpx/components/containers/partitioned_vector")
 
-add_hpx_component(vector
+add_hpx_component(partitioned_vector
   FOLDER "Core/Components/Containers"
   HEADER_ROOT ${root}
   AUTOGLOB
   ESSENTIAL)
 
-add_hpx_pseudo_dependencies(components.containers.vector vector_component)
+add_hpx_pseudo_dependencies(
+    components.containers.partitioned_vector partitioned_vector_component)
 

--- a/src/components/containers/partitioned_vector/partitioned_vector_component.cpp
+++ b/src/components/containers/partitioned_vector/partitioned_vector_component.cpp
@@ -4,18 +4,18 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-/// \file src/components/containers/vector/partition_vector_component.cpp
+/// \file src/components/containers/partitioned_vector/partitioned_vector_component.cpp
 
 /// This file defines the necessary component boilerplate code which is
 /// required for proper functioning of components in the context of HPX.
 
 #include <hpx/include/components.hpp>
 
-#include <hpx/components/containers/vector/partition_vector_component.hpp>
-#include <hpx/components/containers/vector/vector.hpp>
+#include <hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp>
+#include <hpx/components/containers/partitioned_vector/partitioned_vector.hpp>
 
-HPX_DISTRIBUTED_METADATA(hpx::server::vector_config_data,
-    hpx_server_vector_config_data);
+HPX_DISTRIBUTED_METADATA(hpx::server::partitioned_vector_config_data,
+    hpx_server_partitioned_vector_config_data);
 
 HPX_REGISTER_COMPONENT_MODULE();
 

--- a/tests/performance/local/CMakeLists.txt
+++ b/tests/performance/local/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Copyright (c) 2014-2015 Hartmut Kaiser
 # Copyright (c) 2011 Bryce Adelstein-Lelbach
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -117,7 +118,7 @@ if(HPX_WITH_CXX11_LAMBDAS)
       spinlock_overhead2
       stencil3_iterators
       transform_reduce_scaling
-      vector_foreach
+      partitioned_vector_foreach
      )
 
   set(foreach_scaling_FLAGS DEPENDENCIES iostreams_component)
@@ -125,7 +126,8 @@ if(HPX_WITH_CXX11_LAMBDAS)
   set(spinlock_overhead2_FLAGS DEPENDENCIES iostreams_component)
   set(stencil3_iterators_FLAGS DEPENDENCIES iostreams_component)
   set(transform_reduce_scaling_FLAGS DEPENDENCIES iostreams_component)
-  set(vector_foreach_FLAGS DEPENDENCIES iostreams_component)
+  set(partitioned_vector_foreach_FLAGS
+    DEPENDENCIES iostreams_component partitioned_vector_component)
 endif()
 
 
@@ -156,8 +158,10 @@ foreach(benchmark ${benchmarks})
 endforeach()
 
 if(OPENMP_FOUND)
-  set_target_properties(openmp_homogeneous_timed_task_spawn_exe PROPERTIES COMPILE_FLAGS ${OpenMP_CXX_FLAGS})
-  set_target_properties(openmp_homogeneous_timed_task_spawn_exe PROPERTIES LINK_FLAGS ${OpenMP_CXX_FLAGS})
+  set_target_properties(openmp_homogeneous_timed_task_spawn_exe
+    PROPERTIES COMPILE_FLAGS ${OpenMP_CXX_FLAGS})
+  set_target_properties(openmp_homogeneous_timed_task_spawn_exe
+    PROPERTIES LINK_FLAGS ${OpenMP_CXX_FLAGS})
 endif()
 
 add_hpx_pseudo_target(tests.performance.local.htts_v2)

--- a/tests/performance/local/partitioned_vector_foreach.cpp
+++ b/tests/performance/local/partitioned_vector_foreach.cpp
@@ -8,7 +8,7 @@
 #include <hpx/util/high_resolution_clock.hpp>
 #include <hpx/include/parallel_algorithm.hpp>
 #include <hpx/include/iostreams.hpp>
-#include <hpx/include/vector.hpp>
+#include <hpx/include/partitioned_vector.hpp>
 #include <hpx/include/parallel_for_each.hpp>
 
 #include <boost/cstdint.hpp>
@@ -21,7 +21,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 // Define the vector types to be used.
-HPX_REGISTER_VECTOR(int);
+HPX_REGISTER_PARTITIONED_VECTOR(int);
 
 ///////////////////////////////////////////////////////////////////////////////
 int delay = 1000;
@@ -85,36 +85,36 @@ int hpx_main(boost::program_options::variables_map& vm)
         boost::uint64_t par_ref = foreach_vector(
             hpx::parallel::par.with(cs), ref); //-V106
 
-        // sequential hpx::vector iteration
+        // sequential hpx::partitioned_vector iteration
         {
-            hpx::vector<int> v(vector_size);
+            hpx::partitioned_vector<int> v(vector_size);
 
-            hpx::cout << "hpx::vector<int>(seq): "
+            hpx::cout << "hpx::partitioned_vector<int>(seq): "
                 << foreach_vector(hpx::parallel::seq, v)/double(seq_ref)
                 << "\n";
-            hpx::cout << "hpx::vector<int>(par): "
+            hpx::cout << "hpx::partitioned_vector<int>(par): "
                 << foreach_vector(hpx::parallel::par.with(cs), v)/double(par_ref) //-V106
                 << "\n";
         }
 
         {
-            hpx::vector<int> v(vector_size, hpx::container_layout(2));
+            hpx::partitioned_vector<int> v(vector_size, hpx::container_layout(2));
 
-            hpx::cout << "hpx::vector<int>(seq, container_layout(2)): "
+            hpx::cout << "hpx::partitioned_vector<int>(seq, container_layout(2)): "
                 << foreach_vector(hpx::parallel::seq, v)/double(seq_ref)
                 << "\n";
-            hpx::cout << "hpx::vector<int>(par, container_layout(2)): "
+            hpx::cout << "hpx::partitioned_vector<int>(par, container_layout(2)): "
                 << foreach_vector(hpx::parallel::par.with(cs), v)/double(par_ref) //-V106
                 << "\n";
         }
 
         {
-            hpx::vector<int> v(vector_size, hpx::container_layout(10));
+            hpx::partitioned_vector<int> v(vector_size, hpx::container_layout(10));
 
-            hpx::cout << "hpx::vector<int>(seq, container_layout(10)): "
+            hpx::cout << "hpx::partitioned_vector<int>(seq, container_layout(10)): "
                 << foreach_vector(hpx::parallel::seq, v)/double(seq_ref)
                 << "\n";
-            hpx::cout << "hpx::vector<int>(par, container_layout(10)): "
+            hpx::cout << "hpx::partitioned_vector<int>(par, container_layout(10)): "
                 << foreach_vector(hpx::parallel::par.with(cs), v)/double(par_ref) //-V106
                 << "\n";
         }

--- a/tests/unit/component/CMakeLists.txt
+++ b/tests/unit/component/CMakeLists.txt
@@ -1,3 +1,4 @@
+#  Copyright (c) 2014-2015 Hartmut Kaiser
 #  Copyright (c) 2011 Thomas Heller
 #
 #  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -20,12 +21,12 @@ set(tests
     new_binpacking
     new_colocated
     unordered_map
-    vector_copy
-    vector_for_each
-    vector_handle_values
-    vector_iter
-    vector_move
-    vector_transform_reduce
+    partitioned_vector_copy
+    partitioned_vector_for_each
+    partitioned_vector_handle_values
+    partitioned_vector_iter
+    partitioned_vector_move
+    partitioned_vector_transform_reduce
    )
 
 
@@ -79,10 +80,12 @@ set(new__PARAMETERS LOCALITIES 2)
 set(new_binpacking_PARAMETERS LOCALITIES 2)
 set(new_colocated_PARAMETERS LOCALITIES 2)
 
-set(vector_iter_FLAGS DEPENDENCIES vector_component)
-set(vector_algorithms_FLAGS DEPENDENCIES vector_component)
-set(vector_copy_FLAGS DEPENDENCIES vector_component)
-set(vector_handle_values_FLAGS DEPENDENCIES vector_component)
+set(partitioned_vector_copy_FLAGS DEPENDENCIES partitioned_vector_component)
+set(partitioned_vector_for_each_FLAGS DEPENDENCIES partitioned_vector_component)
+set(partitioned_vector_handle_values_FLAGS DEPENDENCIES partitioned_vector_component)
+set(partitioned_vector_iter_FLAGS DEPENDENCIES partitioned_vector_component)
+set(partitioned_vector_move_FLAGS DEPENDENCIES partitioned_vector_component)
+set(partitioned_vector_transform_reduce_FLAGS DEPENDENCIES partitioned_vector_component)
 
 foreach(test ${tests})
   set(sources

--- a/tests/unit/component/partitioned_vector_copy.cpp
+++ b/tests/unit/component/partitioned_vector_copy.cpp
@@ -25,8 +25,8 @@ void fill_vector(hpx::partitioned_vector<T>& v, T const& val)
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename T>
-void compare_vectors(hpx::partitioned_vector<T> const& v1, hpx::partitioned_vector<T> const& v2,
-    bool must_be_equal = true)
+void compare_vectors(hpx::partitioned_vector<T> const& v1,
+    hpx::partitioned_vector<T> const& v2, bool must_be_equal = true)
 {
     typedef typename hpx::partitioned_vector<T>::const_iterator const_iterator;
 

--- a/tests/unit/component/partitioned_vector_copy.cpp
+++ b/tests/unit/component/partitioned_vector_copy.cpp
@@ -4,31 +4,31 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/vector.hpp>
+#include <hpx/include/partitioned_vector.hpp>
 #include <hpx/include/parallel_copy.hpp>
 
 #include <hpx/util/lightweight_test.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 // Define the vector types to be used.
-HPX_REGISTER_VECTOR(double);
-HPX_REGISTER_VECTOR(int);
+HPX_REGISTER_PARTITIONED_VECTOR(double);
+HPX_REGISTER_PARTITIONED_VECTOR(int);
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename T>
-void fill_vector(hpx::vector<T>& v, T const& val)
+void fill_vector(hpx::partitioned_vector<T>& v, T const& val)
 {
-    typename hpx::vector<T>::iterator it = v.begin(), end = v.end();
+    typename hpx::partitioned_vector<T>::iterator it = v.begin(), end = v.end();
     for (/**/; it != end; ++it)
         *it = val;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename T>
-void compare_vectors(hpx::vector<T> const& v1, hpx::vector<T> const& v2,
+void compare_vectors(hpx::partitioned_vector<T> const& v1, hpx::partitioned_vector<T> const& v2,
     bool must_be_equal = true)
 {
-    typedef typename hpx::vector<T>::const_iterator const_iterator;
+    typedef typename hpx::partitioned_vector<T>::const_iterator const_iterator;
 
     HPX_TEST_EQ(v1.size(), v2.size());
 
@@ -48,15 +48,15 @@ void compare_vectors(hpx::vector<T> const& v1, hpx::vector<T> const& v2,
 }
 
 template <typename T>
-void copy_tests(hpx::vector<T> const& v1)
+void copy_tests(hpx::partitioned_vector<T> const& v1)
 {
-    hpx::vector<T> v2(v1);
+    hpx::partitioned_vector<T> v2(v1);
     compare_vectors(v1, v2);
 
     fill_vector(v2, T(43));
     compare_vectors(v1, v2, false);
 
-    hpx::vector<T> v3;
+    hpx::partitioned_vector<T> v3;
     v3 = v1;
     compare_vectors(v1, v3);
 
@@ -69,11 +69,11 @@ template <typename T, typename DistPolicy, typename ExPolicy>
 void copy_algo_tests_with_policy(std::size_t size, std::size_t localities,
     DistPolicy const& policy, ExPolicy const& copy_policy)
 {
-    hpx::vector<T> v1(size, policy);
+    hpx::partitioned_vector<T> v1(size, policy);
     fill_vector(v1, T(43));
 
-    hpx::vector<T> v2(size, policy);
-    typename hpx::vector<T>::iterator it =
+    hpx::partitioned_vector<T> v2(size, policy);
+    typename hpx::partitioned_vector<T>::iterator it =
         hpx::parallel::copy(copy_policy, v1.begin(), v1.end(), v2.begin());
     HPX_TEST(it == v2.end());
     compare_vectors(v1, v2);
@@ -83,13 +83,13 @@ template <typename T, typename DistPolicy, typename ExPolicy>
 void copy_algo_tests_with_policy_async(std::size_t size, std::size_t localities,
     DistPolicy const& policy, ExPolicy const& copy_policy)
 {
-    hpx::vector<T> v1(size, policy);
+    hpx::partitioned_vector<T> v1(size, policy);
     fill_vector(v1, T(43));
 
     using hpx::parallel::task;
 
-    hpx::vector<T> v2(size, policy);
-    hpx::future<typename hpx::vector<T>::iterator> f =
+    hpx::partitioned_vector<T> v2(size, policy);
+    hpx::future<typename hpx::partitioned_vector<T>::iterator> f =
         hpx::parallel::copy(copy_policy(task), v1.begin(), v1.end(), v2.begin());
 
     HPX_TEST(f.get() == v2.end());
@@ -100,15 +100,15 @@ template <typename T, typename DistPolicy>
 void copy_tests_with_policy(std::size_t size, std::size_t localities,
     DistPolicy const& policy)
 {
-    hpx::vector<T> v1(size, policy);
+    hpx::partitioned_vector<T> v1(size, policy);
 
-    hpx::vector<T> v2(v1);
+    hpx::partitioned_vector<T> v2(v1);
     compare_vectors(v1, v2);
 
     fill_vector(v2, T(43));
     compare_vectors(v1, v2, false);
 
-    hpx::vector<T> v3;
+    hpx::partitioned_vector<T> v3;
     v3 = v1;
     compare_vectors(v1, v3);
 
@@ -132,17 +132,17 @@ void copy_tests()
     std::vector<hpx::id_type> localities = hpx::find_all_localities();
 
     {
-        hpx::vector<T> v;
+        hpx::partitioned_vector<T> v;
         copy_tests(v);
     }
 
     {
-        hpx::vector<T> v(length);
+        hpx::partitioned_vector<T> v(length);
         copy_tests(v);
     }
 
     {
-        hpx::vector<T> v(length, T(42));
+        hpx::partitioned_vector<T> v(length, T(42));
         copy_tests(v);
     }
 

--- a/tests/unit/component/partitioned_vector_for_each.cpp
+++ b/tests/unit/component/partitioned_vector_for_each.cpp
@@ -4,7 +4,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/vector.hpp>
+#include <hpx/include/partitioned_vector.hpp>
 #include <hpx/include/parallel_for_each.hpp>
 #include <hpx/include/parallel_count.hpp>
 
@@ -12,8 +12,8 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 // Define the vector types to be used.
-HPX_REGISTER_VECTOR(double);
-HPX_REGISTER_VECTOR(int);
+HPX_REGISTER_PARTITIONED_VECTOR(double);
+HPX_REGISTER_PARTITIONED_VECTOR(int);
 
 struct pfo
 {
@@ -46,9 +46,10 @@ struct cmp
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename ExPolicy, typename T>
-void verify_values(ExPolicy && policy, hpx::vector<T> const& v, T const& val)
+void verify_values(ExPolicy && policy, hpx::partitioned_vector<T> const& v,
+    T const& val)
 {
-    typedef typename hpx::vector<T>::const_iterator const_iterator;
+    typedef typename hpx::partitioned_vector<T>::const_iterator const_iterator;
 
     std::size_t size = 0;
 
@@ -62,7 +63,8 @@ void verify_values(ExPolicy && policy, hpx::vector<T> const& v, T const& val)
 }
 
 template <typename ExPolicy, typename T>
-void verify_values_count(ExPolicy && policy, hpx::vector<T> const& v, T const& val)
+void verify_values_count(ExPolicy && policy, hpx::partitioned_vector<T> const& v,
+    T const& val)
 {
     HPX_TEST_EQ(
         std::size_t(hpx::parallel::count(
@@ -75,7 +77,7 @@ void verify_values_count(ExPolicy && policy, hpx::vector<T> const& v, T const& v
 }
 
 template <typename ExPolicy, typename T>
-void test_for_each(ExPolicy && policy, hpx::vector<T>& v, T val)
+void test_for_each(ExPolicy && policy, hpx::partitioned_vector<T>& v, T val)
 {
     verify_values(policy, v, val);
     verify_values_count(policy, v, val);
@@ -87,8 +89,8 @@ void test_for_each(ExPolicy && policy, hpx::vector<T>& v, T val)
 }
 
 template <typename ExPolicy, typename T>
-void verify_values_count_async(ExPolicy && policy, hpx::vector<T> const& v,
-    T const& val)
+void verify_values_count_async(ExPolicy && policy,
+    hpx::partitioned_vector<T> const& v, T const& val)
 {
     HPX_TEST_EQ(
         std::size_t(hpx::parallel::count(
@@ -101,7 +103,7 @@ void verify_values_count_async(ExPolicy && policy, hpx::vector<T> const& v,
 }
 
 template <typename ExPolicy, typename T>
-void test_for_each_async(ExPolicy && policy, hpx::vector<T>& v, T val)
+void test_for_each_async(ExPolicy && policy, hpx::partitioned_vector<T>& v, T val)
 {
     verify_values(policy, v, val);
     verify_values_count_async(policy, v, val);
@@ -119,7 +121,7 @@ void for_each_tests()
     std::size_t const length = 12;
 
     {
-        hpx::vector<T> v;
+        hpx::partitioned_vector<T> v;
         hpx::parallel::for_each(hpx::parallel::seq, v.begin(), v.end(), pfo());
         hpx::parallel::for_each(hpx::parallel::par, v.begin(), v.end(), pfo());
         hpx::parallel::for_each(hpx::parallel::seq(hpx::parallel::task),
@@ -129,7 +131,7 @@ void for_each_tests()
     }
 
     {
-        hpx::vector<T> v(length, T(0));
+        hpx::partitioned_vector<T> v(length, T(0));
         test_for_each(hpx::parallel::seq, v, T(0));
         test_for_each(hpx::parallel::par, v, T(1));
         test_for_each_async(hpx::parallel::seq(hpx::parallel::task), v, T(2));

--- a/tests/unit/component/partitioned_vector_handle_values.cpp
+++ b/tests/unit/component/partitioned_vector_handle_values.cpp
@@ -4,7 +4,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/vector.hpp>
+#include <hpx/include/partitioned_vector.hpp>
 #include <hpx/include/parallel_for_each.hpp>
 
 #include <hpx/util/lightweight_test.hpp>
@@ -15,14 +15,14 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 // Define the vector types to be used.
-HPX_REGISTER_VECTOR(double);
-HPX_REGISTER_VECTOR(int);
+HPX_REGISTER_PARTITIONED_VECTOR(double);
+HPX_REGISTER_PARTITIONED_VECTOR(int);
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename T>
-void fill_vector(hpx::vector<T>& v, T const& val)
+void fill_vector(hpx::partitioned_vector<T>& v, T const& val)
 {
-    typename hpx::vector<T>::iterator it = v.begin(), end = v.end();
+    typename hpx::partitioned_vector<T>::iterator it = v.begin(), end = v.end();
     for (/**/; it != end; ++it)
         *it = val;
 }
@@ -64,7 +64,7 @@ void compare_vectors(Vector const& v1, Vector const& v2,
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename T>
-void handle_values_tests(hpx::vector<T>& v)
+void handle_values_tests(hpx::partitioned_vector<T>& v)
 {
     fill_vector(v, T(42));
 
@@ -81,7 +81,7 @@ void handle_values_tests(hpx::vector<T>& v)
 }
 
 template <typename T>
-void handle_values_tests_distributed_access(hpx::vector<T>& v)
+void handle_values_tests_distributed_access(hpx::partitioned_vector<T>& v)
 {
     fill_vector (v, T(42));
 
@@ -110,12 +110,12 @@ void handle_values_tests_with_policy(std::size_t size, std::size_t localities,
     DistPolicy const& policy)
 {
     {
-        hpx::vector<T> v(size, policy);
+        hpx::partitioned_vector<T> v(size, policy);
         handle_values_tests(v);
     }
 
     {
-        hpx::vector<T> v(size, policy);
+        hpx::partitioned_vector<T> v(size, policy);
         handle_values_tests_distributed_access(v);
     }
 }
@@ -127,15 +127,15 @@ void handle_values_tests()
     std::vector<hpx::id_type> localities = hpx::find_all_localities();
 
     {
-        hpx::vector<T> v(length);
+        hpx::partitioned_vector<T> v(length);
         handle_values_tests(v);
     }
     {
-        hpx::vector<T> v(length);
+        hpx::partitioned_vector<T> v(length);
         handle_values_tests_distributed_access(v);
     }
     {
-        hpx::vector<T> v(length, T(42));
+        hpx::partitioned_vector<T> v(length, T(42));
         handle_values_tests(v);
     }
 

--- a/tests/unit/component/partitioned_vector_iter.cpp
+++ b/tests/unit/component/partitioned_vector_iter.cpp
@@ -4,7 +4,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/vector.hpp>
+#include <hpx/include/partitioned_vector.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <algorithm>
@@ -15,18 +15,19 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 // Define the vector types to be used.
-HPX_REGISTER_VECTOR(double);
-HPX_REGISTER_VECTOR(int);
+HPX_REGISTER_PARTITIONED_VECTOR(double);
+HPX_REGISTER_PARTITIONED_VECTOR(int);
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename T>
-void test_global_iteration(hpx::vector<T>& v, std::size_t size, T const& val)
+void test_global_iteration(hpx::partitioned_vector<T>& v, std::size_t size,
+    T const& val)
 {
-    typedef typename hpx::vector<T>::iterator iterator;
+    typedef typename hpx::partitioned_vector<T>::iterator iterator;
     typedef hpx::traits::segmented_iterator_traits<iterator> traits;
     HPX_TEST(traits::is_segmented_iterator::value);
 
-    typedef typename hpx::vector<T>::const_iterator const_iterator;
+    typedef typename hpx::partitioned_vector<T>::const_iterator const_iterator;
     typedef hpx::traits::segmented_iterator_traits<const_iterator> const_traits;
     HPX_TEST(const_traits::is_segmented_iterator::value);
 
@@ -60,17 +61,17 @@ void test_global_iteration(hpx::vector<T>& v, std::size_t size, T const& val)
 
 // test segmented iteration
 template <typename T>
-void test_segmented_iteration(hpx::vector<T>& v, std::size_t size,
+void test_segmented_iteration(hpx::partitioned_vector<T>& v, std::size_t size,
     std::size_t parts)
 {
-    typedef typename hpx::vector<T>::iterator iterator;
+    typedef typename hpx::partitioned_vector<T>::iterator iterator;
     typedef hpx::traits::segmented_iterator_traits<iterator> traits;
     typedef typename traits::segment_iterator segment_iterator;
     typedef typename traits::local_segment_iterator local_segment_iterator;
     typedef typename traits::local_iterator local_iterator;
     typedef typename traits::local_raw_iterator local_raw_iterator;
 
-    typedef typename hpx::vector<T>::const_iterator const_iterator;
+    typedef typename hpx::partitioned_vector<T>::const_iterator const_iterator;
     typedef hpx::traits::segmented_iterator_traits<const_iterator> const_traits;
     typedef typename const_traits::segment_iterator const_segment_iterator;
     typedef typename const_traits::local_segment_iterator const_local_segment_iterator;
@@ -158,7 +159,8 @@ void test_segmented_iteration(hpx::vector<T>& v, std::size_t size,
         for (const_iterator it = v.cbegin(locality_id); it != end; ++it, ++count)
         {
             std::size_t i = 42;
-            const_local_iterator loc_end = const_traits::end(const_traits::segment(it));
+            const_local_iterator loc_end =
+                const_traits::end(const_traits::segment(it));
             for (const_local_iterator lcit =
                 const_traits::begin(const_traits::segment(it));
                  lcit != loc_end; ++lcit, ++i)
@@ -236,7 +238,7 @@ void trivial_test_without_policy(std::size_t size, char const* prefix)
 
     {
         // create empty vector
-        hpx::vector<T> v;
+        hpx::partitioned_vector<T> v;
 
         test_global_iteration(v, 0, T());
         test_segmented_iteration(v, 0, 0);
@@ -246,10 +248,10 @@ void trivial_test_without_policy(std::size_t size, char const* prefix)
         // create and connect to empty vector
         std::string empty(prefix_ + "empty");
 
-        hpx::vector<T> base;
+        hpx::partitioned_vector<T> base;
         base.register_as_sync(empty);
 
-        hpx::vector<T> v;
+        hpx::partitioned_vector<T> v;
         v.connect_to_sync(empty);
 
         test_global_iteration(v, 0, T());
@@ -258,7 +260,7 @@ void trivial_test_without_policy(std::size_t size, char const* prefix)
 
     {
         // create vector with initial size != 0
-        hpx::vector<T> v(size);
+        hpx::partitioned_vector<T> v(size);
 
         test_global_iteration(v, size, T());
         test_segmented_iteration(v, size, 1);
@@ -268,10 +270,10 @@ void trivial_test_without_policy(std::size_t size, char const* prefix)
         // create vector with initial size != 0
         std::string size_(prefix_ + "size");
 
-        hpx::vector<T> base(size);
+        hpx::partitioned_vector<T> base(size);
         base.register_as_sync(size_);
 
-        hpx::vector<T> v;
+        hpx::partitioned_vector<T> v;
         v.connect_to_sync(size_);
 
         test_global_iteration(v, size, T());
@@ -280,7 +282,7 @@ void trivial_test_without_policy(std::size_t size, char const* prefix)
 
     {
         // create vector with initial size and values
-        hpx::vector<T> v(size, T(999));
+        hpx::partitioned_vector<T> v(size, T(999));
 
         test_global_iteration(v, size, T(999));
         test_segmented_iteration(v, size, 1);
@@ -290,10 +292,10 @@ void trivial_test_without_policy(std::size_t size, char const* prefix)
         // create vector with initial size and values
         std::string size_value(prefix_ + "size_value");
 
-        hpx::vector<T> base(size, T(999));
+        hpx::partitioned_vector<T> base(size, T(999));
         base.register_as_sync(size_value);
 
-        hpx::vector<T> v;
+        hpx::partitioned_vector<T> v;
         v.connect_to_sync(size_value);
 
         test_global_iteration(v, size, T(999));
@@ -308,7 +310,7 @@ void trivial_test_with_policy(std::size_t size, std::size_t parts,
     std::string prefix_(prefix);
 
     {
-        hpx::vector<T> v(size, policy);
+        hpx::partitioned_vector<T> v(size, policy);
 
         test_global_iteration(v, size, T(0));
         test_segmented_iteration(v, size, parts);
@@ -317,10 +319,10 @@ void trivial_test_with_policy(std::size_t size, std::size_t parts,
     {
         std::string policy_(prefix_ + "policy");
 
-        hpx::vector<T> base(size, policy);
+        hpx::partitioned_vector<T> base(size, policy);
         base.register_as_sync(policy_);
 
-        hpx::vector<T> v;
+        hpx::partitioned_vector<T> v;
         v.connect_to_sync(policy_);
 
         test_global_iteration(v, size, T(0));
@@ -328,7 +330,7 @@ void trivial_test_with_policy(std::size_t size, std::size_t parts,
     }
 
     {
-        hpx::vector<T> v(size, T(999), policy);
+        hpx::partitioned_vector<T> v(size, T(999), policy);
 
         test_global_iteration(v, size, T(999));
         test_segmented_iteration(v, size, parts);
@@ -337,10 +339,10 @@ void trivial_test_with_policy(std::size_t size, std::size_t parts,
     {
         std::string policy_value(prefix_ + "policy_value");
 
-        hpx::vector<T> base(size, T(999), policy);
+        hpx::partitioned_vector<T> base(size, T(999), policy);
         base.register_as_sync(policy_value);
 
-        hpx::vector<T> v;
+        hpx::partitioned_vector<T> v;
         v.connect_to_sync(policy_value);
 
         test_global_iteration(v, size, T(999));

--- a/tests/unit/component/partitioned_vector_move.cpp
+++ b/tests/unit/component/partitioned_vector_move.cpp
@@ -4,31 +4,31 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/vector.hpp>
+#include <hpx/include/partitioned_vector.hpp>
 #include <hpx/include/parallel_for_each.hpp>
 
 #include <hpx/util/lightweight_test.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 // Define the vector types to be used.
-HPX_REGISTER_VECTOR(double);
-HPX_REGISTER_VECTOR(int);
+HPX_REGISTER_PARTITIONED_VECTOR(double);
+HPX_REGISTER_PARTITIONED_VECTOR(int);
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename T>
-void fill_vector(hpx::vector<T>& v, T const& val)
+void fill_vector(hpx::partitioned_vector<T>& v, T const& val)
 {
-    typename hpx::vector<T>::iterator it = v.begin(), end = v.end();
+    typename hpx::partitioned_vector<T>::iterator it = v.begin(), end = v.end();
     for (/**/; it != end; ++it)
         *it = val;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename T>
-void compare_vectors(hpx::vector<T> const& v1, hpx::vector<T> const& v2,
-    bool must_be_equal = true)
+void compare_vectors(hpx::partitioned_vector<T> const& v1,
+    hpx::partitioned_vector<T> const& v2, bool must_be_equal = true)
 {
-    typedef typename hpx::vector<T>::const_iterator const_iterator;
+    typedef typename hpx::partitioned_vector<T>::const_iterator const_iterator;
 
     HPX_TEST_EQ(v1.size(), v2.size());
 
@@ -48,22 +48,22 @@ void compare_vectors(hpx::vector<T> const& v1, hpx::vector<T> const& v2,
 }
 
 template <typename T>
-void move_tests(hpx::vector<T> const& v1)
+void move_tests(hpx::partitioned_vector<T> const& v1)
 {
-    hpx::vector<T> v2(v1);
+    hpx::partitioned_vector<T> v2(v1);
     compare_vectors(v1, v2);
 
-    hpx::vector<T> v3(std::move(v2));
+    hpx::partitioned_vector<T> v3(std::move(v2));
     compare_vectors(v1, v3);
 
     fill_vector(v3, T(43));
     compare_vectors(v1, v3, false);
 
-    hpx::vector<T> v4;
+    hpx::partitioned_vector<T> v4;
     v4 = v1;
     compare_vectors(v1, v4);
 
-    hpx::vector<T> v5;
+    hpx::partitioned_vector<T> v5;
     v5 = std::move(v4);
     compare_vectors(v1, v5);
 
@@ -76,22 +76,22 @@ template <typename T, typename DistPolicy>
 void move_tests_with_policy(std::size_t size, std::size_t localities,
     DistPolicy const& policy)
 {
-    hpx::vector<T> v1(size, policy);
+    hpx::partitioned_vector<T> v1(size, policy);
 
-    hpx::vector<T> v2(v1);
+    hpx::partitioned_vector<T> v2(v1);
     compare_vectors(v1, v2);
 
-    hpx::vector<T> v3(std::move(v2));
+    hpx::partitioned_vector<T> v3(std::move(v2));
     compare_vectors(v1, v3);
 
     fill_vector(v3, T(43));
     compare_vectors(v1, v3, false);
 
-    hpx::vector<T> v4;
+    hpx::partitioned_vector<T> v4;
     v4 = v1;
     compare_vectors(v1, v4);
 
-    hpx::vector<T> v5;
+    hpx::partitioned_vector<T> v5;
     v5 = std::move(v4);
     compare_vectors(v1, v5);
 
@@ -107,17 +107,17 @@ void move_tests()
     std::vector<hpx::id_type> localities = hpx::find_all_localities();
 
     {
-        hpx::vector<T> v;
+        hpx::partitioned_vector<T> v;
         move_tests(v);
     }
 
     {
-        hpx::vector<T> v(length);
+        hpx::partitioned_vector<T> v(length);
         move_tests(v);
     }
 
     {
-        hpx::vector<T> v(length, T(42));
+        hpx::partitioned_vector<T> v(length, T(42));
         move_tests(v);
     }
 

--- a/tests/unit/component/partitioned_vector_transform_reduce.cpp
+++ b/tests/unit/component/partitioned_vector_transform_reduce.cpp
@@ -4,7 +4,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/vector.hpp>
+#include <hpx/include/partitioned_vector.hpp>
 #include <hpx/include/parallel_for_each.hpp>
 #include <hpx/include/parallel_transform_reduce.hpp>
 
@@ -14,8 +14,8 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 // Define the vector types to be used.
-HPX_REGISTER_VECTOR(double);
-HPX_REGISTER_VECTOR(int);
+HPX_REGISTER_PARTITIONED_VECTOR(double);
+HPX_REGISTER_PARTITIONED_VECTOR(int);
 
 struct multiply
 {
@@ -30,8 +30,9 @@ struct multiply
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename ExPolicy, typename T>
-T test_transform_reduce(ExPolicy && policy, hpx::vector<T> const& xvalues,
-    hpx::vector<T> const& yvalues)
+T test_transform_reduce(ExPolicy && policy,
+    hpx::partitioned_vector<T> const& xvalues,
+    hpx::partitioned_vector<T> const& yvalues)
 {
     using hpx::util::make_zip_iterator;
     return
@@ -44,8 +45,9 @@ T test_transform_reduce(ExPolicy && policy, hpx::vector<T> const& xvalues,
 
 template <typename ExPolicy, typename T>
 hpx::future<T>
-test_transform_reduce_async(ExPolicy && policy, hpx::vector<T> const& xvalues,
-    hpx::vector<T> const& yvalues)
+test_transform_reduce_async(ExPolicy && policy,
+    hpx::partitioned_vector<T> const& xvalues,
+    hpx::partitioned_vector<T> const& yvalues)
 {
     using hpx::util::make_zip_iterator;
     return
@@ -57,8 +59,9 @@ test_transform_reduce_async(ExPolicy && policy, hpx::vector<T> const& xvalues,
 }
 
 template <typename T>
-void transform_reduce_tests(std::size_t num, hpx::vector<T> const& xvalues,
-    hpx::vector<T> const& yvalues)
+void transform_reduce_tests(std::size_t num,
+    hpx::partitioned_vector<T> const& xvalues,
+    hpx::partitioned_vector<T> const& yvalues)
 {
     HPX_TEST_EQ(
         test_transform_reduce(hpx::parallel::seq, xvalues, yvalues),
@@ -83,15 +86,15 @@ void transform_reduce_tests()
     std::size_t const num = 10007;
 
     {
-        hpx::vector<T> xvalues(num, T(1));
-        hpx::vector<T> yvalues(num, T(1));
+        hpx::partitioned_vector<T> xvalues(num, T(1));
+        hpx::partitioned_vector<T> yvalues(num, T(1));
 
         transform_reduce_tests(num, xvalues, yvalues);
     }
 
     {
-        hpx::vector<T> xvalues(num, T(1), hpx::container_layout(2));
-        hpx::vector<T> yvalues(num, T(1), hpx::container_layout(2));
+        hpx::partitioned_vector<T> xvalues(num, T(1), hpx::container_layout(2));
+        hpx::partitioned_vector<T> yvalues(num, T(1), hpx::container_layout(2));
 
         transform_reduce_tests(num, xvalues, yvalues);
     }

--- a/tools/inspect/length_check.cpp
+++ b/tools/inspect/length_check.cpp
@@ -43,17 +43,33 @@ namespace boost
             limit = setting;
         }
 
+        struct pattern
+        {
+            char const* const rx_;
+            int pos_;
+        };
+
+        static pattern const patterns[] =
+        {
+            { "\\s*#\\s*error", 0 },
+            { "\\s*#\\s*include", 0 },
+            { "https?://", -1 },
+        };
+
         void length_check::inspect(
             const string & library_name,
             const path & full_path,   // ex: c:/foo/boost/filesystem/path.hpp
             const string & contents)     // contents of file to be inspected
         {
-            if (contents.find("hpxinspect:" "length") != string::npos)
+            if (contents.find("hpxinspect:" "linelength") != string::npos)
                 return;
+
             string pathname = full_path.string();
             if (pathname.find("CMakeLists.txt") != string::npos)
                 return;
-            //Temporary, until we are ready to format documentation files in this limitation.
+
+            // Temporary, until we are ready to format documentation files in
+            // this limitation.
             if (library_name.find(".qbk") != string::npos)
                 return;
 
@@ -79,26 +95,29 @@ namespace boost
                     }
                 }
             }
+
             while (p < someline.size())
             {
                 currline++;
                 size_t rend = someline[p].find_last_of("\r");
                 bool check_not = 0;
                 boost::regex error_note, http_note;
-                error_note = "\\s*#\\s*error";
-                http_note = "https?://";
-                boost::smatch m;
-                if (boost::regex_search(someline[p], m, error_note)) //#error
+
+                for (std::size_t i = 0;
+                     i != sizeof(patterns)/sizeof(patterns[0]);
+                     ++i)
                 {
-                    if (m.position() == 0)
+                    boost::regex rx(patterns[i].rx_);
+                    boost::smatch m;
+                    if (boost::regex_search(someline[p], m, rx))
                     {
-                        check_not = 1;
+                        // skip this line if either no position is specified
+                        // or the pattern was found at the given position
+                        if (patterns[i].pos_ == -1 || m.position() == patterns[i].pos_)
+                            check_not = 1;
                     }
                 }
-                else if (boost::regex_search(someline[p], m, http_note)) //http:://
-                {
-                    check_not = 1;
-                }
+
                 size_t size = someline[p].size();
                 if (size > limit && check_not == 0)
                 {
@@ -106,8 +125,9 @@ namespace boost
                     linenum = to_string(currline);
                     lineorder.push_back(linenum);
                 }
-                p++;
+                ++p;
             }
+
             p = 0;
             while (p < lineorder.size())
             {
@@ -120,7 +140,7 @@ namespace boost
             }
             if (errors > 0)
             {
-                string errored = "Character Limit*: " + total;
+                string errored = "Line length limit*: " + total;
                 error(library_name, full_path, errored);
                 ++m_files_with_errors;
             }

--- a/tools/inspect/length_check.hpp
+++ b/tools/inspect/length_check.hpp
@@ -22,8 +22,8 @@ namespace boost
 
             length_check(size_t setting);
 
-            std::string a = "*Character Limit*";
-            std::string b = "The line is larger than the character limit";
+            std::string a = "*Line length limit*";
+            std::string b = "The line is longer than allowed by the character limit";
             virtual const char * name() const { return a.c_str(); }
             virtual const char * desc() const { return b.c_str(); }
 
@@ -34,7 +34,7 @@ namespace boost
 
             virtual void print_summary(std::ostream& out)
             {
-                string c = " files exceeding the character limit";
+                string c = " lines exceeding the character limit";
                 out << "  " << m_files_with_errors << c << line_break();
             }
 


### PR DESCRIPTION
This is  renaming hpx::vector to hpx::deque

- the rationale is that this data structure does not store its elements sequentially
  in memory, but in non-contiguous segments
 