### PR TITLE
Support for data-parallelism for parallel algorithms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,10 +248,6 @@ hpx_option(HPX_WITH_VC_DATAPAR BOOL
 if(HPX_WITH_VC_DATAPAR)
   include(HPX_SetupVc)
 endif()
-if(NOT Vc_FOUND AND HPX_WITH_VC_DATAPAR)
-  hpx_warn("Vc was not found while datapar support was requested, forcing HPX_WITH_VC_DATAPAR=OFF. Set Vc_ROOT to installation path of Vc")
-  set(HPX_WITH_VC_DATAPAR OFF CACHE BOOL "" FORCE)
-endif()
 
 ################################################################################
 # Native TLS configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,9 +236,22 @@ if(HPX_WITH_CUDA)
   hpx_add_config_define(HPX_HAVE_COMPUTE)
 endif()
 hpx_option(HPX_WITH_HCC BOOL
-  "Enable hcc support (default: OFF)" ADVANCED)
+  "Enable hcc support (default: OFF)" OFF ADVANCED)
 hpx_option(HPX_WITH_SYCL BOOL
-  "Enable sycl support (default: OFF)" ADVANCED)
+  "Enable sycl support (default: OFF)" OFF ADVANCED)
+
+################################################################################
+# HPX datapar configuration
+################################################################################
+hpx_option(HPX_WITH_VC_DATAPAR BOOL
+  "Enable data parallel algorithm support (default: OFF)" OFF ADVANCED)
+if(HPX_WITH_VC_DATAPAR)
+  include(HPX_SetupVc)
+endif()
+if(NOT Vc_FOUND AND HPX_WITH_VC_DATAPAR)
+  hpx_warn("Vc was not found while datapar support was requested, forcing HPX_WITH_VC_DATAPAR=OFF. Set Vc_ROOT to installation path of Vc")
+  set(HPX_WITH_VC_DATAPAR OFF CACHE BOOL "" FORCE)
+endif()
 
 ################################################################################
 # Native TLS configuration

--- a/cmake/HPX_SetupVc.cmake
+++ b/cmake/HPX_SetupVc.cmake
@@ -1,0 +1,44 @@
+# Copyright (c) 2016 Hartmut Kaiser
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# Locate the Vc template library. Vc can be found at https://github.com/VcDevel/Vc
+#
+# This file is meant to be copied into projects that want to use Vc. It will
+# search for VcConfig.cmake, which ships with Vc and will provide up-to-date
+# buildsystem changes. Thus there should not be any need to update FindVc.cmake
+# again after you integrated it into your project.
+#
+# This module defines the following variables:
+# Vc_FOUND
+# Vc_INCLUDE_DIR
+# Vc_LIBRARIES
+# Vc_DEFINITIONS
+# Vc_COMPILE_FLAGS
+# Vc_ARCHITECTURE_FLAGS
+# Vc_ALL_FLAGS (the union of the above three variables)
+# Vc_VERSION_MAJOR
+# Vc_VERSION_MINOR
+# Vc_VERSION_PATCH
+# Vc_VERSION
+# Vc_VERSION_STRING
+# Vc_INSTALL_DIR
+# Vc_LIB_DIR
+# Vc_CMAKE_MODULES_DIR
+#
+# The following two variables are set according to the compiler used. Feel free
+# to use them to skip whole compilation units.
+# Vc_SSE_INTRINSICS_BROKEN
+# Vc_AVX_INTRINSICS_BROKEN
+
+find_package(Vc ${Vc_FIND_VERSION} QUIET NO_MODULE PATHS ${Vc_ROOT})
+
+if(Vc_FOUND)
+  include_directories(SYSTEM ${Vc_INCLUDE_DIR})
+  link_directories(${Vc_LIB_DIR})
+  hpx_libraries(${Vc_LIBRARIES})
+
+  hpx_add_config_define(HPX_HAVE_VC_DATAPAR)
+endif()
+

--- a/cmake/HPX_SetupVc.cmake
+++ b/cmake/HPX_SetupVc.cmake
@@ -39,6 +39,10 @@ if(Vc_FOUND)
   link_directories(${Vc_LIB_DIR})
   hpx_libraries(${Vc_LIBRARIES})
 
+  foreach(_flag ${Vc_DEFINITIONS})
+    add_definitions(${_flag})
+  endforeach()
+
   hpx_add_config_define(HPX_HAVE_VC_DATAPAR)
 endif()
 

--- a/docs/manual/build_system/cmake_variables.qbk
+++ b/docs/manual/build_system/cmake_variables.qbk
@@ -57,6 +57,7 @@ The options are split into these categories:
 * [link build_system.cmake_variables.HPX_WITH_SECURITY HPX_WITH_SECURITY]
 * [link build_system.cmake_variables.HPX_WITH_STATIC_LINKING HPX_WITH_STATIC_LINKING]
 * [link build_system.cmake_variables.HPX_WITH_SYCL HPX_WITH_SYCL]
+* [link build_system.cmake_variables.HPX_WITH_VC_DATAPAR HPX_WITH_VC_DATAPAR]
 
 [variablelist
         [[[#build_system.cmake_variables.HPX_WITH_ASYNC_FUNCTION_COMPATIBILITY] `HPX_WITH_ASYNC_FUNCTION_COMPATIBILITY:BOOL`][Enable old style ..._sync/..._async functions in API (default: OFF)]]
@@ -89,6 +90,7 @@ The options are split into these categories:
         [[[#build_system.cmake_variables.HPX_WITH_SECURITY] `HPX_WITH_SECURITY:BOOL`][Enable security support via libsodium.]]
         [[[#build_system.cmake_variables.HPX_WITH_STATIC_LINKING] `HPX_WITH_STATIC_LINKING:BOOL`][Compile HPX statically linked libraries (Default: OFF)]]
         [[[#build_system.cmake_variables.HPX_WITH_SYCL] `HPX_WITH_SYCL:BOOL`][Enable sycl support (default: OFF)]]
+        [[[#build_system.cmake_variables.HPX_WITH_VC_DATAPAR] `HPX_WITH_VC_DATAPAR:BOOL`][Enable data parallel algorithm support (default: OFF)]]
 ] [/ Generic Options]
 
 [#build_system.cmake_variables.Build_Targets][h3 Build Targets Options]

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp
@@ -42,7 +42,7 @@ namespace hpx { namespace server
     /// \brief This is the basic wrapper class for stl vector.
     ///
     /// This contain the implementation of the partitioned_vector_partition's
-    /// fcomponent unctionality.
+    /// component functionality.
     template <typename T, typename Data>
     class partitioned_vector
       : public components::locking_hook<

--- a/hpx/config/compiler_specific.hpp
+++ b/hpx/config/compiler_specific.hpp
@@ -60,11 +60,12 @@
 #endif
 
 #if defined(_MSC_VER)
-#   define HPX_MSVC _MSC_VER
-#   define HPX_WINDOWS
-#   if defined(__NVCC__)
-#       define HPX_SINGLE_INHERITANCE __single_inheritance
-#   endif
+#  define HPX_MSVC _MSC_VER
+#  define HPX_WINDOWS
+#  if defined(__NVCC__)
+#    define HPX_SINGLE_INHERITANCE __single_inheritance
+#  endif
+#  define HPX_CDECL __cdecl
 #endif
 
 #if defined(__MINGW32__)
@@ -82,6 +83,10 @@
 
 #if !defined(HPX_SINGLE_INHERITANCE)
 #define HPX_SINGLE_INHERITANCE /* empty */
+#endif
+
+#if !defined(HPX_CDECL)
+#define HPX_CDECL
 #endif
 
 #endif

--- a/hpx/hpx_main_impl.hpp
+++ b/hpx/hpx_main_impl.hpp
@@ -25,7 +25,7 @@
 //
 // Note: this function is intentionally not marked as inline
 //
-int main(int argc, char** argv)
+int HPX_CDECL main(int argc, char** argv)
 {
     // allow for unknown options
     std::vector<std::string> const cfg = {

--- a/hpx/parallel/algorithms/adjacent_difference.hpp
+++ b/hpx/parallel/algorithms/adjacent_difference.hpp
@@ -72,24 +72,32 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 FwdIter prev = first;
                 *dest++ = *first++;
 
-                if (count == 0) {
+                if (count == 0)
+                {
                     return result::get(std::move(dest));
                 }
+
+                auto f1 =
+                    [op, policy](
+                        zip_iterator part_begin, std::size_t part_size
+                    ) mutable
+                    {
+                        // VS2015RC bails out when op is captured by ref
+                        using hpx::util::get;
+                        util::loop_n(
+                            policy, part_begin, part_size,
+                            [op](zip_iterator it)
+                            {
+                                get<2>(*it) = hpx::util::invoke(
+                                    op, get<0>(*it), get<1>(*it));
+                            });
+                    };
 
                 using hpx::util::make_zip_iterator;
                 return util::partitioner<ExPolicy, Iter, void>::call(
                     std::forward<ExPolicy>(policy),
                     make_zip_iterator(first, prev, dest), count,
-                    [op](zip_iterator part_begin, std::size_t part_size)
-                    {
-                        // VS2015RC bails out when op is captured by ref
-                        using hpx::util::get;
-                        util::loop_n(part_begin, part_size,
-                            [op](zip_iterator it)
-                            {
-                                get<2>(*it) = op(get<0>(*it), get<1>(*it));
-                            });
-                    },
+                    std::move(f1),
                     [dest, count](std::vector<hpx::future<void> > &&)
                         mutable -> Iter
                     {

--- a/hpx/parallel/algorithms/all_any_none.hpp
+++ b/hpx/parallel/algorithms/all_any_none.hpp
@@ -63,21 +63,26 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 }
 
                 util::cancellation_token<> tok;
-                return util::partitioner<ExPolicy, bool>::call(
-                    std::forward<ExPolicy>(policy),
-                    first, std::distance(first, last),
-                    [op, tok](FwdIter part_begin, std::size_t part_count)
-                        mutable -> bool
+                auto f1 =
+                    [op, tok, policy](
+                        FwdIter part_begin, std::size_t part_count
+                    ) mutable -> bool
                     {
                         util::loop_n(
-                            part_begin, part_count, tok,
+                            policy, part_begin, part_count, tok,
                             [&op, &tok](FwdIter const& curr)
                             {
                                 if (op(*curr))
                                     tok.cancel();
                             });
+
                         return !tok.was_cancelled();
-                    },
+                    };
+
+                return util::partitioner<ExPolicy, bool>::call(
+                    std::forward<ExPolicy>(policy),
+                    first, std::distance(first, last),
+                    std::move(f1),
                     [](std::vector<hpx::future<bool> > && results)
                     {
                         return std::all_of(
@@ -204,21 +209,26 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 }
 
                 util::cancellation_token<> tok;
-                return util::partitioner<ExPolicy, bool>::call(
-                    std::forward<ExPolicy>(policy),
-                    first, std::distance(first, last),
-                    [op, tok](FwdIter part_begin, std::size_t part_count)
-                        mutable -> bool
+                auto f1 =
+                    [op, tok, policy](
+                        FwdIter part_begin, std::size_t part_count
+                    ) mutable -> bool
                     {
                         util::loop_n(
-                            part_begin, part_count, tok,
+                            policy, part_begin, part_count, tok,
                             [&op, &tok](FwdIter const& curr)
                             {
                                 if (op(*curr))
                                     tok.cancel();
                             });
+
                         return tok.was_cancelled();
-                    },
+                    };
+
+                return util::partitioner<ExPolicy, bool>::call(
+                    std::forward<ExPolicy>(policy),
+                    first, std::distance(first, last),
+                    std::move(f1),
                     [](std::vector<hpx::future<bool> > && results)
                     {
                         return std::any_of(
@@ -344,21 +354,26 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 }
 
                 util::cancellation_token<> tok;
-                return util::partitioner<ExPolicy, bool>::call(
-                    std::forward<ExPolicy>(policy),
-                    first, std::distance(first, last),
-                    [op, tok](FwdIter part_begin, std::size_t part_count)
-                        mutable -> bool
+                auto f1 =
+                    [op, tok, policy](
+                        FwdIter part_begin, std::size_t part_count
+                    ) mutable -> bool
                     {
                         util::loop_n(
-                            part_begin, part_count, tok,
+                            policy, part_begin, part_count, tok,
                             [&op, &tok](FwdIter const& curr)
                             {
                                 if (!op(*curr))
                                     tok.cancel();
                             });
+
                         return !tok.was_cancelled();
-                    },
+                    };
+
+                return util::partitioner<ExPolicy, bool>::call(
+                    std::forward<ExPolicy>(policy),
+                    first, std::distance(first, last),
+                    std::move(f1),
                     [](std::vector<hpx::future<bool> > && results)
                     {
                         return std::all_of(

--- a/hpx/parallel/algorithms/count.hpp
+++ b/hpx/parallel/algorithms/count.hpp
@@ -11,6 +11,7 @@
 #include <hpx/config.hpp>
 #include <hpx/traits/is_iterator.hpp>
 #include <hpx/traits/segmented_iterator_traits.hpp>
+#include <hpx/util/bind.hpp>
 #include <hpx/util/unwrapped.hpp>
 
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
@@ -24,6 +25,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <functional>
 #include <iterator>
 #include <type_traits>
 #include <utility>
@@ -36,6 +38,63 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     namespace detail
     {
         /// \cond NOINTERNAL
+        template <typename ExPolicy, typename Op>
+        struct count_iteration
+        {
+            typedef typename hpx::util::decay<ExPolicy>::type execution_policy_type;
+            typedef typename hpx::util::decay<Op>::type op_type;
+
+            execution_policy_type policy_;
+            op_type op_;
+
+            template <typename ExPolicy_, typename Op_>
+            HPX_HOST_DEVICE count_iteration(ExPolicy_ && policy, Op_ && op)
+              : policy_(std::forward<ExPolicy_>(policy))
+              , op_(std::forward<Op_>(op))
+            {}
+
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__)
+            count_iteration(count_iteration const&) = default;
+            count_iteration(count_iteration&&) = default;
+#else
+            HPX_HOST_DEVICE count_iteration(count_iteration const& rhs)
+              : policy_(rhs.policy_)
+              , op_(rhs.op_)
+            {}
+
+            HPX_HOST_DEVICE count_iteration(count_iteration && rhs)
+              : policy_(std::move(rhs.policy_))
+              , op_(std::move(rhs.op_))
+            {}
+#endif
+
+            HPX_DELETE_COPY_ASSIGN(count_iteration);
+            HPX_DELETE_MOVE_ASSIGN(count_iteration);
+
+            template <typename Iter>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            typename std::iterator_traits<Iter>::difference_type
+            operator()(Iter part_begin, std::size_t part_size)
+            {
+                using hpx::util::placeholders::_1;
+                typename std::iterator_traits<Iter>::difference_type ret = 0;
+                util::loop_n(
+                    policy_, part_begin, part_size,
+                    hpx::util::bind(*this, _1, std::ref(ret))
+                );
+                return ret;
+            }
+
+            template <typename Iter>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            void operator()(Iter curr,
+                typename std::iterator_traits<Iter>::difference_type& ret)
+            {
+                ret += util::detail::count_bits(op_(*curr)); //util::detail::count_bits(hpx::util::invoke(op_, *curr));
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////
         template <typename Value>
         struct count
           : public detail::algorithm<count<Value>, Value>
@@ -68,20 +127,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 }
 
                 auto f1 =
-                    [value, policy](
-                        Iter part_begin, std::size_t part_size
-                    ) -> difference_type
-                    {
-                        difference_type ret = 0;
-                        util::loop_n(
-                            policy, part_begin, part_size,
-                            [&value, &ret](Iter const& curr)
-                            {
-                                if (value == *curr)
-                                    ++ret;
-                            });
-                        return ret;
-                    };
+                    count_iteration<ExPolicy, detail::compare_to<T> >(
+                        policy, detail::compare_to<T>(value));
 
                 return util::partitioner<ExPolicy, difference_type>::call(
                     std::forward<ExPolicy>(policy),
@@ -225,24 +272,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         >::get(0);
                 }
 
-                auto f1 =
-                    [op, policy](
-                        Iter part_begin, std::size_t part_size
-                    ) ->  difference_type
-                    {
-                        difference_type ret = 0;
-
-                        // MSVC bails out if 'op' is captured by reference
-                        util::loop_n(
-                            policy, part_begin, part_size,
-                            [op, &ret](Iter const& curr)
-                            {
-                                if (hpx::util::invoke(op, *curr))
-                                    ++ret;
-                            });
-
-                        return ret;
-                    };
+                auto f1 = count_iteration<ExPolicy, Pred>(policy, op);
 
                 return util::partitioner<ExPolicy, difference_type>::call(
                     std::forward<ExPolicy>(policy),

--- a/hpx/parallel/algorithms/count.hpp
+++ b/hpx/parallel/algorithms/count.hpp
@@ -70,10 +70,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 return util::partitioner<ExPolicy, difference_type>::call(
                     std::forward<ExPolicy>(policy),
                     first, std::distance(first, last),
-                    [value](Iter part_begin, std::size_t part_size) -> difference_type
+                    [value](ExPolicy && policy,
+                        Iter part_begin, std::size_t part_size
+                    ) -> difference_type
                     {
                         difference_type ret = 0;
-                        util::loop_n(part_begin, part_size,
+                        util::loop_n(
+                            std::forward<ExPolicy>(policy),
+                            part_begin, part_size,
                             [&value, &ret](Iter const& curr)
                             {
                                 if (value == *curr)
@@ -222,13 +226,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 return util::partitioner<ExPolicy, difference_type>::call(
                     std::forward<ExPolicy>(policy),
                     first, std::distance(first, last),
-                    [op](Iter part_begin, std::size_t part_size)
-                    ->  difference_type
+                    [op](ExPolicy && policy,
+                        Iter part_begin, std::size_t part_size
+                    ) ->  difference_type
                     {
                         difference_type ret = 0;
 
                         // MSVC bails out if 'op' is captured by reference
-                        util::loop_n(part_begin, part_size,
+                        util::loop_n(
+                            std::forward<ExPolicy>(policy),
+                            part_begin, part_size,
                             [op, &ret](Iter const& curr)
                             {
                                 if (hpx::util::invoke(op, *curr))

--- a/hpx/parallel/algorithms/detail/dispatch.hpp
+++ b/hpx/parallel/algorithms/detail/dispatch.hpp
@@ -281,6 +281,41 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
             return call_sequential(policy, std::forward<Args>(args)...);
         }
 
+#if defined(HPX_HAVE_VC_DATAPAR)
+        template <typename Executor, typename Parameters, typename... Args>
+        typename parallel::util::detail::algorithm_result<
+            datapar_task_execution_policy_shim<Executor, Parameters>,
+            local_result_type
+        >::type
+        call(datapar_task_execution_policy_shim<Executor, Parameters>& policy,
+            std::true_type, Args&&... args) const
+        {
+            return call_sequential(policy, std::forward<Args>(args)...);
+        }
+
+        template <typename Executor, typename Parameters, typename... Args>
+        typename parallel::util::detail::algorithm_result<
+            datapar_task_execution_policy_shim<Executor, Parameters>,
+            local_result_type
+        >::type
+        call(datapar_task_execution_policy_shim<Executor, Parameters> && policy,
+            std::true_type, Args&&... args) const
+        {
+            return call_sequential(policy, std::forward<Args>(args)...);
+        }
+
+        template <typename Executor, typename Parameters, typename... Args>
+        typename parallel::util::detail::algorithm_result<
+            datapar_task_execution_policy_shim<Executor, Parameters>,
+            local_result_type
+        >::type
+        call(datapar_task_execution_policy_shim<Executor, Parameters> const& policy,
+            std::true_type, Args&&... args) const
+        {
+            return call_sequential(policy, std::forward<Args>(args)...);
+        }
+#endif
+
         template <typename ExPolicy, typename... Args>
         typename parallel::util::detail::algorithm_result<
             ExPolicy, local_result_type

--- a/hpx/parallel/algorithms/detail/predicates.hpp
+++ b/hpx/parallel/algorithms/detail/predicates.hpp
@@ -9,6 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/traits/is_iterator.hpp>
 #include <hpx/util/assert.hpp>
+#include <hpx/util/invoke.hpp>
 
 #include <hpx/parallel/algorithms/detail/is_negative.hpp>
 #include <hpx/parallel/config/inline_namespace.hpp>
@@ -17,6 +18,7 @@
 #include <cstddef>
 #include <cstdlib>
 #include <type_traits>
+#include <utility>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
 {
@@ -222,6 +224,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
     struct equal_to
     {
         template <typename T1, typename T2>
+        HPX_HOST_DEVICE HPX_FORCEINLINE
         auto operator()(T1 const& t1, T2 const& t2) const
         ->  decltype(t1 == t2)
         {
@@ -232,12 +235,19 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
     template <typename Value>
     struct compare_to
     {
+        HPX_HOST_DEVICE HPX_FORCEINLINE
+        compare_to(Value && val)
+          : value_(std::move(val))
+        {}
+        HPX_HOST_DEVICE HPX_FORCEINLINE
         compare_to(Value const& val)
           : value_(val)
         {}
 
         template <typename T>
-        auto operator()(T const& t) const -> decltype(value_ == t)
+        HPX_HOST_DEVICE HPX_FORCEINLINE
+        auto operator()(T const& t) const
+        ->  decltype(std::declval<Value>() == t)
         {
             return value_ == t;
         }

--- a/hpx/parallel/algorithms/detail/predicates.hpp
+++ b/hpx/parallel/algorithms/detail/predicates.hpp
@@ -222,17 +222,35 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
     struct equal_to
     {
         template <typename T1, typename T2>
-        bool operator()(T1 const& t1, T2 const& t2) const
+        auto operator()(T1 const& t1, T2 const& t2) const
+        ->  decltype(t1 == t2)
         {
             return t1 == t2;
         }
+    };
+
+    template <typename Value>
+    struct compare_to
+    {
+        compare_to(Value const& val)
+          : value_(val)
+        {}
+
+        template <typename T>
+        auto operator()(T const& t) const -> decltype(value_ == t)
+        {
+            return value_ == t;
+        }
+
+        Value value_;
     };
 
     ///////////////////////////////////////////////////////////////////////////
     struct less
     {
         template <typename T1, typename T2>
-        bool operator()(T1 const& t1, T2 const& t2) const
+        auto operator()(T1 const& t1, T2 const& t2) const
+        ->  decltype(t1 == t2)
         {
             return t1 < t2;
         }

--- a/hpx/parallel/algorithms/detail/predicates.hpp
+++ b/hpx/parallel/algorithms/detail/predicates.hpp
@@ -260,7 +260,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
     {
         template <typename T1, typename T2>
         auto operator()(T1 const& t1, T2 const& t2) const
-        ->  decltype(t1 == t2)
+        ->  decltype(t1 < t2)
         {
             return t1 < t2;
         }
@@ -283,6 +283,47 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         T operator()(T const& t1, T const& t2) const
         {
             return (std::max)(t1, t2);
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    struct plus
+    {
+        template <typename T1, typename T2>
+        auto operator()(T1 const& t1, T2 const& t2) const
+        ->  decltype(t1 + t2)
+        {
+            return t1 + t2;
+        }
+    };
+
+    struct minus
+    {
+        template <typename T1, typename T2>
+        auto operator()(T1 const& t1, T2 const& t2) const
+        ->  decltype(t1 - t2)
+        {
+            return t1 - t2;
+        }
+    };
+
+    struct multiplies
+    {
+        template <typename T1, typename T2>
+        auto operator()(T1 const& t1, T2 const& t2) const
+        ->  decltype(t1 * t2)
+        {
+            return t1 * t2;
+        }
+    };
+
+    struct divides
+    {
+        template <typename T1, typename T2>
+        auto operator()(T1 const& t1, T2 const& t2) const
+        ->  decltype(t1 / t2)
+        {
+            return t1 / t2;
         }
     };
 }}}}

--- a/hpx/parallel/algorithms/equal.hpp
+++ b/hpx/parallel/algorithms/equal.hpp
@@ -110,14 +110,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 typedef typename zip_iterator::reference reference;
 
                 util::cancellation_token<> tok;
-                return util::partitioner<ExPolicy, bool>::call(
-                    std::forward<ExPolicy>(policy),
-                    hpx::util::make_zip_iterator(first1, first2), count1,
-                    [f, tok](zip_iterator it, std::size_t part_count)
-                        mutable -> bool
+                auto f1 =
+                    [f, tok, policy](
+                        zip_iterator it, std::size_t part_count
+                    ) mutable -> bool
                     {
                         util::loop_n(
-                            it, part_count, tok,
+                            policy, it, part_count, tok,
                             [&f, &tok](zip_iterator const& curr)
                             {
                                 using hpx::util::get;
@@ -126,7 +125,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                                     tok.cancel();
                             });
                         return !tok.was_cancelled();
-                    },
+                    };
+
+                return util::partitioner<ExPolicy, bool>::call(
+                    std::forward<ExPolicy>(policy),
+                    hpx::util::make_zip_iterator(first1, first2), count1,
+                    std::move(f1),
                     [](std::vector<hpx::future<bool> > && results)
                     {
                         return std::all_of(
@@ -281,14 +285,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 typedef typename zip_iterator::reference reference;
 
                 util::cancellation_token<> tok;
-                return util::partitioner<ExPolicy, bool>::call(
-                    std::forward<ExPolicy>(policy),
-                    hpx::util::make_zip_iterator(first1, first2), count,
-                    [f, tok](zip_iterator it, std::size_t part_count)
-                        mutable -> bool
+                auto f1 =
+                    [f, tok, policy](
+                        zip_iterator it, std::size_t part_count
+                    ) mutable -> bool
                     {
                         util::loop_n(
-                            it, part_count, tok,
+                            policy, it, part_count, tok,
                             [&f, &tok](zip_iterator const& curr)
                             {
                                 reference t = *curr;
@@ -297,7 +300,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                                     tok.cancel();
                             });
                         return !tok.was_cancelled();
-                    },
+                    };
+
+                return util::partitioner<ExPolicy, bool>::call(
+                    std::forward<ExPolicy>(policy),
+                    hpx::util::make_zip_iterator(first1, first2), count,
+                    std::move(f1),
                     [](std::vector<hpx::future<bool> > && results)
                     {
                         return std::all_of(

--- a/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -10,6 +10,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/traits/is_iterator.hpp>
+#include <hpx/util/invoke.hpp>
 #include <hpx/util/unwrapped.hpp>
 #include <hpx/util/zip_iterator.hpp>
 
@@ -115,6 +116,28 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 using hpx::util::get;
                 using hpx::util::make_zip_iterator;
+
+                auto f3 =
+                    [op, policy](
+                        zip_iterator part_begin, std::size_t part_size,
+                        hpx::shared_future<T> curr, hpx::shared_future<T> next
+                    )
+                    {
+                        next.get();     // rethrow exceptions
+
+                        T val = curr.get();
+                        OutIter dst = get<1>(part_begin.get_iterator_tuple());
+                        *dst++ = val;
+
+                        // MSVC 2015 fails if op is captured by reference
+                        util::loop_n(
+                            policy, dst, part_size - 1,
+                            [=, &val](OutIter it)
+                            {
+                                *it = hpx::util::invoke(op, val, *it);
+                            });
+                    };
+
                 return util::scan_partitioner<ExPolicy, OutIter, T>::call(
                     std::forward<ExPolicy>(policy),
                     make_zip_iterator(first, dest), count, init,
@@ -132,21 +155,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     // to right
                     hpx::util::unwrapped(op),
                     // step 3 runs final accumulation on each partition
-                    [op](zip_iterator part_begin, std::size_t part_size,
-                        hpx::shared_future<T> curr, hpx::shared_future<T> next)
-                    {
-                        next.get();     // rethrow exceptions
-
-                        T val = curr.get();
-                        OutIter dst = get<1>(part_begin.get_iterator_tuple());
-                        *dst++ = val;
-                        // MSVC 2015 fails if op is captured by reference
-                        util::loop_n(dst, part_size - 1,
-                            [=, &val](OutIter it)
-                            {
-                                *it = op(val, *it);
-                            });
-                    },
+                    std::move(f3),
                     // step 4 use this return value
                     [final_dest](std::vector<hpx::shared_future<T> > &&,
                         std::vector<hpx::future<void> > &&)

--- a/hpx/parallel/algorithms/for_each.hpp
+++ b/hpx/parallel/algorithms/for_each.hpp
@@ -38,18 +38,22 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     namespace detail
     {
         /// \cond NOINTERNAL
-        template <typename F, typename Proj>
+        template <typename ExPolicy, typename F, typename Proj>
         struct for_each_iteration
         {
+            typedef typename hpx::util::decay<ExPolicy>::type execution_policy_type;
             typedef typename hpx::util::decay<F>::type fun_type;
             typedef typename hpx::util::decay<Proj>::type proj_type;
 
+            execution_policy_type policy_;
             fun_type f_;
             proj_type proj_;
 
-            template <typename F_, typename Proj_>
-            HPX_HOST_DEVICE for_each_iteration(F_ && f, Proj_ && proj)
-              : f_(std::forward<F_>(f))
+            template <typename ExPolicy_, typename F_, typename Proj_>
+            HPX_HOST_DEVICE for_each_iteration(
+                    ExPolicy_ && policy, F_ && f, Proj_ && proj)
+              : policy_(std::forward<ExPolicy_>(policy))
+              , f_(std::forward<F_>(f))
               , proj_(std::forward<Proj_>(proj))
             {}
 
@@ -58,12 +62,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             for_each_iteration(for_each_iteration&&) = default;
 #else
             HPX_HOST_DEVICE for_each_iteration(for_each_iteration const& rhs)
-              : f_(rhs.f_)
+              : policy_(rhs.policy_)
+              , f_(rhs.f_)
               , proj_(rhs.proj_)
             {}
 
             HPX_HOST_DEVICE for_each_iteration(for_each_iteration && rhs)
-              : f_(std::move(rhs.f_))
+              : policy_(std::move(rhs.policy_))
+              , f_(std::move(rhs.f_))
               , proj_(std::move(rhs.proj_))
             {}
 #endif
@@ -76,14 +82,15 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             void operator()(Iter part_begin, std::size_t part_size,
                 std::size_t /*part_index*/)
             {
-                typedef typename util::detail::loop_n<Iter>::type it_type;
+                util::loop_n(policy_, part_begin, part_size, *this);
+            }
 
-                util::loop_n(
-                    part_begin, part_size,
-                    [this](it_type curr) mutable
-                    {
-                        hpx::util::invoke(f_, hpx::util::invoke(proj_, *curr));
-                    });
+            template <typename Iter>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            void operator()(Iter curr)
+            {
+                hpx::util::invoke(f_, hpx::util::invoke(proj_, *curr));
+                //f_(proj_(*curr));
             }
         };
 
@@ -98,12 +105,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 typename Proj = util::projection_identity>
             HPX_HOST_DEVICE
             static Iter
-            sequential(ExPolicy, InIter first, std::size_t count, F && f,
-                Proj && proj/* = Proj()*/)
+            sequential(ExPolicy && policy, InIter first, std::size_t count,
+                F && f, Proj && proj/* = Proj()*/)
             {
                 typedef typename util::detail::loop_n<InIter>::type it_type;
 
-                return util::loop_n(first, count,
+                return util::loop_n(
+                    policy, first, count,
                     [&f, &proj](it_type curr)
                     {
                         hpx::util::invoke(f, hpx::util::invoke(proj, *curr));
@@ -119,11 +127,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             {
                 if (count != 0)
                 {
+                    auto f1 = for_each_iteration<ExPolicy, F, Proj>(policy,
+                        std::forward<F>(f), std::forward<Proj>(proj));
+
                     return util::foreach_partitioner<ExPolicy>::call(
                         std::forward<ExPolicy>(policy), first, count,
-                        for_each_iteration<F, Proj>(
-                            std::forward<F>(f), std::forward<Proj>(proj)
-                        ),
+                        std::move(f1),
                         [](InIter && last) -> InIter
                         {
                             return std::move(last);
@@ -271,7 +280,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 return util::loop(first, last,
                     [&f, &proj](it_type curr)
                     {
-                        f(hpx::util::invoke(proj, *curr));
+                        hpx::util::invoke(f, hpx::util::invoke(proj, *curr));
                     });
             }
 
@@ -282,10 +291,23 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             parallel(ExPolicy && policy, InIter first, InIter last, F && f,
                 Proj && proj)
             {
-                return detail::for_each_n<Iter>().call(
-                    std::forward<ExPolicy>(policy), std::false_type(),
-                    first, std::distance(first, last), std::forward<F>(f),
-                    std::forward<Proj>(proj));
+                if (first != last)
+                {
+                    auto f1 = for_each_iteration<ExPolicy, F, Proj>(policy,
+                        std::forward<F>(f), std::forward<Proj>(proj));
+
+                    return util::foreach_partitioner<ExPolicy>::call(
+                        std::forward<ExPolicy>(policy), first,
+                        std::distance(first, last),
+                        std::move(f1),
+                        [](InIter && last) -> InIter
+                        {
+                            return std::move(last);
+                        });
+                }
+
+                return util::detail::algorithm_result<ExPolicy, InIter>::get(
+                    std::move(first));
             }
         };
 

--- a/hpx/parallel/algorithms/for_each.hpp
+++ b/hpx/parallel/algorithms/for_each.hpp
@@ -120,8 +120,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
             template <typename ExPolicy, typename InIter, typename F,
                 typename Proj = util::projection_identity>
-            static typename util::detail::algorithm_result<ExPolicy,
-                InIter>::type
+            static typename util::detail::algorithm_result<
+                ExPolicy, InIter
+            >::type
             parallel(ExPolicy && policy, InIter first, std::size_t count,
                 F && f, Proj && proj/* = Proj()*/)
             {
@@ -286,8 +287,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
             template <typename ExPolicy, typename InIter, typename F,
                 typename Proj>
-            static typename util::detail::algorithm_result<ExPolicy,
-                InIter>::type
+            static typename util::detail::algorithm_result<
+                ExPolicy, InIter
+            >::type
             parallel(ExPolicy && policy, InIter first, InIter last, F && f,
                 Proj && proj)
             {

--- a/hpx/parallel/algorithms/for_each.hpp
+++ b/hpx/parallel/algorithms/for_each.hpp
@@ -90,7 +90,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             void operator()(Iter curr)
             {
                 hpx::util::invoke(f_, hpx::util::invoke(proj_, *curr));
-                //f_(proj_(*curr));
             }
         };
 

--- a/hpx/parallel/algorithms/inner_product.hpp
+++ b/hpx/parallel/algorithms/inner_product.hpp
@@ -312,7 +312,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
         return detail::inner_product<T>().call(
             std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
-            std::move(init), std::plus<T>(), std::multiplies<T>());
+            std::move(init), detail::plus(), detail::multiplies());
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/hpx/parallel/algorithms/inner_product.hpp
+++ b/hpx/parallel/algorithms/inner_product.hpp
@@ -35,6 +35,42 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     namespace detail
     {
         /// \cond NOINTERNAL
+        template <typename F>
+        struct inner_product_indirect
+        {
+            typename hpx::util::decay<F>::type& f_;
+
+            template <typename Iter1, typename Iter2>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            auto operator()(Iter1 it1, Iter2 it2)
+            ->  decltype(hpx::util::invoke(f_, *it1, *it2))
+            {
+                return hpx::util::invoke(f_, *it1, *it2);
+            }
+        };
+
+        template <typename ExPolicy, typename Op1, typename Op2, typename T>
+        struct inner_product_partition
+        {
+            typedef typename hpx::util::decay<ExPolicy>::type execution_policy_type;
+            typedef typename hpx::util::decay<Op1>::type op1_type;
+            typedef typename hpx::util::decay<Op2>::type op2_type;
+            typedef typename hpx::util::decay<T>::type value_type;
+
+            execution_policy_type const& policy_;
+            op1_type& op1_;
+            op2_type& op2_;
+            value_type& part_sum_;
+
+            template <typename Iter1, typename Iter2>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            void operator()(Iter1 it1, Iter2 it2)
+            {
+                part_sum_ = hpx::util::invoke(
+                    op1_, part_sum_, hpx::util::invoke(op2_, *it1, *it2));
+            }
+        };
+
         template <typename T>
         struct inner_product
           : public detail::algorithm<inner_product<T>, T>
@@ -46,12 +82,60 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             template <typename ExPolicy, typename InIter1, typename InIter2,
                 typename T_, typename Op1, typename Op2>
             static T
-            sequential(ExPolicy, InIter1 first1, InIter1 last1, InIter2 first2,
-                T_ && init, Op1 && op1, Op2 && op2)
+            sequential(ExPolicy && policy, InIter1 first1, InIter1 last1,
+                InIter2 first2, T_ init, Op1 && op1, Op2 && op2)
             {
-                return std::inner_product(
-                    first1, last1, first2, std::forward<T_>(init),
-                    std::forward<Op1>(op1), std::forward<Op2>(op2));
+                if (first1 == last1)
+                    return std::move(init);
+
+                // check whether we should apply vectorization
+                if (!util::loop_optimization(policy, first1, last1))
+                {
+                    util::loop2(
+                        parallel::v1::seq, first1, last1, first2,
+                        inner_product_partition<
+                            parallel::v1::sequential_execution_policy,
+                            Op1, Op2, T
+                        >{parallel::v1::seq, op1, op2, init});
+
+                    return init;
+                }
+
+                // loop_step properly advances the iterators
+                auto part_sum = util::loop_step(policy,
+                    inner_product_indirect<Op2>{op2}, first1, first2);
+
+                std::pair<InIter1, InIter2> p = util::loop2(
+                    policy, first1, last1, first2,
+                    inner_product_partition<
+                            ExPolicy, Op1, Op2, decltype(part_sum)
+                        >{policy, op1, op2, part_sum}
+                );
+
+                // this is to support vectorization, it will call op1 for each
+                // of the elements of a value-pack
+                T result =
+                    util::detail::accumulate_values(policy,
+                        [&op1](T const& sum, T const& val)
+                        {
+                            return hpx::util::invoke(op1, sum, val);
+                        },
+                        std::move(part_sum),
+                        std::move(init));
+
+                // the vectorization might not cover all of the sequences,
+                // handle the remainder directly
+                if (p.first != last1)
+                {
+                    util::loop2(
+                        parallel::v1::seq, p.first, last1, p.second,
+                        inner_product_partition<
+                            parallel::v1::sequential_execution_policy,
+                            Op1, Op2, T
+                        >{parallel::v1::seq, op1, op2, result});
+                }
+
+                return result;
             }
 
             template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
@@ -76,23 +160,64 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 auto f1 =
                     [op1, op2, policy](
                         zip_iterator part_begin, std::size_t part_size
-                    ) -> T
+                    ) mutable -> T
                     {
-                        using hpx::util::get;
-                        T part_sum = op2(
-                            get<0>(*part_begin), get<1>(*part_begin));
-                        ++part_begin;
+                        auto && iters = part_begin.get_iterator_tuple();
+                        FwdIter1 it1 = hpx::util::get<0>(iters);
+                        FwdIter2 it2 = hpx::util::get<1>(iters);
 
-                        // VS2015RC bails out when op is captured by ref
-                        util::loop_n(
-                            policy, part_begin, part_size - 1,
-                            [=, &part_sum](zip_iterator it)
+                        FwdIter1 last1 = it1;
+                        std::advance(last1, part_size);
+
+                        if (!util::loop_optimization(policy, it1, last1))
+                        {
+                            // loop_step properly advances the iterators
+                            T result = util::loop_step(parallel::v1::seq,
+                                inner_product_indirect<Op2>{op2}, it1, it2);
+
+                            util::loop2(
+                                parallel::v1::seq, it1, last1, it2,
+                                inner_product_partition<
+                                    parallel::v1::sequential_execution_policy,
+                                    Op1, Op2, T
+                                >{parallel::v1::seq, op1, op2, result});
+
+                            return result;
+                        }
+
+                        // loop_step properly advances the iterators
+                        auto part_sum = util::loop_step(policy,
+                            inner_product_indirect<Op2>{op2}, it1, it2);
+
+                        std::pair<FwdIter1, FwdIter2> p = util::loop2(
+                            policy, it1, last1, it2,
+                            inner_product_partition<
+                                    ExPolicy, Op1, Op2, decltype(part_sum)
+                                >{policy, op1, op2, part_sum}
+                        );
+
+                        // this is to support vectorization, it will call op1
+                        // for each of the elements of a value-pack
+                        T result = util::detail::accumulate_values(policy,
+                            [&op1](T const& sum, T const& val)
                             {
-                                part_sum = hpx::util::invoke(op1,
-                                    part_sum, hpx::util::invoke(
-                                        op2, get<0>(*it), get<1>(*it)));
-                            });
-                        return part_sum;
+                                return hpx::util::invoke(op1, sum, val);
+                            },
+                            part_sum);
+
+                        // the vectorization might not cover all of the sequences,
+                        // handle the remainder directly
+                        if (p.first != last1)
+                        {
+                            util::loop2(
+                                parallel::v1::seq, p.first, last1, p.second,
+                                inner_product_partition<
+                                    parallel::v1::sequential_execution_policy,
+                                    Op1, Op2, T
+                                >{parallel::v1::seq, op1, op2, result});
+                        }
+
+                        return result;
                     };
 
                 using hpx::util::make_zip_iterator;
@@ -105,7 +230,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         T ret = init;
                         for(auto && fut : results)
                         {
-                            ret = op1(ret, fut.get());
+                            ret = hpx::util::invoke(op1, ret, fut.get());
                         }
                         return ret;
                     });

--- a/hpx/parallel/algorithms/is_partitioned.hpp
+++ b/hpx/parallel/algorithms/is_partitioned.hpp
@@ -88,15 +88,17 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     return result::get(true);
 
                 util::cancellation_token<> tok;
-                return util::partitioner<ExPolicy, bool>::call(
-                    std::forward<ExPolicy>(policy), first, count,
-                    [pred, tok](Iter part_begin,
-                        std::size_t part_count) mutable -> bool
+                auto f1 =
+                    [pred, tok, policy](
+                        Iter part_begin, std::size_t part_count
+                    ) mutable -> bool
                     {
                         bool fst_bool = pred(*part_begin);
                         if (part_count == 1)
                             return fst_bool;
-                        util::loop_n(++part_begin, --part_count, tok,
+
+                        util::loop_n(
+                            policy, ++part_begin, --part_count, tok,
                             [&fst_bool, &pred, &tok](Iter const& a) {
                                 if (fst_bool != pred(*a))
                                 {
@@ -106,8 +108,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                                         tok.cancel();
                                 }
                             });
+
                         return fst_bool;
-                    },
+                    };
+
+                return util::partitioner<ExPolicy, bool>::call(
+                    std::forward<ExPolicy>(policy), first, count,
+                    std::move(f1),
                     [tok](std::vector<hpx::future<bool> > && results) -> bool
                     {
                         if (tok.was_cancelled()) return false;

--- a/hpx/parallel/algorithms/minmax.hpp
+++ b/hpx/parallel/algorithms/minmax.hpp
@@ -133,7 +133,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 auto f2 =
                     [f, proj, policy](std::vector<FwdIter> && positions)
                     {
-                        return min_element::sequential_min_element_ind(
+                        return sequential_min_element_ind(
                             policy, positions.begin(), positions.size(),
                             f, proj);
                     };
@@ -360,7 +360,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 auto f2 =
                     [f, proj, policy](std::vector<FwdIter> && positions)
                     {
-                        return max_element::sequential_max_element_ind(
+                        return sequential_max_element_ind(
                             policy, positions.begin(), positions.size(),
                             f, proj);
                     };

--- a/hpx/parallel/algorithms/minmax.hpp
+++ b/hpx/parallel/algorithms/minmax.hpp
@@ -43,15 +43,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     namespace detail
     {
         /// \cond NOINTERNAL
-        template <typename FwdIter, typename F, typename Proj>
-        FwdIter sequential_min_element(FwdIter it, std::size_t count,
-            F const& f, Proj const& proj)
+        template <typename ExPolicy, typename FwdIter, typename F, typename Proj>
+        FwdIter sequential_min_element(ExPolicy && policy, FwdIter it,
+            std::size_t count, F const& f, Proj const& proj)
         {
             if (count == 0 || count == 1)
                 return it;
 
             FwdIter smallest = it;
-            util::loop_n(++it, count-1,
+            util::loop_n(
+                std::forward<ExPolicy>(policy), ++it, count-1,
                 [&f, &smallest, &proj](FwdIter const& curr)
                 {
                     if (hpx::util::invoke(f,
@@ -61,9 +62,37 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         smallest = curr;
                     }
                 });
+
             return smallest;
         }
 
+        template <typename ExPolicy, typename FwdIter, typename F, typename Proj>
+        typename std::iterator_traits<FwdIter>::value_type
+        sequential_min_element_ind(ExPolicy && policy, FwdIter it,
+            std::size_t count, F const& f, Proj const& proj)
+        {
+            HPX_ASSERT(count != 0);
+
+            if (count == 1)
+                return *it;
+
+            typename std::iterator_traits<FwdIter>::value_type smallest = *it;
+            util::loop_n(
+                std::forward<ExPolicy>(policy), ++it, count-1,
+                [&f, &smallest, &proj](FwdIter const& curr)
+                {
+                    if (hpx::util::invoke(f,
+                            hpx::util::invoke(proj, **curr),
+                            hpx::util::invoke(proj, *smallest)))
+                    {
+                        smallest = *curr;
+                    }
+                });
+
+            return smallest;
+        }
+
+        ///////////////////////////////////////////////////////////////////////
         template <typename Iter>
         struct min_element
           : public detail::algorithm<min_element<Iter>, Iter>
@@ -71,30 +100,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             min_element()
               : min_element::algorithm("min_element")
             {}
-
-            template <typename FwdIter, typename F, typename Proj>
-            static typename std::iterator_traits<FwdIter>::value_type
-            sequential_minmax_element_ind(FwdIter it, std::size_t count,
-                F const& f, Proj const& proj)
-            {
-                HPX_ASSERT(count != 0);
-
-                if (count == 1)
-                    return *it;
-
-                typename std::iterator_traits<FwdIter>::value_type smallest = *it;
-                util::loop_n(++it, count-1,
-                    [&f, &smallest, &proj](FwdIter const& curr)
-                    {
-                        if (hpx::util::invoke(f,
-                                hpx::util::invoke(proj, **curr),
-                                hpx::util::invoke(proj, *smallest)))
-                        {
-                            smallest = *curr;
-                        }
-                    });
-                return smallest;
-            }
 
             template <typename ExPolicy, typename FwdIter, typename F, typename Proj>
             static FwdIter
@@ -119,21 +124,24 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         get(std::move(first));
                 }
 
+                auto f1 =
+                    [f, proj, policy](FwdIter it, std::size_t part_count)
+                    {
+                        return sequential_min_element(
+                            policy, it, part_count, f, proj);
+                    };
+                auto f2 =
+                    [f, proj, policy](std::vector<FwdIter> && positions)
+                    {
+                        return min_element::sequential_min_element_ind(
+                            policy, positions.begin(), positions.size(),
+                            f, proj);
+                    };
+
                 return util::partitioner<ExPolicy, FwdIter, FwdIter>::call(
                         std::forward<ExPolicy>(policy),
                         first, std::distance(first, last),
-                        [f, proj](FwdIter it, std::size_t part_count)
-                        {
-                            return sequential_min_element(
-                                it, part_count, f, proj);
-                        },
-                        hpx::util::unwrapped(
-                            [f, proj](std::vector<FwdIter> && positions)
-                            {
-                                return min_element::sequential_minmax_element_ind(
-                                    positions.begin(), positions.size(), f, proj);
-                            }
-                        )
+                        std::move(f1), hpx::util::unwrapped(std::move(f2))
                     );
             }
         };
@@ -259,15 +267,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     namespace detail
     {
         /// \cond NOINTERNAL
-        template <typename FwdIter, typename F, typename Proj>
-        FwdIter sequential_max_element(FwdIter it, std::size_t count,
-            F const& f, Proj const& proj)
+        template <typename ExPolicy, typename FwdIter, typename F, typename Proj>
+        FwdIter sequential_max_element(ExPolicy && policy, FwdIter it,
+            std::size_t count, F const& f, Proj const& proj)
         {
             if (count == 0 || count == 1)
                 return it;
 
             FwdIter greatest = it;
-            util::loop_n(++it, count-1,
+            util::loop_n(
+                std::forward<ExPolicy>(policy), ++it, count-1,
                 [&f, &greatest, &proj](FwdIter const& curr)
                 {
                     if (hpx::util::invoke(f,
@@ -277,9 +286,37 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         greatest = curr;
                     }
                 });
+
             return greatest;
         }
 
+        template <typename ExPolicy, typename FwdIter, typename F, typename Proj>
+        typename std::iterator_traits<FwdIter>::value_type
+        sequential_max_element_ind(ExPolicy && policy, FwdIter it,
+            std::size_t count, F const& f, Proj const& proj)
+        {
+            HPX_ASSERT(count != 0);
+
+            if (count == 1)
+                return *it;
+
+            typename std::iterator_traits<FwdIter>::value_type greatest = *it;
+            util::loop_n(
+                std::forward<ExPolicy>(policy), ++it, count-1,
+                [&f, &greatest, &proj](FwdIter const& curr)
+                {
+                    if (hpx::util::invoke(f,
+                            hpx::util::invoke(proj, *greatest),
+                            hpx::util::invoke(proj, **curr)))
+                    {
+                        greatest = *curr;
+                    }
+                });
+
+            return greatest;
+        }
+
+        ///////////////////////////////////////////////////////////////////////
         template <typename Iter>
         struct max_element
           : public detail::algorithm<max_element<Iter>, Iter>
@@ -287,30 +324,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             max_element()
               : max_element::algorithm("max_element")
             {}
-
-            template <typename FwdIter, typename F, typename Proj>
-            static typename std::iterator_traits<FwdIter>::value_type
-            sequential_minmax_element_ind(FwdIter it, std::size_t count,
-                F const& f, Proj const& proj)
-            {
-                HPX_ASSERT(count != 0);
-
-                if (count == 1)
-                    return *it;
-
-                typename std::iterator_traits<FwdIter>::value_type greatest = *it;
-                util::loop_n(++it, count-1,
-                    [&f, &greatest, &proj](FwdIter const& curr)
-                    {
-                        if (hpx::util::invoke(f,
-                                hpx::util::invoke(proj, *greatest),
-                                hpx::util::invoke(proj, **curr)))
-                        {
-                            greatest = *curr;
-                        }
-                    });
-                return greatest;
-            }
 
             template <typename ExPolicy, typename FwdIter, typename F,
                 typename Proj>
@@ -338,21 +351,24 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         get(std::move(first));
                 }
 
+                auto f1 =
+                    [f, proj, policy](FwdIter it, std::size_t part_count)
+                    {
+                        return sequential_max_element(
+                            policy, it, part_count, f, proj);
+                    };
+                auto f2 =
+                    [f, proj, policy](std::vector<FwdIter> && positions)
+                    {
+                        return max_element::sequential_max_element_ind(
+                            policy, positions.begin(), positions.size(),
+                            f, proj);
+                    };
+
                 return util::partitioner<ExPolicy, FwdIter, FwdIter>::call(
                         std::forward<ExPolicy>(policy),
                         first, std::distance(first, last),
-                        [f, proj](FwdIter it, std::size_t part_count)
-                        {
-                            return sequential_max_element(
-                                it, part_count, f, proj);
-                        },
-                        hpx::util::unwrapped(
-                            [f, proj](std::vector<FwdIter> && positions)
-                            {
-                                return max_element::sequential_minmax_element_ind(
-                                    positions.begin(), positions.size(), f, proj);
-                            }
-                        )
+                        std::move(f1), hpx::util::unwrapped(std::move(f2))
                     );
             }
         };
@@ -479,17 +495,18 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     namespace detail
     {
         /// \cond NOINTERNAL
-        template <typename FwdIter, typename F, typename Proj>
+        template <typename ExPolicy, typename FwdIter, typename F, typename Proj>
         std::pair<FwdIter, FwdIter>
-        sequential_minmax_element(FwdIter it, std::size_t count, F const& f,
-            Proj const& proj)
+        sequential_minmax_element(ExPolicy && policy, FwdIter it,
+            std::size_t count, F const& f, Proj const& proj)
         {
             std::pair<FwdIter, FwdIter> result(it, it);
 
             if (count == 0 || count == 1)
                 return result;
 
-            util::loop_n(++it, count-1,
+            util::loop_n(
+                std::forward<ExPolicy>(policy), ++it, count-1,
                 [&f, &result, &proj](FwdIter const& curr)
                 {
                     if (hpx::util::invoke(f,
@@ -506,13 +523,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         result.second = curr;
                     }
                 });
+
             return result;
         }
 
-        template <typename PairIter, typename F, typename Proj>
+        template <typename ExPolicy, typename PairIter, typename F, typename Proj>
         typename std::iterator_traits<PairIter>::value_type
-        sequential_minmax_element_ind(PairIter it, std::size_t count,
-            F const& f, Proj const& proj)
+        sequential_minmax_element_ind(ExPolicy && policy, PairIter it,
+            std::size_t count, F const& f, Proj const& proj)
         {
             HPX_ASSERT(count != 0);
 
@@ -520,7 +538,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 return *it;
 
             typename std::iterator_traits<PairIter>::value_type result = *it;
-            util::loop_n(++it, count-1,
+            util::loop_n(
+                std::forward<ExPolicy>(policy), ++it, count-1,
                 [&f, &result, &proj](PairIter const& curr)
                 {
                     if (hpx::util::invoke(f,
@@ -537,6 +556,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         result.second = curr->second;
                     }
                 });
+
             return result;
         }
 
@@ -580,23 +600,25 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         >::get(std::move(result));
                 }
 
+                auto f1 =
+                    [f, proj, policy](FwdIter it, std::size_t part_count)
+                    {
+                        return sequential_minmax_element(
+                            policy, it, part_count, f, proj);
+                    };
+                auto f2 =
+                    [f, proj, policy](std::vector<result_type> && positions)
+                    {
+                        return sequential_minmax_element_ind(
+                            policy, positions.begin(), positions.size(),
+                            f, proj);
+                    };
+
                 return util::partitioner<ExPolicy, result_type, result_type>::
                     call(
                         std::forward<ExPolicy>(policy),
                         result.first, std::distance(result.first, last),
-                        [f, proj](FwdIter it, std::size_t part_count)
-                        {
-                            return sequential_minmax_element(
-                                it, part_count, f, proj);
-                        },
-                        hpx::util::unwrapped(
-                            [f, proj](std::vector<result_type> && positions)
-                            {
-                                return sequential_minmax_element_ind(
-                                    positions.begin(), positions.size(), f,
-                                    proj);
-                            }
-                        )
+                        std::move(f1), hpx::util::unwrapped(std::move(f2))
                     );
             }
         };

--- a/hpx/parallel/algorithms/transform.hpp
+++ b/hpx/parallel/algorithms/transform.hpp
@@ -18,16 +18,18 @@
 #include <hpx/util/tuple.hpp>
 
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
-#include <hpx/parallel/algorithms/for_each.hpp>
 #include <hpx/parallel/config/inline_namespace.hpp>
 #include <hpx/parallel/execution_policy.hpp>
 #include <hpx/parallel/tagspec.hpp>
 #include <hpx/parallel/traits/projected.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/foreach_partitioner.hpp>
+#include <hpx/parallel/util/transform_loop.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 #include <hpx/parallel/util/zip_iterator.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <iterator>
 #include <type_traits>
 #include <utility>
@@ -39,34 +41,80 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     namespace detail
     {
         /// \cond NOINTERNAL
-        template <typename InIter1, typename OutIter, typename F,
-            typename Proj>
-        HPX_HOST_DEVICE
-        HPX_FORCEINLINE std::pair<InIter1, OutIter>
-        sequential_transform(InIter1 first1, InIter1 last1,
-            OutIter dest, F && f, Proj && proj)
-        {
-            while (first1 != last1)
-            {
-                using hpx::util::invoke;
-                *dest++ = invoke(f, invoke(proj, *first1++));
-            }
-            return std::make_pair(first1, dest);
-        }
-
         template <typename F, typename Proj>
+        struct transform_projected
+        {
+            typename hpx::util::decay<F>::type& f_;
+            typename hpx::util::decay<Proj>::type& proj_;
+
+            template <typename Iter>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            auto operator()(Iter curr)
+            ->  decltype(
+                    hpx::util::invoke(f_, hpx::util::invoke(proj_, *curr))
+                )
+            {
+                return hpx::util::invoke(f_, hpx::util::invoke(proj_, *curr));
+            }
+        };
+
+        template <typename ExPolicy, typename F, typename Proj>
         struct transform_iteration
         {
-            typename hpx::util::decay<F>::type f_;
-            typename hpx::util::decay<Proj>::type proj_;
+            typedef typename hpx::util::decay<ExPolicy>::type execution_policy_type;
+            typedef typename hpx::util::decay<F>::type fun_type;
+            typedef typename hpx::util::decay<Proj>::type proj_type;
 
-            template <typename Tuple>
+            execution_policy_type policy_;
+            fun_type f_;
+            proj_type proj_;
+
+            template <typename ExPolicy_, typename F_, typename Proj_>
+            HPX_HOST_DEVICE transform_iteration(
+                    ExPolicy_ && policy, F_ && f, Proj_ && proj)
+              : policy_(std::forward<ExPolicy_>(policy))
+              , f_(std::forward<F_>(f))
+              , proj_(std::forward<Proj_>(proj))
+            {}
+
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__)
+            transform_iteration(transform_iteration const&) = default;
+            transform_iteration(transform_iteration&&) = default;
+#else
+            HPX_HOST_DEVICE transform_iteration(transform_iteration const& rhs)
+              : policy_(rhs.policy_)
+              , f_(rhs.f_)
+              , proj_(rhs.proj_)
+            {}
+
+            HPX_HOST_DEVICE transform_iteration(transform_iteration && rhs)
+              : policy_(std::move(rhs.policy_))
+              , f_(std::move(rhs.f_))
+              , proj_(std::move(rhs.proj_))
+            {}
+#endif
+
+            HPX_DELETE_COPY_ASSIGN(transform_iteration);
+            HPX_DELETE_MOVE_ASSIGN(transform_iteration);
+
+            template <typename Iter>
             HPX_HOST_DEVICE HPX_FORCEINLINE
-            void operator()(Tuple && t)
+            std::pair<
+                typename hpx::util::tuple_element<
+                    0, typename Iter::iterator_tuple_type
+                >::type,
+                typename hpx::util::tuple_element<
+                    1, typename Iter::iterator_tuple_type
+                >::type
+            >
+            operator()(Iter part_begin, std::size_t part_size,
+                std::size_t /*part_index*/)
             {
-                using hpx::util::get;
-                using hpx::util::invoke;
-                get<1>(t) = invoke(f_, invoke(proj_, get<0>(t))); //-V573
+                auto && iters = part_begin.get_iterator_tuple();
+                return util::transform_loop_n(policy_,
+                    hpx::util::get<0>(iters), part_size,
+                    hpx::util::get<1>(iters),
+                    transform_projected<F, Proj>{f_, proj_});
             }
         };
 
@@ -82,11 +130,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 typename F, typename Proj>
             HPX_HOST_DEVICE
             static std::pair<InIter, OutIter>
-            sequential(ExPolicy, InIter first, InIter last,
+            sequential(ExPolicy && policy, InIter first, InIter last,
                 OutIter dest, F && f, Proj && proj)
             {
-                return sequential_transform(first, last, dest,
-                    std::forward<F>(f), std::forward<Proj>(proj));
+                return util::transform_loop(std::forward<ExPolicy>(policy),
+                    first, last, dest, transform_projected<F, Proj>{f, proj});
             }
 
             template <typename ExPolicy, typename FwdIter, typename OutIter,
@@ -97,18 +145,22 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             parallel(ExPolicy && policy, FwdIter first, FwdIter last,
                 OutIter dest, F && f, Proj && proj)
             {
-                typedef hpx::util::zip_iterator<FwdIter, OutIter>
-                    zip_iterator;
-                typedef typename zip_iterator::reference reference;
+                if (first != last)
+                {
+                    auto f1 = transform_iteration<ExPolicy, F, Proj>(policy,
+                        std::forward<F>(f), std::forward<Proj>(proj));
 
-                return get_iter_pair(
-                    for_each_n<zip_iterator>().call(
-                        std::forward<ExPolicy>(policy), std::false_type(),
-                        hpx::util::make_zip_iterator(first, dest),
-                        std::distance(first, last),
-                        transform_iteration<F, Proj>{std::forward<F>(f),
-                            std::forward<Proj>(proj)},
-                        util::projection_identity()));
+                    return get_iter_pair(
+                        util::foreach_partitioner<ExPolicy>::call(
+                            std::forward<ExPolicy>(policy),
+                            hpx::util::make_zip_iterator(first, dest),
+                            std::distance(first, last),
+                            std::move(f1), util::projection_identity()));
+                }
+
+                return util::detail::algorithm_result<
+                        ExPolicy, std::pair<FwdIter, OutIter>
+                    >::get(std::make_pair(std::move(first), std::move(dest)));
             }
         };
         /// \endcond
@@ -232,43 +284,102 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     {
         /// \cond NOINTERNAL
         template <typename F, typename Proj1, typename Proj2>
-        struct transform_binary_iteration
+        struct transform_binary_projected
         {
-            typename hpx::util::decay<F>::type f_;
-            typename hpx::util::decay<Proj1>::type proj1_;
-            typename hpx::util::decay<Proj2>::type proj2_;
+            typename hpx::util::decay<F>::type& f_;
+            typename hpx::util::decay<Proj1>::type& proj1_;
+            typename hpx::util::decay<Proj2>::type& proj2_;
 
-            template <typename Tuple>
-            HPX_HOST_DEVICE
-            void operator()(Tuple && t)
+            template <typename Iter1, typename Iter2>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            auto operator()(Iter1 curr1, Iter2 curr2)
+            ->  decltype(
+                    hpx::util::invoke(f_,
+                        hpx::util::invoke(proj1_, *curr1),
+                        hpx::util::invoke(proj2_, *curr2))
+                )
             {
-                using hpx::util::get;
-                using hpx::util::invoke;
-                get<2>(t) = invoke(f_, //-V573
-                        invoke(proj1_, get<0>(t)),
-                        invoke(proj2_, get<1>(t)));
+                return hpx::util::invoke(f_,
+                    hpx::util::invoke(proj1_, *curr1),
+                    hpx::util::invoke(proj2_, *curr2));
             }
         };
 
-        template <typename InIter1, typename InIter2, typename OutIter,
-            typename F, typename Proj1, typename Proj2>
-        HPX_HOST_DEVICE
-        HPX_FORCEINLINE hpx::util::tuple<InIter1, InIter2, OutIter>
-        sequential_transform(InIter1 first1, InIter1 last1,
-            InIter2 first2,  OutIter dest, F && f,
-            Proj1 && proj1, Proj2 && proj2)
+        template <typename ExPolicy, typename F, typename Proj1, typename Proj2>
+        struct transform_binary_iteration
         {
-            while (first1 != last1)
-            {
-                using hpx::util::invoke;
-                *dest++ =
-                    invoke(f,
-                        invoke(proj1, *first1++),
-                        invoke(proj2, *first2++));
-            }
-            return hpx::util::make_tuple(first1, first2, dest);
-        }
+            typedef typename hpx::util::decay<ExPolicy>::type execution_policy_type;
+            typedef typename hpx::util::decay<F>::type fun_type;
+            typedef typename hpx::util::decay<Proj1>::type proj1_type;
+            typedef typename hpx::util::decay<Proj2>::type proj2_type;
 
+            execution_policy_type policy_;
+            fun_type f_;
+            proj1_type proj1_;
+            proj2_type proj2_;
+
+            template <typename ExPolicy_, typename F_, typename Proj1_,
+                typename Proj2_>
+            HPX_HOST_DEVICE
+            transform_binary_iteration(ExPolicy_ && policy, F_ && f,
+                    Proj1_ && proj1, Proj2_ && proj2)
+              : policy_(std::forward<ExPolicy_>(policy))
+              , f_(std::forward<F_>(f))
+              , proj1_(std::forward<Proj1_>(proj1))
+              , proj2_(std::forward<Proj2_>(proj2))
+            {}
+
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__)
+            transform_binary_iteration(transform_binary_iteration const&) = default;
+            transform_binary_iteration(transform_binary_iteration&&) = default;
+#else
+            HPX_HOST_DEVICE
+            transform_binary_iteration(transform_binary_iteration const& rhs)
+              : policy_(rhs.policy_)
+              , f_(rhs.f_)
+              , proj1_(rhs.proj1_)
+              , proj2_(rhs.proj2_)
+            {}
+
+            HPX_HOST_DEVICE
+            transform_binary_iteration(transform_binary_iteration && rhs)
+              : policy_(std::move(rhs.policy_))
+              , f_(std::move(rhs.f_))
+              , proj1_(std::move(rhs.proj1_))
+              , proj2_(std::move(rhs.proj2_))
+            {}
+#endif
+
+            HPX_DELETE_COPY_ASSIGN(transform_binary_iteration);
+            HPX_DELETE_MOVE_ASSIGN(transform_binary_iteration);
+
+            template <typename Iter>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            hpx::util::tuple<
+                typename hpx::util::tuple_element<
+                    0, typename Iter::iterator_tuple_type
+                >::type,
+                typename hpx::util::tuple_element<
+                    1, typename Iter::iterator_tuple_type
+                >::type,
+                typename hpx::util::tuple_element<
+                    2, typename Iter::iterator_tuple_type
+                >::type
+            >
+            operator()(Iter part_begin, std::size_t part_size,
+                std::size_t /*part_index*/)
+            {
+                auto && iters = part_begin.get_iterator_tuple();
+                return util::transform_binary_loop_n(policy_,
+                    hpx::util::get<0>(iters), part_size,
+                    hpx::util::get<1>(iters), hpx::util::get<2>(iters),
+                    transform_binary_projected<F, Proj1, Proj2>{
+                        f_, proj1_, proj2_
+                    });
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////
         template <typename IterTuple>
         struct transform_binary
           : public detail::algorithm<transform_binary<IterTuple>, IterTuple>
@@ -280,12 +391,15 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             template <typename ExPolicy, typename InIter1, typename InIter2,
                 typename OutIter, typename F, typename Proj1, typename Proj2>
             static hpx::util::tuple<InIter1, InIter2, OutIter>
-            sequential(ExPolicy, InIter1 first1, InIter1 last1, InIter2 first2,
-                OutIter dest, F && f, Proj1 && proj1, Proj2 && proj2)
+            sequential(ExPolicy && policy, InIter1 first1, InIter1 last1,
+                InIter2 first2, OutIter dest, F && f, Proj1 && proj1,
+                Proj2 && proj2)
             {
-                return sequential_transform(first1, last1, first2, dest,
-                    std::forward<F>(f), std::forward<Proj1>(proj1),
-                    std::forward<Proj2>(proj2));
+                return util::transform_binary_loop(
+                    std::forward<ExPolicy>(policy), first1, last1, first2, dest,
+                    transform_binary_projected<F, Proj1, Proj2>{
+                        f, proj1, proj2
+                    });
             }
 
             template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
@@ -294,24 +408,27 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 ExPolicy, hpx::util::tuple<FwdIter1, FwdIter2, OutIter>
             >::type
             parallel(ExPolicy && policy, FwdIter1 first1, FwdIter1 last1,
-                FwdIter2 first2, OutIter dest, F && f,
-                Proj1 && proj1, Proj2 && proj2)
+                FwdIter2 first2, OutIter dest, F && f, Proj1 && proj1,
+                Proj2 && proj2)
             {
-                typedef hpx::util::zip_iterator<
-                        FwdIter1, FwdIter2, OutIter
-                    > zip_iterator;
-                typedef typename zip_iterator::reference reference;
+                if (first1 != last1)
+                {
+                    auto f1 = transform_binary_iteration<ExPolicy, F, Proj1, Proj2>(
+                        policy, std::forward<F>(f), std::forward<Proj1>(proj1),
+                        std::forward<Proj2>(proj2));
 
-                return get_iter_tuple(
-                    for_each_n<zip_iterator>().call(
-                        std::forward<ExPolicy>(policy), std::false_type(),
-                        hpx::util::make_zip_iterator(first1, first2, dest),
-                        std::distance(first1, last1),
-                        transform_binary_iteration<F, Proj1, Proj2>{
-                            std::forward<F>(f), std::forward<Proj1>(proj1),
-                            std::forward<Proj2>(proj2)
-                        },
-                        util::projection_identity()));
+                    return get_iter_tuple(
+                        util::foreach_partitioner<ExPolicy>::call(
+                            std::forward<ExPolicy>(policy),
+                            hpx::util::make_zip_iterator(first1, first2, dest),
+                            std::distance(first1, last1),
+                            std::move(f1), util::projection_identity()));
+                }
+
+                return util::detail::algorithm_result<
+                        ExPolicy, hpx::util::tuple<FwdIter1, FwdIter2, OutIter>
+                    >::get(hpx::util::make_tuple(std::move(first1),
+                        std::move(first2), std::move(dest)));
             }
         };
         /// \endcond
@@ -469,24 +586,6 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     namespace detail
     {
         /// \cond NOINTERNAL
-        template <typename InIter1, typename InIter2, typename OutIter,
-            typename F, typename Proj1, typename Proj2>
-        HPX_FORCEINLINE hpx::util::tuple<InIter1, InIter2, OutIter>
-        sequential_transform(InIter1 first1, InIter1 last1,
-            InIter2 first2, InIter2 last2, OutIter dest, F && f,
-            Proj1 && proj1, Proj2 && proj2)
-        {
-            while (first1 != last1 && first2 != last2)
-            {
-                using hpx::util::invoke;
-                *dest++ =
-                    invoke(f,
-                        invoke(proj1, *first1++),
-                        invoke(proj2, *first2++));
-            }
-            return hpx::util::make_tuple(first1, first2, dest);
-        }
-
         template <typename IterTuple>
         struct transform_binary2
           : public detail::algorithm<transform_binary2<IterTuple>, IterTuple>
@@ -498,13 +597,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             template <typename ExPolicy, typename InIter1, typename InIter2,
                 typename OutIter, typename F, typename Proj1, typename Proj2>
             static hpx::util::tuple<InIter1, InIter2, OutIter>
-            sequential(ExPolicy, InIter1 first1, InIter1 last1,
+            sequential(ExPolicy && policy, InIter1 first1, InIter1 last1,
                 InIter2 first2, InIter2 last2,
                 OutIter dest, F && f, Proj1 && proj1, Proj2 && proj2)
             {
-                return sequential_transform(first1, last1, first2, last2, dest,
-                    std::forward<F>(f), std::forward<Proj1>(proj1),
-                    std::forward<Proj2>(proj2));
+                return util::transform_binary_loop(
+                    std::forward<ExPolicy>(policy),
+                    first1, last1, first2, last2, dest,
+                    transform_binary_projected<F, Proj1, Proj2>{
+                        f, proj1, proj2
+                    });
             }
 
             template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
@@ -516,23 +618,26 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 FwdIter2 first2, FwdIter2 last2, OutIter dest, F && f,
                 Proj1 && proj1, Proj2 && proj2)
             {
-                typedef hpx::util::zip_iterator<
-                        FwdIter1, FwdIter2, OutIter
-                    > zip_iterator;
-                typedef typename zip_iterator::reference reference;
+                if (first1 != last1 && first2 != last2)
+                {
+                    auto f1 = transform_binary_iteration<ExPolicy, F, Proj1, Proj2>(
+                        policy, std::forward<F>(f), std::forward<Proj1>(proj1),
+                        std::forward<Proj2>(proj2));
 
-                return get_iter_tuple(
-                    for_each_n<zip_iterator>().call(
-                        std::forward<ExPolicy>(policy), std::false_type(),
-                        hpx::util::make_zip_iterator(first1, first2, dest),
-                        (std::min)(
-                            std::distance(first1, last1),
-                            std::distance(first2, last2)),
-                        transform_binary_iteration<F, Proj1, Proj2>{
-                            std::forward<F>(f), std::forward<Proj1>(proj1),
-                            std::forward<Proj2>(proj2)
-                        },
-                        util::projection_identity()));
+                    return get_iter_tuple(
+                        util::foreach_partitioner<ExPolicy>::call(
+                            std::forward<ExPolicy>(policy),
+                            hpx::util::make_zip_iterator(first1, first2, dest),
+                            (std::min)(
+                                std::distance(first1, last1),
+                                std::distance(first2, last2)),
+                            std::move(f1), util::projection_identity()));
+                }
+
+                return util::detail::algorithm_result<
+                        ExPolicy, hpx::util::tuple<FwdIter1, FwdIter2, OutIter>
+                    >::get(hpx::util::make_tuple(std::move(first1),
+                        std::move(first2), std::move(dest)));
             }
         };
         /// \endcond

--- a/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -10,6 +10,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/traits/is_iterator.hpp>
+#include <hpx/util/invoke.hpp>
 
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/transform_inclusive_scan.hpp>
@@ -115,13 +116,35 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 using hpx::util::get;
                 using hpx::util::make_zip_iterator;
+
+                auto f3 =
+                    [op, policy](
+                        zip_iterator part_begin, std::size_t part_size,
+                        hpx::shared_future<T> curr, hpx::shared_future<T> next
+                    )
+                    {
+                        next.get();     // rethrow exceptions
+
+                        T val = curr.get();
+                        OutIter dst = get<1>(part_begin.get_iterator_tuple());
+                        *dst++ = val;
+
+                        util::loop_n(
+                            policy, dst, part_size - 1,
+                            [&op, &val](OutIter it)
+                            {
+                                *it = hpx::util::invoke(op, *it, val);
+                            });
+                    };
+
                 return util::scan_partitioner<ExPolicy, OutIter, T>::call(
                     std::forward<ExPolicy>(policy),
                     make_zip_iterator(first, dest), count, init,
                     // step 1 performs first part of scan algorithm
                     [op, conv](zip_iterator part_begin, std::size_t part_size) -> T
                     {
-                        T part_init = conv(get<0>(*part_begin++));
+                        T part_init =
+                            hpx::util::invoke(conv, get<0>(*part_begin++));
                         return sequential_transform_exclusive_scan_n(
                             get<0>(part_begin.get_iterator_tuple()),
                             part_size - 1,
@@ -132,20 +155,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     // to right
                     hpx::util::unwrapped(op),
                     // step 3 runs final_accumulation on each partition
-                    [op](zip_iterator part_begin, std::size_t part_size,
-                        hpx::shared_future<T> curr, hpx::shared_future<T> next)
-                    {
-                        next.get();     // rethrow exceptions
-
-                        T val = curr.get();
-                        OutIter dst = get<1>(part_begin.get_iterator_tuple());
-                        *dst++ = val;
-                        util::loop_n(dst, part_size - 1,
-                            [&op, &val](OutIter it)
-                            {
-                                *it = op(*it, val);
-                            });
-                    },
+                    std::move(f3),
                     // use this return value
                     [final_dest](std::vector<hpx::shared_future<T> > &&,
                         std::vector<hpx::future<void> > &&)

--- a/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -10,6 +10,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/traits/is_iterator.hpp>
+#include <hpx/util/invoke.hpp>
 
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/inclusive_scan.hpp>
@@ -112,15 +113,38 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                 using hpx::util::get;
                 using hpx::util::make_zip_iterator;
+
+                auto f3 =
+                    [op, policy](
+                        zip_iterator part_begin, std::size_t part_size,
+                        hpx::shared_future<T> curr, hpx::shared_future<T> next
+                    )
+                    {
+                        next.get();     // rethrow exceptions
+
+                        T val = curr.get();
+                        OutIter dst = get<1>(part_begin.get_iterator_tuple());
+
+                        util::loop_n(
+                            policy, dst, part_size,
+                            [&op, &val](OutIter it)
+                            {
+                                *it = hpx::util::invoke(op, *it, val);
+                            });
+                    };
+
                 return util::scan_partitioner<ExPolicy, OutIter, T>::call(
                     std::forward<ExPolicy>(policy),
                     make_zip_iterator(first, dest), count, init,
                     // step 1 performs first part of scan algorithm
-                    [op, conv](zip_iterator part_begin, std::size_t part_size)
-                        -> T
+                    [op, conv](
+                        zip_iterator part_begin, std::size_t part_size
+                    ) -> T
                     {
-                        T part_init = conv(get<0>(*part_begin));
+                        T part_init =
+                            hpx::util::invoke(conv, get<0>(*part_begin));
                         get<1>(*part_begin++) = part_init;
+
                         return sequential_transform_inclusive_scan_n(
                             get<0>(part_begin.get_iterator_tuple()),
                             part_size-1,
@@ -131,19 +155,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     // to right
                     hpx::util::unwrapped(op),
                     // step 3 runs final accumulation on each partition
-                    [op](zip_iterator part_begin, std::size_t part_size,
-                        hpx::shared_future<T> curr, hpx::shared_future<T> next)
-                    {
-                        next.get();     // rethrow exceptions
-
-                        T val = curr.get();
-                        OutIter dst = get<1>(part_begin.get_iterator_tuple());
-                        util::loop_n(dst, part_size,
-                            [&op, &val](OutIter it)
-                            {
-                                *it = op(*it, val);
-                            });
-                    },
+                    std::move(f3),
                     // step 4 use this return value
                     [final_dest](std::vector<hpx::shared_future<T> > &&,
                         std::vector<hpx::future<void> > &&)

--- a/hpx/parallel/datapar/detail/iterator_helpers.hpp
+++ b/hpx/parallel/datapar/detail/iterator_helpers.hpp
@@ -1,0 +1,215 @@
+//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2016 Matthias Kretz
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_DATAPAR_ITERATOR_HELPERS_SEP_09_2016_0143PM)
+#define HPX_PARALLEL_DATAPAR_ITERATOR_HELPERS_SEP_09_2016_0143PM
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_VC_DATAPAR)
+#include <hpx/util/decay.hpp>
+
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+
+#include <Vc/Vc>
+
+namespace hpx { namespace parallel { namespace util
+{
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        template <typename Iter>
+        HPX_FORCEINLINE std::size_t data_alignment(Iter it)
+        {
+            return reinterpret_cast<std::uintptr_t>(std::addressof(*it)) &
+                (Vc::Vector<typename Iter::value_type>::MemoryAlignment - 1);
+        }
+
+        template <typename Iter1, typename Iter2>
+        struct iterators_datapar_compatible_impl
+        {
+            typedef typename hpx::util::decay<Iter1>::type iterator1_type;
+            typedef typename hpx::util::decay<Iter2>::type iterator2_type;
+
+            typedef Vc::Vector<typename iterator1_type::value_type> V1;
+            typedef Vc::Vector<typename iterator2_type::value_type> V2;
+
+            typedef std::integral_constant<bool,
+                    V1::size == V2::size &&
+                        V1::MemoryAlignment == V2::MemoryAlignment
+                > type;
+        };
+
+        template <typename Iter1, typename Iter2>
+        struct iterators_datapar_compatible
+          : iterators_datapar_compatible_impl<Iter1, Iter2>::type
+        {};
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        template <typename Iter, typename V, typename Enable = void>
+        struct store_on_exit
+        {
+            store_on_exit(Iter& iter)
+              : value_(std::addressof(*iter), Vc::Aligned),
+                iter_(iter)
+            {
+            }
+            ~store_on_exit()
+            {
+                value_.store(std::addressof(*iter_), Vc::Aligned);
+            }
+
+            V* operator&() { return &value_; }
+            V const* operator&() const { return &value_; }
+
+            V value_;
+            Iter& iter_;
+        };
+
+        template <typename Iter, typename V>
+        struct store_on_exit<Iter, V,
+            typename std::enable_if<
+                std::is_const<
+                    typename std::iterator_traits<Iter>::value_type
+                >::value
+            >::type>
+        {
+            store_on_exit(Iter& iter)
+              : value_(std::addressof(*iter), Vc::Aligned)
+            {}
+
+            V* operator&() { return &value_; }
+            V const* operator&() const { return &value_; }
+
+            V value_;
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Iter, typename Enable = void>
+        struct datapar_loop_step
+        {
+            typedef Vc::Scalar::Vector<typename Iter::value_type> V1;
+            typedef Vc::Vector<typename Iter::value_type> V;
+
+            template <typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::result_of<F&&(V1*)>::type
+            call1(F && f, Iter it)
+            {
+                store_on_exit<Iter, V1> tmp(it);
+                return hpx::util::invoke(f, &tmp);
+            }
+
+            template <typename F, typename Iter>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::result_of<F&&(V*)>::type
+            callv(F && f, Iter it)
+            {
+                store_on_exit<Iter, V> tmp(it);
+                return hpx::util::invoke(f, &tmp);
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Iter1, typename Iter2>
+        struct datapar_loop_step2
+        {
+            typedef Vc::Scalar::Vector<typename Iter1::value_type> V11;
+            typedef Vc::Scalar::Vector<typename Iter2::value_type> V12;
+
+            typedef Vc::Vector<typename Iter1::value_type> V1;
+            typedef Vc::Vector<typename Iter2::value_type> V2;
+
+            template <typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::result_of<F&&(V11*, V12*)>::type
+            call1(F && f, Iter1 it1, Iter2 it2)
+            {
+                V11 tmp1(std::addressof(*it1), Vc::Aligned);
+                V12 tmp2(std::addressof(*it2), Vc::Aligned);
+                return hpx::util::invoke(f, &tmp1, &tmp2);
+            }
+
+            template <typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::result_of<F&&(V1*, V1*)>::type
+            callv(F && f, Iter1 it1, Iter2 it2)
+            {
+                V1 tmp1(std::addressof(*it1), Vc::Aligned);
+                V2 tmp2(std::addressof(*it2), Vc::Aligned);
+                return hpx::util::invoke(f, &tmp1, &tmp2);
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        struct datapar_transform_loop_step
+        {
+            template <typename F, typename InIter, typename OutIter,
+                typename AlignTag>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static void call1(F && f, InIter it, OutIter dest, AlignTag align)
+            {
+                typedef Vc::Scalar::Vector<typename InIter::value_type> V1;
+
+                V1 tmp(std::addressof(*it), align);
+                auto ret = hpx::util::invoke(f, &tmp);
+                ret.store(std::addressof(*dest), align);
+            }
+
+            template <typename F, typename InIter1, typename InIter2,
+                typename OutIter, typename AlignTag>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static void call1(F && f, InIter1 it1, InIter2 it2, OutIter dest,
+                AlignTag align)
+            {
+                typedef Vc::Scalar::Vector<typename InIter1::value_type> V1;
+                typedef Vc::Scalar::Vector<typename InIter2::value_type> V2;
+
+                V1 tmp1(std::addressof(*it1), align);
+                V2 tmp2(std::addressof(*it2), align);
+                auto ret = hpx::util::invoke(f, &tmp1, &tmp2);
+                ret.store(std::addressof(*dest), align);
+            }
+
+            ///////////////////////////////////////////////////////////////////
+            template <typename F, typename InIter, typename OutIter,
+                typename AlignTag>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static void callv(F && f, InIter it, OutIter dest, AlignTag align)
+            {
+                typedef Vc::Vector<typename InIter::value_type> V;
+
+                V tmp(std::addressof(*it), align);
+                auto ret = hpx::util::invoke(f, &tmp);
+                ret.store(std::addressof(*dest), align);
+            }
+
+            template <typename F, typename InIter1, typename InIter2,
+                typename OutIter, typename AlignTag>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static void callv(F && f, InIter1 it1, InIter2 it2, OutIter dest,
+                AlignTag align)
+            {
+                typedef Vc::Vector<typename InIter1::value_type> V1;
+                typedef Vc::Vector<typename InIter2::value_type> V2;
+
+                V1 tmp1(std::addressof(*it1), align);
+                V2 tmp2(std::addressof(*it2), align);
+                auto ret = hpx::util::invoke(f, &tmp1, &tmp2);
+                ret.store(std::addressof(*dest), align);
+            }
+        };
+    }
+}}}
+
+#endif
+#endif
+

--- a/hpx/parallel/datapar/detail/iterator_helpers.hpp
+++ b/hpx/parallel/datapar/detail/iterator_helpers.hpp
@@ -11,6 +11,7 @@
 
 #if defined(HPX_HAVE_VC_DATAPAR)
 #include <hpx/util/decay.hpp>
+#include <hpx/traits/is_iterator.hpp>
 
 #include <cstddef>
 #include <iterator>
@@ -23,6 +24,7 @@ namespace hpx { namespace parallel { namespace util
     ///////////////////////////////////////////////////////////////////////////
     namespace detail
     {
+        ///////////////////////////////////////////////////////////////////////
         template <typename Iter>
         HPX_FORCEINLINE std::size_t data_alignment(Iter it)
         {
@@ -30,14 +32,19 @@ namespace hpx { namespace parallel { namespace util
                 (Vc::Vector<typename Iter::value_type>::MemoryAlignment - 1);
         }
 
+        ///////////////////////////////////////////////////////////////////////
         template <typename Iter1, typename Iter2>
         struct iterators_datapar_compatible_impl
         {
             typedef typename hpx::util::decay<Iter1>::type iterator1_type;
             typedef typename hpx::util::decay<Iter2>::type iterator2_type;
 
-            typedef Vc::Vector<typename iterator1_type::value_type> V1;
-            typedef Vc::Vector<typename iterator2_type::value_type> V2;
+            typedef Vc::Vector<
+                    typename std::iterator_traits<iterator1_type>::value_type
+                > V1;
+            typedef Vc::Vector<
+                    typename std::iterator_traits<iterator2_type>::value_type
+                > V2;
 
             typedef std::integral_constant<bool,
                     V1::size == V2::size &&
@@ -49,6 +56,25 @@ namespace hpx { namespace parallel { namespace util
         struct iterators_datapar_compatible
           : iterators_datapar_compatible_impl<Iter1, Iter2>::type
         {};
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Iter>
+        struct iterator_datapar_compatible_impl
+        {
+            typedef typename hpx::util::decay<Iter>::type iterator_type;
+            typedef typename std::iterator_traits<iterator_type>::value_type
+                value_type;
+
+            typedef std::integral_constant<bool,
+                    hpx::traits::is_random_access_iterator<iterator_type>::value &&
+                        std::is_arithmetic<value_type>::value
+                > type;
+        };
+
+        template <typename Iter>
+        struct iterator_datapar_compatible
+          : iterator_datapar_compatible_impl<Iter>::type
+        {};
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -57,7 +83,7 @@ namespace hpx { namespace parallel { namespace util
         template <typename Iter, typename V, typename Enable = void>
         struct store_on_exit
         {
-            store_on_exit(Iter& iter)
+            store_on_exit(Iter const& iter)
               : value_(std::addressof(*iter), Vc::Aligned),
                 iter_(iter)
             {
@@ -71,7 +97,7 @@ namespace hpx { namespace parallel { namespace util
             V const* operator&() const { return &value_; }
 
             V value_;
-            Iter& iter_;
+            Iter iter_;
         };
 
         template <typename Iter, typename V>
@@ -82,9 +108,10 @@ namespace hpx { namespace parallel { namespace util
                 >::value
             >::type>
         {
-            store_on_exit(Iter& iter)
+            store_on_exit(Iter const& iter)
               : value_(std::addressof(*iter), Vc::Aligned)
-            {}
+            {
+            }
 
             V* operator&() { return &value_; }
             V const* operator&() const { return &value_; }
@@ -96,24 +123,28 @@ namespace hpx { namespace parallel { namespace util
         template <typename Iter, typename Enable = void>
         struct datapar_loop_step
         {
-            typedef Vc::Scalar::Vector<typename Iter::value_type> V1;
-            typedef Vc::Vector<typename Iter::value_type> V;
+            typedef typename std::iterator_traits<Iter>::value_type value_type;
+
+            typedef Vc::Scalar::Vector<value_type> V1;
+            typedef Vc::Vector<value_type> V;
 
             template <typename F>
             HPX_HOST_DEVICE HPX_FORCEINLINE
             static typename std::result_of<F&&(V1*)>::type
-            call1(F && f, Iter it)
+            call1(F && f, Iter& it)
             {
                 store_on_exit<Iter, V1> tmp(it);
+                it += V1::Size;
                 return hpx::util::invoke(f, &tmp);
             }
 
             template <typename F, typename Iter>
             HPX_HOST_DEVICE HPX_FORCEINLINE
             static typename std::result_of<F&&(V*)>::type
-            callv(F && f, Iter it)
+            callv(F && f, Iter& it)
             {
                 store_on_exit<Iter, V> tmp(it);
+                it += V::Size;
                 return hpx::util::invoke(f, &tmp);
             }
         };
@@ -122,29 +153,43 @@ namespace hpx { namespace parallel { namespace util
         template <typename Iter1, typename Iter2>
         struct datapar_loop_step2
         {
-            typedef Vc::Scalar::Vector<typename Iter1::value_type> V11;
-            typedef Vc::Scalar::Vector<typename Iter2::value_type> V12;
+            typedef typename std::iterator_traits<Iter1>::value_type value1_type;
+            typedef typename std::iterator_traits<Iter2>::value_type value2_type;
 
-            typedef Vc::Vector<typename Iter1::value_type> V1;
-            typedef Vc::Vector<typename Iter2::value_type> V2;
+            typedef Vc::Scalar::Vector<value1_type> V11;
+            typedef Vc::Scalar::Vector<value2_type> V12;
+
+            typedef Vc::Vector<value1_type> V1;
+            typedef Vc::Vector<value2_type> V2;
 
             template <typename F>
             HPX_HOST_DEVICE HPX_FORCEINLINE
             static typename std::result_of<F&&(V11*, V12*)>::type
-            call1(F && f, Iter1 it1, Iter2 it2)
+            call1(F && f, Iter1& it1, Iter2& it2)
             {
                 V11 tmp1(std::addressof(*it1), Vc::Aligned);
                 V12 tmp2(std::addressof(*it2), Vc::Aligned);
+                it1 += V11::Size;
+                it2 += V12::Size;
                 return hpx::util::invoke(f, &tmp1, &tmp2);
             }
 
             template <typename F>
             HPX_HOST_DEVICE HPX_FORCEINLINE
-            static typename std::result_of<F&&(V1*, V1*)>::type
-            callv(F && f, Iter1 it1, Iter2 it2)
+            static typename std::result_of<F&&(V1*, V2*)>::type
+            callv(F && f, Iter1& it1, Iter2& it2)
             {
+//                 if (data_alignment(it1) || data_alignment(it2))
+//                 {
+//                     V1 tmp1(std::addressof(*it1), Vc::Unaligned);
+//                     V2 tmp2(std::addressof(*it2), Vc::Unaligned);
+//                     return hpx::util::invoke(f, &tmp1, &tmp2);
+//                 }
+
                 V1 tmp1(std::addressof(*it1), Vc::Aligned);
                 V2 tmp2(std::addressof(*it2), Vc::Aligned);
+                it1 += V1::Size;
+                it2 += V2::Size;
                 return hpx::util::invoke(f, &tmp1, &tmp2);
             }
         };
@@ -152,59 +197,101 @@ namespace hpx { namespace parallel { namespace util
         ///////////////////////////////////////////////////////////////////////
         struct datapar_transform_loop_step
         {
-            template <typename F, typename InIter, typename OutIter,
-                typename AlignTag>
+            template <typename F, typename InIter, typename OutIter>
             HPX_HOST_DEVICE HPX_FORCEINLINE
-            static void call1(F && f, InIter it, OutIter dest, AlignTag align)
+            static void call1(F && f, InIter& it, OutIter& dest)
             {
-                typedef Vc::Scalar::Vector<typename InIter::value_type> V1;
+                typedef typename std::iterator_traits<InIter>::value_type
+                    value_type;
 
-                V1 tmp(std::addressof(*it), align);
+                typedef Vc::Scalar::Vector<value_type> V1;
+
+                V1 tmp(std::addressof(*it), Vc::Aligned);
                 auto ret = hpx::util::invoke(f, &tmp);
-                ret.store(std::addressof(*dest), align);
+                ret.store(std::addressof(*dest), Vc::Aligned);
+
+                it += V1::Size;
+                dest += ret.size();
             }
 
             template <typename F, typename InIter1, typename InIter2,
-                typename OutIter, typename AlignTag>
+                typename OutIter>
             HPX_HOST_DEVICE HPX_FORCEINLINE
-            static void call1(F && f, InIter1 it1, InIter2 it2, OutIter dest,
-                AlignTag align)
+            static void call1(F && f, InIter1& it1, InIter2& it2, OutIter& dest)
             {
-                typedef Vc::Scalar::Vector<typename InIter1::value_type> V1;
-                typedef Vc::Scalar::Vector<typename InIter2::value_type> V2;
+                typedef typename std::iterator_traits<InIter1>::value_type
+                    value1_type;
+                typedef typename std::iterator_traits<InIter2>::value_type
+                    value2_type;
 
-                V1 tmp1(std::addressof(*it1), align);
-                V2 tmp2(std::addressof(*it2), align);
+                typedef Vc::Scalar::Vector<value1_type> V1;
+                typedef Vc::Scalar::Vector<value2_type> V2;
+
+                V1 tmp1(std::addressof(*it1), Vc::Aligned);
+                V2 tmp2(std::addressof(*it2), Vc::Aligned);
                 auto ret = hpx::util::invoke(f, &tmp1, &tmp2);
-                ret.store(std::addressof(*dest), align);
+                ret.store(std::addressof(*dest), Vc::Aligned);
+
+                it1 += V1::Size;
+                it2 += V2::Size;
+                dest += ret.size();
             }
 
             ///////////////////////////////////////////////////////////////////
-            template <typename F, typename InIter, typename OutIter,
-                typename AlignTag>
+            template <typename F, typename InIter, typename OutIter>
             HPX_HOST_DEVICE HPX_FORCEINLINE
-            static void callv(F && f, InIter it, OutIter dest, AlignTag align)
+            static void callv(F && f, InIter& it, OutIter& dest)
             {
-                typedef Vc::Vector<typename InIter::value_type> V;
+                typedef typename std::iterator_traits<InIter>::value_type
+                    value_type;
 
-                V tmp(std::addressof(*it), align);
+                typedef Vc::Vector<value_type> V;
+
+//                 if (data_alignment(it) || data_alignment(dest))
+//                 {
+//                     V tmp(std::addressof(*it), Vc::Unaligned);
+//                     auto ret = hpx::util::invoke(f, &tmp);
+//                     ret.store(std::addressof(*dest), Vc::Unaligned);
+//                 }
+
+                V tmp(std::addressof(*it), Vc::Aligned);
                 auto ret = hpx::util::invoke(f, &tmp);
-                ret.store(std::addressof(*dest), align);
+                ret.store(std::addressof(*dest), Vc::Aligned);
+
+                it += V::Size;
+                dest += ret.size();
             }
 
             template <typename F, typename InIter1, typename InIter2,
-                typename OutIter, typename AlignTag>
+                typename OutIter>
             HPX_HOST_DEVICE HPX_FORCEINLINE
-            static void callv(F && f, InIter1 it1, InIter2 it2, OutIter dest,
-                AlignTag align)
+            static void callv(F && f, InIter1& it1, InIter2& it2, OutIter& dest)
             {
-                typedef Vc::Vector<typename InIter1::value_type> V1;
-                typedef Vc::Vector<typename InIter2::value_type> V2;
+                typedef typename std::iterator_traits<InIter1>::value_type
+                    value1_type;
+                typedef typename std::iterator_traits<InIter2>::value_type
+                    value2_type;
 
-                V1 tmp1(std::addressof(*it1), align);
-                V2 tmp2(std::addressof(*it2), align);
+                typedef Vc::Vector<value1_type> V1;
+                typedef Vc::Vector<value2_type> V2;
+
+//                 if (data_alignment(it1) || data_alignment(it2) ||
+//                     data_alignment(dest))
+//                 {
+//                     V1 tmp1(std::addressof(*it1), Vc::Unaligned);
+//                     V2 tmp2(std::addressof(*it2), Vc::Unaligned);
+//                     auto ret = hpx::util::invoke(f, &tmp1, &tmp2);
+//                     ret.store(std::addressof(*dest), Vc::Unaligned);
+//                 }
+
+                V1 tmp1(std::addressof(*it1), Vc::Aligned);
+                V2 tmp2(std::addressof(*it2), Vc::Aligned);
                 auto ret = hpx::util::invoke(f, &tmp1, &tmp2);
-                ret.store(std::addressof(*dest), align);
+                ret.store(std::addressof(*dest), Vc::Aligned);
+
+                it1 += V1::Size;
+                it2 += V2::Size;
+                dest += ret.size();
             }
         };
     }

--- a/hpx/parallel/datapar/detail/iterator_helpers.hpp
+++ b/hpx/parallel/datapar/detail/iterator_helpers.hpp
@@ -138,7 +138,7 @@ namespace hpx { namespace parallel { namespace util
                 return hpx::util::invoke(f, &tmp);
             }
 
-            template <typename F, typename Iter>
+            template <typename F>
             HPX_HOST_DEVICE HPX_FORCEINLINE
             static typename std::result_of<F&&(V*)>::type
             callv(F && f, Iter& it)
@@ -169,8 +169,8 @@ namespace hpx { namespace parallel { namespace util
             {
                 V11 tmp1(std::addressof(*it1), Vc::Aligned);
                 V12 tmp2(std::addressof(*it2), Vc::Aligned);
-                it1 += V11::Size;
-                it2 += V12::Size;
+                std::advance(it1, V11::Size);
+                std::advance(it2, V12::Size);
                 return hpx::util::invoke(f, &tmp1, &tmp2);
             }
 
@@ -179,17 +179,19 @@ namespace hpx { namespace parallel { namespace util
             static typename std::result_of<F&&(V1*, V2*)>::type
             callv(F && f, Iter1& it1, Iter2& it2)
             {
-//                 if (data_alignment(it1) || data_alignment(it2))
-//                 {
-//                     V1 tmp1(std::addressof(*it1), Vc::Unaligned);
-//                     V2 tmp2(std::addressof(*it2), Vc::Unaligned);
-//                     return hpx::util::invoke(f, &tmp1, &tmp2);
-//                 }
+                if (data_alignment(it1) || data_alignment(it2))
+                {
+                    V1 tmp1(std::addressof(*it1), Vc::Unaligned);
+                    V2 tmp2(std::addressof(*it2), Vc::Unaligned);
+                    std::advance(it1, V1::Size);
+                    std::advance(it2, V2::Size);
+                    return hpx::util::invoke(f, &tmp1, &tmp2);
+                }
 
                 V1 tmp1(std::addressof(*it1), Vc::Aligned);
                 V2 tmp2(std::addressof(*it2), Vc::Aligned);
-                it1 += V1::Size;
-                it2 += V2::Size;
+                std::advance(it1, V1::Size);
+                std::advance(it2, V2::Size);
                 return hpx::util::invoke(f, &tmp1, &tmp2);
             }
         };
@@ -210,8 +212,8 @@ namespace hpx { namespace parallel { namespace util
                 auto ret = hpx::util::invoke(f, &tmp);
                 ret.store(std::addressof(*dest), Vc::Aligned);
 
-                it += V1::Size;
-                dest += ret.size();
+                std::advance(it, V1::Size);
+                std::advance(dest, ret.size());
             }
 
             template <typename F, typename InIter1, typename InIter2,
@@ -232,9 +234,9 @@ namespace hpx { namespace parallel { namespace util
                 auto ret = hpx::util::invoke(f, &tmp1, &tmp2);
                 ret.store(std::addressof(*dest), Vc::Aligned);
 
-                it1 += V1::Size;
-                it2 += V2::Size;
-                dest += ret.size();
+                std::advance(it1, V1::Size);
+                std::advance(it2, V2::Size);
+                std::advance(dest, ret.size());
             }
 
             ///////////////////////////////////////////////////////////////////
@@ -247,19 +249,22 @@ namespace hpx { namespace parallel { namespace util
 
                 typedef Vc::Vector<value_type> V;
 
-//                 if (data_alignment(it) || data_alignment(dest))
-//                 {
-//                     V tmp(std::addressof(*it), Vc::Unaligned);
-//                     auto ret = hpx::util::invoke(f, &tmp);
-//                     ret.store(std::addressof(*dest), Vc::Unaligned);
-//                 }
+                if (data_alignment(it) || data_alignment(dest))
+                {
+                    V tmp(std::addressof(*it), Vc::Unaligned);
+                    auto ret = hpx::util::invoke(f, &tmp);
+                    ret.store(std::addressof(*dest), Vc::Unaligned);
+                    std::advance(dest, ret.size());
+                }
+                else
+                {
+                    V tmp(std::addressof(*it), Vc::Aligned);
+                    auto ret = hpx::util::invoke(f, &tmp);
+                    ret.store(std::addressof(*dest), Vc::Aligned);
+                    std::advance(dest, ret.size());
+                }
 
-                V tmp(std::addressof(*it), Vc::Aligned);
-                auto ret = hpx::util::invoke(f, &tmp);
-                ret.store(std::addressof(*dest), Vc::Aligned);
-
-                it += V::Size;
-                dest += ret.size();
+                std::advance(it, V::Size);
             }
 
             template <typename F, typename InIter1, typename InIter2,
@@ -275,23 +280,23 @@ namespace hpx { namespace parallel { namespace util
                 typedef Vc::Vector<value1_type> V1;
                 typedef Vc::Vector<value2_type> V2;
 
-//                 if (data_alignment(it1) || data_alignment(it2) ||
-//                     data_alignment(dest))
-//                 {
-//                     V1 tmp1(std::addressof(*it1), Vc::Unaligned);
-//                     V2 tmp2(std::addressof(*it2), Vc::Unaligned);
-//                     auto ret = hpx::util::invoke(f, &tmp1, &tmp2);
-//                     ret.store(std::addressof(*dest), Vc::Unaligned);
-//                 }
+                if (data_alignment(it1) || data_alignment(it2) ||
+                    data_alignment(dest))
+                {
+                    V1 tmp1(std::addressof(*it1), Vc::Unaligned);
+                    V2 tmp2(std::addressof(*it2), Vc::Unaligned);
+                    auto ret = hpx::util::invoke(f, &tmp1, &tmp2);
+                    ret.store(std::addressof(*dest), Vc::Unaligned);
+                }
 
                 V1 tmp1(std::addressof(*it1), Vc::Aligned);
                 V2 tmp2(std::addressof(*it2), Vc::Aligned);
                 auto ret = hpx::util::invoke(f, &tmp1, &tmp2);
                 ret.store(std::addressof(*dest), Vc::Aligned);
 
-                it1 += V1::Size;
-                it2 += V2::Size;
-                dest += ret.size();
+                std::advance(it1, V1::Size);
+                std::advance(it2, V2::Size);
+                std::advance(dest, ret.size());
             }
         };
     }

--- a/hpx/parallel/datapar/execution_policy.hpp
+++ b/hpx/parallel/datapar/execution_policy.hpp
@@ -1,0 +1,334 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_DATAPAR_EXECUTION_POLICY_SEP_07_2016_0601AM)
+#define HPX_PARALLEL_DATAPAR_EXECUTION_POLICY_SEP_07_2016_0601AM
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_VC_DATAPAR)
+#include <hpx/parallel/config/inline_namespace.hpp>
+#include <hpx/parallel/datapar/execution_policy_fwd.hpp>
+#include <hpx/parallel/executors/parallel_executor.hpp>
+#include <hpx/parallel/executors/rebind_executor.hpp>
+#include <hpx/parallel/executors/executor_parameter_traits.hpp>
+#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/traits/is_execution_policy.hpp>
+#include <hpx/traits/is_executor.hpp>
+#include <hpx/traits/is_launch_policy.hpp>
+
+#include <utility>
+
+#include <Vc/Vc>
+
+namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    /// Extension: The class datapar_task_execution_policy is an execution
+    /// policy type used as a unique type to disambiguate parallel algorithm
+    /// overloading and indicate that a parallel algorithm's execution may be
+    /// parallelized.
+    ///
+    /// The algorithm returns a future representing the result of the
+    /// corresponding algorithm when invoked with the parallel_execution_policy.
+    struct datapar_task_execution_policy
+    {
+        /// The type of the executor associated with this execution policy
+        typedef parallel::parallel_executor executor_type;
+
+        /// The type of the associated executor parameters object which is
+        /// associated with this execution policy
+        typedef v3::detail::extract_executor_parameters<
+                executor_type
+            >::type executor_parameters_type;
+
+        /// The category of the execution agents created by this execution
+        /// policy.
+        typedef parallel::vector_execution_tag execution_category;
+
+        /// Rebind the type of executor used by this execution policy. The
+        /// execution category of Executor shall not be weaker than that of
+        /// this execution policy
+        template <typename Executor_, typename Parameters_>
+        struct rebind
+        {
+            /// The type of the rebound execution policy
+            typedef datapar_task_execution_policy_shim<
+                    Executor_, Parameters_
+                > type;
+        };
+
+        /// \cond NOINTERNAL
+        datapar_task_execution_policy() {}
+        /// \endcond
+
+        /// Create a new datapar_task_execution_policy from itself
+        ///
+        /// \param tag          [in] Specify that the corresponding asynchronous
+        ///                     execution policy should be used
+        ///
+        /// \returns The new datapar_task_execution_policy
+        ///
+        datapar_task_execution_policy operator()(
+            task_execution_policy_tag tag) const
+        {
+            return *this;
+        }
+
+        /// Create a new datapar_task_execution_policy from given executor
+        ///
+        /// \tparam Executor    The type of the executor to associate with this
+        ///                     execution policy.
+        ///
+        /// \param exec         [in] The executor to use for the
+        ///                     execution of the parallel algorithm the
+        ///                     returned execution policy is used with.
+        ///
+        /// \note Requires: is_executor<Executor>::value is true
+        ///
+        /// \returns The new datapar_task_execution_policy
+        ///
+        template <typename Executor>
+        typename rebind_executor<
+            datapar_task_execution_policy, Executor, executor_parameters_type
+        >::type
+        on(Executor && exec) const
+        {
+            static_assert(
+                hpx::traits::is_executor<Executor>::value ||
+                hpx::traits::is_threads_executor<Executor>::value,
+                "hpx::traits::is_executor<Executor>::value || "
+                "hpx::traits::is_threads_executor<Executor>::value");
+
+            typedef typename rebind_executor<
+                datapar_task_execution_policy, Executor,
+                executor_parameters_type
+            >::type rebound_type;
+            return rebound_type(std::forward<Executor>(exec), parameters());
+        }
+
+        /// Create a new datapar_task_execution_policy_shim from the given
+        /// execution parameters
+        ///
+        /// \tparam Parameters  The type of the executor parameters to
+        ///                     associate with this execution policy.
+        ///
+        /// \param params       [in] The executor parameters to use for the
+        ///                     execution of the parallel algorithm the
+        ///                     returned execution policy is used with.
+        ///
+        /// \note Requires: all parameters are executor_parameters,
+        ///                 different parameter types can't be duplicated
+        ///
+        /// \returns The new parallel_execution_policy_shim
+        ///
+        template <typename... Parameters, typename ParametersType =
+            typename executor_parameters_join<Parameters...>::type>
+        typename rebind_executor<
+            datapar_task_execution_policy, executor_type, ParametersType
+        >::type
+        with(Parameters &&... params) const
+        {
+            typedef typename rebind_executor<
+                datapar_task_execution_policy, executor_type, ParametersType
+            >::type rebound_type;
+            return rebound_type(executor(),
+                join_executor_parameters(std::forward<Parameters>(params)...));
+        }
+
+    public:
+        /// Return the associated executor object.
+        executor_type& executor() { return exec_; }
+        /// Return the associated executor object.
+        executor_type const& executor() const { return exec_; }
+
+        /// Return the associated executor parameters object.
+        executor_parameters_type& parameters() { return params_; }
+        /// Return the associated executor parameters object.
+        executor_parameters_type const& parameters() const { return params_; }
+
+    private:
+        friend class hpx::serialization::access;
+
+        template <typename Archive>
+        void serialize(Archive & ar, const unsigned int version)
+        {
+        }
+
+    private:
+        executor_type exec_;
+        executor_parameters_type params_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// The class datapar_execution_policy is an execution policy type used
+    /// as a unique type to disambiguate parallel algorithm overloading and
+    /// indicate that a parallel algorithm's execution may be parallelized.
+    struct datapar_execution_policy
+    {
+        /// The type of the executor associated with this execution policy
+        typedef parallel::parallel_executor executor_type;
+
+        /// The type of the associated executor parameters object which is
+        /// associated with this execution policy
+        typedef v3::detail::extract_executor_parameters<
+                executor_type
+            >::type executor_parameters_type;
+
+        /// The category of the execution agents created by this execution
+        /// policy.
+        typedef parallel::vector_execution_tag execution_category;
+
+        /// Rebind the type of executor used by this execution policy. The
+        /// execution category of Executor shall not be weaker than that of
+        /// this execution policy
+        template <typename Executor_, typename Parameters_>
+        struct rebind
+        {
+            /// The type of the rebound execution policy
+            typedef datapar_execution_policy_shim<
+                    Executor_, Parameters_
+                > type;
+        };
+
+        /// \cond NOINTERNAL
+        datapar_execution_policy() {}
+        /// \endcond
+
+        /// Create a new datapar_execution_policy referencing a chunk size.
+        ///
+        /// \param tag          [in] Specify that the corresponding asynchronous
+        ///                     execution policy should be used
+        ///
+        /// \returns The new datapar_execution_policy
+        ///
+        datapar_task_execution_policy operator()(
+            task_execution_policy_tag tag) const
+        {
+            return datapar_task_execution_policy();
+        }
+
+        /// Create a new datapar_execution_policy referencing an executor and
+        /// a chunk size.
+        ///
+        /// \param exec         [in] The executor to use for the execution of
+        ///                     the parallel algorithm the returned execution
+        ///                     policy is used with
+        ///
+        /// \returns The new datapar_execution_policy
+        ///
+        template <typename Executor>
+        typename rebind_executor<
+            datapar_execution_policy, Executor, executor_parameters_type
+        >::type
+        on(Executor && exec) const
+        {
+            static_assert(
+                hpx::traits::is_executor<Executor>::value ||
+                hpx::traits::is_threads_executor<Executor>::value,
+                "hpx::traits::is_executor<Executor>::value || "
+                "hpx::traits::is_threads_executor<Executor>::value");
+
+            typedef typename rebind_executor<
+                datapar_execution_policy, Executor, executor_parameters_type
+            >::type rebound_type;
+            return rebound_type(std::forward<Executor>(exec), parameters());
+        }
+
+        /// Create a new datapar_execution_policy from the given
+        /// execution parameters
+        ///
+        /// \tparam Parameters  The type of the executor parameters to
+        ///                     associate with this execution policy.
+        ///
+        /// \param params       [in] The executor parameters to use for the
+        ///                     execution of the parallel algorithm the
+        ///                     returned execution policy is used with.
+        ///
+        /// \note Requires: is_executor_parameters<Parameters>::value is true
+        ///
+        /// \returns The new datapar_execution_policy
+        ///
+        template <typename... Parameters, typename ParametersType =
+            typename executor_parameters_join<Parameters...>::type>
+        typename rebind_executor<
+            datapar_execution_policy, executor_type, ParametersType
+        >::type
+        with(Parameters &&... params) const
+        {
+            typedef typename rebind_executor<
+                datapar_execution_policy, executor_type, ParametersType
+            >::type rebound_type;
+            return rebound_type(executor(),
+                join_executor_parameters(std::forward<Parameters>(params)...));
+        }
+
+    public:
+        /// Return the associated executor object.
+        executor_type& executor() { return exec_; }
+        /// Return the associated executor object.
+        executor_type const& executor() const { return exec_; }
+
+        /// Return the associated executor parameters object.
+        executor_parameters_type& parameters() { return params_; }
+        /// Return the associated executor parameters object.
+        executor_parameters_type const& parameters() const { return params_; }
+
+    private:
+        friend class hpx::serialization::access;
+
+        template <typename Archive>
+        void serialize(Archive & ar, const unsigned int version)
+        {
+        }
+
+    private:
+        executor_type exec_;
+        executor_parameters_type params_;
+    };
+
+    /// Default data-parallel execution policy object.
+    static datapar_execution_policy const datapar_execution;
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Executor, typename Parameters>
+    struct datapar_execution_policy_shim;
+
+    template <typename Executor, typename Parameters>
+    struct datapar_task_execution_policy_shim;
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        // extension
+        template <>
+        struct is_execution_policy<datapar_execution_policy>
+          : std::true_type
+        {};
+
+        template <>
+        struct is_execution_policy<datapar_task_execution_policy>
+          : std::true_type
+        {};
+
+        template <>
+        struct is_parallel_execution_policy<datapar_execution_policy>
+          : std::true_type
+        {};
+
+        template <>
+        struct is_parallel_execution_policy<datapar_task_execution_policy>
+          : std::true_type
+        {};
+
+        template <>
+        struct is_async_execution_policy<datapar_task_execution_policy>
+          : std::true_type
+        {};
+    }
+}}}
+
+#endif
+#endif

--- a/hpx/parallel/datapar/execution_policy.hpp
+++ b/hpx/parallel/datapar/execution_policy.hpp
@@ -19,6 +19,7 @@
 #include <hpx/traits/is_executor.hpp>
 #include <hpx/traits/is_launch_policy.hpp>
 
+#include <type_traits>
 #include <utility>
 
 #include <Vc/Vc>

--- a/hpx/parallel/datapar/execution_policy.hpp
+++ b/hpx/parallel/datapar/execution_policy.hpp
@@ -11,9 +11,10 @@
 #if defined(HPX_HAVE_VC_DATAPAR)
 #include <hpx/parallel/config/inline_namespace.hpp>
 #include <hpx/parallel/datapar/execution_policy_fwd.hpp>
+#include <hpx/parallel/executors/executor_parameter_traits.hpp>
+#include <hpx/parallel/executors/executor_parameters.hpp>
 #include <hpx/parallel/executors/parallel_executor.hpp>
 #include <hpx/parallel/executors/rebind_executor.hpp>
-#include <hpx/parallel/executors/executor_parameter_traits.hpp>
 #include <hpx/runtime/serialization/serialize.hpp>
 #include <hpx/traits/is_execution_policy.hpp>
 #include <hpx/traits/is_executor.hpp>

--- a/hpx/parallel/datapar/execution_policy_fwd.hpp
+++ b/hpx/parallel/datapar/execution_policy_fwd.hpp
@@ -1,0 +1,28 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_DATAPAR_EXECUTION_POLICY_FWD_SEP_07_2016_0528AM)
+#define HPX_PARALLEL_DATAPAR_EXECUTION_POLICY_FWD_SEP_07_2016_0528AM
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_VC_DATAPAR)
+#include <hpx/parallel/config/inline_namespace.hpp>
+
+namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
+{
+    struct datapar_execution_policy;
+
+    template <typename Executor, typename Parameters>
+    struct datapar_execution_policy_shim;
+
+    struct datapar_task_execution_policy;
+
+    template <typename Executor, typename Parameters>
+    struct datapar_task_execution_policy_shim;
+}}}
+
+#endif
+#endif

--- a/hpx/parallel/datapar/loop.hpp
+++ b/hpx/parallel/datapar/loop.hpp
@@ -13,7 +13,8 @@
 #include <hpx/parallel/algorithms/detail/predicates.hpp>
 #include <hpx/parallel/datapar/detail/iterator_helpers.hpp>
 #include <hpx/parallel/datapar/execution_policy_fwd.hpp>
-#include <hpx/traits/is_iterator.hpp>
+#include <hpx/parallel/util/cancellation_token.hpp>
+#include <hpx/util/decay.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -26,167 +27,182 @@
 namespace hpx { namespace parallel { namespace util
 {
     ///////////////////////////////////////////////////////////////////////////
+//     template <typename F, typename Iter>
+//     HPX_HOST_DEVICE HPX_FORCEINLINE
+//     auto loop_step(parallel::v1::datapar_execution_policy, F && f,
+//             Iter& it)
+//     ->  decltype(
+//             detail::datapar_loop_step<Iter>::callv(
+//                 std::forward<F>(f), it)
+//         )
+//     {
+//         return detail::datapar_loop_step<Iter>::callv(
+//             std::forward<F>(f), it);
+//     }
+//
+//     template <typename F, typename Iter>
+//     HPX_HOST_DEVICE HPX_FORCEINLINE
+//     auto loop_step(parallel::v1::datapar_task_execution_policy, F && f,
+//             Iter& it)
+//     ->  decltype(
+//             detail::datapar_loop_step<Iter>::callv(
+//                 std::forward<F>(f), it)
+//             )
+//     {
+//         return detail::datapar_loop_step<Iter>::callv(
+//             std::forward<F>(f), it);
+//     }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename F, typename Iter1, typename Iter2>
+    HPX_HOST_DEVICE HPX_FORCEINLINE
+    auto loop_step(parallel::v1::datapar_execution_policy, F && f,
+            Iter1& it1, Iter2& it2)
+    ->  decltype(
+            detail::datapar_loop_step2<Iter1, Iter2>::callv(
+                std::forward<F>(f), it1, it2)
+            )
+    {
+        return detail::datapar_loop_step2<Iter1, Iter2>::callv(
+            std::forward<F>(f), it1, it2);
+    }
+
+    template <typename F, typename Iter1, typename Iter2>
+    HPX_HOST_DEVICE HPX_FORCEINLINE
+    auto loop_step(parallel::v1::datapar_task_execution_policy, F && f,
+            Iter1& it1, Iter2& it2)
+    ->  decltype(
+            detail::datapar_loop_step2<Iter1, Iter2>::callv(
+                std::forward<F>(f), it1, it2)
+            )
+    {
+        return detail::datapar_loop_step2<Iter1, Iter2>::callv(
+            std::forward<F>(f), it1, it2);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     namespace detail
     {
-        ///////////////////////////////////////////////////////////////////////
-        template <typename Iterator>
-        struct datapar_loop_n
+        template <typename Iter, typename Enable = void>
+        struct loop_optimization
         {
-            typedef typename hpx::util::decay<Iterator>::type iterator_type;
-
-            typedef Vc::Vector<typename iterator_type::value_type> V;
-            typedef Vc::Scalar::Vector<typename iterator_type::value_type> V1;
-
-            ///////////////////////////////////////////////////////////////
-            template <typename InIter, typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
-            static typename std::enable_if<
-                std::is_arithmetic<typename InIter::value_type>::value &&
-                    hpx::traits::is_random_access_iterator<InIter>::value,
-                InIter
-            >::type
-            call(InIter first, std::size_t count, F && f)
+            template <typename Iter1>
+            static bool call(Iter1 const& first1, Iter1 const& last1)
             {
-                std::size_t len = count;
-
-                for (/* */; detail::data_alignment(first) && len != 0;
-                     (void) --len, ++first)
-                {
-                    datapar_loop_step<InIter>::call1(f, first);
-                }
-
-                std::int64_t lenV = std::int64_t(count - (V::Size + 1));
-                for (/* */; lenV > 0;
-                        lenV -= V::Size, len -= V::Size, first += V::Size)
-                {
-                    datapar_loop_step<InIter>::callv(f, first);
-                }
-
-                for (/* */; len != 0; (void) --len, ++first)
-                {
-                    datapar_loop_step<InIter>::call1(f, first);
-                }
-
-                return std::move(first);
-            }
-
-            template <typename InIter, typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
-            static typename std::enable_if<
-                !std::is_arithmetic<typename InIter::value_type>::value ||
-                    !hpx::traits::is_random_access_iterator<InIter>::value,
-                InIter
-            >::type
-            call(InIter first, std::size_t count, F && f)
-            {
-                return util::loop_n(parallel::v1::seq, first, count,
-                    std::forward<F>(f));
-            }
-
-            ///////////////////////////////////////////////////////////////
-            template <typename InIter, typename CancelToken, typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
-            static typename std::enable_if<
-                std::is_arithmetic<typename InIter::value_type>::value &&
-                    hpx::traits::is_random_access_iterator<InIter>::value,
-                InIter
-            >::type
-            call(InIter first, std::size_t count, CancelToken& tok, F && f)
-            {
-                std::size_t len = count;
-
-                for (/* */; detail::data_alignment(first) && len != 0;
-                     (void) --len, ++first)
-                {
-                    V1 tmp(std::addressof(*first), Vc::Aligned);
-                    f(&tmp);
-                    if (tok.was_cancelled())
-                        return first;
-                    tmp.store(std::addressof(*first), Vc::Aligned);
-                }
-
-                std::int64_t lenV = std::int64_t(count - (V::Size + 1));
-                for (/* */; lenV > 0;
-                        lenV -= V::Size, len -= V::Size, first += V::Size)
-                {
-                    V tmp(std::addressof(*first), Vc::Aligned);
-                    f(&tmp);
-                    if (tok.was_cancelled())
-                        return first;
-                    tmp.store(std::addressof(*first), Vc::Aligned);
-                }
-
-                for (/* */; len != 0; (void) --len, ++first)
-                {
-                    V1 tmp(std::addressof(*first), Vc::Aligned);
-                    f(&tmp);
-                    if (tok.was_cancelled())
-                        return first;
-                    tmp.store(std::addressof(*first), Vc::Aligned);
-                }
-
-                return first;
-            }
-
-            template <typename InIter, typename CancelToken, typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
-            static typename std::enable_if<
-                !std::is_arithmetic<typename InIter::value_type>::value ||
-                    !hpx::traits::is_random_access_iterator<InIter>::value,
-                InIter
-            >::type
-            call(InIter first, std::size_t count, CancelToken& tok, F && f)
-            {
-                return util::loop_n(parallel::v1::seq, first, count, tok,
-                    std::forward<F>(f));
+                return false;
             }
         };
 
+        template <typename Iter>
+        struct loop_optimization<Iter,
+            typename std::enable_if<
+                iterator_datapar_compatible<Iter>::value
+            >::type>
+        {
+            template <typename Iter1>
+            static bool call(Iter1 const& first1, Iter1 const& last1)
+            {
+                typedef typename std::iterator_traits<Iter1>::value_type
+                    value_type;
+                typedef Vc::Vector<value_type> V;
+
+                return V::Size <= std::distance(first1, last1);
+            }
+        };
+    }
+
+    template <typename Iter>
+    HPX_HOST_DEVICE HPX_FORCEINLINE
+    bool loop_optimization(parallel::v1::datapar_execution_policy,
+        Iter const& first1, Iter const& last1)
+    {
+        return detail::loop_optimization<Iter>::call(first1, last1);
+    }
+
+    template <typename Iter>
+    HPX_HOST_DEVICE HPX_FORCEINLINE
+    bool loop_optimization(parallel::v1::datapar_task_execution_policy,
+        Iter const& first1, Iter const& last1)
+    {
+        return detail::loop_optimization<Iter1>::call(first1, last1);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
         ///////////////////////////////////////////////////////////////////////
         template <typename T, typename Abi>
-        inline std::size_t count_bits(Vc::Mask<T, Abi> const& mask)
+        HPX_HOST_DEVICE HPX_FORCEINLINE
+        std::size_t count_bits(Vc::Mask<T, Abi> const& mask)
         {
             return mask.count();
+        }
+
+        template <typename F, typename Vector>
+        HPX_HOST_DEVICE HPX_FORCEINLINE
+        typename hpx::util::decay<Vector>::type::EntryType
+        accumulate_values(parallel::v1::datapar_execution_policy,
+            F && f, Vector && value)
+        {
+            typedef typename hpx::util::decay<Vector>::type vector_type;
+            typedef typename vector_type::EntryType entry_type;
+
+            entry_type accum = value[0];
+            for(size_t i = 1; i != value.size(); ++i)
+            {
+                accum = f(accum, entry_type(value[i]));
+            }
+            return accum;
+        }
+
+        template <typename F, typename Vector>
+        HPX_HOST_DEVICE HPX_FORCEINLINE
+        typename hpx::util::decay<Vector>::type::EntryType
+        accumulate_values(parallel::v1::datapar_task_execution_policy,
+            F && f, Vector && value)
+        {
+            typedef typename hpx::util::decay<Vector>::type vector_type;
+            typedef typename vector_type::EntryType entry_type;
+
+            entry_type accum = value[0];
+            for(size_t i = 1; i != value.size(); ++i)
+            {
+                accum = f(accum, entry_type(value[i]));
+            }
+            return accum;
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename F, typename Vector, typename T>
+        HPX_HOST_DEVICE HPX_FORCEINLINE
+        T accumulate_values(parallel::v1::datapar_execution_policy,
+            F && f, Vector && value, T accum)
+        {
+            for(size_t i = 0; i != value.size(); ++i)
+            {
+                accum = f(accum, T(value[i]));
+            }
+            return accum;
+        }
+
+        template <typename F, typename Vector, typename T>
+        HPX_HOST_DEVICE HPX_FORCEINLINE
+        T accumulate_values(parallel::v1::datapar_task_execution_policy,
+            F && f, Vector && value, T accum)
+        {
+            for(size_t i = 0; i != value.size(); ++i)
+            {
+                accum = f(accum, T(value[i]));
+            }
+            return accum;
         }
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Iter, typename F>
-    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
-    loop_n(parallel::v1::datapar_execution_policy, Iter it,
-        std::size_t count, F && f)
-    {
-        return detail::datapar_loop_n<Iter>::call(it, count, std::forward<F>(f));
-    }
+    template <typename ExPolicy, typename Begin, typename End, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Begin
+    loop(ExPolicy&&, Begin begin, End end, F && f);
 
-    template <typename Iter, typename F>
-    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
-    loop_n(parallel::v1::datapar_task_execution_policy, Iter it,
-        std::size_t count, F && f)
-    {
-        return detail::datapar_loop_n<Iter>::call(it, count, std::forward<F>(f));
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename Iter, typename CancelToken, typename F>
-    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
-    loop_n(parallel::v1::datapar_execution_policy, Iter it,
-        std::size_t count, CancelToken& tok, F && f)
-    {
-        return detail::datapar_loop_n<Iter>::call(it, count, tok,
-            std::forward<F>(f));
-    }
-
-    template <typename Iter, typename CancelToken, typename F>
-    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
-    loop_n(parallel::v1::datapar_task_execution_policy, Iter it,
-        std::size_t count, CancelToken& tok, F && f)
-    {
-        return detail::datapar_loop_n<Iter>::call(it, count, tok,
-            std::forward<F>(f));
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
     namespace detail
     {
         ///////////////////////////////////////////////////////////////////////
@@ -196,30 +212,30 @@ namespace hpx { namespace parallel { namespace util
         struct datapar_loop
         {
             typedef typename hpx::util::decay<Iterator>::type iterator_type;
-            typedef Vc::Vector<typename iterator_type::value_type> V;
+            typedef typename std::iterator_traits<iterator_type>::value_type
+                value_type;
+            typedef Vc::Vector<value_type> V;
 
+            ///////////////////////////////////////////////////////////////////
             template <typename Begin, typename End, typename F>
             HPX_HOST_DEVICE HPX_FORCEINLINE
             static typename std::enable_if<
-                std::is_arithmetic<typename Begin::value_type>::value &&
-                    hpx::traits::is_random_access_iterator<Begin>::value &&
-                    hpx::traits::is_random_access_iterator<End>::value,
-                Begin
+                iterator_datapar_compatible<Begin>::value, Begin
             >::type
             call(Begin first, End last, F && f)
             {
-                for (/* */; data_alignment(first) && first != last; ++first)
+                while (data_alignment(first) && first != last)
                 {
                     datapar_loop_step<Begin>::call1(f, first);
                 }
 
-                for (End const lastV = last - (V::Size + 1);
-                    first < lastV; first += V::Size)
+                End const lastV = last - (V::Size + 1);
+                while (first < lastV)
                 {
                     datapar_loop_step<Begin>::callv(f, first);
                 }
 
-                for (/* */; first != last; ++first)
+                while (first != last)
                 {
                     datapar_loop_step<Begin>::call1(f, first);
                 }
@@ -230,16 +246,57 @@ namespace hpx { namespace parallel { namespace util
             template <typename Begin, typename End, typename F>
             HPX_HOST_DEVICE HPX_FORCEINLINE
             static typename std::enable_if<
-               !std::is_arithmetic<typename Begin::value_type>::value ||
-                   !hpx::traits::is_random_access_iterator<Begin>::value ||
-                   !hpx::traits::is_random_access_iterator<End>::value,
-                Begin
+               !iterator_datapar_compatible<Begin>::value, Begin
             >::type
-            call(Begin first, End last, F && f)
+            call(Begin it, End end, F && f)
             {
-                return util::loop(parallel::v1::seq, first, last,
-                    std::forward<F>(f));
+                return util::loop(parallel::v1::seq, it, end, std::forward<F>(f));
             }
+
+//             template <typename Begin, typename End, typename CancelToken,
+//                 typename F>
+//             HPX_HOST_DEVICE HPX_FORCEINLINE
+//             static typename std::enable_if<
+//                 iterator_datapar_compatible<Begin>::value, Begin
+//             >::type
+//             call(Begin first, End last, CancelToken& tok, F && f)
+//             {
+//                 while (data_alignment(first) && first != last)
+//                 {
+//                     if (tok.was_cancelled())
+//                         return first;
+//                     datapar_loop_step<Begin>::call1(f, first);
+//                 }
+//
+//                 End const lastV = last - (V::Size + 1);
+//                 while (first < lastV)
+//                 {
+//                     if (tok.was_cancelled())
+//                         return first;
+//                     datapar_loop_step<Begin>::callv(f, first);
+//                 }
+//
+//                 while (first != last)
+//                 {
+//                     if (tok.was_cancelled())
+//                         break;
+//                     datapar_loop_step<Begin>::call1(f, first);
+//                 }
+//
+//                 return first;
+//             }
+//
+//             template <typename Begin, typename End, typename CancelToken,
+//                 typename F>
+//             HPX_HOST_DEVICE HPX_FORCEINLINE
+//             static typename std::enable_if<
+//                !iterator_datapar_compatible<Begin>::value, Begin
+//             >::type
+//             call(Begin it, End end, CancelToken& tok, F && f)
+//             {
+//                 return util::loop(parallel::v1::seq, it, end, tok,
+//                     std::forward<F>(f));
+//             }
         };
     }
 
@@ -251,13 +308,297 @@ namespace hpx { namespace parallel { namespace util
         return detail::datapar_loop<Begin>::call(begin, end, std::forward<F>(f));
     }
 
-    template <typename Begin, typename End, typename F>
+//     template <typename Begin, typename End, typename CancelToken, typename F>
+//     HPX_HOST_DEVICE HPX_FORCEINLINE Begin
+//     loop(parallel::v1::datapar_execution_policy, Begin begin, End end,
+//         CancelToken& tok, F && f)
+//     {
+//         return detail::datapar_loop<Begin>::call(begin, end, tok,
+//             std::forward<F>(f));
+//     }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename ExPolicy, typename Begin, typename End, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Begin
-    loop(parallel::v1::datapar_task_execution_policy, Begin begin, End end,
-        F && f)
+    loop(ExPolicy&&, Begin begin, End end, F && f);
+
+    namespace detail
     {
-        return detail::datapar_loop<Begin>::call(begin, end, std::forward<F>(f));
+        ///////////////////////////////////////////////////////////////////////
+        // Helper class to repeatedly call a function starting from a given
+        // iterator position.
+        template <typename Iter1, typename Iter2>
+        struct datapar_loop2
+        {
+            ///////////////////////////////////////////////////////////////////
+            template <typename InIter1, typename InIter2, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::enable_if<
+                iterators_datapar_compatible<InIter1, InIter2>::value &&
+                    iterator_datapar_compatible<InIter1>::value &&
+                    iterator_datapar_compatible<InIter2>::value,
+                std::pair<InIter1, InIter2>
+            >::type
+            call(InIter1 it1, InIter1 last1, InIter2 it2, F && f)
+            {
+                typedef typename hpx::util::decay<InIter1>::type iterator_type;
+                typedef typename std::iterator_traits<iterator_type>::value_type
+                    value_type;
+                typedef Vc::Vector<value_type> V;
+
+                if (detail::data_alignment(it1) || detail::data_alignment(it2))
+                {
+                    return std::make_pair(std::move(it1), std::move(it2));
+                }
+
+                InIter1 const last1V = last1 - (V::Size + 1);
+                while (it1 < last1V)
+                {
+                    datapar_loop_step2<InIter1, InIter2>::callv(f, it1, it2);
+                }
+
+                return std::make_pair(std::move(it1), std::move(it2));
+            }
+
+            template <typename InIter1, typename InIter2, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::enable_if<
+                !iterators_datapar_compatible<InIter1, InIter2>::value ||
+                    !iterator_datapar_compatible<InIter1>::value ||
+                    !iterator_datapar_compatible<InIter2>::value,
+                std::pair<Iter1, Iter2>
+            >::type
+            call(Iter1 it1, Iter1 last1, Iter2 it2, F && f)
+            {
+                return std::make_pair(std::move(it1), std::move(it2));
+            }
+        };
     }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Iter1, typename Iter2, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE std::pair<Iter1, Iter2>
+    loop2(parallel::v1::datapar_execution_policy, Iter1 first1, Iter1 last1,
+        Iter2 first2, F && f)
+    {
+        return detail::datapar_loop2<Iter1, Iter2>::call(first1, last1, first2,
+            std::forward<F>(f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename ExPolicy, typename Iter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
+    loop_n(ExPolicy &&, Iter it, std::size_t count, F && f);
+
+    namespace detail
+    {
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Iterator>
+        struct datapar_loop_n
+        {
+            typedef typename hpx::util::decay<Iterator>::type iterator_type;
+            typedef typename std::iterator_traits<iterator_type>::value_type
+                value_type;
+            typedef Vc::Vector<value_type> V;
+
+            ///////////////////////////////////////////////////////////////
+            template <typename InIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::enable_if<
+                iterator_datapar_compatible<InIter>::value, InIter
+            >::type
+            call(InIter first, std::size_t count, F && f)
+            {
+                std::size_t len = count;
+
+                for (/* */; detail::data_alignment(first) && len != 0; --len)
+                {
+                    datapar_loop_step<InIter>::call1(f, first);
+                }
+
+                for (std::int64_t lenV = std::int64_t(count - (V::Size + 1));
+                        lenV > 0; lenV -= V::Size, len -= V::Size)
+                {
+                    datapar_loop_step<InIter>::callv(f, first);
+                }
+
+                for (/* */; len != 0; --len)
+                {
+                    datapar_loop_step<InIter>::call1(f, first);
+                }
+
+                return first;
+            }
+
+            template <typename InIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::enable_if<
+                !iterator_datapar_compatible<InIter>::value, InIter
+            >::type
+            call(InIter first, std::size_t count, F && f)
+            {
+                return util::loop_n(parallel::v1::seq, first, count,
+                    std::forward<F>(f));
+            }
+
+            ///////////////////////////////////////////////////////////////
+            template <typename InIter, typename CancelToken, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::enable_if<
+                iterator_datapar_compatible<InIter>::value, InIter
+            >::type
+            call(InIter first, std::size_t count, CancelToken& tok, F && f)
+            {
+                std::size_t len = count;
+
+                for (/* */; detail::data_alignment(first) && len != 0; --len)
+                {
+                    if (tok.was_cancelled())
+                        return first;
+
+                    datapar_loop_step<InIter>::call1(f, first);
+                }
+
+                for (std::int64_t lenV = std::int64_t(count - (V::Size + 1));
+                        lenV > 0; lenV -= V::Size, len -= V::Size)
+                {
+                    if (tok.was_cancelled())
+                        return first;
+
+                    datapar_loop_step<InIter>::callv(f, first);
+                }
+
+                for (/* */; len != 0; --len)
+                {
+                    if (tok.was_cancelled())
+                        return first;
+
+                    datapar_loop_step<InIter>::call1(f, first);
+                }
+
+                return first;
+            }
+
+            template <typename InIter, typename CancelToken, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::enable_if<
+                !iterator_datapar_compatible<InIter>::value, InIter
+            >::type
+            call(InIter first, std::size_t count, CancelToken& tok, F && f)
+            {
+                return util::loop_n(parallel::v1::seq, first, count, tok,
+                    std::forward<F>(f));
+            }
+        };
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Iter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
+    loop_n(parallel::v1::datapar_execution_policy, Iter it,
+        std::size_t count, F && f)
+    {
+        return detail::datapar_loop_n<Iter>::call(it, count, std::forward<F>(f));
+    }
+
+    template <typename Iter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
+    loop_n(parallel::v1::datapar_task_execution_policy, Iter it,
+        std::size_t count, F && f)
+    {
+        return detail::datapar_loop_n<Iter>::call(it, count, std::forward<F>(f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Iter, typename CancelToken, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
+    loop_n(parallel::v1::datapar_execution_policy, Iter it,
+        std::size_t count, CancelToken& tok, F && f)
+    {
+        return detail::datapar_loop_n<Iter>::call(it, count, tok,
+            std::forward<F>(f));
+    }
+
+    template <typename Iter, typename CancelToken, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
+    loop_n(parallel::v1::datapar_task_execution_policy, Iter it,
+        std::size_t count, CancelToken& tok, F && f)
+    {
+        return detail::datapar_loop_n<Iter>::call(it, count, tok,
+            std::forward<F>(f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+//     namespace detail
+//     {
+//         ///////////////////////////////////////////////////////////////////////
+//         // Helper class to repeatedly call a function starting from a given
+//         // iterator position.
+//         template <typename Iter1, typename Iter2>
+//         struct datapar_loop2_n
+//         {
+//             ///////////////////////////////////////////////////////////////
+//             template <typename InIter1, typename InIter2, typename F>
+//             HPX_HOST_DEVICE HPX_FORCEINLINE
+//             static typename std::enable_if<
+//                 iterators_datapar_compatible<InIter1, InIter2>::value &&
+//                     iterator_datapar_compatible<InIter1>::value &&
+//                     iterator_datapar_compatible<InIter2>::value,
+//                 std::pair<InIter1, InIter2>
+//             >::type
+//             call(InIter1 it1, std::size_t count, InIter2 it2, F && f)
+//             {
+//                 typedef typename hpx::util::decay<InIter1>::type iterator_type;
+//                 typedef typename std::iterator_traits<iterator_type>::value_type
+//                     value_type;
+//                 typedef Vc::Vector<value_type> V;
+//
+//                 if (detail::data_alignment(it1) || detail::data_alignment(it2))
+//                 {
+//                     return std::make_pair(std::move(it1), std::move(it2));
+//                 }
+//
+//                 for (std::int64_t lenV = std::int64_t(count - (V::Size + 1));
+//                         lenV > 0; lenV -= V::Size)
+//                 {
+//                     datapar_loop_step2<InIter1, InIter2>::callv(f, it1, it2);
+//                 }
+//
+//                 return std::make_pair(std::move(it1), std::move(it2));
+//             }
+//
+//             template <typename InIter1, typename InIter2, typename F>
+//             HPX_HOST_DEVICE HPX_FORCEINLINE
+//             static typename std::enable_if<
+//                 !iterators_datapar_compatible<InIter1, InIter2>::value ||
+//                     !iterator_datapar_compatible<InIter1>::value ||
+//                     !iterator_datapar_compatible<InIter2>::value,
+//                 std::pair<InIter1, InIter2>
+//             >::type
+//             call(InIter1 it1, std::size_t count, InIter2 it2, F && f)
+//             {
+//                 return std::make_pair(std::move(it1), std::move(it2));
+//             }
+//         };
+//     }
+//
+//     template <typename Begin1, typename Begin2, typename F>
+//     HPX_HOST_DEVICE HPX_FORCEINLINE std::pair<Begin1, Begin2>
+//     loop2_n(parallel::v1::datapar_execution_policy,
+//         Begin1 begin1, std::size_t count, Begin2 begin2, F && f)
+//     {
+//         return detail::datapar_loop2_n<Begin1, Begin2>::call(begin1, count,
+//             begin2, std::forward<F>(f));
+//     }
+//
+//     template <typename Begin1, typename Begin2, typename F>
+//     HPX_HOST_DEVICE HPX_FORCEINLINE std::pair<Begin1, Begin2>
+//     loop2_n(parallel::v1::datapar_task_execution_policy,
+//         Begin1 begin1, std::size_t count, Begin2 begin2, F && f)
+//     {
+//         return detail::datapar_loop2_n<Begin1, Begin2>::call(begin1, count,
+//             begin2, std::forward<F>(f));
+//     }
 }}}
 
 #endif

--- a/hpx/parallel/datapar/loop.hpp
+++ b/hpx/parallel/datapar/loop.hpp
@@ -1,0 +1,282 @@
+//  Copyright (c) 2007-2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_DATAPAR_UTIL_LOOP_SEP_07_2016_1217PM)
+#define HPX_PARALLEL_DATAPAR_UTIL_LOOP_SEP_07_2016_1217PM
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_VC_DATAPAR)
+#include <hpx/parallel/algorithms/detail/predicates.hpp>
+#include <hpx/parallel/datapar/execution_policy_fwd.hpp>
+#include <hpx/traits/is_iterator.hpp>
+
+#include <cstddef>
+#include <iterator>
+#include <utility>
+#include <type_traits>
+
+#include <Vc/Vc>
+
+namespace hpx { namespace parallel { namespace util
+{
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Iterator>
+        struct datapar_loop_n
+        {
+            typedef typename hpx::util::decay<Iterator>::type iterator_type;
+
+            typedef Vc::Vector<typename iterator_type::value_type> V;
+            typedef Vc::Scalar::Vector<typename iterator_type::value_type> V1;
+
+            typedef V* type;    // this is our iterator type
+
+            ///////////////////////////////////////////////////////////////
+            template <typename InIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::enable_if<
+                std::is_arithmetic<typename InIter::value_type>::value &&
+                    hpx::traits::is_random_access_iterator<InIter>::value,
+                InIter
+            >::type
+            call(InIter first, std::size_t count, F && f)
+            {
+                std::size_t len = count;
+
+                for (/* */;
+                        (reinterpret_cast<std::uintptr_t>(std::addressof(*first)) &
+                            (V::MemoryAlignment - 1)) && len != 0;
+                        (void) --len, ++first)
+                {
+                    V1 tmp(std::addressof(*first), Vc::Aligned);
+                    f(&tmp);
+                    tmp.store(std::addressof(*first), Vc::Aligned);
+                }
+
+                std::int64_t lenV = std::int64_t(count - (V::Size + 1));
+                for (/* */; lenV > 0;
+                        lenV -= V::Size, len -= V::Size, first += V::Size)
+                {
+                    V tmp(std::addressof(*first), Vc::Aligned);
+                    f(&tmp);
+                    tmp.store(std::addressof(*first), Vc::Aligned);
+                }
+
+                for (/* */; len != 0; (void) --len, ++first)
+                {
+                    V1 tmp(std::addressof(*first), Vc::Aligned);
+                    f(&tmp);
+                    tmp.store(std::addressof(*first), Vc::Aligned);
+                }
+
+                return std::move(first);
+            }
+
+            template <typename InIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::enable_if<
+                !std::is_arithmetic<typename InIter::value_type>::value ||
+                    !hpx::traits::is_random_access_iterator<InIter>::value,
+                InIter
+            >::type
+            call(InIter first, std::size_t count, F && f)
+            {
+                return util::loop_n(parallel::v1::seq, first, count,
+                    std::forward<F>(f));
+            }
+
+            ///////////////////////////////////////////////////////////////
+            template <typename InIter, typename CancelToken, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::enable_if<
+                std::is_arithmetic<typename InIter::value_type>::value &&
+                    hpx::traits::is_random_access_iterator<InIter>::value,
+                InIter
+            >::type
+            call(InIter first, std::size_t count, CancelToken& tok, F && f)
+            {
+                std::size_t len = count;
+                bool was_cancelled = false;
+
+                for (/* */;
+                        (reinterpret_cast<std::uintptr_t>(std::addressof(*first)) &
+                            (V::MemoryAlignment - 1)) && len != 0;
+                        (void) --len, ++first)
+                {
+                    V1 tmp(std::addressof(*first), Vc::Aligned);
+                    f(&tmp);
+                    if (tok.was_cancelled())
+                    {
+                        was_cancelled = true;
+                        break;
+                    }
+                    tmp.store(std::addressof(*first), Vc::Aligned);
+                }
+
+                if (was_cancelled)
+                    return first;
+
+                std::int64_t lenV = std::int64_t(count - (V::Size + 1));
+                for (/* */; lenV > 0;
+                        lenV -= V::Size, len -= V::Size, first += V::Size)
+                {
+                    V tmp(std::addressof(*first), Vc::Aligned);
+                    f(&tmp);
+                    if (tok.was_cancelled())
+                    {
+                        was_cancelled = true;
+                        break;
+                    }
+                    tmp.store(std::addressof(*first), Vc::Aligned);
+                }
+
+                if (was_cancelled)
+                    return first;
+
+                for (/* */; len != 0; (void) --len, ++first)
+                {
+                    V1 tmp(std::addressof(*first), Vc::Aligned);
+                    f(&tmp);
+                    if (tok.was_cancelled())
+                    {
+                        was_cancelled = true;
+                        break;
+                    }
+                    tmp.store(std::addressof(*first), Vc::Aligned);
+                }
+
+                return first;
+            }
+
+            template <typename InIter, typename CancelToken, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::enable_if<
+                !std::is_arithmetic<typename InIter::value_type>::value ||
+                    !hpx::traits::is_random_access_iterator<InIter>::value,
+                InIter
+            >::type
+            call(InIter first, std::size_t count, CancelToken& tok, F && f)
+            {
+                return util::loop_n(parallel::v1::seq, first, count, tok,
+                    std::forward<F>(f));
+            }
+        };
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Iter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
+    loop_n(parallel::v1::datapar_execution_policy& policy, Iter it,
+        std::size_t count, F && f)
+    {
+        return detail::datapar_loop_n<Iter>::call(it, count, std::forward<F>(f));
+    }
+
+    template <typename Iter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
+    loop_n(parallel::v1::datapar_execution_policy const& policy, Iter it,
+        std::size_t count, F && f)
+    {
+        return detail::datapar_loop_n<Iter>::call(it, count, std::forward<F>(f));
+    }
+
+    template <typename Iter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
+    loop_n(parallel::v1::datapar_execution_policy && policy, Iter it,
+        std::size_t count, F && f)
+    {
+        return detail::datapar_loop_n<Iter>::call(std::move(policy), it, count,
+            std::forward<F>(f));
+    }
+
+    template <typename Iter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
+    loop_n(parallel::v1::datapar_task_execution_policy& policy, Iter it,
+        std::size_t count, F && f)
+    {
+        return detail::datapar_loop_n<Iter>::call(policy, it, count,
+            std::forward<F>(f));
+    }
+
+    template <typename Iter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
+    loop_n(parallel::v1::datapar_task_execution_policy const& policy, Iter it,
+        std::size_t count, F && f)
+    {
+        return detail::datapar_loop_n<Iter>::call(policy, it, count,
+            std::forward<F>(f));
+    }
+
+    template <typename Iter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
+    loop_n(parallel::v1::datapar_task_execution_policy && policy, Iter it,
+        std::size_t count, F && f)
+    {
+        return detail::datapar_loop_n<Iter>::call(std::move(policy), it, count,
+            std::forward<F>(f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Iter, typename CancelToken, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
+    loop_n(parallel::v1::datapar_execution_policy& policy, Iter it,
+        std::size_t count, CancelToken& tok, F && f)
+    {
+        return detail::datapar_loop_n<Iter>::call(it, count, tok,
+            std::forward<F>(f));
+    }
+
+    template <typename Iter, typename CancelToken, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
+    loop_n(parallel::v1::datapar_execution_policy const& policy, Iter it,
+        std::size_t count, CancelToken& tok, F && f)
+    {
+        return detail::datapar_loop_n<Iter>::call(it, count, tok,
+            std::forward<F>(f));
+    }
+
+    template <typename Iter, typename CancelToken, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
+    loop_n(parallel::v1::datapar_execution_policy && policy, Iter it,
+        std::size_t count, CancelToken& tok, F && f)
+    {
+        return detail::datapar_loop_n<Iter>::call(std::move(policy), it, count,
+            tok, std::forward<F>(f));
+    }
+
+    template <typename Iter, typename CancelToken, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
+    loop_n(parallel::v1::datapar_task_execution_policy& policy, Iter it,
+        std::size_t count, CancelToken& tok, F && f)
+    {
+        return detail::datapar_loop_n<Iter>::call(policy, it, count, tok,
+            std::forward<F>(f));
+    }
+
+    template <typename Iter, typename CancelToken, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
+    loop_n(parallel::v1::datapar_task_execution_policy const& policy, Iter it,
+        std::size_t count, CancelToken& tok, F && f)
+    {
+        return detail::datapar_loop_n<Iter>::call(policy, it, count, tok,
+            std::forward<F>(f));
+    }
+
+    template <typename Iter, typename CancelToken, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
+    loop_n(parallel::v1::datapar_task_execution_policy && policy, Iter it,
+        std::size_t count, CancelToken& tok, F && f)
+    {
+        return detail::datapar_loop_n<Iter>::call(std::move(policy), it, count,
+            tok, std::forward<F>(f));
+    }
+}}}
+
+#endif
+#endif
+

--- a/hpx/parallel/datapar/loop.hpp
+++ b/hpx/parallel/datapar/loop.hpp
@@ -124,7 +124,7 @@ namespace hpx { namespace parallel { namespace util
     bool loop_optimization(parallel::v1::datapar_task_execution_policy,
         Iter const& first1, Iter const& last1)
     {
-        return detail::loop_optimization<Iter1>::call(first1, last1);
+        return detail::loop_optimization<Iter>::call(first1, last1);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -366,9 +366,9 @@ namespace hpx { namespace parallel { namespace util
                 !iterators_datapar_compatible<InIter1, InIter2>::value ||
                     !iterator_datapar_compatible<InIter1>::value ||
                     !iterator_datapar_compatible<InIter2>::value,
-                std::pair<Iter1, Iter2>
+                std::pair<InIter1, InIter2>
             >::type
-            call(Iter1 it1, Iter1 last1, Iter2 it2, F && f)
+            call(InIter1 it1, InIter1 last1, InIter2 it2, F && f)
             {
                 return std::make_pair(std::move(it1), std::move(it2));
             }
@@ -379,6 +379,15 @@ namespace hpx { namespace parallel { namespace util
     template <typename Iter1, typename Iter2, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE std::pair<Iter1, Iter2>
     loop2(parallel::v1::datapar_execution_policy, Iter1 first1, Iter1 last1,
+        Iter2 first2, F && f)
+    {
+        return detail::datapar_loop2<Iter1, Iter2>::call(first1, last1, first2,
+            std::forward<F>(f));
+    }
+
+    template <typename Iter1, typename Iter2, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE std::pair<Iter1, Iter2>
+    loop2(parallel::v1::datapar_task_execution_policy, Iter1 first1, Iter1 last1,
         Iter2 first2, F && f)
     {
         return detail::datapar_loop2<Iter1, Iter2>::call(first1, last1, first2,

--- a/hpx/parallel/datapar/loop.hpp
+++ b/hpx/parallel/datapar/loop.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2016 Matthias Kretz
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -101,7 +102,6 @@ namespace hpx { namespace parallel { namespace util
             call(InIter first, std::size_t count, CancelToken& tok, F && f)
             {
                 std::size_t len = count;
-                bool was_cancelled = false;
 
                 for (/* */;
                         (reinterpret_cast<std::uintptr_t>(std::addressof(*first)) &
@@ -111,15 +111,9 @@ namespace hpx { namespace parallel { namespace util
                     V1 tmp(std::addressof(*first), Vc::Aligned);
                     f(&tmp);
                     if (tok.was_cancelled())
-                    {
-                        was_cancelled = true;
-                        break;
-                    }
+                        return first;
                     tmp.store(std::addressof(*first), Vc::Aligned);
                 }
-
-                if (was_cancelled)
-                    return first;
 
                 std::int64_t lenV = std::int64_t(count - (V::Size + 1));
                 for (/* */; lenV > 0;
@@ -128,25 +122,16 @@ namespace hpx { namespace parallel { namespace util
                     V tmp(std::addressof(*first), Vc::Aligned);
                     f(&tmp);
                     if (tok.was_cancelled())
-                    {
-                        was_cancelled = true;
-                        break;
-                    }
+                        return first;
                     tmp.store(std::addressof(*first), Vc::Aligned);
                 }
-
-                if (was_cancelled)
-                    return first;
 
                 for (/* */; len != 0; (void) --len, ++first)
                 {
                     V1 tmp(std::addressof(*first), Vc::Aligned);
                     f(&tmp);
                     if (tok.was_cancelled())
-                    {
-                        was_cancelled = true;
-                        break;
-                    }
+                        return first;
                     tmp.store(std::addressof(*first), Vc::Aligned);
                 }
 
@@ -171,7 +156,7 @@ namespace hpx { namespace parallel { namespace util
     ///////////////////////////////////////////////////////////////////////////
     template <typename Iter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Iter
-    loop_n(parallel::v1::datapar_execution_policy& policy, Iter it,
+    loop_n(parallel::v1::datapar_execution_policy&, Iter it,
         std::size_t count, F && f)
     {
         return detail::datapar_loop_n<Iter>::call(it, count, std::forward<F>(f));
@@ -179,7 +164,7 @@ namespace hpx { namespace parallel { namespace util
 
     template <typename Iter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Iter
-    loop_n(parallel::v1::datapar_execution_policy const& policy, Iter it,
+    loop_n(parallel::v1::datapar_execution_policy const&, Iter it,
         std::size_t count, F && f)
     {
         return detail::datapar_loop_n<Iter>::call(it, count, std::forward<F>(f));
@@ -187,44 +172,40 @@ namespace hpx { namespace parallel { namespace util
 
     template <typename Iter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Iter
-    loop_n(parallel::v1::datapar_execution_policy && policy, Iter it,
+    loop_n(parallel::v1::datapar_execution_policy &&, Iter it,
         std::size_t count, F && f)
     {
-        return detail::datapar_loop_n<Iter>::call(std::move(policy), it, count,
-            std::forward<F>(f));
+        return detail::datapar_loop_n<Iter>::call(it, count, std::forward<F>(f));
     }
 
     template <typename Iter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Iter
-    loop_n(parallel::v1::datapar_task_execution_policy& policy, Iter it,
+    loop_n(parallel::v1::datapar_task_execution_policy&, Iter it,
         std::size_t count, F && f)
     {
-        return detail::datapar_loop_n<Iter>::call(policy, it, count,
-            std::forward<F>(f));
+        return detail::datapar_loop_n<Iter>::call(it, count, std::forward<F>(f));
     }
 
     template <typename Iter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Iter
-    loop_n(parallel::v1::datapar_task_execution_policy const& policy, Iter it,
+    loop_n(parallel::v1::datapar_task_execution_policy const&, Iter it,
         std::size_t count, F && f)
     {
-        return detail::datapar_loop_n<Iter>::call(policy, it, count,
-            std::forward<F>(f));
+        return detail::datapar_loop_n<Iter>::call(it, count, std::forward<F>(f));
     }
 
     template <typename Iter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Iter
-    loop_n(parallel::v1::datapar_task_execution_policy && policy, Iter it,
+    loop_n(parallel::v1::datapar_task_execution_policy &&, Iter it,
         std::size_t count, F && f)
     {
-        return detail::datapar_loop_n<Iter>::call(std::move(policy), it, count,
-            std::forward<F>(f));
+        return detail::datapar_loop_n<Iter>::call(it, count, std::forward<F>(f));
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Iter, typename CancelToken, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Iter
-    loop_n(parallel::v1::datapar_execution_policy& policy, Iter it,
+    loop_n(parallel::v1::datapar_execution_policy&, Iter it,
         std::size_t count, CancelToken& tok, F && f)
     {
         return detail::datapar_loop_n<Iter>::call(it, count, tok,
@@ -233,7 +214,7 @@ namespace hpx { namespace parallel { namespace util
 
     template <typename Iter, typename CancelToken, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Iter
-    loop_n(parallel::v1::datapar_execution_policy const& policy, Iter it,
+    loop_n(parallel::v1::datapar_execution_policy const&, Iter it,
         std::size_t count, CancelToken& tok, F && f)
     {
         return detail::datapar_loop_n<Iter>::call(it, count, tok,
@@ -245,35 +226,35 @@ namespace hpx { namespace parallel { namespace util
     loop_n(parallel::v1::datapar_execution_policy && policy, Iter it,
         std::size_t count, CancelToken& tok, F && f)
     {
-        return detail::datapar_loop_n<Iter>::call(std::move(policy), it, count,
-            tok, std::forward<F>(f));
-    }
-
-    template <typename Iter, typename CancelToken, typename F>
-    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
-    loop_n(parallel::v1::datapar_task_execution_policy& policy, Iter it,
-        std::size_t count, CancelToken& tok, F && f)
-    {
-        return detail::datapar_loop_n<Iter>::call(policy, it, count, tok,
+        return detail::datapar_loop_n<Iter>::call(it, count, tok,
             std::forward<F>(f));
     }
 
     template <typename Iter, typename CancelToken, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Iter
-    loop_n(parallel::v1::datapar_task_execution_policy const& policy, Iter it,
+    loop_n(parallel::v1::datapar_task_execution_policy&, Iter it,
         std::size_t count, CancelToken& tok, F && f)
     {
-        return detail::datapar_loop_n<Iter>::call(policy, it, count, tok,
+        return detail::datapar_loop_n<Iter>::call(it, count, tok,
             std::forward<F>(f));
     }
 
     template <typename Iter, typename CancelToken, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Iter
-    loop_n(parallel::v1::datapar_task_execution_policy && policy, Iter it,
+    loop_n(parallel::v1::datapar_task_execution_policy const&, Iter it,
         std::size_t count, CancelToken& tok, F && f)
     {
-        return detail::datapar_loop_n<Iter>::call(std::move(policy), it, count,
-            tok, std::forward<F>(f));
+        return detail::datapar_loop_n<Iter>::call(it, count, tok,
+            std::forward<F>(f));
+    }
+
+    template <typename Iter, typename CancelToken, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Iter
+    loop_n(parallel::v1::datapar_task_execution_policy &&, Iter it,
+        std::size_t count, CancelToken& tok, F && f)
+    {
+        return detail::datapar_loop_n<Iter>::call(it, count, tok,
+            std::forward<F>(f));
     }
 }}}
 

--- a/hpx/parallel/datapar/loop.hpp
+++ b/hpx/parallel/datapar/loop.hpp
@@ -50,9 +50,9 @@ namespace hpx { namespace parallel { namespace util
                 std::size_t len = count;
 
                 for (/* */;
-                        (reinterpret_cast<std::uintptr_t>(std::addressof(*first)) &
-                            (V::MemoryAlignment - 1)) && len != 0;
-                        (void) --len, ++first)
+                     (reinterpret_cast<std::uintptr_t>(std::addressof(*first)) &
+                         (V::MemoryAlignment - 1)) && len != 0;
+                     (void) --len, ++first)
                 {
                     V1 tmp(std::addressof(*first), Vc::Aligned);
                     f(&tmp);
@@ -104,9 +104,9 @@ namespace hpx { namespace parallel { namespace util
                 std::size_t len = count;
 
                 for (/* */;
-                        (reinterpret_cast<std::uintptr_t>(std::addressof(*first)) &
-                            (V::MemoryAlignment - 1)) && len != 0;
-                        (void) --len, ++first)
+                     (reinterpret_cast<std::uintptr_t>(std::addressof(*first)) &
+                         (V::MemoryAlignment - 1)) && len != 0;
+                     (void) --len, ++first)
                 {
                     V1 tmp(std::addressof(*first), Vc::Aligned);
                     f(&tmp);
@@ -151,6 +151,13 @@ namespace hpx { namespace parallel { namespace util
                     std::forward<F>(f));
             }
         };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename T, typename Abi>
+        inline std::size_t count_bits(Vc::Mask<T, Abi> const& mask)
+        {
+            return mask.count();
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/hpx/parallel/datapar/transform_loop.hpp
+++ b/hpx/parallel/datapar/transform_loop.hpp
@@ -1,0 +1,507 @@
+//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2016 Matthias Kretz
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_DATAPAR_TRANSFORM_LOOP_SEP_08_2016_0657PM)
+#define HPX_PARALLEL_DATAPAR_TRANSFORM_LOOP_SEP_08_2016_0657PM
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_VC_DATAPAR)
+#include <hpx/util/decay.hpp>
+#include <hpx/util/invoke.hpp>
+#include <hpx/util/tuple.hpp>
+
+#include <hpx/parallel/datapar/detail/iterator_helpers.hpp>
+#include <hpx/parallel/datapar/execution_policy_fwd.hpp>
+#include <hpx/parallel/util/cancellation_token.hpp>
+#include <hpx/traits/is_iterator.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+#include <Vc/Vc>
+
+namespace hpx { namespace parallel { namespace util
+{
+    template <typename F, typename InIter, typename OutIter>
+    HPX_HOST_DEVICE HPX_FORCEINLINE void
+    transform_loop_step(parallel::v1::datapar_execution_policy, F && f,
+        InIter it, OutIter dest)
+    {
+        detail::datapar_transform_loop_step::call1(std::forward<F>(f),
+            it, dest, Vc::Unaligned);
+    }
+
+    template <typename F, typename InIter1, typename InIter2, typename OutIter>
+    HPX_HOST_DEVICE HPX_FORCEINLINE void
+    transform_loop_step(parallel::v1::datapar_execution_policy, F && f,
+        InIter1 it1, InIter2 it2, OutIter dest)
+    {
+        detail::datapar_transform_loop_step::call1(std::forward<F>(f),
+            it1, it2, dest, Vc::Unaligned);
+    }
+
+    template <typename F, typename InIter, typename OutIter>
+    HPX_HOST_DEVICE HPX_FORCEINLINE void
+    transform_loop_step(parallel::v1::datapar_task_execution_policy, F && f,
+        InIter it, OutIter dest)
+    {
+        detail::datapar_transform_loop_step::call1(std::forward<F>(f),
+            it, dest, Vc::Unaligned);
+    }
+
+    template <typename F, typename InIter1, typename InIter2, typename OutIter>
+    HPX_HOST_DEVICE HPX_FORCEINLINE void
+    transform_loop_step(parallel::v1::datapar_task_execution_policy, F && f,
+        InIter1 it1, InIter2 it2, OutIter dest)
+    {
+        detail::datapar_transform_loop_step::call1(std::forward<F>(f),
+            it1, it2, dest, Vc::Unaligned);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        template <typename Iterator>
+        struct datapar_transform_loop_n
+        {
+            typedef typename hpx::util::decay<Iterator>::type iterator_type;
+            typedef Vc::Vector<typename iterator_type::value_type> V;
+
+            template <typename InIter, typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::enable_if<
+                std::is_arithmetic<typename InIter::value_type>::value &&
+                    hpx::traits::is_random_access_iterator<InIter>::value &&
+                    hpx::traits::is_random_access_iterator<OutIter>::value &&
+                    iterators_datapar_compatible<InIter, OutIter>::value,
+                std::pair<InIter, OutIter>
+            >::type
+            call(InIter first, std::size_t count, OutIter dest, F && f)
+            {
+                std::size_t len = count;
+
+                // fall back to unaligned execution if input and output types
+                // are not compatible
+                if (data_alignment(first) != data_alignment(dest))
+                {
+                    for (std::int64_t lenV = std::int64_t(count - (V::Size + 1));
+                            lenV > 0;
+                            lenV -= V::Size, len -= V::Size, first += V::Size,
+                                dest += V::Size)
+                    {
+                        datapar_transform_loop_step::callv(f, first, dest,
+                            Vc::Unaligned);
+                    }
+
+                    for (/* */; len != 0; (void) --len, ++first, ++dest)
+                    {
+                        datapar_transform_loop_step::call1(f, first, dest,
+                            Vc::Unaligned);
+                    }
+                }
+                else
+                {
+                    for (/* */; data_alignment(first) && len != 0;
+                         (void) --len, ++first, ++dest)
+                    {
+                        datapar_transform_loop_step::call1(f, first, dest,
+                            Vc::Aligned);
+                    }
+
+                    for (std::int64_t lenV = std::int64_t(count - (V::Size + 1));
+                            lenV > 0;
+                            lenV -= V::Size, len -= V::Size, first += V::Size,
+                                dest += V::Size)
+                    {
+                        datapar_transform_loop_step::callv(f, first, dest,
+                            Vc::Aligned);
+                    }
+
+                    for (/* */; len != 0; (void) --len, ++first, ++dest)
+                    {
+                        datapar_transform_loop_step::call1(f, first, dest,
+                            Vc::Aligned);
+                    }
+                }
+                return std::make_pair(std::move(first), std::move(dest));
+            }
+
+            template <typename InIter, typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::enable_if<
+               !std::is_arithmetic<typename InIter::value_type>::value ||
+                   !hpx::traits::is_random_access_iterator<InIter>::value ||
+                   !hpx::traits::is_random_access_iterator<OutIter>::value ||
+                   !iterators_datapar_compatible<InIter, OutIter>::value ||
+                   !iterators_datapar_compatible<InIter, OutIter>::value,
+                std::pair<InIter, OutIter>
+            >::type
+            call(InIter first, std::size_t count, OutIter dest, F && f)
+            {
+                return util::transform_loop_n(parallel::v1::seq, first, count,
+                    dest, std::forward<F>(f));
+            }
+        };
+    }
+
+    template <typename Iter, typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE
+    std::pair<Iter, OutIter>
+    transform_loop_n(parallel::v1::datapar_execution_policy, Iter it,
+        std::size_t count, OutIter dest, F && f)
+    {
+        return detail::datapar_transform_loop_n<Iter>::call(it, count, dest,
+            std::forward<F>(f));
+    }
+
+    template <typename Iter, typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE
+    std::pair<Iter, OutIter>
+    transform_loop_n(parallel::v1::datapar_task_execution_policy, Iter it,
+        std::size_t count, OutIter dest, F && f)
+    {
+        return detail::datapar_transform_loop_n<Iter>::call(it, count, dest,
+            std::forward<F>(f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        template <typename Iterator>
+        struct datapar_transform_loop
+        {
+            typedef typename hpx::util::decay<Iterator>::type iterator_type;
+
+            typedef Vc::Vector<typename iterator_type::value_type> V;
+            typedef Vc::Scalar::Vector<typename iterator_type::value_type> V1;
+
+            template <typename InIter, typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::enable_if<
+                std::is_arithmetic<typename InIter::value_type>::value &&
+                    hpx::traits::is_random_access_iterator<InIter>::value &&
+                    hpx::traits::is_random_access_iterator<OutIter>::value &&
+                    iterators_datapar_compatible<InIter, OutIter>::value,
+                std::pair<InIter, OutIter>
+            >::type
+            call(InIter first, InIter last, OutIter dest, F && f)
+            {
+                return util::transform_loop_n(parallel::v1::datapar_execution,
+                    first, std::distance(first, last), dest, std::forward<F>(f));
+            }
+
+            template <typename InIter, typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::enable_if<
+               !std::is_arithmetic<typename InIter::value_type>::value ||
+                   !hpx::traits::is_random_access_iterator<InIter>::value ||
+                   !hpx::traits::is_random_access_iterator<OutIter>::value ||
+                   !iterators_datapar_compatible<InIter, OutIter>::value,
+                std::pair<InIter, OutIter>
+            >::type
+            call(InIter first, InIter last, OutIter dest, F && f)
+            {
+                return util::transform_loop(parallel::v1::seq,
+                    first, last, dest, std::forward<F>(f));
+            }
+        };
+    }
+
+    template <typename Iter, typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE
+    std::pair<Iter, OutIter>
+    transform_loop(parallel::v1::datapar_execution_policy, Iter it, Iter end,
+        OutIter dest, F && f)
+    {
+        return detail::datapar_transform_loop<Iter>::call(it, end, dest,
+            std::forward<F>(f));
+    }
+
+    template <typename Iter, typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE
+    std::pair<Iter, OutIter>
+    transform_loop(parallel::v1::datapar_task_execution_policy, Iter it,
+        Iter end, OutIter dest, F && f)
+    {
+        return detail::datapar_transform_loop<Iter>::call(it, end, dest,
+            std::forward<F>(f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        template <typename Iter1, typename Iter2>
+        struct datapar_transform_binary_loop_n
+        {
+            typedef typename hpx::util::decay<Iter1>::type iterator1_type;
+            typedef Vc::Vector<typename iterator1_type::value_type> V;
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::enable_if<
+                std::is_arithmetic<typename InIter1::value_type>::value &&
+                    std::is_arithmetic<typename InIter2::value_type>::value &&
+                    hpx::traits::is_random_access_iterator<InIter1>::value &&
+                    hpx::traits::is_random_access_iterator<InIter2>::value &&
+                    hpx::traits::is_random_access_iterator<OutIter>::value &&
+                    iterators_datapar_compatible<InIter1, OutIter>::value &&
+                    iterators_datapar_compatible<InIter2, OutIter>::value,
+                hpx::util::tuple<InIter1, InIter2, OutIter>
+            >::type
+            call(InIter1 first1, std::size_t count, InIter2 first2,
+                OutIter dest, F && f)
+            {
+                std::size_t len = count;
+
+                // fall back to unaligned execution if input and output types
+                // are not compatible
+                if (data_alignment(first1) != data_alignment(dest) ||
+                    data_alignment(first2) != data_alignment(dest))
+                {
+                    for (std::int64_t lenV = std::int64_t(count - (V::Size + 1));
+                            lenV > 0;
+                            lenV -= V::Size, len -= V::Size,
+                                first1 += V::Size, first2 += V::Size,
+                                dest += V::Size)
+                    {
+                        datapar_transform_loop_step::callv(f, first1, first2,
+                            dest, Vc::Unaligned);
+                    }
+
+                    for (/* */; len != 0;
+                            (void) --len, ++first1, ++first2, ++dest)
+                    {
+                        datapar_transform_loop_step::call1(f, first1, first2,
+                            dest, Vc::Unaligned);
+                    }
+                }
+                else
+                {
+                    for (/* */; data_alignment(first1) && len != 0;
+                            (void) --len, ++first1, ++first2, ++dest)
+                    {
+                        datapar_transform_loop_step::call1(f, first1, first2,
+                            dest, Vc::Aligned);
+                    }
+
+                    for (std::int64_t lenV = std::int64_t(count - (V::Size + 1));
+                            lenV > 0;
+                            lenV -= V::Size, len -= V::Size,
+                                first1 += V::Size, first2 += V::Size,
+                                dest += V::Size)
+                    {
+                        datapar_transform_loop_step::callv(f, first1, first2,
+                            dest, Vc::Aligned);
+                    }
+
+                    for (/* */; len != 0;
+                            (void) --len, ++first1, ++first2, ++dest)
+                    {
+                        datapar_transform_loop_step::call1(f, first1, first2,
+                            dest, Vc::Aligned);
+                    }
+                }
+                return hpx::util::make_tuple(std::move(first1),
+                    std::move(first2), std::move(dest));
+            }
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::enable_if<
+               !std::is_arithmetic<typename InIter1::value_type>::value ||
+                   !std::is_arithmetic<typename InIter2::value_type>::value ||
+                   !hpx::traits::is_random_access_iterator<InIter1>::value ||
+                   !hpx::traits::is_random_access_iterator<InIter2>::value ||
+                   !hpx::traits::is_random_access_iterator<OutIter>::value ||
+                   !iterators_datapar_compatible<InIter1, OutIter>::value ||
+                   !iterators_datapar_compatible<InIter2, OutIter>::value,
+                hpx::util::tuple<InIter1, InIter2, OutIter>
+            >::type
+            call(InIter1 first1, std::size_t count, InIter2 first2,
+                OutIter dest, F && f)
+            {
+                return util::transform_binary_loop_n(parallel::v1::seq,
+                    first1, count, first2, dest, std::forward<F>(f));
+            }
+        };
+    }
+
+    template <typename InIter1, typename InIter2, typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE
+    hpx::util::tuple<InIter1, InIter2, OutIter>
+    transform_binary_loop_n(parallel::v1::datapar_execution_policy,
+        InIter1 first1, std::size_t count, InIter2 first2, OutIter dest, F && f)
+    {
+        return detail::datapar_transform_binary_loop_n<InIter1, InIter2>::call(
+            first1, count, first2, dest, std::forward<F>(f));
+    }
+
+    template <typename InIter1, typename InIter2, typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE
+    hpx::util::tuple<InIter1, InIter2, OutIter>
+    transform_binary_loop_n(parallel::v1::datapar_task_execution_policy,
+        InIter1 first1, std::size_t count, InIter2 first2, OutIter dest, F && f)
+    {
+        return detail::datapar_transform_binary_loop_n<InIter1, InIter2>::call(
+            first1, count, first2, dest, std::forward<F>(f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        template <typename Iter1, typename Iter2>
+        struct datapar_transform_binary_loop
+        {
+            typedef typename hpx::util::decay<Iter1>::type iterator1_type;
+            typedef Vc::Scalar::Vector<typename iterator1_type::value_type> V11;
+
+            typedef typename hpx::util::decay<Iter2>::type iterator2_type;
+            typedef Vc::Scalar::Vector<typename iterator2_type::value_type> V12;
+
+            typedef Vc::Vector<typename iterator1_type::value_type> V1;
+            typedef Vc::Vector<typename iterator2_type::value_type> V2;
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::enable_if<
+                std::is_arithmetic<typename InIter1::value_type>::value &&
+                    std::is_arithmetic<typename InIter2::value_type>::value &&
+                    hpx::traits::is_random_access_iterator<InIter1>::value &&
+                    hpx::traits::is_random_access_iterator<InIter2>::value &&
+                    hpx::traits::is_random_access_iterator<OutIter>::value &&
+                    iterators_datapar_compatible<InIter1, OutIter>::value &&
+                    iterators_datapar_compatible<InIter2, OutIter>::value,
+                hpx::util::tuple<InIter1, InIter2, OutIter>
+            >::type
+            call(InIter1 first1, InIter1 last1, InIter2 first2, OutIter dest,
+                F && f)
+            {
+                return util::transform_binary_loop_n(
+                    parallel::v1::datapar_execution,
+                    first1, std::distance(first1, last1), first2, dest,
+                    std::forward<F>(f));
+            }
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::enable_if<
+               !std::is_arithmetic<typename InIter1::value_type>::value ||
+                   !std::is_arithmetic<typename InIter2::value_type>::value ||
+                   !hpx::traits::is_random_access_iterator<InIter1>::value ||
+                   !hpx::traits::is_random_access_iterator<InIter2>::value ||
+                   !hpx::traits::is_random_access_iterator<OutIter>::value ||
+                   !iterators_datapar_compatible<InIter1, OutIter>::value ||
+                   !iterators_datapar_compatible<InIter2, OutIter>::value,
+                hpx::util::tuple<InIter1, InIter2, OutIter>
+            >::type
+            call(InIter1 first1, InIter1 last1, InIter2 first2, OutIter dest,
+                F && f)
+            {
+                return util::transform_binary_loop(parallel::v1::seq,
+                    first1, last1, first2, dest, std::forward<F>(f));
+            }
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::enable_if<
+                std::is_arithmetic<typename InIter1::value_type>::value &&
+                    std::is_arithmetic<typename InIter2::value_type>::value &&
+                    hpx::traits::is_random_access_iterator<InIter1>::value &&
+                    hpx::traits::is_random_access_iterator<InIter2>::value &&
+                    hpx::traits::is_random_access_iterator<OutIter>::value &&
+                    iterators_datapar_compatible<InIter1, OutIter>::value &&
+                    iterators_datapar_compatible<InIter2, OutIter>::value,
+                hpx::util::tuple<InIter1, InIter2, OutIter>
+            >::type
+            call(InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2,
+                OutIter dest, F && f)
+            {
+                std::size_t count = (std::min)(std::distance(first1, last1),
+                    std::distance(first2, last2));
+
+                return util::transform_binary_loop_n(
+                    parallel::v1::datapar_execution,
+                    first1, count, first2, dest, std::forward<F>(f));
+            }
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static typename std::enable_if<
+               !std::is_arithmetic<typename InIter1::value_type>::value ||
+                   !std::is_arithmetic<typename InIter2::value_type>::value ||
+                   !hpx::traits::is_random_access_iterator<InIter1>::value ||
+                   !hpx::traits::is_random_access_iterator<InIter2>::value ||
+                   !hpx::traits::is_random_access_iterator<OutIter>::value ||
+                   !iterators_datapar_compatible<InIter1, OutIter>::value ||
+                   !iterators_datapar_compatible<InIter2, OutIter>::value,
+                hpx::util::tuple<InIter1, InIter2, OutIter>
+            >::type
+            call(InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2,
+                OutIter dest, F && f)
+            {
+                return util::transform_binary_loop(parallel::v1::seq,
+                    first1, last1, first2, last2, dest, std::forward<F>(f));
+            }
+        };
+    }
+
+    template <typename InIter1, typename InIter2, typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE
+    hpx::util::tuple<InIter1, InIter2, OutIter>
+    transform_binary_loop(parallel::v1::datapar_execution_policy,
+        InIter1 first1, InIter1 last1, InIter2 first2, OutIter dest, F && f)
+    {
+        return detail::datapar_transform_binary_loop<InIter1, InIter2>::call(
+            first1, last1, first2, dest, std::forward<F>(f));
+    }
+
+    template <typename InIter1, typename InIter2, typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE
+    hpx::util::tuple<InIter1, InIter2, OutIter>
+    transform_binary_loop(parallel::v1::datapar_task_execution_policy,
+        InIter1 first1, InIter1 last1, InIter2 first2, OutIter dest, F && f)
+    {
+        return detail::datapar_transform_binary_loop<InIter1, InIter2>::call(
+            first1, last1, first2, dest, std::forward<F>(f));
+    }
+
+    template <typename InIter1, typename InIter2, typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE
+    hpx::util::tuple<InIter1, InIter2, OutIter>
+    transform_binary_loop(parallel::v1::datapar_execution_policy,
+        InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2,
+        OutIter dest, F && f)
+    {
+        return detail::datapar_transform_binary_loop<InIter1, InIter2>::call(
+            first1, last1, first2, last2, dest, std::forward<F>(f));
+    }
+
+    template <typename InIter1, typename InIter2,
+        typename OutIter, typename F, typename Proj1, typename Proj2>
+    HPX_HOST_DEVICE HPX_FORCEINLINE
+    hpx::util::tuple<InIter1, InIter2, OutIter>
+    transform_binary_loop(parallel::v1::datapar_task_execution_policy,
+        InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2,
+        OutIter dest, F && f)
+    {
+        return detail::datapar_transform_binary_loop<InIter1, InIter2>::call(
+            first1, last1, first2, last2, dest, std::forward<F>(f));
+    }
+}}}
+
+#endif
+#endif
+

--- a/hpx/parallel/exception_list.hpp
+++ b/hpx/parallel/exception_list.hpp
@@ -112,6 +112,36 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
           : handle_exception_impl<parallel_task_execution_policy, Result>
         {};
 
+#if defined(HPX_HAVE_VC_DATAPAR)
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Result>
+        struct handle_exception_impl<datapar_task_execution_policy, Result>
+        {
+            typedef future<Result> type;
+
+            static future<Result> call()
+            {
+                try {
+                    try {
+                        throw; //-V667
+                    }
+                    catch(std::bad_alloc const& e) {
+                        boost::throw_exception(e);
+                    }
+                    catch (...) {
+                        boost::throw_exception(
+                            hpx::exception_list(boost::current_exception())
+                        );
+                    }
+                }
+                catch (...) {
+                    return hpx::make_exceptional_future<Result>(
+                        boost::current_exception());
+                }
+            }
+        };
+#endif
+
         ///////////////////////////////////////////////////////////////////////
         template <typename Result>
         struct handle_exception_impl<parallel_vector_execution_policy, Result>

--- a/hpx/parallel/execution_policy_fwd.hpp
+++ b/hpx/parallel/execution_policy_fwd.hpp
@@ -8,6 +8,9 @@
 
 #include <hpx/config.hpp>
 #include <hpx/parallel/config/inline_namespace.hpp>
+#if defined(HPX_HAVE_VC_DATAPAR)
+#include <hpx/parallel/datapar/execution_policy_fwd.hpp>
+#endif
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 {

--- a/hpx/parallel/executors/executor_parameters.hpp
+++ b/hpx/parallel/executors/executor_parameters.hpp
@@ -57,7 +57,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v3)
             // default constructor is needed for serialization purposes
             unwrapper() : T() {}
 
-            // generic poor-mans forwarding constructor
+            // generic poor-man's forwarding constructor
             template <typename U>
             unwrapper(U && u) : T(std::forward<U>(u)) {}
         };

--- a/hpx/parallel/executors/rebind_executor.hpp
+++ b/hpx/parallel/executors/rebind_executor.hpp
@@ -1,0 +1,55 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_REBIND_EXECUTOR_SEP_07_2016_0658AM)
+#define HPX_PARALLEL_REBIND_EXECUTOR_SEP_07_2016_0658AM
+
+#include <hpx/config.hpp>
+#include <hpx/parallel/config/inline_namespace.hpp>
+#include <hpx/parallel/executors/executor_traits.hpp>
+#include <hpx/util/decay.hpp>
+
+namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    /// \cond NOINTERNAL
+    struct task_execution_policy_tag
+    {
+        task_execution_policy_tag() {}
+    };
+    /// \endcond
+
+    /// The execution policy tag \a task can be used to create a execution
+    /// policy which forces the given algorithm to be executed in an
+    /// asynchronous way.
+    static task_execution_policy_tag const task;
+
+    /// Rebind the type of executor used by an execution policy. The execution
+    /// category of Executor shall not be weaker than that of ExecutionPolicy.
+    template <typename ExecutionPolicy, typename Executor, typename Parameters>
+    struct rebind_executor
+    {
+        /// \cond NOINTERNAL
+        typedef typename hpx::util::decay<Executor>::type executor_type;
+        typedef typename hpx::util::decay<Parameters>::type parameters_type;
+
+        typedef typename ExecutionPolicy::execution_category category1;
+        typedef typename executor_traits<executor_type>::execution_category
+            category2;
+
+        static_assert(
+            (parallel::v3::detail::is_not_weaker<category2, category1>::value),
+            "parallel::v3::detail::is_not_weaker<category2, category1>::value"
+        );
+        /// \endcond
+
+        /// The type of the rebound execution policy
+        typedef typename ExecutionPolicy::template rebind<
+                executor_type, parameters_type
+            >::type type;
+    };
+}}}
+
+#endif

--- a/hpx/parallel/segmented_algorithms/minmax.hpp
+++ b/hpx/parallel/segmented_algorithms/minmax.hpp
@@ -109,7 +109,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             }
 
             return Algo::sequential_minmax_element_ind(
-                positions.begin(), positions.size(), f, proj);
+                policy, positions.begin(), positions.size(), f, proj);
         }
 
         // parallel remote implementation
@@ -219,7 +219,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         std::vector<SegIter> res =
                             hpx::util::unwrapped(std::move(r));
                         return Algo::sequential_minmax_element_ind(
-                            res.begin(), res.size(), f, proj);
+                            policy, res.begin(), res.size(), f, proj);
                     },
                     std::move(segments)));
         }
@@ -383,8 +383,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                 }
             }
 
-            return sequential_minmax_element_ind(
-                positions.begin(), positions.size(), f, proj);
+            return Algo::sequential_minmax_element_ind(
+                policy, positions.begin(), positions.size(), f, proj);
         }
 
         // parallel remote implementation
@@ -508,8 +508,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 
                         std::vector<result_type> res =
                             hpx::util::unwrapped(std::move(r));
-                        return sequential_minmax_element_ind(
-                            res.begin(), res.size(), f, proj);
+                        return Algo::sequential_minmax_element_ind(
+                            policy, res.begin(), res.size(), f, proj);
                     },
                     std::move(segments)));
         }

--- a/hpx/parallel/util/detail/algorithm_result.hpp
+++ b/hpx/parallel/util/detail/algorithm_result.hpp
@@ -8,7 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/lcos/future.hpp>
-#include <hpx/parallel/execution_policy.hpp>
+#include <hpx/parallel/execution_policy_fwd.hpp>
 #include <hpx/traits/concepts.hpp>
 #include <hpx/util/invoke.hpp>
 #include <hpx/util/unused.hpp>
@@ -158,6 +158,56 @@ namespace hpx { namespace parallel { namespace util { namespace detail
             return hpx::future<void>(std::move(t));
         }
     };
+
+#if defined(HPX_HAVE_VC_DATAPAR)
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    struct algorithm_result_impl<datapar_task_execution_policy, T>
+    {
+        // The return type of the initiating function.
+        typedef hpx::future<T> type;
+
+        // Obtain initiating function's return type.
+        static type get(T && t)
+        {
+            return hpx::make_ready_future(std::move(t));
+        }
+
+        static type get(hpx::future<T> && t)
+        {
+            return std::move(t);
+        }
+    };
+
+    template <>
+    struct algorithm_result_impl<datapar_task_execution_policy, void>
+    {
+        // The return type of the initiating function.
+        typedef hpx::future<void> type;
+
+        // Obtain initiating function's return type.
+        static type get()
+        {
+            return hpx::make_ready_future();
+        }
+
+        static type get(hpx::util::unused_type)
+        {
+            return hpx::make_ready_future();
+        }
+
+        static type get(hpx::future<void> && t)
+        {
+            return std::move(t);
+        }
+
+        template <typename T>
+        static type get(hpx::future<T> && t)
+        {
+            return hpx::future<void>(std::move(t));
+        }
+    };
+#endif
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Executor, typename Parameters, typename T>

--- a/hpx/parallel/util/detail/partitioner_iteration.hpp
+++ b/hpx/parallel/util/detail/partitioner_iteration.hpp
@@ -31,6 +31,19 @@ namespace hpx { namespace parallel { namespace util
                 return hpx::util::invoke_fused(f_, std::forward<T>(t));
             }
         };
+
+        template <typename F>
+        struct partitioner_iteration<void, F>
+        {
+            typename hpx::util::decay<F>::type f_;
+
+            template <typename T>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            void operator()(T && t)
+            {
+                hpx::util::invoke_fused(f_, std::forward<T>(t));
+            }
+        };
     }
 }}}
 

--- a/hpx/parallel/util/foreach_partitioner.hpp
+++ b/hpx/parallel/util/foreach_partitioner.hpp
@@ -229,6 +229,25 @@ namespace hpx { namespace parallel { namespace util
             }
         };
 
+#if defined(HPX_HAVE_VC_DATAPAR)
+        template <typename Result>
+        struct foreach_partitioner<datapar_task_execution_policy, Result,
+                parallel::traits::static_partitioner_tag>
+        {
+            template <typename ExPolicy, typename FwdIter, typename F1,
+                typename F2>
+            static hpx::future<FwdIter> call(ExPolicy && policy,
+                FwdIter first, std::size_t count, F1 && f1, F2 && f2)
+            {
+                return foreach_static_partitioner<
+                        parallel_task_execution_policy, Result
+                    >::call(
+                        std::forward<ExPolicy>(policy), first, count,
+                        std::forward<F1>(f1), std::forward<F2>(f2));
+            }
+        };
+#endif
+
         template <typename Executor, typename Parameters, typename Result>
         struct foreach_partitioner<
                 parallel_task_execution_policy_shim<Executor, Parameters>,

--- a/hpx/parallel/util/loop.hpp
+++ b/hpx/parallel/util/loop.hpp
@@ -108,6 +108,12 @@ namespace hpx { namespace parallel { namespace util
                 return it;
             }
         };
+
+        ///////////////////////////////////////////////////////////////////////
+        inline std::size_t count_bits(bool value)
+        {
+            return value ? 1 : 0;
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/hpx/parallel/util/loop.hpp
+++ b/hpx/parallel/util/loop.hpp
@@ -25,10 +25,10 @@
 namespace hpx { namespace parallel { namespace util
 {
     ///////////////////////////////////////////////////////////////////////////
-    template <typename ExPolicy, typename F, typename ... Iters>
+    template <typename ExPolicy, typename VecOnly, typename F, typename ... Iters>
     HPX_HOST_DEVICE HPX_FORCEINLINE
     typename std::result_of<F&&(Iters...)>::type
-    loop_step(ExPolicy&&, F && f, Iters& ... its)
+    loop_step(ExPolicy&&, VecOnly, F && f, Iters& ... its)
     {
         return hpx::util::invoke(std::forward<F>(f), (its++)...);
     }
@@ -114,10 +114,10 @@ namespace hpx { namespace parallel { namespace util
         };
     }
 
-    template <typename ExPolicy, typename Begin1, typename End1,
-        typename Begin2, typename F>
+    template <typename ExPolicy, typename VecOnly,
+        typename Begin1, typename End1, typename Begin2, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE std::pair<Begin1, Begin2>
-    loop2(ExPolicy&&, Begin1 begin1, End1 end1, Begin2 begin2, F && f)
+    loop2(ExPolicy&&, VecOnly, Begin1 begin1, End1 end1, Begin2 begin2, F && f)
     {
         return detail::loop2<Begin1, Begin2>::call(begin1, end1, begin2,
             std::forward<F>(f));
@@ -163,11 +163,18 @@ namespace hpx { namespace parallel { namespace util
             return value ? 1 : 0;
         }
 
+        template <typename ExPolicy, typename T>
+        HPX_HOST_DEVICE HPX_FORCEINLINE
+        T const& extract_value(ExPolicy&&, T const& v)
+        {
+            return v;
+        }
+
         template <typename ExPolicy, typename F, typename T>
         HPX_HOST_DEVICE HPX_FORCEINLINE
-        T && accumulate_values(ExPolicy&&, F &&, T && v)
+        T const& accumulate_values(ExPolicy&&, F &&, T const& v)
         {
-            return std::forward<T>(v);
+            return v;
         }
 
         template <typename ExPolicy, typename F, typename T, typename T1>

--- a/hpx/parallel/util/loop.hpp
+++ b/hpx/parallel/util/loop.hpp
@@ -30,8 +30,6 @@ namespace hpx { namespace parallel { namespace util
         template <typename Iterator>
         struct loop
         {
-            typedef Iterator type;
-
             ///////////////////////////////////////////////////////////////////
             template <typename Begin, typename End, typename F>
             HPX_HOST_DEVICE HPX_FORCEINLINE
@@ -60,16 +58,17 @@ namespace hpx { namespace parallel { namespace util
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Begin, typename End, typename F>
+    template <typename ExPolicy, typename Begin, typename End, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Begin
-    loop(Begin begin, End end, F && f)
+    loop(ExPolicy&&, Begin begin, End end, F && f)
     {
         return detail::loop<Begin>::call(begin, end, std::forward<F>(f));
     }
 
-    template <typename Begin, typename End, typename CancelToken, typename F>
+    template <typename ExPolicy, typename Begin, typename End,
+        typename CancelToken, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Begin
-    loop(Begin begin, End end, CancelToken& tok, F && f)
+    loop(ExPolicy&&, Begin begin, End end, CancelToken& tok, F && f)
     {
         return detail::loop<Begin>::call(begin, end, tok, std::forward<F>(f));
     }
@@ -82,8 +81,6 @@ namespace hpx { namespace parallel { namespace util
         template <typename Iterator>
         struct loop_n
         {
-            typedef Iterator type;
-
             ///////////////////////////////////////////////////////////////////
             // handle sequences of non-futures
             template <typename Iter, typename F>

--- a/hpx/parallel/util/loop.hpp
+++ b/hpx/parallel/util/loop.hpp
@@ -7,6 +7,9 @@
 #define HPX_PARALLEL_UTIL_LOOP_MAY_27_2014_1040PM
 
 #include <hpx/config.hpp>
+#if defined(HPX_HAVE_VC_DATAPAR)
+#include <hpx/parallel/datapar/loop.hpp>
+#endif
 #include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/util/tuple.hpp>
 
@@ -94,8 +97,7 @@ namespace hpx { namespace parallel { namespace util
 
             template <typename Iter, typename CancelToken, typename F>
             HPX_HOST_DEVICE HPX_FORCEINLINE
-            static Iter call(Iter it, std::size_t count, CancelToken& tok,
-                F && f)
+            static Iter call(Iter it, std::size_t count, CancelToken& tok, F && f)
             {
                 for (/**/; count != 0; (void) --count, ++it)
                 {
@@ -109,16 +111,16 @@ namespace hpx { namespace parallel { namespace util
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Iter, typename F>
+    template <typename ExPolicy, typename Iter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Iter
-    loop_n(Iter it, std::size_t count, F && f)
+    loop_n(ExPolicy &&, Iter it, std::size_t count, F && f)
     {
         return detail::loop_n<Iter>::call(it, count, std::forward<F>(f));
     }
 
-    template <typename Iter, typename CancelToken, typename F>
+    template <typename ExPolicy, typename Iter, typename CancelToken, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Iter
-    loop_n(Iter it, std::size_t count, CancelToken& tok, F && f)
+    loop_n(ExPolicy &&, Iter it, std::size_t count, CancelToken& tok, F && f)
     {
         return detail::loop_n<Iter>::call(it, count, tok, std::forward<F>(f));
     }

--- a/hpx/parallel/util/partitioner.hpp
+++ b/hpx/parallel/util/partitioner.hpp
@@ -583,6 +583,52 @@ namespace hpx { namespace parallel { namespace util
             }
         };
 
+#if defined(HPX_HAVE_VC_DATAPAR)
+        template <typename R, typename Result>
+        struct partitioner<datapar_task_execution_policy, R, Result,
+            parallel::traits::static_partitioner_tag>
+        {
+            template <typename ExPolicy, typename FwdIter, typename F1,
+                typename F2>
+            static hpx::future<R> call(ExPolicy && policy,
+                FwdIter first, std::size_t count, F1 && f1, F2 && f2)
+            {
+                return static_partitioner<
+                        parallel_task_execution_policy, R, Result
+                    >::call(
+                        std::forward<ExPolicy>(policy), first, count,
+                        std::forward<F1>(f1), std::forward<F2>(f2));
+            }
+
+            template <typename ExPolicy, typename FwdIter, typename F1,
+                typename F2, typename Data>
+            static hpx::future<R> call_with_data(ExPolicy && policy,
+                FwdIter first, std::size_t count, F1 && f1, F2 && f2,
+                std::vector<std::size_t> const& chunk_sizes, Data && data)
+            {
+                return static_partitioner<
+                        parallel_task_execution_policy, R, Result
+                    >::call_with_data(
+                        std::forward<ExPolicy>(policy), first, count,
+                        std::forward<F1>(f1), std::forward<F2>(f2),
+                        chunk_sizes, std::forward<Data>(data));
+            }
+
+            template <typename ExPolicy, typename FwdIter, typename Stride,
+                typename F1, typename F2>
+            static hpx::future<R> call_with_index(ExPolicy && policy,
+                FwdIter first, std::size_t count, Stride stride,
+                F1 && f1, F2 && f2)
+            {
+                return static_partitioner<
+                        parallel_task_execution_policy, R, Result
+                    >::call_with_index(
+                        std::forward<ExPolicy>(policy), first, count, stride,
+                        std::forward<F1>(f1), std::forward<F2>(f2));
+            }
+        };
+#endif
+
         template <typename Executor, typename Parameters, typename R,
             typename Result>
         struct partitioner<

--- a/hpx/parallel/util/prefetching.hpp
+++ b/hpx/parallel/util/prefetching.hpp
@@ -344,9 +344,9 @@ namespace hpx { namespace parallel { namespace util
                     sizeof...(Ts)
                 >::type index_pack_type;
 
-            template <typename F>
+            template <typename ExPolicy_, typename F>
             static iterator_type
-            call(iterator_type it, std::size_t count, F && f)
+            call(ExPolicy_&&, iterator_type it, std::size_t count, F && f)
             {
                 for (/**/; count != 0; (void) --count, ++it)
                 {
@@ -365,9 +365,10 @@ namespace hpx { namespace parallel { namespace util
                 return it;
             }
 
-            template <typename CancelToken, typename F>
+            template <typename ExPolicy_, typename CancelToken, typename F>
             static iterator_type
-            call(iterator_type it, std::size_t count, CancelToken& tok, F && f)
+            call(ExPolicy_&&, iterator_type it, std::size_t count,
+                CancelToken& tok, F && f)
             {
                 for (/**/; count != 0; (void) --count, ++it)
                 {

--- a/hpx/parallel/util/prefetching.hpp
+++ b/hpx/parallel/util/prefetching.hpp
@@ -344,9 +344,9 @@ namespace hpx { namespace parallel { namespace util
                     sizeof...(Ts)
                 >::type index_pack_type;
 
-            template <typename ExPolicy_, typename F>
+            template <typename F>
             static iterator_type
-            call(ExPolicy_&&, iterator_type it, std::size_t count, F && f)
+            call(iterator_type it, std::size_t count, F && f)
             {
                 for (/**/; count != 0; (void) --count, ++it)
                 {
@@ -365,10 +365,9 @@ namespace hpx { namespace parallel { namespace util
                 return it;
             }
 
-            template <typename ExPolicy_, typename CancelToken, typename F>
+            template <typename CancelToken, typename F>
             static iterator_type
-            call(ExPolicy_&&, iterator_type it, std::size_t count,
-                CancelToken& tok, F && f)
+            call(iterator_type it, std::size_t count, CancelToken& tok, F && f)
             {
                 for (/**/; count != 0; (void) --count, ++it)
                 {

--- a/hpx/parallel/util/transform_loop.hpp
+++ b/hpx/parallel/util/transform_loop.hpp
@@ -21,22 +21,6 @@
 
 namespace hpx { namespace parallel { namespace util
 {
-    template <typename ExPolicy, typename F, typename InIter, typename OutIter>
-    HPX_HOST_DEVICE HPX_FORCEINLINE
-    void transform_loop_step(ExPolicy&&, F && f, InIter it, OutIter dest)
-    {
-        *dest = hpx::util::invoke(std::forward<F>(f), it);
-    }
-
-    template <typename ExPolicy, typename F, typename InIter1,
-        typename InIter2, typename OutIter>
-    HPX_HOST_DEVICE HPX_FORCEINLINE
-    void transform_loop_step(ExPolicy&&, F && f, InIter1 it1, InIter2 it2,
-        OutIter dest)
-    {
-        *dest = hpx::util::invoke(std::forward<F>(f), it1, it2);
-    }
-
     ///////////////////////////////////////////////////////////////////////////
     namespace detail
     {

--- a/hpx/parallel/util/transform_loop.hpp
+++ b/hpx/parallel/util/transform_loop.hpp
@@ -1,0 +1,194 @@
+//  Copyright (c) 2007-2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_UTIL_TRANSFORM_LOOP_SEP_08_2016_0611PM)
+#define HPX_PARALLEL_UTIL_TRANSFORM_LOOP_SEP_08_2016_0611PM
+
+#include <hpx/config.hpp>
+#if defined(HPX_HAVE_VC_DATAPAR)
+#include <hpx/parallel/datapar/transform_loop.hpp>
+#endif
+#include <hpx/parallel/util/cancellation_token.hpp>
+#include <hpx/util/invoke.hpp>
+#include <hpx/util/tuple.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <utility>
+
+namespace hpx { namespace parallel { namespace util
+{
+    template <typename ExPolicy, typename F, typename InIter, typename OutIter>
+    HPX_HOST_DEVICE HPX_FORCEINLINE
+    void transform_loop_step(ExPolicy&&, F && f, InIter it, OutIter dest)
+    {
+        *dest = hpx::util::invoke(std::forward<F>(f), it);
+    }
+
+    template <typename ExPolicy, typename F, typename InIter1,
+        typename InIter2, typename OutIter>
+    HPX_HOST_DEVICE HPX_FORCEINLINE
+    void transform_loop_step(ExPolicy&&, F && f, InIter1 it1, InIter2 it2,
+        OutIter dest)
+    {
+        *dest = hpx::util::invoke(std::forward<F>(f), it1, it2);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        template <typename Iter>
+        struct transform_loop
+        {
+            template <typename InIter, typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static std::pair<InIter, OutIter>
+            call(InIter first, InIter last, OutIter dest, F && f)
+            {
+                for (/* */; first != last; (void) ++first, ++dest)
+                {
+                    *dest = hpx::util::invoke(std::forward<F>(f), first);
+                }
+                return std::make_pair(std::move(first), std::move(dest));
+            }
+        };
+    }
+
+    template <typename ExPolicy, typename Iter, typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE
+    std::pair<Iter, OutIter>
+    transform_loop(ExPolicy&&, Iter it, Iter end, OutIter dest, F && f)
+    {
+        return detail::transform_loop<Iter>::call(it, end, dest,
+            std::forward<F>(f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        template <typename Iter1, typename Iter2>
+        struct transform_binary_loop
+        {
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static hpx::util::tuple<InIter1, InIter2, OutIter>
+            call(InIter1 first1, InIter1 last1, InIter2 first2, OutIter dest,
+                F && f)
+            {
+                for (/* */; first1 != last1; (void) ++first1, ++first2, ++dest)
+                {
+                    *dest = hpx::util::invoke(std::forward<F>(f), first1, first2);
+                }
+                return hpx::util::make_tuple(std::move(first1),
+                    std::move(first2), std::move(dest));
+            }
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static hpx::util::tuple<InIter1, InIter2, OutIter>
+            call(InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2,
+                OutIter dest, F && f)
+            {
+                for (/* */; first1 != last1 && first2 != last2;
+                        (void) ++first1, ++first2, ++dest)
+                {
+                    *dest = hpx::util::invoke(std::forward<F>(f), first1, first2);
+                }
+                return hpx::util::make_tuple(first1, first2, dest);
+            }
+        };
+    }
+
+    template <typename ExPolicy, typename InIter1, typename InIter2,
+        typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE
+    hpx::util::tuple<InIter1, InIter2, OutIter>
+    transform_binary_loop(ExPolicy&&, InIter1 first1, InIter1 last1,
+        InIter2 first2, OutIter dest, F && f)
+    {
+        return detail::transform_binary_loop<InIter1, InIter2>::call(
+            first1, last1, first2, dest, std::forward<F>(f));
+    }
+
+    template <typename ExPolicy, typename InIter1, typename InIter2,
+        typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE
+    hpx::util::tuple<InIter1, InIter2, OutIter>
+    transform_binary_loop(ExPolicy&&, InIter1 first1, InIter1 last1,
+        InIter2 first2, InIter2 last2, OutIter dest, F && f)
+    {
+        return detail::transform_binary_loop<InIter1, InIter2>::call(
+            first1, last1, first2, last2, dest, std::forward<F>(f));
+    }
+
+    namespace detail
+    {
+        template <typename Iter>
+        struct transform_loop_n
+        {
+            template <typename InIter, typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static std::pair<InIter, OutIter>
+            call(InIter first, std::size_t count, OutIter dest, F && f)
+            {
+                for (/* */; count != 0; (void) --count, ++first, ++dest)
+                {
+                    *dest = hpx::util::invoke(f, first);
+                }
+                return std::make_pair(std::move(first), std::move(dest));
+            }
+        };
+    }
+
+    template <typename ExPolicy, typename Iter, typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE
+    std::pair<Iter, OutIter>
+    transform_loop_n(ExPolicy&&, Iter it, std::size_t count, OutIter dest,
+        F && f)
+    {
+        return detail::transform_loop_n<Iter>::call(it, count, dest,
+            std::forward<F>(f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        template <typename Iter1, typename Inter2>
+        struct transform_binary_loop_n
+        {
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            static hpx::util::tuple<InIter1, InIter2, OutIter>
+            call(InIter1 first1, std::size_t count, InIter2 first2,
+                OutIter dest, F && f)
+            {
+                for (/* */; count != 0;
+                    (void) --count, ++first1, first2++, ++dest)
+                {
+                    *dest = hpx::util::invoke(f, first1, first2);
+                }
+                return hpx::util::make_tuple(std::move(first1),
+                    std::move(first2), std::move(dest));
+            }
+        };
+    }
+
+    template <typename ExPolicy, typename InIter1, typename InIter2,
+        typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE
+    hpx::util::tuple<InIter1, InIter2, OutIter>
+    transform_binary_loop_n(ExPolicy&&, InIter1 first1, std::size_t count,
+        InIter2 first2, OutIter dest, F && f)
+    {
+        return detail::transform_binary_loop_n<InIter1, InIter2>::call(
+            first1, count, first2, dest, std::forward<F>(f));
+    }
+}}}
+
+#endif

--- a/hpx/traits/is_execution_policy.hpp
+++ b/hpx/traits/is_execution_policy.hpp
@@ -1,0 +1,128 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_TRAITS_IS_EXECUTION_POLICY_SEP_07_2016_0805AM)
+#define HPX_TRAITS_IS_EXECUTION_POLICY_SEP_07_2016_0805AM
+
+#include <hpx/config.hpp>
+#include <hpx/config/inline_namespace.hpp>
+#include <hpx/parallel/config/inline_namespace.hpp>
+#include <hpx/util/decay.hpp>
+
+#include <type_traits>
+
+namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
+{
+    namespace detail
+    {
+        template <typename T>
+        struct is_execution_policy
+          : std::false_type
+        {};
+
+        template <typename T>
+        struct is_parallel_execution_policy
+          : std::false_type
+        {};
+
+        template <typename T>
+        struct is_sequential_execution_policy
+          : std::false_type
+        {};
+
+        template <typename T>
+        struct is_async_execution_policy
+          : std::false_type
+        {};
+
+        template <typename Executor>
+        struct is_rebound_execution_policy
+          : std::false_type
+        {};
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// 1. The type is_execution_policy can be used to detect execution
+    ///    policies for the purpose of excluding function signatures
+    ///    from otherwise ambiguous overload resolution participation.
+    /// 2. If T is the type of a standard or implementation-defined execution
+    ///    policy, is_execution_policy<T> shall be publicly derived from
+    ///    integral_constant<bool, true>, otherwise from
+    ///    integral_constant<bool, false>.
+    /// 3. The behavior of a program that adds specializations for
+    ///    is_execution_policy is undefined.
+    ///
+    template <typename T>
+    struct is_execution_policy
+      : detail::is_execution_policy<typename hpx::util::decay<T>::type>
+    {};
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Extension: Detect whether given execution policy enables parallelization
+    ///
+    /// 1. The type is_parallel_execution_policy can be used to detect parallel
+    ///    execution policies for the purpose of excluding function signatures
+    ///    from otherwise ambiguous overload resolution participation.
+    /// 2. If T is the type of a standard or implementation-defined execution
+    ///    policy, is_parallel_execution_policy<T> shall be publicly derived
+    ///    from integral_constant<bool, true>, otherwise from
+    ///    integral_constant<bool, false>.
+    /// 3. The behavior of a program that adds specializations for
+    ///    is_parallel_execution_policy is undefined.
+    ///
+    template <typename T>
+    struct is_parallel_execution_policy
+      : detail::is_parallel_execution_policy<typename hpx::util::decay<T>::type>
+    {};
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Extension: Detect whether given execution policy does not enable
+    ///            parallelization
+    ///
+    /// 1. The type is_sequential_execution_policy can be used to detect
+    ///    non-parallel execution policies for the purpose of excluding
+    ///    function signatures from otherwise ambiguous overload resolution
+    ///    participation.
+    /// 2. If T is the type of a standard or implementation-defined execution
+    ///    policy, is_sequential_execution_policy<T> shall be publicly derived
+    ///    from integral_constant<bool, true>, otherwise from
+    ///    integral_constant<bool, false>.
+    /// 3. The behavior of a program that adds specializations for
+    ///    is_sequential_execution_policy is undefined.
+    ///
+    // extension:
+    template <typename T>
+    struct is_sequential_execution_policy
+      : detail::is_sequential_execution_policy<typename hpx::util::decay<T>::type>
+    {};
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Extension: Detect whether given execution policy makes algorithms
+    ///            asynchronous
+    ///
+    /// 1. The type is_async_execution_policy can be used to detect
+    ///    asynchronous execution policies for the purpose of excluding
+    ///    function signatures from otherwise ambiguous overload resolution
+    ///    participation.
+    /// 2. If T is the type of a standard or implementation-defined execution
+    ///    policy, is_async_execution_policy<T> shall be publicly derived
+    ///    from integral_constant<bool, true>, otherwise from
+    ///    integral_constant<bool, false>.
+    /// 3. The behavior of a program that adds specializations for
+    ///    is_async_execution_policy is undefined.
+    ///
+    // extension:
+    template <typename T>
+    struct is_async_execution_policy
+      : detail::is_async_execution_policy<typename hpx::util::decay<T>::type>
+    {};
+
+    template <typename T>
+    struct is_rebound_execution_policy
+      : detail::is_rebound_execution_policy<typename hpx::util::decay<T>::type>
+    {};
+}}}
+
+#endif

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -151,7 +151,7 @@ namespace hpx
         message_handler_registrations;
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT void new_handler()
+    HPX_EXPORT void HPX_CDECL new_handler()
     {
         HPX_THROW_EXCEPTION(out_of_memory, "new_handler",
             "new allocator failed to allocate memory");

--- a/tests/performance/local/CMakeLists.txt
+++ b/tests/performance/local/CMakeLists.txt
@@ -161,18 +161,6 @@ if(HPX_WITH_EXAMPLES_OPENMP)
     PROPERTIES LINK_FLAGS ${OpenMP_CXX_FLAGS})
 endif()
 
-if(HPX_WITH_VC_DATAPAR)
-  if(NOT MSVC)
-    foreach(_flag ${Vc_COMPILE_FLAGS})
-      set_target_properties(inner_product_exe PROPERTIES COMPILE_FLAGS ${_flag})
-    endforeach()
-  endif()
-
-  foreach(_flag ${Vc_ARCHITECTURE_FLAGS})
-    set_target_properties(inner_product_exe PROPERTIES COMPILE_FLAGS ${_flag})
-  endforeach()
-endif()
-
 add_hpx_pseudo_target(tests.performance.local.htts_v2)
 add_subdirectory(htts_v2)
 add_hpx_pseudo_dependencies(tests.performance tests.performance.local.htts_v2)

--- a/tests/performance/local/CMakeLists.txt
+++ b/tests/performance/local/CMakeLists.txt
@@ -161,6 +161,18 @@ if(HPX_WITH_EXAMPLES_OPENMP)
     PROPERTIES LINK_FLAGS ${OpenMP_CXX_FLAGS})
 endif()
 
+if(HPX_WITH_VC_DATAPAR)
+  if(NOT MSVC)
+    foreach(_flag ${Vc_COMPILE_FLAGS})
+      set_target_properties(inner_product_exe PROPERTIES COMPILE_FLAGS ${_flag})
+    endforeach()
+  endif()
+
+  foreach(_flag ${Vc_ARCHITECTURE_FLAGS})
+    set_target_properties(inner_product_exe PROPERTIES COMPILE_FLAGS ${_flag})
+  endforeach()
+endif()
+
 add_hpx_pseudo_target(tests.performance.local.htts_v2)
 add_subdirectory(htts_v2)
 add_hpx_pseudo_dependencies(tests.performance tests.performance.local.htts_v2)

--- a/tests/performance/local/CMakeLists.txt
+++ b/tests/performance/local/CMakeLists.txt
@@ -21,6 +21,14 @@ set(benchmarks
     timed_task_spawn
 )
 
+if(HPX_WITH_VC_DATAPAR)
+  set(benchmarks
+      ${benchmarks}
+      inner_product
+     )
+  set(inner_product_FLAGS DEPENDENCIES iostreams_component)
+endif()
+
 if(HPX_WITH_EXAMPLES_OPENMP)
   set(benchmarks
       ${benchmarks}
@@ -116,7 +124,7 @@ if(HPX_WITH_CXX11_LAMBDAS)
     DEPENDENCIES iostreams_component partitioned_vector_component)
 
   if(HPX_WITH_CUDA)
-    set_source_files_properties( stream.cpp PROPERTIES CUDA_SOURCE_PROPERTY_FORMAT OBJ )
+    set_source_files_properties(stream.cpp PROPERTIES CUDA_SOURCE_PROPERTY_FORMAT OBJ)
   endif()
 endif()
 
@@ -132,7 +140,7 @@ foreach(benchmark ${benchmarks})
                      ${${benchmark}_FLAGS}
                      EXCLUDE_FROM_ALL
                      HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Benchmarks/Local/${benchmark}")
+                     FOLDER "Benchmarks/Local")
 
   # add a custom target for this example
   add_hpx_pseudo_target(tests.performance.local.${benchmark})

--- a/tests/performance/local/inner_product.cpp
+++ b/tests/performance/local/inner_product.cpp
@@ -1,0 +1,149 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+
+#include <hpx/util/high_resolution_clock.hpp>
+#include <hpx/include/parallel_inner_product.hpp>
+#include <hpx/include/iostreams.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <boost/range/functions.hpp>
+
+struct plus
+{
+    template <typename T1, typename T2>
+    auto operator()(T1 && t1, T2 && t2) const -> decltype(t1 + t2)
+    {
+        return t1 + t2;
+    }
+};
+
+struct multiplies
+{
+    template <typename T1, typename T2>
+    auto operator()(T1 && t1, T2 && t2) const -> decltype(t1 * t2)
+    {
+        return t1 * t2;
+    }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy>
+float measure_inner_product(ExPolicy && policy,
+    std::vector<float> const& data1, std::vector<float> const& data2)
+{
+    return
+        hpx::parallel::inner_product(
+            policy,
+            std::begin(data1),
+            std::end(data1),
+            std::begin(data2),
+            0.0f,
+            ::plus(),
+            ::multiplies()
+        );
+}
+
+template <typename ExPolicy>
+std::int64_t measure_inner_product(int count, ExPolicy && policy,
+    std::vector<float> const& data1, std::vector<float> const& data2)
+{
+    std::int64_t start = hpx::util::high_resolution_clock::now();
+
+    for (int i = 0; i != count; ++i)
+        measure_inner_product(policy, data1, data2);
+
+    return (hpx::util::high_resolution_clock::now() - start) / count;
+}
+
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int)std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    hpx::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    std::size_t size = vm["vector_size"].as<std::size_t>();
+    bool csvoutput = vm["csv_output"].as<int>() ?true : false;
+    int test_count = vm["test_count"].as<int>();
+
+    std::vector<float> data1(size);
+    std::vector<float> data2(size);
+
+    std::iota(std::begin(data1), std::end(data1), float(std::rand()));
+    std::iota(std::begin(data2), std::end(data2), float(std::rand()));
+
+    if (test_count <= 0)
+    {
+        hpx::cout << "test_count cannot be less than zero...\n" << hpx::flush;
+    }
+    else
+    {
+        std::uint64_t tr_time_par = measure_inner_product(
+            test_count, hpx::parallel::par, data1, data2);
+        std::uint64_t tr_time_datapar = measure_inner_product(
+            test_count, hpx::parallel::datapar_execution, data1, data2);
+
+        if (csvoutput)
+        {
+            hpx::cout
+                << "," << tr_time_par / 1e9
+                << "," << tr_time_datapar / 1e9
+                << "\n" << hpx::flush;
+        }
+        else
+        {
+            hpx::cout
+                << "inner_product(par): " << std::right
+                    << std::setw(15) << tr_time_par / 1e9 << "\n"
+                << "inner_product(datapar): " << std::right
+                    << std::setw(15) << tr_time_datapar / 1e9 << "\n"
+                << hpx::flush;
+        }
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> const cfg = {
+        "hpx.os_threads=all"
+    };
+
+    boost::program_options::options_description cmdline(
+        "usage: " HPX_APPLICATION_STRING " [options]");
+
+    cmdline.add_options()
+        ("vector_size"
+        , boost::program_options::value<std::size_t>()->default_value(1024)
+        , "size of vector")
+
+        ("csv_output"
+        , boost::program_options::value<int>()->default_value(0)
+        , "print results in csv format")
+
+        ("test_count"
+        , boost::program_options::value<int>()->default_value(10)
+        , "number of tests to take average from")
+
+        ("seed,s"
+        , boost::program_options::value<unsigned int>()
+        , "the random number generator seed to use for this run")
+        ;
+
+    return hpx::init(cmdline, argc, argv, cfg);
+
+}
+

--- a/tests/performance/local/inner_product.cpp
+++ b/tests/performance/local/inner_product.cpp
@@ -90,10 +90,14 @@ int hpx_main(boost::program_options::variables_map& vm)
     }
     else
     {
-        std::uint64_t tr_time_par = measure_inner_product(
-            test_count, hpx::parallel::par, data1, data2);
+        // warm up caches
+        measure_inner_product(hpx::parallel::par, data1, data2);
+
+        // do measurements
         std::uint64_t tr_time_datapar = measure_inner_product(
             test_count, hpx::parallel::datapar_execution, data1, data2);
+        std::uint64_t tr_time_par = measure_inner_product(
+            test_count, hpx::parallel::par, data1, data2);
 
         if (csvoutput)
         {

--- a/tests/unit/parallel/CMakeLists.txt
+++ b/tests/unit/parallel/CMakeLists.txt
@@ -48,6 +48,7 @@ endforeach()
 set(subdirs
     algorithms
     container_algorithms
+    datapar_algorithms
     executors
    )
 

--- a/tests/unit/parallel/algorithms/count_tests.hpp
+++ b/tests/unit/parallel/algorithms/count_tests.hpp
@@ -1,0 +1,219 @@
+//  Copyright (c) 2014-2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_TEST_COUNT_SEP_08_2014_1010AM)
+#define HPX_PARALLEL_TEST_COUNT_SEP_08_2014_1010AM
+
+#include <hpx/include/parallel_count.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <boost/range/functions.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_count(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c(10007);
+    // assure rand() does not evalulate to zero
+    std::iota(boost::begin(c), boost::end(c), std::rand()+1);
+
+    int find_count = (std::rand() % 30) + 1; //-V101
+    for (int i = 0; i != find_count && i != c.size(); ++i)
+    {
+        c[i] = 0;
+    }
+
+    std::int64_t num_items = hpx::parallel::count(policy,
+        iterator(boost::begin(c)), iterator(boost::end(c)), int(0));
+
+    HPX_TEST_EQ(num_items, static_cast<std::int64_t>(find_count));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_count_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef std::vector<int>::difference_type diff_type;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c(10007);
+    // assure rand() does not evaluate to zero
+    std::iota(boost::begin(c), boost::end(c), std::rand()+1);
+
+    int find_count = (std::rand() % 30) + 1; //-V101
+    for (int i = 0; i != find_count && i != c.size(); ++i)
+    {
+        c[i] = 0;
+    }
+
+    hpx::future<diff_type> f =
+        hpx::parallel::count(p,
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            int(0));
+
+    HPX_TEST_EQ(static_cast<diff_type>(find_count), f.get());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_count_exception(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+    std::vector<int> c(10007);
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_exception = false;
+    try {
+        hpx::parallel::count(policy,
+            decorated_iterator(
+                boost::begin(c),
+                [](){ throw std::runtime_error("test"); }),
+            decorated_iterator(boost::end(c)),
+            int(10));
+        HPX_TEST(false);
+    }
+    catch(hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_count_exception_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef std::vector<int>::difference_type diff_type;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<int> c(10007);
+    std::fill(boost::begin(c), boost::end(c), 10);
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try {
+        hpx::future<diff_type> f =
+            hpx::parallel::count(p,
+                decorated_iterator(
+                    boost::begin(c),
+                    [](){ throw std::runtime_error("test"); }),
+                decorated_iterator(boost::end(c)),
+                int(10));
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(p, e);
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_count_bad_alloc(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<int> c(10007);
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_bad_alloc = false;
+    try {
+        hpx::parallel::count(policy,
+            decorated_iterator(
+                boost::begin(c),
+                [](){ throw std::bad_alloc(); }),
+            decorated_iterator(boost::end(c)),
+            int(10));
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&) {
+        caught_bad_alloc = true;
+    }
+    catch (...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_count_bad_alloc_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef std::vector<int>::difference_type diff_type;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<int> c(10007);
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_bad_alloc = false;
+    bool returned_from_algorithm = false;
+    try {
+        hpx::future<diff_type> f =
+            hpx::parallel::count(p,
+                decorated_iterator(
+                    boost::begin(c),
+                    [](){ throw std::bad_alloc(); }),
+                decorated_iterator(boost::end(c)),
+                int(10));
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(std::bad_alloc const&) {
+        caught_bad_alloc = true;
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+    HPX_TEST(returned_from_algorithm);
+}
+
+#endif

--- a/tests/unit/parallel/algorithms/count_tests.hpp
+++ b/tests/unit/parallel/algorithms/count_tests.hpp
@@ -12,6 +12,7 @@
 #include <boost/range/functions.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <numeric>
 #include <string>
@@ -34,8 +35,8 @@ void test_count(ExPolicy policy, IteratorTag)
     // assure rand() does not evalulate to zero
     std::iota(boost::begin(c), boost::end(c), std::rand()+1);
 
-    int find_count = (std::rand() % 30) + 1; //-V101
-    for (int i = 0; i != find_count && i != c.size(); ++i)
+    std::size_t find_count = (std::rand() % 30) + 1; //-V101
+    for (std::size_t i = 0; i != find_count && i != c.size(); ++i)
     {
         c[i] = 0;
     }
@@ -57,8 +58,8 @@ void test_count_async(ExPolicy p, IteratorTag)
     // assure rand() does not evaluate to zero
     std::iota(boost::begin(c), boost::end(c), std::rand()+1);
 
-    int find_count = (std::rand() % 30) + 1; //-V101
-    for (int i = 0; i != find_count && i != c.size(); ++i)
+    std::size_t find_count = (std::rand() % 30) + 1; //-V101
+    for (std::size_t i = 0; i != find_count && i != c.size(); ++i)
     {
         c[i] = 0;
     }

--- a/tests/unit/parallel/algorithms/countif_tests.hpp
+++ b/tests/unit/parallel/algorithms/countif_tests.hpp
@@ -1,0 +1,229 @@
+//  Copyright (c) 2014-2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_TEST_COUNTIF_SEP_08_2014_1214PM)
+#define HPX_PARALLEL_TEST_COUNTIF_SEP_08_2014_1214PM
+
+#include <hpx/include/parallel_count.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <boost/range/functions.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+struct smaller_than_50
+{
+    template <typename T>
+    auto operator()(T const& x) const -> decltype(x < 50)
+    {
+        return x < 50;
+    }
+};
+
+struct always_true
+{
+    template <typename T>
+    bool operator()(T const&) const
+    {
+        return true;
+    }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_count_if(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef std::vector<int>::difference_type diff_type;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c(100007);
+    std::iota(boost::begin(c), boost::begin(c) + 50, 0);
+    std::iota(boost::begin(c) + 50, boost::end(c), std::rand() + 50);
+
+    diff_type num_items = hpx::parallel::count_if(policy,
+        iterator(boost::begin(c)), iterator(boost::end(c)),
+        smaller_than_50());
+
+    HPX_TEST_EQ(num_items, 50u);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_count_if_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef std::vector<int>::difference_type diff_type;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c(10007);
+    std::iota(boost::begin(c), boost::begin(c) + 50, 0);
+    std::iota(boost::begin(c) + 50, boost::end(c), std::rand() + 50);
+
+    hpx::future<diff_type> f =
+        hpx::parallel::count_if(p,
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            smaller_than_50());
+
+    HPX_TEST_EQ(f.get(), 50);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_count_if_exception(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<int> c(10007);
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_exception = false;
+    try {
+        // pred should never proc, so simple 'returns true'
+        hpx::parallel::count_if(policy,
+            decorated_iterator(
+                boost::begin(c),
+                [](){ throw std::runtime_error("test"); }),
+            decorated_iterator(boost::end(c)),
+            always_true());
+        HPX_TEST(false);
+    }
+    catch(hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_count_if_exception_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef std::vector<int>::difference_type diff_type;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<int> c(10007);
+    std::fill(boost::begin(c), boost::end(c), 10);
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try {
+        hpx::future<diff_type> f =
+            hpx::parallel::count_if(p,
+                decorated_iterator(
+                    boost::begin(c),
+                    [](){ throw std::runtime_error("test"); }),
+                decorated_iterator(boost::end(c)),
+                always_true());
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(p, e);
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_count_if_bad_alloc(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<int> c(10007);
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_bad_alloc = false;
+    try {
+        hpx::parallel::count_if(policy,
+            decorated_iterator(
+                boost::begin(c),
+                [](){ throw std::bad_alloc(); }),
+            decorated_iterator(boost::end(c)),
+            always_true());
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&) {
+        caught_bad_alloc = true;
+    }
+    catch (...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_count_if_bad_alloc_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef std::vector<int>::difference_type diff_type;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<int> c(10007);
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    bool caught_bad_alloc = false;
+    bool returned_from_algorithm = false;
+    try {
+        hpx::future<diff_type> f =
+            hpx::parallel::count_if(p,
+                decorated_iterator(
+                    boost::begin(c),
+                    [](){ throw std::bad_alloc(); }),
+                decorated_iterator(boost::end(c)),
+                always_true());
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(std::bad_alloc const&) {
+        caught_bad_alloc = true;
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+    HPX_TEST(returned_from_algorithm);
+}
+
+#endif

--- a/tests/unit/parallel/algorithms/foreach_tests.hpp
+++ b/tests/unit/parallel/algorithms/foreach_tests.hpp
@@ -68,10 +68,10 @@ void test_for_each(ExPolicy && policy, IteratorTag)
     HPX_TEST(result == iterator(boost::end(c)));
 
     // verify values
-    std::size_t count = 0;
+    int count = 0;
     std::for_each(boost::begin(c), boost::end(c),
-        [&count](std::size_t v) -> void {
-            HPX_TEST_EQ(v, std::size_t(42));
+        [&count](int v) -> void {
+            HPX_TEST_EQ(v, int(42));
             ++count;
         });
     HPX_TEST_EQ(count, c.size());
@@ -95,10 +95,10 @@ void test_for_each_async(ExPolicy && p, IteratorTag)
     HPX_TEST(f.get() == iterator(boost::end(c)));
 
     // verify values
-    std::size_t count = 0;
+    int count = 0;
     std::for_each(boost::begin(c), boost::end(c),
-        [&count](std::size_t v) -> void {
-            HPX_TEST_EQ(v, std::size_t(42));
+        [&count](int v) -> void {
+            HPX_TEST_EQ(v, int(42));
             ++count;
         });
     HPX_TEST_EQ(count, c.size());
@@ -205,10 +205,10 @@ void test_for_each_bad_alloc(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_bad_alloc_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
     std::iota(boost::begin(c), boost::end(c), std::rand());
 
     bool caught_exception = false;
@@ -232,6 +232,61 @@ void test_for_each_bad_alloc_async(ExPolicy p, IteratorTag)
 
     HPX_TEST(caught_exception);
     HPX_TEST(returned_from_algorithm);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_for_each_n(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c(10007);
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    iterator result = hpx::parallel::for_each_n(policy,
+        iterator(boost::begin(c)), c.size(),
+        set_42());
+    iterator end = iterator(boost::end(c));
+    HPX_TEST(result == end);
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(boost::begin(c), boost::end(c),
+        [&count](int v) -> void {
+            HPX_TEST_EQ(v, int(42));
+            ++count;
+        });
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_for_each_n_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c(10007);
+    std::iota(boost::begin(c), boost::end(c), std::rand());
+
+    hpx::future<iterator> f =
+        hpx::parallel::for_each_n(p,
+            iterator(boost::begin(c)), c.size(),
+            set_42());
+    HPX_TEST(f.get() == iterator(boost::end(c)));
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(boost::begin(c), boost::end(c),
+        [&count](int v) -> void {
+            HPX_TEST_EQ(v, int(42));
+            ++count;
+        });
+    HPX_TEST_EQ(count, c.size());
 }
 
 #endif

--- a/tests/unit/parallel/algorithms/inner_product.cpp
+++ b/tests/unit/parallel/algorithms/inner_product.cpp
@@ -18,7 +18,6 @@
 #include "test_utils.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
-
 template <typename ExPolicy, typename IteratorTag>
 void test_inner_product(ExPolicy policy, IteratorTag)
 {

--- a/tests/unit/parallel/algorithms/inner_product_tests.hpp
+++ b/tests/unit/parallel/algorithms/inner_product_tests.hpp
@@ -1,0 +1,69 @@
+//  Copyright (c) 2014-2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_TEST_INNER_PRODUCT_SEP_13_2016_1227PM)
+#define HPX_PARALLEL_TEST_INNER_PRODUCT_SEP_13_2016_1227PM
+
+#include <hpx/include/parallel_inner_product.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <boost/range/functions.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_inner_product(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c = test::random_iota<int>(1007);
+    std::vector<int> d = test::random_iota<int>(1007);
+    int init = std::rand() % 1007; //-V101
+
+    int r = hpx::parallel::inner_product(policy,
+        iterator(boost::begin(c)), iterator(boost::end(c)),
+        boost::begin(d), init);
+
+    HPX_TEST_EQ(r, std::inner_product(
+        boost::begin(c), boost::end(c), boost::begin(d), init));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_inner_product_async(ExPolicy p, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c = test::random_iota<int>(1007);
+    std::vector<int> d = test::random_iota<int>(1007);
+    int init = std::rand() % 1007; //-V101
+
+    hpx::future<int> fut_r =
+        hpx::parallel::inner_product(p, iterator(boost::begin(c)),
+        iterator(boost::end(c)), boost::begin(d), init);
+
+    fut_r.wait();
+    HPX_TEST_EQ(fut_r.get(), std::inner_product(
+        boost::begin(c), boost::end(c), boost::begin(d), init));
+}
+
+#endif

--- a/tests/unit/parallel/algorithms/test_utils.hpp
+++ b/tests/unit/parallel/algorithms/test_utils.hpp
@@ -212,6 +212,15 @@ namespace test
         return c;
     }
 
+    template <typename T>
+    inline std::vector<T> random_iota(std::size_t size)
+    {
+        std::vector<T> c(size);
+        std::iota(boost::begin(c), boost::end(c), 0);
+        std::random_shuffle(boost::begin(c), boost::end(c));
+        return c;
+    }
+
     inline std::vector<std::size_t> random_fill(std::size_t size)
     {
         std::vector<std::size_t> c(size);

--- a/tests/unit/parallel/algorithms/transform_binary2_tests.hpp
+++ b/tests/unit/parallel/algorithms/transform_binary2_tests.hpp
@@ -1,0 +1,274 @@
+//  Copyright (c) 2014-2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_TEST_TRANSFORM_SEP_09_2014_1047AM)
+#define HPX_PARALLEL_TEST_TRANSFORM_SEP_09_2014_1047AM
+
+#include <hpx/include/parallel_transform.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <boost/range/functions.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+struct add
+{
+    template <typename T1, typename T2>
+    auto operator()(T1 const& v1, T2 const& v2) const -> decltype(v1 + v2)
+    {
+        return v1 + v2;
+    }
+};
+
+struct throw_always
+{
+    template <typename T1, typename T2>
+    auto operator()(T1 const& v1, T2 const& v2) const -> decltype(v1 + v2)
+    {
+        throw std::runtime_error("test");
+    }
+};
+
+struct throw_bad_alloc
+{
+    template <typename T1, typename T2>
+    auto operator()(T1 const& v1, T2 const& v2) const -> decltype(v1 + v2)
+    {
+        throw std::bad_alloc();
+    }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_binary2(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c1(10007);
+    std::vector<int> c2(c1.size());
+    std::vector<int> d1(c1.size()); //-V656
+    std::iota(boost::begin(c1), boost::end(c1), std::rand());
+    std::iota(boost::begin(c2), boost::end(c2), std::rand());
+
+    auto result =
+        hpx::parallel::transform(policy,
+            iterator(boost::begin(c1)), iterator(boost::end(c1)),
+            boost::begin(c2), boost::end(c2), boost::begin(d1), add());
+
+    HPX_TEST(hpx::util::get<0>(result) == iterator(boost::end(c1)));
+    HPX_TEST(hpx::util::get<1>(result) == boost::end(c2));
+    HPX_TEST(hpx::util::get<2>(result) == boost::end(d1));
+
+    // verify values
+    std::vector<int> d2(c1.size());
+    std::transform(boost::begin(c1), boost::end(c1),
+        boost::begin(c2), boost::begin(d2), add());
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(boost::begin(d1), boost::end(d1), boost::begin(d2),
+        [&count](int v1, int v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d2.size());
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_binary2_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c1(10007);
+    std::vector<int> c2(c1.size());
+    std::vector<int> d1(c1.size()); //-V656
+    std::iota(boost::begin(c1), boost::end(c1), std::rand());
+    std::iota(boost::begin(c2), boost::end(c2), std::rand());
+
+    auto f =
+        hpx::parallel::transform(p,
+            iterator(boost::begin(c1)), iterator(boost::end(c1)),
+            boost::begin(c2), boost::end(c2), boost::begin(d1), add());
+    f.wait();
+
+    hpx::util::tuple<iterator, base_iterator, base_iterator> result = f.get();
+    HPX_TEST(hpx::util::get<0>(result) == iterator(boost::end(c1)));
+    HPX_TEST(hpx::util::get<1>(result) == boost::end(c2));
+    HPX_TEST(hpx::util::get<2>(result) == boost::end(d1));
+
+    // verify values
+    std::vector<int> d2(c1.size());
+    std::transform(boost::begin(c1), boost::end(c1),
+        boost::begin(c2), boost::begin(d2), add());
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(boost::begin(d1), boost::end(d1), boost::begin(d2),
+        [&count](int v1, int v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d2.size());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_binary2_exception(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c1(10007);
+    std::vector<int> c2(c1.size());
+    std::vector<int> d1(c1.size()); //-V656
+    std::iota(boost::begin(c1), boost::end(c1), std::rand());
+    std::iota(boost::begin(c2), boost::end(c2), std::rand());
+
+    bool caught_exception = false;
+    try {
+        hpx::parallel::transform(policy,
+            iterator(boost::begin(c1)), iterator(boost::end(c1)),
+            boost::begin(c2), boost::end(c2), boost::begin(d1),
+            throw_always());
+
+        HPX_TEST(false);
+    }
+    catch(hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_binary2_exception_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c1(10007);
+    std::vector<int> c2(c1.size());
+    std::vector<int> d1(c1.size()); //-V656
+    std::iota(boost::begin(c1), boost::end(c1), std::rand());
+    std::iota(boost::begin(c2), boost::end(c2), std::rand());
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try {
+        auto f =
+            hpx::parallel::transform(p,
+                iterator(boost::begin(c1)), iterator(boost::end(c1)),
+                boost::begin(c2), boost::end(c2), boost::begin(d1),
+                throw_always());
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(p, e);
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_binary2_bad_alloc(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c1(10007);
+    std::vector<int> c2(c1.size());
+    std::vector<int> d1(c1.size()); //-V656
+    std::iota(boost::begin(c1), boost::end(c1), std::rand());
+    std::iota(boost::begin(c2), boost::end(c2), std::rand());
+
+    bool caught_bad_alloc = false;
+    try {
+        hpx::parallel::transform(policy,
+            iterator(boost::begin(c1)), iterator(boost::end(c1)),
+            boost::begin(c2), boost::end(c2), boost::begin(d1),
+            throw_bad_alloc());
+
+        HPX_TEST(false);
+    }
+    catch(std::bad_alloc const&) {
+        caught_bad_alloc = true;
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_binary2_bad_alloc_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c1(10007);
+    std::vector<int> c2(c1.size());
+    std::vector<int> d1(c1.size()); //-V656
+    std::iota(boost::begin(c1), boost::end(c1), std::rand());
+    std::iota(boost::begin(c2), boost::end(c2), std::rand());
+
+    bool caught_bad_alloc = false;
+    bool returned_from_algorithm = false;
+    try {
+        auto f =
+            hpx::parallel::transform(p,
+                iterator(boost::begin(c1)), iterator(boost::end(c1)),
+                boost::begin(c2), boost::end(c2), boost::begin(d1),
+                throw_bad_alloc());
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(std::bad_alloc const&) {
+        caught_bad_alloc = true;
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+    HPX_TEST(returned_from_algorithm);
+}
+
+#endif

--- a/tests/unit/parallel/algorithms/transform_binary_tests.hpp
+++ b/tests/unit/parallel/algorithms/transform_binary_tests.hpp
@@ -1,0 +1,274 @@
+//  Copyright (c) 2014-2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_TEST_TRANSFORM_SEP_08_2014_0927AM)
+#define HPX_PARALLEL_TEST_TRANSFORM_SEP_08_2014_0927AM
+
+#include <hpx/include/parallel_transform.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <boost/range/functions.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+struct add
+{
+    template <typename T1, typename T2>
+    auto operator()(T1 const& v1, T2 const& v2) const -> decltype(v1 + v2)
+    {
+        return v1 + v2;
+    }
+};
+
+struct throw_always
+{
+    template <typename T1, typename T2>
+    auto operator()(T1 const& v1, T2 const& v2) const -> decltype(v1 + v2)
+    {
+        throw std::runtime_error("test");
+    }
+};
+
+struct throw_bad_alloc
+{
+    template <typename T1, typename T2>
+    auto operator()(T1 const& v1, T2 const& v2) const -> decltype(v1 + v2)
+    {
+        throw std::bad_alloc();
+    }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_binary(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c1(10007);
+    std::vector<int> c2(c1.size());
+    std::vector<int> d1(c1.size()); //-V656
+    std::iota(boost::begin(c1), boost::end(c1), std::rand());
+    std::iota(boost::begin(c2), boost::end(c2), std::rand());
+
+    auto result =
+        hpx::parallel::transform(policy,
+            iterator(boost::begin(c1)), iterator(boost::end(c1)),
+            boost::begin(c2), boost::begin(d1), add());
+
+    HPX_TEST(hpx::util::get<0>(result) == iterator(boost::end(c1)));
+    HPX_TEST(hpx::util::get<1>(result) == boost::end(c2));
+    HPX_TEST(hpx::util::get<2>(result) == boost::end(d1));
+
+    // verify values
+    std::vector<int> d2(c1.size());
+    std::transform(boost::begin(c1), boost::end(c1),
+        boost::begin(c2), boost::begin(d2), add());
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(boost::begin(d1), boost::end(d1), boost::begin(d2),
+        [&count](int v1, int v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d2.size());
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_binary_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c1(10007);
+    std::vector<int> c2(c1.size());
+    std::vector<int> d1(c1.size()); //-V656
+    std::iota(boost::begin(c1), boost::end(c1), std::rand());
+    std::iota(boost::begin(c2), boost::end(c2), std::rand());
+
+    auto f =
+        hpx::parallel::transform(p,
+            iterator(boost::begin(c1)), iterator(boost::end(c1)),
+            boost::begin(c2), boost::begin(d1), add());
+    f.wait();
+
+    hpx::util::tuple<iterator, base_iterator, base_iterator> result = f.get();
+    HPX_TEST(hpx::util::get<0>(result) == iterator(boost::end(c1)));
+    HPX_TEST(hpx::util::get<1>(result) == boost::end(c2));
+    HPX_TEST(hpx::util::get<2>(result) == boost::end(d1));
+
+    // verify values
+    std::vector<int> d2(c1.size());
+    std::transform(boost::begin(c1), boost::end(c1),
+        boost::begin(c2), boost::begin(d2), add());
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(boost::begin(d1), boost::end(d1), boost::begin(d2),
+        [&count](int v1, int v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d2.size());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_binary_exception(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c1(10007);
+    std::vector<int> c2(c1.size());
+    std::vector<int> d1(c1.size()); //-V656
+    std::iota(boost::begin(c1), boost::end(c1), std::rand());
+    std::iota(boost::begin(c2), boost::end(c2), std::rand());
+
+    bool caught_exception = false;
+    try {
+        hpx::parallel::transform(policy,
+            iterator(boost::begin(c1)), iterator(boost::end(c1)),
+            boost::begin(c2), boost::begin(d1),
+            throw_always());
+
+        HPX_TEST(false);
+    }
+    catch(hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_binary_exception_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c1(10007);
+    std::vector<int> c2(c1.size());
+    std::vector<int> d1(c1.size()); //-V656
+    std::iota(boost::begin(c1), boost::end(c1), std::rand());
+    std::iota(boost::begin(c2), boost::end(c2), std::rand());
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try {
+        auto f =
+            hpx::parallel::transform(p,
+                iterator(boost::begin(c1)), iterator(boost::end(c1)),
+                boost::begin(c2), boost::begin(d1),
+                throw_always());
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(p, e);
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_binary_bad_alloc(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c1(10007);
+    std::vector<int> c2(c1.size());
+    std::vector<int> d1(c1.size()); //-V656
+    std::iota(boost::begin(c1), boost::end(c1), std::rand());
+    std::iota(boost::begin(c2), boost::end(c2), std::rand());
+
+    bool caught_bad_alloc = false;
+    try {
+        hpx::parallel::transform(policy,
+            iterator(boost::begin(c1)), iterator(boost::end(c1)),
+            boost::begin(c2), boost::begin(d1),
+            throw_bad_alloc());
+
+        HPX_TEST(false);
+    }
+    catch(std::bad_alloc const&) {
+        caught_bad_alloc = true;
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_binary_bad_alloc_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c1(10007);
+    std::vector<int> c2(c1.size());
+    std::vector<int> d1(c1.size()); //-V656
+    std::iota(boost::begin(c1), boost::end(c1), std::rand());
+    std::iota(boost::begin(c2), boost::end(c2), std::rand());
+
+    bool caught_bad_alloc = false;
+    bool returned_from_algorithm = false;
+    try {
+        auto f =
+            hpx::parallel::transform(p,
+                iterator(boost::begin(c1)), iterator(boost::end(c1)),
+                boost::begin(c2), boost::begin(d1),
+                throw_bad_alloc());
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(std::bad_alloc const&) {
+        caught_bad_alloc = true;
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+    HPX_TEST(returned_from_algorithm);
+}
+
+#endif

--- a/tests/unit/parallel/datapar_algorithms/CMakeLists.txt
+++ b/tests/unit/parallel/datapar_algorithms/CMakeLists.txt
@@ -11,6 +11,7 @@ if(HPX_WITH_VC_DATAPAR)
       countif_datapar
       foreach_datapar
       foreachn_datapar
+      inner_product_datapar
       transform_datapar
       transform_binary_datapar
       transform_binary2_datapar
@@ -33,6 +34,16 @@ foreach(test ${tests})
                      HPX_PREFIX ${HPX_BUILD_PREFIX}
                      FOLDER "Tests/Unit/Parallel/DataParAlgorithms")
 
+  if(NOT MSVC)
+    foreach(_flag ${Vc_COMPILE_FLAGS})
+      set_target_properties(${test}_test_exe PROPERTIES COMPILE_FLAGS ${_flag})
+    endforeach()
+  endif()
+
+  foreach(_flag ${Vc_ARCHITECTURE_FLAGS})
+    set_target_properties(${test}_test_exe PROPERTIES COMPILE_FLAGS ${_flag})
+  endforeach()
+
   add_hpx_unit_test("parallel" ${test} ${${test}_PARAMETERS})
 
   # add a custom target for this example
@@ -45,4 +56,5 @@ foreach(test ${tests})
   # add dependencies to pseudo-target
   add_hpx_pseudo_dependencies(tests.unit.parallel.datapar_algorithms.${test}
                               ${test}_test_exe)
+
 endforeach()

--- a/tests/unit/parallel/datapar_algorithms/CMakeLists.txt
+++ b/tests/unit/parallel/datapar_algorithms/CMakeLists.txt
@@ -7,7 +7,10 @@ set(tests)
 
 if(HPX_WITH_VC_DATAPAR)
   set(tests
+      count_datapar
+      countif_datapar
       foreach_datapar
+      foreachn_datapar
      )
 endif()
 
@@ -30,13 +33,13 @@ foreach(test ${tests})
   add_hpx_unit_test("parallel" ${test} ${${test}_PARAMETERS})
 
   # add a custom target for this example
-  add_hpx_pseudo_target(tests.unit.parallel.algorithms.${test})
+  add_hpx_pseudo_target(tests.unit.parallel.datapar_algorithms.${test})
 
   # make pseudo-targets depend on master pseudo-target
-  add_hpx_pseudo_dependencies(tests.unit.parallel.algorithms
-                              tests.unit.parallel.algorithms.${test})
+  add_hpx_pseudo_dependencies(tests.unit.parallel.datapar_algorithms
+                              tests.unit.parallel.datapar_algorithms.${test})
 
   # add dependencies to pseudo-target
-  add_hpx_pseudo_dependencies(tests.unit.parallel.algorithms.${test}
+  add_hpx_pseudo_dependencies(tests.unit.parallel.datapar_algorithms.${test}
                               ${test}_test_exe)
 endforeach()

--- a/tests/unit/parallel/datapar_algorithms/CMakeLists.txt
+++ b/tests/unit/parallel/datapar_algorithms/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Copyright (c) 2014-2015 Hartmut Kaiser
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests
+    foreach_datapar
+   )
+
+foreach(test ${tests})
+  set(sources
+      ${test}.cpp)
+
+  set(${test}_PARAMETERS THREADS_PER_LOCALITY 4)
+
+  source_group("Source Files" FILES ${sources})
+
+  # add example executable
+  add_hpx_executable(${test}_test
+                     SOURCES ${sources}
+                     ${${test}_FLAGS}
+                     EXCLUDE_FROM_ALL
+                     HPX_PREFIX ${HPX_BUILD_PREFIX}
+                     FOLDER "Tests/Unit/Parallel/DataParAlgorithms")
+
+  add_hpx_unit_test("parallel" ${test} ${${test}_PARAMETERS})
+
+  # add a custom target for this example
+  add_hpx_pseudo_target(tests.unit.parallel.algorithms.${test})
+
+  # make pseudo-targets depend on master pseudo-target
+  add_hpx_pseudo_dependencies(tests.unit.parallel.algorithms
+                              tests.unit.parallel.algorithms.${test})
+
+  # add dependencies to pseudo-target
+  add_hpx_pseudo_dependencies(tests.unit.parallel.algorithms.${test}
+                              ${test}_test_exe)
+endforeach()

--- a/tests/unit/parallel/datapar_algorithms/CMakeLists.txt
+++ b/tests/unit/parallel/datapar_algorithms/CMakeLists.txt
@@ -34,16 +34,6 @@ foreach(test ${tests})
                      HPX_PREFIX ${HPX_BUILD_PREFIX}
                      FOLDER "Tests/Unit/Parallel/DataParAlgorithms")
 
-  if(NOT MSVC)
-    foreach(_flag ${Vc_COMPILE_FLAGS})
-      set_target_properties(${test}_test_exe PROPERTIES COMPILE_FLAGS ${_flag})
-    endforeach()
-  endif()
-
-  foreach(_flag ${Vc_ARCHITECTURE_FLAGS})
-    set_target_properties(${test}_test_exe PROPERTIES COMPILE_FLAGS ${_flag})
-  endforeach()
-
   add_hpx_unit_test("parallel" ${test} ${${test}_PARAMETERS})
 
   # add a custom target for this example

--- a/tests/unit/parallel/datapar_algorithms/CMakeLists.txt
+++ b/tests/unit/parallel/datapar_algorithms/CMakeLists.txt
@@ -1,11 +1,15 @@
-# Copyright (c) 2014-2015 Hartmut Kaiser
+# Copyright (c) 2016 Hartmut Kaiser
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests
-    foreach_datapar
-   )
+set(tests)
+
+if(HPX_WITH_VC_DATAPAR)
+  set(tests
+      foreach_datapar
+     )
+endif()
 
 foreach(test ${tests})
   set(sources

--- a/tests/unit/parallel/datapar_algorithms/CMakeLists.txt
+++ b/tests/unit/parallel/datapar_algorithms/CMakeLists.txt
@@ -11,6 +11,9 @@ if(HPX_WITH_VC_DATAPAR)
       countif_datapar
       foreach_datapar
       foreachn_datapar
+      transform_datapar
+      transform_binary_datapar
+      transform_binary2_datapar
      )
 endif()
 

--- a/tests/unit/parallel/datapar_algorithms/count_datapar.cpp
+++ b/tests/unit/parallel/datapar_algorithms/count_datapar.cpp
@@ -10,28 +10,15 @@
 #include <string>
 #include <vector>
 
-#include "count_tests.hpp"
+#include "../algorithms/count_tests.hpp"
 
 ////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
 void test_count()
 {
     using namespace hpx::parallel;
-    test_count(seq, IteratorTag());
-    test_count(par, IteratorTag());
-    test_count(par_vec, IteratorTag());
-
-    test_count_async(seq(task), IteratorTag());
-    test_count_async(par(task), IteratorTag());
-
-#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_count(execution_policy(seq), IteratorTag());
-    test_count(execution_policy(par), IteratorTag());
-    test_count(execution_policy(par_vec), IteratorTag());
-
-    test_count(execution_policy(seq(task)), IteratorTag());
-    test_count(execution_policy(par(task)), IteratorTag());
-#endif
+    test_count(datapar_execution, IteratorTag());
+    test_count_async(datapar_execution(task), IteratorTag());
 }
 
 void count_test()
@@ -47,22 +34,8 @@ void test_count_exception()
 {
     using namespace hpx::parallel;
 
-    // If the execution policy object is of type parallel_vector_execution_policy,
-    // std::terminate shall be called. Therefore we do not test exceptions
-    // with a vector execution policy.
-    test_count_exception(seq, IteratorTag());
-    test_count_exception(par, IteratorTag());
-
-    test_count_exception_async(seq(task), IteratorTag());
-    test_count_exception_async(par(task), IteratorTag());
-
-#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_count_exception(execution_policy(seq), IteratorTag());
-    test_count_exception(execution_policy(par), IteratorTag());
-
-    test_count_exception(execution_policy(seq(task)), IteratorTag());
-    test_count_exception(execution_policy(par(task)), IteratorTag());
-#endif
+    test_count_exception(datapar_execution, IteratorTag());
+    test_count_exception_async(datapar_execution(task), IteratorTag());
 }
 
 void count_exception_test()
@@ -78,22 +51,8 @@ void test_count_bad_alloc()
 {
     using namespace hpx::parallel;
 
-    // If the execution policy object is of type parallel_vector_execution_policy,
-    // std::terminate shall be called. therefore we do not test exceptions
-    // with a vector execution policy
-    test_count_bad_alloc(seq, IteratorTag());
-    test_count_bad_alloc(par, IteratorTag());
-
-    test_count_bad_alloc_async(seq(task), IteratorTag());
-    test_count_bad_alloc_async(par(task), IteratorTag());
-
-#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_count_bad_alloc(execution_policy(seq), IteratorTag());
-    test_count_bad_alloc(execution_policy(par), IteratorTag());
-
-    test_count_bad_alloc(execution_policy(seq(task)), IteratorTag());
-    test_count_bad_alloc(execution_policy(par(task)), IteratorTag());
-#endif
+    test_count_bad_alloc(datapar_execution, IteratorTag());
+    test_count_bad_alloc_async(datapar_execution(task), IteratorTag());
 }
 
 void count_bad_alloc_test()

--- a/tests/unit/parallel/datapar_algorithms/countif_datapar.cpp
+++ b/tests/unit/parallel/datapar_algorithms/countif_datapar.cpp
@@ -10,28 +10,16 @@
 #include <string>
 #include <vector>
 
-#include "countif_tests.hpp"
+#include "../algorithms/countif_tests.hpp"
 
 ////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
 void test_count_if()
 {
     using namespace hpx::parallel;
-    test_count_if(seq, IteratorTag());
-    test_count_if(par, IteratorTag());
-    test_count_if(par_vec, IteratorTag());
 
-    test_count_if_async(seq(task), IteratorTag());
-    test_count_if_async(par(task), IteratorTag());
-
-#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_count_if(execution_policy(seq), IteratorTag());
-    test_count_if(execution_policy(par), IteratorTag());
-    test_count_if(execution_policy(par_vec), IteratorTag());
-
-    test_count_if(execution_policy(seq(task)), IteratorTag());
-    test_count_if(execution_policy(par(task)), IteratorTag());
-#endif
+    test_count_if(datapar_execution, IteratorTag());
+    test_count_if_async(datapar_execution(task), IteratorTag());
 }
 
 void count_if_test()
@@ -47,22 +35,8 @@ void test_count_if_exception()
 {
     using namespace hpx::parallel;
 
-    // If the execution policy object is of type vector_execution_policy,
-    // std::terminate shall be called. therefore we do not test exceptions
-    // with a vector execution policy
-    test_count_if_exception(seq, IteratorTag());
-    test_count_if_exception(par, IteratorTag());
-
-    test_count_if_exception_async(seq(task), IteratorTag());
-    test_count_if_exception_async(par(task), IteratorTag());
-
-#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_count_if_exception(execution_policy(seq), IteratorTag());
-    test_count_if_exception(execution_policy(par), IteratorTag());
-
-    test_count_if_exception(execution_policy(seq(task)), IteratorTag());
-    test_count_if_exception(execution_policy(par(task)), IteratorTag());
-#endif
+    test_count_if_exception(datapar_execution, IteratorTag());
+    test_count_if_exception_async(datapar_execution(task), IteratorTag());
 }
 
 void count_if_exception_test()
@@ -77,22 +51,8 @@ void test_count_if_bad_alloc()
 {
     using namespace hpx::parallel;
 
-    // If the execution policy object is of type vector_execution_policy,
-    // std::terminate shall be called. therefore we do not test exceptions
-    // with a vector execution policy
-    test_count_if_bad_alloc(seq, IteratorTag());
-    test_count_if_bad_alloc(par, IteratorTag());
-
-    test_count_if_bad_alloc_async(seq(task), IteratorTag());
-    test_count_if_bad_alloc_async(par(task), IteratorTag());
-
-#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_count_if_bad_alloc(execution_policy(seq), IteratorTag());
-    test_count_if_bad_alloc(execution_policy(par), IteratorTag());
-
-    test_count_if_bad_alloc(execution_policy(seq(task)), IteratorTag());
-    test_count_if_bad_alloc(execution_policy(par(task)), IteratorTag());
-#endif
+    test_count_if_bad_alloc(datapar_execution, IteratorTag());
+    test_count_if_bad_alloc_async(datapar_execution(task), IteratorTag());
 }
 
 void count_if_bad_alloc_test()

--- a/tests/unit/parallel/datapar_algorithms/foreach_datapar.cpp
+++ b/tests/unit/parallel/datapar_algorithms/foreach_datapar.cpp
@@ -19,7 +19,7 @@ void test_for_each()
     using namespace hpx::parallel;
 
     test_for_each(datapar_execution, IteratorTag());
-//     test_for_each_async(datapar_execution(task), IteratorTag());
+    test_for_each_async(datapar_execution(task), IteratorTag());
 }
 
 void for_each_test()
@@ -35,11 +35,8 @@ void test_for_each_exception()
 {
     using namespace hpx::parallel;
 
-    // If the execution policy object is of type vector_execution_policy,
-    // std::terminate shall be called. therefore we do not test exceptions
-    // with a vector execution policy
     test_for_each_exception(datapar_execution, IteratorTag());
-//     test_for_each_exception_async(datapar_execution(task), IteratorTag());
+    test_for_each_exception_async(datapar_execution(task), IteratorTag());
 }
 
 void for_each_exception_test()
@@ -55,11 +52,8 @@ void test_for_each_bad_alloc()
 {
     using namespace hpx::parallel;
 
-    // If the execution policy object is of type vector_execution_policy,
-    // std::terminate shall be called. therefore we do not test exceptions
-    // with a vector execution policy
-    test_for_each_bad_alloc(seq, IteratorTag());
-//     test_for_each_bad_alloc_async(par(task), IteratorTag());
+    test_for_each_bad_alloc(datapar_execution, IteratorTag());
+    test_for_each_bad_alloc_async(datapar_execution(task), IteratorTag());
 }
 
 void for_each_bad_alloc_test()

--- a/tests/unit/parallel/datapar_algorithms/foreach_datapar.cpp
+++ b/tests/unit/parallel/datapar_algorithms/foreach_datapar.cpp
@@ -1,0 +1,110 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "../algorithms/foreach_tests.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_for_each()
+{
+    using namespace hpx::parallel;
+
+    test_for_each(datapar_execution, IteratorTag());
+//     test_for_each_async(datapar_execution(task), IteratorTag());
+}
+
+void for_each_test()
+{
+    test_for_each<std::random_access_iterator_tag>();
+    test_for_each<std::forward_iterator_tag>();
+    test_for_each<std::input_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_for_each_exception()
+{
+    using namespace hpx::parallel;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_for_each_exception(datapar_execution, IteratorTag());
+//     test_for_each_exception_async(datapar_execution(task), IteratorTag());
+}
+
+void for_each_exception_test()
+{
+    test_for_each_exception<std::random_access_iterator_tag>();
+    test_for_each_exception<std::forward_iterator_tag>();
+    test_for_each_exception<std::input_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_for_each_bad_alloc()
+{
+    using namespace hpx::parallel;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_for_each_bad_alloc(seq, IteratorTag());
+//     test_for_each_bad_alloc_async(par(task), IteratorTag());
+}
+
+void for_each_bad_alloc_test()
+{
+    test_for_each_bad_alloc<std::random_access_iterator_tag>();
+    test_for_each_bad_alloc<std::forward_iterator_tag>();
+    test_for_each_bad_alloc<std::input_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int)std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    for_each_test();
+    for_each_exception_test();
+    for_each_bad_alloc_test();
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace boost::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()
+        ("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run")
+        ;
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {
+        "hpx.os_threads=all"
+    };
+
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/parallel/datapar_algorithms/foreachn_datapar.cpp
+++ b/tests/unit/parallel/datapar_algorithms/foreachn_datapar.cpp
@@ -11,7 +11,7 @@
 #include <string>
 #include <vector>
 
-#include "foreach_tests.hpp"
+#include "../algorithms/foreach_tests.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
@@ -19,21 +19,8 @@ void test_for_each_n()
 {
     using namespace hpx::parallel;
 
-    test_for_each_n(seq, IteratorTag());
-    test_for_each_n(par, IteratorTag());
-    test_for_each_n(par_vec, IteratorTag());
-
-    test_for_each_n_async(seq(task), IteratorTag());
-    test_for_each_n_async(par(task), IteratorTag());
-
-#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_for_each_n(execution_policy(seq), IteratorTag());
-    test_for_each_n(execution_policy(par), IteratorTag());
-    test_for_each_n(execution_policy(par_vec), IteratorTag());
-
-    test_for_each_n(execution_policy(seq(task)), IteratorTag());
-    test_for_each_n(execution_policy(par(task)), IteratorTag());
-#endif
+    test_for_each_n(datapar_execution, IteratorTag());
+    test_for_each_n_async(datapar_execution(task), IteratorTag());
 }
 
 void for_each_n_test()

--- a/tests/unit/parallel/datapar_algorithms/inner_product_datapar.cpp
+++ b/tests/unit/parallel/datapar_algorithms/inner_product_datapar.cpp
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-#include "inner_product_tests.hpp"
+#include "../algorithms/inner_product_tests.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
@@ -18,21 +18,8 @@ void test_inner_product()
 {
     using namespace hpx::parallel;
 
-    test_inner_product(seq, IteratorTag());
-    test_inner_product(par, IteratorTag());
-    test_inner_product(par_vec, IteratorTag());
-
-    test_inner_product_async(seq(task), IteratorTag());
-    test_inner_product_async(par(task), IteratorTag());
-
-#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_inner_product(execution_policy(seq), IteratorTag());
-    test_inner_product(execution_policy(par), IteratorTag());
-    test_inner_product(execution_policy(par_vec), IteratorTag());
-
-    test_inner_product(execution_policy(seq(task)), IteratorTag());
-    test_inner_product(execution_policy(par(task)), IteratorTag());
-#endif
+    test_inner_product(datapar_execution, IteratorTag());
+    test_inner_product_async(datapar_execution(task), IteratorTag());
 }
 
 void inner_product_test()

--- a/tests/unit/parallel/datapar_algorithms/transform_binary2_datapar.cpp
+++ b/tests/unit/parallel/datapar_algorithms/transform_binary2_datapar.cpp
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-#include "transform_binary2_tests.hpp"
+#include "../algorithms/transform_binary2_tests.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
@@ -18,21 +18,8 @@ void test_transform_binary2()
 {
     using namespace hpx::parallel;
 
-    test_transform_binary2(seq, IteratorTag());
-    test_transform_binary2(par, IteratorTag());
-    test_transform_binary2(par_vec, IteratorTag());
-
-    test_transform_binary2_async(seq(task), IteratorTag());
-    test_transform_binary2_async(par(task), IteratorTag());
-
-#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_transform_binary2(execution_policy(seq), IteratorTag());
-    test_transform_binary2(execution_policy(par), IteratorTag());
-    test_transform_binary2(execution_policy(par_vec), IteratorTag());
-
-    test_transform_binary2(execution_policy(seq(task)), IteratorTag());
-    test_transform_binary2(execution_policy(par(task)), IteratorTag());
-#endif
+    test_transform_binary2(datapar_execution, IteratorTag());
+    test_transform_binary2_async(datapar_execution(task), IteratorTag());
 }
 
 void transform_binary2_test()
@@ -48,22 +35,8 @@ void test_transform_binary2_exception()
 {
     using namespace hpx::parallel;
 
-    // If the execution policy object is of type vector_execution_policy,
-    // std::terminate shall be called. therefore we do not test exceptions
-    // with a vector execution policy
-    test_transform_binary2_exception(seq, IteratorTag());
-    test_transform_binary2_exception(par, IteratorTag());
-
-    test_transform_binary2_exception_async(seq(task), IteratorTag());
-    test_transform_binary2_exception_async(par(task), IteratorTag());
-
-#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_transform_binary2_exception(execution_policy(seq), IteratorTag());
-    test_transform_binary2_exception(execution_policy(par), IteratorTag());
-
-    test_transform_binary2_exception(execution_policy(seq(task)), IteratorTag());
-    test_transform_binary2_exception(execution_policy(par(task)), IteratorTag());
-#endif
+    test_transform_binary2_exception(datapar_execution, IteratorTag());
+    test_transform_binary2_exception_async(datapar_execution(task), IteratorTag());
 }
 
 void transform_binary2_exception_test()
@@ -79,22 +52,8 @@ void test_transform_binary2_bad_alloc()
 {
     using namespace hpx::parallel;
 
-    // If the execution policy object is of type vector_execution_policy,
-    // std::terminate shall be called. therefore we do not test exceptions
-    // with a vector execution policy
-    test_transform_binary2_bad_alloc(seq, IteratorTag());
-    test_transform_binary2_bad_alloc(par, IteratorTag());
-
-    test_transform_binary2_bad_alloc_async(seq(task), IteratorTag());
-    test_transform_binary2_bad_alloc_async(par(task), IteratorTag());
-
-#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_transform_binary2_bad_alloc(execution_policy(seq), IteratorTag());
-    test_transform_binary2_bad_alloc(execution_policy(par), IteratorTag());
-
-    test_transform_binary2_bad_alloc(execution_policy(seq(task)), IteratorTag());
-    test_transform_binary2_bad_alloc(execution_policy(par(task)), IteratorTag());
-#endif
+    test_transform_binary2_bad_alloc(datapar_execution, IteratorTag());
+    test_transform_binary2_bad_alloc_async(datapar_execution(task), IteratorTag());
 }
 
 void transform_binary2_bad_alloc_test()

--- a/tests/unit/parallel/datapar_algorithms/transform_binary_datapar.cpp
+++ b/tests/unit/parallel/datapar_algorithms/transform_binary_datapar.cpp
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-#include "transform_binary_tests.hpp"
+#include "../algorithms/transform_binary_tests.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
@@ -18,21 +18,8 @@ void test_transform_binary()
 {
     using namespace hpx::parallel;
 
-    test_transform_binary(seq, IteratorTag());
-    test_transform_binary(par, IteratorTag());
-    test_transform_binary(par_vec, IteratorTag());
-
-    test_transform_binary_async(seq(task), IteratorTag());
-    test_transform_binary_async(par(task), IteratorTag());
-
-#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_transform_binary(execution_policy(seq), IteratorTag());
-    test_transform_binary(execution_policy(par), IteratorTag());
-    test_transform_binary(execution_policy(par_vec), IteratorTag());
-
-    test_transform_binary(execution_policy(seq(task)), IteratorTag());
-    test_transform_binary(execution_policy(par(task)), IteratorTag());
-#endif
+    test_transform_binary(datapar_execution, IteratorTag());
+    test_transform_binary_async(datapar_execution(task), IteratorTag());
 }
 
 void transform_binary_test()
@@ -48,22 +35,8 @@ void test_transform_binary_exception()
 {
     using namespace hpx::parallel;
 
-    // If the execution policy object is of type vector_execution_policy,
-    // std::terminate shall be called. therefore we do not test exceptions
-    // with a vector execution policy
-    test_transform_binary_exception(seq, IteratorTag());
-    test_transform_binary_exception(par, IteratorTag());
-
-    test_transform_binary_exception_async(seq(task), IteratorTag());
-    test_transform_binary_exception_async(par(task), IteratorTag());
-
-#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_transform_binary_exception(execution_policy(seq), IteratorTag());
-    test_transform_binary_exception(execution_policy(par), IteratorTag());
-
-    test_transform_binary_exception(execution_policy(seq(task)), IteratorTag());
-    test_transform_binary_exception(execution_policy(par(task)), IteratorTag());
-#endif
+    test_transform_binary_exception(datapar_execution, IteratorTag());
+    test_transform_binary_exception_async(datapar_execution(task), IteratorTag());
 }
 
 void transform_binary_exception_test()
@@ -79,22 +52,8 @@ void test_transform_binary_bad_alloc()
 {
     using namespace hpx::parallel;
 
-    // If the execution policy object is of type vector_execution_policy,
-    // std::terminate shall be called. therefore we do not test exceptions
-    // with a vector execution policy
-    test_transform_binary_bad_alloc(seq, IteratorTag());
-    test_transform_binary_bad_alloc(par, IteratorTag());
-
-    test_transform_binary_bad_alloc_async(seq(task), IteratorTag());
-    test_transform_binary_bad_alloc_async(par(task), IteratorTag());
-
-#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_transform_binary_bad_alloc(execution_policy(seq), IteratorTag());
-    test_transform_binary_bad_alloc(execution_policy(par), IteratorTag());
-
-    test_transform_binary_bad_alloc(execution_policy(seq(task)), IteratorTag());
-    test_transform_binary_bad_alloc(execution_policy(par(task)), IteratorTag());
-#endif
+    test_transform_binary_bad_alloc(datapar_execution, IteratorTag());
+    test_transform_binary_bad_alloc_async(datapar_execution(task), IteratorTag());
 }
 
 void transform_binary_bad_alloc_test()

--- a/tests/unit/parallel/datapar_algorithms/transform_datapar.cpp
+++ b/tests/unit/parallel/datapar_algorithms/transform_datapar.cpp
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-#include "transform_tests.hpp"
+#include "../algorithms/transform_tests.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
@@ -18,21 +18,8 @@ void test_transform()
 {
     using namespace hpx::parallel;
 
-    test_transform(seq, IteratorTag());
-    test_transform(par, IteratorTag());
-    test_transform(par_vec, IteratorTag());
-
-    test_transform_async(seq(task), IteratorTag());
-    test_transform_async(par(task), IteratorTag());
-
-#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_transform(execution_policy(seq), IteratorTag());
-    test_transform(execution_policy(par), IteratorTag());
-    test_transform(execution_policy(par_vec), IteratorTag());
-
-    test_transform(execution_policy(seq(task)), IteratorTag());
-    test_transform(execution_policy(par(task)), IteratorTag());
-#endif
+    test_transform(datapar_execution, IteratorTag());
+    test_transform_async(datapar_execution(task), IteratorTag());
 }
 
 void transform_test()
@@ -47,22 +34,8 @@ void test_transform_exception()
 {
     using namespace hpx::parallel;
 
-    // If the execution policy object is of type vector_execution_policy,
-    // std::terminate shall be called. therefore we do not test exceptions
-    // with a vector execution policy
-    test_transform_exception(seq, IteratorTag());
-    test_transform_exception(par, IteratorTag());
-
-    test_transform_exception_async(seq(task), IteratorTag());
-    test_transform_exception_async(par(task), IteratorTag());
-
-#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_transform_exception(execution_policy(seq), IteratorTag());
-    test_transform_exception(execution_policy(par), IteratorTag());
-
-    test_transform_exception(execution_policy(seq(task)), IteratorTag());
-    test_transform_exception(execution_policy(par(task)), IteratorTag());
-#endif
+    test_transform_exception(datapar_execution, IteratorTag());
+    test_transform_exception_async(datapar_execution(task), IteratorTag());
 }
 
 void transform_exception_test()
@@ -78,22 +51,8 @@ void test_transform_bad_alloc()
 {
     using namespace hpx::parallel;
 
-    // If the execution policy object is of type vector_execution_policy,
-    // std::terminate shall be called. therefore we do not test exceptions
-    // with a vector execution policy
-    test_transform_bad_alloc(seq, IteratorTag());
-    test_transform_bad_alloc(par, IteratorTag());
-
-    test_transform_bad_alloc_async(seq(task), IteratorTag());
-    test_transform_bad_alloc_async(par(task), IteratorTag());
-
-#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_transform_bad_alloc(execution_policy(seq), IteratorTag());
-    test_transform_bad_alloc(execution_policy(par), IteratorTag());
-
-    test_transform_bad_alloc(execution_policy(seq(task)), IteratorTag());
-    test_transform_bad_alloc(execution_policy(par(task)), IteratorTag());
-#endif
+    test_transform_bad_alloc(datapar_execution, IteratorTag());
+    test_transform_bad_alloc_async(datapar_execution(task), IteratorTag());
 }
 
 void transform_bad_alloc_test()


### PR DESCRIPTION
This PR proposes to add a new execution policy (currently called `datapar_execution`, this name may change in the future) which applies certain transformations to each of the elements of the input/output sequences in order to be able to vectorize the loop iterations. The transformations pack a number of input elements into a 'vector-pack' which is then passed to the iteration. Note that the iteration function needs to be either a generic lambda or a polymorphic function object as the types used are not always 'known' to the user. 

The patch also supports using `datapar_execution(task)` to make the algorithm invocations asynchronous.

The transformations are applied for random-access input/output sequences of arithmetic types only. For all other cases the execution will silently fall back to the `par` execution policy..

This PR adds the `for_each`, `for_each_n`, `count`, `count_if`, and `transform` algorithms. Later commits add support for `inner_product` as well.

Code using the new execution policies depends on the [Vc library](https://github.com/VcDevel/Vc). Specify `Vc_ROOT=<vc_install_dir>` to cmake for it to be located.

Other execution policies will be added in the future, such as `dataseq_execution` and `dataseq_executon(task)`, i.e. vectorization without parallelization. We will also add support for executors and executor parameters.