### PR TITLE
Fixing parcel compression, adding test

### DIFF
--- a/hpx/include/compression_registration.hpp
+++ b/hpx/include/compression_registration.hpp
@@ -1,0 +1,15 @@
+//  Copyright (c) 2007-2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_COMPRESSION_REGISTRATION_APR_28_2016_1022AM)
+#define HPX_COMPRESSION_REGISTRATION_APR_28_2016_1022AM
+
+#include <hpx/config.hpp>
+#include <hpx/plugins/binary_filter/bzip2_serialization_filter_registration.hpp>
+#include <hpx/plugins/binary_filter/snappy_serialization_filter_registration.hpp>
+#include <hpx/plugins/binary_filter/zlib_serialization_filter_registration.hpp>
+
+#endif
+

--- a/hpx/performance_counters/parcels/gatherer.hpp
+++ b/hpx/performance_counters/parcels/gatherer.hpp
@@ -34,7 +34,8 @@ namespace hpx { namespace performance_counters { namespace parcels
 #endif
             num_parcels_(0),
             num_messages_(0),
-            overall_raw_bytes_(0)
+            overall_raw_bytes_(0),
+            buffer_allocate_time_(0)
         {}
 
         void add_data(data_point const& x);

--- a/hpx/plugins/binary_filter/bzip2_serialization_filter.hpp
+++ b/hpx/plugins/binary_filter/bzip2_serialization_filter.hpp
@@ -1,16 +1,17 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(HPX_ACTION_BZIP2_SERIALIZATION_FILTER_FEB_18_2013_1240AM)
-#define HPX_ACTION_BZIP2_SERIALIZATION_FILTER_FEB_18_2013_1240AM
+#if !defined(HPX_ACTION_BZIP2_SERIALIZATION_FILTER_REGISTRATION_APR_28_2016_1006AM)
+#define HPX_ACTION_BZIP2_SERIALIZATION_FILTER_REGISTRATION_APR_28_2016_1006AM
 
 #include <hpx/config.hpp>
 
+#include <hpx/plugins/binary_filter/bzip2_serialization_filter_registration.hpp>
+
 #if defined(HPX_HAVE_COMPRESSION_BZIP2)
 
-#include <hpx/traits/action_serialization_filter.hpp>
 #include <hpx/runtime/serialization/binary_filter.hpp>
 
 #include <boost/iostreams/filter/bzip2.hpp>
@@ -63,7 +64,7 @@ namespace hpx { namespace plugins { namespace compression
     }
 
     struct HPX_LIBRARY_EXPORT bzip2_serialization_filter
-        : public serialization::binary_filter
+      : public serialization::binary_filter
     {
         bzip2_serialization_filter()
           : current_(0)
@@ -103,29 +104,5 @@ namespace hpx { namespace plugins { namespace compression
 
 #include <hpx/config/warnings_suffix.hpp>
 
-///////////////////////////////////////////////////////////////////////////////
-#define HPX_ACTION_USES_BZIP2_COMPRESSION(action)                             \
-    namespace hpx { namespace traits                                          \
-    {                                                                         \
-        template <>                                                           \
-        struct action_serialization_filter<action>                            \
-        {                                                                     \
-            /* Note that the caller is responsible for deleting the filter */ \
-            /* instance returned from this function */                        \
-            static serialization::binary_filter* call(                        \
-                    parcelset::parcel const& p)                               \
-            {                                                                 \
-                return hpx::create_binary_filter(                             \
-                    "bzip2_serialization_filter", true);                      \
-            }                                                                 \
-        };                                                                    \
-    }}                                                                        \
-/**/
-
-#else
-
-#define HPX_ACTION_USES_BZIP2_COMPRESSION(action)
-
 #endif
-
 #endif

--- a/hpx/plugins/binary_filter/bzip2_serialization_filter_registration.hpp
+++ b/hpx/plugins/binary_filter/bzip2_serialization_filter_registration.hpp
@@ -1,0 +1,40 @@
+//  Copyright (c) 2007-2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_ACTION_BZIP2_SERIALIZATION_FILTER_FEB_18_2013_1240AM)
+#define HPX_ACTION_BZIP2_SERIALIZATION_FILTER_FEB_18_2013_1240AM
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_COMPRESSION_BZIP2)
+
+#include <hpx/traits/action_serialization_filter.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+#define HPX_ACTION_USES_BZIP2_COMPRESSION(action)                             \
+    namespace hpx { namespace traits                                          \
+    {                                                                         \
+        template <>                                                           \
+        struct action_serialization_filter<action>                            \
+        {                                                                     \
+            /* Note that the caller is responsible for deleting the filter */ \
+            /* instance returned from this function */                        \
+            static serialization::binary_filter* call(                        \
+                    parcelset::parcel const& p)                               \
+            {                                                                 \
+                return hpx::create_binary_filter(                             \
+                    "bzip2_serialization_filter", true);                      \
+            }                                                                 \
+        };                                                                    \
+    }}                                                                        \
+/**/
+
+#else
+
+#define HPX_ACTION_USES_BZIP2_COMPRESSION(action)
+
+#endif
+
+#endif

--- a/hpx/plugins/binary_filter/snappy_serialization_filter.hpp
+++ b/hpx/plugins/binary_filter/snappy_serialization_filter.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -7,9 +7,10 @@
 #define HPX_ACTION_SNAPPY_SERIALIZATION_FILTER_FEB_21_2013_0203PM
 
 #include <hpx/config.hpp>
+#include <hpx/plugins/binary_filter/snappy_serialization_filter_registration.hpp>
 
 #if defined(HPX_HAVE_COMPRESSION_SNAPPY)
-#include <hpx/traits/action_serialization_filter.hpp>
+
 #include <hpx/runtime/serialization/binary_filter.hpp>
 
 #include <boost/iostreams/filter/zlib.hpp>
@@ -55,29 +56,5 @@ namespace hpx { namespace plugins { namespace compression
 
 #include <hpx/config/warnings_suffix.hpp>
 
-///////////////////////////////////////////////////////////////////////////////
-#define HPX_ACTION_USES_SNAPPY_COMPRESSION(action)                            \
-    namespace hpx { namespace traits                                          \
-    {                                                                         \
-        template <>                                                           \
-        struct action_serialization_filter<action>                            \
-        {                                                                     \
-            /* Note that the caller is responsible for deleting the filter */ \
-            /* instance returned from this function */                        \
-            static serialization::binary_filter* call(                        \
-                    parcelset::parcel const& p)                               \
-            {                                                                 \
-                return hpx::create_binary_filter(                             \
-                    "snappy_serialization_filter", true);                     \
-            }                                                                 \
-        };                                                                    \
-    }}                                                                        \
-/**/
-
-#else
-
-#define HPX_ACTION_USES_SNAPPY_COMPRESSION(action)
-
 #endif
-
 #endif

--- a/hpx/plugins/binary_filter/snappy_serialization_filter_registration.hpp
+++ b/hpx/plugins/binary_filter/snappy_serialization_filter_registration.hpp
@@ -1,0 +1,39 @@
+//  Copyright (c) 2007-2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_ACTION_SNAPPY_SERIALIZATION_FILTER_REGISTRATION_APR_28_2016_1008AM)
+#define HPX_ACTION_SNAPPY_SERIALIZATION_FILTER_REGISTRATION_APR_28_2016_1008AM
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_COMPRESSION_SNAPPY)
+
+#include <hpx/traits/action_serialization_filter.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+#define HPX_ACTION_USES_SNAPPY_COMPRESSION(action)                            \
+    namespace hpx { namespace traits                                          \
+    {                                                                         \
+        template <>                                                           \
+        struct action_serialization_filter<action>                            \
+        {                                                                     \
+            /* Note that the caller is responsible for deleting the filter */ \
+            /* instance returned from this function */                        \
+            static serialization::binary_filter* call(                        \
+                    parcelset::parcel const& p)                               \
+            {                                                                 \
+                return hpx::create_binary_filter(                             \
+                    "snappy_serialization_filter", true);                     \
+            }                                                                 \
+        };                                                                    \
+    }}                                                                        \
+/**/
+
+#else
+
+#define HPX_ACTION_USES_SNAPPY_COMPRESSION(action)
+
+#endif
+#endif

--- a/hpx/plugins/binary_filter/zlib_serialization_filter.hpp
+++ b/hpx/plugins/binary_filter/zlib_serialization_filter.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -8,9 +8,10 @@
 
 #include <hpx/config.hpp>
 
+#include <hpx/plugins/binary_filter/zlib_serialization_filter_registration.hpp>
+
 #if defined(HPX_HAVE_COMPRESSION_ZLIB)
 
-#include <hpx/traits/action_serialization_filter.hpp>
 #include <hpx/runtime/serialization/binary_filter.hpp>
 
 #include <boost/iostreams/filter/zlib.hpp>
@@ -91,29 +92,5 @@ namespace hpx { namespace plugins { namespace compression
 
 #include <hpx/config/warnings_suffix.hpp>
 
-///////////////////////////////////////////////////////////////////////////////
-#define HPX_ACTION_USES_ZLIB_COMPRESSION(action)                              \
-    namespace hpx { namespace traits                                          \
-    {                                                                         \
-        template <>                                                           \
-        struct action_serialization_filter<action>                            \
-        {                                                                     \
-            /* Note that the caller is responsible for deleting the filter */ \
-            /* instance returned from this function */                        \
-            static serialization::binary_filter* call(                        \
-                    parcelset::parcel const& p)                               \
-            {                                                                 \
-                return hpx::create_binary_filter(                             \
-                    "zlib_serialization_filter", true);                       \
-            }                                                                 \
-        };                                                                    \
-    }}                                                                        \
-/**/
-
-#else
-
-#define HPX_ACTION_USES_ZLIB_COMPRESSION(action)
-
 #endif
-
 #endif

--- a/hpx/plugins/binary_filter/zlib_serialization_filter_registration.hpp
+++ b/hpx/plugins/binary_filter/zlib_serialization_filter_registration.hpp
@@ -1,0 +1,40 @@
+//  Copyright (c) 2007-2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_ACTION_ZLIB_SERIALIZATION_FILTER_REGISTRATION_APR_28_2016_1003AM)
+#define HPX_ACTION_ZLIB_SERIALIZATION_FILTER_REGISTRATION_APR_28_2016_1003AM
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_COMPRESSION_ZLIB)
+
+#include <hpx/traits/action_serialization_filter.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+#define HPX_ACTION_USES_ZLIB_COMPRESSION(action)                              \
+    namespace hpx { namespace traits                                          \
+    {                                                                         \
+        template <>                                                           \
+        struct action_serialization_filter<action>                            \
+        {                                                                     \
+            /* Note that the caller is responsible for deleting the filter */ \
+            /* instance returned from this function */                        \
+            static serialization::binary_filter* call(                        \
+                    parcelset::parcel const& p)                               \
+            {                                                                 \
+                return hpx::create_binary_filter(                             \
+                    "zlib_serialization_filter", true);                       \
+            }                                                                 \
+        };                                                                    \
+    }}                                                                        \
+/**/
+
+#else
+
+#define HPX_ACTION_USES_ZLIB_COMPRESSION(action)
+
+#endif
+
+#endif

--- a/hpx/runtime/actions/plain_action.hpp
+++ b/hpx/runtime/actions/plain_action.hpp
@@ -180,18 +180,12 @@ namespace hpx { namespace traits
 /// \cond NOINTERNAL
 
 #define HPX_DECLARE_PLAIN_DIRECT_ACTION(...)                                  \
-    HPX_DECLARE_PLAIN_DIRECT_ACTION_(__VA_ARGS__)                             \
+    HPX_DECLARE_PLAIN_ACTION(__VA_ARGS__)                                     \
     /**/
 
 #define HPX_DECLARE_PLAIN_ACTION_(...)                                        \
     HPX_UTIL_EXPAND_(BOOST_PP_CAT(                                            \
         HPX_DECLARE_PLAIN_ACTION_, HPX_UTIL_PP_NARG(__VA_ARGS__)              \
-    )(__VA_ARGS__))                                                           \
-    /**/
-
-#define HPX_DECLARE_PLAIN_DIRECT_ACTION_(...)                                 \
-    HPX_UTIL_EXPAND_(BOOST_PP_CAT(                                            \
-        HPX_DECLARE_PLAIN_DIRECT_ACTION_, HPX_UTIL_PP_NARG(__VA_ARGS__)       \
     )(__VA_ARGS__))                                                           \
     /**/
 

--- a/hpx/runtime/parcelset/encode_parcels.hpp
+++ b/hpx/runtime/parcelset/encode_parcels.hpp
@@ -78,8 +78,8 @@ namespace hpx
                 LPT_(debug) << binary_archive_content(buffer);
 
                 performance_counters::parcels::data_point& data = buffer.data_point_;
-                data.bytes_ = arg_size;
-                data.raw_bytes_ = buffer.data_.size();
+                data.bytes_ = buffer.data_.size();
+                data.raw_bytes_ = arg_size;
 
                 // prepare chunk data for transmission, the transmission_chunks data
                 // first holds all zero-copy, then all non-zero-copy chunk infos

--- a/hpx/runtime/parcelset/parcelport.hpp
+++ b/hpx/runtime/parcelset/parcelport.hpp
@@ -282,6 +282,12 @@ namespace hpx { namespace parcelset
             return parcels_received_.total_bytes(reset);
         }
 
+        /// total data (uncompressed) received (bytes)
+        boost::uint64_t get_raw_data_received(bool reset)
+        {
+            return parcels_received_.total_raw_bytes(reset);
+        }
+
         boost::int64_t get_buffer_allocate_time_sent(bool reset)
         {
             return parcels_sent_.total_buffer_allocate_time(reset);
@@ -292,19 +298,13 @@ namespace hpx { namespace parcelset
             return parcels_received_.total_buffer_allocate_time(reset);
         }
 
-        /// total data (uncompressed) received (bytes)
-        boost::uint64_t get_raw_data_received(bool reset)
-        {
-            return parcels_received_.total_raw_bytes(reset);
-        }
-
         boost::uint64_t get_pending_parcels_count(bool /*reset*/)
         {
             std::lock_guard<lcos::local::spinlock> l(mtx_);
             return pending_parcels_.size();
         }
 
-
+        ///////////////////////////////////////////////////////////////////////
         void set_applier(applier::applier * applier)
         {
             applier_ = applier;

--- a/hpx/runtime/serialization/output_container.hpp
+++ b/hpx/runtime/serialization/output_container.hpp
@@ -50,7 +50,7 @@ namespace hpx { namespace serialization
             }
 
             static bool flush(binary_filter* filter, Container& cont,
-                std::size_t current, std::size_t size, std::size_t written)
+                std::size_t current, std::size_t size, std::size_t& written)
             {
                 return filter->flush(&cont[current], size, written);
             }

--- a/plugins/binary_filter/bzip2/CMakeLists.txt
+++ b/plugins/binary_filter/bzip2/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2007-2013 Hartmut Kaiser
+# Copyright (c) 2007-2016 Hartmut Kaiser
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -26,8 +26,11 @@ macro(add_bzip2_module)
 
     add_hpx_library(compress_bzip2
       PLUGIN
-      SOURCES "${PROJECT_SOURCE_DIR}/plugins/binary_filter/bzip2/bzip2_serialization_filter.cpp"
-      HEADERS "${PROJECT_SOURCE_DIR}/hpx/plugins/binary_filter/bzip2_serialization_filter.hpp"
+      SOURCES
+        "${PROJECT_SOURCE_DIR}/plugins/binary_filter/bzip2/bzip2_serialization_filter.cpp"
+      HEADERS
+        "${PROJECT_SOURCE_DIR}/hpx/plugins/binary_filter/bzip2_serialization_filter.hpp"
+        "${PROJECT_SOURCE_DIR}/hpx/plugins/binary_filter/bzip2_serialization_filter_registration.hpp"
       FOLDER "Core/Plugins/Compression"
       DEPENDENCIES ${BZIP2_LIBRARIES})
 

--- a/plugins/binary_filter/snappy/CMakeLists.txt
+++ b/plugins/binary_filter/snappy/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2007-2013 Hartmut Kaiser
+# Copyright (c) 2007-2016 Hartmut Kaiser
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -22,8 +22,11 @@ macro(add_snappy_module)
 
     add_hpx_library(compress_snappy
       PLUGIN
-      SOURCES "${PROJECT_SOURCE_DIR}/plugins/binary_filter/snappy/snappy_serialization_filter.cpp"
-      HEADERS "${PROJECT_SOURCE_DIR}/hpx/plugins/binary_filter/snappy_serialization_filter.hpp"
+      SOURCES
+        "${PROJECT_SOURCE_DIR}/plugins/binary_filter/snappy/snappy_serialization_filter.cpp"
+      HEADERS
+        "${PROJECT_SOURCE_DIR}/hpx/plugins/binary_filter/snappy_serialization_filter.hpp"
+        "${PROJECT_SOURCE_DIR}/hpx/plugins/binary_filter/snappy_serialization_filter_registration.hpp"
       FOLDER "Core/Plugins/Compression"
       DEPENDENCIES ${SNAPPY_LIBRARY})
 

--- a/plugins/binary_filter/zlib/CMakeLists.txt
+++ b/plugins/binary_filter/zlib/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2007-2013 Hartmut Kaiser
+# Copyright (c) 2007-2016 Hartmut Kaiser
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -26,8 +26,11 @@ macro(add_zlib_module)
 
     add_hpx_library(compress_zlib
       PLUGIN
-      SOURCES "${PROJECT_SOURCE_DIR}/plugins/binary_filter/zlib/zlib_serialization_filter.cpp"
-      HEADERS "${PROJECT_SOURCE_DIR}/hpx/plugins/binary_filter/zlib_serialization_filter.hpp"
+      SOURCES
+        "${PROJECT_SOURCE_DIR}/plugins/binary_filter/zlib/zlib_serialization_filter.cpp"
+      HEADERS
+        "${PROJECT_SOURCE_DIR}/hpx/plugins/binary_filter/zlib_serialization_filter.hpp"
+        "${PROJECT_SOURCE_DIR}/hpx/plugins/binary_filter/zlib_serialization_filter_registration.hpp"
       FOLDER "Core/Plugins/Compression"
       DEPENDENCIES ${ZLIB_LIBRARIES})
 

--- a/tests/unit/parcelset/CMakeLists.txt
+++ b/tests/unit/parcelset/CMakeLists.txt
@@ -20,6 +20,12 @@ if(HPX_WITH_PARCEL_COALESCING)
   set(put_parcels_with_coalescing_FLAGS DEPENDENCIES iostreams_component)
 endif()
 
+if(HPX_WITH_COMPRESSION_BZIP2 OR HPX_WITH_COMPRESSION_ZLIB OR HPX_WITH_COMPRESSION_SNAPPY)
+  set(tests ${tests} put_parcels_with_compression)
+  set(put_parcels_with_compression_PARAMETERS LOCALITIES 2)
+  set(put_parcels_with_compression_FLAGS DEPENDENCIES iostreams_component)
+endif()
+
 foreach(test ${tests})
   set(sources
       ${test}.cpp)

--- a/tests/unit/parcelset/put_parcels_with_compression.cpp
+++ b/tests/unit/parcelset/put_parcels_with_compression.cpp
@@ -1,0 +1,305 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/actions.hpp>
+#include <hpx/include/performance_counters.hpp>
+#include <hpx/include/iostreams.hpp>
+#include <hpx/include/compression_registration.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+std::size_t const vsize_default = 1024;
+std::size_t const numparcels_default = 10;
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename Action, typename T>
+hpx::parcelset::parcel
+generate_parcel(hpx::id_type const& dest, hpx::id_type const& cont, T && data)
+{
+    hpx::naming::address addr;
+    hpx::parcelset::parcel p(dest, addr,
+        hpx::actions::typed_continuation<hpx::id_type>(cont),
+        Action(), hpx::threads::thread_priority_normal,
+        std::forward<T>(data));
+
+    p.parcel_id() = hpx::parcelset::parcel::generate_unique_id();
+    p.set_source_id(hpx::find_here());
+
+    return p;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+struct test_server : hpx::components::component_base<test_server>
+{
+    typedef hpx::components::component_base<test_server> base_type;
+
+    hpx::id_type test1(std::vector<double> const& data)
+    {
+        return hpx::find_here();
+    }
+
+    HPX_DEFINE_COMPONENT_ACTION(test_server, test1, test1_action);
+};
+
+typedef hpx::components::component<test_server> server_type;
+HPX_REGISTER_COMPONENT(server_type, test_server);
+
+typedef test_server::test1_action test1_action;
+
+HPX_REGISTER_ACTION_DECLARATION(test1_action);
+
+#if defined(HPX_HAVE_COMPRESSION_BZIP2)
+HPX_ACTION_USES_BZIP2_COMPRESSION(test1_action)
+#elif defined(HPX_HAVE_COMPRESSION_ZLIB)
+HPX_ACTION_USES_ZLIB_COMPRESSION(test1_action)
+#elif defined(HPX_HAVE_COMPRESSION_SNAPPY)
+HPX_ACTION_USES_SNAPPY_COMPRESSION(test1_action)
+#endif
+
+HPX_REGISTER_ACTION(test1_action);
+
+///////////////////////////////////////////////////////////////////////////////
+void test_plain_argument(hpx::id_type const& id)
+{
+    std::vector<double> data(vsize_default);
+    std::generate(data.begin(), data.end(), std::rand);
+
+    std::vector<hpx::future<hpx::id_type> > results;
+    results.reserve(numparcels_default);
+
+    hpx::components::client<test_server> c = hpx::new_<test_server>(id);
+
+    // create parcels
+    std::vector<hpx::parcelset::parcel> parcels;
+    for (std::size_t i = 0; i != numparcels_default; ++i)
+    {
+        hpx::lcos::promise<hpx::id_type> p;
+        parcels.push_back(
+            generate_parcel<test1_action>(c.get_id(), p.get_id(), data)
+        );
+        results.push_back(p.get_future());
+    }
+
+    // send parcels
+    hpx::get_runtime().get_parcel_handler().put_parcels(std::move(parcels));
+
+    // verify all messages got actually sent to the correct locality
+    hpx::wait_all(results);
+
+    for (hpx::future<hpx::id_type>& f : results)
+    {
+        HPX_TEST(f.get() == id);
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+hpx::id_type test2(hpx::future<double> const& data)
+{
+    return hpx::find_here();
+}
+
+HPX_DECLARE_PLAIN_ACTION(test2, test2_action);
+
+#if defined(HPX_HAVE_COMPRESSION_BZIP2)
+HPX_ACTION_USES_BZIP2_COMPRESSION(test2_action)
+#elif defined(HPX_HAVE_COMPRESSION_ZLIB)
+HPX_ACTION_USES_ZLIB_COMPRESSION(test2_action)
+#elif defined(HPX_HAVE_COMPRESSION_SNAPPY)
+HPX_ACTION_USES_SNAPPY_COMPRESSION(test2_action)
+#endif
+
+HPX_PLAIN_ACTION(test2, test2_action);
+
+void test_future_argument(hpx::id_type const& id)
+{
+    std::vector<hpx::lcos::local::promise<double> > args;
+    args.reserve(numparcels_default);
+
+    std::vector<hpx::future<hpx::id_type> > results;
+    results.reserve(numparcels_default);
+
+    // create parcels
+    std::vector<hpx::parcelset::parcel> parcels;
+    for (std::size_t i = 0; i != numparcels_default; ++i)
+    {
+        hpx::lcos::local::promise<double> p_arg;
+        hpx::lcos::promise<hpx::id_type> p_cont;
+
+        parcels.push_back(
+            generate_parcel<test2_action>(id, p_cont.get_id(),
+                p_arg.get_future())
+        );
+
+        args.push_back(std::move(p_arg));
+        results.push_back(p_cont.get_future());
+    }
+
+    // send parcels
+    hpx::get_runtime().get_parcel_handler().put_parcels(std::move(parcels));
+
+    // now make the futures ready
+    for (hpx::lcos::local::promise<double>& arg : args)
+    {
+        arg.set_value(42.0);
+    }
+
+    // verify all messages got actually sent to the correct locality
+    hpx::wait_all(results);
+
+    for (hpx::future<hpx::id_type>& f : results)
+    {
+        HPX_TEST(f.get() == id);
+    }
+}
+
+void test_mixed_arguments(hpx::id_type const& id)
+{
+    std::vector<double> data(vsize_default);
+    std::generate(data.begin(), data.end(), std::rand);
+
+    std::vector<hpx::lcos::local::promise<double> > args;
+    args.reserve(numparcels_default);
+
+    std::vector<hpx::future<hpx::id_type> > results;
+    results.reserve(numparcels_default);
+
+    hpx::components::client<test_server> c = hpx::new_<test_server>(id);
+
+    // create parcels
+    std::vector<hpx::parcelset::parcel> parcels;
+    for (std::size_t i = 0; i != numparcels_default; ++i)
+    {
+        hpx::lcos::promise<hpx::id_type> p_cont;
+
+        if (std::rand() % 2)
+        {
+            parcels.push_back(
+                generate_parcel<test1_action>(c.get_id(), p_cont.get_id(), data)
+            );
+        }
+        else
+        {
+            hpx::lcos::local::promise<double> p_arg;
+
+            parcels.push_back(
+                generate_parcel<test2_action>(id, p_cont.get_id(),
+                    p_arg.get_future())
+            );
+
+            args.push_back(std::move(p_arg));
+        }
+
+        results.push_back(p_cont.get_future());
+    }
+
+    // send parcels
+    hpx::get_runtime().get_parcel_handler().put_parcels(std::move(parcels));
+
+    // now make the futures ready
+    for (hpx::lcos::local::promise<double>& arg : args)
+    {
+        arg.set_value(42.0);
+    }
+
+    // verify all messages got actually sent to the correct locality
+    hpx::wait_all(results);
+
+    for (hpx::future<hpx::id_type>& f : results)
+    {
+        HPX_TEST(f.get() == id);
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void verify_counters()
+{
+    using namespace hpx::performance_counters;
+
+    std::vector<performance_counter> data_counters =
+        discover_counters("/data/count/*/*");
+    std::vector<performance_counter> serialize_counters =
+        discover_counters("/serialize/count/*/*");
+
+    HPX_TEST_EQ(data_counters.size(), serialize_counters.size());
+
+    for (std::size_t i = 0; i != data_counters.size(); ++i)
+    {
+        performance_counter const& serialize_counter = serialize_counters[i];
+        performance_counter const& data_counter = data_counters[i];
+
+        counter_value serialize_value = serialize_counter.get_counter_value_sync();
+        counter_value data_value = data_counter.get_counter_value_sync();
+
+        double serialize_val = serialize_value.get_value<double>();
+        double data_val = data_value.get_value<double>();
+
+        std::string serialize_name = serialize_counter.get_name_sync();
+        std::string data_name = data_counter.get_name_sync();
+
+        if (data_val != 0 && serialize_val != 0)
+        {
+            // compression should reduce the transmitted amount of data
+            HPX_TEST(data_val >= serialize_val);
+        }
+
+        hpx::cout
+            << "counter: " << serialize_name
+            << ", value: " << serialize_value.get_value<double>()
+            << std::endl;
+        hpx::cout
+            << "counter: " << data_name
+            << ", value: " << data_value.get_value<double>()
+            << std::endl;
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int)std::time(0);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    for (hpx::id_type const& id : hpx::find_remote_localities())
+    {
+        test_plain_argument(id);
+        test_future_argument(id);
+        test_mixed_arguments(id);
+    }
+
+    // make sure compression was actually invoked
+    verify_counters();
+
+    return hpx::finalize();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace boost::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()
+        ("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run")
+        ;
+
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
- extract registration macros for compression into separate files
- flyby: make client<>::client(future<id_type>&&) non-explicit
- flyby: added HPX_DECLARE_PLAIN_ACTION
- flyby: fix performance counter mix-up of sent bytes and serialized bytes

This also fixes #2124