### PR TITLE
Removing superfluous includes of boost/lockfree/detail/branch_hints.hpp

### DIFF
--- a/external/lockfree/boost/lockfree/queue.hpp
+++ b/external/lockfree/boost/lockfree/queue.hpp
@@ -26,6 +26,7 @@
 #include <boost/lockfree/detail/atomic.hpp>
 #include <boost/lockfree/detail/tagged_ptr.hpp>
 #include <boost/lockfree/detail/freelist.hpp>
+#include <boost/lockfree/detail/branch_hints.hpp>
 
 namespace boost {
 namespace lockfree {

--- a/external/lockfree/boost/lockfree/ringbuffer.hpp
+++ b/external/lockfree/boost/lockfree/ringbuffer.hpp
@@ -18,8 +18,8 @@
 #include <boost/noncopyable.hpp>
 #include <boost/smart_ptr/scoped_array.hpp>
 
-#include "detail/branch_hints.hpp"
-#include "detail/prefix.hpp"
+#include <boost/lockfree/detail/branch_hints.hpp>
+#include <boost/lockfree/detail/prefix.hpp>
 
 #include <algorithm>
 

--- a/hpx/runtime/threads/thread_data.hpp
+++ b/hpx/runtime/threads/thread_data.hpp
@@ -28,7 +28,6 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/noncopyable.hpp>
-#include <boost/lockfree/detail/branch_hints.hpp>
 #include <boost/lockfree/stack.hpp>
 
 #include <stack>

--- a/hpx/util/lockfree/detail/tagged_ptr_pair.hpp
+++ b/hpx/util/lockfree/detail/tagged_ptr_pair.hpp
@@ -16,7 +16,6 @@
 #include <hpx/config.hpp>
 
 #include <boost/cstdint.hpp>
-#include <boost/lockfree/detail/branch_hints.hpp>
 
 #include <cstddef> // for std::size_t
 


### PR DESCRIPTION
Since this header has been removed in Boost 1.60.0, this also fixes
the compilation with newer Boost versions.