### PR TITLE
Fixed #1688: Add timer counters for tfunc_total and exec_total

### DIFF
--- a/src/runtime/threads/detail/thread_pool.cpp
+++ b/src/runtime/threads/detail/thread_pool.cpp
@@ -770,7 +770,7 @@ namespace hpx { namespace threads { namespace detail
             if (reset) {
                 tfunc_times_[num] = boost::uint64_t(-1);
             }
-            return boost::uint64_t(exec_total * timestamp_scale_);
+            return boost::uint64_t(exec_total * timestamp_scale_ * 1e-9);
         }
 
         double exec_total = std::accumulate(exec_times_.begin(),
@@ -780,7 +780,7 @@ namespace hpx { namespace threads { namespace detail
             std::fill(tfunc_times_.begin(), tfunc_times_.end(),
                 boost::uint64_t(-1));
         }
-        return boost::uint64_t(exec_total * timestamp_scale_);
+        return boost::uint64_t(exec_total * timestamp_scale_ * 1e-9);
     }
 
     template <typename Scheduler>
@@ -794,7 +794,8 @@ namespace hpx { namespace threads { namespace detail
             if (reset) {
                 tfunc_times_[num] = boost::uint64_t(-1);
             }
-            return boost::uint64_t((tfunc_total - exec_total) * timestamp_scale_);
+            return boost::uint64_t(
+                (tfunc_total - exec_total) * timestamp_scale_ * 1e-9);
         }
 
         double exec_total = std::accumulate(exec_times_.begin(),
@@ -807,7 +808,8 @@ namespace hpx { namespace threads { namespace detail
             std::fill(tfunc_times_.begin(), tfunc_times_.end(),
                 boost::uint64_t(-1));
         }
-        return boost::uint64_t((tfunc_total - exec_total) * timestamp_scale_);
+        return boost::uint64_t(
+            (tfunc_total - exec_total) * timestamp_scale_ * 1e-9);
     }
 #endif
 #endif

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -1273,13 +1273,13 @@ namespace hpx { namespace threads
               "returns the cumulative time spent executing HPX-threads",
               HPX_PERFORMANCE_COUNTER_V1, counts_creator,
               &performance_counters::locality_thread_counter_discoverer,
-              "ns"
+              "s"
             },
             { "/threads/time/cumulative-overhead", performance_counters::counter_raw,
               "returns the cumulative overhead time incurred by executing HPX threads",
               HPX_PERFORMANCE_COUNTER_V1, counts_creator,
               &performance_counters::locality_thread_counter_discoverer,
-              "ns"
+              "s"
             },
 #endif
 #endif


### PR DESCRIPTION
- making returned times be measured in seconds (not ns)