### PR TITLE
Moving coalescing registration to TUs

### DIFF
--- a/hpx/components/iostreams/write_functions.hpp
+++ b/hpx/components/iostreams/write_functions.hpp
@@ -12,11 +12,12 @@
 #include <hpx/util/bind.hpp>
 #include <hpx/util/function.hpp>
 
-#include <ostream>
-#include <iterator>
 #include <algorithm>
 #include <deque>
+#include <iterator>
+#include <ostream>
 #include <type_traits>
+#include <vector>
 
 namespace hpx { namespace iostreams
 {

--- a/hpx/lcos/base_lco.hpp
+++ b/hpx/lcos/base_lco.hpp
@@ -14,10 +14,6 @@
 #include <hpx/runtime/actions/component_action.hpp>
 #include <hpx/util/ini.hpp>
 
-#include <hpx/plugins/parcel/coalescing_message_handler_registration.hpp>
-
-#include <boost/mpl/bool.hpp>
-
 namespace hpx { namespace lcos
 {
     /// The \a base_lco class is the common base class for all LCO's
@@ -123,13 +119,5 @@ HPX_REGISTER_ACTION_DECLARATION(
     hpx::lcos::base_lco::connect_action, base_connect_action)
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::lcos::base_lco::disconnect_action, base_disconnect_action)
-
-///////////////////////////////////////////////////////////////////////////////
-HPX_ACTION_USES_MESSAGE_COALESCING_NOTHROW(
-    hpx::lcos::base_lco::set_event_action, "lco_set_value_action",
-    std::size_t(-1), std::size_t(-1))
-HPX_ACTION_USES_MESSAGE_COALESCING_NOTHROW(
-    hpx::lcos::base_lco::set_exception_action, "lco_set_value_action",
-    std::size_t(-1), std::size_t(-1))
 
 #endif

--- a/hpx/lcos/base_lco_with_value.hpp
+++ b/hpx/lcos/base_lco_with_value.hpp
@@ -18,10 +18,11 @@
 #include <hpx/util/unused.hpp>
 #include <hpx/util/void_guard.hpp>
 
-#include <boost/mpl/bool.hpp>
-#include <boost/mpl/if.hpp>
+#include <hpx/plugins/parcel/coalescing_message_handler_registration.hpp>
+
 #include <boost/preprocessor/cat.hpp>
-#include <boost/type_traits/is_same.hpp>
+
+#include <type_traits>
 
 namespace hpx { namespace lcos
 {
@@ -35,8 +36,8 @@ namespace hpx { namespace lcos
     template <typename Result, typename RemoteResult>
     class base_lco_with_value : public base_lco
     {
-        typedef typename boost::mpl::if_<
-            boost::is_same<void, Result>, util::unused_type, Result
+        typedef typename std::conditional<
+            std::is_void<Result>::value, util::unused_type, Result
         >::type result_type;
 
     protected:
@@ -162,9 +163,6 @@ namespace hpx { namespace traits
     HPX_REGISTER_TYPED_CONTINUATION_DECLARATION(                                \
         Value                                                                   \
       , BOOST_PP_CAT(typed_continuation_, Name))                                \
-    HPX_ACTION_USES_MESSAGE_COALESCING_NOTHROW(                                 \
-        hpx::lcos::base_lco_with_value<Value>::set_value_action,                \
-        "lco_set_value_action", std::size_t(-1), std::size_t(-1))               \
 /**/
 
 #define HPX_REGISTER_BASE_LCO_WITH_VALUE(Value, Name)                           \
@@ -177,6 +175,9 @@ namespace hpx { namespace traits
     HPX_REGISTER_TYPED_CONTINUATION(                                            \
         Value                                                                   \
       , BOOST_PP_CAT(typed_continuation_, Name))                                \
+    HPX_ACTION_USES_MESSAGE_COALESCING_NOTHROW(                                 \
+        hpx::lcos::base_lco_with_value<Value>::set_value_action,                \
+        "lco_set_value_action", std::size_t(-1), std::size_t(-1))               \
 /**/
 
 #define HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(                                    \

--- a/hpx/parallel/segmented_algorithms/count.hpp
+++ b/hpx/parallel/segmented_algorithms/count.hpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <numeric>
 #include <type_traits>
 #include <list>
 

--- a/hpx/plugins/parcel/coalescing_message_handler_registration.hpp
+++ b/hpx/plugins/parcel/coalescing_message_handler_registration.hpp
@@ -47,8 +47,8 @@ namespace hpx { namespace parcelset
 #define HPX_REGISTER_COALESCING_COUNTERS(Action, coalescing_name)             \
     namespace hpx { namespace parcelset                                       \
     {                                                                         \
-        template<>                                                            \
-        inline char const* get_action_coalescing_name<Action>()               \
+        template<> HPX_ALWAYS_EXPORT                                          \
+        char const* get_action_coalescing_name<Action>()                      \
         {                                                                     \
             return coalescing_name;                                           \
         }                                                                     \

--- a/hpx/util/ini.hpp
+++ b/hpx/util/ini.hpp
@@ -8,12 +8,13 @@
 #if !defined(HPX_UTIL_SECTION_SEP_17_2008_022PM)
 #define HPX_UTIL_SECTION_SEP_17_2008_022PM
 
-#include <map>
-#include <iostream>
-
 #include <hpx/runtime/serialization/serialization_fwd.hpp>
 
 #include <boost/lexical_cast.hpp>
+
+#include <iostream>
+#include <map>
+#include <vector>
 
 // suppress warnings about dependent classes not being exported from the dll
 #if defined(HPX_MSVC)

--- a/src/lcos/base_lco.cpp
+++ b/src/lcos/base_lco.cpp
@@ -4,7 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/hpx_fwd.hpp>
+#include <hpx/config.hpp>
 #include <hpx/runtime/applier/applier.hpp>
 #include <hpx/runtime/components/component_factory.hpp>
 #include <hpx/runtime/components/derived_component_factory.hpp>
@@ -12,6 +12,8 @@
 #include <hpx/lcos/base_lco.hpp>
 #include <hpx/util/ini.hpp>
 #include <hpx/util/serialize_exception.hpp>
+
+#include <hpx/plugins/parcel/coalescing_message_handler_registration.hpp>
 
 namespace hpx { namespace lcos
 {
@@ -72,6 +74,14 @@ HPX_REGISTER_ACTION_ID(hpx::lcos::base_lco::connect_action,
     base_connect_action, hpx::actions::base_connect_action_id)
 HPX_REGISTER_ACTION_ID(hpx::lcos::base_lco::disconnect_action,
     base_disconnect_action, hpx::actions::base_disconnect_action_id)
+
+///////////////////////////////////////////////////////////////////////////////
+HPX_ACTION_USES_MESSAGE_COALESCING_NOTHROW(
+    hpx::lcos::base_lco::set_event_action, "lco_set_value_action",
+    std::size_t(-1), std::size_t(-1))
+HPX_ACTION_USES_MESSAGE_COALESCING_NOTHROW(
+    hpx::lcos::base_lco::set_exception_action, "lco_set_value_action",
+    std::size_t(-1), std::size_t(-1))
 
 ///////////////////////////////////////////////////////////////////////////////
 HPX_DEFINE_GET_COMPONENT_TYPE_STATIC(

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -6,7 +6,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/hpx_fwd.hpp>
+#include <hpx/config.hpp>
 #include <hpx/state.hpp>
 #include <hpx/exception.hpp>
 #include <hpx/config/asio.hpp>
@@ -18,6 +18,7 @@
 #include <hpx/runtime/naming/resolver_client.hpp>
 #include <hpx/runtime/parcelset/parcelhandler.hpp>
 #include <hpx/runtime/parcelset/static_parcelports.hpp>
+#include <hpx/runtime/parcelset/policies/message_handler.hpp>
 #include <hpx/runtime/threads/threadmanager.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/runtime/applier/applier.hpp>

--- a/tests/unit/parcelset/put_parcels_with_coalescing.cpp
+++ b/tests/unit/parcelset/put_parcels_with_coalescing.cpp
@@ -5,6 +5,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
+#include <hpx/include/actions.hpp>
 #include <hpx/include/performance_counters.hpp>
 #include <hpx/include/iostreams.hpp>
 #include <hpx/util/lightweight_test.hpp>

--- a/tests/unit/serialization/serialize_buffer.cpp
+++ b/tests/unit/serialization/serialize_buffer.cpp
@@ -6,6 +6,7 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
+#include <hpx/include/actions.hpp>
 #include <hpx/util/lightweight_test.hpp>
 #include <hpx/runtime/serialization/serialize_buffer.hpp>
 


### PR DESCRIPTION
This patch moves the parcel coalescing registration macros from the
headers into the translation units.

flyby: remove boost::mpl from base_lco and some minor header cleanup

This also fixes a memory leak reported from LeakSanitizer