### PR TITLE
Add support for compilers that have thread_local

### DIFF
--- a/hpx/util/thread_specific_ptr.hpp
+++ b/hpx/util/thread_specific_ptr.hpp
@@ -25,14 +25,22 @@
 
 #if (!defined(__ANDROID__) && !defined(ANDROID)) && !defined(__bgq__)
 
-#if defined(_GLIBCXX_HAVE_TLS)
-#  define HPX_NATIVE_TLS __thread
-#elif defined(BOOST_WINDOWS)
-#  define HPX_NATIVE_TLS __declspec(thread)
-#elif defined(__FreeBSD__) || (defined(__APPLE__) && defined(__MACH__))
-#  define HPX_NATIVE_TLS __thread
-#else
-#  error "Native thread local storage is not supported for this platform, please undefine HPX_HAVE_NATIVE_TLS"
+#if defined(__has_feature)
+#  if __has_feature(cxx_thread_local)
+#    define HPX_NATIVE_TLS thread_local
+#  endif
+#endif
+
+#if !defined(HPX_NATIVE_TLS)
+#  if defined(_GLIBCXX_HAVE_TLS)
+#    define HPX_NATIVE_TLS __thread
+#  elif defined(BOOST_WINDOWS)
+#    define HPX_NATIVE_TLS __declspec(thread)
+#  elif defined(__FreeBSD__) || (defined(__APPLE__) && defined(__MACH__))
+#    define HPX_NATIVE_TLS __thread
+#  else
+#    error "Native thread local storage is not supported for this platform, please undefine HPX_HAVE_NATIVE_TLS"
+#  endif
 #endif
 
 namespace hpx { namespace util

--- a/tests/performance/local/native_tls_overhead.cpp
+++ b/tests/performance/local/native_tls_overhead.cpp
@@ -17,14 +17,22 @@
 
 #include <hpx/util/high_resolution_timer.hpp>
 
-#if defined(_GLIBCXX_HAVE_TLS)
-    #define HPX_NATIVE_TLS __thread
-#elif defined(BOOST_WINDOWS)
-    #define HPX_NATIVE_TLS __declspec(thread)
-#elif defined(__FreeBSD__) || (defined(__APPLE__) && defined(__MACH__))
-    #define HPX_NATIVE_TLS __thread
-#else
-    #error Unsupported platform.
+#if defined(__has_feature)
+#  if __has_feature(cxx_thread_local)
+#    define HPX_NATIVE_TLS thread_local
+#  endif
+#endif
+
+#if !defined(HPX_NATIVE_TLS)
+#  if defined(_GLIBCXX_HAVE_TLS)
+#    define HPX_NATIVE_TLS __thread
+#  elif defined(BOOST_WINDOWS)
+#    define HPX_NATIVE_TLS __declspec(thread)
+#  elif defined(__FreeBSD__) || (defined(__APPLE__) && defined(__MACH__))
+#    define HPX_NATIVE_TLS __thread
+#  else
+#    error Unsupported platform.
+#  endif
 #endif
 
 using boost::program_options::variables_map;


### PR DESCRIPTION
Clang exposes the ability to test for the C++ feature `thread_local` via
the `__has_feature` macro.

Here we test for the presence of the macro and the feature in two
separate steps to avoid the preprocessor bailing out on invalid syntax.

As preprocessors replace before evaluating, naively going:
`#if defined(__has_feature) && __has_feature(cxx_thread_local)`
will result in the preprocessor seeing `0 && 0(0)` if the compiler
doesn't have Clang-style feature testing.