### PR TITLE
Touch local::mutex

### DIFF
--- a/hpx/lcos/local/mutex.hpp
+++ b/hpx/lcos/local/mutex.hpp
@@ -1,24 +1,21 @@
 //  Copyright (c) 2007-2012 Hartmut Kaiser
-//  Copyright (c) 2013-2014 Agustin Berge
+//  Copyright (c) 2013-2015 Agustin Berge
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(HPX_LCOS_MUTEX_JUN_23_2008_0530PM)
-#define HPX_LCOS_MUTEX_JUN_23_2008_0530PM
+#ifndef HPX_LCOS_MUTEX_HPP
+#define HPX_LCOS_MUTEX_HPP
 
 #include <hpx/config.hpp>
 #include <hpx/config/emulate_deleted.hpp>
+#include <hpx/config/export_definitions.hpp>
+#include <hpx/exception_fwd.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 #include <hpx/lcos/local/detail/condition_variable.hpp>
-#include <hpx/runtime/threads/thread_helpers.hpp>
-#include <hpx/util/assert.hpp>
+#include <hpx/runtime/threads/thread_data_fwd.hpp>
 #include <hpx/util/date_time_chrono.hpp>
-#include <hpx/util/itt_notify.hpp>
-#include <hpx/util/register_locks.hpp>
-#include <hpx/util/unlock_guard.hpp>
 
-#include <boost/intrusive/slist.hpp>
 #include <boost/thread/locks.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -26,6 +23,8 @@ namespace hpx { namespace lcos { namespace local
 {
     class mutex
     {
+        HPX_NON_COPYABLE(mutex);
+
     private:
         typedef lcos::local::spinlock mutex_type;
 
@@ -34,111 +33,26 @@ namespace hpx { namespace lcos { namespace local
         typedef boost::detail::try_lock_wrapper<mutex> scoped_try_lock;
 
     public:
-        mutex(char const* const description = "")
-          : owner_id_(threads::invalid_thread_id_repr)
-        {
-            HPX_ITT_SYNC_CREATE(this, "lcos::local::mutex", description);
-            HPX_ITT_SYNC_RENAME(this, "lcos::local::mutex");
-        }
+        HPX_EXPORT mutex(char const* const description = "");
 
-        HPX_NON_COPYABLE(mutex);
+        HPX_EXPORT ~mutex();
 
-        ~mutex()
-        {
-            HPX_ITT_SYNC_DESTROY(this);
-        }
-
-        void lock(char const* description, error_code& ec = throws)
-        {
-            HPX_ASSERT(threads::get_self_ptr() != 0);
-
-            HPX_ITT_SYNC_PREPARE(this);
-            boost::unique_lock<mutex_type> l(mtx_);
-
-            threads::thread_id_repr_type self_id = threads::get_self_id().get();
-            if(owner_id_ == self_id)
-            {
-                HPX_ITT_SYNC_CANCEL(this);
-                HPX_THROWS_IF(ec, deadlock,
-                    description,
-                    "The calling thread already owns the mutex");
-                return;
-            }
-
-            while (owner_id_ != threads::invalid_thread_id_repr)
-            {
-                cond_.wait(l, ec);
-                if (ec) { HPX_ITT_SYNC_CANCEL(this); return; }
-            }
-
-            util::register_lock(this);
-            HPX_ITT_SYNC_ACQUIRED(this);
-            owner_id_ = self_id;
-        }
+        HPX_EXPORT void lock(char const* description, error_code& ec = throws);
 
         void lock(error_code& ec = throws)
         {
             return lock("mutex::lock", ec);
         }
 
-        bool try_lock(char const* description, error_code& ec = throws)
-        {
-            HPX_ASSERT(threads::get_self_ptr() != 0);
-
-            HPX_ITT_SYNC_PREPARE(this);
-            boost::unique_lock<mutex_type> l(mtx_);
-
-            if (owner_id_ != threads::invalid_thread_id_repr)
-            {
-                HPX_ITT_SYNC_CANCEL(this);
-                return false;
-            }
-
-            threads::thread_id_repr_type self_id = threads::get_self_id().get();
-            util::register_lock(this);
-            HPX_ITT_SYNC_ACQUIRED(this);
-            owner_id_ = self_id;
-            return true;
-        }
+        HPX_EXPORT bool try_lock(char const* description, error_code& ec = throws);
 
         bool try_lock(error_code& ec = throws)
         {
             return try_lock("mutex::try_lock", ec);
         }
 
-        bool try_lock_until(util::steady_time_point const& abs_time,
-            char const* description, error_code& ec = throws)
-        {
-            HPX_ASSERT(threads::get_self_ptr() != 0);
-
-            HPX_ITT_SYNC_PREPARE(this);
-            boost::unique_lock<mutex_type> l(mtx_);
-
-            threads::thread_id_repr_type self_id = threads::get_self_id().get();
-            if (owner_id_ != threads::invalid_thread_id_repr)
-            {
-                threads::thread_state_ex_enum const reason =
-                    cond_.wait_until(l, abs_time, ec);
-                if (ec) { HPX_ITT_SYNC_CANCEL(this); return false; }
-
-                if (reason == threads::wait_timeout) //-V110
-                {
-                    HPX_ITT_SYNC_CANCEL(this);
-                    return false;
-                }
-
-                if (owner_id_ != threads::invalid_thread_id_repr) //-V110
-                {
-                    HPX_ITT_SYNC_CANCEL(this);
-                    return false;
-                }
-            }
-
-            util::register_lock(this);
-            HPX_ITT_SYNC_ACQUIRED(this);
-            owner_id_ = self_id;
-            return true;
-        }
+        HPX_EXPORT bool try_lock_until(util::steady_time_point const& abs_time,
+            char const* description, error_code& ec = throws);
 
         bool try_lock_until(util::steady_time_point const& abs_time,
             error_code& ec = throws)
@@ -158,29 +72,7 @@ namespace hpx { namespace lcos { namespace local
             return try_lock_for(rel_time, "mutex::try_lock_for", ec);
         }
 
-        void unlock(error_code& ec = throws)
-        {
-            HPX_ASSERT(threads::get_self_ptr() != 0);
-
-            HPX_ITT_SYNC_RELEASING(this);
-            boost::unique_lock<mutex_type> l(mtx_);
-
-            threads::thread_id_repr_type self_id = threads::get_self_id().get();
-            if (HPX_UNLIKELY(owner_id_ != self_id))
-            {
-                util::unregister_lock(this);
-                HPX_THROWS_IF(ec, lock_error,
-                    "mutex::unlock",
-                    "The calling thread does not own the mutex");
-                return;
-            }
-
-            util::unregister_lock(this);
-            HPX_ITT_SYNC_RELEASED(this);
-            owner_id_ = threads::invalid_thread_id_repr;
-
-            cond_.notify_one(std::move(l), ec);
-        }
+        HPX_EXPORT void unlock(error_code& ec = throws);
 
     private:
         mutable mutex_type mtx_;

--- a/hpx/runtime/threads/detail/tagged_thread_state.hpp
+++ b/hpx/runtime/threads/detail/tagged_thread_state.hpp
@@ -6,6 +6,8 @@
 #if !defined(HPX_TAGGED_THREAD_STATE_MAR_12_2010_0125PM)
 #define HPX_TAGGED_THREAD_STATE_MAR_12_2010_0125PM
 
+#include <boost/cstdint.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace threads { namespace detail
 {
@@ -122,5 +124,3 @@ namespace hpx { namespace threads { namespace detail
 }}}
 
 #endif
-
-

--- a/src/lcos/local/mutex.cpp
+++ b/src/lcos/local/mutex.cpp
@@ -1,0 +1,138 @@
+//  Copyright (c) 2007-2012 Hartmut Kaiser
+//  Copyright (c) 2013-2015 Agustin Berge
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/lcos/local/mutex.hpp>
+
+#include <hpx/exception.hpp>
+#include <hpx/lcos/local/spinlock.hpp>
+#include <hpx/lcos/local/detail/condition_variable.hpp>
+#include <hpx/runtime/threads/thread_data.hpp>
+#include <hpx/util/assert.hpp>
+#include <hpx/util/date_time_chrono.hpp>
+#include <hpx/util/itt_notify.hpp>
+#include <hpx/util/register_locks.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace lcos { namespace local
+{
+    mutex::mutex(char const* const description)
+      : owner_id_(threads::invalid_thread_id_repr)
+    {
+        HPX_ITT_SYNC_CREATE(this, "lcos::local::mutex", description);
+        HPX_ITT_SYNC_RENAME(this, "lcos::local::mutex");
+    }
+
+    mutex::~mutex()
+    {
+        HPX_ITT_SYNC_DESTROY(this);
+    }
+
+    void mutex::lock(char const* description, error_code& ec)
+    {
+        HPX_ASSERT(threads::get_self_ptr() != 0);
+
+        HPX_ITT_SYNC_PREPARE(this);
+        boost::unique_lock<mutex_type> l(mtx_);
+
+        threads::thread_id_repr_type self_id = threads::get_self_id().get();
+        if(owner_id_ == self_id)
+        {
+            HPX_ITT_SYNC_CANCEL(this);
+            HPX_THROWS_IF(ec, deadlock,
+                description,
+                "The calling thread already owns the mutex");
+            return;
+        }
+
+        while (owner_id_ != threads::invalid_thread_id_repr)
+        {
+            cond_.wait(l, ec);
+            if (ec) { HPX_ITT_SYNC_CANCEL(this); return; }
+        }
+
+        util::register_lock(this);
+        HPX_ITT_SYNC_ACQUIRED(this);
+        owner_id_ = self_id;
+    }
+
+    bool mutex::try_lock(char const* description, error_code& ec)
+    {
+        HPX_ASSERT(threads::get_self_ptr() != 0);
+
+        HPX_ITT_SYNC_PREPARE(this);
+        boost::unique_lock<mutex_type> l(mtx_);
+
+        if (owner_id_ != threads::invalid_thread_id_repr)
+        {
+            HPX_ITT_SYNC_CANCEL(this);
+            return false;
+        }
+
+        threads::thread_id_repr_type self_id = threads::get_self_id().get();
+        util::register_lock(this);
+        HPX_ITT_SYNC_ACQUIRED(this);
+        owner_id_ = self_id;
+        return true;
+    }
+
+    bool mutex::try_lock_until(util::steady_time_point const& abs_time,
+        char const* description, error_code& ec)
+    {
+        HPX_ASSERT(threads::get_self_ptr() != 0);
+
+        HPX_ITT_SYNC_PREPARE(this);
+        boost::unique_lock<mutex_type> l(mtx_);
+
+        threads::thread_id_repr_type self_id = threads::get_self_id().get();
+        if (owner_id_ != threads::invalid_thread_id_repr)
+        {
+            threads::thread_state_ex_enum const reason =
+                cond_.wait_until(l, abs_time, ec);
+            if (ec) { HPX_ITT_SYNC_CANCEL(this); return false; }
+
+            if (reason == threads::wait_timeout) //-V110
+            {
+                HPX_ITT_SYNC_CANCEL(this);
+                return false;
+            }
+
+            if (owner_id_ != threads::invalid_thread_id_repr) //-V110
+            {
+                HPX_ITT_SYNC_CANCEL(this);
+                return false;
+            }
+        }
+
+        util::register_lock(this);
+        HPX_ITT_SYNC_ACQUIRED(this);
+        owner_id_ = self_id;
+        return true;
+    }
+
+    void mutex::unlock(error_code& ec)
+    {
+        HPX_ASSERT(threads::get_self_ptr() != 0);
+
+        HPX_ITT_SYNC_RELEASING(this);
+        boost::unique_lock<mutex_type> l(mtx_);
+
+        threads::thread_id_repr_type self_id = threads::get_self_id().get();
+        if (HPX_UNLIKELY(owner_id_ != self_id))
+        {
+            util::unregister_lock(this);
+            HPX_THROWS_IF(ec, lock_error,
+                "mutex::unlock",
+                "The calling thread does not own the mutex");
+            return;
+        }
+
+        util::unregister_lock(this);
+        HPX_ITT_SYNC_RELEASED(this);
+        owner_id_ = threads::invalid_thread_id_repr;
+
+        cond_.notify_one(std::move(l), ec);
+    }
+}}}


### PR DESCRIPTION
Split timed functionality out of `local::mutex` into `local::timed_mutex`. Move definitions to a source file.