### PR TITLE
Fixing Static Parcelport initialization

### DIFF
--- a/cmake/templates/static_parcelports.hpp.in
+++ b/cmake/templates/static_parcelports.hpp.in
@@ -13,7 +13,8 @@
 @_parcelport_export@
 namespace hpx { namespace parcelset
 {
-    void init_static_parcelport_factories()
+    void init_static_parcelport_factories(
+        std::vector<plugins::parcelport_factory_base *>& factories)
     {
 @_parcelport_init@    }
 }}

--- a/hpx/plugins/parcelport_factory.hpp
+++ b/hpx/plugins/parcelport_factory.hpp
@@ -54,6 +54,12 @@ namespace hpx { namespace plugins
             parcelset::parcelhandler::add_parcelport_factory(this);
         }
 
+        parcelport_factory(
+            std::vector<plugins::parcelport_factory_base*>& factories)
+        {
+            factories.push_back(this);
+        }
+
         ///
         ~parcelport_factory() {}
 
@@ -137,11 +143,14 @@ namespace hpx { namespace plugins
     HPX_DEF_UNIQUE_PLUGIN_NAME(                                               \
         BOOST_PP_CAT(pluginname, _plugin_factory_type), pp)                   \
     template struct hpx::plugins::parcelport_factory<Parcelport>;             \
-    static BOOST_PP_CAT(pluginname, _plugin_factory_type)                     \
-        BOOST_PP_CAT(pluginname, _factory);                                   \
-    HPX_EXPORT hpx::plugins::parcelport_factory_base *                        \
-        BOOST_PP_CAT(pluginname, _factory_base_ptr) =                         \
-            &BOOST_PP_CAT(pluginname, _factory);                              \
+    HPX_EXPORT hpx::plugins::parcelport_factory_base*                         \
+    BOOST_PP_CAT(pluginname, _factory_init)                                   \
+    (std::vector<hpx::plugins::parcelport_factory_base *>& factories)         \
+    {                                                                         \
+        static BOOST_PP_CAT(pluginname, _plugin_factory_type) factory(factories);\
+        return &factory;                                                      \
+    }                                                                         \
+/**/
 
 #define HPX_REGISTER_PARCELPORT(Parcelport, pluginname)                       \
         HPX_REGISTER_PARCELPORT_(Parcelport,                                  \

--- a/hpx/plugins/parcelport_factory_base.hpp
+++ b/hpx/plugins/parcelport_factory_base.hpp
@@ -30,8 +30,6 @@ namespace hpx { namespace plugins
     {
         virtual ~parcelport_factory_base() {}
 
-        void force_init() {}
-
         virtual void get_plugin_info(std::vector<std::string> & fillini) = 0;
 
         virtual void init(int *argc, char ***argv, util::command_line_handling &cfg) = 0;

--- a/plugins/parcelport/CMakeLists.txt
+++ b/plugins/parcelport/CMakeLists.txt
@@ -105,9 +105,9 @@ macro(add_parcelport_modules)
   set(_parcelport_init)
   foreach(parcelport ${HPX_STATIC_PARCELPORT_PLUGINS})
     set(_parcelport_export
-        "${_parcelport_export}extern hpx::plugins::parcelport_factory_base *parcelport_${parcelport}_factory_base_ptr;\n")
+      "${_parcelport_export}HPX_EXPORT hpx::plugins::parcelport_factory_base *parcelport_${parcelport}_factory_init(std::vector<hpx::plugins::parcelport_factory_base *>& factories);\n")
     set(_parcelport_init
-        "${_parcelport_init}        HPX_ASSERT(parcelport_${parcelport}_factory_base_ptr);\n        parcelport_${parcelport}_factory_base_ptr->force_init();\n")
+      "${_parcelport_init}        parcelport_${parcelport}_factory_init(factories);\n")
   endforeach()
 
   configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/static_parcelports.hpp.in"

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -1146,7 +1146,7 @@ namespace hpx { namespace parcelset
         static std::vector<plugins::parcelport_factory_base *> factories;
         if(factories.empty())
         {
-            init_static_parcelport_factories();
+            init_static_parcelport_factories(factories);
         }
 
         return factories;
@@ -1154,7 +1154,12 @@ namespace hpx { namespace parcelset
 
     void parcelhandler::add_parcelport_factory(plugins::parcelport_factory_base *factory)
     {
-        get_parcelport_factories().push_back(factory);
+        auto & factories = get_parcelport_factories();
+        if(std::find(factories.begin(), factories.end(), factory) != factories.end())
+        {
+            return;
+        }
+        factories.push_back(factory);
     }
 
     void parcelhandler::init(int *argc, char ***argv, util::command_line_handling &cfg)


### PR DESCRIPTION
This fixes some UB in the Parcelport plugin initialization phase. This UB shows up in static release builds.