### PR TITLE
Use CMake policy CMP0060

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,9 @@ endif()
 if(POLICY CMP0054)
   cmake_policy(SET CMP0054 OLD)
 endif()
+if(POLICY CMP0060)
+  cmake_policy(SET CMP0060 NEW)
+endif()
 
 # Overrides must go before the project() statement, otherwise they are ignored.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,11 @@ cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 # explicitly set certain policies
 cmake_policy(VERSION 2.8.12)
-if(NOT(CMAKE_VERSION VERSION_LESS 3.1.0))
-  cmake_policy(SET CMP0054 OLD)
+if(POLICY CMP0042)
   cmake_policy(SET CMP0042 NEW)
+endif()
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 OLD)
 endif()
 
 # Overrides must go before the project() statement, otherwise they are ignored.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,15 +14,14 @@ cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 # explicitly set certain policies
 cmake_policy(VERSION 2.8.12)
-if(POLICY CMP0042)
-  cmake_policy(SET CMP0042 NEW)
-endif()
-if(POLICY CMP0054)
-  cmake_policy(SET CMP0054 OLD)
-endif()
-if(POLICY CMP0060)
-  cmake_policy(SET CMP0060 NEW)
-endif()
+macro(hpx_set_cmake_policy policy value)
+  if(POLICY ${policy})
+    cmake_policy(SET ${policy} ${value})
+  endif()
+endmacro()
+hpx_set_cmake_policy(CMP0042 NEW)
+hpx_set_cmake_policy(CMP0054 OLD)
+hpx_set_cmake_policy(CMP0060 NEW)
 
 # Overrides must go before the project() statement, otherwise they are ignored.
 


### PR DESCRIPTION
This PR is related to Issue #2396.
Reference: [CMP0060](https://cmake.org/cmake/help/v3.3/policy/CMP0060.html)
See commit logs.

CMP0060 will only be available for CMake versions 3.3 and newer. For CMake versions less than 3.3, a more invasive change to the HPX build system is required to introduce CMake feature 'imported libraries'.