### PR TITLE
Fixing #1620

### DIFF
--- a/tests/regressions/lcos/CMakeLists.txt
+++ b/tests/regressions/lcos/CMakeLists.txt
@@ -24,6 +24,7 @@ set(tests
     lifetime_588
     lifetime_588_1
     promise_leak_996
+    promise_1620
     receive_buffer_1733
     safely_destroy_promise_1481
     set_hpx_limit_798
@@ -33,6 +34,7 @@ set(tests
     when_all_vectors_1623
    )
 
+set(promise_1620_FLAGS DEPENDENCIES iostreams_component)
 set(dataflow_future_swap_FLAGS DEPENDENCIES iostreams_component)
 set(dataflow_future_swap_PARAMETERS THREADS_PER_LOCALITY 4)
 set(after_588_PARAMETERS LOCALITIES 2)
@@ -45,7 +47,6 @@ set(ignore_while_locked_1485_PARAMETERS THREADS_PER_LOCALITY 2)
 set(lifetime_588_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 2)
 set(lifetime_588_1_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 2)
 set(receive_buffer_1733_PARAMETERS LOCALITIES 2)
-set(set_hpx_limit_771_FLAGS DEPENDENCIES dataflow_component)
 set(safely_destroy_cv_1481_PARAMETERS THREADS_PER_LOCALITY 2)
 set(shared_mutex_1702_PARAMETERS THREADS_PER_LOCALITY 4)
 set(wait_for_1751_PARAMETERS THREADS_PER_LOCALITY 4)

--- a/tests/regressions/lcos/promise_1620.cpp
+++ b/tests/regressions/lcos/promise_1620.cpp
@@ -7,10 +7,44 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_start.hpp>
 #include <hpx/include/iostreams.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+struct test
+{
+    test() { ++count; }
+    test(test const & t) { ++count; }
+    test& operator=(test const & t) { ++count; return *this; }
+    ~test() { --count; }
+
+    static boost::atomic<int> count;
+};
+
+boost::atomic<int> test::count(0);
+
+test call() { return test(); }
+HPX_PLAIN_ACTION(call);
+
+void test_leak()
+{
+    {
+        hpx::lcos::promise<test> p;
+        hpx::apply_c<call_action>(p.get_id(), hpx::find_here());
+        hpx::future<test> f = p.get_future();
+        f.get();
+    }
+
+    hpx::agas::garbage_collect();
+    hpx::this_thread::yield();
+    hpx::agas::garbage_collect();
+    hpx::this_thread::yield();
+    HPX_TEST_EQ(test::count, 0);
+}
 
 int hpx_main(int argc, char* argv[])
 {
     {
+        test_leak();
+
         hpx::id_type promise_id;
         {
             hpx::promise<int> p;

--- a/tests/regressions/lcos/promise_1620.cpp
+++ b/tests/regressions/lcos/promise_1620.cpp
@@ -3,11 +3,12 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_start.hpp>
 #include <hpx/include/iostreams.hpp>
 #include <hpx/util/lightweight_test.hpp>
+
+#include <boost/atomic.hpp>
 
 struct test
 {
@@ -27,10 +28,15 @@ HPX_PLAIN_ACTION(call);
 void test_leak()
 {
     {
-        hpx::lcos::promise<test> p;
-        hpx::apply_c<call_action>(p.get_id(), hpx::find_here());
-        hpx::future<test> f = p.get_future();
-        f.get();
+        hpx::shared_future<test> f;
+
+        {
+            hpx::lcos::promise<test> p;
+            hpx::apply_c<call_action>(p.get_id(), hpx::find_here());
+            f = p.get_future();
+        }
+
+        test t = f.get();
     }
 
     hpx::agas::garbage_collect();

--- a/tests/regressions/lcos/promise_1620.cpp
+++ b/tests/regressions/lcos/promise_1620.cpp
@@ -1,0 +1,46 @@
+// Copyright (c)       2015 Martin Stumpf
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_start.hpp>
+#include <hpx/include/iostreams.hpp>
+
+int hpx_main(int argc, char* argv[])
+{
+    {
+        hpx::id_type promise_id;
+        {
+            hpx::promise<int> p;
+
+            {
+                auto local_promise_id = p.get_id();
+                hpx::cout << local_promise_id << hpx::endl;
+            }
+
+            hpx::this_thread::sleep_for(boost::chrono::milliseconds(100));
+
+            promise_id = p.get_id();
+            hpx::cout << promise_id << hpx::endl;
+        }
+
+        hpx::this_thread::sleep_for(boost::chrono::milliseconds(100));
+
+        // This segfaults, because the promise is not alive any more.
+        // It SHOULD get kept alive by AGAS though.
+        hpx::set_lco_value(promise_id, 10, false);
+
+    }
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // initialize HPX, run hpx_main.
+    hpx::start(argc, argv);
+
+    // wait for hpx::finalize being called.
+    return hpx::stop();
+}


### PR DESCRIPTION
This patch makes sure that the id of a promise can be retrieved multiple times
keeping the promise alive long enough.