### PR TITLE
Allowing for plain suspend to reschedule thread right away 

### DIFF
--- a/docs/manual/config_defaults.qbk
+++ b/docs/manual/config_defaults.qbk
@@ -60,6 +60,9 @@ by section basis below.
     lock_detection = ${HPX_LOCK_DETECTION:0}
     throw_on_held_lock = ${HPX_THROW_ON_HELD_LOCK:1}
     minimal_deadlock_detection = <debug>
+    max_background_threads = ${HPX_MAX_BACKGROUND_THREADS:$[hpx.os_threads]}
+    max_idle_loop_count = ${HPX_MAX_IDLE_LOOP_COUNT:<hpx_idle_loop_count_max>}
+    max_busy_loop_count = ${HPX_MAX_BUSY_LOOP_COUNT:<hpx_busy_loop_count_max>}
 
     [hpx.stacks]
     small_size = ${HPX_SMALL_STACK_SIZE:<hpx_small_stack_size>}
@@ -115,6 +118,21 @@ by section basis below.
       RelWithDebInfo, RelMinSize builds), this setting is effective only if
       `HPX_WITH_THREAD_DEADLOCK_DETECTION` is set during configuration in
       CMake.]]
+    [[`hpx.max_background_threads`]
+     [This setting defines the maximum value of the idle-loop counter in the
+      scheduler. By default this is defined by the preprocessor constant
+      `HPX_IDLE_LOOP_COUNT_MAX`. This is an internal setting which you should
+      change only if you know exactly what you are doing.]]
+    [[`hpx.max_idle_loop_count`]
+     [This setting defines the maximum value of the busy-loop counter in the
+      scheduler. By default this is defined by the preprocessor constant
+      `HPX_BUSY_LOOP_COUNT_MAX`. This is an internal setting which you should
+      change only if you know exactly what you are doing.]]
+    [[`hpx.max_busy_loop_count`]
+     [This setting defines the number of threads in the scheduler which are used
+      to execute background work. By default this is the same as the number of
+      cores used for the scheduler.]]
+
     [[`hpx.stacks.small_size`]
      [This is initialized to the small stack size to be used by __hpx__-threads.
       Set by default to the value of the compile time preprocessor constant
@@ -540,7 +558,7 @@ to `ON`).
     [[`hpx.parcel.mpi.multithreaded`]
      [This property is used to determine what threading mode to use when
       initializing MPI. If this setting is `0`, __hpx__ will initialize MPI
-      with `MPI_THREAD_SINGLE`, if the value is not equal to `0` __hpx__ will 
+      with `MPI_THREAD_SINGLE`, if the value is not equal to `0` __hpx__ will
       initialize MPI with `MPI_THREAD_MULTI`.]]
     [[`hpx.parcel.mpi.rank`]
      [This property will be initialized to the MPI rank of the locality.]]

--- a/docs/manual/config_defaults.qbk
+++ b/docs/manual/config_defaults.qbk
@@ -119,19 +119,19 @@ by section basis below.
       `HPX_WITH_THREAD_DEADLOCK_DETECTION` is set during configuration in
       CMake.]]
     [[`hpx.max_background_threads`]
+     [This setting defines the number of threads in the scheduler which are used
+      to execute background work. By default this is the same as the number of
+      cores used for the scheduler.]]
+    [[`hpx.max_idle_loop_count`]
      [This setting defines the maximum value of the idle-loop counter in the
       scheduler. By default this is defined by the preprocessor constant
       `HPX_IDLE_LOOP_COUNT_MAX`. This is an internal setting which you should
       change only if you know exactly what you are doing.]]
-    [[`hpx.max_idle_loop_count`]
+    [[`hpx.max_busy_loop_count`]
      [This setting defines the maximum value of the busy-loop counter in the
       scheduler. By default this is defined by the preprocessor constant
       `HPX_BUSY_LOOP_COUNT_MAX`. This is an internal setting which you should
       change only if you know exactly what you are doing.]]
-    [[`hpx.max_busy_loop_count`]
-     [This setting defines the number of threads in the scheduler which are used
-      to execute background work. By default this is the same as the number of
-      cores used for the scheduler.]]
 
     [[`hpx.stacks.small_size`]
      [This is initialized to the small stack size to be used by __hpx__-threads.

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -597,7 +597,7 @@ namespace detail
             // handle all threads waiting for the future to become ready
 
             // Note: we use notify_one repeatedly instead of notify_all as we
-            //       know: a) that most of the time have at most one thread
+            //       know: a) that most of the time we have at most one thread
             //       waiting on the future (most futures are not shared), and
             //       b) our implementation of condition_variable::notify_one
             //       relinquishes the lock before resuming the waiting thread
@@ -642,7 +642,7 @@ namespace detail
             // handle all threads waiting for the future to become ready
 
             // Note: we use notify_one repeatedly instead of notify_all as we
-            //       know: a) that most of the time have at most one thread
+            //       know: a) that most of the time we have at most one thread
             //       waiting on the future (most futures are not shared), and
             //       b) our implementation of condition_variable::notify_one
             //       relinquishes the lock before resuming the waiting thread

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -595,9 +595,20 @@ namespace detail
             state_ = value;
 
             // handle all threads waiting for the future to become ready
-            cond_.notify_all(std::move(l), threads::thread_priority_boost, ec);
 
-            // Note: cv.notify_all() above 'consumes' the lock 'l' and leaves
+            // Note: we use notify_one repeatedly instead of notify_all as we
+            //       know: a) that most of the time have at most one thread
+            //       waiting on the future (most futures are not shared), and
+            //       b) our implementation of condition_variable::notify_one
+            //       relinquishes the lock before resuming the waiting thread
+            //       which avoids suspension of this thread when it tries to
+            //       re-lock the mutex while exiting from condition_variable::wait
+            while (cond_.notify_one(std::move(l), threads::thread_priority_boost, ec))
+            {
+                l = std::unique_lock<mutex_type>(this->mtx_);
+            }
+
+            // Note: cv.notify_one() above 'consumes' the lock 'l' and leaves
             //       it unlocked when returning.
 
             // invoke the callback (continuation) function
@@ -629,9 +640,20 @@ namespace detail
             state_ = exception;
 
             // handle all threads waiting for the future to become ready
-            cond_.notify_all(std::move(l), ec);
 
-            // Note: cv.notify_all() above 'consumes' the lock 'l' and leaves
+            // Note: we use notify_one repeatedly instead of notify_all as we
+            //       know: a) that most of the time have at most one thread
+            //       waiting on the future (most futures are not shared), and
+            //       b) our implementation of condition_variable::notify_one
+            //       relinquishes the lock before resuming the waiting thread
+            //       which avoids suspension of this thread when it tries to
+            //       re-lock the mutex while exiting from condition_variable::wait
+            while (cond_.notify_one(std::move(l), threads::thread_priority_boost, ec))
+            {
+                l = std::unique_lock<mutex_type>(this->mtx_);
+            }
+
+            // Note: cv.notify_one() above 'consumes' the lock 'l' and leaves
             //       it unlocked when returning.
 
             // invoke the callback (continuation) function

--- a/hpx/lcos/local/spinlock.hpp
+++ b/hpx/lcos/local/spinlock.hpp
@@ -103,7 +103,7 @@ namespace hpx { namespace lcos { namespace local
 
                 if (hpx::threads::get_self_ptr())
                 {
-                    hpx::this_thread::suspend(hpx::threads::pending_boost,
+                    hpx::this_thread::suspend(hpx::threads::pending,
                         "hpx::lcos::local::spinlock::yield");
                 }
                 else

--- a/hpx/lcos/local/spinlock.hpp
+++ b/hpx/lcos/local/spinlock.hpp
@@ -76,7 +76,7 @@ namespace hpx { namespace lcos { namespace local
             {
                 if (hpx::threads::get_self_ptr())
                 {
-                    hpx::this_thread::suspend(hpx::threads::pending,
+                    hpx::this_thread::suspend(hpx::threads::pending_boost,
                         "hpx::lcos::local::spinlock::yield");
                 }
                 else
@@ -103,7 +103,7 @@ namespace hpx { namespace lcos { namespace local
 
                 if (hpx::threads::get_self_ptr())
                 {
-                    hpx::this_thread::suspend(hpx::threads::pending,
+                    hpx::this_thread::suspend(hpx::threads::pending_boost,
                         "hpx::lcos::local::spinlock::yield");
                 }
                 else

--- a/hpx/runtime/threads/detail/create_thread.hpp
+++ b/hpx/runtime/threads/detail/create_thread.hpp
@@ -28,6 +28,7 @@ namespace hpx { namespace threads { namespace detail
         switch (initial_state) {
         case pending:
         case pending_do_not_schedule:
+        case pending_boost:
         case suspended:
             break;
 

--- a/hpx/runtime/threads/detail/create_work.hpp
+++ b/hpx/runtime/threads/detail/create_work.hpp
@@ -26,6 +26,7 @@ namespace hpx { namespace threads { namespace detail
         switch (initial_state) {
         case pending:
         case pending_do_not_schedule:
+        case pending_boost:
         case suspended:
             break;
 

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -319,7 +319,8 @@ namespace hpx { namespace threads { namespace detail
 
                 detail::write_old_state_log(num_thread, thrd, state_val);
 
-                if (HPX_LIKELY(pending == state_val)) {
+                if (HPX_LIKELY(pending == state_val))
+                {
                     // switch the state of the thread to active and back to
                     // what the thread reports as its return value
 
@@ -406,7 +407,8 @@ namespace hpx { namespace threads { namespace detail
                     // Re-add this work item to our list of work items if the HPX
                     // thread should be re-scheduled. If the HPX thread is suspended
                     // now we just keep it in the map of threads.
-                    if (HPX_UNLIKELY(state_val == pending)) {
+                    if (HPX_UNLIKELY(state_val == pending))
+                    {
                         if (HPX_LIKELY(next_thrd == nullptr)) {
                             // schedule other work
                             scheduler.SchedulingPolicy::wait_or_add_new(
@@ -418,6 +420,23 @@ namespace hpx { namespace threads { namespace detail
                         // the end of the queue
                         scheduler.SchedulingPolicy::schedule_thread_last(thrd,
                             num_thread);
+                        scheduler.SchedulingPolicy::do_some_work(num_thread);
+                    }
+                    else if (HPX_UNLIKELY(state_val == pending_boost))
+                    {
+                        if (HPX_LIKELY(next_thrd == nullptr)) {
+                            // schedule other work
+                            scheduler.SchedulingPolicy::wait_or_add_new(
+                                num_thread, this_state.load() < state_stopping,
+                                idle_loop_count);
+                        }
+
+                        thrd->set_state(pending);
+
+                        // schedule this thread again immediately with boosted
+                        // priority
+                        scheduler.SchedulingPolicy::schedule_thread(thrd,
+                            num_thread, thread_priority_boost);
                         scheduler.SchedulingPolicy::do_some_work(num_thread);
                     }
                 }

--- a/hpx/runtime/threads/detail/set_thread_state.hpp
+++ b/hpx/runtime/threads/detail/set_thread_state.hpp
@@ -170,6 +170,7 @@ namespace hpx { namespace threads { namespace detail
                 }
                 break;
             case pending:
+            case pending_boost:
                 if (suspended == new_state) {
                     // we do not allow explicit resetting of a state to suspended
                     // without the thread being executed.

--- a/hpx/runtime/threads/policies/thread_queue.hpp
+++ b/hpx/runtime/threads/policies/thread_queue.hpp
@@ -206,14 +206,18 @@ namespace hpx { namespace threads { namespace policies
             }
             HPX_ASSERT(heap);
 
+            if (state == pending_do_not_schedule || state == pending_boost)
+            {
+                state = pending;
+            }
+
             // Check for an unused thread object.
             if (!heap->empty())
             {
                 // Take ownership of the thread object and rebind it.
                 thrd = heap->front();
                 heap->pop_front();
-                thrd->rebind(data,
-                    state == pending_do_not_schedule ? pending : state);
+                thrd->rebind(data, state);
             }
 
             else
@@ -221,9 +225,7 @@ namespace hpx { namespace threads { namespace policies
                 hpx::util::unlock_guard<Lock> ull(lk);
 
                 // Allocate a new thread object.
-                thrd = threads::thread_data::create(
-                    data, memory_pool_,
-                    state == pending_do_not_schedule ? pending : state);
+                thrd = threads::thread_data::create(data, memory_pool_, state);
             }
         }
 

--- a/hpx/runtime/threads/thread_data.hpp
+++ b/hpx/runtime/threads/thread_data.hpp
@@ -146,7 +146,8 @@ namespace hpx { namespace threads
         ///                 thread's status word. To change the thread's
         ///                 scheduling status \a threadmanager#set_state should
         ///                 be used.
-        thread_state set_state(thread_state_enum state, thread_state_ex_enum state_ex)
+        thread_state set_state(thread_state_enum state,
+            thread_state_ex_enum state_ex = wait_unknown)
         {
             thread_state prev_state =
                 current_state_.load(boost::memory_order_acquire);
@@ -158,6 +159,9 @@ namespace hpx { namespace threads
                 std::int64_t tag = tmp.tag();
                 if (state != tmp.state())
                     ++tag;
+
+                if (state_ex == wait_unknown)
+                    state_ex = tmp.state_ex();
 
                 if (HPX_LIKELY(current_state_.compare_exchange_strong(tmp,
                         thread_state(state, state_ex, tag))))

--- a/hpx/runtime/threads/thread_enums.hpp
+++ b/hpx/runtime/threads/thread_enums.hpp
@@ -40,9 +40,12 @@ namespace hpx { namespace threads
                                  allows to reference staged task descriptions,
                                  which eventually will be converted into
                                  thread objects */
-        pending_do_not_schedule = 7 /*< this is not a real thread state,
+        pending_do_not_schedule = 7, /*< this is not a real thread state,
                                  but allows to create a thread in pending state
                                  without scheduling it (internal, do not use) */
+        pending_boost = 8   /*< this is not a real thread state,
+                                 but allows to suspend a thread in pending state
+                                 without high priority rescheduling */
     };
 
     /// Get the readable string representing the name of the given

--- a/hpx/util/detail/yield_k.hpp
+++ b/hpx/util/detail/yield_k.hpp
@@ -40,7 +40,8 @@ namespace hpx { namespace util { namespace detail {
             }
             else
             {
-                hpx::this_thread::suspend(hpx::threads::pending, thread_name);
+                hpx::this_thread::suspend(hpx::threads::pending_boost,
+                    thread_name);
             }
         }
         else

--- a/src/lcos/local/mutex.cpp
+++ b/src/lcos/local/mutex.cpp
@@ -103,7 +103,7 @@ namespace hpx { namespace lcos { namespace local
         HPX_ITT_SYNC_RELEASED(this);
         owner_id_ = threads::invalid_thread_id_repr;
 
-        cond_.notify_one(std::move(l), ec);
+        cond_.notify_one(std::move(l), threads::thread_priority_boost, ec);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/util/runtime_configuration.cpp
+++ b/src/util/runtime_configuration.cpp
@@ -186,7 +186,13 @@ namespace hpx { namespace util
             "pu_step = 1",
             "pu_offset = 0",
             "numa_sensitive = 0",
-            "max_background_threads = ${MAX_BACKGROUND_THREADS:$[hpx.os_threads]}",
+            "max_background_threads = "
+                "${HPX_MAX_BACKGROUND_THREADS:$[hpx.os_threads]}",
+
+            "max_idle_loop_count = ${HPX_MAX_IDLE_LOOP_COUNT:"
+                BOOST_STRINGIZE(HPX_IDLE_LOOP_COUNT_MAX) "}",
+            "max_busy_loop_count = ${HPX_MAX_BUSY_LOOP_COUNT:"
+                BOOST_STRINGIZE(HPX_BUSY_LOOP_COUNT_MAX) "}",
 
             // arity for collective operations implemented in a tree fashion
             "[hpx.lcos.collectives]",


### PR DESCRIPTION
This reschedules a thread waiting (being suspended) on a spinlock right away without having to wait to get through the whole thread queue.