### PR TITLE
Agas fixes

### DIFF
--- a/hpx/runtime/agas/addressing_service.hpp
+++ b/hpx/runtime/agas/addressing_service.hpp
@@ -313,6 +313,9 @@ public:
       , error_code& ec = throws
         );
 
+    /// \brief remove given locality from locality cache
+    void remove_resolved_locality(naming::gid_type const& gid);
+
     /// \brief Get locality locality_id of the console locality.
     ///
     /// \param locality_id     [out] The locality_id value uniquely identifying the

--- a/hpx/runtime/agas/addressing_service.hpp
+++ b/hpx/runtime/agas/addressing_service.hpp
@@ -215,6 +215,22 @@ struct HPX_EXPORT addressing_service : boost::noncopyable
       , boost::int64_t compensated_credit
         );
 
+    naming::address::address_type get_primary_ns_lva() const
+    {
+        return reinterpret_cast<naming::address::address_type>(
+            is_bootstrap() ?
+                get_bootstrap_primary_ns_ptr() :
+                get_hosted_primary_ns_ptr());
+    }
+
+    naming::address::address_type get_symbol_ns_lva() const
+    {
+        return reinterpret_cast<naming::address::address_type>(
+            is_bootstrap() ?
+                get_bootstrap_symbol_ns_ptr() :
+                get_hosted_symbol_ns_ptr());
+    }
+
 protected:
     void launch_bootstrap(
         boost::shared_ptr<parcelset::parcelport> const& pp
@@ -1127,7 +1143,7 @@ public:
     void route(
         parcelset::parcel p
       , util::function_nonser<void(boost::system::error_code const&,
-            parcelset::parcel const&)> const&
+            parcelset::parcel const&)> &&
         );
 
     /// \brief Increment the global reference count for the given id

--- a/hpx/runtime/agas/server/primary_namespace.hpp
+++ b/hpx/runtime/agas/server/primary_namespace.hpp
@@ -361,7 +361,8 @@ struct HPX_EXPORT primary_namespace
 
   private:
     resolved_type resolve_gid_locked(
-        naming::gid_type const& gid
+        boost::unique_lock<mutex_type>& l
+      , naming::gid_type const& gid
       , error_code& ec
         );
 

--- a/hpx/runtime/applier/detail/apply_colocated.hpp
+++ b/hpx/runtime/applier/detail/apply_colocated.hpp
@@ -24,6 +24,12 @@ namespace hpx { namespace detail
     template <typename Action, typename ...Ts>
     bool apply_colocated(naming::id_type const& gid, Ts&&... vs)
     {
+        // shortcut co-location code if target already is a locality
+        if (naming::is_locality(gid))
+        {
+            return apply<Action>(gid, std::forward<Ts>(vs)...);
+        }
+
         // Attach the requested action as a continuation to a resolve_async
         // call on the locality responsible for the target gid.
         agas::request req(agas::primary_ns_resolve_gid, gid.get_gid());
@@ -59,6 +65,13 @@ namespace hpx { namespace detail
     apply_colocated(Continuation && cont,
         naming::id_type const& gid, Ts&&... vs)
     {
+        // shortcut co-location code if target already is a locality
+        if (naming::is_locality(gid))
+        {
+            return apply_c<Action>(std::forward<Continuation>(cont), gid,
+                std::forward<Ts>(vs)...);
+        }
+
         // Attach the requested action as a continuation to a resolve_async
         // call on the locality responsible for the target gid.
         agas::request req(agas::primary_ns_resolve_gid, gid.get_gid());

--- a/hpx/runtime/applier/detail/apply_colocated_callback.hpp
+++ b/hpx/runtime/applier/detail/apply_colocated_callback.hpp
@@ -26,6 +26,13 @@ namespace hpx { namespace detail
     bool apply_colocated_cb(naming::id_type const& gid, Callback&& cb,
         Ts&&... vs)
     {
+        // shortcut co-location code if target already is a locality
+        if (naming::is_locality(gid))
+        {
+            return apply_cb<Action>(gid, std::forward<Callback>(cb),
+                std::forward<Ts>(vs)...);
+        }
+
         // Attach the requested action as a continuation to a resolve_async
         // call on the locality responsible for the target gid.
         agas::request req(agas::primary_ns_resolve_gid, gid.get_gid());
@@ -59,6 +66,14 @@ namespace hpx { namespace detail
     bool apply_colocated_cb(Continuation && cont,
         naming::id_type const& gid, Callback&& cb, Ts&&... vs)
     {
+        // shortcut co-location code if target already is a locality
+        if (naming::is_locality(gid))
+        {
+            return apply_p_cb<Action>(std::forward<Continuation>(cont), gid,
+                actions::action_priority<Action>(),
+                std::forward<Callback>(cb), std::forward<Ts>(vs)...);
+        }
+
         // Attach the requested action as a continuation to a resolve_async
         // call on the locality responsible for the target gid.
         agas::request req(agas::primary_ns_resolve_gid, gid.get_gid());

--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -217,7 +217,8 @@ namespace hpx { namespace components { namespace server
         boost::int32_t get_instance_count(components::component_type);
 
         /// \brief Remove the given locality from our connection cache
-        void remove_from_connection_cache(parcelset::endpoints_type const& eps);
+        void remove_from_connection_cache(naming::gid_type const& gid,
+            parcelset::endpoints_type const& eps);
 
         /// \brief termination detection
 #if defined(HPX_USE_FAST_DIJKSTRA_TERMINATION_DETECTION)

--- a/hpx/runtime/components/stubs/runtime_support.hpp
+++ b/hpx/runtime/components/stubs/runtime_support.hpp
@@ -338,7 +338,8 @@ namespace hpx { namespace components { namespace stubs
 
         ///////////////////////////////////////////////////////////////////////
         static void
-        call_shutdown_functions_async(naming::id_type const& gid,
+        remove_from_connection_cache_async(naming::id_type const& target,
+            naming::gid_type const& gid,
             parcelset::endpoints_type const& endpoints);
     };
 }}}

--- a/hpx/runtime/parcelset/parcelhandler.hpp
+++ b/hpx/runtime/parcelset/parcelhandler.hpp
@@ -233,7 +233,8 @@ namespace hpx { namespace parcelset
 
         /// \brief Make sure the specified locality is not held by any
         /// connection caches anymore
-        void remove_from_connection_cache(endpoints_type const& endpoints);
+        void remove_from_connection_cache(naming::gid_type const& gid,
+            endpoints_type const& endpoints);
 
         /// \brief return the endpoints associated with this parcelhandler
         /// \returns all connection information for the enabled parcelports

--- a/src/runtime/agas/server/route.cpp
+++ b/src/runtime/agas/server/route.cpp
@@ -49,7 +49,7 @@ namespace hpx { namespace agas { namespace server
                     // wait for any migration to be completed
                     wait_for_migration_locked(l, gid, ec);
 
-                    cache_addresses.push_back(resolve_gid_locked(gid, ec));
+                    cache_addresses.push_back(resolve_gid_locked(l, gid, ec));
                     resolved_type const& r = cache_addresses.back();
 
                     if (ec || boost::fusion::at_c<0>(r) == naming::invalid_gid)

--- a/src/runtime/applier/applier.cpp
+++ b/src/runtime/applier/applier.cpp
@@ -503,7 +503,26 @@ namespace hpx { namespace applier
             // support component
             if (0 == lva)
             {
-                lva = get_runtime_support_raw_gid().get_lsb();
+                switch(comptype)
+                {
+                case components::component_runtime_support:
+                    lva = get_runtime_support_raw_gid().get_lsb();
+                    break;
+
+                case components::component_agas_primary_namespace:
+                    lva = get_agas_client().get_primary_ns_lva();
+                    break;
+
+                case components::component_agas_symbol_namespace:
+                    lva = get_agas_client().get_symbol_ns_lva();
+                    break;
+
+                case components::component_plain_function:
+                    break;
+
+                default:
+                    HPX_ASSERT(false);
+                }
             }
             else if (comptype == components::component_memory)
             {

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -984,14 +984,14 @@ namespace hpx { namespace components { namespace server
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Remove the given locality from our connection cache
-    void runtime_support::remove_from_connection_cache(parcelset::endpoints_type
-        const& eps)
+    void runtime_support::remove_from_connection_cache(
+        naming::gid_type const& gid, parcelset::endpoints_type const& eps)
     {
         runtime* rt = get_runtime_ptr();
         if (rt == 0) return;
 
         // instruct our connection cache to drop all connections it is holding
-        rt->get_parcel_handler().remove_from_connection_cache(eps);
+        rt->get_parcel_handler().remove_from_connection_cache(gid, eps);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1225,11 +1225,13 @@ namespace hpx { namespace components { namespace server
 
         std::vector<naming::id_type> locality_ids = find_remote_localities();
 
-        typedef server::runtime_support::remove_from_connection_cache_action action_type;
+        typedef server::runtime_support::remove_from_connection_cache_action
+            action_type;
+
         action_type act;
         for (naming::id_type const& id : locality_ids)
         {
-            apply(act, id, rt->endpoints());
+            apply(act, id, hpx::get_locality(), rt->endpoints());
         }
     }
 

--- a/src/runtime/components/stubs/runtime_support_stubs.cpp
+++ b/src/runtime/components/stubs/runtime_support_stubs.cpp
@@ -352,12 +352,13 @@ namespace hpx { namespace components { namespace stubs
     }
 
     ///////////////////////////////////////////////////////////////////////
-    void runtime_support::call_shutdown_functions_async(
-        naming::id_type const& gid, parcelset::endpoints_type const& endpoints)
+    void runtime_support::remove_from_connection_cache_async(
+        naming::id_type const& target, naming::gid_type const& gid,
+        parcelset::endpoints_type const& endpoints)
     {
         typedef server::runtime_support::remove_from_connection_cache_action
             action_type;
-        hpx::apply<action_type>(gid, endpoints);
+        hpx::apply<action_type>(target, gid, endpoints);
     }
 }}}
 

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -198,7 +198,7 @@ namespace hpx { namespace parcelset
     /// \brief Make sure the specified locality is not held by any
     /// connection caches anymore
     void parcelhandler::remove_from_connection_cache(
-        endpoints_type const& endpoints)
+        naming::gid_type const& gid, endpoints_type const& endpoints)
     {
         for (endpoints_type::value_type const& loc : endpoints)
         {
@@ -210,6 +210,9 @@ namespace hpx { namespace parcelset
                 }
             }
         }
+
+        HPX_ASSERT(resolver_);
+        resolver_->remove_resolved_locality(gid);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -301,7 +304,8 @@ namespace hpx { namespace parcelset
         naming::gid_type const& dest_gid)
     {
         HPX_ASSERT(resolver_);
-        endpoints_type const & dest_endpoints = resolver_->resolve_locality(dest_gid);
+        endpoints_type const & dest_endpoints =
+            resolver_->resolve_locality(dest_gid);
 
         for (pports_type::value_type& pp : pports_)
         {


### PR DESCRIPTION
Stop routing AGAS parcels through locality 0 

Also minor flyby changes, such as:

- enforce owned lock for resolve_gid_locked
- enable more resolved gids in resolve_locally_known_addresses
- explicit unlocking of mutexes before throwing exceptions

This addresses the slowdown over time we observe for various applications. 

@quantomb, @justwagle: please check how applying this patch changes the picture.