### PR TITLE
Fixing cv

### DIFF
--- a/hpx/lcos/local/condition_variable.hpp
+++ b/hpx/lcos/local/condition_variable.hpp
@@ -39,7 +39,6 @@ namespace hpx { namespace lcos { namespace local
 
         void notify_all(error_code& ec = throws)
         {
-            util::ignore_all_while_checking ignore_lock;
             boost::unique_lock<mutex_type> l(mtx_);
             cond_.notify_all(std::move(l), ec);
         }
@@ -47,8 +46,8 @@ namespace hpx { namespace lcos { namespace local
         template <class Lock>
         void wait(Lock& lock, error_code& ec = throws)
         {
-            util::ignore_all_while_checking ignore_lock;
             boost::unique_lock<mutex_type> l(mtx_);
+            util::ignore_while_checking<boost::unique_lock<mutex_type> > il(&l);
             util::unlock_guard<Lock> unlock(lock);
 
             cond_.wait(l, ec);
@@ -70,8 +69,8 @@ namespace hpx { namespace lcos { namespace local
         wait_until(Lock& lock, util::steady_time_point const& abs_time,
             error_code& ec = throws)
         {
-            util::ignore_all_while_checking ignore_lock;
             boost::unique_lock<mutex_type> l(mtx_);
+            util::ignore_while_checking<boost::unique_lock<mutex_type> > il(&l);
             util::unlock_guard<Lock> unlock(lock);
 
             threads::thread_state_ex_enum const reason =

--- a/tools/gdb/hpx.py
+++ b/tools/gdb/hpx.py
@@ -66,7 +66,7 @@ class Unordered(object):
         '''Iterator for Boost.Unordered types'''
 
         def __init__(self, start_node, node_type, value_type, extractor):
-            assert start_node
+            #assert start_node
             self.node = None
             self.next_node = start_node
             self.node_type = node_type
@@ -222,7 +222,7 @@ class HPXThread():
 
     prev_context = self.context.switch()
     frame = gdb.newest_frame()
-    function_name = frame.function().name
+    function_name = frame.name()
     p = re.compile("^hpx::util::coroutines.*$")
 
     try:
@@ -230,13 +230,14 @@ class HPXThread():
         if frame.older() is None:
           break
         frame = frame.older()
-        function_name = frame.function().name
+        function_name = frame.name()
+
 
       if not frame.older() is None:
         frame = frame.older()
-        function_name = frame.function().name
-      line = frame.function().line
+        function_name = frame.name()
 
+      line = frame.function().line
       filename = frame.find_sal().symtab.filename
 
       self.pc_string = "0x%x in " % frame.pc() + "%s at " % function_name + "%s:" % filename + "%d" % line
@@ -272,13 +273,14 @@ class HPXListThreads(gdb.Command):
     return addr.reinterpret_cast(gdb.lookup_type("std::size_t").pointer()).dereference()
 
   def invoke(self, arg, from_tty):
-
-    runtime = gdb.selected_frame().read_var("hpx::runtime::runtime_::ptr_").dereference()#["ptr_"]
+    #gdb.selected_frame().read_var("hpx::runtime::runtime_")
+    runtime = gdb.lookup_global_symbol("hpx::runtime::runtime_").value()["ptr_"].dereference()
+    #gdb.selected_frame().read_var("hpx::runtime::runtime_.ptr_").dereference()#["ptr_"]
     thread_manager_ptr = runtime.cast(runtime.dynamic_type)["thread_manager_"]['px']
     thread_manager = thread_manager_ptr.cast(thread_manager_ptr.dynamic_type).dereference();
 
-    scheduler = thread_manager['scheduler_']
-    scheduler_type = scheduler.type.target().target()
+    scheduler = thread_manager['pool_']['sched_']
+    scheduler_type = scheduler.type.target()#.target()
 
     queues = {}
     for f in scheduler_type.fields():
@@ -291,8 +293,6 @@ class HPXListThreads(gdb.Command):
 
     for name in queues:
       if name == "queues_":
-        type = queues[name].type.strip_typedefs()
-
         item = queues[name]['_M_impl']['_M_start']
         end = queues[name]['_M_impl']['_M_finish']
 
@@ -307,6 +307,29 @@ class HPXListThreads(gdb.Command):
             print ""
           item = item + 1
           count = count + 1
+      if name == "high_priority_queues_":
+        item = queues[name]['_M_impl']['_M_start']
+        end = queues[name]['_M_impl']['_M_finish']
+
+        count = 0
+        while not item == end:
+          print "High Priority Thread queue %d:" % count
+          thread_map = Set(item.dereference().dereference()['thread_map_'])
+          for k, v in thread_map:
+            thread = HPXThread(v['px'])
+
+            thread.info()
+            print ""
+          item = item + 1
+          count = count + 1
+
+    print "Low priority queue:"
+    thread_map = Set(queues["low_priority_queue_"]['thread_map_'])
+    for k, v in thread_map:
+      thread = HPXThread(v['px'])
+
+      thread.info()
+      print ""
 
 class HPXGdbState():
   def __init__(self):


### PR DESCRIPTION
Fixing CV to not lead to segfaults.
 - Fixing `reset_queue_entry`
 - Removed `reset_queue_entry` from `wait` because the entry is always removed
   by `notify_XXX` once the thread has been reactivated
 - Flyby change: removed unnecessary explicit unlocks