### PR TITLE
Agas optimizations

### DIFF
--- a/hpx/lcos/detail/async_implementations.hpp
+++ b/hpx/lcos/detail/async_implementations.hpp
@@ -28,13 +28,47 @@ namespace hpx { namespace detail
     struct sync_local_invoke
     {
         template <typename ...Ts>
-        BOOST_FORCEINLINE static lcos::future<Result> call(
-            naming::id_type const& gid, naming::address const&,
-            Ts&&... vs)
+        static lcos::future<Result> call(
+            naming::id_type const& id, naming::address && addr,
+            Ts &&... vs)
         {
             lcos::packaged_action<Action, Result> p;
-            p.apply(launch::sync, gid, std::forward<Ts>(vs)...);
-            return p.get_future();
+            bool target_is_managed = false;
+
+            if (id.get_management_type() == naming::id_type::managed)
+            {
+                naming::id_type id1(id.get_gid(), naming::id_type::unmanaged);
+                if (addr)
+                {
+                    p.apply(launch::sync, std::move(addr), id1,
+                        std::forward<Ts>(vs)...);
+                }
+                else
+                {
+                    p.apply(launch::sync, id1, std::forward<Ts>(vs)...);
+                }
+                target_is_managed = true;
+            }
+            else
+            {
+                p.apply(launch::sync, id, std::forward<Ts>(vs)...);
+            }
+
+            // keep id alive, if needed - this allows to send the destination
+            // as an unmanaged id
+            future<Result> f = p.get_future();
+
+            if (target_is_managed)
+            {
+                typedef typename traits::detail::shared_state_ptr_for<
+                    future<Result>
+                >::type shared_state_ptr;
+
+                shared_state_ptr const& state = traits::detail::get_shared_state(f);
+                state->set_on_completed(hpx::detail::keep_id_alive(id));
+            }
+
+            return f;
         }
     };
 
@@ -44,10 +78,11 @@ namespace hpx { namespace detail
         template <typename ...Ts>
         BOOST_FORCEINLINE static lcos::future<R> call(
             boost::mpl::true_, naming::id_type const&,
-            naming::address const& addr, Ts&&... vs)
+            naming::address && addr, Ts &&... vs)
         {
             HPX_ASSERT(traits::component_type_is_compatible<
                 typename Action::component_type>::call(addr));
+
             return Action::execute_function(addr.address_,
                 std::forward<Ts>(vs)...);
         }
@@ -58,14 +93,49 @@ namespace hpx { namespace detail
     struct sync_local_invoke_cb
     {
         template <typename Callback, typename ...Ts>
-        BOOST_FORCEINLINE static lcos::future<Result> call(
-            naming::id_type const& gid, naming::address const&,
-            Callback&& cb, Ts&&... vs)
+        static lcos::future<Result> call(
+            naming::id_type const& id, naming::address && addr,
+            Callback && cb, Ts &&... vs)
         {
             lcos::packaged_action<Action, Result> p;
-            p.apply_cb(launch::sync, gid, std::forward<Callback>(cb),
-                std::forward<Ts>(vs)...);
-            return p.get_future();
+            bool target_is_managed = false;
+
+            if (id.get_management_type() == naming::id_type::managed)
+            {
+                naming::id_type id1(id.get_gid(), naming::id_type::unmanaged);
+                if (addr)
+                {
+                    p.apply_cb(launch::sync, std::move(addr), id1,
+                        std::forward<Callback>(cb), std::forward<Ts>(vs)...);
+                }
+                else
+                {
+                    p.apply_cb(launch::sync, id1, std::forward<Callback>(cb),
+                        std::forward<Ts>(vs)...);
+                }
+                target_is_managed = true;
+            }
+            else
+            {
+                p.apply_cb(launch::sync, id, std::forward<Callback>(cb),
+                    std::forward<Ts>(vs)...);
+            }
+
+            // keep id alive, if needed - this allows to send the destination
+            // as an unmanaged id
+            future<Result> f = p.get_future();
+
+            if (target_is_managed)
+            {
+                typedef typename traits::detail::shared_state_ptr_for<
+                    future<Result>
+                >::type shared_state_ptr;
+
+                shared_state_ptr const& state = traits::detail::get_shared_state(f);
+                state->set_on_completed(hpx::detail::keep_id_alive(id));
+            }
+
+            return f;
         }
     };
 
@@ -75,10 +145,11 @@ namespace hpx { namespace detail
         template <typename Callback, typename ...Ts>
         BOOST_FORCEINLINE static lcos::future<R> call(
             boost::mpl::true_, naming::id_type const&,
-            naming::address const& addr, Callback&& cb, Ts&&... vs)
+            naming::address && addr, Callback && cb, Ts&&... vs)
         {
             HPX_ASSERT(traits::component_type_is_compatible<
                 typename Action::component_type>::call(addr));
+
             lcos::future<R> f = Action::execute_function(addr.address_,
                 std::forward<Ts>(vs)...);
 
@@ -119,7 +190,7 @@ namespace hpx { namespace detail
         if (agas::is_local_address_cached(id, addr) && policy == launch::sync)
         {
             return hpx::detail::sync_local_invoke<action_type, result_type>::
-                call(id, addr, std::forward<Ts>(vs)...);
+                call(id, std::move(addr), std::forward<Ts>(vs)...);
         }
 
         lcos::packaged_action<action_type, result_type> p;
@@ -127,17 +198,22 @@ namespace hpx { namespace detail
         bool target_is_managed = false;
         if (policy == launch::sync || hpx::detail::has_async_policy(policy))
         {
-            if (addr) {
-                p.apply(policy, std::move(addr), id,
-                    std::forward<Ts>(vs)...);
-            }
-            else if (id.get_management_type() == naming::id_type::managed) {
-                p.apply(policy,
-                    naming::id_type(id.get_gid(), naming::id_type::unmanaged),
-                    std::forward<Ts>(vs)...);
+            if (id.get_management_type() == naming::id_type::managed)
+            {
+                naming::id_type id1(id.get_gid(), naming::id_type::unmanaged);
+                if (addr)
+                {
+                    p.apply(policy, std::move(addr), id1,
+                        std::forward<Ts>(vs)...);
+                }
+                else
+                {
+                    p.apply(policy, id1, std::forward<Ts>(vs)...);
+                }
                 target_is_managed = true;
             }
-            else {
+            else
+            {
                 p.apply(policy, id, std::forward<Ts>(vs)...);
             }
         }
@@ -179,7 +255,7 @@ namespace hpx { namespace detail
         if (agas::is_local_address_cached(id, addr) && policy == launch::sync)
         {
             return hpx::detail::sync_local_invoke_cb<action_type, result_type>::
-                call(id, addr, std::forward<Callback>(cb),
+                call(id, std::move(addr), std::forward<Callback>(cb),
                     std::forward<Ts>(vs)...);
         }
 
@@ -188,17 +264,23 @@ namespace hpx { namespace detail
         bool target_is_managed = false;
         if (policy == launch::sync || hpx::detail::has_async_policy(policy))
         {
-            if (addr) {
-                p.apply_cb(policy, std::move(addr), id,
-                    std::forward<Callback>(cb), std::forward<Ts>(vs)...);
-            }
-            else if (id.get_management_type() == naming::id_type::managed) {
-                p.apply_cb(policy,
-                    naming::id_type(id.get_gid(), naming::id_type::unmanaged),
-                    std::forward<Callback>(cb), std::forward<Ts>(vs)...);
+            if (id.get_management_type() == naming::id_type::managed)
+            {
+                naming::id_type id1(id.get_gid(), naming::id_type::unmanaged);
+                if (addr)
+                {
+                    p.apply_cb(policy, std::move(addr), id1,
+                        std::forward<Callback>(cb), std::forward<Ts>(vs)...);
+                }
+                else
+                {
+                    p.apply_cb(policy, id1, std::forward<Callback>(cb),
+                        std::forward<Ts>(vs)...);
+                }
                 target_is_managed = true;
             }
-            else {
+            else
+            {
                 p.apply_cb(policy, id, std::forward<Callback>(cb),
                     std::forward<Ts>(vs)...);
             }

--- a/hpx/lcos/detail/async_implementations.hpp
+++ b/hpx/lcos/detail/async_implementations.hpp
@@ -24,6 +24,19 @@ namespace hpx { namespace detail
             static_cast<int>(launch::async_policies)) ? true : false;
     }
 
+    ///////////////////////////////////////////////////////////////////////////
+    struct keep_id_alive
+    {
+        explicit keep_id_alive(naming::id_type const& gid)
+            : gid_(gid)
+        {}
+
+        void operator()() const {}
+
+        naming::id_type gid_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Result>
     struct sync_local_invoke
     {
@@ -158,18 +171,6 @@ namespace hpx { namespace detail
 
             return f;
         }
-    };
-
-    ///////////////////////////////////////////////////////////////////////////
-    struct keep_id_alive
-    {
-        explicit keep_id_alive(naming::id_type const& gid)
-            : gid_(gid)
-        {}
-
-        void operator()() const {}
-
-        naming::id_type gid_;
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/hpx/lcos/packaged_action.hpp
+++ b/hpx/lcos/packaged_action.hpp
@@ -127,7 +127,10 @@ namespace hpx { namespace lcos
         {
             util::block_profiler_wrapper<profiler_tag> bp(apply_logger_);
 
-            hpx::apply_c_cb<action_type>(this->get_id(), gid,
+            naming::id_type cont_id(this->get_id());
+            naming::detail::set_dont_store_in_cache(cont_id);
+
+            hpx::apply_c_cb<action_type>(cont_id, gid,
                 util::bind(&packaged_action::parcel_write_handler,
                     this->impl_, util::placeholders::_1, util::placeholders::_2),
                 std::forward<Ts>(vs)...);
@@ -139,7 +142,10 @@ namespace hpx { namespace lcos
         {
             util::block_profiler_wrapper<profiler_tag> bp(apply_logger_);
 
-            hpx::apply_c_cb<action_type>(this->get_id(), std::move(addr), gid,
+            naming::id_type cont_id(this->get_id());
+            naming::detail::set_dont_store_in_cache(cont_id);
+
+            hpx::apply_c_cb<action_type>(cont_id, std::move(addr), gid,
                 util::bind(&packaged_action::parcel_write_handler,
                     this->impl_, util::placeholders::_1, util::placeholders::_2),
                 std::forward<Ts>(vs)...);
@@ -153,7 +159,10 @@ namespace hpx { namespace lcos
 
             typedef typename util::decay<Callback>::type callback_type;
 
-            hpx::apply_c_cb<action_type>(this->get_id(), gid,
+            naming::id_type cont_id(this->get_id());
+            naming::detail::set_dont_store_in_cache(cont_id);
+
+            hpx::apply_c_cb<action_type>(cont_id, gid,
                 util::bind(
                     &packaged_action::parcel_write_handler_cb<callback_type>,
                     util::protect(std::forward<Callback>(cb)), this->impl_,
@@ -169,7 +178,10 @@ namespace hpx { namespace lcos
 
             typedef typename util::decay<Callback>::type callback_type;
 
-            hpx::apply_c_cb<action_type>(this->get_id(), std::move(addr), gid,
+            naming::id_type cont_id(this->get_id());
+            naming::detail::set_dont_store_in_cache(cont_id);
+
+            hpx::apply_c_cb<action_type>(cont_id, std::move(addr), gid,
                 util::bind(
                     &packaged_action::parcel_write_handler_cb<callback_type>,
                     util::protect(std::forward<Callback>(cb)), this->impl_,
@@ -183,7 +195,10 @@ namespace hpx { namespace lcos
         {
             util::block_profiler_wrapper<profiler_tag> bp(apply_logger_);
 
-            hpx::apply_c_p_cb<action_type>(this->get_id(), gid, priority,
+            naming::id_type cont_id(this->get_id());
+            naming::detail::set_dont_store_in_cache(cont_id);
+
+            hpx::apply_c_p_cb<action_type>(cont_id, gid, priority,
                 util::bind(&packaged_action::parcel_write_handler,
                     this->impl_, util::placeholders::_1, util::placeholders::_2),
                 std::forward<Ts>(vs)...);
@@ -196,7 +211,10 @@ namespace hpx { namespace lcos
         {
             util::block_profiler_wrapper<profiler_tag> bp(apply_logger_);
 
-            hpx::apply_c_p_cb<action_type>(this->get_id(), std::move(addr),
+            naming::id_type cont_id(this->get_id());
+            naming::detail::set_dont_store_in_cache(cont_id);
+
+            hpx::apply_c_p_cb<action_type>(cont_id, std::move(addr),
                 gid, priority,
                 util::bind(&packaged_action::parcel_write_handler,
                     this->impl_, util::placeholders::_1, util::placeholders::_2),
@@ -211,7 +229,10 @@ namespace hpx { namespace lcos
 
             typedef typename util::decay<Callback>::type callback_type;
 
-            hpx::apply_c_p_cb<action_type>(this->get_id(), gid, priority,
+            naming::id_type cont_id(this->get_id());
+            naming::detail::set_dont_store_in_cache(cont_id);
+
+            hpx::apply_c_p_cb<action_type>(cont_id, gid, priority,
                 util::bind(
                     &packaged_action::parcel_write_handler_cb<callback_type>,
                     util::protect(std::forward<Callback>(cb)), this->impl_,
@@ -228,7 +249,10 @@ namespace hpx { namespace lcos
 
             typedef typename util::decay<Callback>::type callback_type;
 
-            hpx::apply_c_p_cb<action_type>(this->get_id(), std::move(addr),
+            naming::id_type cont_id(this->get_id());
+            naming::detail::set_dont_store_in_cache(cont_id);
+
+            hpx::apply_c_p_cb<action_type>(cont_id, std::move(addr),
                 gid, priority,
                 util::bind(
                     &packaged_action::parcel_write_handler_cb<callback_type>,
@@ -359,8 +383,11 @@ namespace hpx { namespace lcos
             }
             else {
                 // remote execution
+                naming::id_type cont_id(this->get_id());
+                naming::detail::set_dont_store_in_cache(cont_id);
+
                 hpx::applier::detail::apply_c_cb<action_type>(
-                    std::move(addr), this->get_id(), gid,
+                    std::move(addr), cont_id, gid,
                     util::bind(&packaged_action::parcel_write_handler,
                         this->impl_, util::placeholders::_1, util::placeholders::_2),
                     std::forward<Ts>(vs)...);
@@ -383,8 +410,11 @@ namespace hpx { namespace lcos
             }
             else {
                 // remote execution
+                naming::id_type cont_id(this->get_id());
+                naming::detail::set_dont_store_in_cache(cont_id);
+
                 hpx::applier::detail::apply_c_cb<action_type>(
-                    std::move(addr), this->get_id(), gid,
+                    std::move(addr), cont_id, gid,
                     util::bind(&packaged_action::parcel_write_handler,
                         this->impl_, util::placeholders::_1, util::placeholders::_2),
                     std::forward<Ts>(vs)...);
@@ -413,8 +443,11 @@ namespace hpx { namespace lcos
                 // remote execution
                 typedef typename util::decay<Callback>::type callback_type;
 
+                naming::id_type cont_id(this->get_id());
+                naming::detail::set_dont_store_in_cache(cont_id);
+
                 hpx::applier::detail::apply_c_cb<action_type>(
-                    std::move(addr), this->get_id(), gid,
+                    std::move(addr), cont_id, gid,
                     util::bind(
                         &packaged_action::parcel_write_handler_cb<callback_type>,
                         util::protect(std::forward<Callback>(cb)), this->impl_,
@@ -444,8 +477,11 @@ namespace hpx { namespace lcos
                 // remote execution
                 typedef typename util::decay<Callback>::type callback_type;
 
+                naming::id_type cont_id(this->get_id());
+                naming::detail::set_dont_store_in_cache(cont_id);
+
                 hpx::applier::detail::apply_c_cb<action_type>(
-                    std::move(addr), this->get_id(), gid,
+                    std::move(addr), cont_id, gid,
                     util::bind(
                         &packaged_action::parcel_write_handler_cb<callback_type>,
                         util::protect(std::forward<Callback>(cb)), this->impl_,

--- a/hpx/runtime/agas/server/primary_namespace.hpp
+++ b/hpx/runtime/agas/server/primary_namespace.hpp
@@ -73,7 +73,10 @@ char const* const primary_namespace_service_name = "primary/";
 ///                  Bit 95 is a flag that is set if a GID's credit count is
 ///                  ever split (e.g. if the GID is ever passed to another
 ///                  locality).
-///     identifier - Bit 64 to bit 87 of the MSB, and the entire LSB. The
+///                - Bit 87 marks the gid such that it will not be stored in
+///                  any of the AGAS caches. This is used mainly for ids
+///                  which represent 'one-shot' objects (like promises).
+///     identifier - Bit 64 to bit 86 of the MSB, and the entire LSB. The
 ///                  content of these bits depends on the component type of
 ///                  the underlying object. For all user-defined components,
 ///                  these bits contain a unique 88-bit number which is

--- a/hpx/runtime/naming/name.hpp
+++ b/hpx/runtime/naming/name.hpp
@@ -68,21 +68,26 @@ namespace hpx { namespace naming
         typedef gid_type size_type;
         typedef gid_type difference_type;
 
-        static boost::uint64_t const credit_base_mask = 0x1ful;
+        static boost::uint64_t const credit_base_mask = 0x1full;
         static boost::uint16_t const credit_shift = 24;
 
         static boost::uint64_t const credit_mask = credit_base_mask << credit_shift;
-        static boost::uint64_t const was_split_mask = 0x80000000ul; //-V112
-        static boost::uint64_t const has_credits_mask = 0x40000000ul; //-V112
-        static boost::uint64_t const is_locked_mask = 0x20000000ul; //-V112
+        static boost::uint64_t const was_split_mask = 0x80000000ull; //-V112
+        static boost::uint64_t const has_credits_mask = 0x40000000ull; //-V112
+        static boost::uint64_t const is_locked_mask = 0x20000000ull; //-V112
 
         static boost::uint64_t const locality_id_mask = 0xffffffff00000000ull;
-        static boost::uint64_t const virtual_memory_mask = 0xffffffull;
+        static boost::uint16_t const locality_id_shift = 32;
+
+        static boost::uint64_t const virtual_memory_mask = 0x7fffffull;
+
+        // don't cache this id in the AGAS caches
+        static boost::uint64_t const dont_cache_mask = 0x800000ull; //-V112
 
         static boost::uint64_t const credit_bits_mask =
             credit_mask | was_split_mask | has_credits_mask;
         static boost::uint64_t const internal_bits_mask =
-            credit_bits_mask | is_locked_mask;
+            credit_bits_mask | is_locked_mask | dont_cache_mask;
         static boost::uint64_t const special_bits_mask =
             locality_id_mask | internal_bits_mask;
 
@@ -404,14 +409,16 @@ namespace hpx { namespace naming
 
     inline gid_type get_gid_from_locality_id(boost::uint32_t locality_id)
     {
-        return gid_type(boost::uint64_t(locality_id+1) << 32, 0); //-V112
+        return gid_type(
+            boost::uint64_t(locality_id+1) << gid_type::locality_id_shift,
+            0);
     }
 
     inline boost::uint32_t get_locality_id_from_gid(boost::uint64_t msb) HPX_PURE;
 
     inline boost::uint32_t get_locality_id_from_gid(boost::uint64_t msb)
     {
-        return boost::uint32_t(msb >> 32)-1; //-V112
+        return boost::uint32_t(msb >> gid_type::locality_id_shift) - 1;
     }
 
     inline boost::uint32_t get_locality_id_from_gid(gid_type const& id) HPX_PURE;
@@ -495,6 +502,17 @@ namespace hpx { namespace naming
         inline void set_credit_split_mask_for_gid(gid_type& id)
         {
             id.set_msb(id.get_msb() | gid_type::was_split_mask);
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        inline bool store_in_cache(gid_type const& id)
+        {
+            return (id.get_msb() & gid_type::dont_cache_mask) ? false : true;
+        }
+
+        inline void set_dont_store_in_cache(id_type& id)
+        {
+            id.set_msb(id.get_msb() | gid_type::dont_cache_mask);
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -853,15 +871,16 @@ namespace hpx { namespace naming
 
     inline id_type get_id_from_locality_id(boost::uint32_t locality_id)
     {
-        return id_type(boost::uint64_t(locality_id+1) << 32, 0, id_type::unmanaged);
-        //-V112
+        return id_type(
+            boost::uint64_t(locality_id+1) << gid_type::locality_id_shift,
+            0, id_type::unmanaged);
     }
 
     inline boost::uint32_t get_locality_id_from_id(id_type const& id) HPX_PURE;
 
     inline boost::uint32_t get_locality_id_from_id(id_type const& id)
     {
-        return boost::uint32_t(id.get_msb() >> 32) - 1; //-V112
+        return boost::uint32_t(id.get_msb() >> gid_type::locality_id_shift) - 1;
     }
 
     inline id_type get_locality_from_id(id_type const& id)

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -1523,6 +1523,14 @@ bool addressing_service::resolve_cached(
         return false;
     }
 
+    // don't look at cache if id is marked as non-cache-able
+    if (!naming::detail::store_in_cache(id))
+    {
+        if (&ec != &throws)
+            ec = make_success_code();
+        return false;
+    }
+
     // don't look at the cache if the id is locally managed
     if (naming::get_locality_id_from_gid(id) ==
         naming::get_locality_id_from_gid(locality_))
@@ -2334,6 +2342,14 @@ void addressing_service::insert_cache_entry(
         return;
     }
 
+    // don't look at cache if id is marked as non-cacheable
+    if (!naming::detail::store_in_cache(gid))
+    {
+        if (&ec != &throws)
+            ec = make_success_code();
+        return;
+    }
+
     // don't look at the cache if the id is locally managed
     if (naming::get_locality_id_from_gid(gid) ==
         naming::get_locality_id_from_gid(locality_))
@@ -2408,6 +2424,14 @@ void addressing_service::update_cache_entry(
     if (!caching_)
     {
         // If caching is disabled, we silently pretend success.
+        if (&ec != &throws)
+            ec = make_success_code();
+        return;
+    }
+
+    // don't look at cache if id is marked as non-cache-able
+    if (!naming::detail::store_in_cache(gid))
+    {
         if (&ec != &throws)
             ec = make_success_code();
         return;
@@ -2504,6 +2528,14 @@ void addressing_service::remove_cache_entry(
 {
     // If caching is disabled, we silently pretend success.
     if (!caching_)
+    {
+        if (&ec != &throws)
+            ec = make_success_code();
+        return;
+    }
+
+    // don't look at cache if id is marked as non-cache-able
+    if (!naming::detail::store_in_cache(gid))
     {
         if (&ec != &throws)
             ec = make_success_code();

--- a/src/runtime/agas/server/route.cpp
+++ b/src/runtime/agas/server/route.cpp
@@ -92,16 +92,17 @@ namespace hpx { namespace agas { namespace server
             // asynchronously update cache on source locality
             for (std::size_t i = 0; i != cache_addresses.size(); ++i)
             {
+                // update remote cache if the id is not flagged otherwise
                 resolved_type const& r = cache_addresses[i];
-                if (boost::fusion::at_c<0>(r))
+                naming::gid_type const& id = boost::fusion::at_c<0>(r);
+                if (id && !naming::detail::store_in_cache(id))
                 {
                     gva const& g = boost::fusion::at_c<1>(r);
                     naming::address addr(g.prefix, g.type, g.lva());
 
                     using components::stubs::runtime_support;
                     runtime_support::update_agas_cache_entry_colocated(
-                        source, boost::fusion::at_c<0>(r), addr, g.count,
-                        g.offset);
+                        source, id, addr, g.count, g.offset);
                 }
             }
         }


### PR DESCRIPTION
-  Making sure AGAS cache is not touched for objects managed locally 
-  Adding dont_cache_mask for gid_type which prevents any gid from being stored in an AGAS cache.
- some fly-by optimizations tothe implementations of async and async_cb