### PR TITLE
Adding sliding semaphore

### DIFF
--- a/examples/1d_stencil/1d_stencil_4.cpp
+++ b/examples/1d_stencil/1d_stencil_4.cpp
@@ -131,8 +131,9 @@ struct stepper
     }
 
     // do all the work on 'np' partitions, 'nx' data points each, for 'nt'
-    // time steps
-    hpx::future<space> do_work(std::size_t np, std::size_t nx, std::size_t nt)
+    // time steps, limit depth of dependency tree to 'nd'
+    hpx::future<space> do_work(std::size_t np, std::size_t nx, std::size_t nt,
+        std::uint64_t nd)
     {
         using hpx::dataflow;
         using hpx::util::unwrapped;
@@ -153,6 +154,9 @@ struct stepper
             }
         );
 
+        // limit depth of dependency tree
+        hpx::lcos::local::sliding_semaphore sem(nd);
+
         auto Op = unwrapped(&stepper::heat_part);
 
         // Actual time step loop
@@ -167,7 +171,24 @@ struct stepper
                         hpx::launch::async, Op,
                         current[idx(i, -1, np)], current[i], current[idx(i, +1, np)]
                     );
+
             }
+
+            // every nd time steps, attach additional continuation which will
+            // trigger the semaphore once computation has reached this point
+            if ((t % nd) == 0)
+            {
+                next[0].then(
+                    [&sem, t](partition &&)
+                    {
+                        // inform semaphore about new lower limit
+                        sem.signal(t);
+                    });
+            }
+
+            // suspend if the tree has become too deep, the continuation above
+            // will resume this thread once the computation has caught up
+            sem.wait(t);
         }
 
         // Return the solution at time-step 'nt'.
@@ -181,6 +202,7 @@ int hpx_main(boost::program_options::variables_map& vm)
     std::uint64_t np = vm["np"].as<std::uint64_t>();   // Number of partitions.
     std::uint64_t nx = vm["nx"].as<std::uint64_t>();   // Number of grid points.
     std::uint64_t nt = vm["nt"].as<std::uint64_t>();   // Number of steps.
+    std::uint64_t nd = vm["nd"].as<std::uint64_t>();   // Max depth of dep tree.
 
     if (vm.count("no-header"))
         header = false;
@@ -193,7 +215,7 @@ int hpx_main(boost::program_options::variables_map& vm)
     std::uint64_t t = hpx::util::high_resolution_clock::now();
 
     // Execute nt time steps on nx grid points and print the final solution.
-    hpx::future<stepper::space> result = step.do_work(np, nx, nt);
+    hpx::future<stepper::space> result = step.do_work(np, nx, nt, nd);
 
     stepper::space solution = result.get();
     hpx::wait_all(solution);
@@ -226,6 +248,8 @@ int main(int argc, char* argv[])
          "Local x dimension (of each partition)")
         ("nt", value<std::uint64_t>()->default_value(45),
          "Number of time steps")
+        ("nd", value<std::uint64_t>()->default_value(10),
+         "Number of time steps to allow the dependency tree to grow to")
         ("np", value<std::uint64_t>()->default_value(10),
          "Number of partitions")
         ("k", value<double>(&k)->default_value(0.5),

--- a/hpx/include/local_lcos.hpp
+++ b/hpx/include/local_lcos.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2012 Hartmut Kaiser
+//  Copyright (c) 2007-2016 Hartmut Kaiser
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -19,6 +19,7 @@
 #include <hpx/lcos/local/no_mutex.hpp>
 #include <hpx/lcos/local/recursive_mutex.hpp>
 #include <hpx/lcos/local/shared_mutex.hpp>
+#include <hpx/lcos/local/sliding_semaphore.hpp>
 
 #include <hpx/lcos/future.hpp>
 #include <hpx/lcos/local/and_gate.hpp>

--- a/hpx/lcos/local/detail/sliding_semaphore.hpp
+++ b/hpx/lcos/local/detail/sliding_semaphore.hpp
@@ -1,0 +1,100 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_LCOS_DETAIL_SLIDING_SEMAPHORE_AUG_25_2016_1026AM)
+#define HPX_LCOS_DETAIL_SLIDING_SEMAPHORE_AUG_25_2016_1026AM
+
+#include <hpx/config.hpp>
+#include <hpx/lcos/local/detail/condition_variable.hpp>
+#include <hpx/lcos/local/spinlock.hpp>
+#include <hpx/util/assert.hpp>
+#include <hpx/util/assert_owns_lock.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <mutex>
+#include <utility>
+
+#if defined(HPX_MSVC)
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace lcos { namespace local { namespace detail
+{
+    class sliding_semaphore
+    {
+    private:
+        typedef lcos::local::spinlock mutex_type;
+
+    public:
+        sliding_semaphore(std::int64_t max_difference, std::int64_t lower_limit)
+          : max_difference_(max_difference), lower_limit_(lower_limit), cond_()
+        {}
+
+        void wait(std::unique_lock<mutex_type>& l, std::int64_t upper_limit)
+        {
+            HPX_ASSERT_OWNS_LOCK(l);
+
+            while (upper_limit - max_difference_ > lower_limit_)
+            {
+                cond_.wait(l, "sliding_semaphore::wait");
+            }
+        }
+
+        bool try_wait(std::unique_lock<mutex_type>& l, std::int64_t upper_limit)
+        {
+            HPX_ASSERT_OWNS_LOCK(l);
+
+            if (!(upper_limit - max_difference_ > lower_limit_))
+            {
+                // enter wait_locked only if necessary
+                wait(l, upper_limit);
+                return true;
+            }
+            return false;
+        }
+
+        void signal(std::unique_lock<mutex_type> l, std::int64_t lower_limit)
+        {
+            HPX_ASSERT_OWNS_LOCK(l);
+
+            mutex_type* mtx = l.mutex();
+
+            // touch upon all threads
+            std::int64_t count = static_cast<std::int64_t>(cond_.size(l));
+            for (/**/; count > 0; --count)
+            {
+                // notify_one() returns false if no more threads are waiting
+                if (!cond_.notify_one(std::move(l)))
+                    break;
+
+                l = std::unique_lock<mutex_type>(*mtx);
+            }
+            lower_limit_ = (std::max)(lower_limit, lower_limit_);
+        }
+
+        std::int64_t signal_all(std::unique_lock<mutex_type> l)
+        {
+            HPX_ASSERT_OWNS_LOCK(l);
+
+            signal(std::move(l), lower_limit_);
+            return lower_limit_;
+        }
+
+    private:
+        std::int64_t max_difference_;
+        std::int64_t lower_limit_;
+        local::detail::condition_variable cond_;
+    };
+}}}}
+
+#if defined(HPX_MSVC)
+#pragma warning(pop)
+#endif
+
+#endif
+

--- a/hpx/lcos/local/sliding_semaphore.hpp
+++ b/hpx/lcos/local/sliding_semaphore.hpp
@@ -1,0 +1,124 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_LCOS_SLIDING_SEMAPHORE_AUG_25_2016_1028AM)
+#define HPX_LCOS_SLIDING_SEMAPHORE_AUG_25_2016_1028AM
+
+#include <hpx/config.hpp>
+#include <hpx/lcos/local/detail/sliding_semaphore.hpp>
+#include <hpx/lcos/local/spinlock.hpp>
+
+#include <cstdint>
+#include <mutex>
+#include <utility>
+
+#if defined(HPX_MSVC)
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace lcos { namespace local
+{
+    /// A semaphore is a protected variable (an entity storing a value) or
+    /// abstract data type (an entity grouping several variables that may or
+    /// may not be numerical) which constitutes the classic method for
+    /// restricting access to shared resources, such as shared memory, in a
+    /// multiprogramming environment. Semaphores exist in many variants, though
+    /// usually the term refers to a counting semaphore, since a binary
+    /// semaphore is better known as a mutex. A counting semaphore is a counter
+    /// for a set of available resources, rather than a locked/unlocked flag of
+    /// a single resource. It was invented by Edsger Dijkstra. Semaphores are
+    /// the classic solution to preventing race conditions in the dining
+    /// philosophers problem, although they do not prevent resource deadlocks.
+    ///
+    /// Sliding semaphores can be used for synchronizing multiple threads as
+    /// well: one thread waiting for several other threads to touch (signal)
+    /// the semaphore, or several threads waiting for one other thread to touch
+    /// this semaphore. The difference to a counting semaphore is that a
+    /// sliding semaphore will not limit the number of threads which are
+    /// allowed to proceed, but will make sure that the difference between
+    /// the (arbitrary) number passed to set and wait does not exceed a given
+    /// threshold.
+    template <typename Mutex = hpx::lcos::local::spinlock>
+    class sliding_semaphore_var
+    {
+    private:
+        typedef Mutex mutex_type;
+
+    public:
+        /// \brief Construct a new sliding semaphore
+        ///
+        /// \param max_difference
+        ///                 [in] The max difference between the upper limit
+        ///                 (as set by wait()) and the lower limit (as set by
+        ///                 signal()) which is allowed without suspending any
+        ///                 thread calling wait().
+        /// \param lower_limit  [in] The initial lower limit.
+        sliding_semaphore_var(std::int64_t max_difference,
+                std::int64_t lower_limit = 0)
+          : sem_(max_difference, lower_limit)
+        {}
+
+        /// \brief Wait for the semaphore to be signaled
+        ///
+        /// \param upper_limit [in] The new upper limit.
+        ///           The calling thread will be suspended if the difference
+        ///           between this value and the largest lower_limit which was
+        ///           set by signal() is larger than the max_difference.
+        void wait(std::int64_t upper_limit)
+        {
+            std::unique_lock<mutex_type> l(mtx_);
+            sem_.wait(l, upper_limit);
+        }
+
+        /// \brief Try to wait for the semaphore to be signaled
+        ///
+        /// \param upper_limit [in] The new upper limit.
+        ///           The calling thread will be suspended if the difference
+        ///           between this value and the largest lower_limit which was
+        ///           set by signal() is larger than the max_difference.
+        ///
+        /// \returns  The function returns true if the calling thread
+        ///           would not block if it was calling wait().
+        bool try_wait(std::int64_t upper_limit = 1)
+        {
+            std::unique_lock<mutex_type> l(mtx_);
+            return sem_.try_wait(l, upper_limit);
+        }
+
+        /// \brief Signal the semaphore
+        ///
+        /// \param lower_limit  [in] The new lower limit. This will update the
+        ///             current lower limit of this semaphore. It will also
+        ///             re-schedule all suspended threads for which their
+        ///             associated upper limit is not larger than the lower
+        ///             limit plus the max_difference.
+        void signal(std::int64_t lower_limit)
+        {
+            std::unique_lock<mutex_type> l(mtx_);
+            sem_.signal(std::move(l), lower_limit);
+        }
+
+        std::int64_t signal_all()
+        {
+            std::unique_lock<mutex_type> l(mtx_);
+            return sem_.signal_all(std::move(l));
+        }
+
+    private:
+        mutable mutex_type mtx_;
+        detail::sliding_semaphore sem_;
+    };
+
+    typedef sliding_semaphore_var<> sliding_semaphore;
+}}}
+
+#if defined(HPX_MSVC)
+#pragma warning(pop)
+#endif
+
+#endif
+

--- a/tests/unit/lcos/CMakeLists.txt
+++ b/tests/unit/lcos/CMakeLists.txt
@@ -48,6 +48,7 @@ set(tests
     remote_latch
     run_guarded
     shared_future
+    sliding_semaphore
     unwrapped
     when_all
     when_any
@@ -93,6 +94,7 @@ set(future_wait_PARAMETERS THREADS_PER_LOCALITY 4)
 
 set(counting_semaphore_PARAMETERS THREADS_PER_LOCALITY 4)
 set(local_barrier_PARAMETERS THREADS_PER_LOCALITY 4)
+set(sliding_semaphore_PARAMETERS THREADS_PER_LOCALITY 4)
 
 set(local_latch_PARAMETERS THREADS_PER_LOCALITY 4)
 set(remote_latch_PARAMETERS LOCALITIES 2)

--- a/tests/unit/lcos/sliding_semaphore.cpp
+++ b/tests/unit/lcos/sliding_semaphore.cpp
@@ -1,0 +1,56 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/apply.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/threads.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <boost/atomic.hpp>
+
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+boost::atomic<int> count(0);
+
+void worker(hpx::lcos::local::sliding_semaphore& sem, std::size_t i)
+{
+    sem.signal(i);   // signal main thread
+    ++count;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main()
+{
+    hpx::lcos::local::sliding_semaphore sem(9);
+
+    for (std::size_t i = 0; i != 10; ++i)
+        hpx::apply(&worker, std::ref(sem), i + 1);
+
+    // Wait for all threads to finish executing.
+    sem.wait(19);
+
+    HPX_TEST(count == 10);
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {
+        "hpx.os_threads=all"
+    };
+
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
A sliding semaphore is similar to a counting semaphore. The difference is that it does not guard a given number of resources, but it makes sure that the difference between an upper limit (set by `signal()`) and a lower limit (passed to `wait()`) does not exceed a given maximum. The thread calling `wait()` will be suspended if the upper limit is farther away from the lower limit than the given threshold. All suspended threads will be resumed as soon as their assocuated limit is closer to the lower limit than defined by the threshold (done during during `signal()`).

This facility is useful to limit the depth of a dependency tree, for instance. See the examples `1d_stencil_4` or `1d_stencil_8` for more details on how to use it.

- adding test
- adding sliding_semaphore to stencil_1d examples