### PR TITLE
Making sure the sine performance counter module gets loaded only for …

### DIFF
--- a/examples/performance_counters/sine/sine.cpp
+++ b/examples/performance_counters/sine/sine.cpp
@@ -245,8 +245,15 @@ namespace performance_counters { namespace sine
     ///////////////////////////////////////////////////////////////////////////
     bool get_startup(hpx::startup_function_type& startup_func, bool& pre_startup)
     {
+        // exit silently if this gets loaded outside of the sine_client example
+        if (hpx::get_config_entry("hpx.components.sine.enabled", "0") == "0")
+        {
+            return false;
+        }
+
         // check whether the performance counters need to be enabled
-        if (!need_perf_counters()) {
+        if (!need_perf_counters())
+        {
             HPX_THROW_EXCEPTION(hpx::dynamic_link_failure,
                 "performance_counters::sine::get_startup",
                 "the sine component is not enabled on the commandline "

--- a/examples/performance_counters/sine/sine_client.cpp
+++ b/examples/performance_counters/sine/sine_client.cpp
@@ -11,6 +11,8 @@
 
 #include <cstdint>
 #include <iostream>
+#include <string>
+#include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
 // This example demonstrates the creation and use of different types of
@@ -161,7 +163,11 @@ int main(int argc, char* argv[])
              "number of performance counter queries to perform")
         ;
 
+    std::vector<std::string> cfg = {
+        "hpx.components.sine.enabled! = 1"
+    };
+
     // Initialize and run HPX.
-    return hpx::init(desc_commandline, argc, argv);
+    return hpx::init(desc_commandline, argc, argv, cfg);
 }
 


### PR DESCRIPTION
…the corresponding example

- this avoids spurious exceptions at startup