### PR TITLE
Fixed host::block_allocator::bulk_construct

### DIFF
--- a/hpx/compute/host/block_allocator.hpp
+++ b/hpx/compute/host/block_allocator.hpp
@@ -15,11 +15,19 @@
 #include <hpx/parallel/algorithms/for_each.hpp>
 #include <hpx/parallel/execution_policy.hpp>
 #include <hpx/parallel/executors/static_chunk_size.hpp>
+#include <hpx/parallel/util/cancellation_token.hpp>
+#include <hpx/parallel/util/partitioner_with_cleanup.hpp>
 #include <hpx/runtime/threads/executors/thread_pool_attached_executors.hpp>
+#include <hpx/runtime/threads/topology.hpp>
 #include <hpx/util/functional/new.hpp>
+#include <hpx/util/invoke_fused.hpp>
+#include <hpx/util/tuple.hpp>
 
 #include <boost/range/iterator_range_core.hpp>
 
+#include <limits>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace hpx { namespace compute { namespace host
@@ -28,7 +36,7 @@ namespace hpx { namespace compute { namespace host
     /// passed vector of targets. This is done by using first touch memory
     /// placement. (maybe better methods will be used in the future...);
     ///
-    /// This allocator can be used to write numa aware algorithms:
+    /// This allocator can be used to write NUMA aware algorithms:
     ///
     /// typedef hpx::compute::host::block_allocator<int> allocator_type;
     /// typedef hpx::compute::vector<int, allocator_type> vector_type;
@@ -105,12 +113,13 @@ namespace hpx { namespace compute { namespace host
         }
 
         // Allocates n * sizeof(T) bytes of uninitialized storage by calling
-        // ::operator new. The pointer hint may be used to provide locality of
+        // topo.allocate(). The pointer hint may be used to provide locality of
         // reference: the allocator, if supported by the implementation, will
         // attempt to allocate the new memory block as close as possible to hint.
         pointer allocate(size_type n, std::allocator<void>::const_pointer hint = 0)
         {
-            return static_cast<pointer>(::operator new(n * sizeof(T)));
+            return reinterpret_cast<pointer>(
+                hpx::threads::get_topology().allocate(n * sizeof(T)));
         }
 
         // Deallocates the storage referenced by the pointer p, which must be a
@@ -119,7 +128,7 @@ namespace hpx { namespace compute { namespace host
         // originally produced p; otherwise, the behavior is undefined.
         void deallocate(pointer p, size_type n)
         {
-            delete p;
+            hpx::threads::get_topology().deallocate(p, n);
         }
 
         // Returns the maximum theoretically possible value of n, for which the
@@ -138,20 +147,64 @@ namespace hpx { namespace compute { namespace host
         template <typename U, typename ... Args>
         void bulk_construct(U* p, std::size_t count, Args &&... args)
         {
-            // FIXME: Handle exceptions thrown from constructors
-
-            // first touch policy, distribute evenly onto targets
             auto irange = boost::irange(std::size_t(0), count);
-            hpx::parallel::for_each(
+            auto policy =
                 hpx::parallel::par
                     .on(executor_)
-                    .with(hpx::parallel::static_chunk_size()),
-                boost::begin(irange), boost::end(irange),
-                [p, args...](std::size_t i)
+                    .with(hpx::parallel::static_chunk_size());
+
+            typedef boost::range_detail::integer_iterator<std::size_t>
+                iterator_type;
+            typedef std::pair<iterator_type, iterator_type> partition_result_type;
+
+            typedef parallel::util::partitioner_with_cleanup<
+                    decltype(policy), void, partition_result_type
+                > partitioner;
+            typedef parallel::util::cancellation_token<
+                    parallel::util::detail::no_data
+                > cancellation_token;
+
+            auto && arguments =
+                hpx::util::forward_as_tuple(std::forward<Args>(args)...);
+
+            cancellation_token tok;
+            partitioner::call(std::move(policy),
+                boost::begin(irange), count,
+                [&arguments, p, tok](iterator_type it, std::size_t part_size)
+                    mutable -> partition_result_type
                 {
-                    ::new (p + i) U (std::move(args)...);
-                }
-            );
+                    iterator_type last =
+                        parallel::util::loop_with_cleanup_n_with_token(
+                            it, part_size, tok,
+                            [&arguments, p](iterator_type it)
+                            {
+                                using hpx::util::functional::placement_new_one;
+                                hpx::util::invoke_fused(
+                                    placement_new_one<U>(p + *it), arguments);
+                            },
+                            // cleanup function, called for all elements of
+                            // current partition which succeeded before exception
+                            [p](iterator_type it)
+                            {
+                                (p + *it)->~U();
+                            });
+                    return std::make_pair(it, last);
+                },
+                // finalize, called once if no error occurred
+                [](std::vector<hpx::future<partition_result_type> > &&)
+                {
+                    // do nothing
+                },
+                // cleanup function, called for each partition which
+                // didn't fail, but only if at least one failed
+                [p](partition_result_type && r) -> void
+                {
+                    while (r.first != r.second)
+                    {
+                        (p + *r.first)->~U();
+                        ++r.first;
+                    }
+                });
         }
 
         // Constructs an object of type T in allocated uninitialized storage

--- a/hpx/compute/host/block_executor.hpp
+++ b/hpx/compute/host/block_executor.hpp
@@ -103,9 +103,8 @@ namespace hpx { namespace compute { namespace host
         }
 
         template <typename F, typename ... Ts>
-        auto
+        typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
         execute(F && f, Ts &&... ts)
-            ->  typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
         {
             std::size_t current = ++current_ % executors_.size();
             return executor_traits::execute(executors_[current],

--- a/hpx/runtime/threads/policies/hwloc_topology.hpp
+++ b/hpx/runtime/threads/policies/hwloc_topology.hpp
@@ -176,10 +176,10 @@ namespace hpx { namespace threads
 
         /// This is equivalent to malloc(), except that it tries to allocate
         /// page-aligned memory from the OS.
-        void* allocate(std::size_t len);
+        void* allocate(std::size_t len) const;
 
         /// Free memory that was previously allocated by allocate
-        void deallocate(void* addr, std::size_t len);
+        void deallocate(void* addr, std::size_t len) const;
 
     private:
         static mask_type empty_mask;

--- a/hpx/runtime/threads/policies/noop_topology.hpp
+++ b/hpx/runtime/threads/policies/noop_topology.hpp
@@ -220,13 +220,13 @@ public:
 
     /// This is equivalent to malloc(), except that it tries to allocate
     /// page-aligned memory from the OS.
-    void* allocate(std::size_t len)
+    void* allocate(std::size_t len) const
     {
         return ::operator new(len);
     }
 
     /// Free memory that was previously allocated by allocate
-    void deallocate(void* addr, std::size_t len)
+    void deallocate(void* addr, std::size_t len) const
     {
         ::operator delete(addr/*, len*/);
     }

--- a/hpx/runtime/threads/topology.hpp
+++ b/hpx/runtime/threads/topology.hpp
@@ -190,10 +190,10 @@ namespace hpx { namespace threads
 
         /// This is equivalent to malloc(), except that it tries to allocate
         /// page-aligned memory from the OS.
-        virtual void* allocate(std::size_t len) = 0;
+        virtual void* allocate(std::size_t len) const = 0;
 
         /// Free memory that was previously allocated by allocate
-        virtual void deallocate(void* addr, std::size_t len) = 0;
+        virtual void deallocate(void* addr, std::size_t len) const = 0;
     };
 
     HPX_API_EXPORT std::size_t hardware_concurrency();

--- a/hpx/util/functional/new.hpp
+++ b/hpx/util/functional/new.hpp
@@ -29,6 +29,22 @@ namespace hpx { namespace util { namespace functional
             return new (p) T(std::forward<Ts>(vs)...);
         }
     };
+
+    template <typename T>
+    struct placement_new_one
+    {
+        placement_new_one(void* p)
+          : p_(p)
+        {}
+
+        template <typename ...Ts>
+        T* operator()(Ts&&... vs) const
+        {
+            return new (p_) T(std::forward<Ts>(vs)...);
+        }
+
+        void* p_;
+    };
 }}}
 
 #endif

--- a/src/runtime/threads/policies/hwloc_topology.cpp
+++ b/src/runtime/threads/policies/hwloc_topology.cpp
@@ -1095,13 +1095,13 @@ namespace hpx { namespace threads
 
     /// This is equivalent to malloc(), except that it tries to allocate
     /// page-aligned memory from the OS.
-    void* hwloc_topology::allocate(std::size_t len)
+    void* hwloc_topology::allocate(std::size_t len) const
     {
         return hwloc_alloc(topo, len);
     }
 
     /// Free memory that was previously allocated by allocate
-    void hwloc_topology::deallocate(void* addr, std::size_t len)
+    void hwloc_topology::deallocate(void* addr, std::size_t len) const
     {
         hwloc_free(topo, addr, len);
     }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -31,9 +31,7 @@ if(HPX_WITH_CXX11_LAMBDAS)
   set(subdirs ${subdirs} parallel)
 endif()
 
-if(HPX_WITH_COMPUTE)
-  set(subdirs ${subdirs} computeapi)
-endif()
+set(subdirs ${subdirs} computeapi)
 
 foreach(subdir ${subdirs})
   add_hpx_pseudo_target(tests.unit.${subdir})

--- a/tests/unit/computeapi/CMakeLists.txt
+++ b/tests/unit/computeapi/CMakeLists.txt
@@ -4,6 +4,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(subdirs
+    host
    )
 
 if(HPX_WITH_CUDA)

--- a/tests/unit/computeapi/host/CMakeLists.txt
+++ b/tests/unit/computeapi/host/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Copyright (c) 2016 Hartmut Kaiser
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests
+    block_allocator
+   )
+
+foreach(test ${tests})
+  set(sources
+      ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  # add example executable
+  add_hpx_executable(${test}_test
+                     SOURCES ${sources}
+                     ${${test}_FLAGS}
+                     EXCLUDE_FROM_ALL
+                     HPX_PREFIX ${HPX_BUILD_PREFIX}
+                     FOLDER "Tests/Unit/Compute/Host")
+
+  add_hpx_unit_test("host_" ${test} ${${test}_PARAMETERS})
+
+  # add a custom target for this example
+  add_hpx_pseudo_target(tests.unit.computeapi.host_.${test})
+
+  # make pseudo-targets depend on master pseudo-target
+  add_hpx_pseudo_dependencies(tests.unit.computeapi.host_
+                              tests.unit.computeapi.host_.${test})
+
+  # add dependencies to pseudo-target
+  add_hpx_pseudo_dependencies(tests.unit.computeapi.host_.${test}
+                              ${test}_test_exe)
+endforeach()
+

--- a/tests/unit/computeapi/host/block_allocator.cpp
+++ b/tests/unit/computeapi/host/block_allocator.cpp
@@ -1,0 +1,118 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/compute.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <boost/atomic.hpp>
+
+#include <string>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename T>
+T* test_block_allocation(hpx::compute::host::block_allocator<T>& alloc,
+    std::size_t count)
+{
+    return alloc.allocate(count);
+}
+
+template <typename T>
+void test_block_construction(hpx::compute::host::block_allocator<T>& alloc,
+    T* p, std::size_t count)
+{
+    alloc.bulk_construct(p, count);
+}
+
+template <typename T>
+void test_block_destruction(hpx::compute::host::block_allocator<T>& alloc,
+    T* p, std::size_t count)
+{
+    return alloc.bulk_destroy(p, count);
+}
+
+template <typename T>
+void test_block_deallocation(hpx::compute::host::block_allocator<T>& alloc,
+    T* p, std::size_t count)
+{
+    return alloc.deallocate(p, count);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename T>
+void test_bulk_allocator(std::size_t count)
+{
+    hpx::compute::host::block_allocator<T> alloc;
+    T* p = test_block_allocation(alloc, count);
+    test_block_construction(alloc, p, count);
+    test_block_destruction(alloc, p, count);
+    test_block_deallocation(alloc, p, count);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+boost::atomic<std::size_t> construction_count(0);
+boost::atomic<std::size_t> destruction_count(0);
+
+struct test
+{
+    test()
+    {
+        ++construction_count;
+    }
+    ~test()
+    {
+        ++destruction_count;
+    }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int)std::time(0);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    {
+        std::size_t count = std::rand();
+        test_bulk_allocator<int>(count);
+    }
+
+    {
+        std::size_t count = std::rand();
+        test_bulk_allocator<test>(count);
+        HPX_TEST_EQ(construction_count.load(), count);
+        HPX_TEST_EQ(destruction_count.load(), count);
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace boost::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()
+        ("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run")
+        ;
+
+    // By default this test should run on all available cores
+    std::vector<std::string> cfg;
+    cfg.push_back("hpx.os_threads=" +
+        std::to_string(hpx::threads::hardware_concurrency()));
+
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
- fixed capturing of args... for older compilers
- properly handling exceptions in bulk construction loop
- added minimal test for block_allocator
- changed to allocate page-aligned memory