### PR TITLE
Simplify functions

### DIFF
--- a/cmake/tests/cxx11_std_type_traits.cpp
+++ b/cmake/tests/cxx11_std_type_traits.cpp
@@ -9,6 +9,8 @@
 
 struct callable
 {
+    callable() {}
+    explicit callable(int) {}
     int operator()(){ return 0; }
 };
 
@@ -21,4 +23,5 @@ int main()
     decay<int const&>::type* d = &x;
     result_of<callable()>::type* ro = &x;
     is_convertible<int, long>::type ic;
+    is_constructible<callable, int>::type icc;
 }

--- a/hpx/util/detail/basic_function.hpp
+++ b/hpx/util/detail/basic_function.hpp
@@ -9,19 +9,25 @@
 #define HPX_UTIL_DETAIL_BASIC_FUNCTION_HPP
 
 #include <hpx/config.hpp>
+#include <hpx/runtime/serialization/access.hpp>
+#include <hpx/runtime/serialization/serialize.hpp>
 #include <hpx/traits/is_callable.hpp>
 #include <hpx/util/detail/empty_function.hpp>
+#include <hpx/util/detail/function_registration.hpp>
 #include <hpx/util/detail/get_table.hpp>
 #include <hpx/util/detail/vtable/vtable.hpp>
+#include <hpx/util/detail/vtable/serializable_vtable.hpp>
 #include <hpx/util/decay.hpp>
 #include <hpx/util/move.hpp>
 #include <hpx/util/safe_bool.hpp>
 
 #include <boost/mpl/bool.hpp>
+#include <boost/mpl/identity.hpp>
 #include <boost/type_traits/is_pointer.hpp>
 #include <boost/type_traits/is_member_pointer.hpp>
 
 #include <typeinfo>
+#include <utility>
 
 namespace hpx { namespace util { namespace detail
 {
@@ -47,6 +53,60 @@ namespace hpx { namespace util { namespace detail
         > is_pointer;
         return is_empty_function(f, is_pointer);
     }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Function>
+    struct init_registration;
+
+    template <typename VTablePtr, typename IAr, typename OAr>
+    struct serializable_function_vtable_ptr
+      : VTablePtr
+    {
+        char const* name;
+        typename serializable_vtable<IAr, OAr>::save_object_t save_object;
+        typename serializable_vtable<IAr, OAr>::load_object_t load_object;
+
+        template <typename T>
+        serializable_function_vtable_ptr(boost::mpl::identity<T>) BOOST_NOEXCEPT
+          : VTablePtr(boost::mpl::identity<T>())
+          , name("empty")
+          , save_object(&serializable_vtable<IAr, OAr>::template save_object<T>)
+          , load_object(&serializable_vtable<IAr, OAr>::template load_object<T>)
+        {
+            if (!this->empty)
+            {
+                name = get_function_name<std::pair<
+                        serializable_function_vtable_ptr, T
+                       > >();
+            }
+            init_registration<std::pair<
+                serializable_function_vtable_ptr, T
+            > >::g.register_function();
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    // registration code for serialization
+    template <typename VTablePtr, typename IAr, typename OAr, typename T>
+    struct init_registration<
+        std::pair<serializable_function_vtable_ptr<VTablePtr, IAr, OAr>, T>
+    >
+    {
+        typedef std::pair<
+            serializable_function_vtable_ptr<VTablePtr, IAr, OAr>, T
+        > vtable_ptr;
+
+        static automatic_function_registration<vtable_ptr> g;
+    };
+
+    template <typename VTablePtr, typename IAr, typename OAr, typename T>
+    automatic_function_registration<
+        std::pair<serializable_function_vtable_ptr<VTablePtr, IAr, OAr>, T>
+    > init_registration<
+        std::pair<serializable_function_vtable_ptr<VTablePtr, IAr, OAr>, T>
+    >::g =  automatic_function_registration<
+                std::pair<serializable_function_vtable_ptr<VTablePtr, IAr, OAr>, T>
+            >();
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename VTablePtr, typename Sig>
@@ -185,11 +245,105 @@ namespace hpx { namespace util { namespace detail
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename VTablePtr, typename Sig>
+    template <typename VTablePtr, typename Sig, typename IAr, typename OAr>
     class basic_function;
 
+    template <
+        typename VTablePtr, typename R, typename ...Ts
+      , typename IAr, typename OAr
+    >
+    class basic_function<VTablePtr, R(Ts...), IAr, OAr>
+      : public function_base<
+            serializable_function_vtable_ptr<VTablePtr, IAr, OAr>
+          , R(Ts...)
+        >
+    {
+        HPX_MOVABLE_BUT_NOT_COPYABLE(basic_function);
+
+        typedef serializable_function_vtable_ptr<VTablePtr, IAr, OAr> vtable_ptr;
+        typedef function_base<vtable_ptr, R(Ts...)> base_type;
+
+    public:
+        typedef R result_type;
+
+        basic_function() BOOST_NOEXCEPT
+          : base_type()
+        {}
+
+        basic_function(basic_function&& other) BOOST_NOEXCEPT
+          : base_type(static_cast<base_type&&>(other))
+        {}
+
+        basic_function& operator=(basic_function&& other) BOOST_NOEXCEPT
+        {
+            base_type::operator=(static_cast<base_type&&>(other));
+            return *this;
+        }
+
+        BOOST_FORCEINLINE R operator()(Ts... vs) const
+        {
+            return this->vptr->invoke(&this->object, std::forward<Ts>(vs)...);
+        }
+
+        template <typename T>
+        T* target() BOOST_NOEXCEPT
+        {
+            BOOST_STATIC_ASSERT_MSG(
+                (traits::is_callable<T(Ts...), R>::value)
+              , "T shall be Callable with the function signature"
+            );
+
+            return base_type::template target<T>();
+        }
+
+        template <typename T>
+        T* target() const BOOST_NOEXCEPT
+        {
+            BOOST_STATIC_ASSERT_MSG(
+                (traits::is_callable<T(Ts...), R>::value)
+              , "T shall be Callable with the function signature"
+            );
+
+            return base_type::template target<T>();
+        }
+
+    private:
+        friend class hpx::serialization::access;
+
+        void load(IAr& ar, const unsigned version)
+        {
+            this->reset();
+
+            bool is_empty = false;
+            ar >> is_empty;
+            if (!is_empty)
+            {
+                std::string name;
+                ar >> name;
+
+                this->vptr = detail::get_table_ptr<vtable_ptr>(name);
+                this->vptr->load_object(&this->object, ar, version);
+            }
+        }
+
+        void save(OAr& ar, const unsigned version) const
+        {
+            bool is_empty = this->empty();
+            ar << is_empty;
+            if (!is_empty)
+            {
+                std::string function_name = this->vptr->name;
+                ar << function_name;
+
+                this->vptr->save_object(&this->object, ar, version);
+            }
+        }
+
+        HPX_SERIALIZATION_SPLIT_MEMBER()
+    };
+
     template <typename VTablePtr, typename R, typename ...Ts>
-    class basic_function<VTablePtr, R(Ts...)>
+    class basic_function<VTablePtr, R(Ts...), void, void>
       : public function_base<VTablePtr, R(Ts...)>
     {
         HPX_MOVABLE_BUT_NOT_COPYABLE(basic_function);
@@ -241,11 +395,55 @@ namespace hpx { namespace util { namespace detail
         }
     };
 
-    template <typename Sig, typename VTablePtr>
-    static bool is_empty_function(basic_function<VTablePtr, Sig> const& f) BOOST_NOEXCEPT
+    template <typename Sig, typename VTablePtr, typename IAr, typename OAr>
+    static bool is_empty_function(
+        basic_function<VTablePtr, Sig, IAr, OAr> const& f) BOOST_NOEXCEPT
     {
         return f.empty();
     }
 }}}
+
+// Pseudo registration for empty functions.
+// We don't want to serialize empty functions.
+namespace hpx { namespace util { namespace detail
+{
+    template <typename VTablePtr, typename Sig>
+    struct get_function_name_impl<
+        std::pair<
+            hpx::util::detail::serializable_function_vtable_ptr<
+                VTablePtr
+              , hpx::serialization::input_archive
+              , hpx::serialization::output_archive
+            >
+          , hpx::util::detail::empty_function<Sig>
+        >
+    >
+    {
+        static char const * call()
+        {
+            hpx::throw_exception(bad_function_call,
+                "empty function object should not be used",
+                "get_function_name<empty_function>");
+            return "";
+        }
+    };
+}}}
+
+namespace hpx { namespace traits
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename VTablePtr, typename Sig>
+    struct needs_automatic_registration<
+        std::pair<
+            hpx::util::detail::serializable_function_vtable_ptr<
+                VTablePtr
+              , hpx::serialization::input_archive
+              , hpx::serialization::output_archive
+            >
+          , hpx::util::detail::empty_function<Sig>
+        >
+    > : boost::mpl::false_
+    {};
+}}
 
 #endif

--- a/hpx/util/detail/basic_function.hpp
+++ b/hpx/util/detail/basic_function.hpp
@@ -17,15 +17,13 @@
 #include <hpx/util/detail/get_table.hpp>
 #include <hpx/util/detail/vtable/vtable.hpp>
 #include <hpx/util/detail/vtable/serializable_vtable.hpp>
-#include <hpx/util/decay.hpp>
 #include <hpx/util/move.hpp>
 #include <hpx/util/safe_bool.hpp>
 
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/identity.hpp>
-#include <boost/type_traits/is_pointer.hpp>
-#include <boost/type_traits/is_member_pointer.hpp>
 
+#include <type_traits>
 #include <typeinfo>
 #include <utility>
 
@@ -33,13 +31,13 @@ namespace hpx { namespace util { namespace detail
 {
     ///////////////////////////////////////////////////////////////////////////
     template <typename F>
-    static bool is_empty_function(F const&, boost::mpl::false_) BOOST_NOEXCEPT
+    static bool is_empty_function(F const&, std::false_type) BOOST_NOEXCEPT
     {
         return false;
     }
 
     template <typename F>
-    static bool is_empty_function(F const& f, boost::mpl::true_) BOOST_NOEXCEPT
+    static bool is_empty_function(F const& f, std::true_type) BOOST_NOEXCEPT
     {
         return f == 0;
     }
@@ -47,9 +45,9 @@ namespace hpx { namespace util { namespace detail
     template <typename F>
     static bool is_empty_function(F const& f) BOOST_NOEXCEPT
     {
-        boost::mpl::bool_<
-            boost::is_pointer<F>::value
-         || boost::is_member_pointer<F>::value
+        std::integral_constant<bool,
+            std::is_pointer<F>::value
+         || std::is_member_pointer<F>::value
         > is_pointer;
         return is_empty_function(f, is_pointer);
     }
@@ -152,7 +150,7 @@ namespace hpx { namespace util { namespace detail
         {
             if (!is_empty_function(f))
             {
-                typedef typename util::decay<F>::type target_type;
+                typedef typename std::decay<F>::type target_type;
 
                 VTablePtr const* f_vptr = get_table_ptr<target_type>();
                 if (vptr == f_vptr)
@@ -213,7 +211,7 @@ namespace hpx { namespace util { namespace detail
         template <typename T>
         T* target() const BOOST_NOEXCEPT
         {
-            typedef typename util::decay<T>::type target_type;
+            typedef typename std::decay<T>::type target_type;
 
             VTablePtr const* f_vptr = get_table_ptr<target_type>();
             if (vptr != f_vptr || empty())

--- a/hpx/util/detail/basic_function.hpp
+++ b/hpx/util/detail/basic_function.hpp
@@ -21,7 +21,6 @@
 #include <hpx/util/safe_bool.hpp>
 
 #include <boost/mpl/bool.hpp>
-#include <boost/mpl/identity.hpp>
 
 #include <type_traits>
 #include <typeinfo>
@@ -65,8 +64,8 @@ namespace hpx { namespace util { namespace detail
         typename serializable_vtable<IAr, OAr>::load_object_t load_object;
 
         template <typename T>
-        serializable_function_vtable_ptr(boost::mpl::identity<T>) BOOST_NOEXCEPT
-          : VTablePtr(boost::mpl::identity<T>())
+        serializable_function_vtable_ptr(construct_vtable<T>) BOOST_NOEXCEPT
+          : VTablePtr(construct_vtable<T>())
           , name("empty")
           , save_object(&serializable_vtable<IAr, OAr>::template save_object<T>)
           , load_object(&serializable_vtable<IAr, OAr>::template load_object<T>)
@@ -234,7 +233,7 @@ namespace hpx { namespace util { namespace detail
 
     template <typename VTablePtr, typename Sig>
     VTablePtr const function_base<VTablePtr, Sig>::empty_table =
-        boost::mpl::identity<detail::empty_function<Sig> >();
+        detail::construct_vtable<detail::empty_function<Sig> >();
 
     template <typename Sig, typename VTablePtr>
     static bool is_empty_function(function_base<VTablePtr, Sig> const& f) BOOST_NOEXCEPT

--- a/hpx/util/detail/basic_function.hpp
+++ b/hpx/util/detail/basic_function.hpp
@@ -55,6 +55,9 @@ namespace hpx { namespace util { namespace detail
     template <typename Function>
     struct init_registration;
 
+    template <typename VTablePtr, typename IAr, typename OAr, typename T>
+    struct serializable_function_registration;
+
     template <typename VTablePtr, typename IAr, typename OAr>
     struct serializable_function_vtable_ptr
       : VTablePtr
@@ -72,37 +75,42 @@ namespace hpx { namespace util { namespace detail
         {
             if (!this->empty)
             {
-                name = get_function_name<std::pair<
-                        serializable_function_vtable_ptr, T
-                       > >();
+                name = get_function_name<
+                    serializable_function_registration<VTablePtr, IAr, OAr, T>
+                >();
             }
-            init_registration<std::pair<
-                serializable_function_vtable_ptr, T
-            > >::g.register_function();
+            init_registration<
+                serializable_function_registration<VTablePtr, IAr, OAr, T>
+            >::g.register_function();
         }
+    };
+
+    template <typename VTablePtr, typename IAr, typename OAr, typename T>
+    struct serializable_function_registration
+    {
+        typedef serializable_function_vtable_ptr<VTablePtr, IAr, OAr> first_type;
+        typedef T second_type;
     };
 
     ///////////////////////////////////////////////////////////////////////////
     // registration code for serialization
     template <typename VTablePtr, typename IAr, typename OAr, typename T>
     struct init_registration<
-        std::pair<serializable_function_vtable_ptr<VTablePtr, IAr, OAr>, T>
+        serializable_function_registration<VTablePtr, IAr, OAr, T>
     >
     {
-        typedef std::pair<
-            serializable_function_vtable_ptr<VTablePtr, IAr, OAr>, T
-        > vtable_ptr;
-
-        static automatic_function_registration<vtable_ptr> g;
+        static automatic_function_registration<
+            serializable_function_registration<VTablePtr, IAr, OAr, T>
+        > g;
     };
 
     template <typename VTablePtr, typename IAr, typename OAr, typename T>
     automatic_function_registration<
-        std::pair<serializable_function_vtable_ptr<VTablePtr, IAr, OAr>, T>
+        serializable_function_registration<VTablePtr, IAr, OAr, T>
     > init_registration<
-        std::pair<serializable_function_vtable_ptr<VTablePtr, IAr, OAr>, T>
+        serializable_function_registration<VTablePtr, IAr, OAr, T>
     >::g =  automatic_function_registration<
-                std::pair<serializable_function_vtable_ptr<VTablePtr, IAr, OAr>, T>
+                serializable_function_registration<VTablePtr, IAr, OAr, T>
             >();
 
     ///////////////////////////////////////////////////////////////////////////
@@ -406,12 +414,10 @@ namespace hpx { namespace util { namespace detail
 {
     template <typename VTablePtr, typename Sig>
     struct get_function_name_impl<
-        std::pair<
-            hpx::util::detail::serializable_function_vtable_ptr<
-                VTablePtr
-              , hpx::serialization::input_archive
-              , hpx::serialization::output_archive
-            >
+        hpx::util::detail::serializable_function_registration<
+            VTablePtr
+          , hpx::serialization::input_archive
+          , hpx::serialization::output_archive
           , hpx::util::detail::empty_function<Sig>
         >
     >
@@ -431,12 +437,10 @@ namespace hpx { namespace traits
     ///////////////////////////////////////////////////////////////////////////
     template <typename VTablePtr, typename Sig>
     struct needs_automatic_registration<
-        std::pair<
-            hpx::util::detail::serializable_function_vtable_ptr<
-                VTablePtr
-              , hpx::serialization::input_archive
-              , hpx::serialization::output_archive
-            >
+        hpx::util::detail::serializable_function_registration<
+            VTablePtr
+          , hpx::serialization::input_archive
+          , hpx::serialization::output_archive
           , hpx::util::detail::empty_function<Sig>
         >
     > : boost::mpl::false_

--- a/hpx/util/detail/function_registration.hpp
+++ b/hpx/util/detail/function_registration.hpp
@@ -13,10 +13,11 @@
 #include <hpx/runtime/serialization/detail/polymorphic_intrusive_factory.hpp>
 #include <hpx/traits/needs_automatic_registration.hpp>
 #include <hpx/util/demangle_helper.hpp>
-#include <hpx/util/tuple.hpp>
 
 #include <boost/mpl/bool.hpp>
 #include <boost/smart_ptr/shared_ptr.hpp>
+
+#include <utility>
 
 namespace hpx { namespace util { namespace detail
 {
@@ -80,7 +81,7 @@ namespace hpx { namespace util { namespace detail
         {
             hpx::serialization::detail::polymorphic_intrusive_factory::instance().
                 register_class(
-                    detail::get_function_name<util::tuple<VTable, T> >()
+                    detail::get_function_name<std::pair<VTable, T> >()
                   , &function_registration::create
                 );
         }
@@ -108,8 +109,8 @@ namespace hpx { namespace util { namespace detail
         automatic_function_registration()
         {
             function_registration<
-                typename util::tuple_element<0, VTablePair>::type
-              , typename util::tuple_element<1, VTablePair>::type
+                typename VTablePair::first_type,
+                typename VTablePair::second_type
             > auto_register;
         }
 

--- a/hpx/util/detail/function_registration.hpp
+++ b/hpx/util/detail/function_registration.hpp
@@ -66,14 +66,17 @@ namespace hpx { namespace util { namespace detail
         }
     };
 
-    template <typename VTable, typename T>
+    template <typename VTablePair>
     struct function_registration
     {
         typedef function_registration_info_base base_type;
 
         static void * create()
         {
-            static function_registration_info<VTable, T> ri;
+            static function_registration_info<
+                typename VTablePair::first_type,
+                typename VTablePair::second_type
+            > ri;
             return &ri;
         }
 
@@ -81,7 +84,7 @@ namespace hpx { namespace util { namespace detail
         {
             hpx::serialization::detail::polymorphic_intrusive_factory::instance().
                 register_class(
-                    detail::get_function_name<std::pair<VTable, T> >()
+                    detail::get_function_name<VTablePair>()
                   , &function_registration::create
                 );
         }
@@ -108,10 +111,7 @@ namespace hpx { namespace util { namespace detail
     {
         automatic_function_registration()
         {
-            function_registration<
-                typename VTablePair::first_type,
-                typename VTablePair::second_type
-            > auto_register;
+            function_registration<VTablePair> auto_register;
         }
 
         automatic_function_registration& register_function()

--- a/hpx/util/detail/function_template.hpp
+++ b/hpx/util/detail/function_template.hpp
@@ -109,7 +109,7 @@ namespace hpx { namespace util
           : base_type()
         {
             static_assert(
-                std::is_copy_constructible<FD>::value,
+                std::is_constructible<FD, FD const&>::value,
                 "F shall be CopyConstructible");
             assign(std::forward<F>(f));
         }
@@ -146,7 +146,7 @@ namespace hpx { namespace util
         function& operator=(F&& f)
         {
             static_assert(
-                std::is_copy_constructible<FD>::value,
+                std::is_constructible<FD, FD const&>::value,
                 "F shall be CopyConstructible");
             assign(std::forward<F>(f));
             return *this;

--- a/hpx/util/detail/function_template.hpp
+++ b/hpx/util/detail/function_template.hpp
@@ -15,8 +15,6 @@
 #include <hpx/util/detail/vtable/copyable_vtable.hpp>
 #include <hpx/util/detail/vtable/vtable.hpp>
 
-#include <boost/mpl/identity.hpp>
-
 #include <type_traits>
 #include <utility>
 
@@ -34,7 +32,7 @@ namespace hpx { namespace util { namespace detail
         bool empty;
 
         template <typename T>
-        function_vtable_ptr(boost::mpl::identity<T>) BOOST_NOEXCEPT
+        function_vtable_ptr(construct_vtable<T>) BOOST_NOEXCEPT
           : invoke(&callable_vtable<Sig>::template invoke<T>)
           , copy(&copyable_vtable::template copy<T>)
           , get_type(&vtable::template get_type<T>)

--- a/hpx/util/detail/function_template.hpp
+++ b/hpx/util/detail/function_template.hpp
@@ -157,6 +157,9 @@ namespace hpx { namespace util
         function(F&& f)
           : base_type()
         {
+            static_assert(
+                std::is_copy_constructible<typename decay<F>::type>::value,
+                "F shall be CopyConstructible");
             assign(std::forward<F>(f));
         }
 
@@ -188,6 +191,9 @@ namespace hpx { namespace util
             >::type>
         function& operator=(F&& f)
         {
+            static_assert(
+                std::is_copy_constructible<typename decay<F>::type>::value,
+                "F shall be CopyConstructible");
             assign(std::forward<F>(f));
             return *this;
         }
@@ -275,6 +281,9 @@ namespace hpx { namespace util
         function(F&& f)
           : base_type()
         {
+            static_assert(
+                std::is_copy_constructible<typename decay<F>::type>::value,
+                "F shall be CopyConstructible");
             assign(std::forward<F>(f));
         }
 
@@ -306,6 +315,9 @@ namespace hpx { namespace util
             >::type>
         function& operator=(F&& f)
         {
+            static_assert(
+                std::is_copy_constructible<typename decay<F>::type>::value,
+                "F shall be CopyConstructible");
             assign(std::forward<F>(f));
             return *this;
         }

--- a/hpx/util/detail/function_template.hpp
+++ b/hpx/util/detail/function_template.hpp
@@ -58,22 +58,18 @@ namespace hpx { namespace util { namespace detail
 namespace hpx { namespace util
 {
     ///////////////////////////////////////////////////////////////////////////
-    template <
-        typename Sig
-      , typename IAr = serialization::input_archive
-      , typename OAr = serialization::output_archive
-    >
+    template <typename Sig, bool Serializable = true>
     class function;
 
-    template <typename R, typename ...Ts, typename IAr, typename OAr>
-    class function<R(Ts...), IAr, OAr>
+    template <typename R, typename ...Ts, bool Serializable>
+    class function<R(Ts...), Serializable>
       : public detail::basic_function<
             detail::function_vtable_ptr<R(Ts...)>
-          , R(Ts...), IAr, OAr
+          , R(Ts...), Serializable
         >
     {
         typedef detail::function_vtable_ptr<R(Ts...)> vtable_ptr;
-        typedef detail::basic_function<vtable_ptr, R(Ts...), IAr, OAr> base_type;
+        typedef detail::basic_function<vtable_ptr, R(Ts...), Serializable> base_type;
 
     public:
         typedef typename base_type::result_type result_type;
@@ -160,9 +156,9 @@ namespace hpx { namespace util
         using base_type::target;
     };
 
-    template <typename Sig, typename IAr, typename OAr>
-    static bool is_empty_function(function<Sig, IAr,
-        OAr> const& f) BOOST_NOEXCEPT
+    template <typename Sig, bool Serializable>
+    static bool is_empty_function(
+        function<Sig, Serializable> const& f) BOOST_NOEXCEPT
     {
         return f.empty();
     }
@@ -171,7 +167,7 @@ namespace hpx { namespace util
 #   ifdef HPX_HAVE_CXX11_ALIAS_TEMPLATES
 
     template <typename Sig>
-    using function_nonser = function<Sig, void, void>;
+    using function_nonser = function<Sig, false>;
 
 #   else
 
@@ -180,9 +176,9 @@ namespace hpx { namespace util
 
     template <typename R, typename ...Ts>
     class function_nonser<R(Ts...)>
-      : public function<R(Ts...), void, void>
+      : public function<R(Ts...), false>
     {
-        typedef function<R(Ts...), void, void> base_type;
+        typedef function<R(Ts...), false> base_type;
 
     public:
         function_nonser() BOOST_NOEXCEPT
@@ -231,7 +227,8 @@ namespace hpx { namespace util
     };
 
     template <typename Sig>
-    static bool is_empty_function(function_nonser<Sig> const& f) BOOST_NOEXCEPT
+    static bool is_empty_function(
+        function_nonser<Sig> const& f) BOOST_NOEXCEPT
     {
         return f.empty();
     }

--- a/hpx/util/detail/function_template.hpp
+++ b/hpx/util/detail/function_template.hpp
@@ -18,9 +18,9 @@
 #include <hpx/util/detail/vtable/serializable_vtable.hpp>
 #include <hpx/util/detail/vtable/vtable.hpp>
 
-#include <boost/type_traits/is_same.hpp>
-#include <boost/utility/enable_if.hpp>
+#include <boost/mpl/identity.hpp>
 
+#include <type_traits>
 #include <utility>
 
 namespace hpx { namespace util { namespace detail
@@ -49,7 +49,7 @@ namespace hpx { namespace util { namespace detail
           , get_type(&vtable::template get_type<T>)
           , destruct(&vtable::template destruct<T>)
           , delete_(&vtable::template delete_<T>)
-          , empty(boost::is_same<T, empty_function<Sig> >::value)
+          , empty(std::is_same<T, empty_function<Sig> >::value)
         {}
 
         template <typename T, typename Arg>
@@ -150,12 +150,12 @@ namespace hpx { namespace util
           : base_type(static_cast<base_type&&>(other))
         {}
 
-        template <typename F>
-        function(F&& f,
-            typename boost::disable_if<
-                boost::is_same<function, typename util::decay<F>::type>
-            >::type* = 0
-        ) : base_type()
+        template <typename F, typename Enable =
+            typename std::enable_if<
+                !std::is_same<F, function>::value
+            >::type>
+        function(F&& f)
+          : base_type()
         {
             assign(std::forward<F>(f));
         }
@@ -182,11 +182,11 @@ namespace hpx { namespace util
             return *this;
         }
 
-        template <typename F>
-        typename boost::disable_if<
-            boost::is_same<function, typename util::decay<F>::type>
-          , function&
-        >::type operator=(F&& f)
+        template <typename F, typename Enable =
+            typename std::enable_if<
+                !std::is_same<F, function>::value
+            >::type>
+        function& operator=(F&& f)
         {
             assign(std::forward<F>(f));
             return *this;
@@ -268,12 +268,12 @@ namespace hpx { namespace util
           : base_type(static_cast<base_type&&>(other))
         {}
 
-        template <typename F>
-        function(F&& f,
-            typename boost::disable_if<
-                boost::is_same<function, typename util::decay<F>::type>
-            >::type* = 0
-        ) : base_type()
+        template <typename F, typename Enable =
+            typename std::enable_if<
+                !std::is_same<F, function>::value
+            >::type>
+        function(F&& f)
+          : base_type()
         {
             assign(std::forward<F>(f));
         }
@@ -300,11 +300,11 @@ namespace hpx { namespace util
             return *this;
         }
 
-        template <typename F>
-        typename boost::disable_if<
-            boost::is_same<function, typename util::decay<F>::type>
-          , function&
-        >::type operator=(F&& f)
+        template <typename F, typename Enable =
+            typename std::enable_if<
+                !std::is_same<F, function>::value
+            >::type>
+        function& operator=(F&& f)
         {
             assign(std::forward<F>(f));
             return *this;
@@ -352,12 +352,12 @@ namespace hpx { namespace util
           : base_type(static_cast<base_type&&>(other))
         {}
 
-        template <typename F>
-        function_nonser(F&& f,
-            typename boost::disable_if<
-                boost::is_same<function_nonser, typename util::decay<F>::type>
-            >::type* = 0
-        ) : base_type(std::forward<F>(f))
+        template <typename F, typename Enable =
+            typename std::enable_if<
+                !std::is_same<F, function_nonser>::value
+            >::type>
+        function_nonser(F&& f)
+          : base_type(std::forward<F>(f))
         {}
 
         function_nonser& operator=(function_nonser const& other)
@@ -372,11 +372,11 @@ namespace hpx { namespace util
             return *this;
         }
 
-        template <typename F>
-        typename boost::disable_if<
-            boost::is_same<function_nonser, typename util::decay<F>::type>
-          , function_nonser&
-        >::type operator=(F&& f)
+        template <typename F, typename Enable =
+            typename std::enable_if<
+                !std::is_same<F, function_nonser>::value
+            >::type>
+        function_nonser& operator=(F&& f)
         {
             base_type::operator=(std::forward<F>(f));
             return *this;

--- a/hpx/util/detail/get_table.hpp
+++ b/hpx/util/detail/get_table.hpp
@@ -8,14 +8,14 @@
 #define HPX_UTIL_DETAIL_GET_TABLE_HPP
 
 #include <hpx/config.hpp>
-#include <boost/mpl/identity.hpp>
+#include <hpx/util/detail/vtable/vtable.hpp>
 
 namespace hpx { namespace util { namespace detail
 {
     template <typename VTable, typename T>
     static VTable const* get_table() BOOST_NOEXCEPT
     {
-        static VTable const vtable = boost::mpl::identity<T>();
+        static VTable const vtable = construct_vtable<T>();
         return &vtable;
     }
 }}}

--- a/hpx/util/detail/reset_function.hpp
+++ b/hpx/util/detail/reset_function.hpp
@@ -11,8 +11,8 @@
 
 namespace hpx { namespace util { namespace detail
 {
-    template <typename Sig, typename IArchive, typename OArchive>
-    inline void reset_function(hpx::util::function<Sig, IArchive, OArchive>& f)
+    template <typename Sig, bool Serializable>
+    inline void reset_function(hpx::util::function<Sig, Serializable>& f)
     {
         f.reset();
     }
@@ -23,8 +23,8 @@ namespace hpx { namespace util { namespace detail
         f.reset();
     }
 
-    template <typename Sig, typename IArchive, typename OArchive>
-    inline void reset_function(hpx::util::unique_function<Sig, IArchive, OArchive>& f)
+    template <typename Sig, bool Serializable>
+    inline void reset_function(hpx::util::unique_function<Sig, Serializable>& f)
     {
         f.reset();
     }

--- a/hpx/util/detail/unique_function_template.hpp
+++ b/hpx/util/detail/unique_function_template.hpp
@@ -55,22 +55,18 @@ namespace hpx { namespace util { namespace detail
 namespace hpx { namespace util
 {
     ///////////////////////////////////////////////////////////////////////////
-    template <
-        typename Sig
-      , typename IAr = serialization::input_archive
-      , typename OAr = serialization::output_archive
-    >
+    template <typename Sig, bool Serializable = true>
     class unique_function;
 
-    template <typename R, typename ...Ts, typename IAr, typename OAr>
-    class unique_function<R(Ts...), IAr, OAr>
+    template <typename R, typename ...Ts, bool Serializable>
+    class unique_function<R(Ts...), Serializable>
       : public detail::basic_function<
             detail::unique_function_vtable_ptr<R(Ts...)>
-          , R(Ts...), IAr, OAr
+          , R(Ts...), Serializable
         >
     {
         typedef detail::unique_function_vtable_ptr<R(Ts...)> vtable_ptr;
-        typedef detail::basic_function<vtable_ptr, R(Ts...), IAr, OAr> base_type;
+        typedef detail::basic_function<vtable_ptr, R(Ts...), Serializable> base_type;
 
         HPX_MOVABLE_BUT_NOT_COPYABLE(unique_function);
 
@@ -121,9 +117,9 @@ namespace hpx { namespace util
         using base_type::target;
     };
 
-    template <typename Sig, typename IAr, typename OAr>
+    template <typename Sig, bool Serializable>
     static bool is_empty_function(
-        unique_function<Sig, IAr, OAr> const& f) BOOST_NOEXCEPT
+        unique_function<Sig, Serializable> const& f) BOOST_NOEXCEPT
     {
         return f.empty();
     }
@@ -132,7 +128,7 @@ namespace hpx { namespace util
 #   ifdef HPX_HAVE_CXX11_ALIAS_TEMPLATES
 
     template <typename Sig>
-    using unique_function_nonser = unique_function<Sig, void, void>;
+    using unique_function_nonser = unique_function<Sig, false>;
 
 #   else
 
@@ -141,9 +137,9 @@ namespace hpx { namespace util
 
     template <typename R, typename ...Ts>
     class unique_function_nonser<R(Ts...)>
-      : public unique_function<R(Ts...), void, void>
+      : public unique_function<R(Ts...), false>
     {
-        typedef unique_function<R(Ts...), void, void> base_type;
+        typedef unique_function<R(Ts...), false> base_type;
 
         HPX_MOVABLE_BUT_NOT_COPYABLE(unique_function_nonser);
 

--- a/hpx/util/detail/unique_function_template.hpp
+++ b/hpx/util/detail/unique_function_template.hpp
@@ -9,30 +9,19 @@
 #define HPX_UTIL_DETAIL_UNIQUE_FUNCTION_TEMPLATE_HPP
 
 #include <hpx/config.hpp>
-#include <hpx/runtime/serialization/serialize.hpp>
-#include <hpx/util/tuple.hpp>
 #include <hpx/util/detail/basic_function.hpp>
-#include <hpx/util/detail/function_registration.hpp>
 #include <hpx/util/detail/vtable/callable_vtable.hpp>
-#include <hpx/util/detail/vtable/serializable_vtable.hpp>
 #include <hpx/util/detail/vtable/vtable.hpp>
 
 #include <boost/mpl/identity.hpp>
-
 #include <type_traits>
 #include <utility>
 
 namespace hpx { namespace util { namespace detail
 {
-    template <typename Function>
-    struct init_registration;
-
     ///////////////////////////////////////////////////////////////////////
-    template <typename Sig, typename IAr, typename OAr>
-    struct unique_function_vtable_ptr;
-
     template <typename Sig>
-    struct unique_function_vtable_ptr<Sig, void, void>
+    struct unique_function_vtable_ptr
     {
         typename callable_vtable<Sig>::invoke_t invoke;
         vtable::get_type_t get_type;
@@ -61,48 +50,6 @@ namespace hpx { namespace util { namespace detail
             vtable::reconstruct<T>(v, std::forward<Arg>(arg));
         }
     };
-
-    template <typename Sig, typename IAr, typename OAr>
-    struct unique_function_vtable_ptr
-      : unique_function_vtable_ptr<Sig, void, void>
-    {
-        char const* name;
-        typename serializable_vtable<IAr, OAr>::save_object_t save_object;
-        typename serializable_vtable<IAr, OAr>::load_object_t load_object;
-
-        template <typename T>
-        unique_function_vtable_ptr(boost::mpl::identity<T>) BOOST_NOEXCEPT
-          : unique_function_vtable_ptr<Sig, void, void>(boost::mpl::identity<T>())
-          , name(get_function_name<util::tuple<unique_function_vtable_ptr, T> >())
-          , save_object(&serializable_vtable<IAr, OAr>::template save_object<T>)
-          , load_object(&serializable_vtable<IAr, OAr>::template load_object<T>)
-        {
-            init_registration<
-                util::tuple<unique_function_vtable_ptr, T>
-            >::g.register_function();
-        }
-    };
-
-    ///////////////////////////////////////////////////////////////////////////
-    // registration code for serialization
-    template <typename Sig, typename IAr, typename OAr, typename T>
-    struct init_registration<
-        util::tuple<unique_function_vtable_ptr<Sig, IAr, OAr>, T>
-    >
-    {
-        typedef util::tuple<unique_function_vtable_ptr<Sig, IAr, OAr>, T> vtable_ptr;
-
-        static automatic_function_registration<vtable_ptr> g;
-    };
-
-    template <typename Sig, typename IAr, typename OAr, typename T>
-    automatic_function_registration<
-        util::tuple<unique_function_vtable_ptr<Sig, IAr, OAr>, T>
-    > init_registration<
-        util::tuple<unique_function_vtable_ptr<Sig, IAr, OAr>, T>
-    >::g =  automatic_function_registration<
-                util::tuple<unique_function_vtable_ptr<Sig, IAr, OAr>, T>
-            >();
 }}}
 
 namespace hpx { namespace util
@@ -110,108 +57,17 @@ namespace hpx { namespace util
     ///////////////////////////////////////////////////////////////////////////
     template <
         typename Sig
-      , typename IArchive = serialization::input_archive
-      , typename OArchive = serialization::output_archive
+      , typename IAr = serialization::input_archive
+      , typename OAr = serialization::output_archive
     >
     class unique_function
       : public detail::basic_function<
-            detail::unique_function_vtable_ptr<Sig, IArchive, OArchive>
-          , Sig
+            detail::unique_function_vtable_ptr<Sig>
+          , Sig, IAr, OAr
         >
     {
-        typedef detail::unique_function_vtable_ptr<Sig, IArchive, OArchive> vtable_ptr;
-        typedef detail::basic_function<vtable_ptr, Sig> base_type;
-
-        HPX_MOVABLE_BUT_NOT_COPYABLE(unique_function);
-
-    public:
-        typedef typename base_type::result_type result_type;
-
-        unique_function() BOOST_NOEXCEPT
-          : base_type()
-        {}
-
-        unique_function(unique_function&& other) BOOST_NOEXCEPT
-          : base_type(static_cast<base_type&&>(other))
-        {}
-
-        template <typename F, typename Enable =
-            typename std::enable_if<
-                !std::is_same<F, unique_function>::value
-            >::type>
-        unique_function(F&& f)
-          : base_type()
-        {
-            assign(std::forward<F>(f));
-        }
-
-        unique_function& operator=(unique_function&& other) BOOST_NOEXCEPT
-        {
-            base_type::operator=(static_cast<base_type&&>(other));
-            return *this;
-        }
-
-        template <typename F, typename Enable =
-            typename std::enable_if<
-                !std::is_same<F, unique_function>::value
-            >::type>
-        unique_function& operator=(F&& f)
-        {
-            assign(std::forward<F>(f));
-            return *this;
-        }
-
-        using base_type::operator();
-        using base_type::assign;
-        using base_type::reset;
-        using base_type::empty;
-        using base_type::target_type;
-        using base_type::target;
-
-    private:
-        friend class hpx::serialization::access;
-
-        void load(IArchive& ar, const unsigned version)
-        {
-            reset();
-
-            bool is_empty = false;
-            ar >> is_empty;
-            if (!is_empty)
-            {
-                std::string name;
-                ar >> name;
-
-                this->vptr = detail::get_table_ptr<vtable_ptr>(name);
-                this->vptr->load_object(&this->object, ar, version);
-            }
-        }
-
-        void save(OArchive& ar, const unsigned version) const
-        {
-            bool is_empty = empty();
-            ar << is_empty;
-            if (!is_empty)
-            {
-                std::string function_name = this->vptr->name;
-                ar << function_name;
-
-                this->vptr->save_object(&this->object, ar, version);
-            }
-        }
-
-        HPX_SERIALIZATION_SPLIT_MEMBER()
-    };
-
-    template <typename Sig>
-    class unique_function<Sig, void, void>
-      : public detail::basic_function<
-            detail::unique_function_vtable_ptr<Sig, void, void>
-          , Sig
-        >
-    {
-        typedef detail::unique_function_vtable_ptr<Sig, void, void> vtable_ptr;
-        typedef detail::basic_function<vtable_ptr, Sig> base_type;
+        typedef detail::unique_function_vtable_ptr<Sig> vtable_ptr;
+        typedef detail::basic_function<vtable_ptr, Sig, IAr, OAr> base_type;
 
         HPX_MOVABLE_BUT_NOT_COPYABLE(unique_function);
 
@@ -260,9 +116,9 @@ namespace hpx { namespace util
         using base_type::target;
     };
 
-    template <typename Sig, typename IArchive, typename OArchive>
-    static bool is_empty_function(unique_function<Sig, IArchive,
-        OArchive> const& f) BOOST_NOEXCEPT
+    template <typename Sig, typename IAr, typename OAr>
+    static bool is_empty_function(unique_function<Sig, IAr,
+        OAr> const& f) BOOST_NOEXCEPT
     {
         return f.empty();
     }

--- a/hpx/util/detail/unique_function_template.hpp
+++ b/hpx/util/detail/unique_function_template.hpp
@@ -14,8 +14,6 @@
 #include <hpx/util/detail/vtable/callable_vtable.hpp>
 #include <hpx/util/detail/vtable/vtable.hpp>
 
-#include <boost/mpl/identity.hpp>
-
 #include <type_traits>
 #include <utility>
 
@@ -32,7 +30,7 @@ namespace hpx { namespace util { namespace detail
         bool empty;
 
         template <typename T>
-        unique_function_vtable_ptr(boost::mpl::identity<T>) BOOST_NOEXCEPT
+        unique_function_vtable_ptr(construct_vtable<T>) BOOST_NOEXCEPT
           : invoke(&callable_vtable<Sig>::template invoke<T>)
           , get_type(&vtable::template get_type<T>)
           , destruct(&vtable::template destruct<T>)

--- a/hpx/util/detail/unique_function_template.hpp
+++ b/hpx/util/detail/unique_function_template.hpp
@@ -17,8 +17,10 @@
 #include <hpx/util/detail/vtable/serializable_vtable.hpp>
 #include <hpx/util/detail/vtable/vtable.hpp>
 
-#include <boost/type_traits/is_same.hpp>
-#include <boost/utility/enable_if.hpp>
+#include <boost/mpl/identity.hpp>
+
+#include <type_traits>
+#include <utility>
 
 namespace hpx { namespace util { namespace detail
 {
@@ -44,7 +46,7 @@ namespace hpx { namespace util { namespace detail
           , get_type(&vtable::template get_type<T>)
           , destruct(&vtable::template destruct<T>)
           , delete_(&vtable::template delete_<T>)
-          , empty(boost::is_same<T, empty_function<Sig> >::value)
+          , empty(std::is_same<T, empty_function<Sig> >::value)
         {}
 
         template <typename T, typename Arg>
@@ -133,12 +135,12 @@ namespace hpx { namespace util
           : base_type(static_cast<base_type&&>(other))
         {}
 
-        template <typename F>
-        unique_function(F&& f,
-            typename boost::disable_if<
-                boost::is_same<unique_function, typename util::decay<F>::type>
-            >::type* = 0
-        ) : base_type()
+        template <typename F, typename Enable =
+            typename std::enable_if<
+                !std::is_same<F, unique_function>::value
+            >::type>
+        unique_function(F&& f)
+          : base_type()
         {
             assign(std::forward<F>(f));
         }
@@ -149,7 +151,10 @@ namespace hpx { namespace util
             return *this;
         }
 
-        template <typename F>
+        template <typename F, typename Enable =
+            typename std::enable_if<
+                !std::is_same<F, unique_function>::value
+            >::type>
         unique_function& operator=(F&& f)
         {
             assign(std::forward<F>(f));
@@ -221,12 +226,12 @@ namespace hpx { namespace util
           : base_type(static_cast<base_type&&>(other))
         {}
 
-        template <typename F>
-        unique_function(F&& f,
-            typename boost::disable_if<
-                boost::is_same<unique_function, typename util::decay<F>::type>
-            >::type* = 0
-        ) : base_type()
+        template <typename F, typename Enable =
+            typename std::enable_if<
+                !std::is_same<F, unique_function>::value
+            >::type>
+        unique_function(F&& f)
+          : base_type()
         {
             assign(std::forward<F>(f));
         }
@@ -237,7 +242,10 @@ namespace hpx { namespace util
             return *this;
         }
 
-        template <typename F>
+        template <typename F, typename Enable =
+            typename std::enable_if<
+                !std::is_same<F, unique_function>::value
+            >::type>
         unique_function& operator=(F&& f)
         {
             assign(std::forward<F>(f));
@@ -284,12 +292,12 @@ namespace hpx { namespace util
           : base_type(static_cast<base_type&&>(other))
         {}
 
-        template <typename F>
-        unique_function_nonser(F&& f,
-            typename boost::disable_if<
-                boost::is_same<unique_function_nonser, typename util::decay<F>::type>
-            >::type* = 0
-        ) : base_type(std::forward<F>(f))
+        template <typename F, typename Enable =
+            typename std::enable_if<
+                !std::is_same<F, unique_function_nonser>::value
+            >::type>
+        unique_function_nonser(F&& f)
+          : base_type(std::forward<F>(f))
         {}
 
         unique_function_nonser& operator=(unique_function_nonser&& other) BOOST_NOEXCEPT
@@ -298,7 +306,10 @@ namespace hpx { namespace util
             return *this;
         }
 
-        template <typename F>
+        template <typename F, typename Enable =
+            typename std::enable_if<
+                !std::is_same<F, unique_function_nonser>::value
+            >::type>
         unique_function_nonser& operator=(F&& f)
         {
             base_type::operator=(std::forward<F>(f));

--- a/hpx/util/detail/vtable/callable_vtable.hpp
+++ b/hpx/util/detail/vtable/callable_vtable.hpp
@@ -11,9 +11,9 @@
 #include <hpx/config/forceinline.hpp>
 #include <hpx/util/detail/vtable/vtable.hpp>
 #include <hpx/util/invoke.hpp>
-#include <hpx/util/move.hpp>
 
 #include <typeinfo>
+#include <utility>
 
 namespace hpx { namespace util { namespace detail
 {

--- a/hpx/util/detail/vtable/serializable_vtable.hpp
+++ b/hpx/util/detail/vtable/serializable_vtable.hpp
@@ -9,27 +9,31 @@
 #define HPX_UTIL_DETAIL_VTABLE_SERIALIZABLE_VTABLE_HPP
 
 #include <hpx/config/forceinline.hpp>
+#include <hpx/runtime/serialization/serialization_fwd.hpp>
 #include <hpx/util/detail/vtable/vtable.hpp>
 
 namespace hpx { namespace util { namespace detail
 {
-    template <typename IArchive, typename OArchive>
     struct serializable_vtable
     {
         template <typename T>
-        static void save_object(void* const* v, OArchive& ar, unsigned version)
+        static void save_object(void* const* v,
+            serialization::output_archive& ar, unsigned version)
         {
             ar << vtable::get<T>(v);
         }
-        typedef void (*save_object_t)(void* const*, OArchive&, unsigned);
+        typedef void (*save_object_t)(void* const*,
+            serialization::output_archive&, unsigned);
 
         template <typename T>
-        static void load_object(void** v, IArchive& ar, unsigned version)
+        static void load_object(void** v,
+            serialization::input_archive& ar, unsigned version)
         {
             vtable::default_construct<T>(v);
             ar >> vtable::get<T>(v);
         }
-        typedef void (*load_object_t)(void**, IArchive&, unsigned);
+        typedef void (*load_object_t)(void**,
+            serialization::input_archive&, unsigned);
     };
 }}}
 

--- a/hpx/util/detail/vtable/vtable.hpp
+++ b/hpx/util/detail/vtable/vtable.hpp
@@ -9,10 +9,10 @@
 #define HPX_UTIL_DETAIL_VTABLE_VTABLE_HPP
 
 #include <hpx/config/forceinline.hpp>
-#include <hpx/util/move.hpp>
 
 #include <memory>
 #include <typeinfo>
+#include <utility>
 
 namespace hpx { namespace util { namespace detail
 {
@@ -52,7 +52,7 @@ namespace hpx { namespace util { namespace detail
         {
             if (sizeof(T) <= sizeof(void*))
             {
-                new (v) T;
+                ::new (static_cast<void*>(v)) T;
             } else {
                 *v = new T;
             }
@@ -63,7 +63,7 @@ namespace hpx { namespace util { namespace detail
         {
             if (sizeof(T) <= sizeof(void*))
             {
-                new (v) T(std::forward<Arg>(arg));
+                ::new (static_cast<void*>(v)) T(std::forward<Arg>(arg));
             } else {
                 *v = new T(std::forward<Arg>(arg));
             }

--- a/hpx/util/detail/vtable/vtable.hpp
+++ b/hpx/util/detail/vtable/vtable.hpp
@@ -95,6 +95,9 @@ namespace hpx { namespace util { namespace detail
         }
         typedef void (*delete_t)(void**);
     };
+
+    template <typename T>
+    struct construct_vtable {};
 }}}
 
 #endif

--- a/hpx/util/function.hpp
+++ b/hpx/util/function.hpp
@@ -8,7 +8,6 @@
 #define HPX_UTIL_FUNCTION_HPP
 
 #include <hpx/config.hpp>
-#include <hpx/error.hpp>
 #include <hpx/runtime/serialization/serialization_fwd.hpp>
 #include <hpx/traits/needs_automatic_registration.hpp>
 #include <hpx/util/detail/basic_function.hpp>

--- a/hpx/util/function.hpp
+++ b/hpx/util/function.hpp
@@ -21,12 +21,9 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 #define HPX_CONTINUATION_REGISTER_FUNCTION_FACTORY(VTable, Name)              \
-    static ::hpx::util::detail::function_registration<                        \
-        VTable::first_type, VTable::second_type                               \
-    > const BOOST_PP_CAT(Name, _function_factory_registration) =              \
-            ::hpx::util::detail::function_registration<                       \
-                VTable::first_type, VTable::second_type                       \
-            >();                                                              \
+    static ::hpx::util::detail::function_registration<VTable> const           \
+        BOOST_PP_CAT(Name, _function_factory_registration) =                  \
+            ::hpx::util::detail::function_registration<VTable>();             \
 /**/
 
 #define HPX_DECLARE_GET_FUNCTION_NAME(VTable, Name)                           \
@@ -39,12 +36,10 @@
 #define HPX_UTIL_REGISTER_FUNCTION_DECLARATION(Sig, Functor, Name)            \
     namespace hpx { namespace util { namespace detail {                       \
         typedef                                                               \
-            std::pair<                                                        \
-                serializable_function_vtable_ptr<                             \
-                    function_vtable_ptr<Sig>                                  \
-                  , ::hpx::serialization::input_archive                       \
-                  , ::hpx::serialization::output_archive                      \
-                >                                                             \
+            serializable_function_registration<                               \
+                function_vtable_ptr<Sig>                                      \
+              , ::hpx::serialization::input_archive                           \
+              , ::hpx::serialization::output_archive                          \
               , util::decay<HPX_UTIL_STRIP(Functor)>::type                    \
             >                                                                 \
             BOOST_PP_CAT(BOOST_PP_CAT(__,                                     \

--- a/hpx/util/function.hpp
+++ b/hpx/util/function.hpp
@@ -38,8 +38,6 @@
         typedef                                                               \
             serializable_function_registration<                               \
                 function_vtable_ptr<Sig>                                      \
-              , ::hpx::serialization::input_archive                           \
-              , ::hpx::serialization::output_archive                          \
               , util::decay<HPX_UTIL_STRIP(Functor)>::type                    \
             >                                                                 \
             BOOST_PP_CAT(BOOST_PP_CAT(__,                                     \

--- a/hpx/util/unique_function.hpp
+++ b/hpx/util/unique_function.hpp
@@ -9,7 +9,6 @@
 #define HPX_UTIL_UNIQUE_FUNCTION_HPP
 
 #include <hpx/config.hpp>
-#include <hpx/error.hpp>
 #include <hpx/runtime/serialization/serialization_fwd.hpp>
 #include <hpx/traits/needs_automatic_registration.hpp>
 #include <hpx/util/detail/basic_function.hpp>

--- a/hpx/util/unique_function.hpp
+++ b/hpx/util/unique_function.hpp
@@ -10,10 +10,12 @@
 
 #include <hpx/config.hpp>
 #include <hpx/error.hpp>
+#include <hpx/runtime/serialization/serialization_fwd.hpp>
+#include <hpx/traits/needs_automatic_registration.hpp>
+#include <hpx/util/detail/basic_function.hpp>
 #include <hpx/util/detail/unique_function_template.hpp>
 #include <hpx/util/detail/pp_strip_parens.hpp>
 #include <hpx/util/decay.hpp>
-#include <hpx/util/tuple.hpp>
 
 #include <boost/preprocessor/cat.hpp>
 
@@ -22,12 +24,10 @@
 ///////////////////////////////////////////////////////////////////////////////
 #define HPX_CONTINUATION_REGISTER_UNIQUE_FUNCTION_FACTORY(VTable, Name)       \
     static ::hpx::util::detail::function_registration<                        \
-        ::hpx::util::tuple_element<0, VTable>::type                           \
-      , ::hpx::util::tuple_element<1, VTable>::type                           \
+        VTable::first_type, VTable::second_type                               \
     > const BOOST_PP_CAT(Name, _unique_function_factory_registration) =       \
             ::hpx::util::detail::function_registration<                       \
-                ::hpx::util::tuple_element<0, VTable>::type                   \
-              , ::hpx::util::tuple_element<1, VTable>::type                   \
+                VTable::first_type, VTable::second_type                       \
             >();                                                              \
 /**/
 
@@ -41,9 +41,9 @@
 #define HPX_UTIL_REGISTER_UNIQUE_FUNCTION_DECLARATION(Sig, Functor, Name)     \
     namespace hpx { namespace util { namespace detail {                       \
         typedef                                                               \
-            hpx::util::tuple<                                                 \
-                unique_function_vtable_ptr<                                   \
-                    Sig                                                       \
+            std::pair<                                                        \
+                serializable_function_vtable_ptr<                             \
+                    unique_function_vtable_ptr<Sig>                           \
                   , serialization::input_archive                              \
                   , serialization::output_archive                             \
                 >                                                             \

--- a/hpx/util/unique_function.hpp
+++ b/hpx/util/unique_function.hpp
@@ -39,8 +39,6 @@
         typedef                                                               \
             serializable_function_registration<                               \
                 unique_function_vtable_ptr<Sig>                               \
-              , serialization::input_archive                                  \
-              , serialization::output_archive                                 \
               , util::decay<HPX_UTIL_STRIP(Functor)>::type                    \
             >                                                                 \
             BOOST_PP_CAT(BOOST_PP_CAT(__,                                     \

--- a/hpx/util/unique_function.hpp
+++ b/hpx/util/unique_function.hpp
@@ -22,12 +22,9 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 #define HPX_CONTINUATION_REGISTER_UNIQUE_FUNCTION_FACTORY(VTable, Name)       \
-    static ::hpx::util::detail::function_registration<                        \
-        VTable::first_type, VTable::second_type                               \
-    > const BOOST_PP_CAT(Name, _unique_function_factory_registration) =       \
-            ::hpx::util::detail::function_registration<                       \
-                VTable::first_type, VTable::second_type                       \
-            >();                                                              \
+    static ::hpx::util::detail::function_registration<VTable> const           \
+        BOOST_PP_CAT(Name, _unique_function_factory_registration) =           \
+            ::hpx::util::detail::function_registration<VTable>();             \
 /**/
 
 #define HPX_DECLARE_GET_UNIQUE_FUNCTION_NAME(VTable, Name)                    \
@@ -40,12 +37,10 @@
 #define HPX_UTIL_REGISTER_UNIQUE_FUNCTION_DECLARATION(Sig, Functor, Name)     \
     namespace hpx { namespace util { namespace detail {                       \
         typedef                                                               \
-            std::pair<                                                        \
-                serializable_function_vtable_ptr<                             \
-                    unique_function_vtable_ptr<Sig>                           \
-                  , serialization::input_archive                              \
-                  , serialization::output_archive                             \
-                >                                                             \
+            serializable_function_registration<                               \
+                unique_function_vtable_ptr<Sig>                               \
+              , serialization::input_archive                                  \
+              , serialization::output_archive                                 \
               , util::decay<HPX_UTIL_STRIP(Functor)>::type                    \
             >                                                                 \
             BOOST_PP_CAT(BOOST_PP_CAT(__,                                     \

--- a/tests/performance/local/function_object_wrapper_overhead.cpp
+++ b/tests/performance/local/function_object_wrapper_overhead.cpp
@@ -59,7 +59,7 @@ int app_main(
         run(f, iterations);
     }
     {
-        hpx::util::function<void(), void, void> f = foo();
+        hpx::util::function<void(), false> f = foo();
         std::cout << "hpx::util::function (non-serializable)";
         run(f, iterations);
     }

--- a/tests/unit/util/function.cpp
+++ b/tests/unit/util/function.cpp
@@ -226,11 +226,11 @@ int hpx_main(variables_map& vm)
 
             small_object const f(17);
 
-            function<boost::uint64_t(boost::uint64_t const&), void, void> f0(f);
+            function<boost::uint64_t(boost::uint64_t const&), false> f0(f);
 
-            function<boost::uint64_t(boost::uint64_t const&), void, void> f1(f0);
+            function<boost::uint64_t(boost::uint64_t const&), false> f1(f0);
 
-            function<boost::uint64_t(boost::uint64_t const&), void, void> f2;
+            function<boost::uint64_t(boost::uint64_t const&), false> f2;
 
             f2 = f0;
 
@@ -248,13 +248,13 @@ int hpx_main(variables_map& vm)
             big_object const f(5, 12);
 
             function<boost::uint64_t(boost::uint64_t const&, boost::uint64_t const&),
-                void, void> f0(f);
+                false> f0(f);
 
             function<boost::uint64_t(boost::uint64_t const&, boost::uint64_t const&),
-                void, void> f1(f0);
+                false> f1(f0);
 
             function<boost::uint64_t(boost::uint64_t const&, boost::uint64_t const&),
-                void, void> f2;
+                false> f2;
 
             f2 = f0;
 


### PR DESCRIPTION
Simplify `function` and `unique_function`. Unify duplicated functionality. Drop support for generic archive types.