### PR TITLE
Add action to update data owned by the partitioned_vector component

### DIFF
--- a/hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp
@@ -767,9 +767,9 @@ namespace hpx
         ///
         /// \return This returns the data of the partition_vector
         ///
-        auto set_data_sync(typename server_type::data_type && other) const
+        void set_data_sync(typename server_type::data_type && other) const
         {
-            return set_data(std::forward<data_type>(other)).get();
+            set_data(std::forward<typename server_type::data_type>(other)).get();
         }
 
         /// Updates the data owned by the partition_vector
@@ -777,11 +777,11 @@ namespace hpx
         ///
         /// \return This returns the hpx::future of type void
         ///
-        auto set_data(typename server_type::data_type && other) const
+        hpx::future<void> set_data(typename server_type::data_type && other) const
         {
             HPX_ASSERT(this->get_id());
             return hpx::async<typename server_type::set_data_action>(
-                this->get_id(), std::forward<data_type>(other) );
+                this->get_id(), std::forward<typename server_type::data_type>(other) );
         }
    };
 }

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp
@@ -124,7 +124,7 @@ namespace hpx { namespace server
         }
 
         ///////////////////////////////////////////////////////////////////////
-        void set_data(data_type other)
+        void set_data(data_type && other)
         {
             partition_vector_ = other;
         }
@@ -781,7 +781,7 @@ namespace hpx
         {
             HPX_ASSERT(this->get_id());
             return hpx::async<typename server_type::set_data_action>(
-                this->get_id(), std::forward<typename server_type::data_type>(other) );
+                this->get_id(), std::move(other) );
         }
    };
 }

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp
@@ -124,6 +124,12 @@ namespace hpx { namespace server
         }
 
         ///////////////////////////////////////////////////////////////////////
+        void set_data(data_type other)
+        {
+            partition_vector_ = other;
+        }
+
+        ///////////////////////////////////////////////////////////////////////
         iterator_type begin()
         {
             return partition_vector_.begin();
@@ -366,6 +372,7 @@ namespace hpx { namespace server
 
 //         HPX_DEFINE_COMPONENT_ACTION(partition_vector, clear);
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, get_copied_data);
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, set_data);
     };
 }}
 
@@ -404,6 +411,9 @@ namespace hpx { namespace server
     HPX_REGISTER_ACTION_DECLARATION(                                          \
         hpx::server::partitioned_vector<type>::get_copied_data_action,        \
         BOOST_PP_CAT(__vector_get_copied_data_action_, name));                \
+    HPX_REGISTER_ACTION_DECLARATION(                                          \
+        hpx::server::partitioned_vector<type>::set_data_action,               \
+        BOOST_PP_CAT(__vector_set_data_action_, name));                       \
 /**/
 
 #define HPX_REGISTER_PARTITIONED_VECTOR(...)                                  \
@@ -440,6 +450,9 @@ namespace hpx { namespace server
     HPX_REGISTER_ACTION(                                                      \
         hpx::server::partitioned_vector<type>::get_copied_data_action,        \
         BOOST_PP_CAT(__vector_get_copied_data_action_, name));                \
+    HPX_REGISTER_ACTION(                                                      \
+        hpx::server::partitioned_vector<type>::set_data_action,               \
+        BOOST_PP_CAT(__vector_set_data_action_, name));                       \
     typedef ::hpx::components::simple_component<                              \
         ::hpx::server::partitioned_vector<type>                               \
     > BOOST_PP_CAT(__vector_, name);                                          \
@@ -747,6 +760,28 @@ namespace hpx
             HPX_ASSERT(this->get_id());
             return hpx::async<typename server_type::get_copied_data_action>(
                 this->get_id());
+        }
+
+        /// Updates the data owned by the partition_vector
+        /// component.
+        ///
+        /// \return This returns the data of the partition_vector
+        ///
+        auto set_data_sync(typename server_type::data_type && other) const
+        {
+            return set_data(std::forward<data_type>(other)).get();
+        }
+
+        /// Updates the data owned by the partition_vector
+        /// component.
+        ///
+        /// \return This returns the hpx::future of type void
+        ///
+        auto set_data(typename server_type::data_type && other) const
+        {
+            HPX_ASSERT(this->get_id());
+            return hpx::async<typename server_type::set_data_action>(
+                this->get_id(), std::forward<data_type>(other) );
         }
    };
 }

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp
@@ -126,7 +126,7 @@ namespace hpx { namespace server
         ///////////////////////////////////////////////////////////////////////
         void set_data(data_type && other)
         {
-            partition_vector_ = other;
+            partition_vector_ = std::move(other);
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -769,7 +769,7 @@ namespace hpx
         ///
         void set_data_sync(typename server_type::data_type && other) const
         {
-            set_data(std::forward<typename server_type::data_type>(other)).get();
+            set_data(std::move(other)).get();
         }
 
         /// Updates the data owned by the partition_vector


### PR DESCRIPTION
The action is needed to perform a classic "put" operation from remote locality.