### PR TITLE
added convenience c-tor and begin()/end() to serialize_buffer

### DIFF
--- a/hpx/runtime/serialization/serialize_buffer.hpp
+++ b/hpx/runtime/serialization/serialize_buffer.hpp
@@ -59,7 +59,10 @@ namespace hpx { namespace serialization
           , size_(size)
           , alloc_(alloc)
         {
-            data_.reset(alloc_.allocate(size));
+            using util::placeholders::_1;
+            data_.reset(alloc_.allocate(size),
+                        util::bind(&serialize_buffer::deleter<allocator_type>,
+                                   _1, alloc_, size_));
         }
 
         // The default mode is 'copy' which is consistent with the constructor

--- a/hpx/runtime/serialization/serialize_buffer.hpp
+++ b/hpx/runtime/serialization/serialize_buffer.hpp
@@ -201,6 +201,7 @@ namespace hpx { namespace serialization
           , alloc_(alloc)
         {
             if (mode == copy) {
+                using util::placeholders::_1;
                 data_.reset(alloc_.allocate(size),
                     util::bind(&serialize_buffer::deleter<allocator_type>,
                         _1, alloc_, size_));

--- a/hpx/runtime/serialization/serialize_buffer.hpp
+++ b/hpx/runtime/serialization/serialize_buffer.hpp
@@ -57,7 +57,8 @@ namespace hpx { namespace serialization
           , alloc_(alloc)
         {}
 
-        explicit serialize_buffer(std::size_t size, allocator_type const& alloc = allocator_type())
+        explicit serialize_buffer(std::size_t size,
+                allocator_type const& alloc = allocator_type())
           : data_(alloc.allocate(size))
           , size_(size)
           , alloc_(alloc)

--- a/hpx/runtime/serialization/serialize_buffer.hpp
+++ b/hpx/runtime/serialization/serialize_buffer.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2013-2014 Hartmut Kaiser
-//  Copyright (c) 2015 Andreas Schäfer
+//  Copyright (c) 2015 Andreas Schaefer
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/hpx/runtime/serialization/serialize_buffer.hpp
+++ b/hpx/runtime/serialization/serialize_buffer.hpp
@@ -57,6 +57,12 @@ namespace hpx { namespace serialization
           , alloc_(alloc)
         {}
 
+        explicit serialize_buffer(std::size_t size, allocator_type const& alloc = allocator_type())
+          : data_(alloc.allocate(size))
+          , size_(size)
+          , alloc_(alloc)
+        {}
+
         // The default mode is 'copy' which is consistent with the constructor
         // taking a T const * below.
         serialize_buffer (T* data, std::size_t size, init_mode mode = copy,
@@ -216,6 +222,9 @@ namespace hpx { namespace serialization
         T* data() { return data_.get(); }
         T const* data() const { return data_.get(); }
 
+        T* begin() { return data(); }
+        T* end() { return data() + size_; }
+
         T& operator[](std::size_t idx) { return data_[idx]; }
         T operator[](std::size_t idx) const { return data_[idx]; }
 
@@ -297,6 +306,11 @@ namespace hpx { namespace serialization
 
         serialize_buffer()
           : size_(0)
+        {}
+
+        explicit serialize_buffer(std::size_t size)
+          : data_(new T[size])
+          , size_(size)
         {}
 
         // The default mode is 'copy' which is consistent with the constructor
@@ -396,6 +410,9 @@ namespace hpx { namespace serialization
         // accessors enabling data access
         T* data() { return data_.get(); }
         T const* data() const { return data_.get(); }
+
+        T* begin() { return data(); }
+        T* end() { return data() + size_; }
 
         T& operator[](std::size_t idx) { return data_[idx]; }
         T operator[](std::size_t idx) const { return data_[idx]; }

--- a/hpx/runtime/serialization/serialize_buffer.hpp
+++ b/hpx/runtime/serialization/serialize_buffer.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2013-2014 Hartmut Kaiser
+//  Copyright (c) 2015 Andreas Schäfer
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -20,13 +21,8 @@
 
 namespace hpx { namespace serialization
 {
-    namespace detail
-    {
-        struct serialize_buffer_no_allocator {};
-    }
-
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T, typename Allocator = detail::serialize_buffer_no_allocator>
+    template <typename T, typename Allocator = std::allocator<T> >
     class serialize_buffer
     {
     private:
@@ -59,10 +55,12 @@ namespace hpx { namespace serialization
 
         explicit serialize_buffer(std::size_t size,
                 allocator_type const& alloc = allocator_type())
-          : data_(alloc.allocate(size))
+          : data_()
           , size_(size)
           , alloc_(alloc)
-        {}
+        {
+            data_.reset(alloc_.allocate(size));
+        }
 
         // The default mode is 'copy' which is consistent with the constructor
         // taking a T const * below.
@@ -279,190 +277,6 @@ namespace hpx { namespace serialization
         boost::shared_array<T> data_;
         std::size_t size_;
         Allocator alloc_;
-    };
-
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename T>
-    class serialize_buffer<T, detail::serialize_buffer_no_allocator>
-    {
-    private:
-        static void no_deleter(T*) {}
-
-        static void array_delete(T * x)
-        {
-            delete [] x;
-        }
-
-    public:
-        enum init_mode
-        {
-            copy = 0,       // constructor copies data
-            reference = 1,  // constructor does not copy data and does not
-                            // manage the lifetime of it
-            take = 2        // constructor does not copy data but does take
-                            // ownership and manages the lifetime of it
-         };
-
-        typedef T value_type;
-
-        serialize_buffer()
-          : size_(0)
-        {}
-
-        explicit serialize_buffer(std::size_t size)
-          : data_(new T[size])
-          , size_(size)
-        {}
-
-        // The default mode is 'copy' which is consistent with the constructor
-        // taking a T const * below.
-        serialize_buffer (T* data, std::size_t size, init_mode mode = copy)
-          : data_(), size_(size)
-        {
-            if (mode == copy) {
-                data_ = boost::shared_array<T>(data,
-                    &serialize_buffer::array_delete);
-                if (size != 0)
-                    std::copy(data, data + size, data_.get());
-            }
-            else if (mode == reference) {
-                data_ = boost::shared_array<T>(data,
-                    &serialize_buffer::no_deleter);
-            }
-            else {
-                // take ownership
-                data_ = boost::shared_array<T>(data,
-                    &serialize_buffer::array_delete);
-            }
-        }
-
-        template <typename Deleter>
-        serialize_buffer (T* data, std::size_t size, init_mode mode,
-                Deleter const& deleter)
-          : data_(), size_(size)
-        {
-            if (mode == copy) {
-                data_.reset(new T[size], deleter);
-                if (size != 0)
-                    std::copy(data, data + size, data_.get());
-            }
-            else {
-                // reference or take ownership, behavior is defined by deleter
-                data_ = boost::shared_array<T>(data, deleter);
-            }
-        }
-
-        template <typename Deleter>
-        serialize_buffer (T const* data, std::size_t size, init_mode mode,
-                Deleter const& deleter)
-          : data_(), size_(size)
-        {
-            if (mode == copy) {
-                data_.reset(new T[size], deleter);
-                if (size != 0)
-                    std::copy(data, data + size, data_.get());
-            }
-            else if (mode == reference) {
-                data_ = boost::shared_array<T>(const_cast<T*>(data), deleter);
-            }
-            else {
-                // can't take ownership of const buffer
-                HPX_THROW_EXCEPTION(bad_parameter,
-                    "serialize_buffer::serialize_buffer",
-                    "can't take ownership of const data");
-            }
-        }
-
-        // same set of constructors, but taking const data
-        serialize_buffer (T const* data, std::size_t size,
-                init_mode mode = copy)
-          : data_(), size_(size)
-        {
-            if (mode == copy) {
-                data_ = boost::shared_array<T>(new T[size],
-                    &serialize_buffer::array_delete);
-                if (size != 0)
-                    std::copy(data, data + size, data_.get());
-            }
-            else if (mode == reference) {
-                data_ = boost::shared_array<T>(
-                    const_cast<T*>(data),
-                    &serialize_buffer::no_deleter);
-            }
-            else {
-                // can't take ownership of const buffer
-                HPX_THROW_EXCEPTION(bad_parameter,
-                    "serialize_buffer::serialize_buffer",
-                    "can't take ownership of const data");
-            }
-        }
-
-        template <typename Deleter>
-        serialize_buffer (T const* data, std::size_t size,
-                Deleter const& deleter)
-          : data_(), size_(size)
-        {
-            // create from const data implies 'copy' mode
-            data_.reset(new T[size], deleter);
-            if (size != 0)
-                std::copy(data, data + size, data_.get());
-        }
-
-        // accessors enabling data access
-        T* data() { return data_.get(); }
-        T const* data() const { return data_.get(); }
-
-        T* begin() { return data(); }
-        T* end() { return data() + size_; }
-
-        T& operator[](std::size_t idx) { return data_[idx]; }
-        T operator[](std::size_t idx) const { return data_[idx]; }
-
-        boost::shared_array<T> data_array() const { return data_; }
-
-        std::size_t size() const { return size_; }
-
-    private:
-        // serialization support
-        friend class hpx::serialization::access;
-
-        ///////////////////////////////////////////////////////////////////////
-        template <typename Archive>
-        void save(Archive& ar, const unsigned int version) const
-        {
-            ar << size_; //-V128
-
-            if (size_ != 0)
-            {
-                ar << hpx::serialization::make_array(data_.get(), size_);
-            }
-        }
-
-        ///////////////////////////////////////////////////////////////////////
-        template <typename Archive>
-        void load(Archive& ar, const unsigned int version)
-        {
-            ar >> size_; //-V128
-            data_.reset(new T[size_]);
-
-            if (size_ != 0)
-            {
-                ar >> hpx::serialization::make_array(data_.get(), size_);
-            }
-        }
-
-        HPX_SERIALIZATION_SPLIT_MEMBER()
-
-        // this is needed for util::any
-        friend bool
-        operator==(serialize_buffer const& rhs, serialize_buffer const& lhs)
-        {
-            return rhs.data_.get() == lhs.data_.get() && rhs.size_ == lhs.size_;
-        }
-
-    private:
-        boost::shared_array<T> data_;
-        std::size_t size_;
     };
 }}
 

--- a/tests/unit/serialization/serialize_buffer.cpp
+++ b/tests/unit/serialization/serialize_buffer.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014 Hartmut Kaiser
+//  Copyright (c) 2015 Andreas Schäfer
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -23,21 +24,6 @@ HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(
     buffer_plain_type, serialization_buffer_char);
 HPX_REGISTER_BASE_LCO_WITH_VALUE(
     buffer_plain_type, serialization_buffer_char);
-
-///////////////////////////////////////////////////////////////////////////////
-typedef hpx::serialization::serialize_buffer<char, std::allocator<char> >
-    buffer_allocator_type;
-
-buffer_allocator_type bounce_allocator(buffer_allocator_type const& receive_buffer)
-{
-    return receive_buffer;
-}
-HPX_PLAIN_ACTION(bounce_allocator);
-
-HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(
-    buffer_allocator_type, serialization_buffer_char_allocator);
-HPX_REGISTER_BASE_LCO_WITH_VALUE(
-    buffer_allocator_type, serialization_buffer_char_allocator);
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename Buffer, typename Action>
@@ -69,13 +55,13 @@ template <typename Allocator>
 void test_stateful_allocator(hpx::id_type dest, char* send_buffer,
     std::size_t size, Allocator const& alloc)
 {
-    typedef buffer_allocator_type buffer_type;
+    typedef buffer_plain_type buffer_type;
     buffer_type recv_buffer;
 
     std::vector<hpx::future<buffer_type> > recv_buffers;
     recv_buffers.reserve(10);
 
-    bounce_allocator_action act;
+    bounce_plain_action act;
     for(std::size_t j = 0; j != 10; ++j)
     {
         recv_buffers.push_back(hpx::async(act, dest,
@@ -124,8 +110,6 @@ int hpx_main(int argc, char* argv[])
         for (std::size_t size = 1; size <= max_size; size *= 2)
         {
             test<buffer_plain_type, bounce_plain_action>(
-                loc, send_buffer.get(), size);
-            test<buffer_allocator_type, bounce_allocator_action>(
                 loc, send_buffer.get(), size);
             test_stateful_allocator(
                 loc, send_buffer.get(), size, std::allocator<char>());

--- a/tests/unit/serialization/serialize_buffer.cpp
+++ b/tests/unit/serialization/serialize_buffer.cpp
@@ -99,6 +99,29 @@ void test_fixed_size_initialization_for_persistent_buffers(std::size_t max_size)
     }
 }
 
+template <typename T>
+void test_initialization_from_vector(std::size_t max_size)
+{
+    for (std::size_t size = 1; size <= max_size; size *= 2)
+    {
+        std::vector<T> send_vec;
+        std::vector<T> recv_vec;
+        send_vec.reserve(size);
+        for (std::size_t i = 0; i < size; ++i) {
+            send_vec.push_back(size - i);
+        }
+
+        // default init mode is "copy"
+        hpx::serialization::serialize_buffer<T> send_buffer(send_vec[0], send_vec.size());
+        hpx::serialization::serialize_buffer<T> recv_buffer;
+        std::copy(send_vec.begin(), send_vec.end(), send_buffer.begin());
+        recv_buffer = send_buffer;
+
+        std::copy(recv_buffer.begin(), recv_buffer.end(), std::back_inserter(recv_vec));
+        HPX_TEST(send_vec == recv_vec);
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {

--- a/tests/unit/serialization/serialize_buffer.cpp
+++ b/tests/unit/serialization/serialize_buffer.cpp
@@ -91,6 +91,28 @@ void test_stateful_allocator(hpx::id_type dest, char* send_buffer,
     }
 }
 
+template <typename T>
+void test_fixed_size_initialization_for_persistent_buffers(std::size_t max_size)
+{
+    for (std::size_t size = 1; size <= max_size; size *= 2)
+    {
+        std::vector<T> send_vec;
+        std::vector<T> recv_vec;
+        send_vec.reserve(size);
+        for (std::size_t i = 0; i < size; ++i) {
+            send_vec.push_back(size - i);
+        }
+
+        hpx::serialization::serialize_buffer<T> send_buffer(size);
+        hpx::serialization::serialize_buffer<T> recv_buffer;
+        std::copy(send_vec.begin(), send_vec.end(), send_buffer.begin());
+        recv_buffer = send_buffer;
+
+        std::copy(recv_buffer.begin(), recv_buffer.end(), std::back_inserter(recv_vec));
+        HPX_TEST(send_vec == recv_vec);
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
@@ -108,6 +130,14 @@ int hpx_main(int argc, char* argv[])
             test_stateful_allocator(
                 loc, send_buffer.get(), size, std::allocator<char>());
         }
+    }
+
+    for (std::size_t size = 1; size <= max_size; size *= 2)
+    {
+        test_fixed_size_initialization_for_persistent_buffers<int>(size);
+        test_fixed_size_initialization_for_persistent_buffers<char>(size);
+        test_fixed_size_initialization_for_persistent_buffers<float>(size);
+        test_fixed_size_initialization_for_persistent_buffers<double>(size);
     }
 
     return hpx::finalize();

--- a/tests/unit/serialization/serialize_buffer.cpp
+++ b/tests/unit/serialization/serialize_buffer.cpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2014 Hartmut Kaiser
-//  Copyright (c) 2015 Andreas Schäfer
+//  Copyright (c) 2015 Andreas Schaefer
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)


### PR DESCRIPTION
While testing my changes I realized that of the two nearly identical implementations found in serialize_buffer.hpp, each was working only partially. I removed the duplication and fixed related bugs.