### PR TITLE
Making sure the winsock library is properly initialized

### DIFF
--- a/examples/async_io/async_io_low_level.cpp
+++ b/examples/async_io/async_io_low_level.cpp
@@ -11,6 +11,7 @@
 #include <hpx/include/runtime.hpp>
 #include <hpx/include/iostreams.hpp>
 #include <hpx/include/util.hpp>
+#include <hpx/util/io_service_pool.hpp>
 
 // this function will be executed by a dedicated OS thread
 void do_async_io(char const* string_to_write,

--- a/hpx/hpx_init_impl.hpp
+++ b/hpx/hpx_init_impl.hpp
@@ -25,6 +25,10 @@ namespace hpx
             startup_function_type const& startup,
             shutdown_function_type const& shutdown, hpx::runtime_mode mode,
             bool blocking);
+
+#if defined(HPX_WINDOWS)
+        void init_winsocket();
+#endif
     }
     /// \endcond
 
@@ -44,6 +48,9 @@ namespace hpx
         util::function_nonser<void()> const& shutdown,
         hpx::runtime_mode mode)
     {
+#if defined(HPX_WINDOWS)
+        detail::init_winsocket();
+#endif
         util::set_hpx_prefix(HPX_PREFIX);
         return detail::run_or_start(f, desc_cmdline, argc, argv,
             hpx_startup::user_main_config(cfg),

--- a/hpx/hpx_start_impl.hpp
+++ b/hpx/hpx_start_impl.hpp
@@ -24,6 +24,10 @@ namespace hpx
             startup_function_type const& startup,
             shutdown_function_type const& shutdown, hpx::runtime_mode mode,
             bool blocking);
+
+#if defined(HPX_WINDOWS)
+        void init_winsocket();
+#endif
     }
     /// \endcond
 
@@ -45,6 +49,9 @@ namespace hpx
         util::function_nonser<void()> const& shutdown,
         hpx::runtime_mode mode)
     {
+#if defined(HPX_WINDOWS)
+        detail::init_winsocket();
+#endif
         util::set_hpx_prefix(HPX_PREFIX);
         return 0 == detail::run_or_start(f, desc_cmdline, argc, argv,
             hpx_startup::user_main_config(cfg),

--- a/hpx/runtime/parcelset/parcelport.hpp
+++ b/hpx/runtime/parcelset/parcelport.hpp
@@ -11,8 +11,8 @@
 #define HPX_PARCELSET_PARCELPORT_MAR_26_2008_1214PM
 
 #include <hpx/config.hpp>
+#include <hpx/util_fwd.hpp>
 #include <hpx/util/runtime_configuration.hpp>
-#include <hpx/util/io_service_pool.hpp>
 #include <hpx/runtime/applier_fwd.hpp>
 #include <hpx/runtime/parcelset/locality.hpp>
 #include <hpx/runtime/parcelset/parcel.hpp>

--- a/hpx/runtime_fwd.hpp
+++ b/hpx/runtime_fwd.hpp
@@ -11,6 +11,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/exception_fwd.hpp>
+#include <hpx/util_fwd.hpp>
 #include <hpx/util/function.hpp>
 #include <hpx/runtime/naming_fwd.hpp>
 
@@ -44,11 +45,6 @@ namespace hpx
     HPX_API_EXPORT bool register_on_exit(util::function_nonser<void()> const&);
 
     /// \cond NOINTERNAL
-    namespace util
-    {
-        class HPX_EXPORT io_service_pool;
-        class HPX_EXPORT runtime_configuration;
-    }
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_API_EXPORT bool is_scheduler_numa_sensitive();

--- a/hpx/util/thread_aware_timer.hpp
+++ b/hpx/util/thread_aware_timer.hpp
@@ -9,7 +9,6 @@
 #include <hpx/lcos/future.hpp>
 #include <hpx/lcos/local/promise.hpp>
 #include <hpx/util/high_resolution_clock.hpp>
-#include <hpx/util/io_service_pool.hpp>
 
 #include <boost/cstdint.hpp>
 
@@ -74,17 +73,7 @@ namespace hpx { namespace util
             p.set_value(util::high_resolution_clock::now());
         }
 
-        static boost::uint64_t take_time_stamp()
-        {
-            hpx::lcos::local::promise<boost::uint64_t> p;
-
-            // Get a reference to the Timer specific HPX io_service object ...
-            hpx::util::io_service_pool* pool = hpx::get_thread_pool("timer_pool");
-
-            // ... and schedule the handler to run on the first of its OS-threads.
-            pool->get_io_service(0).post(hpx::util::bind(&sample_time, boost::ref(p)));
-            return p.get_future().get();
-        }
+        HPX_EXPORT static boost::uint64_t take_time_stamp();
 
     private:
         boost::uint64_t start_time_;

--- a/hpx/util_fwd.hpp
+++ b/hpx/util_fwd.hpp
@@ -1,0 +1,22 @@
+//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2011      Bryce Lelbach
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file util_fwd.hpp
+
+#ifndef HPX_UTIL_FWD_HPP
+#define HPX_UTIL_FWD_HPP
+
+#include <hpx/config.hpp>
+
+namespace hpx { namespace util
+{
+    /// \cond NOINTERNAL
+    class HPX_EXPORT io_service_pool;
+    class HPX_EXPORT runtime_configuration;
+    /// \endcond
+}}
+
+#endif

--- a/src/hpx_main_winsocket.cpp
+++ b/src/hpx_main_winsocket.cpp
@@ -1,0 +1,37 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_WINDOWS)
+
+#if !defined(WIN32)
+#  define WIN32
+#endif
+#include <winsock2.h>
+#include <windows.h>
+#include <boost/asio/detail/winsock_init.hpp>
+
+namespace hpx { namespace detail
+{
+    // Make sure the Winsocket library is explicitly initialized before main
+    // is executed.
+    struct winsocket_init_helper
+    {
+        static const boost::asio::detail::winsock_init<> init;
+    };
+
+    boost::asio::detail::winsock_init<> const winsocket_init_helper::init =
+        boost::asio::detail::winsock_init<>(false);
+
+    // This function makes sure this file is actually linked to the executable.
+    void init_winsocket()
+    {
+        static winsocket_init_helper init;
+    }
+}}
+
+#endif
+

--- a/src/util/asio_util.cpp
+++ b/src/util/asio_util.cpp
@@ -22,6 +22,18 @@
 #include <string>
 #include <sstream>
 
+#if defined(HPX_WINDOWS)
+// Prevent asio from initialising Winsock, the object must be constructed
+// before any Asio's own global objects. With MSVC, this may be accomplished
+// by adding the following code to the DLL:
+
+#pragma warning(push)
+#pragma warning(disable:4073)
+#pragma init_seg(lib)
+boost::asio::detail::winsock_init<>::manual manual_winsock_init;
+#pragma warning(pop)
+#endif
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace util
 {

--- a/src/util/thread_aware_timer.cpp
+++ b/src/util/thread_aware_timer.cpp
@@ -1,0 +1,26 @@
+//  Copyright (c) 2005-2012 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/util/thread_aware_timer.hpp>
+#include <hpx/util/io_service_pool.hpp>
+
+#include <boost/cstdint.hpp>
+
+namespace hpx { namespace util
+{
+    boost::uint64_t thread_aware_timer::take_time_stamp()
+    {
+        hpx::lcos::local::promise<boost::uint64_t> p;
+
+        // Get a reference to the Timer specific HPX io_service object ...
+        hpx::util::io_service_pool* pool = hpx::get_thread_pool("timer_pool");
+
+        // ... and schedule the handler to run on the first of its OS-threads.
+        pool->get_io_service(0).post(hpx::util::bind(&sample_time, boost::ref(p)));
+        return p.get_future().get();
+    }
+}}
+


### PR DESCRIPTION
Making sure the winsock library is initialized from the main executable only (not from any DLLMain routine)

- this is a Windows specific change