### PR TITLE
Updating the activeharmony CMake module

### DIFF
--- a/cmake/FindActiveHarmony.cmake
+++ b/cmake/FindActiveHarmony.cmake
@@ -31,6 +31,35 @@ find_package_handle_standard_args(ACTIVEHARMONY  DEFAULT_MSG
 
 mark_as_advanced(ACTIVEHARMONY_INCLUDE_DIR ACTIVEHARMONY_LIBRARY)
 
+# --------- DOWNLOAD AND BUILD THE EXTERNAL PROJECT! ------------ #
+if(NOT ACTIVEHARMONY_FOUND)
+  message("Attention: Downloading and Building ActiveHarmony as external project!")
+  message(INFO " A working internet connection is required!")
+  include(ExternalProject)
+  ExternalProject_Add(project_activeharmony
+    URL http://www.dyninst.org/sites/default/files/downloads/harmony/ah-4.5.tar.gz
+    PREFIX ${CMAKE_CURRENT_BINARY_DIR}/activeharmony-4.5
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND cd ${CMAKE_CURRENT_BINARY_DIR}/activeharmony-4.5/src/project_activeharmony && make CFLAGS=-O3
+    INSTALL_COMMAND cd ${CMAKE_CURRENT_BINARY_DIR}/activeharmony-4.5/src/project_activeharmony && make install PREFIX=${CMAKE_CURRENT_BINARY_DIR}/activeharmony-4.5
+    ##INSTALL_COMMAND cd ${CMAKE_CURRENT_BINARY_DIR}/activeharmony-4.5/src/project_activeharmony && make install PREFIX=${CMAKE_INSTALL_PREFIX}
+  )
+  set(ACTIVEHARMONY_ROOT "${CMAKE_CURRENT_BINARY_DIR}/activeharmony-4.5" CACHE STRING "ActiveHarmony installation directory" FORCE)
+  #set(ACTIVEHARMONY_ROOT ${CMAKE_INSTALL_PREFIX})
+  ExternalProject_Get_Property(project_activeharmony install_dir)
+  add_library(harmony STATIC IMPORTED)
+  set_property(TARGET harmony PROPERTY IMPORTED_LOCATION ${install_dir}/lib/libharmony.a)
+  set(ACTIVEHARMONY_INCLUDE_DIR "${ACTIVEHARMONY_ROOT}/include")
+  set(ACTIVEHARMONY_LIBRARY "${ACTIVEHARMONY_ROOT}/lib/libharmony.a")
+  # handle the QUIETLY and REQUIRED arguments and set ACTIVEHARMONY_FOUND to TRUE
+  # if all listed variables are TRUE
+  find_package_handle_standard_args(ACTIVEHARMONY  DEFAULT_MSG
+                                    ACTIVEHARMONY_LIBRARY ACTIVEHARMONY_INCLUDE_DIR)
+  set(ACTIVEHARMONY_FOUND TRUE)
+else()
+  add_hpx_pseudo_target(project_activeharmony)
+endif()
+
 if(ACTIVEHARMONY_FOUND)
   set(ACTIVEHARMONY_LIBRARIES ${ACTIVEHARMONY_LIBRARY} )
   set(ACTIVEHARMONY_INCLUDE_DIRS ${ACTIVEHARMONY_INCLUDE_DIR})


### PR DESCRIPTION
Updating the activeharmony CMake module to use externalproject support if the library is requested but not yet installed.  This way the user doesn't have to pre-install the active harmony library, and it is a quick build.