### PR TITLE
Rewrite tuple unwrap

### DIFF
--- a/hpx/util/unwrapped.hpp
+++ b/hpx/util/unwrapped.hpp
@@ -12,15 +12,16 @@
 #include <hpx/traits/is_future.hpp>
 #include <hpx/traits/is_future_range.hpp>
 #include <hpx/traits/is_future_tuple.hpp>
-#include <hpx/util/decay.hpp>
 #include <hpx/util/invoke_fused.hpp>
 #include <hpx/util/result_of.hpp>
 #include <hpx/util/tuple.hpp>
 #include <hpx/util/detail/pack.hpp>
 
 #include <boost/mpl/eval_if.hpp>
-#include <boost/fusion/include/fold.hpp>
 #include <boost/utility/enable_if.hpp>
+
+#include <type_traits>
+#include <utility>
 
 namespace hpx { namespace util
 {
@@ -124,80 +125,103 @@ namespace hpx { namespace util
         {
             typedef util::tuple<Ts..., U> type;
 
-            template <std::size_t ...Is, typename Tuple_, typename U_>
+            template <std::size_t ...Is, typename State_, typename U_>
             static type call(util::detail::pack_c<std::size_t, Is...>,
-                Tuple_&& tuple, U_&& value)
+                State_&& tuple, U_&& value)
             {
                 return type(
-                    util::get<Is>(std::forward<Tuple_>(tuple))...,
+                    util::get<Is>(std::forward<State_>(tuple))...,
                     std::forward<U_>(value));
             }
 
-            template <typename Tuple_, typename U_>
-            static type call(Tuple_&& tuple, U_&& value)
+            template <typename State_, typename U_>
+            static type call(State_&& tuple, U_&& value)
             {
                 return call(
                     typename util::detail::make_index_pack<sizeof...(Ts)>::type(),
-                    std::forward<Tuple_>(tuple), std::forward<U_>(value));
+                    std::forward<State_>(tuple), std::forward<U_>(value));
             }
         };
 
+        template <
+            typename State, typename Future,
+            bool IsVoid =
+                unwrap_impl<typename std::decay<Future>::type>::is_void::value
+        >
         struct unwrap_tuple_impl
         {
-            template <typename>
-            struct result;
+            typedef typename unwrap_tuple_push_back<
+                typename std::decay<State>::type
+              , typename unwrap_impl<
+                    typename std::decay<Future>::type
+                >::type
+            >::type type;
 
-            template <typename This, typename Tuple, typename Future>
-            struct result<This(Tuple, Future)>
-              : boost::mpl::eval_if<
-                    typename unwrap_impl<
-                        typename util::decay<Future>::type
-                    >::is_void
-                  , util::decay<Tuple>
-                  , unwrap_tuple_push_back<
-                        typename util::decay<Tuple>::type
-                      , typename unwrap_impl<
-                            typename util::decay<Future>::type
-                        >::type
-                    >
-                >
-            {};
-
-            template <typename Tuple, typename Future>
-            typename result<unwrap_tuple_impl(Tuple, Future)>::type
-            operator()(Tuple tuple, Future&& f, typename boost::disable_if<
-                typename unwrap_impl<
-                    typename util::decay<Future>::type>::is_void>::type* = 0
-            ) const
+            static type call(State&& tuple, Future&& f)
             {
                 typedef
-                    unwrap_impl<typename util::decay<Future>::type>
+                    unwrap_impl<typename std::decay<Future>::type>
                     unwrap_impl_t;
 
                 typedef
                     unwrap_tuple_push_back<
-                        typename util::decay<Tuple>::type
+                        typename std::decay<State>::type
                       , typename unwrap_impl_t::type
                     >
                     unwrap_tuple_push_back_t;
 
                 return unwrap_tuple_push_back_t::call(
-                    std::move(tuple), unwrap_impl_t::call(f));
+                    std::forward<State>(tuple), unwrap_impl_t::call(f));
             }
+        };
 
-            template <typename Tuple, typename Future>
-            typename result<unwrap_tuple_impl(Tuple, Future)>::type
-            operator()(Tuple tuple, Future&& f, typename boost::enable_if<
-                typename unwrap_impl<
-                    typename util::decay<Future>::type>::is_void>::type* = 0
-            ) const
+        template <typename State, typename Future>
+        struct unwrap_tuple_impl<State, Future, /*IsVoid=*/true>
+        {
+            typedef typename std::decay<State>::type type;
+
+            static type call(State&& tuple, Future&& f)
             {
                 typedef
-                    unwrap_impl<typename util::decay<Future>::type>
+                    unwrap_impl<typename std::decay<Future>::type>
                     unwrap_impl_t;
 
                 unwrap_impl_t::call(f);
-                return std::move(tuple);
+                return std::forward<State>(tuple);
+            }
+        };
+
+        template <
+            typename Tuple,
+            typename State = util::tuple<>, std::size_t I = 0,
+            bool End =
+                (I == util::tuple_size<typename std::decay<Tuple>::type>::value)
+        >
+        struct unwrap_tuple_fold
+        {
+            typedef decltype(util::get<I>(std::declval<Tuple&>())) element_type;
+            typedef unwrap_tuple_impl<State, element_type> unwrap_impl_t;
+            typedef typename unwrap_impl_t::type next_state;
+
+            typedef typename unwrap_tuple_fold<Tuple, next_state, I + 1>::type type;
+
+            static type call(Tuple& tuple, State&& state)
+            {
+                return unwrap_tuple_fold<Tuple, next_state, I + 1>::call(
+                    tuple,
+                    unwrap_impl_t::call(
+                        std::forward<State>(state), util::get<I>(tuple)));
+            }
+        };
+
+        template <typename Tuple, typename State, std::size_t I>
+        struct unwrap_tuple_fold<Tuple, State, I, /*End=*/true>
+        {
+            typedef State type;
+
+            static type call(Tuple& /*tuple*/, State&& state)
+            {
+                return std::forward<State>(state);
             }
         };
 
@@ -207,15 +231,13 @@ namespace hpx { namespace util
             typename boost::enable_if<traits::is_future_tuple<T> >::type
         >
         {
-            typedef typename boost::fusion::result_of::fold<
-                T, util::tuple<>, unwrap_tuple_impl
-            >::type type;
+            typedef typename unwrap_tuple_fold<T>::type type;
 
             template <typename Tuple>
             static type call(Tuple&& tuple)
             {
-                return boost::fusion::fold(
-                    tuple, util::tuple<>(), unwrap_tuple_impl());
+                return unwrap_tuple_fold<Tuple&>::call(
+                    tuple, util::tuple<>());
             }
         };
 
@@ -315,8 +337,8 @@ namespace hpx { namespace util
                     (util::detail::pack<Ts...>::size == 0)
                   , unwrapped_impl_result<F, T>
                   , unwrapped_impl_result<F, util::tuple<
-                        typename util::decay<T>::type
-                      , typename util::decay<Ts>::type...> >
+                        typename std::decay<T>::type
+                      , typename std::decay<Ts>::type...> >
                 >::type
             {};
 
@@ -393,7 +415,7 @@ namespace hpx { namespace util
             {
                 typedef
                     unwrap_impl<util::tuple<
-                        typename util::decay<Ts>::type...> >
+                        typename std::decay<Ts>::type...> >
                     unwrap_impl_t;
 
                 return util::invoke_fused(f_,
@@ -426,10 +448,10 @@ namespace hpx { namespace util
         traits::is_future<typename decay<F>::type>::value
      || traits::is_future_range<typename decay<F>::type>::value
      || traits::is_future_tuple<typename decay<F>::type>::value
-      , detail::unwrapped_impl<typename util::decay<F>::type >
+      , detail::unwrapped_impl<typename std::decay<F>::type >
     >::type unwrapped(F && f)
     {
-        detail::unwrapped_impl<typename util::decay<F>::type >
+        detail::unwrapped_impl<typename std::decay<F>::type >
             res(std::forward<F>(f));
 
         return res;
@@ -438,15 +460,15 @@ namespace hpx { namespace util
     template <typename ...Ts>
     typename boost::lazy_enable_if_c<
         traits::is_future_tuple<util::tuple<
-            typename util::decay<Ts>::type...
+            typename std::decay<Ts>::type...
         > >::value
       , detail::unwrap_impl<util::tuple<
-            typename util::decay<Ts>::type...
+            typename std::decay<Ts>::type...
         > >
     >::type unwrapped(Ts&&... vs)
     {
         typedef detail::unwrap_impl<util::tuple<
-            typename util::decay<Ts>::type...
+            typename std::decay<Ts>::type...
         > > unwrap_impl_t;
 
         return unwrap_impl_t::call(util::forward_as_tuple(
@@ -473,15 +495,15 @@ namespace hpx { namespace util
      || traits::is_future_range<typename decay<F>::type>::value
      || traits::is_future_tuple<typename decay<F>::type>::value
       , detail::unwrapped_impl<detail::unwrapped_impl<
-            typename util::decay<F>::type
+            typename std::decay<F>::type
         > >
     >::type unwrapped2(F && f)
     {
         typedef detail::unwrapped_impl<detail::unwrapped_impl<
-            typename util::decay<F>::type
+            typename std::decay<F>::type
         > > result_type;
 
-        detail::unwrapped_impl<typename util::decay<F>::type >
+        detail::unwrapped_impl<typename std::decay<F>::type >
             res(std::forward<F>(f));
 
         return result_type(std::move(res));


### PR DESCRIPTION
Rewrite `unwrapped` for tuples without Boost.Fusion, avoid unnecessary intermediate tuples.