### PR TITLE
Adding performance counter exposing instantaneous scheduler utilization

### DIFF
--- a/docs/manual/existing_performance_counters.qbk
+++ b/docs/manual/existing_performance_counters.qbk
@@ -203,7 +203,6 @@ system and application performance.
           transmitted bytes should be queried for. The locality id is a (zero
           based) number identifying the locality.
         ]
-        [None]
         [Returns the overall number of raw (uncompressed) bytes sent or received
          (see `<operation>`, e.g. `sent` or `received`) for the specified
          `<connection_type>`.
@@ -215,6 +214,7 @@ system and application performance.
          `HPX_WITH_PARCELPORT_MPI`).
 
          Please see __cmake_options__ for more details.]
+        [None]
     ]
     [   [`/data/time/<connection_type>/<operation>`
 
@@ -228,7 +228,6 @@ system and application performance.
           time should be queried for. The locality id is a (zero based) number
           identifying the locality.
         ]
-        [None]
         [Returns the total time (in nanoseconds) between the start of each
          asynchronous transmission operation and the end of the corresponding
          operation for the specified `<connection_type>` the given locality
@@ -241,6 +240,7 @@ system and application performance.
          `HPX_WITH_PARCELPORT_MPI`).
 
          Please see __cmake_options__ for more details.]
+        [None]
     ]
     [   [`/serialize/count/<connection_type>/<operation>`
 
@@ -254,10 +254,6 @@ system and application performance.
           transmitted bytes should be queried for. The locality id is a (zero
           based) number identifying the locality.
         ]
-        [If the configure-time option `-DHPX_WITH_PARCELPORT_ACTION_COUNTERS=On`
-         was specified, this counter allows to specify an optional action name
-         as its parameter. In this case the counter will report the number of
-         bytes transmitted for the given action only.]
         [Returns the overall number of bytes transferred (see `<operation>`,
          e.g. `sent` or `received`, possibly compressed) for the specified
          `<connection_type>` by the given locality.
@@ -269,6 +265,10 @@ system and application performance.
          `HPX_WITH_PARCELPORT_MPI`).
 
          Please see __cmake_options__ for more details.]
+        [If the configure-time option `-DHPX_WITH_PARCELPORT_ACTION_COUNTERS=On`
+         was specified, this counter allows to specify an optional action name
+         as its parameter. In this case the counter will report the number of
+         bytes transmitted for the given action only.]
     ]
     [   [`/serialize/time/<connection_type>/<operation>`
 
@@ -282,10 +282,6 @@ system and application performance.
           should be queried for. The locality id is a (zero based) number
           identifying the locality.
         ]
-        [If the configure-time option `-DHPX_WITH_PARCELPORT_ACTION_COUNTERS=On`
-         was specified, this counter allows to specify an optional action name
-         as its parameter. In this case the counter will report the serialization
-         time for the given action only.]
         [Returns the overall time spent performing outgoing data serialization
          for the specified `<connection_type>`on the given locality (see
          `<operation>`, e.g. `sent` or `received`).
@@ -297,6 +293,10 @@ system and application performance.
          `HPX_WITH_PARCELPORT_MPI`).
 
          Please see __cmake_options__ for more details.]
+        [If the configure-time option `-DHPX_WITH_PARCELPORT_ACTION_COUNTERS=On`
+         was specified, this counter allows to specify an optional action name
+         as its parameter. In this case the counter will report the serialization
+         time for the given action only.]
     ]
     [   [`/security/time/<connection_type>/<operation>`
 
@@ -310,7 +310,6 @@ system and application performance.
           security related operation should be queried for. The locality id is
           a (zero based) number identifying the locality.
         ]
-        [None]
         [Returns the overall time spent performing outgoing security operations
          for the specified `<connection_type>`on the given locality (see
          `<operation>`, e.g. `sent` or `received`).
@@ -327,6 +326,7 @@ system and application performance.
          constant is `HPX_WITH_SECURITY`).
 
          Please see __cmake_options__ for more details.]
+        [None]
     ]
     [   [`/parcels/count/routed`
         ]
@@ -336,10 +336,6 @@ system and application performance.
           routed parcels should be queried for. The locality id is a (zero
           based) number identifying the locality.
         ]
-        [If the configure-time option `-DHPX_WITH_PARCELPORT_ACTION_COUNTERS=On`
-         was specified, this counter allows to specify an optional action name
-         as its parameter. In this case the counter will report the number of
-         parcels for the given action only.]
         [Returns the overall number of routed (outbound) parcels transferred
          by the given locality.
 
@@ -349,6 +345,10 @@ system and application performance.
          which is responsible for creating the destination GID (and is
          responsible for resolving the destination address). This AGAS service
          component will deliver the parcel to its final target.]
+        [If the configure-time option `-DHPX_WITH_PARCELPORT_ACTION_COUNTERS=On`
+         was specified, this counter allows to specify an optional action name
+         as its parameter. In this case the counter will report the number of
+         parcels for the given action only.]
     ]
     [   [`/parcels/count/<connection_type>/<operation>`
 
@@ -362,7 +362,6 @@ system and application performance.
           should be queried for. The locality id is a (zero based) number
           identifying the locality.
         ]
-        [None]
         [Returns the overall number of parcels transferred using the specified
          `<connection_type>` by the given locality (see `<operation>`, e.g.
          `sent` or `received`).
@@ -374,6 +373,7 @@ system and application performance.
          `HPX_WITH_PARCELPORT_MPI`).
 
          Please see __cmake_options__ for more details.]
+        [None]
     ]
     [   [`/messages/count/<connection_type>/<operation>`
 
@@ -387,7 +387,6 @@ system and application performance.
           should be queried for. The locality id is a (zero based) number
           identifying the locality.
         ]
-        [None]
         [Returns the overall number of messages [footnote A message can
          potentially consist of more than one parcel.] transferred using
          the specified `<connection_type>` by the given locality (see
@@ -400,6 +399,7 @@ system and application performance.
          `HPX_WITH_PARCELPORT_MPI`).
 
          Please see __cmake_options__ for more details.]
+        [None]
     ]
     [   [`/parcelport/count/<connection_type>/<cache_statistics>`
 
@@ -414,7 +414,6 @@ system and application performance.
           should be queried for. The locality id is a (zero based) number
           identifying the locality.
         ]
-        [None]
         [Returns the overall number cache events (evictions, hits, inserts,
          misses, and reclaims) for the connection cache of the given connection
          type on the given locality (see `<cache_statistics>`, e.g. `cache/insertions`,
@@ -427,6 +426,7 @@ system and application performance.
          `HPX_WITH_PARCELPORT_MPI`).
 
          Please see __cmake_options__ for more details.]
+        [None]
     ]
     [   [`/parcelqueue/length/<operation>`
 
@@ -439,9 +439,9 @@ system and application performance.
           be queried. The locality id is a (zero based) number identifying the
           locality.
         ]
-        [None]
         [Returns the current number of parcels stored in the parcel queue  (see
          `<operation>` for which queue to query, e.g. `send` or `receive`).]
+        [None]
     ]
 ]
 
@@ -465,7 +465,6 @@ system and application performance.
           is usually specified on the command line for the application using the
           option [hpx_cmdline `--hpx:threads`].
         ]
-        [None]
         [Returns the overall number of executed (retired) __hpx__-threads on the
          given locality since application start. If the instance name is `total`
          the counter returns the accumulated number of retired __hpx__-threads
@@ -475,6 +474,7 @@ system and application performance.
          This counter is available only if the configuration time constant
          `HPX_WITH_THREAD_CUMULATIVE_COUNTS` is set to `ON`
          (default: ON).]
+        [None]
     ]
     [   [`/threads/time/average`]
         [`locality#*/total` or[br]
@@ -493,7 +493,6 @@ system and application performance.
           is usually specified on the command line for the application using the
           option [hpx_cmdline `--hpx:threads`].
         ]
-        [None]
         [Returns the average time spent executing one __hpx__-thread on the
          given locality since application start. If the instance name is `total`
          the counter returns the average time spent executing one __hpx__-thread
@@ -503,6 +502,7 @@ system and application performance.
          This counter is available only if the configuration time constants
          `HPX_WITH_THREAD_CUMULATIVE_COUNTS` (default: ON) and
          `HPX_WITH_THREAD_IDLE_RATES` are set to `ON` (default: OFF).]
+        [None]
     ]
     [   [`/threads/time/average-overhead`]
         [`locality#*/total` or[br]
@@ -520,7 +520,6 @@ system and application performance.
           available worker threads is usually specified on the command line for
           the application using the option [hpx_cmdline `--hpx:threads`].
         ]
-        [None]
         [Returns the average time spent on overhead while executing one
          __hpx__-thread on the given locality since application start. If the
          instance name is `total` the counter returns the average time spent on
@@ -531,6 +530,7 @@ system and application performance.
          This counter is available only if the configuration time constants
          `HPX_WITH_THREAD_CUMULATIVE_COUNTS` (default: ON) and
          `HPX_WITH_THREAD_IDLE_RATES` are set to `ON` (default: OFF).]
+        [None]
     ]
     [   [`/threads/count/cumulative-phases`]
         [`locality#*/total` or[br]
@@ -549,7 +549,6 @@ system and application performance.
           available worker threads is usually specified on the command line
           for the application using the option [hpx_cmdline `--hpx:threads`].
         ]
-        [None]
         [Returns the overall number of executed __hpx__-thread phases
          (invocations) on the given locality since application start. If the
          instance name is `total` the counter returns the accumulated number
@@ -559,6 +558,7 @@ system and application performance.
          phases for all worker threads separately.
          This counter is available only if the configuration time constant
          `HPX_WITH_THREAD_CUMULATIVE_COUNTS` is set to `ON` (default: ON).]
+        [None]
     ]
     [   [`/threads/time/average-phase`]
         [`locality#*/total` or[br]
@@ -577,7 +577,6 @@ system and application performance.
           available worker threads is usually specified on the command line
           for the application using the option [hpx_cmdline `--hpx:threads`].
         ]
-        [None]
         [Returns the average time spent executing one __hpx__-thread phase
          (invocation) on the given locality since application start. If the
          instance name is `total` the counter returns the average time spent
@@ -588,6 +587,7 @@ system and application performance.
          This counter is available only if the configuration time constants
          `HPX_WITH_THREAD_CUMULATIVE_COUNTS` (default: ON) and
          `HPX_WITH_THREAD_IDLE_RATES` are set to `ON` (default: OFF).]
+        [None]
     ]
     [   [`/threads/time/average-phase-overhead`]
         [`locality#*/total` or[br]
@@ -606,7 +606,6 @@ system and application performance.
           of available worker threads is usually specified on the command line
           for the application using the option [hpx_cmdline `--hpx:threads`].
         ]
-        [None]
         [Returns the average time spent on overhead executing one __hpx__-thread
         phase (invocation) on the given locality since application start.
         If the instance name is `total` the counter returns the average
@@ -618,6 +617,7 @@ system and application performance.
         if the configuration time constants
         `HPX_WITH_THREAD_CUMULATIVE_COUNTS` (default: ON) and
         `HPX_WITH_THREAD_IDLE_RATES` are set to `ON` (default: OFF).]
+        [None]
     ]
     [   [`/threads/time/overall`]
         [`locality#*/total` or[br]
@@ -636,7 +636,6 @@ system and application performance.
           available worker threads is usually specified on the command line
           for the application using the option [hpx_cmdline `--hpx:threads`].
         ]
-        [None]
         [Returns the overall time spent running the scheduler on the
          given locality since application start. If the
          instance name is `total` the counter returns the overall time spent
@@ -646,6 +645,7 @@ system and application performance.
          for all worker threads separately. This counter is available only
         if the configuration time constant
         `HPX_WITH_THREAD_IDLE_RATES` is set to `ON` (default: OFF).]
+        [None]
     ]
     [   [`/threads/time/cumulative`]
         [`locality#*/total` or[br]
@@ -664,7 +664,6 @@ system and application performance.
           available worker threads is usually specified on the command line
           for the application using the option [hpx_cmdline `--hpx:threads`].
         ]
-        [None]
         [Returns the overall time spent executing all __hpx__-threads on the
          given locality since application start. If the
          instance name is `total` the counter returns the overall time spent
@@ -675,6 +674,7 @@ system and application performance.
          This counter is available only if the configuration time constants
          `HPX_THREAD_MAINTAIN_CUMULATIVE_COUNTS` (default: ON) and
          `HPX_THREAD_MAINTAIN_IDLE_RATES` are set to `ON` (default: OFF).]
+        [None]
     ]
     [   [`/threads/time/cumulative-overheads`]
         [`locality#*/total` or[br]
@@ -693,7 +693,6 @@ system and application performance.
           available worker threads is usually specified on the command line
           for the application using the option [hpx_cmdline `--hpx:threads`].
         ]
-        [None]
         [Returns the overall overhead time incurred executing all __hpx__-threads
          on the given locality since application start. If the
          instance name is `total` the counter returns the overall overhead
@@ -704,6 +703,7 @@ system and application performance.
          This counter is available only if the configuration time constants
          `HPX_THREAD_MAINTAIN_CUMULATIVE_COUNTS` (default: ON) and
          `HPX_THREAD_MAINTAIN_IDLE_RATES` are set to `ON` (default: OFF).]
+        [None]
     ]
     [   [`/threads/count/instantaneous/<thread-state>`
 
@@ -729,7 +729,6 @@ system and application performance.
           The `staged` thread state refers to registered tasks before they are
           converted to thread objects.
         ]
-        [None]
         [Returns the current number of __hpx__-threads having the given thread
          state on the given locality. If the instance
          name is `total` the counter returns the current number of __hpx__-threads
@@ -737,6 +736,7 @@ system and application performance.
          the instance name is `worker-thread#*` the counter will return the
          current number of __hpx__-threads in the given state for all
          worker threads separately.]
+        [None]
     ]
     [   [`/threads/wait-time/<thread-state>`
 
@@ -764,7 +764,6 @@ system and application performance.
           thread state refers to the wait time of threads in any of the
           scheduling queues.
         ]
-        [None]
         [Returns the average wait time of __hpx__-threads (if the thread state
          is `pending`) or of task descriptions (if the thread state is `staged`)
          on the given locality since application start. If the instance
@@ -777,6 +776,7 @@ system and application performance.
          These counters are available only if the compile time constant
          `HPX_WITH_THREAD_QUEUE_WAITTIME` was defined while compiling the
          __hpx__ core library (default: OFF).]
+        [None]
     ]
     [   [`/threads/idle-rate`]
         [`locality#*/total` or[br]
@@ -795,13 +795,13 @@ system and application performance.
           is usually specified on the command line for the application using the
           option [hpx_cmdline `--hpx:threads`].
         ]
-        [None]
         [Returns the average idle rate for the given worker thread(s) on the
          given locality. The idle rate is defined as the ratio of the time
          spent on scheduling and management tasks and the overall time spent
          executing work since the application started.
          This counter is available only if the configuration time constant
          `HPX_WITH_THREAD_IDLE_RATES` is set to `ON` (default: OFF)/.]
+        [None]
     ]
     [   [`/threads/creation-idle-rate`]
         [`locality#*/total` or[br]
@@ -820,7 +820,6 @@ system and application performance.
           is usually specified on the command line for the application using the
           option [hpx_cmdline `--hpx:threads`].
         ]
-        [None]
         [Returns the average idle rate for the given worker thread(s) on the
          given locality which is caused by creating new threads. The creation
          idle rate is defined as the ratio of the time spent on creating new
@@ -829,6 +828,7 @@ system and application performance.
          This counter is available only if the configuration time constants
          `HPX_WITH_THREAD_IDLE_RATES` (default: OFF) and
          `HPX_WITH_THREAD_CREATION_AND_CLEANUP_RATES` are set to `ON`.]
+        [None]
     ]
     [   [`/threads/cleanup-idle-rate`]
         [`locality#*/total` or[br]
@@ -847,7 +847,6 @@ system and application performance.
           is usually specified on the command line for the application using the
           option [hpx_cmdline `--hpx:threads`].
         ]
-        [None]
         [Returns the average idle rate for the given worker thread(s) on the
          given locality which is caused by cleaning up terminated threads. The
          cleanup idle rate is defined as the ratio of the time spent on
@@ -856,6 +855,7 @@ system and application performance.
          This counter is available only if the configuration time constants
          `HPX_WITH_THREAD_IDLE_RATES` (default: OFF) and
          `HPX_WITH_THREAD_CREATION_AND_CLEANUP_RATES` are set to `ON`.]
+        [None]
     ]
     [   [`/threadqueue/length`]
         [`locality#*/total` or[br]
@@ -874,9 +874,9 @@ system and application performance.
           available worker threads is usually specified on the command line
           for the application using the option [hpx_cmdline `--hpx:threads`].
         ]
-        [None]
         [Returns the overall length of all queues for the given worker
          thread(s) on the given locality.]
+        [None]
     ]
     [   [`/threads/count/stack-unbinds`]
         [`locality#*/total`
@@ -885,10 +885,10 @@ system and application performance.
           (madvise) operations should be queried for. The locality id is a
           (zero based) number identifying the locality.
         ]
-        [None]
         [Returns the total number of __hpx__-thread unbind (madvise) operations
          performed for the referenced locality. Note that this counter is not
          available on Windows based platforms.]
+        [None]
     ]
     [   [`/threads/count/stack-recycles`]
         [`locality#*/total`
@@ -897,9 +897,9 @@ system and application performance.
           operations should be queried for. The locality id is a
           (zero based) number identifying the locality.
         ]
-        [None]
         [Returns the total number of __hpx__-thread recycling operations
          performed.]
+        [None]
     ]
     [   [`/threads/count/stolen-from-pending`]
         [`locality#*/total`
@@ -908,7 +908,6 @@ system and application performance.
           'stole' threads should be queried for. The locality id is a
           (zero based) number identifying the locality.
         ]
-        [None]
         [Returns the total number of __hpx__-threads 'stolen' from the pending
          thread queue by a neighboring thread worker thread (these threads are
          executed by a different worker thread than they were initially
@@ -916,6 +915,7 @@ system and application performance.
          This counter is available only if the configuration time constant
          `HPX_WITH_THREAD_STEALING_COUNTS` is set to `ON`
          (default: ON).]
+        [None]
     ]
     [   [`/threads/count/pending-misses`]
         [`locality#*/total` or[br]
@@ -934,13 +934,13 @@ system and application performance.
           is usually specified on the command line for the application using the
           option [hpx_cmdline `--hpx:threads`].
         ]
-        [None]
         [Returns the total number of times that the referenced worker-thread
          on the referenced locality failed to find pending __hpx__-threads in its
          associated queue.
          This counter is available only if the configuration time constant
          `HPX_WITH_THREAD_STEALING_COUNTS` is set to `ON`
          (default: ON).]
+        [None]
     ]
     [   [`/threads/count/pending-accesses`]
         [`locality#*/total` or[br]
@@ -959,13 +959,13 @@ system and application performance.
           is usually specified on the command line for the application using the
           option [hpx_cmdline `--hpx:threads`].
         ]
-        [None]
         [Returns the total number of times that the referenced worker-thread
          on the referenced locality looked for pending __hpx__-threads in its
          associated queue.
          This counter is available only if the configuration time constant
          `HPX_WITH_THREAD_STEALING_COUNTS` is set to `ON`
          (default: ON).]
+        [None]
     ]
     [   [`/threads/count/stolen-from-staged`]
         [`locality#*/total` or[br]
@@ -984,7 +984,6 @@ system and application performance.
           threads is usually specified on the command line for the application
           using the option [hpx_cmdline `--hpx:threads`].
         ]
-        [None]
         [Returns the total number of __hpx__-threads 'stolen' from the staged
          thread queue by a neighboring worker thread (these threads are
          executed by a different worker thread than they were initially
@@ -992,6 +991,7 @@ system and application performance.
          This counter is available only if the configuration time constant
          `HPX_WITH_THREAD_STEALING_COUNTS` is set to `ON`
          (default: ON).]
+        [None]
     ]
     [   [`/threads/count/stolen-to-pending`]
         [`locality#*/total` or[br]
@@ -1010,7 +1010,6 @@ system and application performance.
           threads is usually specified on the command line for the application
           using the option [hpx_cmdline `--hpx:threads`].
         ]
-        [None]
         [Returns the total number of __hpx__-threads 'stolen' to the pending
          thread queue of the worker thread (these threads are
          executed by a different worker thread than they were initially
@@ -1018,6 +1017,7 @@ system and application performance.
          This counter is available only if the configuration time constant
          `HPX_WITH_THREAD_STEALING_COUNTS` is set to `ON`
          (default: ON).]
+        [None]
     ]
     [   [`/threads/count/stolen-to-staged`]
         [`locality#*/total` or[br]
@@ -1037,7 +1037,6 @@ system and application performance.
           is usually specified on the command line for the application using the
           option [hpx_cmdline `--hpx:threads`].
         ]
-        [None]
         [Returns the total number of __hpx__-threads 'stolen' to the staged
          thread queue of a neighboring worker thread (these threads are
          executed by a different worker thread than they were initially
@@ -1045,6 +1044,7 @@ system and application performance.
          This counter is available only if the configuration time constant
          `HPX_WITH_THREAD_STEALING_COUNTS` is set to `ON`
          (default: ON).]
+        [None]
     ]
     [   [`/threads/count/objects`]
         [`locality#*/total` or[br]
@@ -1063,11 +1063,23 @@ system and application performance.
           The allocator id (given by `*`) is a (zero based) number identifying
           the allocator to query.
         ]
-        [None]
         [Returns the total number of __hpx__-thread objects created. Note that
          thread objects are reused to improve system performance, thus this
          number does not reflect the number of actually executed (retired)
          __hpx__-threads.]
+        [None]
+    ]
+    [   [`/scheduler/utilization/instantaneous`]
+        [`locality#*/total`
+
+          where:[br]
+          `locality#*` is defining the locality for which the current
+          (instantaneous) scheduler utilization queried for. The locality id
+          (given by `*`) is a (zero based) number identifying the locality.
+        ]
+        [Returns the total scheduler (instantaneous) utilization. This is the
+        current percentage of scheduler threads executing __hpx__ threads.]
+        [None]
     ]
 ]
 
@@ -1081,13 +1093,13 @@ system and application performance.
           components should be queried. The locality id is a (zero based)
           number identifying the locality.
         ]
+        [Returns the overall number of currently active components of the
+         specified type on the given locality.]
         [The type of the component. This is the string which has been used
          while registering the component with __hpx__, e.g. which has been
          passed as the second parameter to the macro
          [macroref HPX_REGISTER_COMPONENT `HPX_REGISTER_COMPONENT`].
         ]
-        [Returns the overall number of currently active components of the
-         specified type on the given locality.]
     ]
     [   [`/runtime/count/action-invocation`]
         [`locality#*/total`
@@ -1096,14 +1108,14 @@ system and application performance.
           action invocations should be queried. The locality id is a (zero based)
           number identifying the locality.
         ]
+        [Returns the overall (local) invocation count of the specified action
+         type on the given locality.]
         [The action type. This is the string which has been used
          while registering the action with __hpx__, e.g. which has been
          passed as the second parameter to the macro
          [macroref HPX_REGISTER_ACTION `HPX_REGISTER_ACTION`] or
          [macroref HPX_REGISTER_ACTION_ID `HPX_REGISTER_ACTION_ID`].
         ]
-        [Returns the overall (local) invocation count of the specified action
-         type on the given locality.]
     ]
     [   [`/runtime/count/remote-action-invocation`]
         [`locality#*/total`
@@ -1112,14 +1124,14 @@ system and application performance.
           action invocations should be queried. The locality id is a (zero based)
           number identifying the locality.
         ]
+        [Returns the overall (remote) invocation count of the specified action
+         type on the given locality.]
         [The action type. This is the string which has been used
          while registering the action with __hpx__, e.g. which has been
          passed as the second parameter to the macro
          [macroref HPX_REGISTER_ACTION `HPX_REGISTER_ACTION`] or
          [macroref HPX_REGISTER_ACTION_ID `HPX_REGISTER_ACTION_ID`].
         ]
-        [Returns the overall (remote) invocation count of the specified action
-         type on the given locality.]
     ]
     [   [`/runtime/uptime`]
         [`locality#*/total`
@@ -1128,10 +1140,10 @@ system and application performance.
           should be queried. The locality id is a (zero based) number
           identifying the locality.
         ]
-        [None]
         [Returns the overall time since application start on the given locality
          in nanoseconds.
         ]
+        [None]
     ]
     [   [`/runtime/memory/virtual`]
         [`locality#*/total`
@@ -1140,9 +1152,9 @@ system and application performance.
           virtual memory should be queried. The locality id is a (zero based)
           number identifying the locality.
         ]
-        [None]
         [Returns the amount of virtual memory currently allocated by the
          referenced locality (in bytes).]
+        [None]
     ]
     [   [`/runtime/memory/resident`]
         [`locality#*/total`
@@ -1151,9 +1163,9 @@ system and application performance.
           resident memory should be queried. The locality id is a (zero based)
           number identifying the locality.
         ]
-        [None]
         [Returns the amount of resident memory currently allocated by the
          referenced locality (in bytes).]
+        [None]
     ]
     [   [`/runtime/io/read_bytes_issued`]
         [`locality#*/total`
@@ -1162,11 +1174,11 @@ system and application performance.
           read should be queried. The locality id is a (zero based)
           number identifying the locality.
         ]
-        [None]
         [Returns the number of bytes read by the process (aggregate of count
          arguments passed to read() call or its analogues). This performance
          counter is available only on systems which expose the related data
          through the /proc file system.]
+        [None]
     ]
     [   [`/runtime/io/write_bytes_issued`]
         [`locality#*/total`
@@ -1175,11 +1187,11 @@ system and application performance.
           written should be queried. The locality id is a (zero based)
           number identifying the locality.
         ]
-        [None]
         [Returns the number of bytes written by the process (aggregate of count
          arguments passed to write() call or its analogues). This performance
          counter is available only on systems which expose the related data
          through the /proc file system.]
+        [None]
     ]
     [   [`/runtime/io/read_syscalls`]
         [`locality#*/total`
@@ -1188,10 +1200,10 @@ system and application performance.
           system calls should be queried. The locality id is a (zero based)
           number identifying the locality.
         ]
-        [None]
         [Returns the number of system calls that perform I/O reads. This
          performance counter is available only on systems which expose the
          related data through the /proc file system.]
+        [None]
     ]
     [   [`/runtime/io/write_syscalls`]
         [`locality#*/total`
@@ -1200,10 +1212,10 @@ system and application performance.
           system calls should be queried. The locality id is a (zero based)
           number identifying the locality.
         ]
-        [None]
         [Returns the number of system calls that perform I/O writes. This
          performance counter is available only on systems which expose the
          related data through the /proc file system.]
+        [None]
     ]
     [   [`/runtime/io/read_bytes_transferred`]
         [`locality#*/total`
@@ -1212,10 +1224,10 @@ system and application performance.
           transferred should be queried. The locality id is a (zero based)
           number identifying the locality.
         ]
-        [None]
         [Returns the number of bytes retrieved from storage by I/O operations.
          This performance counter is available only on systems which expose the
          related data through the /proc file system.]
+        [None]
     ]
     [   [`/runtime/io/write_bytes_transferred`]
         [`locality#*/total`
@@ -1224,10 +1236,10 @@ system and application performance.
           transferred should be queried. The locality id is a (zero based)
           number identifying the locality.
         ]
-        [None]
         [Returns the number of bytes retrieved from storage by I/O operations.
          This performance counter is available only on systems which expose the
          related data through the /proc file system.]
+        [None]
     ]
     [   [`/runtime/io/write_bytes_cancelled`]
         [`locality#*/total`
@@ -1236,11 +1248,11 @@ system and application performance.
           not being transferred should be queried. The locality id is a (zero
           based) number identifying the locality.
         ]
-        [None]
         [Returns the number of bytes accounted by write_bytes_transferred that
          has not been ultimately stored due to truncation or deletion.
          This performance counter is available only on systems which expose the
          related data through the /proc file system.]
+        [None]
     ]
 ]
 

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -208,21 +208,40 @@ namespace hpx { namespace threads { namespace detail
 #endif
 
     ///////////////////////////////////////////////////////////////////////////
+    struct is_active_wrapper
+    {
+        is_active_wrapper(std::uint8_t& is_active)
+          : is_active_(is_active)
+        {
+            is_active = 1;
+        }
+        ~is_active_wrapper()
+        {
+            is_active_ = 0;
+        }
+
+        std::uint8_t& is_active_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
     struct scheduling_counters
     {
         scheduling_counters(std::int64_t& executed_threads,
                 std::int64_t& executed_thread_phases,
-                std::uint64_t& tfunc_time, std::uint64_t& exec_time)
+                std::uint64_t& tfunc_time, std::uint64_t& exec_time,
+                std::uint8_t& is_active)
           : executed_threads_(executed_threads),
             executed_thread_phases_(executed_thread_phases),
             tfunc_time_(tfunc_time),
-            exec_time_(exec_time)
+            exec_time_(exec_time),
+            is_active_(is_active)
         {}
 
         std::int64_t& executed_threads_;
         std::int64_t& executed_thread_phases_;
         std::uint64_t& tfunc_time_;
         std::uint64_t& exec_time_;
+        std::uint8_t& is_active_;
     };
 
     struct scheduling_callbacks
@@ -313,6 +332,7 @@ namespace hpx { namespace threads { namespace detail
                             // thread returns new required state
                             // store the returned state in the thread
                             {
+                                is_active_wrapper utilization(counters.is_active_);
 #ifdef HPX_HAVE_ITTNOTIFY
                                 util::itt::caller_context cctx(ctx);
                                 util::itt::undo_frame_context undoframe(fctx);

--- a/hpx/runtime/threads/detail/thread_pool.hpp
+++ b/hpx/runtime/threads/detail/thread_pool.hpp
@@ -133,6 +133,8 @@ namespace hpx { namespace threads { namespace detail
         std::int64_t get_thread_count(thread_state_enum state,
             thread_priority priority, std::size_t num_thread, bool reset) const;
 
+        std::int64_t get_scheduler_utilization() const;
+
         bool enumerate_threads(
             util::function_nonser<bool(thread_id_type)> const& f,
             thread_state_enum state = unknown) const;
@@ -226,6 +228,8 @@ namespace hpx { namespace threads { namespace detail
         // tfunc_impl timers
         std::vector<std::uint64_t> exec_times_, tfunc_times_;
         std::vector<std::uint64_t> reset_tfunc_times_;
+
+        std::vector<std::uint8_t> tasks_active_;
 
         // Stores the mask identifying all processing units used by this
         // thread manager.

--- a/hpx/runtime/threads/threadmanager_impl.hpp
+++ b/hpx/runtime/threads/threadmanager_impl.hpp
@@ -313,6 +313,9 @@ namespace hpx { namespace threads
             performance_counters::counter_info const& info, error_code& ec);
 #endif
 
+        naming::gid_type scheduler_utilization_counter_creator(
+            performance_counters::counter_info const& info, error_code& ec);
+
     private:
         mutable mutex_type mtx_;   // mutex protecting the members
 

--- a/src/runtime/threads/detail/thread_pool.cpp
+++ b/src/runtime/threads/detail/thread_pool.cpp
@@ -258,6 +258,13 @@ namespace hpx { namespace threads { namespace detail
     }
 
     template <typename Scheduler>
+    std::int64_t thread_pool<Scheduler>::get_scheduler_utilization() const
+    {
+        return (std::accumulate(tasks_active_.begin(), tasks_active_.end(),
+            std::int64_t(0)) * 100) / thread_count_.load();
+    }
+
+    template <typename Scheduler>
     bool thread_pool<Scheduler>::enumerate_threads(
         util::function_nonser<bool(thread_id_type)> const& f,
         thread_state_enum state) const
@@ -308,6 +315,8 @@ namespace hpx { namespace threads { namespace detail
         exec_times_.resize(num_threads);
 
         reset_tfunc_times_.resize(num_threads);
+
+        tasks_active_.resize(num_threads);
 
         // scale timestamps to nanoseconds
         std::uint64_t base_timestamp = util::hardware::timestamp();
@@ -613,7 +622,8 @@ namespace hpx { namespace threads { namespace detail
                     detail::scheduling_counters counters(
                         executed_threads_[num_thread],
                         executed_thread_phases_[num_thread],
-                        tfunc_times_[num_thread], exec_times_[num_thread]);
+                        tfunc_times_[num_thread], exec_times_[num_thread],
+                        tasks_active_[num_thread]);
 
                     detail::scheduling_callbacks callbacks(
                         util::bind( //-V107

--- a/src/runtime/threads/executors/this_thread_executors.cpp
+++ b/src/runtime/threads/executors/this_thread_executors.cpp
@@ -330,10 +330,11 @@ namespace hpx { namespace threads { namespace executors { namespace detail
             // FIXME: turn these values into performance counters
             std::int64_t executed_threads = 0, executed_thread_phases = 0;
             std::uint64_t overall_times = 0, thread_times = 0;
+            std::uint8_t task_active = 0;
 
             threads::detail::scheduling_counters counters(
                 executed_threads, executed_thread_phases,
-                overall_times, thread_times);
+                overall_times, thread_times, task_active);
 
             threads::detail::scheduling_callbacks callbacks(
                 threads::detail::scheduling_callbacks::callback_type(),

--- a/src/runtime/threads/executors/thread_pool_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_executors.cpp
@@ -330,10 +330,11 @@ namespace hpx { namespace threads { namespace executors { namespace detail
             // FIXME: turn these values into performance counters
             std::int64_t executed_threads = 0, executed_thread_phases = 0;
             std::uint64_t overall_times = 0, thread_times = 0;
+            std::uint8_t task_active = 0;
 
             threads::detail::scheduling_counters counters(
                 executed_threads, executed_thread_phases,
-                overall_times, thread_times);
+                overall_times, thread_times, task_active);
 
             threads::detail::scheduling_callbacks callbacks(
                 threads::detail::scheduling_callbacks::callback_type(),

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -405,6 +405,43 @@ namespace hpx { namespace threads
     }
 #endif
 
+    // scheduler utilization counter creation function
+    template <typename SchedulingPolicy>
+    naming::gid_type threadmanager_impl<SchedulingPolicy>::
+        scheduler_utilization_counter_creator(
+            performance_counters::counter_info const& info, error_code& ec)
+    {
+        // verify the validity of the counter instance name
+        performance_counters::counter_path_elements paths;
+        performance_counters::get_counter_path_elements(info.fullname_, paths, ec);
+        if (ec) return naming::invalid_gid;
+
+        // /scheduler{locality#%d/total}/utilization/instantaneous
+        if (paths.parentinstance_is_basename_) {
+            HPX_THROWS_IF(ec, bad_parameter, "scheduler_utilization_creator",
+                "invalid counter instance parent name: " +
+                    paths.parentinstancename_);
+            return naming::invalid_gid;
+        }
+
+        typedef detail::thread_pool<scheduling_policy_type> spt;
+
+        using util::placeholders::_1;
+        if (paths.instancename_ == "total" && paths.instanceindex_ == -1)
+        {
+            // overall counter
+            using performance_counters::detail::create_raw_counter;
+            util::function_nonser<std::int64_t()> f =
+                util::bind(&spt::get_scheduler_utilization, &pool_);
+            return create_raw_counter(info, std::move(f), ec);
+        }
+
+        HPX_THROWS_IF(ec, bad_parameter, "scheduler_utilization_creator",
+            "invalid counter instance name: " + paths.instancename_);
+        return naming::invalid_gid;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     bool locality_allocator_counter_discoverer(
         performance_counters::counter_info const& info,
         performance_counters::discover_counter_func const& f,
@@ -1087,8 +1124,16 @@ namespace hpx { namespace threads
               counts_creator,
               &performance_counters::locality_thread_counter_discoverer,
               ""
-            }
+            },
 #endif
+            // scheduler utilization
+            { "/scheduler/utilization/instantaneous", performance_counters::counter_raw,
+              "returns the current scheduler utilization",
+              HPX_PERFORMANCE_COUNTER_V1,
+              util::bind(&ti::scheduler_utilization_counter_creator, this, _1, _2),
+              &performance_counters::locality_counter_discoverer,
+              ""
+            }
         };
         performance_counters::install_counter_types(
             counter_types, sizeof(counter_types)/sizeof(counter_types[0]));


### PR DESCRIPTION
This adds a performance counter which acts as a complement to the idle-rate counter by exposing the current percentage of scheduler threads executing hpx-threads.