### PR TITLE
Add include checks for several Boost utilities

### DIFF
--- a/examples/async_io/async_io_action.cpp
+++ b/examples/async_io/async_io_action.cpp
@@ -15,6 +15,9 @@
 #include <hpx/include/runtime.hpp>
 #include <hpx/include/thread_executors.hpp>
 
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
+
 #include <string>
 #include <vector>
 

--- a/examples/async_io/async_io_external.cpp
+++ b/examples/async_io/async_io_external.cpp
@@ -11,6 +11,9 @@
 #include <hpx/include/runtime.hpp>
 #include <hpx/include/iostreams.hpp>
 
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////
 struct registration_wrapper
 {

--- a/examples/async_io/async_io_low_level.cpp
+++ b/examples/async_io/async_io_low_level.cpp
@@ -13,6 +13,9 @@
 #include <hpx/include/util.hpp>
 #include <hpx/util/io_service_pool.hpp>
 
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
+
 // this function will be executed by a dedicated OS thread
 void do_async_io(char const* string_to_write,
     boost::shared_ptr<hpx::lcos::local::promise<int> > p)

--- a/examples/jacobi/jacobi_component/row_range.hpp
+++ b/examples/jacobi/jacobi_component/row_range.hpp
@@ -7,7 +7,7 @@
 #ifndef JACOBI_ROW_RANGE_HPP
 #define JACOBI_ROW_RANGE_HPP
 
-#include <boost/smart_ptr/intrusive_ptr.hpp>
+#include <boost/intrusive_ptr.hpp>
 #include <boost/detail/atomic_count.hpp>
 #include <boost/range/iterator.hpp>
 #include <boost/range/mutable_iterator.hpp>

--- a/examples/jacobi/jacobi_component/server/row.hpp
+++ b/examples/jacobi/jacobi_component/server/row.hpp
@@ -11,6 +11,7 @@
 
 #include <hpx/include/components.hpp>
 
+#include <boost/intrusive_ptr.hpp>
 #include <boost/smart_ptr/shared_array.hpp>
 
 namespace jacobi {

--- a/examples/jacobi_smp/jacobi_hpx.cpp
+++ b/examples/jacobi_smp/jacobi_hpx.cpp
@@ -11,6 +11,8 @@
 #include <hpx/dataflow.hpp>
 #include <hpx/util/high_resolution_timer.hpp>
 
+#include <boost/shared_ptr.hpp>
+
 #include <string>
 #include <vector>
 

--- a/examples/jacobi_smp/jacobi_nonuniform_hpx.cpp
+++ b/examples/jacobi_smp/jacobi_nonuniform_hpx.cpp
@@ -10,6 +10,8 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/util/high_resolution_timer.hpp>
 
+#include <boost/shared_ptr.hpp>
+
 #include <vector>
 
 namespace jacobi_smp {

--- a/examples/quickstart/composable_guard.cpp
+++ b/examples/quickstart/composable_guard.cpp
@@ -5,6 +5,7 @@
 #include <hpx/lcos/local/composable_guard.hpp>
 #include <hpx/hpx_init.hpp>
 #include <boost/atomic.hpp>
+#include <boost/shared_ptr.hpp>
 #include <iostream>
 
 // This program illustrates the use of composable guards to perform

--- a/examples/quickstart/composable_guard.cpp
+++ b/examples/quickstart/composable_guard.cpp
@@ -4,6 +4,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #include <hpx/lcos/local/composable_guard.hpp>
 #include <hpx/hpx_init.hpp>
+#include <boost/atomic.hpp>
 #include <iostream>
 
 // This program illustrates the use of composable guards to perform

--- a/examples/quickstart/fibonacci_await.cpp
+++ b/examples/quickstart/fibonacci_await.cpp
@@ -13,11 +13,13 @@
 #include <hpx/include/util.hpp>
 #include <hpx/include/lcos.hpp>
 
-#include <iostream>
-#include <string>
-
 #include <boost/cstdint.hpp>
 #include <boost/format.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
+
+#include <iostream>
+#include <string>
 
 ///////////////////////////////////////////////////////////////////////////////
 boost::uint64_t threshold = 2;

--- a/examples/quickstart/fibonacci_futures_distributed.cpp
+++ b/examples/quickstart/fibonacci_futures_distributed.cpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 
+#include <boost/atomic.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/format.hpp>
 

--- a/examples/quickstart/fractals_struct.cpp
+++ b/examples/quickstart/fractals_struct.cpp
@@ -13,6 +13,8 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/serialization.hpp>
 
+#include <boost/shared_ptr.hpp>
+
 #include <vector>
 
 const std::size_t sizeY = 256;

--- a/examples/quickstart/pingpong.cpp
+++ b/examples/quickstart/pingpong.cpp
@@ -11,6 +11,9 @@
 #include <hpx/include/iostreams.hpp>
 #include <hpx/include/serialization.hpp>
 
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
+
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/examples/sheneos/sheneos/interpolator.cpp
+++ b/examples/sheneos/sheneos/interpolator.cpp
@@ -14,7 +14,7 @@
 #include <hpx/util/assert.hpp>
 
 #include <boost/make_shared.hpp>
-#include <boost/move/move.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <string>
 #include <vector>

--- a/examples/transpose/transpose_await.cpp
+++ b/examples/transpose/transpose_await.cpp
@@ -10,6 +10,7 @@
 #include <hpx/include/parallel_numeric.hpp>
 
 #include <boost/range/irange.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <algorithm>
 #include <string>

--- a/examples/transpose/transpose_block.cpp
+++ b/examples/transpose/transpose_block.cpp
@@ -10,6 +10,7 @@
 #include <hpx/include/parallel_numeric.hpp>
 
 #include <boost/range/irange.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <algorithm>
 #include <string>

--- a/examples/transpose/transpose_block_numa.cpp
+++ b/examples/transpose/transpose_block_numa.cpp
@@ -13,6 +13,7 @@
 #include <hpx/parallel/util/numa_allocator.hpp>
 
 #include <boost/range/irange.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <algorithm>
 #include <string>

--- a/external/asio/boost/asio/ip/basic_resolver_iterator.hpp
+++ b/external/asio/boost/asio/ip/basic_resolver_iterator.hpp
@@ -198,7 +198,7 @@ private:
 
   std::size_t index_;
   typedef std::vector<basic_resolver_entry<InternetProtocol> > values_type;
-  boost::shared_ptr<values_type> values_;
+  detail::shared_ptr<values_type> values_;
 };
 
 } // namespace ip

--- a/hpx/components/component_storage/server/migrate_from_storage.hpp
+++ b/hpx/components/component_storage/server/migrate_from_storage.hpp
@@ -19,6 +19,8 @@
 #include <hpx/components/component_storage/export_definitions.hpp>
 #include <hpx/components/component_storage/server/component_storage.hpp>
 
+#include <boost/shared_ptr.hpp>
+
 #include <vector>
 
 namespace hpx { namespace components { namespace server

--- a/hpx/components/component_storage/server/migrate_to_storage.hpp
+++ b/hpx/components/component_storage/server/migrate_to_storage.hpp
@@ -17,6 +17,8 @@
 #include <hpx/components/component_storage/export_definitions.hpp>
 #include <hpx/components/component_storage/server/component_storage.hpp>
 
+#include <boost/shared_ptr.hpp>
+
 #include <vector>
 
 namespace hpx { namespace components { namespace server

--- a/hpx/components/containers/partitioned_vector/partitioned_vector.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector.hpp
@@ -20,6 +20,9 @@
 #include <hpx/components/containers/partitioned_vector/partitioned_vector_segmented_iterator.hpp>
 #include <hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp>
 
+#include <boost/cstdint.hpp>
+#include <boost/shared_ptr.hpp>
+
 #include <algorithm>
 #include <cstdint>
 #include <iterator>
@@ -27,8 +30,6 @@
 #include <string>
 #include <type_traits>
 #include <vector>
-
-#include <boost/cstdint.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 /// \cond NOINTERNAL

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp
@@ -22,6 +22,7 @@
 #include <hpx/include/util.hpp>
 
 #include <boost/preprocessor/cat.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <iostream>
 #include <string>

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_segmented_iterator.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_segmented_iterator.hpp
@@ -20,16 +20,17 @@
 
 #include <hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp>
 
+#include <boost/integer.hpp>
+#include <boost/iterator/iterator_facade.hpp>
+#include <boost/iterator/iterator_adaptor.hpp>
+#include <boost/iterator/filter_iterator.hpp>
+#include <boost/shared_ptr.hpp>
+
 #include <cstdint>
 #include <iterator>
 #include <limits>
 #include <type_traits>
 #include <vector>
-
-#include <boost/integer.hpp>
-#include <boost/iterator/iterator_facade.hpp>
-#include <boost/iterator/iterator_adaptor.hpp>
-#include <boost/iterator/filter_iterator.hpp>
 
 namespace hpx
 {

--- a/hpx/components/containers/unordered/partition_unordered_map_component.hpp
+++ b/hpx/components/containers/unordered/partition_unordered_map_component.hpp
@@ -24,6 +24,7 @@
 #include <hpx/include/actions.hpp>
 
 #include <boost/preprocessor/cat.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <iostream>
 #include <string>

--- a/hpx/components/containers/unordered/unordered_map.hpp
+++ b/hpx/components/containers/unordered/unordered_map.hpp
@@ -19,13 +19,14 @@
 #include <hpx/components/containers/unordered/partition_unordered_map_component.hpp>
 #include <hpx/components/containers/unordered/unordered_map_segmented_iterator.hpp>
 
+#include <boost/cstdint.hpp>
+#include <boost/shared_ptr.hpp>
+
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <type_traits>
 #include <vector>
-
-#include <boost/cstdint.hpp>
 
 /// The hpx::unordered_map and its API's are defined here.
 ///

--- a/hpx/lcos/barrier.hpp
+++ b/hpx/lcos/barrier.hpp
@@ -10,6 +10,8 @@
 #include <hpx/include/client.hpp>
 #include <hpx/lcos/stubs/barrier.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace lcos
 {

--- a/hpx/lcos/base_lco.hpp
+++ b/hpx/lcos/base_lco.hpp
@@ -13,6 +13,8 @@
 #include <hpx/runtime/actions/component_action.hpp>
 #include <hpx/util/ini.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 namespace hpx { namespace lcos
 {
     /// The \a base_lco class is the common base class for all LCO's

--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -31,6 +31,7 @@
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 
+#include <boost/exception_ptr.hpp>
 #include <boost/intrusive_ptr.hpp>
 #include <boost/mpl/eval_if.hpp>
 #include <boost/mpl/if.hpp>

--- a/hpx/lcos/latch.hpp
+++ b/hpx/lcos/latch.hpp
@@ -11,6 +11,8 @@
 #include <hpx/runtime/components/new.hpp>
 #include <hpx/lcos/server/latch.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace lcos
 {

--- a/hpx/lcos/packaged_action.hpp
+++ b/hpx/lcos/packaged_action.hpp
@@ -19,6 +19,7 @@
 #include <hpx/traits/component_supports_migration.hpp>
 #include <hpx/traits/action_was_object_migrated.hpp>
 
+#include <boost/exception_ptr.hpp>
 #include <boost/intrusive_ptr.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/identity.hpp>

--- a/hpx/lcos/packaged_action.hpp
+++ b/hpx/lcos/packaged_action.hpp
@@ -19,6 +19,7 @@
 #include <hpx/traits/component_supports_migration.hpp>
 #include <hpx/traits/action_was_object_migrated.hpp>
 
+#include <boost/intrusive_ptr.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/identity.hpp>
 #include <boost/type_traits/is_same.hpp>

--- a/hpx/lcos/promise.hpp
+++ b/hpx/lcos/promise.hpp
@@ -26,9 +26,10 @@
 #include <hpx/util/one_size_heap_list_base.hpp>
 #include <hpx/util/static_reinit.hpp>
 
+#include <boost/exception_ptr.hpp>
 #include <boost/intrusive_ptr.hpp>
 #include <boost/mpl/identity.hpp>
-#include <boost/exception_ptr.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <mutex>
 

--- a/hpx/lcos/queue.hpp
+++ b/hpx/lcos/queue.hpp
@@ -10,6 +10,8 @@
 #include <hpx/include/client.hpp>
 #include <hpx/lcos/server/queue.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace lcos
 {

--- a/hpx/lcos/server/barrier.hpp
+++ b/hpx/lcos/server/barrier.hpp
@@ -16,6 +16,8 @@
 #include <hpx/runtime/components/server/managed_component_base.hpp>
 #include <hpx/runtime/components/server/runtime_support.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 #include <mutex>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hpx/lcos/server/latch.hpp
+++ b/hpx/lcos/server/latch.hpp
@@ -15,6 +15,8 @@
 #include <hpx/runtime/components/server/managed_component_base.hpp>
 #include <hpx/runtime/components/server/runtime_support.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace lcos { namespace server
 {

--- a/hpx/lcos/server/queue.hpp
+++ b/hpx/lcos/server/queue.hpp
@@ -17,6 +17,8 @@
 #include <hpx/lcos/base_lco.hpp>
 #include <hpx/traits/get_remote_result.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 #include <memory>
 #include <mutex>
 #include <queue>

--- a/hpx/lcos/stubs/barrier.hpp
+++ b/hpx/lcos/stubs/barrier.hpp
@@ -11,6 +11,8 @@
 #include <hpx/lcos/base_lco.hpp>
 #include <hpx/lcos/server/barrier.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace lcos { namespace stubs
 {

--- a/hpx/parallel/algorithms/sort.hpp
+++ b/hpx/parallel/algorithms/sort.hpp
@@ -28,6 +28,8 @@
 #include <hpx/parallel/util/projection_identity.hpp>
 #include <hpx/parallel/traits/projected.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 #include <algorithm>
 #include <iterator>
 #include <type_traits>

--- a/hpx/parallel/segmented_algorithms/copy.hpp
+++ b/hpx/parallel/segmented_algorithms/copy.hpp
@@ -17,6 +17,8 @@
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/handle_remote_exceptions.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 #include <algorithm>
 #include <iterator>
 #include <list>

--- a/hpx/parallel/segmented_algorithms/count.hpp
+++ b/hpx/parallel/segmented_algorithms/count.hpp
@@ -17,6 +17,8 @@
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/handle_remote_exceptions.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 #include <algorithm>
 #include <iterator>
 #include <list>

--- a/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
+++ b/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
@@ -18,6 +18,8 @@
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/handle_remote_exceptions.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 #include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail

--- a/hpx/parallel/segmented_algorithms/for_each.hpp
+++ b/hpx/parallel/segmented_algorithms/for_each.hpp
@@ -17,6 +17,8 @@
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/handle_remote_exceptions.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 #include <algorithm>
 #include <iterator>
 #include <list>

--- a/hpx/parallel/segmented_algorithms/generate.hpp
+++ b/hpx/parallel/segmented_algorithms/generate.hpp
@@ -17,6 +17,8 @@
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/handle_remote_exceptions.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 #include <algorithm>
 #include <iterator>
 #include <list>

--- a/hpx/parallel/segmented_algorithms/minmax.hpp
+++ b/hpx/parallel/segmented_algorithms/minmax.hpp
@@ -17,6 +17,8 @@
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/handle_remote_exceptions.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 #include <algorithm>
 #include <iterator>
 #include <list>

--- a/hpx/parallel/segmented_algorithms/transform_reduce.hpp
+++ b/hpx/parallel/segmented_algorithms/transform_reduce.hpp
@@ -17,6 +17,8 @@
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/handle_remote_exceptions.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 #include <algorithm>
 #include <iterator>
 #include <list>

--- a/hpx/parallel/task_block.hpp
+++ b/hpx/parallel/task_block.hpp
@@ -23,11 +23,12 @@
 #include <hpx/parallel/execution_policy.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 #include <memory>                           // std::addressof
 #include <boost/utility/addressof.hpp>      // boost::addressof
 
 #include <mutex>
-
 #include <vector>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)

--- a/hpx/parallel/util/detail/handle_local_exceptions.hpp
+++ b/hpx/parallel/util/detail/handle_local_exceptions.hpp
@@ -12,6 +12,8 @@
 #include <hpx/exception_list.hpp>
 #include <hpx/parallel/execution_policy.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 #include <list>
 #include <utility>
 #include <vector>

--- a/hpx/parallel/util/detail/handle_remote_exceptions.hpp
+++ b/hpx/parallel/util/detail/handle_remote_exceptions.hpp
@@ -12,6 +12,8 @@
 #include <hpx/exception_list.hpp>
 #include <hpx/parallel/execution_policy.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 #include <list>
 #include <utility>
 #include <vector>

--- a/hpx/parallel/util/foreach_partitioner.hpp
+++ b/hpx/parallel/util/foreach_partitioner.hpp
@@ -23,6 +23,8 @@
 #include <hpx/parallel/util/detail/handle_local_exceptions.hpp>
 #include <hpx/parallel/traits/extract_partitioner.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 #include <algorithm>
 #include <vector>
 

--- a/hpx/parallel/util/partitioner.hpp
+++ b/hpx/parallel/util/partitioner.hpp
@@ -22,6 +22,7 @@
 #include <hpx/parallel/util/detail/handle_local_exceptions.hpp>
 #include <hpx/parallel/traits/extract_partitioner.hpp>
 
+#include <boost/exception_ptr.hpp>
 #include <boost/range/functions.hpp>
 
 #include <iterator>

--- a/hpx/parallel/util/partitioner_with_cleanup.hpp
+++ b/hpx/parallel/util/partitioner_with_cleanup.hpp
@@ -20,6 +20,8 @@
 #include <hpx/parallel/util/detail/handle_local_exceptions.hpp>
 #include <hpx/parallel/traits/extract_partitioner.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 #include <algorithm>
 #include <vector>
 

--- a/hpx/parallel/util/scan_partitioner.hpp
+++ b/hpx/parallel/util/scan_partitioner.hpp
@@ -23,6 +23,8 @@
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/traits/extract_partitioner.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 #include <algorithm>
 #include <vector>
 

--- a/hpx/plugins/parcelport/ibverbs/connection_handler.hpp
+++ b/hpx/plugins/parcelport/ibverbs/connection_handler.hpp
@@ -19,6 +19,8 @@
 
 #include <hpx/util/memory_chunk_pool.hpp>
 
+#include <boost/atomic.hpp>
+
 #include <vector>
 
 namespace hpx { namespace parcelset {

--- a/hpx/plugins/parcelport/ibverbs/connection_handler.hpp
+++ b/hpx/plugins/parcelport/ibverbs/connection_handler.hpp
@@ -20,6 +20,7 @@
 #include <hpx/util/memory_chunk_pool.hpp>
 
 #include <boost/atomic.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <vector>
 

--- a/hpx/plugins/parcelport/ibverbs/helper.hpp
+++ b/hpx/plugins/parcelport/ibverbs/helper.hpp
@@ -11,6 +11,7 @@
 
 #include <boost/cache/entries/lru_entry.hpp>
 #include <boost/cache/local_cache.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <netdb.h>
 #include <rdma/rdma_cma.h>

--- a/hpx/plugins/parcelport/ibverbs/sender.hpp
+++ b/hpx/plugins/parcelport/ibverbs/sender.hpp
@@ -20,6 +20,7 @@
 #include <hpx/util/high_resolution_timer.hpp>
 
 #include <boost/asio/placeholders.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <mutex>
 

--- a/hpx/plugins/parcelport/ipc/connection_handler.hpp
+++ b/hpx/plugins/parcelport/ipc/connection_handler.hpp
@@ -17,6 +17,7 @@
 #include <hpx/plugins/parcelport/ipc/data_buffer_cache.hpp>
 #include <hpx/plugins/parcelport/ipc/locality.hpp>
 
+#include <boost/shared_ptr.hpp>
 
 namespace hpx { namespace parcelset {
     namespace policies { namespace ipc

--- a/hpx/plugins/parcelport/ipc/receiver.hpp
+++ b/hpx/plugins/parcelport/ipc/receiver.hpp
@@ -23,6 +23,7 @@
 #include <boost/atomic.hpp>
 #include <boost/bind.hpp>
 #include <boost/enable_shared_from_this.hpp>
+#include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/asio/placeholders.hpp>
 

--- a/hpx/plugins/parcelport/ipc/sender.hpp
+++ b/hpx/plugins/parcelport/ipc/sender.hpp
@@ -21,6 +21,8 @@
 #include <hpx/util/tuple.hpp>
 
 #include <boost/asio/placeholders.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <string>
 

--- a/hpx/plugins/parcelport/mpi/sender.hpp
+++ b/hpx/plugins/parcelport/mpi/sender.hpp
@@ -16,6 +16,9 @@
 #include <hpx/plugins/parcelport/mpi/sender_connection.hpp>
 #include <hpx/plugins/parcelport/mpi/tag_provider.hpp>
 
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
+
 #include <iterator>
 #include <list>
 #include <memory>

--- a/hpx/plugins/parcelport/tcp/connection_handler.hpp
+++ b/hpx/plugins/parcelport/tcp/connection_handler.hpp
@@ -22,6 +22,7 @@
 
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ip/host_name.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <string>
 #include <vector>

--- a/hpx/runtime.hpp
+++ b/hpx/runtime.hpp
@@ -26,6 +26,7 @@
 #include <hpx/components/security/certificate_store.hpp>
 #endif
 
+#include <boost/atomic.hpp>
 #include <boost/smart_ptr/scoped_ptr.hpp>
 
 #include <memory>

--- a/hpx/runtime.hpp
+++ b/hpx/runtime.hpp
@@ -27,6 +27,7 @@
 #endif
 
 #include <boost/atomic.hpp>
+#include <boost/exception_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr/scoped_ptr.hpp>
 

--- a/hpx/runtime.hpp
+++ b/hpx/runtime.hpp
@@ -27,6 +27,7 @@
 #endif
 
 #include <boost/atomic.hpp>
+#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr/scoped_ptr.hpp>
 
 #include <memory>

--- a/hpx/runtime/actions/action_invoke_no_more_than.hpp
+++ b/hpx/runtime/actions/action_invoke_no_more_than.hpp
@@ -17,6 +17,8 @@
 #include <hpx/traits/action_decorate_function.hpp>
 #include <hpx/traits/action_decorate_continuation.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 #include <memory>
 
 namespace hpx { namespace actions { namespace detail

--- a/hpx/runtime/actions/continuation.hpp
+++ b/hpx/runtime/actions/continuation.hpp
@@ -32,6 +32,7 @@
 #include <hpx/traits/is_continuation.hpp>
 #include <hpx/traits/is_executor.hpp>
 
+#include <boost/exception_ptr.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/preprocessor/stringize.hpp>
 #include <boost/utility/enable_if.hpp>

--- a/hpx/runtime/agas/addressing_service.hpp
+++ b/hpx/runtime/agas/addressing_service.hpp
@@ -25,11 +25,12 @@
 #include <hpx/util/unique_function.hpp>
 
 #include <boost/atomic.hpp>
-#include <boost/make_shared.hpp>
 #include <boost/cache/lru_cache.hpp>
 #include <boost/cache/statistics/local_full_statistics.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/dynamic_bitset.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <map>
 #include <mutex>

--- a/hpx/runtime/agas/addressing_service.hpp
+++ b/hpx/runtime/agas/addressing_service.hpp
@@ -24,6 +24,7 @@
 #include <hpx/util/function.hpp>
 #include <hpx/util/unique_function.hpp>
 
+#include <boost/atomic.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/cache/lru_cache.hpp>
 #include <boost/cache/statistics/local_full_statistics.hpp>

--- a/hpx/runtime/applier/trigger.hpp
+++ b/hpx/runtime/applier/trigger.hpp
@@ -10,6 +10,8 @@
 
 #include <hpx/runtime/actions/continuation.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 namespace hpx { namespace applier
 {
 

--- a/hpx/runtime/components/base_lco_factory.hpp
+++ b/hpx/runtime/components/base_lco_factory.hpp
@@ -18,9 +18,10 @@
 #include <hpx/util/unique_function.hpp>
 #include <hpx/util/detail/count_num_args.hpp>
 
+#include <boost/detail/atomic_count.hpp>
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/stringize.hpp>
-#include <boost/detail/atomic_count.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <string>
 

--- a/hpx/runtime/components/client_base.hpp
+++ b/hpx/runtime/components/client_base.hpp
@@ -21,6 +21,7 @@
 #include <hpx/util/safe_bool.hpp>
 #include <hpx/lcos/future.hpp>
 
+#include <boost/exception_ptr.hpp>
 #include <boost/intrusive_ptr.hpp>
 #include <boost/mpl/bool.hpp>
 

--- a/hpx/runtime/components/client_base.hpp
+++ b/hpx/runtime/components/client_base.hpp
@@ -21,12 +21,13 @@
 #include <hpx/util/safe_bool.hpp>
 #include <hpx/lcos/future.hpp>
 
+#include <boost/intrusive_ptr.hpp>
+#include <boost/mpl/bool.hpp>
+
 #include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
-
-#include <boost/mpl/bool.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 // Client objects are equivalent to futures

--- a/hpx/runtime/components/console_error_sink.hpp
+++ b/hpx/runtime/components/console_error_sink.hpp
@@ -11,6 +11,8 @@
 #include <hpx/exception_fwd.hpp>
 #include <hpx/runtime/naming_fwd.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace components
 {

--- a/hpx/runtime/components/server/copy_component.hpp
+++ b/hpx/runtime/components/server/copy_component.hpp
@@ -12,6 +12,8 @@
 #include <hpx/runtime/get_ptr.hpp>
 #include <hpx/runtime/components/stubs/runtime_support.hpp>
 
+#include <boost/shared_ptr.hpp>
+
 namespace hpx { namespace components { namespace server
 {
     ///////////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/components/server/migrate_component.hpp
+++ b/hpx/runtime/components/server/migrate_component.hpp
@@ -15,6 +15,8 @@
 #include <hpx/runtime/components/stubs/runtime_support.hpp>
 #include <hpx/runtime/agas/interface.hpp>
 
+#include <boost/shared_ptr.hpp>
+
 namespace hpx { namespace components { namespace server
 {
     ///////////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/components/stubs/runtime_support.hpp
+++ b/hpx/runtime/components/stubs/runtime_support.hpp
@@ -21,6 +21,8 @@
 #include <hpx/lcos/future.hpp>
 #include <hpx/async.hpp>
 
+#include <boost/shared_ptr.hpp>
+
 #include <vector>
 
 namespace hpx { namespace components { namespace stubs

--- a/hpx/runtime/parcelset/parcelhandler.hpp
+++ b/hpx/runtime/parcelset/parcelhandler.hpp
@@ -24,6 +24,7 @@
 
 #include <hpx/config/warnings_prefix.hpp>
 
+#include <boost/atomic.hpp>
 #include <boost/bind.hpp>
 
 #include <algorithm>

--- a/hpx/runtime/parcelset/parcelhandler.hpp
+++ b/hpx/runtime/parcelset/parcelhandler.hpp
@@ -26,6 +26,7 @@
 
 #include <boost/atomic.hpp>
 #include <boost/bind.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <algorithm>
 #include <map>

--- a/hpx/runtime/parcelset/parcelport.hpp
+++ b/hpx/runtime/parcelset/parcelport.hpp
@@ -23,6 +23,7 @@
 
 #include <boost/cstdint.hpp>
 #include <boost/enable_shared_from_this.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <deque>
 #include <map>

--- a/hpx/runtime/parcelset/parcelport_impl.hpp
+++ b/hpx/runtime/parcelset/parcelport_impl.hpp
@@ -25,6 +25,7 @@
 #include <hpx/util/runtime_configuration.hpp>
 #include <hpx/util/safe_lexical_cast.hpp>
 
+#include <boost/atomic.hpp>
 #include <boost/detail/endian.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>

--- a/hpx/runtime/parcelset/parcelport_impl.hpp
+++ b/hpx/runtime/parcelset/parcelport_impl.hpp
@@ -27,6 +27,7 @@
 
 #include <boost/atomic.hpp>
 #include <boost/detail/endian.hpp>
+#include <boost/exception_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
 

--- a/hpx/runtime/threads/coroutines/detail/context_generic_context.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_generic_context.hpp
@@ -33,6 +33,7 @@
 #error Boost.Context is available only with Boost V1.51 or later
 #endif
 
+#include <boost/atomic.hpp>
 #include <boost/detail/atomic_count.hpp>
 
 #include <boost/context/all.hpp>

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -18,6 +18,7 @@
 #include <hpx/util/function.hpp>
 #include <hpx/util/safe_lexical_cast.hpp>
 
+#include <boost/atomic.hpp>
 #include <boost/cstdint.hpp>
 
 #if defined(HPX_HAVE_APEX)

--- a/hpx/runtime/threads/detail/set_thread_state.hpp
+++ b/hpx/runtime/threads/detail/set_thread_state.hpp
@@ -19,6 +19,7 @@
 #include <hpx/util/io_service_pool.hpp>
 #include <hpx/util/logging.hpp>
 
+#include <boost/atomic.hpp>
 #include <boost/asio/basic_deadline_timer.hpp>
 
 namespace hpx { namespace threads { namespace detail

--- a/hpx/runtime/threads/detail/set_thread_state.hpp
+++ b/hpx/runtime/threads/detail/set_thread_state.hpp
@@ -21,6 +21,8 @@
 
 #include <boost/atomic.hpp>
 #include <boost/asio/basic_deadline_timer.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
 
 namespace hpx { namespace threads { namespace detail
 {

--- a/hpx/runtime/threads/detail/thread_pool.hpp
+++ b/hpx/runtime/threads/detail/thread_pool.hpp
@@ -14,13 +14,14 @@
 #include <hpx/util/thread_specific_ptr.hpp>
 #include <hpx/util/date_time_chrono.hpp>
 
+#include <boost/atomic.hpp>
+#include <boost/cstdint.hpp>
+#include <boost/exception_ptr.hpp>
+#include <boost/ptr_container/ptr_vector.hpp>
+#include <boost/scoped_ptr.hpp>
 #include <boost/thread/barrier.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/atomic.hpp>
-#include <boost/ptr_container/ptr_vector.hpp>
-#include <boost/cstdint.hpp>
-#include <boost/scoped_ptr.hpp>
 
 #include <mutex>
 #include <string>

--- a/hpx/runtime/threads/policies/hierarchy_scheduler.hpp
+++ b/hpx/runtime/threads/policies/hierarchy_scheduler.hpp
@@ -15,6 +15,7 @@
 #include <hpx/runtime/threads/policies/scheduler_base.hpp>
 
 #include <boost/atomic.hpp>
+#include <boost/exception_ptr.hpp>
 #include <boost/mpl/bool.hpp>
 
 #include <memory>

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -17,6 +17,7 @@
 #include <hpx/runtime/threads/policies/scheduler_base.hpp>
 
 #include <boost/atomic.hpp>
+#include <boost/exception_ptr.hpp>
 #include <boost/mpl/bool.hpp>
 
 #include <memory>

--- a/hpx/runtime/threads/policies/local_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_queue_scheduler.hpp
@@ -17,6 +17,7 @@
 #include <hpx/runtime/threads/policies/scheduler_base.hpp>
 
 #include <boost/atomic.hpp>
+#include <boost/exception_ptr.hpp>
 #include <boost/mpl/bool.hpp>
 
 #include <memory>

--- a/hpx/runtime/threads/policies/periodic_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/periodic_priority_queue_scheduler.hpp
@@ -12,6 +12,8 @@
 #include <hpx/runtime/threads/detail/periodic_maintenance.hpp>
 #include <hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp>
 
+#include <boost/atomic.hpp>
+
 #include <string>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/threads/policies/scheduler_base.hpp
+++ b/hpx/runtime/threads/policies/scheduler_base.hpp
@@ -20,10 +20,11 @@
 #include <boost/make_shared.hpp>
 #endif
 
+#include <boost/exception_ptr.hpp>
+#include <boost/ptr_container/ptr_vector.hpp>
 #include <boost/thread/locks.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/condition_variable.hpp>
-#include <boost/ptr_container/ptr_vector.hpp>
 
 #include <hpx/config/warnings_prefix.hpp>
 

--- a/hpx/runtime/threads/policies/thread_queue.hpp
+++ b/hpx/runtime/threads/policies/thread_queue.hpp
@@ -22,9 +22,10 @@
 #   include <hpx/util/tick_counter.hpp>
 #endif
 
+#include <boost/atomic.hpp>
+#include <boost/exception_ptr.hpp>
 #include <boost/thread/condition.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/atomic.hpp>
 #include <boost/unordered_set.hpp>
 
 #include <map>

--- a/hpx/runtime/threads/thread_data.hpp
+++ b/hpx/runtime/threads/thread_data.hpp
@@ -25,6 +25,7 @@
 #include <hpx/util/lockfree/freelist.hpp>
 
 #include <boost/atomic.hpp>
+#include <boost/intrusive_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 
 #include <stack>

--- a/hpx/runtime/threads/threadmanager_impl.hpp
+++ b/hpx/runtime/threads/threadmanager_impl.hpp
@@ -24,9 +24,10 @@
 #include <hpx/config/warnings_prefix.hpp>
 
 #include <boost/atomic.hpp>
+#include <boost/exception_ptr.hpp>
+#include <boost/mpl/bool.hpp>
 #include <boost/ptr_container/ptr_vector.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/mpl/bool.hpp>
 
 #include <memory>
 #include <mutex>

--- a/hpx/runtime_fwd.hpp
+++ b/hpx/runtime_fwd.hpp
@@ -15,6 +15,8 @@
 #include <hpx/util/function.hpp>
 #include <hpx/runtime/naming_fwd.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 namespace hpx
 {
     class HPX_API_EXPORT runtime;

--- a/hpx/traits/acquire_shared_state.hpp
+++ b/hpx/traits/acquire_shared_state.hpp
@@ -15,11 +15,12 @@
 #include <hpx/traits/acquire_future.hpp>
 #include <hpx/util/decay.hpp>
 
+#include <boost/intrusive_ptr.hpp>
+#include <boost/range/functions.hpp>
+#include <boost/utility/enable_if.hpp>
+
 #include <iterator>
 #include <vector>
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/range/functions.hpp>
 
 namespace hpx { namespace traits
 {

--- a/hpx/util/logging/format/destination/rolling_file.hpp
+++ b/hpx/util/logging/format/destination/rolling_file.hpp
@@ -35,6 +35,7 @@
 #include <string>
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
+#include <boost/shared_ptr.hpp>
 
 namespace hpx { namespace util { namespace logging { namespace destination {
 

--- a/hpx/util/logging/writer/on_dedicated_thread.hpp
+++ b/hpx/util/logging/writer/on_dedicated_thread.hpp
@@ -24,9 +24,10 @@
 #include <boost/version.hpp>
 #include <hpx/util/logging/detail/fwd.hpp>
 #include <hpx/util/logging/detail/forward_constructor.hpp>
+#include <boost/bind.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/thread/xtime.hpp>
-#include <boost/bind.hpp>
+#include <boost/shared_ptr.hpp>
 #include <hpx/util/logging/detail/manipulator.hpp> // hpx::util::logging::manipulator
 
 #include <vector>

--- a/hpx/util/memory_chunk.hpp
+++ b/hpx/util/memory_chunk.hpp
@@ -19,6 +19,8 @@
 #include <hpx/runtime/threads/coroutines/detail/posix_utility.hpp>
 #endif
 
+#include <boost/shared_ptr.hpp>
+
 #include <mutex>
 
 namespace hpx { namespace util

--- a/hpx/util/plugin/plugin_factory.hpp
+++ b/hpx/util/plugin/plugin_factory.hpp
@@ -16,6 +16,7 @@
 #include <hpx/util/plugin/export_plugin.hpp>
 
 #include <boost/algorithm/string/case_conv.hpp>
+#include <boost/shared_ptr.hpp>
 #include <boost/type_traits/remove_pointer.hpp>
 
 #include <stdexcept>

--- a/hpx/util/runtime_configuration.hpp
+++ b/hpx/util/runtime_configuration.hpp
@@ -16,6 +16,7 @@
 #include <hpx/plugins/plugin_registry_base.hpp>
 
 #include <boost/cstdint.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <string>
 #include <vector>

--- a/plugins/parcelport/ibverbs/connection_handler_ibverbs.cpp
+++ b/plugins/parcelport/ibverbs/connection_handler_ibverbs.cpp
@@ -18,6 +18,7 @@
 #include <hpx/util/asio_util.hpp>
 #include <hpx/util/safe_lexical_cast.hpp>
 
+#include <boost/atomic.hpp>
 #include <boost/assign/std/vector.hpp>
 #include <boost/io/ios_state.hpp>
 #include <boost/asio/ip/tcp.hpp>

--- a/plugins/parcelport/mpi/parcelport_mpi.cpp
+++ b/plugins/parcelport/mpi/parcelport_mpi.cpp
@@ -33,6 +33,7 @@
 #include <hpx/util/runtime_configuration.hpp>
 #include <hpx/util/safe_lexical_cast.hpp>
 
+#include <boost/atomic.hpp>
 #include <boost/archive/basic_archive.hpp>
 
 #include <string>

--- a/plugins/parcelport/mpi/parcelport_mpi.cpp
+++ b/plugins/parcelport/mpi/parcelport_mpi.cpp
@@ -35,6 +35,7 @@
 
 #include <boost/atomic.hpp>
 #include <boost/archive/basic_archive.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <string>
 

--- a/plugins/parcelport/mpi/parcelport_mpi.cpp
+++ b/plugins/parcelport/mpi/parcelport_mpi.cpp
@@ -35,6 +35,7 @@
 
 #include <boost/atomic.hpp>
 #include <boost/archive/basic_archive.hpp>
+#include <boost/exception_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 
 #include <string>

--- a/src/error_code.cpp
+++ b/src/error_code.cpp
@@ -8,6 +8,7 @@
 #include <hpx/error_code.hpp>
 #include <hpx/exception.hpp>
 
+#include <boost/exception_ptr.hpp>
 #include <boost/system/error_code.hpp>
 
 #include <stdexcept>

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -28,6 +28,7 @@
 #endif
 
 #include <boost/atomic.hpp>
+#include <boost/exception_ptr.hpp>
 #include <boost/format.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -27,8 +27,10 @@
 #  include <unistd.h>
 #endif
 
-#include <boost/format.hpp>
 #include <boost/atomic.hpp>
+#include <boost/format.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <stdexcept>
 #include <algorithm>

--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -25,9 +25,13 @@
 #include <hpx/util/function.hpp>
 #include <hpx/util/apex.hpp>
 
-#if !defined(HPX_WINDOWS)
-#  include <signal.h>
-#endif
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/assign/std/vector.hpp>
+#include <boost/format.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
 
 #if defined(HPX_NATIVE_MIC) || defined(__bgq__)
 #   include <cstdlib>
@@ -40,12 +44,9 @@
 #include <string>
 #include <vector>
 
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/assign/std/vector.hpp>
-#include <boost/format.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/shared_ptr.hpp>
+#if !defined(HPX_WINDOWS)
+#  include <signal.h>
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx

--- a/src/lcos/base_lco.cpp
+++ b/src/lcos/base_lco.cpp
@@ -15,6 +15,8 @@
 
 #include <hpx/plugins/parcel/coalescing_message_handler_registration.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 namespace hpx { namespace lcos
 {
     void base_lco::set_exception(boost::exception_ptr const& e)

--- a/src/lcos/local/composable_guard.cpp
+++ b/src/lcos/local/composable_guard.cpp
@@ -7,6 +7,7 @@
 #include <hpx/apply.hpp>
 
 #include <boost/cstdint.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <vector>
 

--- a/src/performance_counters/manage_counter.cpp
+++ b/src/performance_counters/manage_counter.cpp
@@ -10,6 +10,9 @@
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
 
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
+
 namespace hpx { namespace performance_counters
 {
     counter_status manage_counter::install(naming::id_type const& id,

--- a/src/performance_counters/manage_counter_type.cpp
+++ b/src/performance_counters/manage_counter_type.cpp
@@ -15,6 +15,8 @@
 #include <hpx/util/function.hpp>
 
 #include <boost/bind.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <string>
 

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -35,6 +35,7 @@
 #endif
 
 #include <boost/atomic.hpp>
+#include <boost/exception_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 
 #include <iostream>

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -35,6 +35,7 @@
 #endif
 
 #include <boost/atomic.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <iostream>
 #include <memory>

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -34,6 +34,8 @@
 #include <hpx/util/security/subordinate_certificate_authority.hpp>
 #endif
 
+#include <boost/atomic.hpp>
+
 #include <iostream>
 #include <memory>
 #include <mutex>

--- a/src/runtime/actions/continuation.cpp
+++ b/src/runtime/actions/continuation.cpp
@@ -9,6 +9,8 @@
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/lcos/base_lco.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx
 {

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -41,6 +41,8 @@
 
 #include <boost/format.hpp>
 #include <boost/icl/closed_interval.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <mutex>
 #include <string>

--- a/src/runtime/agas/server/symbol_namespace_server.cpp
+++ b/src/runtime/agas/server/symbol_namespace_server.cpp
@@ -18,6 +18,7 @@
 #include <hpx/util/unlock_guard.hpp>
 
 #include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <mutex>
 

--- a/src/runtime/components/console_error_sink.cpp
+++ b/src/runtime/components/console_error_sink.cpp
@@ -15,6 +15,8 @@
 #include <hpx/runtime/naming/resolver_client.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
 
+#include <boost/exception_ptr.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace components
 {

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -53,6 +53,7 @@
 #include <boost/filesystem/convenience.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/tokenizer.hpp>
 

--- a/src/runtime/parcelset/parcel.cpp
+++ b/src/runtime/parcelset/parcel.cpp
@@ -8,6 +8,8 @@
 #include <hpx/runtime/parcelset/parcel.hpp>
 #include <hpx/runtime/serialization/unique_ptr.hpp>
 
+#include <boost/atomic.hpp>
+
 #include <sstream>
 #include <string>
 

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -33,6 +33,7 @@
 #include <boost/asio/error.hpp>
 #include <boost/assign/std/vector.hpp>
 #include <boost/detail/endian.hpp>
+#include <boost/exception_ptr.hpp>
 #include <boost/format.hpp>
 #include <boost/shared_ptr.hpp>
 

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -29,11 +29,12 @@
 
 #include <hpx/plugins/parcelport_factory_base.hpp>
 
+#include <boost/algorithm/string.hpp>
 #include <boost/asio/error.hpp>
 #include <boost/assign/std/vector.hpp>
-#include <boost/algorithm/string.hpp>
-#include <boost/format.hpp>
 #include <boost/detail/endian.hpp>
+#include <boost/format.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <algorithm>
 #include <mutex>

--- a/src/runtime/threads/coroutines/detail/coroutine_impl.cpp
+++ b/src/runtime/threads/coroutines/detail/coroutine_impl.cpp
@@ -37,6 +37,7 @@
 #include <hpx/util/assert.hpp>
 #include <hpx/util/reinitializable_static.hpp>
 
+#include <boost/exception_ptr.hpp>
 #include <boost/lockfree/stack.hpp>
 
 #include <cstddef>

--- a/src/runtime/threads/coroutines/detail/tss.cpp
+++ b/src/runtime/threads/coroutines/detail/tss.cpp
@@ -17,6 +17,8 @@
 
 #include <hpx/runtime/threads_fwd.hpp>
 
+#include <boost/shared_ptr.hpp>
+
 #include <map>
 
 namespace hpx { namespace threads { namespace coroutines { namespace detail

--- a/src/runtime/threads/detail/thread_pool.cpp
+++ b/src/runtime/threads/detail/thread_pool.cpp
@@ -23,8 +23,9 @@
 #include <hpx/util/high_resolution_clock.hpp>
 #endif
 
-#include <boost/ref.hpp>
+#include <boost/atomic.hpp>
 #include <boost/exception_ptr.hpp>
+#include <boost/ref.hpp>
 
 #include <cstdint>
 #include <mutex>

--- a/src/runtime/threads/executors/this_thread_executors.cpp
+++ b/src/runtime/threads/executors/this_thread_executors.cpp
@@ -23,6 +23,8 @@
 #include <hpx/util/assert.hpp>
 #include <hpx/util/bind.hpp>
 
+#include <boost/atomic.hpp>
+
 #include <mutex>
 
 namespace hpx { namespace threads { namespace detail

--- a/src/runtime/threads/executors/thread_pool_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_executors.cpp
@@ -26,6 +26,8 @@
 #include <hpx/util/assert.hpp>
 #include <hpx/util/bind.hpp>
 
+#include <boost/atomic.hpp>
+
 #include <mutex>
 
 namespace hpx { namespace threads { namespace detail

--- a/src/runtime/threads/executors/thread_pool_os_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_os_executors.cpp
@@ -19,6 +19,8 @@
 #include <hpx/util/assert.hpp>
 #include <hpx/util/bind.hpp>
 
+#include <boost/atomic.hpp>
+
 #include <mutex>
 #include <string>
 

--- a/src/runtime/threads/scheduler_specific_ptr.cpp
+++ b/src/runtime/threads/scheduler_specific_ptr.cpp
@@ -10,6 +10,8 @@
 #include <hpx/runtime/threads/coroutines/detail/tss.hpp>
 #include <hpx/runtime/threads/scheduler_specific_ptr.hpp>
 
+#include <boost/shared_ptr.hpp>
+
 namespace hpx { namespace threads { namespace detail
 {
     void* get_tss_data(void const* key)

--- a/src/runtime/threads/thread.cpp
+++ b/src/runtime/threads/thread.cpp
@@ -14,6 +14,8 @@
 #include <hpx/util/register_locks.hpp>
 #include <hpx/util/unlock_guard.hpp>
 
+#include <boost/intrusive_ptr.hpp>
+
 #include <mutex>
 
 #if defined(__ANDROID__) || defined(ANDROID)

--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -25,6 +25,7 @@
 
 #include <boost/bind.hpp>
 #include <boost/cstdint.hpp>
+#include <boost/exception_ptr.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/condition.hpp>
 #include <boost/ref.hpp>

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -20,9 +20,10 @@
 #include <hpx/runtime/threads/policies/topology.hpp>
 
 #include <boost/asio/ip/host_name.hpp>
-#include <boost/format.hpp>
 #include <boost/assign/std/vector.hpp>
+#include <boost/format.hpp>
 #include <boost/program_options.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <iostream>
 #include <string>

--- a/src/util/init_ini_data.cpp
+++ b/src/util/init_ini_data.cpp
@@ -10,22 +10,23 @@
 #include <hpx/util/init_ini_data.hpp>
 #include <hpx/util/ini.hpp>
 #include <hpx/util/logging.hpp>
+#include <hpx/util/plugin.hpp>
 #include <hpx/runtime/components/component_registry_base.hpp>
 #include <hpx/plugins/plugin_registry_base.hpp>
+
+#include <boost/assign/std/vector.hpp>
+#include <boost/filesystem/path.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/exception.hpp>
+#include <boost/filesystem/convenience.hpp>
+#include <boost/range/iterator_range.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/tokenizer.hpp>
 
 #include <algorithm>
 #include <iostream>
 #include <string>
 #include <vector>
-
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/exception.hpp>
-#include <boost/filesystem/convenience.hpp>
-#include <boost/tokenizer.hpp>
-#include <hpx/util/plugin.hpp>
-#include <boost/assign/std/vector.hpp>
-#include <boost/range/iterator_range.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace util

--- a/src/util/runtime_configuration.cpp
+++ b/src/util/runtime_configuration.cpp
@@ -24,6 +24,7 @@
 #include <boost/tokenizer.hpp>
 
 #include <boost/detail/endian.hpp>
+#include <boost/shared_ptr.hpp>
 #include <boost/spirit/include/qi_parse.hpp>
 #include <boost/spirit/include/qi_string.hpp>
 #include <boost/spirit/include/qi_numeric.hpp>

--- a/tests/performance/local/foreach_scaling.cpp
+++ b/tests/performance/local/foreach_scaling.cpp
@@ -13,7 +13,9 @@
 
 #include <boost/cstdint.hpp>
 #include <boost/format.hpp>
+#include <boost/make_shared.hpp>
 #include <boost/range/functions.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <stdexcept>
 #include <string>

--- a/tests/performance/local/timed_task_spawn.cpp
+++ b/tests/performance/local/timed_task_spawn.cpp
@@ -12,18 +12,19 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/cstdint.hpp>
+#include <boost/date_time/gregorian/gregorian.hpp>
+#include <boost/format.hpp>
+#include <boost/math/common_factor.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/thread/condition.hpp>
+#include <boost/thread/mutex.hpp>
+
 #include <stdexcept>
 #include <string>
 #include <vector>
-
-#include <boost/format.hpp>
-#include <boost/cstdint.hpp>
-#include <boost/date_time/gregorian/gregorian.hpp>
-#include <boost/math/common_factor.hpp>
-#include <boost/thread/condition.hpp>
-#include <boost/thread/mutex.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/classification.hpp>
 
 #include "worker_timed.hpp"
 

--- a/tests/regressions/components/moveonly_constructor_arguments_1405.cpp
+++ b/tests/regressions/components/moveonly_constructor_arguments_1405.cpp
@@ -10,6 +10,8 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/atomic.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////
 struct moveonly
 {

--- a/tests/regressions/lcos/exception_from_continuation_1613.cpp
+++ b/tests/regressions/lcos/exception_from_continuation_1613.cpp
@@ -11,6 +11,8 @@
 #include <hpx/lcos/future.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/atomic.hpp>
+
 #include <vector>
 
 #define NUM_FUTURES std::size_t(2*HPX_CONTINUATION_MAX_RECURSION_DEPTH)

--- a/tests/regressions/lcos/future_serialization_1898.cpp
+++ b/tests/regressions/lcos/future_serialization_1898.cpp
@@ -10,6 +10,8 @@
 
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/atomic.hpp>
+
 struct test_server
     : hpx::components::component_base<test_server>
 {

--- a/tests/regressions/lcos/ignore_while_locked_1485.cpp
+++ b/tests/regressions/lcos/ignore_while_locked_1485.cpp
@@ -11,6 +11,8 @@
 #include <hpx/include/local_lcos.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/atomic.hpp>
+
 #include <mutex>
 
 struct wait_for_flag

--- a/tests/regressions/threads/block_os_threads_1036.cpp
+++ b/tests/regressions/threads/block_os_threads_1036.cpp
@@ -13,6 +13,7 @@
 #include <hpx/runtime/threads/thread_helpers.hpp>
 #include <hpx/runtime/threads/topology.hpp>
 
+#include <boost/atomic.hpp>
 #include <boost/assign/std/vector.hpp>
 #include <boost/scoped_array.hpp>
 

--- a/tests/unit/component/action_invoke_no_more_than.cpp
+++ b/tests/unit/component/action_invoke_no_more_than.cpp
@@ -9,6 +9,8 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/atomic.hpp>
+
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/component/get_ptr.cpp
+++ b/tests/unit/component/get_ptr.cpp
@@ -8,6 +8,8 @@
 #include <hpx/include/actions.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/shared_ptr.hpp>
+
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/lcos/apply_colocated.cpp
+++ b/tests/unit/lcos/apply_colocated.cpp
@@ -9,8 +9,9 @@
 #include <hpx/include/components.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
-#include <mutex>
+#include <boost/atomic.hpp>
 
+#include <mutex>
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/lcos/apply_local.cpp
+++ b/tests/unit/lcos/apply_local.cpp
@@ -9,6 +9,8 @@
 #include <hpx/include/apply.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/atomic.hpp>
+
 #include <mutex>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/lcos/apply_local_executor.cpp
+++ b/tests/unit/lcos/apply_local_executor.cpp
@@ -10,6 +10,8 @@
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/atomic.hpp>
+
 #include <mutex>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/lcos/apply_remote.cpp
+++ b/tests/unit/lcos/apply_remote.cpp
@@ -9,8 +9,9 @@
 #include <hpx/include/components.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
-#include <mutex>
+#include <boost/atomic.hpp>
 
+#include <mutex>
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/lcos/apply_remote_client.cpp
+++ b/tests/unit/lcos/apply_remote_client.cpp
@@ -9,6 +9,8 @@
 #include <hpx/include/components.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/atomic.hpp>
+
 #include <mutex>
 #include <vector>
 

--- a/tests/unit/lcos/async_cb_colocated.cpp
+++ b/tests/unit/lcos/async_cb_colocated.cpp
@@ -10,6 +10,8 @@
 #include <hpx/include/async.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/atomic.hpp>
+
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/lcos/async_cb_remote.cpp
+++ b/tests/unit/lcos/async_cb_remote.cpp
@@ -9,6 +9,8 @@
 #include <hpx/include/async.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/atomic.hpp>
+
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/lcos/async_cb_remote_client.cpp
+++ b/tests/unit/lcos/async_cb_remote_client.cpp
@@ -9,6 +9,8 @@
 #include <hpx/include/async.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/atomic.hpp>
+
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/lcos/async_continue_cb.cpp
+++ b/tests/unit/lcos/async_continue_cb.cpp
@@ -9,6 +9,8 @@
 #include <hpx/include/async.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/atomic.hpp>
+
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/lcos/async_continue_cb_colocated.cpp
+++ b/tests/unit/lcos/async_continue_cb_colocated.cpp
@@ -10,6 +10,8 @@
 #include <hpx/include/async.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/atomic.hpp>
+
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/lcos/local_dataflow.cpp
+++ b/tests/unit/lcos/local_dataflow.cpp
@@ -10,6 +10,8 @@
 #include <hpx/util/lightweight_test.hpp>
 #include <hpx/util/unwrapped.hpp>
 
+#include <boost/atomic.hpp>
+
 #include <string>
 #include <vector>
 

--- a/tests/unit/lcos/local_dataflow_executor.cpp
+++ b/tests/unit/lcos/local_dataflow_executor.cpp
@@ -12,6 +12,8 @@
 #include <hpx/util/lightweight_test.hpp>
 #include <hpx/util/unwrapped.hpp>
 
+#include <boost/atomic.hpp>
+
 #include <string>
 #include <vector>
 

--- a/tests/unit/lcos/local_latch.cpp
+++ b/tests/unit/lcos/local_latch.cpp
@@ -8,6 +8,8 @@
 #include <hpx/include/local_lcos.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/atomic.hpp>
+
 #include <vector>
 
 #define NUM_THREADS std::size_t(100)

--- a/tests/unit/lcos/run_guarded.cpp
+++ b/tests/unit/lcos/run_guarded.cpp
@@ -6,6 +6,7 @@
 #include <hpx/lcos/local/composable_guard.hpp>
 #include <hpx/util/lightweight_test.hpp>
 #include <hpx/hpx_init.hpp>
+#include <boost/atomic.hpp>
 #include <iostream>
 #include <string>
 #include <vector>

--- a/tests/unit/lcos/run_guarded.cpp
+++ b/tests/unit/lcos/run_guarded.cpp
@@ -7,6 +7,7 @@
 #include <hpx/util/lightweight_test.hpp>
 #include <hpx/hpx_init.hpp>
 #include <boost/atomic.hpp>
+#include <boost/shared_ptr.hpp>
 #include <iostream>
 #include <string>
 #include <vector>

--- a/tests/unit/parallel/algorithms/test_utils.hpp
+++ b/tests/unit/parallel/algorithms/test_utils.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/include/parallel_execution_policy.hpp>
 
+#include <boost/atomic.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 
 #include <numeric>

--- a/tests/unit/parallel/algorithms/uninitialized_copy_tests.hpp
+++ b/tests/unit/parallel/algorithms/uninitialized_copy_tests.hpp
@@ -11,6 +11,7 @@
 #include <hpx/include/parallel_uninitialized_copy.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/atomic.hpp>
 #include <boost/range/functions.hpp>
 
 #include <vector>

--- a/tests/unit/parallel/algorithms/uninitialized_copyn.cpp
+++ b/tests/unit/parallel/algorithms/uninitialized_copyn.cpp
@@ -8,6 +8,7 @@
 #include <hpx/include/parallel_uninitialized_copy.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/atomic.hpp>
 #include <boost/range/functions.hpp>
 
 #include <string>

--- a/tests/unit/parallel/algorithms/uninitialized_fill.cpp
+++ b/tests/unit/parallel/algorithms/uninitialized_fill.cpp
@@ -8,6 +8,7 @@
 #include <hpx/include/parallel_uninitialized_fill.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/atomic.hpp>
 #include <boost/range/functions.hpp>
 
 #include <string>

--- a/tests/unit/parallel/algorithms/uninitialized_filln.cpp
+++ b/tests/unit/parallel/algorithms/uninitialized_filln.cpp
@@ -8,6 +8,7 @@
 #include <hpx/include/parallel_uninitialized_fill.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/atomic.hpp>
 #include <boost/range/functions.hpp>
 
 #include <string>

--- a/tests/unit/parallel/container_algorithms/foreach_tests_projection.hpp
+++ b/tests/unit/parallel/container_algorithms/foreach_tests_projection.hpp
@@ -9,6 +9,7 @@
 #include <hpx/include/parallel_container_algorithm.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/atomic.hpp>
 #include <boost/range/functions.hpp>
 
 #include <vector>

--- a/tests/unit/parallel/container_algorithms/test_utils.hpp
+++ b/tests/unit/parallel/container_algorithms/test_utils.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/include/parallel_execution_policy.hpp>
 
+#include <boost/atomic.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 
 #include <numeric>

--- a/tests/unit/serialization/polymorphic/polymorphic_nonintrusive.cpp
+++ b/tests/unit/serialization/polymorphic/polymorphic_nonintrusive.cpp
@@ -13,6 +13,8 @@
 
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/shared_ptr.hpp>
+
 #include <vector>
 
 struct A

--- a/tests/unit/serialization/polymorphic/smart_ptr_polymorphic.cpp
+++ b/tests/unit/serialization/polymorphic/smart_ptr_polymorphic.cpp
@@ -13,6 +13,8 @@
 
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/intrusive_ptr.hpp>
+
 #include <iostream>
 #include <string>
 #include <vector>

--- a/tests/unit/serialization/polymorphic/smart_ptr_polymorphic.cpp
+++ b/tests/unit/serialization/polymorphic/smart_ptr_polymorphic.cpp
@@ -14,6 +14,7 @@
 #include <hpx/util/lightweight_test.hpp>
 
 #include <boost/intrusive_ptr.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <iostream>
 #include <string>

--- a/tests/unit/serialization/polymorphic/smart_ptr_polymorphic_nonintrusive.cpp
+++ b/tests/unit/serialization/polymorphic/smart_ptr_polymorphic_nonintrusive.cpp
@@ -13,6 +13,8 @@
 
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/intrusive_ptr.hpp>
+
 #include <iostream>
 #include <string>
 #include <vector>

--- a/tests/unit/serialization/polymorphic/smart_ptr_polymorphic_nonintrusive.cpp
+++ b/tests/unit/serialization/polymorphic/smart_ptr_polymorphic_nonintrusive.cpp
@@ -14,6 +14,7 @@
 #include <hpx/util/lightweight_test.hpp>
 
 #include <boost/intrusive_ptr.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <iostream>
 #include <string>

--- a/tests/unit/serialization/serialization_custom_constructor.cpp
+++ b/tests/unit/serialization/serialization_custom_constructor.cpp
@@ -13,6 +13,8 @@
 
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/shared_ptr.hpp>
+
 #include <vector>
 
 /**

--- a/tests/unit/serialization/serialization_smart_ptr.cpp
+++ b/tests/unit/serialization/serialization_smart_ptr.cpp
@@ -14,6 +14,7 @@
 #include <hpx/util/lightweight_test.hpp>
 
 #include <boost/intrusive_ptr.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <vector>
 

--- a/tests/unit/serialization/serialization_smart_ptr.cpp
+++ b/tests/unit/serialization/serialization_smart_ptr.cpp
@@ -13,6 +13,8 @@
 
 #include <hpx/util/lightweight_test.hpp>
 
+#include <boost/intrusive_ptr.hpp>
+
 #include <vector>
 
 void test_shared()

--- a/tools/inspect/include_check.cpp
+++ b/tools/inspect/include_check.cpp
@@ -30,6 +30,7 @@ namespace boost
       { "(\\bstd\\s*::\\s*string\\b)", "std::string", "string" },
       { "(\\bstd\\s*::\\s*vector\\b)", "std::vector", "vector" },
       { "(\\bboost\\s*::\\s*atomic\\b)", "boost::atomic", "boost/atomic.hpp" },
+      { "(\\bboost\\s*::\\s*exception_ptr\\b)", "boost::exception_ptr", "boost/exception_ptr.hpp" },
       { "(\\bboost\\s*::\\s*intrusive_ptr\\b)", "boost::intrusive_ptr", "boost/intrusive_ptr.hpp" },
       { "(\\bboost\\s*::\\s*make_shared\\b)", "boost::make_shared", "boost/make_shared.hpp" },
       { "(\\bboost\\s*::\\s*shared_ptr\\b)", "boost::shared_ptr", "boost/shared_ptr.hpp" },

--- a/tools/inspect/include_check.cpp
+++ b/tools/inspect/include_check.cpp
@@ -30,6 +30,7 @@ namespace boost
       { "(\\bstd\\s*::\\s*string\\b)", "std::string", "string" },
       { "(\\bstd\\s*::\\s*vector\\b)", "std::vector", "vector" },
       { "(\\bboost\\s*::\\s*atomic\\b)", "boost::atomic", "boost/atomic.hpp" },
+      { "(\\bboost\\s*::\\s*intrusive_ptr\\b)", "boost::intrusive_ptr", "boost/intrusive_ptr.hpp" },
       { 0, 0, 0 }
     };
 

--- a/tools/inspect/include_check.cpp
+++ b/tools/inspect/include_check.cpp
@@ -29,6 +29,7 @@ namespace boost
     {
       { "(\\bstd\\s*::\\s*string\\b)", "std::string", "string" },
       { "(\\bstd\\s*::\\s*vector\\b)", "std::vector", "vector" },
+      { "(\\bboost\\s*::\\s*atomic\\b)", "boost::atomic", "boost/atomic.hpp" },
       { 0, 0, 0 }
     };
 

--- a/tools/inspect/include_check.cpp
+++ b/tools/inspect/include_check.cpp
@@ -31,6 +31,8 @@ namespace boost
       { "(\\bstd\\s*::\\s*vector\\b)", "std::vector", "vector" },
       { "(\\bboost\\s*::\\s*atomic\\b)", "boost::atomic", "boost/atomic.hpp" },
       { "(\\bboost\\s*::\\s*intrusive_ptr\\b)", "boost::intrusive_ptr", "boost/intrusive_ptr.hpp" },
+      { "(\\bboost\\s*::\\s*make_shared\\b)", "boost::make_shared", "boost/make_shared.hpp" },
+      { "(\\bboost\\s*::\\s*shared_ptr\\b)", "boost::shared_ptr", "boost/shared_ptr.hpp" },
       { 0, 0, 0 }
     };
 


### PR DESCRIPTION
Add `#include` checks for `boost::atomic`|`exception_ptr`|`intrusive_ptr`|`make_shared`|`shared_ptr`. Fix violations.