### PR TITLE
Fix hangs

### DIFF
--- a/hpx/runtime/agas/server/component_namespace.hpp
+++ b/hpx/runtime/agas/server/component_namespace.hpp
@@ -274,6 +274,12 @@ struct HPX_EXPORT component_namespace
 
 }}}
 
+HPX_ACTION_USES_MEDIUM_STACK(
+    hpx::agas::server::component_namespace::service_action)
+
+HPX_ACTION_USES_MEDIUM_STACK(
+    hpx::agas::server::component_namespace::bulk_service_action)
+
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::agas::server::component_namespace::service_action,
     component_namespace_service_action)

--- a/hpx/runtime/agas/server/locality_namespace.hpp
+++ b/hpx/runtime/agas/server/locality_namespace.hpp
@@ -270,6 +270,12 @@ struct HPX_EXPORT locality_namespace
 
 }}}
 
+HPX_ACTION_USES_MEDIUM_STACK(
+    hpx::agas::server::locality_namespace::service_action)
+
+HPX_ACTION_USES_MEDIUM_STACK(
+    hpx::agas::server::locality_namespace::bulk_service_action)
+
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::agas::server::locality_namespace::service_action,
     locality_namespace_service_action)

--- a/hpx/runtime/agas/server/primary_namespace.hpp
+++ b/hpx/runtime/agas/server/primary_namespace.hpp
@@ -467,6 +467,15 @@ struct HPX_EXPORT primary_namespace
 
 }}}
 
+HPX_ACTION_USES_MEDIUM_STACK(
+    hpx::agas::server::primary_namespace::service_action)
+
+HPX_ACTION_USES_MEDIUM_STACK(
+    hpx::agas::server::primary_namespace::bulk_service_action)
+
+HPX_ACTION_USES_MEDIUM_STACK(
+    hpx::agas::server::primary_namespace::route_action)
+
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::agas::server::primary_namespace::service_action,
     primary_namespace_service_action)

--- a/hpx/runtime/agas/server/symbol_namespace.hpp
+++ b/hpx/runtime/agas/server/symbol_namespace.hpp
@@ -247,6 +247,12 @@ struct HPX_EXPORT symbol_namespace
 
 }}}
 
+HPX_ACTION_USES_MEDIUM_STACK(
+    hpx::agas::server::symbol_namespace::service_action)
+
+HPX_ACTION_USES_MEDIUM_STACK(
+    hpx::agas::server::symbol_namespace::bulk_service_action)
+
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::agas::server::symbol_namespace::bulk_service_action,
     symbol_namespace_bulk_service_action)

--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -818,12 +818,12 @@ HPX_ACTION_USES_LARGE_STACK(
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::components::server::runtime_support::call_startup_functions_action,
     call_startup_functions_action)
-HPX_ACTION_USES_LARGE_STACK(
+HPX_ACTION_USES_MEDIUM_STACK(
     hpx::components::server::runtime_support::call_startup_functions_action)
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::components::server::runtime_support::call_shutdown_functions_action,
     call_shutdown_functions_action)
-HPX_ACTION_USES_LARGE_STACK(
+HPX_ACTION_USES_MEDIUM_STACK(
     hpx::components::server::runtime_support::call_shutdown_functions_action)
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::components::server::runtime_support::free_component_action,
@@ -831,9 +831,13 @@ HPX_REGISTER_ACTION_DECLARATION(
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::components::server::runtime_support::shutdown_action,
     shutdown_action)
+HPX_ACTION_USES_MEDIUM_STACK(
+    hpx::components::server::runtime_support::shutdown_action)
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::components::server::runtime_support::shutdown_all_action,
     shutdown_all_action)
+HPX_ACTION_USES_MEDIUM_STACK(
+    hpx::components::server::runtime_support::shutdown_all_action)
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::components::server::runtime_support::terminate_action,
     terminate_action)
@@ -863,6 +867,8 @@ HPX_REGISTER_ACTION_DECLARATION(
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::components::server::runtime_support::dijkstra_termination_action,
     dijkstra_termination_action)
+HPX_ACTION_USES_MEDIUM_STACK(
+    hpx::components::server::runtime_support::dijkstra_termination_action)
 
 namespace hpx { namespace components { namespace server
 {

--- a/hpx/util/command_line_handling.hpp
+++ b/hpx/util/command_line_handling.hpp
@@ -89,7 +89,7 @@ namespace hpx { namespace util
 
     void handle_list_parcelports();
 
-    void attach_debugger();
+    void HPX_EXPORT attach_debugger();
 }}
 
 #endif /*HPX_UTIL_COMMAND_LINE_HANDLING_HPP*/

--- a/src/pre_main.cpp
+++ b/src/pre_main.cpp
@@ -42,12 +42,19 @@
 ///////////////////////////////////////////////////////////////////////////////
 typedef hpx::components::server::runtime_support::call_startup_functions_action
     call_startup_functions_action;
+typedef
+    hpx::lcos::detail::make_broadcast_action<call_startup_functions_action>::type
+    call_startup_functions_broadcast_action;
 
 HPX_REGISTER_BROADCAST_ACTION_DECLARATION(call_startup_functions_action,
-        call_startup_functions_action)
+    call_startup_functions_action)
+
+HPX_ACTION_USES_MEDIUM_STACK(
+    call_startup_functions_broadcast_action)
+
 HPX_REGISTER_BROADCAST_ACTION_ID(call_startup_functions_action,
-        call_startup_functions_action,
-        hpx::actions::broadcast_call_startup_functions_action_id)
+    call_startup_functions_action,
+    hpx::actions::broadcast_call_startup_functions_action_id)
 
 #endif
 

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -1637,6 +1637,24 @@ void addressing_service::route(
   , threads::thread_priority local_priority
     )
 {
+    if (HPX_UNLIKELY(0 == threads::get_self_ptr()))
+    {
+        // reschedule this call as an HPX thread
+        void (addressing_service::*route_ptr)(
+            parcelset::parcel,
+            util::function_nonser<void(boost::system::error_code const&,
+                parcelset::parcel const&)> &&,
+            threads::thread_priority
+        ) = &addressing_service::route;
+
+        threads::register_thread_nullary(
+            util::deferred_call(route_ptr, this, std::move(p), std::move(f), local_priority),
+            "addressing_service::route", threads::pending, true,
+            threads::thread_priority_normal, std::size_t(-1),
+            threads::thread_stacksize_default);
+        return;
+    }
+
     // compose request
     naming::id_type const* ids = p.destinations();
 
@@ -1851,7 +1869,7 @@ void addressing_service::decref(
         ) = &addressing_service::decref;
 
         threads::register_thread_nullary(
-            util::bind(decref_ptr, this, raw, credit, boost::ref(throws)),
+            util::deferred_call(decref_ptr, this, raw, credit, boost::ref(throws)),
             "addressing_service::decref", threads::pending, true,
             threads::thread_priority_normal, std::size_t(-1),
             threads::thread_stacksize_default, ec);
@@ -2177,7 +2195,7 @@ void addressing_service::update_cache_entry(
           , error_code&
         ) = &addressing_service::update_cache_entry;
         threads::register_thread_nullary(
-            util::bind(update_cache_entry_ptr, this, id, g, boost::ref(throws)),
+            util::deferred_call(update_cache_entry_ptr, this, id, g, boost::ref(throws)),
             "addressing_service::update_cache_entry", threads::pending, true,
             threads::thread_priority_normal, std::size_t(-1),
             threads::thread_stacksize_default, ec);

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -1648,7 +1648,8 @@ void addressing_service::route(
         ) = &addressing_service::route;
 
         threads::register_thread_nullary(
-            util::deferred_call(route_ptr, this, std::move(p), std::move(f), local_priority),
+            util::deferred_call(
+                route_ptr, this, std::move(p), std::move(f), local_priority),
             "addressing_service::route", threads::pending, true,
             threads::thread_priority_normal, std::size_t(-1),
             threads::thread_stacksize_default);

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -52,6 +52,8 @@
 #include <hpx/plugins/message_handler_factory_base.hpp>
 #include <hpx/plugins/binary_filter_factory_base.hpp>
 
+#include <hpx/plugins/parcelport/mpi/mpi_environment.hpp>
+
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/convenience.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
@@ -545,9 +547,14 @@ namespace hpx { namespace components { namespace server
 ///////////////////////////////////////////////////////////////////////////////
 typedef hpx::components::server::runtime_support::call_shutdown_functions_action
     call_shutdown_functions_action;
+typedef
+    hpx::lcos::detail::make_broadcast_action<call_shutdown_functions_action>::type
+    call_shutdown_functions_broadcast_action;
 
 HPX_REGISTER_BROADCAST_ACTION_DECLARATION(call_shutdown_functions_action,
         call_shutdown_functions_action)
+HPX_ACTION_USES_MEDIUM_STACK(
+    call_shutdown_functions_broadcast_action)
 HPX_REGISTER_BROADCAST_ACTION_ID(call_shutdown_functions_action,
         call_shutdown_functions_action,
         hpx::actions::broadcast_call_shutdown_functions_action_id)

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -393,7 +393,8 @@ namespace hpx { namespace parcelset
         // addressing_service::resolve_locality.
 
         // if this isn't an HPX thread, the stack space check will return false
-        if (!this_thread::has_sufficient_stack_space() && !hpx::is_starting())
+        if (!this_thread::has_sufficient_stack_space() &&
+            hpx::threads::threadmanager_is(hpx::state::state_running))
         {
             naming::gid_type locality =
                 naming::get_locality_from_gid(ids[0].get_gid());
@@ -495,7 +496,8 @@ namespace hpx { namespace parcelset
         }
 
         // if this isn't an HPX thread, the stack space check will return false
-        if (!this_thread::has_sufficient_stack_space() && !hpx::is_starting())
+        if (!this_thread::has_sufficient_stack_space() &&
+            hpx::threads::threadmanager_is(hpx::state::state_running))
         {
             naming::gid_type locality = naming::get_locality_from_gid(
                 (*parcels[0].destinations()).get_gid());

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -396,9 +396,9 @@ namespace hpx { namespace parcelset
         if (!this_thread::has_sufficient_stack_space() &&
             hpx::threads::threadmanager_is(hpx::state::state_running))
         {
-            naming::gid_type locality =
-                naming::get_locality_from_gid(ids[0].get_gid());
-            if (!resolver_->has_resolved_locality(locality))
+//             naming::gid_type locality =
+//                 naming::get_locality_from_gid(ids[0].get_gid());
+//             if (!resolver_->has_resolved_locality(locality))
             {
                 // reschedule request as an HPX thread to avoid hangs
                 void (parcelhandler::*put_parcel_ptr) (
@@ -409,7 +409,8 @@ namespace hpx { namespace parcelset
                     util::deferred_call(put_parcel_ptr, this,
                         std::move(p), std::move(f)),
                     "parcelhandler::put_parcel", threads::pending, true,
-                    threads::thread_priority_boost);
+                    threads::thread_priority_boost, std::size_t(-1),
+                    threads::thread_stacksize_medium);
                 return;
             }
         }
@@ -499,9 +500,9 @@ namespace hpx { namespace parcelset
         if (!this_thread::has_sufficient_stack_space() &&
             hpx::threads::threadmanager_is(hpx::state::state_running))
         {
-            naming::gid_type locality = naming::get_locality_from_gid(
-                (*parcels[0].destinations()).get_gid());
-            if (!resolver_->has_resolved_locality(locality))
+//             naming::gid_type locality = naming::get_locality_from_gid(
+//                 (*parcels[0].destinations()).get_gid());
+//             if (!resolver_->has_resolved_locality(locality))
             {
                 // reschedule request as an HPX thread to avoid hangs
                 void (parcelhandler::*put_parcels_ptr) (
@@ -512,7 +513,8 @@ namespace hpx { namespace parcelset
                     util::deferred_call(put_parcels_ptr, this,
                         std::move(parcels), std::move(handlers)),
                     "parcelhandler::put_parcels", threads::pending, true,
-                    threads::thread_priority_boost);
+                    threads::thread_priority_boost, std::size_t(-1),
+                    threads::thread_stacksize_medium);
                 return;
             }
         }


### PR DESCRIPTION
This PR fixes hangs that occurred after #2190 have been merged.

It fixes situations where we tried to schedule new threads when the threadmanager was not up and running and introduces a diagnostic that throws an error in that case. In addition, the `parcelhandler::put_parcel` and `parcelhandler::put_parcels` rescheduling needed to schedule the new threads with a larger stack size to avoid endless rescheduling of threads.

Fly-by: Fixing a compiler warning about invalid export attributes with the intel compiler.