### PR TITLE
Keep cmake_module_path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ endif()
 ################################################################################
 # CMake configuration
 ################################################################################
-set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 
 # We safe the passed compiler flag to a special variable. This is needed for our
 # build system unit tests. Some flags might influence the created symbols (


### PR DESCRIPTION
If CMAKE_MODULE_PATH was specified previously, keep the values.
We are improving conan.io (c++ package manager) supporting custom FindXXX.cmake for some packages like Boost and Hwloc. So those packages in conan provides their own FindXXX.
If you override the CMAKE_MODULE_PATH, conan won't be able to find the custom finders and the dependencies will be unresolved.
I think it doesn't affect at all to your build system but would be great for HPX conan package.
We are currently improving HPX Package (current version is a very alpha version) generator for conan.io. We hope to have a better version of HPX when we release conan 0.5