### PR TITLE
Fixing compilation against Boost 1 62

### DIFF
--- a/hpx/lcos/local/spinlock.hpp
+++ b/hpx/lcos/local/spinlock.hpp
@@ -27,13 +27,7 @@
 #  endif
 #else
 #  if !defined(__ANDROID__) && !defined(ANDROID) && !defined(__arm__)
-#    if defined( BOOST_SP_USE_STD_ATOMIC ) && !defined( __clang__ )
-#      include <boost/smart_ptr/detail/spinlock_std_atomic.hpp>
-#    else
-     //  Clang (at least up to 3.4) can't compile spinlock_pool when
-     //  using std::atomic, so substitute the __sync implementation instead.
-#      include <boost/smart_ptr/detail/spinlock_sync.hpp>
-#    endif
+#    include <boost/smart_ptr/detail/spinlock.hpp>
 #    if defined( __ia64__ ) && defined( __INTEL_COMPILER )
 #      include <ia64intrin.h>
 #    endif

--- a/hpx/lcos/local/spinlock_no_backoff.hpp
+++ b/hpx/lcos/local/spinlock_no_backoff.hpp
@@ -21,9 +21,11 @@
 #    include <boost/detail/interlocked.hpp>
 #  endif
 #else
-#  include <boost/smart_ptr/detail/spinlock_sync.hpp>
-#  if defined( __ia64__ ) && defined( __INTEL_COMPILER )
-#    include <ia64intrin.h>
+#  if !defined(__ANDROID__) && !defined(ANDROID) && !defined(__arm__)
+#    include <boost/smart_ptr/detail/spinlock.hpp>
+#    if defined( __ia64__ ) && defined( __INTEL_COMPILER )
+#      include <ia64intrin.h>
+#    endif
 #  endif
 #endif
 

--- a/hpx/util/lightweight_test.hpp
+++ b/hpx/util/lightweight_test.hpp
@@ -8,6 +8,7 @@
 #if !defined(HPX_F646702C_6556_48FA_BF9D_3E7959983122)
 #define HPX_F646702C_6556_48FA_BF9D_3E7959983122
 
+#include <hpx/config.hpp>
 #include <hpx/util/assert.hpp>
 
 #include <boost/current_function.hpp>

--- a/src/util/lightweight_test.cpp
+++ b/src/util/lightweight_test.cpp
@@ -10,6 +10,6 @@
 
 namespace hpx { namespace util { namespace detail
 {
-    fixture global_fixture = fixture(std::cerr);
+    fixture global_fixture{std::cerr};
 }}}
 


### PR DESCRIPTION
This fixes problems introduced by changes to `boost::detail::spinlock` in Boost V1.62