### PR TITLE
This adds an example for handing over a component instance to a dynamically launched locality

### DIFF
--- a/tests/unit/component/CMakeLists.txt
+++ b/tests/unit/component/CMakeLists.txt
@@ -4,6 +4,8 @@
 #  Distributed under the Boost Software License, Version 1.0. (See accompanying
 #  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+add_subdirectory(components)
+
 set(tests
     action_invoke_no_more_than
     copy_component
@@ -36,7 +38,8 @@ add_hpx_executable(launched_process_test
   SOURCES launched_process.cpp
   EXCLUDE_FROM_ALL
   HPX_PREFIX ${HPX_BUILD_PREFIX}
-  FOLDER "Tests/Unit/Components")
+  FOLDER "Tests/Unit/Components"
+  COMPONENT_DEPENDENCIES launch_process_test_server)
 
 set(action_invoke_no_more_than_PARAMETERS
     LOCALITIES 2
@@ -57,7 +60,8 @@ set(get_ptr_PARAMETERS
     THREADS_PER_LOCALITY 2)
 
 set(launch_process_FLAGS
-    DEPENDENCIES iostreams_component process_component)
+    DEPENDENCIES iostreams_component process_component
+                 launch_process_test_server_component)
 set(launch_process_PARAMETERS
   --launch=$<TARGET_FILE:launched_process_test_exe>
 )

--- a/tests/unit/component/components/CMakeLists.txt
+++ b/tests/unit/component/components/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright (c) 2016 Hartmut Kaiser
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+add_hpx_component(
+  launch_process_test_server
+  FOLDER "Tests/Unit/Components"
+  EXCLUDE_FROM_ALL
+  AUTOGLOB)
+

--- a/tests/unit/component/components/launch_process_test_server.cpp
+++ b/tests/unit/component/components/launch_process_test_server.cpp
@@ -1,0 +1,26 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/include/actions.hpp>
+#include <hpx/include/components.hpp>
+
+#include <tests/unit/component/components/launch_process_test_server.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+// Test-component which is instantiated by the launching process and registered
+// with AGAS such that the launched process can use it.
+
+HPX_REGISTER_ACTION(launch_process_get_message_action);
+HPX_REGISTER_ACTION(launch_process_set_message_action);
+
+HPX_REGISTER_COMPONENT_MODULE();
+
+///////////////////////////////////////////////////////////////////////////////
+// We use a special component registry for this component as it has to be
+// disabled by default. All tests requiring this component to be active will
+// enable it explicitly.
+typedef hpx::components::component<launch_process::test_server> server_type;
+HPX_REGISTER_DISABLED_COMPONENT_FACTORY(server_type, launch_process_test_server)
+

--- a/tests/unit/component/components/launch_process_test_server.hpp
+++ b/tests/unit/component/components/launch_process_test_server.hpp
@@ -1,0 +1,51 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(LAUNCH_PROCESS_TEST_SERVER)
+#define LAUNCH_PROCESS_TEST_SERVER
+
+#include <hpx/include/actions.hpp>
+#include <hpx/include/components.hpp>
+
+#include <string>
+
+namespace launch_process
+{
+    // Test-component which is instantiated by the launching process and
+    // registered with AGAS such that the launched process can use it.
+    struct test_server
+      : hpx::components::component_base<test_server>
+    {
+        test_server()
+          : msg_("initialized")
+        {}
+
+        std::string get_message() const
+        {
+            return msg_;
+        }
+        HPX_DEFINE_COMPONENT_ACTION(test_server, get_message,
+            get_message_action);
+
+        void set_message(std::string const& msg)
+        {
+            msg_ = msg;
+        }
+        HPX_DEFINE_COMPONENT_ACTION(test_server, set_message,
+            set_message_action);
+
+        std::string msg_;
+    };
+}
+
+typedef launch_process::test_server::get_message_action
+    launch_process_get_message_action;
+typedef launch_process::test_server::set_message_action
+    launch_process_set_message_action;
+
+HPX_REGISTER_ACTION_DECLARATION(launch_process_get_message_action);
+HPX_REGISTER_ACTION_DECLARATION(launch_process_set_message_action);
+
+#endif

--- a/tests/unit/component/launch_process.cpp
+++ b/tests/unit/component/launch_process.cpp
@@ -6,8 +6,9 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/include/process.hpp>
-
 #include <hpx/util/lightweight_test.hpp>
+
+#include <tests/unit/component/components/launch_process_test_server.hpp>
 
 #include <boost/filesystem.hpp>
 
@@ -55,20 +56,24 @@ int hpx_main(boost::program_options::variables_map &vm)
 
     fs::path exe = base_dir / "launched_process_test" HPX_EXECUTABLE_EXTENSION;
 
-    std::string launch_target = "";
-    if (vm.count("launch")) {
-        launch_target = vm["launch"].as < std::string > ();
-      std::cout << "using launch: " << launch_target << std::endl;
-      exe = launch_target;
+    std::string launch_target;
+    if (vm.count("launch"))
+    {
+        launch_target = vm["launch"].as<std::string>();
+        std::cout << "using launch: " << launch_target << std::endl;
+        exe = launch_target;
     }
-    else {
-      std::cout << "using launch (def) : " << exe << std::endl;
+    else
+    {
+        std::cout << "using launch (default): " << exe << std::endl;
     }
 
     // set up command line for launched executable
     std::vector<std::string> args;
     args.push_back(exe.string());
     args.push_back("--exit_code=42");
+    args.push_back("--component=test_server");
+    args.push_back("--set_message=accessed");
     args.push_back("--hpx:ignore-batch-env");
 
     // set up environment for launched executable
@@ -107,25 +112,38 @@ int hpx_main(boost::program_options::variables_map &vm)
             process::wait_on_latch("launch_process")   // same as above!
         );
 
-    // wait for the HPX locality to be up and running
-    c.wait();
-    HPX_TEST(c);
-
-    // now the launched executable should have connected back as a new locality
     {
-        std::vector<hpx::id_type> localities = hpx::find_all_localities();
-        HPX_TEST_EQ(localities.size(), std::size_t(2));
-    }
+        // now create an instance of the test_server component
+        hpx::components::client<launch_process::test_server> t =
+            hpx::new_<launch_process::test_server>(hpx::find_here());
 
-    // wait for it to exit, we know it returns 42
-    int exit_code = c.wait_for_exit_sync();
-    HPX_TEST_EQ(exit_code, 42);
+        hpx::future<std::string> f =
+            hpx::async(launch_process_get_message_action(), t);
+        HPX_TEST_EQ(f.get(), std::string("initialized"));
+
+        // register the component instance with AGAS
+        t.register_as("test_server");       // same as --component=<> above
+
+        // wait for the HPX locality to be up and running
+        c.wait();
+        HPX_TEST(c);
+
+        // the launched executable should have connected back as a new locality
+        HPX_TEST_EQ(hpx::find_all_localities().size(), std::size_t(2));
+
+        // wait for it to exit, we know it returns 42 (see --exit_code=<> above)
+        int exit_code = c.wait_for_exit_sync();
+        HPX_TEST_EQ(exit_code, 42);
+
+        // make sure the launched process has set the message in the component
+        // this should be the same as --set_message=<> above
+        f = hpx::async(launch_process_get_message_action(), t);
+        HPX_TEST_EQ(f.get(), std::string("accessed"));
+
+    }   // release the component
 
     // the new locality should have disconnected now
-    {
-        std::vector<hpx::id_type> localities = hpx::find_all_localities();
-        HPX_TEST_EQ(localities.size(), std::size_t(1));
-    }
+    HPX_TEST_EQ(hpx::find_all_localities().size(), std::size_t(1));
 
     return hpx::finalize();
 }
@@ -138,9 +156,13 @@ int main(int argc, char* argv[])
     options_description desc_commandline("Usage: " HPX_APPLICATION_STRING " [options]");
 
     desc_commandline.add_options()("launch,l", value<std::string>(),
-        "the process that will be launched and connect back");
+        "the process that will be launched and which connects back");
 
+    // This explicitly enables the component we depend on (it is disabled by
+    // default to avoid being loaded outside of this test).
     std::vector<std::string> cfg;
+    cfg.push_back("hpx.components.launch_process_test_server.enabled!=1");
+
     HPX_TEST_EQ_MSG(
         hpx::init(desc_commandline, argc, argv, cfg), 0,
         "HPX main exited with non-zero status"

--- a/tests/unit/component/launched_process.cpp
+++ b/tests/unit/component/launched_process.cpp
@@ -5,8 +5,9 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-
 #include <hpx/util/lightweight_test.hpp>
+
+#include <tests/unit/component/components/launch_process_test_server.hpp>
 
 #include <boost/program_options.hpp>
 
@@ -21,8 +22,34 @@ int hpx_main(boost::program_options::variables_map& vm)
     if (vm.count("exit_code") != 0)
         exit_code = vm["exit_code"].as<int>();
 
-    // pretend to do some work
-    hpx::this_thread::sleep_for(std::chrono::seconds(1));
+    std::string set_message("accessed");
+    if (vm.count("set_message") != 0)
+        set_message = vm["set_message"].as<std::string>();
+
+    std::string component;
+    if (vm.count("component") != 0)
+    {
+        component = vm["component"].as<std::string>();
+
+        // connect to the component
+        hpx::components::client<launch_process::test_server> t;
+        t.connect_to(component);
+
+        // set the message
+        hpx::future<void> f =
+            hpx::async(launch_process_set_message_action(), t, set_message);
+
+        // pretend to do some work
+        hpx::this_thread::sleep_for(std::chrono::seconds(1));
+
+        // wait for message to be delivered
+        f.get();
+    }
+    else
+    {
+        // pretend to do some work
+        hpx::this_thread::sleep_for(std::chrono::seconds(1));
+    }
 
     hpx::disconnect();
     return exit_code;
@@ -37,6 +64,8 @@ int main(int argc, char* argv[])
 
     desc_commandline.add_options()
         ("exit_code,e", value<int>(), "the value to return to the OS")
+        ("component,c", value<std::string>(), "the name of the component")
+        ("set_message,s", value<std::string>(), "the message to set in the component")
         ;
 
     // Make sure hpx_main above will be executed even if this is not the


### PR DESCRIPTION

- extending the existing launch_process/launched_process example to additionally test the functionality as requested by #2243
- this fixes #2243