### PR TITLE
Renaming get_os_thread_count

### DIFF
--- a/hpx/parallel/algorithms/detail/set_operation.hpp
+++ b/hpx/parallel/algorithms/detail/set_operation.hpp
@@ -85,8 +85,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
             new buffer_type[combiner(len1, len2)]);
 
         typedef typename ExPolicy::executor_type executor_type;
-        std::size_t cores = executor_traits<executor_type>::os_thread_count(
-            policy.executor());
+        std::size_t cores = executor_traits<executor_type>::
+            processing_units_count(policy.executor(), policy.parameters());
+
         std::size_t step = (len1 + cores - 1) / cores;
         boost::shared_array<set_chunk_data> chunks(new set_chunk_data[cores]);
 

--- a/hpx/parallel/executors/auto_chunk_size.hpp
+++ b/hpx/parallel/executors/auto_chunk_size.hpp
@@ -60,7 +60,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         std::size_t get_chunk_size(Executor& exec, F && f, std::size_t count)
         {
             std::size_t const cores =
-                executor_traits<Executor>::os_thread_count(exec);
+                executor_traits<Executor>::processing_units_count(exec, *this);
 
             if (count > 100*cores)
             {

--- a/hpx/parallel/executors/executor_parameter_traits.hpp
+++ b/hpx/parallel/executors/executor_parameter_traits.hpp
@@ -49,6 +49,29 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         };
 
         ///////////////////////////////////////////////////////////////////////
+        struct processing_units_count_parameter_helper
+        {
+            template <typename Parameters>
+            static std::size_t call(wrap_int, Parameters& params)
+            {
+                return hpx::get_os_thread_count();
+            }
+
+            template <typename Parameters>
+            static auto call(int, Parameters& params)
+            ->  decltype(params.processing_units_count())
+            {
+                return params.processing_units_count();
+            }
+        };
+
+        template <typename Parameters>
+        std::size_t call_processing_units_parameter_count(Parameters& params)
+        {
+            return processing_units_count_parameter_helper::call(0, params);
+        }
+
+        ///////////////////////////////////////////////////////////////////////
         struct variable_chunk_size_helper
         {
             template <typename Parameters, typename Executor>
@@ -152,6 +175,24 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         {
             return detail::call_get_chunk_size(params, exec,
                 std::forward<F>(f), num_tasks);
+        }
+
+        /// Retrieve the number of (kernel-)threads used by the associated
+        /// executor.
+        ///
+        /// \param exec  [in] The executor object to use for scheduling of the
+        ///              function \a f.
+        /// \param params [in] The executor parameters object to use as a
+        ///              fallback if the executor does not expose
+        ///
+        /// \note This calls exec.processing_units_count() if it exists;
+        ///       otherwise it forwards teh request to the executor parameters
+        ///       object.
+        ///
+        static std::size_t processing_units_count(
+            executor_parameters_type& params)
+        {
+            return detail::call_processing_units_parameter_count(params);
         }
     };
 

--- a/hpx/parallel/executors/executor_traits.hpp
+++ b/hpx/parallel/executors/executor_traits.hpp
@@ -350,26 +350,31 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         }
 
         ///////////////////////////////////////////////////////////////////////
-        struct os_thread_count_helper
+        template <typename Parameters>
+        std::size_t call_processing_units_parameter_count(Parameters& params);
+
+        struct processing_units_count_helper
         {
-            template <typename Executor>
-            static std::size_t call(wrap_int, Executor& exec)
+            template <typename Executor, typename Parameters>
+            static std::size_t call(wrap_int, Executor& exec,
+                Parameters& params)
             {
-                return hpx::get_os_thread_count();
+                return call_processing_units_parameter_count(params);
             }
 
-            template <typename Executor>
-            static auto call(int, Executor& exec)
-            ->  decltype(exec.os_thread_count())
+            template <typename Executor, typename Parameters>
+            static auto call(int, Executor& exec, Parameters& params)
+            ->  decltype(exec.processing_units_count(params))
             {
-                return exec.os_thread_count();
+                return exec.processing_units_count(params);
             }
         };
 
-        template <typename Executor>
-        std::size_t call_os_thread_count(Executor& exec)
+        template <typename Executor, typename Parameters>
+        std::size_t call_processing_units_count(Executor& exec,
+            Parameters& params)
         {
-            return os_thread_count_helper::call(0, exec);
+            return processing_units_count_helper::call(0, exec, params);
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -611,13 +616,18 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         ///
         /// \param exec  [in] The executor object to use for scheduling of the
         ///              function \a f.
+        /// \param params [in] The executor parameters object to use as a
+        ///              fallback if the executor does not expose
         ///
-        /// \note This calls exec.os_thread_count() if it exists;
-        ///       otherwise it executes hpx::get_os_thread_count().
+        /// \note This calls exec.processing_units_count() if it exists;
+        ///       otherwise it forwards teh request to the executor parameters
+        ///       object.
         ///
-        static std::size_t os_thread_count(executor_type const& exec)
+        template <typename Parameters>
+        static std::size_t processing_units_count(executor_type const& exec,
+            Parameters& params)
         {
-            return detail::call_os_thread_count(exec);
+            return detail::call_processing_units_count(exec, params);
         }
 
         /// Retrieve whether this executor has operations pending or not.

--- a/hpx/parallel/executors/guided_chunk_size.hpp
+++ b/hpx/parallel/executors/guided_chunk_size.hpp
@@ -59,7 +59,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         std::size_t get_chunk_size(Executor& exec, F &&, std::size_t num_tasks)
         {
             std::size_t const cores =
-                executor_traits<Executor>::os_thread_count(exec);
+                executor_traits<Executor>::processing_units_count(exec, *this);
             std::size_t chunk = (num_tasks + cores - 1) / cores;
 
             return (std::max)(min_chunk_size_, chunk);

--- a/hpx/parallel/executors/sequential_executor.hpp
+++ b/hpx/parallel/executors/sequential_executor.hpp
@@ -112,7 +112,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
                 bulk_async_execute(std::forward<F>(f), shape));
         }
 
-        std::size_t os_thread_count()
+        std::size_t processing_units_count()
         {
             return 1;
         }

--- a/hpx/parallel/executors/static_chunk_size.hpp
+++ b/hpx/parallel/executors/static_chunk_size.hpp
@@ -59,7 +59,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
             // by default use static work distribution over number of
             // available compute resources
             std::size_t const cores = executor_traits<Executor>::
-                os_thread_count(exec);
+                processing_units_count(exec, *this);
 
             return (num_tasks + cores - 1) / cores;
         }

--- a/hpx/parallel/executors/thread_executor_traits.hpp
+++ b/hpx/parallel/executors/thread_executor_traits.hpp
@@ -202,7 +202,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         /// \note This calls exec.os_thread_count() if it exists;
         ///       otherwise it executes hpx::get_os_thread_count().
         ///
-        static std::size_t os_thread_count(executor_type const& sched)
+        static std::size_t processing_units_count(executor_type const& sched)
         {
             return hpx::get_os_thread_count(sched);
         }

--- a/hpx/parallel/util/detail/chunk_size.hpp
+++ b/hpx/parallel/util/detail/chunk_size.hpp
@@ -58,7 +58,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail
 
         typedef typename ExPolicy::executor_type executor_type;
         std::size_t const cores = executor_traits<executor_type>::
-            os_thread_count(policy.executor());
+            processing_units_count(policy.executor(), policy.parameters());
 
         bool variable_chunk_sizes = traits::variable_chunk_size(
             policy.parameters(), policy.executor());

--- a/tests/unit/parallel/executors/minimal_sync_executor.cpp
+++ b/tests/unit/parallel/executors/minimal_sync_executor.cpp
@@ -128,7 +128,7 @@ struct test_sync_executor2 : hpx::parallel::executor_tag
         return hpx::async(hpx::launch::sync, std::forward<F>(f));
     }
 
-    std::size_t os_thread_count()
+    std::size_t processing_units_count()
     {
         return 1;
     }

--- a/tests/unit/parallel/executors/minimal_timed_sync_executor.cpp
+++ b/tests/unit/parallel/executors/minimal_timed_sync_executor.cpp
@@ -129,7 +129,7 @@ struct test_timed_async_executor2 : hpx::parallel::timed_executor_tag
         return hpx::async(hpx::launch::sync, std::forward<F>(f));
     }
 
-    std::size_t os_thread_count()
+    std::size_t processing_units_count()
     {
         return 1;
     }


### PR DESCRIPTION
- this also enables the possibility to customize the max number of processing units to use for a particular algorithm through the supplied executor parameters object.