### PR TITLE
Avoid invoking migration table look up for all objects 

### DIFF
--- a/hpx/components/component_storage/server/migrate_from_storage.hpp
+++ b/hpx/components/component_storage/server/migrate_from_storage.hpp
@@ -12,6 +12,7 @@
 #include <hpx/include/runtime.hpp>
 #include <hpx/include/serialization.hpp>
 #include <hpx/include/util.hpp>
+#include <hpx/include/traits.hpp>
 
 #include <hpx/components/component_storage/export_definitions.hpp>
 #include <hpx/components/component_storage/server/component_storage.hpp>
@@ -122,7 +123,7 @@ namespace hpx { namespace components { namespace server
         naming::id_type const& to_resurrect,
         naming::id_type const& target_locality)
     {
-        if (!Component::supports_migration())
+        if (!traits::component_supports_migration<Component>::call())
         {
             HPX_THROW_EXCEPTION(invalid_status,
                 "hpx::components::server::trigger_migrate_from_storage_here",

--- a/hpx/components/component_storage/server/migrate_to_storage.hpp
+++ b/hpx/components/component_storage/server/migrate_to_storage.hpp
@@ -122,7 +122,7 @@ namespace hpx { namespace components { namespace server
         naming::address const& addr,
         naming::id_type const& target_storage)
     {
-        if (!Component::supports_migration())
+        if (!traits::component_supports_migration<Component>::call())
         {
             HPX_THROW_EXCEPTION(invalid_status,
                 "hpx::components::server::migrate_to_storage_here",
@@ -157,7 +157,7 @@ namespace hpx { namespace components { namespace server
         naming::id_type const& to_migrate,
         naming::id_type const& target_storage)
     {
-        if (!Component::supports_migration())
+        if (!traits::component_supports_migration<Component>::call())
         {
             HPX_THROW_EXCEPTION(invalid_status,
                 "hpx::components::server::trigger_migrate_to_storage_here",

--- a/hpx/lcos/packaged_action.hpp
+++ b/hpx/lcos/packaged_action.hpp
@@ -16,6 +16,7 @@
 #include <hpx/util/protect.hpp>
 #include <hpx/util/bind.hpp>
 #include <hpx/traits/component_type_is_compatible.hpp>
+#include <hpx/traits/component_supports_migration.hpp>
 #include <hpx/traits/action_was_object_migrated.hpp>
 
 #include <boost/mpl/bool.hpp>
@@ -361,12 +362,23 @@ namespace hpx { namespace lcos
             naming::address addr;
             if (agas::is_local_address_cached(id, addr))
             {
+                typedef typename Action::component_type component_type;
                 HPX_ASSERT(traits::component_type_is_compatible<
-                    typename Action::component_type>::call(addr));
+                    component_type>::call(addr));
 
-                r = traits::action_was_object_migrated<Action>::call(
-                    id, addr.address_);
-                if (!r.first)
+                if (traits::component_supports_migration<component_type>::call())
+                {
+                    r = traits::action_was_object_migrated<Action>::call(
+                            id, addr.address_);
+                    if (!r.first)
+                    {
+                        // local, direct execution
+                        (*this->impl_)->set_data(action_type::execute_function(
+                            addr.address_, std::forward<Ts>(vs)...));
+                        return;
+                    }
+                }
+                else
                 {
                     // local, direct execution
                     (*this->impl_)->set_data(action_type::execute_function(
@@ -388,12 +400,23 @@ namespace hpx { namespace lcos
 
             if (addr.locality_ == hpx::get_locality())
             {
+                typedef typename Action::component_type component_type;
                 HPX_ASSERT(traits::component_type_is_compatible<
-                    typename Action::component_type>::call(addr));
+                    component_type>::call(addr));
 
-                r = traits::action_was_object_migrated<Action>::call(
-                    id, addr.address_);
-                if (!r.first)
+                if (traits::component_supports_migration<component_type>::call())
+                {
+                    r = traits::action_was_object_migrated<Action>::call(
+                        id, addr.address_);
+                    if (!r.first)
+                    {
+                        // local, direct execution
+                        (*this->impl_)->set_data(action_type::execute_function(
+                            addr.address_, std::forward<Ts>(vs)...));
+                        return;
+                    }
+                }
+                else
                 {
                     // local, direct execution
                     (*this->impl_)->set_data(action_type::execute_function(
@@ -416,12 +439,26 @@ namespace hpx { namespace lcos
             naming::address addr;
             if (agas::is_local_address_cached(id, addr))
             {
+                typedef typename Action::component_type component_type;
                 HPX_ASSERT(traits::component_type_is_compatible<
-                    typename Action::component_type>::call(addr));
+                    component_type>::call(addr));
 
-                r = traits::action_was_object_migrated<Action>::call(
-                    id, addr.address_);
-                if (!r.first)
+                if (traits::component_supports_migration<component_type>::call())
+                {
+                    r = traits::action_was_object_migrated<Action>::call(
+                        id, addr.address_);
+                    if (!r.first)
+                    {
+                        // local, direct execution
+                        (*this->impl_)->set_data(action_type::execute_function(
+                            addr.address_, std::forward<Ts>(vs)...));
+
+                        // invoke callback
+                        cb(boost::system::error_code(), parcelset::parcel());
+                        return;
+                    }
+                }
+                else
                 {
                     // local, direct execution
                     (*this->impl_)->set_data(action_type::execute_function(
@@ -446,12 +483,26 @@ namespace hpx { namespace lcos
 
             if (addr.locality_ == hpx::get_locality())
             {
+                typedef typename Action::component_type component_type;
                 HPX_ASSERT(traits::component_type_is_compatible<
-                    typename Action::component_type>::call(addr));
+                    component_type>::call(addr));
 
-                r = traits::action_was_object_migrated<Action>::call(
-                    id, addr.address_);
-                if (!r.first)
+                if (traits::component_supports_migration<component_type>::call())
+                {
+                    r = traits::action_was_object_migrated<Action>::call(
+                        id, addr.address_);
+                    if (!r.first)
+                    {
+                        // local, direct execution
+                        (*this->impl_)->set_data(action_type::execute_function(
+                            addr.address_, std::forward<Ts>(vs)...));
+
+                        // invoke callback
+                        cb(boost::system::error_code(), parcelset::parcel());
+                        return;
+                    }
+                }
+                else
                 {
                     // local, direct execution
                     (*this->impl_)->set_data(action_type::execute_function(

--- a/hpx/runtime/applier/detail/apply_implementations.hpp
+++ b/hpx/runtime/applier/detail/apply_implementations.hpp
@@ -12,6 +12,7 @@
 #include <hpx/runtime/naming/address.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/traits/is_continuation.hpp>
+#include <hpx/traits/component_supports_migration.hpp>
 #include <hpx/traits/action_was_object_migrated.hpp>
 #include <hpx/util/move.hpp>
 
@@ -40,9 +41,19 @@ namespace hpx { namespace detail
         naming::address addr;
         if (agas::is_local_address_cached(id, addr))
         {
-            r = traits::action_was_object_migrated<Action>::call(
-                id, addr.address_);
-            if (!r.first)
+            typedef typename Action::component_type component_type;
+            if (traits::component_supports_migration<component_type>::call())
+            {
+                r = traits::action_was_object_migrated<Action>::call(
+                        id, addr.address_);
+                if (!r.first)
+                {
+                    return applier::detail::apply_l_p<Action>(
+                        std::forward<Continuation>(c), id, std::move(addr),
+                        priority, std::forward<Ts>(vs)...);
+                }
+            }
+            else
             {
                 return applier::detail::apply_l_p<Action>(
                     std::forward<Continuation>(c), id, std::move(addr),
@@ -73,9 +84,18 @@ namespace hpx { namespace detail
         naming::address addr;
         if (agas::is_local_address_cached(id, addr))
         {
-            r = traits::action_was_object_migrated<Action>::call(
-                id, addr.address_);
-            if (!r.first)
+            typedef typename Action::component_type component_type;
+            if (traits::component_supports_migration<component_type>::call())
+            {
+                r = traits::action_was_object_migrated<Action>::call(
+                        id, addr.address_);
+                if (!r.first)
+                {
+                    return applier::detail::apply_l_p<Action>(
+                        id, std::move(addr), priority, std::forward<Ts>(vs)...);
+                }
+            }
+            else
             {
                 return applier::detail::apply_l_p<Action>(
                     id, std::move(addr), priority, std::forward<Ts>(vs)...);
@@ -108,8 +128,23 @@ namespace hpx { namespace detail
         naming::address addr;
         if (agas::is_local_address_cached(id, addr))
         {
-            r = traits::action_was_object_migrated<Action>::call(id, addr.address_);
-            if (!r.first)
+            typedef typename Action::component_type component_type;
+            if (traits::component_supports_migration<component_type>::call())
+            {
+                r = traits::action_was_object_migrated<Action>::call(
+                        id, addr.address_);
+                if (!r.first)
+                {
+                    bool result = applier::detail::apply_l_p<Action>(
+                        std::forward<Continuation>(c), id, std::move(addr),
+                        priority, std::forward<Ts>(vs)...);
+
+                    // invoke callback
+                    cb(boost::system::error_code(), parcelset::parcel());
+                    return result;
+                }
+            }
+            else
             {
                 bool result = applier::detail::apply_l_p<Action>(
                     std::forward<Continuation>(c), id, std::move(addr),
@@ -139,16 +174,28 @@ namespace hpx { namespace detail
             return false;
         }
 
-
         std::pair<bool, components::pinned_ptr> r;
 
         // Determine whether the id is local or remote
         naming::address addr;
         if (agas::is_local_address_cached(id, addr))
         {
-            r = traits::action_was_object_migrated<Action>::call(
-                id, addr.address_);
-            if (!r.first)
+            typedef typename Action::component_type component_type;
+            if (traits::component_supports_migration<component_type>::call())
+            {
+                r = traits::action_was_object_migrated<Action>::call(
+                    id, addr.address_);
+                if (!r.first)
+                {
+                    bool result = applier::detail::apply_l_p<Action>(
+                        id, std::move(addr),  priority, std::forward<Ts>(vs)...);
+
+                    // invoke callback
+                    cb(boost::system::error_code(), parcelset::parcel());
+                    return result;
+                }
+            }
+            else
             {
                 bool result = applier::detail::apply_l_p<Action>(
                     id, std::move(addr),  priority, std::forward<Ts>(vs)...);

--- a/hpx/runtime/components/server/fixed_component_base.hpp
+++ b/hpx/runtime/components/server/fixed_component_base.hpp
@@ -186,9 +186,6 @@ public:
         return !naming::is_locality(id);
     }
 
-    // This component type does not support migration.
-    static HPX_CONSTEXPR bool supports_migration() { return false; }
-
     // Pinning functionality
     void pin() {}
     void unpin() {}

--- a/hpx/runtime/components/server/migrate_component.hpp
+++ b/hpx/runtime/components/server/migrate_component.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/traits/is_component.hpp>
+#include <hpx/traits/component_supports_migration.hpp>
 #include <hpx/runtime/actions/plain_action.hpp>
 #include <hpx/runtime/naming/name.hpp>
 #include <hpx/runtime/get_ptr.hpp>
@@ -167,7 +168,7 @@ namespace hpx { namespace components { namespace server
             return make_ready_future(to_migrate);
         }
 
-        if (!Component::supports_migration())
+        if (!traits::component_supports_migration<Component>::call())
         {
             return hpx::make_exceptional_future<hpx::id_type>(
                 HPX_GET_EXCEPTION(invalid_status,
@@ -203,7 +204,7 @@ namespace hpx { namespace components { namespace server
     future<id_type> trigger_migrate_component(
         id_type const& to_migrate, DistPolicy const& policy)
     {
-        if (!Component::supports_migration())
+        if (!traits::component_supports_migration<Component>::call())
         {
             return hpx::make_exceptional_future<id_type>(
                 HPX_GET_EXCEPTION(invalid_status,
@@ -261,7 +262,7 @@ namespace hpx { namespace components { namespace server
     future<id_type> perform_migrate_component(
         id_type const& to_migrate, DistPolicy const& policy)
     {
-        if (!Component::supports_migration())
+        if (!traits::component_supports_migration<Component>::call())
         {
             return hpx::make_exceptional_future<id_type>(
                 HPX_GET_EXCEPTION(invalid_status,

--- a/hpx/runtime/components/server/simple_component_base.hpp
+++ b/hpx/runtime/components/server/simple_component_base.hpp
@@ -256,9 +256,6 @@ namespace hpx { namespace components
             return !naming::is_locality(id);
         }
 
-        // This component type does not support migration.
-        static HPX_CONSTEXPR bool supports_migration() { return false; }
-
         // Pinning functionality
         void pin() {}
         void unpin() {}

--- a/hpx/traits.hpp
+++ b/hpx/traits.hpp
@@ -15,7 +15,7 @@ namespace hpx { namespace traits
         // wraps int so that int argument is favored over wrap_int
         struct wrap_int
         {
-            wrap_int(int) {}
+            HPX_CONSTEXPR wrap_int(int) {}
         };
     }
 
@@ -42,6 +42,9 @@ namespace hpx { namespace traits
 
     template <typename Component, typename Enable = void>
     struct component_type_is_compatible;
+
+    template <typename Component, typename Enable = void>
+    struct component_supports_migration;
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T, typename Enable = void>

--- a/hpx/traits/component_supports_migration.hpp
+++ b/hpx/traits/component_supports_migration.hpp
@@ -1,0 +1,59 @@
+//  Copyright (c) 2007-2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_TRAITS_ACTION_SUPPORTS_MIGRATION_FEB_10_2016_1252PM)
+#define HPX_TRAITS_ACTION_SUPPORTS_MIGRATION_FEB_10_2016_1252PM
+
+#include <hpx/config.hpp>
+#include <hpx/traits.hpp>
+
+#include <utility>
+#include <type_traits>
+
+namespace hpx { namespace traits
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // Customization point for component capabilities
+    namespace detail
+    {
+        struct supports_migration_helper
+        {
+            // by default we return 'false' (component does not support
+            // migration)
+            template <typename Component>
+            static HPX_CONSTEXPR bool call(wrap_int)
+            {
+                return false;
+            }
+
+            // forward the call if the component implements the function
+            template <typename Component>
+            static HPX_CONSTEXPR auto call(int)
+            ->  decltype(Component::supports_migration())
+            {
+                return Component::supports_migration();
+            }
+        };
+
+        template <typename Component>
+        HPX_CONSTEXPR bool call_supports_migration()
+        {
+            return supports_migration_helper::template call<Component>(0);
+        }
+    }
+
+    template <typename Component, typename Enable>
+    struct component_supports_migration
+    {
+        // returns whether target supports migration
+        static HPX_CONSTEXPR bool call()
+        {
+            return detail::call_supports_migration<Component>();
+        }
+    };
+}}
+
+#endif
+

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -11,6 +11,8 @@
 #include <hpx/runtime.hpp>
 #include <hpx/exception.hpp>
 #include <hpx/apply.hpp>
+#include <hpx/traits/component_supports_migration.hpp>
+#include <hpx/traits/action_was_object_migrated.hpp>
 #include <hpx/runtime/agas/addressing_service.hpp>
 #include <hpx/runtime/agas/big_boot_barrier.hpp>
 #include <hpx/runtime/agas/component_namespace.hpp>
@@ -1927,9 +1929,26 @@ void addressing_service::route(
     naming::address addr;
     if (is_local_address_cached(target.get_gid(), addr))
     {
-        r = traits::action_was_object_migrated<action_type>::call(
-            target, addr.address_);
-        if (!r.first)
+        typedef typename action_type::component_type component_type;
+        if (traits::component_supports_migration<component_type>::call())
+        {
+            r = traits::action_was_object_migrated<action_type>::call(
+                    target, addr.address_);
+            if (!r.first)
+            {
+                // route through the local AGAS service instance
+                applier::detail::apply_l_p<action_type>(
+                    target, std::move(addr),
+                    local_priority == threads::thread_priority_default ?
+                        action_priority_ : local_priority,
+                    std::move(p));
+
+                // invoke callback
+                f(boost::system::error_code(), parcelset::parcel());
+                return;
+            }
+        }
+        else
         {
             // route through the local AGAS service instance
             applier::detail::apply_l_p<action_type>(

--- a/src/runtime/components/stubs/runtime_support_stubs.cpp
+++ b/src/runtime/components/stubs/runtime_support_stubs.cpp
@@ -16,6 +16,7 @@
 #include <hpx/util/ini.hpp>
 #include <hpx/util/move.hpp>
 #include <hpx/runtime.hpp>
+#include <hpx/traits/component_supports_migration.hpp>
 #include <hpx/traits/action_was_object_migrated.hpp>
 
 #include <utility>
@@ -139,14 +140,27 @@ namespace hpx { namespace components { namespace stubs
         if (g.prefix == hpx::get_locality() ||
             agas::is_local_address_cached(gid, addr))
         {
-            r = traits::action_was_object_migrated<action_type>::call(
-                hpx::id_type(gid, hpx::id_type::unmanaged), addr.address_);
-            if (!r.first)
+            typedef typename action_type::component_type component_type;
+            if (traits::component_supports_migration<component_type>::call())
+            {
+                r = traits::action_was_object_migrated<action_type>::call(
+                    hpx::id_type(gid, hpx::id_type::unmanaged), addr.address_);
+                if (!r.first)
+                {
+                    // apply locally
+                    components::server::runtime_support* p =
+                        reinterpret_cast<components::server::runtime_support*>(
+                            hpx::get_runtime().get_runtime_support_lva());
+                    p->free_component(g, gid, count);
+                    return;
+                }
+            }
+            else
             {
                 // apply locally
                 components::server::runtime_support* p =
                     reinterpret_cast<components::server::runtime_support*>(
-                          hpx::get_runtime().get_runtime_support_lva());
+                        hpx::get_runtime().get_runtime_support_lva());
                 p->free_component(g, gid, count);
                 return;
             }


### PR DESCRIPTION
Avoid invoking migration table look up for objects which don't support migration. This introduces a small optimization avoiding to look up an id in the table of migrated objects for components which do not support migration in the first place. This should remove the slight performance regression we saw after merging the new migration code.

This also introduces a new trait: `traits::component_supports_migration<Component>`