### PR TITLE
Std flag fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -838,8 +838,8 @@ if(NOT MSVC)
       set(CXX_FLAG -std=c++14)
     else()
       # ... otherwise try -std=c++1y
-      check_cxx_compiler_flag(-std=c++1y HPX_WITH_CXX0Y)
-      if(HPX_WITH_CXX0Y)
+      check_cxx_compiler_flag(-std=c++1y HPX_WITH_CXX1Y)
+      if(HPX_WITH_CXX1Y)
         set(CXX_FLAG -std=c++1y)
       else()
         # ... otherwise try -std=c++11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -837,10 +837,10 @@ if(NOT MSVC)
     if(HPX_WITH_CXX14)
       set(CXX_FLAG -std=c++14)
     else()
-      # ... otherwise try -std=c++0y
-      check_cxx_compiler_flag(-std=c++0y HPX_WITH_CXX0Y)
+      # ... otherwise try -std=c++1y
+      check_cxx_compiler_flag(-std=c++1y HPX_WITH_CXX0Y)
       if(HPX_WITH_CXX0Y)
-        set(CXX_FLAG -std=c++0y)
+        set(CXX_FLAG -std=c++1y)
       else()
         # ... otherwise try -std=c++11
         check_cxx_compiler_flag(-std=c++11 HPX_WITH_CXX11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -837,6 +837,8 @@ if(NOT MSVC)
     # The Intel compiler has the C++14 flag, but doesn't have sufficient C++14
     # support to compile Boost. If the user has explicitly asked for it, use it,
     # otherwise don't run the check.
+    # FIXME: This should be replaced with a version-based check in the future
+    # when the Intel compiler is able to build Boost with -std=c++14.
     if(HPX_WITH_CXX14 OR NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel"))
       check_cxx_compiler_flag(-std=c++14 HPX_WITH_CXX14)
     endif()
@@ -847,6 +849,8 @@ if(NOT MSVC)
       # ... otherwise try -std=c++1y
 
       # See comment above.
+      # FIXME: This should be replaced with a version-based check in the future
+      # when the Intel compiler is able to build Boost with -std=c++14.
       if(HPX_WITH_CXX1Y OR NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel"))
         check_cxx_compiler_flag(-std=c++1y HPX_WITH_CXX1Y)
       endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -833,12 +833,24 @@ if(NOT MSVC)
     set(CXX_FLAG -std=c++11)
   else()
     # Try -std=c++14 first
-    check_cxx_compiler_flag(-std=c++14 HPX_WITH_CXX14)
+
+    # The Intel compiler has the C++14 flag, but doesn't have sufficient C++14
+    # support to compile Boost. If the user has explicitly asked for it, use it,
+    # otherwise don't run the check.
+    if(HPX_WITH_CXX14 OR NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel"))
+      check_cxx_compiler_flag(-std=c++14 HPX_WITH_CXX14)
+    endif()
     if(HPX_WITH_CXX14)
+
       set(CXX_FLAG -std=c++14)
     else()
       # ... otherwise try -std=c++1y
-      check_cxx_compiler_flag(-std=c++1y HPX_WITH_CXX1Y)
+
+      # See comment above.
+      if(HPX_WITH_CXX1Y OR NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel"))
+        check_cxx_compiler_flag(-std=c++1y HPX_WITH_CXX1Y)
+      endif()
+
       if(HPX_WITH_CXX1Y)
         set(CXX_FLAG -std=c++1y)
       else()


### PR DESCRIPTION
Fixes #2319, also fixes a typo (I believe -std=c++0y is wrong, and it should be -std=c++1y).