### PR TITLE
Completely removing external/endian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1519,7 +1519,6 @@ install( # Install HPX Python scripts
 
 install( # Install external dependencies
   DIRECTORY external/cache/boost
-            external/endian/boost
   DESTINATION include/hpx/external
   COMPONENT core
   FILES_MATCHING PATTERN "*.hpp"

--- a/cmake/HPX_SetupBoost.cmake
+++ b/cmake/HPX_SetupBoost.cmake
@@ -99,7 +99,6 @@ endif()
 
 set(Boost_LIBRARIES ${Boost_TMP_LIBRARIES})
 set(Boost_INCLUDE_DIRS ${Boost_INCLUDE_DIRS} ${PROJECT_SOURCE_DIR}/external/cache)
-set(Boost_INCLUDE_DIRS ${Boost_INCLUDE_DIRS} ${PROJECT_SOURCE_DIR}/external/endian)
 
 # If we compile natively for the MIC, we need some workarounds for certain
 # Boost headers


### PR DESCRIPTION
Removing remaining external/endian entries from CMake scripts. This
made some external builds using the exported targets fail.