### PR TITLE
Fixing inspect tool

### DIFF
--- a/tools/inspect/CMakeLists.txt
+++ b/tools/inspect/CMakeLists.txt
@@ -5,13 +5,9 @@
 
 # add inpect executable
 
-if(NOT MSVC)
-  set(inspect NOLIBS DEPENDENCIES ${Boost_LIBRARIES})
-endif()
-
 add_hpx_executable(inspect
   AUTOGLOB
-  NOHPX_INIT
+  NOLIBS
   FOLDER "Tools/Inspect")
 
 if(NOT MSVC)

--- a/tools/inspect/function_hyper.hpp
+++ b/tools/inspect/function_hyper.hpp
@@ -8,6 +8,7 @@
 #ifndef FUNCTION_HYPER_HPP
 #define FUNCTION_HYPER_HPP
 
+#include "inspector.hpp"
 #include "boost/filesystem/path.hpp"
 #include <hpx/config/defines.hpp>
 #include <string>
@@ -18,8 +19,8 @@ using boost::filesystem::path;
 inline std::string linelink(const path & full_path, std::string linenumb)
 {
     std::string commit = HPX_HAVE_GIT_COMMIT;
-    std::string location = full_path.string();
-    location.erase(0, 4);
+    std::string location = boost::inspect::relative_to(
+        full_path, boost::inspect::search_root_path() );
     //The erase function for location is to get rid of the first /hpx that will always
     //be present in any full path this tool is used for (repeated in wordlink and
     // loclink)
@@ -34,8 +35,8 @@ inline std::string wordlink(const path & full_path,
     std::string linenumb, std::string word)
 {
     std::string commit = HPX_HAVE_GIT_COMMIT;
-    std::string location = full_path.string();
-    location.erase(0, 4);
+    std::string location = boost::inspect::relative_to(
+        full_path, boost::inspect::search_root_path() );
     std::string total = "<a href = \"https://github.com/STEllAR-GROUP/hpx/blob/"
         + commit + location + "#L" + linenumb + "\">";
     total = total + word;
@@ -46,8 +47,8 @@ inline std::string wordlink(const path & full_path,
 inline std::string loclink(const path & full_path, std::string word)
 {
     std::string commit = HPX_HAVE_GIT_COMMIT;
-    std::string location = full_path.string();
-    location.erase(0, 4);
+    std::string location = boost::inspect::relative_to(
+        full_path, boost::inspect::search_root_path() );
     std::string total = "<a href = \"https://github.com/STEllAR-GROUP/hpx/blob/"
         + commit + location + "\">";
     total = total + word;

--- a/tools/inspect/inspect.cpp
+++ b/tools/inspect/inspect.cpp
@@ -1008,6 +1008,7 @@ int cpp_main( int argc_param, char * argv_param[] )
   //// perform the actual inspection, using the requested type of iteration
     for(auto const& search_root: search_roots)
     {
+        ::search_root = search_root;
         visit_all<fs::directory_iterator>( search_root.leaf().string(),
             search_root, inspectors );
     }

--- a/tools/inspect/inspector.hpp
+++ b/tools/inspect/inspector.hpp
@@ -98,7 +98,7 @@ namespace boost
       string::size_type pos( base.string().size() );
       path src( src_arg.string().substr(pos) );
       src.normalize();
-      return src.string().substr(1);
+      return src.string();
     }
 
     string impute_library( const path & full_dir_path );


### PR DESCRIPTION
The relative path to the search was not calculated correctly. This
fix allows the inspect tool to be invoked from any location.