### PR TITLE
adding persistent_auto_chunk_size and related tests for for_each

### DIFF
--- a/hpx/parallel/executor_parameters.hpp
+++ b/hpx/parallel/executor_parameters.hpp
@@ -12,5 +12,6 @@
 #include <hpx/parallel/executors/dynamic_chunk_size.hpp>
 #include <hpx/parallel/executors/auto_chunk_size.hpp>
 #include <hpx/parallel/executors/guided_chunk_size.hpp>
+#include <hpx/parallel/executors/persistent_auto_chunk_size.hpp>
 
 #endif

--- a/hpx/parallel/executors/persistent_auto_chunk_size.hpp
+++ b/hpx/parallel/executors/persistent_auto_chunk_size.hpp
@@ -5,7 +5,7 @@
 
 /// \file parallel/executors/persistent_auto_chunk_size.hpp
 
-#if !defined(HPX_PARALLEL_PERSISTENT_AUTO_CHUNK_SIZE_CONTROLLER_HPP)
+#if !defined(HPX_PARALLEL_PERSISTENT_AUTO_CHUNK_SIZE_HPP)
 #define HPX_PARALLEL_PERSISTENT_AUTO_CHUNK_SIZE_HPP
 
 #include <hpx/config.hpp>

--- a/hpx/parallel/executors/persistent_auto_chunk_size.hpp
+++ b/hpx/parallel/executors/persistent_auto_chunk_size.hpp
@@ -1,0 +1,126 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/executors/persistent_auto_chunk_size.hpp
+
+#if !defined(HPX_PARALLEL_PERSISTENT_AUTO_CHUNK_SIZE_CONTROLLER_HPP)
+#define HPX_PARALLEL_PERSISTENT_AUTO_CHUNK_SIZE_HPP
+
+#include <hpx/config.hpp>
+#include <hpx/traits/is_executor_parameters.hpp>
+#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/parallel/config/inline_namespace.hpp>
+#include <hpx/parallel/executors/executor_parameter_traits.hpp>
+#include <hpx/parallel/executors/executor_information_traits.hpp>
+#include <hpx/util/high_resolution_clock.hpp>
+#include <hpx/util/date_time_chrono.hpp>
+
+#include <cstddef>
+#include <algorithm>
+
+#include <boost/cstdint.hpp>
+
+namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    /// Loop iterations are divided into pieces and then assigned to threads.
+    /// The number of loop iterations combined is determined based on
+    /// measurements of how long the execution of 1% of the overall number of
+    /// iterations takes.
+    /// This executor parameters type makes sure that as many loop iterations
+    /// are combined as necessary to run for the amount of time specified.
+    ///
+    struct persistent_auto_chunk_size : executor_parameters_tag
+    {
+    public:
+        /// Construct an \a persistent_auto_chunk_size executor parameters object
+        ///
+        /// \note Default constructed \a persistent_auto_chunk_size executor parameter
+        ///       types will use 80 microseconds as the minimal time for which
+        ///       any of the scheduled chunks should run.
+        ///
+
+
+        /// Construct an \a persistent_auto_chunk_size executor parameters object
+        ///
+        /// \param rel_time     [in] The time duration to use as the minimum
+        ///                     to decide how many loop iterations should be
+        ///                     combined.
+        ///
+
+        explicit persistent_auto_chunk_size(hpx::util::steady_duration time_cs = boost::chrono::nanoseconds(0))
+          : chunk_size_time_(time_cs.value().count())
+        {}
+
+        /// \cond NOINTERNAL
+        // Estimate a chunk size based on number of cores used.
+        template <typename Executor, typename F>
+        std::size_t get_chunk_size(Executor& exec, F && f, std::size_t count)
+        {
+            std::size_t const cores = executor_information_traits<Executor>::
+                processing_units_count(exec, *this);
+
+            if (count > 100*cores)
+            {
+                boost::uint64_t t;
+                if(chunk_size_time_ == 0)
+                {
+                    using hpx::util::high_resolution_clock;
+                    t = high_resolution_clock::now();
+
+                    std::size_t test_chunk_size = f();
+                    if (test_chunk_size != 0)
+                    {
+                        
+                        t = (high_resolution_clock::now() - t) / test_chunk_size;
+                        chunk_size_time_ = t;
+                    
+                        if (t != 0)
+                        {
+                            // return chunk size which will create the required
+                            // amount of work
+                            return (std::min)(count, (std::size_t)(min_time_ / t));
+                        }
+                    }
+                }
+
+                else
+                {
+                    t = chunk_size_time_;
+                    return (std::min)(count, (std::size_t)(min_time_ / t));
+                }
+            }
+
+            
+            return (count + cores - 1) / cores;
+            
+        }
+        /// \endcond
+
+        std::size_t get_chunk_size_value() const
+        {
+        return chunk_size_time_;
+        }
+
+    private:
+        /// \cond NOINTERNAL
+        friend class hpx::serialization::access;
+
+        template <typename Archive>
+        void serialize(Archive & ar, const unsigned int version)
+        {
+            ar  & chunk_size_time_& min_time_;
+        }
+        /// \endcond
+
+    private:
+        /// \cond NOINTERNAL
+        boost::uint64_t chunk_size_time_;
+        static constexpr boost::uint64_t min_time_ = 80000;      // nanoseconds
+        /// \endcond
+    };
+}}}
+
+#endif

--- a/hpx/parallel/executors/persistent_auto_chunk_size.hpp
+++ b/hpx/parallel/executors/persistent_auto_chunk_size.hpp
@@ -53,7 +53,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         ///                     combined.
         ///
 
-        explicit persistent_auto_chunk_size(hpx::util::steady_duration const& time_cs, hpx::util::steady_duration const& rel_time)
+        explicit persistent_auto_chunk_size(hpx::util::steady_duration const& time_cs,
+         hpx::util::steady_duration const& rel_time)
           : chunk_size_time_(time_cs.value().count()), min_time_(rel_time.value().count())
         {}
 

--- a/hpx/parallel/executors/persistent_auto_chunk_size.hpp
+++ b/hpx/parallel/executors/persistent_auto_chunk_size.hpp
@@ -38,7 +38,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         /// Construct an \a persistent_auto_chunk_size executor parameters object
         ///
         /// \note Default constructed \a persistent_auto_chunk_size executor parameter
-        ///       types will use 80 microseconds as the minimal time for which
+        ///       types will use 0 microseconds as the execution time for each chunk
+        ///       and 80 microseconds as the minimal time for which
         ///       any of the scheduled chunks should run.
         ///
 
@@ -47,10 +48,26 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         {}
 
         /// Construct an \a persistent_auto_chunk_size executor parameters object
+
+        /// \param time_cs      The execution time for each chunk.
+        ///
+        /// \param rel_time     Constructed \a persistent_auto_chunk_size executor parameter
+        ///                     types will use 80 microseconds as the minimal time for which
+        ///                     any of the scheduled chunks should run.
+        ///
+
+        explicit persistent_auto_chunk_size(hpx::util::steady_duration const& time_cs)
+          : chunk_size_time_(time_cs.value().count()), min_time_(80000)
+        {}
+
+        /// Construct an \a persistent_auto_chunk_size executor parameters object
         ///
         /// \param rel_time     [in] The time duration to use as the minimum
         ///                     to decide how many loop iterations should be
         ///                     combined.
+        ///
+
+        /// \param time_cs       The execution time for each chunk.
         ///
 
         explicit persistent_auto_chunk_size(hpx::util::steady_duration const& time_cs,
@@ -110,8 +127,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
 
     private:
         /// \cond NOINTERNAL
-        boost::uint64_t chunk_size_time_;
-        boost::uint64_t min_time_;      // nanoseconds
+        boost::uint64_t chunk_size_time_; // nanoseconds
+        boost::uint64_t min_time_;        // nanoseconds
         /// \endcond
     };
 }}}

--- a/tests/unit/parallel/executors/executor_parameters.cpp
+++ b/tests/unit/parallel/executors/executor_parameters.cpp
@@ -101,7 +101,7 @@ void test_persistent_auto_chunk_size()
     }
 
     {
-        hpx::parallel::persistent_auto_chunk_size pacs(boost::chrono::milliseconds(0));
+        hpx::parallel::persistent_auto_chunk_size pacs(boost::chrono::milliseconds(0),boost::chrono::milliseconds(1));
         chunk_size_test(pacs);
     }
 }

--- a/tests/unit/parallel/executors/executor_parameters.cpp
+++ b/tests/unit/parallel/executors/executor_parameters.cpp
@@ -93,6 +93,19 @@ void test_auto_chunk_size()
     }
 }
 
+void test_persistent_auto_chunk_size()
+{
+    {
+        hpx::parallel::persistent_auto_chunk_size pacs;
+        chunk_size_test(pacs);
+    }
+
+    {
+        hpx::parallel::persistent_auto_chunk_size pacs(boost::chrono::milliseconds(0));
+        chunk_size_test(pacs);
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
@@ -107,6 +120,7 @@ int hpx_main(boost::program_options::variables_map& vm)
     test_static_chunk_size();
     test_guided_chunk_size();
     test_auto_chunk_size();
+    test_persistent_auto_chunk_size();
 
     return hpx::finalize();
 }

--- a/tests/unit/parallel/executors/executor_parameters.cpp
+++ b/tests/unit/parallel/executors/executor_parameters.cpp
@@ -105,6 +105,11 @@ void test_persistent_auto_chunk_size()
             boost::chrono::milliseconds(0),boost::chrono::milliseconds(1));
         chunk_size_test(pacs);
     }
+
+    {
+        hpx::parallel::persistent_auto_chunk_size pacs(boost::chrono::milliseconds(0));
+        chunk_size_test(pacs);
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/parallel/executors/executor_parameters.cpp
+++ b/tests/unit/parallel/executors/executor_parameters.cpp
@@ -101,7 +101,8 @@ void test_persistent_auto_chunk_size()
     }
 
     {
-        hpx::parallel::persistent_auto_chunk_size pacs(boost::chrono::milliseconds(0),boost::chrono::milliseconds(1));
+        hpx::parallel::persistent_auto_chunk_size pacs(
+            boost::chrono::milliseconds(0),boost::chrono::milliseconds(1));
         chunk_size_test(pacs);
     }
 }

--- a/tests/unit/parallel/executors/persistent_executor_parameters.cpp
+++ b/tests/unit/parallel/executors/persistent_executor_parameters.cpp
@@ -7,6 +7,7 @@
 #include <hpx/hpx.hpp>
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/parallel_executor_parameters.hpp>
+#include <hpx/include/parallel_algorithm.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <iostream>
@@ -20,41 +21,6 @@
 #include "../algorithms/foreach_tests.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
-struct persistent_parameters : hpx::parallel::executor_parameters_tag
-{
-public:
-    persistent_parameters()
-      : chunk_size_(0)
-    {}
-
-    persistent_parameters(persistent_parameters const&)
-      : chunk_size_(0)
-    {
-    }
-
-    persistent_parameters& operator=(persistent_parameters const&)
-    {
-        chunk_size_ = 0;
-        return *this;
-    }
-
-    template <typename Executor, typename F>
-    std::size_t get_chunk_size(Executor& exec, F &&, std::size_t count)
-    {
-        if (0 == chunk_size_)
-        {
-            std::size_t const cores =
-                hpx::parallel::executor_information_traits<Executor>::
-                    processing_units_count(exec, *this);
-
-            chunk_size_ = (count + cores - 1) / cores;
-        }
-
-        return chunk_size_;
-    }
-
-    std::size_t chunk_size_;
-};
 
 void test_persistent_executitor_parameters()
 {
@@ -62,32 +28,32 @@ void test_persistent_executitor_parameters()
 
     typedef std::random_access_iterator_tag iterator_tag;
     {
-        persistent_parameters p;
+        persistent_auto_chunk_size p;
         auto policy = par.with(p);
         test_for_each(policy, iterator_tag());
-        HPX_TEST_NEQ(policy.parameters().chunk_size_, std::size_t(0));
+        HPX_TEST_NEQ(policy.parameters().get_chunk_size_value(), std::size_t(0));
     }
 
     {
-        persistent_parameters p;
+        persistent_auto_chunk_size p;
         auto policy = par(task).with(p);
         test_for_each_async(policy, iterator_tag());
-        HPX_TEST_NEQ(policy.parameters().chunk_size_, std::size_t(0));
+        HPX_TEST_NEQ(policy.parameters().get_chunk_size_value(), std::size_t(0));
     }
 
     parallel_executor par_exec;
     {
-        persistent_parameters p;
+        persistent_auto_chunk_size p;
         auto policy = par.on(par_exec).with(p);
         test_for_each(policy, iterator_tag());
-        HPX_TEST_NEQ(policy.parameters().chunk_size_, std::size_t(0));
+        HPX_TEST_NEQ(policy.parameters().get_chunk_size_value(), std::size_t(0));
     }
 
     {
-        persistent_parameters p;
+        persistent_auto_chunk_size p;
         auto policy = par(task).on(par_exec).with(p);
         test_for_each_async(policy, iterator_tag());
-        HPX_TEST_NEQ(policy.parameters().chunk_size_, std::size_t(0));
+        HPX_TEST_NEQ(policy.parameters().get_chunk_size_value(), std::size_t(0));
     }
 }
 
@@ -96,31 +62,33 @@ void test_persistent_executitor_parameters_ref()
     using namespace hpx::parallel;
 
     typedef std::random_access_iterator_tag iterator_tag;
+
     {
-        persistent_parameters p;
+        persistent_auto_chunk_size p;
         test_for_each(par.with(boost::ref(p)), iterator_tag());
-        HPX_TEST_NEQ(p.chunk_size_, std::size_t(0));
+        HPX_TEST_NEQ(boost::unwrap_ref(par.with(boost::ref(p)).parameters()).get_chunk_size_value(), std::size_t(0));
     }
 
     {
-        persistent_parameters p;
+        persistent_auto_chunk_size p;
         test_for_each_async(par(task).with(boost::ref(p)), iterator_tag());
-        HPX_TEST_NEQ(p.chunk_size_, std::size_t(0));
+        HPX_TEST_NEQ(boost::unwrap_ref(par(task).with(boost::ref(p)).parameters()).get_chunk_size_value(), std::size_t(0));
     }
 
     parallel_executor par_exec;
     {
-        persistent_parameters p;
+        persistent_auto_chunk_size p;
         test_for_each(par.on(par_exec).with(boost::ref(p)), iterator_tag());
-        HPX_TEST_NEQ(p.chunk_size_, std::size_t(0));
+        HPX_TEST_NEQ(boost::unwrap_ref(par.on(par_exec).with(boost::ref(p)).parameters()).get_chunk_size_value(), std::size_t(0));
     }
 
     {
-        persistent_parameters p;
+        persistent_auto_chunk_size p;
         test_for_each_async(par(task).on(par_exec).with(boost::ref(p)),
             iterator_tag());
-        HPX_TEST_NEQ(p.chunk_size_, std::size_t(0));
+        HPX_TEST_NEQ(boost::unwrap_ref(par(task).on(par_exec).with(boost::ref(p)).parameters()).get_chunk_size_value(), std::size_t(0));
     }
+
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/parallel/executors/persistent_executor_parameters.cpp
+++ b/tests/unit/parallel/executors/persistent_executor_parameters.cpp
@@ -31,14 +31,12 @@ void test_persistent_executitor_parameters()
         persistent_auto_chunk_size p;
         auto policy = par.with(p);
         test_for_each(policy, iterator_tag());
-        HPX_TEST_NEQ(policy.parameters().get_chunk_size_value(), std::size_t(0));
     }
 
     {
         persistent_auto_chunk_size p;
         auto policy = par(task).with(p);
         test_for_each_async(policy, iterator_tag());
-        HPX_TEST_NEQ(policy.parameters().get_chunk_size_value(), std::size_t(0));
     }
 
     parallel_executor par_exec;
@@ -46,14 +44,12 @@ void test_persistent_executitor_parameters()
         persistent_auto_chunk_size p;
         auto policy = par.on(par_exec).with(p);
         test_for_each(policy, iterator_tag());
-        HPX_TEST_NEQ(policy.parameters().get_chunk_size_value(), std::size_t(0));
     }
 
     {
         persistent_auto_chunk_size p;
         auto policy = par(task).on(par_exec).with(p);
         test_for_each_async(policy, iterator_tag());
-        HPX_TEST_NEQ(policy.parameters().get_chunk_size_value(), std::size_t(0));
     }
 }
 
@@ -66,27 +62,23 @@ void test_persistent_executitor_parameters_ref()
     {
         persistent_auto_chunk_size p;
         test_for_each(par.with(boost::ref(p)), iterator_tag());
-        HPX_TEST_NEQ(boost::unwrap_ref(par.with(boost::ref(p)).parameters()).get_chunk_size_value(), std::size_t(0));
     }
 
     {
         persistent_auto_chunk_size p;
         test_for_each_async(par(task).with(boost::ref(p)), iterator_tag());
-        HPX_TEST_NEQ(boost::unwrap_ref(par(task).with(boost::ref(p)).parameters()).get_chunk_size_value(), std::size_t(0));
     }
 
     parallel_executor par_exec;
     {
         persistent_auto_chunk_size p;
         test_for_each(par.on(par_exec).with(boost::ref(p)), iterator_tag());
-        HPX_TEST_NEQ(boost::unwrap_ref(par.on(par_exec).with(boost::ref(p)).parameters()).get_chunk_size_value(), std::size_t(0));
     }
 
     {
         persistent_auto_chunk_size p;
         test_for_each_async(par(task).on(par_exec).with(boost::ref(p)),
             iterator_tag());
-        HPX_TEST_NEQ(boost::unwrap_ref(par(task).on(par_exec).with(boost::ref(p)).parameters()).get_chunk_size_value(), std::size_t(0));
     }
 
 }


### PR DESCRIPTION
persistent_auto_chunk_size is created to make all chunk sizes of different loops having the same execution time. persistent_auto_chunk_size has smaller thread idle rate compared to auto_chunk_size, which results in
having a better latency hiding and reducing the overheads.
The change has been done by adding a new policy.
