### PR TITLE
Fixing hpx::lcos::local::barrier

### DIFF
--- a/hpx/lcos/local/barrier.hpp
+++ b/hpx/lcos/local/barrier.hpp
@@ -1,17 +1,20 @@
 //  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2016 Thomas Heller
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+//  The algorithm was taken from http://locklessinc.com/articles/barriers/
 
 #if !defined(HPX_LCOS_BARRIER_JUN_23_2008_0530PM)
 #define HPX_LCOS_BARRIER_JUN_23_2008_0530PM
 
+#include <hpx/config.hpp>
 #include <hpx/lcos/local/detail/condition_variable.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 
+#include <climits>
 #include <cstddef>
-#include <mutex>
-#include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace lcos { namespace local
@@ -24,34 +27,28 @@ namespace hpx { namespace lcos { namespace local
     ///         and it can't be triggered using the action (parcel) mechanism.
     ///         It is just a low level synchronization primitive allowing to
     ///         synchronize a given number of \a threads.
-    class barrier
+    class HPX_EXPORT barrier
     {
     private:
         typedef lcos::local::spinlock mutex_type;
 
+        HPX_STATIC_CONSTEXPR std::size_t barrier_flag =
+            static_cast<std::size_t>(1) << (CHAR_BIT * sizeof(std::size_t) - 1);
+
     public:
-        barrier(std::size_t number_of_threads)
-          : number_of_threads_(number_of_threads), mtx_(), cond_()
-        {}
+        barrier(std::size_t number_of_threads);
+        ~barrier();
 
         /// The function \a wait will block the number of entering \a threads
         /// (as given by the constructor parameter \a number_of_threads),
         /// releasing all waiting threads as soon as the last \a thread
         /// entered this function.
-        void wait()
-        {
-            std::unique_lock<mutex_type> l(mtx_);
-            if (cond_.size(l) < number_of_threads_-1) {
-                cond_.wait(std::move(l), "barrier::wait");
-            }
-            else {
-                // release the threads
-                cond_.notify_all(std::move(l));
-            }
-        }
+        void wait();
 
     private:
         std::size_t const number_of_threads_;
+        std::size_t total_;
+
         mutable mutex_type mtx_;
         local::detail::condition_variable cond_;
     };

--- a/src/lcos/local/barrier.cpp
+++ b/src/lcos/local/barrier.cpp
@@ -1,0 +1,71 @@
+//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2016 Thomas Heller
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/lcos/local/barrier.hpp>
+
+#include <cstddef>
+#include <mutex>
+#include <utility>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace lcos { namespace local
+{
+    barrier::barrier(std::size_t number_of_threads)
+      : number_of_threads_(number_of_threads),
+        total_(barrier_flag),
+        mtx_(),
+        cond_()
+    {}
+
+    barrier::~barrier()
+    {
+        std::unique_lock<mutex_type> l(mtx_);
+
+        while (total_ > barrier_flag)
+        {
+            // Wait until everyone exits the barrier
+            cond_.wait(l, "barrier::~barrier");
+        }
+    }
+
+    void barrier::wait()
+    {
+        std::unique_lock<mutex_type> l(mtx_);
+
+        while (total_ > barrier_flag)
+        {
+            // wait until everyone exits the barrier
+            cond_.wait(l, "barrier::wait");
+        }
+
+        // Are we the first to enter?
+        if (total_ == barrier_flag) total_ = 0;
+
+        ++total_;
+
+        if (total_ == number_of_threads_)
+        {
+            total_ += barrier_flag - 1;
+            cond_.notify_all(std::move(l));
+        }
+        else
+        {
+            while (total_ < barrier_flag)
+            {
+                // wait until enough threads enter the barrier
+                cond_.wait(l, "barrier::wait");
+            }
+            --total_;
+
+            // get entering threads to wake up
+            if (total_ == barrier_flag)
+            {
+                cond_.notify_all(std::move(l));
+            }
+        }
+    }
+
+}}}


### PR DESCRIPTION
This patch implements the algorithm taken from
http://locklessinc.com/articles/barriers/. This fixes the hang that occasionally
occurs in the local_barrier test.