### PR TITLE
Fix nvcc errors due to constexpr specifier

### DIFF
--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -160,10 +160,10 @@ namespace hpx { namespace components { namespace server
 
         /// \brief Actions to create new objects
         template <typename Component>
-        naming::gid_type create_component();
+        HPX_HOST_DEVICE naming::gid_type create_component();
 
         template <typename Component, typename T, typename ...Ts>
-        naming::gid_type create_component(T v, Ts... vs);
+        HPX_HOST_DEVICE naming::gid_type create_component(T v, Ts... vs);
 
         template <typename Component>
         std::vector<naming::gid_type> bulk_create_component(std::size_t count);

--- a/hpx/util/tuple.hpp
+++ b/hpx/util/tuple.hpp
@@ -38,22 +38,22 @@ namespace hpx { namespace util
     struct tuple_element; // undefined
 
     template <std::size_t I, typename Tuple>
-    HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+    HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
     typename tuple_element<I, Tuple>::type&
     get(Tuple& t) HPX_NOEXCEPT;
 
     template <std::size_t I, typename Tuple>
-    HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+    HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
     typename tuple_element<I, Tuple>::type const&
     get(Tuple const& t) HPX_NOEXCEPT;
 
     template <std::size_t I, typename Tuple>
-    HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+    HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
     typename tuple_element<I, Tuple>::type&&
     get(Tuple&& t) HPX_NOEXCEPT;
 
     template <std::size_t I, typename Tuple>
-    HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+    HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
     typename tuple_element<I, Tuple>::type const&&
     get(Tuple const&& t) HPX_NOEXCEPT;
 
@@ -64,7 +64,7 @@ namespace hpx { namespace util
         struct tuple_member //-V690
         {
         public:
-            HPX_HOST_DEVICE HPX_CONSTEXPR tuple_member()
+            HPX_CONSTEXPR HPX_HOST_DEVICE tuple_member()
               : _value()
             {}
 
@@ -72,7 +72,7 @@ namespace hpx { namespace util
                 typename std::enable_if<
                     !std::is_same<tuple_member, typename std::decay<U>::type>::value
                 >::type>
-            explicit HPX_HOST_DEVICE HPX_CONSTEXPR tuple_member(U&& value)
+            explicit HPX_CONSTEXPR HPX_HOST_DEVICE tuple_member(U&& value)
               : _value(std::forward<U>(value))
             {}
 
@@ -80,12 +80,12 @@ namespace hpx { namespace util
             tuple_member(tuple_member const&) = default;
             tuple_member(tuple_member&&) = default;
 #else
-            HPX_HOST_DEVICE HPX_CONSTEXPR
+            HPX_CONSTEXPR HPX_HOST_DEVICE
             tuple_member(tuple_member const& other)
               : _value(other.value())
             {}
 
-            HPX_HOST_DEVICE HPX_CONSTEXPR
+            HPX_CONSTEXPR HPX_HOST_DEVICE
             tuple_member(tuple_member&& other)
               : _value(std::forward<T>(other.value()))
             {}
@@ -109,7 +109,7 @@ namespace hpx { namespace util
         > : T
         {
         public:
-            HPX_HOST_DEVICE HPX_CONSTEXPR tuple_member()
+            HPX_CONSTEXPR HPX_HOST_DEVICE tuple_member()
               : T()
             {}
 
@@ -117,7 +117,7 @@ namespace hpx { namespace util
                 typename std::enable_if<
                     !std::is_same<tuple_member, typename std::decay<U>::type>::value
                 >::type>
-            explicit HPX_HOST_DEVICE HPX_CONSTEXPR tuple_member(U&& value)
+            explicit HPX_CONSTEXPR HPX_HOST_DEVICE tuple_member(U&& value)
               : T(std::forward<U>(value))
             {}
 
@@ -125,12 +125,12 @@ namespace hpx { namespace util
             tuple_member(tuple_member const&) = default;
             tuple_member(tuple_member&&) = default;
 #else
-            HPX_HOST_DEVICE HPX_CONSTEXPR
+            HPX_CONSTEXPR HPX_HOST_DEVICE
             tuple_member(tuple_member const& other)
               : T(other.value())
             {}
 
-            HPX_HOST_DEVICE HPX_CONSTEXPR
+            HPX_CONSTEXPR HPX_HOST_DEVICE
             tuple_member(tuple_member&& other)
               : T(std::forward<T>(other.value()))
             {}
@@ -202,7 +202,7 @@ namespace hpx { namespace util
           : tuple_member<Is, Ts>...
         {
             // 20.4.2.1, tuple construction
-            HPX_HOST_DEVICE HPX_CONSTEXPR tuple_impl()
+            HPX_CONSTEXPR HPX_HOST_DEVICE tuple_impl()
               : tuple_member<Is, Ts>()...
             {}
 
@@ -210,7 +210,7 @@ namespace hpx { namespace util
                 typename std::enable_if<
                     detail::pack<Us...>::size == detail::pack<Ts...>::size
                 >::type>
-            explicit HPX_HOST_DEVICE HPX_CONSTEXPR tuple_impl(Us&&... vs)
+            explicit HPX_CONSTEXPR HPX_HOST_DEVICE tuple_impl(Us&&... vs)
               : tuple_member<Is, Ts>(std::forward<Us>(vs))...
             {}
 
@@ -218,12 +218,12 @@ namespace hpx { namespace util
             tuple_impl(tuple_impl const&) = default;
             tuple_impl(tuple_impl&&) = default;
 #else
-            HPX_HOST_DEVICE HPX_CONSTEXPR
+            HPX_CONSTEXPR HPX_HOST_DEVICE
             tuple_impl(tuple_impl const& other)
               : tuple_member<Is, Ts>(static_cast<tuple_member<Is, Ts> const&>(other))...
             {}
 
-            HPX_HOST_DEVICE HPX_CONSTEXPR
+            HPX_CONSTEXPR HPX_HOST_DEVICE
             tuple_impl(tuple_impl&& other)
               : tuple_member<Is, Ts>(static_cast<tuple_member<Is, Ts>&&>(other))...
             {}
@@ -233,7 +233,7 @@ namespace hpx { namespace util
                 typename std::enable_if<
                     are_tuples_compatible_not_same<tuple<Ts...>, UTuple&&>::value
                 >::type>
-            HPX_HOST_DEVICE HPX_CONSTEXPR tuple_impl(UTuple&& other)
+            HPX_CONSTEXPR HPX_HOST_DEVICE tuple_impl(UTuple&& other)
               : tuple_member<Is, Ts>(util::get<Is>(std::forward<UTuple>(other)))...
             {}
 
@@ -320,19 +320,19 @@ namespace hpx { namespace util
 
         // constexpr tuple();
         // Value initializes each element.
-        HPX_HOST_DEVICE HPX_CONSTEXPR tuple()
+        HPX_CONSTEXPR HPX_HOST_DEVICE tuple()
         {}
 
         // tuple(const tuple& u) = default;
         // Initializes each element of *this with the corresponding element
         // of u.
-        HPX_HOST_DEVICE HPX_CONSTEXPR tuple(tuple const& /*other*/)
+        HPX_CONSTEXPR HPX_HOST_DEVICE tuple(tuple const& /*other*/)
         {}
 
         // tuple(tuple&& u) = default;
         // For all i, initializes the ith element of *this with
         // std::forward<Ti>(get<i>(u)).
-        HPX_HOST_DEVICE HPX_CONSTEXPR tuple(tuple&& /*other*/)
+        HPX_CONSTEXPR HPX_HOST_DEVICE tuple(tuple&& /*other*/)
         {}
 
         // 20.4.2.2, tuple assignment
@@ -373,14 +373,14 @@ namespace hpx { namespace util
 
         // constexpr tuple();
         // Value initializes each element.
-        HPX_HOST_DEVICE HPX_CONSTEXPR tuple()
+        HPX_CONSTEXPR HPX_HOST_DEVICE tuple()
           : _impl()
         {}
 
         // explicit constexpr tuple(const Types&...);
         // Initializes each element with the value of the corresponding
         // parameter.
-        explicit HPX_HOST_DEVICE HPX_CONSTEXPR tuple(Ts const&... vs)
+        explicit HPX_CONSTEXPR HPX_HOST_DEVICE tuple(Ts const&... vs)
           : _impl(vs...)
         {}
 
@@ -404,7 +404,7 @@ namespace hpx { namespace util
                   , detail::are_tuples_compatible<tuple, tuple<U, Us...>&&>
                 >::type::value
             >::type>
-        explicit HPX_HOST_DEVICE HPX_CONSTEXPR tuple(U&& v, Us&&... vs)
+        explicit HPX_CONSTEXPR HPX_HOST_DEVICE tuple(U&& v, Us&&... vs)
           : _impl(std::forward<U>(v), std::forward<Us>(vs)...)
         {}
 
@@ -422,14 +422,14 @@ namespace hpx { namespace util
         // tuple(const tuple& u) = default;
         // Initializes each element of *this with the corresponding element
         // of u.
-        HPX_HOST_DEVICE HPX_CONSTEXPR tuple(tuple const& other)
+        HPX_CONSTEXPR HPX_HOST_DEVICE tuple(tuple const& other)
           : _impl(other._impl)
         {}
 
         // tuple(tuple&& u) = default;
         // For all i, initializes the ith element of *this with
         // std::forward<Ti>(get<i>(u)).
-        HPX_HOST_DEVICE HPX_CONSTEXPR tuple(tuple&& other)
+        HPX_CONSTEXPR HPX_HOST_DEVICE tuple(tuple&& other)
           : _impl(std::move(other._impl))
         {}
 #endif
@@ -445,7 +445,7 @@ namespace hpx { namespace util
             typename std::enable_if<
                 detail::are_tuples_compatible_not_same<tuple, UTuple&&>::value
             >::type>
-        HPX_HOST_DEVICE HPX_CONSTEXPR tuple(UTuple&& other)
+        HPX_CONSTEXPR HPX_HOST_DEVICE tuple(UTuple&& other)
           : _impl(std::forward<UTuple>(other))
         {}
 
@@ -558,13 +558,13 @@ namespace hpx { namespace util
     {
         typedef typename detail::at_index<I, Ts...>::type type;
 
-        static HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE type&
+        static HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE type&
         get(tuple<Ts...>& tuple) HPX_NOEXCEPT
         {
             return tuple._impl.template get<I>();
         }
 
-        static HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE type const&
+        static HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE type const&
         get(tuple<Ts...> const& tuple) HPX_NOEXCEPT
         {
             return tuple._impl.template get<I>();
@@ -576,13 +576,13 @@ namespace hpx { namespace util
     {
         typedef T0 type;
 
-        static HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE type&
+        static HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE type&
         get(std::pair<T0, T1>& tuple) HPX_NOEXCEPT
         {
             return tuple.first;
         }
 
-        static HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE type const&
+        static HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE type const&
         get(std::pair<T0, T1> const& tuple) HPX_NOEXCEPT
         {
             return tuple.first;
@@ -594,13 +594,13 @@ namespace hpx { namespace util
     {
         typedef T1 type;
 
-        static HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE type&
+        static HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE type&
         get(std::pair<T0, T1>& tuple) HPX_NOEXCEPT
         {
             return tuple.second;
         }
 
-        static HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE type const&
+        static HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE type const&
         get(std::pair<T0, T1> const& tuple) HPX_NOEXCEPT
         {
             return tuple.second;
@@ -612,13 +612,13 @@ namespace hpx { namespace util
     {
         typedef Type type;
 
-        static HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE type&
+        static HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE type&
         get(boost::array<Type, Size>& tuple) HPX_NOEXCEPT
         {
             return tuple[I];
         }
 
-        static HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE type const&
+        static HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE type const&
         get(boost::array<Type, Size> const& tuple) HPX_NOEXCEPT
         {
             return tuple[I];
@@ -631,7 +631,7 @@ namespace hpx { namespace util
     // constexpr typename tuple_element<I, tuple<Types...> >::type&
     // get(tuple<Types...>& t) noexcept;
     template <std::size_t I, typename Tuple>
-    HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+    HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
     typename tuple_element<I, Tuple>::type&
     get(Tuple& t) HPX_NOEXCEPT
     {
@@ -642,7 +642,7 @@ namespace hpx { namespace util
     // constexpr typename tuple_element<I, tuple<Types...> >::type const&
     // get(const tuple<Types...>& t) noexcept;
     template <std::size_t I, typename Tuple>
-    HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+    HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
     typename tuple_element<I, Tuple>::type const&
     get(Tuple const& t) HPX_NOEXCEPT
     {
@@ -653,7 +653,7 @@ namespace hpx { namespace util
     // constexpr typename tuple_element<I, tuple<Types...> >::type&&
     // get(tuple<Types...>&& t) noexcept;
     template <std::size_t I, typename Tuple>
-    HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+    HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
     typename tuple_element<I, Tuple>::type&&
     get(Tuple&& t) HPX_NOEXCEPT
     {
@@ -665,7 +665,7 @@ namespace hpx { namespace util
     // constexpr typename tuple_element<I, tuple<Types...> >::type const&&
     // get(const tuple<Types...>&& t) noexcept;
     template <std::size_t I, typename Tuple>
-    HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+    HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
     typename tuple_element<I, Tuple>::type const&&
     get(Tuple const&& t) HPX_NOEXCEPT
     {
@@ -679,7 +679,7 @@ namespace hpx { namespace util
     // template<class... Types>
     // constexpr tuple<VTypes...> make_tuple(Types&&... t);
     template <typename ...Ts>
-    HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+    HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
     tuple<typename decay_unwrap<Ts>::type...>
     make_tuple(Ts&&... vs)
     {
@@ -751,14 +751,14 @@ namespace hpx { namespace util
         {
             typedef tuple_element<I, Head> base_type;
 
-            static HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+            static HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
             typename base_type::type&
             get(Head& head, Tail& ...tail) HPX_NOEXCEPT
             {
                 return base_type::get(head);
             }
 
-            static HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+            static HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
             typename base_type::type const&
             get(Head const& head, Tail& ...tail) HPX_NOEXCEPT
             {
@@ -782,14 +782,14 @@ namespace hpx { namespace util
               , detail::pack<Tail...>
             > base_type;
 
-            static HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+            static HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
             typename base_type::type&
             get(Head& head, Tail& ...tail) HPX_NOEXCEPT
             {
                 return base_type::get(tail...);
             }
 
-            static HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+            static HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
             typename base_type::type const&
             get(Head const& head, Tail& ...tail) HPX_NOEXCEPT
             {
@@ -811,7 +811,7 @@ namespace hpx { namespace util
             > type;
 
             template <typename ...Tuples_>
-            static HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+            static HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
             type make(Tuples_&&... tuples)
             {
                 return type(tuple_cat_element<Is, detail::pack<Tuples...> >::get(
@@ -829,7 +829,7 @@ namespace hpx { namespace util
     }
 
     template <typename ...Tuples>
-    HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+    HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
     typename detail::tuple_cat_result<Tuples...>::type
     tuple_cat(Tuples&&... tuples)
     {
@@ -851,7 +851,7 @@ namespace hpx { namespace util
         struct tuple_equal_to
         {
             template <typename TTuple, typename UTuple>
-            static HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+            static HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
             bool call(TTuple const& t, UTuple const&u)
             {
                 return
@@ -864,7 +864,7 @@ namespace hpx { namespace util
         struct tuple_equal_to<Size, Size>
         {
             template <typename TTuple, typename UTuple>
-            static HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+            static HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
             bool call(TTuple const& t, UTuple const&u)
             {
                 return true;
@@ -873,7 +873,7 @@ namespace hpx { namespace util
     }
 
     template <typename ...Ts, typename ...Us>
-    HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+    HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
     typename std::enable_if<sizeof...(Ts) == sizeof...(Us), bool>::type
     operator==(tuple<Ts...> const& t, tuple<Us...> const& u)
     {
@@ -884,7 +884,7 @@ namespace hpx { namespace util
     // constexpr bool operator!=
     //     (const tuple<TTypes...>& t, const tuple<UTypes...>& u);
     template <typename ...Ts, typename ...Us>
-    HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+    HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
     typename std::enable_if<sizeof...(Ts) == sizeof...(Us), bool>::type
     operator!=(tuple<Ts...> const& t, tuple<Us...> const& u)
     {
@@ -904,7 +904,7 @@ namespace hpx { namespace util
         struct tuple_less_than
         {
             template <typename TTuple, typename UTuple>
-            static HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+            static HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
             bool call(TTuple const& t, UTuple const&u)
             {
                 return
@@ -920,7 +920,7 @@ namespace hpx { namespace util
         struct tuple_less_than<Size, Size>
         {
             template <typename TTuple, typename UTuple>
-            static HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+            static HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
             bool call(TTuple const& t, UTuple const&u)
             {
                 return false;
@@ -929,7 +929,7 @@ namespace hpx { namespace util
     }
 
     template <typename ...Ts, typename ...Us>
-    HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+    HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
     typename std::enable_if<sizeof...(Ts) == sizeof...(Us), bool>::type
     operator<(tuple<Ts...> const& t, tuple<Us...> const& u)
     {
@@ -940,7 +940,7 @@ namespace hpx { namespace util
     // constexpr bool operator>
     //     (const tuple<TTypes...>& t, const tuple<UTypes...>& u);
     template <typename ...Ts, typename ...Us>
-    HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+    HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
     typename std::enable_if<sizeof...(Ts) == sizeof...(Us), bool>::type
     operator>(tuple<Ts...> const& t, tuple<Us...> const& u)
     {
@@ -951,7 +951,7 @@ namespace hpx { namespace util
     // constexpr bool operator<=
     //     (const tuple<TTypes...>& t, const tuple<UTypes...>& u);
     template <typename ...Ts, typename ...Us>
-    HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+    HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
     typename std::enable_if<sizeof...(Ts) == sizeof...(Us), bool>::type
     operator<=(tuple<Ts...> const& t, tuple<Us...> const& u)
     {
@@ -962,7 +962,7 @@ namespace hpx { namespace util
     // constexpr bool operator>=
     //     (const tuple<TTypes...>& t, const tuple<UTypes...>& u);
     template <typename ...Ts, typename ...Us>
-    HPX_HOST_DEVICE HPX_CONSTEXPR HPX_FORCEINLINE
+    HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
     typename std::enable_if<sizeof...(Ts) == sizeof...(Us), bool>::type
     operator>=(tuple<Ts...> const& t, tuple<Us...> const& u)
     {

--- a/hpx/util/unused.hpp
+++ b/hpx/util/unused.hpp
@@ -23,17 +23,17 @@ namespace hpx { namespace util
     ///////////////////////////////////////////////////////////////////////////
     struct unused_type
     {
-        HPX_HOST_DEVICE HPX_CONSTEXPR unused_type() HPX_NOEXCEPT
+        HPX_CONSTEXPR HPX_HOST_DEVICE unused_type() HPX_NOEXCEPT
         {
         }
 
         template <typename T>
-        HPX_HOST_DEVICE HPX_CONSTEXPR unused_type(T const&) HPX_NOEXCEPT
+        HPX_CONSTEXPR HPX_HOST_DEVICE unused_type(T const&) HPX_NOEXCEPT
         {
         }
 
         template <typename T>
-        HPX_HOST_DEVICE HPX_CONSTEXPR unused_type const&
+        HPX_CONSTEXPR HPX_HOST_DEVICE unused_type const&
         operator=(T const&) const HPX_NOEXCEPT
         {
             return *this;
@@ -46,7 +46,7 @@ namespace hpx { namespace util
             return *this;
         }
 
-        HPX_HOST_DEVICE HPX_CONSTEXPR unused_type const&
+        HPX_CONSTEXPR HPX_HOST_DEVICE unused_type const&
         operator=(unused_type const&) const HPX_NOEXCEPT
         {
             return *this;
@@ -59,7 +59,7 @@ namespace hpx { namespace util
         }
     };
 
-    HPX_CONSTANT unused_type HPX_CONSTEXPR_OR_CONST unused = unused_type();
+    HPX_CONSTEXPR_OR_CONST unused_type unused = unused_type();
 }}
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This patch fixes some errors due to the introduction of the constexpr specifier for certain `__host__` `__device__`  or `__constant__` variables