### PR TITLE
Adding new command line options:

### DIFF
--- a/docs/manual/commandline.qbk
+++ b/docs/manual/commandline.qbk
@@ -119,30 +119,40 @@ described in the table below:
                                        cout)]]
     [[`--hpx:debug-clp`]        [debug command line processing]]
     [[`--hpx:attach-debugger arg`] [wait for a debugger to be attached, possible arg values:
-                                    startup or exception (default: startup)]]
+                                    `startup` or `exception` (default: startup)]]
 
     [[[*__hpx__ options related to performance counters]]]
-    [[`--hpx:print-counter`]    [print the specified performance counter either repeatedly or
-                                 before shutting down the system (see option `--hpx:print-counter-interval`)]]
-    [[`--hpx:print-counter-interval`][print the performance counter(s) specified with `--hpx:print-counter`
-                                 repeatedly after the time interval (specified in milliseconds)
-                                 (default: 0, which means print once at shutdown)]]
-    [[`--hpx:print-counter-destination`][print the performance counter(s) specified with `--hpx:print-counter`
-                                 to the given file (default: console)]]
-    [[`--hpx:list-counters`]    [list the names of all registered performance counters, possible
-                                 values: 'minimal' (prints counter name skeletons),
-                                 'full' (prints all available counter names)]]
-    [[`--hpx:list-counter-infos`][list the description of all registered performance counters,
-                                   possible values: 'minimal' (prints info for counter name skeletons),
-                                  'full' (prints all available counter infos)]]
-    [[`--hpx:print-counter-format`][print the performance counter(s) specified with `--hpx:print-counter`,
-                                 possible formats in csv format with  header or
-                                 without any header (see option `--hpx:no-csv-header`)
-                                 values: 'csv' (prints counter values in CSV format with full names as header)
-                                 'csv-short' (prints counter values in CSV format with shortnames provided with `--hpx:print-counter`
-                                 as `--hpx:print-counter shortname,full-countername`)]]
-    [[`--hpx:no-csv-header`][print the performance counter(s) specified with `--hpx:print-counter` and
-                                `csv` or `csv-short` format specified with `--hpx:print-counter-format` without header]]
+    [[`--hpx:print-counter`]    [print the specified performance counter either
+        repeatedly and/or at the times specified by `--hpx:print-counter-at`
+        (see also option `--hpx:print-counter-interval`)]]
+    [[`--hpx:print-counter-interval`][print the performance counter(s)
+        specified with `--hpx:print-counter` repeatedly after the time interval
+        (specified in milliseconds), (default: 0, which means print once at
+        shutdown)]]
+    [[`--hpx:print-counter-destination`][print the performance counter(s)
+        specified with `--hpx:print-counter` to the given file (default:
+        `console`)]]
+    [[`--hpx:list-counters`]    [list the names of all registered performance
+        counters, possible values: `minimal` (prints counter name skeletons),
+        `full` (prints all available counter names)]]
+    [[`--hpx:list-counter-infos`][list the description of all registered
+        performance counters, possible values: `minimal` (prints info for
+        counter name skeletons), 'full' (prints all available counter infos)]]
+    [[`--hpx:print-counter-format`][print the performance counter(s) specified
+        with `--hpx:print-counter`, possible formats in csv format with  header
+        or without any header (see option `--hpx:no-csv-header`), possible
+        values: `csv` (prints counter values in CSV format with full names as
+        header), `csv-short` (prints counter values in CSV format with shortnames
+        provided with `--hpx:print-counter` as
+        `--hpx:print-counter shortname,full-countername`)]]
+    [[`--hpx:no-csv-header`][print the performance counter(s) specified with
+        `--hpx:print-counter` and `csv` or `csv-short` format specified with
+        `--hpx:print-counter-format` without header]]
+    [[`--hpx:printer-counter-at arg`][print the performance counter(s)
+        specified with `--hpx:print-counter` at the given point in time,
+        possible argument values: `startup`, `shutdown` (default), `noshutdown`]]
+    [[`--hpx:reset-counters`][reset the performance counter(s) specified with
+        `--hpx:print-counter` after they have been evaluated]]
 ]
 
 [heading Command Line Argument Shortcuts]

--- a/docs/whats_new.qbk
+++ b/docs/whats_new.qbk
@@ -64,6 +64,10 @@ to the master branch commits since the last release.
   semantically conform to the proposed `std::latch` (see __cpp17_n4399__).
 * Added performance counters exposing data related to data transferred by
   input/output (filesystem) operations.
+* Added performance counters allowing to track the number of action invocations
+  (local and remote invocations).
+* Added new command line options [hpx_cmdline `--hpx:print-counter-at`] and
+  [hpx_cmdline `--hpx:reset-counters`].
 * The `hpx::vector` component has been renamed to `hpx::partitioned_vector` to
   make it explicit that the underlying memory is not contiguous.
 * Introduced a completely new and uniform higher-level parallelism API which is

--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -18,6 +18,7 @@
 #include <hpx/runtime/threads/thread_helpers.hpp>
 #include <hpx/runtime/threads/policies/schedulers.hpp>
 #include <hpx/runtime/applier/applier.hpp>
+#include <hpx/runtime/get_config_entry.hpp>
 #include <hpx/runtime_impl.hpp>
 #include <hpx/util/find_prefix.hpp>
 #include <hpx/util/query_counters.hpp>
@@ -266,7 +267,7 @@ namespace hpx { namespace detail
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    void print_counters(boost::shared_ptr<util::query_counters> const& qc)
+    void start_counters(boost::shared_ptr<util::query_counters> const& qc)
     {
         try {
             HPX_ASSERT(qc);
@@ -396,12 +397,16 @@ namespace hpx
                         boost::ref(counters), interval, destination, counter_format,
                         counter_shortnames, csv_header);
 
-                // schedule to run at shutdown
-                rt.add_pre_shutdown_function(
-                    boost::bind(&util::query_counters::evaluate, qc));
+                // schedule to print counters at shutdown, if requested
+                if (get_config_entry("hpx.print_counter.shutdown", "0") == "1")
+                {
+                    // schedule to run at shutdown
+                    rt.add_pre_shutdown_function(
+                        boost::bind(&util::query_counters::evaluate, qc));
+                }
 
                 // schedule to start all counters
-                rt.add_startup_function(boost::bind(&print_counters, qc));
+                rt.add_startup_function(boost::bind(&start_counters, qc));
 
                 // register the query_counters object with the runtime system
                 rt.register_query_counters(qc);
@@ -419,6 +424,16 @@ namespace hpx
             else if (vm.count("hpx:print-counter-format")) {
                 throw detail::command_line_error("Invalid command line option "
                     "--hpx:print-counter-format, valid in conjunction with "
+                    "--hpx:print-counter only");
+            }
+            else if (vm.count("hpx:print-counter-at")) {
+                throw detail::command_line_error("Invalid command line option "
+                    "--hpx:print-counter-at, valid in conjunction with "
+                    "--hpx:print-counter only");
+            }
+            else if (vm.count("hpx:reset-counters")) {
+                throw detail::command_line_error("Invalid command line option "
+                    "--hpx:reset-counters, valid in conjunction with "
                     "--hpx:print-counter only");
             }
         }

--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -18,8 +18,9 @@
 #include <hpx/runtime/components/server/console_error_sink.hpp>
 #include <hpx/runtime/components/runtime_support.hpp>
 #include <hpx/runtime/threads/threadmanager_impl.hpp>
-#include <hpx/include/performance_counters.hpp>
 #include <hpx/runtime/agas/big_boot_barrier.hpp>
+#include <hpx/runtime/get_config_entry.hpp>
+#include <hpx/include/performance_counters.hpp>
 
 #include <boost/config.hpp>
 #include <boost/bind.hpp>
@@ -245,6 +246,17 @@ namespace hpx {
         set_state(state_running);
 
         parcel_handler_.enable_alternative_parcelports();
+
+        // reset all counters right before running main, if requested
+        if (get_config_entry("hpx.print_counter.startup", "0") == "1")
+        {
+            bool reset = false;
+            if (get_config_entry("hpx.print_counter.reset", "0") == "1")
+                reset = true;
+
+            error_code ec(lightweight);     // ignore errors
+            evaluate_active_counters(reset, "startup", ec);
+        }
 
         // Now, execute the user supplied thread function (hpx_main)
         if (!!func) {

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -262,7 +262,7 @@ namespace hpx { namespace util
                     vm["hpx:numa-sensitive"].as<std::size_t>();
                 if (numa_sensitive > 2)
                 {
-                    throw hpx::detail::command_line_error("Invaid argument "
+                    throw hpx::detail::command_line_error("Invalid argument "
                         "value for --hpx:numa-sensitive. Allowed values are "
                         "0, 1, or 2");
                 }
@@ -787,6 +787,46 @@ namespace hpx { namespace util
         //        scheduler, switch to the 'local' scheduler instead.
         ini_config += std::string("hpx.runtime_mode=") +
             get_runtime_mode_name(mode_);
+
+        bool noshutdown_evaluate = false;
+        if (vm.count("hpx:print-counter-at")) {
+            std::vector<std::string> print_counters_at =
+                vm["hpx:print-counter-at"].as<std::vector<std::string> >();
+
+            for (std::string const& s: print_counters_at)
+            {
+                if (0 == std::string("startup").find(s))
+                {
+                    ini_config += "hpx.print_counter.startup!=1";
+                    continue;
+                }
+                if (0 == std::string("shutdown").find(s))
+                {
+                    ini_config += "hpx.print_counter.shutdown!=1";
+                    continue;
+                }
+                if (0 == std::string("noshutdown").find(s))
+                {
+                    ini_config += "hpx.print_counter.shutdown!=0";
+                    noshutdown_evaluate = true;
+                    continue;
+                }
+
+                throw hpx::detail::command_line_error(boost::str(boost::format(
+                    "Invalid argument for option --hpx:print-counter-at: "
+                    "'%1%', allowed values: 'startup', 'shutdown' (default), "
+                    "'noshutdown'") % s));
+            }
+        }
+
+        // if any counters have to be evaluated, always print at the end
+        if (vm.count("hpx:print-counter"))
+        {
+            if (!noshutdown_evaluate)
+                ini_config += "hpx.print_counter.shutdown!=1";
+            if (vm.count("hpx:reset-counters"))
+                ini_config += "hpx.print_counter.reset!=1";
+        }
 
         if (debug_clp) {
             std::cerr << "Configuration before runtime start:\n";

--- a/src/util/parse_command_line.cpp
+++ b/src/util/parse_command_line.cpp
@@ -534,13 +534,21 @@ namespace hpx { namespace util
                   "print the performance counter(s) specified with --hpx:print-counter "
                   "in a given format (default: normal)")
                 ("hpx:csv-header",
-                  "print the performance counter(s) specified with --hpx:print-counter"
+                  "print the performance counter(s) specified with --hpx:print-counter "
                   "with header when format specified with --hpx:print-counter-format"
                   "is csv or csv-short")
                 ("hpx:no-csv-header",
-                  "print the performance counter(s) specified with --hpx:print-counter"
+                  "print the performance counter(s) specified with --hpx:print-counter "
                   "without header when format specified with --hpx:print-counter-format"
                   "is csv or csv-short")
+                ("hpx:print-counter-at",
+                    value<std::vector<std::string> >()->composing(),
+                  "print the performance counter(s) specified with "
+                  "--hpx:print-counter at the given point in time, possible "
+                  "argument values: 'startup', 'shutdown' (default), 'noshutdown'")
+                ("hpx:reset-counters",
+                  "reset the performance counter(s) specified with --hpx:print-counter "
+                  "after they are evaluated")
             ;
 
             hidden_options.add_options()

--- a/src/util/parse_command_line.cpp
+++ b/src/util/parse_command_line.cpp
@@ -548,7 +548,7 @@ namespace hpx { namespace util
                   "argument values: 'startup', 'shutdown' (default), 'noshutdown'")
                 ("hpx:reset-counters",
                   "reset the performance counter(s) specified with --hpx:print-counter "
-                  "after they are evaluated")
+                  "after they have been evaluated")
             ;
 
             hidden_options.add_options()

--- a/src/util/query_counters.cpp
+++ b/src/util/query_counters.cpp
@@ -11,6 +11,7 @@
 #include <hpx/util/high_resolution_clock.hpp>
 #include <hpx/util/apex.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
+#include <hpx/runtime/get_config_entry.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/stubs/performance_counter.hpp>
 #include <hpx/lcos/wait_all.hpp>
@@ -174,7 +175,11 @@ namespace hpx { namespace util
 
     bool query_counters::evaluate()
     {
-        return evaluate_counters();
+        bool reset = false;
+        if (get_config_entry("hpx.print_counter.reset", "0") == "1")
+            reset = true;
+
+        return evaluate_counters(reset);
     }
 
     void query_counters::terminate()
@@ -232,7 +237,6 @@ namespace hpx { namespace util
             }
         }
     }
-
 
     void query_counters::stop_counters(error_code& ec)
     {


### PR DESCRIPTION
- `--hpx:printer-counter-at=<arg>` where arg could be startup, shutdown or noshutdown (default is shutdown, i.e. the old behavior)
- `--hpx:reset-counters` which resets the counters after they are evaluated by HPX

This fixes #1464: HPX option for pre and post bootstrap performance counters