### PR TITLE
Some fixes around cuda clang partitioned_vector example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,9 @@ if(HPX_WITH_CUDA)
   hpx_add_config_define(HPX_HAVE_CUDA)
   hpx_add_config_define(HPX_HAVE_COMPUTE)
 endif()
+if(HPX_WITH_CUDA_CLANG AND NOT (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
+  hpx_error("To use Cuda Clang, please select Clang as your default C++ compiler")
+endif()
 hpx_option(HPX_WITH_HCC BOOL
   "Enable hcc support (default: OFF)" OFF ADVANCED)
 hpx_option(HPX_WITH_SYCL BOOL

--- a/examples/compute/CMakeLists.txt
+++ b/examples/compute/CMakeLists.txt
@@ -3,12 +3,6 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-
-# Provisionally compile cuda examples with Cuda/Clang in Debug Mode
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND HPX_WITH_CUDA_CLANG)
-  set(CMAKE_BUILD_TYPE Debug)
-endif()
-
 set(subdirs
    )
 

--- a/examples/compute/cuda/partitioned_vector.cu
+++ b/examples/compute/cuda/partitioned_vector.cu
@@ -3,10 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#define HPX_APPLICATION_NAME partitioned_vector_cu
-#define HPX_APPLICATION_STRING "partitioned_vector_cu"
-#define HPX_APPLICATION_EXPORTS
-
 #include <hpx/include/compute.hpp>
 #include <hpx/include/partitioned_vector.hpp>
 #include <hpx/include/parallel_for_each.hpp>

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp
@@ -442,9 +442,12 @@ namespace hpx { namespace server
     HPX_REGISTER_VECTOR_DECLARATION_IMPL(                                     \
         BOOST_PP_CAT(__partitioned_vector_, BOOST_PP_CAT(type, name)), name)  \
 /**/
-
+#ifndef __CUDA_ARCH__
 #define HPX_REGISTER_PARTITIONED_VECTOR(...)                                  \
-    HPX_REGISTER_VECTOR_(__VA_ARGS__)                                         \
+    HPX_REGISTER_VECTOR_(__VA_ARGS__)
+#else
+#define HPX_REGISTER_PARTITIONED_VECTOR(...)
+#endif
 /**/
 #define HPX_REGISTER_VECTOR_(...)                                             \
     HPX_UTIL_EXPAND_(BOOST_PP_CAT(                                            \

--- a/hpx/compute/cuda/default_executor.hpp
+++ b/hpx/compute/cuda/default_executor.hpp
@@ -75,7 +75,7 @@ namespace hpx { namespace compute { namespace cuda
                         int idx = blockIdx.x * blockDim.x + threadIdx.x;
                         if (idx < count)
                         {
-                            hpx::util::invoke(f, *(p + idx), ts...);
+                            hpx::util::invoke_r<void>(f, *(p + idx), ts...);
                         }
                     },
                     std::forward<F>(f), shape_container.data(), count,
@@ -120,7 +120,7 @@ namespace hpx { namespace compute { namespace cuda
                             int idx = blockIdx.x * blockDim.x + threadIdx.x;
                             if(idx < chunk_size)
                             {
-                                hpx::util::invoke(f,
+                                hpx::util::invoke_r<void>(f,
                                     value_type(begin + idx, 1, idx), ts...);
                             }
                         },

--- a/hpx/compute/cuda/value_proxy.hpp
+++ b/hpx/compute/cuda/value_proxy.hpp
@@ -51,11 +51,23 @@ namespace hpx { namespace compute { namespace cuda
             return *this;
         }
 
+        // Note: The code duplication below allows Cuda Clang to not see
+        //       the host side implicit cast during the device code
+        //       compilation. Without this, wrong template parameter
+        //       deduction can occur if a value_proxy is given in the arg
+        //       list of invoke()
+
+#if defined(__CUDA_ARCH__)
+        HPX_DEVICE operator T() const
+        {
+            return access_target::read(*target_, p_);
+        }
+#else
         operator T() const
         {
             return access_target::read(*target_, p_);
         }
-
+#endif
         T* device_ptr() const HPX_NOEXCEPT
         {
             return p_;
@@ -90,10 +102,23 @@ namespace hpx { namespace compute { namespace cuda
           , target_(other.target())
         {}
 
+        // Note: The code duplication below allows Cuda Clang to not see
+        //       the host side implicit cast during the device code
+        //       compilation. Without this, wrong template parameter
+        //       deduction can occur if a value_proxy is given in the arg
+        //       list of invoke()
+
+#if defined(__CUDA_ARCH__)
+        HPX_DEVICE operator T() const
+        {
+            return access_target::read(target_, p_);
+        }
+#else
         operator T() const
         {
             return access_target::read(target_, p_);
         }
+#endif
 
         T* device_ptr() const HPX_NOEXCEPT
         {

--- a/hpx/compute/serialization/vector.hpp
+++ b/hpx/compute/serialization/vector.hpp
@@ -31,16 +31,22 @@ namespace hpx { namespace serialization
             std::false_type)
         {
             // normal load ...
-            typedef typename compute::vector<T, Allocator>::size_type size_type;
+            typedef typename compute::vector<T, Allocator>::value_type
+                value_type;
+            typedef typename compute::vector<T, Allocator>::size_type
+                size_type;
 
             size_type size;
+            value_type v;
+
             ar >> size; //-V128
             if(size == 0) return;
 
             vs.resize(size);
             for(size_type i = 0; i != size; ++i)
             {
-                ar >> vs[i];
+                ar >> v;
+                vs[i] = v;
             }
         }
 
@@ -65,7 +71,7 @@ namespace hpx { namespace serialization
                 if(size == 0) return;
 
                 v.resize(size);
-                load_binary(ar, &v[0], v.size() * sizeof(value_type));
+                load_binary(ar, v.device_data(), v.size() * sizeof(value_type));
             }
         }
     }
@@ -112,7 +118,7 @@ namespace hpx { namespace serialization
                 // bitwise save ...
                 typedef typename compute::vector<T, Allocator>::value_type
                     value_type;
-                save_binary(ar, &v[0], v.size() * sizeof(value_type));
+                save_binary(ar, v.device_data(), v.size() * sizeof(value_type));
             }
         }
     }

--- a/hpx/compute/vector.hpp
+++ b/hpx/compute/vector.hpp
@@ -252,7 +252,11 @@ namespace hpx { namespace compute
         /// allocated on the device.
         T* device_data() const HPX_NOEXCEPT
         {
+#if defined(__CUDACC__)
             return data_.device_ptr();
+#else
+            return data_;
+#endif
         }
 
         //

--- a/hpx/compute/vector.hpp
+++ b/hpx/compute/vector.hpp
@@ -252,7 +252,7 @@ namespace hpx { namespace compute
         /// allocated on the device.
         T* device_data() const HPX_NOEXCEPT
         {
-#if defined(__CUDACC__)
+#if defined(__NVCC__) || defined(__CUDACC__)
             return data_.device_ptr();
 #else
             return data_;

--- a/hpx/config.hpp
+++ b/hpx/config.hpp
@@ -504,7 +504,7 @@
 #if defined(HPX_MSVC)
 #   define HPX_NOINLINE __declspec(noinline)
 #elif defined(__GNUC__)
-#   if defined(__CUDACC__)
+#   if defined(__NVCC__) || defined(__CUDACC__)
         // nvcc doesn't always parse __noinline
 #       define HPX_NOINLINE __attribute__ ((noinline))
 #   else

--- a/hpx/config/compiler_specific.hpp
+++ b/hpx/config/compiler_specific.hpp
@@ -72,7 +72,7 @@
 #   define HPX_WINDOWS
 #endif
 
-#if defined(__CUDACC__)
+#if defined(__NVCC__) || defined(__CUDACC__)
 #define HPX_DEVICE __device__
 #define HPX_HOST __host__
 #define HPX_CONSTANT __constant__

--- a/hpx/config/export_definitions.hpp
+++ b/hpx/config/export_definitions.hpp
@@ -13,7 +13,7 @@
 # define HPX_SYMBOL_INTERNAL    /* empty */
 # define HPX_APISYMBOL_EXPORT   __declspec(dllexport)
 # define HPX_APISYMBOL_IMPORT   __declspec(dllimport)
-#elif defined(__CUDACC__)
+#elif defined(__NVCC__) || defined(__CUDACC__)
 # define HPX_SYMBOL_EXPORT      /* empty */
 # define HPX_SYMBOL_IMPORT      /* empty */
 # define HPX_SYMBOL_INTERNAL    /* empty */

--- a/hpx/config/forceinline.hpp
+++ b/hpx/config/forceinline.hpp
@@ -9,7 +9,7 @@
 #include <hpx/config/compiler_specific.hpp>
 
 #if !defined(HPX_FORCEINLINE)
-#   if defined(__CUDACC__)
+#   if defined(__NVCC__) || defined(__CUDACC__)
 #       define HPX_FORCEINLINE inline
 #   elif defined(HPX_MSVC)
 #       define HPX_FORCEINLINE __forceinline

--- a/hpx/config/forceinline.hpp
+++ b/hpx/config/forceinline.hpp
@@ -9,7 +9,7 @@
 #include <hpx/config/compiler_specific.hpp>
 
 #if !defined(HPX_FORCEINLINE)
-#   if defined(__NVCC__)
+#   if defined(__CUDACC__)
 #       define HPX_FORCEINLINE inline
 #   elif defined(HPX_MSVC)
 #       define HPX_FORCEINLINE __forceinline

--- a/hpx/lcos/base_lco.hpp
+++ b/hpx/lcos/base_lco.hpp
@@ -58,7 +58,7 @@ namespace hpx { namespace lcos
         /// \a set_event_action is applied on a instance of a LCO. This function
         /// just forwards to the virtual function \a set_event, which is
         /// overloaded by the derived concrete LCO.
-#if defined(__CUDACC__)
+#if defined(__NVCC__) || defined(__CUDACC__)
         HPX_DEVICE void set_event_nonvirt() {}
 #else
         void set_event_nonvirt();
@@ -71,7 +71,7 @@ namespace hpx { namespace lcos
         ///
         /// \param e      [in] The exception encapsulating the error to report
         ///               to this LCO instance.
-#if defined(__CUDACC__)
+#if defined(__NVCC__) || defined(__CUDACC__)
         HPX_DEVICE void set_exception_nonvirt(boost::exception_ptr const&) {}
 #else
         void set_exception_nonvirt(boost::exception_ptr const& e);
@@ -83,7 +83,7 @@ namespace hpx { namespace lcos
         /// overloaded by the derived concrete LCO.
         ///
         /// \param id [in] target id
-#if defined(__CUDACC__)
+#if defined(__NVCC__) || defined(__CUDACC__)
         HPX_DEVICE void connect_nonvirt(naming::id_type const & id) {}
 #else
         void connect_nonvirt(naming::id_type const & id);
@@ -94,7 +94,7 @@ namespace hpx { namespace lcos
         /// overloaded by the derived concrete LCO.
         ///
         /// \param id [in] target id
-#if defined(__CUDACC__)
+#if defined(__NVCC__) || defined(__CUDACC__)
         HPX_DEVICE void disconnect_nonvirt(naming::id_type const & id) {}
 #else
         void disconnect_nonvirt(naming::id_type const & id);

--- a/hpx/lcos/base_lco_with_value.hpp
+++ b/hpx/lcos/base_lco_with_value.hpp
@@ -85,7 +85,7 @@ namespace hpx { namespace lcos
         ///
         /// \param result [in] The result value to be transferred from the
         ///               remote operation back to this LCO instance.
-#if defined(__CUDACC__)
+#if defined(__NVCC__) || defined(__CUDACC__)
         HPX_DEVICE void set_value_nonvirt (RemoteResult&&) {}
 #else
         void set_value_nonvirt (RemoteResult&& result)
@@ -98,7 +98,7 @@ namespace hpx { namespace lcos
         /// \a get_result_action is applied on this LCO instance. This
         /// function just forwards to the virtual function \a get_result, which
         /// is overloaded by the derived concrete LCO.
-#if defined(__CUDACC__)
+#if defined(__NVCC__) || defined(__CUDACC__)
         HPX_DEVICE Result get_value_nonvirt() { return Result(); }
 #else
         Result get_value_nonvirt()
@@ -173,7 +173,7 @@ namespace hpx { namespace traits
     };
 }}
 
-#if defined(__CUDACC__)
+#if defined(__NVCC__) || defined(__CUDACC__)
 #define HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(...)
 #define HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION2(...)
 #define HPX_REGISTER_BASE_LCO_WITH_VALUE(...)

--- a/hpx/parallel/algorithms/count.hpp
+++ b/hpx/parallel/algorithms/count.hpp
@@ -57,7 +57,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
               : op_(std::forward<Op_>(op))
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
             count_iteration(count_iteration const&) = default;
             count_iteration(count_iteration&&) = default;
 #else

--- a/hpx/parallel/algorithms/count.hpp
+++ b/hpx/parallel/algorithms/count.hpp
@@ -57,7 +57,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
               : op_(std::forward<Op_>(op))
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__CUDACC__)
             count_iteration(count_iteration const&) = default;
             count_iteration(count_iteration&&) = default;
 #else

--- a/hpx/parallel/algorithms/count.hpp
+++ b/hpx/parallel/algorithms/count.hpp
@@ -57,7 +57,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
               : op_(std::forward<Op_>(op))
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && \
+    !defined(__CUDACC__)
             count_iteration(count_iteration const&) = default;
             count_iteration(count_iteration&&) = default;
 #else

--- a/hpx/parallel/algorithms/for_each.hpp
+++ b/hpx/parallel/algorithms/for_each.hpp
@@ -65,7 +65,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
             call(T && t)
             {
                 auto tmp = hpx::util::invoke(proj_, std::forward<T>(t));
-                hpx::util::invoke(f_, tmp);
+                hpx::util::invoke_r<void>(f_,tmp);
             }
 
             template <typename Iter>
@@ -428,15 +428,22 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///           otherwise.
     ///           It returns \a last.
     ///
+
+
+    // FIXME : Momentary comment out the is_indirect_callable checking for
+    // bug introspection
+
     template <typename ExPolicy, typename InIter, typename F,
         typename Proj = util::projection_identity,
     HPX_CONCEPT_REQUIRES_(
         execution::is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<InIter>::value &&
-        parallel::traits::is_projected<Proj, InIter>::value &&
+        parallel::traits::is_projected<Proj, InIter>::value
+/*        &&
         parallel::traits::is_indirect_callable<
             ExPolicy, F, traits::projected<Proj, InIter>
-        >::value)>
+        >::value*/
+        )>
     typename util::detail::algorithm_result<ExPolicy, InIter>::type
     for_each(ExPolicy && policy, InIter first, InIter last, F && f,
         Proj && proj = Proj())

--- a/hpx/parallel/algorithms/for_each.hpp
+++ b/hpx/parallel/algorithms/for_each.hpp
@@ -430,8 +430,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     ///
 
 
-    // FIXME : Momentary comment out the is_indirect_callable checking for
-    // bug introspection
+    // FIXME : is_indirect_callable does not work properly when compiling
+    //         Cuda device code
 
     template <typename ExPolicy, typename InIter, typename F,
         typename Proj = util::projection_identity,
@@ -439,10 +439,12 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
         execution::is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<InIter>::value &&
         parallel::traits::is_projected<Proj, InIter>::value
-/*        &&
+#if defined(__CUDA_ARCH__)
+        &&
         parallel::traits::is_indirect_callable<
             ExPolicy, F, traits::projected<Proj, InIter>
-        >::value*/
+        >::value
+#endif
         )>
     typename util::detail::algorithm_result<ExPolicy, InIter>::type
     for_each(ExPolicy && policy, InIter first, InIter last, F && f,

--- a/hpx/parallel/algorithms/for_each.hpp
+++ b/hpx/parallel/algorithms/for_each.hpp
@@ -92,7 +92,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
               , proj_(std::forward<Proj_>(proj))
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && \
+    !defined(__CUDACC__)
             for_each_iteration(for_each_iteration const&) = default;
             for_each_iteration(for_each_iteration&&) = default;
 #else

--- a/hpx/parallel/algorithms/for_each.hpp
+++ b/hpx/parallel/algorithms/for_each.hpp
@@ -92,7 +92,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
               , proj_(std::forward<Proj_>(proj))
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__CUDACC__)
             for_each_iteration(for_each_iteration const&) = default;
             for_each_iteration(for_each_iteration&&) = default;
 #else

--- a/hpx/parallel/algorithms/for_each.hpp
+++ b/hpx/parallel/algorithms/for_each.hpp
@@ -92,7 +92,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
               , proj_(std::forward<Proj_>(proj))
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
             for_each_iteration(for_each_iteration const&) = default;
             for_each_iteration(for_each_iteration&&) = default;
 #else

--- a/hpx/parallel/algorithms/transform.hpp
+++ b/hpx/parallel/algorithms/transform.hpp
@@ -74,7 +74,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
               , proj_(std::forward<Proj_>(proj))
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
             transform_iteration(transform_iteration const&) = default;
             transform_iteration(transform_iteration&&) = default;
 #else
@@ -320,7 +320,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
               , proj2_(std::forward<Proj2_>(proj2))
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
             transform_binary_iteration(transform_binary_iteration const&) = default;
             transform_binary_iteration(transform_binary_iteration&&) = default;
 #else

--- a/hpx/parallel/algorithms/transform.hpp
+++ b/hpx/parallel/algorithms/transform.hpp
@@ -74,7 +74,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
               , proj_(std::forward<Proj_>(proj))
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__CUDACC__)
             transform_iteration(transform_iteration const&) = default;
             transform_iteration(transform_iteration&&) = default;
 #else
@@ -320,7 +320,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
               , proj2_(std::forward<Proj2_>(proj2))
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__CUDACC__)
             transform_binary_iteration(transform_binary_iteration const&) = default;
             transform_binary_iteration(transform_binary_iteration&&) = default;
 #else

--- a/hpx/parallel/algorithms/transform.hpp
+++ b/hpx/parallel/algorithms/transform.hpp
@@ -74,7 +74,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
               , proj_(std::forward<Proj_>(proj))
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && \
+    !defined(__CUDACC__)
             transform_iteration(transform_iteration const&) = default;
             transform_iteration(transform_iteration&&) = default;
 #else
@@ -320,7 +321,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
               , proj2_(std::forward<Proj2_>(proj2))
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && \
+    !defined(__CUDACC__)
             transform_binary_iteration(transform_binary_iteration const&) = default;
             transform_binary_iteration(transform_binary_iteration&&) = default;
 #else

--- a/hpx/runtime/actions/plain_action.hpp
+++ b/hpx/runtime/actions/plain_action.hpp
@@ -26,7 +26,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
-#if defined(__NVCC__)
+#if defined(__CUDACC__)
 #include <type_traits>
 #endif
 #include <utility>
@@ -159,7 +159,7 @@ namespace hpx { namespace traits
     HPX_DEFINE_PLAIN_ACTION_2(func, BOOST_PP_CAT(func, _action))              \
     /**/
 
-#if defined(__NVCC__)
+#if defined(__CUDACC__)
 #define HPX_DEFINE_PLAIN_ACTION_2(func, name)                                 \
     struct name : hpx::actions::make_action<                                  \
         typename std::add_pointer<                                            \

--- a/hpx/runtime/actions/plain_action.hpp
+++ b/hpx/runtime/actions/plain_action.hpp
@@ -26,7 +26,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
-#if defined(__CUDACC__)
+#if defined(__NVCC__) || defined(__CUDACC__)
 #include <type_traits>
 #endif
 #include <utility>
@@ -159,7 +159,7 @@ namespace hpx { namespace traits
     HPX_DEFINE_PLAIN_ACTION_2(func, BOOST_PP_CAT(func, _action))              \
     /**/
 
-#if defined(__CUDACC__)
+#if defined(__NVCC__) || defined(__CUDACC__)
 #define HPX_DEFINE_PLAIN_ACTION_2(func, name)                                 \
     struct name : hpx::actions::make_action<                                  \
         typename std::add_pointer<                                            \

--- a/hpx/runtime/components/server/managed_component_base.hpp
+++ b/hpx/runtime/components/server/managed_component_base.hpp
@@ -607,7 +607,7 @@ namespace hpx { namespace components
         }
 #endif
 
-#if defined(HPX_HAVE_CXX11_EXTENDED_FRIEND_DECLARATIONS) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_EXTENDED_FRIEND_DECLARATIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
     private:
         // declare friends which are allowed to access get_base_gid()
         friend Component;

--- a/hpx/runtime/components/server/managed_component_base.hpp
+++ b/hpx/runtime/components/server/managed_component_base.hpp
@@ -607,7 +607,8 @@ namespace hpx { namespace components
         }
 #endif
 
-#if defined(HPX_HAVE_CXX11_EXTENDED_FRIEND_DECLARATIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_EXTENDED_FRIEND_DECLARATIONS) && !defined(__NVCC__) && \
+    !defined(__CUDACC__)
     private:
         // declare friends which are allowed to access get_base_gid()
         friend Component;

--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -455,7 +455,7 @@ namespace hpx { namespace components { namespace server
 
     ///////////////////////////////////////////////////////////////////////////
     // Functions wrapped by creat_component actions below
-#if defined(__CUDACC__)
+#if defined(__NVCC__) || defined(__CUDACC__)
     template <typename Component>
     HPX_HOST_DEVICE naming::gid_type runtime_support::create_component()
     {

--- a/hpx/runtime/serialization/input_archive.hpp
+++ b/hpx/runtime/serialization/input_archive.hpp
@@ -185,7 +185,8 @@ namespace hpx { namespace serialization
             val = static_cast<T>(ul);
         }
 
-#if defined(BOOST_HAS_INT128) && !defined(__NVCC__) && !defined(__CUDACC__)
+#if defined(BOOST_HAS_INT128) && !defined(__NVCC__) && \
+    !defined(__CUDACC__)
         void load_integral(boost::int128_type& t, std::false_type)
         {
             load_integral_impl(t);

--- a/hpx/runtime/serialization/input_archive.hpp
+++ b/hpx/runtime/serialization/input_archive.hpp
@@ -185,7 +185,7 @@ namespace hpx { namespace serialization
             val = static_cast<T>(ul);
         }
 
-#if defined(BOOST_HAS_INT128) && !defined(__CUDACC__)
+#if defined(BOOST_HAS_INT128) && !defined(__NVCC__) && !defined(__CUDACC__)
         void load_integral(boost::int128_type& t, std::false_type)
         {
             load_integral_impl(t);

--- a/hpx/runtime/serialization/output_archive.hpp
+++ b/hpx/runtime/serialization/output_archive.hpp
@@ -222,7 +222,8 @@ namespace hpx { namespace serialization
             save_integral_impl(static_cast<std::uint64_t>(val));
         }
 
-#if defined(BOOST_HAS_INT128) && !defined(__NVCC__) && !defined(__CUDACC__)
+#if defined(BOOST_HAS_INT128) && !defined(__NVCC__) && \
+    !defined(__CUDACC__)
         void save_integral(boost::int128_type t, std::false_type)
         {
             save_integral_impl(t);

--- a/hpx/runtime/serialization/output_archive.hpp
+++ b/hpx/runtime/serialization/output_archive.hpp
@@ -222,7 +222,7 @@ namespace hpx { namespace serialization
             save_integral_impl(static_cast<std::uint64_t>(val));
         }
 
-#if defined(BOOST_HAS_INT128) && !defined(__CUDACC__)
+#if defined(BOOST_HAS_INT128) && !defined(__NVCC__) && !defined(__CUDACC__)
         void save_integral(boost::int128_type t, std::false_type)
         {
             save_integral_impl(t);

--- a/hpx/traits/get_function_address.hpp
+++ b/hpx/traits/get_function_address.hpp
@@ -61,7 +61,7 @@ namespace hpx { namespace traits
 #endif
 
 #if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__NVCC__) && \
-#   !defined(__CUDACC__)
+    !defined(__CUDACC__)
 #  if defined(HPX_GCC_DIAGNOSTIC_PRAGMA_CONTEXTS)
 #    pragma GCC diagnostic push
 #  endif
@@ -71,7 +71,7 @@ namespace hpx { namespace traits
             return reinterpret_cast<std::size_t>(*reinterpret_cast<void**>(&f));
 
 #if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__NVCC__) && \
-#   !defined(__CUDACC__)
+    !defined(__CUDACC__)
 #if defined(HPX_GCC_DIAGNOSTIC_PRAGMA_CONTEXTS)
 #pragma GCC diagnostic pop
 #endif
@@ -94,7 +94,7 @@ namespace hpx { namespace traits
 #endif
 
 #if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__NVCC__) && \
-#   !defined(__CUDACC__)
+    !defined(__CUDACC__)
 #  if defined(HPX_GCC_DIAGNOSTIC_PRAGMA_CONTEXTS)
 #    pragma GCC diagnostic push
 #  endif
@@ -104,7 +104,7 @@ namespace hpx { namespace traits
             return reinterpret_cast<std::size_t>(*reinterpret_cast<void**>(&f));
 
 #if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__NVCC__) && \
-#   !defined(__CUDACC__)
+    !defined(__CUDACC__)
 #if defined(HPX_GCC_DIAGNOSTIC_PRAGMA_CONTEXTS)
 #pragma GCC diagnostic pop
 #endif

--- a/hpx/traits/get_function_address.hpp
+++ b/hpx/traits/get_function_address.hpp
@@ -60,7 +60,7 @@ namespace hpx { namespace traits
 #  pragma clang diagnostic ignored "-Wstrict-aliasing"
 #endif
 
-#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__CUDACC__)
+#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__NVCC__) && !defined(__CUDACC__)
 #  if defined(HPX_GCC_DIAGNOSTIC_PRAGMA_CONTEXTS)
 #    pragma GCC diagnostic push
 #  endif
@@ -69,7 +69,7 @@ namespace hpx { namespace traits
 
             return reinterpret_cast<std::size_t>(*reinterpret_cast<void**>(&f));
 
-#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__CUDACC__)
+#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__NVCC__) && !defined(__CUDACC__)
 #if defined(HPX_GCC_DIAGNOSTIC_PRAGMA_CONTEXTS)
 #pragma GCC diagnostic pop
 #endif
@@ -91,7 +91,7 @@ namespace hpx { namespace traits
 #  pragma clang diagnostic ignored "-Wstrict-aliasing"
 #endif
 
-#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__CUDACC__)
+#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__NVCC__) && !defined(__CUDACC__)
 #  if defined(HPX_GCC_DIAGNOSTIC_PRAGMA_CONTEXTS)
 #    pragma GCC diagnostic push
 #  endif
@@ -100,7 +100,7 @@ namespace hpx { namespace traits
 
             return reinterpret_cast<std::size_t>(*reinterpret_cast<void**>(&f));
 
-#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__CUDACC__)
+#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__NVCC__) && !defined(__CUDACC__)
 #if defined(HPX_GCC_DIAGNOSTIC_PRAGMA_CONTEXTS)
 #pragma GCC diagnostic pop
 #endif

--- a/hpx/traits/get_function_address.hpp
+++ b/hpx/traits/get_function_address.hpp
@@ -60,7 +60,8 @@ namespace hpx { namespace traits
 #  pragma clang diagnostic ignored "-Wstrict-aliasing"
 #endif
 
-#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__NVCC__) && !defined(__CUDACC__)
+#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__NVCC__) && \
+#   !defined(__CUDACC__)
 #  if defined(HPX_GCC_DIAGNOSTIC_PRAGMA_CONTEXTS)
 #    pragma GCC diagnostic push
 #  endif
@@ -69,7 +70,8 @@ namespace hpx { namespace traits
 
             return reinterpret_cast<std::size_t>(*reinterpret_cast<void**>(&f));
 
-#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__NVCC__) && !defined(__CUDACC__)
+#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__NVCC__) && \
+#   !defined(__CUDACC__)
 #if defined(HPX_GCC_DIAGNOSTIC_PRAGMA_CONTEXTS)
 #pragma GCC diagnostic pop
 #endif
@@ -91,7 +93,8 @@ namespace hpx { namespace traits
 #  pragma clang diagnostic ignored "-Wstrict-aliasing"
 #endif
 
-#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__NVCC__) && !defined(__CUDACC__)
+#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__NVCC__) && \
+#   !defined(__CUDACC__)
 #  if defined(HPX_GCC_DIAGNOSTIC_PRAGMA_CONTEXTS)
 #    pragma GCC diagnostic push
 #  endif
@@ -100,7 +103,8 @@ namespace hpx { namespace traits
 
             return reinterpret_cast<std::size_t>(*reinterpret_cast<void**>(&f));
 
-#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__NVCC__) && !defined(__CUDACC__)
+#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__NVCC__) && \
+#   !defined(__CUDACC__)
 #if defined(HPX_GCC_DIAGNOSTIC_PRAGMA_CONTEXTS)
 #pragma GCC diagnostic pop
 #endif

--- a/hpx/traits/is_iterator.hpp
+++ b/hpx/traits/is_iterator.hpp
@@ -23,7 +23,7 @@ namespace hpx { namespace traits
         template <typename T>
         struct is_iterator
         {
-#if defined(HPX_MSVC) && defined(__NVCC__)
+#if defined(HPX_MSVC) && defined(__CUDACC__)
             template <typename U>
             static typename U::iterator_category * test(U); // iterator
 

--- a/hpx/util/bind.hpp
+++ b/hpx/util/bind.hpp
@@ -267,7 +267,7 @@ namespace hpx { namespace util
               , _args(std::forward<Ts>(vs)...)
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
             bound(bound const&) = default;
             bound(bound&&) = default;
 #else

--- a/hpx/util/bind.hpp
+++ b/hpx/util/bind.hpp
@@ -267,7 +267,7 @@ namespace hpx { namespace util
               , _args(std::forward<Ts>(vs)...)
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__CUDACC__)
             bound(bound const&) = default;
             bound(bound&&) = default;
 #else

--- a/hpx/util/bind.hpp
+++ b/hpx/util/bind.hpp
@@ -267,7 +267,8 @@ namespace hpx { namespace util
               , _args(std::forward<Ts>(vs)...)
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && \
+    !defined(__CUDACC__)
             bound(bound const&) = default;
             bound(bound&&) = default;
 #else

--- a/hpx/util/deferred_call.hpp
+++ b/hpx/util/deferred_call.hpp
@@ -64,7 +64,8 @@ namespace hpx { namespace util
               , _args(std::forward<Ts>(vs)...)
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && \
+    !defined(__CUDACC__)
             deferred(deferred&&) = default;
 #else
             HPX_HOST_DEVICE deferred(deferred&& other)

--- a/hpx/util/deferred_call.hpp
+++ b/hpx/util/deferred_call.hpp
@@ -64,7 +64,7 @@ namespace hpx { namespace util
               , _args(std::forward<Ts>(vs)...)
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
             deferred(deferred&&) = default;
 #else
             HPX_HOST_DEVICE deferred(deferred&& other)

--- a/hpx/util/deferred_call.hpp
+++ b/hpx/util/deferred_call.hpp
@@ -64,7 +64,7 @@ namespace hpx { namespace util
               , _args(std::forward<Ts>(vs)...)
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__CUDACC__)
             deferred(deferred&&) = default;
 #else
             HPX_HOST_DEVICE deferred(deferred&& other)

--- a/hpx/util/protect.hpp
+++ b/hpx/util/protect.hpp
@@ -32,7 +32,8 @@ namespace hpx { namespace util
               : F(std::move(f))
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && \
+    !defined(__CUDACC__)
             protected_bind(protected_bind const&) = default;
             protected_bind(protected_bind&&) = default;
 #else

--- a/hpx/util/protect.hpp
+++ b/hpx/util/protect.hpp
@@ -32,7 +32,7 @@ namespace hpx { namespace util
               : F(std::move(f))
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
             protected_bind(protected_bind const&) = default;
             protected_bind(protected_bind&&) = default;
 #else

--- a/hpx/util/protect.hpp
+++ b/hpx/util/protect.hpp
@@ -32,7 +32,7 @@ namespace hpx { namespace util
               : F(std::move(f))
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__CUDACC__)
             protected_bind(protected_bind const&) = default;
             protected_bind(protected_bind&&) = default;
 #else

--- a/hpx/util/tuple.hpp
+++ b/hpx/util/tuple.hpp
@@ -76,7 +76,7 @@ namespace hpx { namespace util
               : _value(std::forward<U>(value))
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__CUDACC__)
             tuple_member(tuple_member const&) = default;
             tuple_member(tuple_member&&) = default;
 #else
@@ -121,7 +121,7 @@ namespace hpx { namespace util
               : T(std::forward<U>(value))
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__CUDACC__)
             tuple_member(tuple_member const&) = default;
             tuple_member(tuple_member&&) = default;
 #else
@@ -214,7 +214,7 @@ namespace hpx { namespace util
               : tuple_member<Is, Ts>(std::forward<Us>(vs))...
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__CUDACC__)
             tuple_impl(tuple_impl const&) = default;
             tuple_impl(tuple_impl&&) = default;
 #else
@@ -408,7 +408,7 @@ namespace hpx { namespace util
           : _impl(std::forward<U>(v), std::forward<Us>(vs)...)
         {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__CUDACC__)
         // tuple(const tuple& u) = default;
         // Initializes each element of *this with the corresponding element
         // of u.

--- a/hpx/util/tuple.hpp
+++ b/hpx/util/tuple.hpp
@@ -76,7 +76,8 @@ namespace hpx { namespace util
               : _value(std::forward<U>(value))
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && \
+    !defined(__CUDACC__)
             tuple_member(tuple_member const&) = default;
             tuple_member(tuple_member&&) = default;
 #else
@@ -121,7 +122,8 @@ namespace hpx { namespace util
               : T(std::forward<U>(value))
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && \
+    !defined(__CUDACC__)
             tuple_member(tuple_member const&) = default;
             tuple_member(tuple_member&&) = default;
 #else
@@ -214,7 +216,8 @@ namespace hpx { namespace util
               : tuple_member<Is, Ts>(std::forward<Us>(vs))...
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && \
+    !defined(__CUDACC__)
             tuple_impl(tuple_impl const&) = default;
             tuple_impl(tuple_impl&&) = default;
 #else
@@ -408,7 +411,8 @@ namespace hpx { namespace util
           : _impl(std::forward<U>(v), std::forward<Us>(vs)...)
         {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && \
+    !defined(__CUDACC__)
         // tuple(const tuple& u) = default;
         // Initializes each element of *this with the corresponding element
         // of u.

--- a/hpx/util/tuple.hpp
+++ b/hpx/util/tuple.hpp
@@ -76,7 +76,7 @@ namespace hpx { namespace util
               : _value(std::forward<U>(value))
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
             tuple_member(tuple_member const&) = default;
             tuple_member(tuple_member&&) = default;
 #else
@@ -121,7 +121,7 @@ namespace hpx { namespace util
               : T(std::forward<U>(value))
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
             tuple_member(tuple_member const&) = default;
             tuple_member(tuple_member&&) = default;
 #else
@@ -214,7 +214,7 @@ namespace hpx { namespace util
               : tuple_member<Is, Ts>(std::forward<Us>(vs))...
             {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
             tuple_impl(tuple_impl const&) = default;
             tuple_impl(tuple_impl&&) = default;
 #else
@@ -408,7 +408,7 @@ namespace hpx { namespace util
           : _impl(std::forward<U>(v), std::forward<Us>(vs)...)
         {}
 
-#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX11_DEFAULTED_FUNCTIONS) && !defined(__NVCC__) && !defined(__CUDACC__)
         // tuple(const tuple& u) = default;
         // Initializes each element of *this with the corresponding element
         // of u.


### PR DESCRIPTION
This patch tries to remove some compilation errors around partitioned_vector when it is used in cuda clang code. Major changes are : 
- Replacing the checking of defined `__NVCC__` by the checking of both defined `__NVCC__` and defined `__CUDACC__` to compile Cuda code with NVCC and CudaClang in the same conditions
- Avoid some action registrations when compiling in device mode