### PR TITLE
The indirect_packaged_task::operator() needs to be run on a HPX thread

### DIFF
--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -1363,13 +1363,10 @@ namespace hpx { namespace components { namespace server
     // working around non-copy-ability of packaged_task
     struct indirect_packaged_task
     {
-        typedef void write_handler_type(
-            boost::system::error_code const&, parcelset::parcel const&);
-        typedef lcos::local::packaged_task<write_handler_type> packaged_task_type;
+        typedef lcos::local::packaged_task<void()> packaged_task_type;
 
         indirect_packaged_task()
-          : pt(std::make_shared<packaged_task_type>(
-                &parcelset::default_write_handler))
+          : pt(std::make_shared<packaged_task_type>([](){}))
         {}
 
         hpx::future<void> get_future()
@@ -1380,7 +1377,9 @@ namespace hpx { namespace components { namespace server
         template <typename ...Ts>
         void operator()(Ts&& ... vs)
         {
-            (*pt)(std::forward<Ts>(vs)...);
+            // This needs to be run on a HPX thread
+            hpx::apply(std::move(*pt));
+            pt.reset();
         }
 
         std::shared_ptr<packaged_task_type> pt;


### PR DESCRIPTION
The current implementation invokes the callback passed to apply_cb on the
parcelport threads, which might not be a HPX thread.