### PR TITLE
Renaming copy_helper/copy_n_helper/move_helper/move_n_helper

### DIFF
--- a/hpx/compute/vector.hpp
+++ b/hpx/compute/vector.hpp
@@ -88,7 +88,7 @@ namespace hpx { namespace compute
           , alloc_(alloc)
           , data_(alloc_traits::allocate(alloc_, size_))
         {
-            hpx::parallel::util::copy_helper(first, last, begin());
+            hpx::parallel::util::copy(first, last, begin());
         }
 
         vector(vector const& other)
@@ -97,7 +97,7 @@ namespace hpx { namespace compute
           , alloc_(other.alloc_)
           , data_(alloc_traits::allocate(alloc_, capacity_))
         {
-            hpx::parallel::util::copy_helper(other.begin(), other.end(), begin());
+            hpx::parallel::util::copy(other.begin(), other.end(), begin());
         }
 
         vector(vector const& other, Allocator const& alloc)
@@ -106,7 +106,7 @@ namespace hpx { namespace compute
           , alloc_(alloc)
           , data_(alloc_traits::allocate(alloc_, capacity_))
         {
-            hpx::parallel::util::copy_helper(other.begin(), other.end(), begin());
+            hpx::parallel::util::copy(other.begin(), other.end(), begin());
         }
 
         vector(vector && other)
@@ -137,7 +137,7 @@ namespace hpx { namespace compute
           , alloc_(alloc)
           , data_(alloc_traits::allocate(alloc_, capacity_))
         {
-            hpx::parallel::util::copy_helper(init.begin(), init.end(), begin());
+            hpx::parallel::util::copy(init.begin(), init.end(), begin());
         }
 
         ~vector()
@@ -165,7 +165,7 @@ namespace hpx { namespace compute
                 return *this;
 
             pointer data = alloc_traits::allocate(other.alloc_, other.capacity_);
-            hpx::parallel::util::copy_helper(other.begin(), other.end(),
+            hpx::parallel::util::copy(other.begin(), other.end(),
                 iterator(data, 0, alloc_traits::target(other.alloc_)));
 
             if(data_ != nullptr)

--- a/hpx/parallel/algorithms/copy.hpp
+++ b/hpx/parallel/algorithms/copy.hpp
@@ -58,7 +58,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             {
                 using hpx::util::get;
                 auto iters = part_begin.get_iterator_tuple();
-                util::copy_n_helper(get<0>(iters), part_size, get<1>(iters));
+                util::copy_n(get<0>(iters), part_size, get<1>(iters));
             }
         };
 
@@ -74,8 +74,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             static std::pair<InIter, OutIter>
             sequential(ExPolicy, InIter first, InIter last, OutIter dest)
             {
-                std::pair<InIter, OutIter> result =
-                    util::copy_helper(first, last, dest);
+                std::pair<InIter, OutIter> result = util::copy(first, last, dest);
                 util::copy_synchronize(first, dest);
                 return result;
             }
@@ -214,7 +213,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             static std::pair<InIter, OutIter>
             sequential(ExPolicy, InIter first, std::size_t count, OutIter dest)
             {
-                return util::copy_n_helper(first, count, dest);
+                return util::copy_n(first, count, dest);
             }
 
             template <typename ExPolicy, typename FwdIter, typename OutIter>
@@ -236,8 +235,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                             using hpx::util::get;
 
                             auto iters = part_begin.get_iterator_tuple();
-                            util::copy_n_helper(get<0>(iters), part_size,
-                                get<1>(iters));
+                            util::copy_n(get<0>(iters), part_size, get<1>(iters));
                         },
                         [](zip_iterator && last) -> zip_iterator
                         {

--- a/hpx/parallel/algorithms/move.hpp
+++ b/hpx/parallel/algorithms/move.hpp
@@ -48,7 +48,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             static std::pair<InIter, OutIter>
             sequential(ExPolicy, InIter first, InIter last, OutIter dest)
             {
-                return util::move_helper(first, last, dest);
+                return util::move(first, last, dest);
             }
 
             template <typename ExPolicy, typename FwdIter, typename OutIter>
@@ -72,8 +72,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                             using hpx::util::get;
 
                             auto iters = part_begin.get_iterator_tuple();
-                            util::move_n_helper(get<0>(iters), part_size,
-                                get<1>(iters));
+                            util::move_n(get<0>(iters), part_size, get<1>(iters));
                         },
                         [](zip_iterator && last) -> zip_iterator
                         {

--- a/hpx/parallel/algorithms/rotate.hpp
+++ b/hpx/parallel/algorithms/rotate.hpp
@@ -215,9 +215,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             OutIter dest_first)
         {
             std::pair<FwdIter, OutIter> p1 =
-                util::copy_helper(new_first, last, dest_first);
+                util::copy(new_first, last, dest_first);
             std::pair<FwdIter, OutIter> p2 =
-                util::copy_helper(first, new_first, std::move(p1.second));
+                util::copy(first, new_first, std::move(p1.second));
             return std::make_pair(std::move(p1.first), std::move(p2.second));
         }
 

--- a/hpx/parallel/util/transfer.hpp
+++ b/hpx/parallel/util/transfer.hpp
@@ -90,7 +90,7 @@ namespace hpx { namespace parallel { namespace util
 
     template <typename InIter, typename OutIter>
     HPX_FORCEINLINE std::pair<InIter, OutIter>
-    copy_helper(InIter first, InIter last, OutIter dest)
+    copy(InIter first, InIter last, OutIter dest)
     {
         typedef
             typename hpx::traits::pointer_category<
@@ -138,11 +138,14 @@ namespace hpx { namespace parallel { namespace util
 
     template <typename InIter, typename OutIter>
     HPX_FORCEINLINE std::pair<InIter, OutIter>
-    copy_n_helper(InIter first, std::size_t count, OutIter dest)
+    copy_n(InIter first, std::size_t count, OutIter dest)
     {
         typedef
             typename hpx::traits::pointer_category<
-                typename hpx::util::decay<InIter>::type,
+                typename hpx::util::decay<
+                    typename hpx::traits::remove_const_iterator_value_type<
+                        InIter
+                    >::type>::type,
                 typename hpx::util::decay<OutIter>::type
             >::type
             category;
@@ -211,7 +214,7 @@ namespace hpx { namespace parallel { namespace util
 
     template <typename InIter, typename OutIter>
     HPX_FORCEINLINE std::pair<InIter, OutIter>
-    move_helper(InIter first, InIter last, OutIter dest)
+    move(InIter first, InIter last, OutIter dest)
     {
         typedef
             typename hpx::traits::pointer_category<
@@ -255,7 +258,7 @@ namespace hpx { namespace parallel { namespace util
 
     template <typename InIter, typename OutIter>
     HPX_FORCEINLINE std::pair<InIter, OutIter>
-    move_n_helper(InIter first, std::size_t count, OutIter dest)
+    move_n(InIter first, std::size_t count, OutIter dest)
     {
         typedef
             typename hpx::traits::pointer_category<


### PR DESCRIPTION
This is a purely cosmetic change to align naming conventions for the copy and move customization points
