### PR TITLE
Add keywords in target_link_libraries in hpx_setup_target

### DIFF
--- a/cmake/HPX_SetupTarget.cmake
+++ b/cmake/HPX_SetupTarget.cmake
@@ -198,7 +198,7 @@ function(hpx_setup_target target)
     target_compile_options(${target} PUBLIC ${CXX_FLAG})
   endif()
 
-  target_link_libraries(${target} ${hpx_libs} ${target_DEPENDENCIES})
+  target_link_libraries(${target} PUBLIC ${hpx_libs} ${target_DEPENDENCIES})
 
   get_target_property(target_EXCLUDE_FROM_ALL ${target} EXCLUDE_FROM_ALL)
 


### PR DESCRIPTION
target_link_libraries in HPX_SetupTarget.cmake does not use keywords and it creates a conflict when third-party libraries (e.g. Codeplay's ComputeCpp) try to modify our targets by adding their link dependencies.

The proposition is to use PUBLIC.