### PR TITLE
Support for HPXCL's opencl::event

### DIFF
--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -739,7 +739,7 @@ namespace detail
             if (!started_test())
                 return future_status::deferred; //-V110
             return this->future_data<Result>::wait_until(abs_time, ec);
-        };
+        }
 
     private:
         bool started_test() const

--- a/hpx/lcos/detail/promise_base.hpp
+++ b/hpx/lcos/detail/promise_base.hpp
@@ -91,10 +91,10 @@ namespace lcos {
         //
         // The LCO is a component, which lifetime is completely controlled by
         // the shared state. That is, in the GID that we send along as the
-        // continuation can be unmanaged, AGAS doesn't participate in the 
-        // promise lifetime management. The LCO is being reset once the shared 
-        // state either contains a value or the data, which is set through the 
-        // LCO interface, which can go out of scope safely when the shared 
+        // continuation can be unmanaged, AGAS doesn't participate in the
+        // promise lifetime management. The LCO is being reset once the shared
+        // state either contains a value or the data, which is set through the
+        // LCO interface, which can go out of scope safely when the shared
         // state is set.
         template <typename Result, typename RemoteResult, typename SharedState>
         class promise_base
@@ -181,7 +181,7 @@ namespace lcos {
 
             naming::id_type get_id(error_code& ec = throws) const
             {
-                if (this->shared_state_ == 0)
+                if (this->shared_state_ == nullptr)
                 {
                     HPX_THROWS_IF(ec, no_state,
                         "detail::promise_base<Result, RemoteResult>::get_id",
@@ -235,8 +235,9 @@ namespace lcos {
         protected:
             void check_abandon_shared_state(const char* fun)
             {
-                if (this->shared_state_ != 0 && this->future_retrieved_ &&
-                    !(this->has_result_ || id_retrieved_))
+                if (this->shared_state_ != nullptr &&
+                    this->future_retrieved_ &&
+                    !(this->shared_state_->is_ready() || id_retrieved_))
                 {
                     this->shared_state_->set_error(broken_promise, fun,
                         "abandoning not ready shared state");

--- a/hpx/lcos/detail/promise_base.hpp
+++ b/hpx/lcos/detail/promise_base.hpp
@@ -16,6 +16,7 @@
 #include <hpx/runtime/naming/address.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/throw_exception.hpp>
+#include <hpx/traits/detail/wrap_int.hpp>
 #include <hpx/util/deferred_call.hpp>
 #include <hpx/util/unique_function.hpp>
 
@@ -56,6 +57,32 @@ namespace lcos {
             util::unique_function_nonser<void()> f_;
         };
 
+        ///////////////////////////////////////////////////////////////////////
+        struct set_id_helper
+        {
+            template <typename SharedState>
+            HPX_FORCEINLINE static void call(hpx::traits::detail::wrap_int,
+                SharedState const& shared_state, id_type const& id)
+            {
+                // by default, do nothing
+            }
+
+            template <typename SharedState>
+            HPX_FORCEINLINE static auto call(int,
+                    SharedState const& shared_state, id_type const& id)
+            ->  decltype(shared_state->set_id(id))
+            {
+                shared_state->set_id(id);
+            }
+        };
+
+        template <typename SharedState>
+        HPX_FORCEINLINE
+        void call_set_id(SharedState const& shared_state, id_type const& id)
+        {
+            set_id_helper::call(0, shared_state, id);
+        }
+
         // Promise base contains the actual implementation for the remotely
         // settable
         // promise. It consists of two parts:
@@ -63,29 +90,25 @@ namespace lcos {
         //  2) The LCO, which is used to set the promise remotely
         //
         // The LCO is a component, which lifetime is completely controlled by
-        // the
-        // shared state. That is, in the GID that we send along as the
-        // continuation
-        // can be unmanaged, AGAS doesn't participate in the promise lifetime
-        // management. The LCO is being reset once the shared state either
-        // contains
-        // a value or the data, which is set through the LCO interface, which
-        // can go
-        // out of scope safely when the shared state is set.
-        template <typename Result, typename RemoteResult>
+        // the shared state. That is, in the GID that we send along as the
+        // continuation can be unmanaged, AGAS doesn't participate in the 
+        // promise lifetime management. The LCO is being reset once the shared 
+        // state either contains a value or the data, which is set through the 
+        // LCO interface, which can go out of scope safely when the shared 
+        // state is set.
+        template <typename Result, typename RemoteResult, typename SharedState>
         class promise_base
-            : public hpx::lcos::local::detail::promise_base<Result,
-                  promise_data<Result>>
+          : public hpx::lcos::local::detail::promise_base<Result, SharedState>
         {
             HPX_MOVABLE_ONLY(promise_base);
 
-            typedef hpx::lcos::local::detail::promise_base<Result,
-                promise_data<Result>>
-                base_type;
+            typedef hpx::lcos::local::detail::promise_base<
+                    Result, SharedState
+                > base_type;
 
         protected:
             typedef Result result_type;
-            typedef lcos::detail::future_data<Result> shared_state_type;
+            typedef SharedState shared_state_type;
             typedef boost::intrusive_ptr<shared_state_type> shared_state_ptr;
 
             typedef promise_lco<Result, RemoteResult> wrapped_type;
@@ -99,8 +122,7 @@ namespace lcos {
                 // The lifetime of the LCO (component) part is completely
                 // handled by the shared state, we create the object to get our
                 // gid and then attach it to the completion handler of the
-                // shared
-                // state.
+                // shared state.
                 typedef std::unique_ptr<wrapping_type> wrapping_ptr;
                 wrapping_ptr lco_ptr(
                     new wrapping_type(new wrapped_type(this->shared_state_)));
@@ -110,12 +132,18 @@ namespace lcos {
                     lco_ptr->get_component_type(),
                     lco_ptr.get());
 
+                // Pass id to shared state if it exposes the set_id() function
+                detail::call_set_id(this->shared_state_, id_);
+
                 // This helper is used to keep the component alive until the
                 // completion handler has been called. We need to manually free
                 // the component here, since we don't rely on reference counting
                 // anymore
                 auto keep_alive = hpx::util::deferred_call(
-                    [](wrapping_ptr ptr) { delete ptr->get(); },
+                    [](wrapping_ptr ptr)
+                    {
+                        delete ptr->get();      // delete wrapped_type
+                    },
                     std::move(lco_ptr));
                 this->shared_state_->set_on_completed(std::move(keep_alive));
             }
@@ -126,6 +154,7 @@ namespace lcos {
                   id_(std::move(other.id_)),
                   addr_(std::move(other.addr_))
             {
+                other.id_retrieved_ = false;
                 other.id_ = naming::invalid_id;
                 other.addr_ = naming::address();
             }
@@ -144,6 +173,7 @@ namespace lcos {
                 id_ = std::move(other.id_);
                 addr_ = std::move(other.addr_);
 
+                other.id_retrieved_ = false;
                 other.id_ = naming::invalid_id;
                 other.addr_ = naming::address();
                 return *this;

--- a/hpx/lcos/detail/promise_lco.hpp
+++ b/hpx/lcos/detail/promise_lco.hpp
@@ -80,10 +80,8 @@ namespace lcos {
             }
 
             // This is the component id. Every component needs to have an
-            // embedded
-            // enumerator 'value' which is used by the generic action
-            // implementation
-            // to associate this component with a given action.
+            // embedded enumerator 'value' which is used by the generic action
+            // implementation to associate this component with a given action.
             enum
             {
                 value = components::component_promise

--- a/hpx/lcos/packaged_action.hpp
+++ b/hpx/lcos/packaged_action.hpp
@@ -22,10 +22,6 @@
 #include <hpx/util/protect.hpp>
 
 #include <boost/exception_ptr.hpp>
-#include <boost/intrusive_ptr.hpp>
-#include <boost/mpl/bool.hpp>
-#include <boost/mpl/identity.hpp>
-#include <boost/type_traits/is_same.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx {
@@ -394,7 +390,6 @@ namespace lcos {
                     if (!r.first)
                     {
                         // local, direct execution
-                        this->has_result_ = true;
                         this->shared_state_->set_data(
                             action_type::execute_function(
                                 addr.address_, std::forward<Ts>(vs)...));
@@ -404,7 +399,6 @@ namespace lcos {
                 else
                 {
                     // local, direct execution
-                    this->has_result_ = true;
                     this->shared_state_->set_data(action_type::execute_function(
                         addr.address_, std::forward<Ts>(vs)...));
                     return;
@@ -437,7 +431,6 @@ namespace lcos {
                     if (!r.first)
                     {
                         // local, direct execution
-                        this->has_result_ = true;
                         this->shared_state_->set_data(
                             action_type::execute_function(
                                 addr.address_, std::forward<Ts>(vs)...));
@@ -447,7 +440,6 @@ namespace lcos {
                 else
                 {
                     // local, direct execution
-                    this->has_result_ = true;
                     this->shared_state_->set_data(action_type::execute_function(
                         addr.address_, std::forward<Ts>(vs)...));
                     return;
@@ -481,7 +473,6 @@ namespace lcos {
                     if (!r.first)
                     {
                         // local, direct execution
-                        this->has_result_ = true;
                         this->shared_state_->set_data(
                             action_type::execute_function(
                                 addr.address_, std::forward<Ts>(vs)...));
@@ -494,7 +485,6 @@ namespace lcos {
                 else
                 {
                     // local, direct execution
-                    this->has_result_ = true;
                     this->shared_state_->set_data(action_type::execute_function(
                         addr.address_, std::forward<Ts>(vs)...));
 
@@ -530,7 +520,6 @@ namespace lcos {
                     if (!r.first)
                     {
                         // local, direct execution
-                        this->has_result_ = true;
                         this->shared_state_->set_data(
                             action_type::execute_function(
                                 addr.address_, std::forward<Ts>(vs)...));
@@ -543,7 +532,6 @@ namespace lcos {
                 else
                 {
                     // local, direct execution
-                    this->has_result_ = true;
                     this->shared_state_->set_data(action_type::execute_function(
                         addr.address_, std::forward<Ts>(vs)...));
 

--- a/hpx/lcos/promise.hpp
+++ b/hpx/lcos/promise.hpp
@@ -55,7 +55,7 @@ namespace lcos {
     ///                  template parameter \a RemoteResult
     ///////////////////////////////////////////////////////////////////////////
     template <typename Result, typename RemoteResult>
-    class promise 
+    class promise
       : public detail::promise_base<
             Result, RemoteResult, detail::promise_data<Result> >
     {

--- a/hpx/lcos/promise.hpp
+++ b/hpx/lcos/promise.hpp
@@ -55,11 +55,15 @@ namespace lcos {
     ///                  template parameter \a RemoteResult
     ///////////////////////////////////////////////////////////////////////////
     template <typename Result, typename RemoteResult>
-    class promise : public detail::promise_base<Result, RemoteResult>
+    class promise 
+      : public detail::promise_base<
+            Result, RemoteResult, detail::promise_data<Result> >
     {
         HPX_MOVABLE_ONLY(promise);
 
-        typedef detail::promise_base<Result, RemoteResult> base_type;
+        typedef detail::promise_base<
+                Result, RemoteResult, detail::promise_data<Result>
+           > base_type;
 
     public:
         // Effects: constructs a promise object and a shared state.
@@ -98,10 +102,7 @@ namespace lcos {
         }
 
         // Returns: true only if *this refers to a shared state.
-        bool valid() const HPX_NOEXCEPT
-        {
-            return base_type::valid();
-        }
+        using base_type::valid;
 
         // Returns: A future<Result> object with the same shared state as *this.
         // Throws: future_error if *this has no shared state or if get_future
@@ -111,10 +112,7 @@ namespace lcos {
         //   - future_already_retrieved if get_future has already been called
         //     on a promise with the same shared state as *this.
         //   - no_state if *this has no shared state.
-        future<Result> get_future(error_code& ec = throws)
-        {
-            return base_type::get_future(ec);
-        }
+        using base_type::get_future;
 
         // Effects: atomically stores the value r in the shared state and makes
         //          that state ready (30.6.4).
@@ -125,11 +123,7 @@ namespace lcos {
         //   - promise_already_satisfied if its shared state already has a
         //     stored value or exception.
         //   - no_state if *this has no shared state.
-        template <typename T>
-        void set_value(T&& t, error_code& ec = throws)
-        {
-            base_type::set_value(std::forward<T>(t), ec);
-        }
+        using base_type::set_value;
 
         // Effects: atomically stores the exception pointer p in the shared
         //          state and makes that state ready (30.6.4).
@@ -139,20 +133,19 @@ namespace lcos {
         //   - promise_already_satisfied if its shared state already has a
         //     stored value or exception.
         //   - no_state if *this has no shared state.
-        void set_exception(
-            boost::exception_ptr const& e, error_code& ec = throws)
-        {
-            base_type::set_exception(e, ec);
-        }
+        using base_type::set_exception;
     };
 
     template <>
     class promise<void, hpx::util::unused_type>
-        : public detail::promise_base<void, hpx::util::unused_type>
+      : public detail::promise_base<
+            void, hpx::util::unused_type, detail::promise_data<void> >
     {
         HPX_MOVABLE_ONLY(promise);
 
-        typedef detail::promise_base<void, hpx::util::unused_type> base_type;
+        typedef detail::promise_base<
+                void, hpx::util::unused_type, detail::promise_data<void>
+            > base_type;
 
     public:
         // Effects: constructs a promise object and a shared state.
@@ -190,10 +183,7 @@ namespace lcos {
         }
 
         // Returns: true only if *this refers to a shared state.
-        bool valid() const HPX_NOEXCEPT
-        {
-            return base_type::valid();
-        }
+        using base_type::valid;
 
         // Returns: A future<Result> object with the same shared state as *this.
         // Throws: future_error if *this has no shared state or if get_future
@@ -203,10 +193,7 @@ namespace lcos {
         //   - future_already_retrieved if get_future has already been called
         //     on a promise with the same shared state as *this.
         //   - no_state if *this has no shared state.
-        future<void> get_future(error_code& ec = throws)
-        {
-            return base_type::get_future(ec);
-        }
+        using base_type::get_future;
 
         // Effects: atomically stores the value r in the shared state and makes
         //          that state ready (30.6.4).
@@ -232,11 +219,7 @@ namespace lcos {
         //   - promise_already_satisfied if its shared state already has a
         //     stored value or exception.
         //   - no_state if *this has no shared state.
-        void set_exception(
-            boost::exception_ptr const& e, error_code& ec = throws)
-        {
-            base_type::set_exception(e, ec);
-        }
+        using base_type::set_exception;
     };
 
     template <typename Result, typename RemoteResult>


### PR DESCRIPTION
- flyby: simplify implementation of lcos::promise