### PR TITLE
Support Boost.Thread v4

### DIFF
--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -423,8 +423,8 @@ namespace hpx { namespace components { namespace server
 
     private:
         mutex_type mtx_;
-        boost::condition wait_condition_;
-        boost::condition stop_condition_;
+        boost::condition_variable wait_condition_;
+        boost::condition_variable stop_condition_;
         bool stopped_;
         bool terminated_;
         bool dijkstra_color_;   // false: white, true: black

--- a/hpx/runtime/threads/policies/thread_queue.hpp
+++ b/hpx/runtime/threads/policies/thread_queue.hpp
@@ -696,7 +696,7 @@ namespace hpx { namespace threads { namespace policies
                 // created, as it might have that the current HPX thread gets
                 // suspended.
                 {
-                    typename mutex_type::scoped_lock lk(mtx_);
+                    std::unique_lock<mutex_type> lk(mtx_);
 
                     create_thread_object(thrd, data, initial_state, lk);
 

--- a/hpx/runtime_impl.hpp
+++ b/hpx/runtime_impl.hpp
@@ -54,7 +54,7 @@ namespace hpx
             util::function_nonser<runtime::hpx_main_function_type> func,
             int& result);
 
-        void wait_helper(boost::mutex& mtx, boost::condition& cond,
+        void wait_helper(boost::mutex& mtx, boost::condition_variable& cond,
             bool& running);
 
     public:
@@ -143,7 +143,7 @@ namespace hpx
         ///                   return immediately. Use a second call to stop
         ///                   with this parameter set to \a true to wait for
         ///                   all internal work to be completed.
-        void stopped(bool blocking, boost::condition& cond, boost::mutex& mtx);
+        void stopped(bool blocking, boost::condition_variable& cond, boost::mutex& mtx);
 
         /// \brief Report a non-recoverable error to the runtime system
         ///

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -1031,7 +1031,7 @@ namespace hpx { namespace components { namespace server
 
     void runtime_support::wait()
     {
-        std::unique_lock<mutex_type> l(mtx_);
+        boost::unique_lock<mutex_type> l(mtx_);
         while (!stopped_) {
             LRT_(info) << "runtime_support: about to enter wait state";
             wait_condition_.wait(l);
@@ -1062,7 +1062,7 @@ namespace hpx { namespace components { namespace server
     void runtime_support::stop(double timeout,
         naming::id_type const& respond_to, bool remove_from_remote_caches)
     {
-        std::unique_lock<mutex_type> l(mtx_);
+        boost::unique_lock<mutex_type> l(mtx_);
         if (!stopped_) {
             // push pending logs
             components::cleanup_logging();
@@ -1151,7 +1151,7 @@ namespace hpx { namespace components { namespace server
 
     void runtime_support::notify_waiting_main()
     {
-        std::unique_lock<mutex_type> l(mtx_);
+        boost::unique_lock<mutex_type> l(mtx_);
         if (!stopped_) {
             stopped_ = true;
             wait_condition_.notify_all();

--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -363,7 +363,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     template <typename SchedulingPolicy>
     void runtime_impl<SchedulingPolicy>::wait_helper(
-        boost::mutex& mtx, boost::condition& cond, bool& running)
+        boost::mutex& mtx, boost::condition_variable& cond, bool& running)
     {
         // signal successful initialization
         {
@@ -395,7 +395,7 @@ namespace hpx {
 
         // start the wait_helper in a separate thread
         boost::mutex mtx;
-        boost::condition cond;
+        boost::condition_variable cond;
         bool running = false;
 
         boost::thread t (util::bind(
@@ -405,7 +405,7 @@ namespace hpx {
 
         // wait for the thread to run
         {
-            std::unique_lock<boost::mutex> lk(mtx);
+            boost::unique_lock<boost::mutex> lk(mtx);
             while (!running)
                 cond.wait(lk);
         }
@@ -444,8 +444,8 @@ namespace hpx {
             // from a HPX thread, so it would deadlock by waiting for the thread
             // manager
             boost::mutex mtx;
-            boost::condition cond;
-            std::unique_lock<boost::mutex> l(mtx);
+            boost::condition_variable cond;
+            boost::unique_lock<boost::mutex> l(mtx);
 
             boost::thread t(util::bind(&runtime_impl::stopped, this, blocking,
                 boost::ref(cond), boost::ref(mtx)));
@@ -476,7 +476,7 @@ namespace hpx {
     // a HPX thread!
     template <typename SchedulingPolicy>
     void runtime_impl<SchedulingPolicy>::stopped(
-        bool blocking, boost::condition& cond, boost::mutex& mtx)
+        bool blocking, boost::condition_variable& cond, boost::mutex& mtx)
     {
         // wait for thread manager to exit
         runtime_support_->stopped();         // re-activate shutdown HPX-thread


### PR DESCRIPTION
- Replace `boost::condition` with `boost::condition_variable`
- Replace `typename Mutex::scoped_lock` with `unique_lock<Mutex>`