### PR TITLE
Add support for minimal thread local data

### DIFF
--- a/hpx/runtime/threads/coroutines/coroutine.hpp
+++ b/hpx/runtime/threads/coroutines/coroutine.hpp
@@ -109,7 +109,6 @@ namespace hpx { namespace threads { namespace coroutines
         }
 #endif
 
-#if defined(HPX_HAVE_THREAD_LOCAL_STORAGE)
         std::size_t get_thread_data() const
         {
             return m_pimpl.get() ? m_pimpl->get_thread_data() : 0;
@@ -119,7 +118,6 @@ namespace hpx { namespace threads { namespace coroutines
         {
             return m_pimpl.get() ? m_pimpl->set_thread_data(data) : 0;
         }
-#endif
 
         void rebind(functor_type&& f, thread_id_repr_type id = nullptr)
         {

--- a/hpx/runtime/threads/coroutines/detail/coroutine_self.hpp
+++ b/hpx/runtime/threads/coroutines/detail/coroutine_self.hpp
@@ -168,7 +168,6 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
           : m_pimpl(pimpl), next_self_(next_self)
         {}
 
-#if defined(HPX_HAVE_THREAD_LOCAL_STORAGE)
         std::size_t get_thread_data() const
         {
             HPX_ASSERT(m_pimpl);
@@ -180,6 +179,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
             return m_pimpl->set_thread_data(data);
         }
 
+#if defined(HPX_HAVE_THREAD_LOCAL_STORAGE)
         tss_storage* get_thread_tss_data()
         {
             HPX_ASSERT(m_pimpl);

--- a/hpx/runtime/threads/thread.hpp
+++ b/hpx/runtime/threads/thread.hpp
@@ -91,10 +91,8 @@ namespace hpx
 
         lcos::future<void> get_future(error_code& ec = throws);
 
-#if defined(HPX_HAVE_THREAD_LOCAL_STORAGE)
         std::size_t get_thread_data() const;
         std::size_t set_thread_data(std::size_t);
-#endif
 
     private:
         bool joinable_locked() const HPX_NOEXCEPT

--- a/hpx/runtime/threads/thread_data.hpp
+++ b/hpx/runtime/threads/thread_data.hpp
@@ -531,7 +531,6 @@ namespace hpx { namespace threads
 #endif
         }
 
-#ifdef HPX_HAVE_THREAD_LOCAL_STORAGE
         std::size_t get_thread_data() const
         {
             return coroutine_.get_thread_data();
@@ -541,7 +540,6 @@ namespace hpx { namespace threads
         {
             return coroutine_.set_thread_data(data);
         }
-#endif
 
         void rebind(thread_init_data& init_data,
             thread_state_enum newstate)

--- a/hpx/runtime/threads/thread_helpers.hpp
+++ b/hpx/runtime/threads/thread_helpers.hpp
@@ -412,14 +412,12 @@ namespace hpx { namespace threads
     HPX_API_EXPORT void free_thread_exit_callbacks(thread_id_type const& id,
         error_code& ec = throws);
 
-#if defined(HPX_HAVE_THREAD_LOCAL_STORAGE)
     ///////////////////////////////////////////////////////////////////////////
     HPX_API_EXPORT std::size_t get_thread_data(thread_id_type const& id,
         error_code& ec = throws);
 
     HPX_API_EXPORT std::size_t set_thread_data(thread_id_type const& id,
         std::size_t data, error_code& ec = throws);
-#endif
 
     HPX_API_EXPORT std::size_t& get_continuation_recursion_count();
     HPX_API_EXPORT void reset_continuation_recursion_count();

--- a/src/runtime/threads/coroutines/detail/tss.cpp
+++ b/src/runtime/threads/coroutines/detail/tss.cpp
@@ -43,7 +43,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 #else
         boost::throw_exception(std::runtime_error(
             "thread local storage has been disabled at configuration time, "
-            "please specify HPX_HAVE_THREAD_LOCAL_STORAGE=ON to cmake"));
+            "please specify HPX_WITH_THREAD_LOCAL_STORAGE=ON to cmake"));
         return nullptr;
 #endif
     }
@@ -78,7 +78,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 #else
         boost::throw_exception(std::runtime_error(
             "thread local storage has been disabled at configuration time, "
-            "please specify HPX_HAVE_THREAD_LOCAL_STORAGE=ON to cmake"));
+            "please specify HPX_WITH_THREAD_LOCAL_STORAGE=ON to cmake"));
         return 0;
 #endif
     }
@@ -114,7 +114,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 #else
         boost::throw_exception(std::runtime_error(
             "thread local storage has been disabled at configuration time, "
-            "please specify HPX_HAVE_THREAD_LOCAL_STORAGE=ON to cmake"));
+            "please specify HPX_WITH_THREAD_LOCAL_STORAGE=ON to cmake"));
         return 0;
 #endif
     }
@@ -138,7 +138,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 #else
         boost::throw_exception(std::runtime_error(
             "thread local storage has been disabled at configuration time, "
-            "please specify HPX_HAVE_THREAD_LOCAL_STORAGE=ON to cmake"));
+            "please specify HPX_WITH_THREAD_LOCAL_STORAGE=ON to cmake"));
         return nullptr;
 #endif
     }

--- a/src/runtime/threads/thread.cpp
+++ b/src/runtime/threads/thread.cpp
@@ -222,7 +222,6 @@ namespace hpx
         threads::interrupt_thread(id.id_, flag);
     }
 
-#ifdef HPX_HAVE_THREAD_LOCAL_STORAGE
     std::size_t thread::get_thread_data() const
     {
         return threads::get_thread_data(native_handle());
@@ -231,7 +230,6 @@ namespace hpx
     {
         return threads::set_thread_data(native_handle(), data);
     }
-#endif
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail

--- a/src/runtime/threads/thread_helpers.cpp
+++ b/src/runtime/threads/thread_helpers.cpp
@@ -164,7 +164,6 @@ namespace hpx { namespace threads
         return id->interruption_requested();
     }
 
-#ifdef HPX_HAVE_THREAD_LOCAL_STORAGE
     ///////////////////////////////////////////////////////////////////////////
     std::size_t get_thread_data(thread_id_type const& id, error_code& ec)
     {
@@ -190,7 +189,6 @@ namespace hpx { namespace threads
 
         return id->set_thread_data(data);
     }
-#endif
 
     ////////////////////////////////////////////////////////////////////////////
     struct continuation_recursion_count_tag {};

--- a/tests/regressions/threads/CMakeLists.txt
+++ b/tests/regressions/threads/CMakeLists.txt
@@ -7,16 +7,13 @@
 set(tests
     block_os_threads_1036
     resume_priority
+    thread_data_1111
     thread_pool_executor_1112
     thread_rescheduling
     thread_suspend_pending
     thread_suspend_duration
     threads_all_1422
    )
-
-if(HPX_HAVE_THREAD_LOCAL_STORAGE)
-  set(tests ${tests} thread_data_1111)
-endif()
 
 if(HPX_WITH_LOCAL_SCHEDULER OR HPX_WITH_ALL_SCHEDULERS)
   set(tests ${tests}

--- a/tests/unit/threads/CMakeLists.txt
+++ b/tests/unit/threads/CMakeLists.txt
@@ -17,7 +17,7 @@ set(tests
     thread_yield
    )
 
-if(HPX_HAVE_THREAD_LOCAL_STORAGE)
+if(HPX_WITH_THREAD_LOCAL_STORAGE)
   set(tests ${tests} tss)
 endif()
 


### PR DESCRIPTION
If `HPX_WITH_THREAD_LOCAL_DATA` is not defined, we now support storing a single size_t as thread local data

This also addresses part of #2371

@dhollman this should enable what you need by default and with reasonably small overheads
