### PR TITLE
Fixing long shutdown times

### DIFF
--- a/hpx/config/compiler_fence.hpp
+++ b/hpx/config/compiler_fence.hpp
@@ -1,0 +1,33 @@
+//  Copyright (c) 2008 Peter Dimov
+//  Copyright (c) 2017 Agustin Berge
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_CONFIG_COMPILER_FENCE_HPP
+#define HPX_CONFIG_COMPILER_FENCE_HPP
+
+#include <hpx/config/compiler_specific.hpp>
+
+#if defined(__INTEL_COMPILER)
+
+#define HPX_COMPILER_FENCE __memory_barrier();
+
+#elif defined( _MSC_VER ) && _MSC_VER >= 1310
+
+extern "C" void _ReadWriteBarrier();
+#pragma intrinsic( _ReadWriteBarrier )
+
+#define HPX_COMPILER_FENCE _ReadWriteBarrier();
+
+#elif defined(__GNUC__)
+
+#define HPX_COMPILER_FENCE __asm__ __volatile__( "" : : : "memory" );
+
+#else
+
+#define HPX_COMPILER_FENCE
+
+#endif
+
+#endif

--- a/hpx/lcos/local/spinlock.hpp
+++ b/hpx/lcos/local/spinlock.hpp
@@ -23,6 +23,7 @@
 #if defined(HPX_WINDOWS)
 #  include <boost/smart_ptr/detail/spinlock.hpp>
 #  if !defined( BOOST_SP_HAS_SYNC )
+#    include <hpx/config/compiler_fence.hpp>
 #    include <boost/detail/interlocked.hpp>
 #  endif
 #else
@@ -183,7 +184,7 @@ namespace hpx { namespace lcos { namespace local
         {
 #if !defined( BOOST_SP_HAS_SYNC )
             std::uint64_t r = BOOST_INTERLOCKED_EXCHANGE(&v_, 1);
-            BOOST_COMPILER_FENCE
+            HPX_COMPILER_FENCE
 #else
             std::uint64_t r = __sync_lock_test_and_set(&v_, 1);
 #endif
@@ -193,7 +194,7 @@ namespace hpx { namespace lcos { namespace local
         void relinquish_lock()
         {
 #if !defined( BOOST_SP_HAS_SYNC )
-            BOOST_COMPILER_FENCE
+            HPX_COMPILER_FENCE
             *const_cast<std::uint64_t volatile*>(&v_) = 0;
 #else
             __sync_lock_release(&v_);

--- a/hpx/lcos/local/spinlock_no_backoff.hpp
+++ b/hpx/lcos/local/spinlock_no_backoff.hpp
@@ -18,6 +18,7 @@
 #if defined(HPX_WINDOWS)
 #  include <boost/smart_ptr/detail/spinlock.hpp>
 #  if !defined( BOOST_SP_HAS_SYNC )
+#    include <hpx/config/compiler_fence.hpp>
 #    include <boost/detail/interlocked.hpp>
 #  endif
 #else
@@ -73,7 +74,7 @@ namespace hpx { namespace lcos { namespace local
 
 #if !defined( BOOST_SP_HAS_SYNC )
             std::uint64_t r = BOOST_INTERLOCKED_EXCHANGE(&v_, 1);
-            BOOST_COMPILER_FENCE
+            HPX_COMPILER_FENCE
 #else
             std::uint64_t r = __sync_lock_test_and_set(&v_, 1);
 #endif
@@ -93,7 +94,7 @@ namespace hpx { namespace lcos { namespace local
             HPX_ITT_SYNC_RELEASING(this);
 
 #if !defined( BOOST_SP_HAS_SYNC )
-            BOOST_COMPILER_FENCE
+            HPX_COMPILER_FENCE
             *const_cast<std::uint64_t volatile*>(&v_) = 0;
 #else
             __sync_lock_release(&v_);

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -481,7 +481,7 @@ namespace hpx { namespace threads { namespace detail
                 }
             }
             else if ((scheduler.get_scheduler_mode() & policies::fast_idle_mode) ||
-                idle_loop_count > HPX_IDLE_LOOP_COUNT_MAX)
+                idle_loop_count > HPX_IDLE_LOOP_COUNT_MAX || may_exit)
             {
                 // clean up terminated threads
                 if (idle_loop_count > HPX_IDLE_LOOP_COUNT_MAX)

--- a/tests/performance/local/spinlock_overhead1.cpp
+++ b/tests/performance/local/spinlock_overhead1.cpp
@@ -128,7 +128,7 @@ namespace test
 
 #if !defined( BOOST_SP_HAS_SYNC )
             std::uint64_t r = BOOST_INTERLOCKED_EXCHANGE(&v_, 1);
-            BOOST_COMPILER_FENCE
+            HPX_COMPILER_FENCE
 #else
             std::uint64_t r = __sync_lock_test_and_set(&v_, 1);
 #endif
@@ -148,7 +148,7 @@ namespace test
             HPX_ITT_SYNC_RELEASING(this);
 
 #if !defined( BOOST_SP_HAS_SYNC )
-            BOOST_COMPILER_FENCE
+            HPX_COMPILER_FENCE
             *const_cast<std::uint64_t volatile*>(&v_) = 0;
 #else
             __sync_lock_release(&v_);

--- a/tests/performance/local/spinlock_overhead2.cpp
+++ b/tests/performance/local/spinlock_overhead2.cpp
@@ -153,7 +153,7 @@ namespace test
 
 #if !defined( BOOST_SP_HAS_SYNC )
             std::uint64_t r = BOOST_INTERLOCKED_EXCHANGE(&v_, 1);
-            BOOST_COMPILER_FENCE
+            HPX_COMPILER_FENCE
 #else
             std::uint64_t r = __sync_lock_test_and_set(&v_, 1);
 #endif
@@ -173,7 +173,7 @@ namespace test
             HPX_ITT_SYNC_RELEASING(this);
 
 #if !defined( BOOST_SP_HAS_SYNC )
-            BOOST_COMPILER_FENCE
+            HPX_COMPILER_FENCE
             *const_cast<std::uint64_t volatile*>(&v_) = 0;
 #else
             __sync_lock_release(&v_);


### PR DESCRIPTION
When running HPX on a larger number of threads (>64) shutdown times
were too long. This patch fixes this, by adding a shortcut in the
scheduling loop when it may exit. This happens after the dijkstra
termination detection so an early exit is fine here.

In addition, the thread count checks at shutdown have an exponential
backoff now.