### PR TITLE
Detect unknown command line options 

### DIFF
--- a/hpx/util/parse_command_line.hpp
+++ b/hpx/util/parse_command_line.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -60,6 +60,17 @@ namespace hpx { namespace util
     ///////////////////////////////////////////////////////////////////////////
     HPX_API_EXPORT std::string reconstruct_command_line(
         boost::program_options::variables_map const &vm);
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        inline std::string enquote(std::string const& arg)
+        {
+            if (arg.find_first_of(" \t") != std::string::npos)
+                return std::string("\"") + arg + "\"";
+            return arg;
+        }
+    }
 }}
 
 #endif

--- a/src/hpx_user_main_argc_argv.cpp
+++ b/src/hpx_user_main_argc_argv.cpp
@@ -1,9 +1,10 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
+#include <hpx/exception.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 // Forwarding of hpx_startup::user_main, if necessary. This has to be in a
@@ -12,5 +13,18 @@
 // or not.
 int hpx_startup::user_main(int argc, char** argv)
 {
+    // If we have seen unknown command line options we can throw here as we
+    // know that the user is not going to look at the arguments.
+    std::string unknown_command_line =
+        hpx::get_config_entry("hpx.unknown_cmd_line_option", "");
+
+    if (!unknown_command_line.empty())
+    {
+        hpx::detail::report_exception_and_terminate(
+            HPX_GET_EXCEPTION(hpx::bad_parameter, "hpx_startup::user_main",
+                "unknown command line option(s): " + unknown_command_line)
+        );
+    }
+
     return hpx_startup::user_main();
 }

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -68,14 +68,6 @@ namespace hpx { namespace util
         {
             encode(str, '\n', "\\n");
             return str;
-        }
-
-        ///////////////////////////////////////////////////////////////////////
-        inline std::string enquote(std::string const& arg)
-        {
-            if (arg.find_first_of(" \t") != std::string::npos)
-                return std::string("\"") + arg + "\"";
-            return arg;
         }
 
         ///////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Detect unknown command line options for applications which use the emulated main().

We know that the user is not going to look at the command line parameters if the application uses the simplest emulated main():

    #include <hpx/hpx_main.hpp>

    int main()
    {
        // ...
    }

This PR reports any unknown options in this case (only). This fixes #1995.
