### PR TITLE
Changing parallel::sort to return the last iterator as proposed by N4560

### DIFF
--- a/hpx/parallel/algorithms/sort.hpp
+++ b/hpx/parallel/algorithms/sort.hpp
@@ -144,7 +144,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             {
                 return executor_traits::async_execute(
                     policy.executor(),
-                    [first, last, comp]()
+                    [first, last, comp]() -> RandomIt
                     {
                         std::sort(first, last, comp);
                         return last;
@@ -198,7 +198,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             std::swap(*first, *c_last);
 
             // spawn tasks for each sub section
-            hpx::future<void> left =
+            hpx::future<RandomIt> left =
                 executor_traits::async_execute(
                     policy.executor(),
                     hpx::util::bind(
@@ -206,7 +206,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         policy, first, c_last, comp
                     ));
 
-            hpx::future<void> right =
+            hpx::future<RandomIt> right =
                 executor_traits::async_execute(
                     policy.executor(),
                     hpx::util::bind(
@@ -215,7 +215,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     ));
 
             return hpx::lcos::local::dataflow(
-                [last](hpx::future<void> && left, hpx::future<void> && right)
+                [last](hpx::future<RandomIt> && left,
+                    hpx::future<RandomIt> && right) -> RandomIt
                 {
                     if (left.has_exception() || right.has_exception())
                     {

--- a/tests/unit/parallel/algorithms/sort.cpp
+++ b/tests/unit/parallel/algorithms/sort.cpp
@@ -6,6 +6,12 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 
+// use smaller array sizes for debug tests
+#if defined(HPX_DEBUG)
+#define HPX_SORT_TEST_SIZE          10000
+#define HPX_SORT_TEST_SIZE_STRINGS  50000
+#endif
+
 #include "sort_tests.hpp"
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/parallel/algorithms/sort_tests.hpp
+++ b/tests/unit/parallel/algorithms/sort_tests.hpp
@@ -25,6 +25,14 @@
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_real_distribution.hpp>
 
+#if !defined(HPX_SORT_TEST_SIZE_STRINGS)
+#define HPX_SORT_TEST_SIZE_STRINGS 1000000
+#endif
+
+#if !defined(HPX_SORT_TEST_SIZE)
+#define HPX_SORT_TEST_SIZE 5000000
+#endif
+
 // --------------------------------------------------------------------
 // Fill a vector with random numbers in the range [lower, upper]
 template <typename T>
@@ -59,8 +67,9 @@ std::string random_string( size_t length )
 
 // --------------------------------------------------------------------
 // fill a vector with random strings
-void rnd_strings(std::vector<std::string> &V) {
-    const std::size_t test_size = 1000000;
+void rnd_strings(std::vector<std::string> &V)
+{
+    const std::size_t test_size = HPX_SORT_TEST_SIZE_STRINGS;
     // Fill vector with random strings
     V.clear();
     V.reserve(test_size);
@@ -117,7 +126,7 @@ void test_sort1(ExPolicy && policy, T)
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", sync, random);
 
     // Fill vector with random values
-    std::vector<T> c(5000000);
+    std::vector<T> c(HPX_SORT_TEST_SIZE);
     rnd_fill<T>(c, (std::numeric_limits<T>::min)(),
         (std::numeric_limits<T>::max)(), T(std::rand()));
 
@@ -143,7 +152,7 @@ template <typename ExPolicy, typename T, typename Compare = std::less<T>>
         sync, random);
 
     // Fill vector with random values
-    std::vector<T> c(5000000);
+    std::vector<T> c(HPX_SORT_TEST_SIZE);
     rnd_fill<T>(c, (std::numeric_limits<T>::min)(),
         (std::numeric_limits<T>::max)(), T(std::rand()));
 
@@ -169,7 +178,7 @@ template <typename ExPolicy, typename T, typename Compare = std::less<T>>
         async, random);
 
     // Fill vector with random values
-    std::vector<T> c(5000000);
+    std::vector<T> c(HPX_SORT_TEST_SIZE);
     rnd_fill<T>(c, (std::numeric_limits<T>::min)(),
         (std::numeric_limits<T>::max)(), T(std::rand()));
 
@@ -523,7 +532,7 @@ void test_sort2(ExPolicy && policy, T)
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", sync, sorted);
 
     // Fill vector with increasing values
-    std::vector<T> c(5000000);
+    std::vector<T> c(HPX_SORT_TEST_SIZE);
     std::iota(boost::begin(c), boost::end(c), 0);
 
     boost::uint64_t t = hpx::util::high_resolution_clock::now();
@@ -547,7 +556,7 @@ void test_sort2_comp(ExPolicy && policy, T, Compare comp = Compare())
         sync, sorted);
 
     // Fill vector with increasing values
-    std::vector<T> c(5000000);
+    std::vector<T> c(HPX_SORT_TEST_SIZE);
     std::iota(boost::begin(c), boost::end(c), 0);
 
     boost::uint64_t t = hpx::util::high_resolution_clock::now();
@@ -571,7 +580,7 @@ void test_sort2_async(ExPolicy && policy, T, Compare comp = Compare())
         async, sorted);
 
     // Fill vector with random values
-    std::vector<T> c(5000000);
+    std::vector<T> c(HPX_SORT_TEST_SIZE);
     std::iota(boost::begin(c), boost::end(c), T(0));
 
     boost::uint64_t t = hpx::util::high_resolution_clock::now();


### PR DESCRIPTION
Second attaempt, the former problems are solved now

- Adding explicit return types for lambdas
- flyby change: reduce array sizes for sort tests in Debug