### PR TITLE
Making sure std containers are cleared before serialization loads data

### DIFF
--- a/hpx/runtime/serialization/list.hpp
+++ b/hpx/runtime/serialization/list.hpp
@@ -19,9 +19,10 @@ namespace hpx { namespace serialization
         typedef typename std::list<T, Allocator>::size_type size_type;
         size_type size;
         ar >> size; //-V128
-        if(size == 0) return;
 
         ls.resize(size);
+        if(size == 0) return;
+
         for(auto & li: ls)
         {
             ar >> li;

--- a/hpx/runtime/serialization/map.hpp
+++ b/hpx/runtime/serialization/map.hpp
@@ -100,6 +100,8 @@ namespace hpx
 
             size_type size;
             ar >> size; //-V128
+
+            t.clear();
             for (size_type i = 0; i < size; ++i)
             {
                 value_type v;

--- a/hpx/runtime/serialization/set.hpp
+++ b/hpx/runtime/serialization/set.hpp
@@ -19,6 +19,8 @@ namespace hpx { namespace serialization
         set.clear();
         boost::uint64_t size;
         ar >> size;
+
+        set.clear();
         for (std::size_t i = 0; i < size; ++i) {
             T t;
             ar >> t;

--- a/hpx/runtime/serialization/vector.hpp
+++ b/hpx/runtime/serialization/vector.hpp
@@ -14,42 +14,46 @@
 
 namespace hpx { namespace serialization
 {
-    // load vector<T>
-    template <typename T, typename Allocator>
-    void load_impl(input_archive & ar, std::vector<T, Allocator> & vs,
-        boost::mpl::false_)
+    namespace detail
     {
-        // normal load ...
-        typedef typename std::vector<T, Allocator>::size_type size_type;
-        size_type size;
-        ar >> size; //-V128
-        if(size == 0) return;
-
-        vs.resize(size);
-        for(size_type i = 0; i != size; ++i)
+        // load vector<T>
+        template <typename T, typename Allocator>
+        void load_impl(input_archive & ar, std::vector<T, Allocator> & vs,
+            boost::mpl::false_)
         {
-            ar >> vs[i];
-        }
-    }
-
-    template <typename T, typename Allocator>
-    void load_impl(input_archive & ar, std::vector<T, Allocator> & v, boost::mpl::true_)
-    {
-        if(ar.disable_array_optimization())
-        {
-            load_impl(ar, v, boost::mpl::false_());
-        }
-        else
-        {
-            // bitwise load ...
-            typedef typename std::vector<T, Allocator>::value_type value_type;
+            // normal load ...
             typedef typename std::vector<T, Allocator>::size_type size_type;
             size_type size;
             ar >> size; //-V128
             if(size == 0) return;
 
-            v.resize(size);
-            load_binary(ar, &v[0], v.size() * sizeof(value_type));
+            vs.resize(size);
+            for(size_type i = 0; i != size; ++i)
+            {
+                ar >> vs[i];
+            }
+        }
+
+        template <typename T, typename Allocator>
+        void load_impl(input_archive & ar, std::vector<T, Allocator> & v,
+            boost::mpl::true_)
+        {
+            if(ar.disable_array_optimization())
+            {
+                load_impl(ar, v, boost::mpl::false_());
+            }
+            else
+            {
+                // bitwise load ...
+                typedef typename std::vector<T, Allocator>::value_type value_type;
+                typedef typename std::vector<T, Allocator>::size_type size_type;
+                size_type size;
+                ar >> size; //-V128
+                if(size == 0) return;
+
+                v.resize(size);
+                load_binary(ar, &v[0], v.size() * sizeof(value_type));
+            }
         }
     }
 
@@ -59,8 +63,9 @@ namespace hpx { namespace serialization
         typedef typename std::vector<bool, Allocator>::size_type size_type;
         size_type size = 0;
         ar >> size; //-V128
-        if(size == 0) return;
+
         v.clear();
+        if(size == 0) return;
 
         v.reserve(size);
         // normal load ... no chance of doing bitwise here ...
@@ -71,11 +76,12 @@ namespace hpx { namespace serialization
             v.push_back(b);
         }
     }
+
     template <typename T, typename Allocator>
     void serialize(input_archive & ar, std::vector<T, Allocator> & v, unsigned)
     {
         v.clear();
-        load_impl(
+        detail::load_impl(
             ar
           , v
           , typename traits::is_bitwise_serializable<
@@ -85,36 +91,40 @@ namespace hpx { namespace serialization
     }
 
     // save vector<T>
-    template <typename T, typename Allocator>
-    void save_impl(output_archive & ar, const std::vector<T, Allocator> & vs,
-        boost::mpl::false_)
+    namespace detail
     {
-        // normal save ...
-        typedef typename std::vector<T, Allocator>::value_type value_type;
-        for(const value_type & v : vs)
+        template <typename T, typename Allocator>
+        void save_impl(output_archive & ar, const std::vector<T, Allocator> & vs,
+            boost::mpl::false_)
         {
-            ar << v;
-        }
-    }
-
-    template <typename T, typename Allocator>
-    void save_impl(output_archive & ar, const std::vector<T, Allocator> & v,
-        boost::mpl::true_)
-    {
-        if(ar.disable_array_optimization())
-        {
-            save_impl(ar, v, boost::mpl::false_());
-        }
-        else
-        {
-            // bitwise save ...
+            // normal save ...
             typedef typename std::vector<T, Allocator>::value_type value_type;
-            save_binary(ar, &v[0], v.size() * sizeof(value_type));
+            for(const value_type & v : vs)
+            {
+                ar << v;
+            }
+        }
+
+        template <typename T, typename Allocator>
+        void save_impl(output_archive & ar, const std::vector<T, Allocator> & v,
+            boost::mpl::true_)
+        {
+            if(ar.disable_array_optimization())
+            {
+                save_impl(ar, v, boost::mpl::false_());
+            }
+            else
+            {
+                // bitwise save ...
+                typedef typename std::vector<T, Allocator>::value_type value_type;
+                save_binary(ar, &v[0], v.size() * sizeof(value_type));
+            }
         }
     }
 
     template <typename Allocator>
-    void serialize(output_archive & ar, const std::vector<bool, Allocator> & v, unsigned)
+    void serialize(output_archive & ar, const std::vector<bool, Allocator> & v,
+        unsigned)
     {
         typedef typename std::vector<bool, Allocator>::size_type size_type;
         ar << v.size(); //-V128
@@ -128,11 +138,12 @@ namespace hpx { namespace serialization
     }
 
     template <typename T, typename Allocator>
-    void serialize(output_archive & ar, const std::vector<T, Allocator> & v, unsigned)
+    void serialize(output_archive & ar, const std::vector<T, Allocator> & v,
+        unsigned)
     {
         ar << v.size(); //-V128
         if(v.empty()) return;
-        save_impl(
+        detail::save_impl(
             ar
           , v
           , typename traits::is_bitwise_serializable<

--- a/tests/unit/serialization/serialization_map.cpp
+++ b/tests/unit/serialization/serialization_map.cpp
@@ -102,7 +102,7 @@ void test_vector_as_value()
     std::vector<char> buffer;
     hpx::serialization::output_archive oarchive(buffer);
     std::map<size_t, std::vector<int> > os;
-    for (size_t k = 0; k < 10; ++k)
+    for (int k = 0; k < 10; ++k)
     {
         std::vector<int> vec(10);
         std::iota(vec.begin(), vec.end(), k);


### PR DESCRIPTION
- flyby warning fix in one of the tests
- flyby change: moving ..._impl functions into namespace detail

This fixes #1900