### PR TITLE
Fix invalid attribute warnings

### DIFF
--- a/hpx/runtime/applier/applier.hpp
+++ b/hpx/runtime/applier/applier.hpp
@@ -9,6 +9,7 @@
 #define HPX_APPLIER_APPLIER_JUN_03_2008_0438PM
 
 #include <hpx/config.hpp>
+#include <hpx/runtime/applier_fwd.hpp> // this needs to go first
 #include <hpx/util/thread_specific_ptr.hpp>
 #include <hpx/runtime/agas_fwd.hpp>
 #include <hpx/runtime/parcelset_fwd.hpp>

--- a/hpx/runtime/components/component_factory_base.hpp
+++ b/hpx/runtime/components/component_factory_base.hpp
@@ -7,6 +7,7 @@
 #define HPX_COMPONENT_FACTORY_BASE_SEP_26_2008_0446PM
 
 #include <hpx/config.hpp>
+#include <hpx/runtime/components_fwd.hpp> // this needs to go first
 #include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/runtime/naming/address.hpp>
 #include <hpx/runtime/naming/name.hpp>

--- a/hpx/runtime_fwd.hpp
+++ b/hpx/runtime_fwd.hpp
@@ -67,12 +67,7 @@ namespace hpx
     /// \cond NOINTERNAL
     namespace util
     {
-        class HPX_EXPORT io_service_pool;
-        class HPX_EXPORT runtime_configuration;
-
         struct binary_filter;
-
-        class HPX_EXPORT section;
 
         /// \brief Expand INI variables in a string
         HPX_API_EXPORT std::string expand(std::string const& expand);

--- a/hpx/util/ini.hpp
+++ b/hpx/util/ini.hpp
@@ -8,6 +8,8 @@
 #if !defined(HPX_UTIL_SECTION_SEP_17_2008_022PM)
 #define HPX_UTIL_SECTION_SEP_17_2008_022PM
 
+#include <hpx/config.hpp>
+#include <hpx/util_fwd.hpp> // this needs to go first
 #include <hpx/runtime/serialization/serialization_fwd.hpp>
 
 #include <boost/lexical_cast.hpp>

--- a/hpx/util_fwd.hpp
+++ b/hpx/util_fwd.hpp
@@ -16,6 +16,7 @@ namespace hpx { namespace util
     /// \cond NOINTERNAL
     class HPX_EXPORT io_service_pool;
     class HPX_EXPORT runtime_configuration;
+    class HPX_EXPORT section;
     /// \endcond
 }}
 


### PR DESCRIPTION
Fixes #2109.

See output from [master](http://hermione.cct.lsu.edu/builders/hpx_gcc_4_6_boost_1_50_debian_x86_64_debug/builds/956/steps/build_unit_tests/logs/warnings%20%2889%29) and the one from [this PR](http://hermione.cct.lsu.edu/builders/hpx_gcc_4_6_boost_1_50_debian_x86_64_debug/builds/957/steps/build_unit_tests/logs/warnings%20%2865%29).