### PR TITLE
Fixed #1751: hpx::future::wait_for fails a simple test

### DIFF
--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -585,7 +585,7 @@ namespace detail
                     cond_.wait_until(l, abs_time, "future_data::wait_until", ec);
                 if (ec) return future_status::uninitialized;
 
-                if (reason == threads::wait_signaled)
+                if (reason == threads::wait_timeout)
                     return future_status::timeout;
 
                 HPX_ASSERT(state_ != empty);

--- a/hpx/lcos/local/condition_variable.hpp
+++ b/hpx/lcos/local/condition_variable.hpp
@@ -80,7 +80,7 @@ namespace hpx { namespace lcos { namespace local
             if (ec) return cv_status::error;
 
             // if the timer has hit, the waiting period timed out
-            return (reason == threads::wait_signaled) ? //-V110
+            return (reason == threads::wait_timeout) ? //-V110
                 cv_status::timeout : cv_status::no_timeout;
         }
 

--- a/hpx/lcos/local/detail/condition_variable.hpp
+++ b/hpx/lcos/local/detail/condition_variable.hpp
@@ -129,7 +129,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail
 
                 threads::set_thread_state(threads::thread_id_type(
                     reinterpret_cast<threads::thread_data_base*>(id)),
-                    threads::pending, threads::wait_timeout,
+                    threads::pending, threads::wait_signaled,
                     threads::thread_priority_default, ec);
                 if (!ec) return not_empty;
             }
@@ -164,7 +164,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail
 
                 threads::set_thread_state(threads::thread_id_type(
                     reinterpret_cast<threads::thread_data_base*>(id)),
-                    threads::pending, threads::wait_timeout,
+                    threads::pending, threads::wait_signaled,
                     threads::thread_priority_default, ec);
                 if (ec) return;
             }
@@ -243,7 +243,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail
                 if (ec) return threads::wait_unknown;
             }
 
-            return (f.id_ == threads::invalid_thread_id_repr) ?
+            return (f.id_ != threads::invalid_thread_id_repr) ?
                 threads::wait_timeout : reason;
         }
 
@@ -276,7 +276,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail
                 if (ec) return threads::wait_unknown;
             }
 
-            return (f.id_ == threads::invalid_thread_id_repr) ?
+            return (f.id_ != threads::invalid_thread_id_repr) ?
                 threads::wait_timeout : reason;
         }
 

--- a/hpx/lcos/local/mutex.hpp
+++ b/hpx/lcos/local/mutex.hpp
@@ -121,7 +121,7 @@ namespace hpx { namespace lcos { namespace local
                     cond_.wait_until(l, abs_time, ec);
                 if (ec) { HPX_ITT_SYNC_CANCEL(this); return false; }
 
-                if (reason == threads::wait_signaled) //-V110
+                if (reason == threads::wait_timeout) //-V110
                 {
                     HPX_ITT_SYNC_CANCEL(this);
                     return false;

--- a/hpx/runtime/threads/detail/set_thread_state.hpp
+++ b/hpx/runtime/threads/detail/set_thread_state.hpp
@@ -254,10 +254,9 @@ namespace hpx { namespace threads { namespace detail
         }
 
         // then re-activate the thread holding the deadline_timer
-        // REVIEW: Why do we ignore errors here?
         error_code ec(lightweight);    // do not throw
         detail::set_thread_state(timer_id, pending, wait_timeout,
-            thread_priority_normal, std::size_t(-1), ec);
+            thread_priority_boost, std::size_t(-1), ec);
         return terminated;
     }
 
@@ -310,14 +309,19 @@ namespace hpx { namespace threads { namespace detail
         // this waits for the thread to be reactivated when the timer fired
         // if it returns signaled the timer has been canceled, otherwise
         // the timer fired and the wake_timer_thread above has been executed
-        bool oldvalue = false;
         thread_state_ex_enum statex = get_self().yield(suspended);
 
-        if (wait_timeout != statex &&
-            triggered->compare_exchange_strong(oldvalue, true)) //-V601
+        if (wait_timeout != statex) //-V601
         {
+            triggered->store(true);
+
             // wake_timer_thread has not been executed yet, cancel timer
             t.cancel();
+
+            // cancel wake_timer_thread
+            error_code ec(lightweight);    // do not throw
+            detail::set_thread_state(wake_id, pending, wait_abort,
+                priority, std::size_t(-1), ec);
         }
 
         return terminated;

--- a/tests/regressions/lcos/CMakeLists.txt
+++ b/tests/regressions/lcos/CMakeLists.txt
@@ -27,6 +27,7 @@ set(tests
     set_hpx_limit_798
     shared_mutex_1702
     shared_stated_leaked_1211
+    wait_for_1751
     when_all_vectors_1623
    )
 
@@ -43,6 +44,7 @@ set(lifetime_588_1_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 2)
 set(set_hpx_limit_771_FLAGS DEPENDENCIES dataflow_component)
 set(safely_destroy_cv_1481_PARAMETERS THREADS_PER_LOCALITY 2)
 set(shared_mutex_1702_PARAMETERS THREADS_PER_LOCALITY 4)
+set(wait_for_1751_PARAMETERS THREADS_PER_LOCALITY 4)
 
 if(HPX_WITH_CXX11_LAMBDAS)
   set(tests ${tests}

--- a/tests/regressions/lcos/wait_for_1751.cpp
+++ b/tests/regressions/lcos/wait_for_1751.cpp
@@ -1,0 +1,56 @@
+//  Copyright 2015 (c) Dominic Marcello
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This test case demonstrates the issue described in #1751:
+// hpx::future::wait_for fails a simple test
+
+#include <hpx/hpx.hpp>
+#include <boost/chrono.hpp>
+
+int hpx_main()
+{
+    auto overall_start_time = boost::chrono::high_resolution_clock::now();
+
+    while(true)
+    {
+        auto start_time = boost::chrono::high_resolution_clock::now();
+
+        // run for 3 seconds max
+        boost::chrono::duration<double> overall_dif = start_time - overall_start_time;
+        if (overall_dif.count() > 3.0)
+            break;
+
+        auto f = hpx::async([](){});
+
+        if (f.wait_for(boost::posix_time::seconds(1)) ==
+            hpx::lcos::future_status::timeout)
+        {
+            auto now = boost::chrono::high_resolution_clock::now();
+            overall_dif = now - overall_start_time;
+            boost::chrono::duration<double> dif = now - start_time;
+
+            std::cout << "Future timed out after "
+                      << dif.count() << " (" << overall_dif << ") seconds.\n";
+            break;
+        }
+        else
+        {
+            f.get();
+        }
+
+        auto now = boost::chrono::high_resolution_clock::now();
+        overall_dif = now - overall_start_time;
+        boost::chrono::duration<double> dif = now - start_time;
+        std::cout << "Future took "
+                  << dif.count() << " (" << overall_dif << ") seconds.\n";
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char *argv[])
+{
+    return hpx::init(argc, argv);
+}


### PR DESCRIPTION
- this also makes more consistent return codes from suspend and other timer related thread functions