### PR TITLE
Fixing 2176

### DIFF
--- a/cmake/HPX_AddTest.cmake
+++ b/cmake/HPX_AddTest.cmake
@@ -35,10 +35,10 @@ macro(add_hpx_test category name)
 
   set(args)
 
-  foreach(arg ${${name}_ARGS})
-    set(args ${args} "'${arg}'")
+  foreach(arg ${ARGN})
+    set(args ${args} "${arg}")
   endforeach()
-  set(args ${args} "-v" "--" ${args})
+  set(args "-v" "--" ${args})
 
   set(cmd "${PYTHON_EXECUTABLE}"
           "${CMAKE_BINARY_DIR}/bin/hpxrun.py"

--- a/hpx/plugins/parcelport/tcp/sender.hpp
+++ b/hpx/plugins/parcelport/tcp/sender.hpp
@@ -22,6 +22,7 @@
 #include <hpx/util/bind.hpp>
 #include <hpx/util/high_resolution_timer.hpp>
 #include <hpx/util/unique_function.hpp>
+#include <hpx/util/asio_util.hpp>
 
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/io_service.hpp>
@@ -84,8 +85,8 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
             // when the runtime is in state_shutdown
             if(!ec)
             {
-                HPX_ASSERT(impl.address() ==
-                    endpoint.address().to_string());
+                HPX_ASSERT(hpx::util::cleanup_ip_address(impl.address())
+                  == hpx::util::cleanup_ip_address(endpoint.address().to_string()));
                 HPX_ASSERT(impl.port() ==
                     endpoint.port());
             }

--- a/hpx/util/asio_util.hpp
+++ b/hpx/util/asio_util.hpp
@@ -39,6 +39,10 @@ namespace hpx { namespace util
     HPX_API_EXPORT bool split_ip_address(std::string const& v,
         std::string& host, boost::uint16_t& port);
 
+    ///////////////////////////////////////////////////////////////////////
+    // Take an ip v4 or v6 address and "standardize" it for comparison checks
+    HPX_API_EXPORT std::string cleanup_ip_address(const std::string &addr);
+
     typedef boost::asio::ip::tcp::resolver::iterator endpoint_iterator_type;
 
     endpoint_iterator_type HPX_EXPORT connect_begin(

--- a/plugins/parcelport/tcp/connection_handler_tcp.cpp
+++ b/plugins/parcelport/tcp/connection_handler_tcp.cpp
@@ -224,7 +224,8 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
 
         std::string connection_addr = s.remote_endpoint().address().to_string();
         boost::uint16_t connection_port = s.remote_endpoint().port();
-        HPX_ASSERT(l.get<locality>().address() == connection_addr);
+        HPX_ASSERT(hpx::util::cleanup_ip_address(l.get<locality>().address())
+            == hpx::util::cleanup_ip_address(connection_addr));
         HPX_ASSERT(l.get<locality>().port() == connection_port);
 #endif
 

--- a/src/util/asio_util.cpp
+++ b/src/util/asio_util.cpp
@@ -172,34 +172,47 @@ namespace hpx { namespace util
         return true;
     }
 
+
     ///////////////////////////////////////////////////////////////////////
     // Take an ip v4 or v6 address and "standardize" it for comparison checks
+    // note that this code doesn't work as expected if we use the boost
+    // inet_pton functions on linux. see issue #2177 for further info
     std::string cleanup_ip_address(const std::string &addr)
     {
-        unsigned char buf[sizeof(struct in6_addr)];
+        char buf[sizeof(struct in6_addr)];
         int i=0, domain[2] = {AF_INET, AF_INET6};
         char str[INET6_ADDRSTRLEN];
-        boost::system::error_code ec;
-        unsigned long scope_id = 0x0e;
 
-        for (i = 0; i < 2; ++i) {
+#if defined(HPX_WINDOWS)
+        unsigned long scope_id;
+        boost::system::error_code ec;
+#endif
+
+        for (i=0; i<2; ++i) {
+#if defined(HPX_WINDOWS)
             int s = boost::asio::detail::socket_ops::inet_pton(
-                domain[i], &addr[0], buf, &scope_id, ec);
-            if (!ec && s > 0)
-                break;
+              domain[i], &addr[0], buf, &scope_id, ec);
+            if (s>0 && !ec) break;
+#else
+            int s = inet_pton(domain[i], &addr[0], buf);
+            if (s>0) break;
+#endif
         }
-        if (i == 2) {
+        if (i==2) {
             HPX_THROW_EXCEPTION(bad_parameter, "cleanup_ip_address",
                 "Invalid IP address string");
         }
 
-        if (boost::asio::detail::socket_ops::inet_ntop(
-                domain[i], buf, str, INET6_ADDRSTRLEN, scope_id, ec) == NULL)
-        {
-            HPX_THROW_EXCEPTION(bad_parameter, "cleanup_ip_address",
-                "inet_ntop failure");
-        }
-        return std::string(str);
+#if defined(HPX_WINDOWS)
+       if (boost::asio::detail::socket_ops::inet_ntop(
+          domain[i], buf, str, INET6_ADDRSTRLEN, scope_id, ec) == 0) {
+#else
+       if (inet_ntop(domain[i], buf, str, INET6_ADDRSTRLEN) == NULL) {
+#endif
+           HPX_THROW_EXCEPTION(bad_parameter, "cleanup_ip_address",
+               "inet_ntop failure");
+       }
+       return std::string(str);
     }
 
     endpoint_iterator_type connect_begin(std::string const & address,
@@ -313,4 +326,3 @@ namespace hpx { namespace util
         return endpoint_iterator_type();
     }
 }}
-

--- a/src/util/asio_util.cpp
+++ b/src/util/asio_util.cpp
@@ -174,30 +174,32 @@ namespace hpx { namespace util
 
     ///////////////////////////////////////////////////////////////////////
     // Take an ip v4 or v6 address and "standardize" it for comparison checks
-    HPX_API_EXPORT std::string cleanup_ip_address(const std::string &addr)
+    std::string cleanup_ip_address(const std::string &addr)
     {
         unsigned char buf[sizeof(struct in6_addr)];
         int i=0, domain[2] = {AF_INET, AF_INET6};
         char str[INET6_ADDRSTRLEN];
         boost::system::error_code ec;
-        unsigned long scope_id=0x0e;
+        unsigned long scope_id = 0x0e;
 
-        for (i=0; i<2; ++i) {
+        for (i = 0; i < 2; ++i) {
             int s = boost::asio::detail::socket_ops::inet_pton(
                 domain[i], &addr[0], buf, &scope_id, ec);
-            if (!ec && s>0) break;
+            if (!ec && s > 0)
+                break;
         }
-        if (i==2) {
+        if (i == 2) {
             HPX_THROW_EXCEPTION(bad_parameter, "cleanup_ip_address",
                 "Invalid IP address string");
         }
 
-       if (boost::asio::detail::socket_ops::inet_ntop(
-          domain[i], buf, str, INET6_ADDRSTRLEN, scope_id, ec) == NULL) {
-           HPX_THROW_EXCEPTION(bad_parameter, "cleanup_ip_address",
-               "inet_ntop failure");
-       }
-       return std::string(str);
+        if (boost::asio::detail::socket_ops::inet_ntop(
+                domain[i], buf, str, INET6_ADDRSTRLEN, scope_id, ec) == NULL)
+        {
+            HPX_THROW_EXCEPTION(bad_parameter, "cleanup_ip_address",
+                "inet_ntop failure");
+        }
+        return std::string(str);
     }
 
     endpoint_iterator_type connect_begin(std::string const & address,

--- a/src/util/asio_util.cpp
+++ b/src/util/asio_util.cpp
@@ -172,6 +172,33 @@ namespace hpx { namespace util
         return true;
     }
 
+    ///////////////////////////////////////////////////////////////////////
+    // Take an ip v4 or v6 address and "standardize" it for comparison checks
+    HPX_API_EXPORT std::string cleanup_ip_address(const std::string &addr)
+    {
+        unsigned char buf[sizeof(struct in6_addr)];
+        int i=0, domain[2] = {AF_INET, AF_INET6};
+        char str[INET6_ADDRSTRLEN];
+        boost::system::error_code ec;
+        unsigned long scope_id=0x0e;
+
+        for (i=0; i<2; ++i) {
+            int s = boost::asio::detail::socket_ops::inet_pton(
+                domain[i], &addr[0], buf, &scope_id, ec);
+            if (!ec && s>0) break;
+        }
+        if (i==2) {
+            HPX_THROW_EXCEPTION(bad_parameter, "cleanup_ip_address",
+                "Invalid IP address string");
+        }
+
+       if (boost::asio::detail::socket_ops::inet_ntop(
+          domain[i], buf, str, INET6_ADDRSTRLEN, scope_id, ec) == NULL) {
+           HPX_THROW_EXCEPTION(bad_parameter, "cleanup_ip_address",
+               "inet_ntop failure");
+       }
+       return std::string(str);
+    }
 
     endpoint_iterator_type connect_begin(std::string const & address,
         boost::uint16_t port,
@@ -284,3 +311,4 @@ namespace hpx { namespace util
         return endpoint_iterator_type();
     }
 }}
+

--- a/tests/unit/component/CMakeLists.txt
+++ b/tests/unit/component/CMakeLists.txt
@@ -58,6 +58,9 @@ set(get_ptr_PARAMETERS
 
 set(launch_process_FLAGS
     DEPENDENCIES iostreams_component process_component)
+set(launch_process_PARAMETERS
+  --launch=$<TARGET_FILE:launched_process_test_exe>
+)
 
 set(migrate_component_PARAMETERS
     LOCALITIES 2


### PR DESCRIPTION
These patches solve the problem of launching the test correctly, but do not address the memory access violations that occur. These could be merged in, independently of the greater fix.

I do not know how to progress with the sanitizer errors and double deletions mentioned in #2176 