### PR TITLE
Fixing problems with is_bitwise_serializable

### DIFF
--- a/hpx/components/security/capability.hpp
+++ b/hpx/components/security/capability.hpp
@@ -14,7 +14,6 @@
 
 #include <boost/array.hpp>
 #include <boost/io/ios_state.hpp>
-#include <boost/mpl/bool.hpp>
 
 #include <climits>
 
@@ -176,14 +175,7 @@ namespace hpx { namespace components { namespace security
 #endif
 }}}
 
-namespace hpx { namespace traits
-{
-    template <>
-    struct is_bitwise_serializable<
-            hpx::components::security::capability>
-       : boost::mpl::true_
-    {};
-}}
+HPX_IS_BITWISE_SERIALIZABLE(hpx::components::security::capability)
 
 #endif
 

--- a/hpx/components/security/certificate.hpp
+++ b/hpx/components/security/certificate.hpp
@@ -19,7 +19,6 @@
 #include "public_key.hpp"
 
 #include <boost/io/ios_state.hpp>
-#include <boost/mpl/bool.hpp>
 
 namespace hpx { namespace components { namespace security
 {
@@ -124,14 +123,7 @@ namespace hpx { namespace components { namespace security
 #endif
 }}}
 
-namespace hpx { namespace traits
-{
-    template <>
-    struct is_bitwise_serializable<
-            hpx::components::security::certificate>
-       : boost::mpl::true_
-    {};
-}}
+HPX_IS_BITWISE_SERIALIZABLE(hpx::components::security::certificate)
 
 #endif
 

--- a/hpx/components/security/certificate_signing_request.hpp
+++ b/hpx/components/security/certificate_signing_request.hpp
@@ -13,11 +13,11 @@
 #include <hpx/runtime/naming/name.hpp>
 #include <hpx/runtime/serialization/serialize.hpp>
 #include <hpx/runtime/serialization/array.hpp>
+#include <hpx/traits/is_bitwise_serializable.hpp>
 
 #include <hpx/components/security/capability.hpp>
 #include <hpx/components/security/public_key.hpp>
 
-#include <boost/mpl/bool.hpp>
 
 namespace hpx { namespace components { namespace security
 {
@@ -104,14 +104,8 @@ namespace hpx { namespace components { namespace security
 #endif
 }}}
 
-namespace hpx { namespace traits
-{
-    template <>
-    struct is_bitwise_serializable<
-            hpx::components::security::certificate_signing_request>
-       : boost::mpl::true_
-    {};
-}}
+HPX_IS_BITWISE_SERIALIZABLE(
+    hpx::components::security::certificate_signing_request)
 
 #endif
 

--- a/hpx/components/security/public_key.hpp
+++ b/hpx/components/security/public_key.hpp
@@ -16,7 +16,6 @@
 
 #include <boost/array.hpp>
 #include <boost/io/ios_state.hpp>
-#include <boost/mpl/bool.hpp>
 
 #include <sodium.h>
 
@@ -85,14 +84,7 @@ namespace hpx { namespace components { namespace security
 #endif
 }}}
 
-namespace hpx { namespace traits
-{
-    template <>
-    struct is_bitwise_serializable<
-            hpx::components::security::public_key>
-       : boost::mpl::true_
-    {};
-}}
+HPX_IS_BITWISE_SERIALIZABLE(hpx::components::security::public_key)
 
 #endif
 

--- a/hpx/components/security/signature.hpp
+++ b/hpx/components/security/signature.hpp
@@ -72,14 +72,7 @@ namespace hpx { namespace components { namespace security
 #endif
 }}}
 
-namespace hpx { namespace traits
-{
-    template <>
-    struct is_bitwise_serializable<
-            hpx::components::security::signature>
-       : boost::mpl::true_
-    {};
-}}
+HPX_IS_BITWISE_SERIALIZABLE(hpx::components::security::signature)
 
 #endif
 

--- a/hpx/components/security/signed_type.hpp
+++ b/hpx/components/security/signed_type.hpp
@@ -15,7 +15,7 @@
 
 #include <hpx/components/security/signature.hpp>
 
-#include <boost/mpl/bool.hpp>
+#include <type_traits>
 
 namespace hpx { namespace components { namespace security
 {
@@ -105,7 +105,7 @@ namespace hpx { namespace traits
     template <typename T>
     struct is_bitwise_serializable<
             hpx::components::security::signed_type<T> >
-       : boost::mpl::true_
+       : std::true_type
     {};
 }}
 

--- a/hpx/runtime/actions/action_support.hpp
+++ b/hpx/runtime/actions/action_support.hpp
@@ -25,7 +25,6 @@
 #include <hpx/util/tuple.hpp>
 #include <hpx/util/detail/count_num_args.hpp>
 
-#include <boost/mpl/bool.hpp>
 #include <boost/preprocessor/cat.hpp>
 
 #include <cstdint>
@@ -73,14 +72,7 @@ namespace hpx { namespace actions { namespace detail
     };
 }}}
 
-namespace hpx { namespace traits
-{
-    template <>
-    struct is_bitwise_serializable<
-            hpx::actions::detail::action_serialization_data>
-       : boost::mpl::true_
-    {};
-}}
+HPX_IS_BITWISE_SERIALIZABLE(hpx::actions::detail::action_serialization_data)
 
 /// \endcond
 

--- a/hpx/runtime/parcelset/parcel.hpp
+++ b/hpx/runtime/parcelset/parcel.hpp
@@ -495,14 +495,7 @@ namespace hpx { namespace parcelset
     HPX_EXPORT std::string dump_parcel(parcel const& p);
 }}
 
-namespace hpx { namespace traits
-{
-    template <>
-    struct is_bitwise_serializable<
-            hpx::parcelset::parcel::data>
-       : boost::mpl::true_
-    {};
-}}
+HPX_IS_BITWISE_SERIALIZABLE(hpx::parcelset::parcel::data)
 
 #include <hpx/config/warnings_suffix.hpp>
 

--- a/hpx/runtime/serialization/array.hpp
+++ b/hpx/runtime/serialization/array.hpp
@@ -65,8 +65,8 @@ namespace hpx { namespace serialization
         template <class Archive>
         void serialize(Archive& ar, unsigned int v)
         {
-            typedef std::integral_constant<bool,
-                hpx::traits::is_bitwise_serializable<T>::value> use_optimized;
+            typedef typename
+                hpx::traits::is_bitwise_serializable<T>::type use_optimized;
 
 #ifdef BOOST_BIG_ENDIAN
             bool archive_endianess_differs = ar.endian_little();

--- a/hpx/runtime/serialization/input_archive.hpp
+++ b/hpx/runtime/serialization/input_archive.hpp
@@ -87,8 +87,8 @@ namespace hpx { namespace serialization
         >::type
         load(T & t)
         {
-            typedef std::integral_constant<bool,
-                hpx::traits::is_bitwise_serializable<T>::value> use_optimized;
+            typedef typename
+                hpx::traits::is_bitwise_serializable<T>::type use_optimized;
 
             load_bitwise(t, use_optimized());
         }

--- a/hpx/runtime/serialization/map.hpp
+++ b/hpx/runtime/serialization/map.hpp
@@ -80,8 +80,8 @@ namespace hpx
         void serialize(input_archive& ar, std::pair<Key, Value>& t, unsigned)
         {
             typedef std::pair<Key, Value> pair_type;
-            typedef std::integral_constant<bool,
-                hpx::traits::is_bitwise_serializable<pair_type>::value> optimized;
+            typedef typename
+                hpx::traits::is_bitwise_serializable<pair_type>::type optimized;
 
             detail::load_pair_impl(ar, t, optimized());
         }
@@ -90,8 +90,8 @@ namespace hpx
         void serialize(output_archive& ar, const std::pair<Key, Value>& t, unsigned)
         {
             typedef std::pair<Key, Value> pair_type;
-            typedef std::integral_constant<bool,
-                hpx::traits::is_bitwise_serializable<pair_type>::value> optimized;
+            typedef typename
+                hpx::traits::is_bitwise_serializable<pair_type>::type optimized;
 
             detail::save_pair_impl(ar, t, optimized());
         }

--- a/hpx/runtime/serialization/output_archive.hpp
+++ b/hpx/runtime/serialization/output_archive.hpp
@@ -132,8 +132,8 @@ namespace hpx { namespace serialization
         >::type
         save(T const & t)
         {
-            typedef std::integral_constant<bool,
-                hpx::traits::is_bitwise_serializable<T>::value> use_optimized;
+            typedef
+                typename hpx::traits::is_bitwise_serializable<T>::type use_optimized;
 
             save_bitwise(t, use_optimized());
         }

--- a/hpx/runtime/serialization/vector.hpp
+++ b/hpx/runtime/serialization/vector.hpp
@@ -81,10 +81,10 @@ namespace hpx { namespace serialization
     template <typename T, typename Allocator>
     void serialize(input_archive & ar, std::vector<T, Allocator> & v, unsigned)
     {
-        typedef std::integral_constant<bool,
-            hpx::traits::is_bitwise_serializable<
+        typedef
+            typename hpx::traits::is_bitwise_serializable<
                 typename std::vector<T, Allocator>::value_type
-            >::value> use_optimized;
+            >::type use_optimized;
 
         v.clear();
         detail::load_impl(ar, v, use_optimized());
@@ -141,10 +141,10 @@ namespace hpx { namespace serialization
     void serialize(output_archive & ar, const std::vector<T, Allocator> & v,
         unsigned)
     {
-        typedef std::integral_constant<bool,
-            hpx::traits::is_bitwise_serializable<
+        typedef
+            typename hpx::traits::is_bitwise_serializable<
                 typename std::vector<T, Allocator>::value_type
-            >::value> use_optimized;
+            >::type use_optimized;
 
         ar << v.size(); //-V128
         if(v.empty()) return;

--- a/hpx/util/tuple.hpp
+++ b/hpx/util/tuple.hpp
@@ -994,8 +994,10 @@ namespace hpx { namespace traits
     template <typename ...Ts>
     struct is_bitwise_serializable<
         ::hpx::util::tuple<Ts...>
-    > : ::hpx::util::detail::all_of<
-            hpx::traits::is_bitwise_serializable<Ts>...
+    > : std::integral_constant<bool,
+            ::hpx::util::detail::all_of<
+                hpx::traits::is_bitwise_serializable<Ts>...
+            >::value
         >
     {};
 }}


### PR DESCRIPTION
The newly introduced switch to is_trivially_copyable introduced problems with
std::true_type/false_type vs boost::mpl::true_/false_. This patch is attempting
to fix those issues.