### PR TITLE
Some minor tweaks to compute prototype

### DIFF
--- a/hpx/compute/cuda/detail/launch.hpp
+++ b/hpx/compute/cuda/detail/launch.hpp
@@ -9,6 +9,8 @@
 #define HPX_COMPUTE_CUDA_DETAIL_LAUNCH_HPP
 
 #include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_CUDA)
 #include <hpx/compute/cuda/target.hpp>
 #include <hpx/compute/cuda/detail/scoped_active_target.hpp>
 #include <hpx/util/deferred_call.hpp>
@@ -26,18 +28,22 @@ namespace hpx { namespace compute { namespace cuda { namespace detail
     // Launch any given function F with the given parameters. This function does
     // not involve any device synchronization.
     template <typename F, typename DimType, typename ...Ts>
-    void launch(target const& t, DimType gridDim, DimType blockDim, F && f, Ts &&... vs)
+    void launch(target const& t, DimType gridDim, DimType blockDim, F && f,
+        Ts &&... vs)
     {
 #if !defined(__CUDA_ARCH__)
         detail::scoped_active_target active(t);
 
-        auto closure = util::deferred_call(std::forward<F>(f), std::forward<Ts>(vs)...);
+        auto closure = util::deferred_call(std::forward<F>(f),
+            std::forward<Ts>(vs)...);
         typedef decltype(closure) closure_type;
 
         void (*launch_function)(closure_type) = launch_helper<closure_type>;
-        launch_function<<<gridDim, blockDim, 0, active.stream()>>>(std::move(closure));
+        launch_function<<<gridDim, blockDim, 0, active.stream()> > >(
+            std::move(closure));
 #endif
     }
 }}}}
 
+#endif
 #endif

--- a/hpx/compute/cuda/detail/scoped_active_target.hpp
+++ b/hpx/compute/cuda/detail/scoped_active_target.hpp
@@ -9,6 +9,8 @@
 #define HPX_COMPUTE_CUDA_DETAIL_SCOPED_ACTIVE_TARGET_HPP
 
 #include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
 #include <hpx/compute/cuda/target.hpp>
 #include <hpx/util/assert.hpp>
 
@@ -58,4 +60,5 @@ namespace hpx { namespace compute { namespace cuda { namespace detail
     };
 }}}}
 
+#endif
 #endif

--- a/hpx/compute/cuda/get_targets.hpp
+++ b/hpx/compute/cuda/get_targets.hpp
@@ -10,6 +10,7 @@
 
 #include <hpx/config.hpp>
 
+#if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
 #include <cuda_runtime.h>
 
 #include <vector>
@@ -33,4 +34,5 @@ namespace hpx { namespace compute { namespace cuda
     }
 }}}
 
+#endif
 #endif

--- a/hpx/compute/cuda/target.hpp
+++ b/hpx/compute/cuda/target.hpp
@@ -10,6 +10,7 @@
 
 #include <hpx/config.hpp>
 
+#if defined(HPX_HAS_CUDA) && defined(__CUDA_ARCH__)
 #include <cuda_runtime.h>
 
 namespace hpx { namespace compute { namespace cuda
@@ -49,4 +50,5 @@ namespace hpx { namespace compute { namespace cuda
     };
 }}}
 
+#endif
 #endif

--- a/hpx/compute/host/target.hpp
+++ b/hpx/compute/host/target.hpp
@@ -9,7 +9,7 @@
 #define HPX_COMPUTE_HOST_TARGET_HPP
 
 #include <hpx/config.hpp>
-#if defined(HPX_WITH_CUDA) && defined(__CUDA_ARCH__)
+#if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
 #include <hpx/compute/cuda/target.hpp>
 #else
 #include <hpx/runtime/threads/topology.hpp>
@@ -17,7 +17,7 @@
 
 namespace hpx { namespace compute { namespace host
 {
-#if defined(HPX_WITH_CUDA) && defined(__CUDA_ARCH__)
+#if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
     using compute::nvidia::target;
 #else
     struct target

--- a/hpx/compute/host/traits/access_target.hpp
+++ b/hpx/compute/host/traits/access_target.hpp
@@ -9,11 +9,13 @@
 #define HPX_COMPUTE_HOST_TARGET_TRAITS_HPP
 
 #include <hpx/config.hpp>
+#include <hpx/compute/traits/access_target.hpp>
 #include <hpx/compute/host/target.hpp>
 
-namespace hpx { namespace compute {
+namespace hpx { namespace compute { namespace traits
+{
     template <>
-    struct target_traits<host::target>
+    struct access_target<host::target>
     {
         typedef host::target target_type;
 
@@ -23,6 +25,6 @@ namespace hpx { namespace compute {
             return *(t + pos);
         }
     };
-}}
+}}}
 
 #endif

--- a/hpx/compute/traits/access_target.hpp
+++ b/hpx/compute/traits/access_target.hpp
@@ -10,10 +10,10 @@
 
 #include <hpx/config.hpp>
 
-namespace hpx { namespace compute
+namespace hpx { namespace compute { namespace traits
 {
-    template <typename Target>
-    struct target_traits;
-}}
+    template <typename Target, typename Enable = void>
+    struct access_target;
+}}}
 
 #endif

--- a/hpx/compute/vector.hpp
+++ b/hpx/compute/vector.hpp
@@ -180,7 +180,7 @@ namespace hpx { namespace compute
         /// Member types (FIXME: add reference to std
         typedef T value_type;
         typedef Allocator allocator_type;
-        typedef typename alloc_traits::access_target access_target;
+        typedef typename alloc_traits::access_target target_type;
         typedef std::size_t size_type;
         typedef std::ptrdiff_t difference_type;
         typedef typename alloc_traits::reference reference;
@@ -319,13 +319,13 @@ namespace hpx { namespace compute
         reference operator[](size_type pos)
         {
             HPX_ASSERT(pos < size_);
-            return access_target::access(target_, data_, pos);
+            return target_type::access(target_, data_, pos);
         }
 
         const_reference operator[](size_type pos) const
         {
             HPX_ASSERT(pos < size_);
-            return access_target::access(target_, data_, pos);
+            return target_type::access(target_, data_, pos);
         }
 
         // TODO: implement front()

--- a/hpx/config/compiler_specific.hpp
+++ b/hpx/config/compiler_specific.hpp
@@ -63,13 +63,13 @@
 #endif
 
 #if defined(__CUDACC__)
-#define HPX_CUDA_DEVICE __device__
-#define HPX_CUDA_HOST __host__
+#define HPX_DEVICE __device__
+#define HPX_HOST __host__
 #else
-#define HPX_CUDA_DEVICE
-#define HPX_CUDA_HOST
+#define HPX_DEVICE
+#define HPX_HOST
 #endif
-#define HPX_CUDA_HOST_DEVICE HPX_CUDA_HOST HPX_CUDA_DEVICE
+#define HPX_HOST_DEVICE HPX_HOST HPX_DEVICE
 
 #endif
 

--- a/hpx/util/deferred_call.hpp
+++ b/hpx/util/deferred_call.hpp
@@ -75,7 +75,7 @@ namespace hpx { namespace util
             HPX_DELETE_MOVE_ASSIGN(deferred);
 
             inline typename deferred_result_of<F(Ts...)>::type
-            HPX_CUDA_HOST_DEVICE operator()()
+            HPX_HOST_DEVICE operator()()
             {
                 return util::invoke_fused(std::move(_f), std::move(_args));
             }

--- a/hpx/util/invoke.hpp
+++ b/hpx/util/invoke.hpp
@@ -24,7 +24,7 @@ namespace hpx { namespace util
         {
             // f(t0, t1, ..., tN)
             template <typename F, typename ...Ts>
-            HPX_CUDA_HOST_DEVICE
+            HPX_HOST_DEVICE
             inline typename util::result_of<F&&(Ts&&...)>::type
             operator()(F&& f, Ts&&... vs)
             {
@@ -37,7 +37,7 @@ namespace hpx { namespace util
         {
             // t0.*f
             template <typename F, typename T0>
-            HPX_CUDA_HOST_DEVICE
+            HPX_HOST_DEVICE
             inline typename std::enable_if<
                 std::is_base_of<C, typename std::decay<T0>::type>::value,
                 typename util::result_of<F&&(T0&)>::type
@@ -48,7 +48,7 @@ namespace hpx { namespace util
             }
 
             template <typename F, typename T0>
-            HPX_CUDA_HOST_DEVICE
+            HPX_HOST_DEVICE
             inline typename std::enable_if<
                 std::is_base_of<C, typename std::decay<T0>::type>::value
              && !std::is_lvalue_reference<T0>::value,
@@ -61,7 +61,7 @@ namespace hpx { namespace util
 
             // (*t0).*f
             template <typename F, typename T0>
-            HPX_CUDA_HOST_DEVICE
+            HPX_HOST_DEVICE
             inline typename std::enable_if<
                 !std::is_base_of<C, typename std::decay<T0>::type>::value,
                 typename util::result_of<F&&(T0&&)>::type
@@ -77,7 +77,7 @@ namespace hpx { namespace util
         {
             // (t0.*f)(t1, ..., tN)
             template <typename F, typename T0, typename ...Ts>
-            HPX_CUDA_HOST_DEVICE
+            HPX_HOST_DEVICE
             inline typename std::enable_if<
                 std::is_base_of<C, typename std::decay<T0>::type>::value,
                 typename util::result_of<F&&(T0&&, Ts&&...)>::type
@@ -89,7 +89,7 @@ namespace hpx { namespace util
 
             // ((*t0).*f)(t1, ..., tN)
             template <typename F, typename T0, typename ...Ts>
-            HPX_CUDA_HOST_DEVICE
+            HPX_HOST_DEVICE
             inline typename std::enable_if<
                 !std::is_base_of<C, typename std::decay<T0>::type>::value,
                 typename util::result_of<F&&(T0&&, Ts&&...)>::type
@@ -111,7 +111,7 @@ namespace hpx { namespace util
         {
             // support boost::[c]ref, which is not callable as std::[c]ref
             template <typename F, typename ...Ts>
-            HPX_CUDA_HOST_DEVICE
+            HPX_HOST_DEVICE
             inline typename util::result_of<F&&(Ts&&...)>::type
             operator()(F f, Ts&&... vs)
             {
@@ -121,7 +121,7 @@ namespace hpx { namespace util
     }
 
     template <typename F, typename ...Ts>
-    HPX_CUDA_HOST_DEVICE
+    HPX_HOST_DEVICE
     inline typename util::result_of<F&&(Ts&&...)>::type
     invoke(F&& f, Ts&&... vs)
     {
@@ -136,7 +136,7 @@ namespace hpx { namespace util
         struct invoke_guard
         {
             template <typename F, typename ...Ts>
-            HPX_CUDA_HOST_DEVICE
+            HPX_HOST_DEVICE
             inline R operator()(F&& f, Ts&&... vs)
             {
                 return detail::invoke_impl<typename std::decay<F>::type>()(
@@ -148,7 +148,7 @@ namespace hpx { namespace util
         struct invoke_guard<void>
         {
             template <typename F, typename ...Ts>
-            HPX_CUDA_HOST_DEVICE
+            HPX_HOST_DEVICE
             inline void operator()(F&& f, Ts&&... vs)
             {
                 detail::invoke_impl<typename std::decay<F>::type>()(
@@ -158,7 +158,7 @@ namespace hpx { namespace util
     }
 
     template <typename R, typename F, typename ...Ts>
-    HPX_CUDA_HOST_DEVICE
+    HPX_HOST_DEVICE
     inline R invoke(F&& f, Ts&&... vs)
     {
         return detail::invoke_guard<R>()(
@@ -171,7 +171,7 @@ namespace hpx { namespace util
         struct invoke
         {
             template <typename F, typename... Ts>
-            HPX_CUDA_HOST_DEVICE
+            HPX_HOST_DEVICE
             typename util::result_of<F&&(Ts &&...)>::type
             operator()(F && f, Ts &&... vs)
             {
@@ -184,7 +184,7 @@ namespace hpx { namespace util
         struct invoke_r
         {
             template <typename F, typename... Ts>
-            HPX_CUDA_HOST_DEVICE
+            HPX_HOST_DEVICE
             R operator()(F && f, Ts &&... vs)
             {
                 return util::invoke<R>(std::forward<F>(f),

--- a/hpx/util/invoke_fused.hpp
+++ b/hpx/util/invoke_fused.hpp
@@ -56,7 +56,7 @@ namespace hpx { namespace util
 
         ///////////////////////////////////////////////////////////////////////
         template <typename F, typename Tuple, std::size_t ...Is>
-        HPX_CUDA_HOST_DEVICE
+        HPX_HOST_DEVICE
         inline typename fused_result_of<F&&(Tuple&&)>::type
         invoke_fused_impl(F&&f, Tuple&& t, pack_c<std::size_t, Is...>)
         {
@@ -67,7 +67,7 @@ namespace hpx { namespace util
     }
 
     template <typename F, typename Tuple>
-    HPX_CUDA_HOST_DEVICE
+    HPX_HOST_DEVICE
     inline typename detail::fused_result_of<F&&(Tuple&&)>::type
     invoke_fused(F&& f, Tuple&& t)
     {
@@ -83,7 +83,7 @@ namespace hpx { namespace util
         struct invoke_fused_guard
         {
             template <typename F, typename Tuple>
-            HPX_CUDA_HOST_DEVICE
+            HPX_HOST_DEVICE
             inline R operator()(F&& f, Tuple&& t)
             {
                 return detail::invoke_fused_impl(
@@ -96,7 +96,7 @@ namespace hpx { namespace util
         struct invoke_fused_guard<void>
         {
             template <typename F, typename Tuple>
-            HPX_CUDA_HOST_DEVICE
+            HPX_HOST_DEVICE
             inline void operator()(F&& f, Tuple&& t)
             {
                 detail::invoke_fused_impl(
@@ -107,7 +107,7 @@ namespace hpx { namespace util
     }
 
     template <typename R, typename F, typename Tuple>
-    HPX_CUDA_HOST_DEVICE
+    HPX_HOST_DEVICE
     inline R invoke_fused(F&& f, Tuple&& t)
     {
         return detail::invoke_fused_guard<R>()(
@@ -119,7 +119,7 @@ namespace hpx { namespace util
         struct invoke_fused
         {
             template <typename F, typename Tuple>
-            HPX_CUDA_HOST_DEVICE
+            HPX_HOST_DEVICE
             typename util::detail::fused_result_of<F&&(Tuple&&)>::type
             operator()(F&& f, Tuple&& args)
             {
@@ -133,7 +133,7 @@ namespace hpx { namespace util
         struct invoke_fused_r
         {
             template <typename F, typename Tuple>
-            HPX_CUDA_HOST_DEVICE
+            HPX_HOST_DEVICE
             R operator()(F&& f, Tuple&& args)
             {
                 return util::invoke_fused<R>(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,6 +118,9 @@ add_hpx_library_headers(hpx
 add_hpx_library_headers(hpx
   GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/hpx/parallel/*.hpp"
   APPEND)
+add_hpx_library_headers(hpx
+  GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/hpx/compute/*.hpp"
+  APPEND)
 
 if(HPX_WITH_STATIC_LINKING)
   add_hpx_library_headers(hpx


### PR DESCRIPTION
- moved traits into sub-namespace traits
- renamed target_traits to traits::access_target
- wrapped all CUDA headers with HPX_HAVE_CUDA
- bulk_construct now takes const& arguments (values are used more than once)
- some fixes to iterator
- added missing #includes
- added compute headers to build system