### PR TITLE
add CMake option to disable package export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,10 +152,6 @@ hpx_option(HPX_WITH_COMPILER_WARNINGS BOOL
   "Enable compiler warnings (default: ON)"
   ON ADVANCED)
 
-hpx_option(HPX_WITH_EXPORT_PACKAGE BOOL
-  "Export the package via CMake."
-  ON ADVANCED)
-
 hpx_option(HPX_WITH_DOCUMENTATION BOOL
   "Build the HPX documentation (default OFF)."
   OFF CATEGORY "Build Targets")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,10 @@ hpx_option(HPX_WITH_COMPILER_WARNINGS BOOL
   "Enable compiler warnings (default: ON)"
   ON ADVANCED)
 
+hpx_option(HPX_WITH_EXPORT_PACKAGE BOOL
+  "Export the package via CMake."
+  ON ADVANCED)
+
 hpx_option(HPX_WITH_DOCUMENTATION BOOL
   "Build the HPX documentation (default OFF)."
   OFF CATEGORY "Build Targets")

--- a/cmake/HPX_GeneratePackage.cmake
+++ b/cmake/HPX_GeneratePackage.cmake
@@ -18,7 +18,9 @@ export(TARGETS ${HPX_EXPORT_TARGETS}
 #  NAMESPACE hpx::
 )
 
-export(PACKAGE ${HPX_PACKAGE_NAME})
+if(HPX_WITH_EXPORT_PACKAGE)
+  export(PACKAGE ${HPX_PACKAGE_NAME})
+endif()
 
 # Generate library list for pkg config ...
 set(_is_debug FALSE)

--- a/cmake/HPX_GeneratePackage.cmake
+++ b/cmake/HPX_GeneratePackage.cmake
@@ -18,10 +18,6 @@ export(TARGETS ${HPX_EXPORT_TARGETS}
 #  NAMESPACE hpx::
 )
 
-if(HPX_WITH_EXPORT_PACKAGE)
-  export(PACKAGE ${HPX_PACKAGE_NAME})
-endif()
-
 # Generate library list for pkg config ...
 set(_is_debug FALSE)
 set(_is_release FALSE)


### PR DESCRIPTION
My autobuilds of LibGeoDecomp with HPX have been randomly crashing in the past weeks. They're running on multiple machines and some of these machines have a shared NFS. If one machine is running CMake for LibGeoDecomp and another machine is simultaneously deleting an HPX build tree, then CMake may fail because of some missing files. This patch enables users to switch off package registration.

It's also good practice not to clutter a user's home directory/registry and bar the user from disabling this.