### PR TITLE
Allowing remote direct actions to be executed without spawning a task

### DIFF
--- a/hpx/lcos/base_lco.hpp
+++ b/hpx/lcos/base_lco.hpp
@@ -94,6 +94,8 @@ namespace hpx { namespace lcos
         /// LCO instances, it carries no additional parameters.
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(base_lco, set_event_nonvirt,
             set_event_action);
+        HPX_DEFINE_COMPONENT_ACTION(base_lco, set_event_nonvirt,
+            set_event_non_direct_action);
 
         /// The \a set_exception_action may be used to transfer arbitrary error
         /// information from the remote site to the LCO instance specified as
@@ -104,6 +106,8 @@ namespace hpx { namespace lcos
         ///               to this LCO instance.
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(base_lco, set_exception_nonvirt,
             set_exception_action);
+        HPX_DEFINE_COMPONENT_ACTION(base_lco, set_exception_nonvirt,
+            set_exception_non_direct_action);
 
         /// The \a connect_action may be used to
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(base_lco, connect_nonvirt,

--- a/hpx/lcos/base_lco_with_value.hpp
+++ b/hpx/lcos/base_lco_with_value.hpp
@@ -114,11 +114,15 @@ namespace hpx { namespace lcos
         ///               back to this LCO instance.
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(base_lco_with_value,
             set_value_nonvirt, set_value_action);
+        HPX_DEFINE_COMPONENT_ACTION(base_lco_with_value,
+            set_value_nonvirt, set_value_non_direct_action);
 
         /// The \a get_value_action may be used to query the value this LCO
         /// instance exposes as its 'result' value.
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(base_lco_with_value,
             get_value_nonvirt, get_value_action);
+        HPX_DEFINE_COMPONENT_ACTION(base_lco_with_value,
+            get_value_nonvirt, get_value_non_direct_action);
     };
 
     /// The base_lco<void> specialization is used whenever the set_event action

--- a/hpx/lcos/server/barrier.hpp
+++ b/hpx/lcos/server/barrier.hpp
@@ -122,5 +122,10 @@ HPX_REGISTER_ACTION_DECLARATION(
   , hpx_lcos_server_barrier_create_component_action
 )
 
+HPX_REGISTER_ACTION_DECLARATION(
+    hpx::lcos::server::barrier::set_event_non_direct_action
+  , hpx_lcos_server_barrier_set_event_non_direct_action
+)
+
 #endif
 

--- a/hpx/lcos/stubs/barrier.hpp
+++ b/hpx/lcos/stubs/barrier.hpp
@@ -22,7 +22,7 @@ namespace hpx { namespace lcos { namespace stubs
         static lcos::future<void>
         wait_async(naming::id_type const& gid)
         {
-            typedef lcos::base_lco::set_event_action action_type;
+            typedef lcos::base_lco::set_event_non_direct_action action_type;
             return hpx::async<action_type>(gid);
         }
 

--- a/hpx/runtime/actions/basic_action.hpp
+++ b/hpx/runtime/actions/basic_action.hpp
@@ -625,6 +625,7 @@ namespace hpx { namespace actions
         get_instance_count_action_id,
         hpx_get_locality_name_action_id,
         hpx_lcos_server_barrier_create_component_action_id,
+        hpx_lcos_server_barrier_set_event_non_direct_action_id,
         hpx_lcos_server_latch_create_component_action_id,
         hpx_lcos_server_latch_wait_action_id,
         list_component_type_action_id,

--- a/hpx/runtime/actions/transfer_action.hpp
+++ b/hpx/runtime/actions/transfer_action.hpp
@@ -290,24 +290,7 @@ namespace hpx { namespace actions
                 reinterpret_cast<threads::thread_id_repr_type>(parent_id_);
             data.parent_locality_id = parent_locality_;
 #endif
-//             FIXME: The commented code should really just work. If we execute
-//             direct action directly, we run into the situation of possible
-//             lockups due to code in direct actions that suspends
-//             if (direct_execution::value || hpx::is_pre_startup())
-            if (hpx::is_pre_startup())
-            {
-                applier::detail::apply_helper<derived_type, true>::call(
-                    std::move(data), target, lva, priority_,
-                    util::get<Is>(std::move(arguments_))...);
-                return;
-            }
-//             else
-//             {
-//                 applier::detail::apply_helper<derived_type>::call(
-//                     std::move(data), target, lva, priority_,
-//                     util::get<Is>(std::move(arguments_))...);
-//             }
-            applier::detail::apply_helper<derived_type, false>::call(
+            applier::detail::apply_helper<derived_type>::call(
                 std::move(data), target, lva, priority_,
                 util::get<Is>(std::move(arguments_))...);
         }
@@ -344,13 +327,7 @@ namespace hpx { namespace actions
                 reinterpret_cast<threads::thread_id_repr_type>(parent_id_);
             data.parent_locality_id = parent_locality_;
 #endif
-//             FIXME: The commented code should really just work. If we execute
-//             direct action directly, we run into the situation of possible
-//             lockups due to code in direct actions that suspends
-//             applier::detail::apply_helper<derived_type>::call(
-//                 std::move(data), std::move(cont), target,
-//                 lva, priority_, util::get<Is>(std::move(arguments_))...);
-            applier::detail::apply_helper<derived_type, false>::call(
+            applier::detail::apply_helper<derived_type>::call(
                 std::move(data), std::move(cont), target,
                 lva, priority_, util::get<Is>(std::move(arguments_))...);
         }

--- a/hpx/runtime/applier/apply_helper.hpp
+++ b/hpx/runtime/applier/apply_helper.hpp
@@ -134,7 +134,10 @@ namespace hpx { namespace applier { namespace detail
             naming::address::address_type lva,
             threads::thread_priority priority, Ts &&... vs)
         {
-            if (this_thread::has_sufficient_stack_space() || hpx::is_pre_startup())
+            // Direct actions should be able to be executed from a non-HPX thread
+            // as well
+            if (this_thread::has_sufficient_stack_space() ||
+                hpx::threads::get_self_ptr() == nullptr)
             {
                 Action::execute_function(lva, std::forward<Ts>(vs)...);
             }
@@ -166,7 +169,10 @@ namespace hpx { namespace applier { namespace detail
             naming::id_type const& target, naming::address::address_type lva,
             threads::thread_priority priority, Ts &&... vs)
         {
-            if (this_thread::has_sufficient_stack_space())
+            // Direct actions should be able to be executed from a non-HPX thread
+            // as well
+            if (this_thread::has_sufficient_stack_space() ||
+                hpx::threads::get_self_ptr() == nullptr)
             {
                 try {
                     cont->trigger(Action::execute_function(lva,

--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -253,7 +253,7 @@ namespace hpx { namespace components { namespace server
         HPX_DEFINE_COMPONENT_ACTION(runtime_support, load_components);
         HPX_DEFINE_COMPONENT_ACTION(runtime_support, call_startup_functions);
         HPX_DEFINE_COMPONENT_ACTION(runtime_support, call_shutdown_functions);
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(runtime_support, free_component,
+        HPX_DEFINE_COMPONENT_ACTION(runtime_support, free_component,
             free_component_action);
         HPX_DEFINE_COMPONENT_ACTION(runtime_support, shutdown);
         HPX_DEFINE_COMPONENT_ACTION(runtime_support, shutdown_all);

--- a/hpx/util/detail/yield_k.hpp
+++ b/hpx/util/detail/yield_k.hpp
@@ -11,6 +11,8 @@
 
 #include <hpx/config.hpp>
 
+#include <hpx/runtime/threads/thread_helpers.hpp>
+
 #include <chrono>
 #include <cstddef>
 

--- a/src/lcos/barrier.cpp
+++ b/src/lcos/barrier.cpp
@@ -25,3 +25,9 @@ HPX_REGISTER_ACTION_ID(
   , hpx_lcos_server_barrier_create_component_action
   , hpx::actions::hpx_lcos_server_barrier_create_component_action_id
 )
+
+HPX_REGISTER_ACTION_ID(
+    hpx::lcos::server::barrier::set_event_non_direct_action
+  , hpx_lcos_server_barrier_set_event_non_direct_action
+  , hpx::actions::hpx_lcos_server_barrier_set_event_non_direct_action_id
+)

--- a/src/lcos/detail/future_data.cpp
+++ b/src/lcos/detail/future_data.cpp
@@ -6,9 +6,11 @@
 #include <hpx/config.hpp>
 #include <hpx/exception.hpp>
 #include <hpx/util/unique_function.hpp>
+#include <hpx/util/detail/yield_k.hpp>
 #include <hpx/lcos/local/futures_factory.hpp>
 #include <hpx/lcos/detail/future_data.hpp>
 #include <hpx/runtime/threads/thread.hpp>
+#include <hpx/runtime/launch_policy.hpp>
 
 #include <utility>
 
@@ -19,16 +21,31 @@ namespace hpx { namespace lcos { namespace detail
     {
         lcos::local::futures_factory<bool()> p(std::move(f));
 
+        bool is_hpx_thread = nullptr != hpx::threads::get_self_ptr();
+        hpx::launch policy = launch::fork;
+        if (!is_hpx_thread)
+            policy = launch::async;
+
         // launch a new thread executing the given function
         threads::thread_id_type tid = p.apply(
-            launch::fork, threads::thread_priority_boost,
+            policy, threads::thread_priority_boost,
             threads::thread_stacksize_default, ec);
         if (ec) return false;
 
-        // make sure this thread is executed last
-        hpx::this_thread::yield_to(thread::id(std::move(tid)));
-
         // wait for the task to run
-        return p.get_future().get(ec);
+        if (is_hpx_thread)
+        {
+            // make sure this thread is executed last
+            hpx::this_thread::yield_to(thread::id(std::move(tid)));
+            return p.get_future().get(ec);
+        }
+        else
+        {
+            // If we are not on a HPX thread, we need to return immediately, to
+            // allow the newly spawned thread to execute. This might swallow
+            // possible exceptions bubbling up from the completion handler (which
+            // shouldn't happen anyway...
+            return true;
+        }
     }
 }}}

--- a/tests/performance/network/osu/osu_latency.cpp
+++ b/tests/performance/network/osu/osu_latency.cpp
@@ -49,7 +49,7 @@ message(hpx::serialization::serialize_buffer<char> const& receive_buffer)
 {
     return receive_buffer;
 }
-HPX_PLAIN_ACTION(message);
+HPX_PLAIN_DIRECT_ACTION(message);
 
 HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(
     hpx::serialization::serialize_buffer<char>, serialization_buffer_char);
@@ -61,7 +61,7 @@ message_double(double d)
 {
     return d;
 }
-HPX_PLAIN_ACTION(message_double);
+HPX_PLAIN_DIRECT_ACTION(message_double);
 
 ///////////////////////////////////////////////////////////////////////////////
 double receive_double(

--- a/tests/regressions/actions/component_action_move_semantics.cpp
+++ b/tests/regressions/actions/component_action_move_semantics.cpp
@@ -171,7 +171,7 @@ void test_actions()
                     action_move_semantics::return_test_non_movable_action,
                 non_movable_object
                 >(id)
-            ), 4u, 8u); // transfer_action + bind + function + ?call +
+            ), 3u, 8u); // transfer_action + function + ?call +
                     // set_value + ?return
         }
     }
@@ -237,14 +237,14 @@ void test_direct_actions()
                     action_move_semantics::test_non_movable_direct_action,
                 non_movable_object
                 >(id)
-            ), 3u); // transfer_action + bind + function
+            ), 1u); // transfer_action
 
             HPX_TEST_EQ((
                 move_object<
                     action_move_semantics::test_non_movable_direct_action,
                 non_movable_object
                 >(id)
-            ), 3u); // transfer_action + bind + function
+            ), 1u); // transfer_action
         }
 
         // test movable_object()
@@ -281,7 +281,7 @@ void test_direct_actions()
                     action_move_semantics::return_test_non_movable_direct_action,
                 non_movable_object
                 >(id)
-            ), 4u, 8u); // transfer_action + bind + function + ?call +
+            ), 3u, 8u); // transfer_action + function + ?call +
                     // set_value + ?return
         }
     }

--- a/tests/regressions/actions/plain_action_move_semantics.cpp
+++ b/tests/regressions/actions/plain_action_move_semantics.cpp
@@ -432,7 +432,7 @@ void test_object_actions()
                 return_object<
                     return_non_movable_object_action, non_movable_object
                 >(id)
-            ), 4u, 8u); // transfer_action + bind + function + ?call +
+            ), 3u, 8u); // transfer_action + function + ?call +
                     // set_value + ?return
         }
     }
@@ -483,12 +483,12 @@ void test_object_direct_actions()
             HPX_TEST_EQ((
                 pass_object<pass_non_movable_object_direct_action,
                 non_movable_object>(id)
-            ), 3u); // transfer_action + bind + function
+            ), 1u); // transfer_action
 
             HPX_TEST_EQ((
                 move_object<pass_non_movable_object_direct_action,
                 non_movable_object>(id)
-            ), 3u); // transfer_action + bind + function
+            ), 1u); // transfer_action
         }
 
         // test std::size_t(movable_object)
@@ -527,12 +527,12 @@ void test_object_direct_actions()
             HPX_TEST_EQ((
                 pass_object<pass_non_movable_object_value_direct_action,
                 non_movable_object>(id)
-            ), 4u); // transfer_action + bind + function + call
+            ), 2u); // transfer_action + call
 
             HPX_TEST_EQ((
                 move_object<pass_non_movable_object_value_direct_action,
                 non_movable_object>(id)
-            ), 4u); // transfer_action + bind + function + call
+            ), 2u); // transfer_action + call
         }
 
         // test movable_object()
@@ -565,7 +565,7 @@ void test_object_direct_actions()
                 return_object<
                     return_non_movable_object_direct_action, non_movable_object
                 >(id)
-            ), 4u, 8u); // transfer_action + bind + function + ?call +
+            ), 3u, 8u); // transfer_action + function + ?call +
                     // set_value + ?return
         }
     }


### PR DESCRIPTION
With this patch, direct actions are now always executed directly on the
receiving side. This means that they might get executed in a non-HPX thread.

This is a breaking change in behavior as it doesn't require direct_actions to run on HPX threads.
