### PR TITLE
fix a wrong use of HPX_MAX_CPU_COUNT instead of HPX_HAVE_MAX_CPU_COUNT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,7 +274,7 @@ hpx_add_config_define(HPX_HAVE_MAX_CPU_COUNT ${HPX_WITH_MAX_CPU_COUNT})
 
 if(NOT (${HPX_WITH_MAX_CPU_COUNT} LESS 65))
   set(HPX_WITH_MORE_THAN_64_THREADS_DEFAULT OFF)
-  hpx_option(HPX_WITH_MORE_THAN_64_THREADS STRING
+  hpx_option(HPX_WITH_MORE_THAN_64_THREADS BOOL
     "HPX applications will be able to run on more than 64 cores"
     ${HPX_WITH_MORE_THAN_64_THREADS_DEFAULT}
     CATEGORY "Thread Manager" ADVANCED)

--- a/cmake/templates/config_defines.hpp.in
+++ b/cmake/templates/config_defines.hpp.in
@@ -16,7 +16,7 @@
 #define HPX_PREFIX "@HPX_DEFINES_PREFIX@"
 #endif
 @hpx_config_defines@
-#if defined(HPX_MAX_CPU_COUNT) && (HPX_MAX_CPU_COUNT > 64) && !defined(HPX_WITH_MORE_THAN_64_THREADS)
+#if defined(HPX_HAVE_MAX_CPU_COUNT) && (HPX_HAVE_MAX_CPU_COUNT > 64) && !defined(HPX_WITH_MORE_THAN_64_THREADS)
 #define HPX_WITH_MORE_THAN_64_THREADS
 #endif
 


### PR DESCRIPTION
@sithhell Please check this, I think during cmake changes a var used for #define was missed