### PR TITLE
Tuple dependencies

### DIFF
--- a/hpx/components/iostreams/server/output_stream.hpp
+++ b/hpx/components/iostreams/server/output_stream.hpp
@@ -8,8 +8,9 @@
 #define HPX_4AFE0EEA_49F8_4F4C_8945_7B55BF395DA0
 
 #include <hpx/hpx_fwd.hpp>
-#include <hpx/runtime/components/server/managed_component_base.hpp>
 #include <hpx/runtime/actions/component_action.hpp>
+#include <hpx/runtime/components/server/managed_component_base.hpp>
+#include <hpx/runtime/serialization/vector.hpp>
 
 #include <hpx/components/iostreams/export_definitions.hpp>
 #include <hpx/components/iostreams/write_functions.hpp>

--- a/hpx/runtime/actions/transfer_action.hpp
+++ b/hpx/runtime/actions/transfer_action.hpp
@@ -16,7 +16,6 @@
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
 #include <hpx/runtime/threads/thread_init_data.hpp>
-#include <hpx/runtime/serialization/serialize_sequence.hpp>
 #include <hpx/runtime/serialization/output_archive.hpp>
 #include <hpx/runtime/serialization/input_archive.hpp>
 #include <hpx/runtime/serialization/base_object.hpp>
@@ -382,7 +381,7 @@ namespace hpx { namespace actions
         // loading ...
         void serialize(hpx::serialization::input_archive & ar)
         {
-            serialization::serialize_sequence(ar, arguments_);
+            ar >> arguments_;
 
             // Always serialize the parent information to maintain binary
             // compatibility on the wire.
@@ -402,7 +401,7 @@ namespace hpx { namespace actions
         // saving ...
         void serialize(hpx::serialization::output_archive & ar)
         {
-            serialization::serialize_sequence(ar, arguments_);
+            ar << arguments_;
 
             // Always serialize the parent information to maintain binary
             // compatibility on the wire.

--- a/hpx/runtime/agas/component_namespace.hpp
+++ b/hpx/runtime/agas/component_namespace.hpp
@@ -10,6 +10,7 @@
 
 #include <hpx/include/client.hpp>
 #include <hpx/runtime/agas/stubs/component_namespace.hpp>
+#include <hpx/runtime/serialization/vector.hpp>
 
 namespace hpx { namespace agas
 {

--- a/hpx/runtime/agas/locality_namespace.hpp
+++ b/hpx/runtime/agas/locality_namespace.hpp
@@ -11,6 +11,7 @@
 
 #include <hpx/include/client.hpp>
 #include <hpx/runtime/agas/stubs/locality_namespace.hpp>
+#include <hpx/runtime/serialization/vector.hpp>
 
 namespace hpx { namespace agas
 {

--- a/hpx/runtime/agas/primary_namespace.hpp
+++ b/hpx/runtime/agas/primary_namespace.hpp
@@ -10,6 +10,7 @@
 
 #include <hpx/include/client.hpp>
 #include <hpx/runtime/agas/stubs/primary_namespace.hpp>
+#include <hpx/runtime/serialization/vector.hpp>
 
 namespace hpx { namespace agas
 {

--- a/hpx/runtime/agas/server/component_namespace.hpp
+++ b/hpx/runtime/agas/server/component_namespace.hpp
@@ -16,6 +16,7 @@
 #include <hpx/runtime/agas/namespace_action_code.hpp>
 #include <hpx/runtime/components/component_type.hpp>
 #include <hpx/runtime/components/server/fixed_component_base.hpp>
+#include <hpx/runtime/serialization/vector.hpp>
 #include <hpx/util/insert_checked.hpp>
 #include <hpx/util/logging.hpp>
 #include <hpx/util/function.hpp>

--- a/hpx/runtime/agas/server/locality_namespace.hpp
+++ b/hpx/runtime/agas/server/locality_namespace.hpp
@@ -18,6 +18,7 @@
 #include <hpx/runtime/components/component_type.hpp>
 #include <hpx/runtime/components/server/fixed_component_base.hpp>
 #include <hpx/runtime/parcelset/locality.hpp>
+#include <hpx/runtime/serialization/vector.hpp>
 #include <hpx/util/insert_checked.hpp>
 #include <hpx/util/logging.hpp>
 #include <hpx/util/high_resolution_clock.hpp>

--- a/hpx/runtime/agas/server/primary_namespace.hpp
+++ b/hpx/runtime/agas/server/primary_namespace.hpp
@@ -17,6 +17,7 @@
 #include <hpx/runtime/agas/namespace_action_code.hpp>
 #include <hpx/runtime/components/component_type.hpp>
 #include <hpx/runtime/components/server/fixed_component_base.hpp>
+#include <hpx/runtime/serialization/vector.hpp>
 #include <hpx/util/insert_checked.hpp>
 #include <hpx/util/logging.hpp>
 #include <hpx/util/high_resolution_clock.hpp>

--- a/hpx/runtime/agas/server/symbol_namespace.hpp
+++ b/hpx/runtime/agas/server/symbol_namespace.hpp
@@ -15,6 +15,7 @@
 #include <hpx/runtime/agas/namespace_action_code.hpp>
 #include <hpx/runtime/components/component_type.hpp>
 #include <hpx/runtime/components/server/fixed_component_base.hpp>
+#include <hpx/runtime/serialization/vector.hpp>
 #include <hpx/util/insert_checked.hpp>
 #include <hpx/util/logging.hpp>
 #include <hpx/util/function.hpp>

--- a/hpx/runtime/agas/symbol_namespace.hpp
+++ b/hpx/runtime/agas/symbol_namespace.hpp
@@ -10,6 +10,7 @@
 
 #include <hpx/include/client.hpp>
 #include <hpx/runtime/agas/stubs/symbol_namespace.hpp>
+#include <hpx/runtime/serialization/vector.hpp>
 
 namespace hpx { namespace agas
 {

--- a/hpx/runtime/parcelset/locality.hpp
+++ b/hpx/runtime/parcelset/locality.hpp
@@ -12,6 +12,7 @@
 
 #include <hpx/hpx_fwd.hpp>
 #include <hpx/exception.hpp>
+#include <hpx/runtime/serialization/map.hpp>
 #include <hpx/util/safe_bool.hpp>
 
 #include <boost/config.hpp>

--- a/hpx/runtime/serialization/detail/polymorphic_intrusive_factory.hpp
+++ b/hpx/runtime/serialization/detail/polymorphic_intrusive_factory.hpp
@@ -8,6 +8,7 @@
 #ifndef HPX_SERIALIZATION_POLYMORPHIC_INTRUSIVE_FACTORY_HPP
 #define HPX_SERIALIZATION_POLYMORPHIC_INTRUSIVE_FACTORY_HPP
 
+#include <hpx/exception.hpp>
 #include <hpx/runtime/serialization/serialization_fwd.hpp>
 
 #include <hpx/util/jenkins_hash.hpp>

--- a/hpx/util/detail/function_registration.hpp
+++ b/hpx/util/detail/function_registration.hpp
@@ -11,6 +11,7 @@
 #include <hpx/config.hpp>
 #include <hpx/util/detail/get_table.hpp>
 #include <hpx/runtime/serialization/detail/polymorphic_intrusive_factory.hpp>
+#include <hpx/traits/needs_automatic_registration.hpp>
 #include <hpx/util/demangle_helper.hpp>
 #include <hpx/util/tuple.hpp>
 

--- a/hpx/util/tuple.hpp
+++ b/hpx/util/tuple.hpp
@@ -11,23 +11,16 @@
 #include <hpx/config.hpp>
 #include <hpx/traits/is_bitwise_serializable.hpp>
 #include <hpx/util/decay.hpp>
-#include <hpx/util/move.hpp>
 #include <hpx/util/detail/pack.hpp>
 
 #include <boost/array.hpp>
 #include <boost/mpl/bool.hpp>
-#include <boost/mpl/if.hpp>
-#include <boost/mpl/size_t.hpp>
-#include <boost/type_traits/add_const.hpp>
-#include <boost/type_traits/add_cv.hpp>
-#include <boost/type_traits/add_volatile.hpp>
-#include <boost/type_traits/is_empty.hpp>
-#include <boost/type_traits/is_same.hpp>
-#include <boost/utility/enable_if.hpp>
+#include <boost/type_traits/integral_constant.hpp>
 
-#include <cstddef> // for size_t
-#include <utility>
 #include <algorithm>
+#include <cstddef> // for size_t
+#include <type_traits>
+#include <utility>
 
 #if defined(BOOST_MSVC)
 #pragma warning(push)
@@ -93,7 +86,12 @@ namespace hpx { namespace util
 
         template <std::size_t I, typename T>
         struct tuple_member<I, T,
-            typename boost::enable_if_c<boost::is_empty<T>::value>::type
+            typename std::enable_if<
+                std::is_empty<T>::value
+#if defined(HPX_HAVE_CXX11_STD_IS_FINAL)
+             && !std::is_final<T>::value
+#endif
+            >::type
         > : T
         {
         public:
@@ -135,11 +133,10 @@ namespace hpx { namespace util
 
             static bool const value =
                 sizeof(
-                    call(util::get<Is>(boost::declval<UTuple>())...)
+                    call(util::get<Is>(std::declval<UTuple>())...)
                 ) == sizeof(yes_type);
 
             typedef boost::mpl::bool_<value> type;
-            type m_;
         };
 
         template <typename TTuple, typename UTuple, typename Enable = void>
@@ -150,9 +147,9 @@ namespace hpx { namespace util
         template <typename ...Ts, typename UTuple>
         struct are_tuples_compatible<
             tuple<Ts...>, UTuple
-          , typename boost::enable_if_c<
+          , typename std::enable_if<
                 tuple_size<
-                    typename boost::remove_reference<UTuple>::type
+                    typename std::remove_reference<UTuple>::type
                 >::value == detail::pack<Ts...>::size
             >::type
         > : are_tuples_compatible_impl<
@@ -163,9 +160,9 @@ namespace hpx { namespace util
 
         template <typename TTuple, typename UTuple>
         struct are_tuples_compatible_not_same
-          : boost::mpl::if_c<
-                boost::is_same<
-                    typename decay<TTuple>::type, typename decay<UTuple>::type
+          : std::conditional<
+                std::is_same<
+                    typename std::decay<TTuple>::type, typename std::decay<UTuple>::type
                 >::value
               , boost::mpl::false_
               , are_tuples_compatible<TTuple, UTuple>
@@ -186,7 +183,7 @@ namespace hpx { namespace util
             {}
 
             template <typename ...Us, typename Enable =
-                typename boost::enable_if_c<
+                typename std::enable_if<
                     detail::pack<Us...>::size == detail::pack<Ts...>::size
                 >::type>
             explicit BOOST_CONSTEXPR tuple_impl(Us&&... vs)
@@ -202,7 +199,7 @@ namespace hpx { namespace util
             {}
 
             template <typename UTuple, typename Enable =
-                typename boost::enable_if_c<
+                typename std::enable_if<
                     are_tuples_compatible_not_same<tuple<Ts...>, UTuple&&>::value
                 >::type>
             BOOST_CONSTEXPR tuple_impl(UTuple&& other)
@@ -364,16 +361,15 @@ namespace hpx { namespace util
         // unless each type in UTypes is implicitly convertible to its
         // corresponding type in Types.
         template <typename U, typename ...Us, typename Enable =
-            typename boost::enable_if_c<
+            typename std::enable_if<
                 detail::pack<U, Us...>::size == detail::pack<Ts...>::size
-             && boost::mpl::eval_if_c<
+             && std::conditional<
                     detail::pack<Us...>::size == 0
-                  , boost::mpl::eval_if_c<
-                        boost::is_same<tuple, typename decay<U>::type>::value
-                     || detail::are_tuples_compatible_not_same<tuple, U&&>::value
-                      , boost::mpl::false_
+                  , typename std::enable_if<
+                        !std::is_same<tuple, typename std::decay<U>::type>::value
+                     && !detail::are_tuples_compatible_not_same<tuple, U&&>::value
                       , detail::are_tuples_compatible<tuple, tuple<U>&&>
-                    >
+                    >::type
                   , detail::are_tuples_compatible<tuple, tuple<U, Us...>&&>
                 >::type::value
             >::type>
@@ -403,7 +399,7 @@ namespace hpx { namespace util
         // unless each type in UTypes is implicitly convertible to its
         // corresponding type in Types
         template <typename UTuple, typename Enable =
-            typename boost::enable_if_c<
+            typename std::enable_if<
                 detail::are_tuples_compatible_not_same<tuple, UTuple&&>::value
             >::type>
         BOOST_CONSTEXPR tuple(UTuple&& other)
@@ -432,8 +428,10 @@ namespace hpx { namespace util
         // template <class... UTypes> tuple& operator=(tuple<UTypes...>&& u);
         // For all i, assigns get<i>(std::forward<U>(u)) to get<i>(*this).
         template <typename UTuple>
-        typename boost::enable_if_c<
-            tuple_size<typename decay<UTuple>::type>::value == detail::pack<Ts...>::size
+        typename std::enable_if<
+            tuple_size<
+                typename std::decay<UTuple>::type
+            >::value == detail::pack<Ts...>::size
           , tuple&
         >::type operator=(UTuple&& other)
         {
@@ -477,17 +475,17 @@ namespace hpx { namespace util
 
     template <typename ...Ts>
     struct tuple_size<tuple<Ts...> >
-      : boost::mpl::size_t<sizeof...(Ts)>
+      : boost::integral_constant<std::size_t, sizeof...(Ts)>
     {};
 
     template <typename T0, typename T1>
     struct tuple_size<std::pair<T0, T1> >
-      : boost::mpl::size_t<2>
+      : boost::integral_constant<std::size_t, 2>
     {};
 
     template <typename Type, std::size_t Size>
     struct tuple_size<boost::array<Type, Size> >
-      : boost::mpl::size_t<Size>
+      : boost::integral_constant<std::size_t, Size>
     {};
 
     // template <size_t I, class Tuple>
@@ -498,17 +496,17 @@ namespace hpx { namespace util
 
     template <std::size_t I, typename T>
     struct tuple_element<I, const T>
-      : boost::add_const<typename tuple_element<I, T>::type>
+      : std::add_const<typename tuple_element<I, T>::type>
     {};
 
     template <std::size_t I, typename T>
     struct tuple_element<I, volatile T>
-      : boost::add_volatile<typename tuple_element<I, T>::type>
+      : std::add_volatile<typename tuple_element<I, T>::type>
     {};
 
     template <std::size_t I, typename T>
     struct tuple_element<I, const volatile T>
-      : boost::add_cv<typename tuple_element<I, T>::type>
+      : std::add_cv<typename tuple_element<I, T>::type>
     {};
 
     template <std::size_t I, typename ...Ts>
@@ -590,7 +588,7 @@ namespace hpx { namespace util
     template <typename ...Ts>
     struct tuple_decay<tuple<Ts...> >
     {
-        typedef tuple<typename decay<Ts>::type...> type;
+        typedef tuple<typename std::decay<Ts>::type...> type;
     };
 
     // 20.4.2.6, element access
@@ -676,8 +674,9 @@ namespace hpx { namespace util
 
         template <std::size_t Size>
         struct tuple_cat_size_impl<Size, detail::pack<> >
-          : boost::mpl::size_t<Size>
-        {};
+        {
+            static const std::size_t value = Size;
+        };
 
         template <std::size_t Size, typename Head, typename ...Tail>
         struct tuple_cat_size_impl<
@@ -699,7 +698,7 @@ namespace hpx { namespace util
         template <std::size_t I, typename Head, typename ...Tail>
         struct tuple_cat_element<
             I, detail::pack<Head, Tail...>
-          , typename boost::enable_if_c<
+          , typename std::enable_if<
                 (I < tuple_size<Head>::value)
             >::type
         > : tuple_element<I, Head>
@@ -724,7 +723,7 @@ namespace hpx { namespace util
         template <std::size_t I, typename Head, typename ...Tail>
         struct tuple_cat_element<
             I, detail::pack<Head, Tail...>
-          , typename boost::enable_if_c<
+          , typename std::enable_if<
                 (I >= tuple_size<Head>::value)
             >::type
         > : tuple_cat_element<
@@ -829,7 +828,7 @@ namespace hpx { namespace util
 
     template <typename ...Ts, typename ...Us>
     BOOST_CONSTEXPR BOOST_FORCEINLINE
-    typename boost::enable_if_c<sizeof...(Ts) == sizeof...(Us), bool>::type
+    typename std::enable_if<sizeof...(Ts) == sizeof...(Us), bool>::type
     operator==(tuple<Ts...> const& t, tuple<Us...> const& u)
     {
         return detail::tuple_equal_to<0, sizeof...(Ts)>::call(t, u);
@@ -840,7 +839,7 @@ namespace hpx { namespace util
     //     (const tuple<TTypes...>& t, const tuple<UTypes...>& u);
     template <typename ...Ts, typename ...Us>
     BOOST_CONSTEXPR BOOST_FORCEINLINE
-    typename boost::enable_if_c<sizeof...(Ts) == sizeof...(Us), bool>::type
+    typename std::enable_if<sizeof...(Ts) == sizeof...(Us), bool>::type
     operator!=(tuple<Ts...> const& t, tuple<Us...> const& u)
     {
         return !(t == u);
@@ -885,7 +884,7 @@ namespace hpx { namespace util
 
     template <typename ...Ts, typename ...Us>
     BOOST_CONSTEXPR BOOST_FORCEINLINE
-    typename boost::enable_if_c<sizeof...(Ts) == sizeof...(Us), bool>::type
+    typename std::enable_if<sizeof...(Ts) == sizeof...(Us), bool>::type
     operator<(tuple<Ts...> const& t, tuple<Us...> const& u)
     {
         return detail::tuple_less_than<0, sizeof...(Ts)>::call(t, u);
@@ -896,7 +895,7 @@ namespace hpx { namespace util
     //     (const tuple<TTypes...>& t, const tuple<UTypes...>& u);
     template <typename ...Ts, typename ...Us>
     BOOST_CONSTEXPR BOOST_FORCEINLINE
-    typename boost::enable_if_c<sizeof...(Ts) == sizeof...(Us), bool>::type
+    typename std::enable_if<sizeof...(Ts) == sizeof...(Us), bool>::type
     operator>(tuple<Ts...> const& t, tuple<Us...> const& u)
     {
         return u < t;
@@ -907,7 +906,7 @@ namespace hpx { namespace util
     //     (const tuple<TTypes...>& t, const tuple<UTypes...>& u);
     template <typename ...Ts, typename ...Us>
     BOOST_CONSTEXPR BOOST_FORCEINLINE
-    typename boost::enable_if_c<sizeof...(Ts) == sizeof...(Us), bool>::type
+    typename std::enable_if<sizeof...(Ts) == sizeof...(Us), bool>::type
     operator<=(tuple<Ts...> const& t, tuple<Us...> const& u)
     {
         return !(u < t);
@@ -918,7 +917,7 @@ namespace hpx { namespace util
     //     (const tuple<TTypes...>& t, const tuple<UTypes...>& u);
     template <typename ...Ts, typename ...Us>
     BOOST_CONSTEXPR BOOST_FORCEINLINE
-    typename boost::enable_if_c<sizeof...(Ts) == sizeof...(Us), bool>::type
+    typename std::enable_if<sizeof...(Ts) == sizeof...(Us), bool>::type
     operator>=(tuple<Ts...> const& t, tuple<Us...> const& u)
     {
         return !(t < u);

--- a/hpx/util/tuple.hpp
+++ b/hpx/util/tuple.hpp
@@ -1,6 +1,6 @@
 //  Copyright (c) 2011-2013 Thomas Heller
 //  Copyright (c) 2011-2013 Hartmut Kaiser
-//  Copyright (c) 2013 Agustin Berge
+//  Copyright (c) 2013-2015 Agustin Berge
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,8 +9,6 @@
 #define HPX_UTIL_TUPLE_HPP
 
 #include <hpx/config.hpp>
-#include <hpx/runtime/serialization/serialize.hpp>
-#include <hpx/runtime/serialization/serialize_sequence.hpp>
 #include <hpx/traits/is_bitwise_serializable.hpp>
 #include <hpx/util/decay.hpp>
 #include <hpx/util/move.hpp>
@@ -265,6 +263,15 @@ namespace hpx { namespace util
                 return static_cast<tuple_member<
                         I, typename detail::at_index<I, Ts...>::type
                     > const&>(*this).value();
+            }
+
+            template <typename Archive>
+            void serialize(Archive& ar, unsigned int const version)
+            {
+                int const _sequencer[] = {
+                    ((ar & this->get<Is>()), 0)...
+                };
+                (void)_sequencer;
             }
         };
 
@@ -940,34 +947,26 @@ namespace hpx { namespace traits
     {};
 }}
 
-namespace hpx { namespace serialization {
-
+namespace hpx { namespace serialization
+{
     ///////////////////////////////////////////////////////////////////////////
     template <typename Archive, typename ...Ts>
     BOOST_FORCEINLINE
     void serialize(
         Archive& ar
       , ::hpx::util::tuple<Ts...>& t
-      , unsigned int const version
+      , unsigned int const version = 0
     )
     {
-        ::hpx::serialization::serialize_sequence(ar, t);
+        t._impl.serialize(ar, version);
     }
 
-    // These are needed to avoid conflicts with serialize_empty_type
+    template <typename Archive>
     BOOST_FORCEINLINE
     void serialize(
-        serialization::output_archive&
-      , ::hpx::util::tuple<>&
-      , unsigned int const
-    )
-    {}
-
-    BOOST_FORCEINLINE
-    void serialize(
-        serialization::input_archive&
-      , ::hpx::util::tuple<>&
-      , unsigned int const
+        Archive& ar
+      , ::hpx::util::tuple<>& t
+      , unsigned int const version = 0
     )
     {}
 }}

--- a/hpx/util/tuple.hpp
+++ b/hpx/util/tuple.hpp
@@ -14,7 +14,6 @@
 #include <hpx/util/detail/pack.hpp>
 
 #include <boost/array.hpp>
-#include <boost/mpl/bool.hpp>
 #include <boost/type_traits/integral_constant.hpp>
 
 #include <algorithm>
@@ -136,12 +135,12 @@ namespace hpx { namespace util
                     call(util::get<Is>(std::declval<UTuple>())...)
                 ) == sizeof(yes_type);
 
-            typedef boost::mpl::bool_<value> type;
+            typedef std::integral_constant<bool, value> type;
         };
 
         template <typename TTuple, typename UTuple, typename Enable = void>
         struct are_tuples_compatible
-          : boost::mpl::false_
+          : std::false_type
         {};
 
         template <typename ...Ts, typename UTuple>
@@ -164,7 +163,7 @@ namespace hpx { namespace util
                 std::is_same<
                     typename std::decay<TTuple>::type, typename std::decay<UTuple>::type
                 >::value
-              , boost::mpl::false_
+              , std::false_type
               , are_tuples_compatible<TTuple, UTuple>
             >::type
         {};

--- a/hpx/util/tuple.hpp
+++ b/hpx/util/tuple.hpp
@@ -24,7 +24,6 @@
 #include <boost/type_traits/is_empty.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <boost/utility/swap.hpp>
 
 #include <cstddef> // for size_t
 #include <utility>
@@ -240,8 +239,9 @@ namespace hpx { namespace util
 
             void swap(tuple_impl& other)
             {
+                using std::swap;
                 int const _sequencer[] = {
-                    ((boost::swap(this->get<Is>(), other.template get<Is>())), 0)...
+                    ((swap(this->get<Is>(), other.template get<Is>())), 0)...
                 };
                 (void)_sequencer;
             }

--- a/hpx/util/tuple.hpp
+++ b/hpx/util/tuple.hpp
@@ -13,7 +13,6 @@
 #include <hpx/util/decay.hpp>
 #include <hpx/util/move.hpp>
 #include <hpx/util/detail/pack.hpp>
-#include <hpx/util/detail/qualify_as.hpp>
 
 #include <boost/array.hpp>
 #include <boost/mpl/bool.hpp>
@@ -680,11 +679,11 @@ namespace hpx { namespace util
           : boost::mpl::size_t<Size>
         {};
 
-        template <std::size_t Size, typename HeadTuple, typename ...TailTuples>
+        template <std::size_t Size, typename Head, typename ...Tail>
         struct tuple_cat_size_impl<
-            Size, detail::pack<HeadTuple, TailTuples...>
+            Size, detail::pack<Head, Tail...>
         > : tuple_cat_size_impl<
-                (Size + tuple_size<HeadTuple>::value), detail::pack<TailTuples...>
+                (Size + tuple_size<Head>::value), detail::pack<Tail...>
             >
         {};
 
@@ -697,51 +696,57 @@ namespace hpx { namespace util
         template <std::size_t I, typename Tuples, typename Enable = void>
         struct tuple_cat_element;
 
-        template <std::size_t I, typename HeadTuple, typename ...TailTuples>
+        template <std::size_t I, typename Head, typename ...Tail>
         struct tuple_cat_element<
-            I, detail::pack<HeadTuple, TailTuples...>
+            I, detail::pack<Head, Tail...>
           , typename boost::enable_if_c<
-                (I < tuple_size<HeadTuple>::value)
+                (I < tuple_size<Head>::value)
             >::type
-        > : tuple_element<I, HeadTuple>
+        > : tuple_element<I, Head>
         {
-            typedef tuple_element<I, HeadTuple> base_type;
+            typedef tuple_element<I, Head> base_type;
 
-            template <typename HeadTuple_, typename ...TailTuples_>
             static BOOST_CONSTEXPR BOOST_FORCEINLINE
-            typename detail::qualify_as<
-                typename base_type::type
-              , HeadTuple_&
-            >::type
-            get(HeadTuple_& head, TailTuples_& ...tail) BOOST_NOEXCEPT
+            typename base_type::type&
+            get(Head& head, Tail& ...tail) BOOST_NOEXCEPT
+            {
+                return base_type::get(head);
+            }
+
+            static BOOST_CONSTEXPR BOOST_FORCEINLINE
+            typename base_type::type const&
+            get(Head const& head, Tail& ...tail) BOOST_NOEXCEPT
             {
                 return base_type::get(head);
             }
         };
 
-        template <std::size_t I, typename HeadTuple, typename ...TailTuples>
+        template <std::size_t I, typename Head, typename ...Tail>
         struct tuple_cat_element<
-            I, detail::pack<HeadTuple, TailTuples...>
+            I, detail::pack<Head, Tail...>
           , typename boost::enable_if_c<
-                (I >= tuple_size<HeadTuple>::value)
+                (I >= tuple_size<Head>::value)
             >::type
         > : tuple_cat_element<
-                I - tuple_size<HeadTuple>::value
-              , detail::pack<TailTuples...>
+                I - tuple_size<Head>::value
+              , detail::pack<Tail...>
             >
         {
             typedef tuple_cat_element<
-                I - tuple_size<HeadTuple>::value
-              , detail::pack<TailTuples...>
+                I - tuple_size<Head>::value
+              , detail::pack<Tail...>
             > base_type;
 
-            template <typename HeadTuple_, typename ...TailTuples_>
             static BOOST_CONSTEXPR BOOST_FORCEINLINE
-            typename detail::qualify_as<
-                typename base_type::type
-              , HeadTuple_&
-            >::type
-            get(HeadTuple_& head, TailTuples_& ...tail) BOOST_NOEXCEPT
+            typename base_type::type&
+            get(Head& head, Tail& ...tail) BOOST_NOEXCEPT
+            {
+                return base_type::get(tail...);
+            }
+
+            static BOOST_CONSTEXPR BOOST_FORCEINLINE
+            typename base_type::type const&
+            get(Head const& head, Tail& ...tail) BOOST_NOEXCEPT
             {
                 return base_type::get(tail...);
             }

--- a/hpx/util/tuple.hpp
+++ b/hpx/util/tuple.hpp
@@ -581,16 +581,6 @@ namespace hpx { namespace util
         }
     };
 
-    template <typename Tuple>
-    struct tuple_decay
-    {};
-
-    template <typename ...Ts>
-    struct tuple_decay<tuple<Ts...> >
-    {
-        typedef tuple<typename std::decay<Ts>::type...> type;
-    };
-
     // 20.4.2.6, element access
 
     // template <size_t I, class... Types>


### PR DESCRIPTION
This PR reduces `hpx::util::tuple` dependencies, and reduces the number of `#include`s to a bare minimum.