### PR TITLE
Rename HPX_MOVABLE_BUT_NOT_COPYABLE to HPX_MOVABLE_ONLY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -772,7 +772,7 @@ hpx_check_for_cxx11_defaulted_functions(
   DEFINITIONS HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS)
 
 hpx_check_for_cxx11_deleted_functions(
-  DEFINITIONS HPX_HAVE_CXX11_DELETED_FUNCTIONS)
+  REQUIRED "HPX needs support for C++11 deleted functions")
 
 hpx_check_for_cxx11_explicit_cvt_ops(
   DEFINITIONS HPX_HAVE_CXX11_EXPLICIT_CONVERSION_OPERATORS)

--- a/examples/1d_stencil/1d_stencil_4.cpp
+++ b/examples/1d_stencil/1d_stencil_4.cpp
@@ -73,7 +73,7 @@ private:
     std::unique_ptr<double[]> data_;
     std::size_t size_;
 
-    HPX_MOVABLE_BUT_NOT_COPYABLE(partition_data);
+    HPX_MOVABLE_ONLY(partition_data);
 };
 
 std::ostream& operator<<(std::ostream& os, partition_data const& c)

--- a/examples/1d_stencil/1d_stencil_4_repart.cpp
+++ b/examples/1d_stencil/1d_stencil_4_repart.cpp
@@ -154,7 +154,7 @@ private:
     std::unique_ptr<double[]> data_;
     std::size_t size_;
 
-    HPX_MOVABLE_BUT_NOT_COPYABLE(partition_data);
+    HPX_MOVABLE_ONLY(partition_data);
 };
 
 std::ostream& operator<<(std::ostream& os, partition_data const& c)

--- a/examples/1d_stencil/1d_stencil_4_throttle.cpp
+++ b/examples/1d_stencil/1d_stencil_4_throttle.cpp
@@ -142,7 +142,7 @@ private:
     std::unique_ptr<double[]> data_;
     std::size_t size_;
 
-    HPX_MOVABLE_BUT_NOT_COPYABLE(partition_data);
+    HPX_MOVABLE_ONLY(partition_data);
 };
 
 std::ostream& operator<<(std::ostream& os, partition_data const& c)

--- a/examples/quickstart/safe_object.cpp
+++ b/examples/quickstart/safe_object.cpp
@@ -18,7 +18,7 @@ template <typename T>
 struct safe_object
 {
 private:
-    HPX_MOVABLE_BUT_NOT_COPYABLE(safe_object);
+    HPX_MOVABLE_ONLY(safe_object);
 
 public:
     safe_object()

--- a/examples/transpose/transpose_await.cpp
+++ b/examples/transpose/transpose_await.cpp
@@ -108,7 +108,7 @@ struct sub_block
     double * data_;
     mode mode_;
 
-    HPX_MOVABLE_BUT_NOT_COPYABLE(sub_block);
+    HPX_MOVABLE_ONLY(sub_block);
 };
 
 struct block_component

--- a/examples/transpose/transpose_block.cpp
+++ b/examples/transpose/transpose_block.cpp
@@ -108,7 +108,7 @@ struct sub_block
     double * data_;
     mode mode_;
 
-    HPX_MOVABLE_BUT_NOT_COPYABLE(sub_block);
+    HPX_MOVABLE_ONLY(sub_block);
 };
 
 struct block_component

--- a/examples/transpose/transpose_block_numa.cpp
+++ b/examples/transpose/transpose_block_numa.cpp
@@ -118,7 +118,7 @@ struct sub_block
     double * data_;
     mode mode_;
 
-    HPX_MOVABLE_BUT_NOT_COPYABLE(sub_block);
+    HPX_MOVABLE_ONLY(sub_block);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/external/cache/boost/cache/local_cache.hpp
+++ b/external/cache/boost/cache/local_cache.hpp
@@ -86,7 +86,7 @@ namespace boost { namespace cache
             Func f_;    // user supplied UpdatePolicy
         };
 
-        HPX_MOVABLE_BUT_NOT_COPYABLE(local_cache)
+        HPX_MOVABLE_ONLY(local_cache)
 
     public:
         typedef Key key_type;

--- a/external/cache/boost/cache/local_cache.hpp
+++ b/external/cache/boost/cache/local_cache.hpp
@@ -86,7 +86,7 @@ namespace boost { namespace cache
             Func f_;    // user supplied UpdatePolicy
         };
 
-        HPX_MOVABLE_ONLY(local_cache)
+        HPX_MOVABLE_ONLY(local_cache);
 
     public:
         typedef Key key_type;

--- a/external/cache/boost/cache/lru_cache.hpp
+++ b/external/cache/boost/cache/lru_cache.hpp
@@ -38,7 +38,7 @@ namespace boost { namespace cache
     >
     class lru_cache
     {
-        HPX_MOVABLE_ONLY(lru_cache)
+        HPX_MOVABLE_ONLY(lru_cache);
     public:
         typedef Key key_type;
         typedef Entry entry_type;

--- a/external/cache/boost/cache/lru_cache.hpp
+++ b/external/cache/boost/cache/lru_cache.hpp
@@ -38,7 +38,7 @@ namespace boost { namespace cache
     >
     class lru_cache
     {
-        HPX_MOVABLE_BUT_NOT_COPYABLE(lru_cache)
+        HPX_MOVABLE_ONLY(lru_cache)
     public:
         typedef Key key_type;
         typedef Entry entry_type;

--- a/hpx/components/iostreams/ostream.hpp
+++ b/hpx/components/iostreams/ostream.hpp
@@ -149,7 +149,7 @@ namespace hpx { namespace iostreams
         typedef BOOST_IOSTREAMS_BASIC_OSTREAM(Char, stream_traits_type) std_stream_type;
         typedef lcos::local::recursive_mutex mutex_type;
 
-        HPX_MOVABLE_BUT_NOT_COPYABLE(ostream);
+        HPX_MOVABLE_ONLY(ostream);
 
     private:
         mutex_type mtx_;

--- a/hpx/components/process/util/windows/child.hpp
+++ b/hpx/components/process/util/windows/child.hpp
@@ -23,7 +23,7 @@ namespace hpx { namespace components { namespace process { namespace windows {
 
 class child
 {
-    HPX_MOVABLE_BUT_NOT_COPYABLE(child);
+    HPX_MOVABLE_ONLY(child);
 
 public:
     PROCESS_INFORMATION proc_info;

--- a/hpx/config/emulate_deleted.hpp
+++ b/hpx/config/emulate_deleted.hpp
@@ -8,61 +8,31 @@
 
 #include <hpx/config.hpp>
 
-#ifdef HPX_HAVE_CXX11_DELETED_FUNCTIONS
-
 #define HPX_DELETE_COPY_CTOR(cls)                                             \
-    cls(cls const&) = delete;                                                 \
+    cls(cls const&) = delete                                                  \
 /**/
 
 #define HPX_DELETE_COPY_ASSIGN(cls)                                           \
-    cls& operator=(cls const&) = delete;                                      \
+    cls& operator=(cls const&) = delete                                       \
 /**/
 
 #define HPX_DELETE_MOVE_CTOR(cls)                                             \
-    cls(cls&&) = delete;                                                      \
+    cls(cls&&) = delete                                                       \
 /**/
 
 #define HPX_DELETE_MOVE_ASSIGN(cls)                                           \
-    cls& operator=(cls&&) = delete;                                           \
+    cls& operator=(cls&&) = delete                                            \
 /**/
-
-#else
-
-#define HPX_DELETE_COPY_CTOR(cls)                                             \
-    private:                                                                  \
-        cls(cls const&);                                                      \
-    public:                                                                   \
-/**/
-
-#define HPX_DELETE_COPY_ASSIGN(cls)                                           \
-    private:                                                                  \
-        cls& operator=(cls const&);                                           \
-    public:                                                                   \
-/**/
-
-#define HPX_DELETE_MOVE_CTOR(cls)                                             \
-    private:                                                                  \
-        cls(cls&&);                                                           \
-    public:                                                                   \
-/**/
-
-#define HPX_DELETE_MOVE_ASSIGN(cls)                                           \
-    private:                                                                  \
-        cls& operator=(cls&&);                                                \
-    public:                                                                   \
-/**/
-
-#endif // HPX_HAVE_CXX11_DELETED_FUNCTIONS
 
 #define HPX_NON_COPYABLE(cls)                                                 \
-    HPX_DELETE_COPY_CTOR(cls)                                                 \
-    HPX_DELETE_COPY_ASSIGN(cls)                                               \
-    HPX_DELETE_MOVE_CTOR(cls)                                                 \
+    HPX_DELETE_COPY_CTOR(cls);                                                \
+    HPX_DELETE_COPY_ASSIGN(cls);                                              \
+    HPX_DELETE_MOVE_CTOR(cls);                                                \
     HPX_DELETE_MOVE_ASSIGN(cls)                                               \
 /**/
 
 #define HPX_MOVABLE_ONLY(cls)                                                 \
-    HPX_DELETE_COPY_CTOR(cls)                                                 \
+    HPX_DELETE_COPY_CTOR(cls);                                                \
     HPX_DELETE_COPY_ASSIGN(cls)                                               \
 /**/
 

--- a/hpx/config/emulate_deleted.hpp
+++ b/hpx/config/emulate_deleted.hpp
@@ -61,7 +61,7 @@
     HPX_DELETE_MOVE_ASSIGN(cls)                                               \
 /**/
 
-#define HPX_MOVABLE_BUT_NOT_COPYABLE(cls)                                     \
+#define HPX_MOVABLE_ONLY(cls)                                                 \
     HPX_DELETE_COPY_CTOR(cls)                                                 \
     HPX_DELETE_COPY_ASSIGN(cls)                                               \
 /**/

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -174,7 +174,7 @@ namespace detail
     template <typename F1, typename F2>
     class compose_cb_impl
     {
-        HPX_MOVABLE_ONLY(compose_cb_impl)
+        HPX_MOVABLE_ONLY(compose_cb_impl);
 
     public:
         template <typename A1, typename A2>

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -174,7 +174,7 @@ namespace detail
     template <typename F1, typename F2>
     class compose_cb_impl
     {
-        HPX_MOVABLE_BUT_NOT_COPYABLE(compose_cb_impl)
+        HPX_MOVABLE_ONLY(compose_cb_impl)
 
     public:
         template <typename A1, typename A2>

--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -705,7 +705,7 @@ namespace hpx { namespace lcos
     template <typename R>
     class future : public detail::future_base<future<R>, R>
     {
-        HPX_MOVABLE_ONLY(future)
+        HPX_MOVABLE_ONLY(future);
 
         typedef detail::future_base<future<R>, R> base_type;
 

--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -705,7 +705,7 @@ namespace hpx { namespace lcos
     template <typename R>
     class future : public detail::future_base<future<R>, R>
     {
-        HPX_MOVABLE_BUT_NOT_COPYABLE(future)
+        HPX_MOVABLE_ONLY(future)
 
         typedef detail::future_base<future<R>, R> base_type;
 

--- a/hpx/lcos/future_wait.hpp
+++ b/hpx/lcos/future_wait.hpp
@@ -53,7 +53,7 @@ namespace hpx { namespace lcos
         struct wait_each
         {
         private:
-            HPX_MOVABLE_BUT_NOT_COPYABLE(wait_each)
+            HPX_MOVABLE_ONLY(wait_each)
 
         protected:
             void on_future_ready_(threads::thread_id_type const& id)

--- a/hpx/lcos/future_wait.hpp
+++ b/hpx/lcos/future_wait.hpp
@@ -53,7 +53,7 @@ namespace hpx { namespace lcos
         struct wait_each
         {
         private:
-            HPX_MOVABLE_ONLY(wait_each)
+            HPX_MOVABLE_ONLY(wait_each);
 
         protected:
             void on_future_ready_(threads::thread_id_type const& id)

--- a/hpx/lcos/local/and_gate.hpp
+++ b/hpx/lcos/local/and_gate.hpp
@@ -29,7 +29,7 @@ namespace hpx { namespace lcos { namespace local
         typedef Mutex mutex_type;
 
     private:
-        HPX_MOVABLE_BUT_NOT_COPYABLE(base_and_gate)
+        HPX_MOVABLE_ONLY(base_and_gate)
         typedef std::list<conditional_trigger*> condition_list_type;
 
     public:
@@ -286,7 +286,7 @@ namespace hpx { namespace lcos { namespace local
     struct and_gate : public base_and_gate<no_mutex>
     {
     private:
-        HPX_MOVABLE_BUT_NOT_COPYABLE(and_gate)
+        HPX_MOVABLE_ONLY(and_gate)
         typedef base_and_gate<no_mutex> base_type;
 
     public:

--- a/hpx/lcos/local/and_gate.hpp
+++ b/hpx/lcos/local/and_gate.hpp
@@ -29,7 +29,7 @@ namespace hpx { namespace lcos { namespace local
         typedef Mutex mutex_type;
 
     private:
-        HPX_MOVABLE_ONLY(base_and_gate)
+        HPX_MOVABLE_ONLY(base_and_gate);
         typedef std::list<conditional_trigger*> condition_list_type;
 
     public:
@@ -286,7 +286,7 @@ namespace hpx { namespace lcos { namespace local
     struct and_gate : public base_and_gate<no_mutex>
     {
     private:
-        HPX_MOVABLE_ONLY(and_gate)
+        HPX_MOVABLE_ONLY(and_gate);
         typedef base_and_gate<no_mutex> base_type;
 
     public:

--- a/hpx/lcos/local/conditional_trigger.hpp
+++ b/hpx/lcos/local/conditional_trigger.hpp
@@ -21,7 +21,7 @@ namespace hpx { namespace lcos { namespace local
     struct conditional_trigger
     {
     private:
-        HPX_MOVABLE_ONLY(conditional_trigger)
+        HPX_MOVABLE_ONLY(conditional_trigger);
 
     public:
         conditional_trigger()

--- a/hpx/lcos/local/conditional_trigger.hpp
+++ b/hpx/lcos/local/conditional_trigger.hpp
@@ -21,7 +21,7 @@ namespace hpx { namespace lcos { namespace local
     struct conditional_trigger
     {
     private:
-        HPX_MOVABLE_BUT_NOT_COPYABLE(conditional_trigger)
+        HPX_MOVABLE_ONLY(conditional_trigger)
 
     public:
         conditional_trigger()

--- a/hpx/lcos/local/latch.hpp
+++ b/hpx/lcos/local/latch.hpp
@@ -36,21 +36,7 @@ namespace hpx { namespace lcos { namespace local
     ///         synchronize a given number of \a threads.
     class latch
     {
-#if defined(HPX_HAVE_CXX11_DELETED_FUNCTIONS)
-    public:
-        latch (latch const&) = delete;
-        latch (latch&&) = delete;
-
-        latch& operator= (latch const&) = delete;
-        latch& operator= (latch&&) = delete;
-#else
-    private:
-        latch (latch const&);
-        latch (latch&&);
-
-        latch& operator= (latch const&);
-        latch& operator= (latch&&);
-#endif
+        HPX_NON_COPYABLE(latch);
 
     private:
         typedef lcos::local::spinlock mutex_type;

--- a/hpx/lcos/local/mutex.hpp
+++ b/hpx/lcos/local/mutex.hpp
@@ -8,7 +8,6 @@
 #define HPX_LCOS_MUTEX_HPP
 
 #include <hpx/config.hpp>
-#include <hpx/config/emulate_deleted.hpp>
 #include <hpx/config/export_definitions.hpp>
 #include <hpx/exception_fwd.hpp>
 #include <hpx/lcos/local/spinlock.hpp>

--- a/hpx/lcos/local/once.hpp
+++ b/hpx/lcos/local/once.hpp
@@ -11,7 +11,7 @@
 #define HPX_LCOS_LOCAL_ONCE_JAN_03_2013_0810PM
 
 #include <hpx/hpx_fwd.hpp>
-#include <hpx/config/emulate_deleted.hpp>
+#include <hpx/config.hpp>
 #include <hpx/lcos/local/event.hpp>
 #include <hpx/lcos/local/once_fwd.hpp>
 #include <hpx/util/assert.hpp>

--- a/hpx/lcos/local/packaged_task.hpp
+++ b/hpx/lcos/local/packaged_task.hpp
@@ -274,7 +274,7 @@ namespace hpx { namespace lcos { namespace local
         typedef lcos::detail::task_base<Result> task_impl_type;
 
     private:
-        HPX_MOVABLE_BUT_NOT_COPYABLE(futures_factory)
+        HPX_MOVABLE_ONLY(futures_factory)
 
     public:
         // support for result_of
@@ -397,7 +397,7 @@ namespace hpx { namespace lcos { namespace local
         class packaged_task_base
         {
         private:
-            HPX_MOVABLE_BUT_NOT_COPYABLE(packaged_task_base)
+            HPX_MOVABLE_ONLY(packaged_task_base)
 
         public:
             // construction and destruction
@@ -521,7 +521,7 @@ namespace hpx { namespace lcos { namespace local
     class packaged_task<R(Ts...)>
       : private detail::packaged_task_base<R, R(Ts...)>
     {
-        HPX_MOVABLE_BUT_NOT_COPYABLE(packaged_task)
+        HPX_MOVABLE_ONLY(packaged_task)
 
         typedef detail::packaged_task_base<R, R(Ts...)> base_type;
 

--- a/hpx/lcos/local/packaged_task.hpp
+++ b/hpx/lcos/local/packaged_task.hpp
@@ -274,7 +274,7 @@ namespace hpx { namespace lcos { namespace local
         typedef lcos::detail::task_base<Result> task_impl_type;
 
     private:
-        HPX_MOVABLE_ONLY(futures_factory)
+        HPX_MOVABLE_ONLY(futures_factory);
 
     public:
         // support for result_of
@@ -397,7 +397,7 @@ namespace hpx { namespace lcos { namespace local
         class packaged_task_base
         {
         private:
-            HPX_MOVABLE_ONLY(packaged_task_base)
+            HPX_MOVABLE_ONLY(packaged_task_base);
 
         public:
             // construction and destruction
@@ -521,7 +521,7 @@ namespace hpx { namespace lcos { namespace local
     class packaged_task<R(Ts...)>
       : private detail::packaged_task_base<R, R(Ts...)>
     {
-        HPX_MOVABLE_ONLY(packaged_task)
+        HPX_MOVABLE_ONLY(packaged_task);
 
         typedef detail::packaged_task_base<R, R(Ts...)> base_type;
 

--- a/hpx/lcos/local/promise.hpp
+++ b/hpx/lcos/local/promise.hpp
@@ -22,7 +22,7 @@ namespace hpx { namespace lcos { namespace local
         template <typename R>
         class promise_base
         {
-            HPX_MOVABLE_ONLY(promise_base)
+            HPX_MOVABLE_ONLY(promise_base);
 
             typedef R result_type;
             typedef lcos::detail::future_data<R> shared_state_type;
@@ -171,7 +171,7 @@ namespace hpx { namespace lcos { namespace local
     template <typename R>
     class promise : public detail::promise_base<R>
     {
-        HPX_MOVABLE_ONLY(promise)
+        HPX_MOVABLE_ONLY(promise);
 
         typedef detail::promise_base<R> base_type;
 
@@ -279,7 +279,7 @@ namespace hpx { namespace lcos { namespace local
     template <typename R>
     class promise<R&> : public detail::promise_base<R&>
     {
-        HPX_MOVABLE_ONLY(promise)
+        HPX_MOVABLE_ONLY(promise);
 
         typedef detail::promise_base<R&> base_type;
 
@@ -369,7 +369,7 @@ namespace hpx { namespace lcos { namespace local
     template <>
     class promise<void> : public detail::promise_base<void>
     {
-        HPX_MOVABLE_ONLY(promise)
+        HPX_MOVABLE_ONLY(promise);
 
         typedef detail::promise_base<void> base_type;
 

--- a/hpx/lcos/local/promise.hpp
+++ b/hpx/lcos/local/promise.hpp
@@ -22,7 +22,7 @@ namespace hpx { namespace lcos { namespace local
         template <typename R>
         class promise_base
         {
-            HPX_MOVABLE_BUT_NOT_COPYABLE(promise_base)
+            HPX_MOVABLE_ONLY(promise_base)
 
             typedef R result_type;
             typedef lcos::detail::future_data<R> shared_state_type;
@@ -171,7 +171,7 @@ namespace hpx { namespace lcos { namespace local
     template <typename R>
     class promise : public detail::promise_base<R>
     {
-        HPX_MOVABLE_BUT_NOT_COPYABLE(promise)
+        HPX_MOVABLE_ONLY(promise)
 
         typedef detail::promise_base<R> base_type;
 
@@ -279,7 +279,7 @@ namespace hpx { namespace lcos { namespace local
     template <typename R>
     class promise<R&> : public detail::promise_base<R&>
     {
-        HPX_MOVABLE_BUT_NOT_COPYABLE(promise)
+        HPX_MOVABLE_ONLY(promise)
 
         typedef detail::promise_base<R&> base_type;
 
@@ -369,7 +369,7 @@ namespace hpx { namespace lcos { namespace local
     template <>
     class promise<void> : public detail::promise_base<void>
     {
-        HPX_MOVABLE_BUT_NOT_COPYABLE(promise)
+        HPX_MOVABLE_ONLY(promise)
 
         typedef detail::promise_base<void> base_type;
 

--- a/hpx/lcos/local/receive_buffer.hpp
+++ b/hpx/lcos/local/receive_buffer.hpp
@@ -33,7 +33,7 @@ namespace hpx { namespace lcos { namespace local
         struct entry_data
         {
         private:
-            HPX_MOVABLE_ONLY(entry_data)
+            HPX_MOVABLE_ONLY(entry_data);
 
         public:
             entry_data()
@@ -80,7 +80,7 @@ namespace hpx { namespace lcos { namespace local
         };
 
     private:
-        HPX_MOVABLE_ONLY(receive_buffer)
+        HPX_MOVABLE_ONLY(receive_buffer);
 
     public:
         receive_buffer() {}
@@ -184,7 +184,7 @@ namespace hpx { namespace lcos { namespace local
         struct entry_data
         {
         private:
-            HPX_MOVABLE_ONLY(entry_data)
+            HPX_MOVABLE_ONLY(entry_data);
 
         public:
             entry_data()
@@ -230,7 +230,7 @@ namespace hpx { namespace lcos { namespace local
         };
 
     private:
-        HPX_MOVABLE_ONLY(receive_buffer)
+        HPX_MOVABLE_ONLY(receive_buffer);
 
     public:
         receive_buffer() {}

--- a/hpx/lcos/local/receive_buffer.hpp
+++ b/hpx/lcos/local/receive_buffer.hpp
@@ -33,7 +33,7 @@ namespace hpx { namespace lcos { namespace local
         struct entry_data
         {
         private:
-            HPX_MOVABLE_BUT_NOT_COPYABLE(entry_data)
+            HPX_MOVABLE_ONLY(entry_data)
 
         public:
             entry_data()
@@ -80,7 +80,7 @@ namespace hpx { namespace lcos { namespace local
         };
 
     private:
-        HPX_MOVABLE_BUT_NOT_COPYABLE(receive_buffer)
+        HPX_MOVABLE_ONLY(receive_buffer)
 
     public:
         receive_buffer() {}
@@ -184,7 +184,7 @@ namespace hpx { namespace lcos { namespace local
         struct entry_data
         {
         private:
-            HPX_MOVABLE_BUT_NOT_COPYABLE(entry_data)
+            HPX_MOVABLE_ONLY(entry_data)
 
         public:
             entry_data()
@@ -230,7 +230,7 @@ namespace hpx { namespace lcos { namespace local
         };
 
     private:
-        HPX_MOVABLE_BUT_NOT_COPYABLE(receive_buffer)
+        HPX_MOVABLE_ONLY(receive_buffer)
 
     public:
         receive_buffer() {}

--- a/hpx/lcos/local/spinlock.hpp
+++ b/hpx/lcos/local/spinlock.hpp
@@ -13,7 +13,6 @@
 #define HPX_B3A83B49_92E0_4150_A551_488F9F5E1113
 
 #include <hpx/config.hpp>
-#include <hpx/config/emulate_deleted.hpp>
 #ifdef HPX_HAVE_SPINLOCK_DEADLOCK_DETECTION
 #include <hpx/exception.hpp>
 #endif

--- a/hpx/lcos/local/spinlock_no_backoff.hpp
+++ b/hpx/lcos/local/spinlock_no_backoff.hpp
@@ -11,7 +11,6 @@
 #define HPX_LCOS_LOCAL_SPINLOCK_NO_BACKOFF
 
 #include <hpx/config.hpp>
-#include <hpx/config/emulate_deleted.hpp>
 #include <hpx/util/itt_notify.hpp>
 #include <hpx/util/register_locks.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>

--- a/hpx/lcos/local/spinlock_pool.hpp
+++ b/hpx/lcos/local/spinlock_pool.hpp
@@ -50,10 +50,10 @@ namespace hpx { namespace lcos { namespace local
 
         class scoped_lock
         {
-            HPX_NON_COPYABLE(scoped_lock);
-
         private:
             hpx::lcos::local::spinlock & sp_;
+
+            HPX_NON_COPYABLE(scoped_lock);
 
         public:
             explicit scoped_lock(void const * pv)

--- a/hpx/lcos/local/spinlock_pool.hpp
+++ b/hpx/lcos/local/spinlock_pool.hpp
@@ -13,7 +13,7 @@
 #ifndef HPX_LCOS_LOCAL_SPINLOCK_POOL_HPP
 #define HPX_LCOS_LOCAL_SPINLOCK_POOL_HPP
 
-#include <hpx/config/emulate_deleted.hpp>
+#include <hpx/config.hpp>
 #include <hpx/runtime/threads_fwd.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 

--- a/hpx/lcos/local/trigger.hpp
+++ b/hpx/lcos/local/trigger.hpp
@@ -28,7 +28,7 @@ namespace hpx { namespace lcos { namespace local
         typedef Mutex mutex_type;
 
     private:
-        HPX_MOVABLE_ONLY(base_trigger)
+        HPX_MOVABLE_ONLY(base_trigger);
         typedef std::list<conditional_trigger*> condition_list_type;
 
     public:
@@ -217,7 +217,7 @@ namespace hpx { namespace lcos { namespace local
     struct trigger : public base_trigger<no_mutex>
     {
     private:
-        HPX_MOVABLE_ONLY(trigger)
+        HPX_MOVABLE_ONLY(trigger);
         typedef base_trigger<no_mutex> base_type;
 
     public:

--- a/hpx/lcos/local/trigger.hpp
+++ b/hpx/lcos/local/trigger.hpp
@@ -28,7 +28,7 @@ namespace hpx { namespace lcos { namespace local
         typedef Mutex mutex_type;
 
     private:
-        HPX_MOVABLE_BUT_NOT_COPYABLE(base_trigger)
+        HPX_MOVABLE_ONLY(base_trigger)
         typedef std::list<conditional_trigger*> condition_list_type;
 
     public:
@@ -217,7 +217,7 @@ namespace hpx { namespace lcos { namespace local
     struct trigger : public base_trigger<no_mutex>
     {
     private:
-        HPX_MOVABLE_BUT_NOT_COPYABLE(trigger)
+        HPX_MOVABLE_ONLY(trigger)
         typedef base_trigger<no_mutex> base_type;
 
     public:

--- a/hpx/lcos/promise.hpp
+++ b/hpx/lcos/promise.hpp
@@ -464,7 +464,7 @@ namespace hpx { namespace lcos
     template <typename Result, typename RemoteResult>
     class promise
     {
-        HPX_MOVABLE_BUT_NOT_COPYABLE(promise)
+        HPX_MOVABLE_ONLY(promise)
 
     public:
         typedef detail::promise<Result, RemoteResult> wrapped_type;
@@ -620,7 +620,7 @@ namespace hpx { namespace lcos
     template <>
     class promise<void, util::unused_type>
     {
-        HPX_MOVABLE_BUT_NOT_COPYABLE(promise)
+        HPX_MOVABLE_ONLY(promise)
 
     public:
         typedef detail::promise<void, util::unused_type> wrapped_type;

--- a/hpx/lcos/promise.hpp
+++ b/hpx/lcos/promise.hpp
@@ -464,7 +464,7 @@ namespace hpx { namespace lcos
     template <typename Result, typename RemoteResult>
     class promise
     {
-        HPX_MOVABLE_ONLY(promise)
+        HPX_MOVABLE_ONLY(promise);
 
     public:
         typedef detail::promise<Result, RemoteResult> wrapped_type;
@@ -620,7 +620,7 @@ namespace hpx { namespace lcos
     template <>
     class promise<void, util::unused_type>
     {
-        HPX_MOVABLE_ONLY(promise)
+        HPX_MOVABLE_ONLY(promise);
 
     public:
         typedef detail::promise<void, util::unused_type> wrapped_type;

--- a/hpx/parallel/task_block.hpp
+++ b/hpx/parallel/task_block.hpp
@@ -10,7 +10,6 @@
 
 #include <hpx/config.hpp>
 #include <hpx/exception.hpp>
-#include <hpx/config/emulate_deleted.hpp>
 #include <hpx/dataflow.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 #include <hpx/lcos/future.hpp>

--- a/hpx/plugins/parcel/coalescing_counter_registry.hpp
+++ b/hpx/plugins/parcel/coalescing_counter_registry.hpp
@@ -25,7 +25,7 @@ namespace hpx { namespace plugins { namespace parcel
     ///////////////////////////////////////////////////////////////////////////
     class coalescing_counter_registry
     {
-        HPX_MOVABLE_BUT_NOT_COPYABLE(coalescing_counter_registry);
+        HPX_MOVABLE_ONLY(coalescing_counter_registry);
 
     public:
         coalescing_counter_registry() {}

--- a/hpx/plugins/parcelport/mpi/mpi_environment.hpp
+++ b/hpx/plugins/parcelport/mpi/mpi_environment.hpp
@@ -43,7 +43,7 @@ namespace hpx { namespace util
             scoped_lock();
             ~scoped_lock();
             void unlock();
-            HPX_MOVABLE_BUT_NOT_COPYABLE(scoped_lock);
+            HPX_MOVABLE_ONLY(scoped_lock);
         };
 
         struct scoped_try_lock
@@ -52,7 +52,7 @@ namespace hpx { namespace util
             ~scoped_try_lock();
             void unlock();
             bool locked;
-            HPX_MOVABLE_BUT_NOT_COPYABLE(scoped_try_lock);
+            HPX_MOVABLE_ONLY(scoped_try_lock);
         };
 
         typedef hpx::lcos::local::spinlock mutex_type;

--- a/hpx/runtime/actions/basic_action.hpp
+++ b/hpx/runtime/actions/basic_action.hpp
@@ -61,7 +61,7 @@ namespace hpx { namespace actions
         template <typename Action, typename F, typename ...Ts>
         struct continuation_thread_function
         {
-            HPX_MOVABLE_BUT_NOT_COPYABLE(continuation_thread_function)
+            HPX_MOVABLE_ONLY(continuation_thread_function)
 
         public:
             explicit continuation_thread_function(

--- a/hpx/runtime/actions/basic_action.hpp
+++ b/hpx/runtime/actions/basic_action.hpp
@@ -61,7 +61,7 @@ namespace hpx { namespace actions
         template <typename Action, typename F, typename ...Ts>
         struct continuation_thread_function
         {
-            HPX_MOVABLE_ONLY(continuation_thread_function)
+            HPX_MOVABLE_ONLY(continuation_thread_function);
 
         public:
             explicit continuation_thread_function(

--- a/hpx/runtime/actions/transfer_action.hpp
+++ b/hpx/runtime/actions/transfer_action.hpp
@@ -54,7 +54,7 @@ namespace hpx { namespace actions
     template <typename Action>
     struct transfer_action : base_action
     {
-        HPX_MOVABLE_BUT_NOT_COPYABLE(transfer_action)
+        HPX_MOVABLE_ONLY(transfer_action)
 
     public:
         typedef typename Action::component_type component_type;

--- a/hpx/runtime/actions/transfer_action.hpp
+++ b/hpx/runtime/actions/transfer_action.hpp
@@ -54,7 +54,7 @@ namespace hpx { namespace actions
     template <typename Action>
     struct transfer_action : base_action
     {
-        HPX_MOVABLE_ONLY(transfer_action)
+        HPX_MOVABLE_ONLY(transfer_action);
 
     public:
         typedef typename Action::component_type component_type;

--- a/hpx/runtime/applier/apply_callback.hpp
+++ b/hpx/runtime/applier/apply_callback.hpp
@@ -355,7 +355,7 @@ namespace hpx
         struct apply_c_p_cb_impl
         {
         private:
-            HPX_MOVABLE_BUT_NOT_COPYABLE(apply_c_p_cb_impl)
+            HPX_MOVABLE_ONLY(apply_c_p_cb_impl)
 
         public:
             typedef util::tuple<Ts...> tuple_type;

--- a/hpx/runtime/applier/apply_callback.hpp
+++ b/hpx/runtime/applier/apply_callback.hpp
@@ -355,7 +355,7 @@ namespace hpx
         struct apply_c_p_cb_impl
         {
         private:
-            HPX_MOVABLE_ONLY(apply_c_p_cb_impl)
+            HPX_MOVABLE_ONLY(apply_c_p_cb_impl);
 
         public:
             typedef util::tuple<Ts...> tuple_type;

--- a/hpx/runtime/components/pinned_ptr.hpp
+++ b/hpx/runtime/components/pinned_ptr.hpp
@@ -18,8 +18,11 @@ namespace hpx { namespace components
 {
     namespace detail
     {
-        struct pinned_ptr_base
+        class pinned_ptr_base
         {
+            HPX_NON_COPYABLE(pinned_ptr_base);
+
+        public:
             pinned_ptr_base() HPX_NOEXCEPT
               : lva_(0)
             {}
@@ -30,21 +33,6 @@ namespace hpx { namespace components
 
             virtual ~pinned_ptr_base() {}
 
-#if defined(HPX_HAVE_CXX11_DELETED_FUNCTIONS)
-            pinned_ptr_base(pinned_ptr_base const&) = delete;
-            pinned_ptr_base(pinned_ptr_base &&) = delete;
-
-            pinned_ptr_base& operator= (pinned_ptr_base const&) = delete;
-            pinned_ptr_base& operator= (pinned_ptr_base &&) = delete;
-#else
-        private:
-            pinned_ptr_base(pinned_ptr_base const&);
-            pinned_ptr_base(pinned_ptr_base &&);
-
-            pinned_ptr_base& operator= (pinned_ptr_base const&);
-            pinned_ptr_base& operator= (pinned_ptr_base &&);
-#endif
-
         protected:
             naming::address::address_type lva_;
         };
@@ -52,6 +40,8 @@ namespace hpx { namespace components
         template <typename Component>
         class pinned_ptr : public pinned_ptr_base
         {
+            HPX_NON_COPYABLE(pinned_ptr);
+
         public:
             pinned_ptr() HPX_NOEXCEPT {}
 
@@ -66,21 +56,6 @@ namespace hpx { namespace components
             {
                 unpin();
             }
-
-#if defined(HPX_HAVE_CXX11_DELETED_FUNCTIONS)
-            pinned_ptr(pinned_ptr const&) = delete;
-            pinned_ptr(pinned_ptr &&) = delete;
-
-            pinned_ptr& operator= (pinned_ptr const&) = delete;
-            pinned_ptr& operator= (pinned_ptr &&) = delete;
-#else
-        private:
-            pinned_ptr(pinned_ptr const&);
-            pinned_ptr(pinned_ptr &&);
-
-            pinned_ptr& operator= (pinned_ptr const&);
-            pinned_ptr& operator= (pinned_ptr &&);
-#endif
 
         protected:
             void pin()
@@ -124,14 +99,8 @@ namespace hpx { namespace components
         }
 
 #if !defined(HPX_INTEL_VERSION) || (HPX_INTEL_VERSION > 1400)
-#if defined(HPX_HAVE_CXX11_DELETED_FUNCTIONS)
-        pinned_ptr(pinned_ptr const&) = delete;
-        pinned_ptr& operator= (pinned_ptr const&) = delete;
-#else
-    private:
-        pinned_ptr(pinned_ptr const&);
-        pinned_ptr& operator= (pinned_ptr const&);
-#endif
+        HPX_DELETE_COPY_CTOR(pinned_ptr);
+        HPX_DELETE_COPY_ASSIGN(pinned_ptr);
 #endif
 
     private:

--- a/hpx/runtime/naming/name.hpp
+++ b/hpx/runtime/naming/name.hpp
@@ -711,7 +711,7 @@ namespace hpx { namespace naming
         ///////////////////////////////////////////////////////////////////////
         struct HPX_EXPORT id_type_impl : gid_type
         {
-            HPX_MOVABLE_BUT_NOT_COPYABLE(id_type_impl)
+            HPX_MOVABLE_ONLY(id_type_impl)
         private:
             typedef void (*deleter_type)(detail::id_type_impl*);
             static deleter_type get_deleter(id_type_management t);

--- a/hpx/runtime/naming/name.hpp
+++ b/hpx/runtime/naming/name.hpp
@@ -711,7 +711,7 @@ namespace hpx { namespace naming
         ///////////////////////////////////////////////////////////////////////
         struct HPX_EXPORT id_type_impl : gid_type
         {
-            HPX_MOVABLE_ONLY(id_type_impl)
+            HPX_MOVABLE_ONLY(id_type_impl);
         private:
             typedef void (*deleter_type)(detail::id_type_impl*);
             static deleter_type get_deleter(id_type_management t);

--- a/hpx/runtime/parcelset/detail/call_for_each.hpp
+++ b/hpx/runtime/parcelset/detail/call_for_each.hpp
@@ -17,7 +17,7 @@ namespace hpx { namespace parcelset
     {
         struct call_for_each
         {
-            HPX_MOVABLE_BUT_NOT_COPYABLE(call_for_each);
+            HPX_MOVABLE_ONLY(call_for_each);
         public:
             typedef void result_type;
 

--- a/hpx/runtime/parcelset/parcel.hpp
+++ b/hpx/runtime/parcelset/parcel.hpp
@@ -47,7 +47,7 @@ namespace hpx { namespace parcelset
     class HPX_EXPORT parcel
     {
     private:
-        HPX_MOVABLE_BUT_NOT_COPYABLE(parcel)
+        HPX_MOVABLE_ONLY(parcel)
 
     private:
 #if defined(HPX_DEBUG)
@@ -138,7 +138,7 @@ namespace hpx { namespace parcelset
         struct data
         {
         private:
-            HPX_MOVABLE_BUT_NOT_COPYABLE(data)
+            HPX_MOVABLE_ONLY(data)
 
         public:
             data()

--- a/hpx/runtime/parcelset/parcel.hpp
+++ b/hpx/runtime/parcelset/parcel.hpp
@@ -47,7 +47,7 @@ namespace hpx { namespace parcelset
     class HPX_EXPORT parcel
     {
     private:
-        HPX_MOVABLE_ONLY(parcel)
+        HPX_MOVABLE_ONLY(parcel);
 
     private:
 #if defined(HPX_DEBUG)
@@ -138,7 +138,7 @@ namespace hpx { namespace parcelset
         struct data
         {
         private:
-            HPX_MOVABLE_ONLY(data)
+            HPX_MOVABLE_ONLY(data);
 
         public:
             data()

--- a/hpx/runtime/parcelset/parcel_buffer.hpp
+++ b/hpx/runtime/parcelset/parcel_buffer.hpp
@@ -99,7 +99,7 @@ namespace hpx { namespace parcelset
 
         /// Counters and their data containers.
         performance_counters::parcels::data_point data_point_;
-        HPX_MOVABLE_ONLY(parcel_buffer)
+        HPX_MOVABLE_ONLY(parcel_buffer);
     };
 }}
 

--- a/hpx/runtime/parcelset/parcel_buffer.hpp
+++ b/hpx/runtime/parcelset/parcel_buffer.hpp
@@ -99,7 +99,7 @@ namespace hpx { namespace parcelset
 
         /// Counters and their data containers.
         performance_counters::parcels::data_point data_point_;
-        HPX_MOVABLE_BUT_NOT_COPYABLE(parcel_buffer)
+        HPX_MOVABLE_ONLY(parcel_buffer)
     };
 }}
 

--- a/hpx/runtime/threads/coroutines/coroutine.hpp
+++ b/hpx/runtime/threads/coroutines/coroutine.hpp
@@ -52,7 +52,7 @@ namespace hpx { namespace threads { namespace coroutines
     class coroutine
     {
     private:
-        HPX_MOVABLE_BUT_NOT_COPYABLE(coroutine)
+        HPX_MOVABLE_ONLY(coroutine)
 
     public:
         friend struct detail::coroutine_accessor;

--- a/hpx/runtime/threads/coroutines/coroutine.hpp
+++ b/hpx/runtime/threads/coroutines/coroutine.hpp
@@ -52,7 +52,7 @@ namespace hpx { namespace threads { namespace coroutines
     class coroutine
     {
     private:
-        HPX_MOVABLE_ONLY(coroutine)
+        HPX_MOVABLE_ONLY(coroutine);
 
     public:
         friend struct detail::coroutine_accessor;

--- a/hpx/runtime/threads/coroutines/detail/tss.hpp
+++ b/hpx/runtime/threads/coroutines/detail/tss.hpp
@@ -111,7 +111,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         }
 
 #if !(defined(HPX_INTEL_VERSION) && __GNUC__ == 4 && __GNUC_MINOR__ == 6)
-        HPX_MOVABLE_ONLY(tss_data_node)
+        HPX_MOVABLE_ONLY(tss_data_node);
 #endif
     };
 

--- a/hpx/runtime/threads/coroutines/detail/tss.hpp
+++ b/hpx/runtime/threads/coroutines/detail/tss.hpp
@@ -111,7 +111,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         }
 
 #if !(defined(HPX_INTEL_VERSION) && __GNUC__ == 4 && __GNUC_MINOR__ == 6)
-        HPX_MOVABLE_BUT_NOT_COPYABLE(tss_data_node)
+        HPX_MOVABLE_ONLY(tss_data_node)
 #endif
     };
 

--- a/hpx/runtime/threads/scheduler_specific_ptr.hpp
+++ b/hpx/runtime/threads/scheduler_specific_ptr.hpp
@@ -12,7 +12,6 @@
 #define HPX_RUNTIME_THREADS_SCHEDULER_TSS_AUG_08_2015_0733PM
 
 #include <hpx/config.hpp>
-#include <hpx/config/emulate_deleted.hpp>
 #include <hpx/runtime/threads/thread_data_fwd.hpp>
 #include <hpx/runtime/threads/coroutines/detail/tss.hpp>
 

--- a/hpx/runtime/threads/thread.hpp
+++ b/hpx/runtime/threads/thread.hpp
@@ -50,7 +50,7 @@ namespace hpx
 
         ~thread();
 
-        HPX_MOVABLE_BUT_NOT_COPYABLE(thread)
+        HPX_MOVABLE_ONLY(thread)
 
     public:
         thread(thread &&) HPX_NOEXCEPT;

--- a/hpx/runtime/threads/thread.hpp
+++ b/hpx/runtime/threads/thread.hpp
@@ -50,7 +50,7 @@ namespace hpx
 
         ~thread();
 
-        HPX_MOVABLE_ONLY(thread)
+        HPX_MOVABLE_ONLY(thread);
 
     public:
         thread(thread &&) HPX_NOEXCEPT;

--- a/hpx/runtime/threads/thread_data.hpp
+++ b/hpx/runtime/threads/thread_data.hpp
@@ -76,7 +76,7 @@ namespace hpx { namespace threads
     /// implemented by the thread-manager.
     class thread_data
     {
-        HPX_MOVABLE_BUT_NOT_COPYABLE(thread_data);
+        HPX_MOVABLE_ONLY(thread_data);
 
         // Avoid warning about using 'this' in initializer list
         thread_data* this_() { return this; }

--- a/hpx/runtime/threads/thread_init_data.hpp
+++ b/hpx/runtime/threads/thread_init_data.hpp
@@ -20,7 +20,7 @@ namespace hpx { namespace threads
     ///////////////////////////////////////////////////////////////////////////
     class thread_init_data
     {
-        HPX_MOVABLE_ONLY(thread_init_data)
+        HPX_MOVABLE_ONLY(thread_init_data);
 
     public:
         thread_init_data()

--- a/hpx/runtime/threads/thread_init_data.hpp
+++ b/hpx/runtime/threads/thread_init_data.hpp
@@ -20,7 +20,7 @@ namespace hpx { namespace threads
     ///////////////////////////////////////////////////////////////////////////
     class thread_init_data
     {
-        HPX_MOVABLE_BUT_NOT_COPYABLE(thread_init_data)
+        HPX_MOVABLE_ONLY(thread_init_data)
 
     public:
         thread_init_data()

--- a/hpx/util/bind.hpp
+++ b/hpx/util/bind.hpp
@@ -261,10 +261,8 @@ namespace hpx { namespace util
             {}
 #endif
 
-#if defined(HPX_HAVE_CXX11_DELETED_FUNCTIONS)
-            bound& operator=(bound const&) = delete;
-            bound& operator=(bound&&) = delete;
-#endif
+            HPX_DELETE_COPY_ASSIGN(bound);
+            HPX_DELETE_MOVE_ASSIGN(bound);
 
             template <typename ...Us>
             inline typename bound_result_of<

--- a/hpx/util/deferred_call.hpp
+++ b/hpx/util/deferred_call.hpp
@@ -71,9 +71,8 @@ namespace hpx { namespace util
             {}
 #endif
 
-#if defined(HPX_HAVE_CXX11_DELETED_FUNCTIONS)
-            deferred& operator=(deferred&&) = delete;
-#endif
+            HPX_DELETE_COPY_ASSIGN(deferred);
+            HPX_DELETE_MOVE_ASSIGN(deferred);
 
             inline typename deferred_result_of<F(Ts...)>::type
             operator()()

--- a/hpx/util/detail/basic_function.hpp
+++ b/hpx/util/detail/basic_function.hpp
@@ -119,7 +119,7 @@ namespace hpx { namespace util { namespace detail
     template <typename VTablePtr, typename R, typename ...Ts>
     class function_base<VTablePtr, R(Ts...)>
     {
-        HPX_MOVABLE_ONLY(function_base)
+        HPX_MOVABLE_ONLY(function_base);
 
         // make sure the empty table instance is initialized in time, even
         // during early startup
@@ -296,7 +296,7 @@ namespace hpx { namespace util { namespace detail
           , R(Ts...)
         >
     {
-        HPX_MOVABLE_ONLY(basic_function)
+        HPX_MOVABLE_ONLY(basic_function);
 
         typedef serializable_function_vtable_ptr<VTablePtr> vtable_ptr;
         typedef function_base<vtable_ptr, R(Ts...)> base_type;
@@ -357,7 +357,7 @@ namespace hpx { namespace util { namespace detail
     class basic_function<VTablePtr, R(Ts...), false>
       : public function_base<VTablePtr, R(Ts...)>
     {
-        HPX_MOVABLE_ONLY(basic_function)
+        HPX_MOVABLE_ONLY(basic_function);
 
         typedef function_base<VTablePtr, R(Ts...)> base_type;
 

--- a/hpx/util/detail/basic_function.hpp
+++ b/hpx/util/detail/basic_function.hpp
@@ -119,7 +119,7 @@ namespace hpx { namespace util { namespace detail
     template <typename VTablePtr, typename R, typename ...Ts>
     class function_base<VTablePtr, R(Ts...)>
     {
-        HPX_MOVABLE_BUT_NOT_COPYABLE(function_base)
+        HPX_MOVABLE_ONLY(function_base)
 
         // make sure the empty table instance is initialized in time, even
         // during early startup
@@ -296,7 +296,7 @@ namespace hpx { namespace util { namespace detail
           , R(Ts...)
         >
     {
-        HPX_MOVABLE_BUT_NOT_COPYABLE(basic_function)
+        HPX_MOVABLE_ONLY(basic_function)
 
         typedef serializable_function_vtable_ptr<VTablePtr> vtable_ptr;
         typedef function_base<vtable_ptr, R(Ts...)> base_type;
@@ -357,7 +357,7 @@ namespace hpx { namespace util { namespace detail
     class basic_function<VTablePtr, R(Ts...), false>
       : public function_base<VTablePtr, R(Ts...)>
     {
-        HPX_MOVABLE_BUT_NOT_COPYABLE(basic_function)
+        HPX_MOVABLE_ONLY(basic_function)
 
         typedef function_base<VTablePtr, R(Ts...)> base_type;
 

--- a/hpx/util/detail/unique_function_template.hpp
+++ b/hpx/util/detail/unique_function_template.hpp
@@ -71,7 +71,7 @@ namespace hpx { namespace util
         typedef detail::unique_function_vtable_ptr<R(Ts...)> vtable_ptr;
         typedef detail::basic_function<vtable_ptr, R(Ts...), Serializable> base_type;
 
-        HPX_MOVABLE_BUT_NOT_COPYABLE(unique_function)
+        HPX_MOVABLE_ONLY(unique_function)
 
     public:
         typedef typename base_type::result_type result_type;
@@ -144,7 +144,7 @@ namespace hpx { namespace util
     {
         typedef unique_function<R(Ts...), false> base_type;
 
-        HPX_MOVABLE_BUT_NOT_COPYABLE(unique_function_nonser);
+        HPX_MOVABLE_ONLY(unique_function_nonser);
 
     public:
         unique_function_nonser() HPX_NOEXCEPT

--- a/hpx/util/detail/unique_function_template.hpp
+++ b/hpx/util/detail/unique_function_template.hpp
@@ -71,7 +71,7 @@ namespace hpx { namespace util
         typedef detail::unique_function_vtable_ptr<R(Ts...)> vtable_ptr;
         typedef detail::basic_function<vtable_ptr, R(Ts...), Serializable> base_type;
 
-        HPX_MOVABLE_ONLY(unique_function)
+        HPX_MOVABLE_ONLY(unique_function);
 
     public:
         typedef typename base_type::result_type result_type;

--- a/hpx/util/functional/colocated_helpers.hpp
+++ b/hpx/util/functional/colocated_helpers.hpp
@@ -51,7 +51,7 @@ namespace hpx { namespace util { namespace functional
         template <typename Bound>
         struct apply_continuation_impl
         {
-            HPX_MOVABLE_BUT_NOT_COPYABLE(apply_continuation_impl)
+            HPX_MOVABLE_ONLY(apply_continuation_impl)
         public:
             typedef typename util::decay<Bound>::type bound_type;
 
@@ -160,7 +160,7 @@ namespace hpx { namespace util { namespace functional
         template <typename Bound>
         struct async_continuation_impl
         {
-            HPX_MOVABLE_BUT_NOT_COPYABLE(async_continuation_impl)
+            HPX_MOVABLE_ONLY(async_continuation_impl)
         public:
             typedef typename util::decay<Bound>::type bound_type;
 

--- a/hpx/util/functional/colocated_helpers.hpp
+++ b/hpx/util/functional/colocated_helpers.hpp
@@ -51,7 +51,7 @@ namespace hpx { namespace util { namespace functional
         template <typename Bound>
         struct apply_continuation_impl
         {
-            HPX_MOVABLE_ONLY(apply_continuation_impl)
+            HPX_MOVABLE_ONLY(apply_continuation_impl);
         public:
             typedef typename util::decay<Bound>::type bound_type;
 
@@ -160,7 +160,7 @@ namespace hpx { namespace util { namespace functional
         template <typename Bound>
         struct async_continuation_impl
         {
-            HPX_MOVABLE_ONLY(async_continuation_impl)
+            HPX_MOVABLE_ONLY(async_continuation_impl);
         public:
             typedef typename util::decay<Bound>::type bound_type;
 

--- a/hpx/util/interval_timer.hpp
+++ b/hpx/util/interval_timer.hpp
@@ -98,7 +98,7 @@ namespace hpx { namespace util
 {
     class HPX_EXPORT interval_timer
     {
-        HPX_MOVABLE_BUT_NOT_COPYABLE(interval_timer)
+        HPX_MOVABLE_ONLY(interval_timer)
 
     public:
         interval_timer();

--- a/hpx/util/interval_timer.hpp
+++ b/hpx/util/interval_timer.hpp
@@ -98,7 +98,7 @@ namespace hpx { namespace util
 {
     class HPX_EXPORT interval_timer
     {
-        HPX_MOVABLE_ONLY(interval_timer)
+        HPX_MOVABLE_ONLY(interval_timer);
 
     public:
         interval_timer();

--- a/hpx/util/spinlock.hpp
+++ b/hpx/util/spinlock.hpp
@@ -8,7 +8,7 @@
 #if !defined(HPX_DF595582_FEBC_4EE0_A606_A1EEB171D770)
 #define HPX_DF595582_FEBC_4EE0_A606_A1EEB171D770
 
-#include <hpx/config/emulate_deleted.hpp>
+#include <hpx/config.hpp>
 #include <hpx/util/itt_notify.hpp>
 #include <hpx/util/register_locks.hpp>
 

--- a/hpx/util/spinlock_pool.hpp
+++ b/hpx/util/spinlock_pool.hpp
@@ -18,7 +18,7 @@
 # pragma once
 #endif
 
-#include <hpx/config/emulate_deleted.hpp>
+#include <hpx/config.hpp>
 #include <hpx/util/itt_notify.hpp>
 #include <hpx/util/register_locks.hpp>
 

--- a/hpx/util/unlock_guard.hpp
+++ b/hpx/util/unlock_guard.hpp
@@ -8,7 +8,6 @@
 #define HPX_UTIL_UNLOCK_GUARD_HPP
 
 #include <hpx/config.hpp>
-#include <hpx/config/emulate_deleted.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace util

--- a/hpx/util/unlock_guard.hpp
+++ b/hpx/util/unlock_guard.hpp
@@ -18,7 +18,7 @@ namespace hpx { namespace util
     template <typename Mutex>
     class unlock_guard
     {
-        HPX_NON_COPYABLE(unlock_guard)
+        HPX_NON_COPYABLE(unlock_guard);
 
     public:
         typedef Mutex mutex_type;

--- a/tests/performance/local/spinlock_overhead1.cpp
+++ b/tests/performance/local/spinlock_overhead1.cpp
@@ -4,7 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config/emulate_deleted.hpp>
+#include <hpx/config.hpp>
 #include <hpx/runtime.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/lcos/wait_each.hpp>

--- a/tests/performance/local/spinlock_overhead2.cpp
+++ b/tests/performance/local/spinlock_overhead2.cpp
@@ -4,7 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config/emulate_deleted.hpp>
+#include <hpx/config.hpp>
 #include <hpx/runtime.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/lcos/wait_each.hpp>

--- a/tests/regressions/actions/shared_future_serialization_1402.cpp
+++ b/tests/regressions/actions/shared_future_serialization_1402.cpp
@@ -13,7 +13,7 @@ struct movable_only
     movable_only(movable_only&&) {}
 
 private:
-    HPX_MOVABLE_BUT_NOT_COPYABLE(movable_only);
+    HPX_MOVABLE_ONLY(movable_only);
 };
 
 void pass_shared_future_movable(hpx::shared_future<movable_only> const& obj) {}

--- a/tests/regressions/components/moveonly_constructor_arguments_1405.cpp
+++ b/tests/regressions/components/moveonly_constructor_arguments_1405.cpp
@@ -14,7 +14,7 @@
 struct moveonly
 {
 private:
-    HPX_MOVABLE_BUT_NOT_COPYABLE(moveonly);
+    HPX_MOVABLE_ONLY(moveonly);
 
 public:
     moveonly() {}

--- a/tests/unit/lcos/future.cpp
+++ b/tests/unit/lcos/future.cpp
@@ -22,7 +22,7 @@
 struct X
 {
 private:
-    HPX_MOVABLE_BUT_NOT_COPYABLE(X);
+    HPX_MOVABLE_ONLY(X);
 
 public:
     int i;

--- a/tests/unit/lcos/shared_mutex/thread_group.hpp
+++ b/tests/unit/lcos/shared_mutex/thread_group.hpp
@@ -30,7 +30,7 @@ namespace test
     class thread_group
     {
     private:
-        HPX_MOVABLE_BUT_NOT_COPYABLE(thread_group);
+        HPX_MOVABLE_ONLY(thread_group);
 
         typedef hpx::lcos::local::shared_mutex mutex_type;
 


### PR DESCRIPTION
Rename `HPX_MOVABLE_BUT_NOT_COPYABLE` to `HPX_MOVABLE_ONLY`, mark C++11 deleted functions as required.