### PR TITLE
Possible missing include in test_utils.hpp

### DIFF
--- a/tests/unit/parallel/container_algorithms/test_utils.hpp
+++ b/tests/unit/parallel/container_algorithms/test_utils.hpp
@@ -10,6 +10,7 @@
 
 #include <boost/iterator/iterator_adaptor.hpp>
 
+#include <numeric>
 #include <random>
 
 namespace test


### PR DESCRIPTION
Attempting to fix the error [here](http://hermione.cct.lsu.edu/builders/hpx_msvc_14_boost_1_59_dev_windows_x86_64_release/builds/273/steps/build_unit_tests/logs/stdio)

MSVC builder seems to fail to find std::iota here, perhaps because the <numeric> header is not included?