### PR TITLE
Fix some redundant qualifiers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -948,9 +948,6 @@ if(HPX_WITH_COMPILER_WARNINGS)
     # interface requirements
     hpx_add_compile_flag_if_available(-Wno-unused-parameter)
 
-    # There are ignored qualifiers in Boost, so we have to ignore them
-    hpx_add_compile_flag_if_available(-Wno-ignored-qualifiers)
-
     # Be extra strict about format checks
     # Boost.Logging is built on fprintf, sadly
     hpx_add_compile_flag_if_available(-Wformat=2)

--- a/hpx/runtime/parcelset/parcel.hpp
+++ b/hpx/runtime/parcelset/parcel.hpp
@@ -414,7 +414,7 @@ namespace hpx { namespace parcelset
             return addrs()[0].locality_;
         }
 
-        double const start_time() const
+        double start_time() const
         {
             return data_.start_time_;
         }
@@ -424,7 +424,7 @@ namespace hpx { namespace parcelset
             data_.start_time_ = time;
         }
 
-        double const creation_time() const
+        double creation_time() const
         {
             return data_.creation_time_;
         }


### PR DESCRIPTION
Reintroduce ignored-qualifiers warning, now that Boost warnings are hidden from sight.