### PR TITLE
Forwarding decay to std::

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -771,6 +771,9 @@ hpx_check_for_cxx11_std_is_null_pointer(
 hpx_check_for_cxx11_std_is_placeholder(
   DEFINITIONS HPX_HAVE_CXX11_STD_IS_PLACEHOLDER)
 
+hpx_check_for_cxx11_std_reference_wrapper(
+  DEFINITIONS HPX_HAVE_CXX11_STD_REFERENCE_WRAPPER)
+
 hpx_check_for_cxx11_std_unique_ptr(
   REQUIRED "HPX needs support for C++11 std::unique_ptr")
 

--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -289,6 +289,13 @@ macro(hpx_check_for_cxx11_std_is_placeholder)
 endmacro()
 
 ###############################################################################
+macro(hpx_check_for_cxx11_std_reference_wrapper)
+  add_hpx_config_test(HPX_WITH_CXX11_REFERENCE_WRAPPER
+    SOURCE cmake/tests/cxx11_std_reference_wrapper.cpp
+    FILE ${ARGN})
+endmacro()
+
+###############################################################################
 macro(hpx_check_for_cxx11_std_initializer_list)
   add_hpx_config_test(HPX_WITH_CXX11_STD_INITIALIZER_LIST
     SOURCE cmake/tests/cxx11_std_initializer_list.cpp

--- a/cmake/tests/cxx11_std_reference_wrapper.cpp
+++ b/cmake/tests/cxx11_std_reference_wrapper.cpp
@@ -1,0 +1,14 @@
+////////////////////////////////////////////////////////////////////////////////
+//  Copyright (c) 2015 Agustin Berge
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+////////////////////////////////////////////////////////////////////////////////
+
+#include <functional>
+
+int main()
+{
+    int lvalue = 0;
+    std::reference_wrapper<int> wrapper = std::ref(lvalue);
+}

--- a/hpx/util/decay.hpp
+++ b/hpx/util/decay.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2012 Thomas Heller
-//  Copyright (c) 2013 Agustin Berge
+//  Copyright (c) 2013-2015 Agustin Berge
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -7,36 +7,17 @@
 #ifndef HPX_UTIL_DECAY_HPP
 #define HPX_UTIL_DECAY_HPP
 
-#include <boost/mpl/eval_if.hpp>
-#include <boost/mpl/identity.hpp>
+#include <hpx/config.hpp>
+
 #include <boost/ref.hpp>
-#include <boost/type_traits/config.hpp>
-#include <boost/type_traits/is_array.hpp>
-#include <boost/type_traits/is_function.hpp>
-#include <boost/type_traits/remove_bounds.hpp>
-#include <boost/type_traits/add_pointer.hpp>
-#include <boost/type_traits/remove_cv.hpp>
-#include <boost/type_traits/remove_reference.hpp>
+
+#include <utility>
 
 namespace hpx { namespace util
 {
     template <typename T>
-    struct decay
-    {
-        typedef typename boost::remove_reference<T>::type Ty;
-
-        typedef
-            typename boost::mpl::eval_if<
-                boost::is_array<Ty>
-              , boost::mpl::identity<typename boost::remove_bounds<Ty>::type *>
-              , typename boost::mpl::eval_if<
-                    boost::is_function<Ty>
-                  , boost::add_pointer<Ty>
-                  , boost::remove_cv<Ty>
-                >
-            >::type
-            type;
-    };
+    struct decay : std::decay<T>
+    {};
 
     namespace detail
     {
@@ -55,7 +36,7 @@ namespace hpx { namespace util
 
     template <typename T>
     struct decay_unwrap
-      : detail::decay_unwrap_impl<typename decay<T>::type>
+      : detail::decay_unwrap_impl<typename std::decay<T>::type>
     {};
 }}
 

--- a/hpx/util/decay.hpp
+++ b/hpx/util/decay.hpp
@@ -11,6 +11,9 @@
 
 #include <boost/ref.hpp>
 
+#if defined(HPX_HAVE_CXX11_STD_REFERENCE_WRAPPER)
+#include <functional>
+#endif
 #include <utility>
 
 namespace hpx { namespace util
@@ -28,10 +31,18 @@ namespace hpx { namespace util
         };
 
         template <typename X>
-        struct decay_unwrap_impl<boost::reference_wrapper<X> >
+        struct decay_unwrap_impl< ::boost::reference_wrapper<X> >
         {
             typedef X& type;
         };
+
+#if defined(HPX_HAVE_CXX11_STD_REFERENCE_WRAPPER)
+        template <typename X>
+        struct decay_unwrap_impl< ::std::reference_wrapper<X> >
+        {
+            typedef X& type;
+        };
+#endif
     }
 
     template <typename T>


### PR DESCRIPTION
Reimplement `util::decay` on top of `std::decay`. The Boost based version has a considerable compile-time cost compared to the standard one. While on the neighborhood, add `std::reference_wrapper` support to `decay_unwrap`.