### PR TITLE
Fixing logging output not to cause hang on shutdown

### DIFF
--- a/hpx/runtime/threads/policies/queue_helpers.hpp
+++ b/hpx/runtime/threads/policies/queue_helpers.hpp
@@ -52,9 +52,6 @@ namespace detail
         if (HPX_LIKELY(idle_loop_count++ < HPX_IDLE_LOOP_COUNT_MAX))
             return false;
 
-        // reset idle loop count
-        idle_loop_count = 0;
-
         bool result = false;
         bool collect_suspended = true;
 

--- a/hpx/util/thread_description.hpp
+++ b/hpx/util/thread_description.hpp
@@ -49,7 +49,7 @@ namespace hpx { namespace util
         thread_description() HPX_NOEXCEPT
           : type_(data_type_description)
         {
-            data_.desc_ = 0;
+            data_.desc_ = "<unknown>";
         }
 
         thread_description(char const* desc) HPX_NOEXCEPT


### PR DESCRIPTION
- flyby: fix bad member initialization in thread_description

This fixes #2183.

I can confirm that this fixes the shutdown hangs I was experiencing