### PR TITLE
Making hpx::lcos::promise move-only

### DIFF
--- a/examples/heartbeat/heartbeat.cpp
+++ b/examples/heartbeat/heartbeat.cpp
@@ -15,7 +15,8 @@
 #include <hpx/lcos/future.hpp>
 #include <hpx/state.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/make_shared.hpp>
 #include <boost/format.hpp>
 #include <boost/cstdint.hpp>
 
@@ -25,9 +26,9 @@
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-void stop_monitor(hpx::promise<void> p)
+void stop_monitor(boost::shared_ptr<hpx::promise<void> > p)
 {
-    p.set_value();      // Kill the monitor.
+    p->set_value();      // Kill the monitor.
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -56,11 +57,14 @@ int monitor(double runfor, std::string const& name, boost::uint64_t pause)
         return 1;
     }
 
-    hpx::promise<void> stop_flag;
-    hpx::register_shutdown_function(boost::bind(&stop_monitor, stop_flag));
+    boost::shared_ptr<hpx::promise<void> > stop_flag =
+        boost::make_shared<hpx::promise<void> >();
+    hpx::future<void> f = stop_flag->get_future();
+
+    hpx::register_shutdown_function(
+        hpx::util::bind(&stop_monitor, stop_flag));
 
     boost::int64_t zero_time = 0;
-    hpx::future<void> f = stop_flag.get_future();
 
     hpx::util::high_resolution_timer t;
     while (runfor < 0 || t.elapsed() < runfor)

--- a/hpx/lcos/promise.hpp
+++ b/hpx/lcos/promise.hpp
@@ -23,6 +23,7 @@
 #include <hpx/lcos/local/spinlock_pool.hpp>
 #include <hpx/util/one_size_heap_list_base.hpp>
 #include <hpx/util/static_reinit.hpp>
+#include <hpx/util/move.hpp>
 
 #include <boost/intrusive_ptr.hpp>
 #include <boost/static_assert.hpp>
@@ -544,6 +545,8 @@ namespace hpx { namespace lcos
     template <typename Result, typename RemoteResult>
     class promise
     {
+        HPX_MOVABLE_BUT_NOT_COPYABLE(promise);
+
     public:
         typedef detail::promise<Result, RemoteResult> wrapped_type;
         typedef components::managed_component<wrapped_type> wrapping_type;
@@ -664,6 +667,8 @@ namespace hpx { namespace lcos
     template <>
     class promise<void, util::unused_type>
     {
+        HPX_MOVABLE_BUT_NOT_COPYABLE(promise);
+
     public:
         typedef detail::promise<void, util::unused_type> wrapped_type;
         typedef components::managed_component<wrapped_type> wrapping_type;


### PR DESCRIPTION
This fixes #1832: hpx::lcos::promise<> must be move-only