### PR TITLE
Touching up make_future

### DIFF
--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -957,7 +957,7 @@ namespace hpx { namespace lcos
     // conversion function: T f(U).
     template <typename R, typename U, typename Conv,
     HPX_CONCEPT_REQUIRES_(
-        hpx::traits::is_callable<Conv(U)>::value)>
+        hpx::traits::is_callable<Conv(U), R>::value)>
     hpx::future<R>
     make_future(hpx::future<U> && f, Conv && conv)
     {
@@ -1187,7 +1187,7 @@ namespace hpx { namespace lcos
     // conversion function: T f(U).
     template <typename R, typename U, typename Conv,
     HPX_CONCEPT_REQUIRES_(
-        hpx::traits::is_callable<Conv(U)>::value)>
+        hpx::traits::is_callable<Conv(U), R>::value)>
     hpx::future<R>
     make_future(hpx::shared_future<U> f, Conv && conv)
     {

--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -26,6 +26,7 @@
 #include <hpx/util/invoke.hpp>
 #include <hpx/util/move.hpp>
 #include <hpx/util/result_of.hpp>
+#include <hpx/util/void_guard.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 
@@ -937,29 +938,14 @@ namespace hpx { namespace lcos
 
         template <typename T, typename Future>
         typename std::enable_if<
-            !std::is_convertible<Future, hpx::future<T> >::value
-         && !std::is_void<T>::value,
+            !std::is_convertible<Future, hpx::future<T> >::value,
             hpx::future<T>
         >::type make_future_helper(Future && f)
         {
             return f.then(
                 [](Future && f) -> T
                 {
-                    return f.get();
-                });
-        }
-
-        template <typename T, typename Future>
-        typename std::enable_if<
-            !std::is_convertible<Future, hpx::future<T> >::value
-         && std::is_void<T>::value,
-            hpx::future<T>
-        >::type make_future_helper(Future && f)
-        {
-            return f.then(
-                [](Future && f) -> void
-                {
-                    f.get();
+                    return util::void_guard<T>(), f.get();
                 });
         }
     }

--- a/tests/unit/lcos/CMakeLists.txt
+++ b/tests/unit/lcos/CMakeLists.txt
@@ -35,6 +35,7 @@ set(tests
     local_dataflow_executor
     local_event
     local_mutex
+    make_future
     packaged_action
     promise
     reduce

--- a/tests/unit/lcos/make_future.cpp
+++ b/tests/unit/lcos/make_future.cpp
@@ -78,7 +78,7 @@ void test_make_shared_future()
         HPX_TEST_EQ(42, f1.get());
     }
 
-    // test make_future<void>(shared_future<U>)
+    // test make_future<void>(shared_future<void>)
     {
         hpx::shared_future<void> f1 = hpx::make_ready_future();
         hpx::shared_future<void> f2 = hpx::make_future<void>(f1);

--- a/tests/unit/lcos/make_future.cpp
+++ b/tests/unit/lcos/make_future.cpp
@@ -1,0 +1,91 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/lcos/future.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <boost/lexical_cast.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+void test_make_future()
+{
+    // test make_future<T>(future<T>)
+    {
+        hpx::future<int> f1 = hpx::make_ready_future(42);
+        hpx::future<int> f2 = hpx::make_future<int>(std::move(f1));
+        HPX_TEST_EQ(42, f2.get());
+    }
+
+    // test make_future<T>(future<U>) where is_convertible<U, T>
+    {
+        hpx::future<int> f1 = hpx::make_ready_future(42);
+        hpx::future<double> f2 = hpx::make_future<double>(std::move(f1));
+        HPX_TEST_EQ(42.0, f2.get());
+    }
+
+    // test make_future<T>(future<U>) with given T conv(U)
+    {
+        hpx::future<int> f1 = hpx::make_ready_future(42);
+        hpx::future<std::string> f2 =
+            hpx::make_future<std::string>(
+                std::move(f1),
+                [](int value) -> std::string
+                {
+                    return boost::lexical_cast<std::string>(value);
+                });
+
+        HPX_TEST_EQ(std::string("42"), f2.get());
+    }
+}
+
+void test_make_shared_future()
+{
+    // test make_future<T>(shared_future<T>)
+    {
+        hpx::shared_future<int> f1 = hpx::make_ready_future(42);
+        hpx::shared_future<int> f2 = hpx::make_future<int>(f1);
+        HPX_TEST_EQ(42, f1.get());
+        HPX_TEST_EQ(42, f2.get());
+    }
+
+    // test make_future<T>(shared_future<U>) where is_convertible<U, T>
+    {
+        hpx::shared_future<int> f1 = hpx::make_ready_future(42);
+        hpx::shared_future<double> f2 = hpx::make_future<double>(f1);
+        HPX_TEST_EQ(42, f1.get());
+        HPX_TEST_EQ(42.0, f2.get());
+    }
+
+    // test make_future<T>(shared_future<U>) with given T conv(U)
+    {
+        hpx::shared_future<int> f1 = hpx::make_ready_future(42);
+        hpx::shared_future<std::string> f2 =
+            hpx::make_future<std::string>(
+                f1,
+                [](int value) -> std::string
+                {
+                    return boost::lexical_cast<std::string>(value);
+                });
+
+        HPX_TEST_EQ(42, f1.get());
+        HPX_TEST_EQ(std::string("42"), f2.get());
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main()
+{
+    test_make_future();
+    test_make_shared_future();
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+    return hpx::util::report_errors();
+}

--- a/tests/unit/lcos/make_future.cpp
+++ b/tests/unit/lcos/make_future.cpp
@@ -26,6 +26,18 @@ void test_make_future()
         HPX_TEST_EQ(42.0, f2.get());
     }
 
+    // test make_future<void>(future<U>)
+    {
+        hpx::future<int> f1 = hpx::make_ready_future(42);
+        hpx::future<void> f2 = hpx::make_future<void>(std::move(f1));
+    }
+
+    // test make_future<void>(future<void>)
+    {
+        hpx::future<void> f1 = hpx::make_ready_future();
+        hpx::future<void> f2 = hpx::make_future<void>(std::move(f1));
+    }
+
     // test make_future<T>(future<U>) with given T conv(U)
     {
         hpx::future<int> f1 = hpx::make_ready_future(42);
@@ -57,6 +69,19 @@ void test_make_shared_future()
         hpx::shared_future<double> f2 = hpx::make_future<double>(f1);
         HPX_TEST_EQ(42, f1.get());
         HPX_TEST_EQ(42.0, f2.get());
+    }
+
+    // test make_future<void>(shared_future<U>)
+    {
+        hpx::shared_future<int> f1 = hpx::make_ready_future(42);
+        hpx::shared_future<void> f2 = hpx::make_future<void>(f1);
+        HPX_TEST_EQ(42, f1.get());
+    }
+
+    // test make_future<void>(shared_future<U>)
+    {
+        hpx::shared_future<void> f1 = hpx::make_ready_future();
+        hpx::shared_future<void> f2 = hpx::make_future<void>(f1);
     }
 
     // test make_future<T>(shared_future<U>) with given T conv(U)


### PR DESCRIPTION
- add overloads for shared_future
- make sure `make_future<T>(future<T>)` does not create ambiguities
- import make_future into namespace hpx
- adding test
- flyby change: import make_future_void into namespace hpx