### PR TITLE
Fixing gcc startup hangs

### DIFF
--- a/hpx/plugins/parcel/coalescing_message_handler_registration.hpp
+++ b/hpx/plugins/parcel/coalescing_message_handler_registration.hpp
@@ -8,7 +8,8 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_PARCEL_COALESCING)
+// the module itself should not register any actions which coalesce parcels
+#if defined(HPX_HAVE_PARCEL_COALESCING) && !defined(HPX_PARCEL_COALESCING_MODULE_EXPORTS)
 
 #include <hpx/exception.hpp>
 #include <hpx/traits/action_message_handler.hpp>

--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -389,8 +389,15 @@ namespace hpx { namespace components { namespace server
             std::set<std::string>& startup_handled);
 
 #if !defined(HPX_HAVE_STATIC_LINKING)
-        bool load_plugin(util::section& ini, std::string const& instance,
+        bool load_plugin(hpx::util::plugin::dll& d,
+            util::section& ini, std::string const& instance,
             std::string const& component, boost::filesystem::path const& lib,
+            bool isenabled,
+            boost::program_options::options_description& options,
+            std::set<std::string>& startup_handled);
+        bool load_plugin_dynamic(
+            util::section& ini, std::string const& instance,
+            std::string const& component, boost::filesystem::path lib,
             bool isenabled,
             boost::program_options::options_description& options,
             std::set<std::string>& startup_handled);

--- a/plugins/parcel/coalescing/CMakeLists.txt
+++ b/plugins/parcel/coalescing/CMakeLists.txt
@@ -22,6 +22,8 @@ macro(add_coalescing_module)
         FOLDER "Core/Plugins/MessageHandler"
         )
 
+    add_definitions(-DHPX_PARCEL_COALESCING_MODULE_EXPORTS)
+
     add_hpx_pseudo_dependencies(plugins.parcel.coalescing parcel_coalescing_lib)
     add_hpx_pseudo_dependencies(core plugins.parcel.coalescing)
   endif()

--- a/src/pre_main.cpp
+++ b/src/pre_main.cpp
@@ -161,6 +161,11 @@ int pre_main(runtime_mode mode)
         LBT_(info) << "(2nd stage) pre_main: loaded components"
             << (exit_code ? ", application exit has been requested" : "");
 
+        // Work on registration requests for message handler plugins
+        register_message_handlers();
+
+        // Register all counter types before the startup functions are being
+        // executed.
         register_counter_types();
 
         rt.set_state(state_pre_startup);

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -1198,7 +1198,7 @@ namespace hpx
         if (NULL != rt)
         {
             state st = rt->get_state();
-            return st == state_stopped || st == state_shutdown;
+            return st >= state_shutdown;
         }
         return true;        // assume stopped
     }

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -440,7 +440,7 @@ namespace hpx { namespace parcelset
             typedef std::pair<boost::shared_ptr<parcelport>, locality> destination_pair;
             destination_pair dest = find_appropriate_destination(addrs[0].locality_);
 
-            if (load_message_handlers_)
+            if (load_message_handlers_ && !hpx::is_stopped_or_shutting_down())
             {
                 policies::message_handler* mh =
                     p.get_message_handler(this, dest.second);


### PR DESCRIPTION
This PR finally fixes the gcc test runner problems we're seeing right now. It corrects mainly:

- fix plugin loading to not re-load the module
- don't register parcel coalescing from coalescing plugin itself
- add missing message handler registration for connected localities