### PR TITLE
Add several include checks for std facilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -875,6 +875,9 @@ hpx_check_for_cxx11_std_unique_ptr(
 hpx_check_for_cxx11_std_unordered_map(
   REQUIRED "HPX needs support for C++11 std::unordered_map")
 
+hpx_check_for_cxx11_std_unordered_set(
+  REQUIRED "HPX needs support for C++11 std::unordered_set")
+
 hpx_check_for_cxx11_std_type_traits(
   DEFINITIONS HPX_HAVE_CXX11_STD_TYPE_TRAITS)
 

--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -396,6 +396,13 @@ macro(hpx_check_for_cxx11_std_unordered_map)
 endmacro()
 
 ###############################################################################
+macro(hpx_check_for_cxx11_std_unordered_set)
+  add_hpx_config_test(HPX_WITH_CXX11_UNORDERED_SET
+    SOURCE cmake/tests/cxx11_std_unordered_set.cpp
+    FILE ${ARGN})
+endmacro()
+
+###############################################################################
 macro(hpx_check_for_cxx11_extended_friend_declarations)
   add_hpx_config_test(HPX_WITH_CXX11_EXTENDED_FRIEND_DECLARATIONS
     SOURCE cmake/tests/cxx11_extended_friend_declarations.cpp

--- a/cmake/tests/cxx11_std_unordered_map.cpp
+++ b/cmake/tests/cxx11_std_unordered_map.cpp
@@ -14,4 +14,9 @@ int main()
     u.insert(std::make_pair("RED", 0xFF0000));
     u.insert(std::make_pair("GREEN", 0x00FF00));
     u.insert(std::make_pair("BLUE", 0x0000FF));
+
+    std::unordered_multimap<std::string, unsigned> um;
+    um.insert(std::make_pair("RED", 0xFF0000));
+    um.insert(std::make_pair("GREEN", 0x00FF00));
+    um.insert(std::make_pair("BLUE", 0x0000FF));
 }

--- a/cmake/tests/cxx11_std_unordered_set.cpp
+++ b/cmake/tests/cxx11_std_unordered_set.cpp
@@ -1,0 +1,21 @@
+////////////////////////////////////////////////////////////////////////////////
+//  Copyright (c) 2016 Agustin Berge
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+////////////////////////////////////////////////////////////////////////////////
+
+#include <unordered_set>
+
+int main()
+{
+    std::unordered_set<unsigned> u;
+    u.insert(0xFF0000);
+    u.insert(0x00FF00);
+    u.insert(0x0000FF);
+
+    std::unordered_multiset<unsigned> um;
+    um.insert(0xFF0000);
+    um.insert(0x00FF00);
+    um.insert(0x0000FF);
+}

--- a/examples/1d_stencil/1d_stencil_4.cpp
+++ b/examples/1d_stencil/1d_stencil_4.cpp
@@ -20,6 +20,7 @@
 #include <hpx/include/parallel_algorithm.hpp>
 #include <boost/range/irange.hpp>
 
+#include <memory>
 #include <vector>
 
 #include "print_time_results.hpp"

--- a/examples/1d_stencil/1d_stencil_4_repart.cpp
+++ b/examples/1d_stencil/1d_stencil_4_repart.cpp
@@ -28,6 +28,7 @@
 #include <limits>
 #include <algorithm>
 #include <string>
+#include <memory>
 #include <vector>
 
 #include <apex_api.hpp>

--- a/examples/1d_stencil/1d_stencil_4_throttle.cpp
+++ b/examples/1d_stencil/1d_stencil_4_throttle.cpp
@@ -28,6 +28,7 @@
 #include <boost/cstdint.hpp>
 #include <boost/format.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/examples/apex/apex_fibonacci.cpp
+++ b/examples/apex/apex_fibonacci.cpp
@@ -14,6 +14,7 @@
 #include <apex_api.hpp>
 
 #include <iostream>
+#include <set>
 
 #include <boost/cstdint.hpp>
 #include <boost/format.hpp>

--- a/examples/sheneos/sheneos/interpolator.cpp
+++ b/examples/sheneos/sheneos/interpolator.cpp
@@ -13,6 +13,7 @@
 #include <hpx/lcos/local/packaged_task.hpp>
 #include <hpx/util/assert.hpp>
 
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/examples/tuplespace/central_tuplespace/server/tuples_warehouse.hpp
+++ b/examples/tuplespace/central_tuplespace/server/tuples_warehouse.hpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <map>
+#include <set>
 #include <vector>
 
 #include <boost/unordered_map.hpp>

--- a/examples/tuplespace/central_tuplespace/server/tuples_warehouse.hpp
+++ b/examples/tuplespace/central_tuplespace/server/tuples_warehouse.hpp
@@ -17,9 +17,9 @@
 #include <algorithm>
 #include <map>
 #include <set>
+#include <unordered_map>
 #include <vector>
 
-#include <boost/unordered_map.hpp>
 #include <hpx/util/storage/tuple.hpp>
 
 // #define TS_DEBUG
@@ -271,7 +271,7 @@ namespace examples { namespace server
                 typedef examples::server::tuples_warehouse::elem_type elem_type;
                 typedef examples::server::tuples_warehouse::index_type index_type;
 
-                typedef boost::unordered_multimap<elem_type,
+                typedef std::unordered_multimap<elem_type,
                     index_type, hash_elem_functor> field_index_map_type;
                 typedef field_index_map_type::iterator
                     field_index_map_iterator_type;

--- a/examples/tuplespace/central_tuplespace/server/tuples_warehouse.hpp
+++ b/examples/tuplespace/central_tuplespace/server/tuples_warehouse.hpp
@@ -15,6 +15,7 @@
 #include <hpx/lcos/local/mutex.hpp>
 
 #include <algorithm>
+#include <map>
 #include <vector>
 
 #include <boost/unordered_map.hpp>

--- a/hpx/components/security/certificate_store.hpp
+++ b/hpx/components/security/certificate_store.hpp
@@ -19,6 +19,7 @@
 #include "public_key.hpp"
 #include "signed_type.hpp"
 
+#include <map>
 #include <sstream>
 
 namespace hpx { namespace components { namespace security

--- a/hpx/performance_counters/registry.hpp
+++ b/hpx/performance_counters/registry.hpp
@@ -11,6 +11,7 @@
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/util/function.hpp>
 
+#include <map>
 #include <string>
 #include <vector>
 

--- a/hpx/plugins/parcelport/ibverbs/connection_handler.hpp
+++ b/hpx/plugins/parcelport/ibverbs/connection_handler.hpp
@@ -23,6 +23,7 @@
 
 #include <boost/atomic.hpp>
 
+#include <map>
 #include <memory>
 #include <vector>
 

--- a/hpx/plugins/parcelport/ipc/connection_handler.hpp
+++ b/hpx/plugins/parcelport/ipc/connection_handler.hpp
@@ -18,6 +18,7 @@
 #include <hpx/util/runtime_configuration.hpp>
 
 #include <memory>
+#include <set>
 
 #include <hpx/config/warnings_prefix.hpp>
 

--- a/hpx/plugins/parcelport/mpi/receiver.hpp
+++ b/hpx/plugins/parcelport/mpi/receiver.hpp
@@ -19,6 +19,7 @@
 #include <list>
 #include <memory>
 #include <mutex>
+#include <set>
 
 namespace hpx { namespace parcelset { namespace policies { namespace mpi
 {

--- a/hpx/plugins/parcelport/tcp/connection_handler.hpp
+++ b/hpx/plugins/parcelport/tcp/connection_handler.hpp
@@ -24,6 +24,7 @@
 #include <boost/asio/ip/host_name.hpp>
 
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 

--- a/hpx/runtime.hpp
+++ b/hpx/runtime.hpp
@@ -34,6 +34,7 @@
 #include <boost/exception_ptr.hpp>
 #include <boost/smart_ptr/scoped_ptr.hpp>
 
+#include <map>
 #include <memory>
 #include <mutex>
 #include <string>

--- a/hpx/runtime/agas/addressing_service.hpp
+++ b/hpx/runtime/agas/addressing_service.hpp
@@ -33,6 +33,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <set>
 #include <string>
 #include <vector>
 

--- a/hpx/runtime/agas/response.hpp
+++ b/hpx/runtime/agas/response.hpp
@@ -23,6 +23,7 @@
 #include <boost/variant.hpp>
 #include <boost/mpl/at.hpp>
 
+#include <map>
 #include <memory>
 #include <numeric>
 #include <string>

--- a/hpx/runtime/components/static_factory_data.hpp
+++ b/hpx/runtime/components/static_factory_data.hpp
@@ -15,6 +15,7 @@
 
 #include <boost/preprocessor/stringize.hpp>
 
+#include <map>
 #include <string>
 
 namespace hpx { namespace components

--- a/hpx/runtime/parcelset/locality.hpp
+++ b/hpx/runtime/parcelset/locality.hpp
@@ -17,6 +17,7 @@
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/or.hpp>
 
+#include <map>
 #include <memory>
 #include <string>
 

--- a/hpx/runtime/serialization/detail/future_await_container.hpp
+++ b/hpx/runtime/serialization/detail/future_await_container.hpp
@@ -15,6 +15,7 @@
 #include <hpx/lcos/local/promise.hpp>
 #include <hpx/util/unwrapped.hpp>
 
+#include <map>
 #include <memory>
 #include <mutex>
 #include <vector>

--- a/hpx/runtime/serialization/input_archive.hpp
+++ b/hpx/runtime/serialization/input_archive.hpp
@@ -20,6 +20,7 @@
 #include <boost/type_traits/is_enum.hpp>
 #include <boost/utility/enable_if.hpp>
 
+#include <map>
 #include <memory>
 #include <vector>
 

--- a/hpx/runtime/serialization/output_archive.hpp
+++ b/hpx/runtime/serialization/output_archive.hpp
@@ -20,6 +20,7 @@
 #include <boost/type_traits/is_enum.hpp>
 #include <boost/utility/enable_if.hpp>
 
+#include <map>
 #include <memory>
 #include <vector>
 

--- a/hpx/runtime/threads/policies/thread_queue.hpp
+++ b/hpx/runtime/threads/policies/thread_queue.hpp
@@ -26,24 +26,28 @@
 #include <boost/exception_ptr.hpp>
 #include <boost/thread/condition.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/unordered_set.hpp>
 
+#include <cstddef>
+#include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
+#include <unordered_set>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace boost
+namespace std
 {
     template <>
-    struct hash<hpx::threads::thread_id_type>
+    struct hash< ::hpx::threads::thread_id_type>
     {
-        std::size_t operator()(hpx::threads::thread_id_type const& v) const
+        typedef ::hpx::threads::thread_id_type argument_type;
+        typedef std::size_t result_type;
+
+        std::size_t operator()(::hpx::threads::thread_id_type const& v) const
         {
+            std::hash<std::size_t> hasher_;
             return hasher_(reinterpret_cast<std::size_t>(v.get()));
         }
-
-        boost::hash<std::size_t> hasher_;
     };
 }
 
@@ -116,7 +120,7 @@ namespace hpx { namespace threads { namespace policies
         };
 
         // this is the type of a map holding all threads (except depleted ones)
-        typedef boost::unordered_set<thread_id_type> thread_map_type;
+        typedef std::unordered_set<thread_id_type> thread_map_type;
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
         typedef

--- a/hpx/runtime/threads/resource_manager.hpp
+++ b/hpx/runtime/threads/resource_manager.hpp
@@ -14,6 +14,7 @@
 
 #include <boost/atomic.hpp>
 
+#include <map>
 #include <memory>
 #include <vector>
 

--- a/hpx/util/init_ini_data.hpp
+++ b/hpx/util/init_ini_data.hpp
@@ -14,6 +14,7 @@
 
 #include <boost/filesystem/path.hpp>
 
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/hpx/util/logging/format/formatter/named_spacer.hpp
+++ b/hpx/util/logging/format/formatter/named_spacer.hpp
@@ -28,6 +28,7 @@
 #include <hpx/util/logging/format/formatter/convert_format.hpp> // do_convert_format
 #include <hpx/util/logging/format/array.hpp> // array
 
+#include <map>
 #include <memory>
 #include <vector>
 

--- a/hpx/util/memory_chunk.hpp
+++ b/hpx/util/memory_chunk.hpp
@@ -19,6 +19,7 @@
 #include <hpx/runtime/threads/coroutines/detail/posix_utility.hpp>
 #endif
 
+#include <map>
 #include <memory>
 #include <mutex>
 

--- a/hpx/util/memory_chunk_pool.hpp
+++ b/hpx/util/memory_chunk_pool.hpp
@@ -15,6 +15,7 @@
 #include <boost/atomic.hpp>
 
 #include <cstdlib>
+#include <map>
 #include <mutex>
 #include <vector>
 

--- a/hpx/util/runtime_configuration.hpp
+++ b/hpx/util/runtime_configuration.hpp
@@ -17,6 +17,7 @@
 
 #include <boost/cstdint.hpp>
 
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -43,6 +43,7 @@
 #include <boost/format.hpp>
 #include <boost/icl/closed_interval.hpp>
 
+#include <map>
 #include <memory>
 #include <mutex>
 #include <string>

--- a/src/runtime/agas/response.cpp
+++ b/src/runtime/agas/response.cpp
@@ -16,6 +16,7 @@
 #include <hpx/runtime/serialization/serialize.hpp>
 #include <hpx/util/tuple.hpp>
 
+#include <map>
 #include <string>
 #include <vector>
 

--- a/src/runtime/agas/server/locality_namespace_server.cpp
+++ b/src/runtime/agas/server/locality_namespace_server.cpp
@@ -18,6 +18,7 @@
 #include <hpx/util/get_and_reset_value.hpp>
 
 #include <list>
+#include <map>
 #include <mutex>
 #include <string>
 #include <vector>

--- a/src/runtime/agas/stubs/locality_namespace_stubs.cpp
+++ b/src/runtime/agas/stubs/locality_namespace_stubs.cpp
@@ -9,6 +9,7 @@
 #include <hpx/apply.hpp>
 #include <hpx/runtime/agas/stubs/locality_namespace.hpp>
 
+#include <map>
 #include <vector>
 
 namespace hpx { namespace agas { namespace stubs

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -58,6 +58,7 @@
 #include <boost/tokenizer.hpp>
 
 #include <algorithm>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <set>

--- a/src/util/init_ini_data.cpp
+++ b/src/util/init_ini_data.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/util/runtime_configuration.cpp
+++ b/src/util/runtime_configuration.cpp
@@ -32,6 +32,7 @@
 
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 

--- a/src/util/runtime_configuration.cpp
+++ b/src/util/runtime_configuration.cpp
@@ -30,6 +30,7 @@
 #include <boost/spirit/include/qi_alternative.hpp>
 #include <boost/spirit/include/qi_sequence.hpp>
 
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/tests/unit/agas/find_clients_from_prefix.cpp
+++ b/tests/unit/agas/find_clients_from_prefix.cpp
@@ -9,6 +9,7 @@
 #include <hpx/include/components.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <set>
 #include <string>
 #include <vector>
 

--- a/tests/unit/agas/find_ids_from_prefix.cpp
+++ b/tests/unit/agas/find_ids_from_prefix.cpp
@@ -9,6 +9,7 @@
 #include <hpx/include/components.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <set>
 #include <string>
 #include <vector>
 

--- a/tests/unit/serialization/serialization_map.cpp
+++ b/tests/unit/serialization/serialization_map.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <map>
 #include <numeric>
 #include <vector>
 

--- a/tests/unit/serialization/serialization_set.cpp
+++ b/tests/unit/serialization/serialization_set.cpp
@@ -12,6 +12,7 @@
 
 #include <hpx/util/lightweight_test.hpp>
 
+#include <set>
 #include <vector>
 
 template <typename CARGO>

--- a/tests/unit/serialization/serialization_unordered_map.cpp
+++ b/tests/unit/serialization/serialization_unordered_map.cpp
@@ -103,7 +103,7 @@ void test_vector_as_value()
 {
     std::vector<char> buffer;
     hpx::serialization::output_archive oarchive(buffer);
-    std::map<size_t, std::vector<int> > os;
+    std::unordered_map<size_t, std::vector<int> > os;
     for (int k = 0; k < 10; ++k)
     {
         std::vector<int> vec(10);

--- a/tests/unit/serialization/serialization_unordered_map.cpp
+++ b/tests/unit/serialization/serialization_unordered_map.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <iterator>
 #include <numeric>
+#include <unordered_map>
 #include <vector>
 
 template <typename T>

--- a/tests/unit/serialization/zero_copy_serialization.cpp
+++ b/tests/unit/serialization/zero_copy_serialization.cpp
@@ -15,6 +15,7 @@
 #include <hpx/util/high_resolution_timer.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/tests/unit/util/any.cpp
+++ b/tests/unit/util/any.cpp
@@ -9,12 +9,12 @@
 #include <hpx/util/any.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
-#include <boost/unordered_map.hpp>
 #include <hpx/util/storage/tuple.hpp>
 
 #include <boost/any.hpp>
 
 #include <string>
+#include <unordered_map>
 
 #include "small_big_object.hpp"
 
@@ -46,7 +46,7 @@ int hpx_main(variables_map& vm)
             typedef hpx::util::any elem_type;
             typedef hpx::util::hash_any hash_elem_functor;
 
-            typedef boost::unordered_multimap<elem_type, index_type,
+            typedef std::unordered_multimap<elem_type, index_type,
                 hash_elem_functor> field_index_map_type;
             typedef field_index_map_type::iterator field_index_map_iterator_type;
 

--- a/tools/inspect/deprecated_include_check.cpp
+++ b/tools/inspect/deprecated_include_check.cpp
@@ -26,6 +26,7 @@ namespace boost
 //       { "boost/thread/locks.hpp", "mutex" },
       { "boost/type_traits\\.hpp", "separate type-traits headers" },
       { "boost/unordered_map\\.hpp", "unordered_map" },
+      { "boost/unordered_set\\.hpp", "unordered_set" },
       { 0, 0 }
     };
 

--- a/tools/inspect/deprecated_include_check.cpp
+++ b/tools/inspect/deprecated_include_check.cpp
@@ -25,6 +25,7 @@ namespace boost
       { "boost/atomic/atomic\\.hpp", "boost/atomic.hpp" },
 //       { "boost/thread/locks.hpp", "mutex" },
       { "boost/type_traits\\.hpp", "separate type-traits headers" },
+      { "boost/unordered_map\\.hpp", "unordered_map" },
       { 0, 0 }
     };
 

--- a/tools/inspect/deprecated_name_check.cpp
+++ b/tools/inspect/deprecated_name_check.cpp
@@ -32,6 +32,8 @@ namespace boost
       { "(\\bboost\\s*::\\s*decay\\b)", "std::decay" },
 //       { "(\\bboost\\s*::\\s*(is_[^\\s]*?\\b))", "std::\\2" },
       { "(\\bboost\\s*::\\s*lock_guard\\b)", "std::lock_guard" },
+      { "(\\bboost\\s*::\\s*unordered_map\\b)", "std::unordered_map" },
+      { "(\\bboost\\s*::\\s*unordered_multimap\\b)", "std::unordered_multimap" },
       { 0, 0 }
     };
 

--- a/tools/inspect/deprecated_name_check.cpp
+++ b/tools/inspect/deprecated_name_check.cpp
@@ -34,6 +34,8 @@ namespace boost
       { "(\\bboost\\s*::\\s*lock_guard\\b)", "std::lock_guard" },
       { "(\\bboost\\s*::\\s*unordered_map\\b)", "std::unordered_map" },
       { "(\\bboost\\s*::\\s*unordered_multimap\\b)", "std::unordered_multimap" },
+      { "(\\bboost\\s*::\\s*unordered_set\\b)", "std::unordered_set" },
+      { "(\\bboost\\s*::\\s*unordered_multiset\\b)", "std::unordered_multiset" },
       { 0, 0 }
     };
 

--- a/tools/inspect/include_check.cpp
+++ b/tools/inspect/include_check.cpp
@@ -36,6 +36,8 @@ namespace boost
       { "(\\bstd\\s*::\\s*unique_ptr\\b)", "std::unique_ptr", "memory" },
       { "(\\bstd\\s*::\\s*unordered_map\\b)", "std::unordered_map", "unordered_map" },
       { "(\\bstd\\s*::\\s*unordered_multimap\\b)", "std::unordered_multimap", "unordered_map" },
+      { "(\\bstd\\s*::\\s*unordered_set\\b)", "std::unordered_set", "unordered_set" },
+      { "(\\bstd\\s*::\\s*unordered_multiset\\b)", "std::unordered_multiset", "unordered_set" },
       { "(\\bstd\\s*::\\s*string\\b)", "std::string", "string" },
       { "(\\bstd\\s*::\\s*vector\\b)", "std::vector", "vector" },
       { "(\\bboost\\s*::\\s*atomic\\b)", "boost::atomic", "boost/atomic.hpp" },

--- a/tools/inspect/include_check.cpp
+++ b/tools/inspect/include_check.cpp
@@ -29,6 +29,7 @@ namespace boost
     {
       { "(\\bstd\\s*::\\s*make_shared\\b)", "std::make_shared", "memory" },
       { "(\\bstd\\s*::\\s*shared_ptr\\b)", "std::shared_ptr", "memory" },
+      { "(\\bstd\\s*::\\s*unique_ptr\\b)", "std::unique_ptr", "memory" },
       { "(\\bstd\\s*::\\s*string\\b)", "std::string", "string" },
       { "(\\bstd\\s*::\\s*vector\\b)", "std::vector", "vector" },
       { "(\\bboost\\s*::\\s*atomic\\b)", "boost::atomic", "boost/atomic.hpp" },

--- a/tools/inspect/include_check.cpp
+++ b/tools/inspect/include_check.cpp
@@ -34,6 +34,8 @@ namespace boost
       { "(\\bstd\\s*::\\s*set\\b)", "std::set", "set" },
       { "(\\bstd\\s*::\\s*shared_ptr\\b)", "std::shared_ptr", "memory" },
       { "(\\bstd\\s*::\\s*unique_ptr\\b)", "std::unique_ptr", "memory" },
+      { "(\\bstd\\s*::\\s*unordered_map\\b)", "std::unordered_map", "unordered_map" },
+      { "(\\bstd\\s*::\\s*unordered_multimap\\b)", "std::unordered_multimap", "unordered_map" },
       { "(\\bstd\\s*::\\s*string\\b)", "std::string", "string" },
       { "(\\bstd\\s*::\\s*vector\\b)", "std::vector", "vector" },
       { "(\\bboost\\s*::\\s*atomic\\b)", "boost::atomic", "boost/atomic.hpp" },

--- a/tools/inspect/include_check.cpp
+++ b/tools/inspect/include_check.cpp
@@ -30,6 +30,8 @@ namespace boost
       { "(\\bstd\\s*::\\s*make_shared\\b)", "std::make_shared", "memory" },
       { "(\\bstd\\s*::\\s*map\\b)", "std::map", "map" },
       { "(\\bstd\\s*::\\s*multimap\\b)", "std::multimap", "map" },
+      { "(\\bstd\\s*::\\s*multiset\\b)", "std::multiset", "set" },
+      { "(\\bstd\\s*::\\s*set\\b)", "std::set", "set" },
       { "(\\bstd\\s*::\\s*shared_ptr\\b)", "std::shared_ptr", "memory" },
       { "(\\bstd\\s*::\\s*unique_ptr\\b)", "std::unique_ptr", "memory" },
       { "(\\bstd\\s*::\\s*string\\b)", "std::string", "string" },

--- a/tools/inspect/include_check.cpp
+++ b/tools/inspect/include_check.cpp
@@ -28,6 +28,8 @@ namespace boost
     names_includes const names[] =
     {
       { "(\\bstd\\s*::\\s*make_shared\\b)", "std::make_shared", "memory" },
+      { "(\\bstd\\s*::\\s*map\\b)", "std::map", "map" },
+      { "(\\bstd\\s*::\\s*multimap\\b)", "std::multimap", "map" },
       { "(\\bstd\\s*::\\s*shared_ptr\\b)", "std::shared_ptr", "memory" },
       { "(\\bstd\\s*::\\s*unique_ptr\\b)", "std::unique_ptr", "memory" },
       { "(\\bstd\\s*::\\s*string\\b)", "std::string", "string" },


### PR DESCRIPTION
Add `#include` checks for `std::unique_ptr`, `std::[multi]map`, `std::[multi]set`, `std::unordered_[multi]map`, `std::unordered_[multi]set`.