### PR TITLE
Adding workaround for tagged_tuple 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -777,6 +777,9 @@ hpx_check_for_cxx11_variadic_macros(
 hpx_check_for_cxx11_variadic_templates(
   REQUIRED "HPX needs support for C++11 variadic templates")
 
+hpx_check_for_cxx11_explicit_variadic_templates(
+  DEFINITIONS HPX_HAVE_CXX11_EXPLICIT_VARIADIC_TEMPLATES)
+
 hpx_check_for_cxx11_extended_friend_declarations(
   DEFINITIONS HPX_HAVE_CXX11_EXTENDED_FRIEND_DECLARATIONS)
 

--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -268,6 +268,13 @@ macro(hpx_check_for_cxx11_variadic_templates)
 endmacro()
 
 ###############################################################################
+macro(hpx_check_for_cxx11_explicit_variadic_templates)
+  add_hpx_config_test(HPX_WITH_CXX11_EXPLICIT_VARIADIC_TEMPLATES
+    SOURCE cmake/tests/cxx11_explicit_variadic_templates.cpp
+    FILE ${ARGN})
+endmacro()
+
+###############################################################################
 macro(hpx_check_for_cxx11_std_chrono)
   add_hpx_config_test(HPX_WITH_CXX11_CHRONO
     SOURCE cmake/tests/cxx11_std_chrono.cpp

--- a/cmake/tests/cxx11_explicit_variadic_templates.cpp
+++ b/cmake/tests/cxx11_explicit_variadic_templates.cpp
@@ -1,0 +1,37 @@
+//  Copyright (C) 2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+template <typename  ... Ts>
+struct tuple
+{
+    tuple() {}
+};
+
+struct tag1 {};
+struct tag2 {};
+struct tag3 {};
+
+template <typename T>
+struct identity
+{
+    typedef T type;
+};
+
+template <typename Tag, typename T>
+struct tagged_type
+{
+    typedef typename identity<Tag(T)>::type type;
+};
+
+template <typename ... Tags, typename ... Ts>
+tuple<typename tagged_type<Tags, Ts>::type...> foo(Ts && ...)
+{
+    return tuple<typename tagged_type<Tags, Ts>::type...>();
+}
+
+int main()
+{
+    auto t = foo<tag1, tag2, tag3>(42, 43, 44);
+}


### PR DESCRIPTION
This is for compilers which don't support explicit variadics (mainly Intel)