### PR TITLE
Instantiate board in nqueen client

### DIFF
--- a/examples/nqueen/nqueen_client.cpp
+++ b/examples/nqueen/nqueen_client.cpp
@@ -40,7 +40,7 @@ int hpx_main(boost::program_options::variables_map&)
 
             std::size_t i = 0;
             std::list<nqueen::board> b;
-            nqueen::board bi;
+            nqueen::board bi = hpx::new_<nqueen::board>(locality_);
             while(i != sz)
             {
                 b.push_back(bi);
@@ -63,7 +63,7 @@ int hpx_main(boost::program_options::variables_map&)
         else if(cmd == "default")
         {
             soln_count_total = 0;
-            nqueen::board a;
+            nqueen::board a = hpx::new_<nqueen::board>(locality_);
             std::size_t i = 0;
             std::vector<nqueen::board> b;
             while(i != default_size)


### PR DESCRIPTION
The previous code gave a future_has_no_valid_shared_state_exception, because the board object was not being instantiated. Now, when the option 'default' is chosen to solve the standard nqueens puzzle having board size 8 X 8, the correct answer 92 is printed. I think this should fix https://github.com/STEllAR-GROUP/hpx/issues/802#issuecomment-194255571.