### PR TITLE
Adding performance counters exposing the internal idle and busy-loop counters

### DIFF
--- a/docs/manual/existing_performance_counters.qbk
+++ b/docs/manual/existing_performance_counters.qbk
@@ -1079,6 +1079,50 @@ system and application performance.
         ]
         [Returns the total scheduler (instantaneous) utilization. This is the
         current percentage of scheduler threads executing __hpx__ threads.]
+        [Percent]
+    ]
+    [   [`/scheduler/idle-loop-count/instantaneous`]
+        [`locality#*/total` or[br]
+         `locality#*/worker-thread#*`
+
+          where:[br]
+          `locality#*` is defining the locality for which the current
+          current accumulated value of all idle-loop counters of all worker
+          threads should be queried. The locality id
+          (given by `*`) is a (zero based) number identifying the locality.
+
+          `worker-thread#*` is defining the worker thread for which the
+          current value of the idle-loop counter should be queried
+          for. The worker thread number (given by the `*`) is a (zero based)
+          worker thread number (given by the `*`) is a (zero based) number
+          identifying the worker thread. The number of available worker threads
+          is usually specified on the command line for the application using the
+          option [hpx_cmdline `--hpx:threads`].
+        ]
+        [Returns the current (instantaneous) idle-loop count for the given
+         __hpx__- worker thread or the accumulated value for all worker threads.]
+        [None]
+    ]
+    [   [`/scheduler/busy-loop-count/instantaneous`]
+        [`locality#*/total` or[br]
+         `locality#*/worker-thread#*`
+
+          where:[br]
+          `locality#*` is defining the locality for which the current
+          current accumulated value of all busy-loop counters of all worker
+          threads should be queried. The locality id
+          (given by `*`) is a (zero based) number identifying the locality.
+
+          `worker-thread#*` is defining the worker thread for which the
+          current value of the busy-loop counter should be queried
+          for. The worker thread number (given by the `*`) is a (zero based)
+          worker thread number (given by the `*`) is a (zero based) number
+          identifying the worker thread. The number of available worker threads
+          is usually specified on the command line for the application using the
+          option [hpx_cmdline `--hpx:threads`].
+        ]
+        [Returns the current (instantaneous) busy-loop count for the given
+         __hpx__- worker thread or the accumulated value for all worker threads.]
         [None]
     ]
 ]

--- a/hpx/config.hpp
+++ b/hpx/config.hpp
@@ -391,7 +391,7 @@
 // Count number of busy thread manager loop executions before forcefully
 // cleaning up terminated thread objects
 #if !defined(HPX_BUSY_LOOP_COUNT_MAX)
-#  define HPX_BUSY_LOOP_COUNT_MAX 200000
+#  define HPX_BUSY_LOOP_COUNT_MAX 2000
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -229,11 +229,14 @@ namespace hpx { namespace threads { namespace detail
         scheduling_counters(std::int64_t& executed_threads,
                 std::int64_t& executed_thread_phases,
                 std::uint64_t& tfunc_time, std::uint64_t& exec_time,
+                std::int64_t& idle_loop_count, std::int64_t& busy_loop_count,
                 std::uint8_t& is_active)
           : executed_threads_(executed_threads),
             executed_thread_phases_(executed_thread_phases),
             tfunc_time_(tfunc_time),
             exec_time_(exec_time),
+            idle_loop_count_(idle_loop_count),
+            busy_loop_count_(busy_loop_count),
             is_active_(is_active)
         {}
 
@@ -241,6 +244,8 @@ namespace hpx { namespace threads { namespace detail
         std::int64_t& executed_thread_phases_;
         std::uint64_t& tfunc_time_;
         std::uint64_t& exec_time_;
+        std::int64_t& idle_loop_count_;
+        std::int64_t& busy_loop_count_;
         std::uint8_t& is_active_;
     };
 
@@ -284,8 +289,8 @@ namespace hpx { namespace threads { namespace detail
 
 //         util::itt::frame_context fctx(domain);
 
-        std::int64_t idle_loop_count = 0;
-        std::int64_t busy_loop_count = 0;
+        std::int64_t& idle_loop_count = counters.idle_loop_count_;
+        std::int64_t& busy_loop_count = counters.busy_loop_count_;
 
         idle_collect_rate idle_rate(counters.tfunc_time_, counters.exec_time_);
         tfunc_time_wrapper tfunc_time_collector(idle_rate);

--- a/hpx/runtime/threads/detail/thread_pool.hpp
+++ b/hpx/runtime/threads/detail/thread_pool.hpp
@@ -135,6 +135,10 @@ namespace hpx { namespace threads { namespace detail
 
         std::int64_t get_scheduler_utilization() const;
 
+        std::int64_t get_idle_loop_count(std::size_t num) const;
+        std::int64_t get_busy_loop_count(std::size_t num) const;
+
+        ///////////////////////////////////////////////////////////////////////
         bool enumerate_threads(
             util::function_nonser<bool(thread_id_type)> const& f,
             thread_state_enum state = unknown) const;
@@ -228,6 +232,8 @@ namespace hpx { namespace threads { namespace detail
         // tfunc_impl timers
         std::vector<std::uint64_t> exec_times_, tfunc_times_;
         std::vector<std::uint64_t> reset_tfunc_times_;
+
+        std::vector<std::int64_t> idle_loop_counts_, busy_loop_counts_;
 
         std::vector<std::uint8_t> tasks_active_;
 

--- a/hpx/runtime/threads/threadmanager_impl.hpp
+++ b/hpx/runtime/threads/threadmanager_impl.hpp
@@ -316,6 +316,11 @@ namespace hpx { namespace threads
         naming::gid_type scheduler_utilization_counter_creator(
             performance_counters::counter_info const& info, error_code& ec);
 
+        naming::gid_type idle_loop_count_counter_creator(
+            performance_counters::counter_info const& info, error_code& ec);
+        naming::gid_type busy_loop_count_counter_creator(
+            performance_counters::counter_info const& info, error_code& ec);
+
     private:
         mutable mutex_type mtx_;   // mutex protecting the members
 

--- a/src/runtime/threads/detail/thread_pool.cpp
+++ b/src/runtime/threads/detail/thread_pool.cpp
@@ -314,6 +314,9 @@ namespace hpx { namespace threads { namespace detail
         tfunc_times_.resize(num_threads);
         exec_times_.resize(num_threads);
 
+        idle_loop_counts_.resize(num_threads);
+        busy_loop_counts_.resize(num_threads);
+
         reset_tfunc_times_.resize(num_threads);
 
         tasks_active_.resize(num_threads);
@@ -623,6 +626,7 @@ namespace hpx { namespace threads { namespace detail
                         executed_threads_[num_thread],
                         executed_thread_phases_[num_thread],
                         tfunc_times_[num_thread], exec_times_[num_thread],
+                        idle_loop_counts_[num_thread], busy_loop_counts_[num_thread],
                         tasks_active_[num_thread]);
 
                     detail::scheduling_callbacks callbacks(
@@ -1404,6 +1408,27 @@ namespace hpx { namespace threads { namespace detail
     }
 #endif
 
+    template <typename Scheduler>
+    std::int64_t thread_pool<Scheduler>::get_idle_loop_count(std::size_t num) const
+    {
+        if (num == std::size_t(-1))
+        {
+            return std::accumulate(idle_loop_counts_.begin(),
+                idle_loop_counts_.end(), 0ll);
+        }
+        return idle_loop_counts_[num];
+    }
+
+    template <typename Scheduler>
+    std::int64_t thread_pool<Scheduler>::get_busy_loop_count(std::size_t num) const
+    {
+        if (num == std::size_t(-1))
+        {
+            return std::accumulate(busy_loop_counts_.begin(),
+                busy_loop_counts_.end(), 0ll);
+        }
+        return busy_loop_counts_[num];
+    }
 }}}
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/runtime/threads/executors/this_thread_executors.cpp
+++ b/src/runtime/threads/executors/this_thread_executors.cpp
@@ -330,11 +330,13 @@ namespace hpx { namespace threads { namespace executors { namespace detail
             // FIXME: turn these values into performance counters
             std::int64_t executed_threads = 0, executed_thread_phases = 0;
             std::uint64_t overall_times = 0, thread_times = 0;
+            std::int64_t idle_loop_count = 0, busy_loop_count = 0;
             std::uint8_t task_active = 0;
 
             threads::detail::scheduling_counters counters(
                 executed_threads, executed_thread_phases,
-                overall_times, thread_times, task_active);
+                overall_times, thread_times, idle_loop_count, busy_loop_count,
+                task_active);
 
             threads::detail::scheduling_callbacks callbacks(
                 threads::detail::scheduling_callbacks::callback_type(),

--- a/src/runtime/threads/executors/thread_pool_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_executors.cpp
@@ -330,11 +330,13 @@ namespace hpx { namespace threads { namespace executors { namespace detail
             // FIXME: turn these values into performance counters
             std::int64_t executed_threads = 0, executed_thread_phases = 0;
             std::uint64_t overall_times = 0, thread_times = 0;
+            std::int64_t idle_loop_count = 0, busy_loop_count = 0;
             std::uint8_t task_active = 0;
 
             threads::detail::scheduling_counters counters(
                 executed_threads, executed_thread_phases,
-                overall_times, thread_times, task_active);
+                overall_times, thread_times, idle_loop_count, busy_loop_count,
+                task_active);
 
             threads::detail::scheduling_callbacks callbacks(
                 threads::detail::scheduling_callbacks::callback_type(),


### PR DESCRIPTION
Those counters are available as
```
/scheduler{counter-instance}/idle-loop-count/instantaneous
/scheduler{counter-instance}/busy-loop-count/instantaneous
```
where `counter-instance` could be `locality#N/total` or `locality#N/worker-thread#M`.
