### PR TITLE
remove unused typedef to get rid of compiler warnings

### DIFF
--- a/hpx/runtime/serialization/vector.hpp
+++ b/hpx/runtime/serialization/vector.hpp
@@ -47,7 +47,6 @@ namespace hpx { namespace serialization
             else
             {
                 // bitwise load ...
-                typedef typename std::vector<T, Allocator>::value_type value_type;
                 typedef typename std::vector<T, Allocator>::size_type size_type;
                 size_type size;
                 ar >> size; //-V128


### PR DESCRIPTION
Trivial change, but that superfluous typedef was generating a lot of noise when compiling.
