### PR TITLE
Embrace static_assert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -750,7 +750,7 @@ hpx_check_for_cxx11_scoped_enums(
   DEFINITIONS HPX_HAVE_CXX11_SCOPED_ENUMS)
 
 hpx_check_for_cxx11_static_assert(
-  DEFINITIONS HPX_HAVE_CXX11_STATIC_ASSERT)
+  REQUIRED "HPX needs support for C++11 static_assert")
 
 hpx_check_for_cxx11_variadic_macros(
   REQUIRED "HPX needs support for C++11 variadic macros")

--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -29,7 +29,6 @@
 #include <boost/intrusive_ptr.hpp>
 #include <boost/mpl/eval_if.hpp>
 #include <boost/mpl/if.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/type_traits/is_void.hpp>
 #include <boost/utility/declval.hpp>
 #include <boost/utility/enable_if.hpp>

--- a/hpx/lcos/local/dataflow.hpp
+++ b/hpx/lcos/local/dataflow.hpp
@@ -32,7 +32,6 @@
 #include <boost/mpl/or.hpp>
 #include <boost/range/functions.hpp>
 #include <boost/ref.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/atomic.hpp>

--- a/hpx/lcos/packaged_action.hpp
+++ b/hpx/lcos/packaged_action.hpp
@@ -24,7 +24,6 @@
 
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/identity.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/type_traits/is_same.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hpx/lcos/promise.hpp
+++ b/hpx/lcos/promise.hpp
@@ -26,7 +26,6 @@
 #include <hpx/util/move.hpp>
 
 #include <boost/intrusive_ptr.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/mpl/identity.hpp>
 #include <boost/exception_ptr.hpp>
 

--- a/hpx/lcos/wait_some.hpp
+++ b/hpx/lcos/wait_some.hpp
@@ -342,7 +342,7 @@ namespace hpx { namespace lcos
         std::vector<Future> const& lazy_values,
         error_code& ec = throws)
     {
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             traits::is_future<Future>::value, "invalid use of wait_some");
 
         typedef

--- a/hpx/lcos/when_each.hpp
+++ b/hpx/lcos/when_each.hpp
@@ -311,7 +311,7 @@ namespace hpx { namespace lcos
     lcos::future<void>
     when_each(F&& func, std::vector<Future>& lazy_values)
     {
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             traits::is_future<Future>::value, "invalid use of when_each");
 
         typedef hpx::util::tuple<std::vector<Future> > argument_type;

--- a/hpx/parallel/algorithms/adjacent_difference.hpp
+++ b/hpx/parallel/algorithms/adjacent_difference.hpp
@@ -23,7 +23,6 @@
 #include <numeric>
 #include <iterator>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -165,11 +164,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             output_iterator_category;
         typedef typename std::iterator_traits<InIter>::value_type value_type;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag,
                 iterator_category>::value),
             "Requires at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,
@@ -269,11 +268,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag,
                 iterator_category>::value),
             "Requires at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,

--- a/hpx/parallel/algorithms/adjacent_find.hpp
+++ b/hpx/parallel/algorithms/adjacent_find.hpp
@@ -21,7 +21,6 @@
 #include <algorithm>
 #include <iterator>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -154,7 +153,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, iterator_category
             >::value),
@@ -239,7 +238,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, iterator_category
             >::value),

--- a/hpx/parallel/algorithms/all_any_none.hpp
+++ b/hpx/parallel/algorithms/all_any_none.hpp
@@ -21,7 +21,6 @@
 #include <hpx/parallel/util/loop.hpp>
 
 #include <boost/range/functions.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 #include <boost/utility/enable_if.hpp>
 
@@ -158,7 +157,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
             "Requires at least input iterator.");
 
@@ -300,7 +299,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
             "Requires at least input iterator.");
 
@@ -442,7 +441,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
             "Requires at least input iterator.");
 

--- a/hpx/parallel/algorithms/copy.hpp
+++ b/hpx/parallel/algorithms/copy.hpp
@@ -24,7 +24,6 @@
 #include <iterator>
 #include <type_traits>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 #include <boost/shared_array.hpp>
@@ -163,12 +162,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category>::value),
             "Required at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,
@@ -289,12 +288,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category>::value),
             "Required at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,
@@ -489,12 +488,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category>::value),
             "Required at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,

--- a/hpx/parallel/algorithms/count.hpp
+++ b/hpx/parallel/algorithms/count.hpp
@@ -20,7 +20,6 @@
 #include <hpx/parallel/util/loop.hpp>
 
 #include <boost/range/functions.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 #include <boost/utility/enable_if.hpp>
 
@@ -177,7 +176,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter>::iterator_category
             category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, category>::value),
             "Required at least input iterator.");
 
@@ -352,7 +351,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter>::iterator_category
             category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, category>::value),
             "Required at least input iterator.");
 

--- a/hpx/parallel/algorithms/equal.hpp
+++ b/hpx/parallel/algorithms/equal.hpp
@@ -21,7 +21,6 @@
 #include <hpx/parallel/util/zip_iterator.hpp>
 
 #include <boost/range/functions.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 #include <boost/utility/enable_if.hpp>
 
@@ -206,10 +205,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter2>::iterator_category
             iterator_category2;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category1>::value),
             "Requires at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category2>::value),
             "Requires at least input iterator.");
 
@@ -309,10 +308,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter2>::iterator_category
             iterator_category2;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category1>::value),
             "Requires at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category2>::value),
             "Requires at least input iterator.");
 
@@ -460,10 +459,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter2>::iterator_category
             iterator_category2;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category1>::value),
             "Requires at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category2>::value),
             "Requires at least input iterator.");
 
@@ -559,10 +558,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter2>::iterator_category
             iterator_category2;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category1>::value),
             "Requires at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category2>::value),
             "Requires at least input iterator.");
 

--- a/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -26,7 +26,6 @@
 #include <numeric>
 #include <iterator>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -249,11 +248,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,
@@ -345,11 +344,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,

--- a/hpx/parallel/algorithms/fill.hpp
+++ b/hpx/parallel/algorithms/fill.hpp
@@ -22,7 +22,6 @@
 #include <algorithm>
 #include <iterator>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -120,7 +119,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter>::iterator_category
              iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, iterator_category>::value),
             "Required at least forward iterator.");
@@ -223,7 +222,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, iterator_category>,

--- a/hpx/parallel/algorithms/find.hpp
+++ b/hpx/parallel/algorithms/find.hpp
@@ -19,7 +19,6 @@
 #include <algorithm>
 #include <iterator>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -146,7 +145,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, iterator_category
             >::value),
@@ -296,7 +295,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, iterator_category
             >::value),
@@ -452,7 +451,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, iterator_category
             >::value),
@@ -626,13 +625,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter2>::iterator_category
             iterator_category2;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, iterator_category1
             >::value),
             "Requires at least forward iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, iterator_category2
             >::value),
@@ -731,13 +730,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter2>::iterator_category
             iterator_category2;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, iterator_category1
             >::value),
             "Requires at least forward iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, iterator_category2
             >::value),
@@ -902,13 +901,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter>::iterator_category
             s_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, iterator_category
             >::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, s_iterator_category
             >::value),
@@ -1011,13 +1010,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter>::iterator_category
             s_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, iterator_category
             >::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, s_iterator_category
             >::value),

--- a/hpx/parallel/algorithms/for_each.hpp
+++ b/hpx/parallel/algorithms/for_each.hpp
@@ -29,7 +29,6 @@
 #include <iterator>
 #include <type_traits>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 #include <boost/type_traits/is_same.hpp>
@@ -181,7 +180,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
             "Requires at least input iterator.");
 
@@ -375,7 +374,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
             "Requires at least input iterator.");
 

--- a/hpx/parallel/algorithms/generate.hpp
+++ b/hpx/parallel/algorithms/generate.hpp
@@ -18,7 +18,6 @@
 #include <algorithm>
 #include <iterator>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -121,7 +120,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, iterator_category>::value),
             "Required at least forward iterator.");
@@ -231,7 +230,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, iterator_category>,

--- a/hpx/parallel/algorithms/includes.hpp
+++ b/hpx/parallel/algorithms/includes.hpp
@@ -21,7 +21,6 @@
 
 #include <boost/mpl/or.hpp>
 #include <boost/range/functions.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 #include <boost/utility/enable_if.hpp>
@@ -276,10 +275,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter2>::iterator_category
             iterator_category2;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category1>::value),
             "Requires at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category2>::value),
             "Requires at least input iterator.");
 
@@ -377,10 +376,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter2>::iterator_category
             iterator_category2;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category1>::value),
             "Requires at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category2>::value),
             "Requires at least input iterator.");
 

--- a/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -25,7 +25,6 @@
 #include <numeric>
 #include <iterator>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -242,11 +241,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,
@@ -338,11 +337,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,
@@ -430,11 +429,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,

--- a/hpx/parallel/algorithms/inner_product.hpp
+++ b/hpx/parallel/algorithms/inner_product.hpp
@@ -23,7 +23,6 @@
 #include <numeric>
 #include <iterator>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -172,11 +171,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter2>::iterator_category
             iterator_category_2;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag,
                 iterator_category_1>::value),
             "Requires at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag,
                 iterator_category_2>::value),
             "Requires at least input iterator.");
@@ -289,11 +288,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter2>::iterator_category
             iterator_category_2;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag,
                 iterator_category_1>::value),
             "Requires at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag,
                 iterator_category_2>::value),
             "Requires at least input iterator.");

--- a/hpx/parallel/algorithms/is_partitioned.hpp
+++ b/hpx/parallel/algorithms/is_partitioned.hpp
@@ -20,7 +20,6 @@
 #include <iterator>
 #include <functional>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 #include <boost/type_traits/is_same.hpp>
@@ -177,7 +176,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     {
         typedef typename std::iterator_traits<InIter>::iterator_category
             iterator_category;
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
              std::input_iterator_tag, iterator_category
                  >::value),

--- a/hpx/parallel/algorithms/is_sorted.hpp
+++ b/hpx/parallel/algorithms/is_sorted.hpp
@@ -17,7 +17,6 @@
 #include <hpx/parallel/util/loop.hpp>
 
 #include <boost/range/functions.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/utility/enable_if.hpp>
@@ -164,7 +163,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     {
         typedef typename std::iterator_traits<FwdIter>::iterator_category
             iterator_category;
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
              std::forward_iterator_tag, iterator_category
                  >::value),
@@ -228,7 +227,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             iterator_category;
         typedef typename std::iterator_traits<FwdIter>::value_type
             value_type;
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
                                 (boost::is_base_of<
                                  std::forward_iterator_tag, iterator_category
                                  >::value),
@@ -387,7 +386,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     {
         typedef typename std::iterator_traits<FwdIter>::iterator_category
             iterator_category;
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
              std::forward_iterator_tag, iterator_category
                  >::value),
@@ -449,7 +448,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             iterator_category;
         typedef typename std::iterator_traits<FwdIter>::value_type
             value_type;
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
              std::forward_iterator_tag, iterator_category
                  >::value),

--- a/hpx/parallel/algorithms/lexicographical_compare.hpp
+++ b/hpx/parallel/algorithms/lexicographical_compare.hpp
@@ -22,7 +22,6 @@
 #include <algorithm>
 #include <iterator>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -193,13 +192,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter2>::iterator_category
             iterator_category2;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, iterator_category1
             >::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, iterator_category2
             >::value),
@@ -302,13 +301,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter2>::iterator_category
             iterator_category2;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, iterator_category1
             >::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, iterator_category2
             >::value),

--- a/hpx/parallel/algorithms/minmax.hpp
+++ b/hpx/parallel/algorithms/minmax.hpp
@@ -22,7 +22,6 @@
 #include <algorithm>
 #include <iterator>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -182,7 +181,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, iterator_category>::value),
             "Required at least forward iterator.");
@@ -248,7 +247,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter>::value_type
             value_type;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, iterator_category>::value),
             "Required at least forward iterator.");
@@ -414,7 +413,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, iterator_category>::value),
             "Required at least forward iterator.");
@@ -480,7 +479,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter>::value_type
             value_type;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, iterator_category>::value),
             "Required at least forward iterator.");
@@ -663,7 +662,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, iterator_category>::value),
             "Required at least forward iterator.");
@@ -734,7 +733,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter>::value_type
             value_type;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, iterator_category>::value),
             "Required at least forward iterator.");

--- a/hpx/parallel/algorithms/mismatch.hpp
+++ b/hpx/parallel/algorithms/mismatch.hpp
@@ -20,7 +20,6 @@
 #include <algorithm>
 #include <iterator>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -204,10 +203,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter2>::iterator_category
             iterator_category2;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category1>::value),
             "Requires at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category2>::value),
             "Requires at least input iterator.");
 
@@ -312,10 +311,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter2>::iterator_category
             iterator_category2;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category1>::value),
             "Requires at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category2>::value),
             "Requires at least input iterator.");
 
@@ -469,10 +468,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter2>::iterator_category
             iterator_category2;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category1>::value),
             "Requires at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category2>::value),
             "Requires at least input iterator.");
 
@@ -568,10 +567,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter2>::iterator_category
             iterator_category2;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category1>::value),
             "Requires at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category2>::value),
             "Requires at least input iterator.");
 

--- a/hpx/parallel/algorithms/move.hpp
+++ b/hpx/parallel/algorithms/move.hpp
@@ -21,7 +21,6 @@
 #include <algorithm>
 #include <iterator>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -132,12 +131,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category>::value),
             "Required at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,

--- a/hpx/parallel/algorithms/reduce.hpp
+++ b/hpx/parallel/algorithms/reduce.hpp
@@ -20,7 +20,6 @@
 #include <hpx/parallel/util/loop.hpp>
 
 #include <boost/range/functions.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 #include <boost/utility/enable_if.hpp>
 
@@ -162,7 +161,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
             "Requires at least input iterator.");
 
@@ -239,7 +238,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
             "Requires at least input iterator.");
 
@@ -319,7 +318,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             iterator_category;
         typedef typename std::iterator_traits<InIter>::value_type value_type;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
             "Requires at least input iterator.");
 

--- a/hpx/parallel/algorithms/remove_copy.hpp
+++ b/hpx/parallel/algorithms/remove_copy.hpp
@@ -18,7 +18,6 @@
 #include <iterator>
 #include <type_traits>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -120,12 +119,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category>::value),
             "Required at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,
@@ -259,12 +258,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category>::value),
             "Required at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,

--- a/hpx/parallel/algorithms/replace.hpp
+++ b/hpx/parallel/algorithms/replace.hpp
@@ -23,7 +23,6 @@
 #include <algorithm>
 #include <iterator>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -122,7 +121,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, iterator_category>::value),
             "Required at least forward iterator.");
@@ -246,7 +245,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, iterator_category>::value),
             "Required at least forward iterator.");
@@ -372,12 +371,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category>::value),
             "Required at least forward iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,
@@ -531,12 +530,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category>::value),
             "Required at least forward iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,

--- a/hpx/parallel/algorithms/reverse.hpp
+++ b/hpx/parallel/algorithms/reverse.hpp
@@ -24,7 +24,6 @@
 #include <algorithm>
 #include <iterator>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -122,7 +121,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<BidirIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::bidirectional_iterator_tag, iterator_category>::value),
             "Required at least bidirectional iterator.");
@@ -234,12 +233,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutputIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::bidirectional_iterator_tag, input_iterator_category>::value),
             "Required at least bidirectional iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,

--- a/hpx/parallel/algorithms/rotate.hpp
+++ b/hpx/parallel/algorithms/rotate.hpp
@@ -22,7 +22,6 @@
 #include <algorithm>
 #include <iterator>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -171,7 +170,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, iterator_category>::value),
             "Required at least forward iterator.");
@@ -301,12 +300,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, forward_iterator_category>::value),
             "Required at least forward iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,

--- a/hpx/parallel/algorithms/search.hpp
+++ b/hpx/parallel/algorithms/search.hpp
@@ -26,7 +26,6 @@
 #include <algorithm>
 #include <iterator>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -188,13 +187,13 @@ namespace hpx {namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter2>::iterator_category
             s_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, iterator_category
             >::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, s_iterator_category
             >::value),
@@ -287,13 +286,13 @@ namespace hpx {namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter2>::iterator_category
             s_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, iterator_category
             >::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, s_iterator_category
             >::value),
@@ -466,13 +465,13 @@ namespace hpx {namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter2>::iterator_category
             s_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, iterator_category
             >::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, s_iterator_category
             >::value),
@@ -566,13 +565,13 @@ namespace hpx {namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter2>::iterator_category
             s_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, iterator_category
             >::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, s_iterator_category
             >::value),

--- a/hpx/parallel/algorithms/set_difference.hpp
+++ b/hpx/parallel/algorithms/set_difference.hpp
@@ -26,7 +26,6 @@
 #include <iterator>
 
 #include <boost/shared_array.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/is_base_of.hpp>
@@ -202,16 +201,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category1>::value),
             "Requires at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category2>::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,
@@ -316,16 +315,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category1>::value),
             "Requires at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category2>::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,

--- a/hpx/parallel/algorithms/set_intersection.hpp
+++ b/hpx/parallel/algorithms/set_intersection.hpp
@@ -26,7 +26,6 @@
 #include <iterator>
 
 #include <boost/shared_array.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/is_base_of.hpp>
@@ -197,16 +196,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category1>::value),
             "Requires at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category2>::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,
@@ -311,16 +310,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category1>::value),
             "Requires at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category2>::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,

--- a/hpx/parallel/algorithms/set_symmetric_difference.hpp
+++ b/hpx/parallel/algorithms/set_symmetric_difference.hpp
@@ -26,7 +26,6 @@
 #include <iterator>
 
 #include <boost/shared_array.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/is_base_of.hpp>
@@ -207,16 +206,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category1>::value),
             "Requires at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category2>::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,
@@ -325,16 +324,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category1>::value),
             "Requires at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category2>::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,

--- a/hpx/parallel/algorithms/set_union.hpp
+++ b/hpx/parallel/algorithms/set_union.hpp
@@ -26,7 +26,6 @@
 #include <iterator>
 
 #include <boost/shared_array.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/is_base_of.hpp>
@@ -199,16 +198,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category1>::value),
             "Requires at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category2>::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,
@@ -313,16 +312,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category1>::value),
             "Requires at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category2>::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,

--- a/hpx/parallel/algorithms/sort.hpp
+++ b/hpx/parallel/algorithms/sort.hpp
@@ -414,7 +414,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<RandomIt>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::random_access_iterator_tag, iterator_category
             >::value),

--- a/hpx/parallel/algorithms/swap_ranges.hpp
+++ b/hpx/parallel/algorithms/swap_ranges.hpp
@@ -21,7 +21,6 @@
 #include <algorithm>
 #include <iterator>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -135,11 +134,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<ForwardIter2>::iterator_category
             iter2_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, iter1_category>::value),
             "Required at least forward iterator tag.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, iter2_category>::value),
             "Required at least forward iterator tag.");

--- a/hpx/parallel/algorithms/transform.hpp
+++ b/hpx/parallel/algorithms/transform.hpp
@@ -27,7 +27,6 @@
 #include <algorithm>
 #include <iterator>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -188,7 +187,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
             "Required at least input iterator.");
 
@@ -390,10 +389,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter1>::iterator_category category1;
         typedef typename std::iterator_traits<InIter2>::iterator_category category2;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, category1>::value),
             "Required at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, category2>::value),
             "Required at least input iterator.");
 
@@ -608,10 +607,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter1>::iterator_category category1;
         typedef typename std::iterator_traits<InIter2>::iterator_category category2;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, category1>::value),
             "Required at least input iterator.");
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, category2>::value),
             "Required at least input iterator.");
 

--- a/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -24,7 +24,6 @@
 #include <numeric>
 #include <iterator>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -265,11 +264,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,

--- a/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -24,7 +24,6 @@
 #include <numeric>
 #include <iterator>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -267,11 +266,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,
@@ -404,11 +403,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<OutIter>::iterator_category
             output_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
             "Requires at least input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::mpl::or_<
                 boost::is_base_of<
                     std::forward_iterator_tag, output_iterator_category>,

--- a/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/hpx/parallel/algorithms/transform_reduce.hpp
@@ -21,7 +21,6 @@
 #include <hpx/parallel/util/loop.hpp>
 
 #include <boost/range/functions.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 #include <boost/utility/enable_if.hpp>
 
@@ -110,7 +109,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typedef typename std::iterator_traits<InIter>::iterator_category
                 iterator_category;
 
-            BOOST_STATIC_ASSERT_MSG(
+            static_assert(
                 (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
                 "Requires at least input iterator.");
 
@@ -243,7 +242,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter>::iterator_category
             iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
             "Requires at least input iterator.");
 

--- a/hpx/parallel/algorithms/uninitialized_copy.hpp
+++ b/hpx/parallel/algorithms/uninitialized_copy.hpp
@@ -23,7 +23,6 @@
 #include <algorithm>
 #include <iterator>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -193,12 +192,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter>::iterator_category
             forward_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category>::value),
             "Requires at least an input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, forward_iterator_category>::value),
             "Requires at least a forward iterator.");
@@ -312,12 +311,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter>::iterator_category
             forward_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category>::value),
             "Requires at least an input iterator.");
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, forward_iterator_category>::value),
             "Requires at least a forward iterator.");

--- a/hpx/parallel/algorithms/uninitialized_fill.hpp
+++ b/hpx/parallel/algorithms/uninitialized_fill.hpp
@@ -23,7 +23,6 @@
 #include <algorithm>
 #include <iterator>
 
-#include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
@@ -176,7 +175,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter>::iterator_category
             input_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::input_iterator_tag, input_iterator_category>::value),
             "Requires at least an input iterator.");
@@ -278,7 +277,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<FwdIter>::iterator_category
             forward_iterator_category;
 
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             (boost::is_base_of<
                 std::forward_iterator_tag, forward_iterator_category>::value),
             "Requires at least a forward iterator.");

--- a/hpx/parallel/execution_policy.hpp
+++ b/hpx/parallel/execution_policy.hpp
@@ -22,7 +22,6 @@
 
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_same.hpp>
@@ -54,8 +53,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename executor_traits<executor_type>::execution_category
             category2;
 
-        BOOST_STATIC_ASSERT(
-            (parallel::v3::detail::is_not_weaker<category2, category1>::value)
+        static_assert(
+            (parallel::v3::detail::is_not_weaker<category2, category1>::value),
+            "parallel::v3::detail::is_not_weaker<category2, category1>::value"
         );
         /// \endcond
 
@@ -144,9 +144,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type
         on(Executor && exec) const
         {
-            BOOST_STATIC_ASSERT(
+            static_assert(
                 hpx::traits::is_executor<Executor>::value ||
-                hpx::traits::is_threads_executor<Executor>::value);
+                hpx::traits::is_threads_executor<Executor>::value,
+                "hpx::traits::is_executor<Executor>::value || "
+                "hpx::traits::is_threads_executor<Executor>::value");
 
             typedef typename rebind_executor<
                 sequential_task_execution_policy, Executor,
@@ -175,7 +177,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type
         with(Parameters && params) const
         {
-            BOOST_STATIC_ASSERT(is_executor_parameters<Parameters>::value);
+            static_assert(
+                is_executor_parameters<Parameters>::value,
+                "is_executor_parameters<Parameters>::value");
 
             typedef typename rebind_executor<
                 sequential_task_execution_policy, executor_type, Parameters
@@ -270,9 +274,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type
         on(Executor_ && exec) const
         {
-            BOOST_STATIC_ASSERT(
+            static_assert(
                 hpx::traits::is_executor<Executor_>::value ||
-                hpx::traits::is_threads_executor<Executor_>::value);
+                hpx::traits::is_threads_executor<Executor_>::value,
+                "hpx::traits::is_executor<Executor_>::value || "
+                "hpx::traits::is_threads_executor<Executor_>::value");
 
             typedef typename rebind_executor<
                 sequential_task_execution_policy_shim, Executor_,
@@ -301,7 +307,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type
         with(Parameters_ && params) const
         {
-            BOOST_STATIC_ASSERT(is_executor_parameters<Parameters_>::value);
+            static_assert(
+                is_executor_parameters<Parameters_>::value,
+                "is_executor_parameters<Parameters_>::value");
 
             typedef typename rebind_executor<
                 sequential_task_execution_policy_shim, Executor, Parameters_
@@ -412,9 +420,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type
         on(Executor && exec) const
         {
-            BOOST_STATIC_ASSERT(
+            static_assert(
                 hpx::traits::is_executor<Executor>::value ||
-                hpx::traits::is_threads_executor<Executor>::value);
+                hpx::traits::is_threads_executor<Executor>::value,
+                "hpx::traits::is_executor<Executor>::value || "
+                "hpx::traits::is_threads_executor<Executor>::value");
 
             typedef typename rebind_executor<
                 sequential_execution_policy, Executor, executor_parameters_type
@@ -442,7 +452,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type
         with(Parameters && params) const
         {
-            BOOST_STATIC_ASSERT(is_executor_parameters<Parameters>::value);
+            static_assert(
+                is_executor_parameters<Parameters>::value,
+                "is_executor_parameters<Parameters>::value");
 
             typedef typename rebind_executor<
                 sequential_execution_policy, executor_type, Parameters
@@ -533,9 +545,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type
         on(Executor_ && exec) const
         {
-            BOOST_STATIC_ASSERT(
+            static_assert(
                 hpx::traits::is_executor<Executor_>::value ||
-                hpx::traits::is_threads_executor<Executor_>::value);
+                hpx::traits::is_threads_executor<Executor_>::value,
+                "hpx::traits::is_executor<Executor_>::value || "
+                "hpx::traits::is_threads_executor<Executor_>::value");
 
             typedef typename rebind_executor<
                 sequential_execution_policy_shim, Executor_,
@@ -564,7 +578,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type
         with(Parameters_& params) const
         {
-            BOOST_STATIC_ASSERT(is_executor_parameters<Parameters_>::value);
+            static_assert(
+                is_executor_parameters<Parameters_>::value,
+                "is_executor_parameters<Parameters_>::value");
 
             typedef typename rebind_executor<
                 sequential_execution_policy_shim, executor_type, Parameters_
@@ -678,9 +694,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type
         on(Executor && exec) const
         {
-            BOOST_STATIC_ASSERT(
+            static_assert(
                 hpx::traits::is_executor<Executor>::value ||
-                hpx::traits::is_threads_executor<Executor>::value);
+                hpx::traits::is_threads_executor<Executor>::value,
+                "hpx::traits::is_executor<Executor>::value || "
+                "hpx::traits::is_threads_executor<Executor>::value");
 
             typedef typename rebind_executor<
                 parallel_task_execution_policy, Executor,
@@ -709,7 +727,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type
         with(Parameters && params) const
         {
-            BOOST_STATIC_ASSERT(is_executor_parameters<Parameters>::value);
+            static_assert(
+                is_executor_parameters<Parameters>::value,
+                "is_executor_parameters<Parameters>::value");
 
             typedef typename rebind_executor<
                 parallel_task_execution_policy, executor_type, Parameters
@@ -803,9 +823,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type
         on(Executor_ && exec) const
         {
-            BOOST_STATIC_ASSERT(
+            static_assert(
                 hpx::traits::is_executor<Executor_>::value ||
-                hpx::traits::is_threads_executor<Executor_>::value);
+                hpx::traits::is_threads_executor<Executor_>::value,
+                "hpx::traits::is_executor<Executor_>::value || "
+                "hpx::traits::is_threads_executor<Executor_>::value");
 
             typedef typename rebind_executor<
                 parallel_task_execution_policy_shim, Executor_,
@@ -834,7 +856,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type
         with(Parameters_ && params) const
         {
-            BOOST_STATIC_ASSERT(is_executor_parameters<Parameters_>::value);
+            static_assert(
+                is_executor_parameters<Parameters_>::value,
+                "is_executor_parameters<Parameters_>::value");
 
             typedef typename rebind_executor<
                 parallel_task_execution_policy_shim, Executor, Parameters_
@@ -940,9 +964,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type
         on(Executor && exec) const
         {
-            BOOST_STATIC_ASSERT(
+            static_assert(
                 hpx::traits::is_executor<Executor>::value ||
-                hpx::traits::is_threads_executor<Executor>::value);
+                hpx::traits::is_threads_executor<Executor>::value,
+                "hpx::traits::is_executor<Executor>::value || "
+                "hpx::traits::is_threads_executor<Executor>::value");
 
             typedef typename rebind_executor<
                 parallel_execution_policy, Executor, executor_parameters_type
@@ -970,7 +996,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type
         with(Parameters && params) const
         {
-            BOOST_STATIC_ASSERT(is_executor_parameters<Parameters>::value);
+            static_assert(
+                is_executor_parameters<Parameters>::value,
+                "is_executor_parameters<Parameters>::value");
 
             typedef typename rebind_executor<
                 parallel_execution_policy, executor_type, Parameters
@@ -1061,9 +1089,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type
         on(Executor_ && exec) const
         {
-            BOOST_STATIC_ASSERT(
+            static_assert(
                 hpx::traits::is_executor<Executor_>::value ||
-                hpx::traits::is_threads_executor<Executor_>::value);
+                hpx::traits::is_threads_executor<Executor_>::value,
+                "hpx::traits::is_executor<Executor_>::value || "
+                "hpx::traits::is_threads_executor<Executor_>::value");
 
             typedef typename rebind_executor<
                 parallel_execution_policy_shim, Executor_,
@@ -1092,7 +1122,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         >::type
         with(Parameters_ && params) const
         {
-            BOOST_STATIC_ASSERT(is_executor_parameters<Parameters_>::value);
+            static_assert(
+                is_executor_parameters<Parameters_>::value,
+                "is_executor_parameters<Parameters_>::value");
 
             typedef typename rebind_executor<
                 parallel_execution_policy_shim, Executor, Parameters_
@@ -1623,10 +1655,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         template <typename ExPolicy>
         ExPolicy* get() BOOST_NOEXCEPT
         {
-            BOOST_STATIC_ASSERT_MSG(
+            static_assert(
                 !(boost::is_same<ExPolicy, execution_policy>::value),
                 "Incorrect execution policy parameter.");
-            BOOST_STATIC_ASSERT_MSG(
+            static_assert(
                 is_execution_policy<ExPolicy>::value,
                 "Execution policy type required.");
 
@@ -1642,10 +1674,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         template <typename ExPolicy>
         ExPolicy const* get() const BOOST_NOEXCEPT
         {
-            BOOST_STATIC_ASSERT_MSG(
+            static_assert(
                 !(boost::is_same<ExPolicy, execution_policy>::value),
                 "Incorrect execution policy parameter.");
-            BOOST_STATIC_ASSERT_MSG(
+            static_assert(
                 is_execution_policy<ExPolicy>::value,
                 "Execution policy type required.");
 

--- a/hpx/parallel/executors/distribution_policy_executor.hpp
+++ b/hpx/parallel/executors/distribution_policy_executor.hpp
@@ -22,7 +22,6 @@
 
 #include <type_traits>
 
-#include <boost/static_assert.hpp>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
 {
@@ -59,7 +58,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
     {
     private:
         /// \cond NOINTERNAL
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             hpx::traits::is_distribution_policy<DistPolicy>::value,
             "distribution_policy_executor needs to be instantiated with a "
                 "distribution policy type");

--- a/hpx/parallel/task_block.hpp
+++ b/hpx/parallel/task_block.hpp
@@ -27,7 +27,6 @@
 #include <memory>                           // std::addressof
 #include <boost/utility/addressof.hpp>      // boost::addressof
 
-#include <boost/static_assert.hpp>
 #include <boost/thread/locks.hpp>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
@@ -350,7 +349,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
     typename util::detail::algorithm_result<ExPolicy>::type
     define_task_block(ExPolicy && policy, F && f)
     {
-        BOOST_STATIC_ASSERT(parallel::is_execution_policy<ExPolicy>::value);
+        static_assert(
+            parallel::is_execution_policy<ExPolicy>::value,
+            "parallel::is_execution_policy<ExPolicy>::value");
 
         typedef typename hpx::util::decay<ExPolicy>::type policy_type;
         task_block<policy_type> trh(std::forward<ExPolicy>(policy));
@@ -474,7 +475,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
     typename util::detail::algorithm_result<ExPolicy>::type
     define_task_block_restore_thread(ExPolicy && policy, F && f)
     {
-        BOOST_STATIC_ASSERT(parallel::is_execution_policy<ExPolicy>::value);
+        static_assert(
+            parallel::is_execution_policy<ExPolicy>::value,
+            "parallel::is_execution_policy<ExPolicy>::value");
 
         // By design we always return on the same (HPX-) thread as we started
         // executing define_task_block_restore_thread.

--- a/hpx/parallel/util/detail/algorithm_result.hpp
+++ b/hpx/parallel/util/detail/algorithm_result.hpp
@@ -11,7 +11,6 @@
 #include <hpx/parallel/execution_policy.hpp>
 #include <hpx/util/unused.hpp>
 
-#include <boost/static_assert.hpp>
 #include <boost/type_traits/is_lvalue_reference.hpp>
 
 namespace hpx { namespace parallel { namespace util { namespace detail
@@ -182,7 +181,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail
     struct algorithm_result
       : algorithm_result_impl<typename hpx::util::decay<ExPolicy>::type, T>
     {
-        BOOST_STATIC_ASSERT_MSG(!boost::is_lvalue_reference<T>::value,
+        static_assert(!boost::is_lvalue_reference<T>::value,
             "T shouldn't be a lvalue reference");
     };
 }}}}

--- a/hpx/plugins/parcelport/ibverbs/acceptor.hpp
+++ b/hpx/plugins/parcelport/ibverbs/acceptor.hpp
@@ -18,7 +18,6 @@
 #include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/system/system_error.hpp>
 #include <boost/thread/thread_time.hpp>
 #include <boost/scope_exit.hpp>

--- a/hpx/plugins/parcelport/ibverbs/context.hpp
+++ b/hpx/plugins/parcelport/ibverbs/context.hpp
@@ -21,7 +21,6 @@
 #include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/system/system_error.hpp>
 #include <boost/thread/thread_time.hpp>
 #include <boost/scope_exit.hpp>

--- a/hpx/plugins/parcelport/ibverbs/ibverbs_errors.hpp
+++ b/hpx/plugins/parcelport/ibverbs/ibverbs_errors.hpp
@@ -11,7 +11,6 @@
 #include <boost/system/system_error.hpp>
 #include <boost/asio/error.hpp>
 #include <boost/asio/detail/throw_error.hpp>
-#include <boost/static_assert.hpp>
 
 #include <string>
 

--- a/hpx/plugins/parcelport/ipc/acceptor.hpp
+++ b/hpx/plugins/parcelport/ipc/acceptor.hpp
@@ -16,7 +16,6 @@
 #include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/system/system_error.hpp>
 #include <boost/thread/thread_time.hpp>
 #include <boost/scope_exit.hpp>

--- a/hpx/plugins/parcelport/ipc/data_window.hpp
+++ b/hpx/plugins/parcelport/ipc/data_window.hpp
@@ -16,7 +16,6 @@
 #include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/system/system_error.hpp>
 #include <boost/thread/thread_time.hpp>
 #include <boost/scope_exit.hpp>

--- a/hpx/plugins/parcelport/ipc/interprocess_errors.hpp
+++ b/hpx/plugins/parcelport/ipc/interprocess_errors.hpp
@@ -9,7 +9,6 @@
 #include <hpx/config.hpp>
 #include <boost/interprocess/errors.hpp>
 #include <boost/system/system_error.hpp>
-#include <boost/static_assert.hpp>
 
 #include <string>
 
@@ -65,8 +64,11 @@ namespace hpx { namespace parcelset { namespace policies { namespace ipc
                 using namespace boost::interprocess;
 
                 // make sure our assumption about error codes is reasonably correct
-                BOOST_STATIC_ASSERT(sizeof(error_names)/sizeof(error_names[0]) ==
-                    timeout_when_waiting_error+1);
+                static_assert(
+                    sizeof(error_names)/sizeof(error_names[0]) ==
+                    timeout_when_waiting_error+1,
+                    "sizeof(error_names)/sizeof(error_names[0]) == "
+                    "timeout_when_waiting_error+1");
 
                 if (value >= no_error && value <= timeout_when_waiting_error)
                     return std::string("IPC(") + error_names[value] + ")";

--- a/hpx/plugins/unique_plugin_name.hpp
+++ b/hpx/plugins/unique_plugin_name.hpp
@@ -8,7 +8,6 @@
 #define HPX_UNIQUE_PLUGIN_NAME_MAR_24_2013_245PM
 
 #include <boost/config.hpp>
-#include <boost/mpl/assert.hpp>
 
 #include <boost/preprocessor/stringize.hpp>
 
@@ -17,7 +16,7 @@ namespace hpx { namespace plugins
     template <typename PluginType>
     struct unique_plugin_name
     {
-        BOOST_MPL_ASSERT_MSG(0, plugin_name_is_not_defined, (PluginType));
+        static_assert(sizeof(PluginType) == 0, "plugin name is not defined");
     };
 }}
 

--- a/hpx/runtime/actions/action_invoke_no_more_than.hpp
+++ b/hpx/runtime/actions/action_invoke_no_more_than.hpp
@@ -17,8 +17,6 @@
 #include <hpx/traits/action_decorate_function.hpp>
 #include <hpx/traits/action_decorate_continuation.hpp>
 
-#include <boost/static_assert.hpp>
-
 #include <memory>
 
 namespace hpx { namespace actions { namespace detail
@@ -63,7 +61,7 @@ namespace hpx { namespace actions { namespace detail
     template <typename Action, int N>
     struct action_decorate_function
     {
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             !Action::direct_execution::value,
             "explicit decoration of direct actions is not supported");
 
@@ -201,7 +199,7 @@ namespace hpx { namespace actions { namespace detail
     template <typename Action, int N>
     struct action_decorate_continuation
     {
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             !Action::direct_execution::value,
             "explicit decoration of direct actions is not supported");
 

--- a/hpx/runtime/actions/action_support.hpp
+++ b/hpx/runtime/actions/action_support.hpp
@@ -102,11 +102,9 @@ namespace hpx { namespace actions
             /// you have a HPX_REGISTER_ACTION macro somewhere in a source file,
             /// but the header in which the action is defined misses a
             /// HPX_REGISTER_ACTION_DECLARATION
-            BOOST_MPL_ASSERT_MSG(
-                traits::needs_automatic_registration<Action>::value
-              , HPX_REGISTER_ACTION_DECLARATION_MISSING
-              , (Action)
-            );
+            static_assert(
+                traits::needs_automatic_registration<Action>::value,
+                "HPX_REGISTER_ACTION_DECLARATION missing");
             return util::type_id<Action>::typeid_.type_id();
         }
 #endif

--- a/hpx/runtime/actions/basic_action.hpp
+++ b/hpx/runtime/actions/basic_action.hpp
@@ -111,19 +111,19 @@ namespace hpx { namespace actions
     struct basic_action<Component, R(Args...), Derived>
     {
         // Flag the use of raw pointer types as action arguments
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             !util::detail::any_of<std::is_pointer<Args>...>::value,
             "Using raw pointers as arguments for actions is not supported.");
 
         // Flag the use of array types as action arguments
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             !util::detail::any_of<
                 std::is_array<typename std::remove_reference<Args>::type>...
             >::value,
             "Using arrays as arguments for actions is not supported.");
 
         // Flag the use of non-const reference types as action arguments
-        BOOST_STATIC_ASSERT_MSG(
+        static_assert(
             !util::detail::any_of<
                 detail::is_non_const_reference<Args>...
             >::value,

--- a/hpx/runtime/actions/continuation.hpp
+++ b/hpx/runtime/actions/continuation.hpp
@@ -123,11 +123,9 @@ namespace hpx { namespace actions
             // you have a HPX_REGISTER_TYPED_CONTINUATION macro somewhere in a
             // source file, but the header in which the continuation is defined
             // misses a HPX_REGISTER_TYPED_CONTINUATION_DECLARATION
-            BOOST_MPL_ASSERT_MSG(
-                traits::needs_automatic_registration<Continuation>::value
-              , HPX_REGISTER_TYPED_CONTINUATION_DECLARATION_MISSING
-              , (Continuation)
-            );
+            static_assert(
+                traits::needs_automatic_registration<Continuation>::value,
+                "HPX_REGISTER_TYPED_CONTINUATION_DECLARATION missing");
             return util::type_id<Continuation>::typeid_.type_id();
         }
 #endif

--- a/hpx/runtime/components/server/managed_component_base.hpp
+++ b/hpx/runtime/components/server/managed_component_base.hpp
@@ -194,10 +194,13 @@ namespace hpx { namespace components
 
         // make sure that we have a back_ptr whenever we need to control the
         // lifetime of the managed_component
-        BOOST_STATIC_ASSERT((
+        static_assert((
             boost::is_same<ctor_policy, traits::construct_without_back_ptr>::value ||
             boost::is_same<dtor_policy,
-            traits::managed_object_controls_lifetime>::value));
+            traits::managed_object_controls_lifetime>::value),
+            "boost::is_same<ctor_policy, traits::construct_without_back_ptr>::value || "
+            "boost::is_same<dtor_policy, "
+            "traits::managed_object_controls_lifetime>::value");
 
         managed_component_base()
           : back_ptr_(0)

--- a/hpx/runtime/components/unique_component_name.hpp
+++ b/hpx/runtime/components/unique_component_name.hpp
@@ -7,7 +7,6 @@
 #define HPX_A7F46A4F_9AF9_4909_B0D8_5304FEFC5649
 
 #include <boost/config.hpp>
-#include <boost/mpl/assert.hpp>
 
 #include <boost/preprocessor/stringize.hpp>
 
@@ -19,7 +18,7 @@ namespace hpx { namespace components
     template <typename ComponentType, typename Type = derived_name>
     struct unique_component_name
     {
-        BOOST_MPL_ASSERT_MSG(0, component_name_is_not_defined, (ComponentType));
+        static_assert(sizeof(ComponentType) == 0, "component name is not defined");
     };
 }}
 

--- a/hpx/runtime/serialization/basic_archive.hpp
+++ b/hpx/runtime/serialization/basic_archive.hpp
@@ -9,7 +9,6 @@
 
 #include <hpx/traits/is_bitwise_serializable.hpp>
 
-#include <boost/static_assert.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/type_traits/is_pointer.hpp>
 
@@ -59,7 +58,7 @@ namespace hpx { namespace serialization
         template <typename T>
         void invoke(T & t)
         {
-            BOOST_STATIC_ASSERT_MSG(!boost::is_pointer<T>::value,
+            static_assert(!boost::is_pointer<T>::value,
                 "HPX does not support serialization of raw pointers. "
                 "Please use smart pointers.");
 

--- a/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
+++ b/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
@@ -40,11 +40,9 @@ namespace hpx { namespace serialization { namespace detail
             /// you have a HPX_REGISTER_ACTION macro somewhere in a source file,
             /// but the header in which the action is defined misses a
             /// HPX_REGISTER_ACTION_DECLARATION
-            BOOST_MPL_ASSERT_MSG(
-                traits::needs_automatic_registration<T>::value
-                , HPX_REGISTER_ACTION_DECLARATION_MISSING
-                , (T)
-            );
+            static_assert(
+                traits::needs_automatic_registration<T>::value,
+                "HPX_REGISTER_ACTION_DECLARATION missing");
             return util::type_id<T>::typeid_.type_id();
         }
     };

--- a/hpx/runtime/serialization/input_archive.hpp
+++ b/hpx/runtime/serialization/input_archive.hpp
@@ -148,7 +148,7 @@ namespace hpx { namespace serialization
         template <typename T>
         void load_bitwise(T & t, boost::mpl::true_)
         {
-            BOOST_STATIC_ASSERT_MSG(!boost::is_abstract<T>::value,
+            static_assert(!boost::is_abstract<T>::value,
                 "Can not bitwise serialize a class that is abstract");
             if(disable_array_optimization())
             {

--- a/hpx/runtime/serialization/output_archive.hpp
+++ b/hpx/runtime/serialization/output_archive.hpp
@@ -181,7 +181,7 @@ namespace hpx { namespace serialization
         template <typename T>
         void save_bitwise(T const & t, boost::mpl::true_)
         {
-            BOOST_STATIC_ASSERT_MSG(!boost::is_abstract<T>::value,
+            static_assert(!boost::is_abstract<T>::value,
                 "Can not bitwise serialize a class that is abstract");
             if(disable_array_optimization())
             {

--- a/hpx/runtime/threads/detail/partlit.hpp
+++ b/hpx/runtime/threads/detail/partlit.hpp
@@ -32,7 +32,6 @@
 #include <boost/fusion/include/value_at.hpp>
 #include <boost/type_traits/add_reference.hpp>
 #include <boost/type_traits/add_const.hpp>
-#include <boost/mpl/assert.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/detail/workaround.hpp>
 #include <boost/utility/enable_if.hpp>

--- a/hpx/traits/concepts.hpp
+++ b/hpx/traits/concepts.hpp
@@ -10,7 +10,6 @@
 #define HPX_TRAITS_CONCEPTS_JUL_19_2015_0547PM
 
 #include <boost/preprocessor/cat.hpp>
-#include <boost/static_assert.hpp>
 
 #include <type_traits>
 
@@ -32,7 +31,7 @@
     /**/
 
 #define HPX_CONCEPT_ASSERT(...)                                               \
-    BOOST_STATIC_ASSERT_MSG((__VA_ARGS__), "Concept check failed")            \
+    static_assert((__VA_ARGS__), "Concept check failed")                      \
     /**/
 
 #endif

--- a/hpx/util/any.hpp
+++ b/hpx/util/any.hpp
@@ -32,7 +32,6 @@
 #include <boost/type_traits/remove_const.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/throw_exception.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/detail/sp_typeinfo.hpp>
 #include <boost/functional/hash.hpp>
@@ -982,7 +981,9 @@ namespace hpx { namespace util
         // Please use BOOST_BROKEN_COMPILER_TYPE_TRAITS_SPECIALIZATION macro
         // to generate specialization of remove_reference for your class
         // See type traits library documentation for details
-        BOOST_STATIC_ASSERT(!is_reference<nonref>::value);
+        static_assert(
+            !is_reference<nonref>::value,
+            "!is_reference<nonref>::value");
 #endif
 
         nonref* result = any_cast<nonref>(&operand);
@@ -999,7 +1000,9 @@ namespace hpx { namespace util
 #ifdef BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION
         // The comment in the above version of 'any_cast' explains when this
         // assert is fired and what to do.
-        BOOST_STATIC_ASSERT(!is_reference<nonref>::value);
+        static_assert(
+            !is_reference<nonref>::value,
+            "!is_reference<nonref>::value");
 #endif
 
         return any_cast<nonref const&>(const_cast<basic_any<IArchive, OArchive,

--- a/hpx/util/coordinate.hpp
+++ b/hpx/util/coordinate.hpp
@@ -18,8 +18,6 @@
 #include <initializer_list>
 #endif
 
-#include <boost/static_assert.hpp>
-
 namespace hpx { namespace util
 {
     ///////////////////////////////////////////////////////////////////////////
@@ -33,7 +31,7 @@ namespace hpx { namespace util
     template <int Rank>
     class index
     {
-        BOOST_STATIC_ASSERT_MSG(Rank > 0, "Rank shall be greater than 0");
+        static_assert(Rank > 0, "Rank shall be greater than 0");
 
     public:
         // constants and types
@@ -197,7 +195,7 @@ namespace hpx { namespace util
     template <int Rank>
     class bounds
     {
-        BOOST_STATIC_ASSERT_MSG(Rank > 0, "Rank shall be greater than 0");
+        static_assert(Rank > 0, "Rank shall be greater than 0");
 
     public:
         // constants and types

--- a/hpx/util/detail/basic_function.hpp
+++ b/hpx/util/detail/basic_function.hpp
@@ -17,7 +17,6 @@
 #include <hpx/util/move.hpp>
 #include <hpx/util/safe_bool.hpp>
 
-#include <boost/static_assert.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/type_traits/is_pointer.hpp>
 #include <boost/type_traits/is_member_pointer.hpp>
@@ -222,7 +221,7 @@ namespace hpx { namespace util { namespace detail
         template <typename T>
         T* target() BOOST_NOEXCEPT
         {
-            BOOST_STATIC_ASSERT_MSG(
+            static_assert(
                 (traits::is_callable<T(Ts...), R>::value)
               , "T shall be Callable with the function signature"
             );
@@ -233,7 +232,7 @@ namespace hpx { namespace util { namespace detail
         template <typename T>
         T* target() const BOOST_NOEXCEPT
         {
-            BOOST_STATIC_ASSERT_MSG(
+            static_assert(
                 (traits::is_callable<T(Ts...), R>::value)
               , "T shall be Callable with the function signature"
             );

--- a/hpx/util/detail/function_registration.hpp
+++ b/hpx/util/detail/function_registration.hpp
@@ -15,7 +15,6 @@
 #include <hpx/util/demangle_helper.hpp>
 #include <hpx/util/tuple.hpp>
 
-#include <boost/mpl/assert.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/smart_ptr/shared_ptr.hpp>
 
@@ -34,11 +33,9 @@ namespace hpx { namespace util { namespace detail
             // that you have a HPX_UTIL_REGISTER_[UNIQUE_]FUNCTION macro
             // somewhere in a source file, but the header in which the function
             // is defined misses a HPX_UTIL_REGISTER_[UNIQUE_]FUNCTION_DECLARATION
-            BOOST_MPL_ASSERT_MSG(
-                traits::needs_automatic_registration<Function>::value
-              , HPX_UTIL_REGISTER_FUNCTION_DECLARATION_MISSING
-              , (Function)
-            );
+            static_assert(
+                traits::needs_automatic_registration<Function>::value,
+                "HPX_UTIL_REGISTER_FUNCTION_DECLARATION missing");
             return util::type_id<Function>::typeid_.type_id();
         }
 #endif

--- a/hpx/util/integer/endian.hpp
+++ b/hpx/util/integer/endian.hpp
@@ -24,7 +24,7 @@
 #include <boost/detail/endian.hpp>
 #include <boost/type_traits/is_signed.hpp>
 #include <boost/cstdint.hpp>
-#include <boost/static_assert.hpp>
+
 #include <iosfwd>
 #include <climits>
 
@@ -144,7 +144,7 @@ namespace hpx { namespace util
     class endian< big, T, n_bits, unaligned >
       : cover_operators< endian< big, T, n_bits >, T >
     {
-        BOOST_STATIC_ASSERT( (n_bits/8)*8 == n_bits );
+        static_assert((n_bits/8)*8 == n_bits, "(n_bits/8)*8 == n_bits");
       public:
         typedef T value_type;
         endian() {}
@@ -159,7 +159,7 @@ namespace hpx { namespace util
     class endian< little, T, n_bits, unaligned >
       : cover_operators< endian< little, T, n_bits >, T >
     {
-        BOOST_STATIC_ASSERT( (n_bits/8)*8 == n_bits );
+        static_assert((n_bits/8)*8 == n_bits, "(n_bits/8)*8 == n_bits");
       public:
         typedef T value_type;
         endian() {}
@@ -174,7 +174,7 @@ namespace hpx { namespace util
     class endian< native, T, n_bits, unaligned >
       : cover_operators< endian< native, T, n_bits >, T >
     {
-        BOOST_STATIC_ASSERT( (n_bits/8)*8 == n_bits );
+        static_assert((n_bits/8)*8 == n_bits, "(n_bits/8)*8 == n_bits");
       public:
         typedef T value_type;
         endian() {}
@@ -198,8 +198,8 @@ namespace hpx { namespace util
     class endian< big, T, n_bits, aligned  >
       : cover_operators< endian< big, T, n_bits, aligned >, T >
     {
-        BOOST_STATIC_ASSERT( (n_bits/8)*8 == n_bits );
-        BOOST_STATIC_ASSERT( sizeof(T) == n_bits/8 );
+        static_assert((n_bits/8)*8 == n_bits, "(n_bits/8)*8 == n_bits");
+        static_assert(sizeof(T) == n_bits/8, "sizeof(T) == n_bits/8");
       public:
         typedef T value_type;
         endian() {}
@@ -219,8 +219,8 @@ namespace hpx { namespace util
     class endian< little, T, n_bits, aligned  >
       : cover_operators< endian< little, T, n_bits, aligned >, T >
     {
-        BOOST_STATIC_ASSERT( (n_bits/8)*8 == n_bits );
-        BOOST_STATIC_ASSERT( sizeof(T) == n_bits/8 );
+        static_assert((n_bits/8)*8 == n_bits, "(n_bits/8)*8 == n_bits");
+        static_assert(sizeof(T) == n_bits/8, "sizeof(T) == n_bits/8");
       public:
         typedef T value_type;
         endian() {}

--- a/hpx/util/logging/format/formatter/named_spacer.hpp
+++ b/hpx/util/logging/format/formatter/named_spacer.hpp
@@ -24,7 +24,6 @@
 #include <hpx/util/logging/detail/fwd.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/static_assert.hpp>
 #include <hpx/util/logging/detail/manipulator.hpp>
 #include <hpx/util/logging/format/formatter/convert_format.hpp> // do_convert_format
 #include <hpx/util/logging/format/array.hpp> // array
@@ -207,8 +206,9 @@ namespace detail {
             typedef typename formatter::convert_type formatter_convert_type;
             // they must share the same type of conversion
             // - otherwise when trying to prepend we could end up appending or vice versa
-            BOOST_STATIC_ASSERT( (boost::is_same<formatter_convert_type,
-                convert_type>::value) );
+            static_assert( (boost::is_same<formatter_convert_type,
+                convert_type>::value),
+                "boost::is_same<formatter_convert_type, convert_type>::value");
 
             add_impl( name, holder(fmt), boost::false_type() );
         }

--- a/hpx/util/mem_fn.hpp
+++ b/hpx/util/mem_fn.hpp
@@ -11,7 +11,6 @@
 #include <hpx/util/move.hpp>
 #include <hpx/util/result_of.hpp>
 
-#include <boost/static_assert.hpp>
 #include <boost/type_traits/is_member_pointer.hpp>
 
 #include <utility>
@@ -62,7 +61,9 @@ namespace hpx { namespace util
     template <typename MemPtr>
     detail::mem_fn<MemPtr> mem_fn(MemPtr pm)
     {
-        BOOST_STATIC_ASSERT((boost::is_member_pointer<MemPtr>::value));
+        static_assert(
+            boost::is_member_pointer<MemPtr>::value,
+            "boost::is_member_pointer<MemPtr>::value");
 
         return detail::mem_fn<MemPtr>(pm);
     }

--- a/hpx/util/plugin/detail/dll_dlopen.hpp
+++ b/hpx/util/plugin/detail/dll_dlopen.hpp
@@ -13,7 +13,6 @@
 
 #include <boost/bind.hpp>
 #include <boost/config.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/type_traits/remove_pointer.hpp>
 #include <boost/type_traits/is_pointer.hpp>
@@ -212,7 +211,9 @@ namespace hpx { namespace util { namespace plugin {
             initialize_mutex();
             boost::lock_guard<boost::mutex> lock(mutex_instance());
 
-            BOOST_STATIC_ASSERT(boost::is_pointer<SymbolType>::value);
+            static_assert(
+                boost::is_pointer<SymbolType>::value,
+                "boost::is_pointer<SymbolType>::value");
 
             SymbolType address = very_detail::nasty_cast<SymbolType>(
                 MyGetProcAddress(dll_handle, symbol_name.c_str()));

--- a/hpx/util/plugin/detail/dll_windows.hpp
+++ b/hpx/util/plugin/detail/dll_windows.hpp
@@ -12,7 +12,6 @@
 #include <iostream>
 
 #include <boost/config.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/type_traits/remove_pointer.hpp>
 #include <boost/type_traits/is_pointer.hpp>
@@ -134,7 +133,9 @@ namespace hpx { namespace util { namespace plugin {
             // make sure everything is initialized
             if (ec) return std::pair<SymbolType, Deleter>();
 
-            BOOST_STATIC_ASSERT(boost::is_pointer<SymbolType>::value);
+            static_assert(
+                boost::is_pointer<SymbolType>::value,
+                "boost::is_pointer<SymbolType>::value");
 
             // Cast the to right type.
             SymbolType address = (SymbolType)GetProcAddress

--- a/hpx/util/static.hpp
+++ b/hpx/util/static.hpp
@@ -23,7 +23,6 @@
     (_MSC_FULL_VER < 180021114)         // NovCTP_2013
 #include <boost/thread/once.hpp>
 #include <boost/bind.hpp>
-#include <boost/static_assert.hpp>
 
 #include <memory>   // for placement new
 #endif

--- a/hpx/util/zip_iterator.hpp
+++ b/hpx/util/zip_iterator.hpp
@@ -17,8 +17,6 @@
 #include <boost/fusion/algorithm/iteration/for_each.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 
-#include <boost/mpl/assert.hpp>
-
 #include <iterator>
 #include <type_traits>
 
@@ -50,9 +48,9 @@ namespace hpx { namespace util
         template <typename T, typename U>
         struct zip_iterator_category_impl
         {
-            BOOST_MPL_ASSERT_MSG(false,
-                unknown_combination_of_iterator_categories,
-                (T, U));
+            static_assert(
+                sizeof(T) == 0 && sizeof(U) == 0,
+                "unknown combination of iterator categories");
         };
 
         // random_access_iterator_tag

--- a/tests/unit/parallel/algorithms/adjacentdifference.cpp
+++ b/tests/unit/parallel/algorithms/adjacentdifference.cpp
@@ -15,7 +15,9 @@
 template <typename ExPolicy>
 void test_adjacent_difference(ExPolicy policy)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c = test::random_iota(10007);
     std::vector<std::size_t> d(10007);
@@ -38,7 +40,9 @@ void test_adjacent_difference(ExPolicy policy)
 template <typename ExPolicy>
 void test_adjacent_difference_async(ExPolicy p)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c = test::random_iota(10007);
     std::vector<std::size_t> d(10007);

--- a/tests/unit/parallel/algorithms/adjacentdifference_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/adjacentdifference_bad_alloc.cpp
@@ -15,7 +15,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_difference_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator <base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/adjacentdifference_exception.cpp
+++ b/tests/unit/parallel/algorithms/adjacentdifference_exception.cpp
@@ -15,7 +15,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_difference_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator <base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/adjacentfind.cpp
+++ b/tests/unit/parallel/algorithms/adjacentfind.cpp
@@ -15,7 +15,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_find(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/adjacentfind_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/adjacentfind_bad_alloc.cpp
@@ -15,7 +15,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_find_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator <base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/adjacentfind_binary.cpp
+++ b/tests/unit/parallel/algorithms/adjacentfind_binary.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_find(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/adjacentfind_binary_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/adjacentfind_binary_bad_alloc.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_find_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/adjacentfind_binary_exception.cpp
+++ b/tests/unit/parallel/algorithms/adjacentfind_binary_exception.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_find_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/adjacentfind_exception.cpp
+++ b/tests/unit/parallel/algorithms/adjacentfind_exception.cpp
@@ -15,7 +15,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_find_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator <base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/all_of.cpp
+++ b/tests/unit/parallel/algorithms/all_of.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_all_of(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -133,7 +135,9 @@ void all_of_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_all_of_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -235,7 +239,9 @@ void all_of_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_all_of_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/any_of.cpp
+++ b/tests/unit/parallel/algorithms/any_of.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_any_of(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -133,7 +135,9 @@ void any_of_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_any_of_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -235,7 +239,9 @@ void any_of_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_any_of_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/copy.cpp
+++ b/tests/unit/parallel/algorithms/copy.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_copy(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -66,7 +68,9 @@ void test_copy_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_copy_outiter(ExPolicy policy, IteratorTag)
 {
-        BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+        static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -158,7 +162,9 @@ void copy_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_copy_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -259,7 +265,9 @@ void copy_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_copy_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/copyif_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/copyif_bad_alloc.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_copy_if_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/copyif_exception.cpp
+++ b/tests/unit/parallel/algorithms/copyif_exception.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_copy_if_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/copyif_forward.cpp
+++ b/tests/unit/parallel/algorithms/copyif_forward.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy>
 void test_copy_if(ExPolicy policy)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, std::forward_iterator_tag> iterator;
@@ -90,7 +92,9 @@ void test_copy_if_async(ExPolicy p)
 template <typename ExPolicy>
 void test_copy_if_outiter(ExPolicy policy)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, std::forward_iterator_tag> iterator;

--- a/tests/unit/parallel/algorithms/copyif_input.cpp
+++ b/tests/unit/parallel/algorithms/copyif_input.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy>
 void test_copy_if(ExPolicy policy)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, std::input_iterator_tag> iterator;
@@ -90,7 +92,9 @@ void test_copy_if_async(ExPolicy p)
 template <typename ExPolicy>
 void test_copy_if_outiter(ExPolicy policy)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, std::input_iterator_tag> iterator;

--- a/tests/unit/parallel/algorithms/copyif_random.cpp
+++ b/tests/unit/parallel/algorithms/copyif_random.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy>
 void test_copy_if(ExPolicy policy)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, std::random_access_iterator_tag> iterator;
@@ -90,7 +92,9 @@ void test_copy_if_async(ExPolicy p)
 template <typename ExPolicy>
 void test_copy_if_outiter(ExPolicy policy)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, std::random_access_iterator_tag> iterator;

--- a/tests/unit/parallel/algorithms/copyn.cpp
+++ b/tests/unit/parallel/algorithms/copyn.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_copy_n(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -66,7 +68,9 @@ void test_copy_n_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_copy_n_outiter(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -160,7 +164,9 @@ void n_copy_test()
 template<typename ExPolicy, typename IteratorTag>
 void test_copy_n_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -264,7 +270,9 @@ void copy_n_exception_test()
 template< typename ExPolicy, typename IteratorTag>
 void test_copy_n_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/count.cpp
+++ b/tests/unit/parallel/algorithms/count.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_count(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -92,7 +94,9 @@ void count_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_count_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -191,7 +195,9 @@ void count_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_count_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/countif.cpp
+++ b/tests/unit/parallel/algorithms/countif.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_count_if(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -81,7 +83,9 @@ void count_if_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_count_if_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -180,7 +184,9 @@ void count_if_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_count_if_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/equal.cpp
+++ b/tests/unit/parallel/algorithms/equal.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_equal1(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -129,7 +131,9 @@ void equal_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_equal2(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -242,7 +246,9 @@ void equal_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_equal_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -348,7 +354,9 @@ void equal_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_equal_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/equal_binary.cpp
+++ b/tests/unit/parallel/algorithms/equal_binary.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_equal_binary1(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -129,7 +131,9 @@ void equal_binary_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_equal_binary2(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -242,7 +246,9 @@ void equal_binary_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_equal_binary_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -348,7 +354,9 @@ void equal_binary_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_equal_binary_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/exclusive_scan.cpp
+++ b/tests/unit/parallel/algorithms/exclusive_scan.cpp
@@ -17,7 +17,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_exclusive_scan1(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/exclusive_scan2.cpp
+++ b/tests/unit/parallel/algorithms/exclusive_scan2.cpp
@@ -17,7 +17,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_exclusive_scan2(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/exclusive_scan_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/exclusive_scan_bad_alloc.cpp
@@ -17,7 +17,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_exclusive_scan_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/exclusive_scan_exception.cpp
+++ b/tests/unit/parallel/algorithms/exclusive_scan_exception.cpp
@@ -17,7 +17,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_exclusive_scan_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/fill.cpp
+++ b/tests/unit/parallel/algorithms/fill.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_fill(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -90,7 +92,9 @@ void fill_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_fill_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -187,7 +191,9 @@ void fill_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_fill_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/filln.cpp
+++ b/tests/unit/parallel/algorithms/filln.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_fill_n(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -91,7 +93,9 @@ void fill_n_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_fill_n_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator <base_iterator, IteratorTag>
@@ -188,7 +192,9 @@ void fill_n_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_fill_n_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator <base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/find.cpp
+++ b/tests/unit/parallel/algorithms/find.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_find(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -87,7 +89,9 @@ void find_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -187,7 +191,9 @@ void find_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/findend.cpp
+++ b/tests/unit/parallel/algorithms/findend.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end1(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -94,7 +96,9 @@ void find_end_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end2(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -177,7 +181,9 @@ void find_end_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end3(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -261,7 +267,9 @@ void find_end_test3()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end4(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -347,7 +355,9 @@ void find_end_test4()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -457,7 +467,9 @@ void find_end_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/findfirstof.cpp
+++ b/tests/unit/parallel/algorithms/findfirstof.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -94,7 +96,9 @@ void find_first_of_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -198,7 +202,9 @@ void find_first_of_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/findfirstof_binary.cpp
+++ b/tests/unit/parallel/algorithms/findfirstof_binary.cpp
@@ -17,7 +17,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -106,7 +108,9 @@ void find_first_of_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -220,7 +224,9 @@ void find_first_of_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/findif.cpp
+++ b/tests/unit/parallel/algorithms/findif.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_find_if(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -92,7 +94,9 @@ void find_if_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_if_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -192,7 +196,9 @@ void find_if_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_if_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/findifnot.cpp
+++ b/tests/unit/parallel/algorithms/findifnot.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_find_if_not(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/findifnot_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/findifnot_bad_alloc.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_find_if_not_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/findifnot_exception.cpp
+++ b/tests/unit/parallel/algorithms/findifnot_exception.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_find_if_not_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/foreach_tests.hpp
+++ b/tests/unit/parallel/algorithms/foreach_tests.hpp
@@ -17,7 +17,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each(ExPolicy && policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -77,7 +79,9 @@ void test_for_each_async(ExPolicy && p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -141,7 +145,9 @@ void test_for_each_exception_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/foreach_tests_projection.hpp
+++ b/tests/unit/parallel/algorithms/foreach_tests_projection.hpp
@@ -18,7 +18,9 @@
 template <typename ExPolicy, typename IteratorTag, typename Proj>
 void test_for_each(ExPolicy && policy, IteratorTag, Proj && proj)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -70,7 +72,9 @@ void test_for_each_async(ExPolicy && p, IteratorTag, Proj && proj)
 template <typename ExPolicy, typename IteratorTag, typename Proj>
 void test_for_each_exception(ExPolicy policy, IteratorTag, Proj && proj)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -136,7 +140,9 @@ void test_for_each_exception_async(ExPolicy p, IteratorTag, Proj && proj)
 template <typename ExPolicy, typename IteratorTag, typename Proj>
 void test_for_each_bad_alloc(ExPolicy policy, IteratorTag, Proj && proj)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/foreachn.cpp
+++ b/tests/unit/parallel/algorithms/foreachn.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_n(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/foreachn_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/foreachn_bad_alloc.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_n_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/foreachn_exception.cpp
+++ b/tests/unit/parallel/algorithms/foreachn_exception.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_n_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/foreachn_projection.cpp
+++ b/tests/unit/parallel/algorithms/foreachn_projection.cpp
@@ -17,7 +17,9 @@
 template <typename ExPolicy, typename IteratorTag, typename Proj>
 void test_for_each_n(ExPolicy policy, IteratorTag, Proj && proj)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/foreachn_projection_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/foreachn_projection_bad_alloc.cpp
@@ -17,7 +17,9 @@
 template <typename ExPolicy, typename IteratorTag, typename Proj>
 void test_for_each_n_bad_alloc(ExPolicy policy, IteratorTag, Proj && proj)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/foreachn_projection_exception.cpp
+++ b/tests/unit/parallel/algorithms/foreachn_projection_exception.cpp
@@ -17,7 +17,9 @@
 template <typename ExPolicy, typename IteratorTag, typename Proj>
 void test_for_each_n_exception(ExPolicy policy, IteratorTag, Proj && proj)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/generate.cpp
+++ b/tests/unit/parallel/algorithms/generate.cpp
@@ -19,7 +19,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_generate(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -95,7 +97,9 @@ void generate_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_generate_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -194,7 +198,9 @@ void generate_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_generate_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/generaten.cpp
+++ b/tests/unit/parallel/algorithms/generaten.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_generate_n(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -93,7 +95,9 @@ void generate_n_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_generate_n_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -192,7 +196,9 @@ void generate_n_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_generate_n_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/includes.cpp
+++ b/tests/unit/parallel/algorithms/includes.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_includes1(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -154,7 +156,9 @@ void includes_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_includes2(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -292,7 +296,9 @@ void includes_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_includes_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -418,7 +424,9 @@ void includes_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_includes_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/inclusive_scan_tests.hpp
+++ b/tests/unit/parallel/algorithms/inclusive_scan_tests.hpp
@@ -20,7 +20,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_inclusive_scan1(ExPolicy && policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -81,7 +83,9 @@ void test_inclusive_scan1_async(ExPolicy && p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_inclusive_scan2(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -134,7 +138,9 @@ void test_inclusive_scan2_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_inclusive_scan3(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -183,7 +189,9 @@ void test_inclusive_scan3_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_inclusive_scan_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -258,7 +266,9 @@ void test_inclusive_scan_exception_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_inclusive_scan_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/inner_product.cpp
+++ b/tests/unit/parallel/algorithms/inner_product.cpp
@@ -18,7 +18,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_inner_product(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -38,7 +40,9 @@ void test_inner_product(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_inner_product_async(ExPolicy p, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/inner_product_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/inner_product_bad_alloc.cpp
@@ -17,7 +17,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_inner_product_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/inner_product_exception.cpp
+++ b/tests/unit/parallel/algorithms/inner_product_exception.cpp
@@ -17,7 +17,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_inner_product_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/is_partitioned.cpp
+++ b/tests/unit/parallel/algorithms/is_partitioned.cpp
@@ -18,7 +18,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_partitioned1(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -91,7 +93,9 @@ void partitioned_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_partitioned2(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -174,7 +178,9 @@ void partitioned_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_partitioned3(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -206,7 +212,9 @@ void test_partitioned3(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_partitioned3_async(ExPolicy p, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -270,7 +278,9 @@ void partitioned_test3()
 template <typename ExPolicy, typename IteratorTag>
 void test_partitioned_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -377,7 +387,9 @@ void partitioned_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_partitioned_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/is_sorted_tests.hpp
+++ b/tests/unit/parallel/algorithms/is_sorted_tests.hpp
@@ -19,7 +19,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted1(ExPolicy && policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -56,7 +58,9 @@ void test_sorted1_async(ExPolicy && p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted2(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -110,7 +114,9 @@ void test_sorted2_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted3(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -136,7 +142,9 @@ void test_sorted3(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted3_async(ExPolicy p, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -164,7 +172,9 @@ void test_sorted3_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -234,7 +244,9 @@ void test_sorted_exception_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/is_sorted_until.cpp
+++ b/tests/unit/parallel/algorithms/is_sorted_until.cpp
@@ -18,7 +18,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted_until1(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -37,7 +39,9 @@ void test_sorted_until1(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted_until1_async(ExPolicy p, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -87,7 +91,9 @@ void sorted_until_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted_until2(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -116,7 +122,9 @@ void test_sorted_until2(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted_until2_async(ExPolicy p, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -171,7 +179,9 @@ void sorted_until_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted_until3(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -204,7 +214,9 @@ void test_sorted_until3(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted_until3_async(ExPolicy p, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -264,7 +276,9 @@ void sorted_until_test3()
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted_until_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -360,7 +374,9 @@ void sorted_until_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted_until_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/lexicographical_compare.cpp
+++ b/tests/unit/parallel/algorithms/lexicographical_compare.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_lexicographical_compare1(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -89,7 +91,9 @@ void lexicographical_compare_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_lexicographical_compare2(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -160,7 +164,9 @@ void lexicographical_compare_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_lexicographical_compare3(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -233,7 +239,9 @@ void lexicographical_compare_test3()
 template <typename ExPolicy, typename IteratorTag>
 void test_lexicographical_compare_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -340,7 +348,9 @@ void lexicographical_compare_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_lexicographical_compare_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/max_element.cpp
+++ b/tests/unit/parallel/algorithms/max_element.cpp
@@ -17,7 +17,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_max_element(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -108,7 +110,9 @@ void max_element_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_max_element_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -262,7 +266,9 @@ void max_element_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_max_element_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/min_element.cpp
+++ b/tests/unit/parallel/algorithms/min_element.cpp
@@ -19,7 +19,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_min_element(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -110,7 +112,9 @@ void min_element_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_min_element_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -264,7 +268,9 @@ void min_element_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_min_element_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/minmax_element.cpp
+++ b/tests/unit/parallel/algorithms/minmax_element.cpp
@@ -19,7 +19,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_minmax_element(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -119,7 +121,9 @@ void minmax_element_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_minmax_element_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -273,7 +277,9 @@ void minmax_element_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_minmax_element_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/mismatch.cpp
+++ b/tests/unit/parallel/algorithms/mismatch.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch1(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -138,7 +140,9 @@ void mismatch_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch2(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -260,7 +264,9 @@ void mismatch_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -372,7 +378,9 @@ void mismatch_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/mismatch_binary.cpp
+++ b/tests/unit/parallel/algorithms/mismatch_binary.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch_binary1(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -140,7 +142,9 @@ void mismatch_binary_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch_binary2(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -267,7 +271,9 @@ void mismatch_binary_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch_binary_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -379,7 +385,9 @@ void mismatch_binary_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch_binary_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/move.cpp
+++ b/tests/unit/parallel/algorithms/move.cpp
@@ -18,7 +18,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_move(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -79,7 +81,9 @@ void test_move_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_outiter_move(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef std::back_insert_iterator<std::vector<std::size_t> > outiterator;
@@ -184,7 +188,9 @@ void move_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_move_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator,IteratorTag> iterator;
@@ -287,7 +293,9 @@ void move_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_move_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/none_of.cpp
+++ b/tests/unit/parallel/algorithms/none_of.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_none_of(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -133,7 +135,9 @@ void none_of_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_none_of_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -235,7 +239,9 @@ void none_of_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_none_of_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/reduce_.cpp
+++ b/tests/unit/parallel/algorithms/reduce_.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce1(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -94,7 +96,9 @@ void reduce_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce2(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -162,7 +166,9 @@ void reduce_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce3(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -228,7 +234,9 @@ void reduce_test3()
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -326,7 +334,9 @@ void reduce_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/remove_copy.cpp
+++ b/tests/unit/parallel/algorithms/remove_copy.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -73,7 +75,9 @@ void test_remove_copy_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_outiter(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -181,7 +185,9 @@ void remove_copy_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -282,7 +288,9 @@ void remove_copy_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/remove_copy_if.cpp
+++ b/tests/unit/parallel/algorithms/remove_copy_if.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_if(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -92,7 +94,9 @@ void test_remove_copy_if_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_if_outiter(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -190,7 +194,9 @@ void remove_copy_if_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_if_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -289,7 +295,9 @@ void remove_copy_if_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_if_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/replace.cpp
+++ b/tests/unit/parallel/algorithms/replace.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_replace(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -104,7 +106,9 @@ void replace_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -202,7 +206,9 @@ void replace_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/replace_copy.cpp
+++ b/tests/unit/parallel/algorithms/replace_copy.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -109,7 +111,9 @@ void replace_copy_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -210,7 +214,9 @@ void replace_copy_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/replace_copy_if.cpp
+++ b/tests/unit/parallel/algorithms/replace_copy_if.cpp
@@ -28,7 +28,9 @@ struct equal_f
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_if(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -121,7 +123,9 @@ void replace_copy_if_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_if_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -222,7 +226,9 @@ void replace_copy_if_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_if_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/replace_if.cpp
+++ b/tests/unit/parallel/algorithms/replace_if.cpp
@@ -28,7 +28,9 @@ struct equal_f
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_if(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -116,7 +118,9 @@ void replace_if_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_if_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -214,7 +218,9 @@ void replace_if_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_if_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/reverse.cpp
+++ b/tests/unit/parallel/algorithms/reverse.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_reverse(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -100,7 +102,9 @@ void reverse_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_reverse_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -198,7 +202,9 @@ void reverse_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_reverse_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/reverse_copy.cpp
+++ b/tests/unit/parallel/algorithms/reverse_copy.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_reverse_copy(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -101,7 +103,9 @@ void reverse_copy_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_reverse_copy_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -203,7 +207,9 @@ void reverse_copy_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_reverse_copy_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/rotate.cpp
+++ b/tests/unit/parallel/algorithms/rotate.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_rotate(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -114,7 +116,9 @@ void rotate_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_rotate_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -224,7 +228,9 @@ void rotate_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_rotate_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/rotate_copy.cpp
+++ b/tests/unit/parallel/algorithms/rotate_copy.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_rotate_copy(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -108,7 +110,9 @@ void rotate_copy_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_rotate_copy_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -222,7 +226,9 @@ void rotate_copy_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_rotate_copy_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/search.cpp
+++ b/tests/unit/parallel/algorithms/search.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_search1(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -94,7 +96,9 @@ void search_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_search2(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -176,7 +180,9 @@ void search_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_search3(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -256,7 +262,9 @@ void search_test3()
 template <typename ExPolicy, typename IteratorTag>
 void test_search4(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -348,7 +356,9 @@ void search_test4()
 template <typename ExPolicy, typename IteratorTag>
 void test_search_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -455,7 +465,9 @@ void search_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_search_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/searchn.cpp
+++ b/tests/unit/parallel/algorithms/searchn.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_search_n1(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -94,7 +96,9 @@ void search_n_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_search_n2(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -176,7 +180,9 @@ void search_n_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_search_n3(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -256,7 +262,9 @@ void search_n_test3()
 template <typename ExPolicy, typename IteratorTag>
 void test_search_n4(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -340,7 +348,9 @@ void search_n_test4()
 template <typename ExPolicy, typename IteratorTag>
 void test_search_n5(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -430,7 +440,9 @@ void search_n_test5()
 template <typename ExPolicy, typename IteratorTag>
 void test_search_n_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -533,7 +545,9 @@ void search_n_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_search_n_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/set_difference.cpp
+++ b/tests/unit/parallel/algorithms/set_difference.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference1(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -98,7 +100,9 @@ void set_difference_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference2(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -127,7 +131,9 @@ void test_set_difference2(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference2_async(ExPolicy p, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -186,7 +192,9 @@ void set_difference_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -226,7 +234,9 @@ void test_set_difference_exception(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference_exception_async(ExPolicy p, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -301,7 +311,9 @@ void set_difference_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -340,7 +352,9 @@ void test_set_difference_bad_alloc(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference_bad_alloc_async(ExPolicy p, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/set_intersection.cpp
+++ b/tests/unit/parallel/algorithms/set_intersection.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection1(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -98,7 +100,9 @@ void set_intersection_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection2(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -127,7 +131,9 @@ void test_set_intersection2(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection2_async(ExPolicy p, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -186,7 +192,9 @@ void set_intersection_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -226,7 +234,9 @@ void test_set_intersection_exception(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection_exception_async(ExPolicy p, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -301,7 +311,9 @@ void set_intersection_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -340,7 +352,9 @@ void test_set_intersection_bad_alloc(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection_bad_alloc_async(ExPolicy p, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/set_symmetric_difference.cpp
+++ b/tests/unit/parallel/algorithms/set_symmetric_difference.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference1(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -98,7 +100,9 @@ void set_symmetric_difference_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference2(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -127,7 +131,9 @@ void test_set_symmetric_difference2(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference2_async(ExPolicy p, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -186,7 +192,9 @@ void set_symmetric_difference_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -226,7 +234,9 @@ void test_set_symmetric_difference_exception(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference_exception_async(ExPolicy p, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -301,7 +311,9 @@ void set_symmetric_difference_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -340,7 +352,9 @@ void test_set_symmetric_difference_bad_alloc(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference_bad_alloc_async(ExPolicy p, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/set_union.cpp
+++ b/tests/unit/parallel/algorithms/set_union.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_set_union1(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -98,7 +100,9 @@ void set_union_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_union2(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -127,7 +131,9 @@ void test_set_union2(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_union2_async(ExPolicy p, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -186,7 +192,9 @@ void set_union_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_union_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -226,7 +234,9 @@ void test_set_union_exception(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_union_exception_async(ExPolicy p, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -301,7 +311,9 @@ void set_union_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_union_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -340,7 +352,9 @@ void test_set_union_bad_alloc(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_union_bad_alloc_async(ExPolicy p, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/sort_tests.hpp
+++ b/tests/unit/parallel/algorithms/sort_tests.hpp
@@ -111,7 +111,9 @@ int verify(const std::vector <IA> &A, Compare comp, boost::uint64_t elapsed,
 template <typename ExPolicy, typename T>
 void test_sort1(ExPolicy && policy, T)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", sync, random);
 
     // Fill vector with random values
@@ -134,7 +136,9 @@ void test_sort1(ExPolicy && policy, T)
 template <typename ExPolicy, typename T, typename Compare = std::less<T>>
         void test_sort1_comp(ExPolicy && policy, T, Compare comp = Compare())
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(),
         sync, random);
 
@@ -158,7 +162,9 @@ template <typename ExPolicy, typename T, typename Compare = std::less<T>>
 template <typename ExPolicy, typename T, typename Compare = std::less<T>>
         void test_sort1_async(ExPolicy && policy, T, Compare comp = Compare())
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(),
         async, random);
 
@@ -182,7 +188,9 @@ template <typename ExPolicy, typename T, typename Compare = std::less<T>>
 template <typename ExPolicy, typename T>
 void test_sort_exception(ExPolicy && policy, T)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", sync, random);
 
     // Fill vector with random values
@@ -254,7 +262,9 @@ void test_sort_exception(ExPolicy && policy, T)
 template <typename ExPolicy, typename T, typename Compare>
 void test_sort_exception(ExPolicy && policy, T, Compare comp)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(),
         sync, random);
 
@@ -330,7 +340,9 @@ void test_sort_exception(ExPolicy && policy, T, Compare comp)
 template <typename ExPolicy, typename T>
 void test_sort_exception_async(ExPolicy && policy, T)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", async, random);
 
     // Fill vector with random values
@@ -414,7 +426,9 @@ void test_sort_exception_async(ExPolicy && policy, T)
 template <typename ExPolicy, typename T, typename Compare>
 void test_sort_exception_async(ExPolicy && policy, T, Compare comp)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(),
         async, random);
 
@@ -503,7 +517,9 @@ void test_sort_exception_async(ExPolicy && policy, T, Compare comp)
 template <typename ExPolicy, typename T>
 void test_sort2(ExPolicy && policy, T)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", sync, sorted);
 
     // Fill vector with increasing values
@@ -524,7 +540,9 @@ void test_sort2(ExPolicy && policy, T)
 template <typename ExPolicy, typename T, typename Compare = std::less<T> >
 void test_sort2_comp(ExPolicy && policy, T, Compare comp = Compare())
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(),
         sync, sorted);
 
@@ -546,7 +564,9 @@ void test_sort2_comp(ExPolicy && policy, T, Compare comp = Compare())
 template <typename ExPolicy, typename T, typename Compare = std::less<T> >
 void test_sort2_async(ExPolicy && policy, T, Compare comp = Compare())
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(),
         async, sorted);
 
@@ -571,7 +591,9 @@ void test_sort2_async(ExPolicy && policy, T, Compare comp = Compare())
 template <typename ExPolicy>
 void test_sort1(ExPolicy && policy, const std::string &)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(std::string).name(), "default", sync, random);
 
     // Fill vector with random strings
@@ -595,7 +617,9 @@ template <typename ExPolicy, typename Compare = std::less<std::string>>
         void test_sort1_comp(ExPolicy && policy, const std::string &,
         Compare comp = Compare())
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(std::string).name(), typeid(Compare).name(),
         sync, random);
 
@@ -620,7 +644,9 @@ template <typename ExPolicy, typename Compare = std::less<std::string>>
         void test_sort1_async(ExPolicy && policy, const std::string &,
         Compare comp = Compare())
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(std::string).name(), typeid(Compare).name(),
         async, random);
 

--- a/tests/unit/parallel/algorithms/swapranges.cpp
+++ b/tests/unit/parallel/algorithms/swapranges.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_swap_ranges(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -114,7 +116,9 @@ void swap_ranges_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_swap_ranges_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -216,7 +220,9 @@ void swap_ranges_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_swap_ranges_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/transform.cpp
+++ b/tests/unit/parallel/algorithms/transform.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_transform(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -110,7 +112,9 @@ void transform_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -209,7 +213,9 @@ void transform_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/transform_binary.cpp
+++ b/tests/unit/parallel/algorithms/transform_binary.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -130,7 +132,9 @@ void transform_binary_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -234,7 +238,9 @@ void transform_binary_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/transform_binary2.cpp
+++ b/tests/unit/parallel/algorithms/transform_binary2.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -130,7 +132,9 @@ void transform_binary_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -234,7 +238,9 @@ void transform_binary_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/transform_exclusive_scan.cpp
+++ b/tests/unit/parallel/algorithms/transform_exclusive_scan.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_exclusive_scan(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -100,7 +102,9 @@ void transform_exclusive_scan_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_exclusive_scan_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -207,7 +211,9 @@ void transform_exclusive_scan_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_exclusive_scan_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/transform_inclusive_scan.cpp
+++ b/tests/unit/parallel/algorithms/transform_inclusive_scan.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_inclusive_scan1(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -100,7 +102,9 @@ void transform_inclusive_scan_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_inclusive_scan2(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -184,7 +188,9 @@ void transform_inclusive_scan_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_inclusive_scan_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -291,7 +297,9 @@ void transform_inclusive_scan_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_inclusive_scan_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/transform_reduce.cpp
+++ b/tests/unit/parallel/algorithms/transform_reduce.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_reduce(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -118,7 +120,9 @@ void transform_reduce_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_reduce_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -222,7 +226,9 @@ void transform_reduce_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_reduce_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/tests/unit/parallel/algorithms/uninitialized_copy_tests.hpp
+++ b/tests/unit/parallel/algorithms/uninitialized_copy_tests.hpp
@@ -19,7 +19,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_copy(ExPolicy && policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -70,7 +72,9 @@ void test_uninitialized_copy_async(ExPolicy && p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_copy_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<test::count_instances>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -160,7 +164,9 @@ void test_uninitialized_copy_exception_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_copy_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<test::count_instances>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/uninitialized_copyn.cpp
+++ b/tests/unit/parallel/algorithms/uninitialized_copyn.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_copy_n(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -94,7 +96,9 @@ void uninitialized_copy_n_test()
 template<typename ExPolicy, typename IteratorTag>
 void test_uninitialized_copy_n_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<test::count_instances>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -212,7 +216,9 @@ void uninitialized_copy_n_exception_test()
 template< typename ExPolicy, typename IteratorTag>
 void test_uninitialized_copy_n_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<test::count_instances>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/uninitialized_fill.cpp
+++ b/tests/unit/parallel/algorithms/uninitialized_fill.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_fill(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -90,7 +92,9 @@ void uninitialized_fill_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_fill_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<test::count_instances>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -206,7 +210,9 @@ void uninitialized_fill_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_fill_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<test::count_instances>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/tests/unit/parallel/algorithms/uninitialized_filln.cpp
+++ b/tests/unit/parallel/algorithms/uninitialized_filln.cpp
@@ -16,7 +16,9 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_fill_n(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -90,7 +92,9 @@ void uninitialized_fill_n_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_fill_n_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<test::count_instances>::iterator base_iterator;
     typedef test::decorated_iterator <base_iterator, IteratorTag>
@@ -206,7 +210,9 @@ void uninitialized_fill_n_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_fill_n_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::parallel::is_execution_policy<ExPolicy>::value);
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<test::count_instances>::iterator base_iterator;
     typedef test::decorated_iterator <base_iterator, IteratorTag>


### PR DESCRIPTION
Mark C++11 `static_assert` as required. Replace uses of emulation facilities with the real thing.