### PR TITLE
HPX on ppc64le

### DIFF
--- a/hpx/config.hpp
+++ b/hpx/config.hpp
@@ -462,7 +462,11 @@
 #    if defined(HPX_DEBUG)
 #      define HPX_SMALL_STACK_SIZE  0x20000       // 128kByte
 #    else
-#      define HPX_SMALL_STACK_SIZE  0xC000        // 48kByte
+#      if defined(__powerpc__)
+#         define HPX_SMALL_STACK_SIZE  0x20000       // 128kByte
+#      else
+#         define HPX_SMALL_STACK_SIZE  0xC000        // 48kByte
+#      endif
 #    endif
 #  endif
 #endif

--- a/hpx/runtime/threads/coroutines/detail/get_stack_pointer.hpp
+++ b/hpx/runtime/threads/coroutines/detail/get_stack_pointer.hpp
@@ -28,7 +28,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 #elif defined(__i386__) || defined(__i486__) || defined(__i586__) || defined(__i686__)
         asm("movl %%esp, %0" : "=r"(stack_ptr));
 #elif defined(__powerpc__)
-        std::size_t stack_ptr_p = &stack_ptr;
+        std::size_t stack_ptr_p = (std::size_t)&stack_ptr;
         asm("stw %%r1, 0(%0)" : "=&r"(stack_ptr_p));
 #elif defined(__arm__)
         asm("mov %0, sp" : "=r"(stack_ptr));

--- a/hpx/runtime/threads/coroutines/detail/get_stack_pointer.hpp
+++ b/hpx/runtime/threads/coroutines/detail/get_stack_pointer.hpp
@@ -10,7 +10,6 @@
 #if !defined(HPX_WINDOWS)
 #if defined(__x86_64__) || defined(__amd64)                                    \
     || defined(__i386__) || defined(__i486__) || defined(__i586__) || defined(__i686__) \
-    || defined(__powerpc__)                                                    \
     || defined(__arm__)
 #define HPX_HAVE_THREADS_GET_STACK_POINTER
 #endif


### PR DESCRIPTION
HPX on ppc64le:
Based on {version}: V0.9.99-trunk (AGAS: V3.0), Git: 516da8e9c4
{platform}: linux
{compiler}: GNU C++ version 6.1.0
{stdlib}: GNU libstdc++ version 20160427

Build with boost-1.60, gcc-6.1, and hwloc-1.11.3.


