### PR TITLE
Adding a minimum version for Open MPI

### DIFF
--- a/docs/hpx.qbk
+++ b/docs/hpx.qbk
@@ -127,6 +127,7 @@
 [def __sbatch__                 [@http://slurm.schedmd.com/sbatch.html sbatch]]
 [def __linda__                  [@http://en.wikipedia.org/wiki/Linda_(coordination_language) The Linda Coordination Language]]
 [def __opencl__                 [@https://www.khronos.org/opencl/ OpenCL]]
+[def __openmpi__                [@https://www.open-mpi.org Open MPI]]
 [def __pocl__                   [@http://portablecl.org/ POCL]]
 [def __cuda__                   [@http://www.nvidia.com/object/cuda_home_new.html CUDA]]
 [def __nt2__                    [@http://www.numscale.com/nt2/ NT2]]

--- a/docs/manual/build_system/cmake_toolchains.qbk
+++ b/docs/manual/build_system/cmake_toolchains.qbk
@@ -14,74 +14,16 @@ In order to compile HPX for various platforms, we provide a variety of Toolchain
 take care of setting up various __cmake__ variables like compilers etc. They are located
 in the `cmake/toolchains` directory:
 
-* [link hpx.manual.build_system.building_hpx.cmake_toolchains.Cray_Intel Cray-Intel]
 * [link hpx.manual.build_system.building_hpx.cmake_toolchains.ARM_gcc ARM-gcc]
-* [link hpx.manual.build_system.building_hpx.cmake_toolchains.BGQ BGQ]
 * [link hpx.manual.build_system.building_hpx.cmake_toolchains.BGION_gcc BGION-gcc]
+* [link hpx.manual.build_system.building_hpx.cmake_toolchains.BGQ BGQ]
+* [link hpx.manual.build_system.building_hpx.cmake_toolchains.Cray_Intel Cray-Intel]
 * [link hpx.manual.build_system.building_hpx.cmake_toolchains.XeonPhi XeonPhi]
 
 
 [teletype]
 
 To use them pass the `-DCMAKE_TOOLCHAIN_FILE=<toolchain>` argument to the cmake invocation.
-
-[heading:Cray_Intel Cray-Intel]
-
-``
-    # Copyright (c) 2014 Thomas Heller
-    #
-    # Distributed under the Boost Software License, Version 1.0. (See accompanying
-    # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-    #
-    # This is the default toolchain file to be used with Intel Xeon PHIs. It sets
-    # the appropriate compile flags and compiler such that HPX will compile.
-    # Note that you still need to provide Boost, hwloc and other utility libraries
-    # like a custom allocator yourself.
-    #
-    #set(CMAKE_SYSTEM_NAME Cray-CNK-Intel)
-    if(HPX_WITH_STATIC_LINKING)
-      set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS FALSE)
-    else()
-    endif()
-    # Set the Intel Compiler
-    set(CMAKE_CXX_COMPILER CC)
-    set(CMAKE_C_COMPILER cc)
-    set(CMAKE_Fortran_COMPILER ftn)
-    set(CMAKE_C_FLAGS_INIT "" CACHE STRING "")
-    set(CMAKE_SHARED_LIBRARY_C_FLAGS "-fPIC -shared" CACHE STRING "")
-    set(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "-fPIC -shared" CACHE STRING "")
-    set(CMAKE_C_COMPILE_OBJECT "<CMAKE_C_COMPILER> -shared -fPIC <DEFINES> <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "")
-    set(CMAKE_C_LINK_EXECUTABLE "<CMAKE_C_COMPILER> -fPIC -dynamic <FLAGS> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>" CACHE STRING "")
-    set(CMAKE_C_CREATE_SHARED_LIBRARY "<CMAKE_C_COMPILER> -fPIC -shared <CMAKE_SHARED_LIBRARY_CXX_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS> <SONAME_FLAG><TARGET_SONAME> -o <TARGET> <OBJECTS> <LINK_LIBRARIES> " CACHE STRING "")
-    set(CMAKE_CXX_FLAGS_INIT "" CACHE STRING "")
-    set(CMAKE_SHARED_LIBRARY_CXX_FLAGS "-fPIC -shared" CACHE STRING "")
-    set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-fPIC -shared" CACHE STRING "")
-    set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-fPIC -shared" CACHE STRING "")
-    set(CMAKE_CXX_COMPILE_OBJECT "<CMAKE_CXX_COMPILER> -shared -fPIC <DEFINES> <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "")
-    set(CMAKE_CXX_LINK_EXECUTABLE "<CMAKE_CXX_COMPILER> -fPIC -dynamic <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>" CACHE STRING "")
-    set(CMAKE_CXX_CREATE_SHARED_LIBRARY "<CMAKE_CXX_COMPILER> -fPIC -shared <CMAKE_SHARED_LIBRARY_CXX_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS> <SONAME_FLAG><TARGET_SONAME> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>" CACHE STRING "")
-    set(CMAKE_Fortran_FLAGS_INIT "" CACHE STRING "")
-    set(CMAKE_SHARED_LIBRARY_Fortran_FLAGS "-fPIC" CACHE STRING "")
-    set(CMAKE_SHARED_LIBRARY_CREATE_Fortran_FLAGS "-shared" CACHE STRING "")
-    set(CMAKE_Fortran_COMPILE_OBJECT "<CMAKE_Fortran_COMPILER> -shared -fPIC <DEFINES> <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "")
-    set(CMAKE_Fortran_LINK_EXECUTABLE "<CMAKE_Fortran_COMPILER> -fPIC -dynamic <FLAGS> <CMAKE_Fortran_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
-    set(CMAKE_Fortran_CREATE_SHARED_LIBRARY "<CMAKE_Fortran_COMPILER> -fPIC -shared <CMAKE_SHARED_LIBRARY_Fortran_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_Fortran_FLAGS> <SONAME_FLAG><TARGET_SONAME> -o <TARGET> <OBJECTS> <LINK_LIBRARIES> " CACHE STRING "")
-    # Disable searches in the default system paths. We are cross compiling after all
-    # and cmake might pick up wrong libraries that way
-    set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM BOTH)
-    set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
-    set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
-    set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
-    set(HPX_WITH_PARCELPORT_TCP OFF CACHE BOOL "")
-    set(HPX_WITH_PARCELPORT_MPI ON CACHE BOOL "")
-    set(HPX_WITH_PARCELPORT_MPI_MULTITHREADED OFF CACHE BOOL "")
-    # We default to system as our allocator on the BGQ
-    if(NOT DEFINED HPX_WITH_MALLOC)
-      set(HPX_WITH_MALLOC "system" CACHE STRING "")
-    endif()
-    # We do a cross compilation here ...
-    set(CMAKE_CROSSCOMPILING ON CACHE BOOL "")
-``
 
 [heading:ARM_gcc ARM-gcc]
 
@@ -100,63 +42,6 @@ To use them pass the `-DCMAKE_TOOLCHAIN_FILE=<toolchain>` argument to the cmake 
     set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
     set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
     set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
-``
-
-[heading:BGQ BGQ]
-
-``
-    # Copyright (c) 2014 Thomas Heller
-    #
-    # Distributed under the Boost Software License, Version 1.0. (See accompanying
-    # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-    #
-    # This is the default toolchain file to be used with CNK on a BlueGene/Q. It sets
-    # the appropriate compile flags and compiler such that HPX will compile.
-    # Note that you still need to provide Boost, hwloc and other utility libraries
-    # like a custom allocator yourself.
-    #
-    set(CMAKE_SYSTEM_NAME Linux)
-    # Set the Intel Compiler
-    set(CMAKE_CXX_COMPILER bgclang++11)
-    set(CMAKE_C_COMPILER bgclang)
-    #set(CMAKE_Fortran_COMPILER)
-    set(MPI_CXX_COMPILER mpiclang++11)
-    set(MPI_C_COMPILER mpiclang)
-    #set(MPI_Fortran_COMPILER)
-    set(CMAKE_C_FLAGS_INIT "" CACHE STRING "")
-    set(CMAKE_C_COMPILE_OBJECT "<CMAKE_C_COMPILER> -fPIC <DEFINES> <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "")
-    set(CMAKE_C_LINK_EXECUTABLE "<CMAKE_C_COMPILER> -fPIC -dynamic <FLAGS> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>" CACHE STRING "")
-    set(CMAKE_C_CREATE_SHARED_LIBRARY "<CMAKE_C_COMPILER> -fPIC -shared <CMAKE_SHARED_LIBRARY_CXX_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS> <SONAME_FLAG><TARGET_SONAME> -o <TARGET> <OBJECTS> <LINK_LIBRARIES> " CACHE STRING "")
-    set(CMAKE_CXX_FLAGS_INIT "" CACHE STRING "")
-    set(CMAKE_CXX_COMPILE_OBJECT "<CMAKE_CXX_COMPILER> -fPIC <DEFINES> <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "")
-    set(CMAKE_CXX_LINK_EXECUTABLE "<CMAKE_CXX_COMPILER> -fPIC -dynamic <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>" CACHE STRING "")
-    set(CMAKE_CXX_CREATE_SHARED_LIBRARY "<CMAKE_CXX_COMPILER> -fPIC -shared <CMAKE_SHARED_LIBRARY_CXX_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS> <SONAME_FLAG><TARGET_SONAME> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>" CACHE STRING "")
-    set(CMAKE_Fortran_FLAGS_INIT "" CACHE STRING "")
-    set(CMAKE_Fortran_COMPILE_OBJECT "<CMAKE_Fortran_COMPILER> -fPIC <DEFINES> <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "")
-    set(CMAKE_Fortran_LINK_EXECUTABLE "<CMAKE_Fortran_COMPILER> -fPIC -dynamic <FLAGS> <CMAKE_Fortran_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
-    set(CMAKE_Fortran_CREATE_SHARED_LIBRARY "<CMAKE_Fortran_COMPILER> -fPIC -shared <CMAKE_SHARED_LIBRARY_Fortran_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_Fortran_FLAGS> <SONAME_FLAG><TARGET_SONAME> -o <TARGET> <OBJECTS> <LINK_LIBRARIES> " CACHE STRING "")
-    # Disable searches in the default system paths. We are cross compiling after all
-    # and cmake might pick up wrong libraries that way
-    set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM BOTH)
-    set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
-    set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
-    set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
-    # We do a cross compilation here ...
-    set(CMAKE_CROSSCOMPILING ON)
-    # Set our platform name
-    set(HPX_PLATFORM "BlueGeneQ")
-    # Always disable the ibverbs parcelport as it is nonfunctional on the BGQ.
-    set(HPX_WITH_IBVERBS_PARCELPORT OFF)
-    # Always disable the tcp parcelport as it is nonfunctional on the BGQ.
-    set(HPX_WITH_TCP_PARCELPORT OFF)
-    # Always enable the tcp parcelport as it is currently the only way to communicate on the BGQ.
-    set(HPX_WITH_MPI_PARCELPORT ON)
-    # We have a bunch of cores on the BGQ ...
-    set(HPX_WITH_MAX_CPU_COUNT "64")
-    # We default to tbbmalloc as our allocator on the MIC
-    if(NOT DEFINED HPX_WITH_MALLOC)
-      set(HPX_WITH_MALLOC "system" CACHE STRING "")
-    endif()
 ``
 
 [heading:BGION_gcc BGION-gcc]
@@ -224,6 +109,121 @@ To use them pass the `-DCMAKE_TOOLCHAIN_FILE=<toolchain>` argument to the cmake 
     set(HPX_WITH_TESTS_EXTERNAL_BUILD OFF CACHE BOOL "Turn off build of cmake build tests")
     set(DART_TESTING_TIMEOUT           45  CACHE STRING "Life is too short")
     # HPX_WITH_STATIC_LINKING
+``
+
+[heading:BGQ BGQ]
+
+``
+    # Copyright (c) 2014 Thomas Heller
+    #
+    # Distributed under the Boost Software License, Version 1.0. (See accompanying
+    # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+    #
+    # This is the default toolchain file to be used with CNK on a BlueGene/Q. It sets
+    # the appropriate compile flags and compiler such that HPX will compile.
+    # Note that you still need to provide Boost, hwloc and other utility libraries
+    # like a custom allocator yourself.
+    #
+    set(CMAKE_SYSTEM_NAME Linux)
+    # Set the Intel Compiler
+    set(CMAKE_CXX_COMPILER bgclang++11)
+    set(CMAKE_C_COMPILER bgclang)
+    #set(CMAKE_Fortran_COMPILER)
+    set(MPI_CXX_COMPILER mpiclang++11)
+    set(MPI_C_COMPILER mpiclang)
+    #set(MPI_Fortran_COMPILER)
+    set(CMAKE_C_FLAGS_INIT "" CACHE STRING "")
+    set(CMAKE_C_COMPILE_OBJECT "<CMAKE_C_COMPILER> -fPIC <DEFINES> <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "")
+    set(CMAKE_C_LINK_EXECUTABLE "<CMAKE_C_COMPILER> -fPIC -dynamic <FLAGS> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>" CACHE STRING "")
+    set(CMAKE_C_CREATE_SHARED_LIBRARY "<CMAKE_C_COMPILER> -fPIC -shared <CMAKE_SHARED_LIBRARY_CXX_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS> <SONAME_FLAG><TARGET_SONAME> -o <TARGET> <OBJECTS> <LINK_LIBRARIES> " CACHE STRING "")
+    set(CMAKE_CXX_FLAGS_INIT "" CACHE STRING "")
+    set(CMAKE_CXX_COMPILE_OBJECT "<CMAKE_CXX_COMPILER> -fPIC <DEFINES> <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "")
+    set(CMAKE_CXX_LINK_EXECUTABLE "<CMAKE_CXX_COMPILER> -fPIC -dynamic <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>" CACHE STRING "")
+    set(CMAKE_CXX_CREATE_SHARED_LIBRARY "<CMAKE_CXX_COMPILER> -fPIC -shared <CMAKE_SHARED_LIBRARY_CXX_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS> <SONAME_FLAG><TARGET_SONAME> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>" CACHE STRING "")
+    set(CMAKE_Fortran_FLAGS_INIT "" CACHE STRING "")
+    set(CMAKE_Fortran_COMPILE_OBJECT "<CMAKE_Fortran_COMPILER> -fPIC <DEFINES> <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "")
+    set(CMAKE_Fortran_LINK_EXECUTABLE "<CMAKE_Fortran_COMPILER> -fPIC -dynamic <FLAGS> <CMAKE_Fortran_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
+    set(CMAKE_Fortran_CREATE_SHARED_LIBRARY "<CMAKE_Fortran_COMPILER> -fPIC -shared <CMAKE_SHARED_LIBRARY_Fortran_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_Fortran_FLAGS> <SONAME_FLAG><TARGET_SONAME> -o <TARGET> <OBJECTS> <LINK_LIBRARIES> " CACHE STRING "")
+    # Disable searches in the default system paths. We are cross compiling after all
+    # and cmake might pick up wrong libraries that way
+    set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM BOTH)
+    set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+    set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+    set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+    # We do a cross compilation here ...
+    set(CMAKE_CROSSCOMPILING ON)
+    # Set our platform name
+    set(HPX_PLATFORM "BlueGeneQ")
+    # Always disable the ibverbs parcelport as it is nonfunctional on the BGQ.
+    set(HPX_WITH_IBVERBS_PARCELPORT OFF)
+    # Always disable the tcp parcelport as it is nonfunctional on the BGQ.
+    set(HPX_WITH_TCP_PARCELPORT OFF)
+    # Always enable the tcp parcelport as it is currently the only way to communicate on the BGQ.
+    set(HPX_WITH_MPI_PARCELPORT ON)
+    # We have a bunch of cores on the BGQ ...
+    set(HPX_WITH_MAX_CPU_COUNT "64")
+    # We default to tbbmalloc as our allocator on the MIC
+    if(NOT DEFINED HPX_WITH_MALLOC)
+      set(HPX_WITH_MALLOC "system" CACHE STRING "")
+    endif()
+``
+
+[heading:Cray_Intel Cray-Intel]
+
+``
+    # Copyright (c) 2014 Thomas Heller
+    #
+    # Distributed under the Boost Software License, Version 1.0. (See accompanying
+    # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+    #
+    # This is the default toolchain file to be used with Intel Xeon PHIs. It sets
+    # the appropriate compile flags and compiler such that HPX will compile.
+    # Note that you still need to provide Boost, hwloc and other utility libraries
+    # like a custom allocator yourself.
+    #
+    #set(CMAKE_SYSTEM_NAME Cray-CNK-Intel)
+    if(HPX_WITH_STATIC_LINKING)
+      set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS FALSE)
+    else()
+    endif()
+    # Set the Intel Compiler
+    set(CMAKE_CXX_COMPILER CC)
+    set(CMAKE_C_COMPILER cc)
+    set(CMAKE_Fortran_COMPILER ftn)
+    set(CMAKE_C_FLAGS_INIT "" CACHE STRING "")
+    set(CMAKE_SHARED_LIBRARY_C_FLAGS "-fPIC -shared" CACHE STRING "")
+    set(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "-fPIC -shared" CACHE STRING "")
+    set(CMAKE_C_COMPILE_OBJECT "<CMAKE_C_COMPILER> -shared -fPIC <DEFINES> <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "")
+    set(CMAKE_C_LINK_EXECUTABLE "<CMAKE_C_COMPILER> -fPIC -dynamic <FLAGS> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>" CACHE STRING "")
+    set(CMAKE_C_CREATE_SHARED_LIBRARY "<CMAKE_C_COMPILER> -fPIC -shared <CMAKE_SHARED_LIBRARY_CXX_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS> <SONAME_FLAG><TARGET_SONAME> -o <TARGET> <OBJECTS> <LINK_LIBRARIES> " CACHE STRING "")
+    set(CMAKE_CXX_FLAGS_INIT "" CACHE STRING "")
+    set(CMAKE_SHARED_LIBRARY_CXX_FLAGS "-fPIC -shared" CACHE STRING "")
+    set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-fPIC -shared" CACHE STRING "")
+    set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-fPIC -shared" CACHE STRING "")
+    set(CMAKE_CXX_COMPILE_OBJECT "<CMAKE_CXX_COMPILER> -shared -fPIC <DEFINES> <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "")
+    set(CMAKE_CXX_LINK_EXECUTABLE "<CMAKE_CXX_COMPILER> -fPIC -dynamic <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>" CACHE STRING "")
+    set(CMAKE_CXX_CREATE_SHARED_LIBRARY "<CMAKE_CXX_COMPILER> -fPIC -shared <CMAKE_SHARED_LIBRARY_CXX_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS> <SONAME_FLAG><TARGET_SONAME> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>" CACHE STRING "")
+    set(CMAKE_Fortran_FLAGS_INIT "" CACHE STRING "")
+    set(CMAKE_SHARED_LIBRARY_Fortran_FLAGS "-fPIC" CACHE STRING "")
+    set(CMAKE_SHARED_LIBRARY_CREATE_Fortran_FLAGS "-shared" CACHE STRING "")
+    set(CMAKE_Fortran_COMPILE_OBJECT "<CMAKE_Fortran_COMPILER> -shared -fPIC <DEFINES> <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "")
+    set(CMAKE_Fortran_LINK_EXECUTABLE "<CMAKE_Fortran_COMPILER> -fPIC -dynamic <FLAGS> <CMAKE_Fortran_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
+    set(CMAKE_Fortran_CREATE_SHARED_LIBRARY "<CMAKE_Fortran_COMPILER> -fPIC -shared <CMAKE_SHARED_LIBRARY_Fortran_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_Fortran_FLAGS> <SONAME_FLAG><TARGET_SONAME> -o <TARGET> <OBJECTS> <LINK_LIBRARIES> " CACHE STRING "")
+    # Disable searches in the default system paths. We are cross compiling after all
+    # and cmake might pick up wrong libraries that way
+    set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM BOTH)
+    set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+    set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+    set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+    set(HPX_WITH_PARCELPORT_TCP OFF CACHE BOOL "")
+    set(HPX_WITH_PARCELPORT_MPI ON CACHE BOOL "")
+    set(HPX_WITH_PARCELPORT_MPI_MULTITHREADED OFF CACHE BOOL "")
+    # We default to system as our allocator on the BGQ
+    if(NOT DEFINED HPX_WITH_MALLOC)
+      set(HPX_WITH_MALLOC "system" CACHE STRING "")
+    endif()
+    # We do a cross compilation here ...
+    set(CMAKE_CROSSCOMPILING ON CACHE BOOL "")
 ``
 
 [heading:XeonPhi XeonPhi]

--- a/docs/manual/build_system/prerequisites.qbk
+++ b/docs/manual/build_system/prerequisites.qbk
@@ -125,6 +125,9 @@ listed below.
          diagnostics.]]
     [[__libunwind__              ][0.99               ][0.97            ]
         [Dependency of google-perftools on x86-64, used for stack unwinding.]]
+    [[__openmpi__                ][1.10.1             ][1.8.0           ]
+        [Can be used as a highspeed communication library backend for the
+         parcelport.]]
 ]
 
 [table Optional Software Prerequisites for __hpx__ on Linux systems


### PR DESCRIPTION
Version 1.7 of Open MPI causes problems in HPX. This change
adds Open MPI as a highly suggested software package with
the minimum version being 1.8