### PR TITLE
Making sure all serialization registries/factories are unique 

### DIFF
--- a/hpx/runtime/serialization/detail/polymorphic_id_factory.hpp
+++ b/hpx/runtime/serialization/detail/polymorphic_id_factory.hpp
@@ -29,7 +29,7 @@ namespace hpx { namespace serialization {
 
     namespace detail
     {
-        class HPX_EXPORT id_registry : boost::noncopyable
+        class id_registry : boost::noncopyable
         {
         public:
             typedef void* (*ctor_t) ();
@@ -104,14 +104,10 @@ namespace hpx { namespace serialization {
                 return result;
             }
 
-            static id_registry& instance()
-            {
-                util::static_<id_registry> inst;
-                return inst.get();
-            }
+            HPX_EXPORT static id_registry& instance();
 
         private:
-            id_registry(): max_id(0u) {}
+            id_registry() : max_id(0u) {}
 
             friend struct ::hpx::util::static_<id_registry>;
             friend class polymorphic_id_factory;
@@ -129,7 +125,7 @@ namespace hpx { namespace serialization {
             cache_t cache;
         };
 
-        class HPX_EXPORT polymorphic_id_factory : boost::noncopyable
+        class polymorphic_id_factory : boost::noncopyable
         {
             typedef id_registry::ctor_t ctor_t;
             typedef id_registry::typename_to_ctor_t typename_to_ctor_t;
@@ -169,11 +165,7 @@ namespace hpx { namespace serialization {
         private:
             polymorphic_id_factory() {}
 
-            static polymorphic_id_factory& instance()
-            {
-                hpx::util::static_<polymorphic_id_factory> factory;
-                return factory.get();
-            }
+            HPX_EXPORT static polymorphic_id_factory& instance();
 
             friend struct hpx::util::static_<polymorphic_id_factory>;
         };

--- a/hpx/runtime/serialization/detail/polymorphic_intrusive_factory.hpp
+++ b/hpx/runtime/serialization/detail/polymorphic_intrusive_factory.hpp
@@ -25,18 +25,14 @@
 
 namespace hpx { namespace serialization { namespace detail
 {
-    class HPX_EXPORT polymorphic_intrusive_factory: boost::noncopyable
+    class polymorphic_intrusive_factory : boost::noncopyable
     {
     public:
         typedef void* (*ctor_type) ();
         typedef boost::unordered_map<std::string,
                 ctor_type, hpx::util::jenkins_hash> ctor_map_type;
 
-        static polymorphic_intrusive_factory& instance()
-        {
-            hpx::util::static_<polymorphic_intrusive_factory> factory;
-            return factory.get();
-        }
+        HPX_EXPORT static polymorphic_intrusive_factory& instance();
 
         void register_class(const std::string& name, ctor_type fun)
         {

--- a/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
+++ b/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
@@ -9,6 +9,7 @@
 #ifndef HPX_SERIALIZATION_POLYMORPHIC_NONINTRUSIVE_FACTORY_HPP
 #define HPX_SERIALIZATION_POLYMORPHIC_NONINTRUSIVE_FACTORY_HPP
 
+#include <hpx/exception.hpp>
 #include <hpx/runtime/serialization/serialization_fwd.hpp>
 #include <hpx/util/jenkins_hash.hpp>
 #include <hpx/util/static.hpp>
@@ -88,7 +89,7 @@ namespace hpx { namespace serialization { namespace detail
         }
     };
 
-    class HPX_EXPORT polymorphic_nonintrusive_factory: boost::noncopyable
+    class polymorphic_nonintrusive_factory : boost::noncopyable
     {
     public:
         typedef boost::unordered_map<std::string,
@@ -96,11 +97,7 @@ namespace hpx { namespace serialization { namespace detail
         typedef boost::unordered_map<std::string,
                   std::string, hpx::util::jenkins_hash> serializer_typeinfo_map_type;
 
-        static polymorphic_nonintrusive_factory& instance()
-        {
-            hpx::util::static_<polymorphic_nonintrusive_factory> factory;
-            return factory.get();
-        }
+        HPX_EXPORT static polymorphic_nonintrusive_factory& instance();
 
         void register_class(const std::type_info& typeinfo,
             const std::string& class_name,

--- a/hpx/util/jenkins_hash.hpp
+++ b/hpx/util/jenkins_hash.hpp
@@ -13,6 +13,8 @@
 #include <hpx/runtime/serialization/serialize.hpp>
 #endif
 
+#include <string>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace util
 {

--- a/src/runtime/serialization/detail/polymorphic_id_factory.cpp
+++ b/src/runtime/serialization/detail/polymorphic_id_factory.cpp
@@ -1,0 +1,23 @@
+//  Copyright (c) 2015 Anton Bikineev
+//  Copyright (c) 2014 Thomas Heller
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//  See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/runtime/serialization/detail/polymorphic_id_factory.hpp>
+
+namespace hpx { namespace serialization { namespace detail
+{
+    id_registry& id_registry::instance()
+    {
+        util::static_<id_registry> inst;
+        return inst.get();
+    }
+
+    polymorphic_id_factory& polymorphic_id_factory::instance()
+    {
+        hpx::util::static_<polymorphic_id_factory> factory;
+        return factory.get();
+    }
+}}}

--- a/src/runtime/serialization/detail/polymorphic_intrusive_factory.cpp
+++ b/src/runtime/serialization/detail/polymorphic_intrusive_factory.cpp
@@ -1,0 +1,18 @@
+//  Copyright (c) 2014 Anton Bikineev
+//  Copyright (c) 2014 Thomas Heller
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//  See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/runtime/serialization/detail/polymorphic_intrusive_factory.hpp>
+
+namespace hpx { namespace serialization { namespace detail
+{
+    polymorphic_intrusive_factory& polymorphic_intrusive_factory::instance()
+    {
+        hpx::util::static_<polymorphic_intrusive_factory> factory;
+        return factory.get();
+    }
+}}}
+

--- a/src/runtime/serialization/detail/polymorphic_nonintrusive_factory.cpp
+++ b/src/runtime/serialization/detail/polymorphic_nonintrusive_factory.cpp
@@ -1,0 +1,19 @@
+//  Copyright (c) 2014 Thomas Heller
+//  Copyright (c) 2015 Anton Bikineev
+//  Copyright (c) 2015 Andreas Schaefer
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//  See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp>
+
+namespace hpx { namespace serialization { namespace detail
+{
+    polymorphic_nonintrusive_factory& polymorphic_nonintrusive_factory::instance()
+    {
+        hpx::util::static_<polymorphic_nonintrusive_factory> factory;
+        return factory.get();
+    }
+}}}
+


### PR DESCRIPTION
With visibility=off the factories might end up being duplicated over the shared libraries. This patch makes sure those are really unique.