### PR TITLE
Algorithm cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -625,6 +625,14 @@ if(HPX_WITH_LOCAL_DATAFLOW_COMPATIBILITY)
   hpx_add_config_define(HPX_HAVE_LOCAL_DATAFLOW_COMPATIBILITY)
 endif()
 
+# HPX_WITH_GENERIC_EXECUTION_POLICY: introduced in V0.9.12
+hpx_option(HPX_WITH_GENERIC_EXECUTION_POLICY BOOL
+    "Enable the generic execution policy (default: OFF)"
+    OFF ADVANCED)
+if(HPX_WITH_GENERIC_EXECUTION_POLICY)
+  hpx_add_config_define(HPX_HAVE_GENERIC_EXECUTION_POLICY)
+endif()
+
 # BADBAD: This enables an overload of swap is necessary to work around the
 #         problems caused by zip_iterator not being a real random access iterator.
 #         Dereferencing zip_iterator does not yield a true reference but

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -116,6 +116,7 @@ set(doxygen_dependencies
     "${PROJECT_SOURCE_DIR}/hpx/parallel/executors/executor_parameter_traits.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/executors/guided_chunk_size.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/executors/parallel_executor.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/executors/persistent_auto_chunk_size.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/executors/sequential_executor.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/executors/service_executors.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/executors/static_chunk_size.hpp"

--- a/docs/hpx.idx
+++ b/docs/hpx.idx
@@ -137,6 +137,9 @@ parallel::guided_chunk_size                 "guided_chunk_size"             "hpx
 # hpx/parallel/executors/auto_chunk_size.hpp
 parallel::auto_chunk_size                   "auto_chunk_size"               "hpx\.parallel\.v3\.auto_chunk_size.*"
 
+# hpx/parallel/executors/persistent_auto_chunk_size.hpp
+parallel::persistent_auto_chunk_size        "persistent_auto_chunk_size"    "hpx\.parallel\.v3\.persistent_auto_chunk_size.*"
+
 
 # hpx/parallel/algorithms/adjacent_difference.hpp
 parallel::adjacent_difference         "adjacent_difference" "hpx\.parallel\.v1\.adjacent_difference.*"

--- a/docs/whats_new.qbk
+++ b/docs/whats_new.qbk
@@ -79,6 +79,10 @@ to a different compute node).
 * The facility `hpx::lcos::make_future_void()` has been replaced by
   `hpx::make_future<void>()`.
 * We have removed support for Intel V13 and gcc 4.4.x.
+* We have removed the generic `parallel::execution_policy` by default. This
+  feature was removed by the C++ committee from the Parallelism TS V1 when it
+  was moved to C++17. This can still be enabled by specifying
+  `-DHPX_WITH_GENERIC_EXECUTION_POLICY=On` at the configure step.
 
 [heading Bug Fixes (Closed Tickets)]
 

--- a/hpx/exception_list.hpp
+++ b/hpx/exception_list.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -13,6 +13,8 @@
 #include <hpx/util/unlock_guard.hpp>
 
 #include <boost/thread/locks.hpp>
+#include <boost/exception_ptr.hpp>
+#include <boost/system/error_code.hpp>
 
 #include <list>
 #include <string>

--- a/hpx/hpx_finalize.hpp
+++ b/hpx/hpx_finalize.hpp
@@ -9,6 +9,7 @@
 #define HPX_FINALIZE_OCT_04_2012_0809PM
 
 #include <hpx/config.hpp>
+#include <hpx/exception_fwd.hpp>
 
 /// \namespace hpx
 namespace hpx

--- a/hpx/hpx_finalize.hpp
+++ b/hpx/hpx_finalize.hpp
@@ -8,7 +8,7 @@
 #if !defined(HPX_FINALIZE_OCT_04_2012_0809PM)
 #define HPX_FINALIZE_OCT_04_2012_0809PM
 
-#include <hpx/hpx_fwd.hpp>
+#include <hpx/config.hpp>
 
 /// \namespace hpx
 namespace hpx

--- a/hpx/parallel/algorithm.hpp
+++ b/hpx/parallel/algorithm.hpp
@@ -7,7 +7,7 @@
 #if !defined(HPX_PARALLEL_ALGORITHM_MAY_28_2014_0522PM)
 #define HPX_PARALLEL_ALGORITHM_MAY_28_2014_0522PM
 
-#include <hpx/hpx_fwd.hpp>
+#include <hpx/config.hpp>
 
 /// See N4310: 1.3/3
 #include <algorithm>

--- a/hpx/parallel/algorithms/adjacent_difference.hpp
+++ b/hpx/parallel/algorithms/adjacent_difference.hpp
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_ALGORITHM_ADJACENT_DIF_JUL_15
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 #include <hpx/util/zip_iterator.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
@@ -21,9 +22,7 @@
 #include <algorithm>
 #include <numeric>
 #include <iterator>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -152,37 +151,28 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///
 
     template <typename ExPolicy, typename InIter, typename OutIter>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     >::type
     adjacent_difference(ExPolicy&& policy, InIter first, InIter last,
         OutIter dest)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
         typedef typename std::iterator_traits<InIter>::value_type value_type;
 
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag,
-                iterator_category>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Requires at least input iterator.");
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>,
-            boost::is_same<std::output_iterator_tag, output_iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_input_iterator<InIter>::value
+            > is_seq;
 
         return detail::adjacent_difference<OutIter>().call(
             std::forward<ExPolicy>(policy), is_seq(), first, last, dest,
@@ -256,36 +246,26 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///
     template <typename ExPolicy, typename InIter, typename OutIter,
         typename Op>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     >::type
     adjacent_difference(ExPolicy&& policy, InIter first, InIter last,
         OutIter dest, Op && op)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag,
-                iterator_category>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Requires at least input iterator.");
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>,
-            boost::is_same<std::output_iterator_tag, output_iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_input_iterator<InIter>::value
+            > is_seq;
 
         return detail::adjacent_difference<OutIter>().call(
             std::forward<ExPolicy>(policy), is_seq(), first, last, dest,

--- a/hpx/parallel/algorithms/adjacent_difference.hpp
+++ b/hpx/parallel/algorithms/adjacent_difference.hpp
@@ -170,8 +170,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value
+               !hpx::traits::is_forward_iterator<OutIter>::value ||
+               !hpx::traits::is_forward_iterator<InIter>::value
             > is_seq;
 
         return detail::adjacent_difference<OutIter>().call(
@@ -263,8 +263,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value
+               !hpx::traits::is_forward_iterator<OutIter>::value ||
+               !hpx::traits::is_forward_iterator<InIter>::value
             > is_seq;
 
         return detail::adjacent_difference<OutIter>().call(

--- a/hpx/parallel/algorithms/adjacent_difference.hpp
+++ b/hpx/parallel/algorithms/adjacent_difference.hpp
@@ -161,17 +161,17 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         typedef typename std::iterator_traits<InIter>::value_type value_type;
 
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
+                hpx::traits::is_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
                 hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_input_iterator<InIter>::value
+                hpx::traits::is_just_input_iterator<InIter>::value
             > is_seq;
 
         return detail::adjacent_difference<OutIter>().call(
@@ -254,17 +254,17 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         OutIter dest, Op && op)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
+                hpx::traits::is_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
                 hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_input_iterator<InIter>::value
+                hpx::traits::is_just_input_iterator<InIter>::value
             > is_seq;
 
         return detail::adjacent_difference<OutIter>().call(

--- a/hpx/parallel/algorithms/adjacent_find.hpp
+++ b/hpx/parallel/algorithms/adjacent_find.hpp
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_DETAIL_ADJACENT_FIND_SEP_20_2014_0731PM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 
 #include <hpx/parallel/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/predicates.hpp>
@@ -20,9 +21,7 @@
 
 #include <algorithm>
 #include <iterator>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -145,19 +144,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           \a last is returned
     ///
     template <typename ExPolicy, typename FwdIter>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
     >::type
     adjacent_find(ExPolicy && policy, FwdIter first, FwdIter last)
     {
-        typedef typename std::iterator_traits<FwdIter>::iterator_category
-            iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::forward_iterator_tag, iterator_category
-            >::value),
+            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
             "Requires at least a forward iterator");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;
@@ -230,19 +224,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           predicate \a op.
     ///
     template <typename ExPolicy, typename FwdIter, typename Pred>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
     >::type
     adjacent_find(ExPolicy && policy, FwdIter first, FwdIter last, Pred && op)
     {
-        typedef typename std::iterator_traits<FwdIter>::iterator_category
-            iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::forward_iterator_tag, iterator_category
-            >::value),
+            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
             "Requires at least a forward iterator");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;

--- a/hpx/parallel/algorithms/adjacent_find.hpp
+++ b/hpx/parallel/algorithms/adjacent_find.hpp
@@ -151,7 +151,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     adjacent_find(ExPolicy && policy, FwdIter first, FwdIter last)
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least a forward iterator");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;
@@ -231,7 +231,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     adjacent_find(ExPolicy && policy, FwdIter first, FwdIter last, Pred && op)
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least a forward iterator");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;

--- a/hpx/parallel/algorithms/all_any_none.hpp
+++ b/hpx/parallel/algorithms/all_any_none.hpp
@@ -155,12 +155,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     none_of(ExPolicy && policy, InIter first, InIter last, F && f)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value
+                hpx::traits::is_just_input_iterator<InIter>::value
             > is_seq;
 
         return detail::none_of().call(
@@ -296,12 +296,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     any_of(ExPolicy && policy, InIter first, InIter last, F && f)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value
+                hpx::traits::is_just_input_iterator<InIter>::value
             > is_seq;
 
         return detail::any_of().call(
@@ -436,12 +436,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     all_of(ExPolicy && policy, InIter first, InIter last, F && f)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value
+                hpx::traits::is_just_input_iterator<InIter>::value
             > is_seq;
 
         return detail::all_of().call(

--- a/hpx/parallel/algorithms/all_any_none.hpp
+++ b/hpx/parallel/algorithms/all_any_none.hpp
@@ -160,7 +160,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value
             > is_seq;
 
         return detail::none_of().call(
@@ -301,7 +301,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value
             > is_seq;
 
         return detail::any_of().call(
@@ -441,7 +441,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value
             > is_seq;
 
         return detail::all_of().call(

--- a/hpx/parallel/algorithms/all_any_none.hpp
+++ b/hpx/parallel/algorithms/all_any_none.hpp
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_DETAIL_ALL_ANY_NONE_JUL_05_2014_0940PM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 #include <hpx/util/void_guard.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
@@ -19,11 +20,10 @@
 #include <hpx/parallel/util/loop.hpp>
 
 #include <boost/range/functions.hpp>
-#include <boost/type_traits/is_base_of.hpp>
-#include <boost/utility/enable_if.hpp>
 
 #include <algorithm>
 #include <iterator>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -148,23 +148,20 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           otherwise. It returns true if the range is empty.
     ///
     template <typename ExPolicy, typename InIter, typename F>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, bool>::type
     >::type
     none_of(ExPolicy && policy, InIter first, InIter last, F && f)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value
+            > is_seq;
 
         return detail::none_of().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -292,23 +289,20 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           false otherwise. It returns false if the range is empty.
     ///
     template <typename ExPolicy, typename InIter, typename F>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, bool>::type
     >::type
     any_of(ExPolicy && policy, InIter first, InIter last, F && f)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value
+            > is_seq;
 
         return detail::any_of().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -435,23 +429,20 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           otherwise. It returns true if the range is empty.
     ///
     template <typename ExPolicy, typename InIter, typename F>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, bool>::type
     >::type
     all_of(ExPolicy && policy, InIter first, InIter last, F && f)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value
+            > is_seq;
 
         return detail::all_of().call(
             std::forward<ExPolicy>(policy), is_seq(),

--- a/hpx/parallel/algorithms/copy.hpp
+++ b/hpx/parallel/algorithms/copy.hpp
@@ -102,8 +102,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         {
             typedef std::integral_constant<bool,
                     parallel::is_sequential_execution_policy<ExPolicy>::value ||
-                    hpx::traits::is_just_input_iterator<InIter>::value ||
-                    hpx::traits::is_output_iterator<OutIter>::value
+                   !hpx::traits::is_forward_iterator<InIter>::value ||
+                   !hpx::traits::is_forward_iterator<OutIter>::value
                 > is_seq;
 
             return detail::copy<std::pair<InIter, OutIter> >().call(
@@ -187,8 +187,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 hpx::traits::is_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef hpx::traits::segmented_iterator_traits<InIter> iterator_traits;
-        typedef typename iterator_traits::is_segmented_iterator is_segmented;
+        typedef hpx::traits::is_segmented_iterator<InIter> is_segmented;
 
         return hpx::util::make_tagged_pair<tag::in, tag::out>(
             detail::copy_(
@@ -342,8 +341,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value ||
+               !hpx::traits::is_forward_iterator<OutIter>::value
             > is_seq;
 
         return make_tagged_pair<tag::in, tag::out>(
@@ -572,8 +571,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value ||
+               !hpx::traits::is_forward_iterator<OutIter>::value
             > is_seq;
 
         return hpx::util::make_tagged_pair<tag::in, tag::out>(

--- a/hpx/parallel/algorithms/copy.hpp
+++ b/hpx/parallel/algorithms/copy.hpp
@@ -102,7 +102,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         {
             typedef std::integral_constant<bool,
                     parallel::is_sequential_execution_policy<ExPolicy>::value ||
-                    hpx::traits::is_input_iterator<InIter>::value ||
+                    hpx::traits::is_just_input_iterator<InIter>::value ||
                     hpx::traits::is_output_iterator<OutIter>::value
                 > is_seq;
 
@@ -180,11 +180,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     copy(ExPolicy && policy, InIter first, InIter last, OutIter dest)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Required at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
+                hpx::traits::is_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef hpx::traits::segmented_iterator_traits<InIter> iterator_traits;
@@ -322,11 +322,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     copy_n(ExPolicy && policy, InIter first, Size count, OutIter dest)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Required at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
+                hpx::traits::is_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         using hpx::util::tagged_pair;
@@ -342,7 +342,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_just_input_iterator<InIter>::value ||
                 hpx::traits::is_output_iterator<OutIter>::value
             > is_seq;
 
@@ -563,16 +563,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         Proj && proj = Proj())
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Required at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
+                hpx::traits::is_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_just_input_iterator<InIter>::value ||
                 hpx::traits::is_output_iterator<OutIter>::value
             > is_seq;
 

--- a/hpx/parallel/algorithms/copy.hpp
+++ b/hpx/parallel/algorithms/copy.hpp
@@ -33,8 +33,6 @@
 #include <iterator>
 #include <type_traits>
 
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
 #include <boost/shared_array.hpp>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
@@ -84,7 +82,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 return get_iter_pair(
                     for_each_n<zip_iterator>().call(
-                        std::forward<ExPolicy>(policy), boost::mpl::false_(),
+                        std::forward<ExPolicy>(policy), std::false_type(),
                         hpx::util::make_zip_iterator(first, dest),
                         std::distance(first, last),
                         [](reference t)
@@ -102,16 +100,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         copy_(ExPolicy && policy, InIter first, InIter last, OutIter dest,
             std::false_type)
         {
-            typedef typename std::iterator_traits<InIter>::iterator_category
-                input_iterator_category;
-            typedef typename std::iterator_traits<OutIter>::iterator_category
-                output_iterator_category;
-
-            typedef typename boost::mpl::or_<
-                parallel::is_sequential_execution_policy<ExPolicy>,
-                boost::is_same<std::input_iterator_tag, input_iterator_category>,
-                boost::is_same<std::output_iterator_tag, output_iterator_category>
-            >::type is_seq;
+            typedef std::integral_constant<bool,
+                    parallel::is_sequential_execution_policy<ExPolicy>::value ||
+                    hpx::traits::is_input_iterator<InIter>::value ||
+                    hpx::traits::is_output_iterator<OutIter>::value
+                > is_seq;
 
             return detail::copy<std::pair<InIter, OutIter> >().call(
                 std::forward<ExPolicy>(policy), is_seq(),
@@ -186,23 +179,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     >::type
     copy(ExPolicy && policy, InIter first, InIter last, OutIter dest)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            input_iterator_category;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Required at least input iterator.");
-
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef hpx::traits::segmented_iterator_traits<InIter> iterator_traits;
@@ -262,7 +244,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 return get_iter_pair(
                     for_each_n<zip_iterator>().call(
-                        std::forward<ExPolicy>(policy), boost::mpl::false_(),
+                        std::forward<ExPolicy>(policy), std::false_type(),
                         hpx::util::make_zip_iterator(first, dest),
                         count,
                         [](reference t)
@@ -339,23 +321,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     >::type
     copy_n(ExPolicy && policy, InIter first, Size count, OutIter dest)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            input_iterator_category;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Required at least input iterator.");
-
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         using hpx::util::tagged_pair;
@@ -369,11 +340,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 >::get(make_tagged_pair<tag::in, tag::out>(first, dest));
         }
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, input_iterator_category>,
-            boost::is_same<std::output_iterator_tag, output_iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_output_iterator<OutIter>::value
+            > is_seq;
 
         return make_tagged_pair<tag::in, tag::out>(
             detail::copy_n<std::pair<InIter, OutIter> >().call(
@@ -591,30 +562,19 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     copy_if(ExPolicy&& policy, InIter first, InIter last, OutIter dest, F && f,
         Proj && proj = Proj())
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            input_iterator_category;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Required at least input iterator.");
-
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, input_iterator_category>,
-            boost::is_same<std::output_iterator_tag, output_iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_output_iterator<OutIter>::value
+            > is_seq;
 
         return hpx::util::make_tagged_pair<tag::in, tag::out>(
             detail::copy_if<std::pair<InIter, OutIter> >().call(

--- a/hpx/parallel/algorithms/count.hpp
+++ b/hpx/parallel/algorithms/count.hpp
@@ -96,7 +96,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         {
             typedef std::integral_constant<bool,
                     parallel::is_sequential_execution_policy<ExPolicy>::value ||
-                    hpx::traits::is_input_iterator<InIter>::value
+                    hpx::traits::is_just_input_iterator<InIter>::value
                 > is_seq;
 
             typedef typename std::iterator_traits<InIter>::difference_type
@@ -170,7 +170,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     count(ExPolicy && policy, InIter first, InIter last, T const& value)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Required at least input iterator.");
 
         typedef hpx::traits::segmented_iterator_traits<InIter> iterator_traits;
@@ -249,7 +249,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         {
             typedef std::integral_constant<bool,
                     parallel::is_sequential_execution_policy<ExPolicy>::value ||
-                    hpx::traits::is_input_iterator<InIter>::value
+                    hpx::traits::is_just_input_iterator<InIter>::value
                 > is_seq;
 
             typedef typename std::iterator_traits<InIter>::difference_type
@@ -340,7 +340,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     count_if(ExPolicy && policy, InIter first, InIter last, F && f)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Required at least input iterator.");
 
         typedef hpx::traits::segmented_iterator_traits<InIter> iterator_traits;

--- a/hpx/parallel/algorithms/count.hpp
+++ b/hpx/parallel/algorithms/count.hpp
@@ -96,7 +96,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         {
             typedef std::integral_constant<bool,
                     parallel::is_sequential_execution_policy<ExPolicy>::value ||
-                    hpx::traits::is_just_input_iterator<InIter>::value
+                   !hpx::traits::is_forward_iterator<InIter>::value
                 > is_seq;
 
             typedef typename std::iterator_traits<InIter>::difference_type
@@ -173,8 +173,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             (hpx::traits::is_input_iterator<InIter>::value),
             "Required at least input iterator.");
 
-        typedef hpx::traits::segmented_iterator_traits<InIter> iterator_traits;
-        typedef typename iterator_traits::is_segmented_iterator is_segmented;
+        typedef hpx::traits::is_segmented_iterator<InIter> is_segmented;
 
         return detail::count_(
             std::forward<ExPolicy>(policy), first, last, value,
@@ -249,7 +248,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         {
             typedef std::integral_constant<bool,
                     parallel::is_sequential_execution_policy<ExPolicy>::value ||
-                    hpx::traits::is_just_input_iterator<InIter>::value
+                   !hpx::traits::is_forward_iterator<InIter>::value
                 > is_seq;
 
             typedef typename std::iterator_traits<InIter>::difference_type
@@ -343,8 +342,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             (hpx::traits::is_input_iterator<InIter>::value),
             "Required at least input iterator.");
 
-        typedef hpx::traits::segmented_iterator_traits<InIter> iterator_traits;
-        typedef typename iterator_traits::is_segmented_iterator is_segmented;
+        typedef hpx::traits::is_segmented_iterator<InIter> is_segmented;
 
         return detail::count_if_(
             std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),

--- a/hpx/parallel/algorithms/count.hpp
+++ b/hpx/parallel/algorithms/count.hpp
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_DETAIL_COUNT_JUNE_17_2014_1154AM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 #include <hpx/util/unwrapped.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
@@ -19,8 +20,6 @@
 #include <hpx/parallel/util/loop.hpp>
 
 #include <boost/range/functions.hpp>
-#include <boost/type_traits/is_base_of.hpp>
-#include <boost/utility/enable_if.hpp>
 
 #include <algorithm>
 #include <iterator>
@@ -95,13 +94,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         count_(ExPolicy && policy, InIter first, InIter last, T const& value,
             std::false_type)
         {
-            typedef typename std::iterator_traits<InIter>::iterator_category
-                category;
-
-            typedef typename boost::mpl::or_<
-                parallel::is_sequential_execution_policy<ExPolicy>,
-                boost::is_same<std::input_iterator_tag, category>
-            >::type is_seq;
+            typedef std::integral_constant<bool,
+                    parallel::is_sequential_execution_policy<ExPolicy>::value ||
+                    hpx::traits::is_input_iterator<InIter>::value
+                > is_seq;
 
             typedef typename std::iterator_traits<InIter>::difference_type
                 difference_type;
@@ -165,19 +161,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           satisfying the given criteria.
     ///
     template <typename ExPolicy, typename InIter, typename T>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy,
             typename std::iterator_traits<InIter>::difference_type
         >::type
     >::type
     count(ExPolicy && policy, InIter first, InIter last, T const& value)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            category;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, category>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Required at least input iterator.");
 
         typedef hpx::traits::segmented_iterator_traits<InIter> iterator_traits;
@@ -254,13 +247,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         count_if_(ExPolicy && policy, InIter first, InIter last, F && f,
             std::false_type)
         {
-            typedef typename std::iterator_traits<InIter>::iterator_category
-                category;
-
-            typedef typename boost::mpl::or_<
-                parallel::is_sequential_execution_policy<ExPolicy>,
-                boost::is_same<std::input_iterator_tag, category>
-            >::type is_seq;
+            typedef std::integral_constant<bool,
+                    parallel::is_sequential_execution_policy<ExPolicy>::value ||
+                    hpx::traits::is_input_iterator<InIter>::value
+                > is_seq;
 
             typedef typename std::iterator_traits<InIter>::difference_type
                 difference_type;
@@ -341,19 +331,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           satisfying the given criteria.
     ///
     template <typename ExPolicy, typename InIter, typename F>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy,
             typename std::iterator_traits<InIter>::difference_type
         >::type
     >::type
     count_if(ExPolicy && policy, InIter first, InIter last, F && f)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            category;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, category>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Required at least input iterator.");
 
         typedef hpx::traits::segmented_iterator_traits<InIter> iterator_traits;

--- a/hpx/parallel/algorithms/detail/dispatch.hpp
+++ b/hpx/parallel/algorithms/detail/dispatch.hpp
@@ -235,6 +235,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
                 std::forward<Args>(args)...);
         }
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
         ///////////////////////////////////////////////////////////////////////////
         template <typename... Args>
         local_result_type
@@ -290,6 +291,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         {
             return call(seq, boost::mpl::true_(), std::forward<Args>(args)...);
         }
+#endif
 
     private:
         char const* const name_;

--- a/hpx/parallel/algorithms/detail/dispatch.hpp
+++ b/hpx/parallel/algorithms/detail/dispatch.hpp
@@ -6,7 +6,7 @@
 #if !defined(HPX_PARALLEL_DISPATCH_JUN_25_2014_1145PM)
 #define HPX_PARALLEL_DISPATCH_JUN_25_2014_1145PM
 
-#include <hpx/hpx_fwd.hpp>
+#include <hpx/config.hpp>
 #include <hpx/runtime/serialization/serialize.hpp>
 #include <hpx/traits/segmented_iterator_traits.hpp>
 #include <hpx/util/bind.hpp>
@@ -18,9 +18,8 @@
 #include <hpx/parallel/execution_policy.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 
-#include <boost/mpl/bool.hpp>
-
 #include <string>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
 {
@@ -76,7 +75,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         typename parallel::util::detail::algorithm_result<
             ExPolicy, local_result_type
         >::type
-        call(ExPolicy && policy, boost::mpl::true_, Args&&... args) const
+        call(ExPolicy && policy, std::true_type, Args&&... args) const
         {
             try {
                 return parallel::util::detail::algorithm_result<
@@ -142,7 +141,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         typename parallel::util::detail::algorithm_result<
             sequential_task_execution_policy, local_result_type
         >::type
-        call(sequential_task_execution_policy policy, boost::mpl::true_,
+        call(sequential_task_execution_policy policy, std::true_type,
             Args&&... args) const
         {
             return call_sequential(policy, std::forward<Args>(args)...);
@@ -154,7 +153,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
             local_result_type
         >::type
         call(sequential_task_execution_policy_shim<Executor, Parameters>& policy,
-            boost::mpl::true_, Args&&... args) const
+            std::true_type, Args&&... args) const
         {
             return call_sequential(policy, std::forward<Args>(args)...);
         }
@@ -165,7 +164,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
             local_result_type
         >::type
         call(sequential_task_execution_policy_shim<Executor, Parameters> && policy,
-            boost::mpl::true_, Args&&... args) const
+            std::true_type, Args&&... args) const
         {
             return call_sequential(policy, std::forward<Args>(args)...);
         }
@@ -176,7 +175,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
             local_result_type
         >::type
         call(sequential_task_execution_policy_shim<Executor, Parameters> const& policy,
-            boost::mpl::true_, Args&&... args) const
+            std::true_type, Args&&... args) const
         {
             return call_sequential(policy, std::forward<Args>(args)...);
         }
@@ -186,7 +185,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         typename parallel::util::detail::algorithm_result<
             parallel_task_execution_policy, local_result_type
         >::type
-        call(parallel_task_execution_policy policy, boost::mpl::true_,
+        call(parallel_task_execution_policy policy, std::true_type,
             Args&&... args) const
         {
             return call_sequential(policy, std::forward<Args>(args)...);
@@ -198,7 +197,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
             local_result_type
         >::type
         call(parallel_task_execution_policy_shim<Executor, Parameters>& policy,
-            boost::mpl::true_, Args&&... args) const
+            std::true_type, Args&&... args) const
         {
             return call_sequential(policy, std::forward<Args>(args)...);
         }
@@ -209,7 +208,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
             local_result_type
         >::type
         call(parallel_task_execution_policy_shim<Executor, Parameters> && policy,
-            boost::mpl::true_, Args&&... args) const
+            std::true_type, Args&&... args) const
         {
             return call_sequential(policy, std::forward<Args>(args)...);
         }
@@ -220,7 +219,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
             local_result_type
         >::type
         call(parallel_task_execution_policy_shim<Executor, Parameters> const& policy,
-            boost::mpl::true_, Args&&... args) const
+            std::true_type, Args&&... args) const
         {
             return call_sequential(policy, std::forward<Args>(args)...);
         }
@@ -229,7 +228,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         typename parallel::util::detail::algorithm_result<
             ExPolicy, local_result_type
         >::type
-        call(ExPolicy && policy, boost::mpl::false_, Args&&... args) const
+        call(ExPolicy && policy, std::false_type, Args&&... args) const
         {
             return Derived::parallel(std::forward<ExPolicy>(policy),
                 std::forward<Args>(args)...);
@@ -239,7 +238,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         ///////////////////////////////////////////////////////////////////////////
         template <typename... Args>
         local_result_type
-        call(parallel::execution_policy policy, boost::mpl::false_,
+        call(parallel::execution_policy policy, std::false_type,
             Args&&... args) const
         {
             // this implementation is not nice, however we don't have variadic
@@ -250,19 +249,19 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
             if (t == typeid(sequential_execution_policy))
             {
                 return call(*policy.get<sequential_execution_policy>(),
-                    boost::mpl::true_(), std::forward<Args>(args)...);
+                    std::true_type(), std::forward<Args>(args)...);
             }
 
             if (t == typeid(sequential_task_execution_policy))
             {
-                return call(seq, boost::mpl::true_(),
+                return call(seq, std::true_type(),
                     std::forward<Args>(args)...);
             }
 
             if (t == typeid(parallel_execution_policy))
             {
                 return call(*policy.get<parallel_execution_policy>(),
-                    boost::mpl::false_(), std::forward<Args>(args)...);
+                    std::false_type(), std::forward<Args>(args)...);
             }
 
             if (t == typeid(parallel_task_execution_policy))
@@ -271,13 +270,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
                     *policy.get<parallel_task_execution_policy>();
 
                 return call(par.with(t.parameters()),
-                    boost::mpl::false_(), std::forward<Args>(args)...);
+                    std::false_type(), std::forward<Args>(args)...);
             }
 
             if (t == typeid(parallel_vector_execution_policy))
             {
                 return call(*policy.get<parallel_vector_execution_policy>(),
-                    boost::mpl::false_(), std::forward<Args>(args)...);
+                    std::false_type(), std::forward<Args>(args)...);
             }
 
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
@@ -287,9 +286,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
 
         template <typename... Args>
         local_result_type
-        call(parallel::execution_policy, boost::mpl::true_, Args&&... args) const
+        call(parallel::execution_policy, std::true_type, Args&&... args) const
         {
-            return call(seq, boost::mpl::true_(), std::forward<Args>(args)...);
+            return call(seq, std::true_type(), std::forward<Args>(args)...);
         }
 #endif
 

--- a/hpx/parallel/algorithms/detail/is_negative.hpp
+++ b/hpx/parallel/algorithms/detail/is_negative.hpp
@@ -6,9 +6,7 @@
 #if !defined(HPX_PARALLEL_DETAIL_IS_NEGATIVE_JUL_2014_01_0148PM)
 #define HPX_PARALLEL_DETAIL_IS_NEGATIVE_JUL_2014_01_0148PM
 
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_signed.hpp>
-#include <boost/type_traits/is_unsigned.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
 {
@@ -19,7 +17,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
     // signed integral values may be negative
     template <typename T>
     struct is_negative_helper<T,
-        typename boost::enable_if<boost::is_signed<T> >::type>
+        typename std::enable_if<std::is_signed<T>::value>::type>
     {
         static bool call(T const& size) { return size < 0; }
 
@@ -34,7 +32,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
     // unsigned integral values are never negative
     template <typename T>
     struct is_negative_helper<T,
-        typename boost::enable_if<boost::is_unsigned<T> >::type>
+        typename std::enable_if<std::is_unsigned<T>::value>::type>
     {
         static bool call(T const&) { return false; }
 

--- a/hpx/parallel/algorithms/detail/predicates.hpp
+++ b/hpx/parallel/algorithms/detail/predicates.hpp
@@ -98,7 +98,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
     struct calculate_next<Iterable,
         typename std::enable_if<
             hpx::traits::is_iterator<Iterable>::value &&
-           !hpx::traits::is_bidirectional_iterator<Iterable>::value
+           !hpx::traits::is_at_least_bidirectional_iterator<Iterable>::value
         >::type>
     {
         template <typename Iter, typename Stride>
@@ -130,7 +130,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
     template <typename Iterable>
     struct calculate_next<Iterable,
         typename std::enable_if<
-            hpx::traits::is_bidirectional_iterator<Iterable>::value
+            hpx::traits::is_at_least_bidirectional_iterator<Iterable>::value
         >::type>
     {
         template <typename Iter, typename Stride>

--- a/hpx/parallel/algorithms/detail/predicates.hpp
+++ b/hpx/parallel/algorithms/detail/predicates.hpp
@@ -98,7 +98,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
     struct calculate_next<Iterable,
         typename std::enable_if<
             hpx::traits::is_iterator<Iterable>::value &&
-           !hpx::traits::is_at_least_bidirectional_iterator<Iterable>::value
+           !hpx::traits::is_bidirectional_iterator<Iterable>::value
         >::type>
     {
         template <typename Iter, typename Stride>
@@ -130,7 +130,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
     template <typename Iterable>
     struct calculate_next<Iterable,
         typename std::enable_if<
-            hpx::traits::is_at_least_bidirectional_iterator<Iterable>::value
+            hpx::traits::is_bidirectional_iterator<Iterable>::value
         >::type>
     {
         template <typename Iter, typename Stride>

--- a/hpx/parallel/algorithms/detail/set_operation.hpp
+++ b/hpx/parallel/algorithms/detail/set_operation.hpp
@@ -17,9 +17,9 @@
 #include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/foreach_partitioner.hpp>
 
-#include <boost/mpl/if.hpp>
-#include <boost/type_traits/is_scalar.hpp>
 #include <boost/shared_array.hpp>
+
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
 {
@@ -53,8 +53,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         };
 
         typedef typename std::iterator_traits<OutIter>::value_type value_type;
-        typedef typename boost::mpl::if_<
-            boost::is_scalar<value_type>, value_type, rewritable_ref<value_type>
+        typedef typename std::conditional<
+            std::is_scalar<value_type>::value,
+            value_type, rewritable_ref<value_type>
         >::type type;
     };
 

--- a/hpx/parallel/algorithms/equal.hpp
+++ b/hpx/parallel/algorithms/equal.hpp
@@ -210,8 +210,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter1>::value ||
-                hpx::traits::is_just_input_iterator<InIter2>::value
+               !hpx::traits::is_forward_iterator<InIter1>::value ||
+               !hpx::traits::is_forward_iterator<InIter2>::value
             > is_seq;
 
         return detail::equal_binary().call(
@@ -308,8 +308,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter1>::value ||
-                hpx::traits::is_just_input_iterator<InIter2>::value
+               !hpx::traits::is_forward_iterator<InIter1>::value ||
+               !hpx::traits::is_forward_iterator<InIter2>::value
             > is_seq;
 
         return detail::equal_binary().call(
@@ -455,8 +455,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter1>::value ||
-                hpx::traits::is_just_input_iterator<InIter2>::value
+               !hpx::traits::is_forward_iterator<InIter1>::value ||
+               !hpx::traits::is_forward_iterator<InIter2>::value
             > is_seq;
 
         return detail::equal().call(
@@ -549,8 +549,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter1>::value ||
-                hpx::traits::is_just_input_iterator<InIter2>::value
+               !hpx::traits::is_forward_iterator<InIter1>::value ||
+               !hpx::traits::is_forward_iterator<InIter2>::value
             > is_seq;
 
         return detail::equal().call(

--- a/hpx/parallel/algorithms/equal.hpp
+++ b/hpx/parallel/algorithms/equal.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_DETAIL_EQUAL_JUL_06_2014_0848PM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
 #include <hpx/parallel/execution_policy.hpp>
@@ -20,11 +21,10 @@
 #include <hpx/parallel/util/zip_iterator.hpp>
 
 #include <boost/range/functions.hpp>
-#include <boost/type_traits/is_base_of.hpp>
-#include <boost/utility/enable_if.hpp>
 
 #include <algorithm>
 #include <iterator>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -194,30 +194,25 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           the length of the range [first2, last2), it returns false.
     ///
     template <typename ExPolicy, typename InIter1, typename InIter2>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, bool>::type
     >::type
     equal(ExPolicy&& policy, InIter1 first1, InIter1 last1,
         InIter2 first2, InIter2 last2)
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category
-            iterator_category1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category
-            iterator_category2;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category1>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category2>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category1>,
-            boost::is_same<std::input_iterator_tag, iterator_category2>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter1>::value ||
+                hpx::traits::is_input_iterator<InIter2>::value
+            > is_seq;
 
         return detail::equal_binary().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -297,30 +292,25 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           the length of the range [first2, last2), it returns false.
     ///
     template <typename ExPolicy, typename InIter1, typename InIter2, typename F>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, bool>::type
     >::type
     equal(ExPolicy&& policy, InIter1 first1, InIter1 last1,
         InIter2 first2, InIter2 last2, F && f)
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category
-            iterator_category1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category
-            iterator_category2;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category1>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category2>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category1>,
-            boost::is_same<std::input_iterator_tag, iterator_category2>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter1>::value ||
+                hpx::traits::is_input_iterator<InIter2>::value
+            > is_seq;
 
         return detail::equal_binary().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -450,30 +440,24 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           two ranges are equal, otherwise it returns false.
     ///
     template <typename ExPolicy, typename InIter1, typename InIter2>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, bool>::type
     >::type
-    equal(ExPolicy&& policy, InIter1 first1, InIter1 last1,
-        InIter2 first2)
+    equal(ExPolicy&& policy, InIter1 first1, InIter1 last1, InIter2 first2)
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category
-            iterator_category1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category
-            iterator_category2;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category1>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category2>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category1>,
-            boost::is_same<std::input_iterator_tag, iterator_category2>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter1>::value ||
+                hpx::traits::is_input_iterator<InIter2>::value
+            > is_seq;
 
         return detail::equal().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -549,30 +533,25 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           two ranges are equal, otherwise it returns false.
     ///
     template <typename ExPolicy, typename InIter1, typename InIter2, typename F>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, bool>::type
     >::type
     equal(ExPolicy&& policy, InIter1 first1, InIter1 last1, InIter2 first2,
         F && f)
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category
-            iterator_category1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category
-            iterator_category2;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category1>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category2>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category1>,
-            boost::is_same<std::input_iterator_tag, iterator_category2>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter1>::value ||
+                hpx::traits::is_input_iterator<InIter2>::value
+            > is_seq;
 
         return detail::equal().call(
             std::forward<ExPolicy>(policy), is_seq(),

--- a/hpx/parallel/algorithms/equal.hpp
+++ b/hpx/parallel/algorithms/equal.hpp
@@ -202,16 +202,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         InIter2 first2, InIter2 last2)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter1>::value ||
-                hpx::traits::is_input_iterator<InIter2>::value
+                hpx::traits::is_just_input_iterator<InIter1>::value ||
+                hpx::traits::is_just_input_iterator<InIter2>::value
             > is_seq;
 
         return detail::equal_binary().call(
@@ -300,16 +300,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         InIter2 first2, InIter2 last2, F && f)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter1>::value ||
-                hpx::traits::is_input_iterator<InIter2>::value
+                hpx::traits::is_just_input_iterator<InIter1>::value ||
+                hpx::traits::is_just_input_iterator<InIter2>::value
             > is_seq;
 
         return detail::equal_binary().call(
@@ -447,16 +447,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     equal(ExPolicy&& policy, InIter1 first1, InIter1 last1, InIter2 first2)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter1>::value ||
-                hpx::traits::is_input_iterator<InIter2>::value
+                hpx::traits::is_just_input_iterator<InIter1>::value ||
+                hpx::traits::is_just_input_iterator<InIter2>::value
             > is_seq;
 
         return detail::equal().call(
@@ -541,16 +541,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         F && f)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter1>::value ||
-                hpx::traits::is_input_iterator<InIter2>::value
+                hpx::traits::is_just_input_iterator<InIter1>::value ||
+                hpx::traits::is_just_input_iterator<InIter2>::value
             > is_seq;
 
         return detail::equal().call(

--- a/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -243,16 +243,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         T init, Op && op)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
+                hpx::traits::is_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_just_input_iterator<InIter>::value ||
                 hpx::traits::is_output_iterator<OutIter>::value
             > is_seq;
 
@@ -329,16 +329,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         T init)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
+                hpx::traits::is_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_just_input_iterator<InIter>::value ||
                 hpx::traits::is_output_iterator<OutIter>::value
             > is_seq;
 

--- a/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2015 Hartmut Kaiser
+//  Copyright (c) 2014-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_ALGORITHM_EXCLUSIVE_SCAN_DEC_30_2014_1236PM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 #include <hpx/util/unwrapped.hpp>
 #include <hpx/util/zip_iterator.hpp>
 
@@ -24,9 +25,7 @@
 #include <algorithm>
 #include <numeric>
 #include <iterator>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -236,36 +235,26 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///
     template <typename ExPolicy, typename InIter, typename OutIter, typename T,
         typename Op>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     >::type
     exclusive_scan(ExPolicy&& policy, InIter first, InIter last, OutIter dest,
         T init, Op && op)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Requires at least input iterator.");
-
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>,
-            boost::is_same<std::output_iterator_tag, output_iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_output_iterator<OutIter>::value
+            > is_seq;
 
         return detail::exclusive_scan<OutIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -332,36 +321,26 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
     template <typename ExPolicy, typename InIter, typename OutIter, typename T>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     >::type
     exclusive_scan(ExPolicy&& policy, InIter first, InIter last, OutIter dest,
         T init)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Requires at least input iterator.");
-
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>,
-            boost::is_same<std::output_iterator_tag, output_iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_output_iterator<OutIter>::value
+            > is_seq;
 
         return detail::exclusive_scan<OutIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),

--- a/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -252,8 +252,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value ||
+               !hpx::traits::is_forward_iterator<OutIter>::value
             > is_seq;
 
         return detail::exclusive_scan<OutIter>().call(
@@ -338,8 +338,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value ||
+               !hpx::traits::is_forward_iterator<OutIter>::value
             > is_seq;
 
         return detail::exclusive_scan<OutIter>().call(

--- a/hpx/parallel/algorithms/fill.hpp
+++ b/hpx/parallel/algorithms/fill.hpp
@@ -229,7 +229,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value
+               !hpx::traits::is_forward_iterator<OutIter>::value
             > is_seq;
 
         return detail::fill_n<OutIter>().call(

--- a/hpx/parallel/algorithms/fill.hpp
+++ b/hpx/parallel/algorithms/fill.hpp
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_DETAIL_FILL_JUNE_12_2014_0405PM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 #include <hpx/util/void_guard.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
@@ -20,9 +21,7 @@
 
 #include <algorithm>
 #include <iterator>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -60,7 +59,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 return hpx::util::void_guard<result_type>(),
                     for_each_n<FwdIter>().call(
-                        std::forward<ExPolicy>(policy), boost::mpl::false_(),
+                        std::forward<ExPolicy>(policy), std::false_type(),
                         first, std::distance(first, last),
                         [val](type& v) {
                             v = val;
@@ -109,21 +108,17 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           is defined by \a void.
     ///
     template <typename ExPolicy, typename InIter, typename T>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, void>::type
     >::type
     fill(ExPolicy && policy, InIter first, InIter last, T value)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-             iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::forward_iterator_tag, iterator_category>::value),
-            "Required at least forward iterator.");
+            (hpx::traits::is_at_least_forward_iterator<InIter>::value),
+            "Requires at least forward iterator.");
 
-        typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
+        typedef is_sequential_execution_policy<ExPolicy> is_seq;
 
         return detail::fill().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -161,7 +156,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 return
                     for_each_n<OutIter>().call(
                         std::forward<ExPolicy>(policy),
-                        boost::mpl::false_(), first, count,
+                        std::false_type(), first, count,
                         [val](type& v) -> void
                         {
                             v = val;
@@ -214,23 +209,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           is defined by \a void.
     ///
     template <typename ExPolicy, typename OutIter, typename Size, typename T>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     >::type
     fill_n(ExPolicy && policy, OutIter first, Size count, T value)
     {
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            iterator_category;
-
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, iterator_category>
-            >::value),
-            "Requires at least bidirectional iterator.");
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
+            "Requires at least output iterator.");
 
         // if count is representing a negative value, we do nothing
         if (detail::is_negative(count))
@@ -239,10 +227,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 std::move(first));
         }
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::output_iterator_tag, iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_output_iterator<OutIter>::value
+            > is_seq;
 
         return detail::fill_n<OutIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),

--- a/hpx/parallel/algorithms/fill.hpp
+++ b/hpx/parallel/algorithms/fill.hpp
@@ -115,7 +115,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     fill(ExPolicy && policy, InIter first, InIter last, T value)
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<InIter>::value),
+            (hpx::traits::is_forward_iterator<InIter>::value),
             "Requires at least forward iterator.");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;
@@ -217,7 +217,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     {
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
+                hpx::traits::is_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         // if count is representing a negative value, we do nothing

--- a/hpx/parallel/algorithms/find.hpp
+++ b/hpx/parallel/algorithms/find.hpp
@@ -143,12 +143,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     find(ExPolicy && policy, InIter first, InIter last, T const& val)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value
+                hpx::traits::is_just_input_iterator<InIter>::value
             > is_seq;
 
         return detail::find<InIter>().call(
@@ -288,12 +288,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     find_if(ExPolicy && policy, InIter first, InIter last, F && f)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value
+                hpx::traits::is_just_input_iterator<InIter>::value
             > is_seq;
 
         return detail::find_if<InIter>().call(
@@ -438,12 +438,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     find_if_not(ExPolicy && policy, InIter first, InIter last, F && f)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value
+                hpx::traits::is_just_input_iterator<InIter>::value
             > is_seq;
 
         return detail::find_if_not<InIter>().call(
@@ -604,10 +604,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         FwdIter2 first2, FwdIter2 last2)
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter1>::value),
+            (hpx::traits::is_forward_iterator<FwdIter1>::value),
             "Requires at least forward iterator.");
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter2>::value),
+            (hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;
@@ -698,10 +698,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         FwdIter2 first2, FwdIter2 last2, F && f)
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter1>::value),
+            (hpx::traits::is_forward_iterator<FwdIter1>::value),
             "Requires at least forward iterator.");
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter2>::value),
+            (hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;
@@ -860,15 +860,15 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         FwdIter s_first, FwdIter s_last)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least forward iterator.");
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Subsequence requires at least forward iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value
+                hpx::traits::is_just_input_iterator<InIter>::value
             > is_seq;
 
         return detail::find_first_of<InIter>().call(
@@ -959,15 +959,15 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         FwdIter s_first, FwdIter s_last, Pred && op)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least forward iterator.");
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Subsequence requires at least forward iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value
+                hpx::traits::is_just_input_iterator<InIter>::value
             > is_seq;
 
         return detail::find_first_of<InIter>().call(

--- a/hpx/parallel/algorithms/find.hpp
+++ b/hpx/parallel/algorithms/find.hpp
@@ -148,7 +148,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value
             > is_seq;
 
         return detail::find<InIter>().call(
@@ -293,7 +293,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value
             > is_seq;
 
         return detail::find_if<InIter>().call(
@@ -443,7 +443,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value
             > is_seq;
 
         return detail::find_if_not<InIter>().call(
@@ -868,7 +868,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value
             > is_seq;
 
         return detail::find_first_of<InIter>().call(
@@ -967,7 +967,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value
             > is_seq;
 
         return detail::find_first_of<InIter>().call(

--- a/hpx/parallel/algorithms/find.hpp
+++ b/hpx/parallel/algorithms/find.hpp
@@ -9,6 +9,8 @@
 #define HPX_PARALLEL_DETAIL_FIND_JULY_16_2014_0213PM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
+
 #include <hpx/parallel/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/predicates.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
@@ -18,9 +20,7 @@
 
 #include <algorithm>
 #include <iterator>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -136,25 +136,20 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           \a val, then the algorithm returns \a last.
     ///
     template <typename ExPolicy, typename InIter, typename T>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, InIter>::type
     >::type
     find(ExPolicy && policy, InIter first, InIter last, T const& val)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, iterator_category
-            >::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value
+            > is_seq;
 
         return detail::find<InIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -286,25 +281,20 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           algorithm returns \a last.
     ///
     template <typename ExPolicy, typename InIter, typename F>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, InIter>::type
     >::type
     find_if(ExPolicy && policy, InIter first, InIter last, F && f)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, iterator_category
-            >::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value
+            > is_seq;
 
         return detail::find_if<InIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -441,25 +431,20 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           algorithm returns \a last.
     ///
     template <typename ExPolicy, typename InIter, typename F>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, InIter>::type
     >::type
     find_if_not(ExPolicy && policy, InIter first, InIter last, F && f)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, iterator_category
-            >::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value
+            > is_seq;
 
         return detail::find_if_not<InIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -611,29 +596,18 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           is found, \a last1 is also returned.
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter1>::type
     >::type
     find_end(ExPolicy && policy, FwdIter1 first1, FwdIter1 last1,
         FwdIter2 first2, FwdIter2 last2)
     {
-        typedef typename std::iterator_traits<FwdIter1>::iterator_category
-            iterator_category1;
-
-        typedef typename std::iterator_traits<FwdIter2>::iterator_category
-            iterator_category2;
-
         static_assert(
-            (boost::is_base_of<
-                std::forward_iterator_tag, iterator_category1
-            >::value),
+            (hpx::traits::is_at_least_forward_iterator<FwdIter1>::value),
             "Requires at least forward iterator.");
-
         static_assert(
-            (boost::is_base_of<
-                std::forward_iterator_tag, iterator_category2
-            >::value),
+            (hpx::traits::is_at_least_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;
@@ -716,29 +690,18 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     /// algorithm their own predicate \a f.
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2, typename F>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter1>::type
     >::type
     find_end(ExPolicy && policy, FwdIter1 first1, FwdIter1 last1,
         FwdIter2 first2, FwdIter2 last2, F && f)
     {
-        typedef typename std::iterator_traits<FwdIter1>::iterator_category
-            iterator_category1;
-
-        typedef typename std::iterator_traits<FwdIter2>::iterator_category
-            iterator_category2;
-
         static_assert(
-            (boost::is_base_of<
-                std::forward_iterator_tag, iterator_category1
-            >::value),
+            (hpx::traits::is_at_least_forward_iterator<FwdIter1>::value),
             "Requires at least forward iterator.");
-
         static_assert(
-            (boost::is_base_of<
-                std::forward_iterator_tag, iterator_category2
-            >::value),
+            (hpx::traits::is_at_least_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;
@@ -889,34 +852,24 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           is found, \a last is also returned.
     ///
     template <typename ExPolicy, typename InIter, typename FwdIter>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, InIter>::type
     >::type
     find_first_of(ExPolicy && policy, InIter first, InIter last,
         FwdIter s_first, FwdIter s_last)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-        typedef typename std::iterator_traits<FwdIter>::iterator_category
-            s_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, iterator_category
-            >::value),
-            "Requires at least input iterator.");
-
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            "Requires at least forward iterator.");
         static_assert(
-            (boost::is_base_of<
-                std::forward_iterator_tag, s_iterator_category
-            >::value),
+            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
             "Subsequence requires at least forward iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value
+            > is_seq;
 
         return detail::find_first_of<InIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -998,34 +951,24 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           algorithm their own predicate \a f.
     ///
     template <typename ExPolicy, typename InIter, typename FwdIter, typename Pred>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, InIter>::type
     >::type
     find_first_of(ExPolicy && policy, InIter first, InIter last,
         FwdIter s_first, FwdIter s_last, Pred && op)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-        typedef typename std::iterator_traits<FwdIter>::iterator_category
-            s_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, iterator_category
-            >::value),
-            "Requires at least input iterator.");
-
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            "Requires at least forward iterator.");
         static_assert(
-            (boost::is_base_of<
-                std::forward_iterator_tag, s_iterator_category
-            >::value),
+            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
             "Subsequence requires at least forward iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value
+            > is_seq;
 
         return detail::find_first_of<InIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),

--- a/hpx/parallel/algorithms/for_each.hpp
+++ b/hpx/parallel/algorithms/for_each.hpp
@@ -190,7 +190,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value
             > is_seq;
 
         return detail::for_each_n<InIter>().call(
@@ -255,7 +255,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         {
             typedef std::integral_constant<bool,
                     parallel::is_sequential_execution_policy<ExPolicy>::value ||
-                    hpx::traits::is_just_input_iterator<InIter>::value
+                   !hpx::traits::is_forward_iterator<InIter>::value
                 > is_seq;
 
             if (first == last)
@@ -367,8 +367,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
-        typedef hpx::traits::segmented_iterator_traits<InIter> iterator_traits;
-        typedef typename iterator_traits::is_segmented_iterator is_segmented;
+        typedef hpx::traits::is_segmented_iterator<InIter> is_segmented;
 
         return detail::for_each_(
             std::forward<ExPolicy>(policy), first, last,

--- a/hpx/parallel/algorithms/for_each.hpp
+++ b/hpx/parallel/algorithms/for_each.hpp
@@ -178,7 +178,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         Proj && proj = Proj())
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
         // if count is representing a negative value, we do nothing
@@ -190,7 +190,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value
+                hpx::traits::is_just_input_iterator<InIter>::value
             > is_seq;
 
         return detail::for_each_n<InIter>().call(
@@ -255,7 +255,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         {
             typedef std::integral_constant<bool,
                     parallel::is_sequential_execution_policy<ExPolicy>::value ||
-                    hpx::traits::is_input_iterator<InIter>::value
+                    hpx::traits::is_just_input_iterator<InIter>::value
                 > is_seq;
 
             if (first == last)
@@ -364,7 +364,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         Proj && proj = Proj())
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
         typedef hpx::traits::segmented_iterator_traits<InIter> iterator_traits;

--- a/hpx/parallel/algorithms/for_loop.hpp
+++ b/hpx/parallel/algorithms/for_loop.hpp
@@ -186,12 +186,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
             if (stride < 0)
             {
                 HPX_ASSERT(std::is_integral<E>::value ||
-                    hpx::traits::is_at_least_bidirectional_iterator<E>::value);
+                    hpx::traits::is_bidirectional_iterator<E>::value);
             }
 
             typedef std::integral_constant<bool,
                     is_sequential_execution_policy<ExPolicy>::value ||
-                    hpx::traits::is_at_least_input_iterator<B>::value
+                    hpx::traits::is_input_iterator<B>::value
                 > is_seq;
 
             auto && t = hpx::util::forward_as_tuple(std::forward<Args>(args)...);

--- a/hpx/parallel/algorithms/for_loop.hpp
+++ b/hpx/parallel/algorithms/for_loop.hpp
@@ -191,7 +191,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
 
             typedef std::integral_constant<bool,
                     is_sequential_execution_policy<ExPolicy>::value ||
-                    hpx::traits::is_input_iterator<B>::value
+                   !hpx::traits::is_forward_iterator<B>::value
                 > is_seq;
 
             auto && t = hpx::util::forward_as_tuple(std::forward<Args>(args)...);

--- a/hpx/parallel/algorithms/for_loop.hpp
+++ b/hpx/parallel/algorithms/for_loop.hpp
@@ -27,8 +27,6 @@
 #include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/loop.hpp>
 
-#include <boost/mpl/bool.hpp>
-
 #include <algorithm>
 #include <iterator>
 #include <type_traits>
@@ -188,13 +186,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
             if (stride < 0)
             {
                 HPX_ASSERT(std::is_integral<E>::value ||
-                    hpx::traits::is_bidirectional_iterator<E>::value);
+                    hpx::traits::is_at_least_bidirectional_iterator<E>::value);
             }
 
-            typedef typename boost::mpl::bool_<
-                is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<B>::value
-            >::type is_seq;
+            typedef std::integral_constant<bool,
+                    is_sequential_execution_policy<ExPolicy>::value ||
+                    hpx::traits::is_at_least_input_iterator<B>::value
+                > is_seq;
 
             auto && t = hpx::util::forward_as_tuple(std::forward<Args>(args)...);
 

--- a/hpx/parallel/algorithms/generate.hpp
+++ b/hpx/parallel/algorithms/generate.hpp
@@ -145,8 +145,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
-        typedef hpx::traits::segmented_iterator_traits<FwdIter> iterator_traits;
-        typedef typename iterator_traits::is_segmented_iterator is_segmented;
+        typedef hpx::traits::is_segmented_iterator<FwdIter> is_segmented;
 
         return detail::generate_(
             std::forward<ExPolicy>(policy), first, last,
@@ -265,7 +264,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value
+               !hpx::traits::is_forward_iterator<OutIter>::value
             > is_seq;
 
         return detail::generate_n<OutIter>().call(

--- a/hpx/parallel/algorithms/generate.hpp
+++ b/hpx/parallel/algorithms/generate.hpp
@@ -142,7 +142,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     generate(ExPolicy && policy, FwdIter first, FwdIter last, F && f)
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
         typedef hpx::traits::segmented_iterator_traits<FwdIter> iterator_traits;
@@ -254,7 +254,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     {
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
+                hpx::traits::is_forward_iterator<OutIter>::value),
             "Required at least output iterator.");
 
         if (detail::is_negative(count))

--- a/hpx/parallel/algorithms/includes.hpp
+++ b/hpx/parallel/algorithms/includes.hpp
@@ -277,8 +277,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter1>::value ||
-                hpx::traits::is_just_input_iterator<InIter2>::value
+               !hpx::traits::is_forward_iterator<InIter1>::value ||
+               !hpx::traits::is_forward_iterator<InIter2>::value
             > is_seq;
 
         return detail::includes().call(
@@ -373,8 +373,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter1>::value ||
-                hpx::traits::is_just_input_iterator<InIter2>::value
+               !hpx::traits::is_forward_iterator<InIter1>::value ||
+               !hpx::traits::is_forward_iterator<InIter2>::value
             > is_seq;
 
         return detail::includes().call(

--- a/hpx/parallel/algorithms/includes.hpp
+++ b/hpx/parallel/algorithms/includes.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_ALGORITH_INCLUDES_MAR_10_2015_0737PM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
 #include <hpx/parallel/execution_policy.hpp>
@@ -18,14 +19,11 @@
 #include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
 
-#include <boost/mpl/or.hpp>
 #include <boost/range/functions.hpp>
-#include <boost/type_traits/is_same.hpp>
-#include <boost/type_traits/is_base_of.hpp>
-#include <boost/utility/enable_if.hpp>
 
 #include <algorithm>
 #include <iterator>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -263,30 +261,25 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           [first1, last1). Also returns true if [first2, last2) is empty.
     ///
     template <typename ExPolicy, typename InIter1, typename InIter2>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, bool>::type
     >::type
     includes(ExPolicy&& policy, InIter1 first1, InIter1 last1,
         InIter2 first2, InIter2 last2)
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category
-            iterator_category1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category
-            iterator_category2;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category1>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category2>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category1>,
-            boost::is_same<std::input_iterator_tag, iterator_category2>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter1>::value ||
+                hpx::traits::is_input_iterator<InIter2>::value
+            > is_seq;
 
         return detail::includes().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -364,30 +357,25 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           [first1, last1). Also returns true if [first2, last2) is empty.
     ///
     template <typename ExPolicy, typename InIter1, typename InIter2, typename F>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, bool>::type
     >::type
     includes(ExPolicy&& policy, InIter1 first1, InIter1 last1,
         InIter2 first2, InIter2 last2, F && f)
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category
-            iterator_category1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category
-            iterator_category2;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category1>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category2>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category1>,
-            boost::is_same<std::input_iterator_tag, iterator_category2>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter1>::value ||
+                hpx::traits::is_input_iterator<InIter2>::value
+            > is_seq;
 
         return detail::includes().call(
             std::forward<ExPolicy>(policy), is_seq(),

--- a/hpx/parallel/algorithms/includes.hpp
+++ b/hpx/parallel/algorithms/includes.hpp
@@ -269,16 +269,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         InIter2 first2, InIter2 last2)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter1>::value ||
-                hpx::traits::is_input_iterator<InIter2>::value
+                hpx::traits::is_just_input_iterator<InIter1>::value ||
+                hpx::traits::is_just_input_iterator<InIter2>::value
             > is_seq;
 
         return detail::includes().call(
@@ -365,16 +365,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         InIter2 first2, InIter2 last2, F && f)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter1>::value ||
-                hpx::traits::is_input_iterator<InIter2>::value
+                hpx::traits::is_just_input_iterator<InIter1>::value ||
+                hpx::traits::is_just_input_iterator<InIter2>::value
             > is_seq;
 
         return detail::includes().call(

--- a/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -236,16 +236,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         T init, Op && op)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
+                hpx::traits::is_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_just_input_iterator<InIter>::value ||
                 hpx::traits::is_output_iterator<OutIter>::value
             > is_seq;
 
@@ -322,16 +322,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         T init)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
+                hpx::traits::is_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_just_input_iterator<InIter>::value ||
                 hpx::traits::is_output_iterator<OutIter>::value
             > is_seq;
 
@@ -404,16 +404,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     inclusive_scan(ExPolicy&& policy, InIter first, InIter last, OutIter dest)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
+                hpx::traits::is_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_just_input_iterator<InIter>::value ||
                 hpx::traits::is_output_iterator<OutIter>::value
             > is_seq;
 

--- a/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -245,8 +245,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value ||
+               !hpx::traits::is_forward_iterator<OutIter>::value
             > is_seq;
 
         return detail::inclusive_scan<OutIter>().call(
@@ -331,8 +331,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value ||
+               !hpx::traits::is_forward_iterator<OutIter>::value
             > is_seq;
 
         return detail::inclusive_scan<OutIter>().call(
@@ -413,8 +413,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value ||
+               !hpx::traits::is_forward_iterator<OutIter>::value
             > is_seq;
 
         typedef typename std::iterator_traits<InIter>::value_type value_type;

--- a/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2015 Hartmut Kaiser
+//  Copyright (c) 2014-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_ALGORITHM_INCLUSIVE_SCAN_JAN_03_2015_0136PM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 #include <hpx/util/unwrapped.hpp>
 #include <hpx/util/zip_iterator.hpp>
 
@@ -23,9 +24,7 @@
 #include <algorithm>
 #include <numeric>
 #include <iterator>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -229,36 +228,26 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///
     template <typename ExPolicy, typename InIter, typename OutIter, typename T,
         typename Op>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     >::type
     inclusive_scan(ExPolicy&& policy, InIter first, InIter last, OutIter dest,
         T init, Op && op)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Requires at least input iterator.");
-
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>,
-            boost::is_same<std::output_iterator_tag, output_iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_output_iterator<OutIter>::value
+            > is_seq;
 
         return detail::inclusive_scan<OutIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -325,36 +314,26 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
     template <typename ExPolicy, typename InIter, typename OutIter, typename T>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     >::type
     inclusive_scan(ExPolicy&& policy, InIter first, InIter last, OutIter dest,
         T init)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Requires at least input iterator.");
-
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>,
-            boost::is_same<std::output_iterator_tag, output_iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_output_iterator<OutIter>::value
+            > is_seq;
 
         return detail::inclusive_scan<OutIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -418,35 +397,25 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
     template <typename ExPolicy, typename InIter, typename OutIter>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     >::type
     inclusive_scan(ExPolicy&& policy, InIter first, InIter last, OutIter dest)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Requires at least input iterator.");
-
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>,
-            boost::is_same<std::output_iterator_tag, output_iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_output_iterator<OutIter>::value
+            > is_seq;
 
         typedef typename std::iterator_traits<InIter>::value_type value_type;
 

--- a/hpx/parallel/algorithms/inner_product.hpp
+++ b/hpx/parallel/algorithms/inner_product.hpp
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_ALGORITHM_INNER_PRODUCT_JUL_15_2015_0730AM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 #include <hpx/util/zip_iterator.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
@@ -21,9 +22,7 @@
 #include <algorithm>
 #include <numeric>
 #include <iterator>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -155,32 +154,25 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///
 
     template <typename ExPolicy, typename InIter1, typename InIter2, typename T>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, T>::type
     >::type
     inner_product(ExPolicy&& policy, InIter1 first1, InIter1 last1,
         InIter2 first2, T init)
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category
-            iterator_category_1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category
-            iterator_category_2;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag,
-                iterator_category_1>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag,
-                iterator_category_2>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category_1>,
-            boost::is_same<std::input_iterator_tag, iterator_category_2>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter1>::value ||
+                hpx::traits::is_input_iterator<InIter2>::value
+            > is_seq;
 
         return detail::inner_product<T>().call(
             std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
@@ -272,38 +264,30 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
     template <typename ExPolicy, typename InIter1, typename InIter2, typename T,
         typename Op1, typename Op2>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, T>::type
     >::type
     inner_product(ExPolicy&& policy, InIter1 first1, InIter1 last1,
         InIter2 first2, T init, Op1 && op1, Op2 && op2)
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category
-            iterator_category_1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category
-            iterator_category_2;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag,
-                iterator_category_1>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag,
-                iterator_category_2>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category_1>,
-            boost::is_same<std::input_iterator_tag, iterator_category_2>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter1>::value ||
+                hpx::traits::is_input_iterator<InIter2>::value
+            > is_seq;
 
         return detail::inner_product<T>().call(
             std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
             std::move(init), std::forward<Op1>(op1), std::forward<Op2>(op2));
     }
-
 }}}
 
 #endif

--- a/hpx/parallel/algorithms/inner_product.hpp
+++ b/hpx/parallel/algorithms/inner_product.hpp
@@ -170,8 +170,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter1>::value ||
-                hpx::traits::is_just_input_iterator<InIter2>::value
+               !hpx::traits::is_forward_iterator<InIter1>::value ||
+               !hpx::traits::is_forward_iterator<InIter2>::value
             > is_seq;
 
         return detail::inner_product<T>().call(
@@ -280,8 +280,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter1>::value ||
-                hpx::traits::is_just_input_iterator<InIter2>::value
+               !hpx::traits::is_forward_iterator<InIter1>::value ||
+               !hpx::traits::is_forward_iterator<InIter2>::value
             > is_seq;
 
         return detail::inner_product<T>().call(

--- a/hpx/parallel/algorithms/inner_product.hpp
+++ b/hpx/parallel/algorithms/inner_product.hpp
@@ -162,16 +162,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         InIter2 first2, T init)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter1>::value ||
-                hpx::traits::is_input_iterator<InIter2>::value
+                hpx::traits::is_just_input_iterator<InIter1>::value ||
+                hpx::traits::is_just_input_iterator<InIter2>::value
             > is_seq;
 
         return detail::inner_product<T>().call(
@@ -272,16 +272,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         InIter2 first2, T init, Op1 && op1, Op2 && op2)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter1>::value ||
-                hpx::traits::is_input_iterator<InIter2>::value
+                hpx::traits::is_just_input_iterator<InIter1>::value ||
+                hpx::traits::is_just_input_iterator<InIter2>::value
             > is_seq;
 
         return detail::inner_product<T>().call(

--- a/hpx/parallel/algorithms/is_partitioned.hpp
+++ b/hpx/parallel/algorithms/is_partitioned.hpp
@@ -8,6 +8,10 @@
 #if !defined(HPX_PARALLEL_ALGORITHMS_IS_PARTITIONED_FEB_11_2015_0331PM)
 #define HPX_PARALLEL_ALGORITHMS_IS_PARTITIONED_FEB_11_2015_0331PM
 
+#include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
+#include <hpx/lcos/future.hpp>
+
 #include <hpx/parallel/config/inline_namespace.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/execution_policy.hpp>
@@ -19,10 +23,8 @@
 #include <algorithm>
 #include <iterator>
 #include <functional>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
-#include <boost/type_traits/is_same.hpp>
+#include <type_traits>
+#include <vector>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -31,7 +33,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     namespace detail
     {
         /// \cond NOINTERNAL
-
         inline bool
         sequential_is_partitioned(std::vector<hpx::future<bool > > && res)
         {
@@ -58,7 +59,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             public detail::algorithm<is_partitioned<Iter>, bool>
         {
             is_partitioned()
-                : is_partitioned::algorithm("is_partitioned")
+              : is_partitioned::algorithm("is_partitioned")
             {}
 
             template<typename ExPolicy, typename Pred>
@@ -168,24 +169,20 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           elements, the function is always true.
     ///
     template <typename ExPolicy, typename InIter, typename Pred>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, bool>::type
     >::type
     is_partitioned(ExPolicy && policy, InIter first, InIter last, Pred && pred)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
         static_assert(
-            (boost::is_base_of<
-             std::input_iterator_tag, iterator_category
-                 >::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            parallel::is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value
+            > is_seq;
 
         return detail::is_partitioned<InIter>().call(
             std::forward<ExPolicy>(policy), is_seq(), first, last,

--- a/hpx/parallel/algorithms/is_partitioned.hpp
+++ b/hpx/parallel/algorithms/is_partitioned.hpp
@@ -176,12 +176,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     is_partitioned(ExPolicy && policy, InIter first, InIter last, Pred && pred)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value
+                hpx::traits::is_just_input_iterator<InIter>::value
             > is_seq;
 
         return detail::is_partitioned<InIter>().call(

--- a/hpx/parallel/algorithms/is_partitioned.hpp
+++ b/hpx/parallel/algorithms/is_partitioned.hpp
@@ -181,7 +181,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value
             > is_seq;
 
         return detail::is_partitioned<InIter>().call(

--- a/hpx/parallel/algorithms/is_sorted.hpp
+++ b/hpx/parallel/algorithms/is_sorted.hpp
@@ -160,7 +160,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     is_sorted(ExPolicy && policy, FwdIter first, FwdIter last, Pred && pred)
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;
@@ -218,7 +218,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     is_sorted(ExPolicy && policy, FwdIter first, FwdIter last)
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;
@@ -372,7 +372,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     is_sorted_until(ExPolicy && policy, FwdIter first, FwdIter last, Pred && pred)
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;
@@ -428,7 +428,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     is_sorted_until(ExPolicy && policy, FwdIter first, FwdIter last)
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;

--- a/hpx/parallel/algorithms/is_sorted.hpp
+++ b/hpx/parallel/algorithms/is_sorted.hpp
@@ -8,6 +8,9 @@
 #if !defined(HPX_PARALLEL_ALGORITHMS_IS_SORTED_FEB_9_2015_0331PM)
 #define HPX_PARALLEL_ALGORITHMS_IS_SORTED_FEB_9_2015_0331PM
 
+#include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
+
 #include <hpx/parallel/config/inline_namespace.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/execution_policy.hpp>
@@ -17,13 +20,11 @@
 #include <hpx/parallel/util/loop.hpp>
 
 #include <boost/range/functions.hpp>
-#include <boost/type_traits/is_base_of.hpp>
-#include <boost/type_traits/is_same.hpp>
-#include <boost/utility/enable_if.hpp>
 
 #include <algorithm>
 #include <iterator>
 #include <functional>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -36,7 +37,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         struct is_sorted: public detail::algorithm<is_sorted<FwdIter>, bool>
         {
             is_sorted()
-                : is_sorted::algorithm("is_sorted")
+              : is_sorted::algorithm("is_sorted")
             {}
 
             template<typename ExPolicy, typename Pred>
@@ -75,9 +76,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                                     tok.cancel();
                                 }
                             });
+
                         FwdIter i = trail++;
-                        //trail now points one past the current grouping
-                        //unless cancelled
+                        // trail now points one past the current grouping
+                        // unless canceled
+
                         if (!tok.was_cancelled() && trail != last)
                         {
                             return !pred(*trail, *i);
@@ -150,21 +153,17 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           the function always returns true.
     ///
     template <typename ExPolicy, typename FwdIter, typename Pred>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, bool>::type
     >::type
     is_sorted(ExPolicy && policy, FwdIter first, FwdIter last, Pred && pred)
     {
-        typedef typename std::iterator_traits<FwdIter>::iterator_category
-            iterator_category;
         static_assert(
-            (boost::is_base_of<
-             std::forward_iterator_tag, iterator_category
-                 >::value),
+            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
-        typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
+        typedef is_sequential_execution_policy<ExPolicy> is_seq;
 
         return detail::is_sorted<FwdIter>().call(
             std::forward<ExPolicy>(policy), is_seq(), first, last,
@@ -212,30 +211,23 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           than two elements, the function always returns true.
     ///
     template <typename ExPolicy, typename FwdIter>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, bool>::type
     >::type
     is_sorted(ExPolicy && policy, FwdIter first, FwdIter last)
     {
-        typedef typename std::iterator_traits<FwdIter>::iterator_category
-            iterator_category;
-        typedef typename std::iterator_traits<FwdIter>::value_type
-            value_type;
-
         static_assert(
-            (boost::is_base_of<
-                std::forward_iterator_tag, iterator_category
-            >::value),
+            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
-        typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
+        typedef is_sequential_execution_policy<ExPolicy> is_seq;
+        typedef typename std::iterator_traits<FwdIter>::value_type value_type;
 
         return detail::is_sorted<FwdIter>().call(
-            std::forward<ExPolicy>(policy), is_seq(),first, last,
+            std::forward<ExPolicy>(policy), is_seq(), first, last,
             std::less<value_type>());
     }
-
 
     ////////////////////////////////////////////////////////////////////////////
     // is_sorted_until
@@ -247,7 +239,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             public detail::algorithm<is_sorted_until<FwdIter>, FwdIter>
         {
             is_sorted_until()
-                : is_sorted_until::algorithm("is_sorted_until")
+              : is_sorted_until::algorithm("is_sorted_until")
             {}
 
             template<typename ExPolicy, typename Pred>
@@ -309,7 +301,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                             }
                         }
                     },
-                    [first, tok](std::vector<hpx::future<void> > &&) mutable -> FwdIter
+                    [first, tok](std::vector<hpx::future<void> > &&) mutable
+                    ->  FwdIter
                     {
                         difference_type loc = tok.get_data();
                         std::advance(first, loc);
@@ -372,21 +365,17 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           sequence is sorted, last is returned.
     ///
     template <typename ExPolicy, typename FwdIter, typename Pred>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
     >::type
     is_sorted_until(ExPolicy && policy, FwdIter first, FwdIter last, Pred && pred)
     {
-        typedef typename std::iterator_traits<FwdIter>::iterator_category
-            iterator_category;
         static_assert(
-            (boost::is_base_of<
-             std::forward_iterator_tag, iterator_category
-                 >::value),
+            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
-        typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
+        typedef is_sequential_execution_policy<ExPolicy> is_seq;
 
         return detail::is_sorted_until<FwdIter>().call(
             std::forward<ExPolicy>(policy), is_seq(), first, last,
@@ -432,31 +421,23 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           sequence is sorted, last is returned.
     ///
     template <typename ExPolicy, typename FwdIter>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
     >::type
     is_sorted_until(ExPolicy && policy, FwdIter first, FwdIter last)
     {
-        typedef typename std::iterator_traits<FwdIter>::iterator_category
-            iterator_category;
-        typedef typename std::iterator_traits<FwdIter>::value_type
-            value_type;
         static_assert(
-            (boost::is_base_of<
-             std::forward_iterator_tag, iterator_category
-                 >::value),
+            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
-        typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
+        typedef is_sequential_execution_policy<ExPolicy> is_seq;
+        typedef typename std::iterator_traits<FwdIter>::value_type value_type;
 
         return detail::is_sorted_until<FwdIter>().call(
             std::forward<ExPolicy>(policy), is_seq(), first, last,
             std::less<value_type>());
     }
-
-
-
 }}}
 
 #endif

--- a/hpx/parallel/algorithms/lexicographical_compare.hpp
+++ b/hpx/parallel/algorithms/lexicographical_compare.hpp
@@ -197,8 +197,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter1>::value ||
-                hpx::traits::is_just_input_iterator<InIter2>::value
+               !hpx::traits::is_forward_iterator<InIter1>::value ||
+               !hpx::traits::is_forward_iterator<InIter2>::value
             > is_seq;
 
         return detail::lexicographical_compare().call(
@@ -295,8 +295,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter1>::value ||
-                hpx::traits::is_just_input_iterator<InIter2>::value
+               !hpx::traits::is_forward_iterator<InIter1>::value ||
+               !hpx::traits::is_forward_iterator<InIter2>::value
             > is_seq;
 
         return detail::lexicographical_compare().call(

--- a/hpx/parallel/algorithms/lexicographical_compare.hpp
+++ b/hpx/parallel/algorithms/lexicographical_compare.hpp
@@ -9,6 +9,8 @@
 #define HPX_PARALLEL_DETAIL_LEXI_COMPARE_DEC_30_2014_0312PM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
+
 #include <hpx/parallel/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/predicates.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
@@ -21,9 +23,7 @@
 
 #include <algorithm>
 #include <iterator>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -36,7 +36,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             : public detail::algorithm<lexicographical_compare, bool>
         {
             lexicographical_compare()
-                : lexicographical_compare::algorithm("lexicographical_compare")
+              : lexicographical_compare::algorithm("lexicographical_compare")
             {}
 
            template <typename ExPolicy, typename InIter1, typename InIter2,
@@ -181,35 +181,25 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           it returns false.
     ///
     template <typename ExPolicy, typename InIter1, typename InIter2>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, bool>::type
     >::type
     lexicographical_compare(ExPolicy && policy, InIter1 first1, InIter1 last1,
         InIter2 first2, InIter2 last2)
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category
-            iterator_category1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category
-            iterator_category2;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, iterator_category1
-            >::value),
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            "Requires at least input iterator.");
+        static_assert(
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
-        static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, iterator_category2
-            >::value),
-            "Requires at least input iterator.");
-
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category1>,
-            boost::is_same<std::input_iterator_tag, iterator_category2>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter1>::value ||
+                hpx::traits::is_input_iterator<InIter2>::value
+            > is_seq;
 
         return detail::lexicographical_compare().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -289,35 +279,25 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     /// range [first2, last2), it returns false.
     ///
     template <typename ExPolicy, typename InIter1, typename InIter2, typename Pred>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, bool>::type
     >::type
     lexicographical_compare(ExPolicy && policy, InIter1 first1, InIter1 last1,
         InIter2 first2, InIter2 last2, Pred && pred)
     {
-       typedef typename std::iterator_traits<InIter1>::iterator_category
-            iterator_category1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category
-            iterator_category2;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, iterator_category1
-            >::value),
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            "Requires at least input iterator.");
+        static_assert(
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
-        static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, iterator_category2
-            >::value),
-            "Requires at least input iterator.");
-
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category1>,
-            boost::is_same<std::input_iterator_tag, iterator_category2>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter1>::value ||
+                hpx::traits::is_input_iterator<InIter2>::value
+            > is_seq;
 
         return detail::lexicographical_compare().call(
             std::forward<ExPolicy>(policy), is_seq(),

--- a/hpx/parallel/algorithms/lexicographical_compare.hpp
+++ b/hpx/parallel/algorithms/lexicographical_compare.hpp
@@ -189,16 +189,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         InIter2 first2, InIter2 last2)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter1>::value ||
-                hpx::traits::is_input_iterator<InIter2>::value
+                hpx::traits::is_just_input_iterator<InIter1>::value ||
+                hpx::traits::is_just_input_iterator<InIter2>::value
             > is_seq;
 
         return detail::lexicographical_compare().call(
@@ -287,16 +287,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         InIter2 first2, InIter2 last2, Pred && pred)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter1>::value ||
-                hpx::traits::is_input_iterator<InIter2>::value
+                hpx::traits::is_just_input_iterator<InIter1>::value ||
+                hpx::traits::is_just_input_iterator<InIter2>::value
             > is_seq;
 
         return detail::lexicographical_compare().call(

--- a/hpx/parallel/algorithms/minmax.hpp
+++ b/hpx/parallel/algorithms/minmax.hpp
@@ -243,7 +243,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         Proj && proj = Proj())
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
         typedef hpx::traits::segmented_iterator_traits<FwdIter> iterator_traits;
@@ -467,7 +467,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         Proj && proj = Proj())
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
         typedef hpx::traits::segmented_iterator_traits<FwdIter> iterator_traits;
@@ -730,7 +730,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         F && f = F(), Proj && proj = Proj())
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
         typedef hpx::traits::segmented_iterator_traits<FwdIter> iterator_traits;

--- a/hpx/parallel/algorithms/minmax.hpp
+++ b/hpx/parallel/algorithms/minmax.hpp
@@ -246,8 +246,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::traits::segmented_iterator_traits<FwdIter> iterator_traits;
-        typedef typename iterator_traits::is_segmented_iterator is_segmented;
+        typedef hpx::traits::is_segmented_iterator<FwdIter> is_segmented;
 
         return detail::min_element_(
                 std::forward<ExPolicy>(policy), first, last,
@@ -470,8 +469,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::traits::segmented_iterator_traits<FwdIter> iterator_traits;
-        typedef typename iterator_traits::is_segmented_iterator is_segmented;
+        typedef hpx::traits::is_segmented_iterator<FwdIter> is_segmented;
 
         return detail::max_element_(
                 std::forward<ExPolicy>(policy), first, last,
@@ -733,8 +731,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::traits::segmented_iterator_traits<FwdIter> iterator_traits;
-        typedef typename iterator_traits::is_segmented_iterator is_segmented;
+        typedef hpx::traits::is_segmented_iterator<FwdIter> is_segmented;
 
         return hpx::util::make_tagged_pair<tag::min, tag::max>(
             detail::minmax_element_(

--- a/hpx/parallel/algorithms/minmax.hpp
+++ b/hpx/parallel/algorithms/minmax.hpp
@@ -30,9 +30,7 @@
 
 #include <algorithm>
 #include <iterator>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -94,11 +92,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 return smallest;
             }
 
-            template <typename ExPolicy, typename FwdIter, typename F,
-                typename Proj>
+            template <typename ExPolicy, typename FwdIter, typename F, typename Proj>
             static FwdIter
-            sequential(ExPolicy, FwdIter first, FwdIter last, F && f,
-                Proj && proj)
+            sequential(ExPolicy, FwdIter first, FwdIter last, F && f, Proj && proj)
             {
                 return std::min_element(first, last,
                     util::compare_projected<F, Proj>(
@@ -106,8 +102,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         ));
             }
 
-            template <typename ExPolicy, typename FwdIter, typename F,
-                typename Proj>
+            template <typename ExPolicy, typename FwdIter, typename F, typename Proj>
             static typename util::detail::algorithm_result<
                 ExPolicy, FwdIter
             >::type
@@ -146,9 +141,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         min_element_(ExPolicy && policy, FwdIter first, FwdIter last, F && f,
             Proj && proj, std::false_type)
         {
-            typedef typename parallel::is_sequential_execution_policy<
-                    ExPolicy
-                >::type is_seq;
+            typedef parallel::is_sequential_execution_policy<ExPolicy> is_seq;
 
             return detail::min_element<FwdIter>().call(
                 std::forward<ExPolicy>(policy), is_seq(),
@@ -249,13 +242,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     min_element(ExPolicy && policy, FwdIter first, FwdIter last, F && f = F(),
         Proj && proj = Proj())
     {
-        typedef typename std::iterator_traits<FwdIter>::iterator_category
-            iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::forward_iterator_tag, iterator_category>::value),
-            "Required at least forward iterator.");
+            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            "Requires at least forward iterator.");
 
         typedef hpx::traits::segmented_iterator_traits<FwdIter> iterator_traits;
         typedef typename iterator_traits::is_segmented_iterator is_segmented;
@@ -375,9 +364,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         max_element_(ExPolicy && policy, FwdIter first, FwdIter last, F && f,
             Proj && proj, std::false_type)
         {
-            typedef typename parallel::is_sequential_execution_policy<
-                    ExPolicy
-                >::type is_seq;
+            typedef parallel::is_sequential_execution_policy<ExPolicy> is_seq;
 
             return detail::max_element<FwdIter>().call(
                 std::forward<ExPolicy>(policy), is_seq(),
@@ -479,13 +466,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     max_element(ExPolicy && policy, FwdIter first, FwdIter last, F && f = F(),
         Proj && proj = Proj())
     {
-        typedef typename std::iterator_traits<FwdIter>::iterator_category
-            iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::forward_iterator_tag, iterator_category>::value),
-            "Required at least forward iterator.");
+            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            "Requires at least forward iterator.");
 
         typedef hpx::traits::segmented_iterator_traits<FwdIter> iterator_traits;
         typedef typename iterator_traits::is_segmented_iterator is_segmented;
@@ -631,9 +614,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         minmax_element_(ExPolicy && policy, FwdIter first, FwdIter last, F && f,
             Proj && proj, std::false_type)
         {
-            typedef typename parallel::is_sequential_execution_policy<
-                    ExPolicy
-                >::type is_seq;
+            typedef parallel::is_sequential_execution_policy<ExPolicy> is_seq;
 
             return detail::minmax_element<FwdIter>().call(
                 std::forward<ExPolicy>(policy), is_seq(),
@@ -748,13 +729,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     minmax_element(ExPolicy && policy, FwdIter first, FwdIter last,
         F && f = F(), Proj && proj = Proj())
     {
-        typedef typename std::iterator_traits<FwdIter>::iterator_category
-            iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::forward_iterator_tag, iterator_category>::value),
-            "Required at least forward iterator.");
+            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            "Requires at least forward iterator.");
 
         typedef hpx::traits::segmented_iterator_traits<FwdIter> iterator_traits;
         typedef typename iterator_traits::is_segmented_iterator is_segmented;

--- a/hpx/parallel/algorithms/mismatch.hpp
+++ b/hpx/parallel/algorithms/mismatch.hpp
@@ -200,16 +200,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         InIter2 first2, InIter2 last2)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter1>::value ||
-                hpx::traits::is_input_iterator<InIter2>::value
+                hpx::traits::is_just_input_iterator<InIter1>::value ||
+                hpx::traits::is_just_input_iterator<InIter2>::value
             > is_seq;
 
         typedef std::pair<InIter1, InIter2> result_type;
@@ -303,16 +303,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         InIter2 first2, InIter2 last2, F && f)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter1>::value ||
-                hpx::traits::is_input_iterator<InIter2>::value
+                hpx::traits::is_just_input_iterator<InIter1>::value ||
+                hpx::traits::is_just_input_iterator<InIter2>::value
             > is_seq;
 
         typedef std::pair<InIter1, InIter2> result_type;
@@ -455,16 +455,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     mismatch(ExPolicy&& policy, InIter1 first1, InIter1 last1, InIter2 first2)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter1>::value ||
-                hpx::traits::is_input_iterator<InIter2>::value
+                hpx::traits::is_just_input_iterator<InIter1>::value ||
+                hpx::traits::is_just_input_iterator<InIter2>::value
             > is_seq;
 
         typedef std::pair<InIter1, InIter2> result_type;
@@ -549,16 +549,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         F && f)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter1>::value ||
-                hpx::traits::is_input_iterator<InIter2>::value
+                hpx::traits::is_just_input_iterator<InIter1>::value ||
+                hpx::traits::is_just_input_iterator<InIter2>::value
             > is_seq;
 
         typedef std::pair<InIter1, InIter2> result_type;

--- a/hpx/parallel/algorithms/mismatch.hpp
+++ b/hpx/parallel/algorithms/mismatch.hpp
@@ -208,8 +208,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter1>::value ||
-                hpx::traits::is_just_input_iterator<InIter2>::value
+               !hpx::traits::is_forward_iterator<InIter1>::value ||
+               !hpx::traits::is_forward_iterator<InIter2>::value
             > is_seq;
 
         typedef std::pair<InIter1, InIter2> result_type;
@@ -311,8 +311,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter1>::value ||
-                hpx::traits::is_just_input_iterator<InIter2>::value
+               !hpx::traits::is_forward_iterator<InIter1>::value ||
+               !hpx::traits::is_forward_iterator<InIter2>::value
             > is_seq;
 
         typedef std::pair<InIter1, InIter2> result_type;
@@ -463,8 +463,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter1>::value ||
-                hpx::traits::is_just_input_iterator<InIter2>::value
+               !hpx::traits::is_forward_iterator<InIter1>::value ||
+               !hpx::traits::is_forward_iterator<InIter2>::value
             > is_seq;
 
         typedef std::pair<InIter1, InIter2> result_type;
@@ -557,8 +557,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter1>::value ||
-                hpx::traits::is_just_input_iterator<InIter2>::value
+               !hpx::traits::is_forward_iterator<InIter1>::value ||
+               !hpx::traits::is_forward_iterator<InIter2>::value
             > is_seq;
 
         typedef std::pair<InIter1, InIter2> result_type;

--- a/hpx/parallel/algorithms/mismatch.hpp
+++ b/hpx/parallel/algorithms/mismatch.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +9,8 @@
 #define HPX_PARALLEL_DETAIL_MISMATCH_JUL_13_2014_0142PM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
+
 #include <hpx/parallel/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/predicates.hpp>
@@ -19,9 +21,7 @@
 
 #include <algorithm>
 #include <iterator>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -190,8 +190,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           If the length of the range [first1, last1) does not mismatch
     ///           the length of the range [first2, last2), it returns false.
     template <typename ExPolicy, typename InIter1, typename InIter2>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<
             ExPolicy, std::pair<InIter1, InIter2>
         >::type
@@ -199,23 +199,18 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     mismatch(ExPolicy&& policy, InIter1 first1, InIter1 last1,
         InIter2 first2, InIter2 last2)
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category
-            iterator_category1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category
-            iterator_category2;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category1>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category2>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category1>,
-            boost::is_same<std::input_iterator_tag, iterator_category2>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter1>::value ||
+                hpx::traits::is_input_iterator<InIter2>::value
+            > is_seq;
 
         typedef std::pair<InIter1, InIter2> result_type;
         return detail::mismatch_binary<result_type>().call(
@@ -298,8 +293,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           If the length of the range [first1, last1) does not mismatch
     ///           the length of the range [first2, last2), it returns false.
     template <typename ExPolicy, typename InIter1, typename InIter2, typename F>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<
             ExPolicy, std::pair<InIter1, InIter2>
         >::type
@@ -307,23 +302,18 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     mismatch(ExPolicy&& policy, InIter1 first1, InIter1 last1,
         InIter2 first2, InIter2 last2, F && f)
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category
-            iterator_category1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category
-            iterator_category2;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category1>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category2>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category1>,
-            boost::is_same<std::input_iterator_tag, iterator_category2>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter1>::value ||
+                hpx::traits::is_input_iterator<InIter2>::value
+            > is_seq;
 
         typedef std::pair<InIter1, InIter2> result_type;
         return detail::mismatch_binary<result_type>().call(
@@ -456,32 +446,26 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           and another defined by [first2, last2).
     ///
     template <typename ExPolicy, typename InIter1, typename InIter2>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<
             ExPolicy, std::pair<InIter1, InIter2>
         >::type
     >::type
-    mismatch(ExPolicy&& policy, InIter1 first1, InIter1 last1,
-        InIter2 first2)
+    mismatch(ExPolicy&& policy, InIter1 first1, InIter1 last1, InIter2 first2)
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category
-            iterator_category1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category
-            iterator_category2;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category1>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category2>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category1>,
-            boost::is_same<std::input_iterator_tag, iterator_category2>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter1>::value ||
+                hpx::traits::is_input_iterator<InIter2>::value
+            > is_seq;
 
         typedef std::pair<InIter1, InIter2> result_type;
         return detail::mismatch<result_type>().call(
@@ -555,8 +539,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           and another defined by [first2, last2).
     ///
     template <typename ExPolicy, typename InIter1, typename InIter2, typename F>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<
             ExPolicy, std::pair<InIter1, InIter2>
         >::type
@@ -564,23 +548,18 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     mismatch(ExPolicy&& policy, InIter1 first1, InIter1 last1, InIter2 first2,
         F && f)
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category
-            iterator_category1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category
-            iterator_category2;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category1>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category2>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category1>,
-            boost::is_same<std::input_iterator_tag, iterator_category2>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter1>::value ||
+                hpx::traits::is_input_iterator<InIter2>::value
+            > is_seq;
 
         typedef std::pair<InIter1, InIter2> result_type;
         return detail::mismatch<result_type>().call(

--- a/hpx/parallel/algorithms/move.hpp
+++ b/hpx/parallel/algorithms/move.hpp
@@ -125,16 +125,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     move(ExPolicy && policy, InIter first, InIter last, OutIter dest)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_input_iterator<OutIter>::value),
+                hpx::traits::is_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_just_input_iterator<InIter>::value ||
                 hpx::traits::is_output_iterator<OutIter>::value
             > is_seq;
 

--- a/hpx/parallel/algorithms/move.hpp
+++ b/hpx/parallel/algorithms/move.hpp
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_DETAIL_MOVE_JUNE_16_2014_1106AM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
 #include <hpx/parallel/execution_policy.hpp>
@@ -19,9 +20,7 @@
 
 #include <algorithm>
 #include <iterator>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -59,7 +58,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 return get_iter<1, result_type>(
                     for_each_n<zip_iterator>().call(
-                        std::forward<ExPolicy>(policy), boost::mpl::false_(),
+                        std::forward<ExPolicy>(policy), std::false_type(),
                         hpx::util::make_zip_iterator(first, dest),
                         std::distance(first, last),
                         [](reference t) {
@@ -119,36 +118,25 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           copied.
     ///
     template <typename ExPolicy, typename InIter, typename OutIter>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     >::type
     move(ExPolicy && policy, InIter first, InIter last, OutIter dest)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            input_iterator_category;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category>::value),
-            "Required at least input iterator.");
-
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            "Requires at least input iterator.");
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, input_iterator_category>,
-            boost::is_same<std::output_iterator_tag, output_iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_output_iterator<OutIter>::value
+            > is_seq;
 
         return detail::move<OutIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),

--- a/hpx/parallel/algorithms/move.hpp
+++ b/hpx/parallel/algorithms/move.hpp
@@ -134,8 +134,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value ||
+               !hpx::traits::is_forward_iterator<OutIter>::value
             > is_seq;
 
         return detail::move<OutIter>().call(

--- a/hpx/parallel/algorithms/reduce.hpp
+++ b/hpx/parallel/algorithms/reduce.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_DETAIL_REDUCE_JUN_01_2014_0903AM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 #include <hpx/util/unwrapped.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
@@ -19,12 +20,11 @@
 #include <hpx/parallel/util/loop.hpp>
 
 #include <boost/range/functions.hpp>
-#include <boost/type_traits/is_base_of.hpp>
-#include <boost/utility/enable_if.hpp>
 
 #include <algorithm>
 #include <numeric>
 #include <iterator>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -152,23 +152,20 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     /// non-associative or non-commutative binary predicate.
     ///
     template <typename ExPolicy, typename InIter, typename T, typename F>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, T>::type
     >::type
     reduce(ExPolicy&& policy, InIter first, InIter last, T init, F && f)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value
+            > is_seq;
 
         return detail::reduce<T>().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -229,23 +226,20 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     /// non-associative or non-commutative binary predicate.
     ///
     template <typename ExPolicy, typename InIter, typename T>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, T>::type
     >::type
     reduce(ExPolicy&& policy, InIter first, InIter last, T init)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value
+            > is_seq;
 
         return detail::reduce<T>().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -307,25 +301,25 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     /// non-associative or non-commutative binary predicate.
     ///
     template <typename ExPolicy, typename InIter>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy,
-            typename std::iterator_traits<InIter>::value_type>::type
+            typename std::iterator_traits<InIter>::value_type
+        >::type
     >::type
     reduce(ExPolicy&& policy, InIter first, InIter last)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-        typedef typename std::iterator_traits<InIter>::value_type value_type;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>
-        >::type is_seq;
+        typedef typename typename std::iterator_traits<InIter>::value_type
+            value_type
+
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value
+            > is_seq;
 
         return detail::reduce<value_type>().call(
             std::forward<ExPolicy>(policy), is_seq(),

--- a/hpx/parallel/algorithms/reduce.hpp
+++ b/hpx/parallel/algorithms/reduce.hpp
@@ -313,8 +313,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
-        typedef typename typename std::iterator_traits<InIter>::value_type
-            value_type
+        typedef typename std::iterator_traits<InIter>::value_type value_type;
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||

--- a/hpx/parallel/algorithms/reduce.hpp
+++ b/hpx/parallel/algorithms/reduce.hpp
@@ -159,12 +159,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     reduce(ExPolicy&& policy, InIter first, InIter last, T init, F && f)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value
+                hpx::traits::is_just_input_iterator<InIter>::value
             > is_seq;
 
         return detail::reduce<T>().call(
@@ -233,12 +233,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     reduce(ExPolicy&& policy, InIter first, InIter last, T init)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value
+                hpx::traits::is_just_input_iterator<InIter>::value
             > is_seq;
 
         return detail::reduce<T>().call(
@@ -310,14 +310,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     reduce(ExPolicy&& policy, InIter first, InIter last)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
         typedef typename std::iterator_traits<InIter>::value_type value_type;
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value
+                hpx::traits::is_just_input_iterator<InIter>::value
             > is_seq;
 
         return detail::reduce<value_type>().call(

--- a/hpx/parallel/algorithms/reduce.hpp
+++ b/hpx/parallel/algorithms/reduce.hpp
@@ -164,7 +164,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value
             > is_seq;
 
         return detail::reduce<T>().call(
@@ -238,7 +238,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value
             > is_seq;
 
         return detail::reduce<T>().call(
@@ -317,7 +317,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value
             > is_seq;
 
         return detail::reduce<value_type>().call(

--- a/hpx/parallel/algorithms/remove_copy.hpp
+++ b/hpx/parallel/algorithms/remove_copy.hpp
@@ -181,8 +181,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value ||
+               !hpx::traits::is_forward_iterator<OutIter>::value
             > is_seq;
 
         return hpx::util::make_tagged_pair<tag::in, tag::out>(
@@ -363,8 +363,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value ||
+               !hpx::traits::is_forward_iterator<OutIter>::value
             > is_seq;
 
         return hpx::util::make_tagged_pair<tag::in, tag::out>(

--- a/hpx/parallel/algorithms/remove_copy.hpp
+++ b/hpx/parallel/algorithms/remove_copy.hpp
@@ -175,14 +175,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_output_iterator<InIter>::value ||
-                hpx::traits::is_at_least_forward_iterator<InIter>::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
                 hpx::traits::is_input_iterator<InIter>::value ||
-                hpx::traits::is_output_iterator<InIter>::value
+                hpx::traits::is_output_iterator<OutIter>::value
             > is_seq;
 
         return hpx::util::make_tagged_pair<tag::in, tag::out>(

--- a/hpx/parallel/algorithms/remove_copy.hpp
+++ b/hpx/parallel/algorithms/remove_copy.hpp
@@ -172,16 +172,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         T const& val, Proj && proj = Proj())
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
+                hpx::traits::is_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_just_input_iterator<InIter>::value ||
                 hpx::traits::is_output_iterator<OutIter>::value
             > is_seq;
 
@@ -354,16 +354,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         F && f, Proj && proj = Proj())
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
+                hpx::traits::is_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_just_input_iterator<InIter>::value ||
                 hpx::traits::is_output_iterator<OutIter>::value
             > is_seq;
 

--- a/hpx/parallel/algorithms/remove_copy.hpp
+++ b/hpx/parallel/algorithms/remove_copy.hpp
@@ -25,9 +25,6 @@
 #include <iterator>
 #include <type_traits>
 
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
-
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
     /////////////////////////////////////////////////////////////////////////////
@@ -79,7 +76,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 OutIter dest, T const& val, Proj && proj)
             {
                 return copy_if<IterPair>().call(
-                    std::forward<ExPolicy>(policy), boost::mpl::false_(),
+                    std::forward<ExPolicy>(policy), std::false_type(),
                     first, last, dest,
                     [val, proj](T const& a)
                     {
@@ -174,30 +171,19 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     remove_copy(ExPolicy && policy, InIter first, InIter last, OutIter dest,
         T const& val, Proj && proj = Proj())
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            input_iterator_category;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category>::value),
-            "Required at least input iterator.");
-
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            "Requires at least input iterator.");
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<InIter>::value ||
+                hpx::traits::is_at_least_forward_iterator<InIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, input_iterator_category>,
-            boost::is_same<std::output_iterator_tag, output_iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_output_iterator<InIter>::value
+            > is_seq;
 
         return hpx::util::make_tagged_pair<tag::in, tag::out>(
             detail::remove_copy<std::pair<InIter, OutIter> >().call(
@@ -258,7 +244,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     value_type;
 
                 return copy_if<IterPair>().call(
-                    std::forward<ExPolicy>(policy), boost::mpl::false_(),
+                    std::forward<ExPolicy>(policy), std::false_type(),
                     first, last, dest,
                     [f](value_type const& a)
                     {
@@ -367,30 +353,19 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     remove_copy_if(ExPolicy && policy, InIter first, InIter last, OutIter dest,
         F && f, Proj && proj = Proj())
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            input_iterator_category;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category>::value),
-            "Required at least input iterator.");
-
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            "Requires at least input iterator.");
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, input_iterator_category>,
-            boost::is_same<std::output_iterator_tag, output_iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_output_iterator<OutIter>::value
+            > is_seq;
 
         return hpx::util::make_tagged_pair<tag::in, tag::out>(
             detail::remove_copy_if<std::pair<InIter, OutIter> >().call(

--- a/hpx/parallel/algorithms/replace.hpp
+++ b/hpx/parallel/algorithms/replace.hpp
@@ -493,8 +493,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value ||
+               !hpx::traits::is_forward_iterator<OutIter>::value
             > is_seq;
 
         return hpx::util::make_tagged_pair<tag::in, tag::out>(
@@ -684,8 +684,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value ||
+               !hpx::traits::is_forward_iterator<OutIter>::value
             > is_seq;
 
         return hpx::util::make_tagged_pair<tag::in, tag::out>(

--- a/hpx/parallel/algorithms/replace.hpp
+++ b/hpx/parallel/algorithms/replace.hpp
@@ -162,7 +162,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         T1 const& old_value, T2 const& new_value, Proj && proj = Proj())
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;
@@ -320,7 +320,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         F && f, T const& new_value, Proj && proj = Proj())
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;
@@ -484,16 +484,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         T1 const& old_value, T2 const& new_value, Proj && proj = Proj())
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value||
-                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
+                hpx::traits::is_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_just_input_iterator<InIter>::value ||
                 hpx::traits::is_output_iterator<OutIter>::value
             > is_seq;
 
@@ -675,16 +675,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         F && f, T const& new_value, Proj && proj = Proj())
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value||
-                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
+                hpx::traits::is_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_just_input_iterator<InIter>::value ||
                 hpx::traits::is_output_iterator<OutIter>::value
             > is_seq;
 

--- a/hpx/parallel/algorithms/replace.hpp
+++ b/hpx/parallel/algorithms/replace.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2015 Hartmut Kaiser
+//  Copyright (c) 2014-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -27,9 +27,7 @@
 
 #include <algorithm>
 #include <iterator>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -83,7 +81,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 typedef typename std::iterator_traits<FwdIter>::value_type type;
 
                 return for_each_n<FwdIter>().call(
-                    std::forward<ExPolicy>(policy), boost::mpl::false_(),
+                    std::forward<ExPolicy>(policy), std::false_type(),
                     first, std::distance(first, last),
                     [old_value, new_value, proj](type& t)
                     {
@@ -163,15 +161,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     replace(ExPolicy && policy, FwdIter first, FwdIter last,
         T1 const& old_value, T2 const& new_value, Proj && proj = Proj())
     {
-        typedef typename std::iterator_traits<FwdIter>::iterator_category
-            iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::forward_iterator_tag, iterator_category>::value),
+            (hpx::traits::is_at_least_forward_iterator<InIter>::value),
             "Required at least forward iterator.");
 
-        typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
+        typedef is_sequential_execution_policy<ExPolicy> is_seq;
 
         return detail::replace<FwdIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -229,7 +223,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 typedef typename std::iterator_traits<FwdIter>::value_type type;
 
                 return for_each_n<FwdIter>().call(
-                    std::forward<ExPolicy>(policy), boost::mpl::false_(),
+                    std::forward<ExPolicy>(policy), std::false_type(),
                     first, std::distance(first, last),
                     [f, new_value, proj](type& t)
                     {
@@ -325,15 +319,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     replace_if(ExPolicy && policy, FwdIter first, FwdIter last,
         F && f, T const& new_value, Proj && proj = Proj())
     {
-        typedef typename std::iterator_traits<FwdIter>::iterator_category
-            iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::forward_iterator_tag, iterator_category>::value),
+            (hpx::traits::is_at_least_forward_iterator<InIter>::value),
             "Required at least forward iterator.");
 
-        typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
+        typedef is_sequential_execution_policy<ExPolicy> is_seq;
 
         return detail::replace_if<FwdIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -395,7 +385,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 return get_iter_pair(
                     for_each_n<zip_iterator>().call(
-                        std::forward<ExPolicy>(policy), boost::mpl::false_(),
+                        std::forward<ExPolicy>(policy), std::false_type(),
                         hpx::util::make_zip_iterator(first, dest),
                         std::distance(first, last),
                         [old_value, new_value, proj](reference t)
@@ -493,30 +483,19 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     replace_copy(ExPolicy && policy, InIter first, InIter last, OutIter dest,
         T1 const& old_value, T2 const& new_value, Proj && proj = Proj())
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            input_iterator_category;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category>::value),
-            "Required at least forward iterator.");
-
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            "Requires at least input iterator.");
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value||
+                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, input_iterator_category>,
-            boost::is_same<std::output_iterator_tag, output_iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_output_iterator<OutIter>::value
+            > is_seq;
 
         return hpx::util::make_tagged_pair<tag::in, tag::out>(
             detail::replace_copy<std::pair<InIter, OutIter> >().call(
@@ -580,7 +559,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 return get_iter_pair(
                     for_each_n<zip_iterator>().call(
-                        std::forward<ExPolicy>(policy), boost::mpl::false_(),
+                        std::forward<ExPolicy>(policy), std::false_type(),
                         hpx::util::make_zip_iterator(first, dest),
                         std::distance(first, last),
                         [f, new_value, proj](reference t)
@@ -695,30 +674,19 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     replace_copy_if(ExPolicy && policy, InIter first, InIter last, OutIter dest,
         F && f, T const& new_value, Proj && proj = Proj())
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            input_iterator_category;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category>::value),
-            "Required at least forward iterator.");
-
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            "Requires at least input iterator.");
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value||
+                hpx::traits::is_at_least_forward_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, input_iterator_category>,
-            boost::is_same<std::output_iterator_tag, output_iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_output_iterator<OutIter>::value
+            > is_seq;
 
         return hpx::util::make_tagged_pair<tag::in, tag::out>(
             detail::replace_copy_if<std::pair<InIter, OutIter> >().call(

--- a/hpx/parallel/algorithms/replace.hpp
+++ b/hpx/parallel/algorithms/replace.hpp
@@ -162,7 +162,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         T1 const& old_value, T2 const& new_value, Proj && proj = Proj())
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<InIter>::value),
+            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;
@@ -320,7 +320,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         F && f, T const& new_value, Proj && proj = Proj())
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<InIter>::value),
+            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;

--- a/hpx/parallel/algorithms/reverse.hpp
+++ b/hpx/parallel/algorithms/reverse.hpp
@@ -125,7 +125,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     reverse(ExPolicy && policy, BidirIter first, BidirIter last)
     {
         static_assert(
-            (hpx::traits::is_at_least_bidirectional_iterator<BidirIter>::value),
+            (hpx::traits::is_bidirectional_iterator<BidirIter>::value),
             "Requires at least bidirectional iterator.");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;
@@ -260,11 +260,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         OutIter dest_first)
     {
         static_assert(
-            (hpx::traits::is_at_least_bidirectional_iterator<BidirIter>::value),
+            (hpx::traits::is_bidirectional_iterator<BidirIter>::value),
             "Requires at least bidirectional iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_input_iterator<OutIter>::value),
+                hpx::traits::is_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,

--- a/hpx/parallel/algorithms/reverse.hpp
+++ b/hpx/parallel/algorithms/reverse.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -24,9 +24,7 @@
 
 #include <algorithm>
 #include <iterator>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -63,7 +61,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 return util::detail::convert_to_result(
                     for_each_n<zip_iterator>().call(
-                        std::forward<ExPolicy>(policy), boost::mpl::false_(),
+                        std::forward<ExPolicy>(policy), std::false_type(),
                         hpx::util::make_zip_iterator(
                             first, destination_iterator(last)),
                         std::distance(first, last) / 2,
@@ -126,15 +124,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     typename util::detail::algorithm_result<ExPolicy, BidirIter>::type
     reverse(ExPolicy && policy, BidirIter first, BidirIter last)
     {
-        typedef typename std::iterator_traits<BidirIter>::iterator_category
-            iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::bidirectional_iterator_tag, iterator_category>::value),
-            "Required at least bidirectional iterator.");
+            (hpx::traits::is_at_least_bidirectional_iterator<BidirIter>::value),
+            "Requires at least bidirectional iterator.");
 
-        typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
+        typedef is_sequential_execution_policy<ExPolicy> is_seq;
 
         return detail::reverse<BidirIter>().call(
             std::forward<ExPolicy>(policy), is_seq(), first, last);
@@ -186,7 +180,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 return util::detail::convert_to_result(
                     detail::copy<std::pair<iterator, OutIter> >().call(
-                        std::forward<ExPolicy>(policy), boost::mpl::false_(),
+                        std::forward<ExPolicy>(policy), std::false_type(),
                         iterator(last), iterator(first), dest_first
                     ),
                     [](std::pair<iterator, OutIter> const& p)
@@ -265,29 +259,18 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     reverse_copy(ExPolicy && policy, BidirIter first, BidirIter last,
         OutIter dest_first)
     {
-        typedef typename std::iterator_traits<BidirIter>::iterator_category
-            input_iterator_category;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::bidirectional_iterator_tag, input_iterator_category>::value),
-            "Required at least bidirectional iterator.");
-
+            (hpx::traits::is_at_least_bidirectional_iterator<BidirIter>::value),
+            "Requires at least bidirectional iterator.");
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::output_iterator_tag, output_iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_output_iterator<OutIter>::value
+            > is_seq;
 
         return hpx::util::make_tagged_pair<tag::in, tag::out>(
             detail::reverse_copy<std::pair<BidirIter, OutIter> >().call(

--- a/hpx/parallel/algorithms/reverse.hpp
+++ b/hpx/parallel/algorithms/reverse.hpp
@@ -269,7 +269,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value
+               !hpx::traits::is_forward_iterator<OutIter>::value
             > is_seq;
 
         return hpx::util::make_tagged_pair<tag::in, tag::out>(

--- a/hpx/parallel/algorithms/rotate.hpp
+++ b/hpx/parallel/algorithms/rotate.hpp
@@ -186,12 +186,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     rotate(ExPolicy && policy, FwdIter first, FwdIter new_first, FwdIter last)
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_forward_iterator<FwdIter>::value
+                hpx::traits::is_just_forward_iterator<FwdIter>::value
             > is_seq;
 
         return hpx::util::make_tagged_pair<tag::begin, tag::end>(
@@ -339,11 +339,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         FwdIter last, OutIter dest_first)
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_input_iterator<OutIter>::value),
+                hpx::traits::is_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,

--- a/hpx/parallel/algorithms/rotate.hpp
+++ b/hpx/parallel/algorithms/rotate.hpp
@@ -191,7 +191,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_forward_iterator<FwdIter>::value
+               !hpx::traits::is_bidirectional_iterator<FwdIter>::value
             > is_seq;
 
         return hpx::util::make_tagged_pair<tag::begin, tag::end>(
@@ -348,7 +348,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value
+               !hpx::traits::is_bidirectional_iterator<FwdIter>::value ||
+               !hpx::traits::is_forward_iterator<OutIter>::value
             > is_seq;
 
         return hpx::util::make_tagged_pair<tag::in, tag::out>(

--- a/hpx/parallel/algorithms/rotate.hpp
+++ b/hpx/parallel/algorithms/rotate.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -25,9 +25,7 @@
 
 #include <algorithm>
 #include <iterator>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -71,7 +69,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         rotate_helper(ExPolicy policy, FwdIter first, FwdIter new_first,
             FwdIter last)
         {
-            typedef boost::mpl::false_ non_seq;
+            typedef std::false_type non_seq;
 
             parallel_task_execution_policy p =
                 parallel_task_execution_policy()
@@ -187,18 +185,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     >::type
     rotate(ExPolicy && policy, FwdIter first, FwdIter new_first, FwdIter last)
     {
-        typedef typename std::iterator_traits<FwdIter>::iterator_category
-            iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::forward_iterator_tag, iterator_category>::value),
-            "Required at least forward iterator.");
+            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            "Requires at least forward iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::forward_iterator_tag, iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_forward_iterator<FwdIter>::value
+            > is_seq;
 
         return hpx::util::make_tagged_pair<tag::begin, tag::end>(
             detail::rotate<std::pair<FwdIter, FwdIter> >().call(
@@ -230,7 +224,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         rotate_copy_helper(ExPolicy policy, FwdIter first,
             FwdIter new_first, FwdIter last, OutIter dest_first)
         {
-            typedef boost::mpl::false_ non_seq;
+            typedef std::false_type non_seq;
 
             parallel_task_execution_policy p =
                 parallel_task_execution_policy()
@@ -344,29 +338,18 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     rotate_copy(ExPolicy && policy, FwdIter first, FwdIter new_first,
         FwdIter last, OutIter dest_first)
     {
-        typedef typename std::iterator_traits<FwdIter>::iterator_category
-            forward_iterator_category;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::forward_iterator_tag, forward_iterator_category>::value),
-            "Required at least forward iterator.");
-
+            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            "Requires at least forward iterator.");
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::output_iterator_tag, output_iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_output_iterator<OutIter>::value
+            > is_seq;
 
         return hpx::util::make_tagged_pair<tag::in, tag::out>(
             detail::rotate_copy<std::pair<FwdIter, OutIter> >().call(

--- a/hpx/parallel/algorithms/search.hpp
+++ b/hpx/parallel/algorithms/search.hpp
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_ALGORITHMS_SEARCH_NOV_9_2014_0317PM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
 #include <hpx/parallel/execution_policy.hpp>
@@ -23,9 +24,7 @@
 
 #include <algorithm>
 #include <iterator>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 namespace hpx {namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -173,34 +172,21 @@ namespace hpx {namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           is found, \a last is also returned.
     ///
     template <typename ExPolicy, typename FwdIter, typename FwdIter2>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
     >::type
     search(ExPolicy && policy, FwdIter first, FwdIter last,
         FwdIter2 s_first, FwdIter2 s_last)
     {
-        typedef typename std::iterator_traits<FwdIter>::iterator_category
-            iterator_category;
-        typedef typename std::iterator_traits<FwdIter2>::iterator_category
-            s_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, iterator_category
-            >::value),
-            "Requires at least input iterator.");
-
+            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            "Requires at least forward iterator.");
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, s_iterator_category
-            >::value),
+            (hpx::traits::is_at_least_forward_iterator<FwdIter2>::value),
             "Subsequence requires at least forward iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>
-        >::type is_seq;
+        typedef is_sequential_execution_policy<ExPolicy> is_seq;
 
         return detail::search<FwdIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -272,34 +258,21 @@ namespace hpx {namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///
     template <typename ExPolicy, typename FwdIter, typename FwdIter2,
         typename Pred>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
     >::type
     search(ExPolicy && policy, FwdIter first, FwdIter last,
         FwdIter2 s_first, FwdIter2 s_last, Pred && op)
     {
-        typedef typename std::iterator_traits<FwdIter>::iterator_category
-            iterator_category;
-        typedef typename std::iterator_traits<FwdIter2>::iterator_category
-            s_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, iterator_category
-            >::value),
-            "Requires at least input iterator.");
-
+            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            "Requires at least forward iterator.");
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, s_iterator_category
-            >::value),
+            (hpx::traits::is_at_least_forward_iterator<FwdIter2>::value),
             "Subsequence requires at least forward iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>
-        >::type is_seq;
+        typedef is_sequential_execution_policy<ExPolicy> is_seq;
 
         return detail::search<FwdIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -451,34 +424,21 @@ namespace hpx {namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           is found, \a first is also returned.
     ///
     template <typename ExPolicy, typename FwdIter, typename FwdIter2>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
     >::type
     search_n(ExPolicy && policy, FwdIter first, std::size_t count,
         FwdIter2 s_first, FwdIter2 s_last)
     {
-        typedef typename std::iterator_traits<FwdIter>::iterator_category
-            iterator_category;
-        typedef typename std::iterator_traits<FwdIter2>::iterator_category
-            s_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, iterator_category
-            >::value),
-            "Requires at least input iterator.");
-
+            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            "Requires at least forward iterator.");
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, s_iterator_category
-            >::value),
+            (hpx::traits::is_at_least_forward_iterator<FwdIter2>::value),
             "Subsequence requires at least forward iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>
-        >::type is_seq;
+        typedef is_sequential_execution_policy<ExPolicy> is_seq;
 
         return detail::search_n<FwdIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -549,36 +509,22 @@ namespace hpx {namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           Additionally if the size of the subsequence is empty or no subsequence
     ///           is found, \a first is also returned.
     ///
-    template <typename ExPolicy, typename FwdIter, typename FwdIter2,
-        typename Pred>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    template <typename ExPolicy, typename FwdIter, typename FwdIter2, typename Pred>
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
     >::type
     search_n(ExPolicy && policy, FwdIter first, std::size_t count,
         FwdIter2 s_first, FwdIter2 s_last, Pred && op)
     {
-        typedef typename std::iterator_traits<FwdIter>::iterator_category
-            iterator_category;
-        typedef typename std::iterator_traits<FwdIter2>::iterator_category
-            s_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, iterator_category
-            >::value),
-            "Requires at least input iterator.");
-
+            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            "Requires at least forward iterator.");
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, s_iterator_category
-            >::value),
+            (hpx::traits::is_at_least_forward_iterator<FwdIter2>::value),
             "Subsequence requires at least forward iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>
-        >::type is_seq;
+        typedef is_sequential_execution_policy<ExPolicy> is_seq;
 
         return detail::search_n<FwdIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),

--- a/hpx/parallel/algorithms/search.hpp
+++ b/hpx/parallel/algorithms/search.hpp
@@ -180,10 +180,10 @@ namespace hpx {namespace parallel { HPX_INLINE_NAMESPACE(v1)
         FwdIter2 s_first, FwdIter2 s_last)
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter2>::value),
+            (hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Subsequence requires at least forward iterator.");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;
@@ -266,10 +266,10 @@ namespace hpx {namespace parallel { HPX_INLINE_NAMESPACE(v1)
         FwdIter2 s_first, FwdIter2 s_last, Pred && op)
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter2>::value),
+            (hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Subsequence requires at least forward iterator.");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;
@@ -432,10 +432,10 @@ namespace hpx {namespace parallel { HPX_INLINE_NAMESPACE(v1)
         FwdIter2 s_first, FwdIter2 s_last)
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter2>::value),
+            (hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Subsequence requires at least forward iterator.");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;
@@ -518,10 +518,10 @@ namespace hpx {namespace parallel { HPX_INLINE_NAMESPACE(v1)
         FwdIter2 s_first, FwdIter2 s_last, Pred && op)
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter2>::value),
+            (hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Subsequence requires at least forward iterator.");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;

--- a/hpx/parallel/algorithms/set_difference.hpp
+++ b/hpx/parallel/algorithms/set_difference.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_ALGORITHM_SET_DIFFERENCE_MAR_10_2015_0158PM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 #include <hpx/util/decay.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
@@ -21,13 +22,9 @@
 
 #include <algorithm>
 #include <iterator>
+#include <type_traits>
 
 #include <boost/shared_array.hpp>
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_same.hpp>
-#include <boost/type_traits/is_base_of.hpp>
-#include <boost/mpl/or.hpp>
-#include <boost/mpl/not.hpp>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -81,7 +78,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         detail::copy<std::pair<RanIter1, OutIter> >()
                             .call(
                                 std::forward<ExPolicy>(policy),
-                                boost::mpl::false_(), first1, last1, dest
+                                std::false_type(), first1, last1, dest
                             ),
                             [](std::pair<RanIter1, OutIter> const& p) -> OutIter
                             {
@@ -193,50 +190,30 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///
     template <typename ExPolicy, typename InIter1, typename InIter2,
         typename OutIter, typename F>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     >::type
     set_difference(ExPolicy && policy, InIter1 first1, InIter1 last1,
         InIter2 first2, InIter2 last2, OutIter dest, F && f)
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category
-            input_iterator_category1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category
-            input_iterator_category2;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category1>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category2>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
-
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            parallel::is_sequential_execution_policy<ExPolicy>,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, input_iterator_category1
-            > >,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, input_iterator_category2
-            > >,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, output_iterator_category
-            > >
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+               !hpx::traits::is_random_access_iterator<InIter1>::value ||
+               !hpx::traits::is_random_access_iterator<InIter2>::value ||
+               !hpx::traits::is_random_access_iterator<OutIter>::value
+            > is_seq;
 
         return detail::set_difference<OutIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -305,52 +282,31 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           element in the destination range, one past the last element
     ///           copied.
     ///
-    template <typename ExPolicy, typename InIter1, typename InIter2,
-        typename OutIter>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    template <typename ExPolicy, typename InIter1, typename InIter2, typename OutIter>
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     >::type
     set_difference(ExPolicy && policy, InIter1 first1, InIter1 last1,
         InIter2 first2, InIter2 last2, OutIter dest)
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category
-            input_iterator_category1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category
-            input_iterator_category2;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category1>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category2>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
-
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            parallel::is_sequential_execution_policy<ExPolicy>,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, input_iterator_category1
-            > >,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, input_iterator_category2
-            > >,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, output_iterator_category
-            > >
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+               !hpx::traits::is_random_access_iterator<InIter1>::value ||
+               !hpx::traits::is_random_access_iterator<InIter2>::value ||
+               !hpx::traits::is_random_access_iterator<OutIter>::value
+            > is_seq;
 
         return detail::set_difference<OutIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),

--- a/hpx/parallel/algorithms/set_difference.hpp
+++ b/hpx/parallel/algorithms/set_difference.hpp
@@ -198,14 +198,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         InIter2 first2, InIter2 last2, OutIter dest, F && f)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_input_iterator<OutIter>::value),
+                hpx::traits::is_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
@@ -291,14 +291,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         InIter2 first2, InIter2 last2, OutIter dest)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_input_iterator<OutIter>::value),
+                hpx::traits::is_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,

--- a/hpx/parallel/algorithms/set_intersection.hpp
+++ b/hpx/parallel/algorithms/set_intersection.hpp
@@ -184,14 +184,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         InIter2 first2, InIter2 last2, OutIter dest, F && f)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_input_iterator<OutIter>::value),
+                hpx::traits::is_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
@@ -277,14 +277,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         InIter2 first2, InIter2 last2, OutIter dest)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_input_iterator<OutIter>::value),
+                hpx::traits::is_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,

--- a/hpx/parallel/algorithms/set_intersection.hpp
+++ b/hpx/parallel/algorithms/set_intersection.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_ALGORITHM_SET_INTERSECTION_MAR_10_2015_0152PM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 #include <hpx/util/decay.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
@@ -21,13 +22,9 @@
 
 #include <algorithm>
 #include <iterator>
+#include <type_traits>
 
 #include <boost/shared_array.hpp>
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_same.hpp>
-#include <boost/type_traits/is_base_of.hpp>
-#include <boost/mpl/or.hpp>
-#include <boost/mpl/not.hpp>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -179,50 +176,30 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///
     template <typename ExPolicy, typename InIter1, typename InIter2,
         typename OutIter, typename F>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     >::type
     set_intersection(ExPolicy && policy, InIter1 first1, InIter1 last1,
         InIter2 first2, InIter2 last2, OutIter dest, F && f)
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category
-            input_iterator_category1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category
-            input_iterator_category2;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category1>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category2>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
-
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            parallel::is_sequential_execution_policy<ExPolicy>,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, input_iterator_category1
-            > >,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, input_iterator_category2
-            > >,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, output_iterator_category
-            > >
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+               !hpx::traits::is_random_access_iterator<InIter1>::value ||
+               !hpx::traits::is_random_access_iterator<InIter2>::value ||
+               !hpx::traits::is_random_access_iterator<OutIter>::value
+            > is_seq;
 
         return detail::set_intersection<OutIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -291,52 +268,31 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           element in the destination range, one past the last element
     ///           copied.
     ///
-    template <typename ExPolicy, typename InIter1, typename InIter2,
-        typename OutIter>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    template <typename ExPolicy, typename InIter1, typename InIter2, typename OutIter>
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     >::type
     set_intersection(ExPolicy && policy, InIter1 first1, InIter1 last1,
         InIter2 first2, InIter2 last2, OutIter dest)
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category
-            input_iterator_category1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category
-            input_iterator_category2;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category1>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category2>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
-
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            parallel::is_sequential_execution_policy<ExPolicy>,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, input_iterator_category1
-            > >,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, input_iterator_category2
-            > >,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, output_iterator_category
-            > >
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+               !hpx::traits::is_random_access_iterator<InIter1>::value ||
+               !hpx::traits::is_random_access_iterator<InIter2>::value ||
+               !hpx::traits::is_random_access_iterator<OutIter>::value
+            > is_seq;
 
         return detail::set_intersection<OutIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),

--- a/hpx/parallel/algorithms/set_symmetric_difference.hpp
+++ b/hpx/parallel/algorithms/set_symmetric_difference.hpp
@@ -211,14 +211,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         InIter2 first2, InIter2 last2, OutIter dest, F && f)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_input_iterator<OutIter>::value),
+                hpx::traits::is_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
@@ -308,14 +308,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         InIter2 first2, InIter2 last2, OutIter dest)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_input_iterator<OutIter>::value),
+                hpx::traits::is_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,

--- a/hpx/parallel/algorithms/set_symmetric_difference.hpp
+++ b/hpx/parallel/algorithms/set_symmetric_difference.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_ALGORITHM_SET_SYMMETRIC_DIFFERENCE_MAR_10_2015_0204PM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 #include <hpx/util/decay.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
@@ -21,13 +22,9 @@
 
 #include <algorithm>
 #include <iterator>
+#include <type_traits>
 
 #include <boost/shared_array.hpp>
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_same.hpp>
-#include <boost/type_traits/is_base_of.hpp>
-#include <boost/mpl/or.hpp>
-#include <boost/mpl/not.hpp>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -73,7 +70,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         detail::copy<std::pair<RanIter2, OutIter> >()
                             .call(
                                 std::forward<ExPolicy>(policy),
-                                boost::mpl::false_(), first2, last2, dest
+                                std::false_type(), first2, last2, dest
                             ),
                             [](std::pair<RanIter2, OutIter> const& p) -> OutIter
                             {
@@ -87,7 +84,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         detail::copy<std::pair<RanIter1, OutIter> >()
                             .call(
                                 std::forward<ExPolicy>(policy),
-                                boost::mpl::false_(), first1, last1, dest
+                                std::false_type(), first1, last1, dest
                             ),
                             [](std::pair<RanIter1, OutIter> const& p) -> OutIter
                             {
@@ -206,50 +203,30 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///
     template <typename ExPolicy, typename InIter1, typename InIter2,
         typename OutIter, typename F>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     >::type
     set_symmetric_difference(ExPolicy && policy, InIter1 first1, InIter1 last1,
         InIter2 first2, InIter2 last2, OutIter dest, F && f)
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category
-            input_iterator_category1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category
-            input_iterator_category2;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category1>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category2>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
-
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            parallel::is_sequential_execution_policy<ExPolicy>,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, input_iterator_category1
-            > >,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, input_iterator_category2
-            > >,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, output_iterator_category
-            > >
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+               !hpx::traits::is_random_access_iterator<InIter1>::value ||
+               !hpx::traits::is_random_access_iterator<InIter2>::value ||
+               !hpx::traits::is_random_access_iterator<OutIter>::value
+            > is_seq;
 
         return detail::set_symmetric_difference<OutIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -322,52 +299,31 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           element in the destination range, one past the last element
     ///           copied.
     ///
-    template <typename ExPolicy, typename InIter1, typename InIter2,
-        typename OutIter>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    template <typename ExPolicy, typename InIter1, typename InIter2, typename OutIter>
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     >::type
     set_symmetric_difference(ExPolicy && policy, InIter1 first1, InIter1 last1,
         InIter2 first2, InIter2 last2, OutIter dest)
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category
-            input_iterator_category1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category
-            input_iterator_category2;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category1>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category2>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
-
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            parallel::is_sequential_execution_policy<ExPolicy>,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, input_iterator_category1
-            > >,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, input_iterator_category2
-            > >,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, output_iterator_category
-            > >
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+               !hpx::traits::is_random_access_iterator<InIter1>::value ||
+               !hpx::traits::is_random_access_iterator<InIter2>::value ||
+               !hpx::traits::is_random_access_iterator<OutIter>::value
+            > is_seq;
 
         return detail::set_symmetric_difference<OutIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),

--- a/hpx/parallel/algorithms/set_union.hpp
+++ b/hpx/parallel/algorithms/set_union.hpp
@@ -203,14 +203,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         InIter2 first2, InIter2 last2, OutIter dest, F && f)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_input_iterator<OutIter>::value),
+                hpx::traits::is_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
@@ -296,14 +296,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         InIter2 first2, InIter2 last2, OutIter dest)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_input_iterator<OutIter>::value),
+                hpx::traits::is_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,

--- a/hpx/parallel/algorithms/set_union.hpp
+++ b/hpx/parallel/algorithms/set_union.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_ALGORITHM_SET_UNION_MAR_06_2015_1028AM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 #include <hpx/util/decay.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
@@ -21,13 +22,9 @@
 
 #include <algorithm>
 #include <iterator>
+#include <type_traits>
 
 #include <boost/shared_array.hpp>
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_same.hpp>
-#include <boost/type_traits/is_base_of.hpp>
-#include <boost/mpl/or.hpp>
-#include <boost/mpl/not.hpp>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -72,7 +69,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         detail::copy<std::pair<RanIter2, OutIter> >()
                             .call(
                                 std::forward<ExPolicy>(policy),
-                                boost::mpl::false_(), first2, last2, dest
+                                std::false_type(), first2, last2, dest
                             ),
                             [](std::pair<RanIter2, OutIter> const& p) -> OutIter
                             {
@@ -86,7 +83,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         detail::copy<std::pair<RanIter1, OutIter> >()
                             .call(
                                 std::forward<ExPolicy>(policy),
-                                boost::mpl::false_(), first1, last1, dest
+                                std::false_type(), first1, last1, dest
                             ),
                             [](std::pair<RanIter1, OutIter> const& p) -> OutIter
                             {
@@ -198,50 +195,30 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///
     template <typename ExPolicy, typename InIter1, typename InIter2,
         typename OutIter, typename F>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     >::type
     set_union(ExPolicy && policy, InIter1 first1, InIter1 last1,
         InIter2 first2, InIter2 last2, OutIter dest, F && f)
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category
-            input_iterator_category1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category
-            input_iterator_category2;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category1>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category2>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
-
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            parallel::is_sequential_execution_policy<ExPolicy>,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, input_iterator_category1
-            > >,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, input_iterator_category2
-            > >,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, output_iterator_category
-            > >
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+               !hpx::traits::is_random_access_iterator<InIter1>::value ||
+               !hpx::traits::is_random_access_iterator<InIter2>::value ||
+               !hpx::traits::is_random_access_iterator<OutIter>::value
+            > is_seq;
 
         return detail::set_union<OutIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -310,52 +287,31 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           element in the destination range, one past the last element
     ///           copied.
     ///
-    template <typename ExPolicy, typename InIter1, typename InIter2,
-        typename OutIter>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    template <typename ExPolicy, typename InIter1, typename InIter2, typename OutIter>
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     >::type
     set_union(ExPolicy && policy, InIter1 first1, InIter1 last1,
         InIter2 first2, InIter2 last2, OutIter dest)
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category
-            input_iterator_category1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category
-            input_iterator_category2;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category1>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category2>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
-
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            parallel::is_sequential_execution_policy<ExPolicy>,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, input_iterator_category1
-            > >,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, input_iterator_category2
-            > >,
-            boost::mpl::not_<boost::is_same<
-                std::random_access_iterator_tag, output_iterator_category
-            > >
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+               !hpx::traits::is_random_access_iterator<InIter1>::value ||
+               !hpx::traits::is_random_access_iterator<InIter2>::value ||
+               !hpx::traits::is_random_access_iterator<OutIter>::value
+            > is_seq;
 
         return detail::set_union<OutIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),

--- a/hpx/parallel/algorithms/sort.hpp
+++ b/hpx/parallel/algorithms/sort.hpp
@@ -32,6 +32,7 @@
 #include <iterator>
 #include <type_traits>
 #include <utility>
+#include <list>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -407,13 +408,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     sort(ExPolicy && policy, RandomIt first, RandomIt last,
         Compare && comp = Compare(), Proj && proj = Proj())
     {
-        typedef typename std::iterator_traits<RandomIt>::iterator_category
-            iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::random_access_iterator_tag, iterator_category
-            >::value),
+            (hpx::traits::is_random_access_iterator<RandomIt>::value),
             "Requires a random access iterator.");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;

--- a/hpx/parallel/algorithms/sort_by_key.hpp
+++ b/hpx/parallel/algorithms/sort_by_key.hpp
@@ -10,15 +10,15 @@
 #include <hpx/config.hpp>
 #include <hpx/util/tuple.hpp>
 #include <hpx/util/tagged_pair.hpp>
+
 #include <hpx/parallel/algorithms/sort.hpp>
 #include <hpx/parallel/util/zip_iterator.hpp>
 #include <hpx/parallel/tagspec.hpp>
-//
+
 #include <algorithm>
 #include <iterator>
 #include <type_traits>
 #include <utility>
-//
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -135,22 +135,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             "sort_by_key is not supported unless HPX_HAVE_TUPLE_RVALUE_SWAP "
             "is defined");
 #else
-        typedef typename std::iterator_traits<KeyIter>::iterator_category
-            iterator_category;
-        typedef typename std::iterator_traits<ValueIter>::iterator_category
-            iterator_category2;
-        typedef typename util::detail::algorithm_result<
-                ExPolicy,
-                hpx::util::tagged_pair<tag::in1(KeyIter), tag::in2(ValueIter)>
-            >::type result_type;
-
         static_assert(
-            (boost::is_base_of<
-                std::random_access_iterator_tag, iterator_category
-            >::value) ||
-            (boost::is_base_of<
-                std::random_access_iterator_tag, iterator_category2
-            >::value),
+            (hpx::traits::is_random_access_iterator<KeyIter>::value),
+            "Requires a random access iterator.");
+        static_assert(
+            (hpx::traits::is_random_access_iterator<ValueIter>::value),
             "Requires a random access iterator.");
 
         ValueIter value_last = value_first;

--- a/hpx/parallel/algorithms/swap_ranges.hpp
+++ b/hpx/parallel/algorithms/swap_ranges.hpp
@@ -128,10 +128,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         ForwardIter2 first2)
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<ForwardIter1>::value),
+            (hpx::traits::is_forward_iterator<ForwardIter1>::value),
             "Requires at least forward iterator.");
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<ForwardIter2>::value),
+            (hpx::traits::is_forward_iterator<ForwardIter2>::value),
             "Requires at least forward iterator.");
 
         typedef is_sequential_execution_policy<ExPolicy> is_seq;

--- a/hpx/parallel/algorithms/swap_ranges.hpp
+++ b/hpx/parallel/algorithms/swap_ranges.hpp
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_DETAIL_SWAP_RANGES_JUNE_20_2014_1006AM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
 #include <hpx/parallel/execution_policy.hpp>
@@ -19,9 +20,7 @@
 
 #include <algorithm>
 #include <iterator>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -62,7 +61,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 return get_iter<1, result_type>(
                     for_each_n<zip_iterator>().call(
-                        std::forward<ExPolicy>(policy), boost::mpl::false_(),
+                        std::forward<ExPolicy>(policy), std::false_type(),
                         hpx::util::make_zip_iterator(first1, first2),
                         std::distance(first1, last1),
                         [](reference t) {
@@ -128,21 +127,15 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     swap_ranges(ExPolicy && policy, ForwardIter1 first1, ForwardIter1 last1,
         ForwardIter2 first2)
     {
-        typedef typename std::iterator_traits<ForwardIter1>::iterator_category
-            iter1_category;
-        typedef typename std::iterator_traits<ForwardIter2>::iterator_category
-            iter2_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::forward_iterator_tag, iter1_category>::value),
-            "Required at least forward iterator tag.");
+            (hpx::traits::is_at_least_forward_iterator<ForwardIter1>::value),
+            "Requires at least forward iterator.");
         static_assert(
-            (boost::is_base_of<
-                std::forward_iterator_tag, iter2_category>::value),
-            "Required at least forward iterator tag.");
+            (hpx::traits::is_at_least_forward_iterator<ForwardIter2>::value),
+            "Requires at least forward iterator.");
 
-        typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
+        typedef is_sequential_execution_policy<ExPolicy> is_seq;
+
         return detail::swap_ranges<ForwardIter2>().call(
             std::forward<ExPolicy>(policy), is_seq(),
             first1, last1, first2);

--- a/hpx/parallel/algorithms/transform.hpp
+++ b/hpx/parallel/algorithms/transform.hpp
@@ -195,8 +195,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value ||
+               !hpx::traits::is_forward_iterator<OutIter>::value
             > is_seq;
 
         return hpx::util::make_tagged_pair<tag::in, tag::out>(
@@ -410,9 +410,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter1>::value ||
-                hpx::traits::is_just_input_iterator<InIter2>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value
+               !hpx::traits::is_forward_iterator<InIter1>::value ||
+               !hpx::traits::is_forward_iterator<InIter2>::value ||
+               !hpx::traits::is_forward_iterator<OutIter>::value
             > is_seq;
 
         typedef hpx::util::tuple<InIter1, InIter2, OutIter> result_type;
@@ -638,9 +638,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter1>::value ||
-                hpx::traits::is_just_input_iterator<InIter2>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value
+               !hpx::traits::is_forward_iterator<InIter1>::value ||
+               !hpx::traits::is_forward_iterator<InIter2>::value ||
+               !hpx::traits::is_forward_iterator<OutIter>::value
             > is_seq;
 
         typedef hpx::util::tuple<InIter1, InIter2, OutIter> result_type;

--- a/hpx/parallel/algorithms/transform.hpp
+++ b/hpx/parallel/algorithms/transform.hpp
@@ -186,16 +186,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         F && f, Proj && proj = Proj())
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_input_iterator<OutIter>::value),
+                hpx::traits::is_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_just_input_iterator<InIter>::value ||
                 hpx::traits::is_output_iterator<OutIter>::value
             > is_seq;
 
@@ -398,20 +398,20 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         Proj1 && proj1 = Proj1{}, Proj2 && proj2 = Proj2{})
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_input_iterator<OutIter>::value),
+                hpx::traits::is_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter1>::value ||
-                hpx::traits::is_input_iterator<InIter2>::value ||
+                hpx::traits::is_just_input_iterator<InIter1>::value ||
+                hpx::traits::is_just_input_iterator<InIter2>::value ||
                 hpx::traits::is_output_iterator<OutIter>::value
             > is_seq;
 
@@ -626,20 +626,20 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         Proj1 && proj1 = Proj1(), Proj2 && proj2 = Proj2())
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            (hpx::traits::is_input_iterator<InIter1>::value),
             "Requires at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            (hpx::traits::is_input_iterator<InIter2>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_input_iterator<OutIter>::value),
+                hpx::traits::is_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter1>::value ||
-                hpx::traits::is_input_iterator<InIter2>::value ||
+                hpx::traits::is_just_input_iterator<InIter1>::value ||
+                hpx::traits::is_just_input_iterator<InIter2>::value ||
                 hpx::traits::is_output_iterator<OutIter>::value
             > is_seq;
 

--- a/hpx/parallel/algorithms/transform.hpp
+++ b/hpx/parallel/algorithms/transform.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -29,9 +29,7 @@
 
 #include <algorithm>
 #include <iterator>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -86,7 +84,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 return get_iter_pair(
                     for_each_n<zip_iterator>().call(
-                        std::forward<ExPolicy>(policy), boost::mpl::false_(),
+                        std::forward<ExPolicy>(policy), std::false_type(),
                         hpx::util::make_zip_iterator(first, dest),
                         std::distance(first, last),
                         [f, proj](reference t)
@@ -187,17 +185,19 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     transform(ExPolicy && policy, InIter first, InIter last, OutIter dest,
         F && f, Proj && proj = Proj())
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
-            "Required at least input iterator.");
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            "Requires at least input iterator.");
+        static_assert(
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_input_iterator<OutIter>::value),
+            "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_output_iterator<OutIter>::value
+            > is_seq;
 
         return hpx::util::make_tagged_pair<tag::in, tag::out>(
             detail::transform<std::pair<InIter, OutIter> >().call(
@@ -264,7 +264,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 return get_iter_tuple(
                     for_each_n<zip_iterator>().call(
-                        std::forward<ExPolicy>(policy), boost::mpl::false_(),
+                        std::forward<ExPolicy>(policy), std::false_type(),
                         hpx::util::make_zip_iterator(first1, first2, dest),
                         std::distance(first1, last1),
                         [f, proj1, proj2](reference t)
@@ -397,21 +397,23 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         InIter1 first1, InIter1 last1, InIter2 first2, OutIter dest, F && f,
         Proj1 && proj1 = Proj1{}, Proj2 && proj2 = Proj2{})
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category category1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category category2;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, category1>::value),
-            "Required at least input iterator.");
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            "Requires at least input iterator.");
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, category2>::value),
-            "Required at least input iterator.");
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            "Requires at least input iterator.");
+        static_assert(
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_input_iterator<OutIter>::value),
+            "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, category1>,
-            boost::is_same<std::input_iterator_tag, category2>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter1>::value ||
+                hpx::traits::is_input_iterator<InIter2>::value ||
+                hpx::traits::is_output_iterator<OutIter>::value
+            > is_seq;
 
         typedef hpx::util::tuple<InIter1, InIter2, OutIter> result_type;
 
@@ -481,7 +483,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 return get_iter_tuple(
                     for_each_n<zip_iterator>().call(
-                        std::forward<ExPolicy>(policy), boost::mpl::false_(),
+                        std::forward<ExPolicy>(policy), std::false_type(),
                         hpx::util::make_zip_iterator(first1, first2, dest),
                         (std::min)(
                             std::distance(first1, last1),
@@ -621,23 +623,25 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     transform(ExPolicy && policy,
         InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2,
         OutIter dest, F && f,
-        Proj1 && proj1 = Proj1{}, Proj2 && proj2 = Proj2{})
+        Proj1 && proj1 = Proj1(), Proj2 && proj2 = Proj2())
     {
-        typedef typename std::iterator_traits<InIter1>::iterator_category category1;
-        typedef typename std::iterator_traits<InIter2>::iterator_category category2;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, category1>::value),
-            "Required at least input iterator.");
+            (hpx::traits::is_at_least_input_iterator<InIter1>::value),
+            "Requires at least input iterator.");
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, category2>::value),
-            "Required at least input iterator.");
+            (hpx::traits::is_at_least_input_iterator<InIter2>::value),
+            "Requires at least input iterator.");
+        static_assert(
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_input_iterator<OutIter>::value),
+            "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, category1>,
-            boost::is_same<std::input_iterator_tag, category2>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter1>::value ||
+                hpx::traits::is_input_iterator<InIter2>::value ||
+                hpx::traits::is_output_iterator<OutIter>::value
+            > is_seq;
 
         typedef hpx::util::tuple<InIter1, InIter2, OutIter> result_type;
 

--- a/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2015 Hartmut Kaiser
+//  Copyright (c) 2014-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_ALGORITHM_TRANSFORM_EXCLUSIVE_SCAN_JAN_04_2015_0354PM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
 #include <hpx/parallel/execution_policy.hpp>
@@ -22,9 +23,7 @@
 #include <algorithm>
 #include <numeric>
 #include <iterator>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -252,36 +251,26 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///
     template <typename ExPolicy, typename InIter, typename OutIter,
         typename Conv, typename T, typename Op>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     >::type
     transform_exclusive_scan(ExPolicy&& policy, InIter first, InIter last,
         OutIter dest, Conv && conv, T init, Op && op)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Requires at least input iterator.");
-
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>,
-            boost::is_same<std::output_iterator_tag, output_iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_output_iterator<OutIter>::value
+            > is_seq;
 
         return detail::transform_exclusive_scan<OutIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),

--- a/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -268,8 +268,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value ||
+               !hpx::traits::is_forward_iterator<OutIter>::value
             > is_seq;
 
         return detail::transform_exclusive_scan<OutIter>().call(

--- a/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -259,16 +259,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         OutIter dest, Conv && conv, T init, Op && op)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_input_iterator<OutIter>::value),
+                hpx::traits::is_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_just_input_iterator<InIter>::value ||
                 hpx::traits::is_output_iterator<OutIter>::value
             > is_seq;
 

--- a/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -270,8 +270,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value ||
+               !hpx::traits::is_forward_iterator<OutIter>::value
             > is_seq;
 
         return detail::transform_inclusive_scan<OutIter>().call(
@@ -397,8 +397,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value ||
-                hpx::traits::is_output_iterator<OutIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value ||
+               !hpx::traits::is_forward_iterator<OutIter>::value
             > is_seq;
 
         typedef typename std::iterator_traits<InIter>::value_type value_type;

--- a/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2015 Hartmut Kaiser
+//  Copyright (c) 2014-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_ALGORITHM_TRANSFORM_INCLUSIVE_SCAN_JAN_04_2015_0556PM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
 #include <hpx/parallel/execution_policy.hpp>
@@ -22,9 +23,7 @@
 #include <algorithm>
 #include <numeric>
 #include <iterator>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -254,36 +253,26 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///
     template <typename ExPolicy, typename InIter, typename OutIter,
         typename Conv, typename T, typename Op>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     >::type
     transform_inclusive_scan(ExPolicy&& policy, InIter first, InIter last,
         OutIter dest, Conv && conv, T init, Op && op)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Requires at least input iterator.");
-
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>,
-            boost::is_same<std::output_iterator_tag, output_iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_output_iterator<OutIter>::value
+            > is_seq;
 
         return detail::transform_inclusive_scan<OutIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -391,36 +380,26 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///
     template <typename ExPolicy, typename InIter, typename OutIter,
         typename Conv, typename Op>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     >::type
     transform_inclusive_scan(ExPolicy&& policy, InIter first, InIter last,
         OutIter dest, Conv && conv, Op && op)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-            output_iterator_category;
-
         static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
             "Requires at least input iterator.");
-
         static_assert(
-            (boost::mpl::or_<
-                boost::is_base_of<
-                    std::forward_iterator_tag, output_iterator_category>,
-                boost::is_same<
-                    std::output_iterator_tag, output_iterator_category>
-            >::value),
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_at_least_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, iterator_category>,
-            boost::is_same<std::output_iterator_tag, output_iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_output_iterator<OutIter>::value
+            > is_seq;
 
         typedef typename std::iterator_traits<InIter>::value_type value_type;
 

--- a/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -261,16 +261,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         OutIter dest, Conv && conv, T init, Op && op)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_input_iterator<OutIter>::value),
+                hpx::traits::is_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_just_input_iterator<InIter>::value ||
                 hpx::traits::is_output_iterator<OutIter>::value
             > is_seq;
 
@@ -388,16 +388,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         OutIter dest, Conv && conv, Op && op)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
         static_assert(
             (hpx::traits::is_output_iterator<OutIter>::value ||
-                hpx::traits::is_at_least_input_iterator<OutIter>::value),
+                hpx::traits::is_input_iterator<OutIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value ||
+                hpx::traits::is_just_input_iterator<InIter>::value ||
                 hpx::traits::is_output_iterator<OutIter>::value
             > is_seq;
 

--- a/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/hpx/parallel/algorithms/transform_reduce.hpp
@@ -106,12 +106,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             T && init, Reduce && red_op, Convert && conv_op, std::false_type)
         {
             static_assert(
-                (hpx::traits::is_at_least_input_iterator<InIter>::value),
+                (hpx::traits::is_input_iterator<InIter>::value),
                 "Requires at least input iterator.");
 
             typedef std::integral_constant<bool,
                     parallel::is_sequential_execution_policy<ExPolicy>::value ||
-                    hpx::traits::is_input_iterator<InIter>::value
+                    hpx::traits::is_just_input_iterator<InIter>::value
                 > is_seq;
 
             typedef typename hpx::util::decay<T>::type init_type;

--- a/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/hpx/parallel/algorithms/transform_reduce.hpp
@@ -111,7 +111,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
             typedef std::integral_constant<bool,
                     parallel::is_sequential_execution_policy<ExPolicy>::value ||
-                    hpx::traits::is_just_input_iterator<InIter>::value
+                   !hpx::traits::is_forward_iterator<InIter>::value
                 > is_seq;
 
             typedef typename hpx::util::decay<T>::type init_type;

--- a/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/hpx/parallel/algorithms/transform_reduce.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_DETAIL_TRANSFORM_REDUCE_JUL_11_2014_0428PM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 #include <hpx/util/unwrapped.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
@@ -20,8 +21,6 @@
 #include <hpx/parallel/util/loop.hpp>
 
 #include <boost/range/functions.hpp>
-#include <boost/type_traits/is_base_of.hpp>
-#include <boost/utility/enable_if.hpp>
 
 #include <algorithm>
 #include <numeric>
@@ -106,17 +105,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         transform_reduce_(ExPolicy && policy, InIter first, InIter last,
             T && init, Reduce && red_op, Convert && conv_op, std::false_type)
         {
-            typedef typename std::iterator_traits<InIter>::iterator_category
-                iterator_category;
-
             static_assert(
-                (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
+                (hpx::traits::is_at_least_input_iterator<InIter>::value),
                 "Requires at least input iterator.");
 
-            typedef typename boost::mpl::or_<
-                parallel::is_sequential_execution_policy<ExPolicy>,
-                boost::is_same<std::input_iterator_tag, iterator_category>
-            >::type is_seq;
+            typedef std::integral_constant<bool,
+                    parallel::is_sequential_execution_policy<ExPolicy>::value ||
+                    hpx::traits::is_input_iterator<InIter>::value
+                > is_seq;
 
             typedef typename hpx::util::decay<T>::type init_type;
 

--- a/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/hpx/parallel/algorithms/transform_reduce.hpp
@@ -228,22 +228,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///
     template <typename ExPolicy, typename InIter, typename T, typename Reduce,
         typename Convert>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, T>::type
     >::type
     transform_reduce(ExPolicy&& policy, InIter first, InIter last,
         Convert && conv_op, T init, Reduce && red_op)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            iterator_category;
-
-        static_assert(
-            (boost::is_base_of<std::input_iterator_tag, iterator_category>::value),
-            "Requires at least input iterator.");
-
-        typedef hpx::traits::segmented_iterator_traits<InIter> iterator_traits;
-        typedef typename iterator_traits::is_segmented_iterator is_segmented;
+        typedef hpx::traits::is_segmented_iterator<InIter> is_segmented;
 
         return detail::transform_reduce_(
             std::forward<ExPolicy>(policy), first, last, std::move(init),

--- a/hpx/parallel/algorithms/uninitialized_copy.hpp
+++ b/hpx/parallel/algorithms/uninitialized_copy.hpp
@@ -188,15 +188,15 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         FwdIter dest)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Required at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least output iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value
+                hpx::traits::is_just_input_iterator<InIter>::value
             > is_seq;
 
         return detail::uninitialized_copy<FwdIter>().call(
@@ -299,10 +299,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         FwdIter dest)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Required at least input iterator.");
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
         // if count is representing a negative value, we do nothing

--- a/hpx/parallel/algorithms/uninitialized_copy.hpp
+++ b/hpx/parallel/algorithms/uninitialized_copy.hpp
@@ -299,11 +299,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         FwdIter dest)
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<InIter>::value),
-            "Required at least forward iterator.");
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            "Required at least input iterator.");
         static_assert(
             (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
-            "Requires at least output iterator.");
+            "Requires at least forward iterator.");
 
         // if count is representing a negative value, we do nothing
         if (detail::is_negative(count))

--- a/hpx/parallel/algorithms/uninitialized_copy.hpp
+++ b/hpx/parallel/algorithms/uninitialized_copy.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014 Hartmut Kaiser
+//  Copyright (c) 2014-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_DETAIL_UNINITIALIZED_COPY_OCT_02_2014_1145AM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
 #include <hpx/parallel/execution_policy.hpp>
@@ -21,9 +22,7 @@
 
 #include <algorithm>
 #include <iterator>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -181,32 +180,24 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           the last element copied.
     ///
     template <typename ExPolicy, typename InIter, typename FwdIter>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
     >::type
     uninitialized_copy(ExPolicy && policy, InIter first, InIter last,
         FwdIter dest)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            input_iterator_category;
-        typedef typename std::iterator_traits<FwdIter>::iterator_category
-            forward_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category>::value),
-            "Requires at least an input iterator.");
-
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            "Required at least input iterator.");
         static_assert(
-            (boost::is_base_of<
-                std::forward_iterator_tag, forward_iterator_category>::value),
-            "Requires at least a forward iterator.");
+            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            "Requires at least output iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, input_iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value
+            > is_seq;
 
         return detail::uninitialized_copy<FwdIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -300,27 +291,19 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           the last element copied.
     ///
     template <typename ExPolicy, typename InIter, typename Size, typename FwdIter>
-    typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
     >::type
     uninitialized_copy_n(ExPolicy && policy, InIter first, Size count,
         FwdIter dest)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            input_iterator_category;
-        typedef typename std::iterator_traits<FwdIter>::iterator_category
-            forward_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category>::value),
-            "Requires at least an input iterator.");
-
+            (hpx::traits::is_at_least_forward_iterator<InIter>::value),
+            "Required at least forward iterator.");
         static_assert(
-            (boost::is_base_of<
-                std::forward_iterator_tag, forward_iterator_category>::value),
-            "Requires at least a forward iterator.");
+            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            "Requires at least output iterator.");
 
         // if count is representing a negative value, we do nothing
         if (detail::is_negative(count))
@@ -329,10 +312,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 std::move(dest));
         }
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, input_iterator_category>
-        >::type is_seq;
+        typedef is_sequential_execution_policy<ExPolicy> is_seq;
 
         return detail::uninitialized_copy_n<FwdIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),

--- a/hpx/parallel/algorithms/uninitialized_copy.hpp
+++ b/hpx/parallel/algorithms/uninitialized_copy.hpp
@@ -196,7 +196,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value
             > is_seq;
 
         return detail::uninitialized_copy<FwdIter>().call(
@@ -312,7 +312,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 std::move(dest));
         }
 
-        typedef is_sequential_execution_policy<ExPolicy> is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+               !hpx::traits::is_forward_iterator<InIter>::value
+            > is_seq;
 
         return detail::uninitialized_copy_n<FwdIter>().call(
             std::forward<ExPolicy>(policy), is_seq(),

--- a/hpx/parallel/algorithms/uninitialized_fill.hpp
+++ b/hpx/parallel/algorithms/uninitialized_fill.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014 Hartmut Kaiser
+//  Copyright (c) 2014-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_DETAIL_UNINITIALIZED_FILL_OCT_06_2014_1019AM
 
 #include <hpx/config.hpp>
+#include <hpx/traits/is_iterator.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
 #include <hpx/parallel/execution_policy.hpp>
@@ -21,9 +22,7 @@
 
 #include <algorithm>
 #include <iterator>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -165,25 +164,21 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           otherwise.
     ///
     template <typename ExPolicy, typename InIter, typename T>
-    inline typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy>::type
     >::type
     uninitialized_fill(ExPolicy && policy, InIter first, InIter last,
         T const& value)
     {
-        typedef typename std::iterator_traits<InIter>::iterator_category
-            input_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::input_iterator_tag, input_iterator_category>::value),
-            "Requires at least an input iterator.");
+            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            "Required at least input iterator.");
 
-        typedef typename boost::mpl::or_<
-            is_sequential_execution_policy<ExPolicy>,
-            boost::is_same<std::input_iterator_tag, input_iterator_category>
-        >::type is_seq;
+        typedef std::integral_constant<bool,
+                is_sequential_execution_policy<ExPolicy>::value ||
+                hpx::traits::is_input_iterator<InIter>::value
+            > is_seq;
 
         return detail::uninitialized_fill().call(
             std::forward<ExPolicy>(policy), is_seq(),
@@ -267,26 +262,24 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           otherwise.
     ///
     template <typename ExPolicy, typename FwdIter, typename Size, typename T>
-    typename boost::enable_if<
-        is_execution_policy<ExPolicy>,
+    inline typename std::enable_if<
+        is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy>::type
     >::type
     uninitialized_fill_n(ExPolicy && policy, FwdIter first, Size count,
         T const& value)
     {
-        typedef typename std::iterator_traits<FwdIter>::iterator_category
-            forward_iterator_category;
-
         static_assert(
-            (boost::is_base_of<
-                std::forward_iterator_tag, forward_iterator_category>::value),
-            "Requires at least a forward iterator.");
+            (hpx::traits::is_at_least_forward_iterator<InIter>::value),
+            "Required at least forward iterator.");
 
         // if count is representing a negative value, we do nothing
         if (detail::is_negative(count))
+        {
             return util::detail::algorithm_result<ExPolicy>::get();
+        }
 
-        typedef typename is_sequential_execution_policy<ExPolicy>::type is_seq;
+        typedef is_sequential_execution_policy<ExPolicy> is_seq;
 
         return detail::uninitialized_fill_n().call(
             std::forward<ExPolicy>(policy), is_seq(),

--- a/hpx/parallel/algorithms/uninitialized_fill.hpp
+++ b/hpx/parallel/algorithms/uninitialized_fill.hpp
@@ -177,7 +177,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_just_input_iterator<InIter>::value
+               !hpx::traits::is_forward_iterator<InIter>::value
             > is_seq;
 
         return detail::uninitialized_fill().call(

--- a/hpx/parallel/algorithms/uninitialized_fill.hpp
+++ b/hpx/parallel/algorithms/uninitialized_fill.hpp
@@ -270,7 +270,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         T const& value)
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<InIter>::value),
+            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
         // if count is representing a negative value, we do nothing

--- a/hpx/parallel/algorithms/uninitialized_fill.hpp
+++ b/hpx/parallel/algorithms/uninitialized_fill.hpp
@@ -172,12 +172,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         T const& value)
     {
         static_assert(
-            (hpx::traits::is_at_least_input_iterator<InIter>::value),
+            (hpx::traits::is_input_iterator<InIter>::value),
             "Required at least input iterator.");
 
         typedef std::integral_constant<bool,
                 is_sequential_execution_policy<ExPolicy>::value ||
-                hpx::traits::is_input_iterator<InIter>::value
+                hpx::traits::is_just_input_iterator<InIter>::value
             > is_seq;
 
         return detail::uninitialized_fill().call(
@@ -270,7 +270,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         T const& value)
     {
         static_assert(
-            (hpx::traits::is_at_least_forward_iterator<FwdIter>::value),
+            (hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
         // if count is representing a negative value, we do nothing

--- a/hpx/parallel/execution_policy.hpp
+++ b/hpx/parallel/execution_policy.hpp
@@ -1262,6 +1262,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
       : detail::is_rebound_execution_policy<typename hpx::util::decay<T>::type>
     {};
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     ///////////////////////////////////////////////////////////////////////////
     class execution_policy;
 
@@ -1316,6 +1317,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         };
         /// \endcond
     }
+#endif
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail
@@ -1376,10 +1378,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
           : boost::mpl::true_
         {};
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
         template <>
         struct is_execution_policy<execution_policy>
           : boost::mpl::true_
         {};
+#endif
         /// \endcond
     }
 
@@ -1539,6 +1543,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
       : detail::is_async_execution_policy<typename hpx::util::decay<T>::type>
     {};
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     ///////////////////////////////////////////////////////////////////////////
     ///
     /// An execution policy is an object that expresses the requirements on the
@@ -1723,6 +1728,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         }
         /// \endcond
     }
+#endif
 }}}
 
 #endif

--- a/hpx/parallel/execution_policy.hpp
+++ b/hpx/parallel/execution_policy.hpp
@@ -21,13 +21,10 @@
 
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
-#include <boost/mpl/bool.hpp>
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_same.hpp>
-#include <boost/type_traits/is_base_of.hpp>
 
 #include <memory>
 #include <type_traits>
+#include <utility>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -1325,63 +1322,63 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         /// \cond NOINTERNAL
         template <typename T>
         struct is_execution_policy
-          : boost::mpl::false_
+          : std::false_type
         {};
 
         template <>
         struct is_execution_policy<parallel_execution_policy>
-          : boost::mpl::true_
+          : std::true_type
         {};
 
         template <typename Executor, typename Parameters>
         struct is_execution_policy<
                 parallel_execution_policy_shim<Executor, Parameters> >
-          : boost::mpl::true_
+          : std::true_type
         {};
 
         template <>
         struct is_execution_policy<parallel_vector_execution_policy>
-          : boost::mpl::true_
+          : std::true_type
         {};
 
         template <>
         struct is_execution_policy<sequential_execution_policy>
-          : boost::mpl::true_
+          : std::true_type
         {};
 
         template <typename Executor, typename Parameters>
         struct is_execution_policy<
                 sequential_execution_policy_shim<Executor, Parameters> >
-          : boost::mpl::true_
+          : std::true_type
         {};
 
         // extension
         template <>
         struct is_execution_policy<sequential_task_execution_policy>
-          : boost::mpl::true_
+          : std::true_type
         {};
 
         template <typename Executor, typename Parameters>
         struct is_execution_policy<
                 sequential_task_execution_policy_shim<Executor, Parameters> >
-          : boost::mpl::true_
+          : std::true_type
         {};
 
         template <>
         struct is_execution_policy<parallel_task_execution_policy>
-          : boost::mpl::true_
+          : std::true_type
         {};
 
         template <typename Executor, typename Parameters>
         struct is_execution_policy<
                 parallel_task_execution_policy_shim<Executor, Parameters> >
-          : boost::mpl::true_
+          : std::true_type
         {};
 
 #if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
         template <>
         struct is_execution_policy<execution_policy>
-          : boost::mpl::true_
+          : std::true_type
         {};
 #endif
         /// \endcond
@@ -1409,22 +1406,22 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         /// \cond NOINTERNAL
         template <typename T>
         struct is_parallel_execution_policy
-          : boost::mpl::false_
+          : std::false_type
         {};
 
         template <>
         struct is_parallel_execution_policy<parallel_execution_policy>
-          : boost::mpl::true_
+          : std::true_type
         {};
 
         template <>
         struct is_parallel_execution_policy<parallel_vector_execution_policy>
-          : boost::mpl::true_
+          : std::true_type
         {};
 
         template <>
         struct is_parallel_execution_policy<parallel_task_execution_policy>
-          : boost::mpl::true_
+          : std::true_type
         {};
         /// \endcond
     }
@@ -1453,29 +1450,29 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         /// \cond NOINTERNAL
         template <typename T>
         struct is_sequential_execution_policy
-          : boost::mpl::false_
+          : std::false_type
         {};
 
         template <>
         struct is_sequential_execution_policy<sequential_task_execution_policy>
-          : boost::mpl::true_
+          : std::true_type
         {};
 
         template <typename Executor, typename Parameters>
         struct is_sequential_execution_policy<
                 sequential_task_execution_policy_shim<Executor, Parameters> >
-          : boost::mpl::true_
+          : std::true_type
         {};
 
         template <>
         struct is_sequential_execution_policy<sequential_execution_policy>
-          : boost::mpl::true_
+          : std::true_type
         {};
 
         template <typename Executor, typename Parameters>
         struct is_sequential_execution_policy<
                 sequential_execution_policy_shim<Executor, Parameters> >
-          : boost::mpl::true_
+          : std::true_type
         {};
         /// \endcond
     }
@@ -1507,17 +1504,17 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         /// \cond NOINTERNAL
         template <typename T>
         struct is_async_execution_policy
-          : boost::mpl::false_
+          : std::false_type
         {};
 
         template <>
         struct is_async_execution_policy<sequential_task_execution_policy>
-          : boost::mpl::true_
+          : std::true_type
         {};
 
         template <>
         struct is_async_execution_policy<parallel_task_execution_policy>
-          : boost::mpl::true_
+          : std::true_type
         {};
         /// \endcond
     }
@@ -1663,7 +1660,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         ExPolicy* get() HPX_NOEXCEPT
         {
             static_assert(
-                !(boost::is_same<ExPolicy, execution_policy>::value),
+                !(std::is_same<ExPolicy, execution_policy>::value),
                 "Incorrect execution policy parameter.");
             static_assert(
                 is_execution_policy<ExPolicy>::value,
@@ -1682,7 +1679,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         ExPolicy const* get() const HPX_NOEXCEPT
         {
             static_assert(
-                !(boost::is_same<ExPolicy, execution_policy>::value),
+                !(std::is_same<ExPolicy, execution_policy>::value),
                 "Incorrect execution policy parameter.");
             static_assert(
                 is_execution_policy<ExPolicy>::value,

--- a/hpx/parallel/executors/distribution_policy_executor.hpp
+++ b/hpx/parallel/executors/distribution_policy_executor.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -20,7 +20,6 @@
 #include <hpx/util/result_of.hpp>
 
 #include <type_traits>
-
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
 {

--- a/hpx/parallel/executors/executor_traits.hpp
+++ b/hpx/parallel/executors/executor_traits.hpp
@@ -309,8 +309,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
 
         template <typename F, typename Shape>
         struct bulk_execute_result<F, Shape,
-            typename boost::enable_if_c<
-                boost::is_void<
+            typename std::enable_if<
+                std::is_void<
                     typename detail::bulk_async_execute_result<F, Shape>::type
                 >::value
             >::type>

--- a/hpx/parallel/executors/persistent_auto_chunk_size.hpp
+++ b/hpx/parallel/executors/persistent_auto_chunk_size.hpp
@@ -42,20 +42,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         ///       and 80 microseconds as the minimal time for which
         ///       any of the scheduled chunks should run.
         ///
-
         persistent_auto_chunk_size()
           : chunk_size_time_(0) , min_time_(80000)
         {}
 
         /// Construct an \a persistent_auto_chunk_size executor parameters object
-
+        ///
         /// \param time_cs      The execution time for each chunk.
         ///
-        /// \param rel_time     Constructed \a persistent_auto_chunk_size executor parameter
-        ///                     types will use 80 microseconds as the minimal time for which
-        ///                     any of the scheduled chunks should run.
-        ///
-
         explicit persistent_auto_chunk_size(hpx::util::steady_duration const& time_cs)
           : chunk_size_time_(time_cs.value().count()), min_time_(80000)
         {}
@@ -65,14 +59,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         /// \param rel_time     [in] The time duration to use as the minimum
         ///                     to decide how many loop iterations should be
         ///                     combined.
-        ///
-
         /// \param time_cs       The execution time for each chunk.
         ///
-
-        explicit persistent_auto_chunk_size(hpx::util::steady_duration const& time_cs,
-         hpx::util::steady_duration const& rel_time)
-          : chunk_size_time_(time_cs.value().count()), min_time_(rel_time.value().count())
+        persistent_auto_chunk_size(hpx::util::steady_duration const& time_cs,
+                hpx::util::steady_duration const& rel_time)
+          : chunk_size_time_(time_cs.value().count()),
+            min_time_(rel_time.value().count())
         {}
 
         /// \cond NOINTERNAL
@@ -91,15 +83,15 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
                 std::size_t test_chunk_size = f();
                 if (test_chunk_size != 0)
                 {
-
-                    if(chunk_size_time_ == 0)
+                    if (chunk_size_time_ == 0)
                     {
                         t = (high_resolution_clock::now() - t) / test_chunk_size;
                         chunk_size_time_ = t;
                     }
-
                     else
+                    {
                         t = chunk_size_time_;
+                    }
 
                     if (t != 0)
                     {

--- a/hpx/parallel/executors/sequential_executor.hpp
+++ b/hpx/parallel/executors/sequential_executor.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -21,10 +21,6 @@
 #include <type_traits>
 #include <utility>
 #include <iterator>
-
-#include <boost/range/functions.hpp>
-#include <boost/range/const_iterator.hpp>
-#include <boost/type_traits/is_void.hpp>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
 {

--- a/hpx/parallel/executors/timed_executor_traits.hpp
+++ b/hpx/parallel/executors/timed_executor_traits.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -19,9 +19,6 @@
 
 #include <type_traits>
 #include <utility>
-
-#include <boost/range/functions.hpp>
-#include <boost/range/irange.hpp>
 
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION < 40700
 #define HPX_ENABLE_WORKAROUND_FOR_GCC46

--- a/hpx/parallel/memory.hpp
+++ b/hpx/parallel/memory.hpp
@@ -6,7 +6,7 @@
 #if !defined(HPX_PARALLEL_MEMORY_OCT_05_2014_0414PM)
 #define HPX_PARALLEL_MEMORY_OCT_05_2014_0414PM
 
-#include <hpx/hpx_fwd.hpp>
+#include <hpx/config.hpp>
 
 /// See N4071: 1.3/3
 #include <memory>

--- a/hpx/parallel/numeric.hpp
+++ b/hpx/parallel/numeric.hpp
@@ -7,7 +7,7 @@
 #if !defined(HPX_PARALLEL_NUMERIC_JUN_02_2014_1151AM)
 #define HPX_PARALLEL_NUMERIC_JUN_02_2014_1151AM
 
-#include <hpx/hpx_fwd.hpp>
+#include <hpx/config.hpp>
 
 /// See N4310: 1.3/3
 #include <numeric>

--- a/hpx/parallel/segmented_algorithms/copy.hpp
+++ b/hpx/parallel/segmented_algorithms/copy.hpp
@@ -150,7 +150,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     local_iterator_type, local_output_iterator_type
                 > local_iterator_pair;
 
-            typedef hpx::traits::is_input_iterator<SegIter> forced_seq;
+            typedef hpx::traits::is_just_input_iterator<SegIter> forced_seq;
 
             segment_iterator sit = traits::segment(first);
             segment_iterator send = traits::segment(last);

--- a/hpx/parallel/segmented_algorithms/copy.hpp
+++ b/hpx/parallel/segmented_algorithms/copy.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,7 +6,7 @@
 #if !defined(HPX_PARALLEL_SEGMENTED_ALGORITHM_COPY_JAN_05_2014_0125PM)
 #define HPX_PARALLEL_SEGMENTED_ALGORITHM_COPY_JAN_05_2014_0125PM
 
-#include <hpx/hpx_fwd.hpp>
+#include <hpx/config.hpp>
 #include <hpx/traits/segmented_iterator_traits.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
@@ -20,8 +20,7 @@
 #include <algorithm>
 #include <iterator>
 #include <type_traits>
-
-#include <boost/type_traits/is_same.hpp>
+#include <list>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -38,7 +37,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         static typename util::detail::algorithm_result<
             ExPolicy, std::pair<SegIter, SegOutIter>
         >::type
-        segmented_copy(Algo && algo, ExPolicy const& policy, boost::mpl::true_,
+        segmented_copy(Algo && algo, ExPolicy const& policy, std::true_type,
             SegIter first, SegIter last, SegOutIter dest)
         {
             typedef hpx::traits::segmented_iterator_traits<SegIter> traits;
@@ -61,8 +60,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
             segment_output_iterator sdest = traits::segment(dest);
 
-            using boost::mpl::true_;
-
             if (sit == send)
             {
                 // all elements are on the same partition
@@ -73,7 +70,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 {
                     local_iterator_pair p = dispatch(
                         traits::get_id(sit),
-                        algo, policy, true_(),
+                        algo, policy, std::true_type(),
                         beg, end, traits::local(dest));
 
                     dest = output_traits::compose(sdest, p.second);
@@ -89,7 +86,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 {
                     local_iterator_pair p = dispatch(
                         traits::get_id(sit),
-                        algo, policy, true_(), beg, end, out);
+                        algo, policy, std::true_type(), beg, end, out);
                     out = p.second;
                 }
 
@@ -104,7 +101,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     {
                         local_iterator_pair p = dispatch(
                             traits::get_id(sit),
-                            algo, policy, true_(), beg, end, out);
+                            algo, policy, std::true_type(), beg, end, out);
                         out = p.second;
                     }
                 }
@@ -116,7 +113,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 {
                     local_iterator_pair p = dispatch(
                         traits::get_id(sit),
-                        algo, policy, true_(), beg, end, traits::begin(sdest));
+                        algo, policy, std::true_type(), beg, end,
+                        traits::begin(sdest));
                     out = p.second;
                 }
 
@@ -134,7 +132,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         static typename util::detail::algorithm_result<
             ExPolicy, std::pair<SegIter, SegOutIter>
         >::type
-        segmented_copy(Algo && algo, ExPolicy const& policy, boost::mpl::false_,
+        segmented_copy(Algo && algo, ExPolicy const& policy, std::false_type,
             SegIter first, SegIter last, SegOutIter dest)
         {
             typedef hpx::traits::segmented_iterator_traits<SegIter> traits;
@@ -152,11 +150,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     local_iterator_type, local_output_iterator_type
                 > local_iterator_pair;
 
-            typedef typename std::iterator_traits<SegIter>::iterator_category
-                iterator_category;
-            typedef typename boost::mpl::bool_<boost::is_same<
-                    iterator_category, std::input_iterator_tag
-                >::value> forced_seq;
+            typedef hpx::traits::is_input_iterator<SegIter> forced_seq;
 
             segment_iterator sit = traits::segment(first);
             segment_iterator send = traits::segment(last);
@@ -255,9 +249,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     >::get(std::make_pair(last, dest));
             }
 
-            typedef typename parallel::is_sequential_execution_policy<
-                    ExPolicy
-                >::type is_seq;
+            typedef parallel::is_sequential_execution_policy<ExPolicy> is_seq;
 
             typedef hpx::traits::segmented_iterator_traits<InIter>
                 input_iterator_traits;

--- a/hpx/parallel/segmented_algorithms/copy.hpp
+++ b/hpx/parallel/segmented_algorithms/copy.hpp
@@ -150,7 +150,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     local_iterator_type, local_output_iterator_type
                 > local_iterator_pair;
 
-            typedef hpx::traits::is_just_input_iterator<SegIter> forced_seq;
+            typedef std::integral_constant<bool,
+                    !hpx::traits::is_forward_iterator<SegIter>::value
+                > forced_seq;
 
             segment_iterator sit = traits::segment(first);
             segment_iterator send = traits::segment(last);

--- a/hpx/parallel/segmented_algorithms/count.hpp
+++ b/hpx/parallel/segmented_algorithms/count.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,7 +6,7 @@
 #if !defined(HPX_PARALLEL_SEGMENTED_ALGORITHM_COUNT_DEC_25_2014_0207PM)
 #define HPX_PARALLEL_SEGMENTED_ALGORITHM_COUNT_DEC_25_2014_0207PM
 
-#include <hpx/hpx_fwd.hpp>
+#include <hpx/config.hpp>
 #include <hpx/traits/segmented_iterator_traits.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
@@ -20,8 +20,7 @@
 #include <algorithm>
 #include <iterator>
 #include <type_traits>
-
-#include <boost/type_traits/is_same.hpp>
+#include <list>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -39,7 +38,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             ExPolicy, typename std::iterator_traits<SegIter>::difference_type
         >::type
         segmented_count(Algo && algo, ExPolicy const& policy,
-            SegIter first, SegIter last, T const& value, boost::mpl::true_)
+            SegIter first, SegIter last, T const& value, std::true_type)
         {
             typedef hpx::traits::segmented_iterator_traits<SegIter> traits;
             typedef typename traits::segment_iterator segment_iterator;
@@ -47,8 +46,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typedef typename std::iterator_traits<SegIter>::difference_type
                 value_type;
             typedef util::detail::algorithm_result<ExPolicy, value_type> result;
-
-            using boost::mpl::true_;
 
             segment_iterator sit = traits::segment(first);
             segment_iterator send = traits::segment(last);
@@ -63,7 +60,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 if (beg != end)
                 {
                     overall_result = dispatch(traits::get_id(sit),
-                        algo, policy, true_(), beg, end, value);
+                        algo, policy, std::true_type(), beg, end, value);
                 }
             }
             else {
@@ -73,7 +70,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 if (beg != end)
                 {
                     overall_result += dispatch(traits::get_id(sit),
-                        algo, policy, true_(), beg, end, value);
+                        algo, policy, std::true_type(), beg, end, value);
                 }
 
                 // handle all of the full partitions
@@ -84,7 +81,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     if (beg != end)
                     {
                         overall_result += dispatch(traits::get_id(sit),
-                            algo, policy, true_(), beg, end, value);
+                            algo, policy, std::true_type(), beg, end, value);
                     }
                 }
 
@@ -94,7 +91,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 if (beg != end)
                 {
                     overall_result += dispatch(traits::get_id(sit),
-                        algo, policy, true_(), beg, end, value);
+                        algo, policy, std::true_type(), beg, end, value);
                 }
             }
 
@@ -108,17 +105,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             ExPolicy, typename std::iterator_traits<SegIter>::difference_type
         >::type
         segmented_count(Algo && algo, ExPolicy const& policy,
-            SegIter first, SegIter last, T const& value, boost::mpl::false_)
+            SegIter first, SegIter last, T const& value, std::false_type)
         {
             typedef hpx::traits::segmented_iterator_traits<SegIter> traits;
             typedef typename traits::segment_iterator segment_iterator;
             typedef typename traits::local_iterator local_iterator_type;
 
-            typedef typename std::iterator_traits<SegIter>::iterator_category
-                iterator_category;
-            typedef typename boost::mpl::bool_<boost::is_same<
-                    iterator_category, std::input_iterator_tag
-                >::value> forced_seq;
+            typedef hpx::traits::is_input_iterator<SegIter> forced_seq;
+
             typedef typename std::iterator_traits<SegIter>::difference_type
                 value_type;
             typedef util::detail::algorithm_result<ExPolicy, value_type> result;
@@ -190,9 +184,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         count_(ExPolicy&& policy, InIter first, InIter last, T const& value,
             std::true_type)
         {
-            typedef typename parallel::is_sequential_execution_policy<
-                    ExPolicy
-                >::type is_seq;
+            typedef parallel::is_sequential_execution_policy<ExPolicy>is_seq;
 
             typedef typename std::iterator_traits<InIter>::difference_type
                 difference_type;
@@ -233,7 +225,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             ExPolicy, typename std::iterator_traits<SegIter>::difference_type
         >::type
         segmented_count_if(Algo && algo, ExPolicy const& policy,
-            SegIter first, SegIter last, F && f, boost::mpl::true_)
+            SegIter first, SegIter last, F && f, std::true_type)
         {
             typedef hpx::traits::segmented_iterator_traits<SegIter> traits;
             typedef typename traits::segment_iterator segment_iterator;
@@ -241,8 +233,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typedef typename std::iterator_traits<SegIter>::difference_type
                 value_type;
             typedef util::detail::algorithm_result<ExPolicy, value_type> result;
-
-            using boost::mpl::true_;
 
             segment_iterator sit = traits::segment(first);
             segment_iterator send = traits::segment(last);
@@ -257,7 +247,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 if (beg != end)
                 {
                     overall_result = dispatch(traits::get_id(sit),
-                        algo, policy, true_(),
+                        algo, policy, std::true_type(),
                         beg, end, std::forward<F>(f));
                 }
             }
@@ -268,7 +258,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 if (beg != end)
                 {
                     overall_result += dispatch(traits::get_id(sit),
-                        algo, policy, true_(),
+                        algo, policy, std::true_type(),
                         beg, end, std::forward<F>(f));
                 }
 
@@ -280,7 +270,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     if (beg != end)
                     {
                         overall_result += dispatch(traits::get_id(sit),
-                            algo, policy, true_(),
+                            algo, policy, std::true_type(),
                             beg, end, std::forward<F>(f));
                     }
                 }
@@ -291,7 +281,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 if (beg != end)
                 {
                     overall_result += dispatch(traits::get_id(sit),
-                        algo, policy, true_(),
+                        algo, policy, std::true_type(),
                         beg, end, std::forward<F>(f));
                 }
             }
@@ -306,17 +296,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             ExPolicy, typename std::iterator_traits<SegIter>::difference_type
         >::type
         segmented_count_if(Algo && algo, ExPolicy const& policy,
-            SegIter first, SegIter last, F && f, boost::mpl::false_)
+            SegIter first, SegIter last, F && f, std::false_type)
         {
             typedef hpx::traits::segmented_iterator_traits<SegIter> traits;
             typedef typename traits::segment_iterator segment_iterator;
             typedef typename traits::local_iterator local_iterator_type;
 
-            typedef typename std::iterator_traits<SegIter>::iterator_category
-                iterator_category;
-            typedef typename boost::mpl::bool_<boost::is_same<
-                    iterator_category, std::input_iterator_tag
-                >::value> forced_seq;
+            typedef hpx::traits::is_input_iterator<SegIter> forced_seq;
+
             typedef typename std::iterator_traits<SegIter>::difference_type
                 value_type;
             typedef util::detail::algorithm_result<ExPolicy, value_type> result;
@@ -401,9 +388,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         count_if_(ExPolicy && policy, InIter first, InIter last, F && f,
             std::true_type)
         {
-            typedef typename parallel::is_sequential_execution_policy<
-                    ExPolicy
-                >::type is_seq;
+            typedef parallel::is_sequential_execution_policy<ExPolicy>is_seq;
 
             typedef typename std::iterator_traits<InIter>::difference_type
                 difference_type;

--- a/hpx/parallel/segmented_algorithms/count.hpp
+++ b/hpx/parallel/segmented_algorithms/count.hpp
@@ -111,7 +111,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typedef typename traits::segment_iterator segment_iterator;
             typedef typename traits::local_iterator local_iterator_type;
 
-            typedef hpx::traits::is_just_input_iterator<SegIter> forced_seq;
+            typedef std::integral_constant<bool,
+                    !hpx::traits::is_forward_iterator<SegIter>::value
+                > forced_seq;
 
             typedef typename std::iterator_traits<SegIter>::difference_type
                 value_type;
@@ -302,7 +304,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typedef typename traits::segment_iterator segment_iterator;
             typedef typename traits::local_iterator local_iterator_type;
 
-            typedef hpx::traits::is_just_input_iterator<SegIter> forced_seq;
+            typedef std::integral_constant<bool,
+                    !hpx::traits::is_forward_iterator<SegIter>::value
+                > forced_seq;
 
             typedef typename std::iterator_traits<SegIter>::difference_type
                 value_type;

--- a/hpx/parallel/segmented_algorithms/count.hpp
+++ b/hpx/parallel/segmented_algorithms/count.hpp
@@ -111,7 +111,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typedef typename traits::segment_iterator segment_iterator;
             typedef typename traits::local_iterator local_iterator_type;
 
-            typedef hpx::traits::is_input_iterator<SegIter> forced_seq;
+            typedef hpx::traits::is_just_input_iterator<SegIter> forced_seq;
 
             typedef typename std::iterator_traits<SegIter>::difference_type
                 value_type;
@@ -302,7 +302,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typedef typename traits::segment_iterator segment_iterator;
             typedef typename traits::local_iterator local_iterator_type;
 
-            typedef hpx::traits::is_input_iterator<SegIter> forced_seq;
+            typedef hpx::traits::is_just_input_iterator<SegIter> forced_seq;
 
             typedef typename std::iterator_traits<SegIter>::difference_type
                 value_type;

--- a/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
+++ b/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
@@ -261,7 +261,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
             >::type result_type;
 
         algorithm_invoker_action<
-            algo_type, ExPolicy, IsSeq,
+            algo_type, ExPolicy, typename IsSeq::type,
             result_type(typename hpx::util::decay<Args>::type const&...)
         > act;
 

--- a/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
+++ b/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,7 +6,7 @@
 #if !defined(HPX_PARALLEL_ALGORITHM_REMOTE_DISPATCH_OCT_15_2014_0938PM)
 #define HPX_PARALLEL_ALGORITHM_REMOTE_DISPATCH_OCT_15_2014_0938PM
 
-#include <hpx/hpx_fwd.hpp>
+#include <hpx/config.hpp>
 #include <hpx/traits/segmented_iterator_traits.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime/actions/plain_action.hpp>
@@ -18,7 +18,7 @@
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/handle_remote_exceptions.hpp>
 
-#include <boost/utility/enable_if.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
 {
@@ -27,7 +27,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
     struct algorithm_result_helper
     {
         template <typename T_>
-        static BOOST_FORCEINLINE T_ call(T_&& val)
+        static HPX_FORCEINLINE T_ call(T_&& val)
         {
             return std::forward<T_>(val);
         }
@@ -36,7 +36,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
     template <>
     struct algorithm_result_helper<future<void> >
     {
-        static BOOST_FORCEINLINE future<void> call(future<void>&& f)
+        static HPX_FORCEINLINE future<void> call(future<void>&& f)
         {
             return std::move(f);
         }
@@ -45,16 +45,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
     template <typename Iterator>
     struct algorithm_result_helper<
         Iterator,
-        typename boost::enable_if<
-                typename hpx::traits::segmented_local_iterator_traits<
-                        Iterator
-                    >::is_segmented_local_iterator
+        typename std::enable_if<
+                hpx::traits::is_segmented_local_iterator<Iterator>::value
             >::type>
     {
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator>
-            traits;
+        typedef hpx::traits::segmented_local_iterator_traits<Iterator> traits;
 
-        static BOOST_FORCEINLINE Iterator
+        static HPX_FORCEINLINE Iterator
         call(typename traits::local_raw_iterator&& it)
         {
             return traits::remote(std::move(it));
@@ -64,23 +61,15 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
     template <typename Iterator1, typename Iterator2>
     struct algorithm_result_helper<
         std::pair<Iterator1, Iterator2>,
-        typename boost::enable_if<
-            typename boost::mpl::or_<
-                typename hpx::traits::segmented_local_iterator_traits<
-                        Iterator1
-                    >::is_segmented_local_iterator,
-                typename hpx::traits::segmented_local_iterator_traits<
-                        Iterator2
-                    >::is_segmented_local_iterator
-            >::type
-        >::type>
+        typename std::enable_if<
+                hpx::traits::is_segmented_local_iterator<Iterator1>::value ||
+                hpx::traits::is_segmented_local_iterator<Iterator2>::value
+            >::type>
     {
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator1>
-            traits1;
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator2>
-            traits2;
+        typedef hpx::traits::segmented_local_iterator_traits<Iterator1> traits1;
+        typedef hpx::traits::segmented_local_iterator_traits<Iterator2> traits2;
 
-        static BOOST_FORCEINLINE
+        static HPX_FORCEINLINE
         std::pair<
             typename traits1::local_iterator, typename traits2::local_iterator
         >
@@ -98,15 +87,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
     template <typename Iterator>
     struct algorithm_result_helper<
         future<Iterator>,
-        typename boost::enable_if<
-                typename hpx::traits::segmented_local_iterator_traits<
-                        Iterator
-                    >::is_segmented_local_iterator
+        typename std::enable_if<
+                hpx::traits::is_segmented_local_iterator<Iterator>::value
             >::type>
     {
         typedef hpx::traits::segmented_local_iterator_traits<Iterator> traits;
 
-        static BOOST_FORCEINLINE future<Iterator>
+        static HPX_FORCEINLINE future<Iterator>
         call(future<typename traits::local_raw_iterator>&& f)
         {
             typedef future<typename traits::local_raw_iterator> argtype;
@@ -121,28 +108,20 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
     template <typename Iterator1, typename Iterator2>
     struct algorithm_result_helper<
         future<std::pair<Iterator1, Iterator2> >,
-        typename boost::enable_if<
-            typename boost::mpl::or_<
-                typename hpx::traits::segmented_local_iterator_traits<
-                        Iterator1
-                    >::is_segmented_local_iterator,
-                typename hpx::traits::segmented_local_iterator_traits<
-                        Iterator2
-                    >::is_segmented_local_iterator
-            >::type
-        >::type>
+        typename std::enable_if<
+                hpx::traits::is_segmented_local_iterator<Iterator1>::value ||
+                hpx::traits::is_segmented_local_iterator<Iterator2>::value
+            >::type>
     {
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator1>
-            traits1;
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator2>
-            traits2;
+        typedef hpx::traits::segmented_local_iterator_traits<Iterator1> traits1;
+        typedef hpx::traits::segmented_local_iterator_traits<Iterator2> traits2;
 
         typedef std::pair<
                 typename traits1::local_raw_iterator,
                 typename traits2::local_raw_iterator
             > arg_type;
 
-        static BOOST_FORCEINLINE
+        static HPX_FORCEINLINE
         future<std::pair<
             typename traits1::local_iterator, typename traits2::local_iterator
         > >
@@ -167,25 +146,25 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
     template <typename R, typename Algo, typename ExPolicy, typename... Args>
     struct dispatcher_helper
     {
-        static BOOST_FORCEINLINE R sequential(Algo const& algo,
+        static HPX_FORCEINLINE R sequential(Algo const& algo,
             ExPolicy const& policy, Args const&... args)
         {
             using hpx::traits::segmented_local_iterator_traits;
             return
                 detail::algorithm_result_helper<R>::call(
-                    algo.call(policy, boost::mpl::true_(),
+                    algo.call(policy, std::true_type(),
                         segmented_local_iterator_traits<Args>::local(args)...
                     )
                 );
         }
 
-        static BOOST_FORCEINLINE R parallel(Algo const& algo,
+        static HPX_FORCEINLINE R parallel(Algo const& algo,
             ExPolicy const& policy, Args const&... args)
         {
             using hpx::traits::segmented_local_iterator_traits;
             return
                 detail::algorithm_result_helper<R>::call(
-                    algo.call(policy, boost::mpl::false_(),
+                    algo.call(policy, std::false_type(),
                         segmented_local_iterator_traits<Args>::local(args)...
                     )
                 );
@@ -195,22 +174,22 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
     template <typename Algo, typename ExPolicy, typename... Args>
     struct dispatcher_helper<void, Algo, ExPolicy, Args...>
     {
-        static BOOST_FORCEINLINE
+        static HPX_FORCEINLINE
         typename parallel::util::detail::algorithm_result<ExPolicy>::type
         sequential(Algo const& algo, ExPolicy const& policy, Args const&... args)
         {
             using hpx::traits::segmented_local_iterator_traits;
-            algo.call(policy, boost::mpl::true_(),
+            algo.call(policy, std::true_type(),
                     segmented_local_iterator_traits<Args>::local(args)...
                 );
         }
 
-        static BOOST_FORCEINLINE
+        static HPX_FORCEINLINE
         typename parallel::util::detail::algorithm_result<ExPolicy>::type
         parallel(Algo const& algo, ExPolicy const& policy, Args const&... args)
         {
             using hpx::traits::segmented_local_iterator_traits;
-            algo.call(policy, boost::mpl::false_(),
+            algo.call(policy, std::false_type(),
                     segmented_local_iterator_traits<Args>::local(args)...
                 );
         }
@@ -228,13 +207,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
                 result_type, Algo, ExPolicy, Args...
             > base_dispatcher;
 
-        static BOOST_FORCEINLINE result_type sequential(Algo const& algo,
+        static HPX_FORCEINLINE result_type sequential(Algo const& algo,
             ExPolicy const& policy, Args const&... args)
         {
             return base_dispatcher::sequential(algo, policy, args...);
         }
 
-        static BOOST_FORCEINLINE result_type parallel(Algo const& algo,
+        static HPX_FORCEINLINE result_type parallel(Algo const& algo,
             ExPolicy const& policy, Args const&... args)
         {
             return base_dispatcher::sequential(algo, policy, args...);
@@ -248,30 +227,30 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
     // sequential
     template <typename Algo, typename ExPolicy, typename R, typename... Args>
     struct algorithm_invoker_action<
-                Algo, ExPolicy, boost::mpl::true_, R(Args const& ...)>
-        : hpx::actions::make_action<
+                Algo, ExPolicy, std::true_type, R(Args const& ...)>
+      : hpx::actions::make_action<
             R (*)(Algo const&, ExPolicy const&, Args const&...),
             &dispatcher<Algo, ExPolicy, Args...>::sequential,
             algorithm_invoker_action<
-                Algo, ExPolicy, boost::mpl::true_, R(Args const& ...)>
+                Algo, ExPolicy, std::true_type, R(Args const& ...)>
         >::type
     {};
 
     // parallel
     template <typename Algo, typename ExPolicy, typename R, typename... Args>
     struct algorithm_invoker_action<
-                Algo, ExPolicy, boost::mpl::false_, R(Args const& ...)>
-        : hpx::actions::make_action<
+                Algo, ExPolicy, std::false_type, R(Args const& ...)>
+      : hpx::actions::make_action<
             R (*)(Algo const&, ExPolicy const&, Args const&...),
             &dispatcher<Algo, ExPolicy, Args...>::parallel,
             algorithm_invoker_action<
-                Algo, ExPolicy, boost::mpl::false_, R(Args const& ...)>
+                Algo, ExPolicy, std::false_type, R(Args const& ...)>
         >::type
     {};
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Algo, typename ExPolicy, typename IsSeq, typename... Args>
-    BOOST_FORCEINLINE
+    HPX_FORCEINLINE
     future<typename hpx::util::decay<Algo>::type::result_type>
     dispatch_async(id_type const& id, Algo && algo, ExPolicy const& policy,
         IsSeq, Args&&... args)
@@ -291,7 +270,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
     }
 
     template <typename Algo, typename ExPolicy, typename IsSeq, typename... Args>
-    BOOST_FORCEINLINE
+    HPX_FORCEINLINE
     typename hpx::util::decay<Algo>::type::result_type
     dispatch(id_type const& id, Algo && algo, ExPolicy const& policy,
         IsSeq is_seq, Args&&... args)

--- a/hpx/parallel/segmented_algorithms/for_each.hpp
+++ b/hpx/parallel/segmented_algorithms/for_each.hpp
@@ -115,7 +115,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typedef typename traits::local_iterator local_iterator_type;
             typedef util::detail::algorithm_result<ExPolicy, SegIter> result;
 
-            typedef hpx::traits::is_input_iterator<SegIter> forced_seq;
+            typedef hpx::traits::is_just_input_iterator<SegIter> forced_seq;
 
             segment_iterator sit = traits::segment(first);
             segment_iterator send = traits::segment(last);

--- a/hpx/parallel/segmented_algorithms/for_each.hpp
+++ b/hpx/parallel/segmented_algorithms/for_each.hpp
@@ -115,7 +115,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typedef typename traits::local_iterator local_iterator_type;
             typedef util::detail::algorithm_result<ExPolicy, SegIter> result;
 
-            typedef hpx::traits::is_just_input_iterator<SegIter> forced_seq;
+            typedef std::integral_constant<bool,
+                    !hpx::traits::is_forward_iterator<SegIter>::value
+                > forced_seq;
 
             segment_iterator sit = traits::segment(first);
             segment_iterator send = traits::segment(last);

--- a/hpx/parallel/segmented_algorithms/for_each.hpp
+++ b/hpx/parallel/segmented_algorithms/for_each.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,7 +6,7 @@
 #if !defined(HPX_PARALLEL_SEGMENTED_ALGORITHM_FOR_EACH_OCT_15_2014_0839PM)
 #define HPX_PARALLEL_SEGMENTED_ALGORITHM_FOR_EACH_OCT_15_2014_0839PM
 
-#include <hpx/hpx_fwd.hpp>
+#include <hpx/config.hpp>
 #include <hpx/traits/segmented_iterator_traits.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
@@ -20,9 +20,7 @@
 #include <algorithm>
 #include <iterator>
 #include <type_traits>
-
-#include <boost/mpl/bool.hpp>
-#include <boost/type_traits/is_same.hpp>
+#include <list>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -38,15 +36,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typename F, typename Proj>
         static typename util::detail::algorithm_result<ExPolicy, SegIter>::type
         segmented_for_each(Algo && algo, ExPolicy const& policy,
-            SegIter first, SegIter last, F && f, Proj && proj,
-            boost::mpl::true_)
+            SegIter first, SegIter last, F && f, Proj && proj, std::true_type)
         {
             typedef hpx::traits::segmented_iterator_traits<SegIter> traits;
             typedef typename traits::segment_iterator segment_iterator;
             typedef typename traits::local_iterator local_iterator_type;
             typedef util::detail::algorithm_result<ExPolicy, SegIter> result;
-
-            using boost::mpl::true_;
 
             segment_iterator sit = traits::segment(first);
             segment_iterator send = traits::segment(last);
@@ -59,7 +54,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 if (beg != end)
                 {
                     local_iterator_type out = dispatch(traits::get_id(sit),
-                        algo, policy, true_(), beg, end, f, proj
+                        algo, policy, std::true_type(), beg, end, f, proj
                     );
                     last = traits::compose(send, out);
                 }
@@ -73,7 +68,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 if (beg != end)
                 {
                     out = dispatch(traits::get_id(sit),
-                        algo, policy, true_(), beg, end, f, proj
+                        algo, policy, std::true_type(), beg, end, f, proj
                     );
                 }
 
@@ -87,7 +82,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     if (beg != end)
                     {
                         out = dispatch(traits::get_id(sit),
-                            algo, policy, true_(), beg, end, f, proj
+                            algo, policy, std::true_type(), beg, end, f, proj
                         );
                     }
                 }
@@ -98,7 +93,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 if (beg != end)
                 {
                     out = dispatch(traits::get_id(sit),
-                        algo, policy, true_(), beg, end, f, proj
+                        algo, policy, std::true_type(), beg, end, f, proj
                     );
                 }
 
@@ -113,19 +108,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typename F, typename Proj>
         static typename util::detail::algorithm_result<ExPolicy, SegIter>::type
         segmented_for_each(Algo && algo, ExPolicy const& policy,
-            SegIter first, SegIter last, F && f, Proj && proj,
-            boost::mpl::false_)
+            SegIter first, SegIter last, F && f, Proj && proj, std::false_type)
         {
             typedef hpx::traits::segmented_iterator_traits<SegIter> traits;
             typedef typename traits::segment_iterator segment_iterator;
             typedef typename traits::local_iterator local_iterator_type;
             typedef util::detail::algorithm_result<ExPolicy, SegIter> result;
 
-            typedef typename std::iterator_traits<SegIter>::iterator_category
-                iterator_category;
-            typedef typename boost::mpl::bool_<boost::is_same<
-                    iterator_category, std::input_iterator_tag
-                >::value> forced_seq;
+            typedef hpx::traits::is_input_iterator<SegIter> forced_seq;
 
             segment_iterator sit = traits::segment(first);
             segment_iterator send = traits::segment(last);
@@ -203,9 +193,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         for_each_(ExPolicy && policy, SegIter first, SegIter last, F && f,
             Proj && proj, std::true_type)
         {
-            typedef typename parallel::is_sequential_execution_policy<
-                    ExPolicy
-                >::type is_seq;
+            typedef parallel::is_sequential_execution_policy<ExPolicy> is_seq;
 
             if (first == last)
             {

--- a/hpx/parallel/segmented_algorithms/generate.hpp
+++ b/hpx/parallel/segmented_algorithms/generate.hpp
@@ -108,7 +108,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typedef typename traits::segment_iterator segment_iterator;
             typedef typename traits::local_iterator local_iterator_type;
 
-            typedef hpx::traits::is_input_iterator<SegIter> forced_seq;
+            typedef hpx::traits::is_just_input_iterator<SegIter> forced_seq;
             typedef util::detail::algorithm_result<ExPolicy, SegIter> result;
 
             segment_iterator sit = traits::segment(first);

--- a/hpx/parallel/segmented_algorithms/generate.hpp
+++ b/hpx/parallel/segmented_algorithms/generate.hpp
@@ -20,8 +20,7 @@
 #include <algorithm>
 #include <iterator>
 #include <type_traits>
-
-#include <boost/type_traits/is_same.hpp>
+#include <list>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -37,14 +36,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typename F>
         static typename util::detail::algorithm_result<ExPolicy, SegIter>::type
         segmented_generate(Algo && algo, ExPolicy const& policy,
-            SegIter first, SegIter last, F && f, boost::mpl::true_)
+            SegIter first, SegIter last, F && f, std::true_type)
         {
             typedef hpx::traits::segmented_iterator_traits<SegIter> traits;
             typedef typename traits::segment_iterator segment_iterator;
             typedef typename traits::local_iterator local_iterator_type;
             typedef util::detail::algorithm_result<ExPolicy, SegIter> result;
-
-            using boost::mpl::true_;
 
             segment_iterator sit = traits::segment(first);
             segment_iterator send = traits::segment(last);
@@ -57,7 +54,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 if (beg != end)
                 {
                     local_iterator_type out = dispatch(traits::get_id(sit),
-                        algo, policy, true_(), beg, end, f);
+                        algo, policy, std::true_type(), beg, end, f);
                     last = traits::compose(send, out);
                 }
             }
@@ -69,8 +66,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 if (beg != end)
                 {
-                    out = dispatch(traits::get_id(sit), algo, policy, true_(),
-                        beg, end, f);
+                    out = dispatch(traits::get_id(sit), algo, policy,
+                        std::true_type(), beg, end, f);
                 }
 
                 // handle all of the full partitions
@@ -81,7 +78,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     if (beg != end)
                     {
                         out = dispatch(traits::get_id(sit), algo, policy,
-                            true_(), beg, end, f);
+                            std::true_type(), beg, end, f);
                     }
                 }
 
@@ -90,8 +87,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 end = traits::local(last);
                 if (beg != end)
                 {
-                    out = dispatch(traits::get_id(sit), algo, policy, true_(),
-                        beg, end, f);
+                    out = dispatch(traits::get_id(sit), algo, policy,
+                        std::true_type(), beg, end, f);
                 }
 
                 last = traits::compose(send, out);
@@ -105,17 +102,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typename F>
         static typename util::detail::algorithm_result<ExPolicy, SegIter>::type
         segmented_generate(Algo && algo, ExPolicy const& policy,
-            SegIter first, SegIter last, F && f, boost::mpl::false_)
+            SegIter first, SegIter last, F && f, std::false_type)
         {
             typedef hpx::traits::segmented_iterator_traits<SegIter> traits;
             typedef typename traits::segment_iterator segment_iterator;
             typedef typename traits::local_iterator local_iterator_type;
 
-            typedef typename std::iterator_traits<SegIter>::iterator_category
-                iterator_category;
-            typedef typename boost::mpl::bool_<boost::is_same<
-                    iterator_category, std::input_iterator_tag
-                >::value> forced_seq;
+            typedef hpx::traits::is_input_iterator<SegIter> forced_seq;
             typedef util::detail::algorithm_result<ExPolicy, SegIter> result;
 
             segment_iterator sit = traits::segment(first);
@@ -189,9 +182,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         generate_(ExPolicy && policy, FwdIter first, FwdIter last, F && f,
             std::true_type)
         {
-            typedef typename parallel::is_sequential_execution_policy<
-                    ExPolicy
-                >::type is_seq;
+            typedef parallel::is_sequential_execution_policy<ExPolicy> is_seq;
 
             if (first == last)
             {

--- a/hpx/parallel/segmented_algorithms/generate.hpp
+++ b/hpx/parallel/segmented_algorithms/generate.hpp
@@ -108,7 +108,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typedef typename traits::segment_iterator segment_iterator;
             typedef typename traits::local_iterator local_iterator_type;
 
-            typedef hpx::traits::is_just_input_iterator<SegIter> forced_seq;
+            typedef std::integral_constant<bool,
+                    !hpx::traits::is_forward_iterator<SegIter>::value
+                > forced_seq;
             typedef util::detail::algorithm_result<ExPolicy, SegIter> result;
 
             segment_iterator sit = traits::segment(first);

--- a/hpx/parallel/segmented_algorithms/minmax.hpp
+++ b/hpx/parallel/segmented_algorithms/minmax.hpp
@@ -20,8 +20,8 @@
 #include <algorithm>
 #include <iterator>
 #include <type_traits>
-
-#include <boost/type_traits/is_same.hpp>
+#include <list>
+#include <vector>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -37,14 +37,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typename F, typename Proj>
         static typename util::detail::algorithm_result<ExPolicy, SegIter>::type
         segmented_minormax(Algo && algo, ExPolicy const& policy,
-            SegIter first, SegIter last, F && f, Proj && proj,
-            boost::mpl::true_)
+            SegIter first, SegIter last, F && f, Proj && proj, std::true_type)
         {
             typedef hpx::traits::segmented_iterator_traits<SegIter> traits;
             typedef typename traits::segment_iterator segment_iterator;
             typedef typename traits::local_iterator local_iterator_type;
-
-            using boost::mpl::true_;
 
             segment_iterator sit = traits::segment(first);
             segment_iterator send = traits::segment(last);
@@ -59,7 +56,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 if (beg != end)
                 {
                     local_iterator_type out = dispatch(
-                        traits::get_id(sit), algo, policy, true_(),
+                        traits::get_id(sit), algo, policy, std::true_type(),
                         beg, end, f, proj);
 
                     positions.push_back(traits::compose(send, out));
@@ -73,7 +70,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 if (beg != end)
                 {
                     local_iterator_type out = dispatch(
-                        traits::get_id(sit), algo, policy, true_(),
+                        traits::get_id(sit), algo, policy, std::true_type(),
                         beg, end, f, proj);
 
                     positions.push_back(traits::compose(sit, out));
@@ -88,7 +85,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     if (beg != end)
                     {
                         local_iterator_type out = dispatch(
-                            traits::get_id(sit), algo, policy, true_(),
+                            traits::get_id(sit), algo, policy, std::true_type(),
                             beg, end, f, proj);
 
                         positions.push_back(traits::compose(sit, out));
@@ -101,7 +98,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 if (beg != end)
                 {
                     local_iterator_type out = dispatch(
-                        traits::get_id(sit), algo, policy, true_(),
+                        traits::get_id(sit), algo, policy, std::true_type(),
                         beg, end, f, proj);
 
                     positions.push_back(traits::compose(sit, out));
@@ -117,18 +114,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typename F, typename Proj>
         static typename util::detail::algorithm_result<ExPolicy, SegIter>::type
         segmented_minormax(Algo && algo, ExPolicy const& policy,
-            SegIter first, SegIter last, F && f, Proj && proj,
-            boost::mpl::false_)
+            SegIter first, SegIter last, F && f, Proj && proj, std::false_type)
         {
             typedef hpx::traits::segmented_iterator_traits<SegIter> traits;
             typedef typename traits::segment_iterator segment_iterator;
             typedef typename traits::local_iterator local_iterator_type;
 
-            typedef typename std::iterator_traits<SegIter>::iterator_category
-                iterator_category;
-            typedef typename boost::mpl::bool_<boost::is_same<
-                    iterator_category, std::input_iterator_tag
-                >::value> forced_seq;
+            typedef hpx::traits::is_input_iterator<SegIter> forced_seq;
             typedef util::detail::algorithm_result<ExPolicy, SegIter> result;
 
             segment_iterator sit = traits::segment(first);
@@ -234,9 +226,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         min_element_(ExPolicy && policy, SegIter first, SegIter last, F && f,
             Proj && proj, std::true_type)
         {
-            typedef typename parallel::is_sequential_execution_policy<
-                    ExPolicy
-                >::type is_seq;
+            typedef parallel::is_sequential_execution_policy<ExPolicy> is_seq;
 
             SegIter result = first;
             if (first == last || ++first == last)
@@ -260,9 +250,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         max_element_(ExPolicy && policy, SegIter first, SegIter last, F && f,
             Proj && proj, std::true_type)
         {
-            typedef typename parallel::is_sequential_execution_policy<
-                    ExPolicy
-                >::type is_seq;
+            typedef parallel::is_sequential_execution_policy<ExPolicy> is_seq;
 
             SegIter result = first;
             if (first == last || ++first == last)
@@ -309,8 +297,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             ExPolicy, std::pair<SegIter, SegIter>
         >::type
         segmented_minmax(Algo && algo, ExPolicy const& policy,
-            SegIter first, SegIter last, F && f, Proj && proj,
-            boost::mpl::true_)
+            SegIter first, SegIter last, F && f, Proj && proj, std::true_type)
         {
             typedef hpx::traits::segmented_iterator_traits<SegIter> traits;
             typedef typename traits::segment_iterator segment_iterator;
@@ -320,8 +307,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typedef std::pair<
                     local_iterator_type, local_iterator_type
                 > local_iterator_pair_type;
-
-            using boost::mpl::true_;
 
             segment_iterator sit = traits::segment(first);
             segment_iterator send = traits::segment(last);
@@ -336,7 +321,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 if (beg != end)
                 {
                     local_iterator_pair_type out = dispatch(
-                        traits::get_id(sit), algo, policy, true_(),
+                        traits::get_id(sit), algo, policy, std::true_type(),
                         beg, end, f, proj);
 
                     positions.push_back(std::make_pair(
@@ -352,7 +337,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 if (beg != end)
                 {
                     local_iterator_pair_type out = dispatch(
-                        traits::get_id(sit), algo, policy, true_(),
+                        traits::get_id(sit), algo, policy, std::true_type(),
                         beg, end, f, proj);
 
                     positions.push_back(std::make_pair(
@@ -369,7 +354,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     if (beg != end)
                     {
                         local_iterator_pair_type out = dispatch(
-                            traits::get_id(sit), algo, policy, true_(),
+                            traits::get_id(sit), algo, policy, std::true_type(),
                             beg, end, f, proj);
 
                         positions.push_back(std::make_pair(
@@ -384,7 +369,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 if (beg != end)
                 {
                     local_iterator_pair_type out = dispatch(
-                        traits::get_id(sit), algo, policy, true_(),
+                        traits::get_id(sit), algo, policy, std::true_type(),
                         beg, end, f, proj);
 
                     positions.push_back(std::make_pair(
@@ -404,18 +389,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             ExPolicy, std::pair<SegIter, SegIter>
         >::type
         segmented_minmax(Algo && algo, ExPolicy const& policy,
-            SegIter first, SegIter last, F && f, Proj && proj,
-            boost::mpl::false_)
+            SegIter first, SegIter last, F && f, Proj && proj, std::false_type)
         {
             typedef hpx::traits::segmented_iterator_traits<SegIter> traits;
             typedef typename traits::segment_iterator segment_iterator;
             typedef typename traits::local_iterator local_iterator_type;
 
-            typedef typename std::iterator_traits<SegIter>::iterator_category
-                iterator_category;
-            typedef typename boost::mpl::bool_<boost::is_same<
-                    iterator_category, std::input_iterator_tag
-                >::value> forced_seq;
+            typedef hpx::traits::is_input_iterator<SegIter> forced_seq;
             typedef std::pair<SegIter, SegIter> result_type;
             typedef util::detail::algorithm_result<ExPolicy, result_type> result;
 
@@ -536,9 +516,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         minmax_element_(ExPolicy && policy, SegIter first, SegIter last, F && f,
             Proj && proj, std::true_type)
         {
-            typedef typename parallel::is_sequential_execution_policy<
-                    ExPolicy
-                >::type is_seq;
+            typedef parallel::is_sequential_execution_policy<ExPolicy> is_seq;
             typedef std::pair<SegIter, SegIter> result_type;
 
             result_type result(first, first);

--- a/hpx/parallel/segmented_algorithms/minmax.hpp
+++ b/hpx/parallel/segmented_algorithms/minmax.hpp
@@ -120,7 +120,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typedef typename traits::segment_iterator segment_iterator;
             typedef typename traits::local_iterator local_iterator_type;
 
-            typedef hpx::traits::is_input_iterator<SegIter> forced_seq;
+            typedef hpx::traits::is_just_input_iterator<SegIter> forced_seq;
             typedef util::detail::algorithm_result<ExPolicy, SegIter> result;
 
             segment_iterator sit = traits::segment(first);
@@ -395,7 +395,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typedef typename traits::segment_iterator segment_iterator;
             typedef typename traits::local_iterator local_iterator_type;
 
-            typedef hpx::traits::is_input_iterator<SegIter> forced_seq;
+            typedef hpx::traits::is_just_input_iterator<SegIter> forced_seq;
             typedef std::pair<SegIter, SegIter> result_type;
             typedef util::detail::algorithm_result<ExPolicy, result_type> result;
 

--- a/hpx/parallel/segmented_algorithms/minmax.hpp
+++ b/hpx/parallel/segmented_algorithms/minmax.hpp
@@ -120,7 +120,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typedef typename traits::segment_iterator segment_iterator;
             typedef typename traits::local_iterator local_iterator_type;
 
-            typedef hpx::traits::is_just_input_iterator<SegIter> forced_seq;
+            typedef std::integral_constant<bool,
+                    !hpx::traits::is_forward_iterator<SegIter>::value
+                > forced_seq;
             typedef util::detail::algorithm_result<ExPolicy, SegIter> result;
 
             segment_iterator sit = traits::segment(first);
@@ -395,7 +397,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typedef typename traits::segment_iterator segment_iterator;
             typedef typename traits::local_iterator local_iterator_type;
 
-            typedef hpx::traits::is_just_input_iterator<SegIter> forced_seq;
+            typedef std::integral_constant<bool,
+                    !hpx::traits::is_forward_iterator<SegIter>::value
+                > forced_seq;
             typedef std::pair<SegIter, SegIter> result_type;
             typedef util::detail::algorithm_result<ExPolicy, result_type> result;
 

--- a/hpx/parallel/segmented_algorithms/transform_reduce.hpp
+++ b/hpx/parallel/segmented_algorithms/transform_reduce.hpp
@@ -118,7 +118,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typedef typename traits::local_iterator local_iterator_type;
             typedef util::detail::algorithm_result<ExPolicy, T> result;
 
-            typedef hpx::traits::is_input_iterator<SegIter> forced_seq;
+            typedef hpx::traits::is_just_input_iterator<SegIter> forced_seq;
 
             segment_iterator sit = traits::segment(first);
             segment_iterator send = traits::segment(last);

--- a/hpx/parallel/segmented_algorithms/transform_reduce.hpp
+++ b/hpx/parallel/segmented_algorithms/transform_reduce.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,7 +6,7 @@
 #if !defined(HPX_PARALLEL_SEGMENTED_ALGORITHM_TRANSFORM_REDUCE_DEC_17_2014_1157AM)
 #define HPX_PARALLEL_SEGMENTED_ALGORITHM_TRANSFORM_REDUCE_DEC_17_2014_1157AM
 
-#include <hpx/hpx_fwd.hpp>
+#include <hpx/config.hpp>
 #include <hpx/traits/segmented_iterator_traits.hpp>
 
 #include <hpx/parallel/config/inline_namespace.hpp>
@@ -20,8 +20,7 @@
 #include <algorithm>
 #include <iterator>
 #include <type_traits>
-
-#include <boost/type_traits/is_same.hpp>
+#include <list>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
@@ -38,14 +37,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         static typename util::detail::algorithm_result<ExPolicy, T>::type
         segmented_transform_reduce(Algo && algo, ExPolicy const& policy,
             SegIter first, SegIter last, T && init,
-            Reduce && red_op, Convert && conv_op, boost::mpl::true_)
+            Reduce && red_op, Convert && conv_op, std::true_type)
         {
             typedef hpx::traits::segmented_iterator_traits<SegIter> traits;
             typedef typename traits::segment_iterator segment_iterator;
             typedef typename traits::local_iterator local_iterator_type;
             typedef util::detail::algorithm_result<ExPolicy, T> result;
-
-            using boost::mpl::true_;
 
             segment_iterator sit = traits::segment(first);
             segment_iterator send = traits::segment(last);
@@ -60,8 +57,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 if (beg != end)
                 {
                     overall_result =
-                        dispatch(traits::get_id(sit), algo, policy, true_(),
-                            beg, end, init, red_op, conv_op);
+                        dispatch(traits::get_id(sit), algo, policy,
+                            std::true_type(), beg, end, init, red_op, conv_op);
                 }
             }
             else {
@@ -72,8 +69,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 {
                     overall_result = red_op(
                         overall_result,
-                        dispatch(traits::get_id(sit), algo, policy, true_(),
-                            beg, end, init, red_op, conv_op)
+                        dispatch(traits::get_id(sit), algo, policy,
+                            std::true_type(), beg, end, init, red_op, conv_op)
                     );
                 }
 
@@ -87,7 +84,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         overall_result = red_op(
                             overall_result,
                             dispatch(traits::get_id(sit), algo, policy,
-                                true_(), beg, end, init, red_op, conv_op)
+                                std::true_type(), beg, end, init, red_op, conv_op)
                         );
                     }
                 }
@@ -99,8 +96,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 {
                     overall_result = red_op(
                         overall_result,
-                        dispatch(traits::get_id(sit), algo, policy, true_(),
-                            beg, end, init, red_op, conv_op)
+                        dispatch(traits::get_id(sit), algo, policy,
+                            std::true_type(), beg, end, init, red_op, conv_op)
                     );
                 }
             }
@@ -114,18 +111,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         static typename util::detail::algorithm_result<ExPolicy, T>::type
         segmented_transform_reduce(Algo && algo, ExPolicy const& policy,
             SegIter first, SegIter last, T && init,
-            Reduce && red_op, Convert && conv_op, boost::mpl::false_)
+            Reduce && red_op, Convert && conv_op, std::false_type)
         {
             typedef hpx::traits::segmented_iterator_traits<SegIter> traits;
             typedef typename traits::segment_iterator segment_iterator;
             typedef typename traits::local_iterator local_iterator_type;
             typedef util::detail::algorithm_result<ExPolicy, T> result;
 
-            typedef typename std::iterator_traits<SegIter>::iterator_category
-                iterator_category;
-            typedef typename boost::mpl::bool_<boost::is_same<
-                    iterator_category, std::input_iterator_tag
-                >::value> forced_seq;
+            typedef hpx::traits::is_input_iterator<SegIter> forced_seq;
 
             segment_iterator sit = traits::segment(first);
             segment_iterator send = traits::segment(last);
@@ -219,10 +212,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         transform_reduce_(ExPolicy&& policy, InIter first, InIter last, T && init,
             Reduce && red_op, Convert && conv_op, std::true_type)
         {
-            typedef typename parallel::is_sequential_execution_policy<
-                    ExPolicy
-                >::type is_seq;
-
+            typedef parallel::is_sequential_execution_policy<ExPolicy> is_seq;
             typedef typename hpx::util::decay<T>::type init_type;
 
             if (first == last)

--- a/hpx/parallel/segmented_algorithms/transform_reduce.hpp
+++ b/hpx/parallel/segmented_algorithms/transform_reduce.hpp
@@ -118,7 +118,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             typedef typename traits::local_iterator local_iterator_type;
             typedef util::detail::algorithm_result<ExPolicy, T> result;
 
-            typedef hpx::traits::is_just_input_iterator<SegIter> forced_seq;
+            typedef std::integral_constant<bool,
+                    !hpx::traits::is_forward_iterator<SegIter>::value
+                > forced_seq;
 
             segment_iterator sit = traits::segment(first);
             segment_iterator send = traits::segment(last);

--- a/hpx/parallel/task_block.hpp
+++ b/hpx/parallel/task_block.hpp
@@ -8,7 +8,7 @@
 #if !defined(HPX_PARALLEL_TASK_BLOCK_JUL_09_2014_1250PM)
 #define HPX_PARALLEL_TASK_BLOCK_JUL_09_2014_1250PM
 
-#include <hpx/hpx_fwd.hpp>
+#include <hpx/config.hpp>
 #include <hpx/exception.hpp>
 #include <hpx/config/emulate_deleted.hpp>
 #include <hpx/dataflow.hpp>

--- a/hpx/parallel/task_block.hpp
+++ b/hpx/parallel/task_block.hpp
@@ -452,6 +452,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
     }
 
     /// \cond NOINTERNAL
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
 #if defined(HPX_HAVE_CXX14_LAMBDAS)
     template <typename F>
     inline void define_task_block(parallel::execution_policy && policy, F && f)
@@ -499,6 +500,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
             "define_task_block",
             "The given execution policy is not supported");
     }
+#endif
 #endif
     /// \endcond
 

--- a/hpx/parallel/traits/extract_partitioner.hpp
+++ b/hpx/parallel/traits/extract_partitioner.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,7 +6,7 @@
 #if !defined(HPX_PARALLEL_TRAITS_EXTRACT_PARTITIONER_OCT_03_2014_0105PM)
 #define HPX_PARALLEL_TRAITS_EXTRACT_PARTITIONER_OCT_03_2014_0105PM
 
-#include <hpx/hpx_fwd.hpp>
+#include <hpx/config.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace parallel { namespace traits

--- a/hpx/parallel/util/cancellation_token.hpp
+++ b/hpx/parallel/util/cancellation_token.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,7 +6,7 @@
 #if !defined(HPX_PARALLEL_UTIL_CANCELLATION_TOKEN_OCT_05_1205PM)
 #define HPX_PARALLEL_UTIL_CANCELLATION_TOKEN_OCT_05_1205PM
 
-#include <hpx/hpx_fwd.hpp>
+#include <hpx/config.hpp>
 
 #include <algorithm>
 

--- a/hpx/parallel/util/detail/algorithm_result.hpp
+++ b/hpx/parallel/util/detail/algorithm_result.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -13,7 +13,7 @@
 #include <hpx/util/invoke.hpp>
 #include <hpx/parallel/execution_policy.hpp>
 
-#include <boost/type_traits/is_lvalue_reference.hpp>
+#include <type_traits>
 
 namespace hpx { namespace parallel { namespace util { namespace detail
 {
@@ -183,7 +183,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail
     struct algorithm_result
       : algorithm_result_impl<typename hpx::util::decay<ExPolicy>::type, T>
     {
-        static_assert(!boost::is_lvalue_reference<T>::value,
+        static_assert(!std::is_lvalue_reference<T>::value,
             "T shouldn't be a lvalue reference");
     };
 

--- a/hpx/parallel/util/detail/handle_local_exceptions.hpp
+++ b/hpx/parallel/util/detail/handle_local_exceptions.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,12 +6,15 @@
 #if !defined(HPX_PARALLEL_UTIL_DETAIL_HANDLE_LOCAL_EXCEPTIONS_OCT_03_2014_0142PM)
 #define HPX_PARALLEL_UTIL_DETAIL_HANDLE_LOCAL_EXCEPTIONS_OCT_03_2014_0142PM
 
-#include <hpx/hpx_fwd.hpp>
+#include <hpx/config.hpp>
+#include <hpx/hpx_finalize.hpp>
 #include <hpx/async.hpp>
 #include <hpx/exception_list.hpp>
 #include <hpx/parallel/execution_policy.hpp>
 
 #include <vector>
+#include <list>
+#include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace parallel { namespace util { namespace detail

--- a/hpx/parallel/util/detail/handle_remote_exceptions.hpp
+++ b/hpx/parallel/util/detail/handle_remote_exceptions.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,12 +6,15 @@
 #if !defined(HPX_PARALLEL_UTIL_DETAIL_HANDLE_REMOTE_EXCEPTIONS_DEC_28_2014_0316PM)
 #define HPX_PARALLEL_UTIL_DETAIL_HANDLE_REMOTE_EXCEPTIONS_DEC_28_2014_0316PM
 
-#include <hpx/hpx_fwd.hpp>
-#include <hpx/async.hpp>
+#include <hpx/config.hpp>
+#include <hpx/hpx_finalize.hpp>
+#include <hpx/lcos/future.hpp>
 #include <hpx/exception_list.hpp>
 #include <hpx/parallel/execution_policy.hpp>
 
 #include <vector>
+#include <list>
+#include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace parallel { namespace util { namespace detail

--- a/hpx/parallel/util/loop.hpp
+++ b/hpx/parallel/util/loop.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,7 +6,7 @@
 #if !defined(HPX_PARALLEL_UTIL_LOOP_MAY_27_2014_1040PM)
 #define HPX_PARALLEL_UTIL_LOOP_MAY_27_2014_1040PM
 
-#include <hpx/hpx_fwd.hpp>
+#include <hpx/config.hpp>
 #include <hpx/parallel/util/cancellation_token.hpp>
 
 #include <iterator>

--- a/hpx/parallel/util/numa_allocator.hpp
+++ b/hpx/parallel/util/numa_allocator.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2015 Thomas Heller
-//  Copyright (c) 2015 Hartmut Kaiser
+//  Copyright (c) 2015-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,7 +9,9 @@
 
 #include <hpx/config.hpp>
 #include <hpx/lcos/future.hpp>
+#include <hpx/lcos/wait_all.hpp>
 #include <hpx/runtime/threads/topology.hpp>
+#include <hpx/runtime/get_worker_thread_num.hpp>
 #include <hpx/parallel/execution_policy.hpp>
 #include <hpx/parallel/algorithms/for_each.hpp>
 #include <hpx/parallel/executors/executor_information_traits.hpp>
@@ -17,6 +19,7 @@
 #include <hpx/util/assert.hpp>
 
 #include <cstddef>
+#include <limits>
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hpx/parallel/util/projection_identity.hpp
+++ b/hpx/parallel/util/projection_identity.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015 Hartmut Kaiser
+//  Copyright (c) 2015-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -7,7 +7,8 @@
 #define HPX_PARALLEL_UTIL_PROJECTION_IDENTITY_JUL_18_2015_1105AM
 
 #include <hpx/config.hpp>
-#include <hpx/util/decay.hpp>
+
+#include <utility>
 
 namespace hpx { namespace parallel { namespace util
 {

--- a/hpx/traits.hpp
+++ b/hpx/traits.hpp
@@ -139,17 +139,30 @@ namespace hpx { namespace traits
     struct is_input_iterator;
 
     template <typename Iterator, typename Enable = void>
+    struct is_at_least_input_iterator;
+
+    template <typename Iterator, typename Enable = void>
     struct is_output_iterator;
 
     template <typename Iterator, typename Enable = void>
     struct is_forward_iterator;
 
     template <typename Iterator, typename Enable = void>
+    struct is_at_least_forward_iterator;
+
+    template <typename Iterator, typename Enable = void>
     struct is_bidirectional_iterator;
+
+    template <typename Iterator, typename Enable = void>
+    struct is_at_least_bidirectional_iterator;
 
     template <typename Iterator, typename Enable = void>
     struct is_random_access_iterator;
 
+    template <typename Iterator, typename Enable = void>
+    struct is_at_least_random_access_iterator;
+
+    ///////////////////////////////////////////////////////////////////////////
     template <typename Range, typename Enable = void>
     struct is_range;
 
@@ -203,6 +216,9 @@ namespace hpx { namespace traits
 
     template <typename Iterator, typename Enable = void>
     struct segmented_local_iterator_traits;
+
+    template <typename Iterator, typename Enable = void>
+    struct is_segmented_local_iterator;
 
     template <typename T, typename Enable = void>
     struct projected_iterator;

--- a/hpx/traits.hpp
+++ b/hpx/traits.hpp
@@ -136,22 +136,13 @@ namespace hpx { namespace traits
     struct is_iterator;
 
     template <typename Iterator, typename Enable = void>
-    struct is_just_input_iterator;
-
-    template <typename Iterator, typename Enable = void>
     struct is_input_iterator;
 
     template <typename Iterator, typename Enable = void>
     struct is_output_iterator;
 
     template <typename Iterator, typename Enable = void>
-    struct is_just_forward_iterator;
-
-    template <typename Iterator, typename Enable = void>
     struct is_forward_iterator;
-
-    template <typename Iterator, typename Enable = void>
-    struct is_just_bidirectional_iterator;
 
     template <typename Iterator, typename Enable = void>
     struct is_bidirectional_iterator;

--- a/hpx/traits.hpp
+++ b/hpx/traits.hpp
@@ -136,31 +136,28 @@ namespace hpx { namespace traits
     struct is_iterator;
 
     template <typename Iterator, typename Enable = void>
-    struct is_input_iterator;
+    struct is_just_input_iterator;
 
     template <typename Iterator, typename Enable = void>
-    struct is_at_least_input_iterator;
+    struct is_input_iterator;
 
     template <typename Iterator, typename Enable = void>
     struct is_output_iterator;
 
     template <typename Iterator, typename Enable = void>
+    struct is_just_forward_iterator;
+
+    template <typename Iterator, typename Enable = void>
     struct is_forward_iterator;
 
     template <typename Iterator, typename Enable = void>
-    struct is_at_least_forward_iterator;
+    struct is_just_bidirectional_iterator;
 
     template <typename Iterator, typename Enable = void>
     struct is_bidirectional_iterator;
 
     template <typename Iterator, typename Enable = void>
-    struct is_at_least_bidirectional_iterator;
-
-    template <typename Iterator, typename Enable = void>
     struct is_random_access_iterator;
-
-    template <typename Iterator, typename Enable = void>
-    struct is_at_least_random_access_iterator;
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Range, typename Enable = void>

--- a/hpx/traits/is_iterator.hpp
+++ b/hpx/traits/is_iterator.hpp
@@ -75,33 +75,15 @@ namespace hpx { namespace traits
     {};
 
     template <typename Iter, typename Enable>
-    struct is_just_input_iterator
-      : detail::has_category<
-            typename std::decay<Iter>::type, std::input_iterator_tag>
-    {};
-
-    template <typename Iter, typename Enable>
     struct is_input_iterator
       : detail::belongs_to_category<
             typename std::decay<Iter>::type, std::input_iterator_tag>
     {};
 
     template <typename Iter, typename Enable>
-    struct is_just_forward_iterator
-      : detail::has_category<
-            typename std::decay<Iter>::type, std::forward_iterator_tag>
-    {};
-
-    template <typename Iter, typename Enable>
     struct is_forward_iterator
       : detail::belongs_to_category<
             typename std::decay<Iter>::type, std::forward_iterator_tag>
-    {};
-
-    template <typename Iter, typename Enable>
-    struct is_just_bidirectional_iterator
-      : detail::has_category<
-            typename std::decay<Iter>::type, std::bidirectional_iterator_tag>
     {};
 
     template <typename Iter, typename Enable>

--- a/hpx/traits/is_iterator.hpp
+++ b/hpx/traits/is_iterator.hpp
@@ -43,6 +43,19 @@ namespace hpx { namespace traits
     {
         ///////////////////////////////////////////////////////////////////////
         template <typename Iter, typename Cat, typename Enable = void>
+        struct belongs_to_category
+          : std::false_type
+        {};
+
+        template <typename Iter, typename Cat>
+        struct belongs_to_category<Iter, Cat,
+                typename std::enable_if<is_iterator<Iter>::value>::type>
+          : std::is_base_of<
+                Cat, typename std::iterator_traits<Iter>::iterator_category>
+        {};
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Iter, typename Cat, typename Enable = void>
         struct has_category
           : std::false_type
         {};
@@ -50,14 +63,26 @@ namespace hpx { namespace traits
         template <typename Iter, typename Cat>
         struct has_category<Iter, Cat,
                 typename std::enable_if<is_iterator<Iter>::value>::type>
-          : std::is_base_of<
+          : std::is_same<
                 Cat, typename std::iterator_traits<Iter>::iterator_category>
         {};
     }
 
     template <typename Iter, typename Enable>
+    struct is_output_iterator
+      : detail::has_category<
+            typename std::decay<Iter>::type, std::output_iterator_tag>
+    {};
+
+    template <typename Iter, typename Enable>
     struct is_input_iterator
       : detail::has_category<
+            typename std::decay<Iter>::type, std::input_iterator_tag>
+    {};
+
+    template <typename Iter, typename Enable>
+    struct is_at_least_input_iterator
+      : detail::belongs_to_category<
             typename std::decay<Iter>::type, std::input_iterator_tag>
     {};
 
@@ -68,14 +93,32 @@ namespace hpx { namespace traits
     {};
 
     template <typename Iter, typename Enable>
+    struct is_at_least_forward_iterator
+      : detail::belongs_to_category<
+            typename std::decay<Iter>::type, std::forward_iterator_tag>
+    {};
+
+    template <typename Iter, typename Enable>
     struct is_bidirectional_iterator
       : detail::has_category<
             typename std::decay<Iter>::type, std::bidirectional_iterator_tag>
     {};
 
     template <typename Iter, typename Enable>
+    struct is_at_least_bidirectional_iterator
+      : detail::belongs_to_category<
+            typename std::decay<Iter>::type, std::bidirectional_iterator_tag>
+    {};
+
+    template <typename Iter, typename Enable>
     struct is_random_access_iterator
       : detail::has_category<
+            typename std::decay<Iter>::type, std::random_access_iterator_tag>
+    {};
+
+    template <typename Iter, typename Enable>
+    struct is_at_least_random_access_iterator
+      : detail::belongs_to_category<
             typename std::decay<Iter>::type, std::random_access_iterator_tag>
     {};
 }}

--- a/hpx/traits/is_iterator.hpp
+++ b/hpx/traits/is_iterator.hpp
@@ -75,37 +75,37 @@ namespace hpx { namespace traits
     {};
 
     template <typename Iter, typename Enable>
-    struct is_input_iterator
+    struct is_just_input_iterator
       : detail::has_category<
             typename std::decay<Iter>::type, std::input_iterator_tag>
     {};
 
     template <typename Iter, typename Enable>
-    struct is_at_least_input_iterator
+    struct is_input_iterator
       : detail::belongs_to_category<
             typename std::decay<Iter>::type, std::input_iterator_tag>
+    {};
+
+    template <typename Iter, typename Enable>
+    struct is_just_forward_iterator
+      : detail::has_category<
+            typename std::decay<Iter>::type, std::forward_iterator_tag>
     {};
 
     template <typename Iter, typename Enable>
     struct is_forward_iterator
-      : detail::has_category<
-            typename std::decay<Iter>::type, std::forward_iterator_tag>
-    {};
-
-    template <typename Iter, typename Enable>
-    struct is_at_least_forward_iterator
       : detail::belongs_to_category<
             typename std::decay<Iter>::type, std::forward_iterator_tag>
     {};
 
     template <typename Iter, typename Enable>
-    struct is_bidirectional_iterator
+    struct is_just_bidirectional_iterator
       : detail::has_category<
             typename std::decay<Iter>::type, std::bidirectional_iterator_tag>
     {};
 
     template <typename Iter, typename Enable>
-    struct is_at_least_bidirectional_iterator
+    struct is_bidirectional_iterator
       : detail::belongs_to_category<
             typename std::decay<Iter>::type, std::bidirectional_iterator_tag>
     {};
@@ -113,12 +113,6 @@ namespace hpx { namespace traits
     template <typename Iter, typename Enable>
     struct is_random_access_iterator
       : detail::has_category<
-            typename std::decay<Iter>::type, std::random_access_iterator_tag>
-    {};
-
-    template <typename Iter, typename Enable>
-    struct is_at_least_random_access_iterator
-      : detail::belongs_to_category<
             typename std::decay<Iter>::type, std::random_access_iterator_tag>
     {};
 }}

--- a/hpx/traits/segmented_iterator_traits.hpp
+++ b/hpx/traits/segmented_iterator_traits.hpp
@@ -59,6 +59,11 @@ namespace hpx { namespace traits
         }
     };
 
+    template <typename Iterator, typename Enable>
+    struct is_segmented_local_iterator
+      : segmented_local_iterator_traits<Iterator>::is_segmented_local_iterator
+    {};
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename T, typename Enable>
     struct projected_iterator

--- a/tests/performance/local/htts_v2/htts2_payload_precision.cpp
+++ b/tests/performance/local/htts_v2/htts2_payload_precision.cpp
@@ -9,6 +9,7 @@
 
 #include "htts2.hpp"
 
+#if !defined(HPX_MOVABLE_BUT_NOT_COPYABLE)
 #if defined(HPX_HAVE_CXX11_DELETED_FUNCTIONS)
 #define HPX_MOVABLE_BUT_NOT_COPYABLE(TYPE)                                    \
     public:                                                                   \
@@ -22,6 +23,7 @@
         TYPE(TYPE const &);                                                   \
         TYPE& operator=(TYPE const &);                                        \
 /**/
+#endif
 #endif
 
 template <typename BaseClock = boost::chrono::steady_clock>

--- a/tests/performance/local/htts_v2/htts2_payload_precision.cpp
+++ b/tests/performance/local/htts_v2/htts2_payload_precision.cpp
@@ -9,23 +9,6 @@
 
 #include "htts2.hpp"
 
-#if !defined(HPX_MOVABLE_BUT_NOT_COPYABLE)
-#if defined(HPX_HAVE_CXX11_DELETED_FUNCTIONS)
-#define HPX_MOVABLE_BUT_NOT_COPYABLE(TYPE)                                    \
-    public:                                                                   \
-        TYPE(TYPE const &) = delete;                                          \
-        TYPE& operator=(TYPE const &) = delete;                               \
-    private:                                                                  \
-/**/
-#else
-#define HPX_MOVABLE_BUT_NOT_COPYABLE(TYPE)                                    \
-    private:                                                                  \
-        TYPE(TYPE const &);                                                   \
-        TYPE& operator=(TYPE const &);                                        \
-/**/
-#endif
-#endif
-
 template <typename BaseClock = boost::chrono::steady_clock>
 struct payload_precision_tracker : htts2::clocksource<BaseClock>
 {

--- a/tests/performance/local/stencil3_iterators.cpp
+++ b/tests/performance/local/stencil3_iterators.cpp
@@ -21,14 +21,6 @@ int partition_size = 10000;
 namespace hpx { namespace experimental { namespace detail
 {
     template <typename Iterator>
-    struct is_random_access_iterator
-        : boost::is_same<
-            std::random_access_iterator_tag,
-            typename std::iterator_traits<Iterator>::iterator_category
-            >
-    {};
-
-    template <typename Iterator>
     HPX_FORCEINLINE
     Iterator previous(Iterator it, boost::mpl::false_)
     {
@@ -46,7 +38,7 @@ namespace hpx { namespace experimental { namespace detail
     HPX_FORCEINLINE
     Iterator previous(Iterator const& it)
     {
-        return previous(it, is_random_access_iterator<Iterator>());
+        return previous(it, hpx::traits::is_random_access_iterator<Iterator>());
     }
 
     template <typename Iterator>
@@ -67,7 +59,7 @@ namespace hpx { namespace experimental { namespace detail
     HPX_FORCEINLINE
     Iterator next(Iterator const& it)
     {
-        return next(it, is_random_access_iterator<Iterator>());
+        return next(it, hpx::traits::is_random_access_iterator<Iterator>());
     }
 }}}
 

--- a/tests/performance/local/stencil3_iterators.cpp
+++ b/tests/performance/local/stencil3_iterators.cpp
@@ -5,9 +5,12 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
+#include <hpx/traits/is_iterator.hpp>
 #include <hpx/util/high_resolution_clock.hpp>
 #include <hpx/util/transform_iterator.hpp>
 #include <hpx/include/iostreams.hpp>
+
+#include <type_traits>
 
 #include <boost/cstdint.hpp>
 #include <boost/range/irange.hpp>
@@ -22,14 +25,14 @@ namespace hpx { namespace experimental { namespace detail
 {
     template <typename Iterator>
     HPX_FORCEINLINE
-    Iterator previous(Iterator it, boost::mpl::false_)
+    Iterator previous(Iterator it, std::false_type)
     {
         return --it;
     }
 
     template <typename Iterator>
     HPX_FORCEINLINE
-    Iterator previous(Iterator const& it, boost::mpl::true_)
+    Iterator previous(Iterator const& it, std::true_type)
     {
         return it - 1;
     }
@@ -43,14 +46,14 @@ namespace hpx { namespace experimental { namespace detail
 
     template <typename Iterator>
     HPX_FORCEINLINE
-    Iterator next(Iterator it, boost::mpl::false_)
+    Iterator next(Iterator it, std::false_type)
     {
         return ++it;
     }
 
     template <typename Iterator>
     HPX_FORCEINLINE
-    Iterator next(Iterator const& it, boost::mpl::true_)
+    Iterator next(Iterator const& it, std::true_type)
     {
         return it + 1;
     }

--- a/tests/regressions/parallel/search_zerolength.cpp
+++ b/tests/regressions/parallel/search_zerolength.cpp
@@ -10,7 +10,6 @@
 
 void search_zero_dist_test()
 {
-    using hpx::parallel::execution_policy;
     using hpx::parallel::seq;
     using hpx::parallel::par;
     using hpx::parallel::search;

--- a/tests/unit/parallel/algorithms/adjacentdifference.cpp
+++ b/tests/unit/parallel/algorithms/adjacentdifference.cpp
@@ -73,12 +73,14 @@ void adjacent_difference_test()
     test_adjacent_difference_async(seq(task));
     test_adjacent_difference_async(par(task));
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_adjacent_difference(execution_policy(seq));
     test_adjacent_difference(execution_policy(par));
     test_adjacent_difference(execution_policy(par_vec));
 
     test_adjacent_difference(execution_policy(seq(task)));
     test_adjacent_difference(execution_policy(par(task)));
+#endif
 }
 
 int hpx_main(boost::program_options::variables_map& vm)

--- a/tests/unit/parallel/algorithms/adjacentdifference_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/adjacentdifference_bad_alloc.cpp
@@ -101,11 +101,13 @@ void test_adjacent_difference_bad_alloc()
     test_adjacent_difference_bad_alloc_async(seq(task), IteratorTag());
     test_adjacent_difference_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_adjacent_difference_bad_alloc(execution_policy(seq), IteratorTag());
     test_adjacent_difference_bad_alloc(execution_policy(par), IteratorTag());
 
     test_adjacent_difference_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_adjacent_difference_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void adjacent_difference_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/adjacentdifference_exception.cpp
+++ b/tests/unit/parallel/algorithms/adjacentdifference_exception.cpp
@@ -104,11 +104,13 @@ void test_adjacent_difference_exception()
     test_adjacent_difference_exception_async(seq(task), IteratorTag());
     test_adjacent_difference_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_adjacent_difference_exception(execution_policy(seq), IteratorTag());
     test_adjacent_difference_exception(execution_policy(par), IteratorTag());
 
     test_adjacent_difference_exception(execution_policy(seq(task)), IteratorTag());
     test_adjacent_difference_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void adjacent_difference_exception_test()

--- a/tests/unit/parallel/algorithms/adjacentfind.cpp
+++ b/tests/unit/parallel/algorithms/adjacentfind.cpp
@@ -76,12 +76,14 @@ void test_adjacent_find()
     test_adjacent_find_async(seq(task), IteratorTag());
     test_adjacent_find_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_adjacent_find(execution_policy(seq), IteratorTag());
     test_adjacent_find(execution_policy(par), IteratorTag());
     test_adjacent_find(execution_policy(par_vec), IteratorTag());
 
     test_adjacent_find(execution_policy(seq(task)), IteratorTag());
     test_adjacent_find(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void adjacent_find_test()

--- a/tests/unit/parallel/algorithms/adjacentfind_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/adjacentfind_bad_alloc.cpp
@@ -97,11 +97,13 @@ void test_adjacent_find_bad_alloc()
     test_adjacent_find_bad_alloc_async(seq(task), IteratorTag());
     test_adjacent_find_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_adjacent_find_bad_alloc(execution_policy(seq), IteratorTag());
     test_adjacent_find_bad_alloc(execution_policy(par), IteratorTag());
 
     test_adjacent_find_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_adjacent_find_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void adjacent_find_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/adjacentfind_binary.cpp
+++ b/tests/unit/parallel/algorithms/adjacentfind_binary.cpp
@@ -78,12 +78,14 @@ void test_adjacent_find()
     test_adjacent_find_async(seq(task), IteratorTag());
     test_adjacent_find_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_adjacent_find(execution_policy(seq), IteratorTag());
     test_adjacent_find(execution_policy(par), IteratorTag());
     test_adjacent_find(execution_policy(par_vec), IteratorTag());
 
     test_adjacent_find(execution_policy(seq(task)), IteratorTag());
     test_adjacent_find(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void adjacent_find_test()

--- a/tests/unit/parallel/algorithms/adjacentfind_binary_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/adjacentfind_binary_bad_alloc.cpp
@@ -98,11 +98,13 @@ void test_adjacent_find_bad_alloc()
     test_adjacent_find_bad_alloc_async(seq(task), IteratorTag());
     test_adjacent_find_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_adjacent_find_bad_alloc(execution_policy(seq), IteratorTag());
     test_adjacent_find_bad_alloc(execution_policy(par), IteratorTag());
 
     test_adjacent_find_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_adjacent_find_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void adjacent_find_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/adjacentfind_binary_exception.cpp
+++ b/tests/unit/parallel/algorithms/adjacentfind_binary_exception.cpp
@@ -100,11 +100,13 @@ void test_adjacent_find_exception()
     test_adjacent_find_exception_async(seq(task), IteratorTag());
     test_adjacent_find_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_adjacent_find_exception(execution_policy(seq), IteratorTag());
     test_adjacent_find_exception(execution_policy(par), IteratorTag());
 
     test_adjacent_find_exception(execution_policy(seq(task)), IteratorTag());
     test_adjacent_find_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void adjacent_find_exception_test()

--- a/tests/unit/parallel/algorithms/adjacentfind_exception.cpp
+++ b/tests/unit/parallel/algorithms/adjacentfind_exception.cpp
@@ -98,11 +98,13 @@ void test_adjacent_find_exception()
     test_adjacent_find_exception_async(seq(task), IteratorTag());
     test_adjacent_find_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_adjacent_find_exception(execution_policy(seq), IteratorTag());
     test_adjacent_find_exception(execution_policy(par), IteratorTag());
 
     test_adjacent_find_exception(execution_policy(seq(task)), IteratorTag());
     test_adjacent_find_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void adjacent_find_exception_test()

--- a/tests/unit/parallel/algorithms/all_of.cpp
+++ b/tests/unit/parallel/algorithms/all_of.cpp
@@ -88,12 +88,14 @@ void test_all_of()
     test_all_of_async(seq(task), IteratorTag());
     test_all_of_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_all_of(execution_policy(seq), IteratorTag());
     test_all_of(execution_policy(par), IteratorTag());
     test_all_of(execution_policy(par_vec), IteratorTag());
 
     test_all_of(execution_policy(seq(task)), IteratorTag());
     test_all_of(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 // template <typename IteratorTag>
@@ -221,11 +223,13 @@ void test_all_of_exception()
     test_all_of_exception_async(seq(task), IteratorTag());
     test_all_of_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_all_of_exception(execution_policy(seq), IteratorTag());
     test_all_of_exception(execution_policy(par), IteratorTag());
 
     test_all_of_exception(execution_policy(seq(task)), IteratorTag());
     test_all_of_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void all_of_exception_test()
@@ -323,11 +327,13 @@ void test_all_of_bad_alloc()
     test_all_of_bad_alloc_async(seq(task), IteratorTag());
     test_all_of_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_all_of_bad_alloc(execution_policy(seq), IteratorTag());
     test_all_of_bad_alloc(execution_policy(par), IteratorTag());
 
     test_all_of_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_all_of_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void all_of_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/any_of.cpp
+++ b/tests/unit/parallel/algorithms/any_of.cpp
@@ -88,12 +88,14 @@ void test_any_of()
     test_any_of_async(seq(task), IteratorTag());
     test_any_of_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_any_of(execution_policy(seq), IteratorTag());
     test_any_of(execution_policy(par), IteratorTag());
     test_any_of(execution_policy(par_vec), IteratorTag());
 
     test_any_of(execution_policy(seq(task)), IteratorTag());
     test_any_of(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 // template <typename IteratorTag>
@@ -221,11 +223,13 @@ void test_any_of_exception()
     test_any_of_exception_async(seq(task), IteratorTag());
     test_any_of_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_any_of_exception(execution_policy(seq), IteratorTag());
     test_any_of_exception(execution_policy(par), IteratorTag());
 
     test_any_of_exception(execution_policy(seq(task)), IteratorTag());
     test_any_of_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void any_of_exception_test()
@@ -323,11 +327,13 @@ void test_any_of_bad_alloc()
     test_any_of_bad_alloc_async(seq(task), IteratorTag());
     test_any_of_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_any_of_bad_alloc(execution_policy(seq), IteratorTag());
     test_any_of_bad_alloc(execution_policy(par), IteratorTag());
 
     test_any_of_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_any_of_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void any_of_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/copy.cpp
+++ b/tests/unit/parallel/algorithms/copy.cpp
@@ -128,12 +128,14 @@ void test_copy()
     test_copy_async(seq(task), IteratorTag());
     test_copy_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_copy(execution_policy(seq), IteratorTag());
     test_copy(execution_policy(par), IteratorTag());
     test_copy(execution_policy(par_vec), IteratorTag());
 
     test_copy(execution_policy(seq(task)), IteratorTag());
     test_copy(execution_policy(par(task)), IteratorTag());
+#endif
 
     //assure output iterator will work
     test_copy_outiter(seq, IteratorTag());
@@ -143,12 +145,14 @@ void test_copy()
     test_copy_outiter_async(seq(task), IteratorTag());
     test_copy_outiter_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_copy_outiter(execution_policy(seq), IteratorTag());
     test_copy_outiter(execution_policy(par), IteratorTag());
     test_copy_outiter(execution_policy(par_vec), IteratorTag());
 
     test_copy_outiter(execution_policy(seq(task)), IteratorTag());
     test_copy_outiter(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void copy_test()
@@ -247,11 +251,13 @@ void test_copy_exception()
     test_copy_exception_async(seq(task), IteratorTag());
     test_copy_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_copy_exception(execution_policy(seq), IteratorTag());
     test_copy_exception(execution_policy(par), IteratorTag());
 
     test_copy_exception(execution_policy(seq(task)), IteratorTag());
     test_copy_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void copy_exception_test()
@@ -348,11 +354,13 @@ void test_copy_bad_alloc()
     test_copy_bad_alloc_async(seq(task), IteratorTag());
     test_copy_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_copy_bad_alloc(execution_policy(seq), IteratorTag());
     test_copy_bad_alloc(execution_policy(par), IteratorTag());
 
     test_copy_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_copy_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void copy_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/copyif_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/copyif_bad_alloc.cpp
@@ -98,12 +98,13 @@ void test_copy_if_bad_alloc()
     test_copy_if_bad_alloc_async(seq(task), IteratorTag());
     test_copy_if_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_copy_if_bad_alloc(execution_policy(seq), IteratorTag());
     test_copy_if_bad_alloc(execution_policy(par), IteratorTag());
 
     test_copy_if_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_copy_if_bad_alloc(execution_policy(par(task)), IteratorTag());
-}
+#endif}
 
 void copy_if_bad_alloc_test()
 {

--- a/tests/unit/parallel/algorithms/copyif_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/copyif_bad_alloc.cpp
@@ -104,7 +104,8 @@ void test_copy_if_bad_alloc()
 
     test_copy_if_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_copy_if_bad_alloc(execution_policy(par(task)), IteratorTag());
-#endif}
+#endif
+}
 
 void copy_if_bad_alloc_test()
 {

--- a/tests/unit/parallel/algorithms/copyif_exception.cpp
+++ b/tests/unit/parallel/algorithms/copyif_exception.cpp
@@ -99,11 +99,13 @@ void test_copy_if_exception()
     test_copy_if_exception_async(seq(task), IteratorTag());
     test_copy_if_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_copy_if_exception(execution_policy(seq), IteratorTag());
     test_copy_if_exception(execution_policy(par), IteratorTag());
 
     test_copy_if_exception(execution_policy(seq(task)), IteratorTag());
     test_copy_if_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void copy_if_exception_test()

--- a/tests/unit/parallel/algorithms/copyif_forward.cpp
+++ b/tests/unit/parallel/algorithms/copyif_forward.cpp
@@ -157,12 +157,14 @@ void test_copy_if()
     test_copy_if_async(seq(task));
     test_copy_if_async(par(task));
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_copy_if(execution_policy(seq));
     test_copy_if(execution_policy(par));
     test_copy_if(execution_policy(par_vec));
 
     test_copy_if(execution_policy(seq(task)));
     test_copy_if(execution_policy(par(task)));
+#endif
 
     test_copy_if_outiter(seq);
     test_copy_if_outiter(par);
@@ -171,12 +173,14 @@ void test_copy_if()
     test_copy_if_outiter_async(seq(task));
     test_copy_if_outiter_async(par(task));
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_copy_if_outiter(execution_policy(seq));
     test_copy_if_outiter(execution_policy(par));
     test_copy_if_outiter(execution_policy(par_vec));
 
     test_copy_if_outiter(execution_policy(seq(task)));
     test_copy_if_outiter(execution_policy(par(task)));
+#endif
 }
 
 int hpx_main(boost::program_options::variables_map& vm)

--- a/tests/unit/parallel/algorithms/copyif_input.cpp
+++ b/tests/unit/parallel/algorithms/copyif_input.cpp
@@ -157,12 +157,14 @@ void test_copy_if()
     test_copy_if_async(seq(task));
     test_copy_if_async(par(task));
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_copy_if(execution_policy(seq));
     test_copy_if(execution_policy(par));
     test_copy_if(execution_policy(par_vec));
 
     test_copy_if(execution_policy(seq(task)));
     test_copy_if(execution_policy(par(task)));
+#endif
 
     test_copy_if_outiter(seq);
     test_copy_if_outiter(par);
@@ -171,12 +173,14 @@ void test_copy_if()
     test_copy_if_outiter_async(seq(task));
     test_copy_if_outiter_async(par(task));
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_copy_if_outiter(execution_policy(seq));
     test_copy_if_outiter(execution_policy(par));
     test_copy_if_outiter(execution_policy(par_vec));
 
     test_copy_if_outiter(execution_policy(seq(task)));
     test_copy_if_outiter(execution_policy(par(task)));
+#endif
 }
 
 int hpx_main(boost::program_options::variables_map& vm)

--- a/tests/unit/parallel/algorithms/copyif_random.cpp
+++ b/tests/unit/parallel/algorithms/copyif_random.cpp
@@ -161,12 +161,14 @@ void test_copy_if()
     test_copy_if_async(seq(task));
     test_copy_if_async(par(task));
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_copy_if(execution_policy(seq));
     test_copy_if(execution_policy(par));
     test_copy_if(execution_policy(par_vec));
 
     test_copy_if(execution_policy(seq(task)));
     test_copy_if(execution_policy(par(task)));
+#endif
 
     test_copy_if_outiter(seq);
     test_copy_if_outiter(par);
@@ -175,12 +177,14 @@ void test_copy_if()
     test_copy_if_outiter_async(seq(task));
     test_copy_if_outiter_async(par(task));
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_copy_if_outiter(execution_policy(seq));
     test_copy_if_outiter(execution_policy(par));
     test_copy_if_outiter(execution_policy(par_vec));
 
     test_copy_if_outiter(execution_policy(seq(task)));
     test_copy_if_outiter(execution_policy(par(task)));
+#endif
 }
 
 int hpx_main(boost::program_options::variables_map& vm)

--- a/tests/unit/parallel/algorithms/copyn.cpp
+++ b/tests/unit/parallel/algorithms/copyn.cpp
@@ -130,12 +130,14 @@ void test_copy_n()
     test_copy_n_async(seq(task), IteratorTag());
     test_copy_n_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_copy_n(execution_policy(seq), IteratorTag());
     test_copy_n(execution_policy(par), IteratorTag());
     test_copy_n(execution_policy(par_vec), IteratorTag());
 
     test_copy_n(execution_policy(seq(task)), IteratorTag());
     test_copy_n(execution_policy(par(task)), IteratorTag());
+#endif
 
     // assure output iterator will run
     test_copy_n_outiter(seq, IteratorTag());
@@ -145,12 +147,14 @@ void test_copy_n()
     test_copy_n_outiter_async(seq(task), IteratorTag());
     test_copy_n_outiter_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_copy_n_outiter(execution_policy(seq), IteratorTag());
     test_copy_n_outiter(execution_policy(par), IteratorTag());
     test_copy_n_outiter(execution_policy(par_vec), IteratorTag());
 
     test_copy_n_outiter(execution_policy(seq(task)), IteratorTag());
     test_copy_n_outiter(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void n_copy_test()
@@ -252,11 +256,13 @@ void test_copy_n_exception()
     test_copy_n_exception_async(seq(task), IteratorTag());
     test_copy_n_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_copy_n_exception(execution_policy(seq), IteratorTag());
     test_copy_n_exception(execution_policy(par), IteratorTag());
 
     test_copy_n_exception(execution_policy(seq(task)), IteratorTag());
     test_copy_n_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void copy_n_exception_test()
@@ -357,11 +363,13 @@ void test_copy_n_bad_alloc()
     test_copy_n_bad_alloc_async(seq(task), IteratorTag());
     test_copy_n_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_copy_n_bad_alloc(execution_policy(seq), IteratorTag());
     test_copy_n_bad_alloc(execution_policy(par), IteratorTag());
 
     test_copy_n_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_copy_n_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void copy_n_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/count.cpp
+++ b/tests/unit/parallel/algorithms/count.cpp
@@ -75,12 +75,14 @@ void test_count()
     test_count_async(seq(task), IteratorTag());
     test_count_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_count(execution_policy(seq), IteratorTag());
     test_count(execution_policy(par), IteratorTag());
     test_count(execution_policy(par_vec), IteratorTag());
 
     test_count(execution_policy(seq(task)), IteratorTag());
     test_count(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void count_test()
@@ -177,11 +179,13 @@ void test_count_exception()
     test_count_exception_async(seq(task), IteratorTag());
     test_count_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_count_exception(execution_policy(seq), IteratorTag());
     test_count_exception(execution_policy(par), IteratorTag());
 
     test_count_exception(execution_policy(seq(task)), IteratorTag());
     test_count_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void count_exception_test()
@@ -277,11 +281,13 @@ void test_count_bad_alloc()
     test_count_bad_alloc_async(seq(task), IteratorTag());
     test_count_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_count_bad_alloc(execution_policy(seq), IteratorTag());
     test_count_bad_alloc(execution_policy(par), IteratorTag());
 
     test_count_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_count_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void count_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/countif.cpp
+++ b/tests/unit/parallel/algorithms/countif.cpp
@@ -64,12 +64,14 @@ void test_count_if()
     test_count_if_async(seq(task), IteratorTag());
     test_count_if_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_count_if(execution_policy(seq), IteratorTag());
     test_count_if(execution_policy(par), IteratorTag());
     test_count_if(execution_policy(par_vec), IteratorTag());
 
     test_count_if(execution_policy(seq(task)), IteratorTag());
     test_count_if(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void count_if_test()
@@ -167,11 +169,13 @@ void test_count_if_exception()
     test_count_if_exception_async(seq(task), IteratorTag());
     test_count_if_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_count_if_exception(execution_policy(seq), IteratorTag());
     test_count_if_exception(execution_policy(par), IteratorTag());
 
     test_count_if_exception(execution_policy(seq(task)), IteratorTag());
     test_count_if_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void count_if_exception_test()
@@ -266,11 +270,13 @@ void test_count_if_bad_alloc()
     test_count_if_bad_alloc_async(seq(task), IteratorTag());
     test_count_if_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_count_if_bad_alloc(execution_policy(seq), IteratorTag());
     test_count_if_bad_alloc(execution_policy(par), IteratorTag());
 
     test_count_if_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_count_if_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void count_if_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/equal.cpp
+++ b/tests/unit/parallel/algorithms/equal.cpp
@@ -112,12 +112,14 @@ void test_equal1()
     test_equal1_async(seq(task), IteratorTag());
     test_equal1_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_equal1(execution_policy(seq), IteratorTag());
     test_equal1(execution_policy(par), IteratorTag());
     test_equal1(execution_policy(par_vec), IteratorTag());
 
     test_equal1(execution_policy(seq(task)), IteratorTag());
     test_equal1(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void equal_test1()
@@ -227,12 +229,14 @@ void test_equal2()
     test_equal2_async(seq(task), IteratorTag());
     test_equal2_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_equal2(execution_policy(seq), IteratorTag());
     test_equal2(execution_policy(par), IteratorTag());
     test_equal2(execution_policy(par_vec), IteratorTag());
 
     test_equal2(execution_policy(seq(task)), IteratorTag());
     test_equal2(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void equal_test2()
@@ -336,11 +340,13 @@ void test_equal_exception()
     test_equal_exception_async(seq(task), IteratorTag());
     test_equal_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_equal_exception(execution_policy(seq), IteratorTag());
     test_equal_exception(execution_policy(par), IteratorTag());
 
     test_equal_exception(execution_policy(seq(task)), IteratorTag());
     test_equal_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void equal_exception_test()
@@ -442,11 +448,13 @@ void test_equal_bad_alloc()
     test_equal_bad_alloc_async(seq(task), IteratorTag());
     test_equal_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_equal_bad_alloc(execution_policy(seq), IteratorTag());
     test_equal_bad_alloc(execution_policy(par), IteratorTag());
 
     test_equal_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_equal_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void equal_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/equal_binary.cpp
+++ b/tests/unit/parallel/algorithms/equal_binary.cpp
@@ -112,12 +112,14 @@ void test_equal_binary1()
     test_equal_binary1_async(seq(task), IteratorTag());
     test_equal_binary1_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_equal_binary1(execution_policy(seq), IteratorTag());
     test_equal_binary1(execution_policy(par), IteratorTag());
     test_equal_binary1(execution_policy(par_vec), IteratorTag());
 
     test_equal_binary1(execution_policy(seq(task)), IteratorTag());
     test_equal_binary1(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void equal_binary_test1()
@@ -227,12 +229,14 @@ void test_equal_binary2()
     test_equal_binary2_async(seq(task), IteratorTag());
     test_equal_binary2_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_equal_binary2(execution_policy(seq), IteratorTag());
     test_equal_binary2(execution_policy(par), IteratorTag());
     test_equal_binary2(execution_policy(par_vec), IteratorTag());
 
     test_equal_binary2(execution_policy(seq(task)), IteratorTag());
     test_equal_binary2(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void equal_binary_test2()
@@ -336,11 +340,13 @@ void test_equal_binary_exception()
     test_equal_binary_exception_async(seq(task), IteratorTag());
     test_equal_binary_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_equal_binary_exception(execution_policy(seq), IteratorTag());
     test_equal_binary_exception(execution_policy(par), IteratorTag());
 
     test_equal_binary_exception(execution_policy(seq(task)), IteratorTag());
     test_equal_binary_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void equal_binary_exception_test()
@@ -442,11 +448,13 @@ void test_equal_binary_bad_alloc()
     test_equal_binary_bad_alloc_async(seq(task), IteratorTag());
     test_equal_binary_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_equal_binary_bad_alloc(execution_policy(seq), IteratorTag());
     test_equal_binary_bad_alloc(execution_policy(par), IteratorTag());
 
     test_equal_binary_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_equal_binary_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void equal_binary_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/exclusive_scan.cpp
+++ b/tests/unit/parallel/algorithms/exclusive_scan.cpp
@@ -123,12 +123,14 @@ void test_exclusive_scan1()
     test_exclusive_scan1_async(seq(task), IteratorTag());
     test_exclusive_scan1_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_exclusive_scan1(execution_policy(seq), IteratorTag());
     test_exclusive_scan1(execution_policy(par), IteratorTag());
     test_exclusive_scan1(execution_policy(par_vec), IteratorTag());
 
     test_exclusive_scan1(execution_policy(seq(task)), IteratorTag());
     test_exclusive_scan1(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void exclusive_scan_test1()

--- a/tests/unit/parallel/algorithms/exclusive_scan.cpp
+++ b/tests/unit/parallel/algorithms/exclusive_scan.cpp
@@ -19,7 +19,7 @@ void exclusive_scan_benchmark()
     try {
       std::vector<double> c(100000000);
       std::vector<double> d(c.size());
-      std::fill(boost::begin(c), boost::end(c), std::size_t(1));
+      std::fill(boost::begin(c), boost::end(c), 1.0);
 
       double const val(0);
       auto op =

--- a/tests/unit/parallel/algorithms/exclusive_scan2.cpp
+++ b/tests/unit/parallel/algorithms/exclusive_scan2.cpp
@@ -80,12 +80,14 @@ void test_exclusive_scan2()
     test_exclusive_scan2_async(seq(task), IteratorTag());
     test_exclusive_scan2_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_exclusive_scan2(execution_policy(seq), IteratorTag());
     test_exclusive_scan2(execution_policy(par), IteratorTag());
     test_exclusive_scan2(execution_policy(par_vec), IteratorTag());
 
     test_exclusive_scan2(execution_policy(seq(task)), IteratorTag());
     test_exclusive_scan2(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void exclusive_scan_test2()

--- a/tests/unit/parallel/algorithms/exclusive_scan_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/exclusive_scan_bad_alloc.cpp
@@ -102,11 +102,13 @@ void test_exclusive_scan_bad_alloc()
     test_exclusive_scan_bad_alloc_async(seq(task), IteratorTag());
     test_exclusive_scan_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_exclusive_scan_bad_alloc(execution_policy(seq), IteratorTag());
     test_exclusive_scan_bad_alloc(execution_policy(par), IteratorTag());
 
     test_exclusive_scan_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_exclusive_scan_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void exclusive_scan_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/exclusive_scan_exception.cpp
+++ b/tests/unit/parallel/algorithms/exclusive_scan_exception.cpp
@@ -104,11 +104,13 @@ void test_exclusive_scan_exception()
     test_exclusive_scan_exception_async(seq(task), IteratorTag());
     test_exclusive_scan_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_exclusive_scan_exception(execution_policy(seq), IteratorTag());
     test_exclusive_scan_exception(execution_policy(par), IteratorTag());
 
     test_exclusive_scan_exception(execution_policy(seq(task)), IteratorTag());
     test_exclusive_scan_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void exclusive_scan_exception_test()

--- a/tests/unit/parallel/algorithms/fill.cpp
+++ b/tests/unit/parallel/algorithms/fill.cpp
@@ -74,12 +74,14 @@ void test_fill()
     test_fill_async(seq(task), IteratorTag());
     test_fill_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_fill(execution_policy(seq), IteratorTag());
     test_fill(execution_policy(par), IteratorTag());
     test_fill(execution_policy(par_vec), IteratorTag());
 
     test_fill(execution_policy(seq(task)), IteratorTag());
     test_fill(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void fill_test()
@@ -174,11 +176,13 @@ void test_fill_exception()
     test_fill_exception_async(seq(task), IteratorTag());
     test_fill_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_fill_exception(execution_policy(seq), IteratorTag());
     test_fill_exception(execution_policy(par), IteratorTag());
 
     test_fill_exception(execution_policy(seq(task)), IteratorTag());
     test_fill_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void fill_exception_test()
@@ -272,11 +276,13 @@ void test_fill_bad_alloc()
     test_fill_bad_alloc_async(seq(task), IteratorTag());
     test_fill_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_fill_bad_alloc(execution_policy(seq), IteratorTag());
     test_fill_bad_alloc(execution_policy(par), IteratorTag());
 
     test_fill_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_fill_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void fill_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/filln.cpp
+++ b/tests/unit/parallel/algorithms/filln.cpp
@@ -74,12 +74,14 @@ void test_fill_n()
     test_fill_n_async(seq(task), IteratorTag());
     test_fill_n_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_fill_n(execution_policy(seq), IteratorTag());
     test_fill_n(execution_policy(par), IteratorTag());
     test_fill_n(execution_policy(par_vec), IteratorTag());
 
     test_fill_n(execution_policy(seq(task)), IteratorTag());
     test_fill_n(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void fill_n_test()
@@ -175,11 +177,13 @@ void test_fill_n_exception()
     test_fill_n_exception_async(seq(task), IteratorTag());
     test_fill_n_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_fill_n_exception(execution_policy(seq), IteratorTag());
     test_fill_n_exception(execution_policy(par), IteratorTag());
 
     test_fill_n_exception(execution_policy(seq(task)), IteratorTag());
     test_fill_n_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void fill_n_exception_test()
@@ -273,11 +277,13 @@ void test_fill_n_bad_alloc()
     test_fill_n_bad_alloc_async(seq(task), IteratorTag());
     test_fill_n_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_fill_n_bad_alloc(execution_policy(seq), IteratorTag());
     test_fill_n_bad_alloc(execution_policy(par), IteratorTag());
 
     test_fill_n_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_fill_n_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void fill_n_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/find.cpp
+++ b/tests/unit/parallel/algorithms/find.cpp
@@ -70,12 +70,14 @@ void test_find()
     test_find_async(seq(task), IteratorTag());
     test_find_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find(execution_policy(seq), IteratorTag());
     test_find(execution_policy(par), IteratorTag());
     test_find(execution_policy(par_vec), IteratorTag());
 
     test_find(execution_policy(seq(task)), IteratorTag());
     test_find(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void find_test()
@@ -173,11 +175,13 @@ void test_find_exception()
     test_find_exception_async(seq(task), IteratorTag());
     test_find_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_exception(execution_policy(seq), IteratorTag());
     test_find_exception(execution_policy(par), IteratorTag());
 
     test_find_exception(execution_policy(seq(task)), IteratorTag());
     test_find_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void find_exception_test()
@@ -274,11 +278,13 @@ void test_find_bad_alloc()
     test_find_bad_alloc_async(seq(task), IteratorTag());
     test_find_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_bad_alloc(execution_policy(seq), IteratorTag());
     test_find_bad_alloc(execution_policy(par), IteratorTag());
 
     test_find_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_find_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void find_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/findend.cpp
+++ b/tests/unit/parallel/algorithms/findend.cpp
@@ -79,12 +79,14 @@ void test_find_end1()
     test_find_end1_async(seq(task), IteratorTag());
     test_find_end1_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_end1(execution_policy(seq), IteratorTag());
     test_find_end1(execution_policy(par), IteratorTag());
     test_find_end1(execution_policy(par_vec), IteratorTag());
 
     test_find_end1(execution_policy(seq(task)), IteratorTag());
     test_find_end1(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void find_end_test1()
@@ -164,12 +166,14 @@ void test_find_end2()
     test_find_end2_async(seq(task), IteratorTag());
     test_find_end2_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_end2(execution_policy(seq), IteratorTag());
     test_find_end2(execution_policy(par), IteratorTag());
     test_find_end2(execution_policy(par_vec), IteratorTag());
 
     test_find_end2(execution_policy(seq(task)), IteratorTag());
     test_find_end2(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void find_end_test2()
@@ -250,12 +254,14 @@ void test_find_end3()
     test_find_end3_async(seq(task), IteratorTag());
     test_find_end3_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_end3(execution_policy(seq), IteratorTag());
     test_find_end3(execution_policy(par), IteratorTag());
     test_find_end3(execution_policy(par_vec), IteratorTag());
 
     test_find_end3(execution_policy(seq(task)), IteratorTag());
     test_find_end3(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void find_end_test3()
@@ -337,12 +343,14 @@ void test_find_end4()
     test_find_end4_async(seq(task), IteratorTag());
     test_find_end4_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_end4(execution_policy(seq), IteratorTag());
     test_find_end4(execution_policy(par), IteratorTag());
     test_find_end4(execution_policy(par_vec), IteratorTag());
 
     test_find_end4(execution_policy(seq(task)), IteratorTag());
     test_find_end4(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void find_end_test4()
@@ -451,10 +459,12 @@ void test_find_end_exception()
     test_find_end_exception_async(seq(task), IteratorTag());
     test_find_end_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_end_exception(execution_policy(seq), IteratorTag());
 
     test_find_end_exception(execution_policy(seq(task)), IteratorTag());
     test_find_end_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void find_end_exception_test()
@@ -558,11 +568,13 @@ void test_find_end_bad_alloc()
     test_find_end_bad_alloc_async(seq(task), IteratorTag());
     test_find_end_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_end_bad_alloc(execution_policy(seq), IteratorTag());
     test_find_end_bad_alloc(execution_policy(par), IteratorTag());
 
     test_find_end_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_find_end_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void find_end_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/findfirstof.cpp
+++ b/tests/unit/parallel/algorithms/findfirstof.cpp
@@ -77,12 +77,14 @@ void test_find_first_of()
     test_find_first_of_async(seq(task), IteratorTag());
     test_find_first_of_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_first_of(execution_policy(seq), IteratorTag());
     test_find_first_of(execution_policy(par), IteratorTag());
     test_find_first_of(execution_policy(par_vec), IteratorTag());
 
     test_find_first_of(execution_policy(seq(task)), IteratorTag());
     test_find_first_of(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void find_first_of_test()
@@ -184,11 +186,13 @@ void test_find_first_of_exception()
     test_find_first_of_exception_async(seq(task), IteratorTag());
     test_find_first_of_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_first_of_exception(execution_policy(seq), IteratorTag());
     test_find_first_of_exception(execution_policy(par), IteratorTag());
 
     test_find_first_of_exception(execution_policy(seq(task)), IteratorTag());
     test_find_first_of_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void find_first_of_exception_test()
@@ -289,11 +293,13 @@ void test_find_first_of_bad_alloc()
     test_find_first_of_bad_alloc_async(seq(task), IteratorTag());
     test_find_first_of_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_first_of_bad_alloc(execution_policy(seq), IteratorTag());
     test_find_first_of_bad_alloc(execution_policy(par), IteratorTag());
 
     test_find_first_of_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_find_first_of_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void find_first_of_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/findfirstof_binary.cpp
+++ b/tests/unit/parallel/algorithms/findfirstof_binary.cpp
@@ -89,12 +89,14 @@ void test_find_first_of()
     test_find_first_of_async(seq(task), IteratorTag());
     test_find_first_of_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_first_of(execution_policy(seq), IteratorTag());
     test_find_first_of(execution_policy(par), IteratorTag());
     test_find_first_of(execution_policy(par_vec), IteratorTag());
 
     test_find_first_of(execution_policy(seq(task)), IteratorTag());
     test_find_first_of(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void find_first_of_test()
@@ -206,11 +208,13 @@ void test_find_first_of_exception()
     test_find_first_of_exception_async(seq(task), IteratorTag());
     test_find_first_of_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_first_of_exception(execution_policy(seq), IteratorTag());
     test_find_first_of_exception(execution_policy(par), IteratorTag());
 
     test_find_first_of_exception(execution_policy(seq(task)), IteratorTag());
     test_find_first_of_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void find_first_of_exception_test()
@@ -321,11 +325,13 @@ void test_find_first_of_bad_alloc()
     test_find_first_of_bad_alloc_async(seq(task), IteratorTag());
     test_find_first_of_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_first_of_bad_alloc(execution_policy(seq), IteratorTag());
     test_find_first_of_bad_alloc(execution_policy(par), IteratorTag());
 
     test_find_first_of_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_find_first_of_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void find_first_of_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/findif.cpp
+++ b/tests/unit/parallel/algorithms/findif.cpp
@@ -75,12 +75,14 @@ void test_find_if()
     test_find_if_async(seq(task), IteratorTag());
     test_find_if_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_if(execution_policy(seq), IteratorTag());
     test_find_if(execution_policy(par), IteratorTag());
     test_find_if(execution_policy(par_vec), IteratorTag());
 
     test_find_if(execution_policy(seq(task)), IteratorTag());
     test_find_if(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void find_if_test()
@@ -178,11 +180,13 @@ void test_find_if_exception()
     test_find_if_exception_async(seq(task), IteratorTag());
     test_find_if_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_if_exception(execution_policy(seq), IteratorTag());
     test_find_if_exception(execution_policy(par), IteratorTag());
 
     test_find_if_exception(execution_policy(seq(task)), IteratorTag());
     test_find_if_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void find_if_exception_test()
@@ -279,11 +283,13 @@ void test_find_if_bad_alloc()
     test_find_if_bad_alloc_async(seq(task), IteratorTag());
     test_find_if_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_if_bad_alloc(execution_policy(seq), IteratorTag());
     test_find_if_bad_alloc(execution_policy(par), IteratorTag());
 
     test_find_if_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_find_if_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void find_if_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/findifnot.cpp
+++ b/tests/unit/parallel/algorithms/findifnot.cpp
@@ -75,12 +75,14 @@ void test_find_if_not()
     test_find_if_not_async(seq(task), IteratorTag());
     test_find_if_not_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_if_not(execution_policy(seq), IteratorTag());
     test_find_if_not(execution_policy(par), IteratorTag());
     test_find_if_not(execution_policy(par_vec), IteratorTag());
 
     test_find_if_not(execution_policy(seq(task)), IteratorTag());
     test_find_if_not(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void find_if_not_test()

--- a/tests/unit/parallel/algorithms/findifnot_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/findifnot_bad_alloc.cpp
@@ -99,11 +99,13 @@ void test_find_if_not_bad_alloc()
     test_find_if_not_bad_alloc_async(seq(task), IteratorTag());
     test_find_if_not_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_if_not_bad_alloc(execution_policy(seq), IteratorTag());
     test_find_if_not_bad_alloc(execution_policy(par), IteratorTag());
 
     test_find_if_not_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_find_if_not_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void find_if_not_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/findifnot_exception.cpp
+++ b/tests/unit/parallel/algorithms/findifnot_exception.cpp
@@ -100,11 +100,13 @@ void test_find_if_not_exception()
     test_find_if_not_exception_async(seq(task), IteratorTag());
     test_find_if_not_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_if_not_exception(execution_policy(seq), IteratorTag());
     test_find_if_not_exception(execution_policy(par), IteratorTag());
 
     test_find_if_not_exception(execution_policy(seq(task)), IteratorTag());
     test_find_if_not_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void find_if_not_exception_test()

--- a/tests/unit/parallel/algorithms/foreach.cpp
+++ b/tests/unit/parallel/algorithms/foreach.cpp
@@ -21,12 +21,14 @@ void test_for_each()
     test_for_each_async(seq(task), IteratorTag());
     test_for_each_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_for_each(execution_policy(seq), IteratorTag());
     test_for_each(execution_policy(par), IteratorTag());
     test_for_each(execution_policy(par_vec), IteratorTag());
 
     test_for_each(execution_policy(seq(task)), IteratorTag());
     test_for_each(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void for_each_test()
@@ -55,10 +57,12 @@ void test_for_each_exception()
     test_for_each_exception_async(seq(task), IteratorTag());
     test_for_each_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_for_each_exception(execution_policy(seq), IteratorTag());
     test_for_each_exception(execution_policy(par), IteratorTag());
     test_for_each_exception(execution_policy(seq(task)), IteratorTag());
     test_for_each_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void for_each_exception_test()
@@ -83,10 +87,12 @@ void test_for_each_bad_alloc()
     test_for_each_bad_alloc_async(seq(task), IteratorTag());
     test_for_each_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_for_each_bad_alloc(execution_policy(seq), IteratorTag());
     test_for_each_bad_alloc(execution_policy(par), IteratorTag());
     test_for_each_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_for_each_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void for_each_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/foreach_projection.cpp
+++ b/tests/unit/parallel/algorithms/foreach_projection.cpp
@@ -21,12 +21,14 @@ void test_for_each()
     test_for_each_async(seq(task), IteratorTag(), Proj());
     test_for_each_async(par(task), IteratorTag(), Proj());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_for_each(execution_policy(seq), IteratorTag(), Proj());
     test_for_each(execution_policy(par), IteratorTag(), Proj());
     test_for_each(execution_policy(par_vec), IteratorTag(), Proj());
 
     test_for_each(execution_policy(seq(task)), IteratorTag(), Proj());
     test_for_each(execution_policy(par(task)), IteratorTag(), Proj());
+#endif
 }
 
 template <typename Proj>
@@ -52,10 +54,12 @@ void test_for_each_exception()
     test_for_each_exception_async(seq(task), IteratorTag(), Proj());
     test_for_each_exception_async(par(task), IteratorTag(), Proj());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_for_each_exception(execution_policy(seq), IteratorTag(), Proj());
     test_for_each_exception(execution_policy(par), IteratorTag(), Proj());
     test_for_each_exception(execution_policy(seq(task)), IteratorTag(), Proj());
     test_for_each_exception(execution_policy(par(task)), IteratorTag(), Proj());
+#endif
 }
 
 template <typename Proj>
@@ -81,10 +85,12 @@ void test_for_each_bad_alloc()
     test_for_each_bad_alloc_async(seq(task), IteratorTag(), Proj());
     test_for_each_bad_alloc_async(par(task), IteratorTag(), Proj());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_for_each_bad_alloc(execution_policy(seq), IteratorTag(), Proj());
     test_for_each_bad_alloc(execution_policy(par), IteratorTag(), Proj());
     test_for_each_bad_alloc(execution_policy(seq(task)), IteratorTag(), Proj());
     test_for_each_bad_alloc(execution_policy(par(task)), IteratorTag(), Proj());
+#endif
 }
 
 template <typename Proj>

--- a/tests/unit/parallel/algorithms/foreachn.cpp
+++ b/tests/unit/parallel/algorithms/foreachn.cpp
@@ -83,12 +83,14 @@ void test_for_each_n()
     test_for_each_n_async(seq(task), IteratorTag());
     test_for_each_n_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_for_each_n(execution_policy(seq), IteratorTag());
     test_for_each_n(execution_policy(par), IteratorTag());
     test_for_each_n(execution_policy(par_vec), IteratorTag());
 
     test_for_each_n(execution_policy(seq(task)), IteratorTag());
     test_for_each_n(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void for_each_n_test()

--- a/tests/unit/parallel/algorithms/foreachn_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/foreachn_bad_alloc.cpp
@@ -90,11 +90,13 @@ void test_for_each_n_bad_alloc()
     test_for_each_n_bad_alloc_async(seq(task), IteratorTag());
     test_for_each_n_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_for_each_n_bad_alloc(execution_policy(seq), IteratorTag());
     test_for_each_n_bad_alloc(execution_policy(par), IteratorTag());
 
     test_for_each_n_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_for_each_n_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void for_each_n_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/foreachn_exception.cpp
+++ b/tests/unit/parallel/algorithms/foreachn_exception.cpp
@@ -92,11 +92,13 @@ void test_for_each_n_exception()
     test_for_each_n_exception_async(seq(task), IteratorTag());
     test_for_each_n_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_for_each_n_exception(execution_policy(seq), IteratorTag());
     test_for_each_n_exception(execution_policy(par), IteratorTag());
 
     test_for_each_n_exception(execution_policy(seq(task)), IteratorTag());
     test_for_each_n_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void for_each_n_exception_test()

--- a/tests/unit/parallel/algorithms/foreachn_projection.cpp
+++ b/tests/unit/parallel/algorithms/foreachn_projection.cpp
@@ -78,12 +78,14 @@ void test_for_each_n()
     test_for_each_n_async(seq(task), IteratorTag(), Proj());
     test_for_each_n_async(par(task), IteratorTag(), Proj());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_for_each_n(execution_policy(seq), IteratorTag(), Proj());
     test_for_each_n(execution_policy(par), IteratorTag(), Proj());
     test_for_each_n(execution_policy(par_vec), IteratorTag(), Proj());
 
     test_for_each_n(execution_policy(seq(task)), IteratorTag(), Proj());
     test_for_each_n(execution_policy(par(task)), IteratorTag(), Proj());
+#endif
 }
 
 template <typename Proj>

--- a/tests/unit/parallel/algorithms/foreachn_projection_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/foreachn_projection_bad_alloc.cpp
@@ -93,11 +93,13 @@ void test_for_each_n_bad_alloc()
     test_for_each_n_bad_alloc_async(seq(task), IteratorTag(), Proj());
     test_for_each_n_bad_alloc_async(par(task), IteratorTag(), Proj());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_for_each_n_bad_alloc(execution_policy(seq), IteratorTag(), Proj());
     test_for_each_n_bad_alloc(execution_policy(par), IteratorTag(), Proj());
 
     test_for_each_n_bad_alloc(execution_policy(seq(task)), IteratorTag(), Proj());
     test_for_each_n_bad_alloc(execution_policy(par(task)), IteratorTag(), Proj());
+#endif
 }
 
 template <typename Proj>

--- a/tests/unit/parallel/algorithms/foreachn_projection_exception.cpp
+++ b/tests/unit/parallel/algorithms/foreachn_projection_exception.cpp
@@ -95,11 +95,13 @@ void test_for_each_n_exception()
     test_for_each_n_exception_async(seq(task), IteratorTag(), Proj());
     test_for_each_n_exception_async(par(task), IteratorTag(), Proj());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_for_each_n_exception(execution_policy(seq), IteratorTag(), Proj());
     test_for_each_n_exception(execution_policy(par), IteratorTag(), Proj());
 
     test_for_each_n_exception(execution_policy(seq(task)), IteratorTag(), Proj());
     test_for_each_n_exception(execution_policy(par(task)), IteratorTag(), Proj());
+#endif
 }
 
 template <typename Proj>

--- a/tests/unit/parallel/algorithms/generate.cpp
+++ b/tests/unit/parallel/algorithms/generate.cpp
@@ -79,12 +79,14 @@ void test_generate()
     test_generate_async(seq(task), IteratorTag());
     test_generate_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_generate(execution_policy(seq), IteratorTag());
     test_generate(execution_policy(par), IteratorTag());
     test_generate(execution_policy(par_vec), IteratorTag());
 
     test_generate(execution_policy(seq(task)), IteratorTag());
     test_generate(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void generate_test()
@@ -181,11 +183,13 @@ void test_generate_exception()
     test_generate_exception_async(seq(task), IteratorTag());
     test_generate_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_generate_exception(execution_policy(seq), IteratorTag());
     test_generate_exception(execution_policy(par), IteratorTag());
 
     test_generate_exception(execution_policy(seq(task)), IteratorTag());
     test_generate_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void generate_exception_test()
@@ -281,11 +285,13 @@ void test_generate_bad_alloc()
     test_generate_bad_alloc_async(seq(task), IteratorTag());
     test_generate_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_generate_bad_alloc(execution_policy(seq), IteratorTag());
     test_generate_bad_alloc(execution_policy(par), IteratorTag());
 
     test_generate_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_generate_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void generate_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/generaten.cpp
+++ b/tests/unit/parallel/algorithms/generaten.cpp
@@ -76,12 +76,14 @@ void test_generate_n()
     test_generate_n_async(seq(task), IteratorTag());
     test_generate_n_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_generate_n(execution_policy(seq), IteratorTag());
     test_generate_n(execution_policy(par), IteratorTag());
     test_generate_n(execution_policy(par_vec), IteratorTag());
 
     test_generate_n(execution_policy(seq(task)), IteratorTag());
     test_generate_n(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void generate_n_test()
@@ -179,11 +181,13 @@ void test_generate_n_exception()
     test_generate_n_exception_async(seq(task), IteratorTag());
     test_generate_n_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_generate_n_exception(execution_policy(seq), IteratorTag());
     test_generate_n_exception(execution_policy(par), IteratorTag());
 
     test_generate_n_exception(execution_policy(seq(task)), IteratorTag());
     test_generate_n_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void generate_n_exception_test()
@@ -279,11 +283,13 @@ void test_generate_n_bad_alloc()
     test_generate_n_bad_alloc_async(seq(task), IteratorTag());
     test_generate_n_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_generate_n_bad_alloc(execution_policy(seq), IteratorTag());
     test_generate_n_bad_alloc(execution_policy(par), IteratorTag());
 
     test_generate_n_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_generate_n_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void generate_n_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/includes.cpp
+++ b/tests/unit/parallel/algorithms/includes.cpp
@@ -137,12 +137,14 @@ void test_includes1()
     test_includes1_async(seq(task), IteratorTag());
     test_includes1_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_includes1(execution_policy(seq), IteratorTag());
     test_includes1(execution_policy(par), IteratorTag());
     test_includes1(execution_policy(par_vec), IteratorTag());
 
     test_includes1(execution_policy(seq(task)), IteratorTag());
     test_includes1(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void includes_test1()
@@ -277,12 +279,14 @@ void test_includes2()
     test_includes2_async(seq(task), IteratorTag());
     test_includes2_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_includes2(execution_policy(seq), IteratorTag());
     test_includes2(execution_policy(par), IteratorTag());
     test_includes2(execution_policy(par_vec), IteratorTag());
 
     test_includes2(execution_policy(seq(task)), IteratorTag());
     test_includes2(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void includes_test2()
@@ -406,11 +410,13 @@ void test_includes_exception()
     test_includes_exception_async(seq(task), IteratorTag());
     test_includes_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_includes_exception(execution_policy(seq), IteratorTag());
     test_includes_exception(execution_policy(par), IteratorTag());
 
     test_includes_exception(execution_policy(seq(task)), IteratorTag());
     test_includes_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void includes_exception_test()
@@ -532,11 +538,13 @@ void test_includes_bad_alloc()
     test_includes_bad_alloc_async(seq(task), IteratorTag());
     test_includes_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_includes_bad_alloc(execution_policy(seq), IteratorTag());
     test_includes_bad_alloc(execution_policy(par), IteratorTag());
 
     test_includes_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_includes_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void includes_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/inclusive_scan.cpp
+++ b/tests/unit/parallel/algorithms/inclusive_scan.cpp
@@ -21,12 +21,14 @@ void test_inclusive_scan1()
     test_inclusive_scan1_async(seq(task), IteratorTag());
     test_inclusive_scan1_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_inclusive_scan1(execution_policy(seq), IteratorTag());
     test_inclusive_scan1(execution_policy(par), IteratorTag());
     test_inclusive_scan1(execution_policy(par_vec), IteratorTag());
 
     test_inclusive_scan1(execution_policy(seq(task)), IteratorTag());
     test_inclusive_scan1(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void inclusive_scan_test1()
@@ -49,12 +51,14 @@ void test_inclusive_scan2()
     test_inclusive_scan2_async(seq(task), IteratorTag());
     test_inclusive_scan2_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_inclusive_scan2(execution_policy(seq), IteratorTag());
     test_inclusive_scan2(execution_policy(par), IteratorTag());
     test_inclusive_scan2(execution_policy(par_vec), IteratorTag());
 
     test_inclusive_scan2(execution_policy(seq(task)), IteratorTag());
     test_inclusive_scan2(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void inclusive_scan_test2()
@@ -77,12 +81,14 @@ void test_inclusive_scan3()
     test_inclusive_scan3_async(seq(task), IteratorTag());
     test_inclusive_scan3_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_inclusive_scan3(execution_policy(seq), IteratorTag());
     test_inclusive_scan3(execution_policy(par), IteratorTag());
     test_inclusive_scan3(execution_policy(par_vec), IteratorTag());
 
     test_inclusive_scan3(execution_policy(seq(task)), IteratorTag());
     test_inclusive_scan3(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void inclusive_scan_test3()
@@ -107,11 +113,13 @@ void test_inclusive_scan_exception()
     test_inclusive_scan_exception_async(seq(task), IteratorTag());
     test_inclusive_scan_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_inclusive_scan_exception(execution_policy(seq), IteratorTag());
     test_inclusive_scan_exception(execution_policy(par), IteratorTag());
 
     test_inclusive_scan_exception(execution_policy(seq(task)), IteratorTag());
     test_inclusive_scan_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void inclusive_scan_exception_test()
@@ -136,11 +144,13 @@ void test_inclusive_scan_bad_alloc()
     test_inclusive_scan_bad_alloc_async(seq(task), IteratorTag());
     test_inclusive_scan_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_inclusive_scan_bad_alloc(execution_policy(seq), IteratorTag());
     test_inclusive_scan_bad_alloc(execution_policy(par), IteratorTag());
 
     test_inclusive_scan_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_inclusive_scan_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void inclusive_scan_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/inner_product.cpp
+++ b/tests/unit/parallel/algorithms/inner_product.cpp
@@ -72,12 +72,14 @@ void test_inner_product()
     test_inner_product_async(seq(task), IteratorTag());
     test_inner_product_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_inner_product(execution_policy(seq), IteratorTag());
     test_inner_product(execution_policy(par), IteratorTag());
     test_inner_product(execution_policy(par_vec), IteratorTag());
 
     test_inner_product(execution_policy(seq(task)), IteratorTag());
     test_inner_product(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void inner_product_test()

--- a/tests/unit/parallel/algorithms/inner_product_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/inner_product_bad_alloc.cpp
@@ -103,11 +103,13 @@ void test_inner_product_bad_alloc()
     test_inner_product_bad_alloc_async(seq(task), IteratorTag());
     test_inner_product_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_inner_product_bad_alloc(execution_policy(seq), IteratorTag());
     test_inner_product_bad_alloc(execution_policy(par), IteratorTag());
 
     test_inner_product_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_inner_product_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void inner_product_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/inner_product_exception.cpp
+++ b/tests/unit/parallel/algorithms/inner_product_exception.cpp
@@ -101,11 +101,13 @@ void test_inner_product_exception()
     test_inner_product_exception_async(seq(task), IteratorTag());
     test_inner_product_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_inner_product_exception(execution_policy(seq), IteratorTag());
     test_inner_product_exception(execution_policy(par), IteratorTag());
 
     test_inner_product_exception(execution_policy(seq(task)), IteratorTag());
     test_inner_product_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void inner_product_exception_test()

--- a/tests/unit/parallel/algorithms/is_partitioned.cpp
+++ b/tests/unit/parallel/algorithms/is_partitioned.cpp
@@ -74,12 +74,13 @@ void test_partitioned1()
     test_partitioned1_async(seq(task), IteratorTag());
     test_partitioned1_async(par(task), IteratorTag());
 
-
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_partitioned1(execution_policy(seq), IteratorTag());
     test_partitioned1(execution_policy(par), IteratorTag());
     test_partitioned1(execution_policy(par_vec), IteratorTag());
     test_partitioned1(execution_policy(seq(task)), IteratorTag());
     test_partitioned1(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void partitioned_test1()
@@ -159,12 +160,13 @@ void test_partitioned2()
     test_partitioned2_async(seq(task), IteratorTag());
     test_partitioned2_async(par(task), IteratorTag());
 
-
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_partitioned2(execution_policy(seq), IteratorTag());
     test_partitioned2(execution_policy(par), IteratorTag());
     test_partitioned2(execution_policy(par_vec), IteratorTag());
     test_partitioned2(execution_policy(seq(task)), IteratorTag());
     test_partitioned2(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void partitioned_test2()
@@ -259,12 +261,13 @@ void test_partitioned3()
     test_partitioned3_async(seq(task), IteratorTag());
     test_partitioned3_async(par(task), IteratorTag());
 
-
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_partitioned3(execution_policy(seq), IteratorTag());
     test_partitioned3(execution_policy(par), IteratorTag());
     test_partitioned3(execution_policy(par_vec), IteratorTag());
     test_partitioned3(execution_policy(seq(task)), IteratorTag());
     test_partitioned3(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void partitioned_test3()
@@ -372,10 +375,13 @@ void test_partitioned_exception()
     test_partitioned_async_exception(seq(task), IteratorTag());
     test_partitioned_async_exception(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_partitioned_exception(execution_policy(par), IteratorTag());
     test_partitioned_exception(execution_policy(seq(task)), IteratorTag());
     test_partitioned_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
+
 void partitioned_exception_test()
 {
     test_partitioned_exception<std::random_access_iterator_tag>();
@@ -479,10 +485,12 @@ void test_partitioned_bad_alloc()
     test_partitioned_async_bad_alloc(seq(task), IteratorTag());
     test_partitioned_async_bad_alloc(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_partitioned_bad_alloc(execution_policy(par), IteratorTag());
     test_partitioned_bad_alloc(execution_policy(seq), IteratorTag());
     test_partitioned_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_partitioned_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void partitioned_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/is_sorted.cpp
+++ b/tests/unit/parallel/algorithms/is_sorted.cpp
@@ -21,12 +21,13 @@ void test_sorted1()
     test_sorted1_async(seq(task), IteratorTag());
     test_sorted1_async(par(task), IteratorTag());
 
-
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_sorted1(execution_policy(seq), IteratorTag());
     test_sorted1(execution_policy(par), IteratorTag());
     test_sorted1(execution_policy(par_vec), IteratorTag());
     test_sorted1(execution_policy(seq(task)), IteratorTag());
     test_sorted1(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void sorted_test1()
@@ -47,12 +48,13 @@ void test_sorted2()
     test_sorted2_async(seq(task), IteratorTag());
     test_sorted2_async(par(task), IteratorTag());
 
-
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_sorted2(execution_policy(seq), IteratorTag());
     test_sorted2(execution_policy(par), IteratorTag());
     test_sorted2(execution_policy(par_vec), IteratorTag());
     test_sorted2(execution_policy(seq(task)), IteratorTag());
     test_sorted2(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void sorted_test2()
@@ -73,12 +75,13 @@ void test_sorted3()
     test_sorted3_async(seq(task), IteratorTag());
     test_sorted3_async(par(task), IteratorTag());
 
-
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_sorted3(execution_policy(seq), IteratorTag());
     test_sorted3(execution_policy(par), IteratorTag());
     test_sorted3(execution_policy(par_vec), IteratorTag());
     test_sorted3(execution_policy(seq(task)), IteratorTag());
     test_sorted3(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void sorted_test3()
@@ -101,10 +104,13 @@ void test_sorted_exception()
     test_sorted_exception_async(seq(task), IteratorTag());
     test_sorted_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_sorted_exception(execution_policy(par), IteratorTag());
     test_sorted_exception(execution_policy(seq(task)), IteratorTag());
     test_sorted_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
+
 void sorted_exception_test()
 {
     test_sorted_exception<std::random_access_iterator_tag>();
@@ -126,10 +132,12 @@ void test_sorted_bad_alloc()
     test_sorted_bad_alloc_async(seq(task), IteratorTag());
     test_sorted_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_sorted_bad_alloc(execution_policy(par), IteratorTag());
     test_sorted_bad_alloc(execution_policy(seq), IteratorTag());
     test_sorted_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_sorted_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void sorted_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/is_sorted_until.cpp
+++ b/tests/unit/parallel/algorithms/is_sorted_until.cpp
@@ -69,6 +69,7 @@ void test_sorted_until1()
     test_sorted_until1_async(seq(task), IteratorTag());//calls sequential and gets future
     test_sorted_until1_async(par(task), IteratorTag());//calls parallel and gets future
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_sorted_until1(execution_policy(seq), IteratorTag());
     //calls sequential and gets iter
     test_sorted_until1(execution_policy(par), IteratorTag());
@@ -79,6 +80,7 @@ void test_sorted_until1()
     //calls sequential and gets iter
     test_sorted_until1(execution_policy(par(task)), IteratorTag());
     //calls parallel and gets iter
+#endif
 }
 
 void sorted_until_test1()
@@ -161,12 +163,13 @@ void test_sorted_until2()
     test_sorted_until2_async(seq(task), IteratorTag());
     test_sorted_until2_async(par(task), IteratorTag());
 
-
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_sorted_until2(execution_policy(seq), IteratorTag());
     test_sorted_until2(execution_policy(par), IteratorTag());
     test_sorted_until2(execution_policy(par_vec), IteratorTag());
     test_sorted_until2(execution_policy(seq(task)), IteratorTag());
     test_sorted_until2(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void sorted_until_test2()
@@ -258,12 +261,13 @@ void test_sorted_until3()
     test_sorted_until3_async(seq(task), IteratorTag());
     test_sorted_until3_async(par(task), IteratorTag());
 
-
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_sorted_until3(execution_policy(seq), IteratorTag());
     test_sorted_until3(execution_policy(par), IteratorTag());
     test_sorted_until3(execution_policy(par_vec), IteratorTag());
     test_sorted_until3(execution_policy(seq(task)), IteratorTag());
     test_sorted_until3(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void sorted_until_test3()
@@ -360,10 +364,13 @@ void test_sorted_until_exception()
     test_sorted_until_async_exception(seq(task), IteratorTag());
     test_sorted_until_async_exception(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_sorted_until_exception(execution_policy(par), IteratorTag());
     test_sorted_until_exception(execution_policy(seq(task)), IteratorTag());
     test_sorted_until_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
+
 void sorted_until_exception_test()
 {
     test_sorted_until_exception<std::random_access_iterator_tag>();
@@ -464,10 +471,12 @@ void test_sorted_until_bad_alloc()
     test_sorted_until_async_bad_alloc(seq(task), IteratorTag());
     test_sorted_until_async_bad_alloc(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_sorted_until_bad_alloc(execution_policy(par), IteratorTag());
     test_sorted_until_bad_alloc(execution_policy(seq), IteratorTag());
     test_sorted_until_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_sorted_until_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void sorted_until_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/lexicographical_compare.cpp
+++ b/tests/unit/parallel/algorithms/lexicographical_compare.cpp
@@ -73,11 +73,13 @@ void test_lexicographical_compare1()
     test_lexicographical_compare1_async(seq(task), IteratorTag());
     test_lexicographical_compare1_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_lexicographical_compare1(execution_policy(seq), IteratorTag());
     test_lexicographical_compare1(execution_policy(par), IteratorTag());
     test_lexicographical_compare1(execution_policy(par_vec), IteratorTag());
     test_lexicographical_compare1(execution_policy(seq(task)), IteratorTag());
     test_lexicographical_compare1(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void lexicographical_compare_test1()
@@ -146,11 +148,13 @@ void test_lexicographical_compare2()
     test_lexicographical_compare2_async(seq(task), IteratorTag());
     test_lexicographical_compare2_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_lexicographical_compare2(execution_policy(seq), IteratorTag());
     test_lexicographical_compare2(execution_policy(par), IteratorTag());
     test_lexicographical_compare2(execution_policy(par_vec), IteratorTag());
     test_lexicographical_compare2(execution_policy(seq(task)), IteratorTag());
     test_lexicographical_compare2(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void lexicographical_compare_test2()
@@ -221,11 +225,13 @@ void test_lexicographical_compare3()
     test_lexicographical_compare3_async(seq(task), IteratorTag());
     test_lexicographical_compare3_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_lexicographical_compare3(execution_policy(seq), IteratorTag());
     test_lexicographical_compare3(execution_policy(par), IteratorTag());
     test_lexicographical_compare3(execution_policy(par_vec), IteratorTag());
     test_lexicographical_compare3(execution_policy(seq(task)), IteratorTag());
     test_lexicographical_compare3(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void lexicographical_compare_test3()
@@ -333,9 +339,11 @@ void test_lexicographical_compare_exception()
     test_lexicographical_compare_async_exception(seq(task), IteratorTag());
     test_lexicographical_compare_async_exception(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_lexicographical_compare_exception(execution_policy(par), IteratorTag());
     test_lexicographical_compare_exception(execution_policy(seq(task)), IteratorTag());
     test_lexicographical_compare_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void lexicographical_compare_exception_test()
@@ -440,10 +448,12 @@ void test_lexicographical_compare_bad_alloc()
     test_lexicographical_compare_async_bad_alloc(seq(task), IteratorTag());
     test_lexicographical_compare_async_bad_alloc(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_lexicographical_compare_bad_alloc(execution_policy(par), IteratorTag());
     test_lexicographical_compare_bad_alloc(execution_policy(seq), IteratorTag());
     test_lexicographical_compare_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_lexicographical_compare_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void lexicographical_compare_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/max_element.cpp
+++ b/tests/unit/parallel/algorithms/max_element.cpp
@@ -92,12 +92,14 @@ void test_max_element()
     test_max_element_async(seq(task), IteratorTag());
     test_max_element_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_max_element(execution_policy(seq), IteratorTag());
     test_max_element(execution_policy(par), IteratorTag());
     test_max_element(execution_policy(par_vec), IteratorTag());
 
     test_max_element(execution_policy(seq(task)), IteratorTag());
     test_max_element(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void max_element_test()
@@ -249,11 +251,13 @@ void test_max_element_exception()
     test_max_element_exception_async(seq(task), IteratorTag());
     test_max_element_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_max_element_exception(execution_policy(seq), IteratorTag());
     test_max_element_exception(execution_policy(par), IteratorTag());
 
     test_max_element_exception(execution_policy(seq(task)), IteratorTag());
     test_max_element_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void max_element_exception_test()
@@ -401,11 +405,13 @@ void test_max_element_bad_alloc()
     test_max_element_bad_alloc_async(seq(task), IteratorTag());
     test_max_element_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_max_element_bad_alloc(execution_policy(seq), IteratorTag());
     test_max_element_bad_alloc(execution_policy(par), IteratorTag());
 
     test_max_element_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_max_element_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void max_element_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/min_element.cpp
+++ b/tests/unit/parallel/algorithms/min_element.cpp
@@ -94,12 +94,14 @@ void test_min_element()
     test_min_element_async(seq(task), IteratorTag());
     test_min_element_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_min_element(execution_policy(seq), IteratorTag());
     test_min_element(execution_policy(par), IteratorTag());
     test_min_element(execution_policy(par_vec), IteratorTag());
 
     test_min_element(execution_policy(seq(task)), IteratorTag());
     test_min_element(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void min_element_test()
@@ -251,11 +253,13 @@ void test_min_element_exception()
     test_min_element_exception_async(seq(task), IteratorTag());
     test_min_element_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_min_element_exception(execution_policy(seq), IteratorTag());
     test_min_element_exception(execution_policy(par), IteratorTag());
 
     test_min_element_exception(execution_policy(seq(task)), IteratorTag());
     test_min_element_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void min_element_exception_test()
@@ -403,11 +407,13 @@ void test_min_element_bad_alloc()
     test_min_element_bad_alloc_async(seq(task), IteratorTag());
     test_min_element_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_min_element_bad_alloc(execution_policy(seq), IteratorTag());
     test_min_element_bad_alloc(execution_policy(par), IteratorTag());
 
     test_min_element_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_min_element_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void min_element_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/minmax_element.cpp
+++ b/tests/unit/parallel/algorithms/minmax_element.cpp
@@ -103,12 +103,14 @@ void test_minmax_element()
     test_minmax_element_async(seq(task), IteratorTag());
     test_minmax_element_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_minmax_element(execution_policy(seq), IteratorTag());
     test_minmax_element(execution_policy(par), IteratorTag());
     test_minmax_element(execution_policy(par_vec), IteratorTag());
 
     test_minmax_element(execution_policy(seq(task)), IteratorTag());
     test_minmax_element(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void minmax_element_test()
@@ -260,11 +262,13 @@ void test_minmax_element_exception()
     test_minmax_element_exception_async(seq(task), IteratorTag());
     test_minmax_element_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_minmax_element_exception(execution_policy(seq), IteratorTag());
     test_minmax_element_exception(execution_policy(par), IteratorTag());
 
     test_minmax_element_exception(execution_policy(seq(task)), IteratorTag());
     test_minmax_element_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void minmax_element_exception_test()
@@ -412,11 +416,13 @@ void test_minmax_element_bad_alloc()
     test_minmax_element_bad_alloc_async(seq(task), IteratorTag());
     test_minmax_element_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_minmax_element_bad_alloc(execution_policy(seq), IteratorTag());
     test_minmax_element_bad_alloc(execution_policy(par), IteratorTag());
 
     test_minmax_element_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_minmax_element_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void minmax_element_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/mismatch.cpp
+++ b/tests/unit/parallel/algorithms/mismatch.cpp
@@ -121,12 +121,14 @@ void test_mismatch1()
     test_mismatch1_async(seq(task), IteratorTag());
     test_mismatch1_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_mismatch1(execution_policy(seq), IteratorTag());
     test_mismatch1(execution_policy(par), IteratorTag());
     test_mismatch1(execution_policy(par_vec), IteratorTag());
 
     test_mismatch1(execution_policy(seq(task)), IteratorTag());
     test_mismatch1(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void mismatch_test1()
@@ -245,12 +247,14 @@ void test_mismatch2()
     test_mismatch2_async(seq(task), IteratorTag());
     test_mismatch2_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_mismatch2(execution_policy(seq), IteratorTag());
     test_mismatch2(execution_policy(par), IteratorTag());
     test_mismatch2(execution_policy(par_vec), IteratorTag());
 
     test_mismatch2(execution_policy(seq(task)), IteratorTag());
     test_mismatch2(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void mismatch_test2()
@@ -360,11 +364,13 @@ void test_mismatch_exception()
     test_mismatch_exception_async(seq(task), IteratorTag());
     test_mismatch_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_mismatch_exception(execution_policy(seq), IteratorTag());
     test_mismatch_exception(execution_policy(par), IteratorTag());
 
     test_mismatch_exception(execution_policy(seq(task)), IteratorTag());
     test_mismatch_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void mismatch_exception_test()
@@ -472,11 +478,13 @@ void test_mismatch_bad_alloc()
     test_mismatch_bad_alloc_async(seq(task), IteratorTag());
     test_mismatch_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_mismatch_bad_alloc(execution_policy(seq), IteratorTag());
     test_mismatch_bad_alloc(execution_policy(par), IteratorTag());
 
     test_mismatch_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_mismatch_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void mismatch_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/mismatch_binary.cpp
+++ b/tests/unit/parallel/algorithms/mismatch_binary.cpp
@@ -123,12 +123,14 @@ void test_mismatch_binary1()
     test_mismatch_binary1_async(seq(task), IteratorTag());
     test_mismatch_binary1_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_mismatch_binary1(execution_policy(seq), IteratorTag());
     test_mismatch_binary1(execution_policy(par), IteratorTag());
     test_mismatch_binary1(execution_policy(par_vec), IteratorTag());
 
     test_mismatch_binary1(execution_policy(seq(task)), IteratorTag());
     test_mismatch_binary1(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void mismatch_binary_test1()
@@ -252,12 +254,14 @@ void test_mismatch_binary2()
     test_mismatch_binary2_async(seq(task), IteratorTag());
     test_mismatch_binary2_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_mismatch_binary2(execution_policy(seq), IteratorTag());
     test_mismatch_binary2(execution_policy(par), IteratorTag());
     test_mismatch_binary2(execution_policy(par_vec), IteratorTag());
 
     test_mismatch_binary2(execution_policy(seq(task)), IteratorTag());
     test_mismatch_binary2(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void mismatch_binary_test2()
@@ -367,11 +371,13 @@ void test_mismatch_binary_exception()
     test_mismatch_binary_exception_async(seq(task), IteratorTag());
     test_mismatch_binary_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_mismatch_binary_exception(execution_policy(seq), IteratorTag());
     test_mismatch_binary_exception(execution_policy(par), IteratorTag());
 
     test_mismatch_binary_exception(execution_policy(seq(task)), IteratorTag());
     test_mismatch_binary_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void mismatch_binary_exception_test()
@@ -479,11 +485,13 @@ void test_mismatch_binary_bad_alloc()
     test_mismatch_binary_bad_alloc_async(seq(task), IteratorTag());
     test_mismatch_binary_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_mismatch_binary_bad_alloc(execution_policy(seq), IteratorTag());
     test_mismatch_binary_bad_alloc(execution_policy(par), IteratorTag());
 
     test_mismatch_binary_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_mismatch_binary_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void mismatch_binary_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/move.cpp
+++ b/tests/unit/parallel/algorithms/move.cpp
@@ -154,12 +154,14 @@ void test_move()
     test_move_async(seq(task), IteratorTag());
     test_move_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_move(execution_policy(seq), IteratorTag());
     test_move(execution_policy(par), IteratorTag());
     test_move(execution_policy(par_vec), IteratorTag());
 
     test_move(execution_policy(seq(task)), IteratorTag());
     test_move(execution_policy(par(task)), IteratorTag());
+#endif
 
     // output iterator test
     test_outiter_move(seq, IteratorTag());
@@ -169,12 +171,14 @@ void test_move()
     test_outiter_move_async(seq(task), IteratorTag());
     test_outiter_move_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_outiter_move(execution_policy(seq), IteratorTag());
     test_outiter_move(execution_policy(par), IteratorTag());
     test_outiter_move(execution_policy(par_vec), IteratorTag());
 
     test_outiter_move(execution_policy(seq(task)), IteratorTag());
     test_outiter_move(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void move_test()
@@ -275,11 +279,13 @@ void test_move_exception()
     test_move_exception_async(seq(task), IteratorTag());
     test_move_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_move_exception(execution_policy(seq), IteratorTag());
     test_move_exception(execution_policy(par), IteratorTag());
 
     test_move_exception(execution_policy(seq(task)), IteratorTag());
     test_move_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void move_exception_test()
@@ -378,11 +384,13 @@ void test_move_bad_alloc()
     test_move_bad_alloc_async(seq(task), IteratorTag());
     test_move_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_move_bad_alloc(execution_policy(seq), IteratorTag());
     test_move_bad_alloc(execution_policy(par), IteratorTag());
 
     test_move_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_move_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void move_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/none_of.cpp
+++ b/tests/unit/parallel/algorithms/none_of.cpp
@@ -88,12 +88,14 @@ void test_none_of()
     test_none_of_async(seq(task), IteratorTag());
     test_none_of_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_none_of(execution_policy(seq), IteratorTag());
     test_none_of(execution_policy(par), IteratorTag());
     test_none_of(execution_policy(par_vec), IteratorTag());
 
     test_none_of(execution_policy(seq(task)), IteratorTag());
     test_none_of(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 // template <typename IteratorTag>
@@ -221,11 +223,13 @@ void test_none_of_exception()
     test_none_of_exception_async(seq(task), IteratorTag());
     test_none_of_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_none_of_exception(execution_policy(seq), IteratorTag());
     test_none_of_exception(execution_policy(par), IteratorTag());
 
     test_none_of_exception(execution_policy(seq(task)), IteratorTag());
     test_none_of_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void none_of_exception_test()
@@ -323,11 +327,13 @@ void test_none_of_bad_alloc()
     test_none_of_bad_alloc_async(seq(task), IteratorTag());
     test_none_of_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_none_of_bad_alloc(execution_policy(seq), IteratorTag());
     test_none_of_bad_alloc(execution_policy(par), IteratorTag());
 
     test_none_of_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_none_of_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void none_of_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/reduce_.cpp
+++ b/tests/unit/parallel/algorithms/reduce_.cpp
@@ -77,12 +77,14 @@ void test_reduce1()
     test_reduce1_async(seq(task), IteratorTag());
     test_reduce1_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_reduce1(execution_policy(seq), IteratorTag());
     test_reduce1(execution_policy(par), IteratorTag());
     test_reduce1(execution_policy(par_vec), IteratorTag());
 
     test_reduce1(execution_policy(seq(task)), IteratorTag());
     test_reduce1(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void reduce_test1()
@@ -147,12 +149,14 @@ void test_reduce2()
     test_reduce2_async(seq(task), IteratorTag());
     test_reduce2_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_reduce2(execution_policy(seq), IteratorTag());
     test_reduce2(execution_policy(par), IteratorTag());
     test_reduce2(execution_policy(par_vec), IteratorTag());
 
     test_reduce2(execution_policy(seq(task)), IteratorTag());
     test_reduce2(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void reduce_test2()
@@ -215,12 +219,14 @@ void test_reduce3()
     test_reduce3_async(seq(task), IteratorTag());
     test_reduce3_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_reduce3(execution_policy(seq), IteratorTag());
     test_reduce3(execution_policy(par), IteratorTag());
     test_reduce3(execution_policy(par_vec), IteratorTag());
 
     test_reduce3(execution_policy(seq(task)), IteratorTag());
     test_reduce3(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void reduce_test3()
@@ -316,11 +322,13 @@ void test_reduce_exception()
     test_reduce_exception_async(seq(task), IteratorTag());
     test_reduce_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_reduce_exception(execution_policy(seq), IteratorTag());
     test_reduce_exception(execution_policy(par), IteratorTag());
 
     test_reduce_exception(execution_policy(seq(task)), IteratorTag());
     test_reduce_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void reduce_exception_test()
@@ -414,11 +422,13 @@ void test_reduce_bad_alloc()
     test_reduce_bad_alloc_async(seq(task), IteratorTag());
     test_reduce_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_reduce_bad_alloc(execution_policy(seq), IteratorTag());
     test_reduce_bad_alloc(execution_policy(par), IteratorTag());
 
     test_reduce_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_reduce_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void reduce_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/remove_copy.cpp
+++ b/tests/unit/parallel/algorithms/remove_copy.cpp
@@ -151,12 +151,14 @@ void test_remove_copy()
     test_remove_copy_async(seq(task), IteratorTag());
     test_remove_copy_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_remove_copy(execution_policy(seq), IteratorTag());
     test_remove_copy(execution_policy(par), IteratorTag());
     test_remove_copy(execution_policy(par_vec), IteratorTag());
 
     test_remove_copy(execution_policy(seq(task)), IteratorTag());
     test_remove_copy(execution_policy(par(task)), IteratorTag());
+#endif
 
     //assure output iterator will work
     test_remove_copy_outiter(seq, IteratorTag());
@@ -166,12 +168,14 @@ void test_remove_copy()
     test_remove_copy_outiter_async(seq(task), IteratorTag());
     test_remove_copy_outiter_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_remove_copy_outiter(execution_policy(seq), IteratorTag());
     test_remove_copy_outiter(execution_policy(par), IteratorTag());
     test_remove_copy_outiter(execution_policy(par_vec), IteratorTag());
 
     test_remove_copy_outiter(execution_policy(seq(task)), IteratorTag());
     test_remove_copy_outiter(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void remove_copy_test()
@@ -270,11 +274,13 @@ void test_remove_copy_exception()
     test_remove_copy_exception_async(seq(task), IteratorTag());
     test_remove_copy_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_remove_copy_exception(execution_policy(seq), IteratorTag());
     test_remove_copy_exception(execution_policy(par), IteratorTag());
 
     test_remove_copy_exception(execution_policy(seq(task)), IteratorTag());
     test_remove_copy_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void remove_copy_exception_test()
@@ -371,11 +377,13 @@ void test_remove_copy_bad_alloc()
     test_remove_copy_bad_alloc_async(seq(task), IteratorTag());
     test_remove_copy_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_remove_copy_bad_alloc(execution_policy(seq), IteratorTag());
     test_remove_copy_bad_alloc(execution_policy(par), IteratorTag());
 
     test_remove_copy_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_remove_copy_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void remove_copy_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/remove_copy.cpp
+++ b/tests/unit/parallel/algorithms/remove_copy.cpp
@@ -160,7 +160,7 @@ void test_remove_copy()
     test_remove_copy(execution_policy(par(task)), IteratorTag());
 #endif
 
-    //assure output iterator will work
+    // assure output iterator will work
     test_remove_copy_outiter(seq, IteratorTag());
     test_remove_copy_outiter(par, IteratorTag());
     test_remove_copy_outiter(par_vec, IteratorTag());

--- a/tests/unit/parallel/algorithms/remove_copy_if.cpp
+++ b/tests/unit/parallel/algorithms/remove_copy_if.cpp
@@ -161,12 +161,14 @@ void test_remove_copy_if()
     test_remove_copy_if_async(seq(task), IteratorTag());
     test_remove_copy_if_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_remove_copy_if(execution_policy(seq), IteratorTag());
     test_remove_copy_if(execution_policy(par), IteratorTag());
     test_remove_copy_if(execution_policy(par_vec), IteratorTag());
 
     test_remove_copy_if(execution_policy(seq(task)), IteratorTag());
     test_remove_copy_if(execution_policy(par(task)), IteratorTag());
+#endif
 
     test_remove_copy_if_outiter(seq, IteratorTag());
     test_remove_copy_if_outiter(par, IteratorTag());
@@ -175,12 +177,14 @@ void test_remove_copy_if()
     test_remove_copy_if_outiter_async(seq(task), IteratorTag());
     test_remove_copy_if_outiter_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_remove_copy_if_outiter(execution_policy(seq), IteratorTag());
     test_remove_copy_if_outiter(execution_policy(par), IteratorTag());
     test_remove_copy_if_outiter(execution_policy(par_vec), IteratorTag());
 
     test_remove_copy_if_outiter(execution_policy(seq(task)), IteratorTag());
     test_remove_copy_if_outiter(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void remove_copy_if_test()
@@ -277,11 +281,13 @@ void test_remove_copy_if_exception()
     test_remove_copy_if_exception_async(seq(task), IteratorTag());
     test_remove_copy_if_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_remove_copy_if_exception(execution_policy(seq), IteratorTag());
     test_remove_copy_if_exception(execution_policy(par), IteratorTag());
 
     test_remove_copy_if_exception(execution_policy(seq(task)), IteratorTag());
     test_remove_copy_if_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void remove_copy_if_exception_test()
@@ -377,11 +383,13 @@ void test_remove_copy_if_bad_alloc()
     test_remove_copy_if_bad_alloc_async(seq(task), IteratorTag());
     test_remove_copy_if_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_remove_copy_if_bad_alloc(execution_policy(seq), IteratorTag());
     test_remove_copy_if_bad_alloc(execution_policy(par), IteratorTag());
 
     test_remove_copy_if_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_remove_copy_if_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void remove_copy_if_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/replace.cpp
+++ b/tests/unit/parallel/algorithms/replace.cpp
@@ -88,12 +88,14 @@ void test_replace()
     test_replace_async(seq(task), IteratorTag());
     test_replace_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace(execution_policy(seq), IteratorTag());
     test_replace(execution_policy(par), IteratorTag());
     test_replace(execution_policy(par_vec), IteratorTag());
 
     test_replace(execution_policy(seq(task)), IteratorTag());
     test_replace(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_test()
@@ -189,11 +191,13 @@ void test_replace_exception()
     test_replace_exception_async(seq(task), IteratorTag());
     test_replace_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace_exception(execution_policy(seq), IteratorTag());
     test_replace_exception(execution_policy(par), IteratorTag());
 
     test_replace_exception(execution_policy(seq(task)), IteratorTag());
     test_replace_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_exception_test()
@@ -287,11 +291,13 @@ void test_replace_bad_alloc()
     test_replace_bad_alloc_async(seq(task), IteratorTag());
     test_replace_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace_bad_alloc(execution_policy(seq), IteratorTag());
     test_replace_bad_alloc(execution_policy(par), IteratorTag());
 
     test_replace_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_replace_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/replace_copy.cpp
+++ b/tests/unit/parallel/algorithms/replace_copy.cpp
@@ -92,12 +92,14 @@ void test_replace_copy()
     test_replace_copy_async(seq(task), IteratorTag());
     test_replace_copy_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace_copy(execution_policy(seq), IteratorTag());
     test_replace_copy(execution_policy(par), IteratorTag());
     test_replace_copy(execution_policy(par_vec), IteratorTag());
 
     test_replace_copy(execution_policy(seq(task)), IteratorTag());
     test_replace_copy(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_copy_test()
@@ -196,11 +198,13 @@ void test_replace_copy_exception()
     test_replace_copy_exception_async(seq(task), IteratorTag());
     test_replace_copy_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace_copy_exception(execution_policy(seq), IteratorTag());
     test_replace_copy_exception(execution_policy(par), IteratorTag());
 
     test_replace_copy_exception(execution_policy(seq(task)), IteratorTag());
     test_replace_copy_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_copy_exception_test()
@@ -297,11 +301,13 @@ void test_replace_copy_bad_alloc()
     test_replace_copy_bad_alloc_async(seq(task), IteratorTag());
     test_replace_copy_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace_copy_bad_alloc(execution_policy(seq), IteratorTag());
     test_replace_copy_bad_alloc(execution_policy(par), IteratorTag());
 
     test_replace_copy_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_replace_copy_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_copy_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/replace_copy_if.cpp
+++ b/tests/unit/parallel/algorithms/replace_copy_if.cpp
@@ -104,12 +104,14 @@ void test_replace_copy_if()
     test_replace_copy_if_async(seq(task), IteratorTag());
     test_replace_copy_if_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace_copy_if(execution_policy(seq), IteratorTag());
     test_replace_copy_if(execution_policy(par), IteratorTag());
     test_replace_copy_if(execution_policy(par_vec), IteratorTag());
 
     test_replace_copy_if(execution_policy(seq(task)), IteratorTag());
     test_replace_copy_if(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_copy_if_test()
@@ -208,11 +210,13 @@ void test_replace_copy_if_exception()
     test_replace_copy_if_exception_async(seq(task), IteratorTag());
     test_replace_copy_if_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace_copy_if_exception(execution_policy(seq), IteratorTag());
     test_replace_copy_if_exception(execution_policy(par), IteratorTag());
 
     test_replace_copy_if_exception(execution_policy(seq(task)), IteratorTag());
     test_replace_copy_if_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_copy_if_exception_test()
@@ -309,11 +313,13 @@ void test_replace_copy_if_bad_alloc()
     test_replace_copy_if_bad_alloc_async(seq(task), IteratorTag());
     test_replace_copy_if_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace_copy_if_bad_alloc(execution_policy(seq), IteratorTag());
     test_replace_copy_if_bad_alloc(execution_policy(par), IteratorTag());
 
     test_replace_copy_if_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_replace_copy_if_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_copy_if_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/replace_if.cpp
+++ b/tests/unit/parallel/algorithms/replace_if.cpp
@@ -100,12 +100,14 @@ void test_replace_if()
     test_replace_if_async(seq(task), IteratorTag());
     test_replace_if_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace_if(execution_policy(seq), IteratorTag());
     test_replace_if(execution_policy(par), IteratorTag());
     test_replace_if(execution_policy(par_vec), IteratorTag());
 
     test_replace_if(execution_policy(seq(task)), IteratorTag());
     test_replace_if(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_if_test()
@@ -201,11 +203,13 @@ void test_replace_if_exception()
     test_replace_if_exception_async(seq(task), IteratorTag());
     test_replace_if_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace_if_exception(execution_policy(seq), IteratorTag());
     test_replace_if_exception(execution_policy(par), IteratorTag());
 
     test_replace_if_exception(execution_policy(seq(task)), IteratorTag());
     test_replace_if_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_if_exception_test()
@@ -299,11 +303,13 @@ void test_replace_if_bad_alloc()
     test_replace_if_bad_alloc_async(seq(task), IteratorTag());
     test_replace_if_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace_if_bad_alloc(execution_policy(seq), IteratorTag());
     test_replace_if_bad_alloc(execution_policy(par), IteratorTag());
 
     test_replace_if_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_replace_if_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_if_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/reverse.cpp
+++ b/tests/unit/parallel/algorithms/reverse.cpp
@@ -84,12 +84,14 @@ void test_reverse()
     test_reverse_async(seq(task), IteratorTag());
     test_reverse_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_reverse(execution_policy(seq), IteratorTag());
     test_reverse(execution_policy(par), IteratorTag());
     test_reverse(execution_policy(par_vec), IteratorTag());
 
     test_reverse(execution_policy(seq(task)), IteratorTag());
     test_reverse(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void reverse_test()
@@ -185,11 +187,13 @@ void test_reverse_exception()
     test_reverse_exception_async(seq(task), IteratorTag());
     test_reverse_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_reverse_exception(execution_policy(seq), IteratorTag());
     test_reverse_exception(execution_policy(par), IteratorTag());
 
     test_reverse_exception(execution_policy(seq(task)), IteratorTag());
     test_reverse_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void reverse_exception_test()
@@ -283,11 +287,13 @@ void test_reverse_bad_alloc()
     test_reverse_bad_alloc_async(seq(task), IteratorTag());
     test_reverse_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_reverse_bad_alloc(execution_policy(seq), IteratorTag());
     test_reverse_bad_alloc(execution_policy(par), IteratorTag());
 
     test_reverse_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_reverse_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void reverse_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/reverse_copy.cpp
+++ b/tests/unit/parallel/algorithms/reverse_copy.cpp
@@ -85,12 +85,14 @@ void test_reverse_copy()
     test_reverse_copy_async(seq(task), IteratorTag());
     test_reverse_copy_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_reverse_copy(execution_policy(seq), IteratorTag());
     test_reverse_copy(execution_policy(par), IteratorTag());
     test_reverse_copy(execution_policy(par_vec), IteratorTag());
 
     test_reverse_copy(execution_policy(seq(task)), IteratorTag());
     test_reverse_copy(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void reverse_copy_test()
@@ -190,11 +192,13 @@ void test_reverse_copy_exception()
     test_reverse_copy_exception_async(seq(task), IteratorTag());
     test_reverse_copy_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_reverse_copy_exception(execution_policy(seq), IteratorTag());
     test_reverse_copy_exception(execution_policy(par), IteratorTag());
 
     test_reverse_copy_exception(execution_policy(seq(task)), IteratorTag());
     test_reverse_copy_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void reverse_copy_exception_test()
@@ -292,11 +296,13 @@ void test_reverse_copy_bad_alloc()
     test_reverse_copy_bad_alloc_async(seq(task), IteratorTag());
     test_reverse_copy_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_reverse_copy_bad_alloc(execution_policy(seq), IteratorTag());
     test_reverse_copy_bad_alloc(execution_policy(par), IteratorTag());
 
     test_reverse_copy_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_reverse_copy_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void reverse_copy_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/rotate.cpp
+++ b/tests/unit/parallel/algorithms/rotate.cpp
@@ -98,12 +98,14 @@ void test_rotate()
     test_rotate_async(seq(task), IteratorTag());
     test_rotate_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_rotate(execution_policy(seq), IteratorTag());
     test_rotate(execution_policy(par), IteratorTag());
     test_rotate(execution_policy(par_vec), IteratorTag());
 
     test_rotate(execution_policy(seq(task)), IteratorTag());
     test_rotate(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void rotate_test()
@@ -211,11 +213,13 @@ void test_rotate_exception()
     test_rotate_exception_async(seq(task), IteratorTag());
     test_rotate_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_rotate_exception(execution_policy(seq), IteratorTag());
     test_rotate_exception(execution_policy(par), IteratorTag());
 
     test_rotate_exception(execution_policy(seq(task)), IteratorTag());
     test_rotate_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void rotate_exception_test()
@@ -321,11 +325,13 @@ void test_rotate_bad_alloc()
     test_rotate_bad_alloc_async(seq(task), IteratorTag());
     test_rotate_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_rotate_bad_alloc(execution_policy(seq), IteratorTag());
     test_rotate_bad_alloc(execution_policy(par), IteratorTag());
 
     test_rotate_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_rotate_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void rotate_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/rotate_copy.cpp
+++ b/tests/unit/parallel/algorithms/rotate_copy.cpp
@@ -92,12 +92,14 @@ void test_rotate_copy()
     test_rotate_copy_async(seq(task), IteratorTag());
     test_rotate_copy_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_rotate_copy(execution_policy(seq), IteratorTag());
     test_rotate_copy(execution_policy(par), IteratorTag());
     test_rotate_copy(execution_policy(par_vec), IteratorTag());
 
     test_rotate_copy(execution_policy(seq(task)), IteratorTag());
     test_rotate_copy(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void rotate_copy_test()
@@ -209,11 +211,13 @@ void test_rotate_copy_exception()
     test_rotate_copy_exception_async(seq(task), IteratorTag());
     test_rotate_copy_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_rotate_copy_exception(execution_policy(seq), IteratorTag());
     test_rotate_copy_exception(execution_policy(par), IteratorTag());
 
     test_rotate_copy_exception(execution_policy(seq(task)), IteratorTag());
     test_rotate_copy_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void rotate_copy_exception_test()
@@ -323,11 +327,13 @@ void test_rotate_copy_bad_alloc()
     test_rotate_copy_bad_alloc_async(seq(task), IteratorTag());
     test_rotate_copy_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_rotate_copy_bad_alloc(execution_policy(seq), IteratorTag());
     test_rotate_copy_bad_alloc(execution_policy(par), IteratorTag());
 
     test_rotate_copy_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_rotate_copy_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void rotate_copy_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/search.cpp
+++ b/tests/unit/parallel/algorithms/search.cpp
@@ -79,12 +79,13 @@ void test_search1()
     test_search1_async(seq(task), IteratorTag());
     test_search1_async(par(task), IteratorTag());
 
-
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_search1(execution_policy(seq), IteratorTag());
     test_search1(execution_policy(par), IteratorTag());
     test_search1(execution_policy(par_vec), IteratorTag());
     test_search1(execution_policy(seq(task)), IteratorTag());
     test_search1(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void search_test1()
@@ -163,12 +164,14 @@ void test_search2()
     test_search2_async(seq(task), IteratorTag());
     test_search2_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_search2(execution_policy(seq), IteratorTag());
     test_search2(execution_policy(par), IteratorTag());
     test_search2(execution_policy(par_vec), IteratorTag());
 
     test_search2(execution_policy(seq(task)), IteratorTag());
     test_search2(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void search_test2()
@@ -245,12 +248,14 @@ void test_search3()
     test_search3_async(seq(task), IteratorTag());
     test_search3_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_search3(execution_policy(seq), IteratorTag());
     test_search3(execution_policy(par), IteratorTag());
     test_search3(execution_policy(par_vec), IteratorTag());
 
     test_search3(execution_policy(seq(task)), IteratorTag());
     test_search3(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void search_test3()
@@ -338,12 +343,13 @@ void test_search4()
     test_search4_async(seq(task), IteratorTag());
     test_search4_async(par(task), IteratorTag());
 
-
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_search4(execution_policy(seq), IteratorTag());
     test_search4(execution_policy(par), IteratorTag());
     test_search4(execution_policy(par_vec), IteratorTag());
     test_search4(execution_policy(seq(task)), IteratorTag());
     test_search4(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void search_test4()
@@ -450,9 +456,11 @@ void test_search_exception()
     test_search_async_exception(seq(task), IteratorTag());
     test_search_async_exception(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_search_exception(execution_policy(par), IteratorTag());
     test_search_exception(execution_policy(seq(task)), IteratorTag());
     test_search_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void search_exception_test()
@@ -554,10 +562,12 @@ void test_search_bad_alloc()
     test_search_async_bad_alloc(seq(task), IteratorTag());
     test_search_async_bad_alloc(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_search_bad_alloc(execution_policy(par), IteratorTag());
     test_search_bad_alloc(execution_policy(seq), IteratorTag());
     test_search_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_search_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void search_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/searchn.cpp
+++ b/tests/unit/parallel/algorithms/searchn.cpp
@@ -79,12 +79,13 @@ void test_search_n1()
     test_search_n1_async(seq(task), IteratorTag());
     test_search_n1_async(par(task), IteratorTag());
 
-
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_search_n1(execution_policy(seq), IteratorTag());
     test_search_n1(execution_policy(par), IteratorTag());
     test_search_n1(execution_policy(par_vec), IteratorTag());
     test_search_n1(execution_policy(seq(task)), IteratorTag());
     test_search_n1(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void search_n_test1()
@@ -163,12 +164,14 @@ void test_search_n2()
     test_search_n2_async(seq(task), IteratorTag());
     test_search_n2_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_search_n2(execution_policy(seq), IteratorTag());
     test_search_n2(execution_policy(par), IteratorTag());
     test_search_n2(execution_policy(par_vec), IteratorTag());
 
     test_search_n2(execution_policy(seq(task)), IteratorTag());
     test_search_n2(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void search_n_test2()
@@ -245,12 +248,14 @@ void test_search_n3()
     test_search_n3_async(seq(task), IteratorTag());
     test_search_n3_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_search_n3(execution_policy(seq), IteratorTag());
     test_search_n3(execution_policy(par), IteratorTag());
     test_search_n3(execution_policy(par_vec), IteratorTag());
 
     test_search_n3(execution_policy(seq(task)), IteratorTag());
     test_search_n3(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void search_n_test3()
@@ -331,12 +336,14 @@ void test_search_n4()
     test_search_n4_async(seq(task), IteratorTag());
     test_search_n4_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_search_n4(execution_policy(seq), IteratorTag());
     test_search_n4(execution_policy(par), IteratorTag());
     test_search_n4(execution_policy(par_vec), IteratorTag());
 
     test_search_n4(execution_policy(seq(task)), IteratorTag());
     test_search_n4(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void search_n_test4()
@@ -423,11 +430,13 @@ void test_search_n5()
     test_search_n5_async(seq(task), IteratorTag());
     test_search_n5_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_search_n5(execution_policy(seq), IteratorTag());
     test_search_n5(execution_policy(par), IteratorTag());
     test_search_n5(execution_policy(par_vec), IteratorTag());
     test_search_n5(execution_policy(seq(task)), IteratorTag());
     test_search_n5(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void search_n_test5()
@@ -530,9 +539,11 @@ void test_search_n_exception()
     test_search_n_async_exception(seq(task), IteratorTag());
     test_search_n_async_exception(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_search_n_exception(execution_policy(par), IteratorTag());
     test_search_n_exception(execution_policy(seq(task)), IteratorTag());
     test_search_n_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void search_n_exception_test()
@@ -630,10 +641,12 @@ void test_search_n_bad_alloc()
     test_search_n_async_bad_alloc(seq(task), IteratorTag());
     test_search_n_async_bad_alloc(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_search_n_bad_alloc(execution_policy(par), IteratorTag());
     test_search_n_bad_alloc(execution_policy(seq), IteratorTag());
     test_search_n_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_search_n_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void search_n_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/set_difference.cpp
+++ b/tests/unit/parallel/algorithms/set_difference.cpp
@@ -81,12 +81,14 @@ void test_set_difference1()
     test_set_difference1_async(seq(task), IteratorTag());
     test_set_difference1_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_set_difference1(execution_policy(seq), IteratorTag());
     test_set_difference1(execution_policy(par), IteratorTag());
     test_set_difference1(execution_policy(par_vec), IteratorTag());
 
     test_set_difference1(execution_policy(seq(task)), IteratorTag());
     test_set_difference1(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void set_difference_test1()
@@ -173,12 +175,14 @@ void test_set_difference2()
     test_set_difference2_async(seq(task), IteratorTag());
     test_set_difference2_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_set_difference2(execution_policy(seq), IteratorTag());
     test_set_difference2(execution_policy(par), IteratorTag());
     test_set_difference2(execution_policy(par_vec), IteratorTag());
 
     test_set_difference2(execution_policy(seq(task)), IteratorTag());
     test_set_difference2(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void set_difference_test2()
@@ -293,11 +297,13 @@ void test_set_difference_exception()
     test_set_difference_exception_async(seq(task), IteratorTag());
     test_set_difference_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_set_difference_exception(execution_policy(seq), IteratorTag());
     test_set_difference_exception(execution_policy(par), IteratorTag());
 
     test_set_difference_exception(execution_policy(seq(task)), IteratorTag());
     test_set_difference_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void set_difference_exception_test()
@@ -410,11 +416,13 @@ void test_set_difference_bad_alloc()
     test_set_difference_bad_alloc_async(seq(task), IteratorTag());
     test_set_difference_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_set_difference_bad_alloc(execution_policy(seq), IteratorTag());
     test_set_difference_bad_alloc(execution_policy(par), IteratorTag());
 
     test_set_difference_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_set_difference_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void set_difference_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/set_intersection.cpp
+++ b/tests/unit/parallel/algorithms/set_intersection.cpp
@@ -81,12 +81,14 @@ void test_set_intersection1()
     test_set_intersection1_async(seq(task), IteratorTag());
     test_set_intersection1_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_set_intersection1(execution_policy(seq), IteratorTag());
     test_set_intersection1(execution_policy(par), IteratorTag());
     test_set_intersection1(execution_policy(par_vec), IteratorTag());
 
     test_set_intersection1(execution_policy(seq(task)), IteratorTag());
     test_set_intersection1(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void set_intersection_test1()
@@ -173,12 +175,14 @@ void test_set_intersection2()
     test_set_intersection2_async(seq(task), IteratorTag());
     test_set_intersection2_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_set_intersection2(execution_policy(seq), IteratorTag());
     test_set_intersection2(execution_policy(par), IteratorTag());
     test_set_intersection2(execution_policy(par_vec), IteratorTag());
 
     test_set_intersection2(execution_policy(seq(task)), IteratorTag());
     test_set_intersection2(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void set_intersection_test2()
@@ -293,11 +297,13 @@ void test_set_intersection_exception()
     test_set_intersection_exception_async(seq(task), IteratorTag());
     test_set_intersection_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_set_intersection_exception(execution_policy(seq), IteratorTag());
     test_set_intersection_exception(execution_policy(par), IteratorTag());
 
     test_set_intersection_exception(execution_policy(seq(task)), IteratorTag());
     test_set_intersection_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void set_intersection_exception_test()
@@ -410,11 +416,13 @@ void test_set_intersection_bad_alloc()
     test_set_intersection_bad_alloc_async(seq(task), IteratorTag());
     test_set_intersection_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_set_intersection_bad_alloc(execution_policy(seq), IteratorTag());
     test_set_intersection_bad_alloc(execution_policy(par), IteratorTag());
 
     test_set_intersection_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_set_intersection_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void set_intersection_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/set_symmetric_difference.cpp
+++ b/tests/unit/parallel/algorithms/set_symmetric_difference.cpp
@@ -81,12 +81,14 @@ void test_set_symmetric_difference1()
     test_set_symmetric_difference1_async(seq(task), IteratorTag());
     test_set_symmetric_difference1_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_set_symmetric_difference1(execution_policy(seq), IteratorTag());
     test_set_symmetric_difference1(execution_policy(par), IteratorTag());
     test_set_symmetric_difference1(execution_policy(par_vec), IteratorTag());
 
     test_set_symmetric_difference1(execution_policy(seq(task)), IteratorTag());
     test_set_symmetric_difference1(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void set_symmetric_difference_test1()
@@ -173,12 +175,14 @@ void test_set_symmetric_difference2()
     test_set_symmetric_difference2_async(seq(task), IteratorTag());
     test_set_symmetric_difference2_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_set_symmetric_difference2(execution_policy(seq), IteratorTag());
     test_set_symmetric_difference2(execution_policy(par), IteratorTag());
     test_set_symmetric_difference2(execution_policy(par_vec), IteratorTag());
 
     test_set_symmetric_difference2(execution_policy(seq(task)), IteratorTag());
     test_set_symmetric_difference2(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void set_symmetric_difference_test2()
@@ -293,11 +297,13 @@ void test_set_symmetric_difference_exception()
     test_set_symmetric_difference_exception_async(seq(task), IteratorTag());
     test_set_symmetric_difference_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_set_symmetric_difference_exception(execution_policy(seq), IteratorTag());
     test_set_symmetric_difference_exception(execution_policy(par), IteratorTag());
 
     test_set_symmetric_difference_exception(execution_policy(seq(task)), IteratorTag());
     test_set_symmetric_difference_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void set_symmetric_difference_exception_test()
@@ -410,11 +416,13 @@ void test_set_symmetric_difference_bad_alloc()
     test_set_symmetric_difference_bad_alloc_async(seq(task), IteratorTag());
     test_set_symmetric_difference_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_set_symmetric_difference_bad_alloc(execution_policy(seq), IteratorTag());
     test_set_symmetric_difference_bad_alloc(execution_policy(par), IteratorTag());
 
     test_set_symmetric_difference_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_set_symmetric_difference_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void set_symmetric_difference_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/set_union.cpp
+++ b/tests/unit/parallel/algorithms/set_union.cpp
@@ -81,12 +81,14 @@ void test_set_union1()
     test_set_union1_async(seq(task), IteratorTag());
     test_set_union1_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_set_union1(execution_policy(seq), IteratorTag());
     test_set_union1(execution_policy(par), IteratorTag());
     test_set_union1(execution_policy(par_vec), IteratorTag());
 
     test_set_union1(execution_policy(seq(task)), IteratorTag());
     test_set_union1(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void set_union_test1()
@@ -173,12 +175,14 @@ void test_set_union2()
     test_set_union2_async(seq(task), IteratorTag());
     test_set_union2_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_set_union2(execution_policy(seq), IteratorTag());
     test_set_union2(execution_policy(par), IteratorTag());
     test_set_union2(execution_policy(par_vec), IteratorTag());
 
     test_set_union2(execution_policy(seq(task)), IteratorTag());
     test_set_union2(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void set_union_test2()
@@ -293,11 +297,13 @@ void test_set_union_exception()
     test_set_union_exception_async(seq(task), IteratorTag());
     test_set_union_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_set_union_exception(execution_policy(seq), IteratorTag());
     test_set_union_exception(execution_policy(par), IteratorTag());
 
     test_set_union_exception(execution_policy(seq(task)), IteratorTag());
     test_set_union_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void set_union_exception_test()
@@ -410,11 +416,13 @@ void test_set_union_bad_alloc()
     test_set_union_bad_alloc_async(seq(task), IteratorTag());
     test_set_union_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_set_union_bad_alloc(execution_policy(seq), IteratorTag());
     test_set_union_bad_alloc(execution_policy(par), IteratorTag());
 
     test_set_union_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_set_union_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void set_union_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/sort.cpp
+++ b/tests/unit/parallel/algorithms/sort.cpp
@@ -93,6 +93,7 @@ void test_sort1()
     test_sort1_async_str(seq(task), std::greater<std::string>());
     test_sort1_async_str(par(task), std::greater<std::string>());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_sort1(execution_policy(seq),       int());
     test_sort1(execution_policy(par),       int());
     test_sort1(execution_policy(par_vec),   int());
@@ -100,6 +101,7 @@ void test_sort1()
     test_sort1(execution_policy(par(task)), int());
     test_sort1(execution_policy(seq(task)), std::string());
     test_sort1(execution_policy(par(task)), std::string());
+#endif
 }
 
 void test_sort2()
@@ -138,11 +140,13 @@ void test_sort2()
     test_sort2_async(seq(task), double(), std::greater<double>());
     test_sort2_async(par(task), float(),  std::greater<float>());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_sort2(execution_policy(seq),       int());
     test_sort2(execution_policy(par),       int());
     test_sort2(execution_policy(par_vec),   int());
     test_sort2(execution_policy(seq(task)), int());
     test_sort2(execution_policy(par(task)), int());
+#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/parallel/algorithms/swapranges.cpp
+++ b/tests/unit/parallel/algorithms/swapranges.cpp
@@ -98,12 +98,14 @@ void test_swap_ranges()
     test_swap_ranges_async(seq(task), IteratorTag());
     test_swap_ranges_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_swap_ranges(execution_policy(seq), IteratorTag());
     test_swap_ranges(execution_policy(par), IteratorTag());
     test_swap_ranges(execution_policy(par_vec), IteratorTag());
 
     test_swap_ranges(execution_policy(seq(task)), IteratorTag());
     test_swap_ranges(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void swap_ranges_test()
@@ -203,11 +205,13 @@ void test_swap_ranges_exception()
     test_swap_ranges_exception_async(seq(task), IteratorTag());
     test_swap_ranges_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_swap_ranges_exception(execution_policy(seq), IteratorTag());
     test_swap_ranges_exception(execution_policy(par), IteratorTag());
 
     test_swap_ranges_exception(execution_policy(seq(task)), IteratorTag());
     test_swap_ranges_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void swap_ranges_exception_test()
@@ -305,11 +309,13 @@ void test_swap_ranges_bad_alloc()
     test_swap_ranges_bad_alloc_async(seq(task), IteratorTag());
     test_swap_ranges_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_swap_ranges_bad_alloc(execution_policy(seq), IteratorTag());
     test_swap_ranges_bad_alloc(execution_policy(par), IteratorTag());
 
     test_swap_ranges_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_swap_ranges_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void swap_ranges_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/test_utils.hpp
+++ b/tests/unit/parallel/algorithms/test_utils.hpp
@@ -151,6 +151,7 @@ namespace test
         }
     };
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     template <typename IteratorTag>
     struct test_num_exceptions<hpx::parallel::execution_policy, IteratorTag>
     {
@@ -180,6 +181,7 @@ namespace test
             HPX_TEST_EQ(e.size(), 1u);
         }
     };
+#endif
 
     ///////////////////////////////////////////////////////////////////////////
     inline std::vector<std::size_t> iota(std::size_t size, std::size_t start)

--- a/tests/unit/parallel/algorithms/transform.cpp
+++ b/tests/unit/parallel/algorithms/transform.cpp
@@ -93,12 +93,14 @@ void test_transform()
     test_transform_async(seq(task), IteratorTag());
     test_transform_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform(execution_policy(seq), IteratorTag());
     test_transform(execution_policy(par), IteratorTag());
     test_transform(execution_policy(par_vec), IteratorTag());
 
     test_transform(execution_policy(seq(task)), IteratorTag());
     test_transform(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_test()
@@ -195,11 +197,13 @@ void test_transform_exception()
     test_transform_exception_async(seq(task), IteratorTag());
     test_transform_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_exception(execution_policy(seq), IteratorTag());
     test_transform_exception(execution_policy(par), IteratorTag());
 
     test_transform_exception(execution_policy(seq(task)), IteratorTag());
     test_transform_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_exception_test()
@@ -294,11 +298,13 @@ void test_transform_bad_alloc()
     test_transform_bad_alloc_async(seq(task), IteratorTag());
     test_transform_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_bad_alloc(execution_policy(seq), IteratorTag());
     test_transform_bad_alloc(execution_policy(par), IteratorTag());
 
     test_transform_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_transform_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/transform_binary.cpp
+++ b/tests/unit/parallel/algorithms/transform_binary.cpp
@@ -113,12 +113,14 @@ void test_transform_binary()
     test_transform_binary_async(seq(task), IteratorTag());
     test_transform_binary_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_binary(execution_policy(seq), IteratorTag());
     test_transform_binary(execution_policy(par), IteratorTag());
     test_transform_binary(execution_policy(par_vec), IteratorTag());
 
     test_transform_binary(execution_policy(seq(task)), IteratorTag());
     test_transform_binary(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_binary_test()
@@ -220,11 +222,13 @@ void test_transform_binary_exception()
     test_transform_binary_exception_async(seq(task), IteratorTag());
     test_transform_binary_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_binary_exception(execution_policy(seq), IteratorTag());
     test_transform_binary_exception(execution_policy(par), IteratorTag());
 
     test_transform_binary_exception(execution_policy(seq(task)), IteratorTag());
     test_transform_binary_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_binary_exception_test()
@@ -324,11 +328,13 @@ void test_transform_binary_bad_alloc()
     test_transform_binary_bad_alloc_async(seq(task), IteratorTag());
     test_transform_binary_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_binary_bad_alloc(execution_policy(seq), IteratorTag());
     test_transform_binary_bad_alloc(execution_policy(par), IteratorTag());
 
     test_transform_binary_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_transform_binary_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_binary_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/transform_binary2.cpp
+++ b/tests/unit/parallel/algorithms/transform_binary2.cpp
@@ -113,12 +113,14 @@ void test_transform_binary()
     test_transform_binary_async(seq(task), IteratorTag());
     test_transform_binary_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_binary(execution_policy(seq), IteratorTag());
     test_transform_binary(execution_policy(par), IteratorTag());
     test_transform_binary(execution_policy(par_vec), IteratorTag());
 
     test_transform_binary(execution_policy(seq(task)), IteratorTag());
     test_transform_binary(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_binary_test()
@@ -220,11 +222,13 @@ void test_transform_binary_exception()
     test_transform_binary_exception_async(seq(task), IteratorTag());
     test_transform_binary_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_binary_exception(execution_policy(seq), IteratorTag());
     test_transform_binary_exception(execution_policy(par), IteratorTag());
 
     test_transform_binary_exception(execution_policy(seq(task)), IteratorTag());
     test_transform_binary_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_binary_exception_test()
@@ -324,11 +328,13 @@ void test_transform_binary_bad_alloc()
     test_transform_binary_bad_alloc_async(seq(task), IteratorTag());
     test_transform_binary_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_binary_bad_alloc(execution_policy(seq), IteratorTag());
     test_transform_binary_bad_alloc(execution_policy(par), IteratorTag());
 
     test_transform_binary_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_transform_binary_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_binary_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/transform_exclusive_scan.cpp
+++ b/tests/unit/parallel/algorithms/transform_exclusive_scan.cpp
@@ -83,12 +83,14 @@ void test_transform_exclusive_scan()
     test_transform_exclusive_scan_async(seq(task), IteratorTag());
     test_transform_exclusive_scan_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_exclusive_scan(execution_policy(seq), IteratorTag());
     test_transform_exclusive_scan(execution_policy(par), IteratorTag());
     test_transform_exclusive_scan(execution_policy(par_vec), IteratorTag());
 
     test_transform_exclusive_scan(execution_policy(seq(task)), IteratorTag());
     test_transform_exclusive_scan(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_exclusive_scan_test()
@@ -193,11 +195,13 @@ void test_transform_exclusive_scan_exception()
     test_transform_exclusive_scan_exception_async(seq(task), IteratorTag());
     test_transform_exclusive_scan_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_exclusive_scan_exception(execution_policy(seq), IteratorTag());
     test_transform_exclusive_scan_exception(execution_policy(par), IteratorTag());
 
     test_transform_exclusive_scan_exception(execution_policy(seq(task)), IteratorTag());
     test_transform_exclusive_scan_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_exclusive_scan_exception_test()
@@ -300,11 +304,13 @@ void test_transform_exclusive_scan_bad_alloc()
     test_transform_exclusive_scan_bad_alloc_async(seq(task), IteratorTag());
     test_transform_exclusive_scan_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_exclusive_scan_bad_alloc(execution_policy(seq), IteratorTag());
     test_transform_exclusive_scan_bad_alloc(execution_policy(par), IteratorTag());
 
     test_transform_exclusive_scan_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_transform_exclusive_scan_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_exclusive_scan_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/transform_inclusive_scan.cpp
+++ b/tests/unit/parallel/algorithms/transform_inclusive_scan.cpp
@@ -83,12 +83,14 @@ void test_transform_inclusive_scan1()
     test_transform_inclusive_scan1_async(seq(task), IteratorTag());
     test_transform_inclusive_scan1_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_inclusive_scan1(execution_policy(seq), IteratorTag());
     test_transform_inclusive_scan1(execution_policy(par), IteratorTag());
     test_transform_inclusive_scan1(execution_policy(par_vec), IteratorTag());
 
     test_transform_inclusive_scan1(execution_policy(seq(task)), IteratorTag());
     test_transform_inclusive_scan1(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_inclusive_scan_test1()
@@ -169,12 +171,14 @@ void test_transform_inclusive_scan2()
     test_transform_inclusive_scan2_async(seq(task), IteratorTag());
     test_transform_inclusive_scan2_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_inclusive_scan2(execution_policy(seq), IteratorTag());
     test_transform_inclusive_scan2(execution_policy(par), IteratorTag());
     test_transform_inclusive_scan2(execution_policy(par_vec), IteratorTag());
 
     test_transform_inclusive_scan2(execution_policy(seq(task)), IteratorTag());
     test_transform_inclusive_scan2(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_inclusive_scan_test2()
@@ -279,11 +283,13 @@ void test_transform_inclusive_scan_exception()
     test_transform_inclusive_scan_exception_async(seq(task), IteratorTag());
     test_transform_inclusive_scan_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_inclusive_scan_exception(execution_policy(seq), IteratorTag());
     test_transform_inclusive_scan_exception(execution_policy(par), IteratorTag());
 
     test_transform_inclusive_scan_exception(execution_policy(seq(task)), IteratorTag());
     test_transform_inclusive_scan_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_inclusive_scan_exception_test()
@@ -386,11 +392,13 @@ void test_transform_inclusive_scan_bad_alloc()
     test_transform_inclusive_scan_bad_alloc_async(seq(task), IteratorTag());
     test_transform_inclusive_scan_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_inclusive_scan_bad_alloc(execution_policy(seq), IteratorTag());
     test_transform_inclusive_scan_bad_alloc(execution_policy(par), IteratorTag());
 
     test_transform_inclusive_scan_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_transform_inclusive_scan_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_inclusive_scan_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/transform_reduce.cpp
+++ b/tests/unit/parallel/algorithms/transform_reduce.cpp
@@ -101,12 +101,14 @@ void test_transform_reduce()
     test_transform_reduce_async(seq(task), IteratorTag());
     test_transform_reduce_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_reduce(execution_policy(seq), IteratorTag());
     test_transform_reduce(execution_policy(par), IteratorTag());
     test_transform_reduce(execution_policy(par_vec), IteratorTag());
 
     test_transform_reduce(execution_policy(seq(task)), IteratorTag());
     test_transform_reduce(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_reduce_test()
@@ -208,11 +210,13 @@ void test_transform_reduce_exception()
     test_transform_reduce_exception_async(seq(task), IteratorTag());
     test_transform_reduce_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_reduce_exception(execution_policy(seq), IteratorTag());
     test_transform_reduce_exception(execution_policy(par), IteratorTag());
 
     test_transform_reduce_exception(execution_policy(seq(task)), IteratorTag());
     test_transform_reduce_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_reduce_exception_test()
@@ -312,11 +316,13 @@ void test_transform_reduce_bad_alloc()
     test_transform_reduce_bad_alloc_async(seq(task), IteratorTag());
     test_transform_reduce_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_reduce_bad_alloc(execution_policy(seq), IteratorTag());
     test_transform_reduce_bad_alloc(execution_policy(par), IteratorTag());
 
     test_transform_reduce_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_transform_reduce_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_reduce_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/uninitialized_copy.cpp
+++ b/tests/unit/parallel/algorithms/uninitialized_copy.cpp
@@ -20,12 +20,14 @@ void test_uninitialized_copy()
     test_uninitialized_copy_async(seq(task), IteratorTag());
     test_uninitialized_copy_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_uninitialized_copy(execution_policy(seq), IteratorTag());
     test_uninitialized_copy(execution_policy(par), IteratorTag());
     test_uninitialized_copy(execution_policy(par_vec), IteratorTag());
 
     test_uninitialized_copy(execution_policy(seq(task)), IteratorTag());
     test_uninitialized_copy(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void uninitialized_copy_test()
@@ -50,11 +52,13 @@ void test_uninitialized_copy_exception()
     test_uninitialized_copy_exception_async(seq(task), IteratorTag());
     test_uninitialized_copy_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_uninitialized_copy_exception(execution_policy(seq), IteratorTag());
     test_uninitialized_copy_exception(execution_policy(par), IteratorTag());
 
     test_uninitialized_copy_exception(execution_policy(seq(task)), IteratorTag());
     test_uninitialized_copy_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void uninitialized_copy_exception_test()
@@ -79,11 +83,13 @@ void test_uninitialized_copy_bad_alloc()
     test_uninitialized_copy_bad_alloc_async(seq(task), IteratorTag());
     test_uninitialized_copy_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_uninitialized_copy_bad_alloc(execution_policy(seq), IteratorTag());
     test_uninitialized_copy_bad_alloc(execution_policy(par), IteratorTag());
 
     test_uninitialized_copy_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_uninitialized_copy_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void uninitialized_copy_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/uninitialized_copyn.cpp
+++ b/tests/unit/parallel/algorithms/uninitialized_copyn.cpp
@@ -77,12 +77,14 @@ void test_uninitialized_copy_n()
     test_uninitialized_copy_n_async(seq(task), IteratorTag());
     test_uninitialized_copy_n_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_uninitialized_copy_n(execution_policy(seq), IteratorTag());
     test_uninitialized_copy_n(execution_policy(par), IteratorTag());
     test_uninitialized_copy_n(execution_policy(par_vec), IteratorTag());
 
     test_uninitialized_copy_n(execution_policy(seq(task)), IteratorTag());
     test_uninitialized_copy_n(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void uninitialized_copy_n_test()
@@ -198,11 +200,13 @@ void test_uninitialized_copy_n_exception()
     test_uninitialized_copy_n_exception_async(seq(task), IteratorTag());
     test_uninitialized_copy_n_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_uninitialized_copy_n_exception(execution_policy(seq), IteratorTag());
     test_uninitialized_copy_n_exception(execution_policy(par), IteratorTag());
 
     test_uninitialized_copy_n_exception(execution_policy(seq(task)), IteratorTag());
     test_uninitialized_copy_n_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void uninitialized_copy_n_exception_test()
@@ -317,11 +321,13 @@ void test_uninitialized_copy_n_bad_alloc()
     test_uninitialized_copy_n_bad_alloc_async(seq(task), IteratorTag());
     test_uninitialized_copy_n_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_uninitialized_copy_n_bad_alloc(execution_policy(seq), IteratorTag());
     test_uninitialized_copy_n_bad_alloc(execution_policy(par), IteratorTag());
 
     test_uninitialized_copy_n_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_uninitialized_copy_n_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void uninitialized_copy_n_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/uninitialized_fill.cpp
+++ b/tests/unit/parallel/algorithms/uninitialized_fill.cpp
@@ -74,12 +74,14 @@ void test_uninitialized_fill()
     test_uninitialized_fill_async(seq(task), IteratorTag());
     test_uninitialized_fill_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_uninitialized_fill(execution_policy(seq), IteratorTag());
     test_uninitialized_fill(execution_policy(par), IteratorTag());
     test_uninitialized_fill(execution_policy(par_vec), IteratorTag());
 
     test_uninitialized_fill(execution_policy(seq(task)), IteratorTag());
     test_uninitialized_fill(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void uninitialized_fill_test()
@@ -193,11 +195,13 @@ void test_uninitialized_fill_exception()
     test_uninitialized_fill_exception_async(seq(task), IteratorTag());
     test_uninitialized_fill_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_uninitialized_fill_exception(execution_policy(seq), IteratorTag());
     test_uninitialized_fill_exception(execution_policy(par), IteratorTag());
 
     test_uninitialized_fill_exception(execution_policy(seq(task)), IteratorTag());
     test_uninitialized_fill_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void uninitialized_fill_exception_test()
@@ -309,11 +313,13 @@ void test_uninitialized_fill_bad_alloc()
     test_uninitialized_fill_bad_alloc_async(seq(task), IteratorTag());
     test_uninitialized_fill_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_uninitialized_fill_bad_alloc(execution_policy(seq), IteratorTag());
     test_uninitialized_fill_bad_alloc(execution_policy(par), IteratorTag());
 
     test_uninitialized_fill_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_uninitialized_fill_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void uninitialized_fill_bad_alloc_test()

--- a/tests/unit/parallel/algorithms/uninitialized_filln.cpp
+++ b/tests/unit/parallel/algorithms/uninitialized_filln.cpp
@@ -74,12 +74,14 @@ void test_uninitialized_fill_n()
     test_uninitialized_fill_n_async(seq(task), IteratorTag());
     test_uninitialized_fill_n_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_uninitialized_fill_n(execution_policy(seq), IteratorTag());
     test_uninitialized_fill_n(execution_policy(par), IteratorTag());
     test_uninitialized_fill_n(execution_policy(par_vec), IteratorTag());
 
     test_uninitialized_fill_n(execution_policy(seq(task)), IteratorTag());
     test_uninitialized_fill_n(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void uninitialized_fill_n_test()
@@ -193,11 +195,13 @@ void test_uninitialized_fill_n_exception()
     test_uninitialized_fill_n_exception_async(seq(task), IteratorTag());
     test_uninitialized_fill_n_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_uninitialized_fill_n_exception(execution_policy(seq), IteratorTag());
     test_uninitialized_fill_n_exception(execution_policy(par), IteratorTag());
 
     test_uninitialized_fill_n_exception(execution_policy(seq(task)), IteratorTag());
     test_uninitialized_fill_n_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void uninitialized_fill_n_exception_test()
@@ -309,11 +313,13 @@ void test_uninitialized_fill_n_bad_alloc()
     test_uninitialized_fill_n_bad_alloc_async(seq(task), IteratorTag());
     test_uninitialized_fill_n_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_uninitialized_fill_n_bad_alloc(execution_policy(seq), IteratorTag());
     test_uninitialized_fill_n_bad_alloc(execution_policy(par), IteratorTag());
 
     test_uninitialized_fill_n_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_uninitialized_fill_n_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void uninitialized_fill_n_bad_alloc_test()

--- a/tests/unit/parallel/container_algorithms/copy_range.cpp
+++ b/tests/unit/parallel/container_algorithms/copy_range.cpp
@@ -129,14 +129,16 @@ void test_copy()
     test_copy_async(seq(task), IteratorTag());
     test_copy_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_copy(execution_policy(seq), IteratorTag());
     test_copy(execution_policy(par), IteratorTag());
     test_copy(execution_policy(par_vec), IteratorTag());
 
     test_copy(execution_policy(seq(task)), IteratorTag());
     test_copy(execution_policy(par(task)), IteratorTag());
+#endif
 
-    //assure output iterator will work
+    // assure output iterator will work
     test_copy_outiter(seq, IteratorTag());
     test_copy_outiter(par, IteratorTag());
     test_copy_outiter(par_vec, IteratorTag());
@@ -144,12 +146,14 @@ void test_copy()
     test_copy_outiter_async(seq(task), IteratorTag());
     test_copy_outiter_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_copy_outiter(execution_policy(seq), IteratorTag());
     test_copy_outiter(execution_policy(par), IteratorTag());
     test_copy_outiter(execution_policy(par_vec), IteratorTag());
 
     test_copy_outiter(execution_policy(seq(task)), IteratorTag());
     test_copy_outiter(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void copy_test()
@@ -250,11 +254,13 @@ void test_copy_exception()
     test_copy_exception_async(seq(task), IteratorTag());
     test_copy_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_copy_exception(execution_policy(seq), IteratorTag());
     test_copy_exception(execution_policy(par), IteratorTag());
 
     test_copy_exception(execution_policy(seq(task)), IteratorTag());
     test_copy_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void copy_exception_test()
@@ -353,11 +359,13 @@ void test_copy_bad_alloc()
     test_copy_bad_alloc_async(seq(task), IteratorTag());
     test_copy_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_copy_bad_alloc(execution_policy(seq), IteratorTag());
     test_copy_bad_alloc(execution_policy(par), IteratorTag());
 
     test_copy_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_copy_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void copy_bad_alloc_test()

--- a/tests/unit/parallel/container_algorithms/copyif_range.cpp
+++ b/tests/unit/parallel/container_algorithms/copyif_range.cpp
@@ -154,12 +154,14 @@ void test_copy_if()
     test_copy_if_async(seq(task));
     test_copy_if_async(par(task));
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_copy_if(execution_policy(seq));
     test_copy_if(execution_policy(par));
     test_copy_if(execution_policy(par_vec));
 
     test_copy_if(execution_policy(seq(task)));
     test_copy_if(execution_policy(par(task)));
+#endif
 
     test_copy_if_outiter(seq);
     test_copy_if_outiter(par);
@@ -168,12 +170,14 @@ void test_copy_if()
     test_copy_if_outiter_async(seq(task));
     test_copy_if_outiter_async(par(task));
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_copy_if_outiter(execution_policy(seq));
     test_copy_if_outiter(execution_policy(par));
     test_copy_if_outiter(execution_policy(par_vec));
 
     test_copy_if_outiter(execution_policy(seq(task)));
     test_copy_if_outiter(execution_policy(par(task)));
+#endif
 }
 
 int hpx_main(boost::program_options::variables_map& vm)

--- a/tests/unit/parallel/container_algorithms/foreach_range.cpp
+++ b/tests/unit/parallel/container_algorithms/foreach_range.cpp
@@ -21,12 +21,14 @@ void test_for_each()
     test_for_each_async(seq(task), IteratorTag());
     test_for_each_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_for_each(execution_policy(seq), IteratorTag());
     test_for_each(execution_policy(par), IteratorTag());
     test_for_each(execution_policy(par_vec), IteratorTag());
 
     test_for_each(execution_policy(seq(task)), IteratorTag());
     test_for_each(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void for_each_test()
@@ -55,10 +57,12 @@ void test_for_each_exception()
     test_for_each_exception_async(seq(task), IteratorTag());
     test_for_each_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_for_each_exception(execution_policy(seq), IteratorTag());
     test_for_each_exception(execution_policy(par), IteratorTag());
     test_for_each_exception(execution_policy(seq(task)), IteratorTag());
     test_for_each_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void for_each_exception_test()
@@ -83,10 +87,12 @@ void test_for_each_bad_alloc()
     test_for_each_bad_alloc_async(seq(task), IteratorTag());
     test_for_each_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_for_each_bad_alloc(execution_policy(seq), IteratorTag());
     test_for_each_bad_alloc(execution_policy(par), IteratorTag());
     test_for_each_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_for_each_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void for_each_bad_alloc_test()

--- a/tests/unit/parallel/container_algorithms/foreach_range_projection.cpp
+++ b/tests/unit/parallel/container_algorithms/foreach_range_projection.cpp
@@ -21,12 +21,14 @@ void test_for_each()
     test_for_each_async(seq(task), IteratorTag(), Proj());
     test_for_each_async(par(task), IteratorTag(), Proj());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_for_each(execution_policy(seq), IteratorTag(), Proj());
     test_for_each(execution_policy(par), IteratorTag(), Proj());
     test_for_each(execution_policy(par_vec), IteratorTag(), Proj());
 
     test_for_each(execution_policy(seq(task)), IteratorTag(), Proj());
     test_for_each(execution_policy(par(task)), IteratorTag(), Proj());
+#endif
 }
 
 template <typename Proj>
@@ -52,10 +54,12 @@ void test_for_each_exception()
     test_for_each_exception_async(seq(task), IteratorTag(), Proj());
     test_for_each_exception_async(par(task), IteratorTag(), Proj());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_for_each_exception(execution_policy(seq), IteratorTag(), Proj());
     test_for_each_exception(execution_policy(par), IteratorTag(), Proj());
     test_for_each_exception(execution_policy(seq(task)), IteratorTag(), Proj());
     test_for_each_exception(execution_policy(par(task)), IteratorTag(), Proj());
+#endif
 }
 
 template <typename Proj>
@@ -81,10 +85,12 @@ void test_for_each_bad_alloc()
     test_for_each_bad_alloc_async(seq(task), IteratorTag(), Proj());
     test_for_each_bad_alloc_async(par(task), IteratorTag(), Proj());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_for_each_bad_alloc(execution_policy(seq), IteratorTag(), Proj());
     test_for_each_bad_alloc(execution_policy(par), IteratorTag(), Proj());
     test_for_each_bad_alloc(execution_policy(seq(task)), IteratorTag(), Proj());
     test_for_each_bad_alloc(execution_policy(par(task)), IteratorTag(), Proj());
+#endif
 }
 
 template <typename Proj>

--- a/tests/unit/parallel/container_algorithms/generate_range.cpp
+++ b/tests/unit/parallel/container_algorithms/generate_range.cpp
@@ -83,12 +83,14 @@ void test_generate()
     test_generate_async(seq(task), IteratorTag());
     test_generate_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_generate(execution_policy(seq), IteratorTag());
     test_generate(execution_policy(par), IteratorTag());
     test_generate(execution_policy(par_vec), IteratorTag());
 
     test_generate(execution_policy(seq(task)), IteratorTag());
     test_generate(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void generate_test()
@@ -187,11 +189,13 @@ void test_generate_exception()
     test_generate_exception_async(seq(task), IteratorTag());
     test_generate_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_generate_exception(execution_policy(seq), IteratorTag());
     test_generate_exception(execution_policy(par), IteratorTag());
 
     test_generate_exception(execution_policy(seq(task)), IteratorTag());
     test_generate_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void generate_exception_test()
@@ -289,11 +293,13 @@ void test_generate_bad_alloc()
     test_generate_bad_alloc_async(seq(task), IteratorTag());
     test_generate_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_generate_bad_alloc(execution_policy(seq), IteratorTag());
     test_generate_bad_alloc(execution_policy(par), IteratorTag());
 
     test_generate_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_generate_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void generate_bad_alloc_test()

--- a/tests/unit/parallel/container_algorithms/max_element_range.cpp
+++ b/tests/unit/parallel/container_algorithms/max_element_range.cpp
@@ -91,12 +91,14 @@ void test_max_element()
     test_max_element_async(seq(task), IteratorTag());
     test_max_element_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_max_element(execution_policy(seq), IteratorTag());
     test_max_element(execution_policy(par), IteratorTag());
     test_max_element(execution_policy(par_vec), IteratorTag());
 
     test_max_element(execution_policy(seq(task)), IteratorTag());
     test_max_element(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void max_element_test()
@@ -250,11 +252,13 @@ void test_max_element_exception()
     test_max_element_exception_async(seq(task), IteratorTag());
     test_max_element_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_max_element_exception(execution_policy(seq), IteratorTag());
     test_max_element_exception(execution_policy(par), IteratorTag());
 
     test_max_element_exception(execution_policy(seq(task)), IteratorTag());
     test_max_element_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void max_element_exception_test()
@@ -406,11 +410,13 @@ void test_max_element_bad_alloc()
     test_max_element_bad_alloc_async(seq(task), IteratorTag());
     test_max_element_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_max_element_bad_alloc(execution_policy(seq), IteratorTag());
     test_max_element_bad_alloc(execution_policy(par), IteratorTag());
 
     test_max_element_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_max_element_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void max_element_bad_alloc_test()

--- a/tests/unit/parallel/container_algorithms/min_element_range.cpp
+++ b/tests/unit/parallel/container_algorithms/min_element_range.cpp
@@ -92,12 +92,14 @@ void test_min_element()
     test_min_element_async(seq(task), IteratorTag());
     test_min_element_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_min_element(execution_policy(seq), IteratorTag());
     test_min_element(execution_policy(par), IteratorTag());
     test_min_element(execution_policy(par_vec), IteratorTag());
 
     test_min_element(execution_policy(seq(task)), IteratorTag());
     test_min_element(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void min_element_test()
@@ -253,11 +255,13 @@ void test_min_element_exception()
     test_min_element_exception_async(seq(task), IteratorTag());
     test_min_element_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_min_element_exception(execution_policy(seq), IteratorTag());
     test_min_element_exception(execution_policy(par), IteratorTag());
 
     test_min_element_exception(execution_policy(seq(task)), IteratorTag());
     test_min_element_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void min_element_exception_test()
@@ -409,11 +413,13 @@ void test_min_element_bad_alloc()
     test_min_element_bad_alloc_async(seq(task), IteratorTag());
     test_min_element_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_min_element_bad_alloc(execution_policy(seq), IteratorTag());
     test_min_element_bad_alloc(execution_policy(par), IteratorTag());
 
     test_min_element_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_min_element_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void min_element_bad_alloc_test()

--- a/tests/unit/parallel/container_algorithms/minmax_element_range.cpp
+++ b/tests/unit/parallel/container_algorithms/minmax_element_range.cpp
@@ -100,12 +100,14 @@ void test_minmax_element()
     test_minmax_element_async(seq(task), IteratorTag());
     test_minmax_element_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_minmax_element(execution_policy(seq), IteratorTag());
     test_minmax_element(execution_policy(par), IteratorTag());
     test_minmax_element(execution_policy(par_vec), IteratorTag());
 
     test_minmax_element(execution_policy(seq(task)), IteratorTag());
     test_minmax_element(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void minmax_element_test()
@@ -261,11 +263,13 @@ void test_minmax_element_exception()
     test_minmax_element_exception_async(seq(task), IteratorTag());
     test_minmax_element_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_minmax_element_exception(execution_policy(seq), IteratorTag());
     test_minmax_element_exception(execution_policy(par), IteratorTag());
 
     test_minmax_element_exception(execution_policy(seq(task)), IteratorTag());
     test_minmax_element_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void minmax_element_exception_test()
@@ -417,11 +421,13 @@ void test_minmax_element_bad_alloc()
     test_minmax_element_bad_alloc_async(seq(task), IteratorTag());
     test_minmax_element_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_minmax_element_bad_alloc(execution_policy(seq), IteratorTag());
     test_minmax_element_bad_alloc(execution_policy(par), IteratorTag());
 
     test_minmax_element_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_minmax_element_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void minmax_element_bad_alloc_test()

--- a/tests/unit/parallel/container_algorithms/remove_copy_if_range.cpp
+++ b/tests/unit/parallel/container_algorithms/remove_copy_if_range.cpp
@@ -166,12 +166,14 @@ void test_remove_copy_if()
     test_remove_copy_if_async(seq(task), IteratorTag());
     test_remove_copy_if_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_remove_copy_if(execution_policy(seq), IteratorTag());
     test_remove_copy_if(execution_policy(par), IteratorTag());
     test_remove_copy_if(execution_policy(par_vec), IteratorTag());
 
     test_remove_copy_if(execution_policy(seq(task)), IteratorTag());
     test_remove_copy_if(execution_policy(par(task)), IteratorTag());
+#endif
 
     test_remove_copy_if_outiter(seq, IteratorTag());
     test_remove_copy_if_outiter(par, IteratorTag());
@@ -180,12 +182,14 @@ void test_remove_copy_if()
     test_remove_copy_if_outiter_async(seq(task), IteratorTag());
     test_remove_copy_if_outiter_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_remove_copy_if_outiter(execution_policy(seq), IteratorTag());
     test_remove_copy_if_outiter(execution_policy(par), IteratorTag());
     test_remove_copy_if_outiter(execution_policy(par_vec), IteratorTag());
 
     test_remove_copy_if_outiter(execution_policy(seq(task)), IteratorTag());
     test_remove_copy_if_outiter(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void remove_copy_if_test()
@@ -281,11 +285,13 @@ void test_remove_copy_if_exception()
     test_remove_copy_if_exception_async(seq(task), IteratorTag());
     test_remove_copy_if_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_remove_copy_if_exception(execution_policy(seq), IteratorTag());
     test_remove_copy_if_exception(execution_policy(par), IteratorTag());
 
     test_remove_copy_if_exception(execution_policy(seq(task)), IteratorTag());
     test_remove_copy_if_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void remove_copy_if_exception_test()
@@ -380,11 +386,13 @@ void test_remove_copy_if_bad_alloc()
     test_remove_copy_if_bad_alloc_async(seq(task), IteratorTag());
     test_remove_copy_if_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_remove_copy_if_bad_alloc(execution_policy(seq), IteratorTag());
     test_remove_copy_if_bad_alloc(execution_policy(par), IteratorTag());
 
     test_remove_copy_if_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_remove_copy_if_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void remove_copy_if_bad_alloc_test()

--- a/tests/unit/parallel/container_algorithms/remove_copy_range.cpp
+++ b/tests/unit/parallel/container_algorithms/remove_copy_range.cpp
@@ -159,12 +159,14 @@ void test_remove_copy()
     test_remove_copy_async(seq(task), IteratorTag());
     test_remove_copy_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_remove_copy(execution_policy(seq), IteratorTag());
     test_remove_copy(execution_policy(par), IteratorTag());
     test_remove_copy(execution_policy(par_vec), IteratorTag());
 
     test_remove_copy(execution_policy(seq(task)), IteratorTag());
     test_remove_copy(execution_policy(par(task)), IteratorTag());
+#endif
 
     //assure output iterator will work
     test_remove_copy_outiter(seq, IteratorTag());
@@ -174,12 +176,14 @@ void test_remove_copy()
     test_remove_copy_outiter_async(seq(task), IteratorTag());
     test_remove_copy_outiter_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_remove_copy_outiter(execution_policy(seq), IteratorTag());
     test_remove_copy_outiter(execution_policy(par), IteratorTag());
     test_remove_copy_outiter(execution_policy(par_vec), IteratorTag());
 
     test_remove_copy_outiter(execution_policy(seq(task)), IteratorTag());
     test_remove_copy_outiter(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void remove_copy_test()
@@ -280,11 +284,13 @@ void test_remove_copy_exception()
     test_remove_copy_exception_async(seq(task), IteratorTag());
     test_remove_copy_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_remove_copy_exception(execution_policy(seq), IteratorTag());
     test_remove_copy_exception(execution_policy(par), IteratorTag());
 
     test_remove_copy_exception(execution_policy(seq(task)), IteratorTag());
     test_remove_copy_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void remove_copy_exception_test()
@@ -383,11 +389,13 @@ void test_remove_copy_bad_alloc()
     test_remove_copy_bad_alloc_async(seq(task), IteratorTag());
     test_remove_copy_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_remove_copy_bad_alloc(execution_policy(seq), IteratorTag());
     test_remove_copy_bad_alloc(execution_policy(par), IteratorTag());
 
     test_remove_copy_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_remove_copy_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void remove_copy_bad_alloc_test()

--- a/tests/unit/parallel/container_algorithms/replace_copy_if_range.cpp
+++ b/tests/unit/parallel/container_algorithms/replace_copy_if_range.cpp
@@ -106,12 +106,14 @@ void test_replace_copy_if()
     test_replace_copy_if_async(seq(task), IteratorTag());
     test_replace_copy_if_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace_copy_if(execution_policy(seq), IteratorTag());
     test_replace_copy_if(execution_policy(par), IteratorTag());
     test_replace_copy_if(execution_policy(par_vec), IteratorTag());
 
     test_replace_copy_if(execution_policy(seq(task)), IteratorTag());
     test_replace_copy_if(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_copy_if_test()
@@ -212,11 +214,13 @@ void test_replace_copy_if_exception()
     test_replace_copy_if_exception_async(seq(task), IteratorTag());
     test_replace_copy_if_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace_copy_if_exception(execution_policy(seq), IteratorTag());
     test_replace_copy_if_exception(execution_policy(par), IteratorTag());
 
     test_replace_copy_if_exception(execution_policy(seq(task)), IteratorTag());
     test_replace_copy_if_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_copy_if_exception_test()
@@ -315,11 +319,13 @@ void test_replace_copy_if_bad_alloc()
     test_replace_copy_if_bad_alloc_async(seq(task), IteratorTag());
     test_replace_copy_if_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace_copy_if_bad_alloc(execution_policy(seq), IteratorTag());
     test_replace_copy_if_bad_alloc(execution_policy(par), IteratorTag());
 
     test_replace_copy_if_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_replace_copy_if_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_copy_if_bad_alloc_test()

--- a/tests/unit/parallel/container_algorithms/replace_copy_range.cpp
+++ b/tests/unit/parallel/container_algorithms/replace_copy_range.cpp
@@ -91,12 +91,14 @@ void test_replace_copy()
     test_replace_copy_async(seq(task), IteratorTag());
     test_replace_copy_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace_copy(execution_policy(seq), IteratorTag());
     test_replace_copy(execution_policy(par), IteratorTag());
     test_replace_copy(execution_policy(par_vec), IteratorTag());
 
     test_replace_copy(execution_policy(seq(task)), IteratorTag());
     test_replace_copy(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_copy_test()
@@ -197,11 +199,13 @@ void test_replace_copy_exception()
     test_replace_copy_exception_async(seq(task), IteratorTag());
     test_replace_copy_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace_copy_exception(execution_policy(seq), IteratorTag());
     test_replace_copy_exception(execution_policy(par), IteratorTag());
 
     test_replace_copy_exception(execution_policy(seq(task)), IteratorTag());
     test_replace_copy_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_copy_exception_test()
@@ -300,11 +304,13 @@ void test_replace_copy_bad_alloc()
     test_replace_copy_bad_alloc_async(seq(task), IteratorTag());
     test_replace_copy_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace_copy_bad_alloc(execution_policy(seq), IteratorTag());
     test_replace_copy_bad_alloc(execution_policy(par), IteratorTag());
 
     test_replace_copy_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_replace_copy_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_copy_bad_alloc_test()

--- a/tests/unit/parallel/container_algorithms/replace_if_range.cpp
+++ b/tests/unit/parallel/container_algorithms/replace_if_range.cpp
@@ -101,12 +101,14 @@ void test_replace_if()
     test_replace_if_async(seq(task), IteratorTag());
     test_replace_if_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace_if(execution_policy(seq), IteratorTag());
     test_replace_if(execution_policy(par), IteratorTag());
     test_replace_if(execution_policy(par_vec), IteratorTag());
 
     test_replace_if(execution_policy(seq(task)), IteratorTag());
     test_replace_if(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_if_test()
@@ -204,11 +206,13 @@ void test_replace_if_exception()
     test_replace_if_exception_async(seq(task), IteratorTag());
     test_replace_if_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace_if_exception(execution_policy(seq), IteratorTag());
     test_replace_if_exception(execution_policy(par), IteratorTag());
 
     test_replace_if_exception(execution_policy(seq(task)), IteratorTag());
     test_replace_if_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_if_exception_test()
@@ -304,11 +308,13 @@ void test_replace_if_bad_alloc()
     test_replace_if_bad_alloc_async(seq(task), IteratorTag());
     test_replace_if_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace_if_bad_alloc(execution_policy(seq), IteratorTag());
     test_replace_if_bad_alloc(execution_policy(par), IteratorTag());
 
     test_replace_if_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_replace_if_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_if_bad_alloc_test()

--- a/tests/unit/parallel/container_algorithms/replace_range.cpp
+++ b/tests/unit/parallel/container_algorithms/replace_range.cpp
@@ -89,12 +89,14 @@ void test_replace()
     test_replace_async(seq(task), IteratorTag());
     test_replace_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace(execution_policy(seq), IteratorTag());
     test_replace(execution_policy(par), IteratorTag());
     test_replace(execution_policy(par_vec), IteratorTag());
 
     test_replace(execution_policy(seq(task)), IteratorTag());
     test_replace(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_test()
@@ -192,11 +194,13 @@ void test_replace_exception()
     test_replace_exception_async(seq(task), IteratorTag());
     test_replace_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace_exception(execution_policy(seq), IteratorTag());
     test_replace_exception(execution_policy(par), IteratorTag());
 
     test_replace_exception(execution_policy(seq(task)), IteratorTag());
     test_replace_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_exception_test()
@@ -292,11 +296,13 @@ void test_replace_bad_alloc()
     test_replace_bad_alloc_async(seq(task), IteratorTag());
     test_replace_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_replace_bad_alloc(execution_policy(seq), IteratorTag());
     test_replace_bad_alloc(execution_policy(par), IteratorTag());
 
     test_replace_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_replace_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void replace_bad_alloc_test()

--- a/tests/unit/parallel/container_algorithms/reverse_copy_range.cpp
+++ b/tests/unit/parallel/container_algorithms/reverse_copy_range.cpp
@@ -87,12 +87,14 @@ void test_reverse_copy()
     test_reverse_copy_async(seq(task), IteratorTag());
     test_reverse_copy_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_reverse_copy(execution_policy(seq), IteratorTag());
     test_reverse_copy(execution_policy(par), IteratorTag());
     test_reverse_copy(execution_policy(par_vec), IteratorTag());
 
     test_reverse_copy(execution_policy(seq(task)), IteratorTag());
     test_reverse_copy(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void reverse_copy_test()
@@ -194,11 +196,13 @@ void test_reverse_copy_exception()
     test_reverse_copy_exception_async(seq(task), IteratorTag());
     test_reverse_copy_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_reverse_copy_exception(execution_policy(seq), IteratorTag());
     test_reverse_copy_exception(execution_policy(par), IteratorTag());
 
     test_reverse_copy_exception(execution_policy(seq(task)), IteratorTag());
     test_reverse_copy_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void reverse_copy_exception_test()
@@ -298,11 +302,13 @@ void test_reverse_copy_bad_alloc()
     test_reverse_copy_bad_alloc_async(seq(task), IteratorTag());
     test_reverse_copy_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_reverse_copy_bad_alloc(execution_policy(seq), IteratorTag());
     test_reverse_copy_bad_alloc(execution_policy(par), IteratorTag());
 
     test_reverse_copy_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_reverse_copy_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void reverse_copy_bad_alloc_test()

--- a/tests/unit/parallel/container_algorithms/reverse_range.cpp
+++ b/tests/unit/parallel/container_algorithms/reverse_range.cpp
@@ -87,12 +87,14 @@ void test_reverse()
     test_reverse_async(seq(task), IteratorTag());
     test_reverse_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_reverse(execution_policy(seq), IteratorTag());
     test_reverse(execution_policy(par), IteratorTag());
     test_reverse(execution_policy(par_vec), IteratorTag());
 
     test_reverse(execution_policy(seq(task)), IteratorTag());
     test_reverse(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void reverse_test()
@@ -190,11 +192,13 @@ void test_reverse_exception()
     test_reverse_exception_async(seq(task), IteratorTag());
     test_reverse_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_reverse_exception(execution_policy(seq), IteratorTag());
     test_reverse_exception(execution_policy(par), IteratorTag());
 
     test_reverse_exception(execution_policy(seq(task)), IteratorTag());
     test_reverse_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void reverse_exception_test()
@@ -290,11 +294,13 @@ void test_reverse_bad_alloc()
     test_reverse_bad_alloc_async(seq(task), IteratorTag());
     test_reverse_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_reverse_bad_alloc(execution_policy(seq), IteratorTag());
     test_reverse_bad_alloc(execution_policy(par), IteratorTag());
 
     test_reverse_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_reverse_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void reverse_bad_alloc_test()

--- a/tests/unit/parallel/container_algorithms/rotate_copy_range.cpp
+++ b/tests/unit/parallel/container_algorithms/rotate_copy_range.cpp
@@ -103,12 +103,14 @@ void test_rotate_copy()
     test_rotate_copy_async(seq(task), IteratorTag());
     test_rotate_copy_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_rotate_copy(execution_policy(seq), IteratorTag());
     test_rotate_copy(execution_policy(par), IteratorTag());
     test_rotate_copy(execution_policy(par_vec), IteratorTag());
 
     test_rotate_copy(execution_policy(seq(task)), IteratorTag());
     test_rotate_copy(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void rotate_copy_test()
@@ -222,11 +224,13 @@ void test_rotate_copy_exception()
     test_rotate_copy_exception_async(seq(task), IteratorTag());
     test_rotate_copy_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_rotate_copy_exception(execution_policy(seq), IteratorTag());
     test_rotate_copy_exception(execution_policy(par), IteratorTag());
 
     test_rotate_copy_exception(execution_policy(seq(task)), IteratorTag());
     test_rotate_copy_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void rotate_copy_exception_test()
@@ -338,11 +342,13 @@ void test_rotate_copy_bad_alloc()
     test_rotate_copy_bad_alloc_async(seq(task), IteratorTag());
     test_rotate_copy_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_rotate_copy_bad_alloc(execution_policy(seq), IteratorTag());
     test_rotate_copy_bad_alloc(execution_policy(par), IteratorTag());
 
     test_rotate_copy_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_rotate_copy_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void rotate_copy_bad_alloc_test()

--- a/tests/unit/parallel/container_algorithms/rotate_range.cpp
+++ b/tests/unit/parallel/container_algorithms/rotate_range.cpp
@@ -100,12 +100,14 @@ void test_rotate()
     test_rotate_async(seq(task), IteratorTag());
     test_rotate_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_rotate(execution_policy(seq), IteratorTag());
     test_rotate(execution_policy(par), IteratorTag());
     test_rotate(execution_policy(par_vec), IteratorTag());
 
     test_rotate(execution_policy(seq(task)), IteratorTag());
     test_rotate(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void rotate_test()
@@ -215,11 +217,13 @@ void test_rotate_exception()
     test_rotate_exception_async(seq(task), IteratorTag());
     test_rotate_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_rotate_exception(execution_policy(seq), IteratorTag());
     test_rotate_exception(execution_policy(par), IteratorTag());
 
     test_rotate_exception(execution_policy(seq(task)), IteratorTag());
     test_rotate_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void rotate_exception_test()
@@ -327,11 +331,13 @@ void test_rotate_bad_alloc()
     test_rotate_bad_alloc_async(seq(task), IteratorTag());
     test_rotate_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_rotate_bad_alloc(execution_policy(seq), IteratorTag());
     test_rotate_bad_alloc(execution_policy(par), IteratorTag());
 
     test_rotate_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_rotate_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void rotate_bad_alloc_test()

--- a/tests/unit/parallel/container_algorithms/sort_range.cpp
+++ b/tests/unit/parallel/container_algorithms/sort_range.cpp
@@ -67,6 +67,7 @@ void test_sort1()
     test_sort1_async_string(seq(task), std::string(), std::greater<std::string>());
     test_sort1_async_string(par(task), std::string(), std::greater<std::string>());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_sort1(execution_policy(seq),       int());
     test_sort1(execution_policy(par),       int());
     test_sort1(execution_policy(par_vec),   int());
@@ -74,6 +75,7 @@ void test_sort1()
     test_sort1(execution_policy(par(task)), int());
     test_sort1(execution_policy(seq(task)), std::string());
     test_sort1(execution_policy(par(task)), std::string());
+#endif
 }
 
 void test_sort2()
@@ -112,11 +114,13 @@ void test_sort2()
     test_sort2_async(seq(task), double(), std::greater<double>());
     test_sort2_async(par(task), float(),  std::greater<float>());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_sort2(execution_policy(seq),       int());
     test_sort2(execution_policy(par),       int());
     test_sort2(execution_policy(par_vec),   int());
     test_sort2(execution_policy(seq(task)), int());
     test_sort2(execution_policy(par(task)), int());
+#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/parallel/container_algorithms/test_utils.hpp
+++ b/tests/unit/parallel/container_algorithms/test_utils.hpp
@@ -197,6 +197,7 @@ namespace test
         }
     };
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     template <typename IteratorTag>
     struct test_num_exceptions<hpx::parallel::execution_policy, IteratorTag>
     {
@@ -226,6 +227,7 @@ namespace test
             HPX_TEST_EQ(e.size(), 1u);
         }
     };
+#endif
 
     ///////////////////////////////////////////////////////////////////////////
     inline std::vector<std::size_t> iota(std::size_t size, std::size_t start)

--- a/tests/unit/parallel/container_algorithms/transform_range.cpp
+++ b/tests/unit/parallel/container_algorithms/transform_range.cpp
@@ -97,12 +97,14 @@ void test_transform()
     test_transform_async(seq(task), IteratorTag());
     test_transform_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform(execution_policy(seq), IteratorTag());
     test_transform(execution_policy(par), IteratorTag());
     test_transform(execution_policy(par_vec), IteratorTag());
 
     test_transform(execution_policy(seq(task)), IteratorTag());
     test_transform(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_test()
@@ -202,11 +204,13 @@ void test_transform_exception()
     test_transform_exception_async(seq(task), IteratorTag());
     test_transform_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_exception(execution_policy(seq), IteratorTag());
     test_transform_exception(execution_policy(par), IteratorTag());
 
     test_transform_exception(execution_policy(seq(task)), IteratorTag());
     test_transform_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_exception_test()
@@ -304,11 +308,13 @@ void test_transform_bad_alloc()
     test_transform_bad_alloc_async(seq(task), IteratorTag());
     test_transform_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_bad_alloc(execution_policy(seq), IteratorTag());
     test_transform_bad_alloc(execution_policy(par), IteratorTag());
 
     test_transform_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_transform_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_bad_alloc_test()

--- a/tests/unit/parallel/container_algorithms/transform_range_binary.cpp
+++ b/tests/unit/parallel/container_algorithms/transform_range_binary.cpp
@@ -113,12 +113,14 @@ void test_transform_binary()
     test_transform_binary_async(seq(task), IteratorTag());
     test_transform_binary_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_binary(execution_policy(seq), IteratorTag());
     test_transform_binary(execution_policy(par), IteratorTag());
     test_transform_binary(execution_policy(par_vec), IteratorTag());
 
     test_transform_binary(execution_policy(seq(task)), IteratorTag());
     test_transform_binary(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_binary_test()
@@ -222,11 +224,13 @@ void test_transform_binary_exception()
     test_transform_binary_exception_async(seq(task), IteratorTag());
     test_transform_binary_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_binary_exception(execution_policy(seq), IteratorTag());
     test_transform_binary_exception(execution_policy(par), IteratorTag());
 
     test_transform_binary_exception(execution_policy(seq(task)), IteratorTag());
     test_transform_binary_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_binary_exception_test()
@@ -328,11 +332,13 @@ void test_transform_binary_bad_alloc()
     test_transform_binary_bad_alloc_async(seq(task), IteratorTag());
     test_transform_binary_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_binary_bad_alloc(execution_policy(seq), IteratorTag());
     test_transform_binary_bad_alloc(execution_policy(par), IteratorTag());
 
     test_transform_binary_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_transform_binary_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_binary_bad_alloc_test()

--- a/tests/unit/parallel/container_algorithms/transform_range_binary2.cpp
+++ b/tests/unit/parallel/container_algorithms/transform_range_binary2.cpp
@@ -113,12 +113,14 @@ void test_transform_binary()
     test_transform_binary_async(seq(task), IteratorTag());
     test_transform_binary_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_binary(execution_policy(seq), IteratorTag());
     test_transform_binary(execution_policy(par), IteratorTag());
     test_transform_binary(execution_policy(par_vec), IteratorTag());
 
     test_transform_binary(execution_policy(seq(task)), IteratorTag());
     test_transform_binary(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_binary_test()
@@ -228,11 +230,13 @@ void test_transform_binary_exception()
     test_transform_binary_exception_async(seq(task), IteratorTag());
     test_transform_binary_exception_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_binary_exception(execution_policy(seq), IteratorTag());
     test_transform_binary_exception(execution_policy(par), IteratorTag());
 
     test_transform_binary_exception(execution_policy(seq(task)), IteratorTag());
     test_transform_binary_exception(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_binary_exception_test()
@@ -340,11 +344,13 @@ void test_transform_binary_bad_alloc()
     test_transform_binary_bad_alloc_async(seq(task), IteratorTag());
     test_transform_binary_bad_alloc_async(par(task), IteratorTag());
 
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_transform_binary_bad_alloc(execution_policy(seq), IteratorTag());
     test_transform_binary_bad_alloc(execution_policy(par), IteratorTag());
 
     test_transform_binary_bad_alloc(execution_policy(seq(task)), IteratorTag());
     test_transform_binary_bad_alloc(execution_policy(par(task)), IteratorTag());
+#endif
 }
 
 void transform_binary_bad_alloc_test()

--- a/tests/unit/parallel/task_block.cpp
+++ b/tests/unit/parallel/task_block.cpp
@@ -115,6 +115,7 @@ void define_task_block_test2()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
 #if defined(HPX_HAVE_CXX14_LAMBDAS)
 void define_task_block_test3()
 {
@@ -163,6 +164,7 @@ void define_task_block_test3()
     HPX_TEST(task21_flag);
     HPX_TEST(task3_flag);
 }
+#endif
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -291,8 +293,10 @@ int hpx_main()
 {
     define_task_block_test1();
     define_task_block_test2();
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
 #if defined(HPX_HAVE_CXX14_LAMBDAS)
     define_task_block_test3();
+#endif
 #endif
 
     define_task_block_exceptions_test1();


### PR DESCRIPTION
This PR cleans up the implementation of all parallel algorithms, specifically:

- remove generic execution_policy by default (was removed from Parallelism TS V1 when moving to C++17)
- replace `boost::mpl::bool_` with `std::integral_value`
- replace `boost::enable_if` with `std::enable_if`
- replaced `<boost/type_traits/...>` with std `<type_traits>`
- adding various traits::is_iterator variations
- header cleanup (bye bye hpx_fwd.hpp, adding missing headers)