### PR TITLE
Always set correct local IP address to improve console/worker connection

### DIFF
--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -666,8 +666,7 @@ namespace hpx { namespace util
             }
         }
 
-        if ((vm.count("hpx:connect") || mode_ == hpx::runtime_mode_connect) &&
-            hpx_host == "127.0.0.1")
+        if (hpx_host == "127.0.0.1" || hpx_host == "localhost")
         {
             hpx_host = hpx::util::resolve_public_ip_address();
         }


### PR DESCRIPTION
I have not been able to run multi (N>2) node jobs using the verbs PP because of the difficulty in setting the command line to get IP addresses correct (each node requires it's own `--hpx::hpx=ip.addr:port`. This patch fixes things for me by making sure that if --hpx:hpx=xxx.xxx.xxx.xxx is not specified (on the console or on the worker) then the correct ip address is picked up and things work.

I am now able to do the following
```
HPX_ARGS='--hpx:agas=greina14:7910 --hpx:localities=2 -Ihpx.parcel.tcp.enable=1 -Ihpx.parcel.bootstrap=tcp -Ihpx.parcel.verbs.enable=1 --hpx:threads=2'
mpiexec -hostlist greina14,greina15 
    -n 1 bin/check_hpxm $HPX_ARGS --hpx:console --file=result.hdf5 
  : -n 1 bin/check_hpxm $HPX_ARGS --hpx:worker --file=result.hdf5
```
to correctly get 1 console and N worker nodes to connect properly.

This makes it straightforward to create job scripts that fill in the correct nodelists and head node and the rest is taken care of.