### PR TITLE
mask 128-bit ints if CUDA is being used

### DIFF
--- a/hpx/runtime/serialization/input_archive.hpp
+++ b/hpx/runtime/serialization/input_archive.hpp
@@ -193,7 +193,7 @@ namespace hpx { namespace serialization
             val = static_cast<T>(ul);
         }
 
-#if defined(BOOST_HAS_INT128)
+#if defined(BOOST_HAS_INT128) && !defined(__CUDACC__)
         void load_integral(boost::int128_type& t, boost::mpl::false_)
         {
             load_integral_impl(t);

--- a/hpx/runtime/serialization/output_archive.hpp
+++ b/hpx/runtime/serialization/output_archive.hpp
@@ -220,7 +220,7 @@ namespace hpx { namespace serialization
             save_integral_impl(static_cast<boost::uint64_t>(val));
         }
 
-#if defined(BOOST_HAS_INT128)
+#if defined(BOOST_HAS_INT128) && !defined(__CUDACC__)
         void save_integral(boost::int128_type t, boost::mpl::false_)
         {
             save_integral_impl(t);


### PR DESCRIPTION
Recent Boost (1.61.0) will expose 128-bit ints. nvcc isn't compatible with these, so any compilation of HPX-based code with nvcc will fail. This PR adds a check to the two infringing headers inside HPX to fix CUDA-enabled builds.

I don't get it why nvcc complains in the first case as those 128-bit integers aren't used in device code at all.