### PR TITLE
Forward the explicitly given result_type in the hpx invoke

### DIFF
--- a/hpx/compute/cuda/detail/launch.hpp
+++ b/hpx/compute/cuda/detail/launch.hpp
@@ -16,6 +16,7 @@
 #include <hpx/compute/cuda/target.hpp>
 #include <hpx/util/decay.hpp>
 #include <hpx/util/invoke_fused.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <cuda_runtime.h>
 
@@ -63,10 +64,10 @@ namespace hpx { namespace compute { namespace cuda { namespace detail
         HPX_DELETE_COPY_ASSIGN(closure);
         HPX_DELETE_MOVE_ASSIGN(closure);
 
-        HPX_HOST_DEVICE void operator()()
+        HPX_DEVICE void operator()()
         {
             // FIXME: is it possible to move the arguments?
-            hpx::util::invoke_fused(f_, args_);
+            hpx::util::invoke_fused_r<void>(f_, args_);
         }
     };
 
@@ -91,6 +92,7 @@ namespace hpx { namespace compute { namespace cuda { namespace detail
             // This is needed for the device code to make sure the kernel
             // is instantiated correctly.
             launch_function_type launcher = get_launch_function();
+            HPX_UNUSED(launcher);
             Closure c{std::move(f), std::move(args)};
 
             static_assert(sizeof(Closure) < 256,

--- a/hpx/util/detail/vtable/callable_vtable.hpp
+++ b/hpx/util/detail/vtable/callable_vtable.hpp
@@ -42,7 +42,7 @@ namespace hpx { namespace util { namespace detail
         template <typename T>
         HPX_FORCEINLINE static R _invoke(void** f, Ts&&... vs)
         {
-            return util::invoke<R>(
+            return util::invoke_r<R>(
                 vtable::get<T>(f), std::forward<Ts>(vs)...);
         }
         R (*invoke)(void**, Ts&&...);

--- a/hpx/util/invoke.hpp
+++ b/hpx/util/invoke.hpp
@@ -12,6 +12,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/util/result_of.hpp>
+#include <hpx/util/void_guard.hpp>
 
 #include <boost/ref.hpp>
 
@@ -23,32 +24,33 @@ namespace hpx { namespace util
     ///////////////////////////////////////////////////////////////////////////
     namespace detail
     {
-        template <typename FD>
+        template <typename R,typename FD>
         struct invoke_impl
         {
             // f(t0, t1, ..., tN)
             template <typename F, typename ...Ts>
             HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::result_of<F&&(Ts&&...)>::type
-            operator()(F&& f, Ts&&... vs)
+            R operator()(F&& f, Ts&&... vs)
             {
-                return std::forward<F>(f)(std::forward<Ts>(vs)...);
+                return hpx::util::void_guard<R>(),
+                    std::forward<F>(f)(std::forward<Ts>(vs)...);
             }
         };
 
-        template <typename M, typename C>
-        struct invoke_impl<M C::*>
+
+        template <typename R, typename M, typename C>
+        struct invoke_impl<R, M C::*>
         {
             // t0.*f
             template <typename F, typename T0>
             HPX_HOST_DEVICE HPX_FORCEINLINE
             typename std::enable_if<
                 std::is_base_of<C, typename std::decay<T0>::type>::value,
-                typename util::result_of<F&&(T0&)>::type
+                R
             >::type
             operator()(F f, T0& v0)
             {
-                return (v0.*f);
+                return hpx::util::void_guard<R>(), (v0.*f);
             }
 
             template <typename F, typename T0>
@@ -56,11 +58,11 @@ namespace hpx { namespace util
             typename std::enable_if<
                 std::is_base_of<C, typename std::decay<T0>::type>::value
              && !std::is_lvalue_reference<T0>::value,
-                typename util::result_of<F&&(T0&&)>::type
+                R
             >::type
             operator()(F f, T0&& v0)
             {
-                return std::move(v0.*f);
+                return hpx::util::void_guard<R>(), std::move(v0.*f);
             }
 
             // (*t0).*f
@@ -68,27 +70,27 @@ namespace hpx { namespace util
             HPX_HOST_DEVICE HPX_FORCEINLINE
             typename std::enable_if<
                 !std::is_base_of<C, typename std::decay<T0>::type>::value,
-                typename util::result_of<F&&(T0&&)>::type
+                R
             >::type
             operator()(F f, T0&& v0)
             {
-                return (*this)(f, *std::forward<T0>(v0));
+                return hpx::util::void_guard<R>(), (*this)(f, *std::forward<T0>(v0));
             }
         };
 
-        template <typename R, typename C, typename ...Ps>
-        struct invoke_impl<R (C::*)(Ps...)>
+        template <typename R, typename RR, typename C, typename ...Ps>
+        struct invoke_impl<R, RR (C::*)(Ps...)>
         {
             // (t0.*f)(t1, ..., tN)
             template <typename F, typename T0, typename ...Ts>
             HPX_HOST_DEVICE HPX_FORCEINLINE
             typename std::enable_if<
                 std::is_base_of<C, typename std::decay<T0>::type>::value,
-                typename util::result_of<F&&(T0&&, Ts&&...)>::type
+                R
             >::type
             operator()(F f, T0&& v0, Ts&&... vs)
             {
-                return (std::forward<T0>(v0).*f)(std::forward<Ts>(vs)...);
+                return hpx::util::void_guard<R>(), (std::forward<T0>(v0).*f)(std::forward<Ts>(vs)...);
             }
 
             // ((*t0).*f)(t1, ..., tN)
@@ -96,30 +98,29 @@ namespace hpx { namespace util
             HPX_HOST_DEVICE HPX_FORCEINLINE
             typename std::enable_if<
                 !std::is_base_of<C, typename std::decay<T0>::type>::value,
-                typename util::result_of<F&&(T0&&, Ts&&...)>::type
+                R
             >::type
             operator()(F f, T0&& v0, Ts&&... vs)
             {
-                return (*this)(f, *std::forward<T0>(v0), std::forward<Ts>(vs)...);
+                return hpx::util::void_guard<R>(), (*this)(f, *std::forward<T0>(v0), std::forward<Ts>(vs)...);
             }
         };
 
-        template <typename R, typename C, typename ...Ps>
-        struct invoke_impl<R (C::*)(Ps...) const>
-          : invoke_impl<R (C::*)(Ps...)>
+        template <typename R, typename RR, typename C, typename ...Ps>
+        struct invoke_impl<R, RR (C::*)(Ps...) const>
+          : invoke_impl<R, RR (C::*)(Ps...)>
         {};
 
-        template <typename X>
-        struct invoke_impl< ::boost::reference_wrapper<X> >
-          : invoke_impl<X&>
+        template <typename R,typename X>
+        struct invoke_impl<R,::boost::reference_wrapper<X>>
+          : invoke_impl<R,X&>
         {
             // support boost::[c]ref, which is not callable as std::[c]ref
             template <typename F, typename ...Ts>
             HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::result_of<F&&(Ts&&...)>::type
-            operator()(F f, Ts&&... vs)
+            R operator()(F f, Ts&&... vs)
             {
-                return f.get()(std::forward<Ts>(vs)...);
+                return hpx::util::void_guard<R>(), f.get()(std::forward<Ts>(vs)...);
             }
         };
     }
@@ -129,234 +130,17 @@ namespace hpx { namespace util
     typename util::result_of<F&&(Ts&&...)>::type
     invoke(F&& f, Ts&&... vs)
     {
-        return detail::invoke_impl<typename std::decay<F>::type>()(
+        typedef typename util::result_of<F&&(Ts&&...)>::type R;
+
+        return detail::invoke_impl<R,typename std::decay<F>::type>()(
             std::forward<F>(f), std::forward<Ts>(vs)...);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    namespace detail
-    {
-        template <typename R, typename FD>
-        struct invoke_guard_impl
-        {
-            // f(t0, t1, ..., tN)
-            template <typename F, typename ...Ts>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
-            R operator()(F&& f, Ts&&... vs)
-            {
-                return std::forward<F>(f)(std::forward<Ts>(vs)...);
-            }
-        };
-
-        template <typename FD>
-        struct invoke_guard_impl<void,FD>
-        {
-            // f(t0, t1, ..., tN)
-            template <typename F, typename ...Ts>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
-            void operator()(F&& f, Ts&&... vs)
-            {
-                std::forward<F>(f)(std::forward<Ts>(vs)...);
-            }
-        };
-
-        template <typename R, typename M, typename C>
-        struct invoke_guard_impl<R, M C::*>
-        {
-            // t0.*f
-            template <typename F, typename T0>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename std::enable_if<
-                std::is_base_of<C, typename std::decay<T0>::type>::value,
-                R
-            >::type
-            operator()(F f, T0& v0)
-            {
-                return (v0.*f);
-            }
-
-            template <typename F, typename T0>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename std::enable_if<
-                std::is_base_of<C, typename std::decay<T0>::type>::value
-             && !std::is_lvalue_reference<T0>::value,
-                R
-            >::type
-            operator()(F f, T0&& v0)
-            {
-                return std::move(v0.*f);
-            }
-
-            // (*t0).*f
-            template <typename F, typename T0>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename std::enable_if<
-                !std::is_base_of<C, typename std::decay<T0>::type>::value,
-                R
-            >::type
-            operator()(F f, T0&& v0)
-            {
-                return (*this)(f, *std::forward<T0>(v0));
-            }
-        };
-
-        template <typename M, typename C>
-        struct invoke_guard_impl<void, M C::*>
-        {
-            // t0.*f
-            template <typename F, typename T0>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename std::enable_if<
-                std::is_base_of<C, typename std::decay<T0>::type>::value,
-                void
-            >::type
-            operator()(F f, T0& v0)
-            {
-                v0.*f;
-            }
-
-            template <typename F, typename T0>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename std::enable_if<
-                std::is_base_of<C, typename std::decay<T0>::type>::value
-             && !std::is_lvalue_reference<T0>::value,
-                void
-            >::type
-            operator()(F f, T0&& v0)
-            {
-                v0.*f;
-            }
-
-            // (*t0).*f
-            template <typename F, typename T0>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename std::enable_if<
-                !std::is_base_of<C, typename std::decay<T0>::type>::value,
-                void
-            >::type
-            operator()(F f, T0&& v0)
-            {
-                (*this)(f, *std::forward<T0>(v0));
-            }
-        };
-
-        template <typename R, typename RR, typename C, typename ...Ps>
-        struct invoke_guard_impl<R, RR (C::*)(Ps...)>
-        {
-            // (t0.*f)(t1, ..., tN)
-            template <typename F, typename T0, typename ...Ts>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename std::enable_if<
-                std::is_base_of<C, typename std::decay<T0>::type>::value,
-                R
-            >::type
-            operator()(F f, T0&& v0, Ts&&... vs)
-            {
-                return (std::forward<T0>(v0).*f)(std::forward<Ts>(vs)...);
-            }
-
-            // ((*t0).*f)(t1, ..., tN)
-            template <typename F, typename T0, typename ...Ts>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename std::enable_if<
-                !std::is_base_of<C, typename std::decay<T0>::type>::value,
-                R
-            >::type
-            operator()(F f, T0&& v0, Ts&&... vs)
-            {
-                return (*this)(f, *std::forward<T0>(v0), std::forward<Ts>(vs)...);
-            }
-        };
-
-        template <typename RR, typename C, typename ...Ps>
-        struct invoke_guard_impl<void, RR (C::*)(Ps...)>
-        {
-            // (t0.*f)(t1, ..., tN)
-            template <typename F, typename T0, typename ...Ts>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename std::enable_if<
-                std::is_base_of<C, typename std::decay<T0>::type>::value,
-                void
-            >::type
-            operator()(F f, T0&& v0, Ts&&... vs)
-            {
-                (std::forward<T0>(v0).*f)(std::forward<Ts>(vs)...);
-            }
-
-            // ((*t0).*f)(t1, ..., tN)
-            template <typename F, typename T0, typename ...Ts>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename std::enable_if<
-                !std::is_base_of<C, typename std::decay<T0>::type>::value,
-                void
-            >::type
-            operator()(F f, T0&& v0, Ts&&... vs)
-            {
-                (*this)(f, *std::forward<T0>(v0), std::forward<Ts>(vs)...);
-            }
-        };
-
-        template <typename R, typename RR, typename C, typename ...Ps>
-        struct invoke_guard_impl<R, RR (C::*)(Ps...) const>
-          : invoke_guard_impl<R,RR (C::*)(Ps...)>
-        {};
-
-        template <typename R, typename X>
-        struct invoke_guard_impl<R, ::boost::reference_wrapper<X> >
-          : invoke_guard_impl<R,X&>
-        {
-            // support boost::[c]ref, which is not callable as std::[c]ref
-            template <typename F, typename ...Ts>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
-            R operator()(F f, Ts&&... vs)
-            {
-                return f.get()(std::forward<Ts>(vs)...);
-            }
-        };
-
-        template <typename X>
-        struct invoke_guard_impl<void, ::boost::reference_wrapper<X> >
-          : invoke_guard_impl<void,X&>
-        {
-            // support boost::[c]ref, which is not callable as std::[c]ref
-            template <typename F, typename ...Ts>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
-            void operator()(F f, Ts&&... vs)
-            {
-                f.get()(std::forward<Ts>(vs)...);
-            }
-        };
-
-        template <typename R>
-        struct invoke_guard
-        {
-            template <typename F, typename ...Ts>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
-            R operator()(F&& f, Ts&&... vs)
-            {
-                return detail::invoke_guard_impl<R,typename std::decay<F>::type>()(
-                    std::forward<F>(f), std::forward<Ts>(vs)...);
-            }
-        };
-
-        template <>
-        struct invoke_guard<void>
-        {
-            template <typename F, typename ...Ts>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
-            void operator()(F&& f, Ts&&... vs)
-            {
-                detail::invoke_guard_impl<void,typename std::decay<F>::type>()(
-                    std::forward<F>(f), std::forward<Ts>(vs)...);
-            }
-        };
     }
 
     template <typename R, typename F, typename ...Ts>
     HPX_HOST_DEVICE HPX_FORCEINLINE
-    R invoke(F&& f, Ts&&... vs)
+    R invoke_r(F&& f, Ts&&... vs)
     {
-        return detail::invoke_guard<R>()(
+        return detail::invoke_impl<R,typename std::decay<F>::type>()(
             std::forward<F>(f), std::forward<Ts>(vs)...);
     }
 
@@ -370,7 +154,9 @@ namespace hpx { namespace util
             typename util::result_of<F&&(Ts &&...)>::type
             operator()(F && f, Ts &&... vs)
             {
-                return util::invoke(std::forward<F>(f),
+                typedef typename util::result_of<F&&(Ts&&...)>::type R;
+
+                return hpx::util::void_guard<R>(), util::invoke(std::forward<F>(f),
                     std::forward<Ts>(vs)...);
             }
         };
@@ -382,7 +168,7 @@ namespace hpx { namespace util
             HPX_HOST_DEVICE HPX_FORCEINLINE
             R operator()(F && f, Ts &&... vs)
             {
-                return util::invoke<R>(std::forward<F>(f),
+                return hpx::util::void_guard<R>(), util::invoke_r<R>(std::forward<F>(f),
                     std::forward<Ts>(vs)...);
             }
         };

--- a/hpx/util/invoke.hpp
+++ b/hpx/util/invoke.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2013-2015 Agustin Berge
+//  Copyright (c) 2016 Antoine Tran Tan
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -135,6 +136,197 @@ namespace hpx { namespace util
     ///////////////////////////////////////////////////////////////////////////
     namespace detail
     {
+        template <typename R, typename FD>
+        struct invoke_guard_impl
+        {
+            // f(t0, t1, ..., tN)
+            template <typename F, typename ...Ts>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            R operator()(F&& f, Ts&&... vs)
+            {
+                return std::forward<F>(f)(std::forward<Ts>(vs)...);
+            }
+        };
+
+        template <typename FD>
+        struct invoke_guard_impl<void,FD>
+        {
+            // f(t0, t1, ..., tN)
+            template <typename F, typename ...Ts>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            void operator()(F&& f, Ts&&... vs)
+            {
+                std::forward<F>(f)(std::forward<Ts>(vs)...);
+            }
+        };
+
+        template <typename R, typename M, typename C>
+        struct invoke_guard_impl<R, M C::*>
+        {
+            // t0.*f
+            template <typename F, typename T0>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            typename std::enable_if<
+                std::is_base_of<C, typename std::decay<T0>::type>::value,
+                R
+            >::type
+            operator()(F f, T0& v0)
+            {
+                return (v0.*f);
+            }
+
+            template <typename F, typename T0>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            typename std::enable_if<
+                std::is_base_of<C, typename std::decay<T0>::type>::value
+             && !std::is_lvalue_reference<T0>::value,
+                R
+            >::type
+            operator()(F f, T0&& v0)
+            {
+                return std::move(v0.*f);
+            }
+
+            // (*t0).*f
+            template <typename F, typename T0>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            typename std::enable_if<
+                !std::is_base_of<C, typename std::decay<T0>::type>::value,
+                R
+            >::type
+            operator()(F f, T0&& v0)
+            {
+                return (*this)(f, *std::forward<T0>(v0));
+            }
+        };
+
+        template <typename M, typename C>
+        struct invoke_guard_impl<void, M C::*>
+        {
+            // t0.*f
+            template <typename F, typename T0>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            typename std::enable_if<
+                std::is_base_of<C, typename std::decay<T0>::type>::value,
+                void
+            >::type
+            operator()(F f, T0& v0)
+            {
+                v0.*f;
+            }
+
+            template <typename F, typename T0>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            typename std::enable_if<
+                std::is_base_of<C, typename std::decay<T0>::type>::value
+             && !std::is_lvalue_reference<T0>::value,
+                void
+            >::type
+            operator()(F f, T0&& v0)
+            {
+                v0.*f;
+            }
+
+            // (*t0).*f
+            template <typename F, typename T0>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            typename std::enable_if<
+                !std::is_base_of<C, typename std::decay<T0>::type>::value,
+                void
+            >::type
+            operator()(F f, T0&& v0)
+            {
+                (*this)(f, *std::forward<T0>(v0));
+            }
+        };
+
+        template <typename R, typename RR, typename C, typename ...Ps>
+        struct invoke_guard_impl<R, RR (C::*)(Ps...)>
+        {
+            // (t0.*f)(t1, ..., tN)
+            template <typename F, typename T0, typename ...Ts>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            typename std::enable_if<
+                std::is_base_of<C, typename std::decay<T0>::type>::value,
+                R
+            >::type
+            operator()(F f, T0&& v0, Ts&&... vs)
+            {
+                return (std::forward<T0>(v0).*f)(std::forward<Ts>(vs)...);
+            }
+
+            // ((*t0).*f)(t1, ..., tN)
+            template <typename F, typename T0, typename ...Ts>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            typename std::enable_if<
+                !std::is_base_of<C, typename std::decay<T0>::type>::value,
+                R
+            >::type
+            operator()(F f, T0&& v0, Ts&&... vs)
+            {
+                return (*this)(f, *std::forward<T0>(v0), std::forward<Ts>(vs)...);
+            }
+        };
+
+        template <typename RR, typename C, typename ...Ps>
+        struct invoke_guard_impl<void, RR (C::*)(Ps...)>
+        {
+            // (t0.*f)(t1, ..., tN)
+            template <typename F, typename T0, typename ...Ts>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            typename std::enable_if<
+                std::is_base_of<C, typename std::decay<T0>::type>::value,
+                void
+            >::type
+            operator()(F f, T0&& v0, Ts&&... vs)
+            {
+                (std::forward<T0>(v0).*f)(std::forward<Ts>(vs)...);
+            }
+
+            // ((*t0).*f)(t1, ..., tN)
+            template <typename F, typename T0, typename ...Ts>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            typename std::enable_if<
+                !std::is_base_of<C, typename std::decay<T0>::type>::value,
+                void
+            >::type
+            operator()(F f, T0&& v0, Ts&&... vs)
+            {
+                (*this)(f, *std::forward<T0>(v0), std::forward<Ts>(vs)...);
+            }
+        };
+
+        template <typename R, typename RR, typename C, typename ...Ps>
+        struct invoke_guard_impl<R, RR (C::*)(Ps...) const>
+          : invoke_guard_impl<R,RR (C::*)(Ps...)>
+        {};
+
+        template <typename R, typename X>
+        struct invoke_guard_impl<R, ::boost::reference_wrapper<X> >
+          : invoke_guard_impl<R,X&>
+        {
+            // support boost::[c]ref, which is not callable as std::[c]ref
+            template <typename F, typename ...Ts>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            R operator()(F f, Ts&&... vs)
+            {
+                return f.get()(std::forward<Ts>(vs)...);
+            }
+        };
+
+        template <typename X>
+        struct invoke_guard_impl<void, ::boost::reference_wrapper<X> >
+          : invoke_guard_impl<void,X&>
+        {
+            // support boost::[c]ref, which is not callable as std::[c]ref
+            template <typename F, typename ...Ts>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            void operator()(F f, Ts&&... vs)
+            {
+                f.get()(std::forward<Ts>(vs)...);
+            }
+        };
+
         template <typename R>
         struct invoke_guard
         {
@@ -142,7 +334,7 @@ namespace hpx { namespace util
             HPX_HOST_DEVICE HPX_FORCEINLINE
             R operator()(F&& f, Ts&&... vs)
             {
-                return detail::invoke_impl<typename std::decay<F>::type>()(
+                return detail::invoke_guard_impl<R,typename std::decay<F>::type>()(
                     std::forward<F>(f), std::forward<Ts>(vs)...);
             }
         };
@@ -154,7 +346,7 @@ namespace hpx { namespace util
             HPX_HOST_DEVICE HPX_FORCEINLINE
             void operator()(F&& f, Ts&&... vs)
             {
-                detail::invoke_impl<typename std::decay<F>::type>()(
+                detail::invoke_guard_impl<void,typename std::decay<F>::type>()(
                     std::forward<F>(f), std::forward<Ts>(vs)...);
             }
         };

--- a/hpx/util/invoke.hpp
+++ b/hpx/util/invoke.hpp
@@ -90,7 +90,8 @@ namespace hpx { namespace util
             >::type
             operator()(F f, T0&& v0, Ts&&... vs)
             {
-                return hpx::util::void_guard<R>(), (std::forward<T0>(v0).*f)(std::forward<Ts>(vs)...);
+                return hpx::util::void_guard<R>(),
+                    (std::forward<T0>(v0).*f)(std::forward<Ts>(vs)...);
             }
 
             // ((*t0).*f)(t1, ..., tN)
@@ -102,7 +103,8 @@ namespace hpx { namespace util
             >::type
             operator()(F f, T0&& v0, Ts&&... vs)
             {
-                return hpx::util::void_guard<R>(), (*this)(f, *std::forward<T0>(v0), std::forward<Ts>(vs)...);
+                return hpx::util::void_guard<R>(),
+                    (*this)(f, *std::forward<T0>(v0), std::forward<Ts>(vs)...);
             }
         };
 

--- a/hpx/util/invoke_fused.hpp
+++ b/hpx/util/invoke_fused.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2013-2015 Agustin Berge
+//  Copyright (c) 2016 Antoine Tran Tan
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -64,6 +65,16 @@ namespace hpx { namespace util
             return util::invoke(std::forward<F>(f),
                 get<Is>(std::forward<Tuple>(t))...);
         }
+
+        template <typename R, typename F, typename Tuple, std::size_t ...Is>
+        HPX_HOST_DEVICE
+        inline R
+        invoke_fused_impl(F&&f, Tuple&& t, pack_c<std::size_t, Is...>)
+        {
+            using util::get;
+            return util::invoke<R>(std::forward<F>(f),
+                get<Is>(std::forward<Tuple>(t))...);
+        }
     }
 
     template <typename F, typename Tuple>
@@ -86,7 +97,7 @@ namespace hpx { namespace util
             HPX_HOST_DEVICE HPX_FORCEINLINE
             R operator()(F&& f, Tuple&& t)
             {
-                return detail::invoke_fused_impl(
+                return detail::invoke_fused_impl<R>(
                     std::forward<F>(f), std::forward<Tuple>(t),
                     typename detail::fused_index_pack<Tuple>::type());
             }
@@ -99,7 +110,7 @@ namespace hpx { namespace util
             HPX_HOST_DEVICE HPX_FORCEINLINE
             void operator()(F&& f, Tuple&& t)
             {
-                detail::invoke_fused_impl(
+                detail::invoke_fused_impl<void>(
                     std::forward<F>(f), std::forward<Tuple>(t),
                     typename detail::fused_index_pack<Tuple>::type());
             }


### PR DESCRIPTION
This pull request tries to solve the issue when result_of cannot deduce the return type of the callable object, i.e. it happens when the callable object is an HPX_DEVICE lambda.