### PR TITLE
Bug fixes for hpx.compute and hpx::lcos::channel

### DIFF
--- a/hpx/compute/traits/allocator_traits.hpp
+++ b/hpx/compute/traits/allocator_traits.hpp
@@ -137,7 +137,8 @@ namespace hpx { namespace compute { namespace traits
                 Ts &&... vs)
             {
                 typedef typename Allocator::pointer pointer;
-                pointer init_value(std::forward<Ts>(vs)...);
+                typedef typename Allocator::value_type value_type;
+                value_type init_value(std::forward<Ts>(vs)...);
                 pointer end = p + count;
                 typename Allocator::size_type allocated = 0;
                 for(pointer it = p; it != end; ++it)

--- a/hpx/compute/vector.hpp
+++ b/hpx/compute/vector.hpp
@@ -115,6 +115,7 @@ namespace hpx { namespace compute
           , alloc_(std::move(other.alloc_))
           , data_(std::move(other.data_))
         {
+            other.data_ = nullptr;
             other.size_ = 0;
             other.capacity_ = 0;
         }
@@ -125,6 +126,7 @@ namespace hpx { namespace compute
           , alloc_(alloc)
           , data_(std::move(other.data_))
         {
+            other.data_ = nullptr;
             other.size_ = 0;
             other.capacity_ = 0;
         }
@@ -185,11 +187,13 @@ namespace hpx { namespace compute
             if (this == &other)
                 return *this;
 
+
             size_ = other.size_;
             capacity_ = other.capacity_;
             alloc_ = std::move(other.alloc_);
             data_ = std::move(other.data_);
 
+            other.data_ = nullptr;
             other.size_ = 0;
             other.capacity_ = 0;
 

--- a/hpx/lcos/local/channel.hpp
+++ b/hpx/lcos/local/channel.hpp
@@ -117,12 +117,12 @@ namespace hpx { namespace lcos { namespace local
 
                 if (closed_)
                 {
+                    l.unlock();
                     // the requested item must be available, otherwise this
                     // would create a deadlock
                     hpx::future<T> f;
                     if (!buffer_.try_receive(generation, &f))
                     {
-                        l.unlock();
                         return hpx::make_exceptional_future<T>(
                             HPX_GET_EXCEPTION(hpx::invalid_status,
                                 "hpx::lcos::local::channel::get",
@@ -137,14 +137,16 @@ namespace hpx { namespace lcos { namespace local
 
             bool try_get(std::size_t generation, hpx::future<T>* f = nullptr)
             {
-                std::lock_guard<mutex_type> l(mtx_);
+                {
+                    std::lock_guard<mutex_type> l(mtx_);
 
-                if (buffer_.empty() && closed_)
-                    return false;
+                    if (buffer_.empty() && closed_)
+                        return false;
 
-                ++get_generation_;
-                if (generation == std::size_t(-1))
-                    generation = get_generation_;
+                    ++get_generation_;
+                    if (generation == std::size_t(-1))
+                        generation = get_generation_;
+                }
 
                 if (f != nullptr)
                     *f = buffer_.receive(generation);
@@ -154,47 +156,50 @@ namespace hpx { namespace lcos { namespace local
 
             void set(std::size_t generation, T && t)
             {
-                std::unique_lock<mutex_type> l(mtx_);
-                if(closed_)
                 {
-                    l.unlock();
-                    HPX_THROW_EXCEPTION(hpx::invalid_status,
-                        "hpx::lcos::local::channel::set",
-                        "attempting to write to a closed channel");
-                    return;
-                }
+                    std::unique_lock<mutex_type> l(mtx_);
+                    if(closed_)
+                    {
+                        l.unlock();
+                        HPX_THROW_EXCEPTION(hpx::invalid_status,
+                            "hpx::lcos::local::channel::set",
+                            "attempting to write to a closed channel");
+                        return;
+                    }
 
-                ++set_generation_;
-                if (generation == std::size_t(-1))
-                    generation = set_generation_;
+                    ++set_generation_;
+                    if (generation == std::size_t(-1))
+                        generation = set_generation_;
+                }
 
                 buffer_.store_received(generation, std::move(t));
             }
 
             void close()
             {
-                std::unique_lock<mutex_type> l(mtx_);
-                if(closed_)
-                {
-                    l.unlock();
-                    HPX_THROW_EXCEPTION(hpx::invalid_status,
-                        "hpx::lcos::local::channel::close",
-                        "attempting to close an already closed channel");
-                    return;
-                }
-
-                closed_ = true;
-
-                if (buffer_.empty())
-                    return;
-
                 boost::exception_ptr e;
-
                 {
-                    util::scoped_unlock<std::unique_lock<mutex_type> > ul(l);
-                    e = HPX_GET_EXCEPTION(hpx::future_cancelled,
-                            "hpx::lcos::local::close",
-                            "canceled waiting on this entry");
+                    std::unique_lock<mutex_type> l(mtx_);
+                    if(closed_)
+                    {
+                        l.unlock();
+                        HPX_THROW_EXCEPTION(hpx::invalid_status,
+                            "hpx::lcos::local::channel::close",
+                            "attempting to close an already closed channel");
+                        return;
+                    }
+
+                    closed_ = true;
+
+                    if (buffer_.empty())
+                        return;
+
+                    {
+                        util::scoped_unlock<std::unique_lock<mutex_type> > ul(l);
+                        e = HPX_GET_EXCEPTION(hpx::future_cancelled,
+                                "hpx::lcos::local::close",
+                                "canceled waiting on this entry");
+                    }
                 }
 
                 // all pending requests which can't be satisfied have to be


### PR DESCRIPTION
From the commit messages:

    Fixing locking problems in hpx::lcos::channel
    
    This patch fixes problem in the channel implementation that led to locks being
    held during suspension.

    Fixing hpx::compute::traits::allocator_traits and vector
    
     - hpx::compute::traits::allocator_traits didn't work with std::allocator<T>
      because it was using the pointer type instead of value_type for the initial
      value
     - hpx::compute::vector move operations lead to data being double freed because
       the move ctor didn't set the rhs data pointer to nullptr
