### PR TITLE
Extending thread description

### DIFF
--- a/examples/quickstart/component_with_executor.cpp
+++ b/examples/quickstart/component_with_executor.cpp
@@ -38,7 +38,7 @@ struct hello_world_server
         hpx::threads::thread_init_data& data,
         hpx::threads::thread_state_enum initial_state)
     {
-        char const* desc = 0;
+        hpx::util::thread_description desc(&hello_world_server::func);
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
         desc = data.description;
 #endif

--- a/hpx/apply.hpp
+++ b/hpx/apply.hpp
@@ -42,9 +42,10 @@ namespace hpx { namespace detail
         >::type
         call(F&& f, Ts&&... ts)
         {
+            util::thread_description desc(f);
             threads::register_thread_nullary(
                 util::deferred_call(std::forward<F>(f), std::forward<Ts>(ts)...),
-                "hpx::apply");
+                desc);
             return false;
         }
     };

--- a/hpx/lcos/dataflow.hpp
+++ b/hpx/lcos/dataflow.hpp
@@ -210,7 +210,7 @@ namespace hpx { namespace lcos { namespace detail
             boost::intrusive_ptr<dataflow_frame> this_(this);
             threads::register_thread_nullary(
                 util::deferred_call(f, std::move(this_), is_void())
-              , "hpx::dataflow::execute"
+              , util::thread_description(func_)
               , threads::pending
               , true
               , threads::thread_priority_boost);

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -199,6 +199,7 @@ namespace detail
             f2_();
         }
 
+    private:
         F1 f1_;
         F2 f2_;
     };
@@ -789,37 +790,13 @@ namespace detail
             threads::thread_priority priority,
             threads::thread_stacksize stacksize, error_code& ec)
         {
-            check_started();
-
-            future_base_type this_(this);
-
-            char const* desc = hpx::threads::get_thread_description(
-                hpx::threads::get_self_id());
-
-            if (sched_) {
-                sched_->add(util::bind(&task_base::run_impl, std::move(this_)),
-                    desc ? desc : "task_base::apply", threads::pending, false,
-                    stacksize, ec);
-            }
-            else if (policy == launch::fork) {
-                threads::register_thread_plain(
-                    util::bind(&task_base::run_impl, std::move(this_)),
-                    desc ? desc : "task_base::apply", threads::pending, false,
-                    threads::thread_priority_boost, get_worker_thread_num(),
-                    stacksize, ec);
-            }
-            else {
-                threads::register_thread_plain(
-                    util::bind(&task_base::run_impl, std::move(this_)),
-                    desc ? desc : "task_base::apply", threads::pending, false,
-                    priority, std::size_t(-1), stacksize, ec);
-            }
+            HPX_ASSERT(false);      // shouldn't ever be called
         }
 
     protected:
-        threads::thread_state_enum run_impl()
+        static threads::thread_state_enum run_impl(future_base_type this_)
         {
-            this->do_run();
+            this_->do_run();
             return threads::terminated;
         }
 
@@ -891,44 +868,10 @@ namespace detail
         };
 
     protected:
-        // run in a separate thread
-        void apply(BOOST_SCOPED_ENUM(launch) policy,
-            threads::thread_priority priority,
-            threads::thread_stacksize stacksize, error_code& ec)
+        static threads::thread_state_enum run_impl(future_base_type this_)
         {
-            this->check_started();
-
-            future_base_type this_(this);
-
-            char const* desc = hpx::threads::get_thread_description(
-                hpx::threads::get_self_id());
-
-            if (this->sched_) {
-                this->sched_->add(
-                    util::bind(&cancelable_task_base::run_impl, std::move(this_)),
-                    desc ? desc : "cancelable_task_base::apply",
-                    threads::pending, false, stacksize, ec);
-            }
-            else if (policy == launch::fork) {
-                threads::register_thread_plain(
-                    util::bind(&cancelable_task_base::run_impl, std::move(this_)),
-                    desc ? desc : "cancelable_task_base::apply",
-                    threads::pending, false, threads::thread_priority_boost,
-                    get_worker_thread_num(), stacksize, ec);
-            }
-            else {
-                threads::register_thread_plain(
-                    util::bind(&cancelable_task_base::run_impl, std::move(this_)),
-                    desc ? desc : "cancelable_task_base::apply",
-                    threads::pending, false, priority, std::size_t(-1),
-                    stacksize, ec);
-            }
-        }
-
-        threads::thread_state_enum run_impl()
-        {
-            reset_id r(*this);
-            this->do_run();
+            reset_id r(*this_);
+            this_->do_run();
             return threads::terminated;
         }
 

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -15,6 +15,7 @@
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/util/decay.hpp>
 #include <hpx/util/move.hpp>
+#include <hpx/util/thread_description.hpp>
 #include <hpx/lcos/detail/future_data.hpp>
 #include <hpx/lcos/future.hpp>
 
@@ -277,7 +278,7 @@ namespace hpx { namespace lcos { namespace detail
 
             applier::register_thread_plain(
                 util::bind(async_impl_ptr, std::move(this_), f),
-                "continuation::async");
+                util::thread_description(f_));
 
             if (&ec != &throws)
                 ec = make_success_code();
@@ -307,7 +308,7 @@ namespace hpx { namespace lcos { namespace detail
 
             sched.add(
                 util::bind(async_impl_ptr, std::move(this_), f),
-                "continuation::async");
+                util::thread_description(f_));
 
             if (&ec != &throws)
                 ec = make_success_code();

--- a/hpx/lcos/local/packaged_task.hpp
+++ b/hpx/lcos/local/packaged_task.hpp
@@ -62,6 +62,39 @@ namespace hpx { namespace lcos { namespace local
                     this->set_exception(boost::current_exception());
                 }
             }
+
+        protected:
+            // run in a separate thread
+            void apply(BOOST_SCOPED_ENUM(launch) policy,
+                threads::thread_priority priority,
+                threads::thread_stacksize stacksize, error_code& ec)
+            {
+                this->check_started();
+
+                typedef typename Base::future_base_type future_base_type;
+                future_base_type this_(this);
+
+                if (this->sched_) {
+                    this->sched_->add(
+                        util::bind(&base_type::run_impl, std::move(this_)),
+                        util::thread_description(f_),
+                        threads::pending, false, stacksize, ec);
+                }
+                else if (policy == launch::fork) {
+                    threads::register_thread_plain(
+                        util::bind(&base_type::run_impl, std::move(this_)),
+                        util::thread_description(f_),
+                        threads::pending, false, threads::thread_priority_boost,
+                        get_worker_thread_num(), stacksize, ec);
+                }
+                else {
+                    threads::register_thread_plain(
+                        util::bind(&base_type::run_impl, std::move(this_)),
+                        util::thread_description(f_),
+                        threads::pending, false, priority, std::size_t(-1),
+                        stacksize, ec);
+                }
+            }
         };
 
         template <typename F, typename Base>
@@ -96,6 +129,39 @@ namespace hpx { namespace lcos { namespace local
                 }
                 catch(...) {
                     this->set_exception(boost::current_exception());
+                }
+            }
+
+        protected:
+            // run in a separate thread
+            void apply(BOOST_SCOPED_ENUM(launch) policy,
+                threads::thread_priority priority,
+                threads::thread_stacksize stacksize, error_code& ec)
+            {
+                this->check_started();
+
+                typedef typename Base::future_base_type future_base_type;
+                future_base_type this_(this);
+
+                if (this->sched_) {
+                    this->sched_->add(
+                        util::bind(&base_type::run_impl, std::move(this_)),
+                        util::thread_description(f_),
+                        threads::pending, false, stacksize, ec);
+                }
+                else if (policy == launch::fork) {
+                    threads::register_thread_plain(
+                        util::bind(&base_type::run_impl, std::move(this_)),
+                        util::thread_description(f_),
+                        threads::pending, false, threads::thread_priority_boost,
+                        get_worker_thread_num(), stacksize, ec);
+                }
+                else {
+                    threads::register_thread_plain(
+                        util::bind(&base_type::run_impl, std::move(this_)),
+                        util::thread_description(f_),
+                        threads::pending, false, priority, std::size_t(-1),
+                        stacksize, ec);
                 }
             }
         };

--- a/hpx/runtime/actions/basic_action_fwd.hpp
+++ b/hpx/runtime/actions/basic_action_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //  Copyright (c)      2011 Thomas Heller
 //
@@ -18,6 +18,12 @@ namespace hpx { namespace actions
     /// \tparam Derived           derived action class
     template <typename Component, typename Signature, typename Derived>
     struct basic_action;
+
+    //////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        template <typename Action> char const* get_action_name();
+    }
 }}
 
 #endif

--- a/hpx/runtime/threads/detail/create_thread.hpp
+++ b/hpx/runtime/threads/detail/create_thread.hpp
@@ -40,7 +40,7 @@ namespace hpx { namespace threads { namespace detail
         }
 
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
-        if (0 == data.description)
+        if (!data.description)
         {
             HPX_THROWS_IF(ec, bad_parameter,
                 "threads::detail::create_thread", "description is NULL");

--- a/hpx/runtime/threads/detail/create_work.hpp
+++ b/hpx/runtime/threads/detail/create_work.hpp
@@ -39,7 +39,7 @@ namespace hpx { namespace threads { namespace detail
         }
 
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
-        if (0 == data.description)
+        if (!data.description)
         {
             HPX_THROWS_IF(ec, bad_parameter,
                 "thread::detail::create_work", "description is NULL");

--- a/hpx/runtime/threads/executors/current_executor.hpp
+++ b/hpx/runtime/threads/executors/current_executor.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -12,6 +12,7 @@
 #include <hpx/runtime/threads/thread_executor.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 #include <hpx/lcos/local/counting_semaphore.hpp>
+#include <hpx/util/thread_description.hpp>
 
 #include <boost/ptr_container/ptr_vector.hpp>
 
@@ -31,7 +32,7 @@ namespace hpx { namespace threads { namespace executors
             // Schedule the specified function for execution in this executor.
             // Depending on the subclass implementation, this may block in some
             // situations.
-            void add(closure_type && f, char const* description,
+            void add(closure_type && f, util::thread_description const& desc,
                 threads::thread_state_enum initial_state, bool run_now,
                 threads::thread_stacksize stacksize, error_code& ec);
 
@@ -40,7 +41,7 @@ namespace hpx { namespace threads { namespace executors
             // bounds on the executor's queue size.
             void add_at(
                 boost::chrono::steady_clock::time_point const& abs_time,
-                closure_type && f, char const* description,
+                closure_type && f, util::thread_description const& desc,
                 threads::thread_stacksize stacksize, error_code& ec);
 
             // Schedule given function for execution in this executor no sooner
@@ -48,7 +49,7 @@ namespace hpx { namespace threads { namespace executors
             // violate bounds on the executor's queue size.
             void add_after(
                 boost::chrono::steady_clock::duration const& rel_time,
-                closure_type && f, char const* description,
+                closure_type && f, util::thread_description const& desc,
                 threads::thread_stacksize stacksize, error_code& ec);
 
             // Return an estimate of the number of waiting tasks.

--- a/hpx/runtime/threads/executors/default_executor.hpp
+++ b/hpx/runtime/threads/executors/default_executor.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +9,7 @@
 #include <hpx/hpx_fwd.hpp>
 #include <hpx/runtime/threads/policies/scheduler_mode.hpp>
 #include <hpx/runtime/threads/thread_executor.hpp>
+#include <hpx/util/thread_description.hpp>
 
 #include <hpx/config/warnings_prefix.hpp>
 
@@ -28,7 +29,8 @@ namespace hpx { namespace threads { namespace executors
             // Schedule the specified function for execution in this executor.
             // Depending on the subclass implementation, this may block in some
             // situations.
-            void add(closure_type && f, char const* description,
+            void add(closure_type && f,
+                util::thread_description const& description,
                 threads::thread_state_enum initial_state, bool run_now,
                 threads::thread_stacksize stacksize, error_code& ec);
 
@@ -37,7 +39,7 @@ namespace hpx { namespace threads { namespace executors
             // bounds on the executor's queue size.
             void add_at(
                 boost::chrono::steady_clock::time_point const& abs_time,
-                closure_type && f, char const* description,
+                closure_type && f, util::thread_description const& description,
                 threads::thread_stacksize stacksize, error_code& ec);
 
             // Schedule given function for execution in this executor no sooner
@@ -45,7 +47,7 @@ namespace hpx { namespace threads { namespace executors
             // violate bounds on the executor's queue size.
             inline void add_after(
                 boost::chrono::steady_clock::duration const& rel_time,
-                closure_type && f, char const* description,
+                closure_type && f, util::thread_description const& description,
                 threads::thread_stacksize stacksize, error_code& ec)
             {
                 return add_at(boost::chrono::steady_clock::now() + rel_time,

--- a/hpx/runtime/threads/executors/service_executors.hpp
+++ b/hpx/runtime/threads/executors/service_executors.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/runtime/threads/thread_executor.hpp>
 #include <hpx/util/io_service_pool.hpp>
+#include <hpx/util/thread_description.hpp>
 #include <hpx/lcos/local/counting_semaphore.hpp>
 
 #include <boost/atomic.hpp>
@@ -24,13 +25,15 @@ namespace hpx { namespace threads { namespace executors
           : public threads::detail::scheduled_executor_base
         {
         public:
-            service_executor(char const* pool_name, char const* pool_name_suffix = "");
+            service_executor(char const* pool_name,
+                char const* pool_name_suffix = "");
             ~service_executor();
 
             // Schedule the specified function for execution in this executor.
             // Depending on the subclass implementation, this may block in some
             // situations.
-            void add(closure_type && f, char const* description,
+            void add(closure_type && f,
+                util::thread_description const& description,
                 threads::thread_state_enum initial_state, bool run_now,
                 threads::thread_stacksize stacksize, error_code& ec);
 
@@ -39,7 +42,7 @@ namespace hpx { namespace threads { namespace executors
             // bounds on the executor's queue size.
             void add_at(
                 boost::chrono::steady_clock::time_point const& abs_time,
-                closure_type && f, char const* description,
+                closure_type && f, util::thread_description const& description,
                 threads::thread_stacksize stacksize, error_code& ec);
 
             // Schedule given function for execution in this executor no sooner
@@ -47,7 +50,7 @@ namespace hpx { namespace threads { namespace executors
             // violate bounds on the executor's queue size.
             void add_after(
                 boost::chrono::steady_clock::duration const& rel_time,
-                closure_type && f, char const* description,
+                closure_type && f, util::thread_description const& description,
                 threads::thread_stacksize stacksize, error_code& ec);
 
             // Return an estimate of the number of waiting tasks.

--- a/hpx/runtime/threads/executors/this_thread_executors.hpp
+++ b/hpx/runtime/threads/executors/this_thread_executors.hpp
@@ -13,6 +13,7 @@
 #include <hpx/runtime/threads/thread_executor.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 #include <hpx/lcos/local/counting_semaphore.hpp>
+#include <hpx/util/thread_description.hpp>
 
 #include <boost/ptr_container/ptr_vector.hpp>
 
@@ -38,7 +39,8 @@ namespace hpx { namespace threads { namespace executors
             // Schedule the specified function for execution in this executor.
             // Depending on the subclass implementation, this may block in some
             // situations.
-            void add(closure_type && f, char const* description,
+            void add(closure_type && f,
+                util::thread_description const& description,
                 threads::thread_state_enum initial_state, bool run_now,
                 threads::thread_stacksize stacksize, error_code& ec);
 
@@ -47,7 +49,7 @@ namespace hpx { namespace threads { namespace executors
             // bounds on the executor's queue size.
             void add_at(
                 boost::chrono::steady_clock::time_point const& abs_time,
-                closure_type && f, char const* description,
+                closure_type && f, util::thread_description const& description,
                 threads::thread_stacksize stacksize, error_code& ec);
 
             // Schedule given function for execution in this executor no sooner
@@ -55,7 +57,7 @@ namespace hpx { namespace threads { namespace executors
             // violate bounds on the executor's queue size.
             void add_after(
                 boost::chrono::steady_clock::duration const& rel_time,
-                closure_type && f, char const* description,
+                closure_type && f, util::thread_description const& description,
                 threads::thread_stacksize stacksize, error_code& ec);
 
             // Return an estimate of the number of waiting tasks.

--- a/hpx/runtime/threads/executors/thread_pool_attached_executors.hpp
+++ b/hpx/runtime/threads/executors/thread_pool_attached_executors.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -10,6 +10,7 @@
 #include <hpx/runtime/threads/thread_executor.hpp>
 #include <hpx/runtime/threads/detail/thread_pool.hpp>
 #include <hpx/runtime/threads/policies/callback_notifier.hpp>
+#include <hpx/util/thread_description.hpp>
 
 #include <boost/ptr_container/ptr_vector.hpp>
 #include <boost/atomic.hpp>
@@ -36,7 +37,8 @@ namespace hpx { namespace threads { namespace executors
             // Schedule the specified function for execution in this executor.
             // Depending on the subclass implementation, this may block in some
             // situations.
-            void add(closure_type && f, char const* description,
+            void add(closure_type && f,
+                util::thread_description const& description,
                 threads::thread_state_enum initial_state, bool run_now,
                 threads::thread_stacksize stacksize, error_code& ec);
 
@@ -45,7 +47,7 @@ namespace hpx { namespace threads { namespace executors
             // bounds on the executor's queue size.
             void add_at(
                 boost::chrono::steady_clock::time_point const& abs_time,
-                closure_type && f, char const* description,
+                closure_type && f, util::thread_description const& description,
                 threads::thread_stacksize stacksize, error_code& ec);
 
             // Schedule given function for execution in this executor no sooner
@@ -53,7 +55,7 @@ namespace hpx { namespace threads { namespace executors
             // violate bounds on the executor's queue size.
             void add_after(
                 boost::chrono::steady_clock::duration const& rel_time,
-                closure_type && f, char const* description,
+                closure_type && f, util::thread_description const& description,
                 threads::thread_stacksize stacksize, error_code& ec);
 
             // Return an estimate of the number of waiting tasks.

--- a/hpx/runtime/threads/executors/thread_pool_executors.hpp
+++ b/hpx/runtime/threads/executors/thread_pool_executors.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -10,6 +10,7 @@
 #include <hpx/runtime/threads/thread_executor.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 #include <hpx/lcos/local/counting_semaphore.hpp>
+#include <hpx/util/thread_description.hpp>
 
 #include <boost/ptr_container/ptr_vector.hpp>
 #include <boost/atomic.hpp>
@@ -39,7 +40,8 @@ namespace hpx { namespace threads { namespace executors
             // Schedule the specified function for execution in this executor.
             // Depending on the subclass implementation, this may block in some
             // situations.
-            void add(closure_type && f, char const* description,
+            void add(closure_type && f,
+                util::thread_description const& description,
                 threads::thread_state_enum initial_state, bool run_now,
                 threads::thread_stacksize stacksize, error_code& ec);
 
@@ -48,7 +50,7 @@ namespace hpx { namespace threads { namespace executors
             // bounds on the executor's queue size.
             void add_at(
                 boost::chrono::steady_clock::time_point const& abs_time,
-                closure_type && f, char const* description,
+                closure_type && f, util::thread_description const& description,
                 threads::thread_stacksize stacksize, error_code& ec);
 
             // Schedule given function for execution in this executor no sooner
@@ -56,7 +58,7 @@ namespace hpx { namespace threads { namespace executors
             // violate bounds on the executor's queue size.
             void add_after(
                 boost::chrono::steady_clock::duration const& rel_time,
-                closure_type && f, char const* description,
+                closure_type && f, util::thread_description const& description,
                 threads::thread_stacksize stacksize, error_code& ec);
 
             // Return an estimate of the number of waiting tasks.

--- a/hpx/runtime/threads/executors/thread_pool_os_executors.hpp
+++ b/hpx/runtime/threads/executors/thread_pool_os_executors.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -10,6 +10,7 @@
 #include <hpx/runtime/threads/thread_executor.hpp>
 #include <hpx/runtime/threads/detail/thread_pool.hpp>
 #include <hpx/runtime/threads/policies/callback_notifier.hpp>
+#include <hpx/util/thread_description.hpp>
 
 #include <boost/ptr_container/ptr_vector.hpp>
 #include <boost/atomic.hpp>
@@ -36,7 +37,8 @@ namespace hpx { namespace threads { namespace executors
             // Schedule the specified function for execution in this executor.
             // Depending on the subclass implementation, this may block in some
             // situations.
-            void add(closure_type && f, char const* description,
+            void add(closure_type && f,
+                util::thread_description const& description,
                 threads::thread_state_enum initial_state, bool run_now,
                 threads::thread_stacksize stacksize, error_code& ec);
 
@@ -45,7 +47,7 @@ namespace hpx { namespace threads { namespace executors
             // bounds on the executor's queue size.
             void add_at(
                 boost::chrono::steady_clock::time_point const& abs_time,
-                closure_type && f, char const* description,
+                closure_type && f, util::thread_description const& description,
                 threads::thread_stacksize stacksize, error_code& ec);
 
             // Schedule given function for execution in this executor no sooner
@@ -53,7 +55,7 @@ namespace hpx { namespace threads { namespace executors
             // violate bounds on the executor's queue size.
             void add_after(
                 boost::chrono::steady_clock::duration const& rel_time,
-                closure_type && f, char const* description,
+                closure_type && f, util::thread_description const& description,
                 threads::thread_stacksize stacksize, error_code& ec);
 
             // Return an estimate of the number of waiting tasks.

--- a/hpx/runtime/threads/thread_data.hpp
+++ b/hpx/runtime/threads/thread_data.hpp
@@ -21,6 +21,7 @@
 #include <hpx/util/spinlock_pool.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/backtrace.hpp>
+#include <hpx/util/thread_description.hpp>
 #include <hpx/util/coroutine/coroutine.hpp>
 #include <hpx/util/lockfree/freelist.hpp>
 
@@ -288,42 +289,43 @@ namespace hpx { namespace threads
         }
 
 #ifndef HPX_HAVE_THREAD_DESCRIPTION
-        char const* get_description() const
+        util::thread_description get_description() const
         {
-            return "<unknown>";
+            return util::thread_description("<unknown>");
         }
-        char const* set_description(char const* /*value*/)
+        util::thread_description set_description(char const* /*value*/)
         {
-            return "<unknown>";
+            return util::thread_description("<unknown>");
         }
 
-        char const* get_lco_description() const
+        util::thread_description get_lco_description() const
         {
-            return "<unknown>";
+            return util::thread_description("<unknown>");
         }
-        char const* set_lco_description(char const* /*value*/)
+        util::thread_description set_lco_description(char const* /*value*/)
         {
-            return "<unknown>";
+            return util::thread_description("<unknown>");
         }
 #else
-        char const* get_description() const
+        util::thread_description get_description() const
         {
             mutex_type::scoped_lock l(this);
-            return description_ ? description_ : "<unknown>";
+            return description_;
         }
-        char const* set_description(char const* value)
+        util::thread_description set_description(util::thread_description value)
         {
             mutex_type::scoped_lock l(this);
             std::swap(description_, value);
             return value;
         }
 
-        char const* get_lco_description() const
+        util::thread_description get_lco_description() const
         {
             mutex_type::scoped_lock l(this);
-            return lco_description_ ? lco_description_ : "<unknown>";
+            return lco_description_;
         }
-        char const* set_lco_description(char const* value)
+        util::thread_description set_lco_description(
+            util::thread_description value)
         {
             mutex_type::scoped_lock l(this);
             std::swap(lco_description_, value);
@@ -591,8 +593,8 @@ namespace hpx { namespace threads
             component_id_(init_data.lva),
 #endif
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
-            description_(init_data.description ? init_data.description : ""),
-            lco_description_(""),
+            description_(init_data.description),
+            lco_description_(),
 #endif
 #ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
             parent_locality_id_(init_data.parent_locality_id),
@@ -647,8 +649,8 @@ namespace hpx { namespace threads
             component_id_ = init_data.lva;
 #endif
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
-            description_ = (init_data.description ? init_data.description : "");
-            lco_description_ = "";
+            description_ = (init_data.description);
+            lco_description_ = util::thread_description();
 #endif
 #ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
             parent_locality_id_ = init_data.parent_locality_id;
@@ -699,8 +701,8 @@ namespace hpx { namespace threads
 #endif
 
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
-        char const* description_;
-        char const* lco_description_;
+        util::thread_description description_;
+        util::thread_description lco_description_;
 #endif
 
 #ifdef HPX_HAVE_THREAD_PARENT_REFERENCE

--- a/hpx/runtime/threads/thread_executor.hpp
+++ b/hpx/runtime/threads/thread_executor.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -14,6 +14,7 @@
 #include <hpx/util/date_time_chrono.hpp>
 #include <hpx/util/unique_function.hpp>
 #include <hpx/util/safe_bool.hpp>
+#include <hpx/util/thread_description.hpp>
 
 #include <boost/intrusive_ptr.hpp>
 #include <boost/detail/atomic_count.hpp>
@@ -101,7 +102,8 @@ namespace hpx { namespace threads
             // Schedule the specified function for execution in this executor.
             // Depending on the subclass implementation, this may block in some
             // situations.
-            virtual void add(closure_type && f, char const* desc,
+            virtual void add(closure_type && f,
+                util::thread_description const& desc,
                 threads::thread_state_enum initial_state, bool run_now,
                 threads::thread_stacksize stacksize, error_code& ec) = 0;
 
@@ -152,11 +154,11 @@ namespace hpx { namespace threads
             // bounds on the executor's queue size.
             virtual void add_at(
                 boost::chrono::steady_clock::time_point const& abs_time,
-                closure_type && f, char const* desc,
+                closure_type && f, util::thread_description const& desc,
                 threads::thread_stacksize stacksize, error_code& ec) = 0;
 
             void add_at(util::steady_time_point const& abs_time,
-                closure_type && f, char const* desc,
+                closure_type && f, util::thread_description const& desc,
                 threads::thread_stacksize stacksize, error_code& ec)
             {
                 return add_at(abs_time.value(), std::move(f), desc,
@@ -168,11 +170,11 @@ namespace hpx { namespace threads
             // violate bounds on the executor's queue size.
             virtual void add_after(
                 boost::chrono::steady_clock::duration const& rel_time,
-                closure_type && f, char const* desc,
+                closure_type && f, util::thread_description const& desc,
                 threads::thread_stacksize stacksize, error_code& ec) = 0;
 
             void add_after(util::steady_duration const& rel_time,
-                closure_type && f, char const* desc,
+                closure_type && f, util::thread_description const& desc,
                 threads::thread_stacksize stacksize, error_code& ec)
             {
                 return add_after(rel_time.value(), std::move(f), desc,
@@ -211,7 +213,8 @@ namespace hpx { namespace threads
         /// Schedule the specified function for execution in this executor.
         /// Depending on the subclass implementation, this may block in some
         /// situations.
-        void add(closure_type f, char const* desc = "",
+        void add(closure_type f,
+            util::thread_description const& desc = util::thread_description(),
             threads::thread_state_enum initial_state = threads::pending,
             bool run_now = true,
             threads::thread_stacksize stacksize = threads::thread_stacksize_default,

--- a/hpx/runtime/threads/thread_helpers.hpp
+++ b/hpx/runtime/threads/thread_helpers.hpp
@@ -159,15 +159,19 @@ namespace hpx { namespace threads
     ///                   throw but returns the result code using the
     ///                   parameter \a ec. Otherwise it throws an instance
     ///                   of hpx#exception.
-    HPX_API_EXPORT char const* get_thread_description(thread_id_type const& id,
+    HPX_API_EXPORT util::thread_description get_thread_description(
+        thread_id_type const& id, error_code& ec = throws);
+    HPX_API_EXPORT util::thread_description set_thread_description(
+        thread_id_type const& id,
+        util::thread_description const& desc = util::thread_description(),
         error_code& ec = throws);
-    HPX_API_EXPORT char const* set_thread_description(thread_id_type const& id,
-        char const* desc = 0, error_code& ec = throws);
 
-    HPX_API_EXPORT char const* get_thread_lco_description(thread_id_type const& id,
+    HPX_API_EXPORT util::thread_description get_thread_lco_description(
+        thread_id_type const& id, error_code& ec = throws);
+    HPX_API_EXPORT util::thread_description set_thread_lco_description(
+        thread_id_type const& id,
+        util::thread_description const& desc = util::thread_description(),
         error_code& ec = throws);
-    HPX_API_EXPORT char const* set_thread_lco_description(thread_id_type const& id,
-        char const* desc = 0, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
     /// The function get_thread_backtrace is part of the thread related API
@@ -456,7 +460,8 @@ namespace hpx { namespace this_thread
     ///
     HPX_API_EXPORT threads::thread_state_ex_enum suspend(
         threads::thread_state_enum state = threads::pending,
-        char const* description = "this_thread::suspend",
+        util::thread_description const& description =
+            util::thread_description("this_thread::suspend"),
         error_code& ec = throws);
 
     /// The function \a suspend will return control to the thread manager
@@ -478,7 +483,8 @@ namespace hpx { namespace this_thread
     ///
     HPX_API_EXPORT threads::thread_state_ex_enum suspend(
         util::steady_time_point const& abs_time,
-        char const* description = "this_thread::suspend",
+        util::thread_description const& description =
+            util::thread_description("this_thread::suspend"),
         error_code& ec = throws);
 
     /// The function \a suspend will return control to the thread manager
@@ -500,7 +506,8 @@ namespace hpx { namespace this_thread
     ///
     inline threads::thread_state_ex_enum suspend(
         util::steady_duration const& rel_time,
-        char const* description = "this_thread::suspend",
+        util::thread_description const& description =
+            util::thread_description("this_thread::suspend"),
         error_code& ec = throws)
     {
         return suspend(rel_time.from_now(), description, ec);
@@ -523,8 +530,9 @@ namespace hpx { namespace this_thread
     ///         running, it will throw an \a hpx#exception with an error code of
     ///         \a hpx#invalid_status.
     ///
-    inline threads::thread_state_ex_enum suspend(
-        boost::uint64_t ms, char const* description = "this_thread::suspend",
+    inline threads::thread_state_ex_enum suspend(boost::uint64_t ms,
+        util::thread_description const& description =
+            util::thread_description("this_thread::suspend"),
         error_code& ec = throws)
     {
         return suspend(boost::chrono::milliseconds(ms), description, ec);
@@ -616,7 +624,7 @@ namespace hpx { namespace applier
     ///                   of hpx#exception.
     HPX_API_EXPORT threads::thread_id_type register_thread_plain(
         threads::thread_function_type && func,
-        char const* description = 0,
+        util::thread_description const& description = util::thread_description(),
         threads::thread_state_enum initial_state = threads::pending,
         bool run_now = true,
         threads::thread_priority priority = threads::thread_priority_normal,
@@ -639,7 +647,7 @@ namespace hpx { namespace applier
     ///
     HPX_API_EXPORT threads::thread_id_type register_thread(
         util::unique_function_nonser<void(threads::thread_state_ex_enum)> && func,
-        char const* description = 0,
+        util::thread_description const& description = util::thread_description(),
         threads::thread_state_enum initial_state = threads::pending,
         bool run_now = true,
         threads::thread_priority priority = threads::thread_priority_normal,
@@ -661,7 +669,7 @@ namespace hpx { namespace applier
     ///
     HPX_API_EXPORT threads::thread_id_type register_thread_nullary(
         util::unique_function_nonser<void()> && func,
-        char const* description = 0,
+        util::thread_description const& description = util::thread_description(),
         threads::thread_state_enum initial_state = threads::pending,
         bool run_now = true,
         threads::thread_priority priority = threads::thread_priority_normal,
@@ -732,7 +740,7 @@ namespace hpx { namespace applier
     ///
     HPX_API_EXPORT void register_work_plain(
         threads::thread_function_type && func,
-        char const* description = 0,
+        util::thread_description const& description = util::thread_description(),
         boost::uint64_t /*naming::address_type*/ lva = 0,
         threads::thread_state_enum initial_state = threads::pending,
         threads::thread_priority priority = threads::thread_priority_normal,
@@ -742,8 +750,8 @@ namespace hpx { namespace applier
 
 #if !defined(DOXYGEN)
     HPX_API_EXPORT void register_work_plain(
-        threads::thread_function_type && func,
-        naming::id_type const& target, char const* description = 0,
+        threads::thread_function_type && func, naming::id_type const& target,
+        util::thread_description const& description = util::thread_description(),
         boost::uint64_t /*naming::address_type*/ lva = 0,
         threads::thread_state_enum initial_state = threads::pending,
         threads::thread_priority priority = threads::thread_priority_normal,
@@ -767,7 +775,7 @@ namespace hpx { namespace applier
     ///
     HPX_API_EXPORT void register_work(
         util::unique_function_nonser<void(threads::thread_state_ex_enum)> && func,
-        char const* description = 0,
+        util::thread_description const& description = util::thread_description(),
         threads::thread_state_enum initial_state = threads::pending,
         threads::thread_priority priority = threads::thread_priority_normal,
         std::size_t os_thread = std::size_t(-1),
@@ -788,7 +796,7 @@ namespace hpx { namespace applier
     ///
     HPX_API_EXPORT void register_work_nullary(
         util::unique_function_nonser<void()> && func,
-        char const* description = 0,
+        util::thread_description const& description = util::thread_description(),
         threads::thread_state_enum initial_state = threads::pending,
         threads::thread_priority priority = threads::thread_priority_normal,
         std::size_t os_thread = std::size_t(-1),

--- a/hpx/runtime/threads/thread_init_data.hpp
+++ b/hpx/runtime/threads/thread_init_data.hpp
@@ -11,6 +11,7 @@
 #include <hpx/runtime/naming/name.hpp>
 #include <hpx/runtime/naming/address.hpp>
 #include <hpx/util/move.hpp>
+#include <hpx/util/thread_description.hpp>
 
 namespace hpx { namespace threads
 {
@@ -29,7 +30,7 @@ namespace hpx { namespace threads
             lva(0),
 #endif
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
-            description(0),
+            description(),
 #endif
 #if defined(HPX_HAVE_THREAD_PARENT_REFERENCE)
             parent_locality_id(0), parent_id(0), parent_phase(0),
@@ -60,7 +61,7 @@ namespace hpx { namespace threads
         {}
 
         template <typename F>
-        thread_init_data(F && f, char const* desc,
+        thread_init_data(F && f, util::thread_description const& desc,
                 naming::address::address_type lva_ = 0,
                 thread_priority priority_ = thread_priority_normal,
                 std::size_t os_thread = std::size_t(-1),
@@ -90,7 +91,7 @@ namespace hpx { namespace threads
         naming::address::address_type lva;
 #endif
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
-        char const* description;
+        util::thread_description description;
 #endif
 #if defined(HPX_HAVE_THREAD_PARENT_REFERENCE)
         boost::uint32_t parent_locality_id;

--- a/hpx/traits.hpp
+++ b/hpx/traits.hpp
@@ -31,6 +31,10 @@ namespace hpx { namespace traits
     struct get_remote_result;
 
     ///////////////////////////////////////////////////////////////////////////
+    template <typename F, typename Enable = void>
+    struct get_function_address;
+
+    ///////////////////////////////////////////////////////////////////////////
     template <typename Component, typename Enable = void>
     struct is_component;
 

--- a/hpx/traits/get_function_address.hpp
+++ b/hpx/traits/get_function_address.hpp
@@ -34,8 +34,8 @@ namespace hpx { namespace traits
         }
     };
 
-    // For member functions we return the first sizeof(void*) bytes of function
-    // the storage the member function pointer occupies.
+    // For member functions we return the first sizeof(void*) bytes of the
+    // storage the member function pointer occupies.
     //
     // BADBAD: This invokes undefined behavior. What it does is to
     //         access the first sizeof(void*) bytes of the member
@@ -55,8 +55,7 @@ namespace hpx { namespace traits
     {
         static std::size_t call(R (Obj::*f)(Ts...)) HPX_NOEXCEPT
         {
-            return reinterpret_cast<std::size_t>(
-                *reinterpret_cast<void**>(std::addressof(f)));
+            return reinterpret_cast<std::size_t>(*reinterpret_cast<void**>(&f));
         }
     };
 
@@ -65,8 +64,7 @@ namespace hpx { namespace traits
     {
         static std::size_t call(R (Obj::*f)(Ts...) const) HPX_NOEXCEPT
         {
-            return reinterpret_cast<std::size_t>(
-                *reinterpret_cast<void**>(std::addressof(f)));
+            return reinterpret_cast<std::size_t>(*reinterpret_cast<void**>(&f));
         }
     };
 }}

--- a/hpx/traits/get_function_address.hpp
+++ b/hpx/traits/get_function_address.hpp
@@ -1,0 +1,74 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_TRAITS_GET_FUNCTION_ADDRESS_FEB_19_2016_0801PM)
+#define HPX_TRAITS_GET_FUNCTION_ADDRESS_FEB_19_2016_0801PM
+
+#include <hpx/traits.hpp>
+
+#include <cstddef>
+#include <memory>
+
+namespace hpx { namespace traits
+{
+    // By default we return the address of the object which is used to invoke
+    // the trait.
+    template <typename F, typename Enable>
+    struct get_function_address
+    {
+        static std::size_t call(F const& f) HPX_NOEXCEPT
+        {
+            return reinterpret_cast<std::size_t>(std::addressof(f));
+        }
+    };
+
+    // For global (and static) functions we return the function address itself
+    template <typename R, typename ... Ts>
+    struct get_function_address<R (*)(Ts...)>
+    {
+        static std::size_t call(R (*f)(Ts...)) HPX_NOEXCEPT
+        {
+            return reinterpret_cast<std::size_t>(f);
+        }
+    };
+
+    // For member functions we return the first sizeof(void*) bytes of function
+    // the storage the member function pointer occupies.
+    //
+    // BADBAD: This invokes undefined behavior. What it does is to
+    //         access the first sizeof(void*) bytes of the member
+    //         function pointer. In our case this is not a problem as
+    //         the value will be used to resolve a (debug) symbol only.
+    //
+    //         The value is never dereferenced or used in any other
+    //         way. So the worst what can happen is that no matching
+    //         symbol is found.
+    //
+    //         On some systems and for certain types of member function
+    //         pointers this might even give the correct value
+    //         representing the symbol corresponding to the function.
+    //
+    template <typename R, typename Obj, typename ... Ts>
+    struct get_function_address<R (Obj::*)(Ts...)>
+    {
+        static std::size_t call(R (Obj::*f)(Ts...)) HPX_NOEXCEPT
+        {
+            return reinterpret_cast<std::size_t>(
+                *reinterpret_cast<void**>(std::addressof(f)));
+        }
+    };
+
+    template <typename R, typename Obj, typename ... Ts>
+    struct get_function_address<R (Obj::*)(Ts...) const>
+    {
+        static std::size_t call(R (Obj::*f)(Ts...) const) HPX_NOEXCEPT
+        {
+            return reinterpret_cast<std::size_t>(
+                *reinterpret_cast<void**>(std::addressof(f)));
+        }
+    };
+}}
+
+#endif

--- a/hpx/util/apex.hpp
+++ b/hpx/util/apex.hpp
@@ -31,14 +31,14 @@ namespace hpx { namespace util
         apex_wrapper(thread_description const& name)
           : name_(name), stopped(false)
         {
-            if (name->kind() == thread_description::data_type_description)
+            if (name_.kind() == thread_description::data_type_description)
             {
                 profiler_ = apex::start(name_.get_description());
             }
             else
             {
                 profiler_ = apex::start(
-                    apex::apex_function_address(name_.get_address()));
+                    apex_function_address(name_.get_address()));
             }
         }
         ~apex_wrapper()
@@ -60,7 +60,7 @@ namespace hpx { namespace util
             }
         }
 
-        threads::detail::thread_description name_;
+        thread_description name_;
         bool stopped;
         apex::profiler * profiler_;
     };

--- a/hpx/util/apex.hpp
+++ b/hpx/util/apex.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,11 +6,11 @@
 #pragma once // prevent multiple inclusions of this header file.
 
 #include <hpx/config/defines.hpp>
+#include <hpx/util/thread_description.hpp>
 
 #ifdef HPX_HAVE_APEX
 #include "apex_api.hpp"
 #endif
-
 
 namespace hpx { namespace util
 {
@@ -28,10 +28,18 @@ namespace hpx { namespace util
 
     struct apex_wrapper
     {
-        apex_wrapper(char const* const name)
+        apex_wrapper(thread_description const& name)
           : name_(name), stopped(false)
         {
-            profiler_ = apex::start(name_);
+            if (name->kind() == thread_description::data_type_description)
+            {
+                profiler_ = apex::start(name_.get_description());
+            }
+            else
+            {
+                profiler_ = apex::start(
+                    apex::apex_function_address(name_.get_address()));
+            }
         }
         ~apex_wrapper()
         {
@@ -52,7 +60,7 @@ namespace hpx { namespace util
             }
         }
 
-        char const* const name_;
+        threads::detail::thread_description name_;
         bool stopped;
         apex::profiler * profiler_;
     };
@@ -74,7 +82,7 @@ namespace hpx { namespace util
 
     struct apex_wrapper
     {
-        apex_wrapper(char const* const name) {}
+        apex_wrapper(thread_description const& name) {}
         ~apex_wrapper() {}
     };
 

--- a/hpx/util/bind.hpp
+++ b/hpx/util/bind.hpp
@@ -11,6 +11,7 @@
 #include <hpx/traits/is_action.hpp>
 #include <hpx/traits/is_bind_expression.hpp>
 #include <hpx/traits/is_placeholder.hpp>
+#include <hpx/traits/get_function_address.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/decay.hpp>
 #include <hpx/util/invoke.hpp>
@@ -296,6 +297,13 @@ namespace hpx { namespace util
                 ar & _args;
             }
 
+            std::size_t get_function_address() const
+            {
+                return traits::get_function_address<
+                        typename std::decay<F>::type
+                    >::call(_f);
+            }
+
         private:
             typename std::decay<F>::type _f;
             util::tuple<typename std::decay<Ts>::type...> _args;
@@ -383,6 +391,11 @@ namespace hpx { namespace util
                 ar & _f;
             }
 
+            std::size_t get_function_address() const
+            {
+                return traits::get_function_address<F>::call(_f);
+            }
+
         public: // exposition-only
             F _f;
 #           if !defined(HPX_DISABLE_ASSERTS)
@@ -417,6 +430,27 @@ namespace hpx { namespace traits
     struct is_placeholder<util::detail::placeholder<I> >
       : boost::integral_constant<int, I>
     {};
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Sig>
+    struct get_function_address<util::detail::bound<Sig> >
+    {
+        static std::size_t
+            call(util::detail::bound<Sig> const& f) HPX_NOEXCEPT
+        {
+            return f.get_function_address();
+        }
+    };
+
+    template <typename F>
+    struct get_function_address<util::detail::one_shot_wrapper<F> >
+    {
+        static std::size_t
+            call(util::detail::one_shot_wrapper<F> const& f) HPX_NOEXCEPT
+        {
+            return f.get_function_address();
+        }
+    };
 }}
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hpx/util/deferred_call.hpp
+++ b/hpx/util/deferred_call.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/traits/is_callable.hpp>
+#include <hpx/traits/get_function_address.hpp>
 #include <hpx/util/decay.hpp>
 #include <hpx/util/invoke_fused.hpp>
 #include <hpx/util/tuple.hpp>
@@ -72,6 +73,13 @@ namespace hpx { namespace util
                 ar & _args;
             }
 
+            std::size_t get_function_address() const
+            {
+                return traits::get_function_address<
+                        typename util::decay_unwrap<F>::type
+                    >::call(_f);
+            }
+
         private:
             typename util::decay_unwrap<F>::type _f;
             util::tuple<typename util::decay_unwrap<Ts>::type...> _args;
@@ -101,6 +109,21 @@ namespace hpx { namespace util
 
         return std::forward<F>(f);
     }
+}}
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace traits
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Sig>
+    struct get_function_address<util::detail::deferred<Sig> >
+    {
+        static std::size_t
+            call(util::detail::deferred<Sig> const& f) HPX_NOEXCEPT
+        {
+            return f.get_function_address();
+        }
+    };
 }}
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hpx/util/detail/basic_function.hpp
+++ b/hpx/util/detail/basic_function.hpp
@@ -256,6 +256,11 @@ namespace hpx { namespace util { namespace detail
             return vptr->invoke(object, std::forward<Ts>(vs)...);
         }
 
+        std::size_t get_function_address() const
+        {
+            return vptr->get_function_address(object);
+        }
+
     private:
         template <typename T>
         static VTablePtr const* get_table_ptr() HPX_NOEXCEPT

--- a/hpx/util/detail/function_template.hpp
+++ b/hpx/util/detail/function_template.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011 Thomas Heller
-//  Copyright (c) 2013 Hartmut Kaiser
+//  Copyright (c) 2013-2016 Hartmut Kaiser
 //  Copyright (c) 2014 Agustin Berge
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,6 +10,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/traits/is_callable.hpp>
+#include <hpx/traits/get_function_address.hpp>
 #include <hpx/util/detail/basic_function.hpp>
 #include <hpx/util/detail/vtable/callable_vtable.hpp>
 #include <hpx/util/detail/vtable/copyable_vtable.hpp>
@@ -29,6 +30,7 @@ namespace hpx { namespace util { namespace detail
         vtable::get_type_t get_type;
         vtable::destruct_t destruct;
         vtable::delete_t delete_;
+        vtable::get_function_address_t get_function_address;
         bool empty;
 
         template <typename T>
@@ -38,6 +40,7 @@ namespace hpx { namespace util { namespace detail
           , get_type(&vtable::template get_type<T>)
           , destruct(&vtable::template destruct<T>)
           , delete_(&vtable::template delete_<T>)
+          , get_function_address(&vtable::template get_function_address<T>)
           , empty(std::is_same<T, empty_function<Sig> >::value)
         {}
 
@@ -234,6 +237,30 @@ namespace hpx { namespace util
     }
 
 #   endif /*HPX_HAVE_CXX11_ALIAS_TEMPLATES*/
+}}
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace traits
+{
+    template <typename Sig, bool Serializable>
+    struct get_function_address<util::function<Sig, Serializable> >
+    {
+        static std::size_t
+            call(util::function<Sig, Serializable> const& f) HPX_NOEXCEPT
+        {
+            return f.get_function_address();
+        }
+    };
+
+    template <typename Sig>
+    struct get_function_address<util::function_nonser<Sig> >
+    {
+        static std::size_t
+            call(util::function_nonser<Sig> const& f) HPX_NOEXCEPT
+        {
+            return f.get_function_address();
+        }
+    };
 }}
 
 #endif

--- a/hpx/util/detail/unique_function_template.hpp
+++ b/hpx/util/detail/unique_function_template.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011 Thomas Heller
-//  Copyright (c) 2013 Hartmut Kaiser
+//  Copyright (c) 2013-2016 Hartmut Kaiser
 //  Copyright (c) 2014 Agustin Berge
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,6 +10,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/traits/is_callable.hpp>
+#include <hpx/traits/get_function_address.hpp>
 #include <hpx/util/detail/basic_function.hpp>
 #include <hpx/util/detail/vtable/callable_vtable.hpp>
 #include <hpx/util/detail/vtable/vtable.hpp>
@@ -27,6 +28,7 @@ namespace hpx { namespace util { namespace detail
         vtable::get_type_t get_type;
         vtable::destruct_t destruct;
         vtable::delete_t delete_;
+        vtable::get_function_address_t get_function_address;
         bool empty;
 
         template <typename T>
@@ -35,6 +37,7 @@ namespace hpx { namespace util { namespace detail
           , get_type(&vtable::template get_type<T>)
           , destruct(&vtable::template destruct<T>)
           , delete_(&vtable::template delete_<T>)
+          , get_function_address(&vtable::template get_function_address<T>)
           , empty(std::is_same<T, empty_function<Sig> >::value)
         {}
 
@@ -187,6 +190,31 @@ namespace hpx { namespace util
     }
 
 #   endif /*HPX_HAVE_CXX11_ALIAS_TEMPLATES*/
+}}
+
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace traits
+{
+    template <typename Sig, bool Serializable>
+    struct get_function_address<util::unique_function<Sig, Serializable> >
+    {
+        static std::size_t
+            call(util::unique_function<Sig, Serializable> const& f) HPX_NOEXCEPT
+        {
+            return f.get_function_address();
+        }
+    };
+
+    template <typename Sig>
+    struct get_function_address<util::unique_function_nonser<Sig> >
+    {
+        static std::size_t
+            call(util::unique_function_nonser<Sig> const& f) HPX_NOEXCEPT
+        {
+            return f.get_function_address();
+        }
+    };
 }}
 
 #endif

--- a/hpx/util/detail/vtable/vtable.hpp
+++ b/hpx/util/detail/vtable/vtable.hpp
@@ -9,6 +9,7 @@
 #define HPX_UTIL_DETAIL_VTABLE_VTABLE_HPP
 
 #include <hpx/config/forceinline.hpp>
+#include <hpx/traits/get_function_address.hpp>
 
 #include <memory>
 #include <typeinfo>
@@ -97,6 +98,13 @@ namespace hpx { namespace util { namespace detail
             }
         }
         typedef void (*delete_t)(void**);
+
+        template <typename T>
+        HPX_FORCEINLINE static std::size_t get_function_address(void** f)
+        {
+            return traits::get_function_address<T>::call(vtable::get<T>(f));
+        }
+        typedef std::size_t (*get_function_address_t)(void**);
     };
 
     template <typename T>

--- a/hpx/util/itt_notify.hpp
+++ b/hpx/util/itt_notify.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2012 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -7,6 +7,7 @@
 #define HPX_UTIL_ITT_NOTIFY_AUG_17_2010_1237PM
 
 #include <hpx/config.hpp>
+#include <hpx/util/thread_description.hpp>
 
 #include <cstddef>
 
@@ -248,10 +249,19 @@ namespace hpx { namespace util { namespace itt
     //////////////////////////////////////////////////////////////////////////
     struct task
     {
-        task(domain const& domain, char const* name)
+        task(domain const& domain, util::thread_description name)
           : domain_(domain)
         {
-            HPX_ITT_TASK_BEGIN(domain_.domain_, HPX_ITT_TASK_HANDLE_CREATE(name));
+            if (name.kind() == util::thread_description::data_type_description)
+            {
+                HPX_ITT_TASK_BEGIN(domain_.domain_,
+                    HPX_ITT_TASK_HANDLE_CREATE(name));
+            }
+            else
+            {
+                HPX_ITT_TASK_BEGIN(domain_.domain_,
+                    HPX_ITT_TASK_HANDLE_CREATE("address"));
+            }
         }
         ~task()
         {
@@ -432,7 +442,7 @@ namespace hpx { namespace util { namespace itt
     //////////////////////////////////////////////////////////////////////////
     struct task
     {
-        task(domain const&, char const*) {}
+        task(domain const&, util::thread_description const&) {}
         ~task() {}
     };
 

--- a/hpx/util/thread_description.hpp
+++ b/hpx/util/thread_description.hpp
@@ -7,7 +7,9 @@
 #define HPX_RUNTIME_THREADS_DETAIL_THREAD_DESCRIPTION_FEB_19_2016_0200PM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_action.hpp>
 #include <hpx/traits/get_function_address.hpp>
+#include <hpx/runtime/actions/basic_action_fwd.hpp>
 #include <hpx/util/assert.hpp>
 #ifndef HPX_HAVE_CXX11_EXPLICIT_CONVERSION_OPERATORS
 #include <hpx/util/safe_bool.hpp>
@@ -54,7 +56,8 @@ namespace hpx { namespace util
 
         template <typename F, typename =
             typename std::enable_if<
-                !std::is_same<F, thread_description>::value
+                !std::is_same<F, thread_description>::value &&
+                !traits::is_action<F>::value
             >::type>
         explicit thread_description(F const& f) HPX_NOEXCEPT
           : type_(data_type_address)
@@ -62,7 +65,17 @@ namespace hpx { namespace util
             data_.addr_ = traits::get_function_address<F>::call(f);
         }
 
-        HPX_CONSTEXPR data_type kind() const HPX_NOEXCEPT
+        template <typename Action, typename =
+            typename std::enable_if<
+                traits::is_action<Action>::value
+            >::type>
+        explicit thread_description(Action) HPX_NOEXCEPT
+          : type_(data_type_description)
+        {
+            data_.desc_ = hpx::actions::detail::get_action_name<Action>();
+        }
+
+        data_type kind() const HPX_NOEXCEPT
         {
             return type_;
         }

--- a/hpx/util/thread_description.hpp
+++ b/hpx/util/thread_description.hpp
@@ -1,0 +1,110 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_RUNTIME_THREADS_DETAIL_THREAD_DESCRIPTION_FEB_19_2016_0200PM)
+#define HPX_RUNTIME_THREADS_DETAIL_THREAD_DESCRIPTION_FEB_19_2016_0200PM
+
+#include <hpx/config.hpp>
+#include <hpx/traits/get_function_address.hpp>
+#include <hpx/util/assert.hpp>
+#ifndef HPX_HAVE_CXX11_EXPLICIT_CONVERSION_OPERATORS
+#include <hpx/util/safe_bool.hpp>
+#endif
+
+#include <iosfwd>
+#include <string>
+#include <utility>
+#include <type_traits>
+
+namespace hpx { namespace util
+{
+    struct thread_description
+    {
+    public:
+        enum data_type
+        {
+            data_type_description = 0,
+            data_type_address = 1
+        };
+
+    private:
+        union data
+        {
+            char const* desc_;
+            std::size_t addr_;
+        };
+
+        data_type type_;
+        data data_;
+
+    public:
+        thread_description() HPX_NOEXCEPT
+          : type_(data_type_description)
+        {
+            data_.desc_ = 0;
+        }
+
+        thread_description(char const* desc) HPX_NOEXCEPT
+          : type_(data_type_description)
+        {
+            data_.desc_ = desc;
+        }
+
+        template <typename F, typename =
+            typename std::enable_if<
+                !std::is_same<F, thread_description>::value
+            >::type>
+        explicit thread_description(F const& f) HPX_NOEXCEPT
+          : type_(data_type_address)
+        {
+            data_.addr_ = traits::get_function_address<F>::call(f);
+        }
+
+        HPX_CONSTEXPR data_type kind() const HPX_NOEXCEPT
+        {
+            return type_;
+        }
+
+        char const* get_description() const HPX_NOEXCEPT
+        {
+            HPX_ASSERT(type_ == data_type_description);
+            return data_.desc_;
+        }
+
+        std::size_t get_address() const HPX_NOEXCEPT
+        {
+            HPX_ASSERT(type_ == data_type_address);
+            return data_.addr_;
+        }
+
+#ifdef HPX_HAVE_CXX11_EXPLICIT_CONVERSION_OPERATORS
+        explicit operator bool() const HPX_NOEXCEPT
+        {
+            return valid();
+        }
+#else
+        operator typename util::safe_bool<thread_description>
+            ::result_type() const HPX_NOEXCEPT
+        {
+            return util::safe_bool<thread_description>()(valid());
+        }
+#endif
+
+        bool valid() const HPX_NOEXCEPT
+        {
+            if (type_ == data_type_description)
+                return 0 != data_.desc_;
+
+            HPX_ASSERT(type_ == data_type_address);
+            return 0 != data_.addr_;
+        }
+    };
+
+    HPX_EXPORT std::ostream& operator<<(std::ostream&, thread_description const&);
+    HPX_EXPORT std::string as_string(thread_description const& desc);
+}}
+
+#endif
+

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -249,7 +249,7 @@ namespace hpx { namespace detail
 
         std::size_t shepherd = std::size_t(-1);
         threads::thread_id_type thread_id;
-        std::string thread_name;
+        util::thread_description thread_name;
 
         threads::thread_self* self = threads::get_self_ptr();
         if (NULL != self)
@@ -265,8 +265,10 @@ namespace hpx { namespace detail
         std::string config(configuration_string());
 
         return construct_exception(e, func, file, line, back_trace, node,
-            hostname, pid, shepherd, reinterpret_cast<std::size_t>(thread_id.get()),
-            thread_name, env, config, state_name, auxinfo);
+            hostname, pid, shepherd,
+            reinterpret_cast<std::size_t>(thread_id.get()),
+            util::as_string(thread_name), env, config,
+            state_name, auxinfo);
     }
 
     template <typename Exception>

--- a/src/runtime/applier/applier.cpp
+++ b/src/runtime/applier/applier.cpp
@@ -17,6 +17,7 @@
 #include <hpx/runtime/naming/resolver_client.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/util/register_locks.hpp>
+#include <hpx/util/thread_description.hpp>
 #include <hpx/include/async.hpp>
 #if defined(HPX_HAVE_SECURITY)
 #include <hpx/components/security/capability.hpp>
@@ -66,7 +67,8 @@ namespace hpx { namespace applier
 
     ///////////////////////////////////////////////////////////////////////////
     threads::thread_id_type register_thread_nullary(
-        util::unique_function_nonser<void()> && func, char const* desc,
+        util::unique_function_nonser<void()> && func,
+        util::thread_description const& desc,
         threads::thread_state_enum state, bool run_now,
         threads::thread_priority priority, std::size_t os_thread,
         threads::thread_stacksize stacksize, error_code& ec)
@@ -80,10 +82,13 @@ namespace hpx { namespace applier
             return threads::invalid_thread_id;
         }
 
+        util::thread_description d = desc;
+        if (!desc)
+            d = util::thread_description(func);
+
         threads::thread_init_data data(
             util::bind(util::one_shot(&thread_function_nullary), std::move(func)),
-            desc ? desc : "<unknown>", 0, priority, os_thread,
-            threads::get_stack_size(stacksize));
+            d, 0, priority, os_thread, threads::get_stack_size(stacksize));
 
         threads::thread_id_type id = threads::invalid_thread_id;
         app->get_thread_manager().register_thread(data, id, state, run_now, ec);
@@ -92,8 +97,8 @@ namespace hpx { namespace applier
 
     threads::thread_id_type register_thread(
         util::unique_function_nonser<void(threads::thread_state_ex_enum)> && func,
-        char const* desc, threads::thread_state_enum state, bool run_now,
-        threads::thread_priority priority, std::size_t os_thread,
+        util::thread_description const& desc, threads::thread_state_enum state,
+        bool run_now, threads::thread_priority priority, std::size_t os_thread,
         threads::thread_stacksize stacksize, error_code& ec)
     {
         hpx::applier::applier* app = hpx::applier::get_applier_ptr();
@@ -105,10 +110,13 @@ namespace hpx { namespace applier
             return threads::invalid_thread_id;
         }
 
+        util::thread_description d = desc;
+        if (!desc)
+            d = util::thread_description(func);
+
         threads::thread_init_data data(
             util::bind(util::one_shot(&thread_function), std::move(func)),
-            desc ? desc : "<unknown>", 0, priority, os_thread,
-            threads::get_stack_size(stacksize));
+            d, 0, priority, os_thread, threads::get_stack_size(stacksize));
 
         threads::thread_id_type id = threads::invalid_thread_id;
         app->get_thread_manager().register_thread(data, id, state, run_now, ec);
@@ -117,8 +125,8 @@ namespace hpx { namespace applier
 
     threads::thread_id_type register_thread_plain(
         threads::thread_function_type && func,
-        char const* desc, threads::thread_state_enum state, bool run_now,
-        threads::thread_priority priority, std::size_t os_thread,
+        util::thread_description const& desc, threads::thread_state_enum state,
+        bool run_now, threads::thread_priority priority, std::size_t os_thread,
         threads::thread_stacksize stacksize, error_code& ec)
     {
         hpx::applier::applier* app = hpx::applier::get_applier_ptr();
@@ -130,9 +138,12 @@ namespace hpx { namespace applier
             return threads::invalid_thread_id;
         }
 
-        threads::thread_init_data data(
-            std::move(func), desc ? desc : "<unknown>", 0, priority,
-            os_thread, threads::get_stack_size(stacksize));
+        util::thread_description d = desc;
+        if (!desc)
+            d = util::thread_description(func);
+
+        threads::thread_init_data data(std::move(func),
+            d, 0, priority, os_thread, threads::get_stack_size(stacksize));
 
         threads::thread_id_type id = threads::invalid_thread_id;
         app->get_thread_manager().register_thread(data, id, state, run_now, ec);
@@ -159,7 +170,8 @@ namespace hpx { namespace applier
 
     ///////////////////////////////////////////////////////////////////////////
     void register_work_nullary(
-        util::unique_function_nonser<void()> && func, char const* desc,
+        util::unique_function_nonser<void()> && func,
+        util::thread_description const& desc,
         threads::thread_state_enum state, threads::thread_priority priority,
         std::size_t os_thread, threads::thread_stacksize stacksize,
         error_code& ec)
@@ -173,16 +185,20 @@ namespace hpx { namespace applier
             return;
         }
 
+        util::thread_description d = desc;
+        if (!desc)
+            d = util::thread_description(func);
+
         threads::thread_init_data data(
             util::bind(util::one_shot(&thread_function_nullary), std::move(func)),
-            desc ? desc : "<unknown>", 0, priority, os_thread,
-            threads::get_stack_size(stacksize));
+            d, 0, priority, os_thread, threads::get_stack_size(stacksize));
+
         app->get_thread_manager().register_work(data, state, ec);
     }
 
     void register_work(
         util::unique_function_nonser<void(threads::thread_state_ex_enum)> && func,
-        char const* desc, threads::thread_state_enum state,
+        util::thread_description const& desc, threads::thread_state_enum state,
         threads::thread_priority priority, std::size_t os_thread,
         threads::thread_stacksize stacksize, error_code& ec)
     {
@@ -195,16 +211,20 @@ namespace hpx { namespace applier
             return;
         }
 
+        util::thread_description d = desc;
+        if (!desc)
+            d = util::thread_description(func);
+
         threads::thread_init_data data(
             util::bind(util::one_shot(&thread_function), std::move(func)),
-            desc ? desc : "<unknown>", 0, priority, os_thread,
-            threads::get_stack_size(stacksize));
+            d, 0, priority, os_thread, threads::get_stack_size(stacksize));
+
         app->get_thread_manager().register_work(data, state, ec);
     }
 
     void register_work_plain(
         threads::thread_function_type && func,
-        char const* desc, naming::address::address_type lva,
+        util::thread_description const& desc, naming::address::address_type lva,
         threads::thread_state_enum state, threads::thread_priority priority,
         std::size_t os_thread, threads::thread_stacksize stacksize,
         error_code& ec)
@@ -218,16 +238,19 @@ namespace hpx { namespace applier
             return;
         }
 
+        util::thread_description d = desc;
+        if (!desc)
+            d = util::thread_description(func);
+
         threads::thread_init_data data(std::move(func),
-            desc ? desc : "<unknown>", lva, priority, os_thread,
-            threads::get_stack_size(stacksize));
+            d, lva, priority, os_thread, threads::get_stack_size(stacksize));
+
         app->get_thread_manager().register_work(data, state, ec);
     }
 
     void register_work_plain(
-        threads::thread_function_type && func,
-        naming::id_type const& target,
-        char const* desc, naming::address::address_type lva,
+        threads::thread_function_type && func, naming::id_type const& target,
+        util::thread_description const& desc, naming::address::address_type lva,
         threads::thread_state_enum state, threads::thread_priority priority,
         std::size_t os_thread, threads::thread_stacksize stacksize,
         error_code& ec)
@@ -241,9 +264,14 @@ namespace hpx { namespace applier
             return;
         }
 
+        util::thread_description d = desc;
+        if (!desc)
+            d = util::thread_description(func);
+
         threads::thread_init_data data(std::move(func),
-            desc ? desc : "<unknown>", lva, priority, os_thread,
-            threads::get_stack_size(stacksize), target);
+            d, lva, priority, os_thread, threads::get_stack_size(stacksize),
+            target);
+
         app->get_thread_manager().register_work(data, state, ec);
     }
 
@@ -276,9 +304,11 @@ namespace hpx { namespace applier
     void applier::initialize(boost::uint64_t rts, boost::uint64_t mem)
     {
         naming::resolver_client & agas_client = get_agas_client();
-        runtime_support_id_ = naming::id_type(agas_client.get_local_locality().get_msb(),
-                rts, naming::id_type::unmanaged);
-        memory_id_ = naming::id_type(agas_client.get_local_locality().get_msb(),
+        runtime_support_id_ = naming::id_type(
+            agas_client.get_local_locality().get_msb(),
+            rts, naming::id_type::unmanaged);
+        memory_id_ = naming::id_type(
+            agas_client.get_local_locality().get_msb(),
             mem, naming::id_type::unmanaged);
     }
 
@@ -307,7 +337,8 @@ namespace hpx { namespace applier
         return naming::get_locality_id_from_gid(get_raw_locality(ec));
     }
 
-    bool applier::get_raw_remote_localities(std::vector<naming::gid_type>& prefixes,
+    bool applier::get_raw_remote_localities(
+        std::vector<naming::gid_type>& prefixes,
         components::component_type type, error_code& ec) const
     {
         return parcel_handler_.get_raw_remote_localities(prefixes, type, ec);

--- a/src/runtime/threads/executors/current_executor.cpp
+++ b/src/runtime/threads/executors/current_executor.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -38,8 +38,8 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     // Depending on the subclass implementation, this may block in some
     // situations.
     void current_executor::add(
-        closure_type && f,
-        char const* desc, threads::thread_state_enum initial_state,
+        closure_type && f, util::thread_description const& desc,
+        threads::thread_state_enum initial_state,
         bool run_now, threads::thread_stacksize stacksize, error_code& ec)
     {
         // create a new thread
@@ -59,7 +59,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
 
     void current_executor::add_at(
         boost::chrono::steady_clock::time_point const& abs_time,
-        closure_type && f, char const* desc,
+        closure_type && f, util::thread_description const& desc,
         threads::thread_stacksize stacksize, error_code& ec)
     {
         // create a new suspended thread
@@ -88,7 +88,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     // violate bounds on the executor's queue size.
     void current_executor::add_after(
         boost::chrono::steady_clock::duration const& rel_time,
-        closure_type && f, char const* desc,
+        closure_type && f, util::thread_description const& desc,
         threads::thread_stacksize stacksize, error_code& ec)
     {
         return add_at(boost::chrono::steady_clock::now() + rel_time,

--- a/src/runtime/threads/executors/default_executor.cpp
+++ b/src/runtime/threads/executors/default_executor.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -26,7 +26,8 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     // Depending on the subclass implementation, this may block in some
     // situations.
     void default_executor::add(closure_type && f,
-        char const* desc, threads::thread_state_enum initial_state,
+        util::thread_description const& desc,
+        threads::thread_state_enum initial_state,
         bool run_now, threads::thread_stacksize stacksize, error_code& ec)
     {
         if (stacksize == threads::thread_stacksize_default)
@@ -41,7 +42,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     // bounds on the executor's queue size.
     void default_executor::add_at(
         boost::chrono::steady_clock::time_point const& abs_time,
-        closure_type && f, char const* description,
+        closure_type && f, util::thread_description const& description,
         threads::thread_stacksize stacksize, error_code& ec)
     {
         if (stacksize == threads::thread_stacksize_default)
@@ -75,7 +76,8 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     }
 
     // Set the new scheduler mode
-    void default_executor::set_scheduler_mode(threads::policies::scheduler_mode mode)
+    void default_executor::set_scheduler_mode(
+        threads::policies::scheduler_mode mode)
     {
         threads::set_scheduler_mode(mode);
     }

--- a/src/runtime/threads/executors/service_executor.cpp
+++ b/src/runtime/threads/executors/service_executor.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -66,8 +66,9 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     // Depending on the subclass implementation, this may block in some
     // situations.
     void service_executor::add(closure_type && f,
-        char const* desc, threads::thread_state_enum initial_state,
-        bool run_now, threads::thread_stacksize stacksize, error_code& ec)
+        util::thread_description const& desc,
+        threads::thread_state_enum initial_state, bool run_now,
+        threads::thread_stacksize stacksize, error_code& ec)
     {
         ++task_count_;
 
@@ -123,7 +124,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     // bounds on the executor's queue size.
     void service_executor::add_at(
         boost::chrono::steady_clock::time_point const& abs_time,
-        closure_type && f, char const* desc,
+        closure_type && f, util::thread_description const& desc,
         threads::thread_stacksize stacksize, error_code& ec)
     {
         ++task_count_;
@@ -141,7 +142,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     // violate bounds on the executor's queue size.
     void service_executor::add_after(
         boost::chrono::steady_clock::duration const& rel_time,
-        closure_type && f, char const* desc,
+        closure_type && f, util::thread_description const& desc,
         threads::thread_stacksize stacksize, error_code& ec)
     {
         return add_at(boost::chrono::steady_clock::now() + rel_time,

--- a/src/runtime/threads/executors/this_thread_executors.cpp
+++ b/src/runtime/threads/executors/this_thread_executors.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -108,7 +108,8 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     // situations.
     template <typename Scheduler>
     void this_thread_executor<Scheduler>::add(closure_type && f,
-        char const* desc, threads::thread_state_enum initial_state,
+        util::thread_description const& desc,
+        threads::thread_state_enum initial_state,
         bool run_now, threads::thread_stacksize stacksize, error_code& ec)
     {
         HPX_ASSERT(std::size_t(-1) != thread_num_);
@@ -147,7 +148,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     template <typename Scheduler>
     void this_thread_executor<Scheduler>::add_at(
         boost::chrono::steady_clock::time_point const& abs_time,
-        closure_type && f, char const* desc,
+        closure_type && f, util::thread_description const& desc,
         threads::thread_stacksize stacksize, error_code& ec)
     {
         HPX_ASSERT(std::size_t(-1) != thread_num_);
@@ -191,7 +192,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     template <typename Scheduler>
     void this_thread_executor<Scheduler>::add_after(
         boost::chrono::steady_clock::duration const& rel_time,
-        closure_type && f, char const* desc,
+        closure_type && f, util::thread_description const& desc,
         threads::thread_stacksize stacksize, error_code& ec)
     {
         return add_at(boost::chrono::steady_clock::now() + rel_time,

--- a/src/runtime/threads/executors/thread_pool_attached_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_attached_executors.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -57,7 +57,8 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     // situations.
     template <typename Scheduler>
     void thread_pool_attached_executor<Scheduler>::add(closure_type && f,
-        char const* desc, threads::thread_state_enum initial_state,
+        util::thread_description const& desc,
+        threads::thread_state_enum initial_state,
         bool run_now, threads::thread_stacksize stacksize, error_code& ec)
     {
         if (stacksize == threads::thread_stacksize_default)
@@ -73,7 +74,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     template <typename Scheduler>
     void thread_pool_attached_executor<Scheduler>::add_at(
         boost::chrono::steady_clock::time_point const& abs_time,
-        closure_type && f, char const* description,
+        closure_type && f, util::thread_description const& description,
         threads::thread_stacksize stacksize, error_code& ec)
     {
         if (stacksize == threads::thread_stacksize_default)
@@ -97,7 +98,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     template <typename Scheduler>
     void thread_pool_attached_executor<Scheduler>::add_after(
         boost::chrono::steady_clock::duration const& rel_time,
-        closure_type && f, char const* description,
+        closure_type && f, util::thread_description const& description,
         threads::thread_stacksize stacksize, error_code& ec)
     {
         return add_at(boost::chrono::steady_clock::now() + rel_time,

--- a/src/runtime/threads/executors/thread_pool_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_executors.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -136,9 +136,9 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     // Depending on the subclass implementation, this may block in some
     // situations.
     template <typename Scheduler>
-    void thread_pool_executor<Scheduler>::add(
-        closure_type && f,
-        char const* desc, threads::thread_state_enum initial_state,
+    void thread_pool_executor<Scheduler>::add(closure_type && f,
+        util::thread_description const& desc,
+        threads::thread_state_enum initial_state,
         bool run_now, threads::thread_stacksize stacksize, error_code& ec)
     {
         // create a new thread
@@ -168,7 +168,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     template <typename Scheduler>
     void thread_pool_executor<Scheduler>::add_at(
         boost::chrono::steady_clock::time_point const& abs_time,
-        closure_type && f, char const* desc,
+        closure_type && f, util::thread_description const& desc,
         threads::thread_stacksize stacksize, error_code& ec)
     {
         // create a new suspended thread
@@ -203,7 +203,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     template <typename Scheduler>
     void thread_pool_executor<Scheduler>::add_after(
         boost::chrono::steady_clock::duration const& rel_time,
-        closure_type && f, char const* desc,
+        closure_type && f, util::thread_description const& desc,
         threads::thread_stacksize stacksize, error_code& ec)
     {
         return add_at(boost::chrono::steady_clock::now() + rel_time,

--- a/src/runtime/threads/executors/thread_pool_os_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_os_executors.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -145,9 +145,9 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     // Depending on the subclass implementation, this may block in some
     // situations.
     template <typename Scheduler>
-    void thread_pool_os_executor<Scheduler>::add(
-        closure_type && f,
-        char const* desc, threads::thread_state_enum initial_state,
+    void thread_pool_os_executor<Scheduler>::add(closure_type && f,
+        util::thread_description const& desc,
+        threads::thread_state_enum initial_state,
         bool run_now, threads::thread_stacksize stacksize, error_code& ec)
     {
         // create a new thread
@@ -172,7 +172,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     template <typename Scheduler>
     void thread_pool_os_executor<Scheduler>::add_at(
         boost::chrono::steady_clock::time_point const& abs_time,
-        closure_type && f, char const* desc,
+        closure_type && f, util::thread_description const& desc,
         threads::thread_stacksize stacksize, error_code& ec)
     {
         // create a new suspended thread
@@ -202,7 +202,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
     template <typename Scheduler>
     void thread_pool_os_executor<Scheduler>::add_after(
         boost::chrono::steady_clock::duration const& rel_time,
-        closure_type && f, char const* desc,
+        closure_type && f, util::thread_description const& desc,
         threads::thread_stacksize stacksize, error_code& ec)
     {
         return add_at(boost::chrono::steady_clock::now() + rel_time,

--- a/src/runtime/threads/thread_helpers.cpp
+++ b/src/runtime/threads/thread_helpers.cpp
@@ -13,6 +13,7 @@
 #include <hpx/runtime/threads/detail/set_thread_state.hpp>
 #include <hpx/util/register_locks.hpp>
 #include <hpx/util/thread_specific_ptr.hpp>
+#include <hpx/util/thread_description.hpp>
 #ifdef HPX_HAVE_THREAD_BACKTRACE_ON_SUSPENSION
 #include <hpx/util/backtrace.hpp>
 #endif
@@ -253,19 +254,20 @@ namespace hpx { namespace threads
     ///////////////////////////////////////////////////////////////////////////
     /// The get_thread_description function is part of the thread related API and
     /// allows to query the description of one of the thread id
-    char const* get_thread_description(thread_id_type const& id, error_code& ec)
+    util::thread_description get_thread_description(thread_id_type const& id,
+        error_code& ec)
     {
-        return id ? id->get_description() : "<unknown>";
+        return id ? id->get_description() : util::thread_description("<unknown>");
     }
 
-    char const* set_thread_description(thread_id_type const& id,
-        char const* desc, error_code& ec)
+    util::thread_description set_thread_description(thread_id_type const& id,
+        util::thread_description const& desc, error_code& ec)
     {
         if (HPX_UNLIKELY(!id)) {
             HPX_THROWS_IF(ec, null_thread_id,
                 "hpx::threads::set_thread_description",
                 "NULL thread id encountered");
-            return NULL;
+            return util::thread_description();
         }
         if (&ec != &throws)
             ec = make_success_code();
@@ -273,8 +275,8 @@ namespace hpx { namespace threads
         return id->set_description(desc);
     }
 
-    char const* get_thread_lco_description(thread_id_type const& id,
-        error_code& ec)
+    util::thread_description get_thread_lco_description(
+        thread_id_type const& id, error_code& ec)
     {
         if (HPX_UNLIKELY(!id)) {
             HPX_THROWS_IF(ec, null_thread_id,
@@ -288,8 +290,9 @@ namespace hpx { namespace threads
 
         return id ? id->get_lco_description() : "<unknown>";
     }
-    char const* set_thread_lco_description(thread_id_type const& id,
-        char const* desc, error_code& ec)
+    util::thread_description set_thread_lco_description(
+        thread_id_type const& id, util::thread_description const& desc,
+        error_code& ec)
     {
         if (HPX_UNLIKELY(!id)) {
             HPX_THROWS_IF(ec, null_thread_id,
@@ -310,7 +313,8 @@ namespace hpx { namespace threads
 #ifdef HPX_HAVE_THREAD_FULLBACKTRACE_ON_SUSPENSION
     char const* get_thread_backtrace(thread_id_type const& id, error_code& ec)
 #else
-    util::backtrace const* get_thread_backtrace(thread_id_type const& id, error_code& ec)
+    util::backtrace const* get_thread_backtrace(thread_id_type const& id,
+        error_code& ec)
 #endif
     {
         if (HPX_UNLIKELY(!id)) {
@@ -371,7 +375,8 @@ namespace hpx { namespace this_thread
         struct reset_lco_description
         {
             reset_lco_description(threads::thread_id_type const& id,
-                    char const* description, error_code& ec)
+                    util::thread_description const& description,
+                    error_code& ec)
               : id_(id), ec_(ec)
             {
                 old_desc_ = threads::set_thread_lco_description(id_,
@@ -384,7 +389,7 @@ namespace hpx { namespace this_thread
             }
 
             threads::thread_id_type id_;
-            char const* old_desc_;
+            util::thread_description old_desc_;
             error_code& ec_;
         };
 
@@ -427,7 +432,7 @@ namespace hpx { namespace this_thread
     /// If the suspension was aborted, this function will throw a
     /// \a yield_aborted exception.
     threads::thread_state_ex_enum suspend(threads::thread_state_enum state,
-        char const* description, error_code& ec)
+        util::thread_description const& description, error_code& ec)
     {
         // let the thread manager do other things while waiting
         threads::thread_self& self = threads::get_self();
@@ -465,7 +470,7 @@ namespace hpx { namespace this_thread
             strm << "thread(" << threads::get_self_id() << ", "
                   << threads::get_thread_description(id)
                   << ") aborted (yield returned wait_abort)";
-            HPX_THROWS_IF(ec, yield_aborted, description,
+            HPX_THROWS_IF(ec, yield_aborted, "suspend",
                 strm.str());
         }
 
@@ -477,7 +482,7 @@ namespace hpx { namespace this_thread
 
     threads::thread_state_ex_enum suspend(
         util::steady_time_point const& abs_time,
-        char const* description, error_code& ec)
+        util::thread_description const& description, error_code& ec)
     {
         // schedule a thread waking us up at_time
         threads::thread_self& self = threads::get_self();
@@ -528,7 +533,7 @@ namespace hpx { namespace this_thread
             strm << "thread(" << threads::get_self_id() << ", "
                   << threads::get_thread_description(id)
                   << ") aborted (yield returned wait_abort)";
-            HPX_THROWS_IF(ec, yield_aborted, description,
+            HPX_THROWS_IF(ec, yield_aborted, "suspend_at",
                 strm.str());
         }
 

--- a/src/util/thread_description.cpp
+++ b/src/util/thread_description.cpp
@@ -1,0 +1,40 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/util/thread_description.hpp>
+#include <hpx/util/safe_lexical_cast.hpp>
+
+#include <iostream>
+#include <sstream>
+
+namespace hpx { namespace util
+{
+    std::ostream& operator<<(std::ostream& os, thread_description const& d)
+    {
+        if (d.kind() == thread_description::data_type_description)
+        {
+            os << d.get_description();
+        }
+        else
+        {
+            HPX_ASSERT(d.kind() == thread_description::data_type_address);
+            os << d.get_address();
+        }
+        return os;
+    }
+
+    std::string as_string(thread_description const& desc)
+    {
+        if (desc.kind() == util::thread_description::data_type_description)
+            return desc.get_description();
+
+        std::stringstream strm;
+        strm << "address: 0x" << std::hex
+                << util::safe_lexical_cast<std::string>(
+                    desc.get_address());
+        return strm.str();
+    }
+}}

--- a/tools/VS/thread_description.natvis
+++ b/tools/VS/thread_description.natvis
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Copyright (c) 2016 Hartmut Kaiser                                      -->
+
+<!-- Use, modification and distribution are subject to the Boost Software   -->
+<!-- License, Version 1.0. (See accompanying file LICENSE_1_0.txt           -->
+<!-- or copy at http://www.boost.org/LICENSE_1_0.txt)                       -->
+
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+    <Type Name="hpx::util::thread_description">
+        <DisplayString Condition="type_ == 0">[desc] {data_.desc_,s}</DisplayString>
+        <DisplayString Condition="type_ == 1">[addr] {(void*)data_.addr_,na}</DisplayString>
+    </Type>
+</AutoVisualizer>


### PR DESCRIPTION
This PR is meant to improve the diagnostic capabilities of debuggers and tracing tools (like APEX). Especially tools like APEX have a hard time associating pieces of code with events they are hooked into. By passing the addresses of scheduled (local) functions to the tool we allow to establish that missing connection (the address can be resolved to the corresponding symbol using debug information, if available).