### PR TITLE
Fixing #1903

### DIFF
--- a/hpx/lcos/promise.hpp
+++ b/hpx/lcos/promise.hpp
@@ -13,6 +13,7 @@
 #include <hpx/runtime/components/component_type.hpp>
 #include <hpx/runtime/components/server/create_component.hpp>
 #include <hpx/runtime/components/server/managed_component_base.hpp>
+#include <hpx/runtime/naming/split_gid.hpp>
 #include <hpx/lcos/base_lco_with_value.hpp>
 #include <hpx/traits/get_remote_result.hpp>
 #include <hpx/traits/promise_local_result.hpp>

--- a/hpx/runtime/actions/continuation.hpp
+++ b/hpx/runtime/actions/continuation.hpp
@@ -16,8 +16,7 @@
 #include <hpx/runtime/trigger_lco.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime/naming/name.hpp>
-#include <hpx/runtime/serialization/output_archive.hpp>
-#include <hpx/runtime/serialization/input_archive.hpp>
+#include <hpx/runtime/serialization/serialize.hpp>
 #include <hpx/runtime/serialization/base_object.hpp>
 #include <hpx/util/bind.hpp>
 #include <hpx/util/decay.hpp>
@@ -438,30 +437,12 @@ namespace hpx { namespace actions
         /// serialization support
         friend class hpx::serialization::access;
 
-        void serialize(serialization::input_archive & ar)
-        {
-            // serialize function
-            bool have_function = false;
-            ar >> have_function;
-            if (have_function)
-                ar >> f_;
-        }
-
-        void serialize(serialization::output_archive & ar)
-        {
-            // serialize function
-            bool have_function = !f_.empty();
-            ar << have_function;
-            if (have_function)
-                ar << f_;
-        }
         template <typename Archive>
         void serialize(Archive & ar, unsigned)
         {
             // serialize base class
             ar & hpx::serialization::base_object<continuation>(*this);
-
-            serialize(ar);
+            ar & f_;
         }
         HPX_SERIALIZATION_POLYMORPHIC_WITH_NAME(
             typed_continuation
@@ -542,30 +523,13 @@ namespace hpx { namespace actions
         /// serialization support
         friend class hpx::serialization::access;
 
-        void serialize(serialization::input_archive & ar)
-        {
-            // serialize function
-            bool have_function = false;
-            ar >> have_function;
-            if (have_function)
-                ar >> f_;
-        }
-
-        void serialize(serialization::output_archive & ar)
-        {
-            // serialize function
-            bool have_function = !f_.empty();
-            ar << have_function;
-            if (have_function)
-                ar << f_;
-        }
         template <typename Archive>
         void serialize(Archive & ar, unsigned)
         {
             // serialize base class
             ar & hpx::serialization::base_object<continuation>(*this);
 
-            serialize(ar);
+            ar & f_;
         }
         HPX_SERIALIZATION_POLYMORPHIC_WITH_NAME(
             typed_continuation

--- a/hpx/runtime/naming/name.hpp
+++ b/hpx/runtime/naming/name.hpp
@@ -12,7 +12,6 @@
 #include <hpx/exception.hpp>
 #include <hpx/util/safe_bool.hpp>
 #include <hpx/util/register_locks_globally.hpp>
-#include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/runtime/serialization/serialization_fwd.hpp>
 #include <hpx/traits/is_bitwise_serializable.hpp>
 #include <hpx/traits/promise_remote_result.hpp>
@@ -655,9 +654,6 @@ namespace hpx { namespace naming
         }
 
         ///////////////////////////////////////////////////////////////////////
-        HPX_EXPORT hpx::future<gid_type> split_gid_if_needed(gid_type& id);
-        HPX_EXPORT hpx::future<gid_type> split_gid_if_needed_locked(
-            gid_type::mutex_type::scoped_lock &l, gid_type& gid);
 
         HPX_EXPORT gid_type move_gid(gid_type& id);
         HPX_EXPORT gid_type move_gid_locked(gid_type& gid);

--- a/hpx/runtime/naming/name.hpp
+++ b/hpx/runtime/naming/name.hpp
@@ -12,7 +12,9 @@
 #include <hpx/exception.hpp>
 #include <hpx/util/safe_bool.hpp>
 #include <hpx/util/register_locks_globally.hpp>
+#include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/runtime/serialization/serialization_fwd.hpp>
+#include <hpx/traits/is_bitwise_serializable.hpp>
 #include <hpx/traits/promise_remote_result.hpp>
 #include <hpx/traits/promise_local_result.hpp>
 #include <hpx/lcos/local/spinlock_pool.hpp>
@@ -458,8 +460,6 @@ namespace hpx { namespace naming
         msb |= get_gid_from_locality_id(locality_id).get_msb();
         return gid_type(msb, gid.get_lsb());
     }
-
-    BOOST_CONSTEXPR_OR_CONST boost::uint32_t invalid_locality_id = ~0U;
 
     ///////////////////////////////////////////////////////////////////////////
     inline bool refers_to_virtual_memory(gid_type const& gid)

--- a/hpx/runtime/naming/split_gid.hpp
+++ b/hpx/runtime/naming/split_gid.hpp
@@ -1,0 +1,21 @@
+//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2011 Bryce Lelbach
+//  Copyright (c) 2007 Richard D. Guidry Jr.
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_NAMING_SPLIT_GID_HPP
+#define HPX_NAMING_SPLIT_GID_HPP
+
+#include <hpx/runtime/naming_fwd.hpp>
+#include <hpx/lcos/future.hpp>
+
+namespace hpx { namespace naming { namespace detail
+{
+    HPX_EXPORT hpx::future<gid_type> split_gid_if_needed(gid_type& id);
+    HPX_EXPORT hpx::future<gid_type> split_gid_if_needed_locked(
+        gid_type::mutex_type::scoped_lock &l, gid_type& gid);
+}}}
+
+#endif

--- a/hpx/runtime/naming_fwd.hpp
+++ b/hpx/runtime/naming_fwd.hpp
@@ -24,7 +24,7 @@ namespace hpx
     {
         typedef agas::addressing_service resolver_client;
 
-        struct HPX_API_EXPORT gid_type;
+        struct HPX_EXPORT gid_type;
         // NOTE: We do not export the symbol here as id_type was already
         //       exported and generates a warning on gcc otherwise.
         struct id_type;
@@ -33,6 +33,8 @@ namespace hpx
         HPX_API_EXPORT resolver_client& get_agas_client();
 
         typedef boost::uint64_t address_type;
+
+        BOOST_CONSTEXPR_OR_CONST boost::uint32_t invalid_locality_id = ~0U;
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/parcelset/parcelport_impl.hpp
+++ b/hpx/runtime/parcelset/parcelport_impl.hpp
@@ -198,7 +198,7 @@ namespace hpx { namespace parcelset
             boost::shared_ptr<hpx::serialization::output_archive>
                 archive(
                     new hpx::serialization::output_archive(
-                        *future_await, 0, 0, 0, 0, &future_await->new_gids_)
+                        *future_await, 0, 0, 0, 0)
                 );
 
             put_parcel_await(

--- a/hpx/runtime/serialization/container.hpp
+++ b/hpx/runtime/serialization/container.hpp
@@ -9,6 +9,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/lcos_fwd.hpp>
+#include <hpx/runtime/naming/name.hpp>
 #include <hpx/runtime/serialization/binary_filter.hpp>
 #include <hpx/runtime/serialization/basic_archive.hpp>
 #include <hpx/util/assert.hpp>
@@ -23,6 +24,9 @@ namespace hpx { namespace serialization
         virtual bool is_future_awaiting() const = 0;
         virtual void await_future(
             hpx::lcos::detail::future_data_refcnt_base & future_data) = 0;
+        virtual void add_gid(
+            naming::gid_type const & gid,
+            naming::gid_type const & splitted_gid) = 0;
         virtual void set_filter(binary_filter* filter) = 0;
         virtual void save_binary(void const* address, std::size_t count) = 0;
         virtual void save_binary_chunk(void const* address, std::size_t count) = 0;

--- a/hpx/runtime/serialization/detail/future_await_container.hpp
+++ b/hpx/runtime/serialization/detail/future_await_container.hpp
@@ -75,6 +75,14 @@ namespace hpx { namespace serialization { namespace detail
             );
         }
 
+        void add_gid(
+            naming::gid_type const & gid,
+            naming::gid_type const & splitted_gid)
+        {
+            boost::lock_guard<mutex_type> l(mtx_);
+            new_gids_[gid].push_back(splitted_gid);
+        }
+
         void reset()
         {
             done_ = false;
@@ -131,6 +139,13 @@ namespace hpx { namespace serialization { namespace detail
           , hpx::lcos::detail::future_data_refcnt_base & future_data)
         {
             cont.await_future(future_data);
+        }
+
+        static void add_gid(future_await_container& cont,
+                naming::gid_type const & gid,
+                naming::gid_type const & splitted_gid)
+        {
+            cont.add_gid(gid, splitted_gid);
         }
 
         static void

--- a/hpx/runtime/serialization/detail/size_gatherer_container.hpp
+++ b/hpx/runtime/serialization/detail/size_gatherer_container.hpp
@@ -38,6 +38,11 @@ namespace hpx { namespace serialization { namespace detail
           , hpx::lcos::detail::future_data_refcnt_base & future_data)
         {}
 
+        static void add_gid(size_gatherer_container& cont,
+                naming::gid_type const & gid,
+                naming::gid_type const & splitted_gid)
+        {}
+
         static void
         write(size_gatherer_container& cont, std::size_t count,
             std::size_t current, void const* address)

--- a/hpx/runtime/serialization/output_archive.hpp
+++ b/hpx/runtime/serialization/output_archive.hpp
@@ -8,6 +8,7 @@
 #define HPX_SERIALIZATION_OUTPUT_ARCHIVE_HPP
 
 #include <hpx/config.hpp>
+#include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/runtime/serialization/basic_archive.hpp>
 #include <hpx/runtime/serialization/output_container.hpp>
 #include <hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp>
@@ -22,11 +23,6 @@
 #include <memory>
 
 #include <hpx/config/warnings_prefix.hpp>
-
-namespace hpx { namespace naming
-{
-    struct HPX_EXPORT gid_type;
-}}
 
 namespace hpx { namespace serialization
 {

--- a/hpx/runtime/serialization/output_container.hpp
+++ b/hpx/runtime/serialization/output_container.hpp
@@ -11,6 +11,7 @@
 #include <hpx/config.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/lcos_fwd.hpp>
+#include <hpx/runtime/naming/name.hpp>
 #include <hpx/runtime/serialization/container.hpp>
 #include <hpx/runtime/serialization/serialization_chunk.hpp>
 #include <hpx/runtime/serialization/binary_filter.hpp>
@@ -32,6 +33,11 @@ namespace hpx { namespace serialization
             static void await_future(
                 Container& cont
               , hpx::lcos::detail::future_data_refcnt_base & future_data)
+            {}
+
+            static void add_gid(Container& cont,
+                    naming::gid_type const & gid,
+                    naming::gid_type const & splitted_gid)
             {}
 
             static void write(Container& cont, std::size_t count,
@@ -152,7 +158,14 @@ namespace hpx { namespace serialization
         void await_future(
             hpx::lcos::detail::future_data_refcnt_base & future_data)
         {
-            return detail::access_data<Container>::await_future(cont_, future_data);
+            detail::access_data<Container>::await_future(cont_, future_data);
+        }
+
+        void add_gid(
+            naming::gid_type const & gid,
+            naming::gid_type const & splitted_gid)
+        {
+            detail::access_data<Container>::add_gid(cont_, gid, splitted_gid);
         }
 
         void set_filter(binary_filter* filter) // override

--- a/hpx/runtime/threads/executors/current_executor.hpp
+++ b/hpx/runtime/threads/executors/current_executor.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/state.hpp>
+#include <hpx/runtime/threads_fwd.hpp>
 #include <hpx/runtime/threads/thread_executor.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 #include <hpx/lcos/local/counting_semaphore.hpp>

--- a/hpx/runtime/threads/policies/hwloc_topology.hpp
+++ b/hpx/runtime/threads/policies/hwloc_topology.hpp
@@ -20,6 +20,7 @@
 #include <hpx/exception.hpp>
 
 #include <hpx/util/spinlock.hpp>
+#include <hpx/util/static.hpp>
 
 #include <boost/format.hpp>
 
@@ -112,7 +113,7 @@ namespace hpx { namespace threads
             ) const;
 
         mask_type get_thread_affinity_mask_from_lva(
-            naming::address::address_type
+            naming::address_type
           , error_code& ec = throws
             ) const;
 

--- a/hpx/runtime/threads/thread_helpers.hpp
+++ b/hpx/runtime/threads/thread_helpers.hpp
@@ -804,48 +804,6 @@ namespace hpx { namespace applier
         threads::thread_init_data& data,
         threads::thread_state_enum initial_state = threads::pending,
         error_code& ec = throws);
-
-    ///////////////////////////////////////////////////////////////////////////
-    /// The \a create function initiates the creation of a new
-    /// component instance using the runtime_support as given by targetgid.
-    /// This function is non-blocking as it returns a \a lcos#future. The
-    /// caller of this create is responsible to call
-    /// \a lcos#future#get to obtain the result.
-    ///
-    /// \param targetgid
-    /// \param type
-    /// \param count
-    ///
-    /// \returns    The function returns a \a lcos#future instance
-    ///             returning the the global id of the newly created
-    ///             component when used to call get.
-    ///
-    /// \note       For synchronous operation use the function
-    ///             \a threads#create_sync.
-    HPX_API_EXPORT lcos::future<naming::id_type>
-        create(naming::id_type const& targetgid,
-            boost::uint32_t /*components::component_type*/ type,
-            std::size_t count = 1);
-
-    ///////////////////////////////////////////////////////////////////////////
-    /// The \a create_sync function creates a new component instance using the
-    /// \a runtime_support as given by targetgid. This function is blocking
-    /// for the component to be created and until the global id of the new
-    /// component has been returned.
-    ///
-    /// \param targetgid
-    /// \param type
-    /// \param count
-    ///
-    /// \returns    The function returns the global id of the newly created
-    ///             component.
-    ///
-    /// \note       For asynchronous operation use the function
-    ///             \a threads#create.
-    HPX_API_EXPORT naming::id_type
-        create_sync(naming::id_type const& targetgid,
-            boost::uint32_t /*components::component_type*/ type,
-            std::size_t count = 1);
 }}
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/threads/topology.hpp
+++ b/hpx/runtime/threads/topology.hpp
@@ -11,7 +11,9 @@
 #define HPX_E43E0AF0_8A9D_4870_8CC7_E5AD53EF4798
 
 #include <hpx/config.hpp>
-#include <hpx/runtime/naming/address.hpp>
+#include <hpx/exception_fwd.hpp>
+#include <hpx/runtime/naming_fwd.hpp>
+#include <hpx/util/assert.hpp>
 
 #include <boost/thread.hpp>
 #include <boost/variant.hpp>
@@ -324,7 +326,7 @@ namespace hpx { namespace threads
         ///                   if this is pre-initialized to \a hpx#throws
         ///                   the function will throw on error instead.
         virtual mask_type get_thread_affinity_mask_from_lva(
-            naming::address::address_type, error_code& ec = throws) const = 0;
+            naming::address_type, error_code& ec = throws) const = 0;
 
         /// \brief Prints the \param m to os in a human readable form
         virtual void print_affinity_mask(std::ostream& os,

--- a/hpx/util/detail/basic_function.hpp
+++ b/hpx/util/detail/basic_function.hpp
@@ -10,7 +10,6 @@
 
 #include <hpx/config.hpp>
 #include <hpx/runtime/serialization/access.hpp>
-#include <hpx/runtime/serialization/serialize.hpp>
 #include <hpx/traits/is_callable.hpp>
 #include <hpx/util/detail/empty_function.hpp>
 #include <hpx/util/detail/function_registration.hpp>

--- a/hpx/util/ini.hpp
+++ b/hpx/util/ini.hpp
@@ -9,9 +9,9 @@
 #define HPX_UTIL_SECTION_SEP_17_2008_022PM
 
 #include <map>
-#include <iosfwd>
+#include <iostream>
 
-#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/runtime/serialization/serialization_fwd.hpp>
 
 #include <boost/lexical_cast.hpp>
 

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -21,6 +21,7 @@
 #include <hpx/runtime/agas/server/locality_namespace.hpp>
 #include <hpx/runtime/agas/server/primary_namespace.hpp>
 #include <hpx/runtime/agas/server/symbol_namespace.hpp>
+#include <hpx/runtime/naming/split_gid.hpp>
 #include <hpx/util/logging.hpp>
 #include <hpx/util/runtime_configuration.hpp>
 #include <hpx/util/safe_lexical_cast.hpp>

--- a/src/runtime/agas/server/symbol_namespace_server.cpp
+++ b/src/runtime/agas/server/symbol_namespace_server.cpp
@@ -9,6 +9,7 @@
 #include <hpx/hpx_fwd.hpp>
 #include <hpx/apply.hpp>
 #include <hpx/runtime/naming/resolver_client.hpp>
+#include <hpx/runtime/naming/split_gid.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/runtime/agas/interface.hpp>
 #include <hpx/runtime/agas/server/symbol_namespace.hpp>

--- a/src/runtime/naming/name.cpp
+++ b/src/runtime/naming/name.cpp
@@ -13,6 +13,7 @@
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/runtime/agas/addressing_service.hpp>
 #include <hpx/runtime/agas/interface.hpp>
+#include <hpx/runtime/naming/split_gid.hpp>
 #include <hpx/runtime/serialization/serialize.hpp>
 #include <hpx/runtime/serialization/intrusive_ptr.hpp>
 

--- a/src/runtime/serialization/output_archive.cpp
+++ b/src/runtime/serialization/output_archive.cpp
@@ -12,11 +12,8 @@ namespace hpx { namespace serialization
         naming::gid_type const & gid,
         naming::gid_type const & splitted_gid)
     {
-        if(new_gids_)
-        {
-            (*new_gids_)[gid].push_back(splitted_gid);
-            HPX_ASSERT((*new_gids_)[gid].size() == 1);
-        }
+        HPX_ASSERT(is_future_awaiting());
+        buffer_->add_gid(gid, splitted_gid);
     }
 
     naming::gid_type output_archive::get_new_gid(naming::gid_type const & gid)

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -9,7 +9,7 @@
 #if defined(HPX_HAVE_LOGGING)
 
 #include <hpx/exception.hpp>
-#include <hpx/runtime/naming/name.hpp>
+#include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/runtime/naming/resolver_client.hpp>
 #include <hpx/runtime/components/console_logging.hpp>
 #include <hpx/runtime/threads/threadmanager.hpp>


### PR DESCRIPTION
 - Removed wrong assert (might fire in situations we actually do allow)
 - Made adding of splitted GIDs thread safe as we might add GIDs concurrently when requesting new credit from AGAS

Flyby change: Cleaned up some headers, as this was necessary to make the proposed changes compile.