### PR TITLE
Warning cleaning pass

### DIFF
--- a/examples/transpose/transpose_block_numa.cpp
+++ b/examples/transpose/transpose_block_numa.cpp
@@ -489,7 +489,6 @@ int hpx_main(boost::program_options::variables_map& vm)
 
         ///////////////////////////////////////////////////////////////////////
         // Analyze and output results
-        double epsilon = 1.e-8;
         if(root)
         {
             double errsq = std::accumulate(errsqs.begin(), errsqs.end(), 0.0);

--- a/tests/performance/local/transform_reduce_scaling.cpp
+++ b/tests/performance/local/transform_reduce_scaling.cpp
@@ -42,6 +42,7 @@ void measure_transform_reduce(std::size_t size)
         0.0,
         std::plus<double>()
     );
+    HPX_UNUSED(result);
 }
 
 void measure_transform_reduce_old(std::size_t size)
@@ -61,6 +62,7 @@ void measure_transform_reduce_old(std::size_t size)
                 res.x * res.y + curr.x * curr.y, 1.0};
         }
     );
+    HPX_UNUSED(result);
 }
 
 boost::uint64_t average_out_transform_reduce(std::size_t vector_size)

--- a/tests/regressions/agas/register_with_basename_1804.cpp
+++ b/tests/regressions/agas/register_with_basename_1804.cpp
@@ -76,7 +76,7 @@ void test()
         std::cout << "lookup: " << name << "\n";
         std::vector<hpx::future<hpx::id_type> > ids =
             hpx::find_all_from_basename(name, 1);
-        boundingBoxAccepters.push_back(std::move(ids[0].get()));
+        boundingBoxAccepters.push_back(ids[0].get());
     }
 
     std::cout << "all done " << rank << "\n";

--- a/tests/regressions/lcos/shared_mutex_1702.cpp
+++ b/tests/regressions/lcos/shared_mutex_1702.cpp
@@ -25,6 +25,7 @@ int main()
     {
         boost::shared_lock<shared_mutex_type> l(mtx);
         int i = data;
+        HPX_UNUSED(i);
     }
 
     return 0;

--- a/tests/regressions/parallel/scan_different_inits.cpp
+++ b/tests/regressions/parallel/scan_different_inits.cpp
@@ -112,6 +112,13 @@ void test_one(std::vector<int> a)
         transform_exclusive_scan(par, a.begin(), a.end(), g.begin(),
         fun_conv, 10, fun_add);
 
+    HPX_UNUSED(f_inc_add);
+    HPX_UNUSED(f_inc_mult);
+    HPX_UNUSED(f_exc_add);
+    HPX_UNUSED(f_exc_mult);
+    HPX_UNUSED(f_transform_inc);
+    HPX_UNUSED(f_transform_exc);
+
     hpx::parallel::v1::detail::sequential_inclusive_scan(
         a.begin(), a.end(), b_ans.begin(), 10, fun_add);
     hpx::parallel::v1::detail::sequential_inclusive_scan(

--- a/tests/regressions/parallel/scan_shortlength.cpp
+++ b/tests/regressions/parallel/scan_shortlength.cpp
@@ -83,6 +83,10 @@ void test_one(std::vector<int> a)
     Iter i_remove_copy =
         remove_copy(par, a.begin(), a.end(), d.begin(), 0);
 
+    HPX_UNUSED(i_copy_if);
+    HPX_UNUSED(i_remove_copy_if);
+    HPX_UNUSED(i_remove_copy);
+
     std::copy_if(a.begin(), a.end(), b_ans.begin(),
         [](int bar){ return bar % 2 == 1; });
     std::remove_copy_if(a.begin(), a.end(), c_ans.begin(),

--- a/tests/unit/build/src/CMakeLists.txt
+++ b/tests/unit/build/src/CMakeLists.txt
@@ -25,8 +25,8 @@ if(EXISTS "${HPX_DIR}")
     TYPE COMPONENT
   )
 
-  add_executable(test test.cpp)
-  hpx_setup_target(test
+  add_executable(test_executable test.cpp)
+  hpx_setup_target(test_executable
     DEPENDENCIES test_component
     COMPONENT_DEPENDENCIES iostreams
   )

--- a/tests/unit/parallel/executors/minimal_async_executor.cpp
+++ b/tests/unit/parallel/executors/minimal_async_executor.cpp
@@ -163,7 +163,7 @@ struct test_async_executor4 : test_async_executor2
         {
             results.push_back(hpx::async(hpx::launch::async, f, elem));
         }
-        return std::move(results);
+        return results;
     }
 };
 

--- a/tests/unit/parallel/executors/minimal_sync_executor.cpp
+++ b/tests/unit/parallel/executors/minimal_sync_executor.cpp
@@ -171,7 +171,7 @@ struct test_sync_executor4 : test_sync_executor2
             results.push_back(
                 async_execute(hpx::util::deferred_call(f, elem))
             );
-        return std::move(results);
+        return results;
     }
 };
 

--- a/tests/unit/parallel/executors/timed_this_thread_executors.cpp
+++ b/tests/unit/parallel/executors/timed_this_thread_executors.cpp
@@ -70,6 +70,7 @@ void test_timed_this_thread_executor(Executor& exec)
 int hpx_main(int argc, char* argv[])
 {
     std::size_t num_threads = hpx::get_os_thread_count();
+    HPX_UNUSED(num_threads);
 
 #if defined(HPX_HAVE_STATIC_SCHEDULER)
     {

--- a/tests/unit/serialization/serialization_variant.cpp
+++ b/tests/unit/serialization/serialization_variant.cpp
@@ -29,7 +29,7 @@ struct A
 
     friend std::ostream& operator<<(std::ostream& os, A a)
     {
-        os << a;
+        os << a.t_;
         return os;
     }
 


### PR DESCRIPTION
I've gone over the warnings I got from Clang 3.7, CMake 3.3.2 and libc++-trunk. This pull request has one commit per kind of warning:

* unused variables,
* pessimistic move,
* CMake diagnostic,
* infinite recursion.

Please inspect the files touched by the commits and see if my commonly suggested actions of `HPX_UNUSED`:ing the variables is desirable or if the automatic variables can be removed without losing test coverage or expressiveness.