### PR TITLE
Adding hook functions for executor_parameter_traits supporting timers

### DIFF
--- a/hpx/parallel/executors/executor_parameter_traits.hpp
+++ b/hpx/parallel/executors/executor_parameter_traits.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -184,6 +184,66 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
                     typename hpx::util::decay_unwrap<Parameters>::type
                 >::call(params, exec);
         }
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Parameters_>
+        struct mark_begin_execution_helper
+        {
+            template <typename Parameters>
+            static void call(hpx::traits::detail::wrap_int, Parameters&)
+            {
+            }
+
+            template <typename Parameters>
+            static auto call(int, Parameters& params)
+            ->  decltype(params.mark_begin_execution())
+            {
+                params.mark_begin_execution();
+            }
+
+            static void call(Parameters_& params)
+            {
+                call(0, params);
+            }
+        };
+
+        template <typename Parameters>
+        void call_mark_begin_execution(Parameters& params)
+        {
+            mark_begin_execution_helper<
+                    typename hpx::util::decay_unwrap<Parameters>::type
+                >::call(params);
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Parameters_>
+        struct mark_end_execution_helper
+        {
+            template <typename Parameters>
+            static void call(hpx::traits::detail::wrap_int, Parameters&)
+            {
+            }
+
+            template <typename Parameters>
+            static auto call(int, Parameters& params)
+            ->  decltype(params.mark_end_execution())
+            {
+                params.mark_end_execution();
+            }
+
+            static void call(Parameters_& params)
+            {
+                call(0, params);
+            }
+        };
+
+        template <typename Parameters>
+        void call_mark_end_execution(Parameters& params)
+        {
+            mark_end_execution_helper<
+                    typename hpx::util::decay_unwrap<Parameters>::type
+                >::call(params);
+        }
     }
     /// \endcond
 
@@ -264,14 +324,40 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         /// \param params [in] The executor parameters object to use as a
         ///              fallback if the executor does not expose
         ///
-        /// \note This calls exec.processing_units_count() if it exists;
-        ///       otherwise it forwards teh request to the executor parameters
+        /// \note This calls params.processing_units_count() if it exists;
+        ///       otherwise it forwards the request to the executor parameters
         ///       object.
         ///
         static std::size_t processing_units_count(
             executor_parameters_type& params)
         {
             return detail::call_processing_units_parameter_count(params);
+        }
+
+        /// Mark the begin of a parallel algorithm execution
+        ///
+        /// \param params [in] The executor parameters object to use as a
+        ///              fallback if the executor does not expose
+        ///
+        /// \note This calls params.mark_begin_execution(exec) if it exists;
+        ///       otherwise it does nothing.
+        ///
+        static void mark_begin_execution(executor_parameters_type& params)
+        {
+            detail::call_mark_begin_execution(params);
+        }
+
+        /// Mark the end of a parallel algorithm execution
+        ///
+        /// \param params [in] The executor parameters object to use as a
+        ///              fallback if the executor does not expose
+        ///
+        /// \note This calls params.mark_end_execution(exec) if it exists;
+        ///       otherwise it does nothing.
+        ///
+        static void mark_end_execution(executor_parameters_type& params)
+        {
+            detail::call_mark_end_execution(params);
         }
     };
 

--- a/hpx/parallel/executors/thread_executor_parameter_traits.hpp
+++ b/hpx/parallel/executors/thread_executor_parameter_traits.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -107,6 +107,32 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
             executor_parameters_type& params)
         {
             return detail::call_processing_units_parameter_count(params);
+        }
+
+        /// Mark the begin of a parallel algorithm execution
+        ///
+        /// \param params [in] The executor parameters object to use as a
+        ///              fallback if the executor does not expose
+        ///
+        /// \note This calls params.mark_begin_execution(exec) if it exists;
+        ///       otherwise it does nothing.
+        ///
+        static void mark_begin_execution(executor_parameters_type& params)
+        {
+            detail::call_mark_begin_execution(params);
+        }
+
+        /// Mark the end of a parallel algorithm execution
+        ///
+        /// \param params [in] The executor parameters object to use as a
+        ///              fallback if the executor does not expose
+        ///
+        /// \note This calls params.mark_end_execution(exec) if it exists;
+        ///       otherwise it does nothing.
+        ///
+        static void mark_end_execution(executor_parameters_type& params)
+        {
+            detail::call_mark_end_execution(params);
         }
     };
 }}}

--- a/hpx/parallel/util/detail/scoped_executor_parameters.hpp
+++ b/hpx/parallel/util/detail/scoped_executor_parameters.hpp
@@ -1,0 +1,38 @@
+//  Copyright (c) 2007-2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_UTIL_DETAIL_SCOPED_EXECUTOR_PARAMETERS_APR_22_1221PM)
+#define HPX_PARALLEL_UTIL_DETAIL_SCOPED_EXECUTOR_PARAMETERS_APR_22_1221PM
+
+#include <hpx/config.hpp>
+#include <hpx/parallel/executors/executor_parameter_traits.hpp>
+
+namespace hpx { namespace parallel { namespace util { namespace detail
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Parameters>
+    struct scoped_executor_parameters
+    {
+    private:
+        typedef executor_parameter_traits<Parameters> parameter_traits;
+
+    public:
+        scoped_executor_parameters(Parameters const& params)
+          : params_(params)
+        {
+            parameter_traits::mark_begin_execution(params_);
+        }
+
+        ~scoped_executor_parameters()
+        {
+            parameter_traits::mark_end_execution(params_);
+        }
+
+    private:
+        Parameters params_;
+    };
+}}}}
+
+#endif

--- a/hpx/parallel/util/partitioner.hpp
+++ b/hpx/parallel/util/partitioner.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -17,12 +17,16 @@
 #include <hpx/util/tuple.hpp>
 
 #include <hpx/parallel/executors/executor_traits.hpp>
+#include <hpx/parallel/executors/executor_parameter_traits.hpp>
 #include <hpx/parallel/execution_policy.hpp>
 #include <hpx/parallel/util/detail/chunk_size.hpp>
 #include <hpx/parallel/util/detail/handle_local_exceptions.hpp>
+#include <hpx/parallel/util/detail/scoped_executor_parameters.hpp>
 #include <hpx/parallel/traits/extract_partitioner.hpp>
 
 #include <boost/exception_ptr.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/make_shared.hpp>
 #include <boost/range/functions.hpp>
 
 #include <iterator>
@@ -48,8 +52,17 @@ namespace hpx { namespace parallel { namespace util
                     executor_type;
                 typedef typename hpx::parallel::executor_traits<executor_type>
                     executor_traits;
+
+                typedef typename
+                    hpx::util::decay<ExPolicy>::type::executor_parameters_type
+                    parameters_type;
+
                 typedef typename hpx::util::tuple<FwdIter, std::size_t>
                     tuple_type;
+
+                // inform parameter traits
+                scoped_executor_parameters<parameters_type> scoped_param(
+                    policy.parameters());
 
                 std::vector<hpx::future<Result> > inititems;
                 std::list<boost::exception_ptr> errors;
@@ -57,35 +70,45 @@ namespace hpx { namespace parallel { namespace util
 
                 try {
                     // estimate a chunk size based on number of cores used
-                    shape = get_bulk_iteration_shape(policy, inititems, f1,
-                        first, count, 1);
-
-                    std::vector<hpx::future<Result> > workitems;
-                    workitems.reserve(shape.size());
+                    std::vector<tuple_type> shape =
+                        get_bulk_iteration_shape(policy, inititems, f1,
+                            first, count, 1);
 
                     using hpx::util::bind;
                     using hpx::util::functional::invoke_fused;
                     using hpx::util::placeholders::_1;
-                    workitems = executor_traits::async_execute(
-                        policy.executor(),
-                        bind(invoke_fused(), std::forward<F1>(f1), _1),
-                        shape);
 
+                    std::vector<hpx::future<Result> > workitems =
+                        executor_traits::async_execute(
+                            policy.executor(),
+                            bind(invoke_fused(), std::forward<F1>(f1), _1),
+                            std::move(shape));
+
+                    // add the newly created workitems to the list
+                    inititems.reserve(inititems.size() + workitems.size());
                     std::move(workitems.begin(), workitems.end(),
                         std::back_inserter(inititems));
                 }
                 catch (...) {
-                    detail::handle_local_exceptions<ExPolicy>::call(
+                    handle_local_exceptions<ExPolicy>::call(
                         boost::current_exception(), errors);
                 }
 
                 // wait for all tasks to finish
                 hpx::wait_all(inititems);
 
-                detail::handle_local_exceptions<ExPolicy>::call(
-                    inititems, errors);
+                // always rethrow if 'errors' is not empty or inititems has
+                // exceptional future
+                handle_local_exceptions<ExPolicy>::call(inititems, errors);
 
-                return f2(std::move(inititems));
+                try {
+                    return f2(std::move(inititems));
+                }
+                catch (...) {
+                    // rethrow either bad_alloc or exception_list
+                    handle_local_exceptions<ExPolicy>::call(
+                        boost::current_exception());
+                }
             }
 
             template <typename ExPolicy, typename FwdIter, typename F1,
@@ -101,7 +124,16 @@ namespace hpx { namespace parallel { namespace util
                     executor_type;
                 typedef typename hpx::parallel::executor_traits<executor_type>
                     executor_traits;
+
+                typedef typename
+                    hpx::util::decay<ExPolicy>::type::executor_parameters_type
+                    parameters_type;
+
                 typedef typename hpx::util::decay<Data>::type data_type;
+
+                // inform parameter traits
+                scoped_executor_parameters<parameters_type> scoped_param(
+                    policy.parameters());
 
                 typename data_type::const_iterator data_it = boost::begin(data);
                 typename std::vector<std::size_t>::const_iterator chunk_size_it =
@@ -113,11 +145,12 @@ namespace hpx { namespace parallel { namespace util
 
                 std::vector<hpx::future<Result> > workitems;
                 std::list<boost::exception_ptr> errors;
-                std::vector<tuple_type> shape;
 
                 try {
                     // schedule every chunk on a separate thread
+                    std::vector<tuple_type> shape;
                     shape.reserve(chunk_sizes.size());
+
                     while(count != 0)
                     {
                         std::size_t chunk = (std::min)(count, *chunk_size_it);
@@ -134,31 +167,40 @@ namespace hpx { namespace parallel { namespace util
                     }
 
                     HPX_ASSERT(chunk_size_it == chunk_sizes.end());
-                    workitems.reserve(chunk_sizes.size());
 
                     using hpx::util::bind;
                     using hpx::util::functional::invoke_fused;
                     using hpx::util::placeholders::_1;
+
                     workitems = executor_traits::async_execute(
                         policy.executor(),
                         bind(invoke_fused(), std::forward<F1>(f1), _1),
-                        shape);
+                        std::move(shape));
                 }
                 catch (...) {
-                    detail::handle_local_exceptions<ExPolicy>::call(
+                    handle_local_exceptions<ExPolicy>::call(
                         boost::current_exception(), errors);
                 }
 
                 // wait for all tasks to finish
                 hpx::wait_all(workitems);
-                detail::handle_local_exceptions<ExPolicy>::call(
-                    workitems, errors);
 
-                return f2(std::move(workitems));
+                // always rethrow if 'errors' is not empty or inititems has
+                // exceptional future
+                handle_local_exceptions<ExPolicy>::call(workitems, errors);
+
+                try {
+                    return f2(std::move(workitems));
+                }
+                catch (...) {
+                    // rethrow either bad_alloc or exception_list
+                    handle_local_exceptions<ExPolicy>::call(
+                        boost::current_exception());
+                }
             }
 
-            template <typename ExPolicy, typename FwdIter, typename Stride, typename F1,
-                typename F2>
+            template <typename ExPolicy, typename FwdIter, typename Stride,
+                typename F1, typename F2>
             static R call_with_index(ExPolicy && policy, FwdIter first,
                 std::size_t count, Stride stride, F1 && f1, F2 && f2)
             {
@@ -166,43 +208,61 @@ namespace hpx { namespace parallel { namespace util
                     executor_type;
                 typedef typename hpx::parallel::executor_traits<executor_type>
                     executor_traits;
+
+                typedef typename
+                    hpx::util::decay<ExPolicy>::type::executor_parameters_type
+                    parameters_type;
+
                 typedef hpx::util::tuple<std::size_t, FwdIter, std::size_t>
                     tuple_type;
 
+                // inform parameter traits
+                scoped_executor_parameters<parameters_type> scoped_param(
+                    policy.parameters());
+
                 std::vector<hpx::future<Result> > inititems;
                 std::list<boost::exception_ptr> errors;
-                std::vector<tuple_type> shape;
 
                 try {
                     // estimate a chunk size based on number of cores used
-                    shape = get_bulk_iteration_shape_idx(policy, inititems, f1,
-                        first, count, stride);
-
-                    std::vector<hpx::future<Result> > workitems;
-                    workitems.reserve(shape.size());
+                    std::vector<tuple_type> shape =
+                        get_bulk_iteration_shape_idx(policy, inititems, f1,
+                            first, count, stride);
 
                     using hpx::util::bind;
                     using hpx::util::functional::invoke_fused;
                     using hpx::util::placeholders::_1;
-                    workitems = executor_traits::async_execute(
-                        policy.executor(),
-                        bind(invoke_fused(), std::forward<F1>(f1), _1),
-                        shape);
 
+                    std::vector<hpx::future<Result> > workitems =
+                        executor_traits::async_execute(
+                            policy.executor(),
+                            bind(invoke_fused(), std::forward<F1>(f1), _1),
+                            std::move(shape));
+
+                    inititems.reserve(inititems.size() + workitems.size());
                     std::move(workitems.begin(), workitems.end(),
                         std::back_inserter(inititems));
                 }
                 catch (...) {
-                    detail::handle_local_exceptions<ExPolicy>::call(
+                    handle_local_exceptions<ExPolicy>::call(
                         boost::current_exception(), errors);
                 }
 
                 // wait for all tasks to finish
                 hpx::wait_all(inititems);
-                detail::handle_local_exceptions<ExPolicy>::call(
-                    inititems, errors);
 
-                return f2(std::move(inititems));
+                // always rethrow if 'errors' is not empty or inititems has
+                // exceptional future
+                handle_local_exceptions<ExPolicy>::call(inititems, errors);
+
+                try {
+                    return f2(std::move(inititems));
+                }
+                catch (...) {
+                    // rethrow either bad_alloc or exception_list
+                    handle_local_exceptions<ExPolicy>::call(
+                        boost::current_exception());
+                }
             }
         };
 
@@ -217,45 +277,57 @@ namespace hpx { namespace parallel { namespace util
                     executor_type;
                 typedef typename hpx::parallel::executor_traits<executor_type>
                     executor_traits;
+
+                typedef typename
+                    hpx::util::decay<ExPolicy>::type::executor_parameters_type
+                    parameters_type;
+                typedef scoped_executor_parameters<parameters_type>
+                    scoped_executor_parameters;
+
                 typedef typename hpx::util::tuple<FwdIter, std::size_t>
                     tuple_type;
 
+                // inform parameter traits
+                boost::shared_ptr<scoped_executor_parameters>
+                    scoped_param(boost::make_shared<
+                            scoped_executor_parameters
+                        >(policy.parameters()));
+
                 std::vector<hpx::future<Result> > inititems;
                 std::list<boost::exception_ptr> errors;
-                std::vector<tuple_type> shape;
 
                 try {
                     // estimate a chunk size based on number of cores used
-                    shape = get_bulk_iteration_shape(policy, inititems, f1,
-                        first, count, 1);
-
-                    std::vector<hpx::future<Result> > workitems;
-                    workitems.reserve(shape.size());
+                    std::vector<tuple_type> shape =
+                        get_bulk_iteration_shape(policy, inititems, f1,
+                            first, count, 1);
 
                     using hpx::util::bind;
                     using hpx::util::functional::invoke_fused;
                     using hpx::util::placeholders::_1;
-                    workitems = executor_traits::async_execute(
-                        policy.executor(),
-                        bind(invoke_fused(), std::forward<F1>(f1), _1),
-                        shape);
 
+                    std::vector<hpx::future<Result> > workitems =
+                        executor_traits::async_execute(
+                            policy.executor(),
+                            bind(invoke_fused(), std::forward<F1>(f1), _1),
+                            std::move(shape));
+
+                    inititems.reserve(inititems.size() + workitems.size());
                     std::move(workitems.begin(), workitems.end(),
                         std::back_inserter(inititems));
                 }
-                catch (std::bad_alloc const&) {
-                    return hpx::make_exceptional_future<R>(
-                        boost::current_exception());
-                }
                 catch (...) {
-                    errors.push_back(boost::current_exception());
+                    handle_local_exceptions<ExPolicy>::call(
+                        boost::current_exception(), errors);
                 }
 
                 // wait for all tasks to finish
                 return hpx::dataflow(
-                    [f2, errors](std::vector<hpx::future<Result> > && r) mutable -> R
+                    [f2, errors, scoped_param](
+                        std::vector<hpx::future<Result> > && r) mutable -> R
                     {
-                        detail::handle_local_exceptions<ExPolicy>::call(r, errors);
+                        // inform parameter traits
+                        handle_local_exceptions<ExPolicy>::call(r, errors);
                         return f2(std::move(r));
                     },
                     std::move(inititems));
@@ -274,7 +346,20 @@ namespace hpx { namespace parallel { namespace util
                     executor_type;
                 typedef typename hpx::parallel::executor_traits<executor_type>
                     executor_traits;
+
+                typedef typename
+                    hpx::util::decay<ExPolicy>::type::executor_parameters_type
+                    parameters_type;
+                typedef scoped_executor_parameters<parameters_type>
+                    scoped_executor_parameters;
+
                 typedef typename hpx::util::decay<Data>::type data_type;
+
+                // inform parameter traits
+                boost::shared_ptr<scoped_executor_parameters>
+                    scoped_param(boost::make_shared<
+                            scoped_executor_parameters
+                        >(policy.parameters()));
 
                 typename data_type::const_iterator data_it = boost::begin(data);
                 typename std::vector<std::size_t>::const_iterator chunk_size_it =
@@ -286,11 +371,12 @@ namespace hpx { namespace parallel { namespace util
 
                 std::vector<hpx::future<Result> > workitems;
                 std::list<boost::exception_ptr> errors;
-                std::vector<tuple_type> shape;
 
                 try {
                     // schedule every chunk on a separate thread
+                    std::vector<tuple_type> shape;
                     shape.reserve(chunk_sizes.size());
+
                     while(count != 0)
                     {
                         std::size_t chunk = (std::min)(count, *chunk_size_it);
@@ -305,31 +391,29 @@ namespace hpx { namespace parallel { namespace util
                         ++data_it;
                         ++chunk_size_it;
                     }
-
                     HPX_ASSERT(chunk_size_it == chunk_sizes.end());
-                    workitems.reserve(chunk_sizes.size());
 
                     using hpx::util::bind;
                     using hpx::util::functional::invoke_fused;
                     using hpx::util::placeholders::_1;
+
                     workitems = executor_traits::async_execute(
                         policy.executor(),
                         bind(invoke_fused(), std::forward<F1>(f1), _1),
-                        shape);
-                }
-                catch (std::bad_alloc const&) {
-                    return hpx::make_exceptional_future<R>(
-                        boost::current_exception());
+                        std::move(shape));
                 }
                 catch (...) {
-                    errors.push_back(boost::current_exception());
+                    handle_local_exceptions<ExPolicy>::call(
+                        boost::current_exception(), errors);
                 }
 
                 // wait for all tasks to finish
                 return hpx::dataflow(
-                    [f2, errors](std::vector<hpx::future<Result> > && r) mutable -> R
+                    [f2, errors, scoped_param](
+                        std::vector<hpx::future<Result> > && r) mutable -> R
                     {
-                        detail::handle_local_exceptions<ExPolicy>::call(r, errors);
+                        // inform parameter traits
+                        handle_local_exceptions<ExPolicy>::call(r, errors);
                         return f2(std::move(r));
                     },
                     std::move(workitems));
@@ -345,8 +429,21 @@ namespace hpx { namespace parallel { namespace util
                     executor_type;
                 typedef typename hpx::parallel::executor_traits<executor_type>
                     executor_traits;
+
+                typedef typename
+                    hpx::util::decay<ExPolicy>::type::executor_parameters_type
+                    parameters_type;
+                typedef scoped_executor_parameters<parameters_type>
+                    scoped_executor_parameters;
+
                 typedef hpx::util::tuple<std::size_t, FwdIter, std::size_t>
                     tuple_type;
+
+                // inform parameter traits
+                boost::shared_ptr<scoped_executor_parameters>
+                    scoped_param(boost::make_shared<
+                            scoped_executor_parameters
+                        >(policy.parameters()));
 
                 std::vector<hpx::future<Result> > inititems;
                 std::list<boost::exception_ptr> errors;
@@ -354,37 +451,35 @@ namespace hpx { namespace parallel { namespace util
 
                 try {
                     // estimate a chunk size based on number of cores used
-                    shape = get_bulk_iteration_shape_idx(policy, inititems, f1,
-                        first, count, stride);
-
-                    std::vector<hpx::future<Result> > workitems;
-                    workitems.reserve(shape.size());
+                    std::vector<tuple_type> shape =
+                        get_bulk_iteration_shape_idx(policy, inititems, f1,
+                            first, count, stride);
 
                     using hpx::util::bind;
                     using hpx::util::functional::invoke_fused;
                     using hpx::util::placeholders::_1;
-                    workitems = executor_traits::async_execute(
-                        policy.executor(),
-                        bind(invoke_fused(), std::forward<F1>(f1), _1),
-                        shape);
+
+                    std::vector<hpx::future<Result> > workitems =
+                        executor_traits::async_execute(
+                            policy.executor(),
+                            bind(invoke_fused(), std::forward<F1>(f1), _1),
+                            std::move(shape));
 
                     std::move(workitems.begin(), workitems.end(),
                         std::back_inserter(inititems));
                 }
-                catch (std::bad_alloc const&) {
-                    return hpx::make_exceptional_future<R>(
-                        boost::current_exception());
-                }
                 catch (...) {
-                    errors.push_back(boost::current_exception());
+                    handle_local_exceptions<ExPolicy>::call(
+                        boost::current_exception(), errors);
                 }
 
                 // wait for all tasks to finish
                 return hpx::dataflow(
-                    [f2, errors](std::vector<hpx::future<Result> > && r)
-                        mutable -> R
+                    [f2, errors, scoped_param](
+                        std::vector<hpx::future<Result> > && r) mutable -> R
                     {
-                        detail::handle_local_exceptions<ExPolicy>::call(r, errors);
+                        // inform parameter traits
+                        handle_local_exceptions<ExPolicy>::call(r, errors);
                         return f2(std::move(r));
                     },
                     std::move(inititems));

--- a/hpx/traits/is_executor.hpp
+++ b/hpx/traits/is_executor.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2015 Hartmut Kaiser
+//  Copyright (c) 2014-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -14,8 +14,6 @@
 
 #include <type_traits>
 
-#include <boost/type_traits/is_base_of.hpp>
-
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
 {
     ///////////////////////////////////////////////////////////////////////////
@@ -26,7 +24,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         /// \cond NOINTERNAL
         template <typename T>
         struct is_executor
-          : boost::is_base_of<executor_tag, T>
+          : std::is_base_of<executor_tag, T>
         {};
 
         template <>

--- a/hpx/traits/is_executor_parameters.hpp
+++ b/hpx/traits/is_executor_parameters.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2015 Hartmut Kaiser
+//  Copyright (c) 2014-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -18,7 +18,6 @@
 #endif
 
 #include <boost/ref.hpp>
-#include <boost/type_traits/is_base_of.hpp>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
 {
@@ -30,7 +29,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         /// \cond NOINTERNAL
         template <typename T>
         struct is_executor_parameters
-          : boost::is_base_of<executor_parameters_tag, T>
+          : std::is_base_of<executor_parameters_tag, T>
         {};
 
         template <>

--- a/tests/unit/parallel/executors/CMakeLists.txt
+++ b/tests/unit/parallel/executors/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2015 Hartmut Kaiser
+# Copyright (c) 2014-2016 Hartmut Kaiser
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -7,6 +7,7 @@ set(tests
     bulk_async
     created_executor
     executor_parameters
+    executor_parameters_timer_hooks
     minimal_async_executor
     minimal_sync_executor
     minimal_timed_async_executor

--- a/tests/unit/parallel/executors/executor_parameters_timer_hooks.cpp
+++ b/tests/unit/parallel/executors/executor_parameters_timer_hooks.cpp
@@ -1,0 +1,120 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/include/parallel_executors.hpp>
+#include <hpx/include/parallel_executor_parameters.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <string>
+#include <vector>
+
+#include <boost/ref.hpp>
+#include <boost/atomic.hpp>
+
+#include "../algorithms/foreach_tests.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename Parameters>
+void chunk_size_test_seq(Parameters && params)
+{
+    using namespace hpx::parallel;
+
+    typedef std::random_access_iterator_tag iterator_tag;
+    test_for_each(seq.with(boost::ref(params)), iterator_tag());
+    test_for_each_async(seq(task).with(boost::ref(params)), iterator_tag());
+
+    sequential_executor seq_exec;
+    test_for_each(seq.on(seq_exec).with(boost::ref(params)), iterator_tag());
+    test_for_each_async(seq(task).on(seq_exec).with(boost::ref(params)), iterator_tag());
+}
+
+template <typename Parameters>
+void chunk_size_test_par(Parameters && params)
+{
+    using namespace hpx::parallel;
+
+    typedef std::random_access_iterator_tag iterator_tag;
+    test_for_each(par.with(boost::ref(params)), iterator_tag());
+    test_for_each_async(par(task).with(boost::ref(params)), iterator_tag());
+
+    parallel_executor par_exec;
+    test_for_each(par.on(par_exec).with(boost::ref(params)), iterator_tag());
+    test_for_each_async(par(task).on(par_exec).with(boost::ref(params)), iterator_tag());
+}
+
+struct timer_hooks_parameters : hpx::parallel::executor_parameters_tag
+{
+    timer_hooks_parameters(char const* name)
+      : name_(name), time_(0), count_(0)
+    {}
+
+    void mark_begin_execution()
+    {
+        ++count_;
+        time_ = hpx::util::high_resolution_clock::now();
+    }
+
+    void mark_end_execution()
+    {
+        time_ = hpx::util::high_resolution_clock::now() - time_;
+        ++count_;
+    }
+
+    std::string name_;
+    boost::uint64_t time_;
+    boost::atomic<std::size_t> count_;
+};
+
+void test_timer_hooks()
+{
+    timer_hooks_parameters pacs("time_hooks");
+
+    chunk_size_test_seq(pacs);
+    HPX_TEST_EQ(pacs.count_, std::size_t(0));
+
+    chunk_size_test_par(pacs);
+    HPX_TEST_EQ(pacs.count_, std::size_t(8));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    unsigned int seed = static_cast<unsigned int>(std::time(0));
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    test_timer_hooks();
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace boost::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()
+        ("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run")
+        ;
+
+    // By default this test should run on all available cores
+    std::vector<std::string> cfg;
+    cfg.push_back("hpx.os_threads=" +
+        std::to_string(hpx::threads::hardware_concurrency()));
+
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
- flyby: fix using std type traits