### PR TITLE
Delay-initialize members of partitoned iterator

### DIFF
--- a/hpx/components/containers/partitioned_vector/partitioned_vector_segmented_iterator.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_segmented_iterator.hpp
@@ -256,12 +256,14 @@ namespace hpx
         ///////////////////////////////////////////////////////////////////////
         local_raw_iterator local()
         {
-            HPX_ASSERT(data_);
+            if (partition_ && !data_)
+                data_ = partition_.get_ptr();
             return local_raw_iterator(data_->begin() + local_index_, data_);
         }
         local_raw_const_iterator local() const
         {
-            HPX_ASSERT(data_);
+            if (partition_ && !data_)
+                data_ = partition_.get_ptr();
             return local_raw_iterator(data_->cbegin() + local_index_, data_);
         }
 
@@ -272,8 +274,6 @@ namespace hpx
         void load(Archive& ar, unsigned version)
         {
             ar & partition_ & local_index_;
-            if (partition_)
-                data_ = partition_.get_ptr();
         }
         template <typename Archive>
         void save(Archive& ar, unsigned version) const
@@ -326,11 +326,15 @@ namespace hpx
 
         std::shared_ptr<server::partitioned_vector<T, Data> >& get_data()
         {
+            if (partition_ && !data_)
+                data_ = partition_.get_ptr();
             return data_;
         }
         std::shared_ptr<server::partitioned_vector<T, Data> > const&
             get_data() const
         {
+            if (partition_ && !data_)
+                data_ = partition_.get_ptr();
             return data_;
         }
 
@@ -342,7 +346,7 @@ namespace hpx
         size_type local_index_;
 
         // caching address of component
-        std::shared_ptr<server::partitioned_vector<T, Data> > data_;
+        mutable std::shared_ptr<server::partitioned_vector<T, Data> > data_;
     };
 
     template <typename T, typename Data>
@@ -391,12 +395,14 @@ namespace hpx
         ///////////////////////////////////////////////////////////////////////
         local_raw_iterator local()
         {
-            HPX_ASSERT(data_);
+            if (partition_ && !data_)
+                data_ = partition_.get_ptr();
             return local_raw_iterator(data_->cbegin() + local_index_, data_);
         }
         local_raw_const_iterator local() const
         {
-            HPX_ASSERT(data_);
+            if (partition_ && !data_)
+                data_ = partition_.get_ptr();
             return local_raw_const_iterator(data_->cbegin() + local_index_, data_);
         }
 
@@ -407,8 +413,6 @@ namespace hpx
         void load(Archive& ar, unsigned version)
         {
             ar & partition_ & local_index_;
-            if (partition_)
-                data_ = partition_.get_ptr();
         }
         template <typename Archive>
         void save(Archive& ar, unsigned version) const
@@ -462,11 +466,15 @@ namespace hpx
 
         std::shared_ptr<server::partitioned_vector<T, Data> >& get_data()
         {
+            if (partition_ && !data_)
+                data_ = partition_.get_ptr();
             return data_;
         }
         std::shared_ptr<server::partitioned_vector<T, Data> > const&
             get_data() const
         {
+            if (partition_ && !data_)
+                data_ = partition_.get_ptr();
             return data_;
         }
 
@@ -478,7 +486,7 @@ namespace hpx
         size_type local_index_;
 
         // caching address of component
-        std::shared_ptr<server::partitioned_vector<T, Data> > data_;
+        mutable std::shared_ptr<server::partitioned_vector<T, Data> > data_;
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/tests/regressions/components/CMakeLists.txt
+++ b/tests/regressions/components/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 set(tests
     moveonly_constructor_arguments_1405
+    partitioned_vector_2201
     returned_client_2150
    )
 

--- a/tests/regressions/components/partitioned_vector_2201.cpp
+++ b/tests/regressions/components/partitioned_vector_2201.cpp
@@ -1,0 +1,63 @@
+//  Copyright (c) 2016 Daniel Bourgeois
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+
+#include <hpx/include/parallel_generate.hpp>
+#include <hpx/include/partitioned_vector.hpp>
+
+#include <boost/random.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+// Define the vector types to be used.
+HPX_REGISTER_PARTITIONED_VECTOR(int);
+
+///////////////////////////////////////////////////////////////////////////////
+struct random_fill
+{
+    random_fill()
+      : gen(std::rand()),
+        dist(0, RAND_MAX)
+    {}
+
+    int operator()()
+    {
+        return dist(gen);
+    }
+
+    boost::random::mt19937 gen;
+    boost::random::uniform_int_distribution<> dist;
+
+    template <typename Archive>
+    void serialize(Archive& ar, unsigned)
+    {}
+};
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        // create as many partitions as we have localities
+        std::size_t size = 10000;
+        hpx::partitioned_vector<int> v(
+            size, hpx::container_layout(hpx::find_all_localities()));
+
+        // initialize data
+        // segmented version of algorithm used
+        using namespace  hpx::parallel;
+        generate(par, v.begin(), v.end(), random_fill());
+
+        return hpx::finalize();
+    }
+
+    return 0;
+}
+
+int main(int argc, char* argv[])
+{
+    return hpx::init(argc, argv);
+}


### PR DESCRIPTION
This avoids suspension during decode_parcel (which may be called on a non-HPX-thread.

Fixes #2201