### PR TITLE
Drop legacy forwarding action traits

### DIFF
--- a/hpx/lcos/async_fwd.hpp
+++ b/hpx/lcos/async_fwd.hpp
@@ -10,7 +10,6 @@
 
 #include <hpx/config.hpp>
 #include <hpx/traits.hpp>
-#include <hpx/util/always_void.hpp>
 #include <hpx/util/move.hpp>
 #include <hpx/util/decay.hpp>
 
@@ -27,12 +26,6 @@ namespace hpx { namespace actions
         typedef typename type::result_type result_type;
         typedef typename type::remote_result_type remote_result_type;
     };
-
-    template <typename Action>
-    struct extract_action<Action
-      , typename util::always_void<typename Action::type>::type>
-      : extract_action<typename Action::type>
-    {};
 }}
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hpx/traits/action_capability_provider.hpp
+++ b/hpx/traits/action_capability_provider.hpp
@@ -11,7 +11,6 @@
 #if defined(HPX_HAVE_SECURITY)
 #include <hpx/components/security/capability.hpp>
 #include <hpx/runtime/naming/address.hpp>
-#include <hpx/util/always_void.hpp>
 
 namespace hpx { namespace traits
 {
@@ -29,12 +28,6 @@ namespace hpx { namespace traits
             return components::security::capability();
         }
     };
-
-    template <typename Action>
-    struct action_capability_provider<Action
-      , typename util::always_void<typename Action::type>::type>
-      : action_capability_provider<typename Action::type>
-    {};
 }}
 
 #endif

--- a/hpx/traits/action_decorate_continuation.hpp
+++ b/hpx/traits/action_decorate_continuation.hpp
@@ -7,7 +7,6 @@
 #define HPX_TRAITS_ACTION_DECORATE_CONTINUATION_MAR_30_2014_0725PM
 
 #include <hpx/runtime/actions/continuation_fwd.hpp>
-#include <hpx/util/always_void.hpp>
 
 #include <memory>
 
@@ -24,12 +23,6 @@ namespace hpx { namespace traits
             return false; // continuation has not been modified
         }
     };
-
-    template <typename Action>
-    struct action_decorate_continuation<Action
-      , typename util::always_void<typename Action::type>::type>
-      : action_decorate_continuation<typename Action::type>
-    {};
 }}
 
 #endif

--- a/hpx/traits/action_decorate_function.hpp
+++ b/hpx/traits/action_decorate_function.hpp
@@ -7,7 +7,6 @@
 #define HPX_TRAITS_ACTION_DECORATE_FUNCTION_MAR_30_2014_1054AM
 
 #include <hpx/runtime/naming/name.hpp>
-#include <hpx/util/always_void.hpp>
 
 namespace hpx { namespace traits
 {
@@ -25,12 +24,6 @@ namespace hpx { namespace traits
             return component_type::decorate_action(lva, std::forward<F>(f));
         }
     };
-
-    template <typename Action>
-    struct action_decorate_function<Action
-      , typename util::always_void<typename Action::type>::type>
-      : action_decorate_function<typename Action::type>
-    {};
 }}
 
 #endif

--- a/hpx/traits/action_does_termination_detection.hpp
+++ b/hpx/traits/action_does_termination_detection.hpp
@@ -6,8 +6,6 @@
 #if !defined(HPX_TRAITS_ACTION_DOES_TERMINATION_DETECTION_MAR_21_2014_0818PM)
 #define HPX_TRAITS_ACTION_DOES_TERMINATION_DETECTION_MAR_21_2014_0818PM
 
-#include <hpx/util/always_void.hpp>
-
 namespace hpx { namespace traits
 {
     ///////////////////////////////////////////////////////////////////////////
@@ -20,12 +18,6 @@ namespace hpx { namespace traits
             return false;
         }
     };
-
-    template <typename Action>
-    struct action_does_termination_detection<Action
-      , typename util::always_void<typename Action::type>::type>
-      : action_does_termination_detection<typename Action::type>
-    {};
 }}
 
 #endif

--- a/hpx/traits/action_is_target_valid.hpp
+++ b/hpx/traits/action_is_target_valid.hpp
@@ -7,7 +7,6 @@
 #define HPX_TRAITS_ACTION_IS_TARGET_VALID_MAR_10_2014_1103AM
 
 #include <hpx/runtime/naming/id_type.hpp>
-#include <hpx/util/always_void.hpp>
 
 namespace hpx { namespace traits
 {
@@ -21,12 +20,6 @@ namespace hpx { namespace traits
             return Action::is_target_valid(id);
         }
     };
-
-    template <typename Action>
-    struct action_is_target_valid<Action
-      , typename util::always_void<typename Action::type>::type>
-      : action_is_target_valid<typename Action::type>
-    {};
 }}
 
 #endif

--- a/hpx/traits/action_message_handler.hpp
+++ b/hpx/traits/action_message_handler.hpp
@@ -7,7 +7,6 @@
 #define HPX_TRAITS_ACTION_MESSAGE_HANDLER_FEB_24_2013_0318PM
 
 #include <hpx/runtime/parcelset_fwd.hpp>
-#include <hpx/util/always_void.hpp>
 
 namespace hpx { namespace traits
 {
@@ -24,12 +23,6 @@ namespace hpx { namespace traits
             return 0;   // by default actions don't have a message_handler
         }
     };
-
-    template <typename Action>
-    struct action_message_handler<Action
-      , typename util::always_void<typename Action::type>::type>
-      : action_message_handler<typename Action::type>
-    {};
 }}
 
 #endif

--- a/hpx/traits/action_priority.hpp
+++ b/hpx/traits/action_priority.hpp
@@ -7,7 +7,6 @@
 #define HPX_TRAITS_ACTION_PRIORITY_SEP_03_2012_1138AM
 
 #include <hpx/runtime/threads/thread_enums.hpp>
-#include <hpx/util/always_void.hpp>
 
 namespace hpx { namespace traits
 {
@@ -18,12 +17,6 @@ namespace hpx { namespace traits
     {
         enum { value = threads::thread_priority_default };
     };
-
-    template <typename Action>
-    struct action_priority<Action
-      , typename util::always_void<typename Action::type>::type>
-      : action_priority<typename Action::type>
-    {};
 }}
 
 #endif

--- a/hpx/traits/action_schedule_thread.hpp
+++ b/hpx/traits/action_schedule_thread.hpp
@@ -9,7 +9,6 @@
 #include <hpx/runtime/naming/address.hpp>
 #include <hpx/runtime/threads/thread_enums.hpp>
 #include <hpx/runtime/threads/thread_init_data.hpp>
-#include <hpx/util/always_void.hpp>
 
 namespace hpx { namespace traits
 {
@@ -27,12 +26,6 @@ namespace hpx { namespace traits
             return component_type::schedule_thread(lva, data, initial_state);
         }
     };
-
-    template <typename Action>
-    struct action_schedule_thread<Action
-      , typename util::always_void<typename Action::type>::type>
-      : action_schedule_thread<typename Action::type>
-    {};
 }}
 
 #endif

--- a/hpx/traits/action_serialization_filter.hpp
+++ b/hpx/traits/action_serialization_filter.hpp
@@ -8,7 +8,6 @@
 
 #include <hpx/runtime/parcelset_fwd.hpp>
 #include <hpx/runtime/serialization/serialization_fwd.hpp>
-#include <hpx/util/always_void.hpp>
 
 namespace hpx { namespace traits
 {
@@ -23,12 +22,6 @@ namespace hpx { namespace traits
             return 0;   // by default actions don't have a serialization filter
         }
     };
-
-    template <typename Action>
-    struct action_serialization_filter<Action
-      , typename util::always_void<typename Action::type>::type>
-      : action_serialization_filter<typename Action::type>
-    {};
 }}
 
 #endif

--- a/hpx/traits/action_stacksize.hpp
+++ b/hpx/traits/action_stacksize.hpp
@@ -7,7 +7,6 @@
 #define HPX_TRAITS_ACTION_STACKSIZE_SEP_03_2012_1136AM
 
 #include <hpx/runtime/threads/thread_enums.hpp>
-#include <hpx/util/always_void.hpp>
 
 namespace hpx { namespace traits
 {
@@ -18,12 +17,6 @@ namespace hpx { namespace traits
     {
         enum { value = threads::thread_stacksize_default };
     };
-
-    template <typename Action>
-    struct action_stacksize<Action
-      , typename util::always_void<typename Action::type>::type>
-      : action_stacksize<typename Action::type>
-    {};
 }}
 
 #endif


### PR DESCRIPTION
Remove legacy forwarding traits, they are not needed anymore and cause early instantiation of arguments