### PR TITLE
Downcast to future<void>

### DIFF
--- a/hpx/lcos/dataflow.hpp
+++ b/hpx/lcos/dataflow.hpp
@@ -331,10 +331,10 @@ namespace hpx { namespace lcos { namespace detail
                     typename traits::future_traits<future_type>::type
                     future_result_type;
 
-                boost::intrusive_ptr<
-                    lcos::detail::future_data<future_result_type>
-                > next_future_data
-                    = traits::detail::get_shared_state(*next);
+                typename traits::detail::shared_state_ptr<
+                        future_result_type
+                    >::type next_future_data =
+                        traits::detail::get_shared_state(*next);
 
                 if (!next_future_data->is_ready())
                 {
@@ -390,10 +390,10 @@ namespace hpx { namespace lcos { namespace detail
                 typename traits::future_traits<future_type>::type
                 future_result_type;
 
-            boost::intrusive_ptr<
-                lcos::detail::future_data<future_result_type>
-            > next_future_data
-                = traits::detail::get_shared_state(f_);
+            typename traits::detail::shared_state_ptr<
+                    future_result_type
+                >::type next_future_data =
+                    traits::detail::get_shared_state(f_);
 
             if(!next_future_data->is_ready())
             {

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2017 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -317,7 +317,9 @@ namespace detail
         typedef typename future_data_result<Result>::type result_type;
         typedef util::unique_function_nonser<void()> completed_callback_type;
         typedef lcos::local::spinlock mutex_type;
-        typedef typename future_data<void>::init_no_addref init_no_addref;
+        typedef typename future_data<
+                traits::detail::future_data_void
+            >::init_no_addref init_no_addref;
 
         future_data()
         {}

--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2017 Hartmut Kaiser
 //  Copyright (c) 2013 Agustin Berge
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -391,6 +391,29 @@ namespace hpx { namespace lcos { namespace detail
     };
 
     ///////////////////////////////////////////////////////////////////////////
+    template <typename R>
+    struct future_get_result
+    {
+        template <typename SharedState>
+        HPX_FORCEINLINE static R*
+        call(SharedState const& state, error_code& ec = throws)
+        {
+            return state->get_result(ec);
+        }
+    };
+
+    template <>
+    struct future_get_result<util::unused_type>
+    {
+        template <typename SharedState>
+        HPX_FORCEINLINE static util::unused_type*
+        call(SharedState const& state, error_code& ec = throws)
+        {
+            return state->get_result_void(ec);
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
     template <typename Future, typename F, typename ContResult>
     class continuation;
 
@@ -424,11 +447,9 @@ namespace hpx { namespace lcos { namespace detail
     unwrap(Future&& future, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
-    class void_continuation;
-
     template <typename Future>
     inline typename hpx::traits::detail::shared_state_ptr<void>::type
-    make_void_continuation(Future& future);
+    downcast_to_void(Future& future);
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Derived, typename R>
@@ -436,7 +457,9 @@ namespace hpx { namespace lcos { namespace detail
     {
     public:
         typedef R result_type;
-        typedef future_data<R> shared_state_type;
+        typedef future_data<
+                typename traits::detail::shared_state_ptr_result<R>::type
+            > shared_state_type;
 
     public:
         future_base() HPX_NOEXCEPT
@@ -526,9 +549,11 @@ namespace hpx { namespace lcos { namespace detail
                     "this future has no valid shared state");
             }
 
+            typedef typename shared_state_type::result_type result_type;
+
             error_code ec(lightweight);
-            this->shared_state_->get_result(ec);
-            if (!ec) return boost::exception_ptr();
+            detail::future_get_result<result_type>::call(this->shared_state_, ec);
+            if (ec) return boost::exception_ptr();
             return hpx::detail::access_exception(ec);
         }
 
@@ -848,7 +873,7 @@ namespace hpx { namespace lcos
         template <typename T>
         future(future<T>&& other,
             typename std::enable_if<std::is_void<R>::value, T>::type* = nullptr
-        ) : base_type(other.valid() ? detail::make_void_continuation(other) : nullptr)
+        ) : base_type(other.valid() ? detail::downcast_to_void(other) : nullptr)
         {
             other = future<T>();
         }
@@ -903,7 +928,8 @@ namespace hpx { namespace lcos
             invalidate on_exit(*this);
 
             typedef typename shared_state_type::result_type result_type;
-            result_type* result = this->shared_state_->get_result();
+            result_type* result = detail::future_get_result<result_type>::call(
+                this->shared_state_);
 
             // no error has been reported, return the result
             return detail::future_value<R>::get(std::move(*result));
@@ -923,7 +949,8 @@ namespace hpx { namespace lcos
             invalidate on_exit(*this);
 
             typedef typename shared_state_type::result_type result_type;
-            result_type* result = this->shared_state_->get_result(ec);
+            result_type* result = detail::future_get_result<result_type>::call(
+                this->shared_state_, ec);
             if (ec) return detail::future_value<R>::get_default();
 
             // no error has been reported, return the result
@@ -1145,7 +1172,7 @@ namespace hpx { namespace lcos
         template <typename T>
         shared_future(shared_future<T> const& other,
             typename std::enable_if<std::is_void<R>::value, T>::type* = nullptr
-        ) : base_type(other.valid() ? detail::make_void_continuation(other) : nullptr)
+        ) : base_type(other.valid() ? detail::downcast_to_void(other) : nullptr)
         {}
 
         // Effects:
@@ -1201,7 +1228,8 @@ namespace hpx { namespace lcos
             }
 
             typedef typename shared_state_type::result_type result_type;
-            result_type* result = this->shared_state_->get_result();
+            result_type* result = detail::future_get_result<result_type>::call(
+                this->shared_state_);
 
             // no error has been reported, return the result
             return detail::future_value<R>::get(*result);
@@ -1219,7 +1247,8 @@ namespace hpx { namespace lcos
                 return res;
             }
 
-            result_type* result = this->shared_state_->get_result(ec);
+            result_type* result = detail::future_get_result<result_type>::call(
+                this->shared_state_, ec);
             if (ec)
             {
                 static result_type res(detail::future_value<R>::get_default());

--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -449,7 +449,7 @@ namespace hpx { namespace lcos { namespace detail
     ///////////////////////////////////////////////////////////////////////////
     template <typename Future>
     inline typename hpx::traits::detail::shared_state_ptr<void>::type
-    downcast_to_void(Future& future);
+    downcast_to_void(Future& future, bool addref);
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Derived, typename R>
@@ -873,9 +873,11 @@ namespace hpx { namespace lcos
         template <typename T>
         future(future<T>&& other,
             typename std::enable_if<std::is_void<R>::value, T>::type* = nullptr
-        ) : base_type(other.valid() ? detail::downcast_to_void(other) : nullptr)
+        ) : base_type(other.valid() ?
+                detail::downcast_to_void(other, false) : nullptr)
         {
-            other = future<T>();
+            traits::future_access<future<T> >::
+                detach_shared_state(std::move(other));
         }
 
         // Effects:
@@ -1172,7 +1174,8 @@ namespace hpx { namespace lcos
         template <typename T>
         shared_future(shared_future<T> const& other,
             typename std::enable_if<std::is_void<R>::value, T>::type* = nullptr
-        ) : base_type(other.valid() ? detail::downcast_to_void(other) : nullptr)
+        ) : base_type(other.valid() ?
+                detail::downcast_to_void(other, true) : nullptr)
         {}
 
         // Effects:

--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -876,8 +876,13 @@ namespace hpx { namespace lcos
         ) : base_type(other.valid() ?
                 detail::downcast_to_void(other, false) : nullptr)
         {
+#if BOOST_VERSION >= 105600
             traits::future_access<future<T> >::
                 detach_shared_state(std::move(other));
+#else
+            // Boost before 1.56 doesn't support detaching intrusive pointers
+            other = future<T>();
+#endif
         }
 
         // Effects:

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -714,10 +714,17 @@ namespace hpx { namespace lcos { namespace detail
             shared_state_type;
         typedef typename shared_state_type::element_type element_type;
 
+#if BOOST_VERSION >= 105600
         // same as static_pointer_cast, but with addref option
         return shared_state_type(static_cast<element_type*>(
                 traits::detail::get_shared_state(future).get()
             ), addref);
+#else
+        // Boost before 1.56 doesn't support detaching intrusive pointers
+        return boost::static_pointer_cast<element_type>(
+                traits::detail::get_shared_state(future)
+            );
+#endif
     }
 }}}
 

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -706,74 +706,15 @@ namespace hpx { namespace lcos { namespace detail
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace lcos { namespace detail
 {
-    class void_continuation : public future_data<void>
-    {
-    private:
-        template <typename Future>
-        void on_ready(
-            typename traits::detail::shared_state_ptr_for<
-                Future
-            >::type && state)
-        {
-            try {
-                (void)state->get_result();
-                this->set_value(util::unused);
-            }
-            catch (...) {
-                this->set_exception(boost::current_exception());
-            }
-        }
-
-    public:
-        typedef future_data<void>::init_no_addref init_no_addref;
-
-        void_continuation() {}
-
-        void_continuation(init_no_addref no_addref)
-          : future_data<void>(no_addref)
-        {}
-
-        template <typename Future>
-        void attach(Future& future)
-        {
-            typedef
-                typename traits::detail::shared_state_ptr_for<Future>::type
-                shared_state_ptr;
-
-            // Bind an on_completed handler to this future which will wait for
-            // the inner future and will transfer its result to the new future.
-            boost::intrusive_ptr<void_continuation> this_(this);
-            void (void_continuation::*ready)(shared_state_ptr &&) =
-                &void_continuation::on_ready<Future>;
-
-            shared_state_ptr state = traits::detail::get_shared_state(future);
-            typename shared_state_ptr::element_type* ptr = state.get();
-
-            if (ptr == nullptr)
-            {
-                HPX_THROW_EXCEPTION(no_state,
-                    "void_continuation::attach",
-                    "the future has no valid shared state");
-            }
-
-            ptr->execute_deferred();
-            ptr->set_on_completed(
-                util::deferred_call(ready, std::move(this_), std::move(state)));
-        }
-    };
-
     template <typename Future>
     inline typename traits::detail::shared_state_ptr<void>::type
-    make_void_continuation(Future& future)
+    downcast_to_void(Future& future)
     {
-        typedef detail::void_continuation void_shared_state;
-        typedef typename void_shared_state::init_no_addref init_no_addref;
+        typedef typename traits::detail::shared_state_ptr<void>::type::element_type
+            shared_state_type;
 
-        // create a continuation
-        typename traits::detail::shared_state_ptr<void>::type p(
-            new void_shared_state(init_no_addref()), false);
-        static_cast<void_shared_state*>(p.get())->attach(future);
-        return p;
+        return boost::static_pointer_cast<shared_state_type>(
+            traits::detail::get_shared_state(future));
     }
 }}}
 

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -708,13 +708,16 @@ namespace hpx { namespace lcos { namespace detail
 {
     template <typename Future>
     inline typename traits::detail::shared_state_ptr<void>::type
-    downcast_to_void(Future& future)
+    downcast_to_void(Future& future, bool addref)
     {
-        typedef typename traits::detail::shared_state_ptr<void>::type::element_type
+        typedef typename traits::detail::shared_state_ptr<void>::type
             shared_state_type;
+        typedef typename shared_state_type::element_type element_type;
 
-        return boost::static_pointer_cast<shared_state_type>(
-            traits::detail::get_shared_state(future));
+        // same as static_pointer_cast, but with addref option
+        return shared_state_type(static_cast<element_type*>(
+                traits::detail::get_shared_state(future).get()
+            ), addref);
     }
 }}}
 

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2017 Hartmut Kaiser
 //  Copyright (c) 2014-2015 Agustin Berge
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/hpx/lcos/wait_all.hpp
+++ b/hpx/lcos/wait_all.hpp
@@ -223,9 +223,9 @@ namespace hpx { namespace lcos
 
                 for (/**/; next != end; ++next)
                 {
-                    boost::intrusive_ptr<
-                        lcos::detail::future_data<future_result_type>
-                    > next_future_data =
+                    typename traits::detail::shared_state_ptr<
+                        future_result_type
+                    >::type next_future_data =
                         traits::detail::get_shared_state(*next);
 
                     if (!next_future_data->is_ready())
@@ -274,10 +274,10 @@ namespace hpx { namespace lcos
                         future_type
                     >::type future_result_type;
 
-                boost::intrusive_ptr<
-                    lcos::detail::future_data<future_result_type>
-                > next_future_data = traits::detail::get_shared_state(
-                    util::get<I>(t_));
+                typename traits::detail::shared_state_ptr<
+                        future_result_type
+                    >::type next_future_data =
+                        traits::detail::get_shared_state(util::get<I>(t_));
 
                 if (!next_future_data->is_ready())
                 {

--- a/hpx/lcos/when_all.hpp
+++ b/hpx/lcos/when_all.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2017 Hartmut Kaiser
 //  Copyright (c) 2013 Agustin Berge
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/hpx/lcos/when_all.hpp
+++ b/hpx/lcos/when_all.hpp
@@ -247,10 +247,10 @@ namespace hpx { namespace lcos
 
                 for (/**/; next != end; ++next)
                 {
-                    boost::intrusive_ptr<
-                        lcos::detail::future_data<future_result_type>
-                    > next_future_data =
-                        traits::detail::get_shared_state(*next);
+                    typename traits::detail::shared_state_ptr<
+                            future_result_type
+                        >::type next_future_data =
+                            traits::detail::get_shared_state(*next);
 
                     if (!next_future_data->is_ready())
                     {
@@ -297,10 +297,10 @@ namespace hpx { namespace lcos
                 typedef typename traits::future_traits<future_type>::type
                     future_result_type;
 
-                boost::intrusive_ptr<
-                    lcos::detail::future_data<future_result_type>
-                > next_future_data =
-                    traits::detail::get_shared_state(f_);
+                typename traits::detail::shared_state_ptr<
+                        future_result_type
+                    >::type next_future_data =
+                        traits::detail::get_shared_state(f_);
 
                 if (!next_future_data->is_ready())
                 {

--- a/hpx/lcos/when_each.hpp
+++ b/hpx/lcos/when_each.hpp
@@ -226,10 +226,10 @@ namespace hpx { namespace lcos
 
                 for(/**/; next != end; ++next)
                 {
-                    boost::intrusive_ptr<
-                        lcos::detail::future_data<future_result_type>
-                    > next_future_data =
-                        traits::detail::get_shared_state(*next);
+                    typename traits::detail::shared_state_ptr<
+                            future_result_type
+                        >::type next_future_data =
+                            traits::detail::get_shared_state(*next);
 
                     if (!next_future_data->is_ready())
                     {
@@ -290,10 +290,10 @@ namespace hpx { namespace lcos
 
                 future_type& fut = util::get<I>(t_);
 
-                boost::intrusive_ptr<
-                    lcos::detail::future_data<future_result_type>
-                > next_future_data =
-                    traits::detail::get_shared_state(fut);
+                typename traits::detail::shared_state_ptr<
+                        future_result_type
+                    >::type next_future_data =
+                        traits::detail::get_shared_state(fut);
 
                 if (!next_future_data->is_ready())
                 {

--- a/hpx/lcos/when_each.hpp
+++ b/hpx/lcos/when_each.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2017 Hartmut Kaiser
 //  Copyright (c) 2013 Agustin Berge
 //  Copyright (c) 2016 Lukas Troska
 //

--- a/hpx/runtime/components/client_base.hpp
+++ b/hpx/runtime/components/client_base.hpp
@@ -100,12 +100,14 @@ namespace hpx { namespace traits
                 return client.shared_state_;
             }
 
+#if BOOST_VERSION >= 105600
             HPX_FORCEINLINE static
             typename traits::detail::shared_state_ptr<id_type>::type::element_type*
             detach_shared_state(Derived const& f)
             {
                 return f.shared_state_.get();
             }
+#endif
         };
 
         ///////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/components/client_base.hpp
+++ b/hpx/runtime/components/client_base.hpp
@@ -99,6 +99,13 @@ namespace hpx { namespace traits
             {
                 return client.shared_state_;
             }
+
+            HPX_FORCEINLINE static
+            typename traits::detail::shared_state_ptr<id_type>::type::element_type*
+            detach_shared_state(Derived const& f)
+            {
+                return f.shared_state_.get();
+            }
         };
 
         ///////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/components/client_base.hpp
+++ b/hpx/runtime/components/client_base.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2017 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/hpx/traits/future_access.hpp
+++ b/hpx/traits/future_access.hpp
@@ -144,12 +144,14 @@ namespace hpx { namespace traits
             return f.shared_state_;
         }
 
+#if BOOST_VERSION >= 105600
         HPX_FORCEINLINE static
         typename traits::detail::shared_state_ptr<R>::type::element_type*
         detach_shared_state(lcos::future<R> && f)
         {
             return f.shared_state_.detach();
         }
+#endif
     };
 
     template <typename R>
@@ -184,12 +186,14 @@ namespace hpx { namespace traits
             return f.shared_state_;
         }
 
+#if BOOST_VERSION >= 105600
         HPX_FORCEINLINE static
         typename traits::detail::shared_state_ptr<R>::type::element_type*
         detach_shared_state(lcos::shared_future<R> const& f)
         {
             return f.shared_state_.get();
         }
+#endif
     };
 }}
 

--- a/hpx/traits/future_access.hpp
+++ b/hpx/traits/future_access.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2017 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -82,10 +82,10 @@ namespace hpx { namespace traits
         template <typename Future>
         struct shared_state_ptr_for<std::vector<Future> >
         {
-            typedef typename traits::future_traits<Future>::type data_type;
-            typedef std::vector<boost::intrusive_ptr<
-                    lcos::detail::future_data<data_type>
-                > > type;
+//             typedef typename traits::future_traits<Future>::type data_type;
+            typedef std::vector<
+                    typename shared_state_ptr_for<Future>::type
+                > type;
         };
     }
 

--- a/hpx/traits/future_access.hpp
+++ b/hpx/traits/future_access.hpp
@@ -31,10 +31,32 @@ namespace hpx { namespace traits
     ///////////////////////////////////////////////////////////////////////////
     namespace detail
     {
+        struct future_data_void {};
+
+        template <typename Result>
+        struct shared_state_ptr_result
+        {
+            typedef Result type;
+        };
+
+        template <typename Result>
+        struct shared_state_ptr_result<Result&>
+        {
+            typedef Result& type;
+        };
+
+        template <>
+        struct shared_state_ptr_result<void>
+        {
+            typedef future_data_void type;
+        };
+
         template <typename R>
         struct shared_state_ptr
         {
-            typedef boost::intrusive_ptr<lcos::detail::future_data<R> > type;
+            typedef typename shared_state_ptr_result<R>::type result_type;
+            typedef boost::intrusive_ptr<lcos::detail::future_data<result_type> >
+                type;
         };
 
         template <typename Future, typename Enable = void>

--- a/hpx/traits/future_access.hpp
+++ b/hpx/traits/future_access.hpp
@@ -143,6 +143,13 @@ namespace hpx { namespace traits
         {
             return f.shared_state_;
         }
+
+        HPX_FORCEINLINE static
+        typename traits::detail::shared_state_ptr<R>::type::element_type*
+        detach_shared_state(lcos::future<R> && f)
+        {
+            return f.shared_state_.detach();
+        }
     };
 
     template <typename R>
@@ -175,6 +182,13 @@ namespace hpx { namespace traits
         get_shared_state(lcos::shared_future<R> const& f)
         {
             return f.shared_state_;
+        }
+
+        HPX_FORCEINLINE static
+        typename traits::detail::shared_state_ptr<R>::type::element_type*
+        detach_shared_state(lcos::shared_future<R> const& f)
+        {
+            return f.shared_state_.get();
         }
     };
 }}

--- a/tests/unit/lcos/future.cpp
+++ b/tests/unit/lcos/future.cpp
@@ -1,4 +1,4 @@
-//  Copyright (C) 2012 Hartmut Kaiser
+//  Copyright (C) 2012-2017 Hartmut Kaiser
 //  (C) Copyright 2008-10 Anthony Williams
 //
 //  Distributed under the Boost Software License, Version 1.0. (See
@@ -539,7 +539,7 @@ void test_assign_to_void()
     hpx::lcos::future<void> f1 = hpx::lcos::make_ready_future(42);
     f1.get();
 
-    hpx::lcos::shared_future<void> f2 = hpx::lcos::make_ready_future(42);
+    hpx::lcos::shared_future<void> f2 = hpx::lcos::make_ready_future(42).share();
     f2.get();
 }
 

--- a/tests/unit/lcos/future.cpp
+++ b/tests/unit/lcos/future.cpp
@@ -534,6 +534,15 @@ void test_destroying_a_packaged_task_stores_broken_task()
     }
 }
 
+void test_assign_to_void()
+{
+    hpx::lcos::future<void> f1 = hpx::lcos::make_ready_future(42);
+    f1.get();
+
+    hpx::lcos::shared_future<void> f2 = hpx::lcos::make_ready_future(42);
+    f2.get();
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 using boost::program_options::variables_map;
 using boost::program_options::options_description;
@@ -565,6 +574,7 @@ int hpx_main(variables_map&)
         test_packaged_task_can_be_moved();
         test_destroying_a_promise_stores_broken_promise();
         test_destroying_a_packaged_task_stores_broken_task();
+        test_assign_to_void();
     }
 
     hpx::finalize();


### PR DESCRIPTION
 Assigning any `future<T>` to `future<void>` does not require any allocation nor any atomic increfs anymore