### PR TITLE
Fixing shared_executor_test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -854,6 +854,10 @@ hpx_check_for_cxx14_std_integer_sequence(
 hpx_check_for_cxx14_std_result_of_sfinae(
   DEFINITIONS HPX_HAVE_CXX14_STD_RESULT_OF_SFINAE)
 
+# check for experimental facilities
+hpx_check_for_cxx_experimental_std_optional(
+  DEFINITIONS HPX_HAVE_CXX1Y_EXPERIMENTAL_OPTIONAL)
+
 ################################################################################
 # Check for misc system headers
 ################################################################################

--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -391,3 +391,10 @@ macro(hpx_check_for_cxx14_std_result_of_sfinae)
     SOURCE cmake/tests/cxx14_std_result_of_sfinae.cpp
     FILE ${ARGN})
 endmacro()
+
+###############################################################################
+macro(hpx_check_for_cxx_experimental_std_optional)
+  add_hpx_config_test(HPX_WITH_CXX1Y_EXPERIMENTAL_OPTIONAL
+    SOURCE cmake/tests/cxx1y_experimental_std_optional.cpp
+    FILE ${ARGN})
+endmacro()

--- a/cmake/tests/cxx1y_experimental_std_optional.cpp
+++ b/cmake/tests/cxx1y_experimental_std_optional.cpp
@@ -1,0 +1,11 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <experimental/optional>
+
+int main()
+{
+    std::experimental::optional<int> opt;
+}

--- a/hpx/parallel/executors/distribution_policy_executor.hpp
+++ b/hpx/parallel/executors/distribution_policy_executor.hpp
@@ -29,15 +29,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
     namespace detail
     {
         template <typename F, typename Enable = void>
-        struct async_execute_result
+        struct distribution_policy_execute_result
         {
-            typedef typename hpx::util::result_of<
-                    typename hpx::util::decay<F>::type()
-                >::type type;
+            typedef typename hpx::util::result_of<F()>::type type;
         };
 
         template <typename Action>
-        struct async_execute_result<Action,
+        struct distribution_policy_execute_result<Action,
             typename std::enable_if<hpx::traits::is_action<Action>::value>::type>
         {
             typedef typename Action::local_result_type type;
@@ -91,7 +89,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         template <typename F>
         typename std::enable_if<
             !hpx::traits::is_action<F>::value,
-            hpx::future<typename detail::async_execute_result<F>::type>
+            hpx::future<
+                typename detail::distribution_policy_execute_result<F>::type
+            >
         >::type
         async_execute_impl(F && f) const
         {
@@ -134,10 +134,19 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         }
 
         template <typename F>
-        hpx::future<typename detail::async_execute_result<F>::type>
+        hpx::future<
+            typename detail::distribution_policy_execute_result<F>::type
+        >
         async_execute(F && f) const
         {
             return async_execute_impl(std::forward<F>(f));
+        }
+
+        template <typename F>
+        typename detail::distribution_policy_execute_result<F>::type
+        execute(F && f)
+        {
+            return async_execute_impl(std::forward<F>(f)).get();
         }
         /// \endcond
 

--- a/hpx/parallel/executors/parallel_executor.hpp
+++ b/hpx/parallel/executors/parallel_executor.hpp
@@ -16,7 +16,6 @@
 #include <hpx/parallel/executors/executor_traits.hpp>
 #include <hpx/parallel/executors/auto_chunk_size.hpp>
 #include <hpx/runtime/threads/thread_executor.hpp>
-#include <hpx/util/decay.hpp>
 
 #include <boost/detail/scoped_enum_emulation.hpp>
 
@@ -49,9 +48,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         }
 
         template <typename F>
-        hpx::future<typename hpx::util::result_of<
-            typename hpx::util::decay<F>::type()
-        >::type>
+        hpx::future<typename hpx::util::result_of<F()>::type>
         async_execute(F && f)
         {
             return hpx::async(l_, std::forward<F>(f));

--- a/hpx/parallel/executors/sequential_executor.hpp
+++ b/hpx/parallel/executors/sequential_executor.hpp
@@ -14,7 +14,7 @@
 #include <hpx/parallel/exception_list.hpp>
 #include <hpx/parallel/executors/executor_traits.hpp>
 #include <hpx/runtime/threads/thread_executor.hpp>
-#include <hpx/util/decay.hpp>
+#include <hpx/util/invoke.hpp>
 #include <hpx/util/result_of.hpp>
 #include <hpx/util/unwrapped.hpp>
 
@@ -50,13 +50,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         }
 
         template <typename F>
-        static typename hpx::util::result_of<
-            typename hpx::util::decay<F>::type()
-        >::type
+        static typename hpx::util::result_of<F()>::type
         execute(F && f)
         {
             try {
-                return f();
+                return hpx::util::invoke(f);
             }
             catch (std::bad_alloc const& ba) {
                 boost::throw_exception(ba);
@@ -69,9 +67,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         }
 
         template <typename F>
-        static hpx::future<typename hpx::util::result_of<
-            typename hpx::util::decay<F>::type()
-        >::type>
+        static hpx::future<typename hpx::util::result_of<F()>::type>
         async_execute(F && f)
         {
             return hpx::async(launch::deferred, std::forward<F>(f));

--- a/hpx/parallel/executors/thread_timed_executor_traits.hpp
+++ b/hpx/parallel/executors/thread_timed_executor_traits.hpp
@@ -120,15 +120,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         /// \returns f()'s result through a future
         ///
         template <typename F>
-        static hpx::future<typename hpx::util::result_of<
-            typename hpx::util::decay<F>::type()
-        >::type>
+        static hpx::future<typename hpx::util::result_of<F()>::type>
         async_execute_at(executor_type& sched,
                 hpx::util::steady_time_point const& abs_time, F && f)
         {
-            typedef typename hpx::util::result_of<
-                    typename hpx::util::decay<F>::type()
-                >::type result_type;
+            typedef typename hpx::util::result_of<F()>::type result_type;
 
             lcos::local::packaged_task<result_type()> task(std::forward<F>(f));
             hpx::future<result_type> result = task.get_future();
@@ -152,15 +148,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         /// \returns f()'s result through a future
         ///
         template <typename F>
-        static hpx::future<typename hpx::util::result_of<
-            typename hpx::util::decay<F>::type()
-        >::type>
+        static hpx::future<typename hpx::util::result_of<F()>::type>
         async_execute_after(executor_type& sched,
                 hpx::util::steady_duration const& rel_time, F && f)
         {
-            typedef typename hpx::util::result_of<
-                    typename hpx::util::decay<F>::type()
-                >::type result_type;
+            typedef typename hpx::util::result_of<F()>::type result_type;
 
             lcos::local::packaged_task<result_type()> task(std::forward<F>(f));
             hpx::future<result_type> result = task.get_future();
@@ -185,9 +177,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         /// \returns f()'s result
         ///
         template <typename F>
-        static typename hpx::util::result_of<
-            typename hpx::util::decay<F>::type()
-        >::type
+        static typename hpx::util::result_of<F()>::type
         execute_at(executor_type& sched,
                 hpx::util::steady_time_point const& abs_time, F && f)
         {
@@ -211,9 +201,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         /// \returns f()'s result
         ///
         template <typename F>
-        static typename hpx::util::result_of<
-            typename hpx::util::decay<F>::type()
-        >::type
+        static typename hpx::util::result_of<F()>::type
         execute_after(executor_type& sched,
                 hpx::util::steady_duration const& rel_time, F && f)
         {

--- a/hpx/parallel/executors/timed_executor_traits.hpp
+++ b/hpx/parallel/executors/timed_executor_traits.hpp
@@ -95,10 +95,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
                     util::steady_time_point const& abs_time, F && f)
 #if defined(HPX_ENABLE_WORKAROUND_FOR_GCC46)
             ->  typename future_type<
-                    Executor,
-                    typename hpx::util::result_of<
-                        typename hpx::util::decay<F>::type()
-                    >::type
+                    Executor, typename hpx::util::result_of<F()>::type
                 >::type
 #else
             ->  decltype(exec.async_execute(std::forward<F>(f)))
@@ -128,10 +125,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
                     util::steady_time_point const& abs_time, F && f)
 #if defined(HPX_ENABLE_WORKAROUND_FOR_GCC46)
             ->  typename future_type<
-                    Executor,
-                    typename hpx::util::result_of<
-                        typename hpx::util::decay<F>::type()
-                    >::type
+                    Executor, typename hpx::util::result_of<F()>::type
                 >::type
 #else
             ->  decltype(exec.async_execute(std::forward<F>(f)))
@@ -155,10 +149,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
                 util::steady_time_point const& abs_time, F && f)
 #if defined(HPX_ENABLE_WORKAROUND_FOR_GCC46)
         ->  typename future_type<
-                Executor,
-                typename hpx::util::result_of<
-                    typename hpx::util::decay<F>::type()
-                >::type
+                Executor, typename hpx::util::result_of<F()>::type
             >::type
 #else
         ->  decltype(
@@ -181,9 +172,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
             static auto call(hpx::traits::detail::wrap_int, Executor& exec,
                     util::steady_time_point const& abs_time, F && f)
 #if defined(HPX_ENABLE_WORKAROUND_FOR_GCC46)
-            ->  typename hpx::util::result_of<
-                    typename hpx::util::decay<F>::type()
-                >::type
+            ->  typename hpx::util::result_of<F()>::type
 #else
             ->  decltype(call_execute(exec, std::forward<F>(f)))
 #endif
@@ -211,9 +200,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
             static auto call(hpx::traits::detail::wrap_int, Executor& exec,
                     util::steady_time_point const& abs_time, F && f)
 #if defined(HPX_ENABLE_WORKAROUND_FOR_GCC46)
-            ->  typename hpx::util::result_of<
-                    typename hpx::util::decay<F>::type()
-                >::type
+            ->  typename hpx::util::result_of<F()>::type
 #else
             ->  decltype(call_execute(exec, std::forward<F>(f)))
 #endif
@@ -235,9 +222,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         auto call_execute_at(Executor& exec,
                 util::steady_time_point const& abs_time, F && f)
 #if defined(HPX_ENABLE_WORKAROUND_FOR_GCC46)
-        ->  typename hpx::util::result_of<
-                typename hpx::util::decay<F>::type()
-            >::type
+        ->  typename hpx::util::result_of<F()>::type
 #else
         ->  decltype(
                 execute_at_helper<
@@ -368,9 +353,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
                 hpx::util::steady_time_point const& abs_time, F && f)
 #if defined(HPX_ENABLE_WORKAROUND_FOR_GCC46)
         ->  typename future<
-                typename hpx::util::result_of<
-                    typename hpx::util::decay<F>::type()
-                >::type
+                typename hpx::util::result_of<F()>::type
             >::type
 #else
         ->  decltype(
@@ -408,9 +391,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
                 hpx::util::steady_duration const& rel_time, F && f)
 #if defined(HPX_ENABLE_WORKAROUND_FOR_GCC46)
         ->  typename future<
-                typename hpx::util::result_of<
-                    typename hpx::util::decay<F>::type()
-                >::type
+                typename hpx::util::result_of<F()>::type
             >::type
 #else
         ->  decltype(
@@ -449,9 +430,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         execute_at(executor_type& exec,
                 hpx::util::steady_time_point const& abs_time, F && f)
 #if defined(HPX_ENABLE_WORKAROUND_FOR_GCC46)
-        ->  typename hpx::util::result_of<
-                typename hpx::util::decay<F>::type()
-            >::type
+        ->  typename hpx::util::result_of<F()>::type
 #else
         ->  decltype(detail::call_execute_at(exec, abs_time, std::forward<F>(f)))
 #endif
@@ -485,9 +464,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         execute_after(executor_type& exec,
                 hpx::util::steady_duration const& rel_time, F && f)
 #if defined(HPX_ENABLE_WORKAROUND_FOR_GCC46)
-        ->  typename hpx::util::result_of<
-                typename hpx::util::decay<F>::type()
-            >::type
+        ->  typename hpx::util::result_of<F()>::type
 #else
         ->  decltype(
                 detail::call_execute_at(exec, rel_time.from_now(),

--- a/hpx/traits/acquire_shared_state.hpp
+++ b/hpx/traits/acquire_shared_state.hpp
@@ -68,6 +68,7 @@ namespace hpx { namespace traits
     struct acquire_shared_state_impl<T,
         typename boost::disable_if_c<is_future_or_future_range<T>::value>::type>
     {
+        typedef T type;
 
         template <typename T_>
         HPX_FORCEINLINE

--- a/tests/unit/parallel/executors/shared_parallel_executor.cpp
+++ b/tests/unit/parallel/executors/shared_parallel_executor.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <vector>
+#include <type_traits>
 
 #include <boost/range/functions.hpp>
 
@@ -31,6 +32,17 @@ struct shared_parallel_executor
     async_execute(F && f)
     {
         return hpx::async(std::forward<F>(f));
+    }
+
+    template <typename F>
+    typename std::remove_reference<
+        typename hpx::util::result_of<
+            typename hpx::util::decay<F>::type()
+        >::type
+    >::type
+    execute(F && f)
+    {
+        return async_execute(std::forward<F>(f)).get();
     }
 };
 

--- a/tests/unit/parallel/executors/shared_parallel_executor.cpp
+++ b/tests/unit/parallel/executors/shared_parallel_executor.cpp
@@ -101,12 +101,38 @@ void test_bulk_async()
     hpx::when_all(futs).get();
 }
 
+///////////////////////////////////////////////////////////////////////////////
+void void_test() {}
+
+void test_sync_void()
+{
+    typedef shared_parallel_executor executor;
+    typedef hpx::parallel::executor_traits<executor> traits;
+
+    executor exec;
+    traits::execute(exec, &void_test);
+}
+
+void test_async_void()
+{
+    typedef shared_parallel_executor executor;
+    typedef hpx::parallel::executor_traits<executor> traits;
+
+    executor exec;
+    hpx::shared_future<void> fut = traits::async_execute(exec, &void_test);
+    fut.get();
+}
+
+///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
     test_sync();
     test_async();
     test_bulk_sync();
     test_bulk_async();
+
+    test_sync_void();
+    test_async_void();
 
     return hpx::finalize();
 }

--- a/tests/unit/parallel/executors/shared_parallel_executor.cpp
+++ b/tests/unit/parallel/executors/shared_parallel_executor.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -26,23 +26,10 @@ struct shared_parallel_executor
     };
 
     template <typename F>
-    hpx::shared_future<typename hpx::util::result_of<
-        typename hpx::util::decay<F>::type()
-    >::type>
+    hpx::shared_future<typename hpx::util::result_of<F()>::type>
     async_execute(F && f)
     {
         return hpx::async(std::forward<F>(f));
-    }
-
-    template <typename F>
-    typename std::remove_reference<
-        typename hpx::util::result_of<
-            typename hpx::util::decay<F>::type()
-        >::type
-    >::type
-    execute(F && f)
-    {
-        return async_execute(std::forward<F>(f)).get();
     }
 };
 


### PR DESCRIPTION
- flyby: adding missing typedef