### PR TITLE
Warning fixes

### DIFF
--- a/hpx/components/performance_counters/papi/server/papi.hpp
+++ b/hpx/components/performance_counters/papi/server/papi.hpp
@@ -71,7 +71,7 @@ namespace hpx { namespace performance_counters { namespace papi { namespace serv
         PAPI_COUNTER_TERMINATED
     };
 
-    struct papi_counter;
+    class papi_counter;
 
     ///////////////////////////////////////////////////////////////////////////
     struct thread_counters

--- a/hpx/runtime/agas/namespace_action_code.hpp
+++ b/hpx/runtime/agas/namespace_action_code.hpp
@@ -444,15 +444,6 @@ namespace detail
         );
 }
 
-namespace server
-{
-    // forward declarations
-    struct HPX_EXPORT locality_namespace;
-    struct HPX_EXPORT primary_namespace;
-    struct HPX_EXPORT component_namespace;
-    struct HPX_EXPORT symbol_namespace;
-}
-
 }}
 
 #endif // HPX_60B7914E_21A5_4977_AA9C_8E66C44EE0FB

--- a/hpx/runtime/parcelset/locality.hpp
+++ b/hpx/runtime/parcelset/locality.hpp
@@ -11,6 +11,7 @@
 #include <hpx/config.hpp>
 
 #include <hpx/exception.hpp>
+#include <hpx/runtime/parcelset_fwd.hpp>
 #include <hpx/runtime/serialization/map.hpp>
 #include <hpx/traits/is_iterator.hpp>
 

--- a/hpx/runtime/threads/executors/current_executor.hpp
+++ b/hpx/runtime/threads/executors/current_executor.hpp
@@ -89,7 +89,7 @@ namespace hpx { namespace threads { namespace executors
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    struct HPX_EXPORT current_executor : public scheduled_executor
+    struct current_executor : public scheduled_executor
     {
         current_executor();
         explicit current_executor(policies::scheduler_base* scheduler);

--- a/hpx/runtime/threads/policies/callback_notifier.hpp
+++ b/hpx/runtime/threads/policies/callback_notifier.hpp
@@ -7,6 +7,7 @@
 #define HPX_THREADMANAGER_POLICIES_CALLBACK_NOTIFIER_JUN_18_2009_1132AM
 
 #include <hpx/config.hpp>
+#include <hpx/runtime/threads_fwd.hpp>
 #include <hpx/util/function.hpp>
 
 #include <boost/exception_ptr.hpp>

--- a/hpx/runtime/threads/thread.hpp
+++ b/hpx/runtime/threads/thread.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/exception_fwd.hpp>
+#include <hpx/runtime_fwd.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 #include <hpx/lcos_fwd.hpp>
 #include <hpx/runtime/threads/thread_data_fwd.hpp>

--- a/hpx/runtime/threads/thread_helpers.hpp
+++ b/hpx/runtime/threads/thread_helpers.hpp
@@ -11,6 +11,7 @@
 #include <hpx/config.hpp>
 #include <hpx/exception_fwd.hpp>
 #include <hpx/runtime/naming_fwd.hpp>
+#include <hpx/runtime/threads_fwd.hpp>
 #include <hpx/runtime/threads/policies/scheduler_mode.hpp>
 #include <hpx/runtime/threads/thread_data_fwd.hpp>
 #include <hpx/runtime/threads/thread_enums.hpp>
@@ -28,11 +29,6 @@ namespace hpx { namespace threads
 {
     /// \cond NOINTERNAL
     class thread_init_data;
-
-    namespace executors
-    {
-        struct HPX_EXPORT current_executor;
-    }
     /// \endcond
 
     ///////////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/threads_fwd.hpp
+++ b/hpx/runtime/threads_fwd.hpp
@@ -118,6 +118,11 @@ namespace hpx
 
             class HPX_EXPORT callback_notifier;
         }
+
+        namespace executors
+        {
+            struct HPX_EXPORT current_executor;
+        }
     }
 }
 

--- a/hpx/util/coordinate.hpp
+++ b/hpx/util/coordinate.hpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <functional>
 #include <initializer_list>
 #include <numeric>
 


### PR DESCRIPTION
These patches contain a few patches that remove some warnings about invalid attributes and one about a class/struct mismatch.