### PR TITLE
Simplify callables

### DIFF
--- a/cmake/tests/cxx11_defaulted_functions.cpp
+++ b/cmake/tests/cxx11_defaulted_functions.cpp
@@ -14,4 +14,19 @@ struct foo {
     ~foo() = default;
 };
 
-int main() {}
+// GCC4.6 doesn't get it quite right
+struct bar {
+  bar() {}
+  bar(bar const&) {};
+};
+
+template <typename T>
+struct baz : bar {
+  baz() {}
+  baz(baz const&) = default;
+  baz(baz&&) = default; // deleted
+};
+
+int main() {
+  baz<int> x, y(static_cast<baz<int>&&>(x));
+}

--- a/hpx/apply.hpp
+++ b/hpx/apply.hpp
@@ -37,7 +37,7 @@ namespace hpx { namespace detail
         template <typename F, typename ...Ts>
         BOOST_FORCEINLINE static
         typename boost::enable_if_c<
-            traits::detail::is_deferred_callable<F(Ts...)>::value,
+            traits::detail::is_deferred_callable<F(Ts&&...)>::value,
             bool
         >::type
         call(F&& f, Ts&&... ts)
@@ -59,7 +59,7 @@ namespace hpx { namespace detail
         template <typename F, typename ...Ts>
         BOOST_FORCEINLINE static
         typename boost::enable_if_c<
-            traits::detail::is_deferred_callable<F(Ts...)>::value,
+            traits::detail::is_deferred_callable<F(Ts&&...)>::value,
             bool
         >::type
         call(Executor& sched, F&& f, Ts&&... ts)
@@ -81,7 +81,7 @@ namespace hpx { namespace detail
         template <typename F, typename ...Ts>
         BOOST_FORCEINLINE static
         typename boost::enable_if_c<
-            traits::detail::is_deferred_callable<F(Ts...)>::value,
+            traits::detail::is_deferred_callable<F(Ts&&...)>::value,
             bool
         >::type
         call(Executor& exec, F&& f, Ts&&... ts)

--- a/hpx/async.hpp
+++ b/hpx/async.hpp
@@ -29,13 +29,13 @@ namespace hpx { namespace detail
     // Defer the evaluation of result_of during the SFINAE checks below
 #if defined(__clang__)
     template <typename F, typename Result =
-        typename util::deferred_call_result_of<F>::type>
+        typename util::detail::deferred_result_of<F>::type>
     struct create_future
     {
         typedef lcos::future<Result> type;
     };
 #else
-    template <typename F, typename ResultOf = util::deferred_call_result_of<F> >
+    template <typename F, typename ResultOf = util::detail::deferred_result_of<F> >
     struct create_future
     {
         typedef lcos::future<typename ResultOf::type> type;
@@ -45,12 +45,12 @@ namespace hpx { namespace detail
     template <typename F>
     BOOST_FORCEINLINE
     typename boost::lazy_enable_if<
-        boost::is_reference<typename util::deferred_call_result_of<F()>::type>
+        boost::is_reference<typename util::detail::deferred_result_of<F()>::type>
       , detail::create_future<F()>
     >::type
     call_sync(F&& f, boost::mpl::false_)
     {
-        typedef typename util::deferred_call_result_of<F()>::type result_type;
+        typedef typename util::detail::deferred_result_of<F()>::type result_type;
         try
         {
             return lcos::make_ready_future(boost::ref(f()));
@@ -63,12 +63,12 @@ namespace hpx { namespace detail
     template <typename F>
     BOOST_FORCEINLINE
     typename boost::lazy_disable_if<
-        boost::is_reference<typename util::deferred_call_result_of<F()>::type>
+        boost::is_reference<typename util::detail::deferred_result_of<F()>::type>
       , detail::create_future<F()>
     >::type
     call_sync(F&& f, boost::mpl::false_) //-V659
     {
-        typedef typename util::deferred_call_result_of<F()>::type result_type;
+        typedef typename util::detail::deferred_result_of<F()>::type result_type;
         try
         {
             return lcos::make_ready_future(f());
@@ -101,12 +101,12 @@ namespace hpx { namespace detail
         template <typename F, typename ...Ts>
         BOOST_FORCEINLINE static
         typename boost::enable_if_c<
-            traits::detail::is_deferred_callable<F(Ts...)>::value,
-            hpx::future<typename util::deferred_call_result_of<F(Ts...)>::type>
+            traits::detail::is_deferred_callable<F(Ts&&...)>::value,
+            hpx::future<typename util::detail::deferred_result_of<F(Ts&&...)>::type>
         >::type
         call(BOOST_SCOPED_ENUM(launch) launch_policy, F&& f, Ts&&... ts)
         {
-            typedef typename util::deferred_call_result_of<
+            typedef typename util::detail::deferred_result_of<
                 F(Ts...)
             >::type result_type;
 
@@ -138,8 +138,8 @@ namespace hpx { namespace detail
         template <typename F, typename ...Ts>
         BOOST_FORCEINLINE static
         typename boost::enable_if_c<
-            traits::detail::is_deferred_callable<F(Ts...)>::value,
-            hpx::future<typename util::deferred_call_result_of<F(Ts...)>::type>
+            traits::detail::is_deferred_callable<F(Ts&&...)>::value,
+            hpx::future<typename util::detail::deferred_result_of<F(Ts&&...)>::type>
         >::type
         call(F&& f, Ts&&... ts)
         {
@@ -158,12 +158,12 @@ namespace hpx { namespace detail
         template <typename F, typename ...Ts>
         BOOST_FORCEINLINE static
         typename boost::enable_if_c<
-            traits::detail::is_deferred_callable<F(Ts...)>::value,
-            hpx::future<typename util::deferred_call_result_of<F(Ts...)>::type>
+            traits::detail::is_deferred_callable<F(Ts&&...)>::value,
+            hpx::future<typename util::detail::deferred_result_of<F(Ts&&...)>::type>
         >::type
         call(Executor& sched, F&& f, Ts&&... ts)
         {
-            typedef typename util::deferred_call_result_of<
+            typedef typename util::detail::deferred_result_of<
                     F(Ts...)
                 >::type result_type;
 
@@ -184,8 +184,8 @@ namespace hpx { namespace detail
         template <typename F, typename ...Ts>
         BOOST_FORCEINLINE static
         typename boost::enable_if_c<
-            traits::detail::is_deferred_callable<F(Ts...)>::value,
-            hpx::future<typename util::deferred_call_result_of<F(Ts...)>::type>
+            traits::detail::is_deferred_callable<F(Ts&&...)>::value,
+            hpx::future<typename util::detail::deferred_result_of<F(Ts&&...)>::type>
         >::type
         call(Executor& exec, F&& f, Ts&&... ts)
         {

--- a/hpx/async.hpp
+++ b/hpx/async.hpp
@@ -107,7 +107,7 @@ namespace hpx { namespace detail
         call(BOOST_SCOPED_ENUM(launch) launch_policy, F&& f, Ts&&... ts)
         {
             typedef typename util::detail::deferred_result_of<
-                F(Ts...)
+                F(Ts&&...)
             >::type result_type;
 
             if (launch_policy == launch::sync) {
@@ -164,7 +164,7 @@ namespace hpx { namespace detail
         call(Executor& sched, F&& f, Ts&&... ts)
         {
             typedef typename util::detail::deferred_result_of<
-                    F(Ts...)
+                    F(Ts&&...)
                 >::type result_type;
 
             lcos::local::futures_factory<result_type()> p(sched,

--- a/hpx/lcos/detail/async_colocated.hpp
+++ b/hpx/lcos/detail/async_colocated.hpp
@@ -33,11 +33,10 @@ namespace hpx { namespace detail
         typedef
             util::tuple<
                 hpx::util::detail::bound<
-                    hpx::util::functional::extract_locality
-                  , hpx::util::tuple<
-                        hpx::util::detail::placeholder<2ul>
-                      , hpx::id_type
-                    >
+                    hpx::util::functional::extract_locality(
+                        hpx::util::detail::placeholder<2ul> const&
+                      , hpx::id_type&&
+                    )
                 >
               , Ts...
             >

--- a/hpx/runtime/actions/basic_action.hpp
+++ b/hpx/runtime/actions/basic_action.hpp
@@ -62,14 +62,12 @@ namespace hpx { namespace actions
             HPX_MOVABLE_BUT_NOT_COPYABLE(continuation_thread_function);
 
         public:
-            template <typename F_, typename ...Ts_>
             explicit continuation_thread_function(
-                    std::unique_ptr<continuation> cont,
-                    naming::address::address_type lva, F_&& f, Ts_&&... vs)
+                std::unique_ptr<continuation> cont,
+                naming::address::address_type lva, F&& f, Ts&&... vs)
               : cont_(std::move(cont))
               , lva_(lva)
-              , f_(util::deferred_call(
-                    std::forward<F_>(f), std::forward<Ts_>(vs)...))
+              , f_(std::forward<F>(f), std::forward<Ts>(vs)...)
             {}
 
             continuation_thread_function(continuation_thread_function && other)
@@ -91,10 +89,7 @@ namespace hpx { namespace actions
         private:
             std::unique_ptr<continuation> cont_;
             naming::address::address_type lva_;
-            util::detail::deferred_call_impl<
-                typename util::decay<F>::type
-              , util::tuple<typename util::decay_unwrap<Ts>::type...>
-            > f_;
+            util::detail::deferred<F(Ts&&...)> f_;
         };
 
         ///////////////////////////////////////////////////////////////////////
@@ -255,7 +250,7 @@ namespace hpx { namespace actions
             naming::address::address_type lva, Ts&&... vs)
         {
             typedef detail::continuation_thread_function<
-                Derived, invoker, naming::address::address_type, Ts...
+                Derived, invoker, naming::address::address_type&, Ts&&...
             > thread_function;
 
             return traits::action_decorate_function<Derived>::call(lva,

--- a/hpx/runtime/applier/register_apply_colocated.hpp
+++ b/hpx/runtime/applier/register_apply_colocated.hpp
@@ -24,11 +24,10 @@ namespace hpx { namespace detail
         typedef
             util::tuple<
                 hpx::util::detail::bound<
-                    hpx::util::functional::extract_locality
-                  , hpx::util::tuple<
-                        hpx::util::detail::placeholder<2ul>
-                      , hpx::id_type
-                    >
+                    hpx::util::functional::extract_locality(
+                        hpx::util::detail::placeholder<2ul> const&
+                      , hpx::id_type&&
+                    )
                 >
               , Ts...
             >

--- a/hpx/runtime/components/base_lco_factory.hpp
+++ b/hpx/runtime/components/base_lco_factory.hpp
@@ -16,6 +16,7 @@
 #include <hpx/runtime/naming/resolver_client.hpp>
 #include <hpx/util/ini.hpp>
 #include <hpx/util/one_size_heap_list_base.hpp>
+#include <hpx/util/unique_function.hpp>
 #include <hpx/util/detail/count_num_args.hpp>
 
 #include <boost/preprocessor/cat.hpp>
@@ -105,7 +106,7 @@ namespace hpx { namespace components
         /// \return   Returns the GID of the first newly created component
         ///           instance.
         naming::gid_type create_with_args(
-            util::function_nonser<void(void*)> const&)
+            util::unique_function_nonser<void(void*)> const&)
         {
             HPX_THROW_EXCEPTION(bad_request,
                 "base_lco_factory::create_with_args",
@@ -125,7 +126,7 @@ namespace hpx { namespace components
         ///           instance (this is the same as assign_gid, if successful).
         naming::gid_type create_with_args(
             naming::gid_type const& assign_gid,
-            util::function_nonser<void(void*)> const& f)
+            util::unique_function_nonser<void(void*)> const& f)
         {
             HPX_THROW_EXCEPTION(bad_request,
                 "base_lco_factory::create_with_args",

--- a/hpx/runtime/components/component_factory.hpp
+++ b/hpx/runtime/components/component_factory.hpp
@@ -48,6 +48,7 @@
 #include <hpx/runtime/components/server/destroy_component.hpp>
 #include <hpx/runtime/naming/resolver_client.hpp>
 #include <hpx/util/ini.hpp>
+#include <hpx/util/unique_function.hpp>
 #include <hpx/util/detail/count_num_args.hpp>
 
 #include <boost/preprocessor/cat.hpp>
@@ -185,7 +186,7 @@ namespace hpx { namespace components
         /// \return   Returns the GID of the first newly created component
         ///           instance.
         naming::gid_type create_with_args(
-            util::function_nonser<void(void*)> const& ctor)
+            util::unique_function_nonser<void(void*)> const& ctor)
         {
             if (isenabled_)
             {
@@ -214,7 +215,7 @@ namespace hpx { namespace components
         ///           instance (this is the same as assign_gid, if successful).
         naming::gid_type create_with_args(
             naming::gid_type const& assign_gid,
-            util::function_nonser<void(void*)> const& ctor)
+            util::unique_function_nonser<void(void*)> const& ctor)
         {
             if (isenabled_)
             {

--- a/hpx/runtime/components/component_factory_base.hpp
+++ b/hpx/runtime/components/component_factory_base.hpp
@@ -71,7 +71,7 @@ namespace hpx { namespace components
         /// \return   Returns the GID of the first newly created component
         ///           instance.
         virtual naming::gid_type create_with_args(
-            util::function_nonser<void(void*)> const&) = 0;
+            util::unique_function_nonser<void(void*)> const&) = 0;
 
         /// \brief Create one new component instance and initialize it using
         ///        the using the given constructor function. Assign the give
@@ -85,7 +85,7 @@ namespace hpx { namespace components
         ///           instance (this is the same as assign_gid, if successful).
         virtual naming::gid_type create_with_args(
             naming::gid_type const& assign_gid,
-            util::function_nonser<void(void*)> const& f) = 0;
+            util::unique_function_nonser<void(void*)> const& f) = 0;
 
         /// \brief Destroy one or more component instances
         ///

--- a/hpx/runtime/components/derived_component_factory.hpp
+++ b/hpx/runtime/components/derived_component_factory.hpp
@@ -176,7 +176,7 @@ namespace hpx { namespace components
         /// \return   Returns the GID of the first newly created component
         ///           instance.
         naming::gid_type create_with_args(
-            util::function_nonser<void(void*)> const& ctor)
+            util::unique_function_nonser<void(void*)> const& ctor)
         {
             if (isenabled_)
             {
@@ -205,7 +205,7 @@ namespace hpx { namespace components
         ///           instance (this is the same as assign_gid, if successful).
         naming::gid_type create_with_args(
             naming::gid_type const& assign_gid,
-            util::function_nonser<void(void*)> const& ctor)
+            util::unique_function_nonser<void(void*)> const& ctor)
         {
             if (isenabled_)
             {

--- a/hpx/runtime/components/server/create_component.hpp
+++ b/hpx/runtime/components/server/create_component.hpp
@@ -15,6 +15,7 @@
 #include <hpx/util/decay.hpp>
 #include <hpx/util/move.hpp>
 #include <hpx/util/tuple.hpp>
+#include <hpx/util/unique_function.hpp>
 #include <hpx/util/functional/new.hpp>
 
 #include <sstream>
@@ -49,7 +50,8 @@ namespace hpx { namespace components { namespace server
     }
 
     template <typename Component>
-    naming::gid_type create(util::function_nonser<void(void*)> const& ctor)
+    naming::gid_type create(
+        util::unique_function_nonser<void(void*)> const& ctor)
     {
         Component* c = (Component*)Component::heap_type::alloc(1);
         ctor(c);
@@ -75,7 +77,7 @@ namespace hpx { namespace components { namespace server
 
     template <typename Component>
     naming::gid_type create(naming::gid_type const& gid,
-        util::function_nonser<void(void*)> const& ctor)
+        util::unique_function_nonser<void(void*)> const& ctor)
     {
         Component* c = (Component*)Component::heap_type::alloc(1);
         ctor(c);

--- a/hpx/runtime/components/server/create_component.hpp
+++ b/hpx/runtime/components/server/create_component.hpp
@@ -114,11 +114,7 @@ namespace hpx { namespace components { namespace server
         util::detail::bound<
             util::detail::one_shot_wrapper<
                 util::functional::placement_new<typename Component::derived_type>
-            >,
-            util::tuple<
-                util::detail::placeholder<1>,
-                typename util::decay<Ts>::type...
-            >
+            >(util::detail::placeholder<1> const&, Ts&&...)
         > construct_function(Ts&&... vs)
         {
             typedef typename Component::derived_type type;

--- a/hpx/runtime/components/server/create_component_fwd.hpp
+++ b/hpx/runtime/components/server/create_component_fwd.hpp
@@ -10,7 +10,7 @@
 
 #include <hpx/exception.hpp>
 #include <hpx/runtime/naming/address.hpp>
-#include <hpx/util/function.hpp>
+#include <hpx/util/unique_function.hpp>
 
 #include <cstdint>
 
@@ -23,11 +23,12 @@ namespace hpx { namespace components { namespace server
     naming::gid_type create(std::size_t count);
 
     template <typename Component>
-    naming::gid_type create(util::function_nonser<void(void*)> const& ctor);
+    naming::gid_type create(
+        util::unique_function_nonser<void(void*)> const& ctor);
 
     template <typename Component>
     naming::gid_type create(naming::gid_type const& gid,
-        util::function_nonser<void(void*)> const& ctor);
+        util::unique_function_nonser<void(void*)> const& ctor);
 }}}
 
 #endif

--- a/hpx/runtime/components/server/fixed_component_base.hpp
+++ b/hpx/runtime/components/server/fixed_component_base.hpp
@@ -16,6 +16,7 @@
 #include <hpx/runtime/naming/address.hpp>
 #include <hpx/runtime/applier/applier.hpp>
 #include <hpx/runtime/applier/bind_naming_wrappers.hpp>
+#include <hpx/util/unique_function.hpp>
 
 #include <boost/mpl/bool.hpp>
 #include <boost/type_traits/is_base_and_derived.hpp>
@@ -83,11 +84,11 @@ private:
 
     template <typename Component_>
     friend naming::gid_type server::create(
-        util::function_nonser<void(void*)> const& ctor);
+        util::unique_function_nonser<void(void*)> const& ctor);
 
     template <typename Component_>
     friend naming::gid_type server::create(naming::gid_type const& gid,
-        util::function_nonser<void(void*)> const& ctor);
+        util::unique_function_nonser<void(void*)> const& ctor);
 
     // Return the component's fixed GID.
     naming::gid_type get_base_gid(

--- a/hpx/runtime/components/server/managed_component_base.hpp
+++ b/hpx/runtime/components/server/managed_component_base.hpp
@@ -15,6 +15,7 @@
 #include <hpx/runtime/components/server/wrapper_heap_list.hpp>
 #include <hpx/runtime/components/server/create_component_fwd.hpp>
 #include <hpx/util/reinitializable_static.hpp>
+#include <hpx/util/unique_function.hpp>
 
 #include <boost/throw_exception.hpp>
 #include <boost/noncopyable.hpp>
@@ -652,11 +653,11 @@ namespace hpx { namespace components
 
         template <typename Component_>
         friend naming::gid_type server::create(
-            util::function_nonser<void(void*)> const& ctor);
+            util::unique_function_nonser<void(void*)> const& ctor);
 
         template <typename Component_>
         friend naming::gid_type server::create(naming::gid_type const& gid,
-            util::function_nonser<void(void*)> const& ctor);
+            util::unique_function_nonser<void(void*)> const& ctor);
 #endif
 
         naming::gid_type get_base_gid(

--- a/hpx/runtime/components/server/simple_component_base.hpp
+++ b/hpx/runtime/components/server/simple_component_base.hpp
@@ -17,6 +17,7 @@
 #include <hpx/runtime/applier/applier.hpp>
 #include <hpx/runtime/applier/bind_naming_wrappers.hpp>
 #include <hpx/runtime/agas/interface.hpp>
+#include <hpx/util/unique_function.hpp>
 
 #include <boost/mpl/bool.hpp>
 #include <boost/type_traits/is_base_and_derived.hpp>
@@ -107,11 +108,11 @@ namespace hpx { namespace components
 
         template <typename Component_>
         friend naming::gid_type server::create(
-            util::function_nonser<void(void*)> const& ctor);
+            util::unique_function_nonser<void(void*)> const& ctor);
 
         template <typename Component_>
         friend naming::gid_type server::create(naming::gid_type const& gid,
-            util::function_nonser<void(void*)> const& ctor);
+            util::unique_function_nonser<void(void*)> const& ctor);
 
         // Create a new GID (if called for the first time), assign this
         // GID to this instance of a component and register this gid

--- a/hpx/runtime/threads/thread.hpp
+++ b/hpx/runtime/threads/thread.hpp
@@ -9,6 +9,7 @@
 #include <hpx/util/deferred_call.hpp>
 #include <hpx/util/date_time_chrono.hpp>
 #include <hpx/util/move.hpp>
+#include <hpx/util/unique_function.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 
 #include <boost/thread/locks.hpp>
@@ -102,9 +103,9 @@ namespace hpx
         {
             id_ = threads::invalid_thread_id;
         }
-        void start_thread(util::function_nonser<void()> && func);
+        void start_thread(util::unique_function_nonser<void()> && func);
         static threads::thread_state_enum thread_function_nullary(
-            util::function_nonser<void()> const& func);
+            util::unique_function_nonser<void()> const& func);
 
         mutable mutex_type mtx_;
         threads::thread_id_type id_;

--- a/hpx/runtime/threads/thread_helpers.hpp
+++ b/hpx/runtime/threads/thread_helpers.hpp
@@ -23,7 +23,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace threads
 {
-    struct thread_init_data;
+    class thread_init_data;
 
     namespace executors
     {

--- a/hpx/runtime/threads/thread_init_data.hpp
+++ b/hpx/runtime/threads/thread_init_data.hpp
@@ -18,8 +18,11 @@ namespace hpx { namespace threads
     HPX_API_EXPORT std::ptrdiff_t get_stack_size(thread_stacksize);
 
     ///////////////////////////////////////////////////////////////////////////
-    struct thread_init_data
+    class thread_init_data
     {
+        HPX_MOVABLE_BUT_NOT_COPYABLE(thread_init_data);
+
+    public:
         thread_init_data()
           : func(),
 #if defined(HPX_HAVE_THREAD_TARGET_ADDRESS)
@@ -102,11 +105,6 @@ namespace hpx { namespace threads
         naming::id_type target;
 
         policies::scheduler_base* scheduler_base;
-
-    private:
-        // we don't use the assignment operator
-        thread_init_data(thread_init_data const& rhs);
-        thread_init_data& operator=(thread_init_data const& rhs);
     };
 }}
 

--- a/hpx/runtime/threads/threadmanager.hpp
+++ b/hpx/runtime/threads/threadmanager.hpp
@@ -34,7 +34,7 @@ namespace hpx { namespace threads
     struct register_work_tag {};
     struct set_state_tag {};
 
-    struct thread_init_data;
+    class thread_init_data;
 
     ///////////////////////////////////////////////////////////////////////////
     struct threadmanager_base : private boost::noncopyable

--- a/hpx/traits/is_callable.hpp
+++ b/hpx/traits/is_callable.hpp
@@ -9,6 +9,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/util/always_void.hpp>
+#include <hpx/util/decay.hpp>
 #include <hpx/util/result_of.hpp>
 
 #include <boost/type_traits/integral_constant.hpp>
@@ -61,7 +62,8 @@ namespace hpx { namespace traits
         template <typename F, typename ...Ts>
         struct is_deferred_callable<F(Ts...)>
           : is_callable<
-                typename std::decay<F>::type(typename std::decay<Ts>::type...)
+                typename util::decay_unwrap<F>::type(
+                    typename util::decay_unwrap<Ts>::type...)
             >
         {};
     }

--- a/hpx/util/bind.hpp
+++ b/hpx/util/bind.hpp
@@ -297,7 +297,6 @@ namespace hpx { namespace util
             }
 
         private:
-        public: // because serialize_as_future
             typename std::decay<F>::type _f;
             util::tuple<typename std::decay<Ts>::type...> _args;
         };

--- a/hpx/util/bind.hpp
+++ b/hpx/util/bind.hpp
@@ -36,6 +36,9 @@ namespace hpx { namespace util
         {
             static std::size_t const value = I;
         };
+
+        template <>
+        struct placeholder<0>; // not a valid placeholder
     }
 
     namespace placeholders

--- a/hpx/util/bind.hpp
+++ b/hpx/util/bind.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011-2012 Thomas Heller
-//  Copyright (c) 2013 Agustin Berge
+//  Copyright (c) 2013-2015 Agustin Berge
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -7,7 +7,7 @@
 #ifndef HPX_UTIL_BIND_HPP
 #define HPX_UTIL_BIND_HPP
 
-#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/config.hpp>
 #include <hpx/traits/is_action.hpp>
 #include <hpx/traits/is_bind_expression.hpp>
 #include <hpx/traits/is_callable.hpp>
@@ -348,6 +348,12 @@ namespace hpx { namespace util
                 return util::invoke(_f, std::forward<Ts>(vs)...);
             }
 
+            template <typename Archive>
+            void serialize(Archive& ar, unsigned int const /*version*/)
+            {
+                ar & _f;
+            }
+
         public: // exposition-only
             F _f;
 #           if !defined(HPX_DISABLE_ASSERTS)
@@ -408,6 +414,13 @@ namespace hpx { namespace util
             {
                 return detail::bind_invoke(_f, _bound_args,
                     util::forward_as_tuple(std::forward<Us>(us)...));
+            }
+
+            template <typename Archive>
+            void serialize(Archive& ar, unsigned int const /*version*/)
+            {
+                ar & _f;
+                ar & _bound_args;
             }
 
         public: // exposition-only
@@ -492,60 +505,30 @@ namespace hpx { namespace traits
 namespace hpx { namespace serialization
 {
     // serialization of the bound object
-    template <typename F, typename BoundArgs>
+    template <typename Archive, typename F, typename BoundArgs>
     void serialize(
-        ::hpx::serialization::input_archive& ar
+        Archive& ar
       , ::hpx::util::detail::bound<F, BoundArgs>& bound
-      , unsigned int const /*version*/)
+      , unsigned int const version = 0)
     {
-        ar >> bound._f;
-        ar >> bound._bound_args;
+        bound.serialize(ar, version);
     }
 
-    template <typename F, typename BoundArgs>
+    template <typename Archive, typename F>
     void serialize(
-        ::hpx::serialization::output_archive& ar
-      , ::hpx::util::detail::bound<F, BoundArgs>& bound
-      , unsigned int const /*version*/)
-    {
-        ar << bound._f;
-        ar << bound._bound_args;
-    }
-
-    // serialization of the bound object
-    template <typename F>
-    void serialize(
-        ::hpx::serialization::input_archive& ar
+        Archive& ar
       , ::hpx::util::detail::one_shot_wrapper<F>& one_shot_wrapper
-      , unsigned int const /*version*/)
+      , unsigned int const version = 0)
     {
-        ar >> one_shot_wrapper._f;
-        ar >> one_shot_wrapper._called;
-    }
-
-    template <typename F>
-    void serialize(
-        ::hpx::serialization::output_archive& ar
-      , ::hpx::util::detail::one_shot_wrapper<F>& one_shot_wrapper
-      , unsigned int const /*version*/)
-    {
-        ar << one_shot_wrapper._f;
-        ar << one_shot_wrapper._called;
+        one_shot_wrapper.serialize(ar, version);
     }
 
     // serialization of placeholders is trivial, just provide empty functions
-    template <std::size_t I>
+    template <typename Archive, std::size_t I>
     void serialize(
-        ::hpx::serialization::input_archive& ar
-      , ::hpx::util::detail::placeholder<I>& bound
-      , unsigned int const /*version*/)
-    {}
-
-    template <std::size_t I>
-    void serialize(
-        ::hpx::serialization::output_archive& ar
-      , ::hpx::util::detail::placeholder<I>& bound
-      , unsigned int const /*version*/)
+        Archive& ar
+      , ::hpx::util::detail::placeholder<I>& /*placeholder*/
+      , unsigned int const /*version*/ = 0)
     {}
 }}
 

--- a/hpx/util/bind.hpp
+++ b/hpx/util/bind.hpp
@@ -180,6 +180,18 @@ namespace hpx { namespace util
             >
         {};
 
+        template <typename F, typename ...Ts, typename Us>
+        struct bound_result_of<
+            one_shot_wrapper<F> const, util::tuple<Ts...>, Us
+        >
+        {};
+
+        template <typename F, typename ...Ts, typename Us>
+        struct bound_result_of<
+            one_shot_wrapper<F> const, util::tuple<Ts...> const, Us
+        >
+        {};
+
         ///////////////////////////////////////////////////////////////////////
         template <typename F, typename Ts, typename Us, std::size_t ...Is>
         typename bound_result_of<F, Ts, Us>::type
@@ -238,7 +250,7 @@ namespace hpx { namespace util
 
             template <typename ...Us>
             inline typename bound_result_of<
-                typename std::decay<F>::type,
+                typename std::decay<F>::type const,
                 util::tuple<typename std::decay<Ts>::type const...>,
                 util::tuple<Us&&...>
             >::type operator()(Us&&... vs) const

--- a/hpx/util/deferred_call.hpp
+++ b/hpx/util/deferred_call.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014 Agustin Berge
+//  Copyright (c) 2014-2015 Agustin Berge
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,98 +6,97 @@
 #ifndef HPX_UTIL_DEFERRED_CALL_HPP
 #define HPX_UTIL_DEFERRED_CALL_HPP
 
-#include <hpx/runtime/serialization/serialize.hpp>
-#include <hpx/util/decay.hpp>
+#include <hpx/config.hpp>
+#include <hpx/traits/is_callable.hpp>
 #include <hpx/util/invoke_fused.hpp>
-#include <hpx/util/move.hpp>
-#include <hpx/util/result_of.hpp>
 #include <hpx/util/tuple.hpp>
 
-#include <boost/mpl/bool.hpp>
-#include <boost/mpl/identity.hpp>
-#include <boost/type_traits/remove_const.hpp>
-#include <boost/utility/enable_if.hpp>
+#include <boost/static_assert.hpp>
+
+#include <type_traits>
+#include <utility>
 
 namespace hpx { namespace util
 {
     ///////////////////////////////////////////////////////////////////////////
     namespace detail
     {
+        template <typename T>
+        struct deferred_result_of;
+
+        template <typename F, typename ...Ts>
+        struct deferred_result_of<F(Ts...)>
+          : util::result_of<
+                typename std::decay<F>::type(typename std::decay<Ts>::type...)
+            >
+        {};
+
         ///////////////////////////////////////////////////////////////////////
-        template <typename F, typename Args>
-        class deferred_call_impl //-V690
+        template <typename T>
+        class deferred;
+
+        template <typename F, typename ...Ts>
+        class deferred<F(Ts...)>
         {
         public:
-            // default constructor is needed for serialization
-            deferred_call_impl()
+            deferred() {} // needed for serialization
+
+            explicit deferred(F&& f, Ts&&... vs)
+              : _f(std::forward<F>(f))
+              , _args(std::forward<Ts>(vs)...)
             {}
 
-            template <typename F_, typename Args_>
-            explicit deferred_call_impl(
-                F_ && f
-              , Args_ && args
-            ) : _f(std::forward<F_>(f))
-              , _args(std::forward<Args_>(args))
-            {}
-
-            deferred_call_impl(deferred_call_impl const& other)
-              : _f(other._f)
-              , _args(other._args)
-            {}
-
-            deferred_call_impl(deferred_call_impl && other)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS)
+            deferred(deferred&&) = default;
+#else
+            deferred(deferred&& other)
               : _f(std::move(other._f))
               , _args(std::move(other._args))
             {}
+#endif
 
-            typedef
-                typename util::detail::fused_result_of<F(Args)>::type
-                result_type;
+#if defined(HPX_HAVE_CXX11_DELETED_FUNCTIONS)
+            deferred& operator=(deferred&&) = delete;
+#endif
 
-            BOOST_FORCEINLINE result_type operator()()
+            inline typename deferred_result_of<F(Ts...)>::type
+            operator()()
             {
-                return util::invoke_fused(
-                    std::move(_f), std::move(_args));
+                return util::invoke_fused(std::move(_f), std::move(_args));
             }
 
-        public: // exposition-only
-            F _f;
-            Args _args;
+            template <typename Archive>
+            void serialize(Archive& ar, unsigned int const /*version*/)
+            {
+                ar & _f;
+                ar & _args;
+            }
+
+        private:
+            typename std::decay<F>::type _f;
+            util::tuple<typename std::decay<Ts>::type...> _args;
         };
     }
 
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename F>
-    struct deferred_call_result_of
-    {};
-
     template <typename F, typename ...Ts>
-    struct deferred_call_result_of<F(Ts...)>
-      : util::result_of<typename util::decay<F>::type(
-            typename decay_unwrap<Ts>::type...)>
-    {};
-
-    template <typename F, typename ...Ts>
-    detail::deferred_call_impl<
-        typename util::decay<F>::type
-      , util::tuple<typename decay_unwrap<Ts>::type...>
-    >
-    deferred_call(F && f, Ts&&... vs)
+    inline detail::deferred<F(Ts&&...)>
+    deferred_call(F&& f, Ts&&... vs)
     {
-        typedef detail::deferred_call_impl<
-            typename util::decay<F>::type
-          , util::tuple<typename decay_unwrap<Ts>::type...>
-        > result_type;
+        BOOST_STATIC_ASSERT(
+            traits::detail::is_deferred_callable<F(Ts&&...)>::value);
 
-        return result_type(std::forward<F>(f),
-            util::forward_as_tuple(std::forward<Ts>(vs)...));
+        return detail::deferred<F(Ts&&...)>(
+            std::forward<F>(f), std::forward<Ts>(vs)...);
     }
 
     // nullary functions do not need to be bound again
     template <typename F>
-    typename util::decay<F>::type
-    deferred_call(F && f)
+    inline typename std::decay<F>::type
+    deferred_call(F&& f)
     {
+        BOOST_STATIC_ASSERT(
+            traits::detail::is_deferred_callable<F()>::value);
+
         return std::forward<F>(f);
     }
 }}
@@ -105,25 +104,16 @@ namespace hpx { namespace util
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace serialization
 {
-    // serialization of the deferred_call_impl object
-    template <typename F, typename Args>
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Archive, typename T>
+    BOOST_FORCEINLINE
     void serialize(
-        ::hpx::serialization::input_archive& ar
-      , ::hpx::util::detail::deferred_call_impl<F, Args>& deferred_call_impl
-      , unsigned int const /*version*/)
+        Archive& ar
+      , ::hpx::util::detail::deferred<T>& d
+      , unsigned int const version = 0
+    )
     {
-        ar >> deferred_call_impl._f;
-        ar >> deferred_call_impl._args;
-    }
-
-    template <typename F, typename Args>
-    void serialize(
-        ::hpx::serialization::output_archive& ar
-      , ::hpx::util::detail::deferred_call_impl<F, Args>& deferred_call_impl
-      , unsigned int const /*version*/)
-    {
-        ar << deferred_call_impl._f;
-        ar << deferred_call_impl._args;
+        d.serialize(ar, version);
     }
 }}
 

--- a/hpx/util/deferred_call.hpp
+++ b/hpx/util/deferred_call.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/traits/is_callable.hpp>
+#include <hpx/util/decay.hpp>
 #include <hpx/util/invoke_fused.hpp>
 #include <hpx/util/tuple.hpp>
 
@@ -27,7 +28,8 @@ namespace hpx { namespace util
         template <typename F, typename ...Ts>
         struct deferred_result_of<F(Ts...)>
           : util::result_of<
-                typename std::decay<F>::type(typename std::decay<Ts>::type...)
+                typename util::decay_unwrap<F>::type(
+                    typename util::decay_unwrap<Ts>::type...)
             >
         {};
 
@@ -73,8 +75,8 @@ namespace hpx { namespace util
             }
 
         private:
-            typename std::decay<F>::type _f;
-            util::tuple<typename std::decay<Ts>::type...> _args;
+            typename util::decay_unwrap<F>::type _f;
+            util::tuple<typename util::decay_unwrap<Ts>::type...> _args;
         };
     }
 

--- a/hpx/util/mem_fn.hpp
+++ b/hpx/util/mem_fn.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2013 Agustin Berge
+//  Copyright (c) 2013-2015 Agustin Berge
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -8,64 +8,56 @@
 
 #include <hpx/config.hpp>
 #include <hpx/util/invoke.hpp>
-#include <hpx/util/move.hpp>
 #include <hpx/util/result_of.hpp>
-
-#include <boost/type_traits/is_member_pointer.hpp>
 
 #include <utility>
 
 namespace hpx { namespace util
 {
+    ///////////////////////////////////////////////////////////////////////////
     namespace detail
     {
-        ///////////////////////////////////////////////////////////////////////
-        template <typename MemPtr>
+        template <typename MemberPointer>
         struct mem_fn
         {
-            explicit mem_fn(MemPtr mem_ptr)
-              : f(mem_ptr)
+            explicit mem_fn(MemberPointer pm)
+              : _pm(pm)
             {}
 
             mem_fn(mem_fn const& other)
-              : f(other.f)
+              : _pm(other._pm)
             {}
 
-            mem_fn& operator=(mem_fn const& other)
+            template <typename ...Ts>
+            inline typename util::result_of<MemberPointer(Ts&&...)>::type
+            operator()(Ts&&... vs) const
             {
-                f = other.f;
-                return *this;
+                return util::invoke(_pm, std::forward<Ts>(vs)...);
             }
 
-            template <typename>
-            struct result;
-
-            template <typename This, typename ...Ts>
-            struct result<This(Ts...)>
-              : util::result_of<MemPtr(Ts...)>
-            {};
-
-            template <typename T, typename ...Ts>
-            BOOST_FORCEINLINE
-            typename result<mem_fn const(T, Ts...)>::type
-            operator()(T&& t, Ts&&... vs) const
-            {
-                return util::invoke(
-                    f, std::forward<T>(t), std::forward<Ts>(vs)...);
-            }
-
-            MemPtr f;
+            MemberPointer _pm;
         };
     }
 
-    template <typename MemPtr>
-    detail::mem_fn<MemPtr> mem_fn(MemPtr pm)
+    template <typename M, typename C>
+    inline detail::mem_fn<M C::*>
+    mem_fn(M C::*pm)
     {
-        static_assert(
-            boost::is_member_pointer<MemPtr>::value,
-            "boost::is_member_pointer<MemPtr>::value");
+        return detail::mem_fn<M C::*>(pm);
+    }
 
-        return detail::mem_fn<MemPtr>(pm);
+    template <typename R, typename C, typename ...Ps>
+    inline detail::mem_fn<R (C::*)(Ps...)>
+    mem_fn(R (C::*pm)(Ps...))
+    {
+        return detail::mem_fn<R (C::*)(Ps...)>(pm);
+    }
+
+    template <typename R, typename C, typename ...Ps>
+    inline detail::mem_fn<R (C::*)(Ps...) const>
+    mem_fn(R (C::*pm)(Ps...) const)
+    {
+        return detail::mem_fn<R (C::*)(Ps...) const>(pm);
     }
 }}
 

--- a/hpx/util/tuple.hpp
+++ b/hpx/util/tuple.hpp
@@ -68,6 +68,10 @@ namespace hpx { namespace util
               : _value(std::forward<U>(value))
             {}
 
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS)
+            tuple_member(tuple_member const&) = default;
+            tuple_member(tuple_member&&) = default;
+#else
             BOOST_CONSTEXPR tuple_member(tuple_member const& other)
               : _value(other.value())
             {}
@@ -75,6 +79,7 @@ namespace hpx { namespace util
             BOOST_CONSTEXPR tuple_member(tuple_member&& other)
               : _value(std::forward<T>(other.value()))
             {}
+#endif
 
             T& value() BOOST_NOEXCEPT { return _value; }
             T const& value() const BOOST_NOEXCEPT { return _value; }
@@ -103,6 +108,10 @@ namespace hpx { namespace util
               : T(std::forward<U>(value))
             {}
 
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS)
+            tuple_member(tuple_member const&) = default;
+            tuple_member(tuple_member&&) = default;
+#else
             BOOST_CONSTEXPR tuple_member(tuple_member const& other)
               : T(other.value())
             {}
@@ -110,6 +119,7 @@ namespace hpx { namespace util
             BOOST_CONSTEXPR tuple_member(tuple_member&& other)
               : T(std::forward<T>(other.value()))
             {}
+#endif
 
             T& value() BOOST_NOEXCEPT { return *this; }
             T const& value() const BOOST_NOEXCEPT { return *this; }
@@ -189,6 +199,10 @@ namespace hpx { namespace util
               : tuple_member<Is, Ts>(std::forward<Us>(vs))...
             {}
 
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS)
+            tuple_impl(tuple_impl const&) = default;
+            tuple_impl(tuple_impl&&) = default;
+#else
             BOOST_CONSTEXPR tuple_impl(tuple_impl const& other)
               : tuple_member<Is, Ts>(static_cast<tuple_member<Is, Ts> const&>(other))...
             {}
@@ -196,6 +210,7 @@ namespace hpx { namespace util
             BOOST_CONSTEXPR tuple_impl(tuple_impl&& other)
               : tuple_member<Is, Ts>(static_cast<tuple_member<Is, Ts>&&>(other))...
             {}
+#endif
 
             template <typename UTuple, typename Enable =
                 typename std::enable_if<
@@ -376,6 +391,17 @@ namespace hpx { namespace util
           : _impl(std::forward<U>(v), std::forward<Us>(vs)...)
         {}
 
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS)
+        // tuple(const tuple& u) = default;
+        // Initializes each element of *this with the corresponding element
+        // of u.
+        tuple(tuple const&) = default;
+
+        // tuple(tuple&& u) = default;
+        // For all i, initializes the ith element of *this with
+        // std::forward<Ti>(get<i>(u)).
+        tuple(tuple&&) = default;
+#else
         // tuple(const tuple& u) = default;
         // Initializes each element of *this with the corresponding element
         // of u.
@@ -389,6 +415,7 @@ namespace hpx { namespace util
         BOOST_CONSTEXPR tuple(tuple&& other)
           : _impl(std::move(other._impl))
         {}
+#endif
 
         // template <class... UTypes> constexpr tuple(const tuple<UTypes...>& u);
         // template <class... UTypes> constexpr tuple(tuple<UTypes...>&& u);

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -348,7 +348,7 @@ namespace hpx { namespace parcelset
 
     namespace detail
     {
-        void parcel_sent_handler(parcelhandler::write_handler_type && f,
+        void parcel_sent_handler(parcelhandler::write_handler_type & f,
             boost::system::error_code const & ec, parcel const & p)
         {
             // inform termination detection of a sent message
@@ -428,8 +428,7 @@ namespace hpx { namespace parcelset
         using util::placeholders::_1;
         using util::placeholders::_2;
         write_handler_type wrapped_f =
-            util::bind(util::one_shot(&detail::parcel_sent_handler),
-                std::move(f), _1, _2);
+            util::bind(&detail::parcel_sent_handler, std::move(f), _1, _2);
 
         // If we were able to resolve the address(es) locally we send the
         // parcel directly to the destination.

--- a/src/runtime/threads/thread.cpp
+++ b/src/runtime/threads/thread.cpp
@@ -96,7 +96,7 @@ namespace hpx
     }
 
     threads::thread_state_enum thread::thread_function_nullary(
-        util::function_nonser<void()> const& func)
+        util::unique_function_nonser<void()> const& func)
     {
         try {
             // Now notify our calling thread that we started execution.
@@ -137,7 +137,7 @@ namespace hpx
         return hpx::threads::hardware_concurrency();
     }
 
-    void thread::start_thread(util::function_nonser<void()> && func)
+    void thread::start_thread(util::unique_function_nonser<void()> && func)
     {
         threads::thread_init_data data(
             util::bind(util::one_shot(&thread::thread_function_nullary),


### PR DESCRIPTION
Rework `bind`, `mem_fn`, `deferred_call` implementations for readability.

Copiability requirements are enforced after these changes. In particular, movable-only `bind` objects are now movable-only instead of fake-copyable.