### PR TITLE
Fix problems that bubbled up after merging #2278

### DIFF
--- a/hpx/lcos/detail/async_implementations.hpp
+++ b/hpx/lcos/detail/async_implementations.hpp
@@ -27,8 +27,8 @@ namespace hpx { namespace detail
     ///////////////////////////////////////////////////////////////////////////
     struct keep_id_alive
     {
-        explicit keep_id_alive(naming::id_type && id)
-          : id_(std::move(id))
+        explicit keep_id_alive(naming::id_type const& id)
+          : id_(id)
         {}
 
         void operator()() const {}
@@ -43,11 +43,11 @@ namespace hpx { namespace detail
 
     public:
         handle_managed_target(hpx::id_type const& id, future<Result>& f)
-          : target_is_managed_(false), unmanaged_id_(id), f_(f)
+          : target_is_managed_(false), id_(id), f_(f)
         {
             if (id.get_management_type() == naming::id_type::managed)
             {
-                id_ = naming::id_type(id.get_gid(), naming::id_type::unmanaged);
+                unmanaged_id_ = naming::id_type(id.get_gid(), naming::id_type::unmanaged);
                 target_is_managed_ = true;
             }
         }
@@ -67,20 +67,21 @@ namespace hpx { namespace detail
                 if (state)
                 {
                     HPX_ASSERT(id_);
+                    HPX_ASSERT(unmanaged_id_);
                     state->set_on_completed(
-                        hpx::detail::keep_id_alive(std::move(id_)));
+                        hpx::detail::keep_id_alive(id_));
                 }
             }
         }
 
         hpx::id_type const& get_id() const
         {
-            return target_is_managed_ ? id_ : unmanaged_id_;
+            return target_is_managed_ ? unmanaged_id_ : id_;
         }
 
         bool target_is_managed_;
-        naming::id_type id_;
-        naming::id_type const& unmanaged_id_;
+        naming::id_type const& id_;
+        naming::id_type unmanaged_id_;
         future<Result>& f_;
     };
 

--- a/plugins/parcel/coalescing/coalescing_message_handler.cpp
+++ b/plugins/parcel/coalescing/coalescing_message_handler.cpp
@@ -166,6 +166,7 @@ namespace hpx { namespace plugins { namespace parcel
         switch(s) {
         case detail::message_buffer::first_message:
             // start deadline timer to flush buffer
+            l.unlock();
             timer_.start(interval);
             break;
 
@@ -174,6 +175,7 @@ namespace hpx { namespace plugins { namespace parcel
                 break;
 
             // start deadline timer to flush buffer
+            l.unlock();
             timer_.start(interval);
             break;
 

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -241,7 +241,7 @@ void addressing_service::launch_bootstrap(
 
     std::uint32_t num_threads = hpx::util::get_entry_as<std::uint32_t>(
         ini_, "hpx.os_threads", 1u);
-    locality_ns_->allocate(endpoints, 4, num_threads, naming::invalid_gid);
+    locality_ns_->allocate(endpoints, 0, num_threads, naming::invalid_gid);
 
     naming::gid_type runtime_support_gid1(here);
     runtime_support_gid1.set_lsb(rt.get_runtime_support_lva());

--- a/src/runtime/agas/server/locality_namespace_server.cpp
+++ b/src/runtime/agas/server/locality_namespace_server.cpp
@@ -327,15 +327,12 @@ void locality_namespace::free(naming::gid_type locality)
         {
             l.unlock();
 
-            std::uint32_t locality_id =
-                naming::get_locality_id_from_gid(locality);
-
             // remove primary namespace
             {
                 naming::gid_type service(HPX_AGAS_PRIMARY_NS_MSB,
                     HPX_AGAS_PRIMARY_NS_LSB);
                 primary_->unbind_gid(
-                    1, naming::replace_locality_id(service, locality_id));
+                    1, naming::replace_locality_id(service, prefix));
             }
 
             // remove symbol namespace
@@ -343,7 +340,7 @@ void locality_namespace::free(naming::gid_type locality)
                 naming::gid_type service(HPX_AGAS_SYMBOL_NS_MSB,
                     HPX_AGAS_SYMBOL_NS_LSB);
                 primary_->unbind_gid(
-                    1, naming::replace_locality_id(service, locality_id));
+                    1, naming::replace_locality_id(service, prefix));
             }
 
             // remove locality itself


### PR DESCRIPTION
This patch fixes a few problems that occured after merging #2278:

  - The locality endpoints count was not consistent when binding the GID to AGAS
  - Parcel coalescing held a lock during suspension
  - The destination of calls to hpx::async weren't kept alive properly