### PR TITLE
Fixing when_all when only a single future is passed.

### DIFF
--- a/hpx/lcos/when_all.hpp
+++ b/hpx/lcos/when_all.hpp
@@ -174,8 +174,8 @@ namespace hpx { namespace lcos
 
         template <typename T>
         struct when_all_result<util::tuple<T>,
-            typename util::always_void<
-                typename traits::is_future_range<T>::type
+            typename std::enable_if<
+                traits::is_future_range<T>::value
             >::type>
         {
             typedef T type;
@@ -432,9 +432,9 @@ namespace hpx { namespace lcos
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename... Ts>
-    lcos::future<
+    typename detail::when_all_frame<
         hpx::util::tuple<typename traits::acquire_future<Ts>::type...>
-    >
+    >::type
     when_all(Ts&&... ts)
     {
         typedef hpx::util::tuple<

--- a/tests/unit/lcos/when_all.cpp
+++ b/tests/unit/lcos/when_all.cpp
@@ -73,6 +73,24 @@ void test_wait_for_all_from_list_iterators()
     }
 }
 
+void test_wait_for_all_one_future()
+{
+    hpx::lcos::local::futures_factory<int()> pt1(make_int_slowly);
+    hpx::lcos::future<int> f1 = pt1.get_future();
+    pt1.apply();
+
+    typedef hpx::util::tuple<
+        hpx::lcos::future<int> > result_type;
+    hpx::lcos::future<result_type> r =
+        hpx::when_all(f1);
+
+    result_type result = r.get();
+
+    HPX_TEST(!f1.valid());
+
+    HPX_TEST(hpx::util::get<0>(result).is_ready());
+}
+
 void test_wait_for_all_two_futures()
 {
     hpx::lcos::local::futures_factory<int()> pt1(make_int_slowly);
@@ -259,6 +277,7 @@ int hpx_main(variables_map&)
     {
         test_wait_for_all_from_list();
         test_wait_for_all_from_list_iterators();
+        test_wait_for_all_one_future();
         test_wait_for_all_two_futures();
         test_wait_for_all_three_futures();
         test_wait_for_all_four_futures();


### PR DESCRIPTION
when_all did not compile in a case like this:
future<T> f = ...;
when_all(f);
as the wrong result type was computed. A testcase has been added

The testcase and prior failure can be observed here:
https://gist.github.com/sithhell/2f37e44994e596677575