### PR TITLE
nvcc dies with an internal error upon pushing/popping warnings inside templates

### DIFF
--- a/hpx/traits/get_function_address.hpp
+++ b/hpx/traits/get_function_address.hpp
@@ -60,7 +60,7 @@ namespace hpx { namespace traits
 #  pragma clang diagnostic ignored "-Wstrict-aliasing"
 #endif
 
-#if defined(__GNUG__) && !defined(__INTEL_COMPILER)
+#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__CUDACC__)
 #  if defined(HPX_GCC_DIAGNOSTIC_PRAGMA_CONTEXTS)
 #    pragma GCC diagnostic push
 #  endif
@@ -69,7 +69,7 @@ namespace hpx { namespace traits
 
             return reinterpret_cast<std::size_t>(*reinterpret_cast<void**>(&f));
 
-#if defined(__GNUG__) && !defined(__INTEL_COMPILER)
+#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__CUDACC__)
 #if defined(HPX_GCC_DIAGNOSTIC_PRAGMA_CONTEXTS)
 #pragma GCC diagnostic pop
 #endif
@@ -91,7 +91,7 @@ namespace hpx { namespace traits
 #  pragma clang diagnostic ignored "-Wstrict-aliasing"
 #endif
 
-#if defined(__GNUG__) && !defined(__INTEL_COMPILER)
+#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__CUDACC__)
 #  if defined(HPX_GCC_DIAGNOSTIC_PRAGMA_CONTEXTS)
 #    pragma GCC diagnostic push
 #  endif
@@ -100,7 +100,7 @@ namespace hpx { namespace traits
 
             return reinterpret_cast<std::size_t>(*reinterpret_cast<void**>(&f));
 
-#if defined(__GNUG__) && !defined(__INTEL_COMPILER)
+#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__CUDACC__)
 #if defined(HPX_GCC_DIAGNOSTIC_PRAGMA_CONTEXTS)
 #pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
It's a know bug in NVIDIA's CUDA toolkit, but it won't be fixed until the next release and until then this  workaround is required to compile HPX+CUDA codes. I was getting the bug below when compiling LibGeoDecomp with CUDA and HPX enabled. The proposed patch fixes this.

    [ 95%] Building CXX object src/testbed/spmvmtests/CMakeFiles/libgeodecomp_testbed_spmvmtests.dir/mmio.cpp.o
    [ 95%] Linking CXX executable hpxperformancetests
    [ 95%] Built target libgeodecomp_examples_spmvmvectorized
    [ 95%] Built target libgeodecomp_testbed_hpxperformancetests
    /home/gentryx/test_build_libgeodecomp_rei_g++-4.9.3/install/include/hpx/traits/get_function_address.hpp(87): internal error: assertion failed: alloc_copy_of_pending_pragma: copied pragma has source sequence entry (/dvs/p4/build/sw/rel/gpu_drv/r352/r352_00/drivers/compiler/edg/EDG_4.9/src/pragma.c, line 512)
    
    
    1 catastrophic error detected in the compilation of "/tmp/tmpxft_00007077_00000000-5_cudatests.cpp4.ii".
    Compilation aborted.
    nvcc error   : 'cudafe++' died due to signal 6 
    CMake Error at libgeodecomp_testbed_performancetests_cudatests_generated_cudatests.cu.o.cmake:266 (message):
      Error generating file
      /home/gentryx/test_build_libgeodecomp_rei_g++-4.9.3/libgeodecomp/build/src/testbed/performancetests/CMakeFiles/libgeodecomp_testbed_performancetests_cudatests.dir//./libgeodecomp_testbed_performancetests_cudatests_generated_cudatests.cu.o
