### PR TITLE
Action invocation count

### DIFF
--- a/docs/manual/existing_performance_counters.qbk
+++ b/docs/manual/existing_performance_counters.qbk
@@ -1136,6 +1136,38 @@ system and application performance.
         [Returns the overall number of currently active components of the
          specified type on the given locality.]
     ]
+    [   [`/runtime/count/action_invocation`]
+        [`locality#*/total`
+
+          where:[br] `*` is the locality id of the locality the number of
+          action invocations should be queried. The locality id is a (zero based)
+          number identifying the locality.
+        ]
+        [The action type. This is the string which has been used
+         while registering the action with __hpx__, e.g. which has been
+         passed as the second parameter to the macro
+         [macroref HPX_REGISTER_ACTION `HPX_REGISTER_ACTION`] or
+         [macroref HPX_REGISTER_ACTION_ID `HPX_REGISTER_ACTION_ID`].
+        ]
+        [Returns the overall (local) invocation count of the specified action
+         type on the given locality.]
+    ]
+    [   [`/runtime/count/remote_action_invocation`]
+        [`locality#*/total`
+
+          where:[br] `*` is the locality id of the locality the number of
+          action invocations should be queried. The locality id is a (zero based)
+          number identifying the locality.
+        ]
+        [The action type. This is the string which has been used
+         while registering the action with __hpx__, e.g. which has been
+         passed as the second parameter to the macro
+         [macroref HPX_REGISTER_ACTION `HPX_REGISTER_ACTION`] or
+         [macroref HPX_REGISTER_ACTION_ID `HPX_REGISTER_ACTION_ID`].
+        ]
+        [Returns the overall (remote) invocation count of the specified action
+         type on the given locality.]
+    ]
     [   [`/runtime/uptime`]
         [`locality#*/total`
 

--- a/hpx/performance_counters/counter_creators.hpp
+++ b/hpx/performance_counters/counter_creators.hpp
@@ -81,6 +81,15 @@ namespace hpx { namespace performance_counters
     ///
     HPX_API_EXPORT bool agas_counter_discoverer(counter_info const&,
         discover_counter_func const&, discover_counters_mode, error_code&);
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Creation function for action invocation counters.
+    HPX_API_EXPORT naming::gid_type action_invocation_counter_creator(
+        counter_info const&, error_code&);
+
+    // Discoverer function for action invocation counters.
+    HPX_API_EXPORT bool action_invocation_counter_discoverer(counter_info const&,
+        discover_counter_func const&, discover_counters_mode, error_code&);
 }}
 
 #endif

--- a/hpx/performance_counters/counter_creators.hpp
+++ b/hpx/performance_counters/counter_creators.hpp
@@ -84,12 +84,21 @@ namespace hpx { namespace performance_counters
 
     ///////////////////////////////////////////////////////////////////////////
     // Creation function for action invocation counters.
-    HPX_API_EXPORT naming::gid_type action_invocation_counter_creator(
+    HPX_API_EXPORT naming::gid_type local_action_invocation_counter_creator(
         counter_info const&, error_code&);
 
     // Discoverer function for action invocation counters.
-    HPX_API_EXPORT bool action_invocation_counter_discoverer(counter_info const&,
-        discover_counter_func const&, discover_counters_mode, error_code&);
+    HPX_API_EXPORT bool local_action_invocation_counter_discoverer(
+        counter_info const&, discover_counter_func const&,
+        discover_counters_mode, error_code&);
+
+    HPX_API_EXPORT naming::gid_type remote_action_invocation_counter_creator(
+        counter_info const&, error_code&);
+
+    // Discoverer function for action invocation counters.
+    HPX_API_EXPORT bool remote_action_invocation_counter_discoverer(
+        counter_info const&, discover_counter_func const&,
+        discover_counters_mode, error_code&);
 }}
 
 #endif

--- a/hpx/performance_counters/counters.hpp
+++ b/hpx/performance_counters/counters.hpp
@@ -613,12 +613,13 @@ namespace hpx { namespace performance_counters
         //        (milliseconds).
         naming::gid_type create_statistics_counter(
             counter_info const& info, std::string const& base_counter_name,
-            std::vector<boost::int64_t> const& parameters, error_code& ec = throws);
+            std::vector<boost::int64_t> const& parameters,
+            error_code& ec = throws);
 
         // \brief Create a new arithmetics performance counter instance based on
         //        the given base counter names
-        naming::gid_type create_arithmetics_counter(
-            counter_info const& info, std::vector<std::string> const& base_counter_names,
+        naming::gid_type create_arithmetics_counter(counter_info const& info,
+            std::vector<std::string> const& base_counter_names,
             error_code& ec = throws);
 
         // \brief Create a new performance counter instance based on given

--- a/hpx/performance_counters/registry.hpp
+++ b/hpx/performance_counters/registry.hpp
@@ -140,6 +140,12 @@ namespace hpx { namespace performance_counters
     private:
         counter_type_map_type countertypes_;
     };
+
+    namespace detail
+    {
+        std::string regex_from_pattern(std::string const& pattern,
+            error_code& ec);
+    }
 }}
 
 #endif

--- a/hpx/performance_counters/server/base_performance_counter.hpp
+++ b/hpx/performance_counters/server/base_performance_counter.hpp
@@ -38,12 +38,12 @@ namespace hpx { namespace performance_counters { namespace server
 
         virtual bool start()
         {
-            return true;    // nothing to do
+            return false;    // nothing to do
         }
 
         virtual bool stop()
         {
-            return true;    // nothing to do
+            return false;    // nothing to do
         }
 
         virtual counter_info get_counter_info() const

--- a/hpx/runtime/actions/action_support.hpp
+++ b/hpx/runtime/actions/action_support.hpp
@@ -260,6 +260,7 @@ namespace hpx { namespace actions
         template <typename Archive>
         void serialize(Archive &, unsigned)
         {}
+
         HPX_SERIALIZATION_POLYMORPHIC_ABSTRACT(base_action);
     };
 

--- a/hpx/runtime/actions/basic_action.hpp
+++ b/hpx/runtime/actions/basic_action.hpp
@@ -18,6 +18,7 @@
 #include <hpx/runtime/actions/action_support.hpp>
 #include <hpx/runtime/actions/basic_action_fwd.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
+#include <hpx/runtime/actions/invocation_count_registry.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
 #include <hpx/traits/action_decorate_function.hpp>
 #include <hpx/util/bind.hpp>
@@ -427,6 +428,19 @@ namespace hpx { namespace actions
     boost::atomic<boost::int64_t>
         basic_action<Component, R(Args...), Derived>::invocation_count_(0);
 
+    namespace detail
+    {
+        template <typename Action>
+        void register_local_action_invocation_count(
+            invocation_count_registry& registry)
+        {
+            registry.register_class(
+                hpx::actions::detail::get_action_name<Action>(),
+                &Action::get_invocation_count
+            );
+        }
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     namespace detail
     {
@@ -680,7 +694,9 @@ namespace hpx { namespace actions
 /**/
 #define HPX_REGISTER_ACTION_2(action, actionname)                             \
     HPX_DEFINE_GET_ACTION_NAME_(action, actionname)                           \
+    HPX_REGISTER_ACTION_INVOCATION_COUNT(action, actionname)                  \
 /**/
+
 ///////////////////////////////////////////////////////////////////////////////
 #define HPX_REGISTER_ACTION_DECLARATION_NO_DEFAULT_GUID(action)               \
     namespace hpx { namespace actions { namespace detail {                    \

--- a/hpx/runtime/actions/basic_action.hpp
+++ b/hpx/runtime/actions/basic_action.hpp
@@ -694,7 +694,7 @@ namespace hpx { namespace actions
 /**/
 #define HPX_REGISTER_ACTION_2(action, actionname)                             \
     HPX_DEFINE_GET_ACTION_NAME_(action, actionname)                           \
-    HPX_REGISTER_ACTION_INVOCATION_COUNT(action, actionname)                  \
+    HPX_REGISTER_ACTION_INVOCATION_COUNT(action)                              \
 /**/
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/actions/component_action.hpp
+++ b/hpx/runtime/actions/component_action.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2015 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -32,7 +32,7 @@ namespace hpx { namespace actions
     /// \cond NOINTERNAL
 
     ///////////////////////////////////////////////////////////////////////////
-    //  Specialized generic non-conts component action types allowing to hold
+    //  Specialized generic non-const component action types allowing to hold
     //  a different number of arguments
     ///////////////////////////////////////////////////////////////////////////
     template <
@@ -46,9 +46,11 @@ namespace hpx { namespace actions
         static std::string get_action_name(naming::address::address_type lva)
         {
             std::stringstream name;
-            name << "component action(" << detail::get_action_name<Derived>() <<
-                ") lva(" << reinterpret_cast<void const*>(
-                    get_lva<Component>::call(lva)) << ")";
+            name << "component action("
+                 << detail::get_action_name<Derived>()
+                 << ") lva("
+                 << reinterpret_cast<void const*>(get_lva<Component>::call(lva))
+                 << ")";
             return name.str();
         }
 
@@ -61,6 +63,8 @@ namespace hpx { namespace actions
         template <typename ...Ts>
         static R invoke(naming::address::address_type lva, Ts&&... vs)
         {
+            basic_action<Component, R(Ps...), Derived>::
+                increment_invocation_count();
             return (get_lva<Component>::call(lva)->*F)
                 (std::forward<Ts>(vs)...);
         }
@@ -81,9 +85,11 @@ namespace hpx { namespace actions
         static std::string get_action_name(naming::address::address_type lva)
         {
             std::stringstream name;
-            name << "component action(" << detail::get_action_name<Derived>() <<
-                ") lva(" << reinterpret_cast<void const*>(
-                    get_lva<Component>::call(lva)) << ")";
+            name << "component action("
+                 << detail::get_action_name<Derived>()
+                 << ") lva("
+                 << reinterpret_cast<void const*>(get_lva<Component>::call(lva))
+                 << ")";
             return name.str();
         }
 
@@ -96,6 +102,8 @@ namespace hpx { namespace actions
         template <typename ...Ts>
         static R invoke(naming::address::address_type lva, Ts&&... vs)
         {
+            basic_action<Component const, R(Ps...), Derived>::
+                increment_invocation_count();
             return (get_lva<Component const>::call(lva)->*F)
                 (std::forward<Ts>(vs)...);
         }

--- a/hpx/runtime/actions/invocation_count_registry.hpp
+++ b/hpx/runtime/actions/invocation_count_registry.hpp
@@ -82,10 +82,6 @@ namespace hpx { namespace actions { namespace detail
     {                                                                         \
         static register_action_invocation_count<Action>                       \
             BOOST_PP_CAT(register_action_invocation_count_, Name);            \
-        template void register_local_action_invocation_count<Action>(         \
-            invocation_count_registry& registry);                             \
-        template void register_remote_action_invocation_count<Action>(        \
-            invocation_count_registry& registry);                             \
     }}}                                                                       \
 /**/
 

--- a/hpx/runtime/actions/invocation_count_registry.hpp
+++ b/hpx/runtime/actions/invocation_count_registry.hpp
@@ -8,14 +8,13 @@
 
 #include <hpx/config.hpp>
 #include <hpx/exception.hpp>
-#include <hpx/runtime/serialization/serialization_fwd.hpp>
 #include <hpx/performance_counters/counters.hpp>
 
 #include <hpx/util/jenkins_hash.hpp>
 #include <hpx/util/safe_lexical_cast.hpp>
 #include <hpx/util/static.hpp>
 
-#include <boost/preprocessor/stringize.hpp>
+#include <boost/preprocessor/cat.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/unordered_map.hpp>
 #include <boost/atomic.hpp>
@@ -32,7 +31,8 @@ namespace hpx { namespace actions { namespace detail
                 std::string, get_invocation_count_type, hpx::util::jenkins_hash
             > map_type;
 
-        static invocation_count_registry& instance();
+        static invocation_count_registry& local_instance();
+        static invocation_count_registry& remote_instance();
 
         void register_class(std::string const& name, get_invocation_count_type fun);
 
@@ -46,128 +46,49 @@ namespace hpx { namespace actions { namespace detail
             performance_counters::discover_counters_mode mode, error_code& ec);
 
     private:
-        friend struct hpx::util::static_<invocation_count_registry>;
+        struct local_tag {};
+        struct remote_tag {};
+
+        friend struct hpx::util::static_<invocation_count_registry, local_tag>;
+        friend struct hpx::util::static_<invocation_count_registry, remote_tag>;
 
         map_type map_;
     };
 
-//     template <typename T, typename = void>
-//     struct register_class_name
-//     {
-//         register_class_name()
-//         {
-//             invocation_count_registry::instance().
-//                 register_class(
-//                     T::hpx_serialization_get_name_impl(),
-//                     &factory_function
-//                 );
-//         }
-//
-//         static void* factory_function()
-//         {
-//             return new T;
-//         }
-//
-//         register_class_name& instantiate()
-//         {
-//             return *this;
-//         }
-//
-//         static register_class_name instance;
-//     };
-//
-//     template <class T, class Enable>
-//     register_class_name<T, Enable> register_class_name<T, Enable>::instance;
+    template <typename Action>
+    void register_local_action_invocation_count(
+        invocation_count_registry& registry);
 
+    template <typename Action>
+    void register_remote_action_invocation_count(
+        invocation_count_registry& registry);
+
+    template <typename Action>
+    struct register_action_invocation_count
+    {
+        register_action_invocation_count()
+        {
+            register_local_action_invocation_count<Action>(
+                invocation_count_registry::local_instance());
+
+            register_remote_action_invocation_count<Action>(
+                invocation_count_registry::remote_instance());
+        }
+    };
 }}}
 
-#define HPX_SERIALIZATION_ADD_INTRUSIVE_MEMBERS_WITH_NAME(Class, Name)        \
-  template <class, class> friend                                              \
-  struct ::hpx::serialization::detail::register_class_name;                   \
-                                                                              \
-  static std::string hpx_serialization_get_name_impl()                        \
-  {                                                                           \
-      hpx::serialization::detail::register_class_name<                        \
-          Class>::instance.instantiate();                                     \
-      return Name;                                                            \
-  }                                                                           \
-  virtual std::string hpx_serialization_get_name() const                      \
-  {                                                                           \
-      return Class ::hpx_serialization_get_name_impl();                       \
-  }                                                                           \
-/**/
-
-#define HPX_SERIALIZATION_POLYMORPHIC_WITH_NAME(Class, Name)                  \
-  HPX_SERIALIZATION_ADD_INTRUSIVE_MEMBERS_WITH_NAME(Class, Name);             \
-  virtual void load(hpx::serialization::input_archive& ar, unsigned n)        \
-  {                                                                           \
-      serialize<hpx::serialization::input_archive>(ar, n);                    \
-  }                                                                           \
-  virtual void save(hpx::serialization::output_archive& ar, unsigned n) const \
-  {                                                                           \
-      const_cast<Class*>(this)->                                              \
-          serialize<hpx::serialization::output_archive>(ar, n);               \
-  }                                                                           \
-  HPX_SERIALIZATION_SPLIT_MEMBER();                                           \
-/**/
-
-#define HPX_SERIALIZATION_POLYMORPHIC_WITH_NAME_SPLITTED(Class, Name)         \
-  HPX_SERIALIZATION_ADD_INTRUSIVE_MEMBERS_WITH_NAME(Class, Name);             \
-  virtual void load(hpx::serialization::input_archive& ar, unsigned n)        \
-  {                                                                           \
-      load<hpx::serialization::input_archive>(ar, n);                         \
-  }                                                                           \
-  virtual void save(hpx::serialization::output_archive& ar, unsigned n) const \
-  {                                                                           \
-      save<hpx::serialization::output_archive>(ar, n);                        \
-  }                                                                           \
-/**/
-
-#define HPX_SERIALIZATION_POLYMORPHIC_ABSTRACT(Class)                         \
-  virtual std::string hpx_serialization_get_name() const = 0;                 \
-  virtual void load(hpx::serialization::input_archive& ar, unsigned n)        \
-  {                                                                           \
-      serialize<hpx::serialization::input_archive>(ar, n);                    \
-  }                                                                           \
-  virtual void save(hpx::serialization::output_archive& ar, unsigned n) const \
-  {                                                                           \
-      const_cast<Class*>(this)->                                              \
-          serialize<hpx::serialization::output_archive>(ar, n);               \
-  }                                                                           \
-  HPX_SERIALIZATION_SPLIT_MEMBER()                                            \
-/**/
-
-#define HPX_SERIALIZATION_POLYMORPHIC_ABSTRACT_SPLITTED(Class)                \
-  virtual std::string hpx_serialization_get_name() const = 0;                 \
-  virtual void load(hpx::serialization::input_archive& ar, unsigned n)        \
-  {                                                                           \
-      load<hpx::serialization::input_archive>(ar, n);                         \
-  }                                                                           \
-  virtual void save(hpx::serialization::output_archive& ar, unsigned n) const \
-  {                                                                           \
-      save<hpx::serialization::output_archive>(ar, n);                        \
-  }                                                                           \
-/**/
-
-#define HPX_SERIALIZATION_POLYMORPHIC(Class)                                  \
-  HPX_SERIALIZATION_POLYMORPHIC_WITH_NAME(Class, BOOST_PP_STRINGIZE(Class))   \
-/**/
-
-#define HPX_SERIALIZATION_POLYMORPHIC_SPLITTED(Class)                         \
-  HPX_SERIALIZATION_POLYMORPHIC_WITH_NAME_SPLITTED(                           \
-      Class, BOOST_PP_STRINGIZE(Class))                                       \
+#define HPX_REGISTER_ACTION_INVOCATION_COUNT(Action, Name)                    \
+    namespace hpx { namespace actions { namespace detail                      \
+    {                                                                         \
+        static register_action_invocation_count<Action>                       \
+            BOOST_PP_CAT(register_action_invocation_count_, Name);            \
+        template void register_local_action_invocation_count<Action>(         \
+            invocation_count_registry& registry);                             \
+        template void register_remote_action_invocation_count<Action>(        \
+            invocation_count_registry& registry);                             \
+    }}}                                                                       \
 /**/
 
 #include <hpx/config/warnings_suffix.hpp>
-
-#define HPX_SERIALIZATION_POLYMORPHIC_TEMPLATE(Class)                         \
-  HPX_SERIALIZATION_POLYMORPHIC_WITH_NAME(                                    \
-      Class, hpx::util::type_id<Class>::typeid_.type_id();)                   \
-/**/
-
-#define HPX_SERIALIZATION_POLYMORPHIC_TEMPLATE_SPLITTED(Class)                \
-  HPX_SERIALIZATION_POLYMORPHIC_WITH_NAME_SPLITTED(                           \
-      Class, hpx::util::type_id<T>::typeid_.type_id();)                       \
-/**/
 
 #endif

--- a/hpx/runtime/actions/invocation_count_registry.hpp
+++ b/hpx/runtime/actions/invocation_count_registry.hpp
@@ -74,14 +74,20 @@ namespace hpx { namespace actions { namespace detail
             register_remote_action_invocation_count<Action>(
                 invocation_count_registry::remote_instance());
         }
+
+        static register_action_invocation_count instance;
     };
+
+    template <typename Action>
+    register_action_invocation_count<Action>
+        register_action_invocation_count<Action>::instance;
 }}}
 
-#define HPX_REGISTER_ACTION_INVOCATION_COUNT(Action, Name)                    \
+#define HPX_REGISTER_ACTION_INVOCATION_COUNT(Action)                          \
     namespace hpx { namespace actions { namespace detail                      \
     {                                                                         \
-        static register_action_invocation_count<Action>                       \
-            BOOST_PP_CAT(register_action_invocation_count_, Name);            \
+        template register_action_invocation_count<Action>                     \
+            register_action_invocation_count<Action>::instance;               \
     }}}                                                                       \
 /**/
 

--- a/hpx/runtime/actions/invocation_count_registry.hpp
+++ b/hpx/runtime/actions/invocation_count_registry.hpp
@@ -1,0 +1,173 @@
+//  Copyright (c) 2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_ACTIONS_INVOCATION_COUNT_REGISTRY_SEP_25_2015_0727AM)
+#define HPX_ACTIONS_INVOCATION_COUNT_REGISTRY_SEP_25_2015_0727AM
+
+#include <hpx/config.hpp>
+#include <hpx/exception.hpp>
+#include <hpx/runtime/serialization/serialization_fwd.hpp>
+#include <hpx/performance_counters/counters.hpp>
+
+#include <hpx/util/jenkins_hash.hpp>
+#include <hpx/util/safe_lexical_cast.hpp>
+#include <hpx/util/static.hpp>
+
+#include <boost/preprocessor/stringize.hpp>
+#include <boost/noncopyable.hpp>
+#include <boost/unordered_map.hpp>
+#include <boost/atomic.hpp>
+
+#include <hpx/config/warnings_prefix.hpp>
+
+namespace hpx { namespace actions { namespace detail
+{
+    class HPX_EXPORT invocation_count_registry : boost::noncopyable
+    {
+    public:
+        typedef boost::int64_t (*get_invocation_count_type)(bool);
+        typedef boost::unordered_map<
+                std::string, get_invocation_count_type, hpx::util::jenkins_hash
+            > map_type;
+
+        static invocation_count_registry& instance();
+
+        void register_class(std::string const& name, get_invocation_count_type fun);
+
+        get_invocation_count_type
+            get_invocation_counter(std::string const& name) const;
+
+        bool counter_discoverer(
+            performance_counters::counter_info const& info,
+            performance_counters::counter_path_elements const& p,
+            performance_counters::discover_counter_func const& f,
+            performance_counters::discover_counters_mode mode, error_code& ec);
+
+    private:
+        friend struct hpx::util::static_<invocation_count_registry>;
+
+        map_type map_;
+    };
+
+//     template <typename T, typename = void>
+//     struct register_class_name
+//     {
+//         register_class_name()
+//         {
+//             invocation_count_registry::instance().
+//                 register_class(
+//                     T::hpx_serialization_get_name_impl(),
+//                     &factory_function
+//                 );
+//         }
+//
+//         static void* factory_function()
+//         {
+//             return new T;
+//         }
+//
+//         register_class_name& instantiate()
+//         {
+//             return *this;
+//         }
+//
+//         static register_class_name instance;
+//     };
+//
+//     template <class T, class Enable>
+//     register_class_name<T, Enable> register_class_name<T, Enable>::instance;
+
+}}}
+
+#define HPX_SERIALIZATION_ADD_INTRUSIVE_MEMBERS_WITH_NAME(Class, Name)        \
+  template <class, class> friend                                              \
+  struct ::hpx::serialization::detail::register_class_name;                   \
+                                                                              \
+  static std::string hpx_serialization_get_name_impl()                        \
+  {                                                                           \
+      hpx::serialization::detail::register_class_name<                        \
+          Class>::instance.instantiate();                                     \
+      return Name;                                                            \
+  }                                                                           \
+  virtual std::string hpx_serialization_get_name() const                      \
+  {                                                                           \
+      return Class ::hpx_serialization_get_name_impl();                       \
+  }                                                                           \
+/**/
+
+#define HPX_SERIALIZATION_POLYMORPHIC_WITH_NAME(Class, Name)                  \
+  HPX_SERIALIZATION_ADD_INTRUSIVE_MEMBERS_WITH_NAME(Class, Name);             \
+  virtual void load(hpx::serialization::input_archive& ar, unsigned n)        \
+  {                                                                           \
+      serialize<hpx::serialization::input_archive>(ar, n);                    \
+  }                                                                           \
+  virtual void save(hpx::serialization::output_archive& ar, unsigned n) const \
+  {                                                                           \
+      const_cast<Class*>(this)->                                              \
+          serialize<hpx::serialization::output_archive>(ar, n);               \
+  }                                                                           \
+  HPX_SERIALIZATION_SPLIT_MEMBER();                                           \
+/**/
+
+#define HPX_SERIALIZATION_POLYMORPHIC_WITH_NAME_SPLITTED(Class, Name)         \
+  HPX_SERIALIZATION_ADD_INTRUSIVE_MEMBERS_WITH_NAME(Class, Name);             \
+  virtual void load(hpx::serialization::input_archive& ar, unsigned n)        \
+  {                                                                           \
+      load<hpx::serialization::input_archive>(ar, n);                         \
+  }                                                                           \
+  virtual void save(hpx::serialization::output_archive& ar, unsigned n) const \
+  {                                                                           \
+      save<hpx::serialization::output_archive>(ar, n);                        \
+  }                                                                           \
+/**/
+
+#define HPX_SERIALIZATION_POLYMORPHIC_ABSTRACT(Class)                         \
+  virtual std::string hpx_serialization_get_name() const = 0;                 \
+  virtual void load(hpx::serialization::input_archive& ar, unsigned n)        \
+  {                                                                           \
+      serialize<hpx::serialization::input_archive>(ar, n);                    \
+  }                                                                           \
+  virtual void save(hpx::serialization::output_archive& ar, unsigned n) const \
+  {                                                                           \
+      const_cast<Class*>(this)->                                              \
+          serialize<hpx::serialization::output_archive>(ar, n);               \
+  }                                                                           \
+  HPX_SERIALIZATION_SPLIT_MEMBER()                                            \
+/**/
+
+#define HPX_SERIALIZATION_POLYMORPHIC_ABSTRACT_SPLITTED(Class)                \
+  virtual std::string hpx_serialization_get_name() const = 0;                 \
+  virtual void load(hpx::serialization::input_archive& ar, unsigned n)        \
+  {                                                                           \
+      load<hpx::serialization::input_archive>(ar, n);                         \
+  }                                                                           \
+  virtual void save(hpx::serialization::output_archive& ar, unsigned n) const \
+  {                                                                           \
+      save<hpx::serialization::output_archive>(ar, n);                        \
+  }                                                                           \
+/**/
+
+#define HPX_SERIALIZATION_POLYMORPHIC(Class)                                  \
+  HPX_SERIALIZATION_POLYMORPHIC_WITH_NAME(Class, BOOST_PP_STRINGIZE(Class))   \
+/**/
+
+#define HPX_SERIALIZATION_POLYMORPHIC_SPLITTED(Class)                         \
+  HPX_SERIALIZATION_POLYMORPHIC_WITH_NAME_SPLITTED(                           \
+      Class, BOOST_PP_STRINGIZE(Class))                                       \
+/**/
+
+#include <hpx/config/warnings_suffix.hpp>
+
+#define HPX_SERIALIZATION_POLYMORPHIC_TEMPLATE(Class)                         \
+  HPX_SERIALIZATION_POLYMORPHIC_WITH_NAME(                                    \
+      Class, hpx::util::type_id<Class>::typeid_.type_id();)                   \
+/**/
+
+#define HPX_SERIALIZATION_POLYMORPHIC_TEMPLATE_SPLITTED(Class)                \
+  HPX_SERIALIZATION_POLYMORPHIC_WITH_NAME_SPLITTED(                           \
+      Class, hpx::util::type_id<T>::typeid_.type_id();)                       \
+/**/
+
+#endif

--- a/hpx/runtime/actions/invocation_count_registry.hpp
+++ b/hpx/runtime/actions/invocation_count_registry.hpp
@@ -7,11 +7,9 @@
 #define HPX_ACTIONS_INVOCATION_COUNT_REGISTRY_SEP_25_2015_0727AM
 
 #include <hpx/config.hpp>
-#include <hpx/exception.hpp>
 #include <hpx/performance_counters/counters.hpp>
 
 #include <hpx/util/jenkins_hash.hpp>
-#include <hpx/util/safe_lexical_cast.hpp>
 #include <hpx/util/static.hpp>
 
 #include <boost/preprocessor/cat.hpp>

--- a/hpx/runtime/actions/plain_action.hpp
+++ b/hpx/runtime/actions/plain_action.hpp
@@ -31,6 +31,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace actions
 {
+    /// \cond NOINTERNAL
+
     namespace detail
     {
         struct plain_function
@@ -50,7 +52,6 @@ namespace hpx { namespace actions
             }
         };
     }
-    /// \cond NOINTERNAL
 
     ///////////////////////////////////////////////////////////////////////////
     //  Specialized generic plain (free) action types allowing to hold a
@@ -60,9 +61,7 @@ namespace hpx { namespace actions
         typename R, typename ...Ps,
         typename TF, TF F, typename Derived>
     class basic_action_impl<R (*)(Ps...), TF, F, Derived>
-      : public basic_action<
-            detail::plain_function,
-            R(Ps...), Derived>
+      : public basic_action<detail::plain_function, R(Ps...), Derived>
     {
     public:
 
@@ -84,6 +83,8 @@ namespace hpx { namespace actions
         template <typename ...Ts>
         static R invoke(naming::address::address_type /*lva*/, Ts&&... vs)
         {
+            basic_action<detail::plain_function, R(Ps...), Derived>::
+                increment_invocation_count();
             return F(std::forward<Ts>(vs)...);
         }
     };
@@ -91,17 +92,22 @@ namespace hpx { namespace actions
     /// \endcond
 }}
 
-namespace hpx { namespace traits {
-
+namespace hpx { namespace traits
+{
     template <> HPX_ALWAYS_EXPORT
     inline components::component_type
     component_type_database<hpx::actions::detail::plain_function>::get()
-    { return hpx::components::component_plain_function; }
+    {
+        return hpx::components::component_plain_function;
+    }
+
     template <> HPX_ALWAYS_EXPORT
     inline void
-    component_type_database<hpx::actions::detail::plain_function>::
-        set(components::component_type)
-    { HPX_ASSERT(false); }
+    component_type_database<hpx::actions::detail::plain_function>::set(
+        components::component_type)
+    {
+        HPX_ASSERT(false);      // shouldn't be ever called
+    }
 }}
 
 /// \def HPX_DEFINE_PLAIN_ACTION(func, name)

--- a/hpx/runtime/actions/transfer_action.hpp
+++ b/hpx/runtime/actions/transfer_action.hpp
@@ -14,6 +14,7 @@
 #include <hpx/config.hpp>
 #include <hpx/runtime/actions/action_support.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
+#include <hpx/runtime/actions/invocation_count_registry.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
 #include <hpx/runtime/threads/thread_init_data.hpp>
 #include <hpx/runtime/serialization/output_archive.hpp>
@@ -472,6 +473,19 @@ namespace hpx { namespace actions
     template <typename Action>
     boost::atomic<boost::int64_t>
         transfer_action<Action>::invocation_count_(0);
+
+    namespace detail
+    {
+        template <typename Action>
+        void register_remote_action_invocation_count(
+            invocation_count_registry& registry)
+        {
+            registry.register_class(
+                hpx::actions::detail::get_action_name<Action>(),
+                &transfer_action<Action>::get_invocation_count
+            );
+        }
+    }
 
     ///////////////////////////////////////////////////////////////////////////
     template <std::size_t N, typename Action>

--- a/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
+++ b/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
@@ -27,26 +27,26 @@
 
 namespace hpx { namespace serialization { namespace detail
 {
-        template <typename T>
-        struct get_serialization_name
+    template <typename T>
+    struct get_serialization_name
 #ifdef HPX_DISABLE_AUTOMATIC_SERIALIZATION_REGISTRATION
-        ;
+    ;
 #else
+    {
+        const char *operator()()
         {
-            const char *operator()()
-            {
-                /// If you encounter this assert while compiling code, that means that
-                /// you have a HPX_REGISTER_ACTION macro somewhere in a source file,
-                /// but the header in which the action is defined misses a
-                /// HPX_REGISTER_ACTION_DECLARATION
-                BOOST_MPL_ASSERT_MSG(
-                    traits::needs_automatic_registration<T>::value
-                  , HPX_REGISTER_ACTION_DECLARATION_MISSING
-                  , (T)
-                );
-                return util::type_id<T>::typeid_.type_id();
-            }
-        };
+            /// If you encounter this assert while compiling code, that means that
+            /// you have a HPX_REGISTER_ACTION macro somewhere in a source file,
+            /// but the header in which the action is defined misses a
+            /// HPX_REGISTER_ACTION_DECLARATION
+            BOOST_MPL_ASSERT_MSG(
+                traits::needs_automatic_registration<T>::value
+                , HPX_REGISTER_ACTION_DECLARATION_MISSING
+                , (T)
+            );
+            return util::type_id<T>::typeid_.type_id();
+        }
+    };
 #endif
 
     struct function_bunch_type

--- a/src/performance_counters/registry.cpp
+++ b/src/performance_counters/registry.cpp
@@ -130,8 +130,7 @@ namespace hpx { namespace performance_counters
             return result;
         }
 
-        inline std::string
-        regex_from_pattern(std::string const& pattern, error_code& ec)
+        std::string regex_from_pattern(std::string const& pattern, error_code& ec)
         {
             std::string result;
             std::string::const_iterator end = pattern.end();
@@ -234,6 +233,11 @@ namespace hpx { namespace performance_counters
                     discover_counter, boost::ref(ec));
             }
 
+            // split name
+            counter_path_elements p;
+            get_counter_path_elements(fullname, p, ec);
+            if (ec) return status_invalid_data;
+
             bool found_one = false;
             boost::regex rx(str_rx, boost::regex::perl);
 
@@ -245,8 +249,13 @@ namespace hpx { namespace performance_counters
                     continue;
                 found_one = true;
 
+                // propagate parameters
+                counter_info info = (*it).second.info_;
+                if (!p.parameters_.empty())
+                    info.fullname_ += "@" + p.parameters_;
+
                 if (!(*it).second.discover_counters_.empty() &&
-                    !(*it).second.discover_counters_((*it).second.info_,
+                    !(*it).second.discover_counters_(info,
                         discover_counter, mode, ec))
                 {
                     return status_invalid_data;

--- a/src/performance_counters/server/action_invocation_counter.cpp
+++ b/src/performance_counters/server/action_invocation_counter.cpp
@@ -1,0 +1,86 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_fwd.hpp>
+#include <hpx/runtime/components/runtime_support.hpp>
+#include <hpx/performance_counters/counters.hpp>
+#include <hpx/performance_counters/counter_creators.hpp>
+#include <hpx/runtime/actions/invocation_count_registry.hpp>
+#include <hpx/util/function.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace performance_counters
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // Discoverer function for action invocation counters
+    bool action_invocation_counter_discoverer(counter_info const& info,
+        discover_counter_func const& f,
+        discover_counters_mode mode, error_code& ec)
+    {
+        performance_counters::counter_info i = info;
+
+        // compose the counter name templates
+        performance_counters::counter_path_elements p;
+        performance_counters::counter_status status =
+            get_counter_path_elements(info.fullname_, p, ec);
+        if (!status_is_valid(status)) return false;
+
+        bool result =
+            hpx::actions::detail::invocation_count_registry::instance().
+                counter_discoverer(info, p, f, mode, ec);
+        if (!result || ec) return false;
+
+        if (&ec != &throws)
+            ec = make_success_code();
+
+        return true;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Creation function for action invocation counter
+    naming::gid_type action_invocation_counter_creator(
+        counter_info const& info, error_code& ec)
+    {
+        switch (info.type_) {
+        case counter_raw:
+            {
+                counter_path_elements paths;
+                get_counter_path_elements(info.fullname_, paths, ec);
+                if (ec) return naming::invalid_gid;
+
+                if (paths.parentinstance_is_basename_) {
+                    HPX_THROWS_IF(ec, bad_parameter,
+                        "action_invocation_counter_creator",
+                        "invalid action invocation counter name (instance name "
+                        "must not be a valid base counter name)");
+                    return naming::invalid_gid;
+                }
+
+                if (paths.parameters_.empty()) {
+                    HPX_THROWS_IF(ec, bad_parameter,
+                        "action_invocation_counter_creator",
+                        "invalid action invocation counter parameter: must "
+                        "specify an action type");
+                    return naming::invalid_gid;
+                }
+
+                // ask registry
+                hpx::util::function_nonser<boost::int64_t(bool)> f =
+                    hpx::actions::detail::invocation_count_registry::instance().
+                        get_invocation_counter(paths.parameters_);
+
+                return detail::create_raw_counter(info, std::move(f), ec);
+            }
+            break;
+
+        default:
+            HPX_THROWS_IF(ec, bad_parameter,
+                "action_invocation_counter_creator",
+                "invalid counter type requested");
+            return naming::invalid_gid;
+        }
+    }
+}}
+

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -718,8 +718,19 @@ namespace hpx
               "on this locality (the action type has to be specified as the "
               "counter parameter)",
               HPX_PERFORMANCE_COUNTER_V1,
-              &performance_counters::action_invocation_counter_creator,
-              &performance_counters::action_invocation_counter_discoverer,
+              &performance_counters::local_action_invocation_counter_creator,
+              &performance_counters::local_action_invocation_counter_discoverer,
+              ""
+            },
+
+            { "/runtime/count/remote_action_invocation",
+              performance_counters::counter_raw,
+              "returns the number of (remote) invocations of a specific action "
+              "on this locality (the action type has to be specified as the "
+              "counter parameter)",
+              HPX_PERFORMANCE_COUNTER_V1,
+              &performance_counters::remote_action_invocation_counter_creator,
+              &performance_counters::remote_action_invocation_counter_discoverer,
               ""
             }
         };

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -693,7 +693,8 @@ namespace hpx
 
             // uptime counters
             { "/runtime/uptime", performance_counters::counter_elapsed_time,
-              "returns the up time of the runtime instance for the referenced locality",
+              "returns the up time of the runtime instance for the referenced "
+              "locality",
               HPX_PERFORMANCE_COUNTER_V1,
               &performance_counters::detail::uptime_counter_creator,
               &performance_counters::locality_counter_discoverer,
@@ -708,6 +709,17 @@ namespace hpx
               HPX_PERFORMANCE_COUNTER_V1,
               &performance_counters::detail::component_instance_counter_creator,
               &performance_counters::locality_counter_discoverer,
+              ""
+            },
+
+            // action invocation counters
+            { "/runtime/count/action_invocation", performance_counters::counter_raw,
+              "returns the number of (local) invocations of a specific action "
+              "on this locality (the action type has to be specified as the "
+              "counter parameter)",
+              HPX_PERFORMANCE_COUNTER_V1,
+              &performance_counters::action_invocation_counter_creator,
+              &performance_counters::action_invocation_counter_discoverer,
               ""
             }
         };

--- a/src/runtime/actions/invocation_count_registry.cpp
+++ b/src/runtime/actions/invocation_count_registry.cpp
@@ -1,0 +1,159 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_fwd.hpp>
+#include <hpx/exception.hpp>
+#include <hpx/runtime/actions/invocation_count_registry.hpp>
+#include <hpx/performance_counters/registry.hpp>
+
+#include <string>
+
+#include <boost/format.hpp>
+#include <boost/regex.hpp>
+
+namespace hpx { namespace actions { namespace detail
+{
+    invocation_count_registry& invocation_count_registry::instance()
+    {
+        hpx::util::static_<invocation_count_registry> registry;
+        return registry.get();
+    }
+
+    void invocation_count_registry::register_class(std::string const& name,
+        get_invocation_count_type fun)
+    {
+        if(name.empty())
+        {
+            HPX_THROW_EXCEPTION(bad_parameter,
+                "invocation_count_registry::register_class",
+                "Cannot register an action with an empty name");
+        }
+
+        auto it = map_.find(name);
+        if (it == map_.end())
+        {
+#if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION >= 408000
+            map_.emplace(name, fun);
+#else
+            map_.insert(map_type::value_type(name, fun));
+#endif
+        }
+    }
+
+    invocation_count_registry::get_invocation_count_type
+        invocation_count_registry::get_invocation_counter(
+            std::string const& name) const
+    {
+        map_type::const_iterator it = map_.find(name);
+        if (it == map_.end())
+        {
+            HPX_THROW_EXCEPTION(bad_parameter,
+                "invocation_count_registry::get_invocation_counter",
+                "unknown action type");
+            return 0;
+        }
+        return (*it).second;
+    }
+
+    bool invocation_count_registry::counter_discoverer(
+        performance_counters::counter_info const& info,
+        performance_counters::counter_path_elements const& p,
+        performance_counters::discover_counter_func const& f,
+        performance_counters::discover_counters_mode mode, error_code& ec)
+    {
+        if (p.parameters_.find_first_of("*?[]") != std::string::npos)
+        {
+            std::string str_rx(
+                performance_counters::detail::regex_from_pattern(
+                    p.parameters_, ec));
+            if (ec) return false;
+
+            bool found_one = false;
+            boost::regex rx(str_rx, boost::regex::perl);
+
+            map_type::const_iterator end = map_.end();
+            for (map_type::const_iterator it = map_.begin(); it != end; ++it)
+            {
+                if (!boost::regex_match((*it).first, rx))
+                    continue;
+                found_one = true;
+
+                // propagate parameters
+                std::string fullname;
+                performance_counters::counter_path_elements cp = p;
+                cp.parameters_ = (*it).first;
+
+                performance_counters::get_counter_name(cp, fullname, ec);
+                if (ec) return false;
+
+                performance_counters::counter_info cinfo = info;
+                cinfo.fullname_ = fullname;
+
+                if (!f(cinfo, ec) || ec)
+                    return false;
+            }
+
+            if (!found_one)
+            {
+                // compose a list of known action types
+                std::string types;
+                map_type::const_iterator end = map_.end();
+                for (map_type::const_iterator it = map_.begin(); it != end; ++it)
+                {
+                    types += "  " + (*it).first + "\n";
+                }
+
+                HPX_THROWS_IF(ec, bad_parameter,
+                    "invocation_count_registry::counter_discoverer",
+                    boost::str(boost::format(
+                        "action type %s does not match any known type, "
+                        "known action types: \n%s") % p.parameters_ % types));
+                return false;
+            }
+
+            if (&ec != &throws)
+                ec = make_success_code();
+
+            return true;
+        }
+
+        // use given action type directly
+        map_type::const_iterator it = map_.find(p.parameters_);
+        if (it != map_.end())
+        {
+            // compose a list of known action types
+            std::string types;
+            map_type::const_iterator end = map_.end();
+            for (map_type::const_iterator it = map_.begin(); it != end; ++it)
+            {
+                types += "  " + (*it).first + "\n";
+            }
+
+            HPX_THROWS_IF(ec, bad_parameter,
+                "invocation_count_registry::counter_discoverer",
+                boost::str(boost::format(
+                    "action type %s does not match any known type, "
+                    "known action types: \n%s") % p.parameters_ % types));
+            return false;
+        }
+
+        // propagate parameters
+        std::string fullname;
+        performance_counters::get_counter_name(p, fullname, ec);
+        if (ec) return false;
+
+        performance_counters::counter_info cinfo = info;
+        cinfo.fullname_ = fullname;
+
+        if (!f(cinfo, ec) || ec)
+            return false;
+
+        if (&ec != &throws)
+            ec = make_success_code();
+
+        return true;
+    }
+}}}
+

--- a/src/runtime/actions/invocation_count_registry.cpp
+++ b/src/runtime/actions/invocation_count_registry.cpp
@@ -15,16 +15,22 @@
 
 namespace hpx { namespace actions { namespace detail
 {
-    invocation_count_registry& invocation_count_registry::instance()
+    invocation_count_registry& invocation_count_registry::local_instance()
     {
-        hpx::util::static_<invocation_count_registry> registry;
+        hpx::util::static_<invocation_count_registry, local_tag> registry;
+        return registry.get();
+    }
+
+    invocation_count_registry& invocation_count_registry::remote_instance()
+    {
+        hpx::util::static_<invocation_count_registry, remote_tag> registry;
         return registry.get();
     }
 
     void invocation_count_registry::register_class(std::string const& name,
         get_invocation_count_type fun)
     {
-        if(name.empty())
+        if (name.empty())
         {
             HPX_THROW_EXCEPTION(bad_parameter,
                 "invocation_count_registry::register_class",
@@ -121,7 +127,7 @@ namespace hpx { namespace actions { namespace detail
 
         // use given action type directly
         map_type::const_iterator it = map_.find(p.parameters_);
-        if (it != map_.end())
+        if (it == map_.end())
         {
             // compose a list of known action types
             std::string types;


### PR DESCRIPTION
Adding performance counters for local and remote action invocation counts:

    /runtime/count/action_invocation 
    /runtime/count/remote_action_invocation 

The actual action name has to be specified as the parameter argument, for instance:

    /runtime/count/action_invocation@set_value_action_gid_type

In order to get all action invocation counts, wildcard characters can be used (as usual):

    /runtime/count/action_invocation@*