### PR TITLE
 Fixing race condition for early parcels

### DIFF
--- a/hpx/lcos/local/condition_variable.hpp
+++ b/hpx/lcos/local/condition_variable.hpp
@@ -37,14 +37,12 @@ namespace hpx { namespace lcos { namespace local
     public:
         void notify_one(error_code& ec = throws)
         {
-            util::ignore_all_while_checking ignore_lock;
             std::unique_lock<mutex_type> l(mtx_);
             cond_.notify_one(std::move(l), ec);
         }
 
         void notify_all(error_code& ec = throws)
         {
-            util::ignore_all_while_checking ignore_lock;
             std::unique_lock<mutex_type> l(mtx_);
             cond_.notify_all(std::move(l), ec);
         }
@@ -52,8 +50,8 @@ namespace hpx { namespace lcos { namespace local
         void wait(std::unique_lock<mutex>& lock, error_code& ec = throws)
         {
             HPX_ASSERT_OWNS_LOCK(lock);
+            util::ignore_while_checking<std::unique_lock<mutex> > il(&lock);
 
-            util::ignore_all_while_checking ignore_lock;
             std::unique_lock<mutex_type> l(mtx_);
             util::unlock_guard<std::unique_lock<mutex> > unlock(lock);
 
@@ -78,7 +76,7 @@ namespace hpx { namespace lcos { namespace local
         {
             HPX_ASSERT_OWNS_LOCK(lock);
 
-            util::ignore_all_while_checking ignore_lock;
+            util::ignore_while_checking<std::unique_lock<mutex> > il(&lock);
             std::unique_lock<mutex_type> l(mtx_);
             util::unlock_guard<std::unique_lock<mutex> > unlock(lock);
 
@@ -141,7 +139,6 @@ namespace hpx { namespace lcos { namespace local
 
         void notify_all(error_code& ec = throws)
         {
-            util::ignore_all_while_checking ignore_lock;
             std::unique_lock<mutex_type> l(mtx_);
             cond_.notify_all(std::move(l), ec);
         }

--- a/hpx/lcos/local/spinlock_pool.hpp
+++ b/hpx/lcos/local/spinlock_pool.hpp
@@ -73,7 +73,6 @@ namespace hpx { namespace lcos { namespace local
                 HPX_ITT_SYNC_PREPARE(&sp_);
                 sp_.lock();
                 HPX_ITT_SYNC_ACQUIRED(&sp_);
-                util::register_lock(&sp_);
             }
 
             void unlock()
@@ -81,7 +80,6 @@ namespace hpx { namespace lcos { namespace local
                 HPX_ITT_SYNC_RELEASING(&sp_);
                 sp_.unlock();
                 HPX_ITT_SYNC_RELEASED(&sp_);
-                util::unregister_lock(&sp_);
             }
         };
     };

--- a/hpx/runtime/applier/apply_helper.hpp
+++ b/hpx/runtime/applier/apply_helper.hpp
@@ -8,6 +8,7 @@
 #define HPX_APPLIER_APPLY_HELPER_JUN_25_2008_0917PM
 
 #include <hpx/config.hpp>
+#include <hpx/state.hpp>
 #include <hpx/runtime_fwd.hpp>
 #include <hpx/runtime/actions/action_support.hpp>
 #include <hpx/runtime/naming/address.hpp>
@@ -80,6 +81,12 @@ namespace hpx { namespace applier { namespace detail
                 static_cast<threads::thread_stacksize>(
                     traits::action_stacksize<Action>::value));
 
+            while (!threads::threadmanager_is_at_least(state_running))
+            {
+                boost::this_thread::sleep(boost::get_system_time() +
+                    boost::posix_time::milliseconds(HPX_NETWORK_RETRIES_SLEEP));
+            }
+
             traits::action_schedule_thread<Action>::call(
                 lva, data, threads::pending);
         }
@@ -106,6 +113,12 @@ namespace hpx { namespace applier { namespace detail
             data.stacksize = threads::get_stack_size(
                 static_cast<threads::thread_stacksize>(
                     traits::action_stacksize<Action>::value));
+
+            while (!threads::threadmanager_is_at_least(state_running))
+            {
+                boost::this_thread::sleep(boost::get_system_time() +
+                    boost::posix_time::milliseconds(HPX_NETWORK_RETRIES_SLEEP));
+            }
 
             traits::action_schedule_thread<Action>::call(
                 lva, data, threads::pending);

--- a/hpx/state.hpp
+++ b/hpx/state.hpp
@@ -35,6 +35,7 @@ namespace hpx
     {
         // return whether thread manager is in the state described by 'mask'
         HPX_EXPORT bool threadmanager_is(state st);
+        HPX_EXPORT bool threadmanager_is_at_least(state st);
     }
 
     namespace agas

--- a/src/runtime/threads/detail/thread_pool.cpp
+++ b/src/runtime/threads/detail/thread_pool.cpp
@@ -381,7 +381,6 @@ namespace hpx { namespace threads { namespace detail
             );
 
             // run threads and wait for initialization to complete
-            sched_.set_all_states(state_running);
 
             topology const& topology_ = get_topology();
 
@@ -433,6 +432,9 @@ namespace hpx { namespace threads { namespace detail
             // the main thread needs to have a unique thread_num
             init_tss(num_threads);
             startup_->wait();
+
+            // The scheduler is now running.
+            sched_.set_all_states(state_running);
         }
         catch (std::exception const& e) {
             LTM_(always)

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -26,6 +26,15 @@ namespace hpx
             }
             return (rt->get_thread_manager().status() == st);
         }
+        bool threadmanager_is_at_least(state st)
+        {
+            hpx::runtime* rt = get_runtime_ptr();
+            if (nullptr == rt) {
+                // we're probably either starting or stopping
+                return false;
+            }
+            return (rt->get_thread_manager().status() >= st);
+        }
     }
 
     namespace agas


### PR DESCRIPTION
This patch fixes a race condition between creating the scheduler queues
in the thread pool and setting its state to running.
In addition, we need to wait until the thread pool is running before scheduling
tasks onto it.

Flyby: relaxing lock ignoring for condition_variable