### PR TITLE
Fix typo in QT CMakeLists

### DIFF
--- a/examples/qt/CMakeLists.txt
+++ b/examples/qt/CMakeLists.txt
@@ -19,7 +19,7 @@ if(NOT "${HPX_PLATFORM_UC}" STREQUAL "BLUEGENEQ")
   #      hpx_qt.cpp
         ${QT_MOC_SOURCES})
 
-    include_directories(QT4_INCLUDE_DIRS})
+    include_directories(${QT4_INCLUDE_DIRS})
 
     add_hpx_executable(qt
       MODULE qt


### PR DESCRIPTION
Generated CXX flags included on my platform:
-I/home/mcopik/Projekty/stellar/amp/hpx_amp/hpx/examples/qt/QT4_INCLUDE_DIRS}

Now it evaluates to an empty string on my platform.
