### PR TITLE
Fixing cv exceptions

### DIFF
--- a/hpx/lcos/local/detail/condition_variable.hpp
+++ b/hpx/lcos/local/detail/condition_variable.hpp
@@ -48,7 +48,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail
         typedef boost::intrusive::slist<
             queue_entry, slist_option_type,
             boost::intrusive::cache_last<true>,
-            boost::intrusive::constant_time_size<false>
+            boost::intrusive::constant_time_size<true>
         > queue_type;
 
         struct reset_queue_entry
@@ -133,7 +133,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail
                 lock.unlock();
 
                 threads::set_thread_state(threads::thread_id_type(
-                    reinterpret_cast<threads::thread_data*>(id)),
+                        reinterpret_cast<threads::thread_data*>(id)),
                     threads::pending, threads::wait_signaled,
                     threads::thread_priority_default, ec);
                 return not_empty;
@@ -143,6 +143,17 @@ namespace hpx { namespace lcos { namespace local { namespace detail
                 ec = make_success_code();
 
             return false;
+        }
+
+        // re-add the remaining items to the original queue
+        template <typename Mutex>
+        void prepend_entries(boost::unique_lock<Mutex> lock, queue_type& queue)
+        {
+            HPX_ASSERT_OWNS_LOCK(lock);
+
+            // splice is constant time only if it == end
+            queue.splice(queue.end(), queue_);
+            queue_.swap(queue);
         }
 
         template <typename Mutex>
@@ -169,7 +180,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail
 
                     if (HPX_UNLIKELY(id == threads::invalid_thread_id_repr))
                     {
-                        lock.unlock();
+                        prepend_entries(std::move(lock), queue);
 
                         HPX_THROWS_IF(ec, null_thread_id,
                             "condition_variable::notify_all",
@@ -178,13 +189,31 @@ namespace hpx { namespace lcos { namespace local { namespace detail
                     }
 
                     // unlock while notifying thread as this can suspend
-                    util::unlock_guard<boost::unique_lock<Mutex> > unlock(lock);
+                    error_code local_ec;
 
-                    threads::set_thread_state(threads::thread_id_type(
-                        reinterpret_cast<threads::thread_data*>(id)),
-                        threads::pending, threads::wait_signaled,
-                        threads::thread_priority_default, ec);
-                    if (ec) return;
+                    {
+                        util::unlock_guard<boost::unique_lock<Mutex> > unlock(lock);
+
+                        threads::set_thread_state(threads::thread_id_type(
+                                reinterpret_cast<threads::thread_data*>(id)),
+                            threads::pending, threads::wait_signaled,
+                            threads::thread_priority_default, local_ec);
+                    }
+
+                    if (local_ec)
+                    {
+                        prepend_entries(std::move(lock), queue);
+                        if (&ec != &throws)
+                        {
+                            ec = std::move(local_ec);
+                        }
+                        else
+                        {
+                            boost::rethrow_exception(
+                                hpx::detail::access_exception(local_ec));
+                        }
+                        return;
+                    }
 
                 } while (!queue.empty());
             }


### PR DESCRIPTION
@sithhell reported that the segfault does not manifest itself if the mutex is not unlocked while releasing threads. 

- This patch also add proper handling of exceptions happening while executing notify_all.
-  Fly-by change makes slist::size constant time