### PR TITLE
Fixing Performance Problems with MPI Parcelport

### DIFF
--- a/hpx/plugins/parcelport/mpi/receiver.hpp
+++ b/hpx/plugins/parcelport/mpi/receiver.hpp
@@ -11,8 +11,6 @@
 #include <hpx/plugins/parcelport/mpi/header.hpp>
 #include <hpx/plugins/parcelport/mpi/receiver_connection.hpp>
 
-#include <hpx/util/memory_chunk_pool.hpp>
-
 #include <list>
 #include <iterator>
 
@@ -27,16 +25,14 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
         typedef hpx::lcos::local::spinlock mutex_type;
         typedef std::list<std::pair<int, header> > header_list;
         typedef std::set<std::pair<int, int> > handles_header_type;
-        typedef util::memory_chunk_pool<mutex_type> memory_pool_type;
         typedef
             receiver_connection
             connection_type;
         typedef std::shared_ptr<connection_type> connection_ptr;
-        typedef std::list<connection_ptr> connection_list;
+        typedef std::deque<connection_ptr> connection_list;
 
-        receiver(parcelport & pp, memory_pool_type & chunk_pool)
+        receiver(parcelport & pp)
           : pp_(pp)
-          , chunk_pool_(chunk_pool)
         {}
 
         void run()
@@ -45,24 +41,28 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
             new_header();
         }
 
-        bool background_work(std::size_t num_thread)
+        bool background_work()
         {
             // We accept as many connections as we can ...
             connection_list connections;
             {
-                boost::unique_lock<mutex_type> l(connections_mtx_);
-                std::swap(connections, connections_);
+                boost::unique_lock<mutex_type> l(connections_mtx_, boost::try_to_lock);
+                if(l && !connections_.empty())
+                {
+                    connections.push_back(connections_.front());
+                    connections_.pop_front();
+                }
             }
 
             connection_ptr rcv;
-            do
-            {
+//             do
+//             {
                 rcv = accept();
                 if(rcv && !rcv->receive())
                 {
                     connections.push_back(rcv);
                 }
-            } while(rcv);
+//             } while(rcv);
             rcv.reset();
 
             if(!connections.empty())
@@ -89,7 +89,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
             );
 
             // If some are still in progress, give them back
-//             if(end != connections.end())
+            if(connections.begin() != end)
             {
                 boost::unique_lock<mutex_type> l(connections_mtx_);
                 connections_.insert(
@@ -126,7 +126,6 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
                             status.MPI_SOURCE
                           , h
                           , pp_
-                          , chunk_pool_
                         )
                     );
                     return res;
@@ -152,8 +151,6 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
         }
 
         parcelport & pp_;
-
-        memory_pool_type & chunk_pool_;
 
         mutex_type headers_mtx_;
         MPI_Request hdr_request_;

--- a/hpx/plugins/parcelport/mpi/receiver_connection.hpp
+++ b/hpx/plugins/parcelport/mpi/receiver_connection.hpp
@@ -10,9 +10,6 @@
 #include <hpx/runtime/parcelset/decode_parcels.hpp>
 #include <hpx/runtime/parcelset/parcel_buffer.hpp>
 
-#include <hpx/util/memory_chunk_pool.hpp>
-#include <hpx/util/memory_chunk_pool_allocator.hpp>
-
 #include <vector>
 
 namespace hpx { namespace parcelset { namespace policies { namespace mpi
@@ -33,12 +30,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
 
         typedef hpx::lcos::local::spinlock mutex_type;
 
-        typedef util::memory_chunk_pool<mutex_type> memory_pool_type;
-        typedef util::detail::memory_chunk_pool_allocator<
-                char, memory_pool_type
-            > allocator_type;
-        typedef
-            std::vector<char, allocator_type>
+        typedef std::vector<char>
             data_type;
         typedef parcel_buffer<data_type, data_type> buffer_type;
 
@@ -47,14 +39,11 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
             int src
           , header h
           , parcelport & pp
-          , memory_pool_type & chunk_pool
         )
           : state_(initialized)
           , src_(src)
           , tag_(h.tag())
           , header_(h)
-          , allocator_(chunk_pool)
-          , buffer_(allocator_)
           , request_(MPI_REQUEST_NULL)
           , request_ptr_(0)
           , chunks_idx_(0)
@@ -104,7 +93,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
             );
             if(num_zero_copy_chunks != 0)
             {
-                buffer_.chunks_.resize(num_zero_copy_chunks, data_type(allocator_));
+                buffer_.chunks_.resize(num_zero_copy_chunks);
                 {
                     util::mpi_environment::scoped_lock l;
                     MPI_Irecv(
@@ -248,7 +237,6 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
         int src_;
         int tag_;
         header header_;
-        allocator_type allocator_;
         buffer_type buffer_;
 
         MPI_Request request_;

--- a/hpx/plugins/parcelport/mpi/sender.hpp
+++ b/hpx/plugins/parcelport/mpi/sender.hpp
@@ -13,8 +13,6 @@
 #include <hpx/plugins/parcelport/mpi/sender_connection.hpp>
 #include <hpx/plugins/parcelport/mpi/tag_provider.hpp>
 
-#include <hpx/util/memory_chunk_pool.hpp>
-
 #include <list>
 #include <iterator>
 #include <memory>
@@ -25,25 +23,16 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
 {
     struct sender
     {
-        typedef util::memory_chunk_pool<> memory_pool_type;
-        typedef
-            util::detail::memory_chunk_pool_allocator<
-                char, util::memory_chunk_pool<>
-            >
-            allocator_type;
-        typedef
-            std::vector<char, allocator_type>
-            data_type;
         typedef
             sender_connection
             connection_type;
         typedef boost::shared_ptr<connection_type> connection_ptr;
-        typedef std::list<connection_ptr> connection_list;
+        typedef std::deque<connection_ptr> connection_list;
 
         typedef hpx::lcos::local::spinlock mutex_type;
-        sender(memory_pool_type & chunk_pool)
+
+        sender()
           : next_free_tag_(-1)
-          , chunk_pool_(chunk_pool)
         {
         }
 
@@ -57,7 +46,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
         {
             return
                 boost::make_shared<connection_type>(
-                    this, dest, chunk_pool_, parcels_sent);
+                    this, dest, parcels_sent);
         }
 
         void add(connection_ptr const & ptr)
@@ -92,7 +81,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
             );
 
             // If some are still in progress, give them back
-//             if(end != connections.end())
+            if(connections.begin() != end)
             {
                 boost::unique_lock<mutex_type> l(connections_mtx_);
                 connections_.insert(
@@ -103,12 +92,16 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
             }
         }
 
-        bool background_work(std::size_t num_thread)
+        bool background_work()
         {
             connection_list connections;
             {
-                boost::unique_lock<mutex_type> l(connections_mtx_);
-                std::swap(connections, connections_);
+                boost::unique_lock<mutex_type> l(connections_mtx_, boost::try_to_lock);
+                if(l && !connections_.empty())
+                {
+                    connections.push_back(connections_.front());
+                    connections_.pop_front();
+                }
             }
             bool has_work = false;
             if(!connections.empty())
@@ -179,8 +172,6 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
         mutex_type next_free_tag_mtx_;
         MPI_Request next_free_tag_request_;
         int next_free_tag_;
-
-        memory_pool_type & chunk_pool_;
     };
 
 

--- a/hpx/plugins/parcelport/mpi/sender_connection.hpp
+++ b/hpx/plugins/parcelport/mpi/sender_connection.hpp
@@ -10,8 +10,6 @@
 #include <hpx/plugins/parcelport/mpi/header.hpp>
 #include <hpx/plugins/parcelport/mpi/locality.hpp>
 
-#include <hpx/util/memory_chunk_pool.hpp>
-
 #include <boost/shared_ptr.hpp>
 
 namespace hpx { namespace parcelset { namespace policies { namespace mpi
@@ -25,12 +23,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
     struct sender_connection
       : parcelset::parcelport_connection<
             sender_connection
-          , std::vector<
-                char
-              , util::detail::memory_chunk_pool_allocator<
-                    char, util::memory_chunk_pool<>
-                >
-            >
+          , std::vector<char>
         >
     {
     private:
@@ -40,13 +33,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
             void(boost::system::error_code const&, parcel const&)
         > write_handler_type;
 
-        typedef util::memory_chunk_pool<> memory_pool_type;
-        typedef
-            util::detail::memory_chunk_pool_allocator<char, util::memory_chunk_pool<>>
-            allocator_type;
-        typedef
-            std::vector<char, allocator_type>
-            data_type;
+        typedef std::vector<char> data_type;
 
         enum connection_state
         {
@@ -65,18 +52,15 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
         sender_connection(
             sender_type * s
           , int dst
-          , memory_pool_type & chunk_pool
           , performance_counters::parcels::gatherer & parcels_sent
         )
-          : base_type(allocator_type(chunk_pool))
-          , state_(initialized)
+          : state_(initialized)
           , sender_(s)
           , dst_(dst)
           , request_(MPI_REQUEST_NULL)
           , request_ptr_(0)
           , chunks_idx_(0)
           , ack_(0)
-          , chunk_pool_(chunk_pool)
           , parcels_sent_(parcels_sent)
           , there_(
                 parcelset::locality(
@@ -316,8 +300,6 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
         MPI_Request *request_ptr_;
         std::size_t chunks_idx_;
         char ack_;
-
-        memory_pool_type & chunk_pool_;
 
         performance_counters::parcels::gatherer & parcels_sent_;
 

--- a/plugins/parcelport/mpi/parcelport_mpi.cpp
+++ b/plugins/parcelport/mpi/parcelport_mpi.cpp
@@ -30,7 +30,6 @@
 #include <hpx/plugins/parcelport/mpi/sender.hpp>
 #include <hpx/plugins/parcelport/mpi/receiver.hpp>
 
-#include <hpx/util/memory_chunk_pool.hpp>
 #include <hpx/util/runtime_configuration.hpp>
 #include <hpx/util/safe_lexical_cast.hpp>
 
@@ -109,16 +108,11 @@ namespace hpx { namespace parcelset
                 util::function_nonser<void()> const& on_stop)
               : base_type(ini, here(), on_start, on_stop)
               , stopped_(false)
-              , chunk_pool_(4096, max_connections(ini))
-              , sender_(chunk_pool_)
-              , receiver_(*this, chunk_pool_)
-              , handles_parcels_(0)
+              , receiver_(*this)
             {}
 
             ~parcelport()
             {
-                if(receive_early_parcels_thread_.joinable())
-                    receive_early_parcels_thread_.join();
                 util::mpi_environment::finalize();
             }
 
@@ -127,9 +121,14 @@ namespace hpx { namespace parcelset
             {
                 receiver_.run();
                 sender_.run();
-                receive_early_parcels_thread_ =
-                    boost::thread(&parcelport::receive_early_parcels, this,
-                        hpx::get_runtime_ptr());
+                for(std::size_t i = 0; i != io_service_pool_.size(); ++i)
+                {
+                    io_service_pool_.get_io_service(i).post(
+                        hpx::util::bind(
+                            &parcelport::io_service_work, this
+                        )
+                    );
+                }
                 return true;
             }
 
@@ -143,12 +142,6 @@ namespace hpx { namespace parcelset
                             "mpi::parcelport::do_stop");
                 }
                 stopped_ = true;
-                while(handles_parcels_ != 0)
-                {
-                    if(threads::get_self_ptr())
-                        hpx::this_thread::suspend(hpx::threads::pending,
-                            "mpi::parcelport::do_stop");
-                }
                 MPI_Barrier(util::mpi_environment::communicator());
             }
 
@@ -187,67 +180,38 @@ namespace hpx { namespace parcelset
                 if (stopped_)
                     return false;
 
-                handles_parcels h(this);
-
-                bool has_work = sender_.background_work(num_thread);
-                has_work = receiver_.background_work(num_thread) || has_work;
+                bool has_work = false;
+                has_work = sender_.background_work();
+                has_work = receiver_.background_work() || has_work;
                 return has_work;
             }
 
         private:
-            typedef util::memory_chunk_pool<> memory_pool_type;
-            typedef
-                util::detail::memory_chunk_pool_allocator<
-                    char, util::memory_chunk_pool<>
-                > allocator_type;
-            typedef
-                std::vector<char, allocator_type>
-                data_type;
             typedef lcos::local::spinlock mutex_type;
 
             boost::atomic<bool> stopped_;
 
-            memory_pool_type chunk_pool_;
-
             sender sender_;
             receiver receiver_;
 
-            boost::thread receive_early_parcels_thread_;
-
-            boost::atomic<std::size_t> handles_parcels_;
-
-            struct handles_parcels
+            void io_service_work()
             {
-                handles_parcels(parcelport *pp)
-                  : this_(pp)
+                std::size_t k = 0;
+                // We only execute work on the IO service while HPX is starting
+                while(hpx::is_starting())
                 {
-                    ++this_->handles_parcels_;
-                }
-
-                ~handles_parcels()
-                {
-                    --this_->handles_parcels_;
-                }
-
-                parcelport *this_;
-            };
-
-            void receive_early_parcels(hpx::runtime * rt)
-            {
-                rt->register_thread("receive_early_parcel");
-                try
-                {
-                    while(rt->get_state() <= state_startup)
+                    bool has_work = sender_.background_work();
+                    has_work = receiver_.background_work() || has_work;
+                    if(has_work)
                     {
-                        do_background_work(0);
+                        k = 0;
+                    }
+                    else
+                    {
+                        ++k;
+                        hpx::lcos::local::spinlock::yield(k);
                     }
                 }
-                catch(...)
-                {
-                    rt->unregister_thread();
-                    throw;
-                }
-                rt->unregister_thread();
             }
 
             void early_write_handler(


### PR DESCRIPTION
Instead of getting a hold onto all ongoing connections in the background
work, we just grab one. This gives other idling threads the opportunity to grab
Parcelport work as well.

Fly-by-change: The special allocator has been removed as it didn't have any
positive effect over the regular allocation.