### PR TITLE
Introducing clang tidy

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,8 @@ dependencies:
         - docker pull ${IMAGE_NAME}
         - mkdir build
     override:
-        - docker run -v $PWD:/hpx -w /hpx/build ${IMAGE_NAME} cmake .. -DCMAKE_BUILD_TYPE=Debug -DHPX_WITH_MALLOC=system -DHPX_WITH_GIT_COMMIT=${CIRCLE_SHA1} -DHPX_WITH_TOOLS=On -DCMAKE_CXX_FLAGS="-fcolor-diagnostics" -DHPX_WITH_TESTS_HEADERS=On
+        - docker run -v $PWD:/hpx -w /hpx/build ${IMAGE_NAME} cmake .. -DCMAKE_BUILD_TYPE=Debug -DHPX_WITH_MALLOC=system -DHPX_WITH_GIT_COMMIT=${CIRCLE_SHA1} -DHPX_WITH_TOOLS=On -DCMAKE_CXX_FLAGS="-fcolor-diagnostics" -DHPX_WITH_TESTS_HEADERS=On -DCMAKE_EXPORT_COMPILE_COMMANDS=On
+        - docker run -v $PWD:/hpx -w /hpx/build ${IMAGE_NAME} ../tools/clang-tidy.sh -diff-master
         - docker run -v $PWD:/hpx -w /hpx/build ${IMAGE_NAME} make -j2 core
         - docker run -v $PWD:/hpx -w /hpx/build ${IMAGE_NAME} make -j2 -k components
         - docker run -v $PWD:/hpx -w /hpx/build ${IMAGE_NAME} make -j2 -k examples

--- a/examples/compute/cuda/data_copy.cu
+++ b/examples/compute/cuda/data_copy.cu
@@ -15,7 +15,7 @@
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/examples/compute/cuda/hello_compute.cu
+++ b/examples/compute/cuda/hello_compute.cu
@@ -17,7 +17,7 @@
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/examples/compute/cuda/partitioned_vector.cu
+++ b/examples/compute/cuda/partitioned_vector.cu
@@ -27,7 +27,7 @@ HPX_REGISTER_PARTITIONED_VECTOR(int, target_vector);
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/examples/quickstart/init_globally.cpp
+++ b/examples/quickstart/init_globally.cpp
@@ -73,7 +73,7 @@ char** __argv = *_NSGetArgv();
 struct manage_global_runtime
 {
     manage_global_runtime()
-      : running_(false), rts_(0)
+      : running_(false), rts_(nullptr)
     {
 #if defined(HPX_WINDOWS)
         hpx::detail::init_winsocket();
@@ -106,7 +106,7 @@ struct manage_global_runtime
         // notify hpx_main above to tear down the runtime
         {
             std::lock_guard<hpx::lcos::local::spinlock> lk(mtx_);
-            rts_ = 0;               // reset pointer
+            rts_ = nullptr;               // reset pointer
         }
 
         cond_.notify_one();     // signal exit
@@ -145,7 +145,7 @@ protected:
         // Now, wait for destructor to be called.
         {
             std::unique_lock<hpx::lcos::local::spinlock> lk(mtx_);
-            if (rts_ != 0)
+            if (rts_ != nullptr)
                 cond_.wait(lk);
         }
 

--- a/examples/quickstart/partitioned_vector_spmd_foreach.cpp
+++ b/examples/quickstart/partitioned_vector_spmd_foreach.cpp
@@ -114,7 +114,7 @@ private:
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/examples/quickstart/shared_mutex.cpp
+++ b/examples/quickstart/shared_mutex.cpp
@@ -38,7 +38,7 @@ int main()
             [&ready, &stm, i]
             {
                 boost::random::mt19937 urng(
-                    static_cast<boost::uint32_t>(std::time(0)));
+                    static_cast<boost::uint32_t>(std::time(nullptr)));
                 boost::random::uniform_int_distribution<int> dist(1, 1000);
 
                 while (!ready) { /*** wait... ***/ }
@@ -65,7 +65,7 @@ int main()
             [&ready, &stm, k, i]
             {
                 boost::random::mt19937 urng(
-                    static_cast<boost::uint32_t>(std::time(0)));
+                    static_cast<boost::uint32_t>(std::time(nullptr)));
                 boost::random::uniform_int_distribution<int> dist(1, 1000);
 
                 while (!ready) { /*** wait... ***/ }

--- a/examples/quickstart/zerocopy_rdma.cpp
+++ b/examples/quickstart/zerocopy_rdma.cpp
@@ -31,7 +31,7 @@ public:
     typedef std::ptrdiff_t difference_type;
 
     pointer_allocator() HPX_NOEXCEPT
-      : pointer_(0), size_(0)
+      : pointer_(nullptr), size_(0)
     {
     }
 

--- a/examples/sheneos/sheneos_compare.cpp
+++ b/examples/sheneos/sheneos_compare.cpp
@@ -358,7 +358,7 @@ int hpx_main(boost::program_options::variables_map& vm)
 
     std::size_t seed = vm["seed"].as<std::size_t>();
     if (!seed)
-        seed = std::size_t(std::time(0));
+        seed = std::size_t(std::time(nullptr));
 
     std::cout << "Seed: " << seed << std::endl;
 

--- a/examples/sheneos/sheneos_test.cpp
+++ b/examples/sheneos/sheneos_test.cpp
@@ -324,7 +324,7 @@ int hpx_main(boost::program_options::variables_map& vm)
 
     std::size_t seed = vm["seed"].as<std::size_t>();
     if (!seed)
-        seed = std::size_t(std::time(0));
+        seed = std::size_t(std::time(nullptr));
 
     std::cout << "Seed: " << seed << std::endl;
 

--- a/examples/startup_shutdown/server/startup_shutdown.hpp
+++ b/examples/startup_shutdown/server/startup_shutdown.hpp
@@ -16,7 +16,7 @@ namespace startup_shutdown { namespace server
     public:
         // constructor: initialize accumulator value
         startup_shutdown_component()
-          : arg_(0)
+          : arg_(nullptr)
         {}
 
         ///////////////////////////////////////////////////////////////////////

--- a/examples/transpose/transpose_block.cpp
+++ b/examples/transpose/transpose_block.cpp
@@ -33,7 +33,7 @@ struct sub_block
 
     sub_block()
       : size_(0)
-      , data_(0)
+      , data_(nullptr)
       , mode_(reference)
     {}
 
@@ -56,7 +56,7 @@ struct sub_block
       , data_(other.data_)
       , mode_(other.mode_)
     {
-        if(mode_ == owning) { other.data_ = 0; other.size_ = 0; }
+        if(mode_ == owning) { other.data_ = nullptr; other.size_ = 0; }
     }
 
     sub_block & operator=(sub_block && other)
@@ -64,7 +64,7 @@ struct sub_block
         size_ = other.size_;
         data_ = other.data_;
         mode_ = other.mode_;
-        if(mode_ == owning) { other.data_ = 0; other.size_ = 0; }
+        if(mode_ == owning) { other.data_ = nullptr; other.size_ = 0; }
 
         return *this;
     }

--- a/examples/transpose/transpose_block_numa.cpp
+++ b/examples/transpose/transpose_block_numa.cpp
@@ -45,7 +45,7 @@ struct sub_block
 
     sub_block()
       : size_(0)
-      , data_(0)
+      , data_(nullptr)
       , mode_(reference)
     {}
 
@@ -68,7 +68,7 @@ struct sub_block
       , data_(other.data_)
       , mode_(other.mode_)
     {
-        if(mode_ == owning) { other.data_ = 0; other.size_ = 0; }
+        if(mode_ == owning) { other.data_ = nullptr; other.size_ = 0; }
     }
 
     sub_block & operator=(sub_block && other)
@@ -76,7 +76,7 @@ struct sub_block
         size_ = other.size_;
         data_ = other.data_;
         mode_ = other.mode_;
-        if(mode_ == owning) { other.data_ = 0; other.size_ = 0; }
+        if(mode_ == owning) { other.data_ = nullptr; other.size_ = 0; }
 
         return *this;
     }

--- a/hpx/components/component_storage/server/migrate_from_storage.hpp
+++ b/hpx/components/component_storage/server/migrate_from_storage.hpp
@@ -97,7 +97,7 @@ namespace hpx { namespace components { namespace server
 
             {
                 std::vector<char> data = f.get();
-                serialization::input_archive archive(data, data.size(), 0);
+                serialization::input_archive archive(data, data.size(), nullptr);
                 archive >> ptr;
             }
 

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_segmented_iterator.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_segmented_iterator.hpp
@@ -517,7 +517,7 @@ namespace hpx
 
         bool is_at_end() const
         {
-            return data_ == 0 ||
+            return data_ == nullptr ||
                 this->base_type::base_reference() == data_->partitions_.end();
         }
 
@@ -550,7 +550,7 @@ namespace hpx
 
         bool is_at_end() const
         {
-            return data_ == 0 ||
+            return data_ == nullptr ||
                 this->base_type::base_reference() == data_->partitions_.end();
         }
 

--- a/hpx/components/process/util/posix/executor.hpp
+++ b/hpx/components/process/util/posix/executor.hpp
@@ -25,7 +25,7 @@ namespace hpx { namespace components { namespace process { namespace posix {
 
 struct executor
 {
-    executor() : exe(0), cmd_line(0), env(0) {}
+    executor() : exe(nullptr), cmd_line(nullptr), env(nullptr) {}
 
     struct call_on_fork_setup
     {

--- a/hpx/components/process/util/posix/initializers/run_exe.hpp
+++ b/hpx/components/process/util/posix/initializers/run_exe.hpp
@@ -30,14 +30,14 @@ class run_exe_ : public initializer_base
 public:
     run_exe_()
     {
-        cmd_line_[0] = cmd_line_[1] = 0;
+        cmd_line_[0] = cmd_line_[1] = nullptr;
     }
 
     explicit run_exe_(const std::string &s)
       : s_(s)
     {
         cmd_line_[0] = const_cast<char*>(s_.c_str());
-        cmd_line_[1] = 0;
+        cmd_line_[1] = nullptr;
     }
 
     template <class PosixExecutor>
@@ -63,7 +63,7 @@ private:
         ar & s_;
 
         cmd_line_[0] = const_cast<char*>(s_.c_str());
-        cmd_line_[1] = 0;
+        cmd_line_[1] = nullptr;
     }
 
     HPX_SERIALIZATION_SPLIT_MEMBER()

--- a/hpx/components/process/util/posix/initializers/set_args.hpp
+++ b/hpx/components/process/util/posix/initializers/set_args.hpp
@@ -30,7 +30,7 @@ public:
     set_args_()
     {
         args_.resize(1);
-        args_[0] = 0;
+        args_[0] = nullptr;
     }
 
     explicit set_args_(const Range &args)
@@ -42,7 +42,7 @@ public:
             string_args_[i] = args[i];
             args_[i] = const_cast<char*>(string_args_[i].c_str());
         }
-        args_[args.size()] = 0;
+        args_[args.size()] = nullptr;
     }
 
     template <class PosixExecutor>
@@ -72,7 +72,7 @@ private:
         {
             args_[i] = const_cast<char*>(string_args_[i].c_str());
         }
-        args_[string_args_.size()] = 0;
+        args_[string_args_.size()] = nullptr;
     }
 
     HPX_SERIALIZATION_SPLIT_MEMBER()

--- a/hpx/components/process/util/posix/initializers/set_cmd_line.hpp
+++ b/hpx/components/process/util/posix/initializers/set_cmd_line.hpp
@@ -57,7 +57,7 @@ private:
         std::size_t i = 0;
         for (std::string const& s : args_)
             cmd_line_[i++] = const_cast<char*>(s.c_str());
-        cmd_line_[i] = 0;
+        cmd_line_[i] = nullptr;
     }
 
     friend class hpx::serialization::access;

--- a/hpx/components/process/util/posix/initializers/set_env.hpp
+++ b/hpx/components/process/util/posix/initializers/set_env.hpp
@@ -30,7 +30,7 @@ public:
     set_env_()
     {
         env_.resize(1);
-        env_[0] = 0;
+        env_[0] = nullptr;
     }
 
     explicit set_env_(const Range &envs)
@@ -42,7 +42,7 @@ public:
             string_env_[i] = envs[i];
             env_[i] = const_cast<char*>(string_env_[i].c_str());
         }
-        env_[envs.size()] = 0;
+        env_[envs.size()] = nullptr;
     }
 
     template <class PosixExecutor>
@@ -70,7 +70,7 @@ private:
         {
             env_[i] = const_cast<char*>(string_env_[i].c_str());
         }
-        env_[string_env_.size()] = 0;
+        env_[string_env_.size()] = nullptr;
     }
 
     HPX_SERIALIZATION_SPLIT_MEMBER()

--- a/hpx/compute/host/block_allocator.hpp
+++ b/hpx/compute/host/block_allocator.hpp
@@ -116,7 +116,7 @@ namespace hpx { namespace compute { namespace host
         // topo.allocate(). The pointer hint may be used to provide locality of
         // reference: the allocator, if supported by the implementation, will
         // attempt to allocate the new memory block as close as possible to hint.
-        pointer allocate(size_type n, std::allocator<void>::const_pointer hint = 0)
+        pointer allocate(size_type n, std::allocator<void>::const_pointer hint = nullptr)
         {
             return reinterpret_cast<pointer>(
                 hpx::threads::get_topology().allocate(n * sizeof(T)));

--- a/hpx/compute/traits/allocator_traits.hpp
+++ b/hpx/compute/traits/allocator_traits.hpp
@@ -292,7 +292,7 @@ namespace hpx { namespace compute { namespace traits
         HPX_HOST_DEVICE
         static void bulk_destroy(Allocator& alloc, T* p, size_type count) HPX_NOEXCEPT
         {
-            if (p != 0) detail::call_bulk_destroy(alloc, p, count);
+            if (p != nullptr) detail::call_bulk_destroy(alloc, p, count);
         }
     };
 }}}

--- a/hpx/hpx_init_impl.hpp
+++ b/hpx/hpx_init_impl.hpp
@@ -215,7 +215,7 @@ namespace hpx
         options_description desc_commandline(
             std::string("Usage: ") + HPX_APPLICATION_STRING +  " [options]");
 
-        char *dummy_argv[2] = { const_cast<char*>(HPX_APPLICATION_STRING), 0 };
+        char *dummy_argv[2] = { const_cast<char*>(HPX_APPLICATION_STRING), nullptr };
 
         return init(static_cast<hpx_main_type>(::hpx_main), desc_commandline,
             1, dummy_argv, cfg, startup_function_type(),
@@ -236,9 +236,9 @@ namespace hpx
         options_description desc_commandline(
             "Usage: " + app_name +  " [options]");
 
-        if (argc == 0 || argv == 0)
+        if (argc == 0 || argv == nullptr)
         {
-            char *dummy_argv[2] = { const_cast<char*>(app_name.c_str()), 0 };
+            char *dummy_argv[2] = { const_cast<char*>(app_name.c_str()), nullptr };
             return init(desc_commandline, 1, dummy_argv, mode);
         }
 
@@ -282,7 +282,7 @@ namespace hpx
         std::vector<std::string> cfg;
         util::function_nonser<void()> const empty;
 
-        HPX_ASSERT(argc != 0 && argv != 0);
+        HPX_ASSERT(argc != 0 && argv != nullptr);
 
         return init(main_f, desc_commandline, argc, argv, cfg,
             empty, empty, mode);
@@ -311,7 +311,7 @@ namespace hpx
         util::function_nonser<int(boost::program_options::variables_map& vm)>
             main_f = util::bind(detail::init_helper, util::placeholders::_1, f);
 
-        HPX_ASSERT(argc != 0 && argv != 0);
+        HPX_ASSERT(argc != 0 && argv != nullptr);
 
         return init(main_f, desc_commandline, argc, argv, cfg,
             startup_function_type(), shutdown_function_type(), mode);

--- a/hpx/hpx_start_impl.hpp
+++ b/hpx/hpx_start_impl.hpp
@@ -215,7 +215,7 @@ namespace hpx
         options_description desc_commandline(
             std::string("Usage: ") + HPX_APPLICATION_STRING +  " [options]");
 
-        char *dummy_argv[2] = { const_cast<char*>(HPX_APPLICATION_STRING), 0 };
+        char *dummy_argv[2] = { const_cast<char*>(HPX_APPLICATION_STRING), nullptr };
 
         return start(static_cast<hpx_main_type>(::hpx_main), desc_commandline,
             1, dummy_argv, cfg, startup_function_type(),
@@ -238,9 +238,9 @@ namespace hpx
         options_description desc_commandline(
             "Usage: " + app_name +  " [options]");
 
-        if (argc == 0 || argv == 0)
+        if (argc == 0 || argv == nullptr)
         {
-            char *dummy_argv[2] = { const_cast<char*>(app_name.c_str()), 0 };
+            char *dummy_argv[2] = { const_cast<char*>(app_name.c_str()), nullptr };
             return start(desc_commandline, 1, dummy_argv, mode);
         }
 
@@ -279,7 +279,7 @@ namespace hpx
             main_f = util::bind(detail::init_helper, util::placeholders::_1, f);
         std::vector<std::string> cfg;
 
-        HPX_ASSERT(argc != 0 && argv != 0);
+        HPX_ASSERT(argc != 0 && argv != nullptr);
 
         return start(main_f, desc_commandline, argc, argv, cfg,
             startup_function_type(), shutdown_function_type(), mode);
@@ -306,7 +306,7 @@ namespace hpx
         util::function_nonser<int(boost::program_options::variables_map& vm)>
             main_f = util::bind(detail::init_helper, util::placeholders::_1, f);
 
-        HPX_ASSERT(argc != 0 && argv != 0);
+        HPX_ASSERT(argc != 0 && argv != nullptr);
 
         return start(main_f, desc_commandline, argc, argv, cfg,
             startup_function_type(), shutdown_function_type(), mode);

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -357,7 +357,7 @@ namespace detail
         {
             // We need to run the completion asynchronously if we aren't on a
             // HPX thread
-            if (HPX_UNLIKELY(0 == threads::get_self_ptr()))
+            if (HPX_UNLIKELY(nullptr == threads::get_self_ptr()))
             {
                 HPX_THROW_EXCEPTION(null_thread_id,
                         "future_data::handle_on_completed",
@@ -702,12 +702,12 @@ namespace detail
 
     public:
         task_base()
-          : started_(false), sched_(0)
+          : started_(false), sched_(nullptr)
         {}
 
         task_base(threads::executor& sched)
           : started_(false),
-            sched_(sched ? &sched : 0)
+            sched_(sched ? &sched : nullptr)
         {}
 
         virtual void execute_deferred(error_code& ec = throws)

--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -431,7 +431,7 @@ namespace hpx { namespace lcos { namespace detail
         future_base(future_base && other) HPX_NOEXCEPT
           : shared_state_(std::move(other.shared_state_))
         {
-            other.shared_state_ = 0;
+            other.shared_state_ = nullptr;
         }
 
         void swap(future_base& other)
@@ -453,7 +453,7 @@ namespace hpx { namespace lcos { namespace detail
             if (this != &other)
             {
                 shared_state_ = std::move(other.shared_state_);
-                other.shared_state_ = 0;
+                other.shared_state_ = nullptr;
             }
             return *this;
         }
@@ -461,27 +461,27 @@ namespace hpx { namespace lcos { namespace detail
         // Returns: true only if *this refers to a shared state.
         bool valid() const HPX_NOEXCEPT
         {
-            return shared_state_ != 0;
+            return shared_state_ != nullptr;
         }
 
         // Returns: true if the shared state is ready, false if it isn't.
         bool is_ready() const HPX_NOEXCEPT
         {
-            return shared_state_ != 0 && shared_state_->is_ready();
+            return shared_state_ != nullptr && shared_state_->is_ready();
         }
 
         // Returns: true if the shared state is ready and stores a value,
         //          false if it isn't.
         bool has_value() const HPX_NOEXCEPT
         {
-            return shared_state_ != 0 && shared_state_->has_value();
+            return shared_state_ != nullptr && shared_state_->has_value();
         }
 
         // Returns: true if the shared state is ready and stores an exception,
         //          false if it isn't.
         bool has_exception() const HPX_NOEXCEPT
         {
-            return shared_state_ != 0 && shared_state_->has_exception();
+            return shared_state_ != nullptr && shared_state_->has_exception();
         }
 
         // Effects:
@@ -779,7 +779,7 @@ namespace hpx { namespace lcos
         //     constructor invocation.
         //   - other.valid() == false.
         future(future<future> && other) HPX_NOEXCEPT
-          : base_type(other.valid() ? detail::unwrap(std::move(other)) : 0)
+          : base_type(other.valid() ? detail::unwrap(std::move(other)) : nullptr)
         {}
 
         // Effects: constructs a future object by moving the instance referred
@@ -789,7 +789,7 @@ namespace hpx { namespace lcos
         //     constructor invocation.
         //   - other.valid() == false.
         future(future<shared_future<R> > && other) HPX_NOEXCEPT
-          : base_type(other.valid() ? detail::unwrap(std::move(other)) : 0)
+          : base_type(other.valid() ? detail::unwrap(std::move(other)) : nullptr)
         {}
 
         // Effects: constructs a future<void> object that will be ready when
@@ -801,7 +801,7 @@ namespace hpx { namespace lcos
         template <typename T>
         future(future<T>&& other,
             typename boost::enable_if<boost::is_void<R>, T>::type* = nullptr
-        ) : base_type(other.valid() ? detail::make_void_continuation(other) : 0)
+        ) : base_type(other.valid() ? detail::make_void_continuation(other) : nullptr)
         {
             other = future<T>();
         }
@@ -1087,7 +1087,7 @@ namespace hpx { namespace lcos
         //     constructor invocation.
         //   - other.valid() == false.
         shared_future(future<shared_future> && other) HPX_NOEXCEPT
-          : base_type(other.valid() ? detail::unwrap(other.share()) : 0)
+          : base_type(other.valid() ? detail::unwrap(other.share()) : nullptr)
         {}
 
         // Effects: constructs a future<void> object that will be ready when
@@ -1098,7 +1098,7 @@ namespace hpx { namespace lcos
         template <typename T>
         shared_future(shared_future<T> const& other,
             typename boost::enable_if<boost::is_void<R>, T>::type* = nullptr
-        ) : base_type(other.valid() ? detail::make_void_continuation(other) : 0)
+        ) : base_type(other.valid() ? detail::make_void_continuation(other) : nullptr)
         {}
 
         // Effects:

--- a/hpx/lcos/future_wait.hpp
+++ b/hpx/lcos/future_wait.hpp
@@ -133,7 +133,7 @@ namespace hpx { namespace lcos
                 f_(std::move(rhs.f_)),
                 success_counter_(rhs.success_counter_)
             {
-                rhs.success_counter_ = 0;
+                rhs.success_counter_ = nullptr;
             }
 
             wait_each& operator= (wait_each && rhs)
@@ -144,7 +144,7 @@ namespace hpx { namespace lcos
                     rhs.ready_count_ = 0;
                     f_ = std::move(rhs.f_);
                     success_counter_ = rhs.success_counter_;
-                    rhs.success_counter_ = 0;
+                    rhs.success_counter_ = nullptr;
                 }
                 return *this;
             }

--- a/hpx/lcos/local/composable_guard.hpp
+++ b/hpx/lcos/local/composable_guard.hpp
@@ -60,7 +60,7 @@ namespace hpx { namespace lcos { namespace local
     public:
         detail::guard_atomic task;
 
-        guard() : task((detail::guard_task*)0) {}
+        guard() : task(nullptr) {}
         ~guard() {
             detail::free(task.load());
         }

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -123,7 +123,7 @@ namespace hpx { namespace lcos { namespace detail
             inner_shared_state_ptr inner_state =
                 traits::detail::get_shared_state(func(std::move(future)));
 
-            if (inner_state.get() == 0)
+            if (inner_state.get() == nullptr)
             {
                 HPX_THROW_EXCEPTION(no_state,
                     "invoke_continuation",
@@ -183,7 +183,7 @@ namespace hpx { namespace lcos { namespace detail
             reset_id(continuation& target)
               : target_(target)
             {
-                if (threads::get_self_ptr() != 0)
+                if (threads::get_self_ptr() != nullptr)
                     target.set_id(threads::get_self_id());
             }
             ~reset_id()
@@ -575,7 +575,7 @@ namespace hpx { namespace lcos { namespace detail
                 inner_shared_state_ptr inner_state =
                     traits::detail::get_shared_state(outer.get());
 
-                if (inner_state.get() == 0)
+                if (inner_state.get() == nullptr)
                 {
                     HPX_THROW_EXCEPTION(no_state,
                         "unwrap_continuation<ContResult>::on_outer_ready",

--- a/hpx/lcos/local/spinlock.hpp
+++ b/hpx/lcos/local/spinlock.hpp
@@ -118,7 +118,7 @@ namespace hpx { namespace lcos { namespace local
                     rqtp.tv_sec = 0;
                     rqtp.tv_nsec = 1000;
 
-                    nanosleep( &rqtp, 0 );
+                    nanosleep( &rqtp, nullptr );
 #else
 #endif
                 }

--- a/hpx/parallel/util/numa_allocator.hpp
+++ b/hpx/parallel/util/numa_allocator.hpp
@@ -73,7 +73,7 @@ namespace hpx { namespace parallel { namespace util
 
         // memory allocation
         pointer allocate(size_type cnt,
-            typename std::allocator<void>::const_pointer = 0)
+            typename std::allocator<void>::const_pointer = nullptr)
         {
             // allocate memory
             pointer p = reinterpret_cast<pointer>(topo_.allocate(cnt * sizeof(T)));

--- a/hpx/plugins/message_handler_factory.hpp
+++ b/hpx/plugins/message_handler_factory.hpp
@@ -76,7 +76,7 @@ namespace hpx { namespace plugins
         {
             if (isenabled_)
                 return new MessageHandler(action, pp, num_messages, interval);
-            return 0;
+            return nullptr;
         }
 
     protected:

--- a/hpx/plugins/parcel/message_buffer.hpp
+++ b/hpx/plugins/parcel/message_buffer.hpp
@@ -61,7 +61,7 @@ namespace hpx { namespace plugins { namespace parcel { namespace detail
         {
             if (!messages_.empty())
             {
-                if (0 == threads::get_self_ptr())
+                if (nullptr == threads::get_self_ptr())
                 {
                     // reschedule this call on a new HPX thread
                     using parcelset::parcelport;

--- a/hpx/plugins/parcelport/mpi/header.hpp
+++ b/hpx/plugins/parcelport/mpi/header.hpp
@@ -123,7 +123,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
         {
             if(data_[pos_piggy_back_flag])
                 return &data_[pos_piggy_back_data];
-            return 0;
+            return nullptr;
         }
 
     private:

--- a/hpx/plugins/parcelport/mpi/receiver_connection.hpp
+++ b/hpx/plugins/parcelport/mpi/receiver_connection.hpp
@@ -49,7 +49,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
           , tag_(h.tag())
           , header_(h)
           , request_(MPI_REQUEST_NULL)
-          , request_ptr_(0)
+          , request_ptr_(nullptr)
           , chunks_idx_(0)
           , pp_(pp)
         {
@@ -216,7 +216,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
 
         bool request_done()
         {
-            if(request_ptr_ == 0) return true;
+            if(request_ptr_ == nullptr) return true;
 
             util::mpi_environment::scoped_try_lock l;
 
@@ -228,7 +228,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
             HPX_ASSERT(ret == MPI_SUCCESS);
             if(completed)// && status.MPI_ERROR != MPI_ERR_PENDING)
             {
-                request_ptr_ = 0;
+                request_ptr_ = nullptr;
                 return true;
             }
             return false;

--- a/hpx/plugins/parcelport/mpi/sender_connection.hpp
+++ b/hpx/plugins/parcelport/mpi/sender_connection.hpp
@@ -67,7 +67,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
           , sender_(s)
           , dst_(dst)
           , request_(MPI_REQUEST_NULL)
-          , request_ptr_(0)
+          , request_ptr_(nullptr)
           , chunks_idx_(0)
           , ack_(0)
           , parcels_sent_(parcels_sent)
@@ -94,7 +94,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
         void async_write(Handler && handler, ParcelPostprocess && parcel_postprocess)
         {
             HPX_ASSERT(!buffer_.data_.empty());
-            request_ptr_ = 0;
+            request_ptr_ = nullptr;
             chunks_idx_ = 0;
             tag_ = acquire_tag(sender_);
             header_ = header(buffer_, tag_);
@@ -143,7 +143,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
             {
                 util::mpi_environment::scoped_lock l;
                 HPX_ASSERT(state_ == initialized);
-                HPX_ASSERT(request_ptr_ == 0);
+                HPX_ASSERT(request_ptr_ == nullptr);
                 MPI_Isend(
                     header_.data()
                   , header_.data_size_
@@ -163,10 +163,10 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
         bool send_transmission_chunks()
         {
             HPX_ASSERT(state_ == sent_header);
-            HPX_ASSERT(request_ptr_ != 0);
+            HPX_ASSERT(request_ptr_ != nullptr);
             if(!request_done()) return false;
 
-            HPX_ASSERT(request_ptr_ == 0);
+            HPX_ASSERT(request_ptr_ == nullptr);
 
             std::vector<typename parcel_buffer_type::transmission_chunk_type>& chunks =
                 buffer_.transmission_chunks_;
@@ -268,7 +268,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
 
         bool request_done()
         {
-            if(request_ptr_ == 0) return true;
+            if(request_ptr_ == nullptr) return true;
 
             util::mpi_environment::scoped_try_lock l;
 
@@ -280,7 +280,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
             HPX_ASSERT(ret == MPI_SUCCESS);
             if(completed)// && status.MPI_ERROR != MPI_ERR_PENDING)
             {
-                request_ptr_ = 0;
+                request_ptr_ = nullptr;
                 return true;
             }
             return false;

--- a/hpx/plugins/parcelport/tcp/receiver.hpp
+++ b/hpx/plugins/parcelport/tcp/receiver.hpp
@@ -166,7 +166,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
                         static_cast<boost::uint32_t>(buffer_.num_chunks_.second));
 
                 void (receiver::*f)(boost::system::error_code const&,
-                        Handler) = 0;
+                        Handler) = nullptr;
 
                 if (num_zero_copy_chunks != 0) {
                     typedef parcel_buffer_type::transmission_chunk_type

--- a/hpx/runtime/actions/action_invoke_no_more_than.hpp
+++ b/hpx/runtime/actions/action_invoke_no_more_than.hpp
@@ -171,7 +171,7 @@ namespace hpx { namespace actions { namespace detail
         {
             if(cont_)
             {
-                HPX_ASSERT(0 != dynamic_cast<base_type *>(cont_.get()));
+                HPX_ASSERT(nullptr != dynamic_cast<base_type *>(cont_.get()));
                 static_cast<base_type *>(cont_.get())->
                     trigger_value(std::move(result));
             }

--- a/hpx/runtime/actions/continuation.hpp
+++ b/hpx/runtime/actions/continuation.hpp
@@ -336,7 +336,7 @@ namespace hpx { namespace actions
         {
             try {
                 HPX_ASSERT(result.is_ready());
-                HPX_ASSERT((0 !=
+                HPX_ASSERT((nullptr !=
                     dynamic_cast<
                         typed_continuation<Result, RemoteResult>*
                     >(cont.get())));

--- a/hpx/runtime/actions/continuation.hpp
+++ b/hpx/runtime/actions/continuation.hpp
@@ -405,7 +405,7 @@ namespace hpx { namespace actions
             std::unique_ptr<continuation> cont, F&& f, Ts&&... vs)
         {
             try {
-                HPX_ASSERT((0 !=
+                HPX_ASSERT((nullptr !=
                     dynamic_cast<
                         typed_continuation<Result, RemoteResult>*
                     >(cont.get())));
@@ -949,7 +949,7 @@ namespace hpx { namespace actions
         // for cases when Arg0 is a const&. This does not make the code invalid
         // as trigger_value (which is a virtual function) takes its argument
         // by && anyways.
-        HPX_ASSERT(0 != dynamic_cast<
+        HPX_ASSERT(nullptr != dynamic_cast<
                 typed_continuation<typename util::decay<Arg0>::type> *
             >(this));
 

--- a/hpx/runtime/components/client_base.hpp
+++ b/hpx/runtime/components/client_base.hpp
@@ -256,7 +256,7 @@ namespace hpx { namespace components
           : registered_name_(std::move(rhs.registered_name_)),
             shared_state_(std::move(rhs.shared_state_))
         {
-            rhs.shared_state_ = 0;
+            rhs.shared_state_ = nullptr;
         }
 
         // A future to a client_base can be unwrapped to represent the
@@ -327,7 +327,7 @@ namespace hpx { namespace components
         // Returns: true only if *this refers to a shared state.
         bool valid() const HPX_NOEXCEPT
         {
-            return shared_state_ != 0;
+            return shared_state_ != nullptr;
         }
 
         // check whether the embedded shared state is valid

--- a/hpx/runtime/components/client_base.hpp
+++ b/hpx/runtime/components/client_base.hpp
@@ -263,7 +263,7 @@ namespace hpx { namespace components
         // client_base directly as a client_base is semantically a future to
         // the id of the referenced object.
         client_base(future<Derived> && d)
-          : shared_state_(d.valid() ? lcos::detail::unwrap(std::move(d)) : 0)
+          : shared_state_(d.valid() ? lcos::detail::unwrap(std::move(d)) : nullptr)
         {}
 
         ~client_base()
@@ -427,21 +427,21 @@ namespace hpx { namespace components
         // Returns: true if the shared state is ready, false if it isn't.
         bool is_ready() const HPX_NOEXCEPT
         {
-            return shared_state_ != 0 && shared_state_->is_ready();
+            return shared_state_ != nullptr && shared_state_->is_ready();
         }
 
         // Returns: true if the shared state is ready and stores a value,
         //          false if it isn't.
         bool has_value() const HPX_NOEXCEPT
         {
-            return shared_state_ != 0 && shared_state_->has_value();
+            return shared_state_ != nullptr && shared_state_->has_value();
         }
 
         // Returns: true if the shared state is ready and stores an exception,
         //          false if it isn't.
         bool has_exception() const HPX_NOEXCEPT
         {
-            return shared_state_ != 0 && shared_state_->has_exception();
+            return shared_state_ != nullptr && shared_state_->has_exception();
         }
 
         void wait() const

--- a/hpx/runtime/components/server/fixed_component_base.hpp
+++ b/hpx/runtime/components/server/fixed_component_base.hpp
@@ -208,7 +208,7 @@ namespace detail
         static Component* alloc(std::size_t count)
         {
             HPX_ASSERT(false);        // this shouldn't ever be called
-            return 0;
+            return nullptr;
         }
         static void free(void* p, std::size_t count)
         {
@@ -232,7 +232,7 @@ class fixed_component : public Component
     static Component* create(std::size_t count)
     {
         HPX_ASSERT(false);        // this shouldn't ever be called
-        return 0;
+        return nullptr;
     }
 
     /// \brief  The function \a destroy is used for destruction and

--- a/hpx/runtime/components/server/managed_component_base.hpp
+++ b/hpx/runtime/components/server/managed_component_base.hpp
@@ -203,7 +203,7 @@ namespace hpx { namespace components
             "traits::managed_object_controls_lifetime>::value");
 
         managed_component_base()
-          : back_ptr_(0)
+          : back_ptr_(nullptr)
         {}
 
         managed_component_base(managed_component<Component, Wrapper>* back_ptr)
@@ -272,7 +272,7 @@ namespace hpx { namespace components
 
         void set_back_ptr(components::managed_component<Component, Wrapper>* bp)
         {
-            HPX_ASSERT(0 == back_ptr_);
+            HPX_ASSERT(nullptr == back_ptr_);
             HPX_ASSERT(bp);
             back_ptr_ = bp;
         }
@@ -393,7 +393,7 @@ namespace hpx { namespace components
         ///        instance
         template <typename ...Ts>
         managed_component(Ts&&... vs)
-          : component_(0)
+          : component_(nullptr)
         {
             detail_adl_barrier::init<
                 typename traits::managed_component_ctor_policy<Component>::type

--- a/hpx/runtime/components/server/memory_block.hpp
+++ b/hpx/runtime/components/server/memory_block.hpp
@@ -303,11 +303,12 @@ namespace hpx { namespace components
 
             HPX_ASSERT(act->save_function());
             if (config) {
-                act->save_function()(data->get_ptr(), data->get_size(), ar, version,
-                    config->get_ptr());
+                act->save_function()(data->get_ptr(), data->get_size(), ar,
+                    version, config->get_ptr());
             }
             else {
-                act->save_function()(data->get_ptr(), data->get_size(), ar, version, nullptr);
+                act->save_function()(data->get_ptr(), data->get_size(), ar,
+                    version, nullptr);
             }
         }
 

--- a/hpx/runtime/components/server/memory_block.hpp
+++ b/hpx/runtime/components/server/memory_block.hpp
@@ -115,7 +115,7 @@ namespace hpx { namespace components { namespace server { namespace detail
 
         /// Return whether this instance is the master instance of this
         /// memory block
-        bool is_master() const { return 0 != wrapper_; }
+        bool is_master() const { return nullptr != wrapper_; }
 
         static component_type get_component_type()
         {
@@ -307,14 +307,14 @@ namespace hpx { namespace components
                     config->get_ptr());
             }
             else {
-                act->save_function()(data->get_ptr(), data->get_size(), ar, version, 0);
+                act->save_function()(data->get_ptr(), data->get_size(), ar, version, nullptr);
             }
         }
 
         template <class Archive>
         void save(Archive & ar, const unsigned int version) const
         {
-            bool has_config = config_ != 0;
+            bool has_config = config_ != nullptr;
             ar << has_config;
             if (has_config)
                 save_(ar, version, config_.get());
@@ -344,7 +344,7 @@ namespace hpx { namespace components
                     config->get_ptr());
             }
             else {
-                act->load_function()(p->get_ptr(), size, ar, version, 0); //-V522
+                act->load_function()(p->get_ptr(), size, ar, version, nullptr); //-V522
             }
 
             delete act;
@@ -450,7 +450,7 @@ namespace hpx { namespace components { namespace server
 
         /// \brief Construct an empty managed_component
         memory_block()
-          : component_(0)
+          : component_(nullptr)
         {}
 
     private:
@@ -471,7 +471,7 @@ namespace hpx { namespace components { namespace server
         ///             wrapped instance.
         memory_block(std::size_t size,
                 actions::manage_object_action_base const& act)
-          : component_(0)
+          : component_(nullptr)
         {
             typedef detail::memory_block alloc_type;
             alloc_type* p = server::detail::allocate_block<alloc_type>(size);
@@ -483,7 +483,7 @@ namespace hpx { namespace components { namespace server
         ///        parameter
         memory_block(detail::memory_block_header const* rhs,
                 actions::manage_object_action_base const& act)
-          : component_(0)
+          : component_(nullptr)
         {
             std::size_t size = rhs->get_size();
             typedef detail::memory_block alloc_type;

--- a/hpx/runtime/parcelset/encode_parcels.hpp
+++ b/hpx/runtime/parcelset/encode_parcels.hpp
@@ -157,7 +157,7 @@ namespace hpx
                         ps[0].get_serialization_filter());
 
                     int archive_flags = archive_flags_;
-                    if (filter.get() != 0)
+                    if (filter.get() != nullptr)
                         archive_flags |= serialization::enable_compression;
 
                     // Get the chunk size from the allocator if it supports it
@@ -181,7 +181,7 @@ namespace hpx
 
                     {
                         // Serialize the data
-                        if (filter.get() != 0)
+                        if (filter.get() != nullptr)
                             filter->set_max_length(buffer.data_.capacity());
 
                         serialization::output_archive archive(

--- a/hpx/runtime/parcelset/locality.hpp
+++ b/hpx/runtime/parcelset/locality.hpp
@@ -74,12 +74,12 @@ namespace hpx { namespace parcelset
         {}
 
         locality(locality const & other)
-          : impl_(other.impl_ ? other.impl_->clone() : 0)
+          : impl_(other.impl_ ? other.impl_->clone() : nullptr)
         {
         }
 
         locality(locality && other)
-          : impl_(other.impl_ ? other.impl_->move() : 0)
+          : impl_(other.impl_ ? other.impl_->move() : nullptr)
         {
         }
 

--- a/hpx/runtime/parcelset/parcelhandler.hpp
+++ b/hpx/runtime/parcelset/parcelhandler.hpp
@@ -406,7 +406,7 @@ namespace hpx { namespace parcelset
         parcelport *find_parcelport(std::string const& type, error_code = throws) const
         {
             int priority = get_priority(type);
-            if(priority <= 0) return 0;
+            if(priority <= 0) return nullptr;
             HPX_ASSERT(pports_.find(priority) != pports_.end());
             return pports_.find(priority)->second.get();
         }

--- a/hpx/runtime/parcelset/parcelport_impl.hpp
+++ b/hpx/runtime/parcelset/parcelport_impl.hpp
@@ -324,7 +324,7 @@ namespace hpx { namespace parcelset
         {
             if (0 == std::strcmp(name, io_service_pool_.get_name()))
                 return &io_service_pool_;
-            return 0;
+            return nullptr;
         }
 
         bool do_background_work(std::size_t num_thread)

--- a/hpx/runtime/serialization/detail/raw_ptr.hpp
+++ b/hpx/runtime/serialization/detail/raw_ptr.hpp
@@ -31,7 +31,7 @@ namespace hpx { namespace serialization { namespace detail
 
         operator bool() const
         {
-            return t != 0;
+            return t != nullptr;
         }
 
     private:

--- a/hpx/runtime/serialization/input_container.hpp
+++ b/hpx/runtime/serialization/input_container.hpp
@@ -49,7 +49,7 @@ namespace hpx { namespace serialization
         input_container(Container const& cont, std::size_t inbound_data_size)
           : cont_(cont), current_(0), filter_(),
             decompressed_size_(inbound_data_size),
-            chunks_(0), current_chunk_(std::size_t(-1)), current_chunk_size_(0)
+            chunks_(nullptr), current_chunk_(std::size_t(-1)), current_chunk_size_(0)
         {}
 
         input_container(Container const& cont,
@@ -57,7 +57,7 @@ namespace hpx { namespace serialization
                 std::size_t inbound_data_size)
           : cont_(cont), current_(0), filter_(),
             decompressed_size_(inbound_data_size),
-            chunks_(0), current_chunk_(std::size_t(-1)), current_chunk_size_(0)
+            chunks_(nullptr), current_chunk_(std::size_t(-1)), current_chunk_size_(0)
         {
             if (chunks && chunks->size() != 0)
             {

--- a/hpx/runtime/serialization/input_container.hpp
+++ b/hpx/runtime/serialization/input_container.hpp
@@ -129,7 +129,7 @@ namespace hpx { namespace serialization
         {
             HPX_ASSERT((boost::int64_t)count >= 0);
 
-            if (filter_.get() || chunks_ == 0 ||
+            if (filter_.get() || chunks_ == nullptr ||
                 count < HPX_ZERO_COPY_SERIALIZATION_THRESHOLD) {
                 // fall back to serialization_chunk-less archive
                 this->input_container::load_binary(address, count);

--- a/hpx/runtime/serialization/output_archive.hpp
+++ b/hpx/runtime/serialization/output_archive.hpp
@@ -63,7 +63,7 @@ namespace hpx { namespace serialization
             // the same assumptions about the archive format
             save(flags);
 
-            bool has_filter = filter != 0;
+            bool has_filter = filter != nullptr;
             save(has_filter);
 
             if (has_filter && enable_compression())

--- a/hpx/runtime/serialization/output_container.hpp
+++ b/hpx/runtime/serialization/output_container.hpp
@@ -170,7 +170,7 @@ namespace hpx { namespace serialization
 
         void set_filter(binary_filter* filter) // override
         {
-            HPX_ASSERT(0 == filter_);
+            HPX_ASSERT(nullptr == filter_);
             filter_ = filter;
             start_compressing_at_ = current_;
 
@@ -225,7 +225,8 @@ namespace hpx { namespace serialization
 
         void save_binary_chunk(void const* address, std::size_t count) // override
         {
-            if (filter_ || chunks_ == 0 || count < HPX_ZERO_COPY_SERIALIZATION_THRESHOLD)
+            if (filter_ || chunks_ == nullptr ||
+                count < HPX_ZERO_COPY_SERIALIZATION_THRESHOLD)
             {
                 // fall back to serialization_chunk-less archive
                 this->output_container::save_binary(address, count);

--- a/hpx/runtime/serialization/output_container.hpp
+++ b/hpx/runtime/serialization/output_container.hpp
@@ -90,7 +90,7 @@ namespace hpx { namespace serialization
         output_container(Container& cont,
             std::vector<serialization_chunk>* chunks,
             binary_filter* filter)
-            : cont_(cont), current_(0), start_compressing_at_(0), filter_(0),
+            : cont_(cont), current_(0), start_compressing_at_(0), filter_(nullptr),
               chunks_(chunks), current_chunk_(std::size_t(-1))
         {
             if (chunks_)

--- a/hpx/runtime/threads/coroutines/coroutine.hpp
+++ b/hpx/runtime/threads/coroutines/coroutine.hpp
@@ -68,10 +68,10 @@ namespace hpx { namespace threads { namespace coroutines
             thread_state_enum(thread_state_ex_enum)
         > functor_type;
 
-        coroutine() : m_pimpl(0) {}
+        coroutine() : m_pimpl(nullptr) {}
 
         coroutine(functor_type&& f, naming::id_type&& target,
-            thread_id_repr_type id = 0, std::ptrdiff_t stack_size =
+            thread_id_repr_type id = nullptr, std::ptrdiff_t stack_size =
             detail::default_stack_size)
           : m_pimpl(impl_type::create(
                 std::move(f), std::move(target), id, stack_size))
@@ -86,7 +86,7 @@ namespace hpx { namespace threads { namespace coroutines
         coroutine(coroutine && src)
           : m_pimpl(src.m_pimpl)
         {
-            src.m_pimpl = 0;
+            src.m_pimpl = nullptr;
         }
 
         coroutine& operator=(coroutine && src)
@@ -131,7 +131,7 @@ namespace hpx { namespace threads { namespace coroutines
 #endif
 
         void rebind(functor_type&& f, naming::id_type&& target,
-            thread_id_repr_type id = 0)
+            thread_id_repr_type id = nullptr)
         {
             HPX_ASSERT(exited());
             impl_type::rebind(m_pimpl.get(), std::move(f),
@@ -155,7 +155,7 @@ namespace hpx { namespace threads { namespace coroutines
         typedef void(coroutine::*bool_type)();
         operator bool_type() const
         {
-            return good() ? &coroutine::bool_type_f : 0;
+            return good() ? &coroutine::bool_type_f : nullptr;
         }
 
         bool operator==(const coroutine& rhs) const
@@ -195,7 +195,7 @@ namespace hpx { namespace threads { namespace coroutines
 
         bool empty() const
         {
-            return m_pimpl == 0;
+            return m_pimpl == nullptr;
         }
 
         std::ptrdiff_t get_available_stack_space()

--- a/hpx/runtime/threads/coroutines/detail/context_base.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_base.hpp
@@ -178,7 +178,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 #if defined(HPX_HAVE_THREAD_LOCAL_STORAGE)
             delete_tss_storage(m_thread_data);
 #endif
-            m_thread_id = 0;
+            m_thread_id = nullptr;
         }
 
 #if defined(HPX_HAVE_THREAD_OPERATIONS_COUNT)
@@ -440,7 +440,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
                 if (!exited())
                     exit();
                 HPX_ASSERT(exited());
-                m_thread_id = 0;
+                m_thread_id = nullptr;
             }
             catch (...) {
                 /**/;

--- a/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
@@ -141,7 +141,7 @@ namespace hpx { namespace threads { namespace coroutines
             typedef x86_linux_context_impl_base context_impl_base;
 
             x86_linux_context_impl()
-                : m_stack(0)
+                : m_stack(nullptr)
             {}
 
             /**
@@ -153,7 +153,7 @@ namespace hpx { namespace threads { namespace coroutines
               : m_stack_size(stack_size == -1
                   ? static_cast<std::ptrdiff_t>(default_stack_size)
                   : stack_size),
-                m_stack(0)
+                m_stack(nullptr)
             {
                 if (0 != (m_stack_size % EXEC_PAGESIZE))
                 {

--- a/hpx/runtime/threads/coroutines/detail/coroutine_impl.hpp
+++ b/hpx/runtime/threads/coroutines/detail/coroutine_impl.hpp
@@ -75,8 +75,8 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
             thread_id_repr_type id, std::ptrdiff_t stack_size)
           : context_base(*this, stack_size, id)
           , m_result_last(thread_state_enum::unknown)
-          , m_arg(0)
-          , m_result(0)
+          , m_arg(nullptr)
+          , m_result(nullptr)
           , m_fun(std::move(f))
           , target_(std::move(target))
         {}
@@ -90,7 +90,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 
         static inline coroutine_impl* create(
             functor_type&& f,
-            naming::id_type&& target, thread_id_repr_type id = 0,
+            naming::id_type&& target, thread_id_repr_type id = nullptr,
             std::ptrdiff_t stack_size = default_stack_size)
         {
             coroutine_impl* p = allocate(id, stack_size);
@@ -113,7 +113,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 
         static inline void rebind(
             coroutine_impl* p, functor_type&& f,
-            naming::id_type&& target, thread_id_repr_type id = 0)
+            naming::id_type&& target, thread_id_repr_type id = nullptr)
         {
             p->rebind(std::move(f), std::move(target), id);
         }

--- a/hpx/runtime/threads/coroutines/detail/tss.hpp
+++ b/hpx/runtime/threads/coroutines/detail/tss.hpp
@@ -38,7 +38,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 
     public:
         tss_data_node()
-          : value_(0)
+          : value_(nullptr)
         {}
 
         tss_data_node(void* val)
@@ -57,7 +57,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
             value_(rhs.value_)
         {
             rhs.func_.reset();
-            rhs.value_ = 0;
+            rhs.value_ = nullptr;
         }
 #endif
 
@@ -73,7 +73,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
             value_ = rhs.value_;
 
             rhs.func_.reset();
-            rhs.value_ = 0;
+            rhs.value_ = nullptr;
             return *this;
         }
 #endif
@@ -81,14 +81,14 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         template <typename T>
         T get_data() const
         {
-            HPX_ASSERT(value_ != 0);
+            HPX_ASSERT(value_ != nullptr);
             return *reinterpret_cast<T*>(value_);
         }
 
         template <typename T>
         void set_data(T const& val)
         {
-            if (value_ == 0)
+            if (value_ == nullptr)
                 value_ = new T(val);
             else
                 *reinterpret_cast<T*>(value_) = val;
@@ -124,14 +124,14 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         {
             tss_node_data_map::const_iterator it = data_.find(key);
             if (it == data_.end())
-                return 0;
+                return nullptr;
             return &(it->second);
         }
         tss_data_node* find_entry(void const* key)
         {
             tss_node_data_map::iterator it = data_.find(key);
             if (it == data_.end())
-                return 0;
+                return nullptr;
             return &(it->second);
         }
 

--- a/hpx/runtime/threads/detail/create_thread.hpp
+++ b/hpx/runtime/threads/detail/create_thread.hpp
@@ -51,7 +51,7 @@ namespace hpx { namespace threads { namespace detail
         thread_self* self = get_self_ptr();
 
 #ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
-        if (0 == data.parent_id) {
+        if (nullptr == data.parent_id) {
             if (self)
             {
                 data.parent_id = threads::get_self_id().get();
@@ -62,7 +62,7 @@ namespace hpx { namespace threads { namespace detail
             data.parent_locality_id = get_locality_id();
 #endif
 
-        if (0 == data.scheduler_base)
+        if (nullptr == data.scheduler_base)
             data.scheduler_base = scheduler;
 
         // Pass critical priority from parent to child.

--- a/hpx/runtime/threads/detail/create_work.hpp
+++ b/hpx/runtime/threads/detail/create_work.hpp
@@ -59,7 +59,7 @@ namespace hpx { namespace threads { namespace detail
         thread_self* self = get_self_ptr();
 
 #ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
-        if (0 == data.parent_id) {
+        if (nullptr == data.parent_id) {
 
             if (self)
             {
@@ -71,7 +71,7 @@ namespace hpx { namespace threads { namespace detail
             data.parent_locality_id = get_locality_id();
 #endif
 
-        if (0 == data.scheduler_base)
+        if (nullptr == data.scheduler_base)
             data.scheduler_base = scheduler;
 
         // Pass critical priority from parent to child.
@@ -86,12 +86,12 @@ namespace hpx { namespace threads { namespace detail
             thread_priority_boost == data.priority)
         {
             // For critical priority threads, create the thread immediately.
-            scheduler->create_thread(data, 0, initial_state, true, ec,
+            scheduler->create_thread(data, nullptr, initial_state, true, ec,
                 data.num_os_thread);
         }
         else {
             // Create a task description for the new thread.
-            scheduler->create_thread(data, 0, initial_state, false, ec,
+            scheduler->create_thread(data, nullptr, initial_state, false, ec,
                 data.num_os_thread);
         }
     }

--- a/hpx/runtime/threads/detail/set_thread_state.hpp
+++ b/hpx/runtime/threads/detail/set_thread_state.hpp
@@ -344,7 +344,7 @@ namespace hpx { namespace threads { namespace detail
             HPX_THROWS_IF(ec, null_thread_id,
                 "threads::detail::set_thread_state",
                 "null thread id encountered");
-            return 0;
+            return nullptr;
         }
 
         // this creates a new thread which creates the timer and handles the

--- a/hpx/runtime/threads/executors/service_executors.hpp
+++ b/hpx/runtime/threads/executors/service_executors.hpp
@@ -127,7 +127,7 @@ namespace hpx { namespace threads { namespace executors
             HPX_THROW_EXCEPTION(bad_parameter,
                 "hpx::threads::detail::get_service_executor",
                 "unknown pool executor type");
-            return 0;
+            return nullptr;
         }
         /// \endcond
     }

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -1157,7 +1157,7 @@ namespace hpx { namespace threads { namespace policies
         ///////////////////////////////////////////////////////////////////////
         void on_start_thread(std::size_t num_thread)
         {
-            if (0 == queues_[num_thread])
+            if (nullptr == queues_[num_thread])
             {
                 queues_[num_thread] =
                     new thread_queue_type(max_queue_thread_count_);

--- a/hpx/runtime/threads/policies/local_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_queue_scheduler.hpp
@@ -719,7 +719,7 @@ namespace hpx { namespace threads { namespace policies
         ///////////////////////////////////////////////////////////////////////
         void on_start_thread(std::size_t num_thread)
         {
-            if (0 == queues_[num_thread])
+            if (nullptr == queues_[num_thread])
             {
                 queues_[num_thread] =
                     new thread_queue_type(max_queue_thread_count_);

--- a/hpx/runtime/threads/run_as_os_thread.hpp
+++ b/hpx/runtime/threads/run_as_os_thread.hpp
@@ -23,7 +23,7 @@ namespace hpx { namespace threads
     hpx::future<typename util::result_of<F&&(Ts &&...)>::type>
     run_as_os_thread(F && f, Ts &&... vs)
     {
-        HPX_ASSERT(get_self_ptr() != 0);
+        HPX_ASSERT(get_self_ptr() != nullptr);
 
         typedef executors::io_pool_executor executor_type;
         typedef parallel::executor_traits<executor_type> traits;

--- a/hpx/runtime/threads/thread_data.hpp
+++ b/hpx/runtime/threads/thread_data.hpp
@@ -98,7 +98,7 @@ namespace hpx { namespace threads
             thread_state_enum newstate)
         {
             thread_data* ret = pool.allocate();
-            if (ret == 0)
+            if (ret == nullptr)
             {
                 HPX_THROW_EXCEPTION(out_of_memory,
                     "thread_data::operator new",
@@ -372,20 +372,20 @@ namespace hpx { namespace threads
 # ifdef HPX_HAVE_THREAD_FULLBACKTRACE_ON_SUSPENSION
         char const* get_backtrace() const
         {
-            return 0;
+            return nullptr;
         }
         char const* set_backtrace(char const*)
         {
-            return 0;
+            return nullptr;
         }
 # else
         util::backtrace const* get_backtrace() const
         {
-            return 0;
+            return nullptr;
         }
         util::backtrace const* set_backtrace(util::backtrace const*)
         {
-            return 0;
+            return nullptr;
         }
 # endif
 
@@ -584,7 +584,7 @@ namespace hpx { namespace threads
             marked_state_(unknown),
 #endif
 #ifdef HPX_HAVE_THREAD_BACKTRACE_ON_SUSPENSION
-            backtrace_(0),
+            backtrace_(nullptr),
 #endif
             priority_(init_data.priority),
             requested_interrupt_(false),
@@ -603,7 +603,7 @@ namespace hpx { namespace threads
 #ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
             // store the thread id of the parent thread, mainly for debugging
             // purposes
-            if (0 == parent_thread_id_) {
+            if (nullptr == parent_thread_id_) {
                 thread_self* self = get_self_ptr();
                 if (self)
                 {
@@ -640,7 +640,7 @@ namespace hpx { namespace threads
             set_marked_state(unknown);
 #endif
 #ifdef HPX_HAVE_THREAD_BACKTRACE_ON_SUSPENSION
-            backtrace_ = 0;
+            backtrace_ = nullptr;
 #endif
             priority_ = init_data.priority;
             requested_interrupt_ = false;
@@ -657,7 +657,7 @@ namespace hpx { namespace threads
 #ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
             // store the thread id of the parent thread, mainly for debugging
             // purposes
-            if (0 == parent_thread_id_) {
+            if (nullptr == parent_thread_id_) {
                 thread_self* self = get_self_ptr();
                 if (self)
                 {

--- a/hpx/runtime/threads/thread_data_fwd.hpp
+++ b/hpx/runtime/threads/thread_data_fwd.hpp
@@ -45,7 +45,7 @@ namespace hpx { namespace threads
     HPX_API_EXPORT void intrusive_ptr_add_ref(thread_data* p);
     HPX_API_EXPORT void intrusive_ptr_release(thread_data* p);
 
-    HPX_CONSTEXPR_OR_CONST thread_id_repr_type invalid_thread_id_repr = 0;
+    HPX_CONSTEXPR_OR_CONST thread_id_repr_type invalid_thread_id_repr = nullptr;
     thread_id_type const invalid_thread_id = thread_id_type();
     /// \endcond
 

--- a/hpx/runtime/threads/thread_init_data.hpp
+++ b/hpx/runtime/threads/thread_init_data.hpp
@@ -38,13 +38,13 @@ namespace hpx { namespace threads
             description(),
 #endif
 #if defined(HPX_HAVE_THREAD_PARENT_REFERENCE)
-            parent_locality_id(0), parent_id(0), parent_phase(0),
+            parent_locality_id(0), parent_id(nullptr), parent_phase(0),
 #endif
             priority(thread_priority_normal),
             num_os_thread(std::size_t(-1)),
             stacksize(get_default_stack_size()),
             target(),
-            scheduler_base(0)
+            scheduler_base(nullptr)
         {}
 
         thread_init_data(thread_init_data&& rhs)
@@ -82,7 +82,7 @@ namespace hpx { namespace threads
             description(desc),
 #endif
 #if defined(HPX_HAVE_THREAD_PARENT_REFERENCE)
-            parent_locality_id(0), parent_id(0), parent_phase(0),
+            parent_locality_id(0), parent_id(nullptr), parent_phase(0),
 #endif
             priority(priority_), num_os_thread(os_thread),
             stacksize(stacksize_ == std::ptrdiff_t(-1) ?

--- a/hpx/runtime/threads/threadmanager_impl.hpp
+++ b/hpx/runtime/threads/threadmanager_impl.hpp
@@ -207,7 +207,7 @@ namespace hpx { namespace threads
 
         std::size_t get_worker_thread_num(bool* numa_sensitive = nullptr)
         {
-            if (get_self_ptr() == 0)
+            if (get_self_ptr() == nullptr)
                 return std::size_t(-1);
             return pool_.get_worker_thread_num();
         }

--- a/hpx/traits/action_message_handler.hpp
+++ b/hpx/traits/action_message_handler.hpp
@@ -21,7 +21,7 @@ namespace hpx { namespace traits
             parcelset::parcelhandler*, parcelset::locality const&,
             parcelset::parcel const&)
         {
-            return 0;   // by default actions don't have a message_handler
+            return nullptr;   // by default actions don't have a message_handler
         }
     };
 }}

--- a/hpx/traits/action_serialization_filter.hpp
+++ b/hpx/traits/action_serialization_filter.hpp
@@ -19,7 +19,7 @@ namespace hpx { namespace traits
         // return a new instance of a serialization filter
         static serialization::binary_filter* call(parcelset::parcel const& /*p*/)
         {
-            return 0;   // by default actions don't have a serialization filter
+            return nullptr;   // by default actions don't have a serialization filter
         }
     };
 }}

--- a/hpx/traits/component_config_data.hpp
+++ b/hpx/traits/component_config_data.hpp
@@ -18,7 +18,7 @@ namespace hpx { namespace traits
         // by default no additional config data is injected into the factory
         static char const* call()
         {
-            return 0;
+            return nullptr;
         }
     };
 }}

--- a/hpx/traits/plugin_config_data.hpp
+++ b/hpx/traits/plugin_config_data.hpp
@@ -18,7 +18,7 @@ namespace hpx { namespace traits
         // by default no additional config data is injected into the factory
         static char const* call()
         {
-            return 0;
+            return nullptr;
         }
     };
 }}

--- a/hpx/util/any.hpp
+++ b/hpx/util/any.hpp
@@ -432,14 +432,14 @@ namespace hpx { namespace util
         basic_any() HPX_NOEXCEPT
           : table(detail::any::get_table<detail::any::empty>::
                 template get<IArchive, OArchive, Char>()),
-            object(0)
+            object(nullptr)
         {
         }
 
         basic_any(basic_any const& x)
           : table(detail::any::get_table<detail::any::empty>::
                 template get<IArchive, OArchive, Char>()),
-            object(0)
+            object(nullptr)
         {
             assign(x);
         }
@@ -449,7 +449,7 @@ namespace hpx { namespace util
           : table(detail::any::get_table<
                       typename util::decay<T>::type
                   >::template get<IArchive, OArchive, Char>()),
-            object(0)
+            object(nullptr)
         {
             typedef typename util::decay<T>::type value_type;
 
@@ -466,7 +466,7 @@ namespace hpx { namespace util
         {
             x.table = detail::any::get_table<detail::any::empty>::
                 template get<IArchive, OArchive, Char>();
-            x.object = 0;
+            x.object = nullptr;
         }
 
         // Perfect forwarding of T
@@ -480,7 +480,7 @@ namespace hpx { namespace util
           : table(detail::any::get_table<
                       typename util::decay<T>::type
                   >::template get<IArchive, OArchive, Char>()),
-            object(0)
+            object(nullptr)
         {
             typedef typename util::decay<T>::type value_type;
 
@@ -624,7 +624,7 @@ namespace hpx { namespace util
                 table->static_delete(&object);
                 table = detail::any::get_table<detail::any::empty>::
                     template get<IArchive, OArchive, Char>();
-                object = 0;
+                object = nullptr;
             }
         }
 
@@ -715,14 +715,14 @@ namespace hpx { namespace util
         basic_any() HPX_NOEXCEPT
           : table(detail::any::get_table<
                 detail::any::empty>::template get<void, void, Char>()),
-            object(0)
+            object(nullptr)
         {
         }
 
         basic_any(basic_any const& x)
           : table(detail::any::get_table<
                 detail::any::empty>::template get<void, void, Char>()),
-            object(0)
+            object(nullptr)
         {
             assign(x);
         }
@@ -732,7 +732,7 @@ namespace hpx { namespace util
           : table(detail::any::get_table<
                       typename util::decay<T>::type
                   >::template get<void, void, Char>()),
-            object(0)
+            object(nullptr)
         {
             typedef typename util::decay<T>::type value_type;
 
@@ -747,7 +747,7 @@ namespace hpx { namespace util
           : table(x.table),
             object(x.object)
         {
-            x.object = 0;
+            x.object = nullptr;
             x.table = detail::any::get_table<detail::any::empty>::
                 template get<void, void, Char>();
         }
@@ -763,7 +763,7 @@ namespace hpx { namespace util
           : table(detail::any::get_table<
                       typename util::decay<T>::type
                   >::template get<void, void, Char>()),
-            object(0)
+            object(nullptr)
         {
             typedef typename util::decay<T>::type value_type;
 
@@ -906,7 +906,7 @@ namespace hpx { namespace util
                 table->static_delete(&object);
                 table = detail::any::get_table<detail::any::empty>::
                     template get<void, void, Char>();
-                object = 0;
+                object = nullptr;
             }
         }
 
@@ -950,7 +950,7 @@ namespace hpx { namespace util
                 reinterpret_cast<T*>(reinterpret_cast<void*>(&operand->object)) :
                 reinterpret_cast<T*>(reinterpret_cast<void*>(operand->object));
         }
-        return 0;
+        return nullptr;
     }
 
     template <typename T, typename IArchive, typename OArchive, typename Char>
@@ -1043,7 +1043,7 @@ namespace hpx { namespace util
             {
                 std::vector<char> data;
                 serialization::output_archive ar (
-                        data, 0U, ~0U, 0, &hasher);
+                        data, 0U, ~0U, nullptr, &hasher);
                 ar << elem;
             }  // let archive go out of scope
 

--- a/hpx/util/backtrace/backtrace.hpp
+++ b/hpx/util/backtrace/backtrace.hpp
@@ -38,7 +38,7 @@ namespace hpx { namespace util
         {
             if(frames_no == 0)
                 return;
-            frames_.resize(frames_no,0);
+            frames_.resize(frames_no,nullptr);
             std::size_t size = stack_trace::trace(&frames_.front(),frames_no);
             if(size != 0)
                 frames_.resize(size);
@@ -57,7 +57,7 @@ namespace hpx { namespace util
         {
             if(frame_no < stack_size())
                 return frames_[frame_no];
-            return 0;
+            return nullptr;
         }
 
         void trace_line(std::size_t frame_no,std::ostream &out) const

--- a/hpx/util/detail/basic_function.hpp
+++ b/hpx/util/detail/basic_function.hpp
@@ -39,7 +39,7 @@ namespace hpx { namespace util { namespace detail
     template <typename F>
     static bool is_empty_function(F const& f, std::true_type) HPX_NOEXCEPT
     {
-        return f == 0;
+        return f == nullptr;
     }
 
     template <typename F>

--- a/hpx/util/detail/basic_function.hpp
+++ b/hpx/util/detail/basic_function.hpp
@@ -235,7 +235,7 @@ namespace hpx { namespace util { namespace detail
 
             VTablePtr const* f_vptr = get_table_ptr<target_type>();
             if (vptr != f_vptr || empty())
-                return 0;
+                return nullptr;
 
             return &vtable::get<target_type>(object);
         }
@@ -251,7 +251,7 @@ namespace hpx { namespace util { namespace detail
 
             VTablePtr const* f_vptr = get_table_ptr<target_type>();
             if (vptr != f_vptr || empty())
-                return 0;
+                return nullptr;
 
             return &vtable::get<target_type>(object);
         }

--- a/hpx/util/itt_notify.hpp
+++ b/hpx/util/itt_notify.hpp
@@ -348,7 +348,7 @@ inline void itt_sync_releasing(void*) {}
 inline void itt_sync_released(void*) {}
 inline void itt_sync_destroy(void*) {}
 
-inline ___itt_caller* itt_stack_create() { return 0; }
+inline ___itt_caller* itt_stack_create() { return nullptr; }
 inline void itt_stack_enter(___itt_caller*) {}
 inline void itt_stack_leave(___itt_caller*) {}
 inline void itt_stack_destroy(___itt_caller*) {}
@@ -366,15 +366,15 @@ inline void itt_thread_ignore() {}
 inline void itt_task_begin(___itt_domain const*, ___itt_string_handle*) {}
 inline void itt_task_end(___itt_domain const*) {}
 
-inline ___itt_domain* itt_domain_create(char const*) { return 0; }
-inline ___itt_string_handle* itt_task_handle_create(char const*) { return 0; }
+inline ___itt_domain* itt_domain_create(char const*) { return nullptr; }
+inline ___itt_string_handle* itt_task_handle_create(char const*) { return nullptr; }
 
-inline ___itt_id* itt_make_id(void*, unsigned long) { return 0; }
+inline ___itt_id* itt_make_id(void*, unsigned long) { return nullptr; }
 inline void itt_id_create(___itt_domain const*, ___itt_id*) {}
 inline void itt_id_destroy(___itt_id*) {}
 
 inline __itt_heap_function itt_heap_function_create(const char*,
-            const char*) { return 0; }
+            const char*) { return nullptr; }
 inline void itt_heap_allocate_begin(__itt_heap_function, std::size_t, int) {}
 inline void itt_heap_allocate_end(__itt_heap_function, void**, std::size_t, int) {}
 inline void itt_heap_free_begin(__itt_heap_function, void*) {}

--- a/hpx/util/lockfree/deque.hpp
+++ b/hpx/util/lockfree/deque.hpp
@@ -82,7 +82,7 @@ struct deque_anchor //-V690
     atomic_pair pair_;
 
   public:
-    deque_anchor(): pair_(pair(0, 0, stable, 0)) {}
+    deque_anchor(): pair_(pair(nullptr, nullptr, stable, 0)) {}
 
     deque_anchor(deque_anchor const& p): pair_(p.pair_.load()) {}
 
@@ -278,7 +278,7 @@ struct deque
     // Complexity: O(Processes)
     // FIXME: Should we check both pointers here?
     bool empty() const
-    { return anchor_.lrs().get_left_ptr() == 0; }
+    { return anchor_.lrs().get_left_ptr() == nullptr; }
 
     // Thread-safe and non-blocking.
     // Complexity: O(1)
@@ -292,9 +292,9 @@ struct deque
     bool push_left(T const& data)
     {
         // Allocate the new node which we will be inserting.
-        node* n = alloc_node(0, 0, data);
+        node* n = alloc_node(nullptr, nullptr, data);
 
-        if (n == 0)
+        if (n == nullptr)
             return false;
 
         // Loop until we insert successfully.
@@ -305,7 +305,7 @@ struct deque
 
             // Check if the deque is empty.
             // FIXME: Should we check both pointers here?
-            if (lrs.get_left_ptr() == 0)
+            if (lrs.get_left_ptr() == nullptr)
             {
                 // If the deque is empty, we simply install a new anchor which
                 // points to the new node as both its leftmost and rightmost
@@ -411,14 +411,14 @@ struct deque
 
             // Check if the deque is empty.
             // FIXME: Should we check both pointers here?
-            if (lrs.get_left_ptr() == 0)
+            if (lrs.get_left_ptr() == nullptr)
                 return false;
 
             // Check if the deque has 1 element.
             if (lrs.get_left_ptr() == lrs.get_right_ptr())
             {
                 // Try to set both anchor pointer
-                if (anchor_.cas(lrs, anchor_pair(0, 0,
+                if (anchor_.cas(lrs, anchor_pair(nullptr, nullptr,
                         lrs.get_left_tag(), lrs.get_right_tag() + 1)))
                 {
                     // Set the result, deallocate the popped node, and return.
@@ -472,14 +472,14 @@ struct deque
 
             // Check if the deque is empty.
             // FIXME: Should we check both pointers here?
-            if (lrs.get_right_ptr() == 0)
+            if (lrs.get_right_ptr() == nullptr)
                 return false;
 
             // Check if the deque has 1 element.
             if (lrs.get_right_ptr() == lrs.get_left_ptr())
             {
                 // Try to set both anchor pointer
-                if (anchor_.cas(lrs, anchor_pair(0, 0,
+                if (anchor_.cas(lrs, anchor_pair(nullptr, nullptr,
                         lrs.get_left_tag(), lrs.get_right_tag() + 1)))
                 {
                     // Set the result, deallocate the popped node, and return.

--- a/hpx/util/logging/detail/cache_before_init.hpp
+++ b/hpx/util/logging/detail/cache_before_init.hpp
@@ -80,7 +80,7 @@ private:
     };
 
     struct thread_info {
-        thread_info() : last_enabled(0) {}
+        thread_info() : last_enabled(nullptr) {}
         is_enabled_func last_enabled;
     };
 

--- a/hpx/util/logging/detail/log_keeper.hpp
+++ b/hpx/util/logging/detail/log_keeper.hpp
@@ -150,8 +150,8 @@ struct ensure_early_log_creation {
     typedef boost::int64_t long_type ;
         long_type ignore = reinterpret_cast<long_type>(&log);
         // we need to force the compiler to force creation of the log
-        if ( time(0) < 0)
-            if ( time(0) < (time_t)ignore) {
+        if ( time(nullptr) < 0)
+            if ( time(nullptr) < (time_t)ignore) {
                 printf("LOGGING LIB internal error - should NEVER happen. \
                     Please report this to the author of the lib");
                 exit(0);

--- a/hpx/util/logging/detail/log_keeper.hpp
+++ b/hpx/util/logging/detail/log_keeper.hpp
@@ -62,7 +62,7 @@ template<class type> struct logger_holder {
     logger_base_type * base()                { return m_base; }
 
 protected:
-    logger_holder() : m_log(0), m_base(0) {}
+    logger_holder() : m_log(nullptr), m_base(nullptr) {}
     virtual ~logger_holder() {}
 
     void init(type * log) {

--- a/hpx/util/logging/detail/logger.hpp
+++ b/hpx/util/logging/detail/logger.hpp
@@ -139,7 +139,7 @@ namespace hpx { namespace util { namespace logging {
 
         typedef logger<gather_msg, write_msg> original_logger_type;
         forward_to_logger(original_logger_type *original_logger = nullptr)
-          : m_writer(0), m_original_logger( original_logger)
+          : m_writer(nullptr), m_original_logger( original_logger)
         {
             if ( m_original_logger)
                 m_writer = &m_original_logger->writer();

--- a/hpx/util/logging/format/formatter/named_spacer.hpp
+++ b/hpx/util/logging/format/formatter/named_spacer.hpp
@@ -105,7 +105,7 @@ namespace detail {
 
         template<class msg_type> void write(msg_type & msg) const {
             // see type of convert
-            write_with_convert( msg, 0 );
+            write_with_convert( msg, nullptr );
         }
 
     private:
@@ -187,7 +187,7 @@ namespace detail {
                 }
                 else {
                     // last part
-                    info->write_steps.push_back( write_step( unescape(remaining), 0) );
+                    info->write_steps.push_back( write_step( unescape(remaining), nullptr) );
                     remaining.clear();
                 }
             }

--- a/hpx/util/logging/format/formatter/named_spacer.hpp
+++ b/hpx/util/logging/format/formatter/named_spacer.hpp
@@ -187,7 +187,8 @@ namespace detail {
                 }
                 else {
                     // last part
-                    info->write_steps.push_back( write_step( unescape(remaining), nullptr) );
+                    info->write_steps.push_back(
+                        write_step( unescape(remaining), nullptr) );
                     remaining.clear();
                 }
             }

--- a/hpx/util/logging/format/formatter/time.hpp
+++ b/hpx/util/logging/format/formatter/time.hpp
@@ -76,7 +76,7 @@ template<class convert = do_convert_format::prepend> struct time_t
     }
 
     template<class msg_type> void operator()(msg_type & msg) const {
-        ::time_t val = ::time(0);
+        ::time_t val = ::time(nullptr);
         write_time(msg, val);
     }
 

--- a/hpx/util/logging/format/formatter/time_strf.hpp
+++ b/hpx/util/logging/format/formatter/time_strf.hpp
@@ -56,7 +56,7 @@ template<class convert = do_convert_format::prepend> struct time_strf_t : is_gen
 
     template<class msg_type> void operator()(msg_type & msg) const {
         char_type buffer[64];
-        ::time_t t = ::time (0);
+        ::time_t t = ::time (nullptr);
         ::tm t_details = m_localtime ? *localtime( &t) : *gmtime( &t);
     #ifdef HPX_LOG_USE_WCHAR_T
         if (0 != wcsftime (buffer, sizeof (buffer), m_format.c_str (), &t_details))

--- a/hpx/util/logging/tag/defaults.hpp
+++ b/hpx/util/logging/tag/defaults.hpp
@@ -60,7 +60,7 @@ struct level {
 See @ref hpx::util::logging::tag "how to use tags".
 */
 struct time {
-    time() : val( ::time(0) ) {}
+    time() : val( ::time(nullptr) ) {}
     ::time_t val;
 };
 

--- a/hpx/util/one_size_heap_list.hpp
+++ b/hpx/util/one_size_heap_list.hpp
@@ -245,7 +245,7 @@ namespace hpx { namespace util
         // need to reschedule if not using boost::mutex
         bool reschedule(void* p, std::size_t count)
         {
-            if (0 == threads::get_self_ptr())
+            if (nullptr == threads::get_self_ptr())
             {
                 hpx::applier::register_work(
                     util::bind(&one_size_heap_list::free, this, p, count),

--- a/hpx/util/plugin/plugin_factory.hpp
+++ b/hpx/util/plugin/plugin_factory.hpp
@@ -198,7 +198,7 @@ namespace hpx { namespace util { namespace plugin {
                 std::pair<abstract_factory<BasePlugin> *, dll_handle> r =
                     get_abstract_factory<BasePlugin>(this->m_dll, name,
                         this->m_basename, ec);
-                if (ec) return 0;
+                if (ec) return nullptr;
 
                 return r.first->create(r.second, parameters...);
             }
@@ -256,7 +256,7 @@ namespace hpx { namespace util { namespace plugin {
                 std::pair<abstract_factory<BasePlugin> *, dll_handle> r =
                     get_abstract_factory_static<BasePlugin>(
                         this->f, &empty_deleter, name, "", ec);
-                if (ec) return 0;
+                if (ec) return nullptr;
 
                 return r.first->create(r.second, parameters...);
             }

--- a/hpx/util/thread_description.hpp
+++ b/hpx/util/thread_description.hpp
@@ -111,7 +111,7 @@ namespace hpx { namespace util
         bool valid() const HPX_NOEXCEPT
         {
             if (type_ == data_type_description)
-                return 0 != data_.desc_;
+                return nullptr != data_.desc_;
 
             HPX_ASSERT(type_ == data_type_address);
             return 0 != data_.addr_;

--- a/hpx/util/thread_specific_ptr.hpp
+++ b/hpx/util/thread_specific_ptr.hpp
@@ -62,7 +62,7 @@ namespace hpx { namespace util
 
         T& operator*() const
         {
-            HPX_ASSERT(0 != ptr_);
+            HPX_ASSERT(nullptr != ptr_);
             return *ptr_;
         }
 
@@ -136,7 +136,7 @@ namespace hpx { namespace util
 
             ptr = reinterpret_cast<T *>(
                 pthread_getspecific(thread_specific_ptr<T, Tag>::get_key()));
-            HPX_ASSERT(0 != ptr);
+            HPX_ASSERT(nullptr != ptr);
             return *ptr;
         }
 
@@ -148,7 +148,7 @@ namespace hpx { namespace util
 
             ptr = reinterpret_cast<T *>(
                 pthread_getspecific(thread_specific_ptr<T, Tag>::get_key()));
-            if (0 != ptr)
+            if (nullptr != ptr)
                 delete ptr;
 
             ptr = new_value;

--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -66,7 +66,7 @@ namespace hpx
 namespace hpx_startup
 {
     std::vector<std::string> (*user_main_config_function)(
-        std::vector<std::string> const&) = 0;
+        std::vector<std::string> const&) = nullptr;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1072,7 +1072,7 @@ namespace hpx
 
             try {
                 // make sure the runtime system is not active yet
-                if (get_runtime_ptr() != 0)
+                if (get_runtime_ptr() != nullptr)
                 {
                     std::cerr << "hpx::init: can't initialize runtime system "
                         "more than once! Exiting...\n";
@@ -1266,7 +1266,7 @@ namespace hpx
             reinterpret_cast<components::server::runtime_support*>(
                   get_runtime().get_runtime_support_lva());
 
-        if (0 == p) {
+        if (nullptr == p) {
             HPX_THROWS_IF(ec, invalid_status, "hpx::disconnect",
                 "the runtime system is not active (did you already "
                 "call finalize?)");
@@ -1293,7 +1293,7 @@ namespace hpx
             reinterpret_cast<components::server::runtime_support*>(
                   get_runtime().get_runtime_support_lva());
 
-        if (0 == p) {
+        if (nullptr == p) {
             // the runtime system is not running, just terminate
             std::terminate();
         }
@@ -1311,7 +1311,7 @@ namespace hpx
         }
 
         std::unique_ptr<runtime> rt(get_runtime_ptr());    // take ownership!
-        if (0 == rt.get()) {
+        if (nullptr == rt.get()) {
             HPX_THROWS_IF(ec, invalid_status, "hpx::stop",
                 "the runtime system is not active (did you already "
                 "call hpx::stop?)");
@@ -1359,7 +1359,7 @@ namespace hpx
             }
 
             // add a single nullptr in the end as some application rely on that
-            argv[argcount] = 0;
+            argv[argcount] = nullptr;
 
             // Invoke custom startup functions
             return f(static_cast<int>(argcount), argv.data());

--- a/src/hpx_main.cpp
+++ b/src/hpx_main.cpp
@@ -45,7 +45,7 @@ int hpx_main()
     }
 
     // add a single nullptr in the end as some application rely on that
-    argv[argcount] = 0;
+    argv[argcount] = nullptr;
 
     // Invoke hpx_main
     return hpx_main(static_cast<int>(argcount), argv.data());

--- a/src/lcos/local/composable_guard.cpp
+++ b/src/lcos/local/composable_guard.cpp
@@ -36,9 +36,9 @@ namespace hpx { namespace lcos { namespace local
             bool const single_guard;
 
             guard_task()
-              : next((guard_task*)0), run((void(*)())0), single_guard(true) {}
+              : next(nullptr), run(nullptr), single_guard(true) {}
             guard_task(bool sg)
-              : next((guard_task*)0), run((void(*)())0), single_guard(sg) {}
+              : next(nullptr), run(nullptr), single_guard(sg) {}
         };
 
         void free(guard_task* task)

--- a/src/lcos/local/detail/condition_variable.cpp
+++ b/src/lcos/local/detail/condition_variable.cpp
@@ -175,7 +175,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail
         std::unique_lock<mutex_type>&& lock,
         char const* description, error_code& ec)
     {
-        HPX_ASSERT(threads::get_self_ptr() != 0);
+        HPX_ASSERT(threads::get_self_ptr() != nullptr);
         HPX_ASSERT(lock.owns_lock());
 
         // enqueue the request and block this thread
@@ -200,7 +200,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail
         util::steady_time_point const& abs_time,
         char const* description, error_code& ec)
     {
-        HPX_ASSERT(threads::get_self_ptr() != 0);
+        HPX_ASSERT(threads::get_self_ptr() != nullptr);
         HPX_ASSERT(lock.owns_lock());
 
         // enqueue the request and block this thread

--- a/src/lcos/local/mutex.cpp
+++ b/src/lcos/local/mutex.cpp
@@ -35,7 +35,7 @@ namespace hpx { namespace lcos { namespace local
 
     void mutex::lock(char const* description, error_code& ec)
     {
-        HPX_ASSERT(threads::get_self_ptr() != 0);
+        HPX_ASSERT(threads::get_self_ptr() != nullptr);
 
         HPX_ITT_SYNC_PREPARE(this);
         std::unique_lock<mutex_type> l(mtx_);
@@ -63,7 +63,7 @@ namespace hpx { namespace lcos { namespace local
 
     bool mutex::try_lock(char const* description, error_code& ec)
     {
-        HPX_ASSERT(threads::get_self_ptr() != 0);
+        HPX_ASSERT(threads::get_self_ptr() != nullptr);
 
         HPX_ITT_SYNC_PREPARE(this);
         std::unique_lock<mutex_type> l(mtx_);
@@ -83,7 +83,7 @@ namespace hpx { namespace lcos { namespace local
 
     void mutex::unlock(error_code& ec)
     {
-        HPX_ASSERT(threads::get_self_ptr() != 0);
+        HPX_ASSERT(threads::get_self_ptr() != nullptr);
 
         HPX_ITT_SYNC_RELEASING(this);
         std::unique_lock<mutex_type> l(mtx_);
@@ -116,7 +116,7 @@ namespace hpx { namespace lcos { namespace local
     bool timed_mutex::try_lock_until(util::steady_time_point const& abs_time,
         char const* description, error_code& ec)
     {
-        HPX_ASSERT(threads::get_self_ptr() != 0);
+        HPX_ASSERT(threads::get_self_ptr() != nullptr);
 
         HPX_ITT_SYNC_PREPARE(this);
         std::unique_lock<mutex_type> l(mtx_);

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -1499,7 +1499,7 @@ namespace hpx
 
         HPX_THROWS_IF(ec, invalid_status, "create_message_handler",
             "the runtime system is not available at this time");
-        return 0;
+        return nullptr;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1514,7 +1514,7 @@ namespace hpx
 
         HPX_THROWS_IF(ec, invalid_status, "create_binary_filter",
             "the runtime system is not available at this time");
-        return 0;
+        return nullptr;
     }
 
     // helper function to stop evaluating counters during shutdown

--- a/src/runtime/actions/invocation_count_registry.cpp
+++ b/src/runtime/actions/invocation_count_registry.cpp
@@ -58,7 +58,7 @@ namespace hpx { namespace actions { namespace detail
             HPX_THROW_EXCEPTION(bad_parameter,
                 "invocation_count_registry::get_invocation_counter",
                 "unknown action type");
-            return 0;
+            return nullptr;
         }
         return (*it).second;
     }

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -141,7 +141,7 @@ addressing_service::addressing_service(
   , locality_()
 { // {{{
     std::shared_ptr<parcelset::parcelport> pp = ph.get_bootstrap_parcelport();
-    create_big_boot_barrier(pp ? pp.get() : 0, ph.endpoints(), ini_);
+    create_big_boot_barrier(pp ? pp.get() : nullptr, ph.endpoints(), ini_);
 
     if (caching_)
         gva_cache_->reserve(ini_.get_agas_local_cache_size());
@@ -449,7 +449,7 @@ parcelset::endpoints_type const & addressing_service::resolve_locality(
                 future<parcelset::endpoints_type> endpoints_future =
                 client_->get_endpoints(req, action_priority_, ec);
 
-                if (0 == threads::get_self_ptr())
+                if (nullptr == threads::get_self_ptr())
                 {
                     // this should happen only during bootstrap
                     HPX_ASSERT(hpx::is_starting());
@@ -1638,7 +1638,7 @@ void addressing_service::route(
   , threads::thread_priority local_priority
     )
 {
-    if (HPX_UNLIKELY(0 == threads::get_self_ptr()))
+    if (HPX_UNLIKELY(nullptr == threads::get_self_ptr()))
     {
         // reschedule this call as an HPX thread
         void (addressing_service::*route_ptr)(
@@ -1745,7 +1745,7 @@ lcos::future<boost::int64_t> addressing_service::incref_async(
 { // {{{ incref implementation
     naming::gid_type raw(naming::detail::get_stripped_gid(id));
 
-    if (HPX_UNLIKELY(0 == threads::get_self_ptr()))
+    if (HPX_UNLIKELY(nullptr == threads::get_self_ptr()))
     {
         // reschedule this call as an HPX thread
         lcos::future<boost::int64_t> (
@@ -1861,7 +1861,7 @@ void addressing_service::decref(
 { // {{{ decref implementation
     naming::gid_type raw(naming::detail::get_stripped_gid(gid));
 
-    if (HPX_UNLIKELY(0 == threads::get_self_ptr()))
+    if (HPX_UNLIKELY(nullptr == threads::get_self_ptr()))
     {
         // reschedule this call as an HPX thread
         void (addressing_service::*decref_ptr)(
@@ -2186,7 +2186,7 @@ void addressing_service::update_cache_entry(
         return;
     }
 
-    if(hpx::threads::get_self_ptr() == 0)
+    if(hpx::threads::get_self_ptr() == nullptr)
     {
         // Don't update the cache while HPX is starting up ...
         if(hpx::is_starting())

--- a/src/runtime/agas/interface.cpp
+++ b/src/runtime/agas/interface.cpp
@@ -418,7 +418,7 @@ naming::id_type get_console_locality(
 
 boost::uint32_t get_locality_id(error_code& ec)
 {
-    if (get_runtime_ptr() == 0)
+    if (get_runtime_ptr() == nullptr)
         return naming::invalid_locality_id;
 
     naming::gid_type l = naming::get_agas_client().get_local_locality(ec);
@@ -431,7 +431,7 @@ naming::gid_type get_next_id(
   , error_code& ec
     )
 {
-    if (get_runtime_ptr() == 0)
+    if (get_runtime_ptr() == nullptr)
     {
         HPX_THROWS_IF(ec, invalid_status,
             "get_next_id", "the runtime system has not been started yet.");

--- a/src/runtime/applier/bind_naming_wrappers.cpp
+++ b/src/runtime/applier/bind_naming_wrappers.cpp
@@ -19,7 +19,7 @@ namespace hpx { namespace applier
         error_code& ec)
     {
         applier* appl = get_applier_ptr();
-        if (0 == appl) {
+        if (nullptr == appl) {
             HPX_THROWS_IF(ec, invalid_status, "applier::bind_gid_local",
                 "applier is not valid");
             return false;
@@ -31,7 +31,7 @@ namespace hpx { namespace applier
     {
         if (gid_) {
             applier* appl = get_applier_ptr();
-            if (0 == appl) {
+            if (nullptr == appl) {
                 HPX_THROWS_IF(ec, invalid_status, "applier::unbind_gid_local",
                     "applier is not valid");
             }
@@ -49,7 +49,7 @@ namespace hpx { namespace applier
         naming::address const& addr, std::size_t offset, error_code& ec)
     {
         applier* appl = get_applier_ptr();
-        if (0 == appl) {
+        if (nullptr == appl) {
             HPX_THROWS_IF(ec, invalid_status, "applier::bind_range_local",
                 "applier is not valid");
             return false;
@@ -61,7 +61,7 @@ namespace hpx { namespace applier
         error_code& ec)
     {
         applier* appl = get_applier_ptr();
-        if (0 == appl) {
+        if (nullptr == appl) {
             HPX_THROWS_IF(ec, invalid_status, "applier::unbind_range_local",
                 "applier is not valid");
         }

--- a/src/runtime/components/console_logging.cpp
+++ b/src/runtime/components/console_logging.cpp
@@ -102,7 +102,7 @@ namespace hpx { namespace components
 
     void pending_logs::add(message_type const& msg)
     {
-        if (0 == hpx::get_runtime_ptr()) {
+        if (nullptr == hpx::get_runtime_ptr()) {
             // This branch will be taken if it's too early or too late in the
             // game. We do local logging only. Any queued messages which may be
             // still left in the queue are logged locally as well.

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -987,7 +987,7 @@ namespace hpx { namespace components { namespace server
         naming::gid_type const& gid, parcelset::endpoints_type const& eps)
     {
         runtime* rt = get_runtime_ptr();
-        if (rt == 0) return;
+        if (rt == nullptr) return;
 
         // instruct our connection cache to drop all connections it is holding
         rt->get_parcel_handler().remove_from_connection_cache(gid, eps);
@@ -1020,7 +1020,7 @@ namespace hpx { namespace components { namespace server
     {
         // re-acquire pointer to self as it might have changed
         threads::thread_self* self = threads::get_self_ptr();
-        HPX_ASSERT(0 != self);    // needs to be executed by a HPX thread
+        HPX_ASSERT(nullptr != self);    // needs to be executed by a HPX thread
 
         // give the scheduler some time to work on remaining tasks
         {
@@ -1199,7 +1199,7 @@ namespace hpx { namespace components { namespace server
                 std::vector<std::string> still_unregistered_options;
                 util::parse_commandline(ini, options, unknown_cmd_line, vm,
                     std::size_t(-1), mode,
-                    get_runtime_mode_from_name(runtime_mode), 0,
+                    get_runtime_mode_from_name(runtime_mode), nullptr,
                     &still_unregistered_options);
 
                 std::string still_unknown_commandline;
@@ -1209,7 +1209,7 @@ namespace hpx { namespace components { namespace server
                 if (!still_unknown_commandline.empty())
                 {
                     util::section* s = ini.get_section("hpx");
-                    HPX_ASSERT(s != 0);
+                    HPX_ASSERT(s != nullptr);
                     s->add_entry("unknown_cmd_line_option",
                         still_unknown_commandline);
                 }
@@ -1354,7 +1354,7 @@ namespace hpx { namespace components { namespace server
     void runtime_support::remove_here_from_connection_cache()
     {
         runtime* rt = get_runtime_ptr();
-        if (rt == 0)
+        if (rt == nullptr)
             return;
 
         std::vector<naming::id_type> locality_ids = find_remote_localities();
@@ -1468,7 +1468,7 @@ namespace hpx { namespace components { namespace server
                     "attempt to create message handler plugin instance of "
                     "invalid/unknown type");
             }
-            return 0;
+            return nullptr;
         }
 
         l.unlock();
@@ -1480,14 +1480,14 @@ namespace hpx { namespace components { namespace server
 
         parcelset::policies::message_handler* mh = factory->create(action,
             pp, num_messages, interval);
-        if (0 == mh) {
+        if (nullptr == mh) {
             std::ostringstream strm;
             strm << "couldn't create message handler plugin of type: "
                  << message_handler_type;
             HPX_THROWS_IF(ec, hpx::bad_plugin_type,
                 "runtime_support::create_message_handler",
                 strm.str());
-            return 0;
+            return nullptr;
         }
 
         if (&ec != &throws)
@@ -1516,7 +1516,7 @@ namespace hpx { namespace components { namespace server
             HPX_THROWS_IF(ec, hpx::bad_plugin_type,
                 "runtime_support::create_binary_filter",
                 strm.str());
-            return 0;
+            return nullptr;
         }
 
         l.unlock();
@@ -1527,14 +1527,14 @@ namespace hpx { namespace components { namespace server
                 (*it).second.first));
 
         serialization::binary_filter* bf = factory->create(compress, next_filter);
-        if (0 == bf) {
+        if (nullptr == bf) {
             std::ostringstream strm;
             strm << "couldn't to create binary filter plugin of type: "
                  << binary_filter_type;
             HPX_THROWS_IF(ec, hpx::bad_plugin_type,
                 "runtime_support::create_binary_filter",
                 strm.str());
-            return 0;
+            return nullptr;
         }
 
         if (&ec != &throws)
@@ -1568,7 +1568,7 @@ namespace hpx { namespace components { namespace server
                 component_ini = ini.get_section(component_section);
 
             error_code ec(lightweight);
-            if (0 == component_ini ||
+            if (nullptr == component_ini ||
                 "0" == component_ini->get_entry("no_factory", "0"))
             {
                 util::plugin::get_plugins_list_type f;
@@ -2050,7 +2050,7 @@ namespace hpx { namespace components { namespace server
                 component_ini = ini.get_section(component_section);
 
             error_code ec(lightweight);
-            if (0 == component_ini ||
+            if (nullptr == component_ini ||
                 "0" == component_ini->get_entry("no_factory", "0"))
             {
                 // get the factory
@@ -2271,7 +2271,7 @@ namespace hpx { namespace components { namespace server
                 plugin_ini = ini.get_section(plugin_section);
 
             error_code ec(lightweight);
-            if (0 == plugin_ini ||
+            if (nullptr == plugin_ini ||
                 "0" == plugin_ini->get_entry("no_factory", "0"))
             {
                 // get the factory

--- a/src/runtime/get_locality_name.cpp
+++ b/src/runtime/get_locality_name.cpp
@@ -18,7 +18,7 @@ namespace hpx { namespace detail
     std::string get_locality_base_name()
     {
         runtime* rt = get_runtime_ptr();
-        if (rt == 0)
+        if (rt == nullptr)
         {
             HPX_THROW_EXCEPTION(invalid_status,
                 "hpx::detail::get_locality_name",

--- a/src/runtime/naming/name.cpp
+++ b/src/runtime/naming/name.cpp
@@ -219,7 +219,7 @@ namespace hpx { namespace naming
                 HPX_ASSERT(false);          // invalid management type
                 return &detail::gid_unmanaged_deleter;
             }
-            return 0;
+            return nullptr;
         }
 
         ///////////////////////////////////////////////////////////////////////

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -712,9 +712,9 @@ namespace hpx { namespace parcelset
                     HPX_THROWS_IF(ec, internal_server_error,
                         "parcelhandler::get_message_handler",
                         "could not store empty message handler");
-                    return 0;
+                    return nullptr;
                 }
-                return 0;           // no message handler available
+                return nullptr;           // no message handler available
             }
 
             std::pair<message_handler_map::iterator, bool> r =
@@ -725,7 +725,7 @@ namespace hpx { namespace parcelset
                 HPX_THROWS_IF(ec, internal_server_error,
                     "parcelhandler::get_message_handler",
                     "could not store newly created message handler");
-                return 0;
+                return nullptr;
             }
             it = r.first;
         }
@@ -741,7 +741,7 @@ namespace hpx { namespace parcelset
                     "parcelhandler::get_message_handler",
                     "couldn't find an appropriate message handler");
             }
-            return 0;           // no message handler available
+            return nullptr;           // no message handler available
         }
 
         if (&ec != &throws)

--- a/src/runtime/parcelset/parcelport.cpp
+++ b/src/runtime/parcelset/parcelport.cpp
@@ -23,7 +23,7 @@ namespace hpx { namespace parcelset
     ///////////////////////////////////////////////////////////////////////////
     parcelport::parcelport(util::runtime_configuration const& ini, locality const & here,
             std::string const& type)
-      : applier_(0),
+      : applier_(nullptr),
         here_(here),
         max_inbound_message_size_(ini.get_max_inbound_message_size()),
         max_outbound_message_size_(ini.get_max_outbound_message_size()),

--- a/src/runtime/set_parcel_write_handler.cpp
+++ b/src/runtime/set_parcel_write_handler.cpp
@@ -15,7 +15,7 @@ namespace hpx
         parcel_write_handler_type const& f)
     {
         runtime* rt = get_runtime_ptr();
-        if (0 != rt)
+        if (nullptr != rt)
             return rt->get_parcel_handler().set_write_handler(f);
 
         HPX_THROW_EXCEPTION(invalid_status,

--- a/src/runtime/threads/coroutines/detail/tss.cpp
+++ b/src/runtime/threads/coroutines/detail/tss.cpp
@@ -25,12 +25,12 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
     void tss_data_node::cleanup(bool cleanup_existing)
     {
 #ifdef HPX_HAVE_THREAD_LOCAL_STORAGE
-        if (cleanup_existing && func_ && (value_ != 0))
+        if (cleanup_existing && func_ && (value_ != nullptr))
         {
             (*func_)(value_);
         }
         func_.reset();
-        value_ = 0;
+        value_ = nullptr;
 #endif
     }
 
@@ -43,7 +43,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         boost::throw_exception(std::runtime_error(
             "thread local storage has been disabled at configuration time, "
             "please specify HPX_HAVE_THREAD_LOCAL_STORAGE=ON to cmake"));
-        return 0;
+        return nullptr;
 #endif
     }
 
@@ -126,19 +126,19 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         if (nullptr == self)
         {
             boost::throw_exception(null_thread_id_exception());
-            return 0;
+            return nullptr;
         }
 
         detail::tss_storage* tss_map = self->get_thread_tss_data();
         if (nullptr == tss_map)
-            return 0;
+            return nullptr;
 
         return tss_map->find(key);
 #else
         boost::throw_exception(std::runtime_error(
             "thread local storage has been disabled at configuration time, "
             "please specify HPX_HAVE_THREAD_LOCAL_STORAGE=ON to cmake"));
-        return 0;
+        return nullptr;
 #endif
     }
 

--- a/src/runtime/threads/detail/thread_pool.cpp
+++ b/src/runtime/threads/detail/thread_pool.cpp
@@ -364,7 +364,7 @@ namespace hpx { namespace threads { namespace detail
             << " timestamp_scale: " << timestamp_scale_; //-V128
 
         try {
-            HPX_ASSERT(startup_.get() == 0);
+            HPX_ASSERT(startup_.get() == nullptr);
             startup_.reset(
                 new boost::barrier(static_cast<unsigned>(num_threads+1))
             );
@@ -429,7 +429,7 @@ namespace hpx { namespace threads { namespace detail
                 << " failed with: " << e.what();
 
             // trigger the barrier
-            if (startup_.get() != 0)
+            if (startup_.get() != nullptr)
             {
                 while (num_threads-- != 0 && !startup_->wait())
                     ;

--- a/src/runtime/threads/executors/this_thread_executors.cpp
+++ b/src/runtime/threads/executors/this_thread_executors.cpp
@@ -55,7 +55,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         thread_num_(std::size_t(-1)),
         parent_thread_num_(std::size_t(-1)), orig_thread_num_(std::size_t(-1)),
         tasks_scheduled_(0), tasks_completed_(0), cookie_(0),
-        self_(0)
+        self_(nullptr)
     {
         // Inform the resource manager about this new executor. This causes the
         // resource manager to interact with this executor using the
@@ -244,7 +244,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         }
         ~on_self_reset()
         {
-            threads::detail::set_self_ptr(0);
+            threads::detail::set_self_ptr(nullptr);
         }
     };
 
@@ -284,7 +284,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
           : shutdown_sem_(shutdown_sem),
             self_(self)
         {
-            threads::detail::set_self_ptr(0);
+            threads::detail::set_self_ptr(nullptr);
         }
 
         ~this_thread_on_run_exit()

--- a/src/runtime/threads/executors/thread_pool_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_executors.cpp
@@ -247,7 +247,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         }
         ~on_self_reset()
         {
-            threads::detail::set_self_ptr(0);
+            threads::detail::set_self_ptr(nullptr);
         }
     };
 
@@ -286,7 +286,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
             shutdown_sem_(shutdown_sem),
             self_(self)
         {
-            threads::detail::set_self_ptr(0);
+            threads::detail::set_self_ptr(nullptr);
             ++current_concurrency_;
         }
 

--- a/src/runtime/threads/policies/hwloc_topology.cpp
+++ b/src/runtime/threads/policies/hwloc_topology.cpp
@@ -91,7 +91,7 @@ namespace hpx { namespace threads
     mask_type hwloc_topology::empty_mask = mask_type();
 
     hwloc_topology::hwloc_topology()
-      : topo(0), machine_affinity_mask_(0)
+      : topo(nullptr), machine_affinity_mask_(0)
     { // {{{
         int err = hwloc_topology_init(&topo);
         if (err != 0)

--- a/src/runtime/threads/resource_manager.cpp
+++ b/src/runtime/threads/resource_manager.cpp
@@ -37,7 +37,7 @@ namespace hpx { namespace threads
     std::size_t resource_manager::initial_allocation(
         detail::manage_executor* proxy, error_code& ec)
     {
-        if (0 == proxy) {
+        if (nullptr == proxy) {
             HPX_THROWS_IF(ec, bad_parameter,
                 "resource_manager::init_allocation",
                 "manage_executor pointer is a nullptr");

--- a/src/runtime/threads/thread_data.cpp
+++ b/src/runtime/threads/thread_data.cpp
@@ -152,7 +152,7 @@ namespace hpx { namespace threads
         {
             HPX_THROWS_IF(ec, null_thread_id, "threads::get_self_ptr_checked",
                 "null thread id encountered (is this executed on a HPX-thread?)");
-            return 0;
+            return nullptr;
         }
 
         if (&ec != &throws)
@@ -164,7 +164,7 @@ namespace hpx { namespace threads
     thread_id_type get_self_id()
     {
         thread_self* self = get_self_ptr();
-        if (0 == self)
+        if (nullptr == self)
             return threads::invalid_thread_id;
 
         return thread_id_type(
@@ -191,7 +191,7 @@ namespace hpx { namespace threads
     thread_id_repr_type get_parent_id()
     {
         thread_self* self = get_self_ptr();
-        if (0 == self)
+        if (nullptr == self)
             return threads::invalid_thread_id_repr;
         return get_self_id()->get_parent_thread_id();
     }
@@ -199,7 +199,7 @@ namespace hpx { namespace threads
     std::size_t get_parent_phase()
     {
         thread_self* self = get_self_ptr();
-        if (0 == self)
+        if (nullptr == self)
             return 0;
         return get_self_id()->get_parent_thread_phase();
     }
@@ -207,7 +207,7 @@ namespace hpx { namespace threads
     boost::uint32_t get_parent_locality_id()
     {
         thread_self* self = get_self_ptr();
-        if (0 == self)
+        if (nullptr == self)
             return naming::invalid_locality_id;
         return get_self_id()->get_parent_locality_id();
     }
@@ -219,7 +219,7 @@ namespace hpx { namespace threads
         return 0;
 #else
         thread_self* self = get_self_ptr();
-        if (0 == self)
+        if (nullptr == self)
             return 0;
         return get_self_id()->get_component_id();
 #endif

--- a/src/runtime/threads/thread_helpers.cpp
+++ b/src/runtime/threads/thread_helpers.cpp
@@ -203,7 +203,7 @@ namespace hpx { namespace threads
         if (self_ptr)
             return self_ptr->get_continuation_recursion_count();
 
-        if (0 == continuation_recursion_count.get())
+        if (nullptr == continuation_recursion_count.get())
             continuation_recursion_count.reset(new std::size_t(0));
 
         return *continuation_recursion_count.get();
@@ -338,7 +338,7 @@ namespace hpx { namespace threads
         if (&ec != &throws)
             ec = make_success_code();
 
-        return id ? id->get_backtrace() : 0;
+        return id ? id->get_backtrace() : nullptr;
     }
 
 #ifdef HPX_HAVE_THREAD_FULLBACKTRACE_ON_SUSPENSION
@@ -359,7 +359,7 @@ namespace hpx { namespace threads
         if (&ec != &throws)
             ec = make_success_code();
 
-        return id ? id->set_backtrace(bt) : 0;
+        return id ? id->set_backtrace(bt) : nullptr;
     }
 
     threads::executors::current_executor
@@ -369,7 +369,7 @@ namespace hpx { namespace threads
             HPX_THROWS_IF(ec, null_thread_id,
                 "hpx::threads::get_executor",
                 "null thread id encountered");
-            return executors::current_executor(0);
+            return executors::current_executor(nullptr);
         }
 
         if (&ec != &throws)
@@ -573,7 +573,7 @@ namespace hpx { namespace this_thread
 
     bool has_sufficient_stack_space(std::size_t space_needed)
     {
-        if (0 == hpx::threads::get_self_ptr())
+        if (nullptr == hpx::threads::get_self_ptr())
             return false;
 
 #if defined(HPX_HAVE_THREADS_GET_STACK_POINTER)

--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -746,7 +746,7 @@ namespace hpx {
     runtime_impl<SchedulingPolicy>::
         get_thread_pool(char const* name)
     {
-        HPX_ASSERT(name != 0);
+        HPX_ASSERT(name != nullptr);
 
         if (0 == std::strncmp(name, "io", 2))
             return &io_pool_;
@@ -757,7 +757,7 @@ namespace hpx {
         if (0 == std::strncmp(name, "main", 4)) //-V112
             return &main_pool_;
 
-        return 0;
+        return nullptr;
     }
 
     /// Register an external OS-thread with HPX
@@ -772,7 +772,7 @@ namespace hpx {
         std::string thread_name(name);
         thread_name += "-thread";
 
-        init_tss_ex(thread_name.c_str(), num, 0, service_thread, ec);
+        init_tss_ex(thread_name.c_str(), num, nullptr, service_thread, ec);
 
         return !ec ? true : false;
     }

--- a/src/util/backtrace/backtrace.cpp
+++ b/src/util/backtrace/backtrace.cpp
@@ -165,14 +165,15 @@ namespace hpx { namespace util {
             res.imbue(std::locale::classic());
             res << std::left << std::setw(sizeof(void*)*2) << std::setfill(' ')
                 << ptr <<": ";
-            Dl_info info = {0, 0, 0, 0};
+            Dl_info info = {nullptr, nullptr, nullptr, nullptr};
             if(dladdr(ptr,&info) == 0) {
                 res << "???";
             }
             else {
                 if(info.dli_sname) {
                     int status = 0;
-                    char *demangled = abi::__cxa_demangle(info.dli_sname,0,0,&status);
+                    char *demangled =
+                        abi::__cxa_demangle(info.dli_sname,nullptr,nullptr,&status);
                     if(demangled) {
                         res << demangled;
                         free(demangled);
@@ -228,11 +229,11 @@ namespace hpx { namespace util {
         {
             char ** ptr = backtrace_symbols(&address,1);
             try {
-                if(ptr == 0)
+                if(ptr == nullptr)
                     return std::string();
                 std::string res = ptr[0];
                 free(ptr);
-                ptr = 0;
+                ptr = nullptr;
                 return res;
             }
             catch(...) {
@@ -246,7 +247,7 @@ namespace hpx { namespace util {
         {
             char ** ptr = backtrace_symbols(address,size);
             try {
-                if(ptr==0)
+                if(ptr==nullptr)
                     return std::string();
                 std::string res = std::to_string(size)
                     + ((1==size)?" frame:":" frames:");
@@ -255,7 +256,7 @@ namespace hpx { namespace util {
                     res+=ptr[i];
                 }
                 free(ptr);
-                ptr = 0;
+                ptr = nullptr;
                 return res;
             }
             catch(...) {
@@ -270,12 +271,12 @@ namespace hpx { namespace util {
             char ** ptr = backtrace_symbols(addresses,size);
             out << size << ((1==size)?" frame:":" frames:");
             try {
-                if(ptr==0)
+                if(ptr==nullptr)
                     return;
                 for(std::size_t i=0;i<size;i++)
                     out << '\n' << ptr[i];
                 free(ptr);
-                ptr = 0;
+                ptr = nullptr;
                 out << std::flush;
             }
             catch(...) {
@@ -287,12 +288,12 @@ namespace hpx { namespace util {
 #elif defined(HPX_MSVC)
 
         namespace {
-            HANDLE hProcess = 0;
+            HANDLE hProcess = nullptr;
             bool syms_ready = false;
 
             void init()
             {
-                if(hProcess == 0) {
+                if(hProcess == nullptr) {
                     hProcess = GetCurrentProcess();
                     SymSetOptions(SYMOPT_DEFERRED_LOADS);
 
@@ -306,7 +307,7 @@ namespace hpx { namespace util {
 
         HPX_API_EXPORT std::string get_symbol(void *ptr)
         {
-            if(ptr==0)
+            if(ptr==nullptr)
                 return std::string();
             init();
             std::ostringstream ss;
@@ -388,7 +389,7 @@ namespace hpx { namespace util {
         {
             out << size << ((1 == size)?" frame:":" frames:"); //-V128
             for(std::size_t i=0;i<size;i++) {
-                if(addresses[i]!=0)
+                if(addresses[i]!=nullptr)
                     out << '\n' << std::left << std::setw(sizeof(void*)*2)
                     << std::setfill(' ') << addresses[i];
             }
@@ -402,7 +403,7 @@ namespace hpx { namespace util {
     {
         if(frames_.empty())
             return std::string();
-        if (0 == threads::get_self_ptr())
+        if (nullptr == threads::get_self_ptr())
             return trace();
 
         lcos::local::futures_factory<std::string()> p(

--- a/src/util/batch_environments/alps_environment.cpp
+++ b/src/util/batch_environments/alps_environment.cpp
@@ -20,7 +20,7 @@ namespace hpx { namespace util { namespace batch_environments
       , valid_(false)
     {
         char *node_num = std::getenv("ALPS_APP_PE");
-        valid_ = node_num != 0;
+        valid_ = node_num != nullptr;
         if(valid_)
         {
             // Initialize our node number

--- a/src/util/batch_environments/pbs_environment.cpp
+++ b/src/util/batch_environments/pbs_environment.cpp
@@ -31,7 +31,7 @@ namespace hpx { namespace util { namespace batch_environments
         , valid_(false)
     {
         char *node_num = std::getenv("PBS_NODENUM");
-        valid_ = node_num != 0;
+        valid_ = node_num != nullptr;
         if(valid_)
         {
             // Initialize our node number
@@ -51,7 +51,7 @@ namespace hpx { namespace util { namespace batch_environments
             }
 
             char * thread_num = std::getenv("PBS_NUM_PPN");
-            if (thread_num != 0)
+            if (thread_num != nullptr)
             {
                 // Initialize number of cores to run on
                 num_threads_ = safe_lexical_cast<std::size_t>(

--- a/src/util/batch_environments/slurm_environment.cpp
+++ b/src/util/batch_environments/slurm_environment.cpp
@@ -35,7 +35,7 @@ namespace hpx { namespace util { namespace batch_environments
       , valid_(false)
     {
         char *node_num = std::getenv("SLURM_PROCID");
-        valid_ = node_num != 0;
+        valid_ = node_num != nullptr;
         if(valid_)
         {
             // Initialize our node number

--- a/src/util/find_prefix.cpp
+++ b/src/util/find_prefix.cpp
@@ -42,13 +42,13 @@ namespace hpx { namespace util
 
     void set_hpx_prefix(const char * prefix)
     {
-        if (prefix_ == 0)
+        if (prefix_ == nullptr)
             prefix_ = prefix;
     }
 
     char const* hpx_prefix()
     {
-        HPX_ASSERT(0 != prefix_);
+        HPX_ASSERT(nullptr != prefix_);
         return prefix_;
     }
 

--- a/src/util/ini.cpp
+++ b/src/util/ini.cpp
@@ -687,12 +687,12 @@ void section::expand_brace(std::string& value, std::string::size_type begin) con
         std::string::size_type colon = find_next(":", to_expand);
         if (colon == std::string::npos) {
             char* env = getenv(to_expand.c_str());
-            value.replace(begin, end-begin+1, 0 != env ? env : "");
+            value.replace(begin, end-begin+1, nullptr != env ? env : "");
         }
         else {
             char* env = getenv(to_expand.substr(0, colon).c_str());
             value.replace(begin, end-begin+1,
-                0 != env ? std::string(env) : to_expand.substr(colon+1));
+                nullptr != env ? std::string(env) : to_expand.substr(colon+1));
         }
     }
 }
@@ -757,12 +757,12 @@ void section::expand_brace_only(std::string& value,
         std::string::size_type colon = find_next(":", to_expand);
         if (colon == std::string::npos) {
             char* env = getenv(to_expand.c_str());
-            value.replace(begin, end-begin+1, 0 != env ? env : "");
+            value.replace(begin, end-begin+1, nullptr != env ? env : "");
         }
         else {
             char* env = getenv(to_expand.substr(0, colon).c_str());
             value.replace(begin, end-begin+1,
-                0 != env ? std::string(env) : to_expand.substr(colon+1));
+                nullptr != env ? std::string(env) : to_expand.substr(colon+1));
         }
     }
 }

--- a/src/util/init_ini_data.cpp
+++ b/src/util/init_ini_data.cpp
@@ -450,7 +450,7 @@ namespace hpx { namespace util
             return plugin_registries;
 
         // make sure each node loads libraries in a different order
-        std::srand(static_cast<unsigned>(std::time(0)));
+        std::srand(static_cast<unsigned>(std::time(nullptr)));
         std::random_shuffle(libdata.begin(), libdata.end());
 
         typedef std::pair<fs::path, std::string> libdata_type;

--- a/src/util/interval_timer.cpp
+++ b/src/util/interval_timer.cpp
@@ -20,14 +20,14 @@ namespace hpx { namespace util { namespace detail
 {
     ///////////////////////////////////////////////////////////////////////////
     interval_timer::interval_timer()
-      : microsecs_(0), id_(0)
+      : microsecs_(0), id_(nullptr)
     {}
 
     interval_timer::interval_timer(util::function_nonser<bool()> const& f,
             boost::int64_t microsecs, std::string const& description,
             bool pre_shutdown)
       : f_(f), on_term_(),
-        microsecs_(microsecs), id_(0), description_(description),
+        microsecs_(microsecs), id_(nullptr), description_(description),
         pre_shutdown_(pre_shutdown), is_started_(false), first_start_(true),
         is_terminated_(false), is_stopped_(false)
     {}
@@ -37,7 +37,7 @@ namespace hpx { namespace util { namespace detail
             boost::int64_t microsecs, std::string const& description,
             bool pre_shutdown)
       : f_(f), on_term_(on_term),
-        microsecs_(microsecs), id_(0), description_(description),
+        microsecs_(microsecs), id_(nullptr), description_(description),
         pre_shutdown_(pre_shutdown), is_started_(false), first_start_(true),
         is_terminated_(false), is_stopped_(false)
     {}
@@ -122,12 +122,12 @@ namespace hpx { namespace util { namespace detail
                 error_code ec(lightweight);       // avoid throwing on error
                 threads::set_thread_state(id_, threads::pending,
                     threads::wait_abort, threads::thread_priority_boost, ec);
-                id_ = 0;
+                id_ = nullptr;
             }
             return true;
         }
 
-        HPX_ASSERT(id_ == 0);
+        HPX_ASSERT(id_ == nullptr);
         return false;
     }
 
@@ -184,10 +184,10 @@ namespace hpx { namespace util { namespace detail
                 return threads::terminated;        // object has been finalized, exit
             }
 
-            if (id_ != 0 && id_ != threads::get_self_id())
+            if (id_ != nullptr && id_ != threads::get_self_id())
                 return threads::terminated;        // obsolete timer thread
 
-            id_ = 0;
+            id_ = nullptr;
             is_started_ = false;
 
             bool result = false;
@@ -198,7 +198,7 @@ namespace hpx { namespace util { namespace detail
             }
 
             // some other thread might already have started the timer
-            if (0 == id_ && result) {
+            if (nullptr == id_ && result) {
                 HPX_ASSERT(!is_started_);
                 schedule_thread(l);        // wait and repeat
             }

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -195,7 +195,7 @@ namespace hpx { namespace util
         void operator()(param str) const
         {
             threads::thread_self* self = threads::get_self_ptr();
-            if (0 != self) {
+            if (nullptr != self) {
                 // called from inside a HPX thread
                 threads::thread_id_type id = threads::get_self_id();
                 if (id != threads::invalid_thread_id) {
@@ -223,7 +223,7 @@ namespace hpx { namespace util
         void operator()(param str) const
         {
             threads::thread_self* self = threads::get_self_ptr();
-            if (0 != self) {
+            if (nullptr != self) {
                 // called from inside a HPX thread
                 std::size_t phase = self->get_thread_phase();
                 if (0 != phase) {
@@ -274,7 +274,7 @@ namespace hpx { namespace util
         void operator()(param str) const
         {
             threads::thread_id_repr_type parent_id = threads::get_parent_id();
-            if (0 != parent_id && threads::invalid_thread_id != parent_id) {
+            if (nullptr != parent_id && threads::invalid_thread_id != parent_id) {
                 // called from inside a HPX thread
                 std::stringstream out;
                 out << std::hex << std::setw(sizeof(void*)*2)

--- a/src/util/parse_command_line.cpp
+++ b/src/util/parse_command_line.cpp
@@ -679,7 +679,7 @@ namespace hpx { namespace util
         boost::scoped_array<char*> argv(new char* [args.size()+1]);
         for (std::size_t i = 0; i < args.size(); ++i)
             argv[i] = const_cast<char*>(args[i].c_str());
-        argv[args.size()] = 0;
+        argv[args.size()] = nullptr;
 
         return parse_commandline(
             rtcfg, app_options, static_cast<int>(args.size()), argv.get(), vm,

--- a/src/util/pool_timer.cpp
+++ b/src/util/pool_timer.cpp
@@ -135,7 +135,7 @@ namespace hpx { namespace util { namespace detail
             is_stopped_ = false;
             is_started_ = true;
 
-            HPX_ASSERT(timer_ != 0);
+            HPX_ASSERT(timer_ != nullptr);
             timer_->expires_at(abs_time_);
             timer_->async_wait(util::bind(&pool_timer::timer_handler,
                 this->shared_from_this()));
@@ -157,7 +157,7 @@ namespace hpx { namespace util { namespace detail
             is_started_ = false;
             is_stopped_ = true;
 
-            HPX_ASSERT(timer_ != 0);
+            HPX_ASSERT(timer_ != nullptr);
             timer_->cancel();
             return true;
         }
@@ -177,7 +177,7 @@ namespace hpx { namespace util { namespace detail
             }
         }
         delete timer_;
-        timer_ = 0;
+        timer_ = nullptr;
     }
 
     pool_timer::~pool_timer()

--- a/src/util/register_locks.cpp
+++ b/src/util/register_locks.cpp
@@ -26,7 +26,7 @@ namespace hpx { namespace util
         {
             lock_data()
               : ignore_(false)
-              , user_data_(0)
+              , user_data_(nullptr)
             {
 #ifdef HPX_HAVE_VERIFY_LOCKS_BACKTRACE
                 backtrace_ = hpx::detail::backtrace_direct();
@@ -178,7 +178,7 @@ namespace hpx { namespace util
         using detail::register_locks;
 
         if (register_locks::lock_detection_enabled_ &&
-            0 != threads::get_self_ptr())
+            nullptr != threads::get_self_ptr())
         {
             register_locks::held_locks_map& held_locks =
                 register_locks::get_lock_map();
@@ -205,7 +205,7 @@ namespace hpx { namespace util
         using detail::register_locks;
 
         if (register_locks::lock_detection_enabled_ &&
-            0 != threads::get_self_ptr())
+            nullptr != threads::get_self_ptr())
         {
             register_locks::held_locks_map& held_locks =
                 register_locks::get_lock_map();
@@ -248,7 +248,7 @@ namespace hpx { namespace util
             register_locks::get_lock_enabled();
 
         if (enabled && register_locks::lock_detection_enabled_ &&
-            0 != threads::get_self_ptr())
+            nullptr != threads::get_self_ptr())
         {
             register_locks::held_locks_map& held_locks =
                 register_locks::get_lock_map();
@@ -327,7 +327,7 @@ namespace hpx { namespace util
         void set_ignore_status(void const* lock, bool status)
         {
             if (register_locks::lock_detection_enabled_ &&
-                0 != threads::get_self_ptr())
+                nullptr != threads::get_self_ptr())
             {
                 register_locks::held_locks_map& held_locks =
                     register_locks::get_lock_map();

--- a/src/util/thread_description.cpp
+++ b/src/util/thread_description.cpp
@@ -52,7 +52,7 @@ namespace hpx { namespace util
 #if defined(HPX_HAVE_THREAD_DESCRIPTION) && !defined(HPX_HAVE_THREAD_DESCRIPTION_FULL)
         type_ = data_type_description;
         data_.desc_ = altname;
-        if (altname == 0)
+        if (altname == nullptr)
         {
             hpx::threads::thread_id_type id = hpx::threads::get_self_id();
             if (id) *this = hpx::threads::get_thread_description(id);

--- a/tests/performance/local/coroutines_call_overhead.cpp
+++ b/tests/performance/local/coroutines_call_overhead.cpp
@@ -202,7 +202,7 @@ int hpx_main(
             header = false;
 
         if (!seed)
-            seed = boost::uint64_t(std::time(0));
+            seed = boost::uint64_t(std::time(nullptr));
 
         boost::uint64_t const os_thread_count = hpx::get_os_thread_count();
 

--- a/tests/performance/local/hpx_heterogeneous_timed_task_spawn.cpp
+++ b/tests/performance/local/hpx_heterogeneous_timed_task_spawn.cpp
@@ -105,7 +105,7 @@ int hpx_main(
     ///////////////////////////////////////////////////////////////////////////
     // Initialize the PRNG seed.
     if (!seed)
-        seed = boost::uint64_t(std::time(0));
+        seed = boost::uint64_t(std::time(nullptr));
 
     {
 

--- a/tests/performance/local/print_heterogeneous_payloads.cpp
+++ b/tests/performance/local/print_heterogeneous_payloads.cpp
@@ -59,7 +59,7 @@ int app_main(
     ///////////////////////////////////////////////////////////////////////
     // Initialize the PRNG seed.
     if (!seed)
-        seed = boost::uint64_t(std::time(0));
+        seed = boost::uint64_t(std::time(nullptr));
 
     ///////////////////////////////////////////////////////////////////////
     // Validate command-line arguments.

--- a/tests/performance/local/qthreads_heterogeneous_timed_task_spawn.cpp
+++ b/tests/performance/local/qthreads_heterogeneous_timed_task_spawn.cpp
@@ -139,7 +139,7 @@ int qthreads_main(
         ///////////////////////////////////////////////////////////////////////
         // Initialize the PRNG seed.
         if (!seed)
-            seed = boost::uint64_t(std::time(0));
+            seed = boost::uint64_t(std::time(nullptr));
 
         ///////////////////////////////////////////////////////////////////////
         // Validate command-line arguments.

--- a/tests/performance/local/spinlock_overhead1.cpp
+++ b/tests/performance/local/spinlock_overhead1.cpp
@@ -92,7 +92,7 @@ namespace test
                 rqtp.tv_sec = 0;
                 rqtp.tv_nsec = 1000;
 
-                nanosleep( &rqtp, 0 );
+                nanosleep( &rqtp, nullptr );
 #endif
             }
         }

--- a/tests/performance/local/spinlock_overhead2.cpp
+++ b/tests/performance/local/spinlock_overhead2.cpp
@@ -115,7 +115,7 @@ namespace test
                     rqtp.tv_sec = 0;
                     rqtp.tv_nsec = 1000;
 
-                    nanosleep( &rqtp, 0 );
+                    nanosleep( &rqtp, nullptr );
 #else
 #endif
                 }

--- a/tests/performance/network/algorithms/minmax_element_performance.cpp
+++ b/tests/performance/network/algorithms/minmax_element_performance.cpp
@@ -135,7 +135,7 @@ int hpx_main(boost::program_options::variables_map& vm)
 
 int main(int argc, char* argv[])
 {
-    std::srand((unsigned int)std::time(0));
+    std::srand((unsigned int)std::time(nullptr));
 
     // initialize program
     std::vector<std::string> cfg;

--- a/tests/performance/network/network_storage/network_storage.cpp
+++ b/tests/performance/network/network_storage/network_storage.cpp
@@ -179,7 +179,7 @@ public:
   typedef std::ptrdiff_t difference_type;
 
   pointer_allocator() HPX_NOEXCEPT
-    : pointer_(0), size_(0)
+    : pointer_(nullptr), size_(0)
   {
   }
 

--- a/tests/regressions/parallel/scan_different_inits.cpp
+++ b/tests/regressions/parallel/scan_different_inits.cpp
@@ -203,7 +203,7 @@ void test_async_one(std::vector<int> a)
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/regressions/parallel/scan_shortlength.cpp
+++ b/tests/regressions/parallel/scan_shortlength.cpp
@@ -155,7 +155,7 @@ void test_async_one(std::vector<int> a)
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/regressions/util/serialize_buffer_1069.cpp
+++ b/tests/regressions/util/serialize_buffer_1069.cpp
@@ -33,7 +33,7 @@ public:
     // we want to make sure anything else uses the std allocator
     template <typename U> struct rebind { typedef std::allocator<U> other; };
 
-    pointer allocate(size_type n, const void *hint=0)
+    pointer allocate(size_type n, const void *hint=nullptr)
     {
         HPX_TEST_EQ(n, static_cast<size_type>(MEMORY_BLOCK_SIZE));
         return std::allocator<T>::allocate(n, hint);

--- a/tests/unit/actions/fail_compile_const_pointer_argument.cpp
+++ b/tests/unit/actions/fail_compile_const_pointer_argument.cpp
@@ -14,7 +14,7 @@ HPX_PLAIN_ACTION(test);
 ///////////////////////////////////////////////////////////////////////////////
 int main()
 {
-    int const* ptr = 0;
+    int const* ptr = nullptr;
 
     test_action act;
     hpx::apply(act, hpx::find_here(), ptr);

--- a/tests/unit/actions/fail_compile_non_const_pointer_argument.cpp
+++ b/tests/unit/actions/fail_compile_non_const_pointer_argument.cpp
@@ -14,7 +14,7 @@ HPX_PLAIN_ACTION(test);
 ///////////////////////////////////////////////////////////////////////////////
 int main()
 {
-    int* ptr = 0;
+    int* ptr = nullptr;
 
     test_action act;
     hpx::apply(act, hpx::find_here(), ptr);

--- a/tests/unit/computeapi/cuda/for_each_compute.cu
+++ b/tests/unit/computeapi/cuda/for_each_compute.cu
@@ -48,7 +48,7 @@ void test_for_each(executor_type& exec, target_vector& d_A)
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/computeapi/cuda/for_loop_compute.cu
+++ b/tests/unit/computeapi/cuda/for_loop_compute.cu
@@ -55,7 +55,7 @@ void test_for_loop(executor_type& exec,
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/computeapi/cuda/transform_compute.cu
+++ b/tests/unit/computeapi/cuda/transform_compute.cu
@@ -53,7 +53,7 @@ void test_transform(executor_type& exec,
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/computeapi/host/block_allocator.cpp
+++ b/tests/unit/computeapi/host/block_allocator.cpp
@@ -71,7 +71,7 @@ struct test
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/adjacentdifference.cpp
+++ b/tests/unit/parallel/algorithms/adjacentdifference.cpp
@@ -89,7 +89,7 @@ void adjacent_difference_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/adjacentdifference_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/adjacentdifference_bad_alloc.cpp
@@ -121,7 +121,7 @@ void adjacent_difference_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/adjacentdifference_exception.cpp
+++ b/tests/unit/parallel/algorithms/adjacentdifference_exception.cpp
@@ -124,7 +124,7 @@ void adjacent_difference_exception_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/adjacentfind.cpp
+++ b/tests/unit/parallel/algorithms/adjacentfind.cpp
@@ -98,7 +98,7 @@ void adjacent_find_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/adjacentfind_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/adjacentfind_bad_alloc.cpp
@@ -118,7 +118,7 @@ void adjacent_find_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/adjacentfind_binary.cpp
+++ b/tests/unit/parallel/algorithms/adjacentfind_binary.cpp
@@ -100,7 +100,7 @@ void adjacent_find_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/adjacentfind_binary_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/adjacentfind_binary_bad_alloc.cpp
@@ -119,7 +119,7 @@ void adjacent_find_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/adjacentfind_binary_exception.cpp
+++ b/tests/unit/parallel/algorithms/adjacentfind_binary_exception.cpp
@@ -121,7 +121,7 @@ void adjacent_find_exception_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/adjacentfind_exception.cpp
+++ b/tests/unit/parallel/algorithms/adjacentfind_exception.cpp
@@ -119,7 +119,7 @@ void adjacent_find_exception_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/all_of.cpp
+++ b/tests/unit/parallel/algorithms/all_of.cpp
@@ -349,7 +349,7 @@ void all_of_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/any_of.cpp
+++ b/tests/unit/parallel/algorithms/any_of.cpp
@@ -349,7 +349,7 @@ void any_of_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/copy.cpp
+++ b/tests/unit/parallel/algorithms/copy.cpp
@@ -376,7 +376,7 @@ void copy_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/copyif_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/copyif_bad_alloc.cpp
@@ -120,7 +120,7 @@ void copy_if_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/copyif_exception.cpp
+++ b/tests/unit/parallel/algorithms/copyif_exception.cpp
@@ -121,7 +121,7 @@ void copy_if_exception_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/copyif_forward.cpp
+++ b/tests/unit/parallel/algorithms/copyif_forward.cpp
@@ -189,7 +189,7 @@ void test_copy_if()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/copyif_input.cpp
+++ b/tests/unit/parallel/algorithms/copyif_input.cpp
@@ -189,7 +189,7 @@ void test_copy_if()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/copyif_random.cpp
+++ b/tests/unit/parallel/algorithms/copyif_random.cpp
@@ -193,7 +193,7 @@ void test_copy_if()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/copyn.cpp
+++ b/tests/unit/parallel/algorithms/copyn.cpp
@@ -385,7 +385,7 @@ void copy_n_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/count.cpp
+++ b/tests/unit/parallel/algorithms/count.cpp
@@ -303,7 +303,7 @@ void count_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/countif.cpp
+++ b/tests/unit/parallel/algorithms/countif.cpp
@@ -292,7 +292,7 @@ void count_if_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/equal.cpp
+++ b/tests/unit/parallel/algorithms/equal.cpp
@@ -471,7 +471,7 @@ void equal_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/equal_binary.cpp
+++ b/tests/unit/parallel/algorithms/equal_binary.cpp
@@ -471,7 +471,7 @@ void equal_binary_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/exclusive_scan.cpp
+++ b/tests/unit/parallel/algorithms/exclusive_scan.cpp
@@ -148,7 +148,7 @@ void exclusive_scan_test1()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/exclusive_scan2.cpp
+++ b/tests/unit/parallel/algorithms/exclusive_scan2.cpp
@@ -103,7 +103,7 @@ void exclusive_scan_test2()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/exclusive_scan_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/exclusive_scan_bad_alloc.cpp
@@ -123,7 +123,7 @@ void exclusive_scan_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/exclusive_scan_exception.cpp
+++ b/tests/unit/parallel/algorithms/exclusive_scan_exception.cpp
@@ -126,7 +126,7 @@ void exclusive_scan_exception_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/exclusive_scan_validate.cpp
+++ b/tests/unit/parallel/algorithms/exclusive_scan_validate.cpp
@@ -150,7 +150,7 @@ void exclusive_scan_validate()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/fill.cpp
+++ b/tests/unit/parallel/algorithms/fill.cpp
@@ -297,7 +297,7 @@ void fill_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/filln.cpp
+++ b/tests/unit/parallel/algorithms/filln.cpp
@@ -298,7 +298,7 @@ void fill_n_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/find.cpp
+++ b/tests/unit/parallel/algorithms/find.cpp
@@ -301,7 +301,7 @@ void find_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/findend.cpp
+++ b/tests/unit/parallel/algorithms/findend.cpp
@@ -589,7 +589,7 @@ void find_end_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/findfirstof.cpp
+++ b/tests/unit/parallel/algorithms/findfirstof.cpp
@@ -317,7 +317,7 @@ void find_first_of_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/findfirstof_binary.cpp
+++ b/tests/unit/parallel/algorithms/findfirstof_binary.cpp
@@ -349,7 +349,7 @@ void find_first_of_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/findif.cpp
+++ b/tests/unit/parallel/algorithms/findif.cpp
@@ -305,7 +305,7 @@ void find_if_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/findifnot.cpp
+++ b/tests/unit/parallel/algorithms/findifnot.cpp
@@ -97,7 +97,7 @@ void find_if_not_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/findifnot_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/findifnot_bad_alloc.cpp
@@ -121,7 +121,7 @@ void find_if_not_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/findifnot_exception.cpp
+++ b/tests/unit/parallel/algorithms/findifnot_exception.cpp
@@ -122,7 +122,7 @@ void find_if_not_exception_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/for_loop.cpp
+++ b/tests/unit/parallel/algorithms/for_loop.cpp
@@ -173,7 +173,7 @@ void for_loop_test_idx()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/for_loop_induction.cpp
+++ b/tests/unit/parallel/algorithms/for_loop_induction.cpp
@@ -300,7 +300,7 @@ void for_loop_induction_test_idx()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/for_loop_induction_async.cpp
+++ b/tests/unit/parallel/algorithms/for_loop_induction_async.cpp
@@ -300,7 +300,7 @@ void for_loop_induction_test_idx()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/for_loop_n.cpp
+++ b/tests/unit/parallel/algorithms/for_loop_n.cpp
@@ -173,7 +173,7 @@ void for_loop_n_test_idx()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/for_loop_n_strided.cpp
+++ b/tests/unit/parallel/algorithms/for_loop_n_strided.cpp
@@ -233,7 +233,7 @@ void for_loop_n_strided_test_idx()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/for_loop_reduction.cpp
+++ b/tests/unit/parallel/algorithms/for_loop_reduction.cpp
@@ -200,7 +200,7 @@ void for_loop_reduction_test_idx()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/for_loop_reduction_async.cpp
+++ b/tests/unit/parallel/algorithms/for_loop_reduction_async.cpp
@@ -200,7 +200,7 @@ void for_loop_reduction_test_idx()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/for_loop_strided.cpp
+++ b/tests/unit/parallel/algorithms/for_loop_strided.cpp
@@ -233,7 +233,7 @@ void for_loop_strided_test_idx()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/foreach.cpp
+++ b/tests/unit/parallel/algorithms/foreach.cpp
@@ -108,7 +108,7 @@ void for_each_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/foreach_executors.cpp
+++ b/tests/unit/parallel/algorithms/foreach_executors.cpp
@@ -57,7 +57,7 @@ void for_each_executors_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/foreach_projection.cpp
+++ b/tests/unit/parallel/algorithms/foreach_projection.cpp
@@ -116,7 +116,7 @@ struct projection_square
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/foreachn.cpp
+++ b/tests/unit/parallel/algorithms/foreachn.cpp
@@ -107,7 +107,7 @@ void for_each_n_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/foreachn_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/foreachn_bad_alloc.cpp
@@ -113,7 +113,7 @@ void for_each_n_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/foreachn_exception.cpp
+++ b/tests/unit/parallel/algorithms/foreachn_exception.cpp
@@ -115,7 +115,7 @@ void for_each_n_exception_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/foreachn_projection.cpp
+++ b/tests/unit/parallel/algorithms/foreachn_projection.cpp
@@ -111,7 +111,7 @@ struct projection_square
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/foreachn_projection_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/foreachn_projection_bad_alloc.cpp
@@ -126,7 +126,7 @@ struct projection_square
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/foreachn_projection_exception.cpp
+++ b/tests/unit/parallel/algorithms/foreachn_projection_exception.cpp
@@ -128,7 +128,7 @@ struct projection_square
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/generate.cpp
+++ b/tests/unit/parallel/algorithms/generate.cpp
@@ -305,7 +305,7 @@ void generate_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/generaten.cpp
+++ b/tests/unit/parallel/algorithms/generaten.cpp
@@ -303,7 +303,7 @@ void generate_n_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/includes.cpp
+++ b/tests/unit/parallel/algorithms/includes.cpp
@@ -561,7 +561,7 @@ void includes_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/inclusive_scan.cpp
+++ b/tests/unit/parallel/algorithms/inclusive_scan.cpp
@@ -179,7 +179,7 @@ void inclusive_scan_validate()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/inclusive_scan_executors.cpp
+++ b/tests/unit/parallel/algorithms/inclusive_scan_executors.cpp
@@ -61,7 +61,7 @@ void inclusive_scan_executors_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/inner_product.cpp
+++ b/tests/unit/parallel/algorithms/inner_product.cpp
@@ -94,7 +94,7 @@ void inner_product_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/inner_product_bad_alloc.cpp
+++ b/tests/unit/parallel/algorithms/inner_product_bad_alloc.cpp
@@ -123,7 +123,7 @@ void inner_product_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/inner_product_exception.cpp
+++ b/tests/unit/parallel/algorithms/inner_product_exception.cpp
@@ -121,7 +121,7 @@ void inner_product_exception_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/lexicographical_compare.cpp
+++ b/tests/unit/parallel/algorithms/lexicographical_compare.cpp
@@ -469,7 +469,7 @@ void lexicographical_compare_bad_alloc_test()
 int hpx_main(boost::program_options::variables_map& vm)
 {
 
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if(vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/max_element.cpp
+++ b/tests/unit/parallel/algorithms/max_element.cpp
@@ -425,7 +425,7 @@ void max_element_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/min_element.cpp
+++ b/tests/unit/parallel/algorithms/min_element.cpp
@@ -427,7 +427,7 @@ void min_element_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/minmax_element.cpp
+++ b/tests/unit/parallel/algorithms/minmax_element.cpp
@@ -436,7 +436,7 @@ void minmax_element_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/mismatch.cpp
+++ b/tests/unit/parallel/algorithms/mismatch.cpp
@@ -501,7 +501,7 @@ void mismatch_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/mismatch_binary.cpp
+++ b/tests/unit/parallel/algorithms/mismatch_binary.cpp
@@ -508,7 +508,7 @@ void mismatch_binary_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/move.cpp
+++ b/tests/unit/parallel/algorithms/move.cpp
@@ -404,7 +404,7 @@ void move_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/none_of.cpp
+++ b/tests/unit/parallel/algorithms/none_of.cpp
@@ -349,7 +349,7 @@ void none_of_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/reduce_.cpp
+++ b/tests/unit/parallel/algorithms/reduce_.cpp
@@ -445,7 +445,7 @@ void reduce_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/reduce_by_key.cpp
+++ b/tests/unit/parallel/algorithms/reduce_by_key.cpp
@@ -393,7 +393,7 @@ void test_reduce_by_key1()
 ////////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int) std::time(0);
+    unsigned int seed = (unsigned int) std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/remove_copy.cpp
+++ b/tests/unit/parallel/algorithms/remove_copy.cpp
@@ -399,7 +399,7 @@ void remove_copy_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/remove_copy_if.cpp
+++ b/tests/unit/parallel/algorithms/remove_copy_if.cpp
@@ -405,7 +405,7 @@ void remove_copy_if_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/replace.cpp
+++ b/tests/unit/parallel/algorithms/replace.cpp
@@ -312,7 +312,7 @@ void replace_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/replace_copy.cpp
+++ b/tests/unit/parallel/algorithms/replace_copy.cpp
@@ -323,7 +323,7 @@ void replace_copy_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/replace_copy_if.cpp
+++ b/tests/unit/parallel/algorithms/replace_copy_if.cpp
@@ -335,7 +335,7 @@ void replace_copy_if_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/replace_if.cpp
+++ b/tests/unit/parallel/algorithms/replace_if.cpp
@@ -324,7 +324,7 @@ void replace_if_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/reverse.cpp
+++ b/tests/unit/parallel/algorithms/reverse.cpp
@@ -308,7 +308,7 @@ void reverse_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/reverse_copy.cpp
+++ b/tests/unit/parallel/algorithms/reverse_copy.cpp
@@ -317,7 +317,7 @@ void reverse_copy_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/rotate.cpp
+++ b/tests/unit/parallel/algorithms/rotate.cpp
@@ -346,7 +346,7 @@ void rotate_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/rotate_copy.cpp
+++ b/tests/unit/parallel/algorithms/rotate_copy.cpp
@@ -348,7 +348,7 @@ void rotate_copy_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/search.cpp
+++ b/tests/unit/parallel/algorithms/search.cpp
@@ -583,7 +583,7 @@ void search_bad_alloc_test()
 int hpx_main(boost::program_options::variables_map& vm)
 {
 
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if(vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/searchn.cpp
+++ b/tests/unit/parallel/algorithms/searchn.cpp
@@ -662,7 +662,7 @@ void search_n_bad_alloc_test()
 int hpx_main(boost::program_options::variables_map& vm)
 {
 
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if(vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/set_difference.cpp
+++ b/tests/unit/parallel/algorithms/set_difference.cpp
@@ -438,7 +438,7 @@ void set_difference_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/set_intersection.cpp
+++ b/tests/unit/parallel/algorithms/set_intersection.cpp
@@ -438,7 +438,7 @@ void set_intersection_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/set_symmetric_difference.cpp
+++ b/tests/unit/parallel/algorithms/set_symmetric_difference.cpp
@@ -438,7 +438,7 @@ void set_symmetric_difference_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/set_union.cpp
+++ b/tests/unit/parallel/algorithms/set_union.cpp
@@ -438,7 +438,7 @@ void set_union_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/sort.cpp
+++ b/tests/unit/parallel/algorithms/sort.cpp
@@ -157,7 +157,7 @@ void test_sort2()
 ////////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/sort_by_key.cpp
+++ b/tests/unit/parallel/algorithms/sort_by_key.cpp
@@ -256,7 +256,7 @@ void test_sort_by_key1()
 ////////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map &vm)
 {
-    unsigned int seed = (unsigned int) std::time(0);
+    unsigned int seed = (unsigned int) std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/sort_exceptions.cpp
+++ b/tests/unit/parallel/algorithms/sort_exceptions.cpp
@@ -42,7 +42,7 @@ void test_exceptions()
 ////////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/swapranges.cpp
+++ b/tests/unit/parallel/algorithms/swapranges.cpp
@@ -329,7 +329,7 @@ void swap_ranges_bad_alloc_test()
 }
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/transform.cpp
+++ b/tests/unit/parallel/algorithms/transform.cpp
@@ -321,7 +321,7 @@ void transform_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/transform_binary.cpp
+++ b/tests/unit/parallel/algorithms/transform_binary.cpp
@@ -351,7 +351,7 @@ void transform_binary_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/transform_binary2.cpp
+++ b/tests/unit/parallel/algorithms/transform_binary2.cpp
@@ -351,7 +351,7 @@ void transform_binary_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/transform_exclusive_scan.cpp
+++ b/tests/unit/parallel/algorithms/transform_exclusive_scan.cpp
@@ -326,7 +326,7 @@ void transform_exclusive_scan_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/transform_inclusive_scan.cpp
+++ b/tests/unit/parallel/algorithms/transform_inclusive_scan.cpp
@@ -414,7 +414,7 @@ void transform_inclusive_scan_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/transform_reduce.cpp
+++ b/tests/unit/parallel/algorithms/transform_reduce.cpp
@@ -338,7 +338,7 @@ void transform_reduce_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/uninitialized_copy.cpp
+++ b/tests/unit/parallel/algorithms/uninitialized_copy.cpp
@@ -104,7 +104,7 @@ void uninitialized_copy_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/uninitialized_copy_executors.cpp
+++ b/tests/unit/parallel/algorithms/uninitialized_copy_executors.cpp
@@ -62,7 +62,7 @@ void uninitialized_copy_executors_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/uninitialized_copyn.cpp
+++ b/tests/unit/parallel/algorithms/uninitialized_copyn.cpp
@@ -344,7 +344,7 @@ void uninitialized_copy_n_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/uninitialized_fill.cpp
+++ b/tests/unit/parallel/algorithms/uninitialized_fill.cpp
@@ -335,7 +335,7 @@ void uninitialized_fill_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/algorithms/uninitialized_filln.cpp
+++ b/tests/unit/parallel/algorithms/uninitialized_filln.cpp
@@ -335,7 +335,7 @@ void uninitialized_fill_n_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/container_algorithms/copy_range.cpp
+++ b/tests/unit/parallel/container_algorithms/copy_range.cpp
@@ -381,7 +381,7 @@ void copy_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/container_algorithms/copyif_range.cpp
+++ b/tests/unit/parallel/container_algorithms/copyif_range.cpp
@@ -186,7 +186,7 @@ void test_copy_if()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/container_algorithms/foreach_range.cpp
+++ b/tests/unit/parallel/container_algorithms/foreach_range.cpp
@@ -108,7 +108,7 @@ void for_each_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/container_algorithms/foreach_range_projection.cpp
+++ b/tests/unit/parallel/container_algorithms/foreach_range_projection.cpp
@@ -116,7 +116,7 @@ struct projection_square
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/container_algorithms/generate_range.cpp
+++ b/tests/unit/parallel/container_algorithms/generate_range.cpp
@@ -313,7 +313,7 @@ void generate_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/container_algorithms/max_element_range.cpp
+++ b/tests/unit/parallel/container_algorithms/max_element_range.cpp
@@ -430,7 +430,7 @@ void max_element_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/container_algorithms/min_element_range.cpp
+++ b/tests/unit/parallel/container_algorithms/min_element_range.cpp
@@ -433,7 +433,7 @@ void min_element_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/container_algorithms/minmax_element_range.cpp
+++ b/tests/unit/parallel/container_algorithms/minmax_element_range.cpp
@@ -441,7 +441,7 @@ void minmax_element_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/container_algorithms/remove_copy_if_range.cpp
+++ b/tests/unit/parallel/container_algorithms/remove_copy_if_range.cpp
@@ -408,7 +408,7 @@ void remove_copy_if_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/container_algorithms/remove_copy_range.cpp
+++ b/tests/unit/parallel/container_algorithms/remove_copy_range.cpp
@@ -411,7 +411,7 @@ void remove_copy_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/container_algorithms/replace_copy_if_range.cpp
+++ b/tests/unit/parallel/container_algorithms/replace_copy_if_range.cpp
@@ -341,7 +341,7 @@ void replace_copy_if_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/container_algorithms/replace_copy_range.cpp
+++ b/tests/unit/parallel/container_algorithms/replace_copy_range.cpp
@@ -326,7 +326,7 @@ void replace_copy_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/container_algorithms/replace_if_range.cpp
+++ b/tests/unit/parallel/container_algorithms/replace_if_range.cpp
@@ -329,7 +329,7 @@ void replace_if_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/container_algorithms/replace_range.cpp
+++ b/tests/unit/parallel/container_algorithms/replace_range.cpp
@@ -317,7 +317,7 @@ void replace_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/container_algorithms/reverse_copy_range.cpp
+++ b/tests/unit/parallel/container_algorithms/reverse_copy_range.cpp
@@ -323,7 +323,7 @@ void reverse_copy_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/container_algorithms/reverse_range.cpp
+++ b/tests/unit/parallel/container_algorithms/reverse_range.cpp
@@ -315,7 +315,7 @@ void reverse_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/container_algorithms/rotate_copy_range.cpp
+++ b/tests/unit/parallel/container_algorithms/rotate_copy_range.cpp
@@ -363,7 +363,7 @@ void rotate_copy_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/container_algorithms/rotate_range.cpp
+++ b/tests/unit/parallel/container_algorithms/rotate_range.cpp
@@ -352,7 +352,7 @@ void rotate_bad_alloc_test()
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/container_algorithms/sort_range.cpp
+++ b/tests/unit/parallel/container_algorithms/sort_range.cpp
@@ -129,7 +129,7 @@ void test_sort2()
 ////////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/container_algorithms/transform_range.cpp
+++ b/tests/unit/parallel/container_algorithms/transform_range.cpp
@@ -331,7 +331,7 @@ void transform_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/container_algorithms/transform_range_binary.cpp
+++ b/tests/unit/parallel/container_algorithms/transform_range_binary.cpp
@@ -355,7 +355,7 @@ void transform_binary_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/container_algorithms/transform_range_binary2.cpp
+++ b/tests/unit/parallel/container_algorithms/transform_range_binary2.cpp
@@ -367,7 +367,7 @@ void transform_binary_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/executors/created_executor.cpp
+++ b/tests/unit/parallel/executors/created_executor.cpp
@@ -205,7 +205,7 @@ void sum_test()
 ////////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = static_cast<unsigned int>(std::time(0));
+    unsigned int seed = static_cast<unsigned int>(std::time(nullptr));
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/executors/executor_parameters.cpp
+++ b/tests/unit/parallel/executors/executor_parameters.cpp
@@ -117,7 +117,7 @@ void test_persistent_auto_chunk_size()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = static_cast<unsigned int>(std::time(0));
+    unsigned int seed = static_cast<unsigned int>(std::time(nullptr));
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/executors/executor_parameters_timer_hooks.cpp
+++ b/tests/unit/parallel/executors/executor_parameters_timer_hooks.cpp
@@ -83,7 +83,7 @@ void test_timer_hooks()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = static_cast<unsigned int>(std::time(0));
+    unsigned int seed = static_cast<unsigned int>(std::time(nullptr));
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/executors/persistent_executor_parameters.cpp
+++ b/tests/unit/parallel/executors/persistent_executor_parameters.cpp
@@ -88,7 +88,7 @@ void test_persistent_executitor_parameters_ref()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = static_cast<unsigned int>(std::time(0));
+    unsigned int seed = static_cast<unsigned int>(std::time(nullptr));
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parcelset/put_parcels.cpp
+++ b/tests/unit/parcelset/put_parcels.cpp
@@ -199,7 +199,7 @@ void print_counters(char const* name)
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parcelset/put_parcels_with_coalescing.cpp
+++ b/tests/unit/parcelset/put_parcels_with_coalescing.cpp
@@ -228,7 +228,7 @@ void print_counters(char const* name)
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parcelset/put_parcels_with_compression.cpp
+++ b/tests/unit/parcelset/put_parcels_with_compression.cpp
@@ -269,7 +269,7 @@ void verify_counters()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parcelset/set_parcel_write_handler.cpp
+++ b/tests/unit/parcelset/set_parcel_write_handler.cpp
@@ -25,7 +25,7 @@ bool is_test_action(hpx::parcelset::parcel const& p)
 {
     return dynamic_cast<
             hpx::actions::transfer_action<test_action>*
-        >(p.get_action()) != 0;
+        >(p.get_action()) != nullptr;
 }
 
 void write_handler(boost::system::error_code const&,

--- a/tests/unit/serialization/polymorphic/polymorphic_nonintrusive_abstract.cpp
+++ b/tests/unit/serialization/polymorphic/polymorphic_nonintrusive_abstract.cpp
@@ -124,7 +124,7 @@ int main()
         iarchive >> b1;
         iarchive >> hpx::serialization::detail::raw_ptr(b2);
 
-        HPX_TEST(b2 != 0);
+        HPX_TEST(b2 != nullptr);
 
         HPX_TEST_EQ(d.print(), b1.print());
         HPX_TEST_EQ(d.size(), b1.size());

--- a/tests/unit/serialization/zero_copy_serialization.cpp
+++ b/tests/unit/serialization/zero_copy_serialization.cpp
@@ -98,7 +98,7 @@ void test_parcel_serialization(hpx::parcelset::parcel outp,
     // serialize data
     std::vector<hpx::serialization::serialization_chunk> out_chunks;
     std::size_t arg_size = get_archive_size(outp, out_archive_flags,
-        zero_copy ? &out_chunks : 0);
+        zero_copy ? &out_chunks : nullptr);
     std::vector<char> out_buffer;
     boost::uint32_t dest_locality_id = outp.destination_locality_id();
 
@@ -108,7 +108,7 @@ void test_parcel_serialization(hpx::parcelset::parcel outp,
         // create an output archive and serialize the parcel
         hpx::serialization::output_archive archive(
             out_buffer, out_archive_flags, dest_locality_id,
-            zero_copy ? &out_chunks : 0);
+            zero_copy ? &out_chunks : nullptr);
         archive << outp;
 
         arg_size = archive.bytes_written();

--- a/tests/unit/util/boost_any.cpp
+++ b/tests/unit/util/boost_any.cpp
@@ -103,7 +103,8 @@ namespace any_tests // test definitions
         const any value;
 
         HPX_TEST_MSG(value.empty(), "empty");
-        HPX_TEST_EQ_MSG((void*)0, any_cast<int>(&value), "any_cast<int>");
+        HPX_TEST_EQ_MSG(static_cast<void*>(nullptr),
+            any_cast<int>(&value), "any_cast<int>");
         HPX_TEST_EQ_MSG(value.type(), BOOST_SP_TYPEID(hpx::util::detail::any::empty),
             "type");
     }
@@ -115,8 +116,9 @@ namespace any_tests // test definitions
 
         HPX_TEST_EQ_MSG(false, value.empty(), "empty");
         HPX_TEST_EQ_MSG(value.type(), typeid(std::string), "type");
-        HPX_TEST_EQ_MSG((void*)0, any_cast<int>(&value), "any_cast<int>");
-        HPX_TEST_NEQ_MSG((void*)0, any_cast<std::string>(&value),
+        HPX_TEST_EQ_MSG(static_cast<void*>(nullptr),
+            any_cast<int>(&value), "any_cast<int>");
+        HPX_TEST_NEQ_MSG(static_cast<void*>(nullptr), any_cast<std::string>(&value),
             "any_cast<std::string>");
         HPX_TEST_EQ_MSG(
             any_cast<std::string>(value), text,
@@ -174,8 +176,9 @@ namespace any_tests // test definitions
 
         HPX_TEST_EQ_MSG(false, value.empty(), "type");
         HPX_TEST_EQ_MSG(value.type(), typeid(std::string), "type");
-        HPX_TEST_EQ_MSG((void*)0, any_cast<int>(&value), "any_cast<int>");
-        HPX_TEST_NEQ_MSG((void*)0, any_cast<std::string>(&value),
+        HPX_TEST_EQ_MSG(static_cast<void*>(nullptr),
+            any_cast<int>(&value), "any_cast<int>");
+        HPX_TEST_NEQ_MSG(static_cast<void*>(nullptr), any_cast<std::string>(&value),
             "any_cast<std::string>");
         HPX_TEST_EQ_MSG(
             any_cast<std::string>(value), text,
@@ -225,7 +228,8 @@ namespace any_tests // test definitions
         HPX_TEST_EQ_MSG(
             text, any_cast<small_object>(swapped),
             "comparing swapped copy against original text");
-        HPX_TEST_NEQ_MSG((void*)0, original_ptr, "address in pre-swapped original");
+        HPX_TEST_NEQ_MSG(static_cast<void*>(nullptr),
+            original_ptr, "address in pre-swapped original");
         HPX_TEST_NEQ_MSG(
             original_ptr,
             any_cast<small_object>(&swapped),
@@ -258,7 +262,8 @@ namespace any_tests // test definitions
         HPX_TEST_EQ_MSG(
             text, any_cast<big_object>(swapped),
             "comparing swapped copy against original text");
-        HPX_TEST_NEQ_MSG((void*)0, original_ptr, "address in pre-swapped original");
+        HPX_TEST_NEQ_MSG(static_cast<void*>(nullptr),
+            original_ptr, "address in pre-swapped original");
         HPX_TEST_EQ_MSG(
             original_ptr,
             any_cast<big_object>(&swapped),

--- a/tests/unit/util/function/function_arith.cpp
+++ b/tests/unit/util/function/function_arith.cpp
@@ -29,7 +29,7 @@ int main()
     HPX_TEST(f);
     HPX_TEST_EQ(f(5, 3), 5.f/3);
 
-    f = (float(*)(int, int))0;
+    f = nullptr;
     HPX_TEST(!f);
 
     f = &mul_ints;

--- a/tests/unit/util/function/function_target.cpp
+++ b/tests/unit/util/function/function_target.cpp
@@ -21,14 +21,14 @@ int main()
         hpx::util::function<int()> fun = foo();
 
         HPX_TEST(fun.target_type() == typeid(foo));
-        HPX_TEST(fun.target<foo>() != 0);
+        HPX_TEST(fun.target<foo>() != nullptr);
     }
 
     {
         hpx::util::function<int()> fun = foo();
 
         HPX_TEST(fun.target_type() == typeid(foo const));
-        HPX_TEST(fun.target<foo const>() != 0);
+        HPX_TEST(fun.target<foo const>() != nullptr);
     }
 
     return hpx::util::report_errors();

--- a/tests/unit/util/function/function_test.cpp
+++ b/tests/unit/util/function/function_test.cpp
@@ -93,7 +93,7 @@ static void
     HPX_TEST(global_int == 5);
 
     // clear
-    void (*fpv1)() = 0;
+    void (*fpv1)() = 0; // NOLINT
     v1 = fpv1;
     HPX_TEST(v1.empty());
 
@@ -492,7 +492,7 @@ static void
     HPX_TEST(global_int == 2);
 
     // Test construction from 0
-    void (*fpv9)() = 0;
+    void (*fpv9)() = 0; // NOLINT
     func_void_type v9(fpv9);
     HPX_TEST(v9.empty());
 

--- a/tools/clang-tidy.sh
+++ b/tools/clang-tidy.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#  Copyright (c) 2016 Thomas Heller
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+FILES=$(grep '"file":' compile_commands.json | awk '{print $2}' | tr -d '"')
+
+if [[ x"${1}" == x"-diff-master" ]]
+then
+    SRC_PATH=${2}
+    if [[ x"${SRC_PATH}" == x"" ]]
+    then
+        if [[ -f CMakeCache.txt ]]
+        then
+            SRC_PATH=$(grep "CMAKE_HOME_DIRECTORY" CMakeCache.txt | awk -F '=' '{print $2}')
+        else
+            echo "Not executing in the build directory, can not determine source path!"
+            exit 1
+        fi
+    fi
+    cd ${SRC_PATH}
+    CHANGED_FILES=$(git diff --name-only origin/master | grep ".cpp$")
+    CHANGED_FILES=$(echo ${CHANGED_FILES} | awk -v var=${PWD} '{printf("%s/%s\n", var, $1)}')
+    FILES=$(comm -12 <(echo "${FILES}") <(echo "${CHANGED_FILES}"))
+    cd -
+fi
+
+# Filter out header tests ...
+FILES=$(echo "${FILES}" | grep -v "tests/headers")
+if [[ x"${EXTERN_FILTER}" != x"" ]]
+then
+    FILES=$(echo "${FILES}" | grep ${EXTERN_FILTER})
+fi
+
+NUM_FILES=$(echo "${FILES}" | wc -l)
+echo "Checking ${NUM_FILES} files"
+
+RESULT=0
+CHECKS="-*,modernize-use-nullptr"
+
+i=1
+for file in $FILES
+do
+    percentage=$(echo "scale=2; ${i}/${NUM_FILES} * 100" | bc | cut -d '.' -f 1)
+    echo -n "[${i}/${NUM_FILES} ${percentage}%] ${file}:"
+    OUT=$(clang-tidy -header-filter=".*hpx.*" -p . -checks="${CHECKS}" ${file} 2>&1);
+    echo ${OUT} | grep -vq "warning:"
+    if [[ $? != 0 ]]
+    then
+        echo ""
+        echo "${OUT}"
+        RESULT=1
+    else
+        echo " Nothing found"
+    fi
+    i=$((i + 1))
+done
+
+exit ${RESULT}

--- a/tools/inspect/deprecated_include_check.cpp
+++ b/tools/inspect/deprecated_include_check.cpp
@@ -30,7 +30,7 @@ namespace boost
       { "boost/detail/atomic_count\\.hpp", "hpx/util/atomic_count.hpp" },
       { "boost/function\\.hpp", "hpx/util/function.hpp" },
       { "hpx/hpx_fwd\\.hpp", "nothing (remove unconditionally)" },
-      { 0, 0 }
+      { nullptr, nullptr }
     };
 
     //  deprecated_include_check constructor  -------------------------------//
@@ -49,7 +49,7 @@ namespace boost
       register_signature( ".ipp" );
 
       for (deprecated_includes const* includes_it = &names[0];
-           includes_it->include_regex != 0;
+           includes_it->include_regex != nullptr;
            ++includes_it)
       {
         std::string rx =

--- a/tools/inspect/deprecated_name_check.cpp
+++ b/tools/inspect/deprecated_name_check.cpp
@@ -39,7 +39,7 @@ namespace boost
       { "(\\bboost\\s*::\\s*detail\\s*::\\s*atomic_count\\b)", "hpx::util::atomic_count" },
       { "(\\bboost\\s*::\\s*function\\b)", "hpx::util::function_nonser" },
       { "(\\bNULL\\b)", "nullptr" },
-      { 0, 0 }
+      { nullptr, nullptr }
     };
 
     //  deprecated_name_check constructor  --------------------------------- //
@@ -58,7 +58,7 @@ namespace boost
       register_signature( ".ipp" );
 
       for (deprecated_names const* names_it = &names[0];
-           names_it->name_regex != 0;
+           names_it->name_regex != nullptr;
            ++names_it)
       {
         std::string rx(names_it->name_regex);

--- a/tools/inspect/include_check.cpp
+++ b/tools/inspect/include_check.cpp
@@ -39,7 +39,7 @@ namespace boost
       { "(\\bstd\\s*::\\s*(mem((set)|(cpy)|(move)))\\b)", "std::\\2", "cstring" },
       { "(\\bboost\\s*::\\s*atomic\\b)", "boost::atomic", "boost/atomic.hpp" },
       { "(\\bboost\\s*::\\s*(((exception)|(intrusive))_ptr)\\b)", "boost::\\3_ptr", "boost/\\3_ptr.hpp" },
-      { 0, 0, 0 }
+      { nullptr, nullptr, nullptr }
     };
 
     //  include_check constructor  -------------------------------------------//
@@ -58,7 +58,7 @@ namespace boost
       register_signature( ".ipp" );
 
       for (names_includes const* names_it = &names[0];
-           names_it->name_regex != 0;
+           names_it->name_regex != nullptr;
            ++names_it)
       {
         std::string rx(names_it->name_regex);

--- a/tools/inspect/path_name_check.cpp
+++ b/tools/inspect/path_name_check.cpp
@@ -53,7 +53,7 @@ namespace boost
       }
 
       //  allowable initial character
-      if ( std::strchr( initial_char, leaf[0] ) == 0 )
+      if ( std::strchr( initial_char, leaf[0] ) == nullptr )
       {
         ++m_name_errors;
         error( library_name, full_path, loclink(full_path, string(name()))


### PR DESCRIPTION
This PR introduces a clang-tidy pass for circle-ci which currently checks for non nullptr uses only on changed files.
The remaining patch is to eliminate the last remaining uses of 0 over nullptr.