### PR TITLE
Adding regression test for #1946: Hang in wait_all() in distributed run

### DIFF
--- a/tests/regressions/lcos/CMakeLists.txt
+++ b/tests/regressions/lcos/CMakeLists.txt
@@ -31,6 +31,7 @@ set(tests
     set_hpx_limit_798
     shared_mutex_1702
     shared_stated_leaked_1211
+    wait_all_hang_1946
     wait_for_1751
     when_all_vectors_1623
    )
@@ -51,6 +52,8 @@ set(receive_buffer_1733_PARAMETERS LOCALITIES 2)
 set(safely_destroy_cv_1481_PARAMETERS THREADS_PER_LOCALITY 2)
 set(shared_mutex_1702_PARAMETERS THREADS_PER_LOCALITY 4)
 set(wait_for_1751_PARAMETERS THREADS_PER_LOCALITY 4)
+set(wait_all_hang_1946_PARAMETERS THREADS_PER_LOCALITY 8)
+set(wait_all_hang_1946_FLAGS DEPENDENCIES iostreams_component)
 
 if(HPX_WITH_CXX11_LAMBDAS)
   set(tests ${tests}

--- a/tests/regressions/lcos/wait_all_hang_1946.cpp
+++ b/tests/regressions/lcos/wait_all_hang_1946.cpp
@@ -1,0 +1,67 @@
+//  Copyright 2016 (c) Jan-Tobias Sohns
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This test case demonstrates the issue described in #1946:
+// Hang in wait_all() in distributed run
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/include/actions.hpp>
+#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/include/iostreams.hpp>
+
+#include <math.h>
+#include <vector>
+#include <list>
+#include <set>
+#include <stdio.h>
+#include <stdlib.h>
+#include <iostream>
+
+#include <boost/ref.hpp>
+#include <boost/format.hpp>
+#include <boost/thread/locks.hpp>
+#include <boost/serialization/vector.hpp>
+
+void out(std::vector<unsigned int> vec)
+{
+     hpx::cout << "out called " << hpx::find_here() << std::endl;
+}
+HPX_PLAIN_ACTION(out, out_action);
+
+int main(int argc, char* argv[])
+{
+     // Initialize and run HPX.
+     return hpx::init(argc, argv);
+}
+
+int hpx_main(boost::program_options::variables_map& vm)
+{
+     // find locality info
+     std::vector<hpx::naming::id_type> locs = hpx::find_all_localities();
+
+     // create data
+     std::vector<unsigned int> vec;
+     for (unsigned long j=0; j < 300000; j++)
+     {
+         vec.push_back(1);
+     }
+     // send out data
+     for (unsigned int j = 0; j < 8; j++)
+     {
+         std::vector<hpx::future<void> > fut1;
+         for (std::size_t i = 0; i < locs.size(); i++)
+         {
+             typedef out_action out_act;
+             fut1.push_back(hpx::async<out_act>(locs.at(i), vec));
+             hpx::cout << "Scheduled out to " << i+1 << std::endl;
+         }
+         wait_all(fut1);
+         hpx::cout << j+1 << ". round finished " << std::endl;
+     }
+     hpx::cout << "program finished!!!" << std::endl;
+     return hpx::finalize();
+}


### PR DESCRIPTION
This just adds an additional test verifying the issue does not re-appear (#1946 refers to V0.9.11 and the problem was already fixed).