### PR TITLE
Added missing initializer on last constructor for thread_description.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1235,7 +1235,7 @@ if(HPX_WITH_APEX)
   include(GitExternal)
   git_external(apex
     https://github.com/khuck/xpress-apex.git
-    v0.5-rc0
+    v0.5
     VERBOSE)
 
   LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/apex/cmake/Modules")

--- a/hpx/parallel/algorithms/reduce_by_key.hpp
+++ b/hpx/parallel/algorithms/reduce_by_key.hpp
@@ -322,10 +322,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 zip_type_in initial = zip_type_in();
                 //
+                typedef hpx::util::tuple<value_type, reduce_key_series_states>
+                    lambda_type;
                 hpx::parallel::inclusive_scan(sync_policy, states_begin,
                     states_end, states_out_begin, initial,
                     // B is the current entry, A is the one passed in from 'previous'
-                    [&func](zip_type_in a, zip_type_in b)
+                    [&func](zip_type_in a, zip_type_in b)->lambda_type
                     {
                         value_type a_val = get<0>(a);
                         reduce_key_series_states a_state = get<1>(a);
@@ -345,8 +347,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                             // normal add of previous + this
                         else {
                             debug_reduce_by_key(" = " << func(a_val, b_val) << std::endl);
+                            value_type temp = func(a_val, b_val);
                             return make_tuple(
-                                func(a_val, b_val),
+                                temp,
                                 reduce_key_series_states(
                                     a_state.start || b_state.start, b_state.end));
                         }

--- a/hpx/runtime/threads/executors/current_executor.hpp
+++ b/hpx/runtime/threads/executors/current_executor.hpp
@@ -58,11 +58,17 @@ namespace hpx { namespace threads { namespace executors
             // Reset internal (round robin) thread distribution scheme
             void reset_thread_distribution();
 
-            /// Set the new scheduler mode
+            // Set the new scheduler mode
             void set_scheduler_mode(threads::policies::scheduler_mode mode);
 
             // Return the runtime status of the underlying scheduler
             hpx::state get_state() const;
+
+            // retrieve executor id
+            executor_id get_id() const
+            {
+                return create_id(reinterpret_cast<std::size_t>(scheduler_base_));
+            }
 
         protected:
             static threads::thread_state_enum thread_function_nullary(

--- a/hpx/util/thread_description.hpp
+++ b/hpx/util/thread_description.hpp
@@ -64,6 +64,7 @@ namespace hpx { namespace util
                 !traits::is_action<F>::value
             >::type>
         explicit thread_description(F const& f, char const* altname = 0) HPX_NOEXCEPT
+          : type_(data_type_description)
         {
 #if defined(HPX_HAVE_THREAD_DESCRIPTION_FULL)
             type_ = data_type_address;

--- a/tests/unit/parallel/algorithms/reduce_by_key.cpp
+++ b/tests/unit/parallel/algorithms/reduce_by_key.cpp
@@ -146,6 +146,95 @@ void test_reduce_by_key1(ExPolicy && policy, Tkey, Tval, bool benchmark, const O
 
 ////////////////////////////////////////////////////////////////////////////////
 template<typename ExPolicy, typename Tkey, typename Tval, typename Op, typename HelperOp>
+void test_reduce_by_key_const(ExPolicy && policy, Tkey, Tval, bool benchmark,
+    const Op &op, const HelperOp &ho)
+{
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
+    msg(typeid(ExPolicy).name(), typeid(Tval).name(), typeid(Op).name(), sync);
+    std::cout << "\n";
+
+    Tval rnd_min = -256;
+    Tval rnd_max = 256;
+
+    // vector of values, and keys
+    std::vector<Tval> values, o_values;
+    std::vector<Tkey> keys, o_keys;
+    values.reserve(HPX_REDUCE_BY_KEY_TEST_SIZE);
+    keys.reserve(HPX_REDUCE_BY_KEY_TEST_SIZE);
+
+    std::vector<Tval> check_values;
+
+    // use the default random engine and an uniform distribution for values
+    boost::random::mt19937 eng(static_cast<unsigned int>(std::rand()));
+    boost::random::uniform_real_distribution<double> distr(rnd_min, rnd_max);
+
+    // use the default random engine and an uniform distribution for keys
+    boost::random::mt19937 engk(static_cast<unsigned int>(std::rand()));
+    boost::random::uniform_real_distribution<double> distrk(0, 256);
+
+    // generate test data
+    int keysize = 0;
+    Tkey key = 0, helperkey = 0, lastkey = 0;
+    for (/* */; keysize < HPX_REDUCE_BY_KEY_TEST_SIZE;)
+        {
+        do {
+            key = static_cast<Tkey>(distrk(engk));
+        } while (ho(key) == lastkey);
+        helperkey = ho(key);
+        lastkey = helperkey;
+        //
+        int numkeys = static_cast<Tkey>(distrk(engk)) + 1;
+        //
+        Tval sum = 0;
+        for (int i = 0; i < numkeys && keysize < HPX_REDUCE_BY_KEY_TEST_SIZE; ++i) {
+            Tval value = static_cast<Tval>(distr(eng));
+            keys.push_back(key);
+            values.push_back(value);
+            sum += value;
+            keysize++;
+        }
+        check_values.push_back(sum);
+    }
+    o_values = values;
+    o_keys = keys;
+
+    const std::vector<Tkey> const_keys(keys.begin(), keys.end());
+    const std::vector<Tval> const_values(values.begin(), values.end());
+
+    hpx::util::high_resolution_timer t;
+    // reduce_by_key, blocking when seq, par, par_vec
+    auto result = hpx::parallel::reduce_by_key(
+        std::forward<ExPolicy>(policy),
+        const_keys.begin(), const_keys.end(),
+        const_values.begin(),
+        keys.begin(),
+        values.begin(),
+        op);
+    double elapsed = t.elapsed();
+
+    bool is_equal = std::equal(values.begin(), result.second, check_values.begin());
+    HPX_TEST(is_equal);
+    if (is_equal) {
+        if (benchmark) {
+            std::cout << "<DartMeasurement name=\"ReduceByKeyTime\" \n"
+                << "type=\"numeric/double\">" << elapsed << "</DartMeasurement> \n";
+        }
+    }
+    else {
+        debug::output("keys     ", o_keys);
+        debug::output("values   ", o_values);
+        debug::output("key range", keys.begin(), result.first);
+        debug::output("val range", values.begin(), result.second);
+        debug::output("expected ", check_values);
+        throw std::string("Problem");
+    }
+    HPX_TEST(is_equal);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+template<typename ExPolicy, typename Tkey, typename Tval, typename Op, typename HelperOp>
 void test_reduce_by_key_async(ExPolicy && policy, Tkey, Tval, const Op &op,
     const HelperOp &ho)
     {
@@ -265,6 +354,21 @@ void test_reduce_by_key1()
             [](double a) {return std::floor(a);}
             );
     } while (t.elapsed() < 2);
+    //
+    hpx::util::high_resolution_timer t3;
+    do {
+        test_reduce_by_key_const(seq, int(), int(), false, std::equal_to<int>(),
+            [](int key) {return key;});
+        //
+        // default comparison operator (std::equal_to)
+        test_reduce_by_key_const(seq, int(), double(), false, std::equal_to<double>(),
+            [](int key) {return key;});
+        //
+        test_reduce_by_key_const(seq, double(), double(), false,
+            [](double a, double b) {return std::floor(a)==std::floor(b);},
+            [](double a) {return std::floor(a);}
+            );
+    } while (t3.elapsed() < 0.5);
     //
     hpx::util::high_resolution_timer t2;
     do {

--- a/tests/unit/threads/thread_suspension_executor.cpp
+++ b/tests/unit/threads/thread_suspension_executor.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2007-2015 Hartmut Kaiser
+// Copyright (C) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -20,8 +20,9 @@
 
 namespace hpx { namespace threads
 {
-    std::ostream& operator<<(std::ostream& os, executor const&)
+    std::ostream& operator<<(std::ostream& os, executor const& exec)
     {
+        os << exec.get_id();
         return os;
     }
 }}


### PR DESCRIPTION
The thread_description has one constructor missing the initializer for type_. There is a code path through there that causes type_ to be uninitialized.