### PR TITLE
Making sure init_globally always executes hpx_main

### DIFF
--- a/examples/quickstart/init_globally.cpp
+++ b/examples/quickstart/init_globally.cpp
@@ -75,13 +75,17 @@ struct manage_global_runtime
         hpx::detail::init_winsocket();
 #endif
 
+        // make sure hpx_main is always executed
+        std::vector<std::string> cfg;
+        cfg.push_back("hpx.run_hpx_main!=1");
+
         using hpx::util::placeholders::_1;
         using hpx::util::placeholders::_2;
 
-        auto start_function =
+        hpx::util::function_nonser<int(int, char**)> start_function =
             hpx::util::bind(&manage_global_runtime::hpx_main, this, _1, _2);
 
-        if (!hpx::start(start_function, __argc, __argv, hpx::runtime_mode_console))
+        if (!hpx::start(start_function, __argc, __argv, cfg, hpx::runtime_mode_console))
         {
             // Something went wrong while initializing the runtime.
             // This early we can't generate any output, just bail out.

--- a/hpx/hpx_init.hpp
+++ b/hpx/hpx_init.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //  Copyright (c) 2010-2011 Phillip LeBlanc, Dylan Stark
 //  Copyright (c)      2011 Bryce Lelbach
 //
@@ -667,6 +667,46 @@ namespace hpx
     ///                     command line arguments passed in `argc`/`argv`.
     inline int init(util::function_nonser<int(int, char**)> const& f,
         int argc, char** argv, hpx::runtime_mode mode = hpx::runtime_mode_default);
+
+    /// \brief Main entry point for launching the HPX runtime system.
+    ///
+    /// This is a simplified main entry point, which can be used to set up the
+    /// runtime for an HPX application (the runtime system will be set up in
+    /// console mode or worker mode depending on the command line settings).
+    ///
+    /// \param f            [in] The function to be scheduled as an HPX
+    ///                     thread. Usually this function represents the main
+    ///                     entry point of any HPX application.
+    /// \param argc         [in] The number of command line arguments passed
+    ///                     in \p argv. This is usually the unchanged value as
+    ///                     passed by the operating system (to `main()`).
+    /// \param argv         [in] The command line arguments for this
+    ///                     application, usually that is the value as passed
+    ///                     by the operating system (to `main()`).
+    /// \param cfg          A list of configuration settings which will be added
+    ///                     to the system configuration before the runtime
+    ///                     instance is run. Each of the entries in this list
+    ///                     must have the format of a fully defined key/value
+    ///                     pair from an ini-file (for instance
+    ///                     'hpx.component.enabled=1')
+    /// \param mode         [in] The mode the created runtime environment
+    ///                     should be initialized in. There has to be exactly
+    ///                     one locality in each HPX application which is
+    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     all other localities have to be run in worker mode
+    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     set up automatically, but sometimes it is necessary
+    ///                     to explicitly specify the mode.
+    ///
+    /// \returns            The function returns the value, which has been
+    ///                     returned from the user supplied function \p f.
+    ///
+    /// \note               The created runtime system instance will be
+    ///                     executed in console or worker mode depending on the
+    ///                     command line arguments passed in `argc`/`argv`.
+    inline int init(util::function_nonser<int(int, char**)> const& f,
+        int argc, char** argv, std::vector<std::string> const& cfg,
+        hpx::runtime_mode mode = hpx::runtime_mode_default);
 }
 
 #ifndef DOXYGEN

--- a/hpx/hpx_start.hpp
+++ b/hpx/hpx_start.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -674,6 +674,48 @@ namespace hpx
     ///                     command line arguments passed in `argc`/`argv`.
     inline bool start(util::function_nonser<int(int, char**)> const& f,
         int argc, char** argv, hpx::runtime_mode mode = hpx::runtime_mode_default);
+
+    /// \brief Main non-blocking entry point for launching the HPX runtime system.
+    ///
+    /// This is a simplified main, non-blocking entry point, which can be used
+    /// to set up the runtime for an HPX application (the runtime system will
+    /// be set up in console mode or worker mode depending on the command line
+    /// settings). It will return immediatly after that. Use `hpx::wait` and
+    ///
+    /// \param f            [in] The function to be scheduled as an HPX
+    ///                     thread. Usually this function represents the main
+    ///                     entry point of any HPX application.
+    /// \param argc         [in] The number of command line arguments passed
+    ///                     in \p argv. This is usually the unchanged value as
+    ///                     passed by the operating system (to `main()`).
+    /// \param argv         [in] The command line arguments for this
+    ///                     application, usually that is the value as passed
+    ///                     by the operating system (to `main()`).
+    /// \param cfg          A list of configuration settings which will be added
+    ///                     to the system configuration before the runtime
+    ///                     instance is run. Each of the entries in this list
+    ///                     must have the format of a fully defined key/value
+    ///                     pair from an ini-file (for instance
+    ///                     'hpx.component.enabled=1')
+    /// \param mode         [in] The mode the created runtime environment
+    ///                     should be initialized in. There has to be exactly
+    ///                     one locality in each HPX application which is
+    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     all other localities have to be run in worker mode
+    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     set up automatically, but sometimes it is necessary
+    ///                     to explicitly specify the mode.
+    ///
+    /// \returns            The function returns \a true if command line processing
+    ///                     succeeded and the runtime system was started successfully.
+    ///                     It will return \a false otherwise.
+    ///
+    /// \note               The created runtime system instance will be
+    ///                     executed in console or worker mode depending on the
+    ///                     command line arguments passed in `argc`/`argv`.
+    inline bool start(util::function_nonser<int(int, char**)> const& f,
+        int argc, char** argv, std::vector<std::string> const& cfg,
+        hpx::runtime_mode mode = hpx::runtime_mode_default);
 }
 
 #ifndef DOXYGEN

--- a/hpx/hpx_start_impl.hpp
+++ b/hpx/hpx_start_impl.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -7,7 +7,7 @@
 #define HPX_START_IMPL_OCT_04_2012_0252PM
 
 #include <hpx/hpx_start.hpp>
-
+#include <hpx/util/assert.hpp>
 #include <hpx/util/find_prefix.hpp>
 
 namespace hpx
@@ -265,18 +265,15 @@ namespace hpx
         options_description desc_commandline(
             "Usage: " + app_name +  " [options]");
 
-        if (argc == 0 || argv == 0)
-        {
-            char *dummy_argv[2] = { const_cast<char*>(app_name.c_str()), 0 };
-            return start(desc_commandline, 1, dummy_argv, mode);
-        }
-
+        util::function_nonser<int(boost::program_options::variables_map& vm)>
+            main_f = util::bind(detail::init_helper, util::placeholders::_1, f);
         std::vector<std::string> cfg;
         util::function_nonser<void()> const empty;
 
-        return start(
-            util::bind(detail::init_helper, util::placeholders::_1, f),
-            desc_commandline, argc, argv, cfg, empty, empty, mode);
+        HPX_ASSERT(argc != 0 && argv != 0);
+
+        return start(main_f, desc_commandline, argc, argv, cfg, empty, empty,
+            mode);
     }
 
     // Main non-blocking entry point for launching the HPX runtime system.
@@ -285,6 +282,26 @@ namespace hpx
     {
         std::string app_name(HPX_APPLICATION_STRING);
         return start(f, app_name, argc, argv, mode);
+    }
+
+    inline bool start(util::function_nonser<int(int, char**)> const& f,
+        int argc, char** argv, std::vector<std::string> const& cfg,
+        hpx::runtime_mode mode)
+    {
+        std::string app_name(HPX_APPLICATION_STRING);
+        using boost::program_options::options_description;
+
+        options_description desc_commandline(
+            "Usage: " + app_name +  " [options]");
+
+        util::function_nonser<int(boost::program_options::variables_map& vm)>
+            main_f = util::bind(detail::init_helper, util::placeholders::_1, f);
+        util::function_nonser<void()> const empty;
+
+        HPX_ASSERT(argc != 0 && argv != 0);
+
+        return start(main_f, desc_commandline, argc, argv, cfg,
+            empty, empty, mode);
     }
 }
 


### PR DESCRIPTION
- adding another overload for hpx::init() and hpx::start()