### PR TITLE
Fixing compile problems with apply_colocated

### DIFF
--- a/hpx/runtime/applier/apply_helper.hpp
+++ b/hpx/runtime/applier/apply_helper.hpp
@@ -132,16 +132,28 @@ namespace hpx { namespace applier { namespace detail
         template <typename Continuation, typename ...Ts>
         static void
         call (Continuation && c, naming::id_type const& target,
+            naming::address::address_type lva, threads::thread_priority priority,
+            Ts&&... vs)
+        {
+            std::unique_ptr<actions::continuation> cont(
+                new typename util::decay<Continuation>::type(
+                    std::forward<Continuation>(c)));
+            call(std::move(cont), target, lva, priority, std::forward<Ts>(vs)...);
+        }
+
+        template <typename ...Ts>
+        static void
+        call (std::unique_ptr<actions::continuation> cont, naming::id_type const& target,
             naming::address::address_type lva, threads::thread_priority,
             Ts&&... vs)
         {
             try {
-                c.trigger(Action::execute_function(lva,
+                cont->trigger(Action::execute_function(lva,
                     std::forward<Ts>(vs)...));
             }
             catch (hpx::exception const& /*e*/) {
                 // make sure hpx::exceptions are propagated back to the client
-                c.trigger_error(boost::current_exception());
+                cont->trigger_error(boost::current_exception());
             }
         }
     };

--- a/hpx/runtime/applier/detail/apply_colocated.hpp
+++ b/hpx/runtime/applier/detail/apply_colocated.hpp
@@ -52,7 +52,11 @@ namespace hpx { namespace detail
     }
 
     template <typename Action, typename Continuation, typename ...Ts>
-    bool apply_colocated(Continuation && cont,
+    typename std::enable_if<
+        traits::is_continuation<Continuation>::value
+      , bool
+    >::type
+    apply_colocated(Continuation && cont,
         naming::id_type const& gid, Ts&&... vs)
     {
         // Attach the requested action as a continuation to a resolve_async

--- a/hpx/runtime/applier/detail/apply_colocated_fwd.hpp
+++ b/hpx/runtime/applier/detail/apply_colocated_fwd.hpp
@@ -9,6 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime/actions/action_support.hpp>
+#include <hpx/traits/is_continuation.hpp>
 
 namespace hpx { namespace detail
 {
@@ -24,7 +25,11 @@ namespace hpx { namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Continuation, typename ...Ts>
-    bool apply_colocated(Continuation && cont,
+    typename std::enable_if<
+        traits::is_continuation<Continuation>::value
+      , bool
+    >::type
+    apply_colocated(Continuation && cont,
         naming::id_type const& gid, Ts&&... vs);
 
     template <typename Continuation, typename Component, typename Signature,


### PR DESCRIPTION
Some errors occurred while compiling hpxcl. This patch fixes those.