### PR TITLE
Fix a couple of compile errors with clang

### DIFF
--- a/hpx/parallel/container_algorithms/remove_copy.hpp
+++ b/hpx/parallel/container_algorithms/remove_copy.hpp
@@ -98,7 +98,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         traits::detail::is_iterator<OutIter>::value &&
         traits::is_projected_range<Proj, Rng>::value &&
         traits::is_indirect_callable<
-            std::equal_to<>,
+            std::equal_to<T>,
                 traits::projected_range<Proj, Rng>,
                 traits::projected<Proj, T const*>
         >::value)>

--- a/hpx/parallel/container_algorithms/replace.hpp
+++ b/hpx/parallel/container_algorithms/replace.hpp
@@ -81,7 +81,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         traits::is_range<Rng>::value &&
         traits::is_projected_range<Proj, Rng>::value &&
         traits::is_indirect_callable<
-            std::equal_to<>,
+            std::equal_to<T1>,
                 traits::projected_range<Proj, Rng>,
                 traits::projected<Proj, T1 const*>
         >::value)>
@@ -254,7 +254,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         traits::is_range<Rng>::value &&
         traits::is_projected_range<Proj, Rng>::value &&
         traits::is_indirect_callable<
-            std::equal_to<>,
+            std::equal_to<T1>,
                 traits::projected_range<Proj, Rng>,
                 traits::projected<Proj, T1 const*>
         >::value)>


### PR DESCRIPTION
This was fixed previously, but lost during a merge