### PR TITLE
Making executor_traits N-nary

### DIFF
--- a/hpx/apply.hpp
+++ b/hpx/apply.hpp
@@ -88,7 +88,7 @@ namespace hpx { namespace detail
         call(Executor& exec, F&& f, Ts&&... ts)
         {
             parallel::executor_traits<Executor>::apply_execute(exec,
-                util::deferred_call(std::forward<F>(f), std::forward<Ts>(ts)...));
+                std::forward<F>(f), std::forward<Ts>(ts)...);
             return false;
         }
     };

--- a/hpx/async.hpp
+++ b/hpx/async.hpp
@@ -44,12 +44,12 @@ namespace hpx { namespace detail
     template <typename F>
     HPX_FORCEINLINE
     typename boost::lazy_enable_if<
-        boost::is_reference<typename util::detail::deferred_result_of<F()>::type>
-      , detail::create_future<F()>
+        boost::is_reference<typename util::detail::deferred_result_of<F&&()>::type>
+      , detail::create_future<F&&()>
     >::type
     call_sync(F&& f, boost::mpl::false_)
     {
-        typedef typename util::detail::deferred_result_of<F()>::type result_type;
+        typedef typename util::detail::deferred_result_of<F&&()>::type result_type;
         try
         {
             return lcos::make_ready_future(boost::ref(f()));
@@ -62,7 +62,7 @@ namespace hpx { namespace detail
     template <typename F>
     HPX_FORCEINLINE
     typename boost::lazy_disable_if<
-        boost::is_reference<typename util::detail::deferred_result_of<F()>::type>
+        boost::is_reference<typename util::detail::deferred_result_of<F&&()>::type>
       , detail::create_future<F()>
     >::type
     call_sync(F&& f, boost::mpl::false_) //-V659
@@ -100,8 +100,10 @@ namespace hpx { namespace detail
         template <typename F, typename ...Ts>
         HPX_FORCEINLINE static
         typename boost::enable_if_c<
-            traits::detail::is_deferred_callable<F(Ts&&...)>::value,
-            hpx::future<typename util::detail::deferred_result_of<F(Ts&&...)>::type>
+            traits::detail::is_deferred_callable<F&&(Ts&&...)>::value,
+            hpx::future<
+                typename util::detail::deferred_result_of<F&&(Ts&&...)>::type
+            >
         >::type
         call(launch launch_policy, F && f, Ts&&... ts)
         {
@@ -137,8 +139,10 @@ namespace hpx { namespace detail
         template <typename F, typename ...Ts>
         HPX_FORCEINLINE static
         typename boost::enable_if_c<
-            traits::detail::is_deferred_callable<F(Ts&&...)>::value,
-            hpx::future<typename util::detail::deferred_result_of<F(Ts&&...)>::type>
+            traits::detail::is_deferred_callable<F&&(Ts&&...)>::value,
+            hpx::future<
+                typename util::detail::deferred_result_of<F&&(Ts&&...)>::type
+            >
         >::type
         call(F&& f, Ts&&... ts)
         {
@@ -157,8 +161,10 @@ namespace hpx { namespace detail
         template <typename F, typename ...Ts>
         HPX_FORCEINLINE static
         typename boost::enable_if_c<
-            traits::detail::is_deferred_callable<F(Ts&&...)>::value,
-            hpx::future<typename util::detail::deferred_result_of<F(Ts&&...)>::type>
+            traits::detail::is_deferred_callable<F&&(Ts&&...)>::value,
+            hpx::future<
+                typename util::detail::deferred_result_of<F&&(Ts&&...)>::type
+            >
         >::type
         call(Executor& sched, F&& f, Ts&&... ts)
         {
@@ -183,13 +189,15 @@ namespace hpx { namespace detail
         template <typename F, typename ...Ts>
         HPX_FORCEINLINE static
         typename boost::enable_if_c<
-            traits::detail::is_deferred_callable<F(Ts&&...)>::value,
-            hpx::future<typename util::detail::deferred_result_of<F(Ts&&...)>::type>
+            traits::detail::is_deferred_callable<F&&(Ts&&...)>::value,
+            hpx::future<
+                typename util::detail::deferred_result_of<F&&(Ts&&...)>::type
+            >
         >::type
         call(Executor& exec, F&& f, Ts&&... ts)
         {
-            return parallel::executor_traits<Executor>::async_execute(exec,
-                util::deferred_call(std::forward<F>(f), std::forward<Ts>(ts)...));
+            return parallel::executor_traits<Executor>::async_execute(
+                exec, std::forward<F>(f), std::forward<Ts>(ts)...);
         }
     };
 

--- a/hpx/lcos/dataflow.hpp
+++ b/hpx/lcos/dataflow.hpp
@@ -160,7 +160,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 // reset futures
                 reset_dataflow_future reset;
-                int const _sequencer[]= {
+                int const _sequencer[] = {
                     ((reset(util::get<Is>(futures_))), 0)...
                 };
                 (void)_sequencer;
@@ -181,7 +181,7 @@ namespace hpx { namespace lcos { namespace detail
 
                 // reset futures
                 reset_dataflow_future reset;
-                int const _sequencer[]= {
+                int const _sequencer[] = {
                     ((reset(util::get<Is>(futures_))), 0)...
                 };
                 (void)_sequencer;
@@ -234,8 +234,7 @@ namespace hpx { namespace lcos { namespace detail
             boost::intrusive_ptr<dataflow_frame> this_(this);
 
             parallel::executor_traits<Executor>::apply_execute(exec,
-                util::deferred_call(
-                    f, std::move(this_), indices_type(), is_void()));
+                f, std::move(this_), indices_type(), is_void());
         }
 
         ///////////////////////////////////////////////////////////////////////

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -335,8 +335,7 @@ namespace hpx { namespace lcos { namespace detail
             ) = &continuation::async_impl;
 
             parallel::executor_traits<Executor>::apply_execute(
-                exec, util::bind(async_impl_ptr, std::move(this_), f)
-            );
+                exec, async_impl_ptr, std::move(this_), f);
 
             if (&ec != &throws)
                 ec = make_success_code();

--- a/hpx/parallel/algorithms/for_loop.hpp
+++ b/hpx/parallel/algorithms/for_loop.hpp
@@ -45,7 +45,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
             hpx::util::detail::pack_c<std::size_t, Is...>,
             std::size_t part_index)
         {
-            int _sequencer[] =
+            int const _sequencer[] =
             {
                 0, (hpx::util::get<Is>(args).init_iteration(part_index), 0)...
             };
@@ -64,7 +64,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
         HPX_FORCEINLINE void next_iteration(hpx::util::tuple<Ts...>& args,
             hpx::util::detail::pack_c<std::size_t, Is...>)
         {
-            int _sequencer[] =
+            int const _sequencer[] =
             {
                 0, (hpx::util::get<Is>(args).next_iteration(), 0)...
             };
@@ -76,7 +76,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
             hpx::util::detail::pack_c<std::size_t, Is...>,
             std::size_t size)
         {
-            int _sequencer[] =
+            int const _sequencer[] =
             {
                 0, (hpx::util::get<Is>(args).exit_iteration(size), 0)...
             };
@@ -96,7 +96,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
             sequential(ExPolicy policy, B first, Size size, S stride, F && f,
                 Args &&... args)
             {
-                int init_sequencer[] = {
+                int const init_sequencer[] = {
                     0, (args.init_iteration(0), 0)...
                 };
                 (void)init_sequencer;
@@ -106,7 +106,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
                 {
                     hpx::util::invoke(f, first, args.iteration_value()...);
 
-                    int next_sequencer[] = {
+                    int const next_sequencer[] = {
                         0, (args.next_iteration(), 0)...
                     };
                     (void)next_sequencer;
@@ -120,7 +120,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
 
                 // make sure live-out variables are properly set on
                 // return
-                int exit_sequencer[] = {
+                int const exit_sequencer[] = {
                     0, (args.exit_iteration(size), 0)...
                 };
                 (void)exit_sequencer;

--- a/hpx/parallel/algorithms/sort.hpp
+++ b/hpx/parallel/algorithms/sort.hpp
@@ -192,18 +192,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             hpx::future<RandomIt> left =
                 executor_traits::async_execute(
                     policy.executor(),
-                    hpx::util::bind(
                         &sort_thread<ExPolicy, RandomIt, Compare>,
-                        std::ref(policy), first, c_last, comp
-                    ));
+                        std::ref(policy), first, c_last, comp);
 
             hpx::future<RandomIt> right =
                 executor_traits::async_execute(
                     policy.executor(),
-                    hpx::util::bind(
                         &sort_thread<ExPolicy, RandomIt, Compare>,
-                        std::ref(policy), c_first, last, comp
-                    ));
+                        std::ref(policy), c_first, last, comp);
 
             return hpx::dataflow(
                 [last](hpx::future<RandomIt> && left,
@@ -261,10 +257,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 result = executor_traits::async_execute(
                     policy.executor(),
-                    hpx::util::bind(
                         &sort_thread<ExPolicy, RandomIt, Compare>,
-                        std::ref(policy), first, last, comp
-                    ));
+                        std::ref(policy), first, last, comp);
             }
             catch (...) {
                 return detail::handle_sort_exception<ExPolicy, RandomIt>::call(

--- a/hpx/parallel/executors/distribution_policy_executor.hpp
+++ b/hpx/parallel/executors/distribution_policy_executor.hpp
@@ -18,6 +18,7 @@
 
 #include <hpx/util/decay.hpp>
 #include <hpx/util/result_of.hpp>
+#include <hpx/util/detail/pack.hpp>
 
 #include <type_traits>
 
@@ -26,18 +27,27 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
     ///////////////////////////////////////////////////////////////////////////
     namespace detail
     {
-        template <typename F, typename Enable = void>
-        struct distribution_policy_execute_result
+        template <typename F, bool IsAction, typename ... Ts>
+        struct distribution_policy_execute_result_impl;
+
+        template <typename F, typename ... Ts>
+        struct distribution_policy_execute_result_impl<F, false, Ts...>
         {
-            typedef typename hpx::util::result_of<F()>::type type;
+            typedef typename hpx::util::result_of<F(Ts...)>::type type;
         };
 
-        template <typename Action>
-        struct distribution_policy_execute_result<Action,
-            typename std::enable_if<hpx::traits::is_action<Action>::value>::type>
+        template <typename Action, typename ... Ts>
+        struct distribution_policy_execute_result_impl<Action, true, Ts...>
         {
-            typedef typename Action::local_result_type type;
+            typedef typename util::decay<Action>::type::local_result_type type;
         };
+
+        template <typename F, typename ... Ts>
+        struct distribution_policy_execute_result
+          : distribution_policy_execute_result_impl<F,
+                hpx::traits::is_action<typename util::decay<F>::type>::value,
+                Ts...>
+        {};
     }
 
     /// A \a distribution_policy_executor creates groups of parallel execution
@@ -60,53 +70,54 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
                 "distribution policy type");
 
         // apply_execute implementations
-        template <typename F>
+        template <typename F, typename ... Ts>
         typename std::enable_if<
             !hpx::traits::is_action<F>::value
         >::type
-        apply_execute(F && f) const
+        apply_execute_impl(F && f, Ts && ... ts) const
         {
             typedef components::server::invoke_function_action<F> action_type;
-            policy_.template apply<action_type>(
-                threads::thread_priority_default, std::forward<F>(f));
+            policy_.template apply<action_type>(threads::thread_priority_default,
+                std::forward<F>(f), std::forward<Ts>(ts)...);
         }
 
 #if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION >= 40700
-        template <typename Action>
+        template <typename Action, typename ... Ts>
         typename std::enable_if<
             hpx::traits::is_action<Action>::value
         >::type
-        apply_execute(Action && act) const
+        apply_execute_impl(Action && act, Ts && ... ts) const
         {
-            policy_.template apply<Action>(
-                threads::thread_priority_default);
+            policy_.template apply<Action>(threads::thread_priority_default,
+                std::forward<Ts>(ts)...);
         }
 #endif
 
         // async_execute implementations
-        template <typename F>
+        template <typename F, typename ... Ts>
         typename std::enable_if<
-            !hpx::traits::is_action<F>::value,
+           !hpx::traits::is_action<F>::value,
             hpx::future<
                 typename detail::distribution_policy_execute_result<F>::type
             >
         >::type
-        async_execute_impl(F && f) const
+        async_execute_impl(F && f, Ts &&... ts) const
         {
             typedef components::server::invoke_function_action<F> action_type;
             return policy_.template async<action_type>(launch::async,
-                std::forward<F>(f));
+                std::forward<F>(f), std::forward<Ts>(ts)...);
         }
 
 #if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION >= 40700
-        template <typename Action>
+        template <typename Action, typename ... Ts>
         typename std::enable_if<
             hpx::traits::is_action<Action>::value,
             hpx::future<typename Action::local_result_type>
         >::type
-        async_execute_impl(Action && act) const
+        async_execute_impl(Action && act, Ts &&... ts) const
         {
-            return policy_.template async<Action>(launch::async);
+            return policy_.template async<Action>(launch::async,
+                std::forward<Ts>(ts)...);
         }
 #endif
         /// \endcond
@@ -125,26 +136,29 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         /// \cond NOINTERNAL
         typedef parallel_execution_tag execution_category;
 
-        template <typename F>
-        void apply_execute(F && f) const
+        template <typename F, typename ... Ts>
+        void apply_execute(F && f, Ts &&... ts) const
         {
-            return apply_execute_impl(std::forward<F>(f));
+            return apply_execute_impl(std::forward<F>(f),
+                std::forward<Ts>(ts)...);
         }
 
-        template <typename F>
+        template <typename F, typename ... Ts>
         hpx::future<
-            typename detail::distribution_policy_execute_result<F>::type
+            typename detail::distribution_policy_execute_result<F&&, Ts&&...>::type
         >
-        async_execute(F && f) const
+        async_execute(F && f, Ts &&... ts) const
         {
-            return async_execute_impl(std::forward<F>(f));
+            return async_execute_impl(std::forward<F>(f),
+                std::forward<Ts>(ts)...);
         }
 
-        template <typename F>
-        typename detail::distribution_policy_execute_result<F>::type
-        execute(F && f)
+        template <typename F, typename ... Ts>
+        typename detail::distribution_policy_execute_result<F&&, Ts&&...>::type
+        execute(F && f, Ts &&... ts) const
         {
-            return async_execute_impl(std::forward<F>(f)).get();
+            return async_execute_impl(std::forward<F>(f),
+                std::forward<Ts>(ts)...).get();
         }
         /// \endcond
 

--- a/hpx/parallel/executors/distribution_policy_executor.hpp
+++ b/hpx/parallel/executors/distribution_policy_executor.hpp
@@ -33,7 +33,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         template <typename F, typename ... Ts>
         struct distribution_policy_execute_result_impl<F, false, Ts...>
         {
-            typedef typename hpx::util::result_of<F(Ts...)>::type type;
+            typedef typename hpx::util::detail::deferred_result_of<
+                    F(Ts...)
+                >::type type;
         };
 
         template <typename Action, typename ... Ts>

--- a/hpx/parallel/executors/executor_traits.hpp
+++ b/hpx/parallel/executors/executor_traits.hpp
@@ -133,42 +133,51 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         ///////////////////////////////////////////////////////////////////////
         struct apply_helper
         {
-            template <typename Executor, typename F>
-            static void call(hpx::traits::detail::wrap_int, Executor& exec, F && f)
+            template <typename Executor, typename F, typename ... Ts>
+            static void call(hpx::traits::detail::wrap_int, Executor& exec,
+                F && f, Ts &&... ts)
             {
-                exec.async_execute(std::forward<F>(f));
+                exec.async_execute(std::forward<F>(f), std::forward<Ts>(ts)...);
             }
 
-            template <typename Executor, typename F>
-            static auto call(int, Executor& exec, F && f)
-            ->  decltype(exec.apply_execute(std::forward<F>(f)))
+            template <typename Executor, typename F, typename ... Ts>
+            static auto call(int, Executor& exec, F && f, Ts &&... ts)
+            ->  decltype(
+                    exec.apply_execute(std::forward<F>(f), std::forward<Ts>(ts)...)
+                )
             {
-                exec.apply_execute(std::forward<F>(f));
+                exec.apply_execute(std::forward<F>(f), std::forward<Ts>(ts)...);
             }
         };
 
-        template <typename Executor, typename F>
-        void call_apply_execute(Executor& exec, F && f)
+        template <typename Executor, typename F, typename ... Ts>
+        void call_apply_execute(Executor& exec, F && f, Ts && ... ts)
         {
-            apply_helper::call(0, exec, std::forward<F>(f));
+            apply_helper::call(0, exec, std::forward<F>(f),
+                std::forward<Ts>(ts)...);
         }
 
         ///////////////////////////////////////////////////////////////////////
         struct execute_helper
         {
-            template <typename Executor, typename F>
-            static auto call_impl(Executor& exec, F && f, std::false_type)
-            ->  decltype(hpx::util::invoke(std::forward<F>(f)))
+            template <typename Executor, typename F, typename ... Ts>
+            static auto call_impl(Executor& exec, F && f, std::false_type,
+                    Ts &&... ts)
+            ->  decltype(
+                    hpx::util::invoke(std::forward<F>(f), std::forward<Ts>(ts)...)
+                )
             {
                 try {
-                    typedef typename hpx::util::result_of<F()>::type result_type;
+                    typedef typename hpx::util::result_of<F&&(Ts&&...)>::type
+                        result_type;
 
 #if defined(HPX_HAVE_CXX1Y_EXPERIMENTAL_OPTIONAL)
                     std::experimental::optional<result_type> out;
                     auto && wrapper =
                         [&]()
                         {
-                            out.emplace(hpx::util::invoke(std::forward<F>(f)));
+                            out.emplace(hpx::util::invoke(std::forward<F>(f),
+                                std::forward<Ts>(ts)...));
                         };
 #else
                     boost::optional<result_type> out;
@@ -176,10 +185,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
                         [&]()
                         {
 #if BOOST_VERSION < 105600
-                            out = boost::in_place(
-                                hpx::util::invoke(std::forward<F>(f)));
+                            out = boost::in_place(hpx::util::invoke(
+                                std::forward<F>(f), std::forward<Ts>(ts)...));
 #else
-                            out.emplace(hpx::util::invoke(std::forward<F>(f)));
+                            out.emplace(hpx::util::invoke(std::forward<F>(f),
+                                std::forward<Ts>(ts)...));
 #endif
                         };
 #endif
@@ -198,42 +208,57 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
                 }
             }
 
-            template <typename Executor, typename F>
-            static void call_impl(Executor& exec, F && f, std::true_type)
+            template <typename Executor, typename F, typename ... Ts>
+            static void call_impl(Executor& exec, F && f, std::true_type,
+                Ts &&... ts)
             {
-                exec.async_execute(std::forward<F>(f)).get();
+                exec.async_execute(
+                    std::forward<F>(f), std::forward<Ts>(ts)...
+                ).get();
             }
 
-            template <typename Executor, typename F>
-            static auto call(hpx::traits::detail::wrap_int, Executor& exec, F && f)
-            ->  decltype(hpx::util::invoke(std::forward<F>(f)))
+            template <typename Executor, typename F, typename ... Ts>
+            static auto call(hpx::traits::detail::wrap_int, Executor& exec,
+                    F && f, Ts &&... ts)
+            ->  decltype(
+                    hpx::util::invoke(std::forward<F>(f), std::forward<Ts>(ts)...)
+                )
             {
-                typedef std::is_void<typename hpx::util::result_of<F()>::type>
-                    is_void;
-                return call_impl(exec, std::forward<F>(f), is_void());
+                typedef std::is_void<
+                        typename hpx::util::result_of<F&&(Ts&&...)>::type
+                    > is_void;
+                return call_impl(exec, std::forward<F>(f), is_void(),
+                    std::forward<Ts>(ts)...);
             }
 
-            template <typename Executor, typename F>
-            static auto call(int, Executor& exec, F && f)
-            ->  decltype(exec.execute(std::forward<F>(f)))
+            template <typename Executor, typename F, typename ... Ts>
+            static auto call(int, Executor& exec, F && f, Ts &&... ts)
+            ->  decltype(
+                    exec.execute(std::forward<F>(f), std::forward<Ts>(ts)...)
+                )
             {
-                return exec.execute(std::forward<F>(f));
+                return exec.execute(std::forward<F>(f),
+                    std::forward<Ts>(ts)...);
             }
         };
 
-        template <typename Executor, typename F>
-        auto call_execute(Executor& exec, F && f)
+        template <typename Executor, typename F, typename ... Ts>
+        auto call_execute(Executor& exec, F && f, Ts &&... ts)
 #if defined(HPX_ENABLE_WORKAROUND_FOR_GCC46)
-        ->  typename hpx::util::result_of<F()>::type
+        ->  typename hpx::util::result_of<F&&(Ts&&...)>::type
 #else
-        ->  decltype(execute_helper::call(0, exec, std::forward<F>(f)))
+        ->  decltype(
+                execute_helper::call(0, exec, std::forward<F>(f),
+                    std::forward<Ts>(ts)...)
+            )
 #endif
         {
-            return execute_helper::call(0, exec, std::forward<F>(f));
+            return execute_helper::call(0, exec, std::forward<F>(f),
+                std::forward<Ts>(ts)...);
         }
 
         ///////////////////////////////////////////////////////////////////////
-        template <typename F, typename Shape>
+        template <typename F, typename Shape, typename ... Ts>
         struct bulk_async_execute_result
         {
             typedef typename
@@ -242,81 +267,94 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
             typedef typename
                     std::iterator_traits<iterator_type>::value_type
                 value_type;
-            typedef typename hpx::util::result_of<F(value_type)>::type type;
+            typedef typename
+                    hpx::util::result_of<F(value_type, Ts...)>::type
+                type;
         };
 
         ///////////////////////////////////////////////////////////////////////
         struct bulk_async_execute_helper
         {
-            template <typename Executor, typename F, typename S>
-            static auto call(hpx::traits::detail::wrap_int, Executor& exec,
-                    F && f, S const& shape)
+            template <typename Executor, typename F, typename S, typename ... Ts>
+            static auto
+            call(hpx::traits::detail::wrap_int, Executor& exec, F && f,
+                    S const& shape, Ts &&... ts)
             ->  std::vector<decltype(
-                    exec.async_execute(
-                        hpx::util::deferred_call(f, *boost::begin(shape))
-                    )
+                    exec.async_execute(f, *boost::begin(shape), ts...)
                 )>
             {
                 std::vector<typename future_type<
                         Executor,
-                        typename bulk_async_execute_result<F, S>::type
+                        typename bulk_async_execute_result<F, S, Ts...>::type
                     >::type> results;
                 results.reserve(boost::size(shape));
 
                 for (auto const& elem: shape)
                 {
-                    results.push_back(exec.async_execute(
-                        hpx::util::deferred_call(f, elem)
-                    ));
+                    results.push_back(exec.async_execute(f, elem, ts...));
                 }
 
                 return results;
             }
 
-            template <typename Executor, typename F, typename S>
-            static auto call(int, Executor& exec, F && f, S const& shape)
-            ->  decltype(exec.bulk_async_execute(std::forward<F>(f), shape))
+            template <typename Executor, typename F, typename S, typename ... Ts>
+            static auto
+            call(int, Executor& exec, F && f, S const& shape, Ts &&... ts)
+            ->  decltype(
+                    exec.bulk_async_execute(std::forward<F>(f), shape,
+                        std::forward<Ts>(ts)...)
+                )
             {
-                return exec.bulk_async_execute(std::forward<F>(f), shape);
+                return exec.bulk_async_execute(std::forward<F>(f), shape,
+                    std::forward<Ts>(ts)...);
             }
         };
 
-        template <typename Executor, typename F, typename S>
-        auto call_bulk_async_execute(Executor& exec, F && f, S const& shape)
+        template <typename Executor, typename F, typename S, typename ... Ts>
+        auto call_bulk_async_execute(Executor& exec, F && f, S const& shape,
+                Ts &&... ts)
 #if defined(HPX_ENABLE_WORKAROUND_FOR_GCC46)
         ->  std::vector<typename future_type<
-                Executor, typename bulk_async_execute_result<F, S>::type
+                Executor,
+                typename bulk_async_execute_result<F, S, Ts...>::type
             >::type>
 #else
         ->  decltype(
                 bulk_async_execute_helper::call(0, exec, std::forward<F>(f),
-                    shape)
+                    shape, std::forward<Ts>(ts)...)
             )
 #endif
         {
             return bulk_async_execute_helper::call(
-                0, exec, std::forward<F>(f), shape);
+                0, exec, std::forward<F>(f), shape, std::forward<Ts>(ts)...);
         }
 
         ///////////////////////////////////////////////////////////////////////
-        template <typename F, typename Shape, typename Enable = void>
-        struct bulk_execute_result
+        template <typename F, typename Shape, bool IsVoid, typename ... Ts>
+        struct bulk_execute_result_impl;
+
+        template <typename F, typename Shape, typename ... Ts>
+        struct bulk_execute_result_impl<F, Shape, false, Ts...>
         {
-            typedef hpx::util::detail::unwrap_impl<
-                    typename detail::bulk_async_execute_result<F, Shape>::type
-                > type;
+            typedef typename hpx::util::detail::unwrap_impl<
+                    typename bulk_async_execute_result<F, Shape, Ts...>::type
+                >::type type;
         };
 
-        template <typename F, typename Shape>
-        struct bulk_execute_result<F, Shape,
-            typename std::enable_if<
-                std::is_void<
-                    typename detail::bulk_async_execute_result<F, Shape>::type
-                >::value
-            >::type>
+        template <typename F, typename Shape, typename ... Ts>
+        struct bulk_execute_result_impl<F, Shape, true, Ts...>
         {
             typedef void type;
         };
+
+        template <typename F, typename Shape, typename ... Ts>
+        struct bulk_execute_result
+          : bulk_execute_result_impl<F, Shape,
+                std::is_void<
+                    typename bulk_async_execute_result<F, Shape, Ts...>::type
+                >::value,
+                Ts...>
+        {};
 
         ///////////////////////////////////////////////////////////////////////
         template <typename T>
@@ -334,27 +372,23 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         struct bulk_execute_helper
         {
             // returns void if F returns void
-            template <typename Executor, typename F, typename S>
+            template <typename Executor, typename F, typename S, typename ... Ts>
             static auto call(hpx::traits::detail::wrap_int, Executor& exec,
-                    F && f, S const& shape)
+                    F && f, S const& shape, Ts &&... ts)
             ->  typename bulk_result_helper<decltype(
-                    exec.async_execute(
-                        hpx::util::deferred_call(f, *boost::begin(shape))
-                    ).get()
+                    exec.async_execute(f, *boost::begin(shape), ts...).get()
                 )>::type
             {
                 std::vector<typename future_type<
                         Executor,
-                        typename bulk_async_execute_result<F, S>::type
+                        typename bulk_async_execute_result<F, S, Ts...>::type
                     >::type> results;
                 results.reserve(boost::size(shape));
 
                 try {
                     for (auto const& elem: shape)
                     {
-                        results.push_back(
-                            exec.async_execute(hpx::util::deferred_call(f, elem))
-                        );
+                        results.push_back(exec.async_execute(f, elem, ts...));
                     }
                     return hpx::util::unwrapped(results);
                 }
@@ -368,23 +402,32 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
                 }
             }
 
-            template <typename Executor, typename F, typename S>
-            static auto call(int, Executor& exec, F && f, S const& shape)
-            ->  decltype(exec.bulk_execute(std::forward<F>(f), shape))
+            template <typename Executor, typename F, typename S, typename ... Ts>
+            static auto
+            call(int, Executor& exec, F && f, S const& shape, Ts &&... ts)
+            ->  decltype(
+                    exec.bulk_execute(std::forward<F>(f), shape,
+                        std::forward<Ts>(ts)...)
+                )
             {
-                return exec.bulk_execute(std::forward<F>(f), shape);
+                return exec.bulk_execute(std::forward<F>(f), shape,
+                    std::forward<Ts>(ts)...);
             }
         };
 
-        template <typename Executor, typename F, typename S>
-        auto call_bulk_execute(Executor& exec, F && f, S const& shape)
+        template <typename Executor, typename F, typename S, typename ... Ts>
+        auto call_bulk_execute(Executor& exec, F && f, S const& shape, Ts &&... ts)
 #if defined(HPX_ENABLE_WORKAROUND_FOR_GCC46)
-        ->  typename detail::bulk_execute_result<F, S>::type
+        ->  typename detail::bulk_execute_result<F, S, Ts...>::type
 #else
-        ->  decltype(bulk_execute_helper::call(0, exec, std::forward<F>(f), shape))
+        ->  decltype(
+                bulk_execute_helper::call(0, exec, std::forward<F>(f), shape,
+                    std::forward<Ts>(ts)...)
+            )
 #endif
         {
-            return bulk_execute_helper::call(0, exec, std::forward<F>(f), shape);
+            return bulk_execute_helper::call(0, exec, std::forward<F>(f), shape,
+                std::forward<Ts>(ts)...);
         }
         /// \endcond
     }
@@ -444,14 +487,15 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         /// \param f    [in] The function which will be scheduled using the
         ///             given executor.
         ///
-        /// \note This calls exec.apply_execute(f), if available, otherwise
+        /// \note This calls exec.apply_execute(f, ts...), if available, otherwise
         ///       it calls exec.async_execute() while discarding the returned
         ///       future
         ///
-        template <typename F>
-        static void apply_execute(executor_type& exec, F && f)
+        template <typename F, typename ... Ts>
+        static void apply_execute(executor_type& exec, F && f, Ts &&... ts)
         {
-            detail::call_apply_execute(exec, std::forward<F>(f));
+            detail::call_apply_execute(exec, std::forward<F>(f),
+                std::forward<Ts>(ts)...);
         }
 
         /// \brief Singleton form of asynchronous execution agent creation.
@@ -473,17 +517,19 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         ///
         /// \returns f()'s result through a future
         ///
-        template <typename F>
-        static auto async_execute(executor_type& exec, F && f)
+        template <typename F, typename ... Ts>
+        static auto async_execute(executor_type& exec, F && f, Ts &&... ts)
 #if defined(HPX_ENABLE_WORKAROUND_FOR_GCC46)
         ->  typename future<
-                typename hpx::util::result_of<F()>::type
+                typename hpx::util::result_of<F&&(Ts&&...)>::type
             >::type
 #else
-        ->  decltype(exec.async_execute(std::forward<F>(f)))
+        ->  decltype(
+                exec.async_execute(std::forward<F>(f), std::forward<Ts>(ts)...)
+            )
 #endif
         {
-            return exec.async_execute(std::forward<F>(f));
+            return exec.async_execute(std::forward<F>(f), std::forward<Ts>(ts)...);
         }
 
         /// \brief Singleton form of synchronous execution agent creation.
@@ -502,15 +548,19 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         /// \note This calls exec.execute(f) if it exists;
         ///       otherwise hpx::async(f).get()
         ///
-        template <typename F>
-        static auto execute(executor_type& exec, F && f)
+        template <typename F, typename ... Ts>
+        static auto execute(executor_type& exec, F && f, Ts &&...ts)
 #if defined(HPX_ENABLE_WORKAROUND_FOR_GCC46)
-        ->  typename hpx::util::result_of<F()>::type
+        ->  typename hpx::util::result_of<F&&(Ts&&...)>::type
 #else
-        ->  decltype(detail::call_execute(exec, std::forward<F>(f)))
+        ->  decltype(
+                detail::call_execute(exec, std::forward<F>(f),
+                    std::forward<Ts>(ts)...)
+            )
 #endif
         {
-            return detail::call_execute(exec, std::forward<F>(f));
+            return detail::call_execute(exec, std::forward<F>(f),
+                std::forward<Ts>(ts)...);
         }
 
         /// \brief Bulk form of asynchronous execution agent creation
@@ -539,21 +589,23 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         /// \note This calls exec.async_execute(f, shape) if it exists;
         ///       otherwise it executes hpx::async(f, i) as often as needed.
         ///
-        template <typename F, typename Shape>
+        template <typename F, typename Shape, typename ... Ts>
         static auto
-        async_execute(executor_type& exec, F && f, Shape const& shape)
+        bulk_async_execute(executor_type& exec, F && f, Shape const& shape,
+            Ts &&... ts)
 #if defined(HPX_ENABLE_WORKAROUND_FOR_GCC46)
         ->  std::vector<typename future<
-                typename detail::bulk_async_execute_result<F, Shape>::type
+                typename detail::bulk_async_execute_result<F, Shape, Ts...>::type
             >::type>
 #else
         ->  decltype(
-                detail::call_bulk_async_execute(exec, std::forward<F>(f), shape)
+                detail::call_bulk_async_execute(exec, std::forward<F>(f),
+                    shape, std::forward<Ts>(ts)...)
             )
 #endif
         {
             return detail::call_bulk_async_execute(
-                exec, std::forward<F>(f), shape);
+                exec, std::forward<F>(f), shape, std::forward<Ts>(ts)...);
         }
 
         /// \brief Bulk form of synchronous execution agent creation
@@ -583,15 +635,20 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         /// \note This calls exec.execute(f, shape) if it exists;
         ///       otherwise it executes hpx::async(f, i) as often as needed.
         ///
-        template <typename F, typename Shape>
-        static auto execute(executor_type& exec, F && f, Shape const& shape)
+        template <typename F, typename Shape, typename ... Ts>
+        static auto
+        bulk_execute(executor_type& exec, F && f, Shape const& shape, Ts &&... ts)
 #if defined(HPX_ENABLE_WORKAROUND_FOR_GCC46)
-        ->  typename detail::bulk_execute_result<F, Shape>::type
+        ->  typename detail::bulk_execute_result<F, Shape, Ts...>::type
 #else
-        ->  decltype(detail::call_bulk_execute(exec, std::forward<F>(f), shape))
+        ->  decltype(
+                detail::call_bulk_execute(exec, std::forward<F>(f), shape,
+                    std::forward<Ts>(ts)...)
+            )
 #endif
         {
-            return detail::call_bulk_execute(exec, std::forward<F>(f), shape);
+            return detail::call_bulk_execute(exec, std::forward<F>(f), shape,
+                std::forward<Ts>(ts)...);
         }
     };
 

--- a/hpx/parallel/executors/parallel_executor.hpp
+++ b/hpx/parallel/executors/parallel_executor.hpp
@@ -12,6 +12,7 @@
 #include <hpx/traits/is_executor.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/util/deferred_call.hpp>
 #include <hpx/parallel/config/inline_namespace.hpp>
 #include <hpx/parallel/executors/executor_traits.hpp>
 #include <hpx/parallel/executors/auto_chunk_size.hpp>
@@ -46,7 +47,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         }
 
         template <typename F, typename ... Ts>
-        hpx::future<typename hpx::util::result_of<F&&(Ts&&...)>::type>
+        hpx::future<
+            typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type>
         async_execute(F && f, Ts &&... ts)
         {
             return hpx::async(l_, std::forward<F>(f), std::forward<Ts>(ts)...);

--- a/hpx/parallel/executors/parallel_executor.hpp
+++ b/hpx/parallel/executors/parallel_executor.hpp
@@ -39,17 +39,17 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         {}
 
         /// \cond NOINTERNAL
-        template <typename F>
-        static void apply_execute(F && f)
+        template <typename F, typename ... Ts>
+        static void apply_execute(F && f, Ts &&... ts)
         {
-            hpx::apply(std::forward<F>(f));
+            hpx::apply(std::forward<F>(f), std::forward<Ts>(ts)...);
         }
 
-        template <typename F>
-        hpx::future<typename hpx::util::result_of<F()>::type>
-        async_execute(F && f)
+        template <typename F, typename ... Ts>
+        hpx::future<typename hpx::util::result_of<F&&(Ts&&...)>::type>
+        async_execute(F && f, Ts &&... ts)
         {
-            return hpx::async(l_, std::forward<F>(f));
+            return hpx::async(l_, std::forward<F>(f), std::forward<Ts>(ts)...);
         }
         /// \endcond
 

--- a/hpx/parallel/executors/sequential_executor.hpp
+++ b/hpx/parallel/executors/sequential_executor.hpp
@@ -15,7 +15,7 @@
 #include <hpx/parallel/executors/executor_traits.hpp>
 #include <hpx/runtime/threads/thread_executor.hpp>
 #include <hpx/util/invoke.hpp>
-#include <hpx/util/result_of.hpp>
+#include <hpx/util/deferred_call.hpp>
 #include <hpx/util/unwrapped.hpp>
 
 #include <iterator>
@@ -47,7 +47,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         }
 
         template <typename F, typename ... Ts>
-        static typename hpx::util::result_of<F&&(Ts&&...)>::type
+        static typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
         execute(F && f, Ts &&... ts)
         {
             try {

--- a/hpx/parallel/executors/sequential_executor.hpp
+++ b/hpx/parallel/executors/sequential_executor.hpp
@@ -40,18 +40,18 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         /// \cond NOINTERNAL
         typedef sequential_execution_tag execution_category;
 
-        template <typename F>
-        static void apply_execute(F && f)
+        template <typename F, typename ... Ts>
+        static void apply_execute(F && f, Ts &&... ts)
         {
-            execute(std::forward<F>(f));
+            execute(std::forward<F>(f), std::forward<Ts>(ts)...);
         }
 
-        template <typename F>
-        static typename hpx::util::result_of<F()>::type
-        execute(F && f)
+        template <typename F, typename ... Ts>
+        static typename hpx::util::result_of<F&&(Ts&&...)>::type
+        execute(F && f, Ts &&... ts)
         {
             try {
-                return hpx::util::invoke(f);
+                return hpx::util::invoke(f, std::forward<Ts>(ts)...);
             }
             catch (std::bad_alloc const& ba) {
                 boost::throw_exception(ba);
@@ -63,27 +63,31 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
             }
         }
 
-        template <typename F>
-        static hpx::future<typename hpx::util::result_of<F()>::type>
-        async_execute(F && f)
+        template <typename F, typename ... Ts>
+        static hpx::future<typename hpx::util::result_of<F&&(Ts&&...)>::type>
+        async_execute(F && f, Ts &&... ts)
         {
-            return hpx::async(launch::deferred, std::forward<F>(f));
+            return hpx::async(launch::deferred, std::forward<F>(f),
+                std::forward<Ts>(ts)...);
         }
 
-        template <typename F, typename Shape>
+        template <typename F, typename Shape, typename ... Ts>
         static std::vector<hpx::future<
-            typename detail::bulk_async_execute_result<F, Shape>::type
+            typename detail::bulk_async_execute_result<F, Shape, Ts...>::type
         > >
-        bulk_async_execute(F && f, Shape const& shape)
+        bulk_async_execute(F && f, Shape const& shape, Ts &&... ts)
         {
             typedef typename
-                    detail::bulk_async_execute_result<F, Shape>::type
+                    detail::bulk_async_execute_result<F, Shape, Ts...>::type
                 result_type;
             std::vector<hpx::future<result_type> > results;
 
             try {
                 for (auto const& elem: shape)
-                    results.push_back(hpx::async(launch::deferred, f, elem));
+                {
+                    results.push_back(hpx::async(
+                        launch::deferred, f, elem, ts...));
+                }
             }
             catch (std::bad_alloc const& ba) {
                 boost::throw_exception(ba);
@@ -97,12 +101,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
             return std::move(results);
         }
 
-        template <typename F, typename Shape>
-        static typename detail::bulk_execute_result<F, Shape>::type
-        bulk_execute(F && f, Shape const& shape)
+        template <typename F, typename Shape, typename ... Ts>
+        static typename detail::bulk_execute_result<F, Shape, Ts...>::type
+        bulk_execute(F && f, Shape const& shape, Ts &&... ts)
         {
             return hpx::util::unwrapped(
-                bulk_async_execute(std::forward<F>(f), shape));
+                bulk_async_execute(std::forward<F>(f), shape,
+                    std::forward<Ts>(ts)...));
         }
 
         std::size_t processing_units_count()

--- a/hpx/parallel/executors/thread_executor_traits.hpp
+++ b/hpx/parallel/executors/thread_executor_traits.hpp
@@ -13,13 +13,14 @@
 #include <hpx/async.hpp>
 #include <hpx/traits/is_launch_policy.hpp>
 #include <hpx/runtime/threads/thread_executor.hpp>
-#include <hpx/util/unwrapped.hpp>
-#include <hpx/util/result_of.hpp>
 #include <hpx/util/decay.hpp>
+#include <hpx/util/deferred_call.hpp>
+#include <hpx/util/unwrapped.hpp>
 #include <hpx/parallel/config/inline_namespace.hpp>
 #include <hpx/parallel/executors/executor_traits.hpp>
 
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
@@ -63,6 +64,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         ///             function \a f.
         /// \param f    [in] The function which will be scheduled using the
         ///             given executor.
+        /// \param ts... [in] Additional arguments to use to invoke \a f.
         ///
         template <typename F, typename ... Ts>
         static void apply_execute(executor_type& sched, F && f, Ts &&... ts)
@@ -80,11 +82,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         ///             function \a f.
         /// \param f    [in] The function which will be scheduled using the
         ///             given executor.
+        /// \param ts... [in] Additional arguments to use to invoke \a f.
         ///
-        /// \returns f()'s result through a future
+        /// \returns f(ts...)'s result through a future
         ///
         template <typename F, typename ... Ts>
-        static hpx::future<typename hpx::util::result_of<F(Ts &&...)>::type>
+        static hpx::future<
+            typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
+        >
         async_execute(executor_type& sched, F && f, Ts &&... ts)
         {
             return hpx::async(sched, std::forward<F>(f),
@@ -102,11 +107,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         ///             function \a f.
         /// \param f    [in] The function which will be scheduled using the
         ///             given executor.
+        /// \param ts... [in] Additional arguments to use to invoke \a f.
         ///
-        /// \returns f()'s result through a future
+        /// \returns f(ts...)'s result through a future
         ///
         template <typename F, typename ... Ts>
-        static typename hpx::util::result_of<F&&(Ts&&...)>::type
+        static typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
         execute(executor_type& sched, F && f, Ts &&... ts)
         {
             return hpx::async(sched, std::forward<F>(f),
@@ -130,6 +136,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         ///              given executor.
         /// \param shape [in] The shape objects which defines the iteration
         ///              boundaries for the arguments to be passed to \a f.
+        /// \param ts... [in] Additional arguments to use to invoke \a f.
         ///
         /// \returns The return type of \a executor_type::async_execute if
         ///          defined by \a executor_type. Otherwise a vector
@@ -176,6 +183,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         ///              given executor.
         /// \param shape [in] The shape objects which defines the iteration
         ///              boundaries for the arguments to be passed to \a f.
+        /// \param ts... [in] Additional arguments to use to invoke \a f.
         ///
         /// \returns The return type of \a executor_type::execute if defined
         ///          by \a executor_type. Otherwise a vector holding the

--- a/hpx/parallel/task_block.hpp
+++ b/hpx/parallel/task_block.hpp
@@ -240,8 +240,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
         /// \throw This function may throw \a task_canceled_exception, as
         ///        described in Exception Handling.
         ///
-        template <typename F>
-        void run(F && f)
+        template <typename F, typename ... Ts>
+        void run(F && f, Ts &&... ts)
         {
             // The proposal requires that the task_block should be
             // 'active' to be usable.
@@ -256,7 +256,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
 
             hpx::future<void> result =
                 executor_traits<executor_type>::async_execute(
-                    policy_.executor(), std::forward<F>(f));
+                    policy_.executor(), std::forward<F>(f),
+                    std::forward<Ts>(ts)...);
 
             std::lock_guard<mutex_type> l(mtx_);
             tasks_.push_back(std::move(result));
@@ -295,8 +296,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
         /// \throw This function may throw \a task_canceled_exception, as
         ///        described in Exception Handling.
         ///
-        template <typename Executor, typename F>
-        void run(Executor& exec, F && f)
+        template <typename Executor, typename F, typename ... Ts>
+        void run(Executor& exec, F && f, Ts &&... ts)
         {
             // The proposal requires that the task_block should be
             // 'active' to be usable.
@@ -311,7 +312,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
 
             hpx::future<void> result =
                 executor_traits<Executor>::async_execute(
-                    exec, std::forward<F>(f));
+                    exec, std::forward<F>(f), std::forward<Ts>(ts)...);
 
             std::lock_guard<mutex_type> l(mtx_);
             tasks_.push_back(std::move(result));

--- a/hpx/parallel/util/foreach_partitioner.hpp
+++ b/hpx/parallel/util/foreach_partitioner.hpp
@@ -80,7 +80,7 @@ namespace hpx { namespace parallel { namespace util
                     using hpx::util::bind;
                     using hpx::util::functional::invoke_fused;
                     using hpx::util::placeholders::_1;
-                    workitems = executor_traits::async_execute(
+                    workitems = executor_traits::bulk_async_execute(
                         policy.executor(),
                         bind(invoke_fused(), std::forward<F1>(f1), _1),
                         std::move(shape));
@@ -146,7 +146,7 @@ namespace hpx { namespace parallel { namespace util
                     using hpx::util::bind;
                     using hpx::util::functional::invoke_fused;
                     using hpx::util::placeholders::_1;
-                    workitems = executor_traits::async_execute(
+                    workitems = executor_traits::bulk_async_execute(
                         policy.executor(),
                         bind(invoke_fused(), std::forward<F1>(f1), _1),
                         std::move(shape));

--- a/hpx/parallel/util/partitioner.hpp
+++ b/hpx/parallel/util/partitioner.hpp
@@ -79,7 +79,7 @@ namespace hpx { namespace parallel { namespace util
                     using hpx::util::placeholders::_1;
 
                     std::vector<hpx::future<Result> > workitems =
-                        executor_traits::async_execute(
+                        executor_traits::bulk_async_execute(
                             policy.executor(),
                             bind(invoke_fused(), std::forward<F1>(f1), _1),
                             std::move(shape));
@@ -172,7 +172,7 @@ namespace hpx { namespace parallel { namespace util
                     using hpx::util::functional::invoke_fused;
                     using hpx::util::placeholders::_1;
 
-                    workitems = executor_traits::async_execute(
+                    workitems = executor_traits::bulk_async_execute(
                         policy.executor(),
                         bind(invoke_fused(), std::forward<F1>(f1), _1),
                         std::move(shape));
@@ -234,7 +234,7 @@ namespace hpx { namespace parallel { namespace util
                     using hpx::util::placeholders::_1;
 
                     std::vector<hpx::future<Result> > workitems =
-                        executor_traits::async_execute(
+                        executor_traits::bulk_async_execute(
                             policy.executor(),
                             bind(invoke_fused(), std::forward<F1>(f1), _1),
                             std::move(shape));
@@ -307,7 +307,7 @@ namespace hpx { namespace parallel { namespace util
                     using hpx::util::placeholders::_1;
 
                     std::vector<hpx::future<Result> > workitems =
-                        executor_traits::async_execute(
+                        executor_traits::bulk_async_execute(
                             policy.executor(),
                             bind(invoke_fused(), std::forward<F1>(f1), _1),
                             std::move(shape));
@@ -400,7 +400,7 @@ namespace hpx { namespace parallel { namespace util
                     using hpx::util::functional::invoke_fused;
                     using hpx::util::placeholders::_1;
 
-                    workitems = executor_traits::async_execute(
+                    workitems = executor_traits::bulk_async_execute(
                         policy.executor(),
                         bind(invoke_fused(), std::forward<F1>(f1), _1),
                         std::move(shape));
@@ -466,7 +466,7 @@ namespace hpx { namespace parallel { namespace util
                     using hpx::util::placeholders::_1;
 
                     std::vector<hpx::future<Result> > workitems =
-                        executor_traits::async_execute(
+                        executor_traits::bulk_async_execute(
                             policy.executor(),
                             bind(invoke_fused(), std::forward<F1>(f1), _1),
                             std::move(shape));

--- a/hpx/parallel/util/partitioner_with_cleanup.hpp
+++ b/hpx/parallel/util/partitioner_with_cleanup.hpp
@@ -78,7 +78,7 @@ namespace hpx { namespace parallel { namespace util
                     using hpx::util::placeholders::_1;
 
                     std::vector<hpx::future<Result> > workitems =
-                        executor_traits::async_execute(
+                        executor_traits::bulk_async_execute(
                             policy.executor(),
                             bind(invoke_fused(), std::forward<F1>(f1), _1),
                             std::move(shape));
@@ -154,7 +154,7 @@ namespace hpx { namespace parallel { namespace util
                     using hpx::util::placeholders::_1;
 
                     std::vector<hpx::future<Result> > workitems =
-                        executor_traits::async_execute(
+                        executor_traits::bulk_async_execute(
                             policy.executor(),
                             bind(invoke_fused(), std::forward<F1>(f1), _1),
                             std::move(shape));

--- a/hpx/parallel/util/scan_partitioner.hpp
+++ b/hpx/parallel/util/scan_partitioner.hpp
@@ -127,7 +127,7 @@ namespace hpx { namespace parallel { namespace util
                                 p, f2, workitems.back(),
                                 executor_traits::async_execute(
                                     policy.executor(),
-                                    deferred_call(f1, get<0>(elem), get<1>(elem))
+                                    f1, get<0>(elem), get<1>(elem)
                                 )
                             )
                         );
@@ -136,7 +136,8 @@ namespace hpx { namespace parallel { namespace util
                             dataflow(
                                 policy.executor(),
                                 hpx::util::bind(
-                                    f3, get<0>(elem), get<1>(elem), _1),
+                                    f3, get<0>(elem), get<1>(elem), _1
+                                ),
                                 workitems[parts - 1], workitems[parts]
                             )
                         );
@@ -258,7 +259,7 @@ namespace hpx { namespace parallel { namespace util
                                 p, f2, workitems.back(),
                                 executor_traits::async_execute(
                                     policy.executor(),
-                                    deferred_call(f1, get<0>(elem), get<1>(elem))
+                                    f1, get<0>(elem), get<1>(elem)
                                 )
                             )
                         );
@@ -267,7 +268,8 @@ namespace hpx { namespace parallel { namespace util
                             dataflow(
                                 policy.executor(),
                                 hpx::util::bind(
-                                    f3, get<0>(elem), get<1>(elem), _1),
+                                    f3, get<0>(elem), get<1>(elem), _1
+                                ),
                                 workitems[parts - 1], workitems[parts]
                             )
                         );

--- a/hpx/runtime/threads/run_as_hpx_thread.hpp
+++ b/hpx/runtime/threads/run_as_hpx_thread.hpp
@@ -32,14 +32,14 @@ namespace hpx { namespace threads
     {
         // This is the overload for running functions which return a value.
         template <typename F, typename... Ts>
-        typename util::result_of<F(Ts &&...)>::type
+        typename util::result_of<F&&(Ts&&...)>::type
         run_as_hpx_thread(std::false_type, F const& f, Ts &&... ts)
         {
             std::mutex mtx;
             std::condition_variable cond;
             bool stopping = false;
 
-            typedef typename util::result_of<F(Ts &&...)>::type result_type;
+            typedef typename util::result_of<F&&(Ts&&...)>::type result_type;
 
             // Using the optional for storing the returned result value
             // allows to support non-default-constructible and move-only
@@ -124,11 +124,11 @@ namespace hpx { namespace threads
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename F, typename... Ts>
-    typename util::result_of<F(Ts &&...)>::type
+    typename util::result_of<F&&(Ts&&...)>::type
     run_as_hpx_thread(F const& f, Ts &&... vs)
     {
         typedef typename std::is_void<
-                typename util::result_of<F(Ts &&...)>::type
+                typename util::result_of<F&&(Ts&&...)>::type
             >::type result_is_void;
 
         return detail::run_as_hpx_thread(result_is_void(),

--- a/hpx/runtime/threads/run_as_os_thread.hpp
+++ b/hpx/runtime/threads/run_as_os_thread.hpp
@@ -20,7 +20,7 @@ namespace hpx { namespace threads
 {
     ///////////////////////////////////////////////////////////////////////////
     template <typename F, typename... Ts>
-    hpx::future<typename util::result_of<F(Ts &&...)>::type>
+    hpx::future<typename util::result_of<F&&(Ts &&...)>::type>
     run_as_os_thread(F && f, Ts &&... vs)
     {
         HPX_ASSERT(get_self_ptr() != 0);
@@ -29,9 +29,8 @@ namespace hpx { namespace threads
         typedef parallel::executor_traits<executor_type> traits;
 
         executor_type scheduler;
-        return traits::async_execute(scheduler, util::deferred_call(
-                std::forward<F>(f), std::forward<Ts>(vs)...
-            ));
+        return traits::async_execute(scheduler, std::forward<F>(f),
+            std::forward<Ts>(vs)...);
     }
 }}
 

--- a/hpx/traits/is_launch_policy.hpp
+++ b/hpx/traits/is_launch_policy.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -12,9 +12,7 @@
 #include <hpx/runtime/threads/thread_data_fwd.hpp>
 #include <hpx/util/decay.hpp>
 
-#include <boost/type_traits/is_same.hpp>
-#include <boost/type_traits/is_base_of.hpp>
-#include <boost/mpl/or.hpp>
+#include <type_traits>
 
 namespace hpx { namespace threads
 {
@@ -27,12 +25,12 @@ namespace hpx { namespace traits
     {
         template <typename Policy>
         struct is_launch_policy
-          : boost::is_same<launch, Policy>
+          : std::is_same<launch, Policy>
         {};
 
         template <typename Policy>
         struct is_threads_executor
-          : boost::is_base_of<threads::executor, Policy>
+          : std::is_base_of<threads::executor, Policy>
         {};
     }
 
@@ -48,7 +46,9 @@ namespace hpx { namespace traits
 
     template <typename Policy>
     struct is_launch_policy_or_executor
-      : boost::mpl::or_<is_launch_policy<Policy>, is_threads_executor<Policy> >
+      : std::integral_constant<bool,
+            is_launch_policy<Policy>::value ||
+                is_threads_executor<Policy>::value>
     {};
 }}
 

--- a/hpx/util/deferred_call.hpp
+++ b/hpx/util/deferred_call.hpp
@@ -11,6 +11,7 @@
 #include <hpx/traits/get_function_address.hpp>
 #include <hpx/util/decay.hpp>
 #include <hpx/util/invoke_fused.hpp>
+#include <hpx/util/result_of.hpp>
 #include <hpx/util/tuple.hpp>
 
 #include <type_traits>

--- a/tests/unit/component/distribution_policy_executor.cpp
+++ b/tests/unit/component/distribution_policy_executor.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015 Hartmut Kaiser
+//  Copyright (c) 2015-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/tests/unit/parallel/executors/bulk_async.cpp
+++ b/tests/unit/parallel/executors/bulk_async.cpp
@@ -17,9 +17,10 @@
 #include <vector>
 
 ////////////////////////////////////////////////////////////////////////////////
-int bulk_test(hpx::thread::id tid, int value, bool is_par)
+int bulk_test(hpx::thread::id tid, int value, bool is_par, int passed_through)
 {
     HPX_TEST(is_par == (tid != hpx::this_thread::get_id()));
+    HPX_TEST_EQ(passed_through, 42);
     return value;
 }
 
@@ -34,11 +35,10 @@ void test_bulk_async(Executor& exec, bool is_par = true)
     std::iota(boost::begin(v), boost::end(v), 0);
 
     using hpx::util::placeholders::_1;
+    using hpx::util::placeholders::_2;
 
-    std::vector<hpx::future<int> > results = traits::async_execute
-    (
-        exec, hpx::util::bind(&bulk_test, tid, _1, is_par), v
-    );
+    std::vector<hpx::future<int> > results = traits::bulk_async_execute(
+        exec, hpx::util::bind(&bulk_test, tid, _1, is_par, _2), v, 42);
 
     HPX_TEST(std::equal(
         boost::begin(results), boost::end(results), boost::begin(v),

--- a/tests/unit/parallel/executors/created_executor.cpp
+++ b/tests/unit/parallel/executors/created_executor.cpp
@@ -55,7 +55,7 @@ struct void_parallel_executor : parallel_executor
 ////////////////////////////////////////////////////////////////////////////////
 // Tests to void_parallel_executor behavior for the bulk executes
 
-void bulk_test(hpx::thread::id tid, int value, int passed_through)
+void bulk_test(int value, hpx::thread::id tid, int passed_through)
 {
     HPX_TEST(tid != hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
@@ -75,7 +75,8 @@ void test_void_bulk_sync()
     using hpx::util::placeholders::_2;
 
     executor exec;
-    traits::bulk_execute(exec, hpx::util::bind(&bulk_test, tid, _1, _2), v, 42);
+    traits::bulk_execute(exec, hpx::util::bind(&bulk_test, _1, tid, _2), v, 42);
+    traits::bulk_execute(exec, &bulk_test, v, tid, 42);
 }
 
 void test_void_bulk_async()
@@ -89,12 +90,14 @@ void test_void_bulk_async()
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
+    using hpx::util::placeholders::_2;
 
     executor exec;
     hpx::when_all(
         traits::bulk_async_execute(exec,
-            hpx::util::bind(&bulk_test, tid, _1, _2), v, 42)
+            hpx::util::bind(&bulk_test, _1, tid, _2), v, 42)
     ).get();
+    hpx::when_all(traits::bulk_async_execute(exec, &bulk_test, v, tid, 42)).get();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/parallel/executors/created_executor.cpp
+++ b/tests/unit/parallel/executors/created_executor.cpp
@@ -30,34 +30,35 @@ typedef std::vector<int>::iterator iter;
 // for bulk_async_execute
 struct void_parallel_executor : parallel_executor
 {
-    template <typename F, typename Shape>
+    template <typename F, typename Shape, typename ... Ts>
     std::vector<hpx::future<void> >
-    bulk_async_execute(F && f, Shape const& shape)
+    bulk_async_execute(F && f, Shape const& shape, Ts &&... ts)
     {
         std::vector<hpx::future<void> > results;
         for(auto const& elem: shape)
         {
-            results.push_back(
-                this->parallel_executor::async_execute(deferred_call(f, elem))
-            );
+            results.push_back(this->parallel_executor::async_execute(
+                f, elem, ts...));
         }
         return results;
     }
 
-    template <typename F, typename Shape>
-    void bulk_execute(F && f, Shape const& shape)
+    template <typename F, typename Shape, typename ... Ts>
+    void bulk_execute(F && f, Shape const& shape, Ts &&... ts)
     {
         return hpx::util::unwrapped(
-            bulk_async_execute(std::forward<F>(f), shape));
+            bulk_async_execute(std::forward<F>(f), shape,
+                std::forward<Ts>(ts)...));
     }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 // Tests to void_parallel_executor behavior for the bulk executes
 
-void bulk_test(hpx::thread::id tid, int value)
+void bulk_test(hpx::thread::id tid, int value, int passed_through)
 {
     HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_EQ(passed_through, 42);
 }
 
 void test_void_bulk_sync()
@@ -71,9 +72,10 @@ void test_void_bulk_sync()
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
+    using hpx::util::placeholders::_2;
 
     executor exec;
-    traits::execute(exec, hpx::util::bind(&bulk_test, tid, _1), v);
+    traits::bulk_execute(exec, hpx::util::bind(&bulk_test, tid, _1, _2), v, 42);
 }
 
 void test_void_bulk_async()
@@ -90,7 +92,8 @@ void test_void_bulk_async()
 
     executor exec;
     hpx::when_all(
-        traits::async_execute(exec, hpx::util::bind(&bulk_test, tid, _1), v)
+        traits::bulk_async_execute(exec,
+            hpx::util::bind(&bulk_test, tid, _1, _2), v, 42)
     ).get();
 }
 
@@ -128,7 +131,7 @@ int parallel_sum(iter first, iter last, int num_parts)
         split(first, last, num_parts);
 
     std::vector<hpx::future<int> > v =
-        traits::async_execute(exec,
+        traits::bulk_async_execute(exec,
             [](boost::iterator_range<iter> const& rng) -> int
             {
                 return std::accumulate(boost::begin(rng), boost::end(rng), 0);
@@ -154,7 +157,7 @@ int void_parallel_sum(iter first, iter last, int num_parts)
 
     std::ptrdiff_t section_size = std::distance(first, last) / num_parts;
 
-    std::vector<hpx::future<void> > f = traits::async_execute(exec,
+    std::vector<hpx::future<void> > f = traits::bulk_async_execute(exec,
         [&](const int& i)
         {
             iter b = first + i*section_size;
@@ -185,12 +188,12 @@ void sum_test()
 
     typedef hpx::parallel::executor_traits<parallel_executor> traits;
     hpx::future<int> f_par =
-        traits::async_execute(exec, deferred_call(&parallel_sum,
-            boost::begin(vec), boost::end(vec), num_parts));
+        traits::async_execute(exec, &parallel_sum,
+            boost::begin(vec), boost::end(vec), num_parts);
 
     hpx::future<int> f_void_par =
-        traits::async_execute(exec, deferred_call(&void_parallel_sum,
-            boost::begin(vec), boost::end(vec), num_parts));
+        traits::async_execute(exec, &void_parallel_sum,
+            boost::begin(vec), boost::end(vec), num_parts);
 
     HPX_TEST(f_par.get() == sum);
     HPX_TEST(f_void_par.get() == sum);

--- a/tests/unit/parallel/executors/minimal_sync_executor.cpp
+++ b/tests/unit/parallel/executors/minimal_sync_executor.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -18,20 +18,24 @@
 #include <boost/type_traits/is_same.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::thread::id sync_test()
+hpx::thread::id sync_test(int passed_through)
 {
+    HPX_TEST_EQ(passed_through, 42);
     return hpx::this_thread::get_id();
 }
 
-void apply_test(hpx::lcos::local::latch& l, hpx::thread::id& id)
+void apply_test(hpx::lcos::local::latch& l, hpx::thread::id& id,
+    int passed_through)
 {
+    HPX_TEST_EQ(passed_through, 42);
     id = hpx::this_thread::get_id();
     l.count_down(1);
 }
 
-void sync_bulk_test(hpx::thread::id tid, int value)
+void sync_bulk_test(hpx::thread::id tid, int value, int passed_through)
 {
     HPX_TEST(tid == hpx::this_thread::get_id());
+    HPX_TEST_EQ(passed_through, 42);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -42,9 +46,7 @@ void test_apply(Executor& exec)
     hpx::thread::id id;
 
     typedef hpx::parallel::executor_traits<Executor> traits;
-    traits::apply_execute(exec,
-        hpx::util::bind(&apply_test, boost::ref(l), boost::ref(id))
-    );
+    traits::apply_execute(exec, &apply_test, boost::ref(l), boost::ref(id), 42);
     l.count_down_and_wait();
 
     HPX_TEST(id == hpx::this_thread::get_id());
@@ -54,7 +56,7 @@ template <typename Executor>
 void test_sync(Executor& exec)
 {
     typedef hpx::parallel::executor_traits<Executor> traits;
-    HPX_TEST(traits::execute(exec, &sync_test) == hpx::this_thread::get_id());
+    HPX_TEST(traits::execute(exec, &sync_test, 42) == hpx::this_thread::get_id());
 }
 
 template <typename Executor>
@@ -62,7 +64,7 @@ void test_async(Executor& exec)
 {
     typedef hpx::parallel::executor_traits<Executor> traits;
     HPX_TEST(
-        traits::async_execute(exec, &sync_test).get() ==
+        traits::async_execute(exec, &sync_test, 42).get() ==
         hpx::this_thread::get_id());
 }
 
@@ -75,9 +77,11 @@ void test_bulk_sync(Executor& exec)
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
+    using hpx::util::placeholders::_2;
 
     typedef hpx::parallel::executor_traits<Executor> traits;
-    traits::execute(exec, hpx::util::bind(&sync_bulk_test, tid, _1), v);
+    traits::bulk_execute(exec,
+        hpx::util::bind(&sync_bulk_test, tid, _1, _2), v, 42);
 }
 
 template <typename Executor>
@@ -89,10 +93,11 @@ void test_bulk_async(Executor& exec)
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
+    using hpx::util::placeholders::_2;
 
     typedef hpx::parallel::executor_traits<Executor> traits;
-    hpx::when_all(traits::async_execute(
-        exec, hpx::util::bind(&sync_bulk_test, tid, _1), v)).get();
+    hpx::when_all(traits::bulk_async_execute(
+        exec, hpx::util::bind(&sync_bulk_test, tid, _1, _2), v, 42)).get();
 }
 
 template <typename Executor>
@@ -120,13 +125,12 @@ struct test_sync_executor2 : hpx::parallel::executor_tag
 {
     typedef hpx::parallel::sequential_execution_tag execution_category;
 
-    template <typename F>
-    hpx::future<typename hpx::util::result_of<
-        typename hpx::util::decay<F>::type()
-    >::type>
-    async_execute(F && f)
+    template <typename F, typename ... Ts>
+    hpx::future<typename hpx::util::result_of<F&&(Ts&&...)>::type>
+    async_execute(F && f, Ts &&... ts)
     {
-        return hpx::async(hpx::launch::sync, std::forward<F>(f));
+        return hpx::async(hpx::launch::sync, std::forward<F>(f),
+            std::forward<Ts>(ts)...);
     }
 
     std::size_t processing_units_count()
@@ -139,11 +143,11 @@ struct test_sync_executor1 : test_sync_executor2
 {
     typedef hpx::parallel::sequential_execution_tag execution_category;
 
-    template <typename F>
-    typename hpx::util::result_of<F()>::type
-    execute(F f)
+    template <typename F, typename ... Ts>
+    typename hpx::util::result_of<F&&(Ts&&...)>::type
+    execute(F && f, Ts &&... ts)
     {
-        return f();
+        return hpx::util::invoke(std::forward<F>(f), std::forward<Ts>(ts)...);
     }
 };
 
@@ -151,11 +155,13 @@ struct test_sync_executor3 : test_sync_executor2
 {
     typedef hpx::parallel::sequential_execution_tag execution_category;
 
-    template <typename F, typename Shape>
-    void bulk_execute(F f, Shape const& shape)
+    template <typename F, typename Shape, typename ... Ts>
+    void bulk_execute(F f, Shape const& shape, Ts &&... ts)
     {
         for (auto const& elem: shape)
-            f(elem);
+        {
+            hpx::util::invoke(f, elem, ts...);
+        }
     }
 };
 
@@ -163,15 +169,15 @@ struct test_sync_executor4 : test_sync_executor2
 {
     typedef hpx::parallel::sequential_execution_tag execution_category;
 
-    template <typename F, typename Shape>
+    template <typename F, typename Shape, typename ... Ts>
     std::vector<hpx::future<void> >
-    bulk_async_execute(F f, Shape const& shape)
+    bulk_async_execute(F f, Shape const& shape, Ts &&... ts)
     {
         std::vector<hpx::future<void> > results;
         for (auto const& elem: shape)
-            results.push_back(
-                async_execute(hpx::util::deferred_call(f, elem))
-            );
+        {
+            results.push_back(async_execute(f, elem, ts...));
+        }
         return results;
     }
 };
@@ -180,10 +186,10 @@ struct test_sync_executor5 : test_sync_executor1  // derive from sync execute
 {
     typedef hpx::parallel::sequential_execution_tag execution_category;
 
-    template <typename F>
-    void apply_execute(F && f)
+    template <typename F, typename ... Ts>
+    void apply_execute(F && f, Ts &&... ts)
     {
-        this->execute(std::forward<F>(f));
+        this->execute(std::forward<F>(f), std::forward<Ts>(ts)...);
     }
 };
 

--- a/tests/unit/parallel/executors/minimal_timed_async_executor.cpp
+++ b/tests/unit/parallel/executors/minimal_timed_async_executor.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,7 +6,6 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/include/parallel_executors.hpp>
-#include <hpx/include/util.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <algorithm>
@@ -16,19 +15,21 @@
 #include <vector>
 
 #include <boost/range/functions.hpp>
-#include <boost/type_traits/is_same.hpp>
 #include <boost/chrono.hpp>
 
 using namespace boost::chrono;
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::thread::id sync_test()
+hpx::thread::id sync_test(int passed_through)
 {
+    HPX_TEST_EQ(passed_through, 42);
     return hpx::this_thread::get_id();
 }
 
-void apply_test(hpx::lcos::local::latch& l, hpx::thread::id& id)
+void apply_test(hpx::lcos::local::latch& l, hpx::thread::id& id,
+    int passed_through)
 {
+    HPX_TEST_EQ(passed_through, 42);
     id = hpx::this_thread::get_id();
     l.count_down(1);
 }
@@ -38,26 +39,36 @@ template <typename Executor>
 void test_timed_apply(Executor& exec)
 {
     {
-        hpx::lcos::local::latch l(2);
+        hpx::lcos::local::latch l(3);
         hpx::thread::id id;
 
         typedef hpx::parallel::timed_executor_traits<Executor> traits;
+
+        using hpx::util::placeholders::_1;
         traits::apply_execute_after(exec, milliseconds(10),
-            hpx::util::bind(&apply_test, boost::ref(l), boost::ref(id))
+            hpx::util::bind(&apply_test, boost::ref(l), boost::ref(id), _1), 42
         );
+
+        traits::apply_execute_after(exec, milliseconds(10),
+            &apply_test, boost::ref(l), boost::ref(id), 42);
+
         l.count_down_and_wait();
 
         HPX_TEST(id != hpx::this_thread::get_id());
     }
 
     {
-        hpx::lcos::local::latch l(2);
+        hpx::lcos::local::latch l(3);
         hpx::thread::id id;
 
         typedef hpx::parallel::timed_executor_traits<Executor> traits;
-        traits::apply_execute_at(exec, steady_clock::now()+milliseconds(10),
-            hpx::util::bind(&apply_test, boost::ref(l), boost::ref(id))
-        );
+        traits::apply_execute_at(exec, steady_clock::now() + milliseconds(10),
+            hpx::util::deferred_call(
+                &apply_test, boost::ref(l), boost::ref(id), 42));
+
+        traits::apply_execute_at(exec, steady_clock::now() + milliseconds(10),
+            &apply_test, boost::ref(l), boost::ref(id), 42);
+
         l.count_down_and_wait();
 
         HPX_TEST(id != hpx::this_thread::get_id());
@@ -68,10 +79,10 @@ template <typename Executor>
 void test_timed_sync(Executor& exec)
 {
     typedef hpx::parallel::timed_executor_traits<Executor> traits;
-    HPX_TEST(traits::execute_after(exec, milliseconds(10), &sync_test) !=
+    HPX_TEST(traits::execute_after(exec, milliseconds(10), &sync_test, 42) !=
         hpx::this_thread::get_id());
     HPX_TEST(traits::execute_at(
-            exec, steady_clock::now()+milliseconds(10), &sync_test) !=
+            exec, steady_clock::now() + milliseconds(10), &sync_test, 42) !=
         hpx::this_thread::get_id());
 }
 
@@ -80,11 +91,12 @@ void test_timed_async(Executor& exec)
 {
     typedef hpx::parallel::timed_executor_traits<Executor> traits;
     HPX_TEST(
-        traits::async_execute_after(exec, milliseconds(10), &sync_test).get() !=
-        hpx::this_thread::get_id());
+        traits::async_execute_after(
+            exec, milliseconds(10), &sync_test, 42
+        ).get() != hpx::this_thread::get_id());
     HPX_TEST(
         traits::async_execute_at(
-            exec, steady_clock::now()+milliseconds(10), &sync_test
+            exec, steady_clock::now() + milliseconds(10), &sync_test, 42
         ).get() != hpx::this_thread::get_id());
 }
 
@@ -95,7 +107,7 @@ void test_timed_executor()
             Executor
         >::execution_category execution_category;
 
-    HPX_TEST((boost::is_same<
+    HPX_TEST((std::is_same<
             hpx::parallel::parallel_execution_tag, execution_category
         >::value));
 
@@ -111,23 +123,22 @@ struct test_timed_async_executor2 : hpx::parallel::timed_executor_tag
 {
     typedef hpx::parallel::parallel_execution_tag execution_category;
 
-    template <typename F>
-    hpx::future<typename hpx::util::result_of<
-        typename hpx::util::decay<F>::type()
-    >::type>
-    async_execute(F && f)
+    template <typename F, typename ... Ts>
+    hpx::future<typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type>
+    async_execute(F && f, Ts &&... ts)
     {
-        return hpx::async(hpx::launch::async, std::forward<F>(f));
+        return hpx::async(hpx::launch::async, std::forward<F>(f),
+            std::forward<Ts>(ts)...);
     }
 
-    template <typename F>
-    hpx::future<typename hpx::util::result_of<
-        typename hpx::util::decay<F>::type()
-    >::type>
-    async_execute_at(hpx::util::steady_time_point const& abs_time, F && f)
+    template <typename F, typename ... Ts>
+    hpx::future<typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type>
+    async_execute_at(hpx::util::steady_time_point const& abs_time, F && f,
+        Ts &&... ts)
     {
         hpx::this_thread::sleep_until(abs_time);
-        return hpx::async(hpx::launch::async, std::forward<F>(f));
+        return hpx::async(hpx::launch::async, std::forward<F>(f),
+            std::forward<Ts>(ts)...);
     }
 };
 
@@ -135,12 +146,13 @@ struct test_timed_async_executor1 : test_timed_async_executor2
 {
     typedef hpx::parallel::parallel_execution_tag execution_category;
 
-    template <typename F>
-    typename hpx::util::result_of<F()>::type
-    execute_at(hpx::util::steady_time_point const& abs_time, F f)
+    template <typename F, typename ... Ts>
+    typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
+    execute_at(hpx::util::steady_time_point const& abs_time, F && f, Ts &&... ts)
     {
         hpx::this_thread::sleep_until(abs_time);
-        return hpx::async(hpx::launch::async, std::forward<F>(f)).get();
+        return hpx::async(hpx::launch::async, std::forward<F>(f),
+            std::forward<Ts>(ts)...).get();
     }
 };
 
@@ -148,11 +160,12 @@ struct test_timed_async_executor3 : test_timed_async_executor1
 {
     typedef hpx::parallel::parallel_execution_tag execution_category;
 
-    template <typename F>
-    void apply_execute(hpx::util::steady_time_point const& abs_time, F && f)
+    template <typename F, typename ... Ts>
+    void apply_execute(hpx::util::steady_time_point const& abs_time, F && f,
+        Ts &&... ts)
     {
         hpx::this_thread::sleep_until(abs_time);
-        hpx::apply(std::forward<F>(f));
+        hpx::apply(std::forward<F>(f), std::forward<Ts>(ts)...);
     }
 };
 

--- a/tests/unit/parallel/executors/minimal_timed_sync_executor.cpp
+++ b/tests/unit/parallel/executors/minimal_timed_sync_executor.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,7 +6,6 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/include/parallel_executors.hpp>
-#include <hpx/include/util.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <algorithm>
@@ -16,19 +15,21 @@
 #include <vector>
 
 #include <boost/range/functions.hpp>
-#include <boost/type_traits/is_same.hpp>
 #include <boost/chrono.hpp>
 
 using namespace boost::chrono;
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::thread::id sync_test()
+hpx::thread::id sync_test(int passed_through)
 {
+    HPX_TEST_EQ(passed_through, 42);
     return hpx::this_thread::get_id();
 }
 
-void apply_test(hpx::lcos::local::latch& l, hpx::thread::id& id)
+void apply_test(hpx::lcos::local::latch& l, hpx::thread::id& id,
+    int passed_through)
 {
+    HPX_TEST_EQ(passed_through, 42);
     id = hpx::this_thread::get_id();
     l.count_down(1);
 }
@@ -38,26 +39,35 @@ template <typename Executor>
 void test_timed_apply(Executor& exec)
 {
     {
-        hpx::lcos::local::latch l(2);
+        hpx::lcos::local::latch l(3);
         hpx::thread::id id;
 
         typedef hpx::parallel::timed_executor_traits<Executor> traits;
         traits::apply_execute_after(exec, milliseconds(10),
-            hpx::util::bind(&apply_test, boost::ref(l), boost::ref(id))
+            hpx::util::bind(&apply_test, boost::ref(l), boost::ref(id), 42)
         );
+
+        traits::apply_execute_after(exec, milliseconds(10),
+            &apply_test, boost::ref(l), boost::ref(id), 42);
+
         l.count_down_and_wait();
 
         HPX_TEST(id == hpx::this_thread::get_id());
     }
 
     {
-        hpx::lcos::local::latch l(2);
+        hpx::lcos::local::latch l(3);
         hpx::thread::id id;
 
         typedef hpx::parallel::timed_executor_traits<Executor> traits;
-        traits::apply_execute_at(exec, steady_clock::now()+milliseconds(10),
-            hpx::util::bind(&apply_test, boost::ref(l), boost::ref(id))
+        traits::apply_execute_at(exec, steady_clock::now() + milliseconds(10),
+            hpx::util::deferred_call(
+                &apply_test, boost::ref(l), boost::ref(id), 42)
         );
+
+        traits::apply_execute_at(exec, steady_clock::now() + milliseconds(10),
+            &apply_test, boost::ref(l), boost::ref(id), 42);
+
         l.count_down_and_wait();
 
         HPX_TEST(id == hpx::this_thread::get_id());
@@ -68,10 +78,10 @@ template <typename Executor>
 void test_timed_sync(Executor& exec)
 {
     typedef hpx::parallel::timed_executor_traits<Executor> traits;
-    HPX_TEST(traits::execute_after(exec, milliseconds(10), &sync_test) ==
+    HPX_TEST(traits::execute_after(exec, milliseconds(10), &sync_test, 42) ==
         hpx::this_thread::get_id());
     HPX_TEST(traits::execute_at(
-            exec, steady_clock::now()+milliseconds(10), &sync_test) ==
+            exec, steady_clock::now() + milliseconds(10), &sync_test, 42) ==
         hpx::this_thread::get_id());
 }
 
@@ -80,11 +90,12 @@ void test_timed_async(Executor& exec)
 {
     typedef hpx::parallel::timed_executor_traits<Executor> traits;
     HPX_TEST(
-        traits::async_execute_after(exec, milliseconds(10), &sync_test).get() ==
-        hpx::this_thread::get_id());
+        traits::async_execute_after(
+            exec, milliseconds(10), &sync_test, 42
+        ).get() == hpx::this_thread::get_id());
     HPX_TEST(
         traits::async_execute_at(
-            exec, steady_clock::now()+milliseconds(10), &sync_test
+            exec, steady_clock::now() + milliseconds(10), &sync_test, 42
         ).get() == hpx::this_thread::get_id());
 }
 
@@ -95,7 +106,7 @@ void test_timed_executor()
             Executor
         >::execution_category execution_category;
 
-    HPX_TEST((boost::is_same<
+    HPX_TEST((std::is_same<
             hpx::parallel::sequential_execution_tag, execution_category
         >::value));
 
@@ -111,23 +122,22 @@ struct test_timed_async_executor2 : hpx::parallel::timed_executor_tag
 {
     typedef hpx::parallel::sequential_execution_tag execution_category;
 
-    template <typename F>
-    hpx::future<typename hpx::util::result_of<
-        typename hpx::util::decay<F>::type()
-    >::type>
-    async_execute(F && f)
+    template <typename F, typename ... Ts>
+    hpx::future<typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type>
+    async_execute(F && f, Ts &&... ts)
     {
-        return hpx::async(hpx::launch::sync, std::forward<F>(f));
+        return hpx::async(hpx::launch::sync, std::forward<F>(f),
+            std::forward<Ts>(ts)...);
     }
 
-    template <typename F>
-    hpx::future<typename hpx::util::result_of<
-        typename hpx::util::decay<F>::type()
-    >::type>
-    async_execute_at(hpx::util::steady_time_point const& abs_time, F && f)
+    template <typename F, typename ... Ts>
+    hpx::future<typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type>
+    async_execute_at(hpx::util::steady_time_point const& abs_time, F && f,
+        Ts &&... ts)
     {
         hpx::this_thread::sleep_until(abs_time);
-        return hpx::async(hpx::launch::sync, std::forward<F>(f));
+        return hpx::async(hpx::launch::sync, std::forward<F>(f),
+            std::forward<Ts>(ts)...);
     }
 
     std::size_t processing_units_count()
@@ -140,12 +150,12 @@ struct test_timed_async_executor1 : test_timed_async_executor2
 {
     typedef hpx::parallel::sequential_execution_tag execution_category;
 
-    template <typename F>
-    typename hpx::util::result_of<F()>::type
-    execute_at(hpx::util::steady_time_point const& abs_time, F f)
+    template <typename F, typename ... Ts>
+    typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
+    execute_at(hpx::util::steady_time_point const& abs_time, F && f, Ts &&... ts)
     {
         hpx::this_thread::sleep_until(abs_time);
-        return f();
+        return hpx::util::invoke(std::forward<F>(f), std::forward<Ts>(ts)...);
     }
 };
 
@@ -153,10 +163,11 @@ struct test_timed_async_executor3 : test_timed_async_executor1
 {
     typedef hpx::parallel::sequential_execution_tag execution_category;
 
-    template <typename F>
-    void apply_execute_at(hpx::util::steady_time_point const& abs_time, F && f)
+    template <typename F, typename ... Ts>
+    void apply_execute_at(hpx::util::steady_time_point const& abs_time, F && f,
+        Ts &&... ts)
     {
-        this->execute_at(abs_time, std::forward<F>(f));
+        this->execute_at(abs_time, std::forward<F>(f), std::forward<Ts>(ts)...);
     }
 };
 

--- a/tests/unit/parallel/executors/parallel_executor.cpp
+++ b/tests/unit/parallel/executors/parallel_executor.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -16,7 +16,11 @@
 #include <boost/range/functions.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::thread::id test() { return hpx::this_thread::get_id(); }
+hpx::thread::id test(int passed_through)
+{
+    HPX_TEST_EQ(passed_through, 42);
+    return hpx::this_thread::get_id();
+}
 
 void test_sync()
 {
@@ -24,7 +28,7 @@ void test_sync()
     typedef hpx::parallel::executor_traits<executor> traits;
 
     executor exec;
-    HPX_TEST(traits::execute(exec, &test) != hpx::this_thread::get_id());
+    HPX_TEST(traits::execute(exec, &test, 42) != hpx::this_thread::get_id());
 }
 
 void test_async()
@@ -34,14 +38,15 @@ void test_async()
 
     executor exec;
     HPX_TEST(
-        traits::async_execute(exec, &test).get() !=
+        traits::async_execute(exec, &test, 42).get() !=
         hpx::this_thread::get_id());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void bulk_test(hpx::thread::id tid, int value)
+void bulk_test(hpx::thread::id tid, int value, int passed_through)
 {
     HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_EQ(passed_through, 42);
 }
 
 void test_bulk_sync()
@@ -55,9 +60,10 @@ void test_bulk_sync()
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
+    using hpx::util::placeholders::_2;
 
     executor exec;
-    traits::execute(exec, hpx::util::bind(&bulk_test, tid, _1), v);
+    traits::bulk_execute(exec, hpx::util::bind(&bulk_test, tid, _1, _2), v, 42);
 }
 
 void test_bulk_async()
@@ -71,10 +77,11 @@ void test_bulk_async()
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
+    using hpx::util::placeholders::_2;
 
     executor exec;
-    hpx::when_all(traits::async_execute(
-        exec, hpx::util::bind(&bulk_test, tid, _1), v)).get();
+    hpx::when_all(traits::bulk_async_execute(
+        exec, hpx::util::bind(&bulk_test, tid, _1, _2), v, 42)).get();
 }
 
 int hpx_main(int argc, char* argv[])

--- a/tests/unit/parallel/executors/parallel_executor.cpp
+++ b/tests/unit/parallel/executors/parallel_executor.cpp
@@ -43,7 +43,7 @@ void test_async()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void bulk_test(hpx::thread::id tid, int value, int passed_through)
+void bulk_test(int value, hpx::thread::id tid, int passed_through)
 {
     HPX_TEST(tid != hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
@@ -63,7 +63,8 @@ void test_bulk_sync()
     using hpx::util::placeholders::_2;
 
     executor exec;
-    traits::bulk_execute(exec, hpx::util::bind(&bulk_test, tid, _1, _2), v, 42);
+    traits::bulk_execute(exec, hpx::util::bind(&bulk_test, _1, tid, _2), v, 42);
+    traits::bulk_execute(exec, &bulk_test, v, tid, 42);
 }
 
 void test_bulk_async()
@@ -81,7 +82,11 @@ void test_bulk_async()
 
     executor exec;
     hpx::when_all(traits::bulk_async_execute(
-        exec, hpx::util::bind(&bulk_test, tid, _1, _2), v, 42)).get();
+        exec, hpx::util::bind(&bulk_test, _1, tid, _2), v, 42)
+    ).get();
+    hpx::when_all(
+        traits::bulk_async_execute(exec, &bulk_test, v, tid, 42)
+    ).get();
 }
 
 int hpx_main(int argc, char* argv[])

--- a/tests/unit/parallel/executors/parallel_fork_executor.cpp
+++ b/tests/unit/parallel/executors/parallel_fork_executor.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -16,7 +16,11 @@
 #include <boost/range/functions.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::thread::id test() { return hpx::this_thread::get_id(); }
+hpx::thread::id test(int passed_through)
+{
+    HPX_TEST_EQ(passed_through, 42);
+    return hpx::this_thread::get_id();
+}
 
 void test_sync()
 {
@@ -24,7 +28,7 @@ void test_sync()
     typedef hpx::parallel::executor_traits<executor> traits;
 
     executor exec(hpx::launch::fork);
-    HPX_TEST(traits::execute(exec, &test) != hpx::this_thread::get_id());
+    HPX_TEST(traits::execute(exec, &test, 42) != hpx::this_thread::get_id());
 }
 
 void test_async()
@@ -34,14 +38,15 @@ void test_async()
 
     executor exec(hpx::launch::fork);
     HPX_TEST(
-        traits::async_execute(exec, &test).get() !=
+        traits::async_execute(exec, &test, 42).get() !=
         hpx::this_thread::get_id());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void bulk_test(hpx::thread::id tid, int value)
+void bulk_test(hpx::thread::id tid, int value, int passed_through)
 {
     HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_EQ(passed_through, 42);
 }
 
 void test_bulk_sync()
@@ -55,9 +60,10 @@ void test_bulk_sync()
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
+    using hpx::util::placeholders::_2;
 
     executor exec(hpx::launch::fork);
-    traits::execute(exec, hpx::util::bind(&bulk_test, tid, _1), v);
+    traits::bulk_execute(exec, hpx::util::bind(&bulk_test, tid, _1, _2), v, 42);
 }
 
 void test_bulk_async()
@@ -71,10 +77,11 @@ void test_bulk_async()
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
+    using hpx::util::placeholders::_2;
 
     executor exec(hpx::launch::fork);
-    hpx::when_all(traits::async_execute(
-        exec, hpx::util::bind(&bulk_test, tid, _1), v)).get();
+    hpx::when_all(traits::bulk_async_execute(
+        exec, hpx::util::bind(&bulk_test, tid, _1, _2), v, 42)).get();
 }
 
 int hpx_main(int argc, char* argv[])

--- a/tests/unit/parallel/executors/parallel_fork_executor.cpp
+++ b/tests/unit/parallel/executors/parallel_fork_executor.cpp
@@ -43,7 +43,7 @@ void test_async()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void bulk_test(hpx::thread::id tid, int value, int passed_through)
+void bulk_test(int value, hpx::thread::id tid, int passed_through)
 {
     HPX_TEST(tid != hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
@@ -63,7 +63,8 @@ void test_bulk_sync()
     using hpx::util::placeholders::_2;
 
     executor exec(hpx::launch::fork);
-    traits::bulk_execute(exec, hpx::util::bind(&bulk_test, tid, _1, _2), v, 42);
+    traits::bulk_execute(exec, hpx::util::bind(&bulk_test, _1, tid, _2), v, 42);
+    traits::bulk_execute(exec, &bulk_test, v, tid, 42);
 }
 
 void test_bulk_async()
@@ -81,7 +82,11 @@ void test_bulk_async()
 
     executor exec(hpx::launch::fork);
     hpx::when_all(traits::bulk_async_execute(
-        exec, hpx::util::bind(&bulk_test, tid, _1, _2), v, 42)).get();
+        exec, hpx::util::bind(&bulk_test, _1, tid, _2), v, 42)
+    ).get();
+    hpx::when_all(
+        traits::bulk_async_execute(exec, &bulk_test, v, tid, 42)
+    ).get();
 }
 
 int hpx_main(int argc, char* argv[])

--- a/tests/unit/parallel/executors/sequential_executor.cpp
+++ b/tests/unit/parallel/executors/sequential_executor.cpp
@@ -16,7 +16,11 @@
 #include <boost/range/functions.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::thread::id test() { return hpx::this_thread::get_id(); }
+hpx::thread::id test(int passed_through)
+{
+    HPX_TEST_EQ(passed_through, 42);
+    return hpx::this_thread::get_id();
+}
 
 void test_sync()
 {
@@ -24,7 +28,7 @@ void test_sync()
     typedef hpx::parallel::executor_traits<executor> traits;
 
     executor exec;
-    HPX_TEST(traits::execute(exec, &test) == hpx::this_thread::get_id());
+    HPX_TEST(traits::execute(exec, &test, 42) == hpx::this_thread::get_id());
 }
 
 void test_async()
@@ -34,14 +38,15 @@ void test_async()
 
     executor exec;
     HPX_TEST(
-        traits::async_execute(exec, &test).get() ==
+        traits::async_execute(exec, &test, 42).get() ==
         hpx::this_thread::get_id());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void bulk_test(hpx::thread::id tid, int value)
+void bulk_test(int value, hpx::thread::id tid, int passed_through)
 {
     HPX_TEST(tid == hpx::this_thread::get_id());
+    HPX_TEST_EQ(passed_through, 42);
 }
 
 void test_bulk_sync()
@@ -55,9 +60,11 @@ void test_bulk_sync()
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
+    using hpx::util::placeholders::_2;
 
     executor exec;
-    traits::bulk_execute(exec, hpx::util::bind(&bulk_test, tid, _1), v);
+    traits::bulk_execute(exec, hpx::util::bind(&bulk_test, _1, tid, _2), v, 42);
+    traits::bulk_execute(exec, &bulk_test, v, tid, 42);
 }
 
 void test_bulk_async()
@@ -71,10 +78,15 @@ void test_bulk_async()
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
+    using hpx::util::placeholders::_2;
 
     executor exec;
     hpx::when_all(traits::bulk_async_execute(
-        exec, hpx::util::bind(&bulk_test, tid, _1), v)).get();
+        exec, hpx::util::bind(&bulk_test, _1, tid, _2), v, 42)
+    ).get();
+    hpx::when_all(
+        traits::bulk_async_execute(exec, &bulk_test, v, tid, 42)
+    ).get();
 }
 
 int hpx_main(int argc, char* argv[])

--- a/tests/unit/parallel/executors/sequential_executor.cpp
+++ b/tests/unit/parallel/executors/sequential_executor.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -57,7 +57,7 @@ void test_bulk_sync()
     using hpx::util::placeholders::_1;
 
     executor exec;
-    traits::execute(exec, hpx::util::bind(&bulk_test, tid, _1), v);
+    traits::bulk_execute(exec, hpx::util::bind(&bulk_test, tid, _1), v);
 }
 
 void test_bulk_async()
@@ -73,7 +73,7 @@ void test_bulk_async()
     using hpx::util::placeholders::_1;
 
     executor exec;
-    hpx::when_all(traits::async_execute(
+    hpx::when_all(traits::bulk_async_execute(
         exec, hpx::util::bind(&bulk_test, tid, _1), v)).get();
 }
 

--- a/tests/unit/parallel/executors/service_executors.cpp
+++ b/tests/unit/parallel/executors/service_executors.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -16,13 +16,17 @@
 #include <boost/thread/thread.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-boost::thread::id test() { return boost::this_thread::get_id(); }
+boost::thread::id test(int passed_through)
+{
+    HPX_TEST_EQ(passed_through, 42);
+    return boost::this_thread::get_id();
+}
 
 template <typename Executor>
 void test_sync(Executor& exec)
 {
     typedef hpx::parallel::executor_traits<Executor> traits;
-    HPX_TEST(traits::execute(exec, &test) != boost::this_thread::get_id());
+    HPX_TEST(traits::execute(exec, &test, 42) != boost::this_thread::get_id());
 }
 
 template <typename Executor>
@@ -31,14 +35,15 @@ void test_async(Executor& exec)
     typedef hpx::parallel::executor_traits<Executor> traits;
 
     HPX_TEST(
-        traits::async_execute(exec, &test).get() !=
+        traits::async_execute(exec, &test, 42).get() !=
         boost::this_thread::get_id());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void bulk_test(boost::thread::id tid, int value)
+void bulk_test(int value, boost::thread::id tid, int passed_through)
 {
     HPX_TEST(tid != boost::this_thread::get_id());
+    HPX_TEST_EQ(passed_through, 42);
 }
 
 template <typename Executor>
@@ -52,7 +57,10 @@ void test_bulk_sync(Executor& exec)
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
-    traits::execute(exec, hpx::util::bind(&bulk_test, tid, _1), v);
+    using hpx::util::placeholders::_2;
+
+    traits::bulk_execute(exec, hpx::util::bind(&bulk_test, _1, tid, _2), v, 42);
+    traits::bulk_execute(exec, &bulk_test, v, tid, 42);
 }
 
 template <typename Executor>
@@ -66,8 +74,11 @@ void test_bulk_async(Executor& exec)
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
-    hpx::when_all(traits::async_execute(
-        exec, hpx::util::bind(&bulk_test, tid, _1), v)).get();
+    using hpx::util::placeholders::_2;
+
+    hpx::when_all(traits::bulk_async_execute(
+        exec, hpx::util::bind(&bulk_test, _1, tid, _2), v, 42)).get();
+    hpx::when_all(traits::bulk_async_execute(exec, &bulk_test, v, tid, 42)).get();
 }
 
 template <typename Executor>

--- a/tests/unit/parallel/executors/this_thread_executors.cpp
+++ b/tests/unit/parallel/executors/this_thread_executors.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -15,14 +15,18 @@
 #include <boost/range/functions.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-std::size_t test() { return hpx::get_worker_thread_num(); }
+std::size_t test(int passed_through)
+{
+    HPX_TEST_EQ(passed_through, 42);
+    return hpx::get_worker_thread_num();
+}
 
 template <typename Executor>
 void test_sync(Executor& exec)
 {
     typedef hpx::parallel::executor_traits<Executor> traits;
 
-    HPX_TEST(traits::execute(exec, &test) == hpx::get_worker_thread_num());
+    HPX_TEST(traits::execute(exec, &test, 42) == hpx::get_worker_thread_num());
 }
 
 template <typename Executor>
@@ -31,14 +35,15 @@ void test_async(Executor& exec)
     typedef hpx::parallel::executor_traits<Executor> traits;
 
     HPX_TEST(
-        traits::async_execute(exec, &test).get() ==
+        traits::async_execute(exec, &test, 42).get() ==
         hpx::get_worker_thread_num());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void bulk_test(std::size_t tid, int value)
+void bulk_test(int value, std::size_t tid, int passed_through)
 {
     HPX_TEST(tid == hpx::get_worker_thread_num());
+    HPX_TEST_EQ(passed_through, 42);
 }
 
 template <typename Executor>
@@ -52,7 +57,10 @@ void test_bulk_sync(Executor& exec)
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
-    traits::execute(exec, hpx::util::bind(&bulk_test, tid, _1), v);
+    using hpx::util::placeholders::_2;
+
+    traits::bulk_execute(exec, hpx::util::bind(&bulk_test, _1, tid, _2), v, 42);
+    traits::bulk_execute(exec, &bulk_test, v, tid, 42);
 }
 
 template <typename Executor>
@@ -66,8 +74,11 @@ void test_bulk_async(Executor& exec)
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
-    hpx::when_all(traits::async_execute(
-        exec, hpx::util::bind(&bulk_test, tid, _1), v)).get();
+    using hpx::util::placeholders::_2;
+
+    hpx::when_all(traits::bulk_async_execute(
+        exec, hpx::util::bind(&bulk_test, _1, tid, _2), v, 42)).get();
+    hpx::when_all(traits::bulk_async_execute(exec, &bulk_test, v, tid, 42)).get();
 }
 
 template <typename Executor>

--- a/tests/unit/parallel/executors/thread_pool_attached_executors.cpp
+++ b/tests/unit/parallel/executors/thread_pool_attached_executors.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -16,14 +16,18 @@
 #include <boost/range/functions.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::thread::id test() { return hpx::this_thread::get_id(); }
+hpx::thread::id test(int passed_through)
+{
+    HPX_TEST_EQ(passed_through, 42);
+    return hpx::this_thread::get_id();
+}
 
 template <typename Executor>
 void test_sync(Executor& exec)
 {
     typedef hpx::parallel::executor_traits<Executor> traits;
 
-    HPX_TEST(traits::execute(exec, &test) != hpx::this_thread::get_id());
+    HPX_TEST(traits::execute(exec, &test, 42) != hpx::this_thread::get_id());
 }
 
 template <typename Executor>
@@ -32,14 +36,15 @@ void test_async(Executor& exec)
     typedef hpx::parallel::executor_traits<Executor> traits;
 
     HPX_TEST(
-        traits::async_execute(exec, &test).get() !=
+        traits::async_execute(exec, &test, 42).get() !=
         hpx::this_thread::get_id());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void bulk_test(hpx::thread::id tid, int value)
+void bulk_test(int value, hpx::thread::id tid, int passed_through)
 {
     HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_EQ(passed_through, 42);
 }
 
 template <typename Executor>
@@ -53,7 +58,10 @@ void test_bulk_sync(Executor& exec)
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
-    traits::execute(exec, hpx::util::bind(&bulk_test, tid, _1), v);
+    using hpx::util::placeholders::_2;
+
+    traits::bulk_execute(exec, hpx::util::bind(&bulk_test, _1, tid, _2), v, 42);
+    traits::bulk_execute(exec, &bulk_test, v, tid, 42);
 }
 
 template <typename Executor>
@@ -67,8 +75,11 @@ void test_bulk_async(Executor& exec)
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
-    hpx::when_all(traits::async_execute(
-        exec, hpx::util::bind(&bulk_test, tid, _1), v)).get();
+    using hpx::util::placeholders::_2;
+
+    hpx::when_all(traits::bulk_async_execute(
+        exec, hpx::util::bind(&bulk_test, _1, tid, _2), v, 42)).get();
+    hpx::when_all(traits::bulk_async_execute(exec, &bulk_test, v, tid, 42)).get();
 }
 
 template <typename Executor>

--- a/tests/unit/parallel/executors/thread_pool_executors.cpp
+++ b/tests/unit/parallel/executors/thread_pool_executors.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -16,14 +16,18 @@
 #include <boost/range/functions.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::thread::id test() { return hpx::this_thread::get_id(); }
+hpx::thread::id test(int passed_through)
+{
+    HPX_TEST_EQ(passed_through, 42);
+    return hpx::this_thread::get_id();
+}
 
 template <typename Executor>
 void test_sync(Executor& exec)
 {
     typedef hpx::parallel::executor_traits<Executor> traits;
 
-    HPX_TEST(traits::execute(exec, &test) != hpx::this_thread::get_id());
+    HPX_TEST(traits::execute(exec, &test, 42) != hpx::this_thread::get_id());
 }
 
 template <typename Executor>
@@ -32,14 +36,15 @@ void test_async(Executor& exec)
     typedef hpx::parallel::executor_traits<Executor> traits;
 
     HPX_TEST(
-        traits::async_execute(exec, &test).get() !=
+        traits::async_execute(exec, &test, 42).get() !=
         hpx::this_thread::get_id());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void bulk_test(hpx::thread::id tid, int value)
+void bulk_test(int value, hpx::thread::id tid, int passed_through)
 {
     HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_EQ(passed_through, 42);
 }
 
 template <typename Executor>
@@ -53,7 +58,10 @@ void test_bulk_sync(Executor& exec)
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
-    traits::execute(exec, hpx::util::bind(&bulk_test, tid, _1), v);
+    using hpx::util::placeholders::_2;
+
+    traits::bulk_execute(exec, hpx::util::bind(&bulk_test, _1, tid, _2), v, 42);
+    traits::bulk_execute(exec, &bulk_test, v, tid, 42);
 }
 
 template <typename Executor>
@@ -67,8 +75,11 @@ void test_bulk_async(Executor& exec)
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
-    hpx::when_all(traits::async_execute(
-        exec, hpx::util::bind(&bulk_test, tid, _1), v)).get();
+    using hpx::util::placeholders::_2;
+
+    hpx::when_all(traits::bulk_async_execute(
+        exec, hpx::util::bind(&bulk_test, _1, tid, _2), v, 42)).get();
+    hpx::when_all(traits::bulk_async_execute(exec, &bulk_test, v, tid, 42)).get();
 }
 
 template <typename Executor>

--- a/tests/unit/parallel/executors/thread_pool_os_executors.cpp
+++ b/tests/unit/parallel/executors/thread_pool_os_executors.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -16,14 +16,18 @@
 #include <boost/range/functions.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::thread::id test() { return hpx::this_thread::get_id(); }
+hpx::thread::id test(int passed_through)
+{
+    HPX_TEST_EQ(passed_through, 42);
+    return hpx::this_thread::get_id();
+}
 
 template <typename Executor>
 void test_sync(Executor& exec)
 {
     typedef hpx::parallel::executor_traits<Executor> traits;
 
-    HPX_TEST(traits::execute(exec, &test) != hpx::this_thread::get_id());
+    HPX_TEST(traits::execute(exec, &test, 42) != hpx::this_thread::get_id());
 }
 
 template <typename Executor>
@@ -32,14 +36,15 @@ void test_async(Executor& exec)
     typedef hpx::parallel::executor_traits<Executor> traits;
 
     HPX_TEST(
-        traits::async_execute(exec, &test).get() !=
+        traits::async_execute(exec, &test, 42).get() !=
         hpx::this_thread::get_id());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void bulk_test(hpx::thread::id tid, int value)
+void bulk_test(int value, hpx::thread::id tid, int passed_through)
 {
     HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_EQ(passed_through, 42);
 }
 
 template <typename Executor>
@@ -53,7 +58,10 @@ void test_bulk_sync(Executor& exec)
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
-    traits::execute(exec, hpx::util::bind(&bulk_test, tid, _1), v);
+    using hpx::util::placeholders::_2;
+
+    traits::bulk_execute(exec, hpx::util::bind(&bulk_test, _1, tid, _2), v, 42);
+    traits::bulk_execute(exec, &bulk_test, v, tid, 42);
 }
 
 template <typename Executor>
@@ -67,8 +75,11 @@ void test_bulk_async(Executor& exec)
     std::iota(boost::begin(v), boost::end(v), std::rand());
 
     using hpx::util::placeholders::_1;
-    hpx::when_all(traits::async_execute(
-        exec, hpx::util::bind(&bulk_test, tid, _1), v)).get();
+    using hpx::util::placeholders::_2;
+
+    hpx::when_all(traits::bulk_async_execute(
+        exec, hpx::util::bind(&bulk_test, _1, tid, _2), v, 42)).get();
+    hpx::when_all(traits::bulk_async_execute(exec, &bulk_test, v, tid, 42)).get();
 }
 
 template <typename Executor>

--- a/tests/unit/parallel/executors/timed_parallel_executor.cpp
+++ b/tests/unit/parallel/executors/timed_parallel_executor.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -19,7 +19,11 @@
 using namespace boost::chrono;
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::thread::id test() { return hpx::this_thread::get_id(); }
+hpx::thread::id test(int passed_through)
+{
+    HPX_TEST_EQ(passed_through, 42);
+    return hpx::this_thread::get_id();
+}
 
 void test_timed_sync()
 {
@@ -28,12 +32,14 @@ void test_timed_sync()
 
     executor exec;
     HPX_TEST(
-        traits::execute_after(exec, milliseconds(1), &test) !=
-            hpx::this_thread::get_id());
+        traits::execute_after(
+            exec, milliseconds(1), &test, 42
+        ) != hpx::this_thread::get_id());
 
     HPX_TEST(
-        traits::execute_at(exec, steady_clock::now()+milliseconds(1), &test) !=
-            hpx::this_thread::get_id());
+        traits::execute_at(
+            exec, steady_clock::now() + milliseconds(1), &test, 42
+        ) != hpx::this_thread::get_id());
 }
 
 void test_timed_async()
@@ -44,11 +50,11 @@ void test_timed_async()
     executor exec;
     HPX_TEST(
         traits::async_execute_after(
-            exec, milliseconds(1), &test
+            exec, milliseconds(1), &test, 42
         ).get() != hpx::this_thread::get_id());
     HPX_TEST(
         traits::async_execute_at(
-            exec, steady_clock::now()+milliseconds(1), &test
+            exec, steady_clock::now() + milliseconds(1), &test, 42
         ).get() != hpx::this_thread::get_id());
 }
 
@@ -58,8 +64,9 @@ void test_timed_apply()
     typedef hpx::parallel::timed_executor_traits<executor> traits;
 
     executor exec;
-    traits::apply_execute_after(exec, milliseconds(1), &test);
-    traits::apply_execute_at(exec, steady_clock::now()+milliseconds(1), &test);
+    traits::apply_execute_after(exec, milliseconds(1), &test, 42);
+    traits::apply_execute_at(
+        exec, steady_clock::now() + milliseconds(1), &test, 42);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/parallel/executors/timed_this_thread_executors.cpp
+++ b/tests/unit/parallel/executors/timed_this_thread_executors.cpp
@@ -18,7 +18,11 @@
 using namespace boost::chrono;
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::thread::id test() { return hpx::this_thread::get_id(); }
+hpx::thread::id test(int passed_through)
+{
+    HPX_TEST_EQ(passed_through, 42);
+    return hpx::this_thread::get_id();
+}
 
 template <typename Executor>
 void test_timed_sync(Executor& exec)
@@ -26,12 +30,14 @@ void test_timed_sync(Executor& exec)
     typedef hpx::parallel::timed_executor_traits<Executor> traits;
 
     HPX_TEST(
-        traits::execute_after(exec, milliseconds(1), &test) !=
-            hpx::this_thread::get_id());
+        traits::execute_after(
+            exec, milliseconds(1), &test, 42
+        ) != hpx::this_thread::get_id());
 
     HPX_TEST(
-        traits::execute_at(exec, steady_clock::now()+milliseconds(1), &test) !=
-            hpx::this_thread::get_id());
+        traits::execute_at(
+            exec, steady_clock::now()+milliseconds(1), &test, 42
+        ) != hpx::this_thread::get_id());
 }
 
 template <typename Executor>
@@ -41,12 +47,12 @@ void test_timed_async(Executor& exec)
 
     HPX_TEST(
         traits::async_execute_after(
-            exec, milliseconds(1), &test
+            exec, milliseconds(1), &test, 42
         ).get() != hpx::this_thread::get_id());
 
     HPX_TEST(
         traits::async_execute_at(
-            exec, steady_clock::now()+milliseconds(1), &test
+            exec, steady_clock::now()+milliseconds(1), &test, 42
         ).get() != hpx::this_thread::get_id());
 }
 
@@ -55,8 +61,9 @@ void test_timed_apply(Executor& exec)
 {
     typedef hpx::parallel::timed_executor_traits<Executor> traits;
 
-    traits::apply_execute_after(exec, milliseconds(1), &test);
-    traits::apply_execute_at(exec, steady_clock::now()+milliseconds(1), &test);
+    traits::apply_execute_after(exec, milliseconds(1), &test, 42);
+    traits::apply_execute_at(
+        exec, steady_clock::now() + milliseconds(1), &test, 42);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/parallel/executors/timed_thread_pool_executors.cpp
+++ b/tests/unit/parallel/executors/timed_thread_pool_executors.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -18,7 +18,11 @@
 using namespace boost::chrono;
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::thread::id test() { return hpx::this_thread::get_id(); }
+hpx::thread::id test(int passed_through)
+{
+    HPX_TEST_EQ(passed_through, 42);
+    return hpx::this_thread::get_id();
+}
 
 template <typename Executor>
 void test_timed_sync(Executor& exec)
@@ -26,12 +30,14 @@ void test_timed_sync(Executor& exec)
     typedef hpx::parallel::timed_executor_traits<Executor> traits;
 
     HPX_TEST(
-        traits::execute_after(exec, milliseconds(1), &test) !=
-            hpx::this_thread::get_id());
+        traits::execute_after(
+            exec, milliseconds(1), &test, 42
+        ) != hpx::this_thread::get_id());
 
     HPX_TEST(
-        traits::execute_at(exec, steady_clock::now()+milliseconds(1), &test) !=
-            hpx::this_thread::get_id());
+        traits::execute_at(
+            exec, steady_clock::now() + milliseconds(1), &test, 42
+        ) != hpx::this_thread::get_id());
 }
 
 template <typename Executor>
@@ -41,12 +47,12 @@ void test_timed_async(Executor& exec)
 
     HPX_TEST(
         traits::async_execute_after(
-            exec, milliseconds(1), &test
+            exec, milliseconds(1), &test, 42
         ).get() != hpx::this_thread::get_id());
 
     HPX_TEST(
         traits::async_execute_at(
-            exec, steady_clock::now()+milliseconds(1), &test
+            exec, steady_clock::now() + milliseconds(1), &test, 42
         ).get() != hpx::this_thread::get_id());
 }
 
@@ -55,8 +61,9 @@ void test_timed_apply(Executor& exec)
 {
     typedef hpx::parallel::timed_executor_traits<Executor> traits;
 
-    traits::apply_execute_after(exec, milliseconds(1), &test);
-    traits::apply_execute_at(exec, steady_clock::now()+milliseconds(1), &test);
+    traits::apply_execute_after(exec, milliseconds(1), &test, 42);
+    traits::apply_execute_at(
+        exec, steady_clock::now() + milliseconds(1), &test, 42);
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This fixes #2104 

The breaking change is that the bulk- `async_execute` was renamed to `bulk_async_execute` and the bulk- `execute` was renamed to `bulk_execute`