### PR TITLE
Add utility member functions for partitioned_vector

### DIFF
--- a/hpx/components/containers/partitioned_vector/partitioned_vector.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector.hpp
@@ -737,7 +737,7 @@ namespace hpx
         {
             std::vector< hpx::id_type > ids;
 
-            for(auto const part_data : partitions_)
+            for(auto const & part_data : partitions_)
             {
                 ids.push_back( part_data.partition_);
             }

--- a/hpx/components/containers/partitioned_vector/partitioned_vector.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector.hpp
@@ -732,6 +732,18 @@ namespace hpx
         }
 
     public:
+
+        std::vector< hpx::id_type > get_partitions_ids()
+        {
+            std::vector< hpx::id_type > ids;
+
+            for(auto const part_data : partitions_)
+            {
+                ids.push_back( part_data.partition_);
+            }
+            return ids;
+        }
+
         /// \brief Array subscript operator. This does not throw any exception.
         ///
         /// \param pos Position of the element in the vector [Note the first

--- a/hpx/components/containers/partitioned_vector/partitioned_vector.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector.hpp
@@ -732,18 +732,6 @@ namespace hpx
         }
 
     public:
-
-        std::vector< hpx::id_type > get_partitions_ids()
-        {
-            std::vector< hpx::id_type > ids;
-
-            for(auto const & part_data : partitions_)
-            {
-                ids.push_back( part_data.partition_);
-            }
-            return ids;
-        }
-
         /// \brief Array subscript operator. This does not throw any exception.
         ///
         /// \param pos Position of the element in the vector [Note the first

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp
@@ -737,7 +737,7 @@ namespace hpx
             return get_copied_data().get();
         }
 
-        /// Returns the data reference of the partition_vector
+        /// Returns a copy of the data owned by the partition_vector
         /// component.
         ///
         /// \return This returns the data as an hpx::future

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp
@@ -50,10 +50,8 @@ namespace hpx { namespace server
                 components::simple_component_base<partitioned_vector<T> > >
             base_type;
 
-    private:
         data_type partition_vector_;
 
-    public:
         ///////////////////////////////////////////////////////////////////////
         // Constructors
         ///////////////////////////////////////////////////////////////////////
@@ -115,6 +113,12 @@ namespace hpx { namespace server
             return partition_vector_;
         }
         data_type const& get_data() const
+        {
+            return partition_vector_;
+        }
+
+        /// Duplicate the copy method for action naming
+        data_type get_copied_data() const
         {
             return partition_vector_;
         }
@@ -361,6 +365,7 @@ namespace hpx { namespace server
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, set_values);
 
 //         HPX_DEFINE_COMPONENT_ACTION(partition_vector, clear);
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, get_copied_data);
     };
 }}
 
@@ -396,6 +401,9 @@ namespace hpx { namespace server
     HPX_REGISTER_ACTION_DECLARATION(                                          \
         hpx::server::partitioned_vector<type>::resize_action,                 \
         BOOST_PP_CAT(__vector_resize_action_, name));                         \
+    HPX_REGISTER_ACTION_DECLARATION(                                          \
+        hpx::server::partitioned_vector<type>::get_copied_data_action,        \
+        BOOST_PP_CAT(__vector_get_copied_data_action_, name));                \
 /**/
 
 #define HPX_REGISTER_PARTITIONED_VECTOR(...)                                  \
@@ -429,6 +437,9 @@ namespace hpx { namespace server
     HPX_REGISTER_ACTION(                                                      \
         hpx::server::partitioned_vector<type>::resize_action,                 \
         BOOST_PP_CAT(__vector_resize_action_, name));                         \
+    HPX_REGISTER_ACTION(                                                      \
+        hpx::server::partitioned_vector<type>::get_copied_data_action,        \
+        BOOST_PP_CAT(__vector_get_copied_data_action_, name));                \
     typedef ::hpx::components::simple_component<                              \
         ::hpx::server::partitioned_vector<type>                               \
     > BOOST_PP_CAT(__vector_, name);                                          \
@@ -449,7 +460,6 @@ namespace hpx
         typedef hpx::components::client_base<
                 partition_vector<T>, server::partitioned_vector<T>
             > base_type;
-
     public:
         partition_vector() {}
 
@@ -716,7 +726,29 @@ namespace hpx
 //             HPX_ASSERT(this->get_id());
 //             this->base_type::clear_async(this->get_id()).get();
 //         }
-    };
+
+        /// Returns a copy of the data owned by the partition_vector
+        /// component.
+        ///
+        /// \return This returns the data of the partition_vector
+        ///
+        auto get_copied_data_sync()
+        {
+            return get_copied_data().get();
+        }
+
+        /// Returns the data reference of the partition_vector
+        /// component.
+        ///
+        /// \return This returns the data as an hpx::future
+        ///
+        auto get_copied_data() const
+        {
+            HPX_ASSERT(this->get_id());
+            return hpx::async<typename server_type::get_copied_data_action>(
+                this->get_id());
+        }
+   };
 }
 
 #endif


### PR DESCRIPTION
This pull request does 2 small changes:
- Give a public access to the type named data_type in hpx::server::partitioned_vector
- Add a member action (get_copied_data) allowing to asynchronously get a copy of the data 
  owned by the server