### PR TITLE
Fixing 1890

### DIFF
--- a/hpx/components/papi/server/papi.hpp
+++ b/hpx/components/papi/server/papi.hpp
@@ -14,6 +14,7 @@
 #include <hpx/hpx_fwd.hpp>
 #include <hpx/util/interval_timer.hpp>
 #include <hpx/performance_counters/server/base_performance_counter.hpp>
+#include <hpx/runtime/components/server/component_base.hpp>
 
 #include <vector>
 #include <map>

--- a/hpx/components/papi/server/papi.hpp
+++ b/hpx/components/papi/server/papi.hpp
@@ -153,7 +153,7 @@ namespace hpx { namespace performance_counters { namespace papi { namespace serv
     ///////////////////////////////////////////////////////////////////////////
     class HPX_COMPONENT_EXPORT papi_counter:
         public hpx::performance_counters::server::base_performance_counter,
-        public hpx::components::managed_component_base<papi_counter>,
+        public hpx::components::component_base<papi_counter>,
         protected papi_counter_base
     {
         friend struct thread_counters;
@@ -172,8 +172,8 @@ namespace hpx { namespace performance_counters { namespace papi { namespace serv
         thread_counters *counters_;
 
     public:
-        typedef hpx::components::managed_component_base<papi_counter> base_type;
-        typedef hpx::components::managed_component<papi_counter> wrapping_type;
+        typedef hpx::components::component_base<papi_counter> base_type;
+        typedef hpx::components::component<papi_counter> wrapping_type;
         typedef papi_counter type_holder;
         typedef hpx::performance_counters::server::base_performance_counter
             base_type_holder;

--- a/src/components/papi_counters/papi_startup.cpp
+++ b/src/components/papi_counters/papi_startup.cpp
@@ -26,7 +26,7 @@
 HPX_REGISTER_COMPONENT_MODULE_DYNAMIC();
 
 ///////////////////////////////////////////////////////////////////////////////
-typedef hpx::components::managed_component<
+typedef hpx::components::component<
     hpx::performance_counters::papi::server::papi_counter
 > papi_counter_type;
 

--- a/src/components/papi_counters/server/papi.cpp
+++ b/src/components/papi_counters/server/papi.cpp
@@ -26,7 +26,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace papi_ns = hpx::performance_counters::papi;
 
-typedef hpx::components::managed_component<
+typedef hpx::components::component<
     papi_ns::server::papi_counter
 > papi_counter_type;
 

--- a/src/components/papi_counters/server/papi.cpp
+++ b/src/components/papi_counters/server/papi.cpp
@@ -9,6 +9,7 @@
 #if defined(HPX_HAVE_PAPI)
 
 #include <hpx/hpx_fwd.hpp>
+#include <hpx/runtime/components/server/component.hpp>
 #include <hpx/runtime/components/derived_component_factory.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/util/thread_mapper.hpp>

--- a/tests/regressions/performance_counters/CMakeLists.txt
+++ b/tests/regressions/performance_counters/CMakeLists.txt
@@ -10,8 +10,9 @@ set(tests
 
 if(PAPI_FOUND)
   set(tests ${tests}
+    papi_counters_active_interface
     papi_counters_basic_functions
-    papi_counters_active_interface)
+    papi_counters_segfault_1890)
 endif()
 
 foreach(test ${tests})

--- a/tests/regressions/performance_counters/papi_counters_segfault_1890.cpp
+++ b/tests/regressions/performance_counters/papi_counters_segfault_1890.cpp
@@ -1,0 +1,37 @@
+//  Copyright (c) 2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Demonstrating #1890: Invoking papi counters give segfault
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/performance_counters.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+int hpx_main(int argc, char ** argv)
+{
+#if defined(HPX_HAVE_PAPI)
+    using hpx::performance_counters::performance_counter;
+
+    performance_counter total_cycles(
+        "/arithmetics/add@/papi{locality#0/worker-thread#*}/PAPI_TOT_CYC");
+    performance_counter cycles(
+        "/papi{locality#0/worker-thread#0}/PAPI_TOT_CYC");
+
+    boost::int64_t val1 = total_cycles.get_value_sync<boost::int64_t>();
+    boost::int64_t val2 = cycles.get_value_sync<boost::int64_t>();
+
+    HPX_TEST(val1 != 0);
+    HPX_TEST(val2 != 0);
+#endif
+
+    return hpx::finalize();
+}
+
+int main(int argc, char **argv)
+{
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Fixes papi counters by converting managed_components to components as was done for other performance counters. see issue #1890 