### PR TITLE
Fix connect with hpx::runtime_mode_connect

### DIFF
--- a/docs/manual/commandline.qbk
+++ b/docs/manual/commandline.qbk
@@ -54,6 +54,10 @@ described in the table below:
     [[`--hpx:node arg`]         [number of the node this locality is run on
                                  (must be unique)]]
     [[`--hpx:ignore-batch-env`] [ignore batch environment variables]]
+    [[`--hpx:expect-connecting-localities`]
+                                [this locality expects other localities to
+                                 dynamically connect (this is implied if the
+                                 number of initial localities is larger than 1)]]
     [[`--hpx:pu-offset`]        [the first processing unit this instance of __hpx__ should be
                                  run on (default: 0), valid for
                                  `--hpx:queuing=local`, `--hpx:queuing=abp-priority`,
@@ -148,7 +152,7 @@ described in the table below:
     [[`--hpx:no-csv-header`][print the performance counter(s) specified with
         `--hpx:print-counter` and `csv` or `csv-short` format specified with
         `--hpx:print-counter-format` without header]]
-    [[`--hpx:printer-counter-at arg`][print the performance counter(s)
+    [[`--hpx:print-counter-at arg`][print the performance counter(s)
         specified with `--hpx:print-counter` at the given point in time,
         possible argument values: `startup`, `shutdown` (default), `noshutdown`]]
     [[`--hpx:reset-counters`][reset the performance counter(s) specified with

--- a/examples/heartbeat/heartbeat_console.cpp
+++ b/examples/heartbeat/heartbeat_console.cpp
@@ -42,5 +42,9 @@ int main(int argc, char* argv[])
           "time to wait before this application exits ([s], default: 600)")
         ;
 
-    return hpx::init(desc_commandline, argc, argv);
+    // we expect other localities to connect
+    std::vector<std::string> cfg;
+    cfg.push_back("hpx.expect_connecting_localities=1");
+
+    return hpx::init(desc_commandline, argc, argv, cfg);
 }

--- a/hpx/lcos/local/packaged_task.hpp
+++ b/hpx/lcos/local/packaged_task.hpp
@@ -282,36 +282,38 @@ namespace hpx { namespace lcos { namespace local
             }
 
             // synchronous execution
-            template <typename F>
-            void invoke(F&& f, boost::mpl::false_, error_code& ec = throws)
+            template <typename ...Ts>
+            void invoke(boost::mpl::false_, Ts&&... vs)
             {
-                if (function_.empty()) {
-                    HPX_THROWS_IF(ec, no_state,
+                if (function_.empty())
+                {
+                    HPX_THROW_EXCEPTION(no_state,
                         "packaged_task_base<Signature>::get_future",
                         "this packaged_task has no valid shared state");
                     return;
                 }
 
                 try {
-                    promise_.set_value(f());
+                    promise_.set_value(function_(std::forward<Ts>(vs)...));
                 }
                 catch(...) {
                     promise_.set_exception(boost::current_exception());
                 }
             }
 
-            template <typename F>
-            void invoke(F&& f, boost::mpl::true_, error_code& ec = throws)
+            template <typename ...Ts>
+            void invoke(boost::mpl::true_, Ts&&... vs)
             {
-                if (function_.empty()) {
-                    HPX_THROWS_IF(ec, no_state,
+                if (function_.empty())
+                {
+                    HPX_THROW_EXCEPTION(no_state,
                         "packaged_task_base<Signature>::get_future",
                         "this packaged_task has no valid shared state");
                     return;
                 }
 
                 try {
-                    f();
+                    function_(std::forward<Ts>(vs)...);
                     promise_.set_value();
                 }
                 catch(...) {
@@ -400,11 +402,10 @@ namespace hpx { namespace lcos { namespace local
             base_type::swap(other);
         }
 
-        void operator()(Ts... vs)
+        template <typename ... Vs>
+        void operator()(Vs&&... vs)
         {
-            base_type::invoke(
-                util::deferred_call(this->function_, std::forward<Ts>(vs)...),
-                boost::is_void<R>());
+            base_type::invoke(boost::is_void<R>(), std::forward<Vs>(vs)...);
         }
 
         // result retrieval

--- a/hpx/runtime/agas/addressing_service.hpp
+++ b/hpx/runtime/agas/addressing_service.hpp
@@ -19,6 +19,7 @@
 #include <hpx/runtime/applier/applier.hpp>
 #include <hpx/runtime/naming/address.hpp>
 #include <hpx/runtime/naming/name.hpp>
+#include <hpx/util/unique_function.hpp>
 
 #include <boost/make_shared.hpp>
 #include <boost/cache/entries/lfu_entry.hpp>
@@ -1142,7 +1143,7 @@ public:
     ///                   destination.
     void route(
         parcelset::parcel p
-      , util::function_nonser<void(boost::system::error_code const&,
+      , util::unique_function_nonser<void(boost::system::error_code const&,
             parcelset::parcel const&)> &&
         );
 

--- a/hpx/runtime/applier/apply.hpp
+++ b/hpx/runtime/applier/apply.hpp
@@ -120,7 +120,7 @@ namespace hpx
         inline bool
         put_parcel_cb(naming::id_type const& id, naming::address&& addr,
             threads::thread_priority priority,
-            parcelset::parcelhandler::write_handler_type const& cb, Ts&&... vs)
+            parcelset::parcelhandler::write_handler_type && cb, Ts&&... vs)
         {
             typedef
                 typename hpx::actions::extract_action<Action>::type
@@ -132,7 +132,7 @@ namespace hpx
             parcelset::parcel p(id, complement_addr<action_type>(addr),
                 action_type(), priority, std::forward<Ts>(vs)...);
 
-            ph.put_parcel(std::move(p), cb);
+            ph.put_parcel(std::move(p), std::move(cb));
 
             return false;     // destinations are remote
         }
@@ -142,7 +142,7 @@ namespace hpx
         put_parcel_cont_cb(naming::id_type const& id,
             naming::address&& addr, threads::thread_priority priority,
             Continuation && cont,
-            parcelset::parcelhandler::write_handler_type const& cb, Ts&&... vs)
+            parcelset::parcelhandler::write_handler_type && cb, Ts&&... vs)
         {
             typedef
                 typename hpx::actions::extract_action<Action>::type
@@ -155,7 +155,7 @@ namespace hpx
                 std::forward<Continuation>(cont),
                 action_type(), priority, std::forward<Ts>(vs)...);
 
-            ph.put_parcel(std::move(p), cb);
+            ph.put_parcel(std::move(p), std::move(cb));
 
             return false;     // destinations are remote
         }

--- a/hpx/runtime/parcelset/parcelhandler.hpp
+++ b/hpx/runtime/parcelset/parcelhandler.hpp
@@ -33,6 +33,9 @@
 
 namespace hpx { namespace parcelset
 {
+    // default callback for put_parcel
+    void default_write_handler(boost::system::error_code const&,
+        parcel const& p);
 
     /// The \a parcelhandler is the representation of the parcelset inside a
     /// locality. It is built on top of a single parcelport. Several
@@ -40,10 +43,6 @@ namespace hpx { namespace parcelset
     class HPX_EXPORT parcelhandler : boost::noncopyable
     {
     private:
-        // default callback for put_parcel
-        static void default_write_handler(boost::system::error_code const&,
-            parcel const& p);
-
         void parcel_sink(parcel const& p);
 
         threads::thread_state_enum decode_parcel(
@@ -73,6 +72,7 @@ namespace hpx { namespace parcelset
 
         typedef parcelport::read_handler_type read_handler_type;
         typedef parcelport::write_handler_type write_handler_type;
+        typedef parcelport::global_write_handler_type global_write_handler_type;
 
         /// Construct a new \a parcelhandler initializing it from a AGAS client
         /// instance (parameter \a resolver) and the parcelport to be used for
@@ -321,7 +321,7 @@ namespace hpx { namespace parcelset
         void invoke_write_handler(
             boost::system::error_code const& ec, parcel const & p) const
         {
-            write_handler_type f;
+            global_write_handler_type f;
             {
                 boost::lock_guard<mutex_type> l(mtx_);
                 f = write_handler_;
@@ -329,7 +329,7 @@ namespace hpx { namespace parcelset
             f(ec, p);
         }
 
-        write_handler_type set_write_handler(write_handler_type f)
+        global_write_handler_type set_write_handler(global_write_handler_type f)
         {
             boost::lock_guard<mutex_type> l(mtx_);
             std::swap(f, write_handler_);
@@ -402,7 +402,7 @@ namespace hpx { namespace parcelset
         /// global exception handler for unhandled exceptions thrown from the
         /// parcel layer
         mutable mutex_type mtx_;
-        write_handler_type write_handler_;
+        global_write_handler_type write_handler_;
 
     private:
         static std::vector<plugins::parcelport_factory_base *> &

--- a/hpx/runtime/parcelset/parcelport.hpp
+++ b/hpx/runtime/parcelset/parcelport.hpp
@@ -16,6 +16,7 @@
 #include <hpx/performance_counters/parcels/data_point.hpp>
 #include <hpx/performance_counters/parcels/gatherer.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
+#include <hpx/util/unique_function.hpp>
 
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/thread/locks.hpp>
@@ -58,9 +59,13 @@ namespace hpx { namespace parcelset
         friend struct agas::big_boot_barrier;
 
     public:
-        typedef util::function_nonser<
+        typedef util::unique_function_nonser<
             void(boost::system::error_code const&, parcel const&)
         > write_handler_type;
+
+        typedef util::function_nonser<
+            void(boost::system::error_code const&, parcel const&)
+        > global_write_handler_type;
 
         typedef util::function_nonser<
             void(parcelport& pp, boost::shared_ptr<std::vector<char> >,

--- a/hpx/runtime/parcelset/policies/message_handler.hpp
+++ b/hpx/runtime/parcelset/policies/message_handler.hpp
@@ -7,12 +7,13 @@
 #define HPX_RUNTIME_PARCELSET_POLICIES_MESSAGE_HANDLER_FEB_24_2013_1141AM
 
 #include <hpx/hpx_fwd.hpp>
+#include <hpx/util/unique_function.hpp>
 
 namespace hpx { namespace parcelset { namespace policies
 {
     struct message_handler
     {
-        typedef util::function_nonser<
+        typedef util::unique_function_nonser<
             void(boost::system::error_code const&, parcel const&)
         > write_handler_type;
 

--- a/plugins/parcel/coalescing/coalescing_message_handler.cpp
+++ b/plugins/parcel/coalescing/coalescing_message_handler.cpp
@@ -87,12 +87,12 @@ namespace hpx { namespace plugins { namespace parcel
             l.unlock();
 
             // this instance should not buffer parcels anymore
-            pp_->put_parcel(dest, std::move(p), f);
+            pp_->put_parcel(dest, std::move(p), std::move(f));
             return;
         }
 
         detail::message_buffer::message_buffer_append_state s =
-            buffer_.append(dest, std::move(p), f);
+            buffer_.append(dest, std::move(p), std::move(f));
 
         switch(s) {
         case detail::message_buffer::first_message:

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -1831,7 +1831,7 @@ bool addressing_service::resolve_cached(
 ///////////////////////////////////////////////////////////////////////////////
 void addressing_service::route(
     parcelset::parcel p
-  , util::function_nonser<void(boost::system::error_code const&,
+  , util::unique_function_nonser<void(boost::system::error_code const&,
         parcelset::parcel const&)> && f
     )
 {

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -39,6 +39,7 @@
 #if defined(HPX_USE_FAST_DIJKSTRA_TERMINATION_DETECTION)
 #include <hpx/lcos/reduce.hpp>
 #endif
+#include <hpx/lcos/local/packaged_task.hpp>
 
 #include <hpx/util/assert.hpp>
 #include <hpx/util/parse_command_line.hpp>
@@ -139,6 +140,13 @@ namespace hpx
 {
     // helper function to stop evaluating counters during shutdown
     void stop_evaluating_counters();
+
+    namespace parcelset
+    {
+        // default parcel-sent handler function
+        void default_write_handler(boost::system::error_code const& ec,
+            parcelset::parcel const& p);
+    }
 }
 
 namespace hpx { namespace components
@@ -1228,11 +1236,22 @@ namespace hpx { namespace components { namespace server
         typedef server::runtime_support::remove_from_connection_cache_action
             action_type;
 
+        typedef void write_handler_type(
+            boost::system::error_code const&, parcelset::parcel const&);
+
+        std::vector<future<void> > callbacks;
+        callbacks.reserve(locality_ids.size());
+
         action_type act;
         for (naming::id_type const& id : locality_ids)
         {
-            apply(act, id, hpx::get_locality(), rt->endpoints());
+            lcos::local::packaged_task<write_handler_type> pt(
+                &parcelset::default_write_handler);
+            callbacks.push_back(pt.get_future());
+            apply_cb(act, id, std::move(pt), hpx::get_locality(), rt->endpoints());
         }
+
+        wait_all(callbacks);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -512,9 +512,25 @@ namespace hpx { namespace util
         std::string hpx_host =
             cfgmap.get_value<std::string>("hpx.parcel.address",
                 env.host_name(HPX_INITIAL_IP_ADDRESS));
+
+        // we expect dynamic connections if:
+        //  - --hpx:expect-connecting-localities or
+        //  - hpx.expect_connecting_localities=1 is given, or
+        //  - num_localities > 1
+        bool expect_connections =
+            cfgmap.get_value<int>("hpx.expect_connecting_localities",
+                num_localities_ > 1 ? 0 : 1) ? true : false;
+
+        if (vm.count("hpx:expect-connecting-localities"))
+            expect_connections = true;
+
+        ini_config += std::string("hpx.expect_connecting_localities=") +
+            (expect_connections ? "1" : "0");
+
         boost::uint16_t hpx_port =
             cfgmap.get_value<boost::uint16_t>("hpx.parcel.port",
-                num_localities_ == 1 ? 0 : HPX_INITIAL_IP_PORT);
+                (num_localities_ == 1 && !expect_connections) ?
+                    0 : HPX_INITIAL_IP_PORT);
 
         bool run_agas_server = vm.count("hpx:run-agas-server") != 0;
         if (node == std::size_t(-1))

--- a/src/util/parse_command_line.cpp
+++ b/src/util/parse_command_line.cpp
@@ -405,6 +405,9 @@ namespace hpx { namespace util
                   "number of the node this locality is run on "
                   "(must be unique, alternatively: -0, -1, ..., -9)")
                 ("hpx:ignore-batch-env", "ignore batch environment variables")
+                ("hpx:expect-connecting-localities",
+                  "this locality expects other localities to dynamically connect "
+                  "(implied if the number of initial localities is larger than 1)")
 #if defined(HPX_HAVE_HWLOC) || defined(BOOST_WINDOWS)
                 ("hpx:pu-offset", value<std::size_t>(),
                   "the first processing unit this instance of HPX should be "

--- a/src/util/runtime_configuration.cpp
+++ b/src/util/runtime_configuration.cpp
@@ -137,11 +137,12 @@ namespace hpx { namespace util
 #endif
 #ifdef HPX_THREAD_MINIMAL_DEADLOCK_DETECTION
 #ifdef HPX_DEBUG
-            "minimal_deadlock_detection = ${MINIMAL_DEADLOCK_DETECTION:1}",
+            "minimal_deadlock_detection = ${HPX_MINIMAL_DEADLOCK_DETECTION:1}",
 #else
-            "minimal_deadlock_detection = ${MINIMAL_DEADLOCK_DETECTION:0}",
+            "minimal_deadlock_detection = ${HPX_MINIMAL_DEADLOCK_DETECTION:0}",
 #endif
 #endif
+            "expect_connecting_localities = ${HPX_EXPECT_CONNECTING_LOCALITIES:0}",
 
             // add placeholders for keys to be added by command line handling
             "os_threads = 1",


### PR DESCRIPTION
- bind to port zero only if num_localities == 1 and no locality is expected to connect
- converting parcelset::write_handler_type to unique_function
- adding command line option --hpx::expect-connecting-localities and cfg setting hpx.expect_connecting_localities
- fixed disconnect, disconnecting locality is now properly removed from connection caches
- fly-by changes to package_task invocation

This fixes #1788: connect with hpx::runtime_mode_connect