### PR TITLE
Replacing uintptr_t (which is not defined everywhere) with std::size_t

### DIFF
--- a/hpx/util/coroutine/detail/context_generic_context.hpp
+++ b/hpx/util/coroutine/detail/context_generic_context.hpp
@@ -38,6 +38,7 @@
 #include <cstddef>
 #include <cstdlib>
 #include <stdexcept>
+#include <limits>
 
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(HPX_GENERIC_CONTEXT_USE_SEGMENTED_STACKS) && BOOST_VERSION >= 105300
@@ -232,8 +233,7 @@ namespace hpx { namespace util { namespace coroutines
             std::ptrdiff_t get_available_stack_space()
             {
 #if defined(HPX_HAVE_THREADS_GET_STACK_POINTER)
-                return
-                    reinterpret_cast<uintptr_type>(stack_pointer_) - get_stack_ptr();
+                return get_stack_ptr() - reinterpret_cast<std::size_t>(stack_pointer_);
 #else
                 return (std::numeric_limits<std::ptrdiff_t>::max)();
 #endif

--- a/hpx/util/coroutine/detail/context_generic_context.hpp
+++ b/hpx/util/coroutine/detail/context_generic_context.hpp
@@ -233,7 +233,7 @@ namespace hpx { namespace util { namespace coroutines
             std::ptrdiff_t get_available_stack_space()
             {
 #if defined(HPX_HAVE_THREADS_GET_STACK_POINTER)
-                return get_stack_ptr() - reinterpret_cast<std::size_t>(stack_pointer_);
+                return reinterpret_cast<std::size_t>(stack_pointer_) - get_stack_ptr();
 #else
                 return (std::numeric_limits<std::ptrdiff_t>::max)();
 #endif

--- a/hpx/util/coroutine/detail/context_linux_x86.hpp
+++ b/hpx/util/coroutine/detail/context_linux_x86.hpp
@@ -241,8 +241,8 @@ namespace hpx { namespace util { namespace coroutines
 
       std::ptrdiff_t get_available_stack_space()
       {
-        return
-          get_stack_ptr() - reinterpret_cast<uintptr_type>(m_stack) - context_size;
+        return get_stack_ptr() - reinterpret_cast<std::size_t>(m_stack) -
+            context_size;
       }
 
       typedef boost::atomic<boost::int64_t> counter_type;

--- a/hpx/util/coroutine/detail/context_posix.hpp
+++ b/hpx/util/coroutine/detail/context_posix.hpp
@@ -59,6 +59,7 @@
 
 #include "pth/pth.h"
 #include <cerrno>
+#include <limits>
 
 namespace hpx { namespace util { namespace coroutines { namespace detail
 {
@@ -241,10 +242,9 @@ namespace hpx { namespace util { namespace coroutines {
         std::ptrdiff_t get_available_stack_space()
         {
 #if defined(HPX_HAVE_THREADS_GET_STACK_POINTER)
-                return
-                    get_stack_ptr() - reinterpret_cast<uintptr_type>(m_stack);
+            return get_stack_ptr() - reinterpret_cast<std::size_t>(m_stack);
 #else
-                return (std::numeric_limits<std::ptrdiff_t>::max)();
+            return (std::numeric_limits<std::ptrdiff_t>::max)();
 #endif
         }
 

--- a/hpx/util/coroutine/detail/get_stack_pointer.hpp
+++ b/hpx/util/coroutine/detail/get_stack_pointer.hpp
@@ -16,28 +16,13 @@
 #endif
 
 #include <boost/cstdint.hpp>
-
-// Only Boost Version > 1.54 defines boost::uintptr_t. For any older versions
-// we use the one defined in the multi index detail namespace. This is safe as
-// it is only needed for older boost versions and thus very unlikely to break
-// in the future.
-#if !defined(BOOST_HAS_INTPTR_T)
-#include <boost/multi_index/detail/uintptr_type.hpp>
-#endif
-
 #include <limits>
 
 namespace hpx { namespace util { namespace coroutines { namespace detail
 {
-#if defined(BOOST_HAS_INTPTR_T)
-    typedef boost::uintptr_t uintptr_type;
-#else
-    typedef boost::multi_index::detail::uintptr_type uintptr_type;
-#endif
-
-    inline uintptr_type get_stack_ptr()
+    inline std::size_t get_stack_ptr()
     {
-        uintptr_type stack_ptr = (std::numeric_limits<uintptr_type>::max)();
+        std::size_t stack_ptr = (std::numeric_limits<std::size_t>::max)();
 #if defined(__x86_64__) || defined(__amd64)
         asm("movq %%rsp, %0" : "=r"(stack_ptr));
 #elif defined(__i386__) || defined(__i486__) || defined(__i586__) || defined(__i686__)


### PR DESCRIPTION
This cleans up the leftovers of #1969.