### PR TITLE
Fix async to dispatch to the correct locality in all cases

### DIFF
--- a/hpx/async.hpp
+++ b/hpx/async.hpp
@@ -92,12 +92,10 @@ namespace hpx { namespace detail
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    // BOOST_SCOPED_ENUM(launch)
-    template <typename Policy>
-    struct async_dispatch<Policy,
+    template <typename Action>
+    struct async_launch_policy_dispatch<Action,
         typename boost::enable_if_c<
-            traits::is_launch_policy<Policy>::value
-         && !traits::is_action<Policy>::value
+            !traits::is_action<Action>::value
         >::type>
     {
         template <typename F, typename ...Ts>
@@ -106,7 +104,7 @@ namespace hpx { namespace detail
             traits::detail::is_deferred_callable<F(Ts...)>::value,
             hpx::future<typename util::deferred_call_result_of<F(Ts...)>::type>
         >::type
-        call(BOOST_SCOPED_ENUM(launch) const& launch_policy, F&& f, Ts&&... ts)
+        call(BOOST_SCOPED_ENUM(launch) launch_policy, F&& f, Ts&&... ts)
         {
             typedef typename util::deferred_call_result_of<
                 F(Ts...)

--- a/hpx/lcos/async.hpp
+++ b/hpx/lcos/async.hpp
@@ -99,6 +99,41 @@ namespace hpx { namespace detail
                 >::call(launch::all, policy, std::forward<Ts>(ts)...);
         }
     };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Action>
+    struct async_launch_policy_dispatch<Action,
+        typename boost::enable_if_c<
+            traits::is_action<Action>::value
+        >::type>
+    {
+        typedef typename traits::promise_local_result<
+                typename hpx::actions::extract_action<
+                    Action
+                >::remote_result_type
+            >::type result_type;
+
+        template <typename ...Ts>
+        BOOST_FORCEINLINE static
+        lcos::future<result_type>
+        call(BOOST_SCOPED_ENUM(launch) launch_policy,
+            Action const&, naming::id_type const& id, Ts&&... ts)
+        {
+            return async<Action>(launch_policy, id, std::forward<Ts>(ts)...);
+        }
+
+        template <typename DistPolicy, typename ...Ts>
+        BOOST_FORCEINLINE static
+        typename boost::enable_if_c<
+            traits::is_distribution_policy<DistPolicy>::value,
+            lcos::future<result_type>
+        >::type
+        call(BOOST_SCOPED_ENUM(launch) launch_policy,
+            Action const&, DistPolicy const& policy, Ts&&... ts)
+        {
+            return async<Action>(launch_policy, policy, std::forward<Ts>(ts)...);
+        }
+    };
 }}
 
 namespace hpx
@@ -158,43 +193,23 @@ namespace hpx { namespace detail
         }
     };
 
-    ///////////////////////////////////////////////////////////////////////////
+    // BOOST_SCOPED_ENUM(launch)
     template <typename Policy>
     struct async_dispatch<Policy,
         typename boost::enable_if_c<
             traits::is_launch_policy<Policy>::value
-         && traits::is_action<Policy>::value
         >::type>
     {
-        template <typename Action, typename ...Ts>
-        BOOST_FORCEINLINE static
-        lcos::future<
-            typename traits::promise_local_result<
-                typename hpx::actions::extract_action<
-                    Action
-                >::remote_result_type
-            >::type>
-        call(BOOST_SCOPED_ENUM(launch) launch_policy,
-            Action const&, naming::id_type const& id, Ts&&... ts)
+        template <typename F, typename ...Ts>
+        BOOST_FORCEINLINE static auto
+        call(BOOST_SCOPED_ENUM(launch) const& launch_policy, F&& f, Ts&&... ts)
+        ->  decltype(detail::async_launch_policy_dispatch<
+                    typename util::decay<F>::type
+                >::call(launch_policy, std::forward<F>(f), std::forward<Ts>(ts)...))
         {
-            return async<Action>(launch_policy, id, std::forward<Ts>(ts)...);
-        }
-
-        template <typename Action, typename DistPolicy, typename ...Ts>
-        BOOST_FORCEINLINE static
-        typename boost::enable_if_c<
-            traits::is_distribution_policy<DistPolicy>::value,
-            lcos::future<
-                typename traits::promise_local_result<
-                    typename hpx::actions::extract_action<
-                        Action
-                    >::remote_result_type
-                >::type>
-        >::type
-        call(BOOST_SCOPED_ENUM(launch) launch_policy,
-            Action const&, DistPolicy const& policy, Ts&&... ts)
-        {
-            return async<Action>(launch_policy, policy, std::forward<Ts>(ts)...);
+            return async_launch_policy_dispatch<
+                    typename util::decay<F>::type
+                >::call(launch_policy, std::forward<F>(f), std::forward<Ts>(ts)...);
         }
     };
 }}

--- a/hpx/lcos/async_fwd.hpp
+++ b/hpx/lcos/async_fwd.hpp
@@ -41,6 +41,10 @@ namespace hpx
         // dispatch point used for async<Action> implementations
         template <typename Action, typename Func, typename Enable = void>
         struct async_action_dispatch;
+
+        // dispatch point used for launch_policy implementations
+        template <typename Action, typename Enable = void>
+        struct async_launch_policy_dispatch;
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -741,8 +741,7 @@ namespace detail
         {
             if (!started_test())
                 return future_status::deferred; //-V110
-            else
-                return this->future_data<Result>::wait_until(abs_time, ec);
+            return this->future_data<Result>::wait_until(abs_time, ec);
         };
 
     private:

--- a/hpx/lcos/promise.hpp
+++ b/hpx/lcos/promise.hpp
@@ -617,7 +617,7 @@ namespace hpx { namespace lcos
             if (future_obtained_) {
                 HPX_THROWS_IF(ec, future_already_retrieved,
                     "promise<Result>::get_future",
-                    "future already has been retrieved from this packaged_action");
+                    "future already has been retrieved from this promise");
                 return lcos::future<Result>();
             }
 

--- a/tests/regressions/lcos/CMakeLists.txt
+++ b/tests/regressions/lcos/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 set(tests
     after_588
+    async_action_1813
     async_callback_with_bound_callback
     async_callback_non_deduced_context
     async_unwrap_1037
@@ -35,6 +36,7 @@ set(tests
 set(dataflow_future_swap_FLAGS DEPENDENCIES iostreams_component)
 set(dataflow_future_swap_PARAMETERS THREADS_PER_LOCALITY 4)
 set(after_588_PARAMETERS LOCALITIES 2)
+set(async_action_1813_PARAMETERS LOCALITIES 2)
 set(async_callback_with_bound_callback_PARAMETERS LOCALITIES 2)
 set(async_callback_non_deduced_context_PARAMETERS THREADS_PER_LOCALITY 4)
 set(future_hang_on_get_629_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 2)

--- a/tests/regressions/lcos/async_action_1813.cpp
+++ b/tests/regressions/lcos/async_action_1813.cpp
@@ -1,0 +1,89 @@
+//  Copyright (c) 2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This test demonstrates the issue described by #1813:
+// async(launch::..., action(), ...) always invokes locally
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/components.hpp>
+#include <hpx/include/async.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+hpx::id_type get_locality()
+{
+    return hpx::find_here();
+}
+HPX_PLAIN_ACTION(get_locality);
+
+///////////////////////////////////////////////////////////////////////////////
+struct get_locality_server
+  : hpx::components::simple_component_base<get_locality_server>
+{
+    hpx::id_type call()
+    {
+        return hpx::find_here();
+    }
+
+    HPX_DEFINE_COMPONENT_ACTION(get_locality_server, call);
+};
+
+typedef hpx::components::simple_component<get_locality_server> server_type;
+HPX_REGISTER_COMPONENT(server_type, get_locality_server);
+
+typedef get_locality_server::call_action call_action;
+HPX_REGISTER_ACTION_DECLARATION(call_action);
+HPX_REGISTER_ACTION(call_action);
+
+///////////////////////////////////////////////////////////////////////////////
+void test_remote_async(hpx::id_type target)
+{
+    {
+        get_locality_action act;
+
+        hpx::future<hpx::id_type> f1 = hpx::async(act, target);
+        HPX_TEST_EQ(f1.get(), target);
+
+        hpx::future<hpx::id_type> f2 =
+            hpx::async(hpx::launch::all, act, target);
+        HPX_TEST_EQ(f2.get(), target);
+    }
+
+    {
+        hpx::future<hpx::id_type> obj_f =
+            hpx::components::new_<get_locality_server>(target);
+        hpx::id_type obj = obj_f.get();
+
+        call_action call;
+
+        hpx::future<hpx::id_type> f1 = hpx::async(call, obj);
+        HPX_TEST_EQ(f1.get(), target);
+
+        hpx::future<hpx::id_type> f2 =
+            hpx::async(hpx::launch::all, call, obj);
+        HPX_TEST_EQ(f2.get(), target);
+    }
+}
+
+int hpx_main()
+{
+    std::vector<hpx::id_type> localities = hpx::find_all_localities();
+    for (hpx::id_type const& id : localities)
+    {
+        test_remote_async(id);
+    }
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}
+


### PR DESCRIPTION
- This fixes #1813: async(launch::..., action(), ...) always invokes locally