### PR TITLE
Fixing partitioned_vector_spmd_foreach example

### DIFF
--- a/examples/quickstart/partitioned_vector_spmd_foreach.cpp
+++ b/examples/quickstart/partitioned_vector_spmd_foreach.cpp
@@ -148,8 +148,9 @@ int hpx_main(boost::program_options::variables_map& vm)
         }
         else
         {
-            v.connect_to(example_vector_name);
+            hpx::future<void> f1 = v.connect_to(example_vector_name);
             l.connect_to(example_latch_name);
+            f1.get();
         }
 
         boost::random::mt19937 gen(std::rand());


### PR DESCRIPTION
- flyby: fixing parcel coalescing to call put_parcels on HPX thread only