### PR TITLE
Add feature test for thread_local on Clang for TLS

### DIFF
--- a/hpx/util/thread_specific_ptr.hpp
+++ b/hpx/util/thread_specific_ptr.hpp
@@ -25,7 +25,9 @@
 
 #if (!defined(__ANDROID__) && !defined(ANDROID)) && !defined(__bgq__)
 
-#if defined(_GLIBCXX_HAVE_TLS)
+#if defined(__has_feature) && __has_feature(cxx_thread_local)
+#  define HPX_NATIVE_TLS thread_local
+#elif defined(_GLIBCXX_HAVE_TLS)
 #  define HPX_NATIVE_TLS __thread
 #elif defined(BOOST_WINDOWS)
 #  define HPX_NATIVE_TLS __declspec(thread)

--- a/tests/performance/local/native_tls_overhead.cpp
+++ b/tests/performance/local/native_tls_overhead.cpp
@@ -17,7 +17,9 @@
 
 #include <hpx/util/high_resolution_timer.hpp>
 
-#if defined(_GLIBCXX_HAVE_TLS)
+#if defined(__has_feature) && __has_feature(cxx_thread_local)
+    #define HPX_NATIVE_TLS thread_local
+#elif defined(_GLIBCXX_HAVE_TLS)
     #define HPX_NATIVE_TLS __thread
 #elif defined(BOOST_WINDOWS)
     #define HPX_NATIVE_TLS __declspec(thread)


### PR DESCRIPTION
Clang has __has_feature which can be used to query for whether
thread_local exists. As clang with libc++ isn't covered by the
existing thread_specific_ptr cases, this adds support for TLS
on this combination of compiler and runtime.

This should resolve the issues in issue #1880.