### PR TITLE
Making sure resolve_localities does not hang during normal operation.

### DIFF
--- a/hpx/runtime/agas/addressing_service.hpp
+++ b/hpx/runtime/agas/addressing_service.hpp
@@ -324,6 +324,10 @@ public:
       , error_code& ec = throws
         );
 
+    bool has_resolved_locality(
+        naming::gid_type const & gid
+        );
+
     /// \brief Remove a locality from the runtime.
     bool unregister_locality(
         naming::gid_type const & gid

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -538,6 +538,14 @@ void addressing_service::register_console(parcelset::endpoints_type const & eps)
     HPX_ASSERT(res.second);
 }
 
+bool addressing_service::has_resolved_locality(
+    naming::gid_type const & gid
+    )
+{ // {{{
+    boost::unique_lock<mutex_type> l(resolved_localities_mtx_);
+    return resolved_localities_.find(gid) != resolved_localities_.end();
+} // }}}
+
 parcelset::endpoints_type const & addressing_service::resolve_locality(
     naming::gid_type const & gid
   , error_code& ec
@@ -578,9 +586,7 @@ parcelset::endpoints_type const & addressing_service::resolve_locality(
                 if (0 == threads::get_self_ptr())
                 {
                     // this should happen only during bootstrap
-                    // FIXME: Disabled this assert cause it fires.
-                    // It should not, but doesn't do any harm
-                    //HPX_ASSERT(hpx::is_starting());
+                    HPX_ASSERT(hpx::is_starting());
 
                     while(!endpoints_future.is_ready())
                         /**/;

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -374,7 +374,9 @@ namespace hpx { namespace parcelset
         if (0 == hpx::threads::get_self_ptr() && !hpx::is_starting())
         {
             HPX_ASSERT(resolver_);
-            if (!resolver_->has_resolved_locality(ids[0].get_gid()))
+            naming::gid_type locality =
+                naming::get_locality_from_gid(ids[0].get_gid());
+            if (!resolver_->has_resolved_locality(locality))
             {
                 // reschedule request as an HPX thread to avoid hangs
                 void (parcelhandler::*put_parcel_ptr) (

--- a/tests/regressions/agas/CMakeLists.txt
+++ b/tests/regressions/agas/CMakeLists.txt
@@ -8,7 +8,10 @@ set(tests
     duplicate_id_registration_1596
     pass_by_value_id_type_action
     send_gid_keep_component_1624
+    register_with_basename_1804
    )
+
+set(register_with_basename_1804_PARAMETERS LOCALITIES 4)
 
 foreach(test ${tests})
   set(sources

--- a/tests/regressions/agas/register_with_basename_1804.cpp
+++ b/tests/regressions/agas/register_with_basename_1804.cpp
@@ -1,0 +1,98 @@
+//  Copyright (c) 2015 Andreas Schaefer
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This illustrates the issue as reported by #1804: register_with_basename
+// causes hangs
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+
+#include <iostream>
+#include <vector>
+
+#include <boost/shared_ptr.hpp>
+
+static std::string itoa(int i)
+{
+    std::stringstream buf;
+    buf << i;
+    return buf.str();
+}
+
+struct test_server
+  : hpx::components::simple_component_base<test_server>
+{
+    test_server()
+    {}
+
+    hpx::id_type call() const
+    {
+        return hpx::find_here();
+    }
+    HPX_DEFINE_COMPONENT_ACTION(test_server, call, call_action);
+};
+
+typedef hpx::components::simple_component<test_server> server_type;
+HPX_REGISTER_COMPONENT(server_type, test_server);
+
+typedef test_server::call_action call_action;
+HPX_REGISTER_ACTION(call_action);
+
+std::string genName(int source, int target)
+{
+    std::string basename = "/0/HPXSimulatorUpdateGroupSdfafafasdasd";
+
+    return basename + "/PatchLink/" +
+        itoa(source) + "-" +
+        itoa(target);
+}
+
+void testBar()
+{
+    int rank = hpx::get_locality_id();
+
+    std::vector<hpx::id_type> boundingBoxReceivers;
+    std::vector<hpx::id_type> boundingBoxAccepters;
+    for (int i = 0; i < 4; ++i) {
+        if (i == rank)
+            continue;
+
+        std::string name = genName(i, rank);
+        std::cout << "registration: " << name << "\n";
+
+        hpx::id_type id = hpx::new_<test_server>(hpx::find_here()).get();
+        hpx::register_with_basename(name, id, 0).get();
+        boundingBoxReceivers.push_back(id);
+    }
+
+    for (int i = 0; i < 4; ++i) {
+        if (i == rank)
+            continue;
+
+        std::string name = genName(rank, i);
+        std::cout << "lookup: " << name << "\n";
+        std::vector<hpx::future<hpx::id_type> > ids =
+            hpx::find_all_from_basename(name, 1);
+        boundingBoxAccepters.push_back(std::move(ids[0].get()));
+    }
+
+    std::cout << "all done " << rank << "\n";
+}
+
+int hpx_main(int argc, char **argv)
+{
+    testBar();
+    return hpx::finalize();
+}
+
+int main(int argc, char **argv)
+{
+    // We want HPX to run hpx_main() on all localities to avoid the
+    // initial overhead caused by broadcasting the work from one to
+    // all other localities:
+    std::vector<std::string> config(1, "hpx.run_hpx_main!=1");
+
+    return hpx::init(argc, argv, config);
+}

--- a/tests/regressions/agas/register_with_basename_1804.cpp
+++ b/tests/regressions/agas/register_with_basename_1804.cpp
@@ -8,6 +8,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
+#include <hpx/util/lightweight_test.hpp>
 
 #include <iostream>
 #include <vector>
@@ -40,7 +41,7 @@ HPX_REGISTER_COMPONENT(server_type, test_server);
 typedef test_server::call_action call_action;
 HPX_REGISTER_ACTION(call_action);
 
-std::string genName(int source, int target)
+std::string gen_name(int source, int target)
 {
     std::string basename = "/0/HPXSimulatorUpdateGroupSdfafafasdasd";
 
@@ -49,7 +50,7 @@ std::string genName(int source, int target)
         itoa(target);
 }
 
-void testBar()
+void test()
 {
     int rank = hpx::get_locality_id();
 
@@ -59,7 +60,7 @@ void testBar()
         if (i == rank)
             continue;
 
-        std::string name = genName(i, rank);
+        std::string name = gen_name(i, rank);
         std::cout << "registration: " << name << "\n";
 
         hpx::id_type id = hpx::new_<test_server>(hpx::find_here()).get();
@@ -71,7 +72,7 @@ void testBar()
         if (i == rank)
             continue;
 
-        std::string name = genName(rank, i);
+        std::string name = gen_name(rank, i);
         std::cout << "lookup: " << name << "\n";
         std::vector<hpx::future<hpx::id_type> > ids =
             hpx::find_all_from_basename(name, 1);
@@ -83,7 +84,10 @@ void testBar()
 
 int hpx_main(int argc, char **argv)
 {
-    testBar();
+    // this test must run using 4 localities
+    HPX_TEST_EQ(hpx::get_num_localities().get(), 4u);
+
+    test();
     return hpx::finalize();
 }
 
@@ -94,5 +98,6 @@ int main(int argc, char **argv)
     // all other localities:
     std::vector<std::string> config(1, "hpx.run_hpx_main!=1");
 
-    return hpx::init(argc, argv, config);
+    HPX_TEST_EQ(hpx::init(argc, argv, config), 0);
+    return hpx::util::report_errors();
 }


### PR DESCRIPTION
- This fixes #1804: `register_with_basename` causes hangs