### PR TITLE
Fix test categorization : regression not unit

### DIFF
--- a/tests/regressions/parallel/executors/CMakeLists.txt
+++ b/tests/regressions/parallel/executors/CMakeLists.txt
@@ -23,7 +23,7 @@ foreach(test ${tests})
                      HPX_PREFIX ${HPX_BUILD_PREFIX}
                      FOLDER "Tests/Regressions/Parallel/Executors")
 
-  add_hpx_unit_test("parallel" ${test} ${${test}_PARAMETERS})
+  add_hpx_regression_test("parallel" ${test} ${${test}_PARAMETERS})
 
   # add a custom target for this example
   add_hpx_pseudo_target(tests.regressions.parallel_dir.executors_dir.${test})


### PR DESCRIPTION
doing a `make tests.unit` followed by `ctest -R tests.unit` produces an error (unless you're lucky and the binary is already there from a previous build) because the regression test is run as part of the unit tests but only built as part of the regression tests.