### PR TITLE
Limit number of chunks produced by iteration_shape

### DIFF
--- a/hpx/parallel/executors/executor_parameter_traits.hpp
+++ b/hpx/parallel/executors/executor_parameter_traits.hpp
@@ -157,7 +157,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
 
         ///////////////////////////////////////////////////////////////////////
         template <typename Parameters_>
-        struct maximal_size_of_chunks_helper
+        struct maximal_number_of_chunks_helper
         {
             template <typename Parameters, typename Executor>
             static std::size_t
@@ -171,10 +171,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
             static auto call(int, Parameters& params, Executor& exec,
                     std::size_t cores)
             ->  decltype(
-                    params.get_maximal_size_of_chunks(exec, cores)
+                    params.get_maximal_number_of_chunks(exec, cores)
                 )
             {
-                return params.get_maximal_size_of_chunks(exec, cores);
+                return params.get_maximal_number_of_chunks(exec, cores);
             }
 
             template <typename Executor>
@@ -186,10 +186,10 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         };
 
         template <typename Parameters, typename Executor>
-        std::size_t call_maximal_size_of_chunks(Parameters& params,
+        std::size_t call_maximal_number_of_chunks(Parameters& params,
             Executor& exec, std::size_t cores)
         {
-            return maximal_size_of_chunks_helper<
+            return maximal_number_of_chunks_helper<
                     typename hpx::util::decay_unwrap<Parameters>::type
                 >::call(params, exec, cores);
         }
@@ -339,22 +339,22 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
                 std::forward<F>(f), num_tasks);
         }
 
-        /// Return the largest reasonable number of iterations to combine in
-        /// a single chunk.
+        /// Return the largest reasonable number of chunks to create for a
+        /// single algorithm invocation.
         ///
         /// \param params   [in] The executor parameters object to use for
-        ///                 determining the chunk size for the given number of
-        ///                 tasks \a num_tasks.
+        ///                 determining the number of chunks for the given
+        ///                 number of \a cores.
         /// \param exec     [in] The executor object which will be used used
         ///                 for scheduling of the the loop iterations.
-        /// \param cores    [in] The number of cores the chunk size should be
-        ///                 determined for
+        /// \param cores    [in] The number of cores the number of chunks
+        ///                 should be determined for.
         ///
         template <typename Executor>
-        static std::size_t maximal_size_of_chunks(
+        static std::size_t maximal_number_of_chunks(
             executor_parameters_type& params, Executor& exec, std::size_t cores)
         {
-            return detail::call_maximal_size_of_chunks(params, exec, cores);
+            return detail::call_maximal_number_of_chunks(params, exec, cores);
         }
 
         /// Reset the internal round robin thread distribution scheme for the

--- a/hpx/parallel/executors/executor_parameter_traits.hpp
+++ b/hpx/parallel/executors/executor_parameter_traits.hpp
@@ -157,6 +157,45 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
 
         ///////////////////////////////////////////////////////////////////////
         template <typename Parameters_>
+        struct maximal_size_of_chunks_helper
+        {
+            template <typename Parameters, typename Executor>
+            static std::size_t
+            call(hpx::traits::detail::wrap_int, Parameters&, Executor&,
+                std::size_t cores)
+            {
+                return 4 * cores;       // assume 4 times the number of cores
+            }
+
+            template <typename Parameters, typename Executor>
+            static auto call(int, Parameters& params, Executor& exec,
+                    std::size_t cores)
+            ->  decltype(
+                    params.get_maximal_size_of_chunks(exec, cores)
+                )
+            {
+                return params.get_maximal_size_of_chunks(exec, cores);
+            }
+
+            template <typename Executor>
+            static std::size_t
+            call(Parameters_& params, Executor& exec, std::size_t cores)
+            {
+                return call(0, params, exec, cores);
+            }
+        };
+
+        template <typename Parameters, typename Executor>
+        std::size_t call_maximal_size_of_chunks(Parameters& params,
+            Executor& exec, std::size_t cores)
+        {
+            return maximal_size_of_chunks_helper<
+                    typename hpx::util::decay_unwrap<Parameters>::type
+                >::call(params, exec, cores);
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Parameters_>
         struct reset_thread_distribution_helper
         {
             template <typename Parameters, typename Executor>
@@ -298,6 +337,24 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
         {
             return detail::call_get_chunk_size(params, exec,
                 std::forward<F>(f), num_tasks);
+        }
+
+        /// Return the largest reasonable number of iterations to combine in
+        /// a single chunk.
+        ///
+        /// \param params   [in] The executor parameters object to use for
+        ///                 determining the chunk size for the given number of
+        ///                 tasks \a num_tasks.
+        /// \param exec     [in] The executor object which will be used used
+        ///                 for scheduling of the the loop iterations.
+        /// \param cores    [in] The number of cores the chunk size should be
+        ///                 determined for
+        ///
+        template <typename Executor>
+        static std::size_t maximal_size_of_chunks(
+            executor_parameters_type& params, Executor& exec, std::size_t cores)
+        {
+            return detail::call_maximal_size_of_chunks(params, exec, cores);
         }
 
         /// Reset the internal round robin thread distribution scheme for the

--- a/hpx/parallel/util/detail/chunk_size.hpp
+++ b/hpx/parallel/util/detail/chunk_size.hpp
@@ -100,8 +100,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail
                 traits::get_chunk_size(policy.parameters(),
                     policy.executor(), test_function, count);
 
-            if (chunk_size == 0)
-                chunk_size = (count + cores - 1) / cores;
+            if (chunk_size < (count/(cores*4)) )
+                chunk_size = (count + 4*cores - 1) / cores;
 
             if (stride != 1)
             {
@@ -129,8 +129,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail
                     traits::get_chunk_size(policy.parameters(),
                         policy.executor(), [](){ return 0; }, count);
 
-                if (chunk_size == 0)
-                    chunk_size = (count + cores - 1) / cores;
+                if (chunk_size < (count/(cores*4)) )
+                    chunk_size = (count + 4*cores - 1) / cores;
 
                 if (stride != 1)
                 {
@@ -234,7 +234,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail
                 traits::get_chunk_size(policy.parameters(),
                     policy.executor(), test_function, count);
 
-            if (chunk_size == 0)
+            if (chunk_size < (count/(cores*4)) )
                 chunk_size = (count + cores - 1) / cores;
 
             if (stride != 1)
@@ -265,8 +265,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail
                     traits::get_chunk_size(policy.parameters(),
                         policy.executor(), [](){ return 0; }, count);
 
-                if (chunk_size == 0)
-                    chunk_size = (count + cores - 1) / cores;
+                if (chunk_size < (count/(cores*4)) )
+                    chunk_size = (count + 4*cores - 1) / cores;
 
                 if (stride != 1)
                 {

--- a/hpx/parallel/util/detail/chunk_size.hpp
+++ b/hpx/parallel/util/detail/chunk_size.hpp
@@ -67,7 +67,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail
 
         bool variable_chunk_sizes = traits::variable_chunk_size(
             policy.parameters(), policy.executor());
-        std::size_t max_chunk_size = traits::maximal_size_of_chunks(
+        std::size_t max_chunk_size = traits::maximal_number_of_chunks(
             policy.parameters(), policy.executor(), cores);
 
         std::vector<tuple_type> shape;
@@ -199,7 +199,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail
 
         bool variable_chunk_sizes = traits::variable_chunk_size(
             policy.parameters(), policy.executor());
-        std::size_t max_chunk_size = traits::maximal_size_of_chunks(
+        std::size_t max_chunk_size = traits::maximal_number_of_chunks(
             policy.parameters(), policy.executor(), cores);
 
         std::vector<tuple_type> shape;

--- a/hpx/parallel/util/detail/chunk_size.hpp
+++ b/hpx/parallel/util/detail/chunk_size.hpp
@@ -67,7 +67,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail
 
         bool variable_chunk_sizes = traits::variable_chunk_size(
             policy.parameters(), policy.executor());
-        std::size_t max_chunk_size = traits::maximal_number_of_chunks(
+        std::size_t max_chunks = traits::maximal_number_of_chunks(
             policy.parameters(), policy.executor(), cores);
 
         std::vector<tuple_type> shape;
@@ -102,8 +102,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail
                 traits::get_chunk_size(policy.parameters(),
                     policy.executor(), test_function, count);
 
-            if (chunk_size < (count / max_chunk_size))
-                chunk_size = (count + max_chunk_size - 1) / cores;
+            if (chunk_size < (count / max_chunks))
+                chunk_size = (count / max_chunks);
 
             if (stride != 1)
             {
@@ -131,8 +131,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail
                     traits::get_chunk_size(policy.parameters(),
                         policy.executor(), [](){ return 0; }, count);
 
-                if (chunk_size < (count / max_chunk_size))
-                    chunk_size = (count + max_chunk_size - 1) / cores;
+                if (chunk_size < (count / max_chunks))
+                    chunk_size = (count / max_chunks);
 
                 if (stride != 1)
                 {
@@ -199,7 +199,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail
 
         bool variable_chunk_sizes = traits::variable_chunk_size(
             policy.parameters(), policy.executor());
-        std::size_t max_chunk_size = traits::maximal_number_of_chunks(
+        std::size_t max_chunks = traits::maximal_number_of_chunks(
             policy.parameters(), policy.executor(), cores);
 
         std::vector<tuple_type> shape;
@@ -238,8 +238,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail
                 traits::get_chunk_size(policy.parameters(),
                     policy.executor(), test_function, count);
 
-            if (chunk_size < (count / max_chunk_size) )
-                chunk_size = (count + max_chunk_size - 1) / cores;
+            if (chunk_size < (count / max_chunks))
+                chunk_size = (count / max_chunks);
 
             if (stride != 1)
             {
@@ -269,8 +269,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail
                     traits::get_chunk_size(policy.parameters(),
                         policy.executor(), [](){ return 0; }, count);
 
-                if (chunk_size < (count / max_chunk_size))
-                    chunk_size = (count + max_chunk_size - 1) / cores;
+                if (chunk_size < (count / max_chunks))
+                    chunk_size = (count / max_chunks);
 
                 if (stride != 1)
                 {

--- a/hpx/parallel/util/detail/chunk_size.hpp
+++ b/hpx/parallel/util/detail/chunk_size.hpp
@@ -67,6 +67,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail
 
         bool variable_chunk_sizes = traits::variable_chunk_size(
             policy.parameters(), policy.executor());
+        std::size_t max_chunk_size = traits::maximal_size_of_chunks(
+            policy.parameters(), policy.executor(), cores);
 
         std::vector<tuple_type> shape;
 
@@ -100,8 +102,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail
                 traits::get_chunk_size(policy.parameters(),
                     policy.executor(), test_function, count);
 
-            if (chunk_size < (count/(cores*4)) )
-                chunk_size = (count + 4*cores - 1) / cores;
+            if (chunk_size < (count / max_chunk_size))
+                chunk_size = (count + max_chunk_size - 1) / cores;
 
             if (stride != 1)
             {
@@ -129,8 +131,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail
                     traits::get_chunk_size(policy.parameters(),
                         policy.executor(), [](){ return 0; }, count);
 
-                if (chunk_size < (count/(cores*4)) )
-                    chunk_size = (count + 4*cores - 1) / cores;
+                if (chunk_size < (count / max_chunk_size))
+                    chunk_size = (count + max_chunk_size - 1) / cores;
 
                 if (stride != 1)
                 {
@@ -197,6 +199,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail
 
         bool variable_chunk_sizes = traits::variable_chunk_size(
             policy.parameters(), policy.executor());
+        std::size_t max_chunk_size = traits::maximal_size_of_chunks(
+            policy.parameters(), policy.executor(), cores);
 
         std::vector<tuple_type> shape;
 
@@ -234,8 +238,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail
                 traits::get_chunk_size(policy.parameters(),
                     policy.executor(), test_function, count);
 
-            if (chunk_size < (count/(cores*4)) )
-                chunk_size = (count + cores - 1) / cores;
+            if (chunk_size < (count / max_chunk_size) )
+                chunk_size = (count + max_chunk_size - 1) / cores;
 
             if (stride != 1)
             {
@@ -265,8 +269,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail
                     traits::get_chunk_size(policy.parameters(),
                         policy.executor(), [](){ return 0; }, count);
 
-                if (chunk_size < (count/(cores*4)) )
-                    chunk_size = (count + 4*cores - 1) / cores;
+                if (chunk_size < (count / max_chunk_size))
+                    chunk_size = (count + max_chunk_size - 1) / cores;
 
                 if (stride != 1)
                 {


### PR DESCRIPTION
During testing, I found that parallel::for() was regularly producing around 5000 chunks in release mode and up to 100,000 chunks in debug mode (especially when stepping through with a debugger) as the chunker uses the time for an iteration to decide how big/small to make chunks (and god forbid that the kernel suspends your thread during that initial check).

This quick fix, limits the chunk size by limiting the number of chunks to 4xCores. It's a small number and there's a strong argument that it should be bigger then 4, but unless the user is running a lot of long running tasks and startving the system of others, it should improve performance overall. I saw a noticable improvement after adding this.

I may experiment with some new parameters for the executor policy that would allow chunk_resolution::micro/millseconds or chunk_resolution::block_size using some unit checks. This would alow the user to place a resolution of (say) 100microseconds per task, or a chunk size, but then we'd also need a maximum_chunks parameter default that would limit the extreme cases when a test takes seconds and the 100useconds limit triggers 100,000 chunks ...
