### PR TITLE
Fixing return type of get_iterator_tuple

### DIFF
--- a/hpx/parallel/algorithms/copy.hpp
+++ b/hpx/parallel/algorithms/copy.hpp
@@ -57,7 +57,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             void operator()(Iter part_begin, std::size_t part_size, std::size_t)
             {
                 using hpx::util::get;
-                auto const& iters = part_begin.get_iterator_tuple();
+                auto iters = part_begin.get_iterator_tuple();
                 util::copy_n_helper(get<0>(iters), part_size, get<1>(iters));
             }
         };
@@ -98,7 +98,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         [](zip_iterator && last) -> zip_iterator
                         {
                             using hpx::util::get;
-                            auto const& iters = last.get_iterator_tuple();
+                            auto iters = last.get_iterator_tuple();
                             util::copy_synchronize(get<0>(iters), get<1>(iters));
                             return std::move(last);
                         }));
@@ -235,14 +235,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         {
                             using hpx::util::get;
 
-                            auto const& iters = part_begin.get_iterator_tuple();
+                            auto iters = part_begin.get_iterator_tuple();
                             util::copy_n_helper(get<0>(iters), part_size,
                                 get<1>(iters));
                         },
                         [](zip_iterator && last) -> zip_iterator
                         {
                             using hpx::util::get;
-                            auto const& iters = last.get_iterator_tuple();
+                            auto iters = last.get_iterator_tuple();
                             util::copy_synchronize(get<0>(iters), get<1>(iters));
                             return std::move(last);
                         }));

--- a/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -146,10 +146,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     [op](zip_iterator part_begin, std::size_t part_size) -> T
                     {
                         T part_init = get<0>(*part_begin++);
+
+                        auto iters = part_begin.get_iterator_tuple();
                         return sequential_exclusive_scan_n(
-                            get<0>(part_begin.get_iterator_tuple()),
+                            get<0>(iters),
                             part_size - 1,
-                            get<1>(part_begin.get_iterator_tuple()),
+                            get<1>(iters),
                             part_init, op);
                     },
                     // step 2 propagates the partition results from left

--- a/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -141,10 +141,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     {
                         T part_init = get<0>(*part_begin);
                         get<1>(*part_begin++) = part_init;
+                        auto iters = part_begin.get_iterator_tuple();
                         return sequential_inclusive_scan_n(
-                            get<0>(part_begin.get_iterator_tuple()),
+                            get<0>(iters),
                             part_size-1,
-                            get<1>(part_begin.get_iterator_tuple()),
+                            get<1>(iters),
                             part_init, op);
                     },
                     // step 2 propagates the partition results from left

--- a/hpx/parallel/algorithms/inner_product.hpp
+++ b/hpx/parallel/algorithms/inner_product.hpp
@@ -155,7 +155,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         zip_iterator part_begin, std::size_t part_size
                     ) mutable -> T
                     {
-                        auto && iters = part_begin.get_iterator_tuple();
+                        auto iters = part_begin.get_iterator_tuple();
                         FwdIter1 it1 = hpx::util::get<0>(iters);
                         FwdIter2 it2 = hpx::util::get<1>(iters);
 

--- a/hpx/parallel/algorithms/move.hpp
+++ b/hpx/parallel/algorithms/move.hpp
@@ -71,7 +71,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         {
                             using hpx::util::get;
 
-                            auto const& iters = part_begin.get_iterator_tuple();
+                            auto iters = part_begin.get_iterator_tuple();
                             util::move_n_helper(get<0>(iters), part_size,
                                 get<1>(iters));
                         },

--- a/hpx/parallel/algorithms/reduce_by_key.hpp
+++ b/hpx/parallel/algorithms/reduce_by_key.hpp
@@ -174,7 +174,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             iVal val_start)
         {
             // the iterator we want is 'second' part of tagged_pair type (from copy_if)
-            auto const &t = zipiter.second.get_iterator_tuple();
+            auto t = zipiter.second.get_iterator_tuple();
             iKey key_end = hpx::util::get<0>(t);
             return std::make_pair(key_end,
                 std::next(val_start, std::distance(key_start, key_end)));
@@ -190,7 +190,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             return lcos::make_future<result_type>(std::move(ziter),
                 [=](ZIter zipiter)
                 {
-                    auto const &t = zipiter.second.get_iterator_tuple();
+                    auto t = zipiter.second.get_iterator_tuple();
                     iKey key_end = hpx::util::get<0>(t);
                     return std::make_pair(key_end,
                         std::next(val_start, std::distance(key_start, key_end)));

--- a/hpx/parallel/algorithms/transform.hpp
+++ b/hpx/parallel/algorithms/transform.hpp
@@ -110,7 +110,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             operator()(Iter part_begin, std::size_t part_size,
                 std::size_t /*part_index*/)
             {
-                auto && iters = part_begin.get_iterator_tuple();
+                auto iters = part_begin.get_iterator_tuple();
                 return util::transform_loop_n(policy_,
                     hpx::util::get<0>(iters), part_size,
                     hpx::util::get<1>(iters),
@@ -369,7 +369,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             operator()(Iter part_begin, std::size_t part_size,
                 std::size_t /*part_index*/)
             {
-                auto && iters = part_begin.get_iterator_tuple();
+                auto iters = part_begin.get_iterator_tuple();
                 return util::transform_binary_loop_n(policy_,
                     hpx::util::get<0>(iters), part_size,
                     hpx::util::get<1>(iters), hpx::util::get<2>(iters),

--- a/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -145,10 +145,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     {
                         T part_init =
                             hpx::util::invoke(conv, get<0>(*part_begin++));
+
+                        auto iters = part_begin.get_iterator_tuple();
                         return sequential_transform_exclusive_scan_n(
-                            get<0>(part_begin.get_iterator_tuple()),
+                            get<0>(iters),
                             part_size - 1,
-                            get<1>(part_begin.get_iterator_tuple()),
+                            get<1>(iters),
                             conv, part_init, op);
                     },
                     // step 2 propagates the partition results from left

--- a/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -145,10 +145,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                             hpx::util::invoke(conv, get<0>(*part_begin));
                         get<1>(*part_begin++) = part_init;
 
+                        auto iters = part_begin.get_iterator_tuple();
                         return sequential_transform_inclusive_scan_n(
-                            get<0>(part_begin.get_iterator_tuple()),
+                            get<0>(iters),
                             part_size-1,
-                            get<1>(part_begin.get_iterator_tuple()),
+                            get<1>(iters),
                             conv, part_init, op);
                     },
                     // step 2 propagates the partition results from left

--- a/hpx/parallel/algorithms/uninitialized_copy.hpp
+++ b/hpx/parallel/algorithms/uninitialized_copy.hpp
@@ -80,10 +80,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         mutable -> partition_result_type
                     {
                         using hpx::util::get;
-                        FwdIter const& dest = get<1>(t.get_iterator_tuple());
+                        auto iters = t.get_iterator_tuple();
+                        FwdIter dest = get<1>(iters);
                         return std::make_pair(dest,
                             sequential_uninitialized_copy_n(
-                                get<0>(t.get_iterator_tuple()), part_size,
+                                get<0>(iters), part_size,
                                 dest, tok));
                     },
                     // finalize, called once if no error occurred

--- a/hpx/parallel/util/zip_iterator.hpp
+++ b/hpx/parallel/util/zip_iterator.hpp
@@ -73,7 +73,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
     {
         typedef typename ZipIter::iterator_tuple_type iterator_tuple_type;
 
-        iterator_tuple_type const& t = zipiter.get_iterator_tuple();
+        iterator_tuple_type t = zipiter.get_iterator_tuple();
         return std::make_pair(hpx::util::get<0>(t), hpx::util::get<1>(t));
     }
 

--- a/hpx/util/zip_iterator.hpp
+++ b/hpx/util/zip_iterator.hpp
@@ -313,11 +313,7 @@ namespace hpx { namespace util
 
             typedef IteratorTuple iterator_tuple_type;
 
-            HPX_HOST_DEVICE iterator_tuple_type get_iterator_tuple()
-            {
-                return iterators_;
-            }
-            HPX_HOST_DEVICE iterator_tuple_type const& get_iterator_tuple() const
+            HPX_HOST_DEVICE iterator_tuple_type get_iterator_tuple() const
             {
                 return iterators_;
             }


### PR DESCRIPTION
`zip_iterator::get_iterator()` should return a reference to be symmetric to the
const overload.

This fixes the failing tests for the uninitialized copy algorithms.