### PR TITLE
Reduce by key, extends #1141

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -84,6 +84,7 @@ set(doxygen_dependencies
     "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/mismatch.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/move.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/reduce.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/reduce_by_key.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/remove_copy.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/replace.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/reverse.hpp"

--- a/docs/hpx.idx
+++ b/docs/hpx.idx
@@ -228,6 +228,9 @@ parallel::move                        "move" "hpx\.parallel\.v1\.move$"
 # hpx/parallel/algorithms/reduce.hpp
 parallel::reduce                      "reduce" "hpx\.parallel\.v1\.reduce.*"
 
+# hpx/parallel/algorithms/reduce_by_key.hpp
+parallel::reduce_by_key               "reduce_by_key" "hpx\.parallel\.v1\.reduce_by_key.*"
+
 # hpx/parallel/algorithms/for_loop_reduction.hpp
 parallel::reduction                   "reduction" "hpx\.parallel\.v2\.reduction"
 parallel::reduction_plus              "reduction_plus" "hpx\.parallel\.v2\.reduction_plus"

--- a/docs/manual/parallel_algorithms.qbk
+++ b/docs/manual/parallel_algorithms.qbk
@@ -314,6 +314,11 @@ __hpx__ provides implementations of the following parallel algorithms:
     [[ [algoref reduce] ]
      [Sums up a range of elements.]
      [`<hpx/include/parallel_reduce.hpp>`]]
+    [[ [algoref reduce_by_key] ]
+     [Performs an inclusive scan on consecutive elements with matching keys, with a reduction
+      to output only the final sum for each key. The key sequence {1,1,1,2,3,3,3,3,1} and value
+      sequence {2,3,4,5,6,7,8,9,10} would be reduced to keys={1,2,3,1}, values={9,5,30,10}]
+     [`<hpx/include/parallel_reduce.hpp>`]]
     [[ [algoref transform_reduce] ]
      [Sums up a range of elements after applying a function.]
      [`<hpx/include/parallel_transform_reduce.hpp>`]]

--- a/hpx/include/parallel_reduce.hpp
+++ b/hpx/include/parallel_reduce.hpp
@@ -8,6 +8,7 @@
 #define HPX_PARALLEL_REDUCE_JUN_28_2014_0827AM
 
 #include <hpx/parallel/algorithms/reduce.hpp>
+#include <hpx/parallel/algorithms/reduce_by_key.hpp>
 
 #endif
 

--- a/hpx/parallel/algorithms/reduce_by_key.hpp
+++ b/hpx/parallel/algorithms/reduce_by_key.hpp
@@ -9,13 +9,13 @@
 #include <hpx/parallel/executors.hpp>
 //
 #include <hpx/parallel/algorithms/sort.hpp>
-#include <hpx/parallel/algorithms/detail/tuple_iterator.hpp>
-#include <hpx/parallel/algorithms/prefix_scan.hpp>
 #include <hpx/parallel/algorithms/inclusive_scan.hpp>
-#include <hpx/parallel/algorithms/exclusive_scan.hpp>
+#include <hpx/parallel/algorithms/copy.hpp>
 #include <hpx/parallel/util/zip_iterator.hpp>
 #include <hpx/util/transform_iterator.hpp>
 #include <hpx/util/tuple.hpp>
+//
+#include <vector>
 //
 #ifdef EXTRA_DEBUG
 # define debug_reduce_by_key(a) std::cout << a
@@ -27,8 +27,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {
     ///////////////////////////////////////////////////////////////////////////
     // reduce_by_key
-    namespace detail
-    {
+    namespace detail {
         /// \cond NOINTERNAL
 
         // -------------------------------------------------------------------
@@ -37,24 +36,29 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         struct reduce_stencil_transformer
         {
             // declare result type as a template
-            template <typename T> struct result;
+            template<typename T>
+            struct result;
 
             // specialize result for iterator type
-            template <typename This, typename Iterator>
+            template<typename This, typename Iterator>
             struct result<This(Iterator)>
             {
-                typedef typename std::iterator_traits<Iterator>::reference element_type;
-                typedef hpx::util::tuple<element_type, element_type, element_type> type;
+                typedef typename std::iterator_traits<
+                    Iterator
+                >::reference element_type;
+                typedef hpx::util::tuple<
+                    element_type, element_type, element_type
+                > type;
             };
 
             // call operator for stencil transform
             // it will dereference tuple(it-1, it, it+1)
-            template <typename Iterator>
+            template<typename Iterator>
             typename result<reduce_stencil_transformer(Iterator)>::type
-            operator()(Iterator const& it) const
+            operator()(Iterator const &it) const
             {
                 typedef typename result<
-                        reduce_stencil_transformer(Iterator)
+                    reduce_stencil_transformer(Iterator)
                 >::type type;
                 return type(*std::prev(it), *it, *std::next(it));
             }
@@ -63,30 +67,34 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         // -------------------------------------------------------------------
         // transform iterator using reduce_stencil_transformer helper
         // -------------------------------------------------------------------
-        template <typename Iterator,
-                typename Transformer = detail::reduce_stencil_transformer>
-        class reduce_stencil_iterator
-                : public hpx::util::transform_iterator<Iterator, Transformer>
+        template<
+            typename Iterator,
+            typename Transformer = detail::reduce_stencil_transformer
+        >
+        class reduce_stencil_iterator : public hpx::util::transform_iterator<
+            Iterator, Transformer
+        >
         {
         private:
-            typedef hpx::util::transform_iterator<Iterator, Transformer> base_type;
+            typedef hpx::util::transform_iterator<
+                Iterator, Transformer
+            > base_type;
 
         public:
 
-            reduce_stencil_iterator() {}
+            reduce_stencil_iterator() { }
 
-            explicit reduce_stencil_iterator(Iterator const& it)
-                    : base_type(it, Transformer())
-            {}
+            explicit reduce_stencil_iterator(Iterator const &it) : base_type(it,
+                Transformer()) { }
 
-            reduce_stencil_iterator(Iterator const& it, Transformer const& t)
-                    : base_type(it, t)
-            {}
+            reduce_stencil_iterator(Iterator const &it, Transformer const &t)
+                : base_type(it, t) { }
         };
 
-        template <typename Iterator, typename Transformer>
-        inline reduce_stencil_iterator<Iterator, Transformer>
-        make_reduce_stencil_iterator(Iterator const& it, Transformer const& t)
+        template<typename Iterator, typename Transformer>
+        inline reduce_stencil_iterator<
+            Iterator, Transformer
+        > make_reduce_stencil_iterator(Iterator const &it, Transformer const &t)
         {
             return reduce_stencil_iterator<Iterator, Transformer>(it, t);
         }
@@ -98,28 +106,35 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         {
             bool fStart;    // START of a segment
             bool fEnd;      // END of a segment
-            ReduceKeySeriesStates(bool start=false, bool end=false) :
-                fStart(start), fEnd(end) {}
+            ReduceKeySeriesStates(bool start = false, bool end = false) : fStart(
+                start), fEnd(end) { }
         };
 
-        template<typename Transformer,
-                typename StencilIterType,
-                typename KeyStateIterType,
-                typename Compare>
+        template<
+            typename Transformer, typename StencilIterType,
+            typename KeyStateIterType, typename Compare
+        >
         struct ReduceStencilGeneration
         {
-            typedef typename Transformer::template result<Transformer(StencilIterType)>::element_type element_type;
-            typedef typename Transformer::template result<Transformer(StencilIterType)>::type tuple_type;
-            typedef typename std::iterator_traits<KeyStateIterType>::reference KeyStateType;
+            typedef typename Transformer::template result<
+                Transformer(StencilIterType)
+            >::element_type element_type;
+            typedef typename Transformer::template result<
+                Transformer(StencilIterType)
+            >::type tuple_type;
+            typedef typename std::iterator_traits<
+                KeyStateIterType
+            >::reference KeyStateType;
 
-            ReduceStencilGeneration() {}
+            ReduceStencilGeneration() { }
 
-            void operator()(const tuple_type &value, KeyStateType &kiter, const Compare &comp) const
+            void operator()(const tuple_type &value, KeyStateType &kiter,
+                const Compare &comp) const
             {
                 // resolves to a tuple of values for *(it-1), *it, *(it+1)
 
-                element_type left  = hpx::util::get<0>(value);
-                element_type mid   = hpx::util::get<1>(value);
+                element_type left = hpx::util::get<0>(value);
+                element_type mid = hpx::util::get<1>(value);
                 element_type right = hpx::util::get<2>(value);
 
                 // we need to determine which of three states this
@@ -130,8 +145,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 // 4. Both the start and end of a set of keys
 
                 {
-                    const bool leftMatches(comp(left,mid));
-                    const bool rightMatches(comp(mid,right));
+                    const bool leftMatches(comp(left, mid));
+                    const bool rightMatches(comp(mid, right));
                     kiter = ReduceKeySeriesStates(!leftMatches, !rightMatches);
                 }
             }
@@ -139,31 +154,31 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         // Zip iterator has 3 iterators inside
         // Iter1, key type : Iter2, value type : Iter3, state type
-        template <typename ZIter, typename iKey, typename iVal>
-        std::pair< iKey, iVal >
-        make_pair_result(ZIter zipiter, iKey key_start, iVal val_start)
+        template<typename ZIter, typename iKey, typename iVal>
+        std::pair<iKey, iVal> make_pair_result(ZIter zipiter, iKey key_start,
+            iVal val_start)
         {
             // the iterator we want is 'second' part of tagged_pair type (from copy_if)
-            auto const& t = zipiter.second.get_iterator_tuple();
+            auto const &t = zipiter.second.get_iterator_tuple();
             iKey key_end = hpx::util::get<0>(t);
             return std::make_pair(key_end,
-                                  std::next(val_start, std::distance(key_start, key_end)));
+                std::next(val_start, std::distance(key_start, key_end)));
         }
 
-        template <typename ZIter, typename iKey, typename iVal>
-        hpx::future< std::pair< iKey, iVal > >
-        make_pair_result(hpx::future<ZIter> && ziter, iKey key_start, iVal val_start)
+        template<typename ZIter, typename iKey, typename iVal>
+        hpx::future<std::pair<iKey, iVal> > make_pair_result(
+            hpx::future<ZIter> &&ziter, iKey key_start, iVal val_start)
         {
-            typedef std::pair< iKey, iVal > result_type;
+            typedef std::pair<iKey, iVal> result_type;
 
-            return lcos::make_future<result_type>(
-                    std::move(ziter),
-                    [=](ZIter zipiter) {
-                        auto const& t = zipiter.second.get_iterator_tuple();
-                        iKey key_end = hpx::util::get<0>(t);
-                        return std::make_pair(key_end,
-                                              std::next(val_start, std::distance(key_start, key_end)));
-                    });
+            return lcos::make_future<result_type>(std::move(ziter),
+                [=](ZIter zipiter)
+                {
+                    auto const &t = zipiter.second.get_iterator_tuple();
+                    iKey key_end = hpx::util::get<0>(t);
+                    return std::make_pair(key_end,
+                        std::next(val_start, std::distance(key_start, key_end)));
+                });
         }
 
         // when we are being run with an asynchronous policy, we do not want to
@@ -171,30 +186,41 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         // would have wait internally on them before proceeding.
         // Instead create a new policy from the old one which removes the async/future
 
-        template <typename ExPolicy>
-        struct remove_asynchronous {
+        template<typename ExPolicy>
+        struct remove_asynchronous
+        {
             typedef ExPolicy type;
         };
 
-        template <>
-        struct remove_asynchronous<hpx::parallel::parallel_vector_execution_policy> {
+        template<>
+        struct remove_asynchronous<
+            hpx::parallel::parallel_vector_execution_policy
+        >
+        {
             typedef hpx::parallel::parallel_execution_policy type;
         };
 
-        template <>
-        struct remove_asynchronous<hpx::parallel::sequential_task_execution_policy> {
+        template<>
+        struct remove_asynchronous<
+            hpx::parallel::sequential_task_execution_policy
+        >
+        {
             typedef hpx::parallel::sequential_execution_policy type;
         };
 
-        template <>
-        struct remove_asynchronous<hpx::parallel::parallel_task_execution_policy> {
+        template<>
+        struct remove_asynchronous<hpx::parallel::parallel_task_execution_policy>
+        {
             typedef hpx::parallel::parallel_execution_policy type;
         };
 
         /// \endcond
     }
 
-    std::ostream& operator << (std::ostream &os, const detail::ReduceKeySeriesStates &rs) {
+    // for debugging
+    std::ostream &operator<<(std::ostream &os,
+        const detail::ReduceKeySeriesStates &rs)
+    {
         os << "{ start=" << rs.fStart << ",end=" << rs.fEnd << "} ";
         return os;
     }
@@ -266,59 +292,61 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           It returns \a last.
     //-----------------------------------------------------------------------------
 
-    template <typename Proj = util::projection_identity,
-        typename ExPolicy, typename RanIter, typename RanIter2, typename OutIter, typename OutIter2,
+    template<
+        typename Proj = util::projection_identity, typename ExPolicy,
+        typename RanIter, typename RanIter2, typename OutIter, typename OutIter2,
         typename Compare = std::equal_to<
             typename std::remove_reference<
                 typename traits::projected_result_of<Proj, RanIter>::type
             >::type
-        >,
-        HPX_CONCEPT_REQUIRES_(
-            is_execution_policy<ExPolicy>::value &&
-            traits::detail::is_iterator<RanIter>::value &&
-            traits::is_projected<Proj, RanIter>::value &&
-            traits::is_indirect_callable<
-                Compare,
-                traits::projected<Proj, RanIter>,
-                traits::projected<Proj, RanIter>
-            >::value)>
+        >, HPX_CONCEPT_REQUIRES_(is_execution_policy<ExPolicy>::value &&
+                                 hpx::traits::is_iterator<RanIter>::value &&
+                                 traits::is_projected<Proj, RanIter>::value &&
+                                 traits::is_indirect_callable<
+                                     Compare, traits::projected<Proj, RanIter>,
+                                     traits::projected<Proj, RanIter>
+                                 >::value)
+    >
 
-    typename util::detail::algorithm_result<ExPolicy, std::pair<OutIter,OutIter2> >::type
-    reduce_by_key(
-        ExPolicy && policy,
-        RanIter key_first,
-        RanIter key_last,
-        RanIter2 values_first,
-        OutIter keys_output,
-        OutIter2 values_output,
-        Compare && comp = Compare(), Proj && proj = Proj())
+    typename util::detail::algorithm_result<
+        ExPolicy, std::pair<OutIter, OutIter2>
+    >::type reduce_by_key(ExPolicy &&policy, RanIter key_first, RanIter key_last,
+        RanIter2 values_first, OutIter keys_output, OutIter2 values_output,
+        Compare &&comp = Compare(), Proj &&proj = Proj())
     {
-        typedef util::detail::algorithm_result<ExPolicy, std::pair<OutIter,OutIter2>>
-                result;
-        typedef typename std::iterator_traits<RanIter>::iterator_category
-                iterator_category1;
-        typedef typename std::iterator_traits<RanIter2>::iterator_category
-                iterator_category2;
-        typedef typename std::iterator_traits<OutIter>::iterator_category
-                iterator_category3;
-        typedef typename std::iterator_traits<OutIter2>::iterator_category
-                iterator_category4;
+        typedef util::detail::algorithm_result<
+            ExPolicy, std::pair<
+                OutIter, OutIter2>> result;
+        typedef typename std::iterator_traits<
+            RanIter
+        >::iterator_category iterator_category1;
+        typedef typename std::iterator_traits<
+            RanIter2
+        >::iterator_category iterator_category2;
+        typedef typename std::iterator_traits<
+            OutIter
+        >::iterator_category iterator_category3;
+        typedef typename std::iterator_traits<
+            OutIter2
+        >::iterator_category iterator_category4;
 
-        static_assert(
-            (boost::is_base_of<
-                std::random_access_iterator_tag, iterator_category1>::value) ||
-            (boost::is_base_of<
-                std::random_access_iterator_tag, iterator_category2>::value) ||
-            (boost::is_base_of<
-                std::output_iterator_tag, iterator_category3>::value) ||
-            (boost::is_base_of<
-                std::output_iterator_tag, iterator_category4>::value),
+        static_assert((boost::is_base_of<
+                std::random_access_iterator_tag, iterator_category1
+            >::value) || (boost::is_base_of<
+                std::random_access_iterator_tag, iterator_category2
+            >::value) || (boost::is_base_of<
+                std::output_iterator_tag, iterator_category3
+            >::value) || (boost::is_base_of<
+                std::output_iterator_tag, iterator_category4
+            >::value),
             "iterators : Random_access for inputs and Output for outputs.");
 
         typedef typename detail::remove_asynchronous<
-                    typename std::decay< ExPolicy >::type >::type sync_policy_type;
+            typename std::decay<ExPolicy>::type
+        >::type sync_policy_type;
 
-        sync_policy_type sync_policy = sync_policy_type().on(policy.executor()).with(policy.parameters());
+        sync_policy_type sync_policy = sync_policy_type().on(policy.executor())
+            .with(policy.parameters());
 
         const uint64_t numberOfKeys = std::distance(key_first, key_last);
 
@@ -326,7 +354,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         { // we only have a single key/value so that is our output
             *keys_output = *key_first;
             *values_output = *values_first;
-            return result::get(std::make_pair(keys_output,values_output));
+            return result::get(std::make_pair(keys_output, values_output));
         }
 
         using namespace hpx::parallel::v1::detail;
@@ -334,120 +362,122 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         //we need to determine based on the keys what is the keystate for
         //each key. The states are start, middle, end of a series and the special
         //state start and end of a series
-        std::vector< ReduceKeySeriesStates > keystate;
-        using KeyStateIterType = std::vector< ReduceKeySeriesStates >::iterator;
-        using reducebykey_iter = detail::reduce_stencil_iterator<RanIter, reduce_stencil_transformer>;
+        std::vector<ReduceKeySeriesStates> keystate;
+        using KeyStateIterType = std::vector<ReduceKeySeriesStates>::iterator;
+        using reducebykey_iter = detail::reduce_stencil_iterator<
+            RanIter, reduce_stencil_transformer
+        >;
         using element_type = typename std::iterator_traits<RanIter>::reference;
-        using zip_ref = typename zip_iterator<reducebykey_iter, KeyStateIterType>::reference;
+        using zip_ref = typename zip_iterator<
+            reducebykey_iter, KeyStateIterType
+        >::reference;
         keystate.assign(numberOfKeys, ReduceKeySeriesStates());
         {
             reduce_stencil_transformer r_s_t;
-            reducebykey_iter reduce_begin = make_reduce_stencil_iterator(key_first, r_s_t);
-            reducebykey_iter reduce_end   = make_reduce_stencil_iterator(key_last, r_s_t);
+            reducebykey_iter reduce_begin = make_reduce_stencil_iterator(
+                key_first, r_s_t);
+            reducebykey_iter reduce_end = make_reduce_stencil_iterator(key_last,
+                r_s_t);
 
-            if (numberOfKeys==2) {
+            if (numberOfKeys == 2) {
                 // for two entries, one is a start, the other an end,
                 // if they are different, then they are both start/end
-                element_type left  = *key_first;
+                element_type left = *key_first;
                 element_type right = *std::next(key_first);
-                keystate[0] = ReduceKeySeriesStates(true, !comp(left,right));
-                keystate[1] = ReduceKeySeriesStates(!comp(left,right), true);
-            }
-            else {
+                keystate[0] = ReduceKeySeriesStates(true, !comp(left, right));
+                keystate[1] = ReduceKeySeriesStates(!comp(left, right), true);
+            } else {
                 // do the first and last elements by hand to simplify the iterator
                 // traversal as there is no prev/next for first/last
                 element_type elem0 = *key_first;
                 element_type elem1 = *std::next(key_first);
-                keystate[0] = ReduceKeySeriesStates(true, elem0!=elem1);
+                keystate[0] = ReduceKeySeriesStates(true, elem0 != elem1);
                 // middle elements
-                ReduceStencilGeneration <reduce_stencil_transformer, RanIter, KeyStateIterType, Compare> kernel;
-                hpx::parallel::for_each(
-                        sync_policy,
-                        make_zip_iterator(reduce_begin + 1, keystate.begin() + 1),
-                        make_zip_iterator(reduce_end - 1, keystate.end() - 1),
-                        [&kernel, &comp](zip_ref ref) {
-                            kernel.operator()(get<0>(ref), get<1>(ref), comp);
-                        }
-                );
+                ReduceStencilGeneration <reduce_stencil_transformer, RanIter,
+                  KeyStateIterType, Compare> kernel;
+                hpx::parallel::for_each(sync_policy,
+                    make_zip_iterator(reduce_begin + 1, keystate.begin() + 1),
+                    make_zip_iterator(reduce_end - 1, keystate.end() - 1),
+                    [&kernel, &comp](zip_ref ref)
+                    {
+                        kernel.operator()(get<0>(ref), get<1>(ref), comp);
+                    });
                 // Last element
                 element_type elemN = *std::prev(key_last);
                 element_type elemn = *std::prev(std::prev(key_last));
-                keystate.back() = ReduceKeySeriesStates(elemN!=elemn, true);
+                keystate.back() = ReduceKeySeriesStates(elemN != elemn, true);
             }
         }
         {
-            typedef zip_iterator<RanIter2, std::vector< ReduceKeySeriesStates >::iterator> zip_iterator;
-            typedef std::vector< ReduceKeySeriesStates >::iterator rki;
+            typedef zip_iterator<
+                RanIter2, std::vector<ReduceKeySeriesStates>::iterator
+            > zip_iterator;
             typedef typename zip_iterator::value_type zip_type;
-            typedef typename std::iterator_traits<RanIter2>::value_type value_type;
+            typedef typename std::iterator_traits<
+                RanIter2
+            >::value_type value_type;
 
-            zip_iterator states_begin = make_zip_iterator(
-                    values_first, std::begin(keystate));
+            zip_iterator states_begin = make_zip_iterator(values_first,
+                std::begin(keystate));
             zip_iterator states_end = make_zip_iterator(
-                    values_first + numberOfKeys, std::end(keystate));
-            zip_iterator states_out_begin = make_zip_iterator(
-                    values_output, std::begin(keystate));
+                values_first + numberOfKeys, std::end(keystate));
+            zip_iterator states_out_begin = make_zip_iterator(values_output,
+                std::begin(keystate));
             //
-            zip_type initial = tuple<float, ReduceKeySeriesStates>(0.0, ReduceKeySeriesStates(true, false));
+            zip_type initial = tuple<float, ReduceKeySeriesStates>(0.0,
+                ReduceKeySeriesStates(true, false));
             //
-            hpx::parallel::prefix_scan_inclusive(
-                    sync_policy,
-                    states_begin,
-                    states_end,
-                    states_out_begin,
-                    initial,
-                    // B is the current entry, A is the one passed in from 'previous'
-                    [](zip_type a, zip_type b) {
-                        value_type            a_val   = get<0>(a);
-                        ReduceKeySeriesStates a_state = get<1>(a);
-                        value_type            b_val   = get<0>(b);
-                        ReduceKeySeriesStates b_state = get<1>(b);
-                        debug_reduce_by_key(
-                                "{ " << a_val << "+" << b_val << " },\t" << a_state << b_state);
-                        // if carrying a start flag, then copy - don't add
-                        if (b_state.fStart) {
-                            debug_reduce_by_key(" = " << b_val << std::endl);
-                            return make_tuple(
-                                    b_val,
-                                    ReduceKeySeriesStates(a_state.fStart || b_state.fStart, b_state.fEnd));
-                        }
-                        // normal add of previous + this
-                        else {
-                            debug_reduce_by_key(" = " << a_val + b_val << std::endl);
-                            return make_tuple(
-                                    a_val + b_val,
-                                    ReduceKeySeriesStates(a_state.fStart || b_state.fStart, b_state.fEnd));
-                        }
+            hpx::parallel::inclusive_scan(sync_policy, states_begin,
+                states_end, states_out_begin, initial,
+                // B is the current entry, A is the one passed in from 'previous'
+                [](zip_type a, zip_type b)
+                {
+                    value_type a_val = get<0>(a);
+                    ReduceKeySeriesStates a_state = get<1>(a);
+                    value_type b_val = get<0>(b);
+                    ReduceKeySeriesStates b_state = get<1>(b);
+                    debug_reduce_by_key(
+                        "{ " << a_val << "+" << b_val << " },\t" << a_state <<
+                        b_state);
+                    // if carrying a start flag, then copy - don't add
+                    if (b_state.fStart) {
+                        debug_reduce_by_key(" = " << b_val << std::endl);
+                        return make_tuple(b_val, ReduceKeySeriesStates(
+                                a_state.fStart || b_state.fStart, b_state.fEnd));
                     }
-            );
+                        // normal add of previous + this
+                    else {
+                        debug_reduce_by_key(" = " << a_val + b_val << std::endl);
+                        return make_tuple(a_val + b_val, ReduceKeySeriesStates(
+                                a_state.fStart || b_state.fStart, b_state.fEnd));
+                    }
+                });
 
             // now copy the values and keys for each element that
             // is marked by an 'END' state to the final output
             using zip_iterator2 = hpx::util::zip_iterator<
-                    RanIter, OutIter2,
-                    std::vector< ReduceKeySeriesStates >::iterator>;
+                RanIter, OutIter2, std::vector<ReduceKeySeriesStates>::iterator
+            >;
             using zip2_ref = typename zip_iterator2::reference;
 
             // @TODO : fix this to write keys to output array instead of input
-            auto return_val = make_pair_result(
-                std::move(hpx::parallel::copy_if(
-                    sync_policy,
-                    make_zip_iterator(
-                        key_first, values_output, std::begin(keystate)),
-                    make_zip_iterator(
-                        key_last, values_output + numberOfKeys, std::end(keystate)),
-                    make_zip_iterator(
-                        key_first, values_output, std::begin(keystate)),
+            auto return_val = make_pair_result(std::move(
+                hpx::parallel::copy_if(sync_policy,
+                    make_zip_iterator(key_first, values_output,
+                        std::begin(keystate)),
+                    make_zip_iterator(key_last, values_output + numberOfKeys,
+                        std::end(keystate)),
+                    make_zip_iterator(key_first, values_output,
+                        std::begin(keystate)),
                     // copies to dest only when 'end' state is true
-                    [](zip2_ref it) {
-                        return get< 2 >(it).fEnd;
-                    }
-                )), key_first, values_output);
+                    [](zip2_ref it)
+                    {
+                        return get<2>(it).fEnd;
+                    })), key_first, values_output);
 
             return result::get(std::move(return_val));
         }
     }
-        }
-}}
+}}}
 
 #endif

--- a/hpx/parallel/algorithms/reduce_by_key.hpp
+++ b/hpx/parallel/algorithms/reduce_by_key.hpp
@@ -1,0 +1,348 @@
+//  Copyright (c) 2015 John Biddiscombe
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_ALGORITHM_REDUCE_BY_KEY_DEC_2015)
+#define HPX_PARALLEL_ALGORITHM_REDUCE_BY_KEY_DEC_2015
+
+#include <hpx/parallel/algorithms/sort.hpp>
+#include <hpx/parallel/algorithms/detail/tuple_iterator.hpp>
+
+#define VTKM_CONT_EXPORT
+#define VTKM_EXEC_EXPORT
+namespace vtkm {
+    typedef uint64_t Id;
+
+    template<typename T1, typename T2> using Pair = std::pair<T1, T2>;
+}
+
+namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // sort
+    namespace detail
+    {
+        /// \cond NOINTERNAL
+
+        struct ReduceKeySeriesStates
+        {
+            bool fStart;    // START of a segment
+            bool fEnd;      // END of a segment
+            ReduceKeySeriesStates(bool start=false, bool end=false) : fStart(start), fEnd(end) {}
+        };
+
+        template<typename InputIterType, typename KeyStateIterType >
+        struct ReduceStencilGeneration
+        {
+            InputIterType keys_last;
+//            KeyStateIterType KeyState;
+
+            VTKM_CONT_EXPORT
+            ReduceStencilGeneration(const InputIterType &key_first, const InputIterType &key_last)
+                    : keys_last(key_last)
+            {  }
+
+            VTKM_EXEC_EXPORT
+            void operator()(const InputIterType centerIter, KeyStateIterType kiter) const
+            {
+                // typedef typename InputIterType::value_type ValueType;
+                // typedef typename KeyStateIterType::value_type KeyStateType;
+
+                typedef typename std::iterator_traits<InputIterType>::value_type ValueType;
+                typedef typename std::iterator_traits<KeyStateIterType>::value_type KeyStateType;
+
+                const InputIterType leftIter = std::prev(centerIter);
+                const InputIterType rightIter = std::next(centerIter);
+
+                //we need to determine which of three states this
+                //index is. It can be:
+                // 1. Middle of a set of equivalent keys.
+                // 2. Start of a set of equivalent keys.
+                // 3. End of a set of equivalent keys.
+                // 4. Both the start and end of a set of keys
+
+                //we don't have to worry about an array of length 1, as
+                //the calling code handles that use case
+
+                if(centerIter == 0)
+                {
+                    //this means we are at the start of the array
+                    //means we are automatically START
+                    //just need to check if we are END
+                    const ValueType centerValue = *centerIter;
+                    const ValueType rightValue = *rightIter;
+                    const KeyStateType state = ReduceKeySeriesStates(true, rightValue != centerValue);
+                    *kiter = state;
+                }
+                else if(rightIter == keys_last)
+                {
+                    //this means we are at the end, so we are at least END
+                    //just need to check if we are START
+                    const ValueType centerValue = *centerIter;
+                    const ValueType leftValue = *leftIter;
+                    const KeyStateType state = ReduceKeySeriesStates(leftValue != centerValue, true);
+                    *kiter = state;
+                }
+                else
+                {
+                    const ValueType centerValue = *centerIter;
+                    const bool leftMatches(*leftIter == centerValue);
+                    const bool rightMatches(*rightIter == centerValue);
+
+                    //assume it is the middle, and check for the other use-case
+                    KeyStateType state = ReduceKeySeriesStates(!leftMatches, !rightMatches);
+                    *kiter = state;
+                }
+            }
+        };
+
+        template<typename BinaryFunctor>
+        struct ReduceByKeyAdd
+        {
+            BinaryFunctor BinaryOperator;
+
+            ReduceByKeyAdd(BinaryFunctor binary_functor):
+                    BinaryOperator( binary_functor )
+            { }
+
+            template<typename T>
+            vtkm::Pair<T, ReduceKeySeriesStates> operator()(const vtkm::Pair<T, ReduceKeySeriesStates>& a,
+                                                            const vtkm::Pair<T, ReduceKeySeriesStates>& b) const
+            {
+                typedef vtkm::Pair<T, ReduceKeySeriesStates> ReturnType;
+                //need too handle how we are going to add two numbers together
+                //based on the keyStates that they have
+
+                // Make it work for parallel inclusive scan.  Will end up with all start bits = 1
+                // the following logic should change if you use a different parallel scan algorithm.
+                if (!b.second.fStart) {
+                    // if b is not START, then it's safe to sum a & b.
+                    // Propagate a's start flag to b
+                    // so that later when b's START bit is set, it means there must exists a START between a and b
+                    return ReturnType(this->BinaryOperator(a.first , b.first),
+                                      ReduceKeySeriesStates(a.second.fStart, b.second.fEnd));
+                }
+                return b;
+            }
+        };
+
+        struct ReduceByKeyUnaryStencilOp
+        {
+            bool operator()(ReduceKeySeriesStates keySeriesState) const
+            {
+                return keySeriesState.fEnd;
+            }
+
+        };
+
+/*
+        template <typename... T>
+        auto sort_zip(T&... containers)
+        -> boost::iterator_range<decltype(hpx::iterators::makeTupleIterator(std::begin(containers)...))> {
+            return boost::make_iterator_range(hpx::iterators::makeTupleIterator(std::begin(containers)...),
+                                              hpx::iterators::makeTupleIterator(std::end(containers)...));
+        }
+*/
+        /// \endcond
+    }
+
+    //-----------------------------------------------------------------------------
+    /// Sorts the elements in the range [first, last) in ascending order. The
+    /// order of equal elements is not guaranteed to be preserved. The function
+    /// uses the given comparison function object comp (defaults to using
+    /// operator<()).
+    ///
+    /// \note   Complexity: O(Nlog(N)), where N = std::distance(first, last)
+    ///                     comparisons.
+    ///
+    /// A sequence is sorted with respect to a comparator \a comp and a
+    /// projection \a proj if for every iterator i pointing to the sequence and
+    /// every non-negative integer n such that i + n is a valid iterator
+    /// pointing to an element of the sequence, and
+    /// INVOKE(comp, INVOKE(proj, *(i + n)), INVOKE(proj, *i)) == false.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it applies user-provided function objects.
+    /// \tparam Iter        The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     random access iterator.
+    /// \tparam Comp        The type of the function/function object to use
+    ///                     (deduced).
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param comp         comp is a callable object. The return value of the
+    ///                     INVOKE operation applied to an object of type Comp,
+    ///                     when contextually converted to bool, yields true if
+    ///                     the first argument of the call is less than the
+    ///                     second, and false otherwise. It is assumed that comp
+    ///                     will not apply any non-constant function through the
+    ///                     dereferenced iterator.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each pair of elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a comp is invoked.
+    ///
+    /// \a comp has to induce a strict weak ordering on the values.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequential_execution_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_execution_policy or \a parallel_task_execution_policy are
+    /// permitted to execute in an unordered fashion in unspecified
+    /// threads, and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a sort algorithm returns a
+    ///           \a hpx::future<Iter> if the execution policy is of
+    ///           type
+    ///           \a sequential_task_execution_policy or
+    ///           \a parallel_task_execution_policy and returns \a Iter
+    ///           otherwise.
+    ///           It returns \a last.
+    //-----------------------------------------------------------------------------
+
+    template <typename Proj = util::projection_identity,
+        typename ExPolicy, typename RanIter, typename RanIter2, typename OutIter, typename OutIter2,
+        typename Compare = std::less<
+            typename std::remove_reference<
+                typename traits::projected_result_of<Proj, RanIter>::type
+            >::type
+        >,
+        HPX_CONCEPT_REQUIRES_(
+            is_execution_policy<ExPolicy>::value &&
+            traits::detail::is_iterator<RanIter>::value &&
+            traits::is_projected<Proj, RanIter>::value &&
+            traits::is_indirect_callable<
+                Compare,
+                traits::projected<Proj, RanIter>,
+                traits::projected<Proj, RanIter>
+            >::value)>
+
+    typename util::detail::algorithm_result<ExPolicy, void>::type
+    reduce_by_key(
+        ExPolicy && policy,
+        RanIter key_first, RanIter key_last,
+        RanIter2 values_first,
+        OutIter keys_output,
+        OutIter2 values_output,
+        Compare && comp = Compare(), Proj && proj = Proj())
+    {
+        typedef typename std::iterator_traits<RanIter>::iterator_category
+                iterator_category1;
+        typedef typename std::iterator_traits<RanIter2>::iterator_category
+                iterator_category2;
+        typedef typename std::iterator_traits<OutIter>::iterator_category
+                iterator_category3;
+        typedef typename std::iterator_traits<OutIter2>::iterator_category
+                iterator_category4;
+
+        static_assert(
+            (boost::is_base_of<
+                std::random_access_iterator_tag, iterator_category1>::value) ||
+            (boost::is_base_of<
+                std::random_access_iterator_tag, iterator_category2>::value) ||
+            (boost::is_base_of<
+                std::output_iterator_tag, iterator_category3>::value) ||
+            (boost::is_base_of<
+                std::output_iterator_tag, iterator_category4>::value),
+            "Requires a random access iterator.");
+
+        typedef is_sequential_execution_policy<ExPolicy> is_seq;
+
+        const uint64_t numberOfKeys = std::distance(key_first, key_last);
+
+        if(numberOfKeys <= 1)
+        { // we only have a single key/value so that is our output
+            *keys_output = *key_first;
+            *values_output = *values_first;
+            return;
+        }
+
+        using namespace hpx::parallel::detail;
+
+        //we need to determine based on the keys what is the keystate for
+        //each key. The states are start, middle, end of a series and the special
+        //state start and end of a series
+        std::vector< ReduceKeySeriesStates > keystate;
+        typedef std::vector< ReduceKeySeriesStates >::iterator KeyStateIterType;
+        keystate.assign(numberOfKeys, ReduceKeySeriesStates());
+        {
+            typedef typename hpx::util::zip_iterator<RanIter, KeyStateIterType>::reference zip_ref;
+            ReduceStencilGeneration<RanIter, KeyStateIterType> kernel(key_first, key_last);
+            hpx::parallel::for_each(
+                    policy,
+                    hpx::util::make_zip_iterator(key_first, keystate.begin()),
+                    key_last,
+                    [&kernel](zip_ref ref) {
+                        kernel.operator()(hpx::util::get<0>(ref), hpx::util::get<1>(ref));
+                    }
+            );
+        }
+/*
+            //next step is we need to reduce the values for each key. This is done
+            //by running an inclusive scan over the values array using the stencil.
+            //
+            // this inclusive scan will write out two values, the first being
+            // the value summed currently, the second being 0 or 1, with 1 being used
+            // when this is a value of a key we need to write ( END or START_AND_END)
+            {
+                hpx::parallel::inclusive_scan(
+                        policy,
+                        std::begin(keystate), std::end(keystate),
+
+                );
+
+                typedef vtkm::cont::ArrayHandle<U,VIn> ValueInHandleType;
+                typedef vtkm::cont::ArrayHandle<U,VOut> ValueOutHandleType;
+                typedef vtkm::cont::ArrayHandle< ReduceKeySeriesStates> StencilHandleType;
+                typedef vtkm::cont::ArrayHandleZip<ValueInHandleType,
+                    StencilHandleType> ZipInHandleType;
+                typedef vtkm::cont::ArrayHandleZip<ValueOutHandleType,
+                    StencilHandleType> ZipOutHandleType;
+
+                StencilHandleType stencil;
+                ValueOutHandleType reducedValues;
+
+                ZipInHandleType scanInput( values, keystate);
+                ZipOutHandleType scanOutput( reducedValues, stencil);
+
+                DerivedAlgorithm::ScanInclusive(scanInput,
+                                                scanOutput,
+                                                ReduceByKeyAdd<BinaryFunctor>(binary_functor) );
+
+                //at this point we are done with keystate, so free the memory
+                keystate.ReleaseResources();
+
+                // all we need know is an efficient way of doing the write back to the
+                // reduced global memory. this is done by using StreamCompact with the
+                // stencil and values we just created with the inclusive scan
+                DerivedAlgorithm::StreamCompact( reducedValues,
+                                                 stencil,
+                                                 values_output,
+                                                 ReduceByKeyUnaryStencilOp());
+
+            } //release all temporary memory
+
+
+            //find all the unique keys
+            DerivedAlgorithm::Copy(keys,keys_output);
+            DerivedAlgorithm::Unique(keys_output);
+            */
+        }
+    }
+}}
+
+#endif

--- a/hpx/parallel/algorithms/reduce_by_key.hpp
+++ b/hpx/parallel/algorithms/reduce_by_key.hpp
@@ -329,7 +329,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             return result::get(std::make_pair(keys_output,values_output));
         }
 
-        using namespace hpx::parallel::detail;
+        using namespace hpx::parallel::v1::detail;
         using namespace hpx::util;
         //we need to determine based on the keys what is the keystate for
         //each key. The states are start, middle, end of a series and the special

--- a/hpx/parallel/algorithms/reduce_by_key.hpp
+++ b/hpx/parallel/algorithms/reduce_by_key.hpp
@@ -225,9 +225,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         };
 
         // -------------------------------------------------------------------
-        // The main algorithm is implemented here, it can be called only
-        // with a sequential or parallel policy.
-        // Async execution is handled by the wrapper code that calls this
+        // The main algorithm is implemented here, it replaces any async
+        // execution policy with a non async one so that no waits are
+        // necessry on the internal algorithms. Async execution is handled
+        // by the wrapper layer that calls this.
         // -------------------------------------------------------------------
         template<
             typename ExPolicy,
@@ -389,8 +390,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     std::forward<Compare>(comp));
                 }
 
-//std::cout << "The result type is " << type_name<result_type>().c_str() << "\n";
-
             template <
                 typename ExPolicy, typename RanIter, typename RanIter2,
                 typename Compare>
@@ -527,16 +526,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     {
         typedef util::detail::algorithm_result<
             ExPolicy, std::pair<OutIter, OutIter2>> result;
-        typedef typename std::iterator_traits<RanIter>::iterator_category  category1;
-        typedef typename std::iterator_traits<RanIter2>::iterator_category category2;
-        typedef typename std::iterator_traits<OutIter>::iterator_category  category3;
-        typedef typename std::iterator_traits<OutIter2>::iterator_category category4;
 
         static_assert(
-            (boost::is_base_of<std::random_access_iterator_tag, category1>::value) ||
-            (boost::is_base_of<std::random_access_iterator_tag, category2>::value) ||
-            (boost::is_base_of<std::output_iterator_tag, category3>::value) ||
-            (boost::is_base_of<std::output_iterator_tag, category4>::value),
+            (hpx::traits::is_random_access_iterator<RanIter>::value) &&
+            (hpx::traits::is_random_access_iterator<RanIter2>::value) &&
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_forward_iterator<OutIter>::value) &&
+            (hpx::traits::is_output_iterator<OutIter>::value ||
+                hpx::traits::is_forward_iterator<OutIter>::value),
             "iterators : Random_access for inputs and Output for outputs.");
 
         const uint64_t number_of_keys = std::distance(key_first, key_last);

--- a/hpx/parallel/algorithms/reduce_by_key.hpp
+++ b/hpx/parallel/algorithms/reduce_by_key.hpp
@@ -19,8 +19,12 @@
 #define VTKM_CONT_EXPORT
 #define VTKM_EXEC_EXPORT
 
-#define boolvals(a,b) \
-  (a?1:0) + (b?2:0)
+#ifdef EXTRA_DEBUG
+# define boolvals(a,b) (a?1:0) + (b?2:0)
+# define debug_reduce_by_key(a) std::cout << a
+#else
+# define debug_reduce_by_key(a)
+#endif
 
 typedef hpx::lcos::local::shared_mutex mutex_type;
 
@@ -384,17 +388,19 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         // if carrying a start flag from both previous ops
                         // then do not add (used in higher level upsweep)
                         boost::lock_guard<mutex_type> m(mtx_);
-                        std::cout << "{ " << a_val << "+" << b_val << " },\t" << a_state << b_state ;
+                        debug_reduce_by_key(
+                                "{ " << a_val << "+" << b_val << " },\t" << a_state << b_state);
+
                         if (b_state.fNull) {
                             throw std::string("help");
-                            std::cout << " * " << a_val << std::endl;
+                            debug_reduce_by_key(" * " << a_val << std::endl);
                             return hpx::util::make_tuple(
                                     //boolvals(a_state.fStart, b_state.fStart) ,
                                     a_val,
                                     ReduceKeySeriesStates(a_state.fStart, b_state.fEnd, false));
                         }
                         else if (/*a_state.fStart && */b_state.fStart) {
-                            std::cout << " = " << b_val << std::endl;
+                            debug_reduce_by_key(" = " << b_val << std::endl);
                             return hpx::util::make_tuple(
                                     //boolvals(a_state.fStart, b_state.fStart) ,
                                      b_val,
@@ -402,7 +408,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         }
                         // if b is a start then reset sequence, just use b value
                         else if (b_state.fStart) {
-                            std::cout << " = " << b_val << std::endl;
+                            debug_reduce_by_key(" = " << b_val << std::endl);
                             return hpx::util::make_tuple(
                                     //boolvals(a_state.fStart, b_state.fStart) ,
                                      b_val,
@@ -410,7 +416,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         }
                         // normal add of previous + this
                         else if (a_state.fStart) {
-                            std::cout << " = " << a_val + b_val << std::endl;
+                            debug_reduce_by_key(" = " << a_val + b_val << std::endl);
                             return hpx::util::make_tuple(
                                     //boolvals(a_state.fStart, b_state.fStart) ,
                                      a_val + b_val,
@@ -418,7 +424,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         }
                         // should not ever be called
                         else {
-                            std::cout << " = " << a_val + b_val << std::endl;
+                            debug_reduce_by_key(" = " << a_val + b_val << std::endl);
                             return hpx::util::make_tuple(
                                     //boolvals(a_state.fStart, b_state.fStart) ,
                                      a_val + b_val,

--- a/hpx/parallel/algorithms/reduce_by_key.hpp
+++ b/hpx/parallel/algorithms/reduce_by_key.hpp
@@ -3,6 +3,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+/// \file parallel/algorithms/reduce_by_key.hpp
+
 #if !defined(HPX_PARALLEL_ALGORITHM_REDUCE_BY_KEY_DEC_2015)
 #define HPX_PARALLEL_ALGORITHM_REDUCE_BY_KEY_DEC_2015
 //

--- a/tests/unit/parallel/algorithms/CMakeLists.txt
+++ b/tests/unit/parallel/algorithms/CMakeLists.txt
@@ -79,6 +79,7 @@ set(tests
     move
     none_of
     reduce_
+    reduce_by_key
     remove_copy
     remove_copy_if
     replace

--- a/tests/unit/parallel/algorithms/reduce_by_key.cpp
+++ b/tests/unit/parallel/algorithms/reduce_by_key.cpp
@@ -1,0 +1,206 @@
+//  Copyright (c) 2015-2016 John Biddiscombe
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/parallel/algorithm.hpp>
+#include <hpx/parallel/algorithms/generate.hpp>
+#include <hpx/parallel/algorithms/sort_by_key.hpp>
+#include <hpx/parallel/algorithms/prefix_scan.hpp>
+#include <hpx/parallel/algorithms/reduce_by_key.hpp>
+
+// --seed=1451424610
+
+// use smaller array sizes for debug tests
+#if defined(HPX_DEBUG)
+#define HPX_SORT_TEST_SIZE          131072
+#define HPX_SORT_TEST_SIZE_STRINGS  50000
+#endif
+
+#include "sort_tests.hpp"
+
+//
+#define DEBUG_OUTPUT
+//
+namespace debug {
+    template<typename T>
+    void output(const std::string &name, const std::vector<T> &v) {
+#ifdef DEBUG_OUTPUT
+        std::cout << name.c_str() << "\t : {" << v.size() << "} : ";
+        std::copy(std::begin(v), std::end(v), std::ostream_iterator<T>(std::cout, ", "));
+        std::cout << "\n";
+#endif
+    }
+
+    template<typename Iter>
+    void output(const std::string &name, Iter begin, Iter end) {
+#ifdef DEBUG_OUTPUT
+        std::cout << name.c_str() << "\t : {" << std::distance(begin,end) << "} : ";
+        std::copy(begin, end,
+                  std::ostream_iterator<typename std::iterator_traits<Iter>::value_type>(std::cout, ", "));
+        std::cout << "\n";
+#endif
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// call reduce_by_key with no comparison operator
+template <typename ExPolicy, typename T>
+void test_reduce_by_key1(ExPolicy && policy, T)
+{
+    static_assert(
+            hpx::parallel::is_execution_policy<ExPolicy>::value,
+            "hpx::parallel::is_execution_policy<ExPolicy>::value");
+    msg(typeid(ExPolicy).name(), typeid(T).name(), "default", sync, random);
+    std::cout << "\n";
+
+    T rnd_min = (std::numeric_limits<T>::min)();
+    T rnd_max = (std::numeric_limits<T>::max)();
+    // just the value 1 for testing
+    rnd_min = 1;
+    rnd_max = 2;
+    // Fill vector with random values
+    std::vector<T> values(HPX_SORT_TEST_SIZE);
+    rnd_fill<T>(values, rnd_min, rnd_max, T(std::rand()));
+
+    // Fill vector with keys
+    std::vector<T> keys(HPX_SORT_TEST_SIZE, 0);
+    rnd_fill<T>(keys, 0, HPX_SORT_TEST_SIZE >> 8, T(std::rand()));
+    std::sort(keys.begin(), keys.end());
+    T key_min = *std::min_element(keys.begin(), keys.end());
+    T key_max = *std::max_element(keys.begin(), keys.end());
+
+    // output
+    //debug::output<T>("\nkeys", keys);
+    //debug::output<T>("\nvalues", values);
+
+    auto policy2 = hpx::parallel::par.with(hpx::parallel::static_chunk_size(2));
+
+    boost::uint64_t t = hpx::util::high_resolution_clock::now();
+    // reduce_by_key, blocking when seq, par, par_vec
+    hpx::parallel::reduce_by_key(
+            policy2,
+            //std::forward<ExPolicy>(policy),
+            keys.begin(), keys.end(),
+            values.begin(),
+            keys.begin(),
+            values.begin());
+    boost::uint64_t elapsed = hpx::util::high_resolution_clock::now() - t;
+
+    // output
+    //debug::output<T>("\nkeys", keys);
+
+    std::vector<T> check_values(HPX_SORT_TEST_SIZE);
+    auto itb = check_values.begin()+1;
+    for (int i=key_min; i<=key_max; i++) {
+        int j = std::count(keys.begin(), keys.end(), i);
+        //std::cout << "Num of " << i << " is " << j << "\n";
+        auto ite = itb + j;
+        if (ite>check_values.end()) ite=check_values.end();
+        std::iota(itb,ite,1);
+        itb = ite;
+    }
+
+
+    //debug::output<T>("\nvalues", values);
+    //debug::output<T>("\nchecks", check_values);
+
+    bool is_equal = std::equal(values.begin(), values.end(), check_values.begin());
+    if (is_equal) {
+        std::cout << "Test Passed\n";
+    }
+    HPX_TEST(is_equal);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+void test_reduce_by_key1()
+{
+    using namespace hpx::parallel;
+
+    // default comparison operator (std::less)
+//    test_reduce_by_key1(seq,     int());
+    test_reduce_by_key1(par,     int());
+//    test_reduce_by_key1(par_vec, int());
+/*
+    // default comparison operator (std::less)
+    test_reduce_by_key1(seq,     double());
+    test_reduce_by_key1(par,     double());
+    test_reduce_by_key1(par_vec, double());
+
+    // user supplied comparison operator (std::less)
+    test_reduce_by_key1_comp(seq,     int(), std::less<std::size_t>());
+    test_reduce_by_key1_comp(par,     int(), std::less<std::size_t>());
+    test_reduce_by_key1_comp(par_vec, int(), std::less<std::size_t>());
+
+    // user supplied comparison operator (std::greater)
+    test_reduce_by_key1_comp(seq,     double(), std::greater<double>());
+    test_reduce_by_key1_comp(par,     double(), std::greater<double>());
+    test_reduce_by_key1_comp(par_vec, double(), std::greater<double>());
+
+    // Async execution, default comparison operator
+    test_reduce_by_key1_async(seq(task), int());
+    test_reduce_by_key1_async(par(task), char());
+    test_reduce_by_key1_async(seq(task), double());
+    test_reduce_by_key1_async(par(task), float());
+    test_reduce_by_key1_async_str(seq(task));
+    test_reduce_by_key1_async_str(par(task));
+
+    // Async execution, user comparison operator
+    test_reduce_by_key1_async(seq(task), int(),    std::less<unsigned int>());
+    test_reduce_by_key1_async(par(task), char(),   std::less<char>());
+    //
+    test_reduce_by_key1_async(seq(task), double(), std::greater<double>());
+    test_reduce_by_key1_async(par(task), float(),  std::greater<float>());
+    //
+    test_reduce_by_key1_async_str(seq(task), std::greater<std::string>());
+    test_reduce_by_key1_async_str(par(task), std::greater<std::string>());
+
+    test_reduce_by_key1(execution_policy(seq),       int());
+    test_reduce_by_key1(execution_policy(par),       int());
+    test_reduce_by_key1(execution_policy(par_vec),   int());
+    test_reduce_by_key1(execution_policy(seq(task)), int());
+    test_reduce_by_key1(execution_policy(par(task)), int());
+    test_reduce_by_key1(execution_policy(seq(task)), std::string());
+    test_reduce_by_key1(execution_policy(par(task)), std::string());
+*/
+}
+
+////////////////////////////////////////////////////////////////////////////////
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int)std::time(0);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    test_reduce_by_key1();
+//    test_reduce_by_key2();
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace boost::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()
+        ("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run")
+        ;
+
+    // By default this test should run on all available cores
+    std::vector<std::string> cfg;
+    cfg.push_back("hpx.os_threads=" +
+        boost::lexical_cast<std::string>(hpx::threads::hardware_concurrency()));
+
+    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/parallel/algorithms/reduce_by_key.cpp
+++ b/tests/unit/parallel/algorithms/reduce_by_key.cpp
@@ -15,7 +15,7 @@
 //
 #include "sort_tests.hpp"
 //
-#define EXTRA_DEBUG
+//#define EXTRA_DEBUG
 //
 namespace debug {
     template<typename T>

--- a/tests/unit/parallel/algorithms/reduce_by_key.cpp
+++ b/tests/unit/parallel/algorithms/reduce_by_key.cpp
@@ -12,7 +12,10 @@
 #include <boost/random/uniform_int_distribution.hpp>
 //
 #include <vector>
-#include <string>
+#ifdef EXTRA_DEBUG
+# include <string>
+# include <iostream>
+#endif
 //
 #define HPX_REDUCE_BY_KEY_TEST_SIZE (1 << 18)
 //

--- a/tests/unit/parallel/algorithms/reduce_by_key.cpp
+++ b/tests/unit/parallel/algorithms/reduce_by_key.cpp
@@ -254,49 +254,6 @@ void test_reduce_by_key1()
         test_reduce_by_key_async(seq(task), int(), double(), std::equal_to<double>(), [](int key){return key;});
         test_reduce_by_key_async(par(task), int(), double(), std::equal_to<double>(), [](int key){return key;});
     } while (t2.elapsed()<5);
-/*
-*/
-/*
-    test_reduce_by_key1(seq,     double(), std::multiplies<double>());
-    test_reduce_by_key1(par,     double(), std::multiplies<double>());
-    test_reduce_by_key1(par_vec, double(), std::multiplies<double>());
-
-    // user supplied comparison operator (std::less)
-    test_reduce_by_key1_comp(seq,     int(), std::less<std::size_t>());
-    test_reduce_by_key1_comp(par,     int(), std::less<std::size_t>());
-    test_reduce_by_key1_comp(par_vec, int(), std::less<std::size_t>());
-
-    // user supplied comparison operator (std::greater)
-    test_reduce_by_key1_comp(seq,     double(), std::greater<double>());
-    test_reduce_by_key1_comp(par,     double(), std::greater<double>());
-    test_reduce_by_key1_comp(par_vec, double(), std::greater<double>());
-
-    // Async execution, default comparison operator
-    test_reduce_by_key1_async(seq(task), int());
-    test_reduce_by_key1_async(par(task), char());
-    test_reduce_by_key1_async(seq(task), double());
-    test_reduce_by_key1_async(par(task), float());
-    test_reduce_by_key1_async_str(seq(task));
-    test_reduce_by_key1_async_str(par(task));
-
-    // Async execution, user comparison operator
-    test_reduce_by_key1_async(seq(task), int(),    std::less<unsigned int>());
-    test_reduce_by_key1_async(par(task), char(),   std::less<char>());
-    //
-    test_reduce_by_key1_async(seq(task), double(), std::greater<double>());
-    test_reduce_by_key1_async(par(task), float(),  std::greater<float>());
-    //
-    test_reduce_by_key1_async_str(seq(task), std::greater<std::string>());
-    test_reduce_by_key1_async_str(par(task), std::greater<std::string>());
-
-    test_reduce_by_key1(execution_policy(seq),       int());
-    test_reduce_by_key1(execution_policy(par),       int());
-    test_reduce_by_key1(execution_policy(par_vec),   int());
-    test_reduce_by_key1(execution_policy(seq(task)), int());
-    test_reduce_by_key1(execution_policy(par(task)), int());
-    test_reduce_by_key1(execution_policy(seq(task)), std::string());
-    test_reduce_by_key1(execution_policy(par(task)), std::string());
-*/
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/parallel/algorithms/reduce_by_key.cpp
+++ b/tests/unit/parallel/algorithms/reduce_by_key.cpp
@@ -11,6 +11,9 @@
 //
 #include <boost/random/uniform_int_distribution.hpp>
 //
+#include <vector>
+#include <string>
+//
 #define HPX_REDUCE_BY_KEY_TEST_SIZE (1 << 18)
 //
 #include "sort_tests.hpp"
@@ -32,7 +35,8 @@ namespace debug {
 #ifdef EXTRA_DEBUG
         std::cout << name.c_str() << "\t : {" << std::distance(begin,end) << "} : ";
         std::copy(begin, end,
-                  std::ostream_iterator<typename std::iterator_traits<Iter>::value_type>(std::cout, ", "));
+            std::ostream_iterator<typename std::iterator_traits<Iter>::
+            value_type>(std::cout, ", "));
         std::cout << "\n";
 #endif
     }
@@ -41,7 +45,8 @@ namespace debug {
 #else
 # define debug_msg(a)
 #endif
-};
+}
+;
 
 #undef msg
 #define msg(a,b,c,d) \
@@ -51,17 +56,18 @@ namespace debug {
         << std::setw(8)  << #d << "\t";
 
 ////////////////////////////////////////////////////////////////////////////////
-template <typename ExPolicy, typename Tkey, typename Tval, typename Op, typename HelperOp>
-void test_reduce_by_key1(ExPolicy && policy, Tkey, Tval, bool benchmark, const Op &op, const HelperOp &ho)
-{
+template<typename ExPolicy, typename Tkey, typename Tval, typename Op, typename HelperOp>
+void test_reduce_by_key1(ExPolicy && policy, Tkey, Tval, bool benchmark, const Op &op,
+    const HelperOp &ho)
+    {
     static_assert(
-            hpx::parallel::is_execution_policy<ExPolicy>::value,
-            "hpx::parallel::is_execution_policy<ExPolicy>::value");
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(Tval).name(), typeid(Op).name(), sync);
     std::cout << "\n";
 
-    Tval rnd_min =  -256;
-    Tval rnd_max =   256;
+    Tval rnd_min = -256;
+    Tval rnd_max = 256;
 
     // vector of values, and keys
     std::vector<Tval> values, o_values;
@@ -81,19 +87,19 @@ void test_reduce_by_key1(ExPolicy && policy, Tkey, Tval, bool benchmark, const O
 
     // generate test data
     int keysize = 0;
-    Tkey key=0, helperkey=0, lastkey = 0;
-    for (/* */; keysize<HPX_REDUCE_BY_KEY_TEST_SIZE; )
-    {
+    Tkey key = 0, helperkey = 0, lastkey = 0;
+    for (/* */; keysize < HPX_REDUCE_BY_KEY_TEST_SIZE;)
+        {
         do {
             key = static_cast<Tkey>(distrk(engk));
-        } while (ho(key)==lastkey);
+        } while (ho(key) == lastkey);
         helperkey = ho(key);
         lastkey = helperkey;
         //
         int numkeys = static_cast<Tkey>(distrk(engk)) + 1;
         //
         Tval sum = 0;
-        for (int i=0; i<numkeys && keysize<HPX_REDUCE_BY_KEY_TEST_SIZE; ++i) {
+        for (int i = 0; i < numkeys && keysize < HPX_REDUCE_BY_KEY_TEST_SIZE; ++i) {
             Tval value = static_cast<Tval>(distr(eng));
             keys.push_back(key);
             values.push_back(value);
@@ -108,12 +114,12 @@ void test_reduce_by_key1(ExPolicy && policy, Tkey, Tval, bool benchmark, const O
     hpx::util::high_resolution_timer t;
     // reduce_by_key, blocking when seq, par, par_vec
     auto result = hpx::parallel::reduce_by_key(
-            std::forward<ExPolicy>(policy),
-            keys.begin(), keys.end(),
-            values.begin(),
-            keys.begin(),
-            values.begin(),
-            op);
+        std::forward<ExPolicy>(policy),
+        keys.begin(), keys.end(),
+        values.begin(),
+        keys.begin(),
+        values.begin(),
+        op);
     double elapsed = t.elapsed();
 
     bool is_equal = std::equal(values.begin(), result.second, check_values.begin());
@@ -122,7 +128,7 @@ void test_reduce_by_key1(ExPolicy && policy, Tkey, Tval, bool benchmark, const O
         if (benchmark) {
             std::cout << "<DartMeasurement name=\"ReduceByKeyTime\" \n"
                 << "type=\"numeric/double\">" << elapsed << "</DartMeasurement> \n";
-        }    
+        }
     }
     else {
         debug::output("keys     ", o_keys);
@@ -130,23 +136,24 @@ void test_reduce_by_key1(ExPolicy && policy, Tkey, Tval, bool benchmark, const O
         debug::output("key range", keys.begin(), result.first);
         debug::output("val range", values.begin(), result.second);
         debug::output("expected ", check_values);
-        throw std::string ("Problem");
+        throw std::string("Problem");
     }
     HPX_TEST(is_equal);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-template <typename ExPolicy, typename Tkey, typename Tval, typename Op, typename HelperOp>
-void test_reduce_by_key_async(ExPolicy && policy, Tkey, Tval, const Op &op, const HelperOp &ho)
-{
+template<typename ExPolicy, typename Tkey, typename Tval, typename Op, typename HelperOp>
+void test_reduce_by_key_async(ExPolicy && policy, Tkey, Tval, const Op &op,
+    const HelperOp &ho)
+    {
     static_assert(
-            hpx::parallel::is_execution_policy<ExPolicy>::value,
-            "hpx::parallel::is_execution_policy<ExPolicy>::value");
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(Tval).name(), typeid(Op).name(), async);
     std::cout << "\n";
 
-    Tval rnd_min =  -256;
-    Tval rnd_max =   256;
+    Tval rnd_min = -256;
+    Tval rnd_max = 256;
 
     // vector of values, and keys
     std::vector<Tval> values, o_values;
@@ -166,19 +173,19 @@ void test_reduce_by_key_async(ExPolicy && policy, Tkey, Tval, const Op &op, cons
 
     // generate test data
     int keysize = 0;
-    Tkey key=0, helperkey=0, lastkey = 0;
-    for (/* */; keysize<HPX_REDUCE_BY_KEY_TEST_SIZE; )
-    {
+    Tkey key = 0, helperkey = 0, lastkey = 0;
+    for (/* */; keysize < HPX_REDUCE_BY_KEY_TEST_SIZE;)
+        {
         do {
             key = static_cast<Tkey>(distrk(engk));
-        } while (ho(key)==lastkey);
+        } while (ho(key) == lastkey);
         helperkey = ho(key);
         lastkey = helperkey;
         //
         int numkeys = static_cast<Tkey>(distrk(engk)) + 1;
         //
         Tval sum = 0;
-        for (int i=0; i<numkeys && keysize<HPX_REDUCE_BY_KEY_TEST_SIZE; ++i) {
+        for (int i = 0; i < numkeys && keysize < HPX_REDUCE_BY_KEY_TEST_SIZE; ++i) {
             Tval value = static_cast<Tval>(distr(eng));
             keys.push_back(key);
             values.push_back(value);
@@ -193,12 +200,12 @@ void test_reduce_by_key_async(ExPolicy && policy, Tkey, Tval, const Op &op, cons
     boost::uint64_t t = hpx::util::high_resolution_clock::now();
     // reduce_by_key, blocking when seq, par, par_vec
     auto fresult = hpx::parallel::reduce_by_key(
-            std::forward<ExPolicy>(policy),
-            keys.begin(), keys.end(),
-            values.begin(),
-            keys.begin(),
-            values.begin(),
-            op);
+        std::forward<ExPolicy>(policy),
+        keys.begin(), keys.end(),
+        values.begin(),
+        keys.begin(),
+        values.begin(),
+        op);
     auto result = fresult.get();
     boost::uint64_t elapsed = hpx::util::high_resolution_clock::now() - t;
 
@@ -212,7 +219,7 @@ void test_reduce_by_key_async(ExPolicy && policy, Tkey, Tval, const Op &op, cons
         debug::output("key range", keys.begin(), result.first);
         debug::output("val range", values.begin(), result.second);
         debug::output("expected ", check_values);
-        throw std::string ("Problem");
+        throw std::string("Problem");
     }
     HPX_TEST(is_equal);
 }
@@ -224,51 +231,61 @@ void test_reduce_by_key1()
     //
     hpx::util::high_resolution_timer t;
     do {
-        test_reduce_by_key1(seq,     int(), int(), false, std::equal_to<int>(), [](int key){return key;});
-        test_reduce_by_key1(par,     int(), int(), false, std::equal_to<int>(), [](int key){return key;});
-        test_reduce_by_key1(par_vec, int(), int(), false, std::equal_to<int>(), [](int key){return key;});
+        test_reduce_by_key1(seq, int(), int(), false, std::equal_to<int>(),
+            [](int key) {return key;});
+        test_reduce_by_key1(par, int(), int(), false, std::equal_to<int>(),
+            [](int key) {return key;});
+        test_reduce_by_key1(par_vec, int(), int(), false, std::equal_to<int>(),
+            [](int key) {return key;});
         //
         // default comparison operator (std::equal_to)
-        test_reduce_by_key1(seq,     int(), double(), false, std::equal_to<double>(), [](int key){return key;});
-        test_reduce_by_key1(par,     int(), double(), false, std::equal_to<double>(), [](int key){return key;});
-        test_reduce_by_key1(par_vec, int(), double(), false, std::equal_to<double>(), [](int key){return key;});
+        test_reduce_by_key1(seq, int(), double(), false, std::equal_to<double>(),
+            [](int key) {return key;});
+        test_reduce_by_key1(par, int(), double(), false, std::equal_to<double>(),
+            [](int key) {return key;});
+        test_reduce_by_key1(par_vec, int(), double(), false, std::equal_to<double>(),
+            [](int key) {return key;});
         //
         //
-        test_reduce_by_key1(seq,     double(), double(), false,
-                            [](double a, double b) { return std::floor(a)==std::floor(b); },
-                            [](double a){ return std::floor(a); }
-        );
-        test_reduce_by_key1(par,     double(), double(), false,
-                            [](double a, double b) { return std::floor(a)==std::floor(b); },
-                            [](double a){ return std::floor(a); }
-        );
+        test_reduce_by_key1(seq, double(), double(), false,
+            [](double a, double b) {return std::floor(a)==std::floor(b);},
+            [](double a) {return std::floor(a);}
+            );
+        test_reduce_by_key1(par, double(), double(), false,
+            [](double a, double b) {return std::floor(a)==std::floor(b);},
+            [](double a) {return std::floor(a);}
+            );
         test_reduce_by_key1(par_vec, double(), double(), false,
-                            [](double a, double b) { return std::floor(a)==std::floor(b); },
-                            [](double a){ return std::floor(a); }
-        );
-    } while (t.elapsed()<2);
+            [](double a, double b) {return std::floor(a)==std::floor(b);},
+            [](double a) {return std::floor(a);}
+            );
+    } while (t.elapsed() < 2);
     //
 
     hpx::util::high_resolution_timer t2;
     do {
-        test_reduce_by_key_async(seq(task), int(), int(), std::equal_to<int>(), [](int key){return key;});
-        test_reduce_by_key_async(par(task), int(), int(), std::equal_to<int>(), [](int key){return key;});
+        test_reduce_by_key_async(seq(task), int(), int(), std::equal_to<int>(),
+            [](int key) {return key;});
+        test_reduce_by_key_async(par(task), int(), int(), std::equal_to<int>(),
+            [](int key) {return key;});
         //
-        test_reduce_by_key_async(seq(task), int(), double(), std::equal_to<double>(), [](int key){return key;});
-        test_reduce_by_key_async(par(task), int(), double(), std::equal_to<double>(), [](int key){return key;});
-    } while (t2.elapsed()<2);
+        test_reduce_by_key_async(seq(task), int(), double(), std::equal_to<double>(),
+            [](int key) {return key;});
+        test_reduce_by_key_async(par(task), int(), double(), std::equal_to<double>(),
+            [](int key) {return key;});
+    } while (t2.elapsed() < 2);
 
     // one last test with timing output enabled
     test_reduce_by_key1(par, double(), double(), true,
-                        [](double a, double b) { return std::floor(a)==std::floor(b); },
-                        [](double a){ return std::floor(a); }
-    );
+        [](double a, double b) {return std::floor(a)==std::floor(b);},
+        [](double a) {return std::floor(a);}
+        );
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int) std::time(0);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 
@@ -284,7 +301,8 @@ int main(int argc, char* argv[])
 {
     // add command line option which controls the random number generator seed
     using namespace boost::program_options;
-    options_description desc_commandline(
+    options_description
+    desc_commandline(
         "Usage: " HPX_APPLICATION_STRING " [options]");
 
     desc_commandline.add_options()

--- a/tests/unit/parallel/algorithms/reduce_by_key.cpp
+++ b/tests/unit/parallel/algorithms/reduce_by_key.cpp
@@ -197,8 +197,8 @@ void test_reduce_by_key_async(ExPolicy && policy, Tkey, Tval, const Op &op,
     o_values = values;
     o_keys = keys;
 
-    boost::uint64_t t = hpx::util::high_resolution_clock::now();
     // reduce_by_key, blocking when seq, par, par_vec
+    hpx::util::high_resolution_timer t;
     auto fresult = hpx::parallel::reduce_by_key(
         std::forward<ExPolicy>(policy),
         keys.begin(), keys.end(),
@@ -206,9 +206,11 @@ void test_reduce_by_key_async(ExPolicy && policy, Tkey, Tval, const Op &op,
         keys.begin(),
         values.begin(),
         op);
+    double async_seconds = t.elapsed();
     auto result = fresult.get();
-    boost::uint64_t elapsed = hpx::util::high_resolution_clock::now() - t;
+    double sync_seconds= t.elapsed();
 
+    std::cout << "Async time " << async_seconds << " Sync time " << sync_seconds << "\n";
     bool is_equal = std::equal(values.begin(), result.second, check_values.begin());
     if (is_equal) {
         //std::cout << "Test Passed\n";
@@ -261,7 +263,6 @@ void test_reduce_by_key1()
             );
     } while (t.elapsed() < 2);
     //
-
     hpx::util::high_resolution_timer t2;
     do {
         test_reduce_by_key_async(seq(task), int(), int(), std::equal_to<int>(),


### PR DESCRIPTION
This is an algorithm present in thrust:: but not included in N4409. It is useful for a number of algorithms that use stream compaction (common in visualization).