### PR TITLE
Resolved memory leak in stencil_8

### DIFF
--- a/examples/1d_stencil/1d_stencil_8.cpp
+++ b/examples/1d_stencil/1d_stencil_8.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014 Hartmut Kaiser
+//  Copyright (c) 2014-2016 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,7 +6,7 @@
 // This is the eighth in a series of examples demonstrating the development
 // of a fully distributed solver for a simple 1D heat distribution problem.
 //
-// This example builds on example seven.
+// This example builds upon and extends example seven.
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
@@ -14,17 +14,21 @@
 #include <hpx/runtime/serialization/serialize.hpp>
 
 #include <boost/shared_array.hpp>
+#include <boost/cstdint.hpp>
 
 #include "print_time_results.hpp"
 
+#include <iostream>
 #include <mutex>
 #include <stack>
 #include <string>
+#include <utility>
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
 // Command-line variables
 bool header = true; // print csv heading
+bool print_results = false;
 double k = 0.5;     // heat transfer coefficient
 double dt = 1.;     // time step
 double dx = 1.;     // grid spacing
@@ -44,8 +48,7 @@ private:
 public:
     partition_allocator(std::size_t max_size = std::size_t(-1))
       : max_size_(max_size)
-    {
-    }
+    {}
 
     ~partition_allocator()
     {
@@ -62,7 +65,9 @@ public:
     {
         std::lock_guard<mutex_type> l(mtx_);
         if (heap_.empty())
+        {
             return new T[n];
+        }
 
         T* next = heap_.top();
         heap_.pop();
@@ -298,7 +303,7 @@ struct partition : hpx::components::client_base<partition, partition_server>
       : base_type(std::move(id))
     {}
 
-    // Unwrap a future<partition> (a partition already holds a future to the
+    // Unwrap a future<partition> (a partition already is a future to the
     // id of the referenced object, thus unwrapping accesses this inner future).
     partition(hpx::future<partition> && c)
       : base_type(std::move(c))
@@ -329,8 +334,7 @@ struct stepper_server : hpx::components::component_base<stepper_server>
         right_(hpx::find_from_basename(
             stepper_basename, idx(hpx::get_locality_id(), +1, nl))),
         U_(2)
-    {
-    }
+    {}
 
     // do all the work on 'np' local partitions, 'nx' data points each, for
     // 'nt' time steps
@@ -352,6 +356,16 @@ struct stepper_server : hpx::components::component_base<stepper_server>
 
     HPX_DEFINE_COMPONENT_ACTION(stepper_server, from_right, from_right_action);
     HPX_DEFINE_COMPONENT_ACTION(stepper_server, from_left, from_left_action);
+
+    // release dependencies
+    void release_dependencies()
+    {
+        left_ = hpx::shared_future<hpx::id_type>();
+        right_ = hpx::shared_future<hpx::id_type>();
+    }
+
+    HPX_DEFINE_COMPONENT_ACTION(stepper_server, release_dependencies,
+        release_dependencies_action);
 
 protected:
     // Our operator
@@ -378,14 +392,8 @@ protected:
 
     // Helper functions to send our left and right boundary elements to
     // the neighbors.
-    void send_left(std::size_t t, partition p)
-    {
-        hpx::apply(from_right_action(), left_.get(), t, p);
-    }
-    void send_right(std::size_t t, partition p)
-    {
-        hpx::apply(from_left_action(), right_.get(), t, p);
-    }
+    inline void send_left(std::size_t t, partition p) const;
+    inline void send_right(std::size_t t, partition p) const;
 
 private:
     hpx::shared_future<hpx::id_type> left_, right_;
@@ -404,8 +412,26 @@ HPX_REGISTER_COMPONENT(stepper_server_type, stepper_server);
 
 // HPX_REGISTER_ACTION() exposes the component member function for remote
 // invocation.
+typedef stepper_server::from_right_action from_right_action;
+HPX_REGISTER_ACTION(from_right_action);
+
+typedef stepper_server::from_left_action from_left_action;
+HPX_REGISTER_ACTION(from_left_action);
+
 typedef stepper_server::do_work_action do_work_action;
 HPX_REGISTER_ACTION(do_work_action);
+
+typedef stepper_server::release_dependencies_action release_dependencies_action;
+HPX_REGISTER_ACTION(release_dependencies_action);
+
+void stepper_server::send_left(std::size_t t, partition p) const
+{
+    hpx::apply(from_right_action(), left_.get(), t, std::move(p));
+}
+void stepper_server::send_right(std::size_t t, partition p) const
+{
+    hpx::apply(from_left_action(), right_.get(), t, std::move(p));
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 // This is a client side member function can now be implemented as the
@@ -415,17 +441,29 @@ struct stepper : hpx::components::client_base<stepper, stepper_server>
     typedef hpx::components::client_base<stepper, stepper_server> base_type;
 
     // construct new instances/wrap existing steppers from other localities
-    stepper()
-      : base_type(hpx::new_<stepper_server>
-          (hpx::find_here(), hpx::get_num_localities_sync()))
+    stepper(std::size_t num_localities)
+      : base_type(hpx::new_<stepper_server>(hpx::find_here(), num_localities))
     {
-        hpx::register_with_basename(
-            stepper_basename, get_id(), hpx::get_locality_id());
+        hpx::register_with_basename(stepper_basename, get_id(),
+            hpx::get_locality_id());
     }
 
     stepper(hpx::future<hpx::id_type> && id)
       : base_type(std::move(id))
     {}
+
+    ~stepper()
+    {
+        // break cyclic dependencies
+        hpx::future<void> f1 = hpx::async(
+            release_dependencies_action(), get_id());
+
+        // release the reference held by AGAS
+        hpx::future<void> f2 = hpx::unregister_with_basename(
+            stepper_basename, hpx::get_locality_id());
+
+        hpx::wait_all(f1, f2);       // ignore exceptions
+    }
 
     hpx::future<stepper_server::space> do_work(
         std::size_t local_np, std::size_t nx, std::size_t nt)
@@ -440,14 +478,11 @@ struct stepper : hpx::components::client_base<stepper, stepper_server>
 partition stepper_server::heat_part(partition const& left,
     partition const& middle, partition const& right)
 {
-    using hpx::dataflow;
-    using hpx::util::unwrapped;
-
     hpx::shared_future<partition_data> middle_data =
         middle.get_data(partition_server::middle_partition);
 
     hpx::future<partition_data> next_middle = middle_data.then(
-        unwrapped(
+        hpx::util::unwrapped(
             [middle](partition_data const& m) -> partition_data
             {
                 // All local operations are performed once the middle data of
@@ -461,9 +496,9 @@ partition stepper_server::heat_part(partition const& left,
         )
     );
 
-    return dataflow(
+    return hpx::dataflow(
         hpx::launch::async,
-        unwrapped(
+        hpx::util::unwrapped(
             [left, middle, right](partition_data next, partition_data const& l,
                 partition_data const& m, partition_data const& r) -> partition
             {
@@ -490,9 +525,6 @@ partition stepper_server::heat_part(partition const& left,
 stepper_server::space stepper_server::do_work(std::size_t local_np,
     std::size_t nx, std::size_t nt)
 {
-    using hpx::dataflow;
-    using hpx::util::unwrapped;
-
     // U[t][i] is the state of position i at time t.
     for (space& s: U_)
         s.resize(local_np);
@@ -514,7 +546,7 @@ stepper_server::space stepper_server::do_work(std::size_t local_np,
         // handle special case (one partition per locality) in a special way
         if (local_np == 1)
         {
-            next[0] = dataflow(
+            next[0] = hpx::dataflow(
                     hpx::launch::async, &stepper_server::heat_part,
                     receive_left(t), current[0], receive_right(t)
                 );
@@ -528,7 +560,7 @@ stepper_server::space stepper_server::do_work(std::size_t local_np,
         }
         else
         {
-            next[0] = dataflow(
+            next[0] = hpx::dataflow(
                     hpx::launch::async, &stepper_server::heat_part,
                     receive_left(t), current[0], current[1]
                 );
@@ -538,13 +570,13 @@ stepper_server::space stepper_server::do_work(std::size_t local_np,
 
             for (std::size_t i = 1; i != local_np-1; ++i)
             {
-                next[i] = dataflow(
+                next[i] = hpx::dataflow(
                         hpx::launch::async, &stepper_server::heat_part,
                         current[i-1], current[i], current[i+1]
                     );
             }
 
-            next[local_np-1] = dataflow(
+            next[local_np-1] = hpx::dataflow(
                     hpx::launch::async, &stepper_server::heat_part,
                     current[local_np-2], current[local_np-1], receive_right(t)
                 );
@@ -560,17 +592,8 @@ stepper_server::space stepper_server::do_work(std::size_t local_np,
 HPX_REGISTER_GATHER(stepper_server::space, stepper_server_space_gatherer);
 
 ///////////////////////////////////////////////////////////////////////////////
-int hpx_main(boost::program_options::variables_map& vm)
+void do_all_work(boost::uint64_t nt, boost::uint64_t nx, boost::uint64_t np)
 {
-    using hpx::dataflow;
-
-    boost::uint64_t nt = vm["nt"].as<boost::uint64_t>();   // Number of steps.
-    boost::uint64_t nx = vm["nx"].as<boost::uint64_t>();   // Number of grid points.
-    boost::uint64_t np = vm["np"].as<boost::uint64_t>();   // Number of partitions.
-
-    if (vm.count("no-header"))
-        header = false;
-
     std::vector<hpx::id_type> localities = hpx::find_all_localities();
     std::size_t nl = localities.size();                    // Number of localities
 
@@ -578,11 +601,11 @@ int hpx_main(boost::program_options::variables_map& vm)
     {
         std::cout << "The number of partitions should not be smaller than "
                      "the number of localities" << std::endl;
-        return hpx::finalize();
+        return;
     }
 
     // Create the local stepper instance, register it
-    stepper step;
+    stepper step(nl);
 
     // Measure execution time.
     boost::uint64_t t = hpx::util::high_resolution_clock::now();
@@ -603,13 +626,15 @@ int hpx_main(boost::program_options::variables_map& vm)
         {
             stepper_server::space const& s = solution[i];
             for (std::size_t i = 0; i != s.size(); ++i)
+            {
                 s[i].get_data(partition_server::middle_partition).wait();
+            }
         }
 
         boost::uint64_t elapsed = hpx::util::high_resolution_clock::now() - t;
 
         // Print the solution at time-step 'nt'.
-        if (vm.count("results"))
+        if (print_results)
         {
             for (std::size_t i = 0; i != nl; ++i)
             {
@@ -630,6 +655,21 @@ int hpx_main(boost::program_options::variables_map& vm)
     {
         hpx::lcos::gather_there(gather_basename, std::move(result)).wait();
     }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    boost::uint64_t nt = vm["nt"].as<boost::uint64_t>();   // Number of steps.
+    boost::uint64_t nx = vm["nx"].as<boost::uint64_t>();   // Number of grid points.
+    boost::uint64_t np = vm["np"].as<boost::uint64_t>();   // Number of partitions.
+
+    if (vm.count("no-header"))
+        header = false;
+    if (vm.count("results"))
+        print_results = true;
+
+    do_all_work(nt, nx, np);
 
     return hpx::finalize();
 }

--- a/hpx/components/component_storage/component_storage.hpp
+++ b/hpx/components/component_storage/component_storage.hpp
@@ -26,6 +26,7 @@ namespace hpx { namespace components
     public:
         component_storage(hpx::id_type target_locality);
         component_storage(hpx::future<naming::id_type> && f);
+        component_storage(hpx::future<component_storage> && f);
 
         hpx::future<naming::id_type> migrate_to_here(std::vector<char> const&,
             naming::id_type, naming::address const&);

--- a/hpx/components/containers/unordered/unordered_map.hpp
+++ b/hpx/components/containers/unordered/unordered_map.hpp
@@ -470,7 +470,7 @@ namespace hpx
         }
 
         // Register this unordered_map with AGAS using the given symbolic name
-        future<void> register_as(std::string const& symbolic_name)
+        unordered_map register_as(std::string const& symbolic_name)
         {
             server::unordered_map_config_data data(partitions_);
 

--- a/hpx/lcos/gather.hpp
+++ b/hpx/lcos/gather.hpp
@@ -148,6 +148,8 @@ namespace hpx { namespace lcos
 
 namespace hpx { namespace lcos
 {
+    template <typename T> struct gather_client;
+
     namespace detail
     {
         ///////////////////////////////////////////////////////////////////////
@@ -180,6 +182,10 @@ namespace hpx { namespace lcos
             gather_server(std::size_t num_sites)
               : num_sites_(num_sites), data_(num_sites), gate_(num_sites)
             {}
+
+            ~gather_server()
+            {
+            }
 
             hpx::future<std::vector<T> > get_result(std::size_t which, T && t)
             {
@@ -222,38 +228,64 @@ namespace hpx { namespace lcos
         };
 
         ///////////////////////////////////////////////////////////////////////
-        inline hpx::id_type register_gather_name(hpx::future<hpx::id_type> f,
+        template <typename T>
+        gather_client<T> register_gather_name(gather_client<T> && c,
             std::string const& basename, std::size_t site)
         {
-            hpx::id_type target = f.get();
-            hpx::register_with_basename(basename, hpx::unmanaged(target), site);
-            return target;
+            hpx::future<void> f = c.register_as(
+                hpx::detail::name_from_basename(basename, site));
+
+            return f.then(
+                [c](hpx::future<void> && f)
+                {
+                    f.get();       // propagate exceptions
+                    return c;
+                });
         }
 
         ///////////////////////////////////////////////////////////////////////
         template <typename T>
         hpx::future<std::vector<T> >
-        gather_data(hpx::future<hpx::id_type> f, std::size_t site,
+        gather_data(gather_client<T> c, std::size_t site,
             hpx::future<T> result)
         {
             typedef typename gather_server<T>::get_result_action action_type;
-            return async(action_type(), f.get(), site, result.get());
+            return async(action_type(), c, site, result.get());
         }
 
         template <typename T>
         hpx::future<void>
-        set_data(hpx::future<hpx::id_type> f, std::size_t which,
+        set_data(gather_client<T> c, std::size_t which,
             hpx::future<T> result)
         {
             typedef typename gather_server<T>::set_result_action action_type;
-            return async(action_type(), f.get(), which, result.get());
+            return async(action_type(), c, which, result.get());
         }
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    hpx::future<hpx::id_type>
-    create_gatherer(char const* basename,
+    struct gather_client
+      : components::client_base<gather_client<T>, detail::gather_server<T> >
+    {
+        typedef components::client_base<
+                gather_client<T>, detail::gather_server<T>
+            > base_type;
+
+        gather_client() {}
+
+        gather_client(hpx::future<id_type> && f)
+          : base_type(std::move(f))
+        {}
+
+        gather_client(hpx::future<gather_client> && f)
+          : base_type(std::move(f))
+        {}
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    gather_client<T> create_gatherer(char const* basename,
         std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1))
@@ -264,10 +296,8 @@ namespace hpx { namespace lcos
             this_site = hpx::get_locality_id();
 
         // create a new gather_server
-        typedef typename util::decay<T>::type result_type;
-        hpx::future<hpx::id_type> id =
-            hpx::new_<detail::gather_server<result_type> >(
-                hpx::find_here(), num_sites);
+        gather_client<T> c = hpx::new_<detail::gather_server<T> >(
+            hpx::find_here(), num_sites);
 
         std::string name(basename);
         if (generation != std::size_t(-1))
@@ -275,8 +305,9 @@ namespace hpx { namespace lcos
 
         // register the gatherer's id using the given basename
         using util::placeholders::_1;
-        return id.then(
-                util::bind(&detail::register_gather_name, _1, name, this_site)
+        return c.then(
+                util::bind(util::one_shot(&detail::register_gather_name<T>),
+                    _1, name, this_site)
             );
     }
 
@@ -284,7 +315,7 @@ namespace hpx { namespace lcos
     // destination site needs to be handled differently
     template <typename T>
     hpx::future<std::vector<T> >
-    gather_here(hpx::future<hpx::id_type> f, hpx::future<T> result,
+    gather_here(gather_client<T> c, hpx::future<T> result,
         std::size_t this_site = std::size_t(-1))
     {
         if (this_site == std::size_t(-1))
@@ -292,9 +323,9 @@ namespace hpx { namespace lcos
 
         using util::placeholders::_1;
         using util::placeholders::_2;
-        return dataflow(
+        return dataflow(launch::sync,
                 util::bind(&detail::gather_data<T>, _1, this_site, _2),
-                std::move(f), std::move(result)
+                std::move(c), std::move(result)
             );
     }
 
@@ -310,8 +341,10 @@ namespace hpx { namespace lcos
         if (this_site == std::size_t(-1))
             this_site = hpx::get_locality_id();
 
+        typedef typename util::decay<T>::type result_type;
         return gather_here(
-            create_gatherer<T>(basename, num_sites, generation, this_site),
+            create_gatherer<result_type>(
+                basename, num_sites, generation, this_site),
             std::move(result), this_site);
     }
 
@@ -319,7 +352,7 @@ namespace hpx { namespace lcos
     // gather plain values
     template <typename T>
     hpx::future<std::vector<typename util::decay<T>::type> >
-    gather_here(hpx::future<hpx::id_type> f, T && result,
+    gather_here(gather_client<T> c, T && result,
         std::size_t this_site = std::size_t(-1))
     {
         if (this_site == std::size_t(-1))
@@ -329,9 +362,9 @@ namespace hpx { namespace lcos
         using util::placeholders::_2;
 
         typedef typename util::decay<T>::type result_type;
-        return dataflow(
+        return dataflow(launch::sync,
                 util::bind(&detail::gather_data<result_type>, _1, this_site, _2),
-                std::move(f), std::forward<T>(result)
+                std::move(c), std::forward<T>(result)
             );
     }
 
@@ -347,15 +380,17 @@ namespace hpx { namespace lcos
         if (this_site == std::size_t(-1))
             this_site = hpx::get_locality_id();
 
+        typedef typename util::decay<T>::type result_type;
         return gather_here(
-            create_gatherer<T>(basename, num_sites, generation, this_site),
+            create_gatherer<result_type>(
+                basename, num_sites, generation, this_site),
             std::forward<T>(result), this_site);
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
     hpx::future<void>
-    gather_there(hpx::future<hpx::id_type> id, hpx::future<T> result,
+    gather_there(gather_client<T> c, hpx::future<T> result,
         std::size_t this_site = std::size_t(-1))
     {
         if (this_site == std::size_t(-1))
@@ -363,9 +398,9 @@ namespace hpx { namespace lcos
 
         using util::placeholders::_1;
         using util::placeholders::_2;
-        return dataflow(
+        return dataflow(launch::sync,
                 util::bind(&detail::set_data<T>, _1, this_site, _2),
-                std::move(id), std::move(result)
+                std::move(c), std::move(result)
             );
     }
 
@@ -382,16 +417,17 @@ namespace hpx { namespace lcos
         if (generation != std::size_t(-1))
             name += std::to_string(generation) + "/";
 
-        return gather_there(
-            hpx::find_from_basename(name, root_site),
-            std::move(result), this_site);
+        gather_client<T> c;
+        c.connect_to(hpx::detail::name_from_basename(name, root_site));
+
+        return gather_there(c, std::move(result), this_site);
     }
 
     ///////////////////////////////////////////////////////////////////////////
     // gather plain values
     template <typename T>
     hpx::future<void>
-    gather_there(hpx::future<hpx::id_type> id, T && result,
+    gather_there(gather_client<T> c, T && result,
         std::size_t this_site = std::size_t(-1))
     {
         if (this_site == std::size_t(-1))
@@ -401,9 +437,9 @@ namespace hpx { namespace lcos
         using util::placeholders::_2;
 
         typedef typename util::decay<T>::type result_type;
-        return dataflow(
+        return dataflow(launch::sync,
                 util::bind(&detail::set_data<result_type>, _1, this_site, _2),
-                std::move(id), std::forward<T>(result)
+                std::move(c), std::forward<T>(result)
             );
     }
 
@@ -420,9 +456,10 @@ namespace hpx { namespace lcos
         if (generation != std::size_t(-1))
             name += std::to_string(generation) + "/";
 
-        return gather_there(
-            hpx::find_from_basename(name, root_site),
-            std::forward<T>(result), this_site);
+        gather_client<T> c;
+        c.connect_to(hpx::detail::name_from_basename(name, root_site));
+
+        return gather_there(c, std::forward<T>(result), this_site);
     }
 }}
 

--- a/hpx/lcos/latch.hpp
+++ b/hpx/lcos/latch.hpp
@@ -43,14 +43,20 @@ namespace hpx { namespace lcos
 
         /// Extension: Create a client side representation for the existing
         /// \a server#latch instance with the given global id \a id.
-        latch(hpx::future<naming::id_type> && id)
-          : base_type(id.share())
+        latch(hpx::future<naming::id_type> && f)
+          : base_type(std::move(f))
         {}
 
         /// Extension: Create a client side representation for the existing
         /// \a server#latch instance with the given global id \a id.
-        latch(hpx::shared_future<naming::id_type> const& id)
-          : base_type(id)
+        latch(hpx::shared_future<naming::id_type> const& latch)
+          : base_type(latch)
+        {}
+
+        /// Extension: Create a client side representation for the existing
+        /// \a server#latch instance with the given global id \a id.
+        latch(hpx::future<latch> && f)
+          : base_type(std::move(f))
         {}
 
         ///////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/basename_registration.hpp
+++ b/hpx/runtime/basename_registration.hpp
@@ -18,6 +18,14 @@
 
 namespace hpx
 {
+    /// \cond NOINTERNAL
+    namespace detail
+    {
+        HPX_API_EXPORT std::string name_from_basename(
+            std::string const& basename, std::size_t idx);
+    }
+    /// \endcond
+
     ///////////////////////////////////////////////////////////////////////////
     /// Return all registered ids from all localities from the given base
     /// name.
@@ -219,8 +227,7 @@ namespace hpx
     /// \note    The operation will fail if the given sequence number is not
     ///          unique.
     ///
-    template <typename Client, typename Stub>
-    hpx::future<bool> register_with_basename(std::string base_name,
+    inline hpx::future<bool> register_with_basename(std::string base_name,
         hpx::future<hpx::id_type> f, std::size_t sequence_nr = ~0U)
     {
         return f.then(

--- a/src/components/component_storage/component_storage.cpp
+++ b/src/components/component_storage/component_storage.cpp
@@ -7,6 +7,7 @@
 
 #include <hpx/components/component_storage/component_storage.hpp>
 
+#include <utility>
 #include <vector>
 
 namespace hpx { namespace components
@@ -16,7 +17,11 @@ namespace hpx { namespace components
     {}
 
     component_storage::component_storage(hpx::future<naming::id_type> && f)
-      : base_type(hpx::new_<server::component_storage>(f.get()))
+      : base_type(std::move(f))
+    {}
+
+    component_storage::component_storage(hpx::future<component_storage> && f)
+      : base_type(std::move(f))
     {}
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -3179,8 +3179,8 @@ namespace hpx
 {
     namespace detail
     {
-        inline std::string
-        name_from_basename(std::string const& basename, std::size_t idx)
+        std::string name_from_basename(std::string const& basename,
+            std::size_t idx)
         {
             HPX_ASSERT(!basename.empty());
 


### PR DESCRIPTION
- flyby: change gather API to rely on clients instead of future<id_type>
- flyby: fixed one of the register_with_basename API overloads


This fixes #2121