### PR TITLE
Refactor local::condition_variable

### DIFF
--- a/examples/quickstart/init_globally.cpp
+++ b/examples/quickstart/init_globally.cpp
@@ -98,7 +98,7 @@ struct manage_global_runtime
     {
         // notify hpx_main above to tear down the runtime
         {
-            std::lock_guard<hpx::lcos::local::spinlock> lk(mtx_);
+            std::lock_guard<hpx::lcos::local::mutex> lk(mtx_);
             rts_ = 0;               // reset pointer
         }
 
@@ -137,7 +137,7 @@ protected:
 
         // Now, wait for destructor to be called.
         {
-            std::unique_lock<hpx::lcos::local::spinlock> lk(mtx_);
+            boost::unique_lock<hpx::lcos::local::mutex> lk(mtx_);
             if (rts_ != 0)
                 cond_.wait(lk);
         }
@@ -147,7 +147,7 @@ protected:
     }
 
 private:
-    hpx::lcos::local::spinlock mtx_;
+    hpx::lcos::local::mutex mtx_;
     hpx::lcos::local::condition_variable cond_;
 
     std::mutex startup_mtx_;

--- a/hpx/exception_list.hpp
+++ b/hpx/exception_list.hpp
@@ -10,7 +10,6 @@
 
 #include <hpx/exception.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
-#include <hpx/util/unlock_guard.hpp>
 
 #include <boost/thread/locks.hpp>
 #include <boost/exception_ptr.hpp>

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -577,10 +577,8 @@ namespace detail
 
             // block if this entry is empty
             if (state_ == empty) {
-                cond_.wait(l, "future_data::wait", ec);
+                cond_.wait(std::move(l), "future_data::wait", ec);
                 if (ec) return;
-
-                HPX_ASSERT(state_ != empty);
             }
 
             if (&ec != &throws)
@@ -596,13 +594,13 @@ namespace detail
             // block if this entry is empty
             if (state_ == empty) {
                 threads::thread_state_ex_enum const reason =
-                    cond_.wait_until(l, abs_time, "future_data::wait_until", ec);
+                    cond_.wait_until(std::move(l), abs_time,
+                        "future_data::wait_until", ec);
                 if (ec) return future_status::uninitialized;
 
                 if (reason == threads::wait_timeout)
                     return future_status::timeout;
 
-                HPX_ASSERT(state_ != empty);
                 return future_status::ready;
             }
 

--- a/hpx/lcos/local/and_gate.hpp
+++ b/hpx/lcos/local/and_gate.hpp
@@ -12,6 +12,7 @@
 #include <hpx/lcos/local/no_mutex.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/assert_owns_lock.hpp>
+#include <hpx/util/unlock_guard.hpp>
 
 #include <boost/dynamic_bitset.hpp>
 #include <boost/thread/locks.hpp>

--- a/hpx/lcos/local/barrier.hpp
+++ b/hpx/lcos/local/barrier.hpp
@@ -40,7 +40,7 @@ namespace hpx { namespace lcos { namespace local
         {
             boost::unique_lock<mutex_type> l(mtx_);
             if (cond_.size(l) < number_of_threads_-1) {
-                cond_.wait(l, "barrier::wait");
+                cond_.wait(std::move(l), "barrier::wait");
             }
             else {
                 // release the threads

--- a/hpx/lcos/local/condition_variable.hpp
+++ b/hpx/lcos/local/condition_variable.hpp
@@ -8,8 +8,11 @@
 #define HPX_LCOS_LOCAL_CONDITION_VARIABLE_DEC_4_2013_0130PM
 
 #include <hpx/config.hpp>
+#include <hpx/exception_fwd.hpp>
 #include <hpx/lcos/local/detail/condition_variable.hpp>
+#include <hpx/lcos/local/mutex.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
+#include <hpx/util/assert_owns_lock.hpp>
 #include <hpx/util/unlock_guard.hpp>
 #include <hpx/util/date_time_chrono.hpp>
 
@@ -43,9 +46,111 @@ namespace hpx { namespace lcos { namespace local
             cond_.notify_all(std::move(l), ec);
         }
 
+        void wait(boost::unique_lock<mutex>& lock, error_code& ec = throws)
+        {
+            HPX_ASSERT_OWNS_LOCK(lock);
+
+            util::ignore_all_while_checking ignore_lock;
+            boost::unique_lock<mutex_type> l(mtx_);
+            util::unlock_guard<boost::unique_lock<mutex> > unlock(lock);
+
+            cond_.wait(l, ec);
+
+            l.unlock();
+        }
+
+        template <class Predicate>
+        void wait(boost::unique_lock<mutex>& lock, Predicate pred,
+            error_code& ec = throws)
+        {
+            HPX_ASSERT_OWNS_LOCK(lock);
+
+            while (!pred())
+            {
+                wait(lock);
+            }
+        }
+
+        cv_status wait_until(boost::unique_lock<mutex>& lock,
+            util::steady_time_point const& abs_time,
+            error_code& ec = throws)
+        {
+            HPX_ASSERT_OWNS_LOCK(lock);
+
+            util::ignore_all_while_checking ignore_lock;
+            boost::unique_lock<mutex_type> l(mtx_);
+            util::unlock_guard<boost::unique_lock<mutex> > unlock(lock);
+
+            threads::thread_state_ex_enum const reason =
+                cond_.wait_until(l, abs_time, ec);
+
+            l.unlock();
+            if (ec) return cv_status::error;
+
+            // if the timer has hit, the waiting period timed out
+            return (reason == threads::wait_timeout) ? //-V110
+                cv_status::timeout : cv_status::no_timeout;
+        }
+
+        template <typename Predicate>
+        bool wait_until(boost::unique_lock<mutex>& lock,
+            util::steady_time_point const& abs_time, Predicate pred,
+            error_code& ec = throws)
+        {
+            HPX_ASSERT_OWNS_LOCK(lock);
+
+            while (!pred())
+            {
+                if (wait_until(lock, abs_time, ec) == cv_status::timeout)
+                    return pred();
+            }
+            return true;
+        }
+
+        cv_status wait_for(boost::unique_lock<mutex>& lock,
+            util::steady_duration const& rel_time,
+            error_code& ec = throws)
+        {
+            return wait_until(lock, rel_time.from_now(), ec);
+        }
+
+        template <typename Predicate>
+        bool wait_for(boost::unique_lock<mutex>& lock,
+            util::steady_duration const& rel_time, Predicate pred,
+            error_code& ec = throws)
+        {
+            return wait_until(lock, rel_time.from_now(), std::move(pred), ec);
+        }
+
+    private:
+        mutable mutex_type mtx_;
+        detail::condition_variable cond_;
+    };
+
+    class condition_variable_any
+    {
+    private:
+        typedef lcos::local::spinlock mutex_type;
+
+    public:
+        void notify_one(error_code& ec = throws)
+        {
+            boost::unique_lock<mutex_type> l(mtx_);
+            cond_.notify_one(std::move(l), ec);
+        }
+
+        void notify_all(error_code& ec = throws)
+        {
+            util::ignore_all_while_checking ignore_lock;
+            boost::unique_lock<mutex_type> l(mtx_);
+            cond_.notify_all(std::move(l), ec);
+        }
+
         template <class Lock>
         void wait(Lock& lock, error_code& ec = throws)
         {
+            HPX_ASSERT_OWNS_LOCK(lock);
+
             util::ignore_all_while_checking ignore_lock;
             boost::unique_lock<mutex_type> l(mtx_);
             util::unlock_guard<Lock> unlock(lock);
@@ -58,6 +163,8 @@ namespace hpx { namespace lcos { namespace local
         template <class Lock, class Predicate>
         void wait(Lock& lock, Predicate pred, error_code& ec = throws)
         {
+            HPX_ASSERT_OWNS_LOCK(lock);
+
             while (!pred())
             {
                 wait(lock);
@@ -69,6 +176,8 @@ namespace hpx { namespace lcos { namespace local
         wait_until(Lock& lock, util::steady_time_point const& abs_time,
             error_code& ec = throws)
         {
+            HPX_ASSERT_OWNS_LOCK(lock);
+
             util::ignore_all_while_checking ignore_lock;
             boost::unique_lock<mutex_type> l(mtx_);
             util::unlock_guard<Lock> unlock(lock);
@@ -88,6 +197,8 @@ namespace hpx { namespace lcos { namespace local
         bool wait_until(Lock& lock, util::steady_time_point const& abs_time,
             Predicate pred, error_code& ec = throws)
         {
+            HPX_ASSERT_OWNS_LOCK(lock);
+
             while (!pred())
             {
                 if (wait_until(lock, abs_time, ec) == cv_status::timeout)

--- a/hpx/lcos/local/condition_variable.hpp
+++ b/hpx/lcos/local/condition_variable.hpp
@@ -13,8 +13,8 @@
 #include <hpx/lcos/local/mutex.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 #include <hpx/util/assert_owns_lock.hpp>
-#include <hpx/util/unlock_guard.hpp>
 #include <hpx/util/date_time_chrono.hpp>
+#include <hpx/util/unlock_guard.hpp>
 
 #include <boost/thread/locks.hpp>
 
@@ -54,9 +54,7 @@ namespace hpx { namespace lcos { namespace local
             boost::unique_lock<mutex_type> l(mtx_);
             util::unlock_guard<boost::unique_lock<mutex> > unlock(lock);
 
-            cond_.wait(l, ec);
-
-            l.unlock();
+            cond_.wait(std::move(l), ec);
         }
 
         template <class Predicate>
@@ -82,9 +80,8 @@ namespace hpx { namespace lcos { namespace local
             util::unlock_guard<boost::unique_lock<mutex> > unlock(lock);
 
             threads::thread_state_ex_enum const reason =
-                cond_.wait_until(l, abs_time, ec);
+                cond_.wait_until(std::move(l), abs_time, ec);
 
-            l.unlock();
             if (ec) return cv_status::error;
 
             // if the timer has hit, the waiting period timed out
@@ -155,9 +152,7 @@ namespace hpx { namespace lcos { namespace local
             boost::unique_lock<mutex_type> l(mtx_);
             util::unlock_guard<Lock> unlock(lock);
 
-            cond_.wait(l, ec);
-
-            l.unlock();
+            cond_.wait(std::move(l), ec);
         }
 
         template <class Lock, class Predicate>
@@ -183,9 +178,8 @@ namespace hpx { namespace lcos { namespace local
             util::unlock_guard<Lock> unlock(lock);
 
             threads::thread_state_ex_enum const reason =
-                cond_.wait_until(l, abs_time, ec);
+                cond_.wait_until(std::move(l), abs_time, ec);
 
-            l.unlock();
             if (ec) return cv_status::error;
 
             // if the timer has hit, the waiting period timed out

--- a/hpx/lcos/local/detail/condition_variable.hpp
+++ b/hpx/lcos/local/detail/condition_variable.hpp
@@ -1,17 +1,19 @@
 //  Copyright (c) 2007-2013 Hartmut Kaiser
-//  Copyright (c) 2013 Agustin Berge
+//  Copyright (c) 2013-2015 Agustin Berge
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(HPX_LCOS_LOCAL_DETAIL_CONDITION_VARIABLE_DEC_4_2013_0130PM)
-#define HPX_LCOS_LOCAL_DETAIL_CONDITION_VARIABLE_DEC_4_2013_0130PM
+#ifndef HPX_LCOS_LOCAL_DETAIL_CONDITION_VARIABLE_HPP
+#define HPX_LCOS_LOCAL_DETAIL_CONDITION_VARIABLE_HPP
 
 #include <hpx/config.hpp>
-#include <hpx/lcos/local/no_mutex.hpp>
-#include <hpx/util/assert_owns_lock.hpp>
-#include <hpx/util/unlock_guard.hpp>
-#include <hpx/runtime/threads/thread_helpers.hpp>
+#include <hpx/config/emulate_deleted.hpp>
+#include <hpx/config/export_definitions.hpp>
+#include <hpx/exception_fwd.hpp>
+#include <hpx/lcos/local/spinlock.hpp>
+#include <hpx/runtime/threads/thread_data_fwd.hpp>
+#include <hpx/util/date_time_chrono.hpp>
 
 #include <boost/intrusive/slist.hpp>
 #include <boost/thread/locks.hpp>
@@ -22,6 +24,9 @@ namespace hpx { namespace lcos { namespace local { namespace detail
     class condition_variable
     {
         HPX_NON_COPYABLE(condition_variable);
+
+    private:
+        typedef lcos::local::spinlock mutex_type;
 
     private:
         // define data structures needed for intrusive slist container used for
@@ -72,280 +77,45 @@ namespace hpx { namespace lcos { namespace local { namespace detail
         };
 
     public:
-        condition_variable()
-        {}
+        HPX_EXPORT condition_variable();
 
-        ~condition_variable()
-        {
-            if (!queue_.empty())
-            {
-                LERR_(fatal)
-                    << "~condition_variable: queue is not empty, "
-                       "aborting threads";
+        HPX_EXPORT ~condition_variable();
 
-                local::no_mutex no_mtx;
-                boost::unique_lock<local::no_mutex> lock(no_mtx);
-                abort_all(std::move(lock));
-            }
-        }
+        HPX_EXPORT bool empty(
+            boost::unique_lock<mutex_type> const& lock) const;
 
-        template <typename Mutex>
-        bool empty(boost::unique_lock<Mutex> const& lock) const
-        {
-            HPX_ASSERT_OWNS_LOCK(lock);
-
-            return queue_.empty();
-        }
-
-        template <typename Mutex>
-        std::size_t size(boost::unique_lock<Mutex> const& lock) const
-        {
-            HPX_ASSERT_OWNS_LOCK(lock);
-
-            return queue_.size();
-        }
+        HPX_EXPORT std::size_t size(
+            boost::unique_lock<mutex_type> const& lock) const;
 
         // Return false if no more threads are waiting (returns true if queue
         // is non-empty).
-        template <typename Mutex>
-        bool notify_one(boost::unique_lock<Mutex> lock, error_code& ec = throws)
-        {
-            HPX_ASSERT_OWNS_LOCK(lock);
+        HPX_EXPORT bool notify_one(
+            boost::unique_lock<mutex_type> lock, error_code& ec = throws);
 
-            if (!queue_.empty())
-            {
-                threads::thread_id_repr_type id = queue_.front().id_;
+        HPX_EXPORT void notify_all(
+            boost::unique_lock<mutex_type> lock, error_code& ec = throws);
 
-                // remove item from queue before error handling
-                queue_.front().id_ = threads::invalid_thread_id_repr;
-                queue_.pop_front();
+        HPX_EXPORT void abort_all(
+            boost::unique_lock<mutex_type> lock);
 
-                if (HPX_UNLIKELY(id == threads::invalid_thread_id_repr))
-                {
-                    lock.unlock();
+        HPX_EXPORT threads::thread_state_ex_enum wait(
+            boost::unique_lock<mutex_type>& lock,
+            char const* description, error_code& ec = throws);
 
-                    HPX_THROWS_IF(ec, null_thread_id,
-                        "condition_variable::notify_one",
-                        "NULL thread id encountered");
-                    return false;
-                }
-
-                bool not_empty = !queue_.empty();
-                lock.unlock();
-
-                threads::set_thread_state(threads::thread_id_type(
-                        reinterpret_cast<threads::thread_data*>(id)),
-                    threads::pending, threads::wait_signaled,
-                    threads::thread_priority_default, ec);
-                return not_empty;
-            }
-
-            if (&ec != &throws)
-                ec = make_success_code();
-
-            return false;
-        }
-
-        // re-add the remaining items to the original queue
-        template <typename Mutex>
-        void prepend_entries(boost::unique_lock<Mutex>& lock, queue_type& queue)
-        {
-            HPX_ASSERT_OWNS_LOCK(lock);
-
-            // splice is constant time only if it == end
-            queue.splice(queue.end(), queue_);
-            queue_.swap(queue);
-        }
-
-        template <typename Mutex>
-        void notify_all(boost::unique_lock<Mutex> lock, error_code& ec = throws)
-        {
-            HPX_ASSERT_OWNS_LOCK(lock);
-
-            // swap the list
-            queue_type queue;
-            queue.swap(queue_);
-
-            if (!queue.empty())
-            {
-                // update reference to queue for all queue entries
-                for (queue_entry& qe : queue)
-                    qe.q_ = &queue;
-
-                do {
-                    threads::thread_id_repr_type id = queue.front().id_;
-
-                    // remove item from queue before error handling
-                    queue.front().id_ = threads::invalid_thread_id_repr;
-                    queue.pop_front();
-
-                    if (HPX_UNLIKELY(id == threads::invalid_thread_id_repr))
-                    {
-                        prepend_entries(lock, queue);
-                        lock.unlock();
-
-                        HPX_THROWS_IF(ec, null_thread_id,
-                            "condition_variable::notify_all",
-                            "NULL thread id encountered");
-                        return;
-                    }
-
-                    error_code local_ec;
-                    threads::set_thread_state(threads::thread_id_type(
-                            reinterpret_cast<threads::thread_data*>(id)),
-                        threads::pending, threads::wait_signaled,
-                        threads::thread_priority_default, local_ec);
-
-                    if (local_ec)
-                    {
-                        prepend_entries(lock, queue);
-                        lock.unlock();
-
-                        if (&ec != &throws)
-                        {
-                            ec = std::move(local_ec);
-                        }
-                        else
-                        {
-                            boost::rethrow_exception(
-                                hpx::detail::access_exception(local_ec));
-                        }
-                        return;
-                    }
-
-                } while (!queue.empty());
-            }
-
-            if (&ec != &throws)
-                ec = make_success_code();
-        }
-
-        template <typename Mutex>
-        void abort_all(boost::unique_lock<Mutex> lock)
-        {
-            HPX_ASSERT_OWNS_LOCK(lock);
-
-            // new threads might have been added while we were notifying
-            while(!queue_.empty())
-            {
-                // swap the list
-                queue_type queue;
-                queue.swap(queue_);
-
-                // update reference to queue for all queue entries
-                for (queue_entry& qe : queue)
-                    qe.q_ = &queue;
-
-                while (!queue.empty())
-                {
-                    threads::thread_id_repr_type id = queue.front().id_;
-
-                    queue.front().id_ = threads::invalid_thread_id_repr;
-                    queue.pop_front();
-
-                    if (HPX_UNLIKELY(id == threads::invalid_thread_id_repr))
-                    {
-                        LERR_(fatal)
-                            << "condition_variable::abort_all:"
-                            << " NULL thread id encountered";
-                        continue;
-                    }
-
-                    // we know that the id is actually the pointer to the thread
-                    threads::thread_id_type tid(
-                        reinterpret_cast<threads::thread_data*>(id));
-
-                    LERR_(fatal)
-                            << "condition_variable::abort_all:"
-                            << " pending thread: "
-                            << get_thread_state_name(
-                                    threads::get_thread_state(tid))
-                            << "(" << tid << "): "
-                            << threads::get_thread_description(tid);
-
-                    // unlock while notifying thread as this can suspend
-                    util::unlock_guard<boost::unique_lock<Mutex> > unlock(lock);
-
-                    // forcefully abort thread, do not throw
-                    error_code ec(lightweight);
-                    threads::set_thread_state(tid,
-                        threads::pending, threads::wait_abort,
-                        threads::thread_priority_default, ec);
-                    if (ec)
-                    {
-                        LERR_(fatal)
-                            << "condition_variable::abort_all:"
-                            << " could not abort thread: "
-                            << get_thread_state_name(
-                                    threads::get_thread_state(tid))
-                            << "(" << tid << "): "
-                            << threads::get_thread_description(tid);
-                    }
-                }
-            }
-        }
-
-        template <typename Mutex>
-        threads::thread_state_ex_enum
-        wait(boost::unique_lock<Mutex>& lock,
-            char const* description, error_code& ec = throws)
-        {
-            HPX_ASSERT(threads::get_self_ptr() != 0);
-            HPX_ASSERT_OWNS_LOCK(lock);
-
-            // enqueue the request and block this thread
-            queue_entry f(threads::get_self_id().get(), &queue_);
-            queue_.push_back(f);
-
-            reset_queue_entry r(f, queue_);
-            threads::thread_state_ex_enum reason = threads::wait_unknown;
-            {
-                // yield this thread
-                util::unlock_guard<boost::unique_lock<Mutex> > unlock(lock);
-                reason = this_thread::suspend(threads::suspended, description, ec);
-                if (ec) return threads::wait_unknown;
-            }
-
-            return (f.id_ != threads::invalid_thread_id_repr) ?
-                threads::wait_timeout : reason;
-        }
-
-        template <typename Mutex>
-        threads::thread_state_ex_enum
-        wait(boost::unique_lock<Mutex>& lock, error_code& ec = throws)
+        threads::thread_state_ex_enum wait(
+            boost::unique_lock<mutex_type>& lock,
+            error_code& ec = throws)
         {
             return wait(lock, "condition_variable::wait", ec);
         }
 
-        template <typename Mutex>
-        threads::thread_state_ex_enum
-        wait_until(boost::unique_lock<Mutex>& lock,
+        HPX_EXPORT threads::thread_state_ex_enum wait_until(
+            boost::unique_lock<mutex_type>& lock,
             util::steady_time_point const& abs_time,
-            char const* description, error_code& ec = throws)
-        {
-            HPX_ASSERT(threads::get_self_ptr() != 0);
-            HPX_ASSERT_OWNS_LOCK(lock);
+            char const* description, error_code& ec = throws);
 
-            // enqueue the request and block this thread
-            queue_entry f(threads::get_self_id().get(), &queue_);
-            queue_.push_back(f);
-
-            reset_queue_entry r(f, queue_);
-            threads::thread_state_ex_enum reason = threads::wait_unknown;
-            {
-                // yield this thread
-                util::unlock_guard<boost::unique_lock<Mutex> > unlock(lock);
-                reason = this_thread::suspend(abs_time, description, ec);
-                if (ec) return threads::wait_unknown;
-            }
-
-            return (f.id_ != threads::invalid_thread_id_repr) ?
-                threads::wait_timeout : reason;
-        }
-
-        template <typename Mutex>
-        threads::thread_state_ex_enum
-        wait_until(boost::unique_lock<Mutex>& lock,
+        threads::thread_state_ex_enum wait_until(
+            boost::unique_lock<mutex_type>& lock,
             util::steady_time_point const& abs_time,
             error_code& ec = throws)
         {
@@ -353,24 +123,30 @@ namespace hpx { namespace lcos { namespace local { namespace detail
                 "condition_variable::wait_until", ec);
         }
 
-        template <typename Mutex>
-        threads::thread_state_ex_enum
-        wait_for(boost::unique_lock<Mutex>& lock,
+        threads::thread_state_ex_enum wait_for(
+            boost::unique_lock<mutex_type>& lock,
             util::steady_duration const& rel_time,
             char const* description, error_code& ec = throws)
         {
             return wait_until(lock, rel_time.from_now(), description, ec);
         }
 
-        template <typename Mutex>
-        threads::thread_state_ex_enum
-        wait_for(boost::unique_lock<Mutex>& lock,
+        threads::thread_state_ex_enum wait_for(
+            boost::unique_lock<mutex_type>& lock,
             util::steady_duration const& rel_time,
             error_code& ec = throws)
         {
             return wait_until(lock, rel_time.from_now(),
                 "condition_variable::wait_for", ec);
         }
+
+    private:
+        template <typename Mutex>
+        void abort_all(boost::unique_lock<Mutex> lock);
+
+        // re-add the remaining items to the original queue
+        HPX_EXPORT void prepend_entries(
+            boost::unique_lock<mutex_type>& lock, queue_type& queue);
 
     private:
         queue_type queue_;

--- a/hpx/lcos/local/detail/counting_semaphore.hpp
+++ b/hpx/lcos/local/detail/counting_semaphore.hpp
@@ -28,13 +28,15 @@ namespace hpx { namespace lcos { namespace local { namespace detail
 {
     class counting_semaphore
     {
+    private:
+        typedef lcos::local::spinlock mutex_type;
+
     public:
         counting_semaphore(boost::int64_t value = 0)
           : value_(value)
         {}
 
-        template <typename Mutex>
-        void wait(boost::unique_lock<Mutex>& l, boost::int64_t count)
+        void wait(boost::unique_lock<mutex_type>& l, boost::int64_t count)
         {
             HPX_ASSERT_OWNS_LOCK(l);
 
@@ -45,8 +47,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail
             value_ -= count;
         }
 
-        template <typename Mutex>
-        bool try_wait(boost::unique_lock<Mutex>& l, boost::int64_t count = 1)
+        bool try_wait(boost::unique_lock<mutex_type>& l, boost::int64_t count = 1)
         {
             HPX_ASSERT_OWNS_LOCK(l);
 
@@ -59,12 +60,11 @@ namespace hpx { namespace lcos { namespace local { namespace detail
             return false;
         }
 
-        template <typename Mutex>
-        void signal(boost::unique_lock<Mutex> l, boost::int64_t count)
+        void signal(boost::unique_lock<mutex_type> l, boost::int64_t count)
         {
             HPX_ASSERT_OWNS_LOCK(l);
 
-            Mutex* mtx = l.mutex();
+            mutex_type* mtx = l.mutex();
 
             // release no more threads than we get resources
             value_ += count;
@@ -75,12 +75,11 @@ namespace hpx { namespace lcos { namespace local { namespace detail
                 if (!cond_.notify_one(std::move(l)))
                     break;
 
-                l = boost::unique_lock<Mutex>(*mtx);
+                l = boost::unique_lock<mutex_type>(*mtx);
             }
         }
 
-        template <typename Mutex>
-        boost::int64_t signal_all(boost::unique_lock<Mutex> l)
+        boost::int64_t signal_all(boost::unique_lock<mutex_type> l)
         {
             HPX_ASSERT_OWNS_LOCK(l);
 

--- a/hpx/lcos/local/event.hpp
+++ b/hpx/lcos/local/event.hpp
@@ -27,78 +27,72 @@ namespace hpx { namespace lcos { namespace local
     /// Event semaphores can be used for synchronizing multiple threads that
     /// need to wait for an event to occur. When the event occurs, all threads
     /// waiting for the event are woken up.
-    namespace detail
+    class event
     {
-        template <typename Mutex = lcos::local::spinlock>
-        class event
+    private:
+        typedef lcos::local::spinlock mutex_type;
+
+    public:
+        /// \brief Construct a new event semaphore
+        event()
+          : event_(false)
+        {}
+
+        /// \brief Check if the event has occurred.
+        bool occurred()
         {
-        private:
-            typedef Mutex mutex_type;
+            return event_.load(boost::memory_order_acquire);
+        }
 
-        public:
-            /// \brief Construct a new event semaphore
-            event()
-              : event_(false)
-            {}
+        /// \brief Wait for the event to occur.
+        void wait()
+        {
+            if (event_.load(boost::memory_order_acquire))
+                return;
 
-            /// \brief Check if the event has occurred.
-            bool occurred()
+            boost::unique_lock<mutex_type> l(mtx_);
+            wait_locked(l);
+        }
+
+        /// \brief Release all threads waiting on this semaphore.
+        void set()
+        {
+            event_.store(true, boost::memory_order_release);
+
+            boost::unique_lock<mutex_type> l(mtx_);
+            set_locked(std::move(l));
+        }
+
+        /// \brief Reset the event
+        void reset()
+        {
+            event_.store(false, boost::memory_order_release);
+        }
+
+    private:
+        void wait_locked(boost::unique_lock<mutex_type>& l)
+        {
+            HPX_ASSERT(l.owns_lock());
+
+            while (!event_.load(boost::memory_order_acquire))
             {
-                return event_.load(boost::memory_order_acquire);
+                cond_.wait(l, "event::wait_locked");
             }
+        }
 
-            /// \brief Wait for the event to occur.
-            void wait()
-            {
-                if (event_.load(boost::memory_order_acquire))
-                    return;
+        void set_locked(boost::unique_lock<mutex_type> l)
+        {
+            HPX_ASSERT(l.owns_lock());
 
-                boost::unique_lock<mutex_type> l(mtx_);
-                wait_locked(l);
-            }
+            // release the threads
+            cond_.notify_all(std::move(l));
+        }
 
-            /// \brief Release all threads waiting on this semaphore.
-            void set()
-            {
-                event_.store(true, boost::memory_order_release);
+        mutex_type mtx_;      ///< This mutex protects the queue.
+        local::detail::condition_variable cond_;
 
-                boost::unique_lock<mutex_type> l(mtx_);
-                set_locked(std::move(l));
-            }
-
-            /// \brief Reset the event
-            void reset()
-            {
-                event_.store(false, boost::memory_order_release);
-            }
-
-        private:
-            void wait_locked(boost::unique_lock<mutex_type>& l)
-            {
-                HPX_ASSERT(l.owns_lock());
-
-                while (!event_.load(boost::memory_order_acquire))
-                {
-                    cond_.wait(l, "event::wait_locked");
-                }
-            }
-
-            void set_locked(boost::unique_lock<mutex_type> l)
-            {
-                HPX_ASSERT(l.owns_lock());
-
-                // release the threads
-                cond_.notify_all(std::move(l));
-            }
-
-            mutex_type mtx_;      ///< This mutex protects the queue.
-            local::detail::condition_variable cond_;
-
-            boost::atomic<bool> event_;
-        };
-    }
-
-    typedef detail::event<> event;
+        boost::atomic<bool> event_;
+    };
 }}}
 
 #if defined(HPX_MSVC)

--- a/hpx/lcos/local/latch.hpp
+++ b/hpx/lcos/local/latch.hpp
@@ -100,7 +100,7 @@ namespace hpx { namespace lcos { namespace local
             if (--counter_ == 0)
                 cond_.notify_all(std::move(l));    // release the threads
             else
-                cond_.wait(l, "hpx::local::latch::count_down_and_wait");
+                cond_.wait(std::move(l), "hpx::local::latch::count_down_and_wait");
         }
 
         /// Decrements counter_ by n. Does not block.
@@ -143,7 +143,7 @@ namespace hpx { namespace lcos { namespace local
         {
             boost::unique_lock<mutex_type> l(mtx_);
             if (counter_ > 0)
-                cond_.wait(l, "hpx::local::latch::wait");
+                cond_.wait(std::move(l), "hpx::local::latch::wait");
         }
 
         void abort_all()

--- a/hpx/lcos/local/shared_mutex.hpp
+++ b/hpx/lcos/local/shared_mutex.hpp
@@ -7,8 +7,9 @@
 #if !defined(HPX_F0757EAC_E2A3_4F80_A1EC_8CC7EB55186F)
 #define HPX_F0757EAC_E2A3_4F80_A1EC_8CC7EB55186F
 
+#include <hpx/config.hpp>
+#include <hpx/lcos/local/condition_variable.hpp>
 #include <hpx/lcos/local/mutex.hpp>
-#include <hpx/lcos/local/detail/condition_variable.hpp>
 
 #include <boost/thread/locks.hpp>
 

--- a/hpx/lcos/local/trigger.hpp
+++ b/hpx/lcos/local/trigger.hpp
@@ -6,13 +6,14 @@
 #if !defined(HPX_LCOS_LOCAL_TRIGGER_SEP_09_2012_1229PM)
 #define HPX_LCOS_LOCAL_TRIGGER_SEP_09_2012_1229PM
 
-#include <hpx/hpx_fwd.hpp>
+#include <hpx/config.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 #include <hpx/lcos/local/conditional_trigger.hpp>
 #include <hpx/lcos/local/no_mutex.hpp>
 #include <hpx/lcos/local/promise.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/assert_owns_lock.hpp>
+#include <hpx/util/unlock_guard.hpp>
 
 #include <boost/thread/locks.hpp>
 

--- a/hpx/lcos/server/barrier.hpp
+++ b/hpx/lcos/server/barrier.hpp
@@ -71,7 +71,7 @@ namespace hpx { namespace lcos { namespace server
         {
             boost::unique_lock<mutex_type> l(mtx_);
             if (cond_.size(l) < number_of_threads_-1) {
-                cond_.wait(l, "barrier::set_event");
+                cond_.wait(std::move(l), "barrier::set_event");
             }
             else {
                 cond_.notify_all(std::move(l));

--- a/hpx/parallel/task_block.hpp
+++ b/hpx/parallel/task_block.hpp
@@ -16,7 +16,6 @@
 #include <hpx/lcos/future.hpp>
 #include <hpx/lcos/when_all.hpp>
 #include <hpx/traits/is_future.hpp>
-#include <hpx/util/unlock_guard.hpp>
 #include <hpx/util/decay.hpp>
 #include <hpx/async.hpp>
 

--- a/hpx/runtime/agas/server/primary_namespace.hpp
+++ b/hpx/runtime/agas/server/primary_namespace.hpp
@@ -141,14 +141,14 @@ struct HPX_EXPORT primary_namespace
 #if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION >= 408000
     typedef std::map<
             naming::gid_type,
-            hpx::util::tuple<bool, std::size_t, lcos::local::condition_variable>
+            hpx::util::tuple<bool, std::size_t, lcos::local::condition_variable_any>
         > migration_table_type;
 #else
     typedef std::map<
             naming::gid_type,
             hpx::util::tuple<
                 bool, std::size_t,
-                boost::shared_ptr<lcos::local::condition_variable>
+                boost::shared_ptr<lcos::local::condition_variable_any>
             >
         > migration_table_type;
 #endif

--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -425,7 +425,7 @@ namespace hpx { namespace components { namespace server
 
         typedef hpx::lcos::local::spinlock dijkstra_mtx_type;
         dijkstra_mtx_type dijkstra_mtx_;
-        lcos::local::condition_variable dijkstra_cond_;
+        lcos::local::condition_variable_any dijkstra_cond_;
 
         component_map_mutex_type cm_mtx_;
         plugin_map_mutex_type p_mtx_;

--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -28,6 +28,7 @@
 #include <hpx/util/plugin.hpp>
 #include <hpx/util/bind.hpp>
 #include <hpx/util/functional/new.hpp>
+#include <hpx/util/unlock_guard.hpp>
 
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/condition.hpp>

--- a/hpx/runtime/components/server/wrapper_heap_list.hpp
+++ b/hpx/runtime/components/server/wrapper_heap_list.hpp
@@ -11,6 +11,7 @@
 #include <hpx/traits/component_type_database.hpp>
 #include <hpx/util/one_size_heap_list.hpp>
 #include <hpx/util/generate_unique_ids.hpp>
+#include <hpx/util/unlock_guard.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace components { namespace detail

--- a/hpx/util/unlock_guard.hpp
+++ b/hpx/util/unlock_guard.hpp
@@ -8,7 +8,6 @@
 #define HPX_UTIL_UNLOCK_GUARD_HPP
 
 #include <hpx/config.hpp>
-#include <hpx/config/emulate_deleted.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace util

--- a/src/exception_list.cpp
+++ b/src/exception_list.cpp
@@ -6,6 +6,7 @@
 #include <hpx/config.hpp>
 #include <hpx/exception.hpp>
 #include <hpx/exception_list.hpp>
+#include <hpx/util/unlock_guard.hpp>
 
 #include <boost/system/system_error.hpp>
 #include <boost/exception_ptr.hpp>

--- a/src/lcos/local/detail/condition_variable.cpp
+++ b/src/lcos/local/detail/condition_variable.cpp
@@ -1,0 +1,289 @@
+//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2013-2015 Agustin Berge
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/lcos/local/detail/condition_variable.hpp>
+
+#include <hpx/config.hpp>
+#include <hpx/lcos/local/mutex.hpp>
+#include <hpx/lcos/local/no_mutex.hpp>
+#include <hpx/runtime/threads/thread_data.hpp>
+#include <hpx/runtime/threads/thread_helpers.hpp>
+#include <hpx/util/assert.hpp>
+#include <hpx/util/unlock_guard.hpp>
+
+#include <boost/intrusive/slist.hpp>
+#include <boost/thread/locks.hpp>
+
+namespace hpx { namespace lcos { namespace local { namespace detail
+{
+    ///////////////////////////////////////////////////////////////////////////
+    condition_variable::condition_variable()
+    {}
+
+    condition_variable::~condition_variable()
+    {
+        if (!queue_.empty())
+        {
+            LERR_(fatal)
+                << "~condition_variable: queue is not empty, "
+                   "aborting threads";
+
+            local::no_mutex no_mtx;
+            boost::unique_lock<local::no_mutex> lock(no_mtx);
+            abort_all<local::no_mutex>(std::move(lock));
+        }
+    }
+
+    bool condition_variable::empty(
+        boost::unique_lock<mutex_type> const& lock) const
+    {
+        HPX_ASSERT(lock.owns_lock());
+
+        return queue_.empty();
+    }
+
+    std::size_t condition_variable::size(
+        boost::unique_lock<mutex_type> const& lock) const
+    {
+        HPX_ASSERT(lock.owns_lock());
+
+        return queue_.size();
+    }
+
+    // Return false if no more threads are waiting (returns true if queue
+    // is non-empty).
+    bool condition_variable::notify_one(
+        boost::unique_lock<mutex_type> lock, error_code& ec)
+    {
+        HPX_ASSERT(lock.owns_lock());
+
+        if (!queue_.empty())
+        {
+            threads::thread_id_repr_type id = queue_.front().id_;
+
+            // remove item from queue before error handling
+            queue_.front().id_ = threads::invalid_thread_id_repr;
+            queue_.pop_front();
+
+            if (HPX_UNLIKELY(id == threads::invalid_thread_id_repr))
+            {
+                lock.unlock();
+
+                HPX_THROWS_IF(ec, null_thread_id,
+                    "condition_variable::notify_one",
+                    "NULL thread id encountered");
+                return false;
+            }
+
+            bool not_empty = !queue_.empty();
+            lock.unlock();
+
+            threads::set_thread_state(threads::thread_id_type(
+                    reinterpret_cast<threads::thread_data*>(id)),
+                threads::pending, threads::wait_signaled,
+                threads::thread_priority_default, ec);
+            return not_empty;
+        }
+
+        if (&ec != &throws)
+            ec = make_success_code();
+
+        return false;
+    }
+
+    void condition_variable::notify_all(
+        boost::unique_lock<mutex_type> lock, error_code& ec)
+    {
+        HPX_ASSERT(lock.owns_lock());
+
+        // swap the list
+        queue_type queue;
+        queue.swap(queue_);
+
+        if (!queue.empty())
+        {
+            // update reference to queue for all queue entries
+            for (queue_entry& qe : queue)
+                qe.q_ = &queue;
+
+            do {
+                threads::thread_id_repr_type id = queue.front().id_;
+
+                // remove item from queue before error handling
+                queue.front().id_ = threads::invalid_thread_id_repr;
+                queue.pop_front();
+
+                if (HPX_UNLIKELY(id == threads::invalid_thread_id_repr))
+                {
+                    prepend_entries(lock, queue);
+                    lock.unlock();
+
+                    HPX_THROWS_IF(ec, null_thread_id,
+                        "condition_variable::notify_all",
+                        "NULL thread id encountered");
+                    return;
+                }
+
+                error_code local_ec;
+                threads::set_thread_state(threads::thread_id_type(
+                        reinterpret_cast<threads::thread_data*>(id)),
+                    threads::pending, threads::wait_signaled,
+                    threads::thread_priority_default, local_ec);
+
+                if (local_ec)
+                {
+                    prepend_entries(lock, queue);
+                    lock.unlock();
+
+                    if (&ec != &throws)
+                    {
+                        ec = std::move(local_ec);
+                    }
+                    else
+                    {
+                        boost::rethrow_exception(
+                            hpx::detail::access_exception(local_ec));
+                    }
+                    return;
+                }
+
+            } while (!queue.empty());
+        }
+
+        if (&ec != &throws)
+            ec = make_success_code();
+    }
+
+    void condition_variable::abort_all(boost::unique_lock<mutex_type> lock)
+    {
+        HPX_ASSERT(lock.owns_lock());
+
+        abort_all<mutex_type>(std::move(lock));
+    }
+
+    threads::thread_state_ex_enum condition_variable::wait(
+        boost::unique_lock<mutex_type>& lock,
+        char const* description, error_code& ec)
+    {
+        HPX_ASSERT(threads::get_self_ptr() != 0);
+        HPX_ASSERT(lock.owns_lock());
+
+        // enqueue the request and block this thread
+        queue_entry f(threads::get_self_id().get(), &queue_);
+        queue_.push_back(f);
+
+        reset_queue_entry r(f, queue_);
+        threads::thread_state_ex_enum reason = threads::wait_unknown;
+        {
+            // yield this thread
+            util::unlock_guard<boost::unique_lock<mutex_type> > unlock(lock);
+            reason = this_thread::suspend(threads::suspended, description, ec);
+            if (ec) return threads::wait_unknown;
+        }
+
+        return (f.id_ != threads::invalid_thread_id_repr) ?
+            threads::wait_timeout : reason;
+    }
+
+    threads::thread_state_ex_enum condition_variable::wait_until(
+        boost::unique_lock<mutex_type>& lock,
+        util::steady_time_point const& abs_time,
+        char const* description, error_code& ec)
+    {
+        HPX_ASSERT(threads::get_self_ptr() != 0);
+        HPX_ASSERT(lock.owns_lock());
+
+        // enqueue the request and block this thread
+        queue_entry f(threads::get_self_id().get(), &queue_);
+        queue_.push_back(f);
+
+        reset_queue_entry r(f, queue_);
+        threads::thread_state_ex_enum reason = threads::wait_unknown;
+        {
+            // yield this thread
+            util::unlock_guard<boost::unique_lock<mutex_type> > unlock(lock);
+            reason = this_thread::suspend(abs_time, description, ec);
+            if (ec) return threads::wait_unknown;
+        }
+
+        return (f.id_ != threads::invalid_thread_id_repr) ?
+            threads::wait_timeout : reason;
+    }
+
+    template <typename Mutex>
+    void condition_variable::abort_all(boost::unique_lock<Mutex> lock)
+    {
+        // new threads might have been added while we were notifying
+        while(!queue_.empty())
+        {
+            // swap the list
+            queue_type queue;
+            queue.swap(queue_);
+
+            // update reference to queue for all queue entries
+            for (queue_entry& qe : queue)
+                qe.q_ = &queue;
+
+            while (!queue.empty())
+            {
+                threads::thread_id_repr_type id = queue.front().id_;
+
+                queue.front().id_ = threads::invalid_thread_id_repr;
+                queue.pop_front();
+
+                if (HPX_UNLIKELY(id == threads::invalid_thread_id_repr))
+                {
+                    LERR_(fatal)
+                        << "condition_variable::abort_all:"
+                        << " NULL thread id encountered";
+                    continue;
+                }
+
+                // we know that the id is actually the pointer to the thread
+                threads::thread_id_type tid(
+                    reinterpret_cast<threads::thread_data*>(id));
+
+                LERR_(fatal)
+                        << "condition_variable::abort_all:"
+                        << " pending thread: "
+                        << get_thread_state_name(
+                                threads::get_thread_state(tid))
+                        << "(" << tid << "): "
+                        << threads::get_thread_description(tid);
+
+                // unlock while notifying thread as this can suspend
+                util::unlock_guard<boost::unique_lock<Mutex> > unlock(lock);
+
+                // forcefully abort thread, do not throw
+                error_code ec(lightweight);
+                threads::set_thread_state(tid,
+                    threads::pending, threads::wait_abort,
+                    threads::thread_priority_default, ec);
+                if (ec)
+                {
+                    LERR_(fatal)
+                        << "condition_variable::abort_all:"
+                        << " could not abort thread: "
+                        << get_thread_state_name(
+                                threads::get_thread_state(tid))
+                        << "(" << tid << "): "
+                        << threads::get_thread_description(tid);
+                }
+            }
+        }
+    }
+
+    // re-add the remaining items to the original queue
+    void condition_variable::prepend_entries(
+        boost::unique_lock<mutex_type>& lock, queue_type& queue)
+    {
+        HPX_ASSERT(lock.owns_lock());
+
+        // splice is constant time only if it == end
+        queue.splice(queue.end(), queue_);
+        queue_.swap(queue);
+    }
+}}}}

--- a/src/lcos/local/detail/condition_variable.cpp
+++ b/src/lcos/local/detail/condition_variable.cpp
@@ -165,7 +165,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail
     }
 
     threads::thread_state_ex_enum condition_variable::wait(
-        boost::unique_lock<mutex_type>& lock,
+        boost::unique_lock<mutex_type>&& lock,
         char const* description, error_code& ec)
     {
         HPX_ASSERT(threads::get_self_ptr() != 0);
@@ -179,7 +179,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail
         threads::thread_state_ex_enum reason = threads::wait_unknown;
         {
             // yield this thread
-            util::unlock_guard<boost::unique_lock<mutex_type> > unlock(lock);
+            lock.unlock();
             reason = this_thread::suspend(threads::suspended, description, ec);
             if (ec) return threads::wait_unknown;
         }
@@ -189,7 +189,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail
     }
 
     threads::thread_state_ex_enum condition_variable::wait_until(
-        boost::unique_lock<mutex_type>& lock,
+        boost::unique_lock<mutex_type>&& lock,
         util::steady_time_point const& abs_time,
         char const* description, error_code& ec)
     {
@@ -204,7 +204,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail
         threads::thread_state_ex_enum reason = threads::wait_unknown;
         {
             // yield this thread
-            util::unlock_guard<boost::unique_lock<mutex_type> > unlock(lock);
+            lock.unlock();
             reason = this_thread::suspend(abs_time, description, ec);
             if (ec) return threads::wait_unknown;
         }

--- a/src/performance_counters/server/statistics_counter.cpp
+++ b/src/performance_counters/server/statistics_counter.cpp
@@ -8,6 +8,7 @@
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/runtime/agas/interface.hpp>
 #include <hpx/util/high_resolution_clock.hpp>
+#include <hpx/util/unlock_guard.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/stubs/performance_counter.hpp>

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -33,6 +33,7 @@
 #include <hpx/util/assert.hpp>
 #include <hpx/util/bind.hpp>
 #include <hpx/util/register_locks.hpp>
+#include <hpx/util/unlock_guard.hpp>
 #include <hpx/include/performance_counters.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/lcos/wait_all.hpp>

--- a/src/runtime/agas/server/primary_namespace_server.cpp
+++ b/src/runtime/agas/server/primary_namespace_server.cpp
@@ -396,7 +396,7 @@ response primary_namespace::begin_migration(
                 id,
                 hpx::util::make_tuple(
                     false, 0,
-                    boost::make_shared<lcos::local::condition_variable>()
+                    boost::make_shared<lcos::local::condition_variable_any>()
                 )
             ));
 #endif

--- a/src/runtime/agas/server/symbol_namespace_server.cpp
+++ b/src/runtime/agas/server/symbol_namespace_server.cpp
@@ -15,6 +15,7 @@
 #include <hpx/runtime/agas/server/symbol_namespace.hpp>
 #include <hpx/include/performance_counters.hpp>
 #include <hpx/util/get_and_reset_value.hpp>
+#include <hpx/util/unlock_guard.hpp>
 
 #include <boost/make_shared.hpp>
 #include <boost/thread/locks.hpp>

--- a/src/runtime/components/console_logging.cpp
+++ b/src/runtime/components/console_logging.cpp
@@ -16,6 +16,7 @@
 #include <hpx/runtime/agas/addressing_service.hpp>
 #include <hpx/runtime/applier/apply.hpp>
 #include <hpx/util/reinitializable_static.hpp>
+#include <hpx/util/unlock_guard.hpp>
 
 #include <boost/fusion/include/at_c.hpp>
 #include <boost/thread/locks.hpp>

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -14,6 +14,7 @@
 #include <hpx/util/safe_lexical_cast.hpp>
 #include <hpx/util/runtime_configuration.hpp>
 #include <hpx/util/bind.hpp>
+#include <hpx/util/unlock_guard.hpp>
 #include <hpx/runtime/naming/resolver_client.hpp>
 #include <hpx/runtime/parcelset/parcelhandler.hpp>
 #include <hpx/runtime/parcelset/static_parcelports.hpp>

--- a/src/runtime/threads/thread.cpp
+++ b/src/runtime/threads/thread.cpp
@@ -12,6 +12,7 @@
 #include <hpx/runtime/components/runtime_support.hpp>
 #include <hpx/lcos/future.hpp>
 #include <hpx/util/register_locks.hpp>
+#include <hpx/util/unlock_guard.hpp>
 
 #include <boost/thread/locks.hpp>
 

--- a/src/runtime/threads/thread_data.cpp
+++ b/src/runtime/threads/thread_data.cpp
@@ -11,6 +11,7 @@
 #include <hpx/runtime/threads/threadmanager.hpp>
 #include <hpx/runtime/threads/thread_data.hpp>
 #include <hpx/util/assert.hpp>
+#include <hpx/util/unlock_guard.hpp>
 
 // #if HPX_DEBUG
 // #  define HPX_DEBUG_THREAD_POOL 1

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -18,7 +18,6 @@
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/unlock_guard.hpp>
 #include <hpx/util/logging.hpp>
 #include <hpx/util/block_profiler.hpp>
 #include <hpx/util/itt_notify.hpp>

--- a/src/util/query_counters.cpp
+++ b/src/util/query_counters.cpp
@@ -10,6 +10,7 @@
 #include <hpx/util/query_counters.hpp>
 #include <hpx/util/high_resolution_clock.hpp>
 #include <hpx/util/apex.hpp>
+#include <hpx/util/unlock_guard.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/runtime/get_config_entry.hpp>
 #include <hpx/performance_counters/counters.hpp>

--- a/tests/regressions/lcos/ignore_while_locked_1485.cpp
+++ b/tests/regressions/lcos/ignore_while_locked_1485.cpp
@@ -14,14 +14,14 @@
 struct wait_for_flag
 {
     hpx::lcos::local::spinlock mutex;
-    hpx::lcos::local::condition_variable cond_var;
+    hpx::lcos::local::condition_variable_any cond_var;
 
     wait_for_flag()
       : flag(false), woken(0)
     {}
 
     void wait(hpx::lcos::local::spinlock& local_mutex,
-        hpx::lcos::local::condition_variable& local_cond_var, bool& running)
+        hpx::lcos::local::condition_variable_any& local_cond_var, bool& running)
     {
         bool first = true;
         while (!flag)
@@ -54,7 +54,7 @@ void test_condition_with_mutex()
 
     bool running = false;
     hpx::lcos::local::spinlock local_mutex;
-    hpx::lcos::local::condition_variable local_cond_var;
+    hpx::lcos::local::condition_variable_any local_cond_var;
 
     hpx::thread thread(&wait_for_flag::wait, boost::ref(data),
         boost::ref(local_mutex), boost::ref(local_cond_var), boost::ref(running));

--- a/tests/unit/lcos/apply_local.cpp
+++ b/tests/unit/lcos/apply_local.cpp
@@ -11,7 +11,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 boost::atomic<boost::int32_t> accumulator;
-hpx::lcos::local::condition_variable result_cv;
+hpx::lcos::local::condition_variable_any result_cv;
 
 void increment(boost::int32_t i)
 {

--- a/tests/unit/lcos/apply_local_executor.cpp
+++ b/tests/unit/lcos/apply_local_executor.cpp
@@ -12,7 +12,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 boost::atomic<boost::int32_t> accumulator;
-hpx::lcos::local::condition_variable result_cv;
+hpx::lcos::local::condition_variable_any result_cv;
 
 void increment(boost::int32_t i)
 {

--- a/tests/unit/lcos/condition_variable.cpp
+++ b/tests/unit/lcos/condition_variable.cpp
@@ -10,7 +10,7 @@
 #include <hpx/hpx_fwd.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/lcos/local/condition_variable.hpp>
-#include <hpx/lcos/local/spinlock.hpp>
+#include <hpx/lcos/local/mutex.hpp>
 #include <hpx/runtime/threads/thread.hpp>
 #include <hpx/runtime/threads/topology.hpp>
 
@@ -21,13 +21,13 @@
 
 namespace
 {
-    hpx::lcos::local::spinlock multiple_wake_mutex;
+    hpx::lcos::local::mutex multiple_wake_mutex;
     hpx::lcos::local::condition_variable multiple_wake_cond;
     unsigned multiple_wake_count=0;
 
     void wait_for_condvar_and_increase_count()
     {
-        boost::unique_lock<hpx::lcos::local::spinlock> lk(multiple_wake_mutex);
+        boost::unique_lock<hpx::lcos::local::mutex> lk(multiple_wake_mutex);
         multiple_wake_cond.wait(lk);
         ++multiple_wake_count;
     }
@@ -43,7 +43,7 @@ namespace
 ///////////////////////////////////////////////////////////////////////////////
 struct wait_for_flag
 {
-    hpx::lcos::local::spinlock mutex;
+    hpx::lcos::local::mutex mutex;
     hpx::lcos::local::condition_variable cond_var;
     bool flag;
     unsigned woken;
@@ -71,7 +71,7 @@ struct wait_for_flag
 
     void wait_without_predicate()
     {
-        boost::unique_lock<hpx::lcos::local::spinlock> lock(mutex);
+        boost::unique_lock<hpx::lcos::local::mutex> lock(mutex);
         while(!flag)
         {
             cond_var.wait(lock);
@@ -81,7 +81,7 @@ struct wait_for_flag
 
     void wait_with_predicate()
     {
-        boost::unique_lock<hpx::lcos::local::spinlock> lock(mutex);
+        boost::unique_lock<hpx::lcos::local::mutex> lock(mutex);
         cond_var.wait(lock,check_flag(flag));
         if(flag)
         {
@@ -94,7 +94,7 @@ struct wait_for_flag
         boost::chrono::system_clock::time_point const timeout =
             boost::chrono::system_clock::now() + boost::chrono::milliseconds(5);
 
-        boost::unique_lock<hpx::lcos::local::spinlock> lock(mutex);
+        boost::unique_lock<hpx::lcos::local::mutex> lock(mutex);
         while(!flag)
         {
             if(cond_var.wait_until(lock,timeout) == hpx::lcos::local::cv_status::timeout)
@@ -110,7 +110,7 @@ struct wait_for_flag
         boost::chrono::system_clock::time_point const timeout =
             boost::chrono::system_clock::now() + boost::chrono::milliseconds(5);
 
-        boost::unique_lock<hpx::lcos::local::spinlock> lock(mutex);
+        boost::unique_lock<hpx::lcos::local::mutex> lock(mutex);
         if(cond_var.wait_until(lock,timeout,check_flag(flag)) && flag)
         {
             ++woken;
@@ -118,7 +118,7 @@ struct wait_for_flag
     }
     void relative_wait_until_with_predicate()
     {
-        boost::unique_lock<hpx::lcos::local::spinlock> lock(mutex);
+        boost::unique_lock<hpx::lcos::local::mutex> lock(mutex);
         if(cond_var.wait_for(lock,boost::chrono::milliseconds(5),
             check_flag(flag)) && flag)
         {
@@ -134,7 +134,7 @@ void test_condition_notify_one_wakes_from_wait()
     hpx::thread thread(&wait_for_flag::wait_without_predicate, boost::ref(data));
 
     {
-        boost::unique_lock<hpx::lcos::local::spinlock> lock(data.mutex);
+        boost::unique_lock<hpx::lcos::local::mutex> lock(data.mutex);
         data.flag=true;
     }
 
@@ -151,7 +151,7 @@ void test_condition_notify_one_wakes_from_wait_with_predicate()
     hpx::thread thread(&wait_for_flag::wait_with_predicate, boost::ref(data));
 
     {
-        boost::unique_lock<hpx::lcos::local::spinlock> lock(data.mutex);
+        boost::unique_lock<hpx::lcos::local::mutex> lock(data.mutex);
         data.flag=true;
     }
 
@@ -168,7 +168,7 @@ void test_condition_notify_one_wakes_from_wait_until()
     hpx::thread thread(&wait_for_flag::wait_until_without_predicate, boost::ref(data));
 
     {
-        boost::unique_lock<hpx::lcos::local::spinlock> lock(data.mutex);
+        boost::unique_lock<hpx::lcos::local::mutex> lock(data.mutex);
         data.flag=true;
     }
 
@@ -185,7 +185,7 @@ void test_condition_notify_one_wakes_from_wait_until_with_predicate()
     hpx::thread thread(&wait_for_flag::wait_until_with_predicate, boost::ref(data));
 
     {
-        boost::unique_lock<hpx::lcos::local::spinlock> lock(data.mutex);
+        boost::unique_lock<hpx::lcos::local::mutex> lock(data.mutex);
         data.flag=true;
     }
 
@@ -203,7 +203,7 @@ void test_condition_notify_one_wakes_from_relative_wait_until_with_predicate()
         boost::ref(data));
 
     {
-        boost::unique_lock<hpx::lcos::local::spinlock> lock(data.mutex);
+        boost::unique_lock<hpx::lcos::local::mutex> lock(data.mutex);
         data.flag=true;
     }
 
@@ -231,7 +231,7 @@ void test_multiple_notify_one_calls_wakes_multiple_threads()
     hpx::this_thread::sleep_for(boost::chrono::milliseconds(200));
 
     {
-        boost::unique_lock<hpx::lcos::local::spinlock> lk(multiple_wake_mutex);
+        boost::unique_lock<hpx::lcos::local::mutex> lk(multiple_wake_mutex);
         HPX_TEST(multiple_wake_count==3);
     }
 
@@ -257,7 +257,7 @@ void test_condition_notify_all_wakes_from_wait()
         }
 
         {
-            boost::unique_lock<hpx::lcos::local::spinlock> lock(data.mutex);
+            boost::unique_lock<hpx::lcos::local::mutex> lock(data.mutex);
             data.flag=true;
         }
 
@@ -288,7 +288,7 @@ void test_condition_notify_all_wakes_from_wait_with_predicate()
         }
 
         {
-            boost::unique_lock<hpx::lcos::local::spinlock> lock(data.mutex);
+            boost::unique_lock<hpx::lcos::local::mutex> lock(data.mutex);
             data.flag=true;
         }
 
@@ -319,7 +319,7 @@ void test_condition_notify_all_wakes_from_wait_until()
         }
 
         {
-            boost::unique_lock<hpx::lcos::local::spinlock> lock(data.mutex);
+            boost::unique_lock<hpx::lcos::local::mutex> lock(data.mutex);
             data.flag=true;
         }
 
@@ -350,7 +350,7 @@ void test_condition_notify_all_wakes_from_wait_until_with_predicate()
         }
 
         {
-            boost::unique_lock<hpx::lcos::local::spinlock> lock(data.mutex);
+            boost::unique_lock<hpx::lcos::local::mutex> lock(data.mutex);
             data.flag=true;
         }
 
@@ -381,7 +381,7 @@ void test_condition_notify_all_wakes_from_relative_wait_until_with_predicate()
         }
 
         {
-            boost::unique_lock<hpx::lcos::local::spinlock> lock(data.mutex);
+            boost::unique_lock<hpx::lcos::local::mutex> lock(data.mutex);
             data.flag=true;
         }
 
@@ -415,7 +415,7 @@ void test_notify_all_following_notify_one_wakes_all_threads()
     hpx::this_thread::sleep_for(boost::chrono::milliseconds(200));
 
     {
-        boost::unique_lock<hpx::lcos::local::spinlock> lk(multiple_wake_mutex);
+        boost::unique_lock<hpx::lcos::local::mutex> lk(multiple_wake_mutex);
         HPX_TEST(multiple_wake_count==3);
     }
 
@@ -429,7 +429,7 @@ struct condition_test_data
 {
     condition_test_data() : notified(0), awoken(0) { }
 
-    hpx::lcos::local::spinlock mutex;
+    hpx::lcos::local::mutex mutex;
     hpx::lcos::local::condition_variable condition;
     int notified;
     int awoken;
@@ -437,7 +437,7 @@ struct condition_test_data
 
 void condition_test_thread(condition_test_data* data)
 {
-    boost::unique_lock<hpx::lcos::local::spinlock> lock(data->mutex);
+    boost::unique_lock<hpx::lcos::local::mutex> lock(data->mutex);
     HPX_TEST(lock ? true : false);
     while (!(data->notified > 0))
         data->condition.wait(lock);
@@ -460,7 +460,7 @@ private:
 
 void condition_test_waits(condition_test_data* data)
 {
-    boost::unique_lock<hpx::lcos::local::spinlock> lock(data->mutex);
+    boost::unique_lock<hpx::lcos::local::mutex> lock(data->mutex);
     HPX_TEST(lock ? true : false);
 
     // Test wait.
@@ -512,7 +512,7 @@ void condition_test_waits(condition_test_data* data)
 
 void test_condition_waits()
 {
-    typedef boost::unique_lock<hpx::lcos::local::spinlock> unique_lock;
+    typedef boost::unique_lock<hpx::lcos::local::mutex> unique_lock;
 
     condition_test_data data;
 
@@ -601,9 +601,9 @@ boost::chrono::milliseconds const timeout_resolution(100);
 void test_wait_until_times_out()
 {
     hpx::lcos::local::condition_variable cond;
-    hpx::lcos::local::spinlock m;
+    hpx::lcos::local::mutex m;
 
-    boost::unique_lock<hpx::lcos::local::spinlock> lock(m);
+    boost::unique_lock<hpx::lcos::local::mutex> lock(m);
     boost::chrono::system_clock::time_point const start =
         boost::chrono::system_clock::now();
     boost::chrono::system_clock::time_point const timeout = start + delay;
@@ -618,9 +618,9 @@ void test_wait_until_times_out()
 void test_wait_until_with_predicate_times_out()
 {
     hpx::lcos::local::condition_variable cond;
-    hpx::lcos::local::spinlock m;
+    hpx::lcos::local::mutex m;
 
-    boost::unique_lock<hpx::lcos::local::spinlock> lock(m);
+    boost::unique_lock<hpx::lcos::local::mutex> lock(m);
     boost::chrono::system_clock::time_point const start =
         boost::chrono::system_clock::now();
     boost::chrono::system_clock::time_point const timeout = start + delay;
@@ -636,9 +636,9 @@ void test_wait_until_with_predicate_times_out()
 void test_relative_wait_until_with_predicate_times_out()
 {
     hpx::lcos::local::condition_variable cond;
-    hpx::lcos::local::spinlock m;
+    hpx::lcos::local::mutex m;
 
-    boost::unique_lock<hpx::lcos::local::spinlock> lock(m);
+    boost::unique_lock<hpx::lcos::local::mutex> lock(m);
     boost::chrono::system_clock::time_point const start =
         boost::chrono::system_clock::now();
 
@@ -653,9 +653,9 @@ void test_relative_wait_until_with_predicate_times_out()
 void test_wait_until_relative_times_out()
 {
     hpx::lcos::local::condition_variable cond;
-    hpx::lcos::local::spinlock m;
+    hpx::lcos::local::mutex m;
 
-    boost::unique_lock<hpx::lcos::local::spinlock> lock(m);
+    boost::unique_lock<hpx::lcos::local::mutex> lock(m);
     boost::chrono::system_clock::time_point const start =
         boost::chrono::system_clock::now();
 

--- a/tests/unit/lcos/local_mutex.cpp
+++ b/tests/unit/lcos/local_mutex.cpp
@@ -29,7 +29,7 @@ struct test_lock
     void operator()()
     {
         mutex_type mutex;
-        hpx::lcos::local::condition_variable condition;
+        hpx::lcos::local::condition_variable_any condition;
 
         // Test the lock's constructors.
         {
@@ -67,7 +67,7 @@ struct test_trylock
     void operator()()
     {
         mutex_type mutex;
-        hpx::lcos::local::condition_variable condition;
+        hpx::lcos::local::condition_variable_any condition;
 
         // Test the lock's constructors.
         {
@@ -113,7 +113,7 @@ struct test_lock_times_out_if_other_thread_has_lock
     hpx::lcos::local::mutex done_mutex;
     bool done;
     bool locked;
-    hpx::lcos::local::condition_variable done_cond;
+    hpx::lcos::local::condition_variable_any done_cond;
 
     test_lock_times_out_if_other_thread_has_lock():
         done(false),locked(false)
@@ -201,7 +201,7 @@ struct test_timedlock
         test_lock_times_out_if_other_thread_has_lock<mutex_type>()();
 
         mutex_type mutex;
-        hpx::lcos::local::condition_variable condition;
+        hpx::lcos::local::condition_variable_any condition;
 
         // Test the lock's constructors.
         {


### PR DESCRIPTION
- Split `condition_variable` and `condition_variable_any`
- Restrict `detail::condition_variable` to spinlocks only, avoid unnecessary relocking
- Adjust uses of cv as needed
