### PR TITLE
Adding new command line option --hpx:print-counter-reset

### DIFF
--- a/docs/manual/commandline.qbk
+++ b/docs/manual/commandline.qbk
@@ -130,6 +130,10 @@ described in the table below:
     [[`--hpx:print-counter`]    [print the specified performance counter either
         repeatedly and/or at the times specified by `--hpx:print-counter-at`
         (see also option `--hpx:print-counter-interval`)]]
+    [[`--hpx:print-counter-reset`] [print the specified performance counter either
+        repeatedly and/or at the times specified by `--hpx:print-counter-at`,
+        reset the counter after the value is queried.
+        (see also option `--hpx:print-counter-interval`)]]
     [[`--hpx:print-counter-interval`][print the performance counter(s)
         specified with `--hpx:print-counter` repeatedly after the time interval
         (specified in milliseconds), (default: 0, which means print once at
@@ -156,8 +160,12 @@ described in the table below:
     [[`--hpx:printer-counter-at arg`][print the performance counter(s)
         specified with `--hpx:print-counter` at the given point in time,
         possible argument values: `startup`, `shutdown` (default), `noshutdown`]]
-    [[`--hpx:reset-counters`][reset the performance counter(s) specified with
+    [[`--hpx:reset-counters`][reset all performance counter(s) specified with
         `--hpx:print-counter` after they have been evaluated]]
+    [[`--hpx:print-counter-at`][print the performance counter(s) specified with
+        `--hpx:print-counter` (or `--hpx:print-counter-reset`) at the given
+        point in time, possible argument are values: 'startup',
+        'shutdown' (default), 'noshutdown'.]]
 ]
 
 [heading Command Line Argument Shortcuts]

--- a/hpx/performance_counters/performance_counter_set.hpp
+++ b/hpx/performance_counters/performance_counter_set.hpp
@@ -16,6 +16,7 @@
 #include <hpx/util/unwrapped.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>
@@ -36,14 +37,17 @@ namespace hpx { namespace performance_counters
 
         /// Create a set of performance counters from a name, possibly
         /// containing wild-card characters
-        performance_counter_set(std::string const& names);
-        performance_counter_set(std::vector<std::string> const& names);
+        explicit performance_counter_set(std::string const& names,
+            bool reset = false);
+        explicit performance_counter_set(std::vector<std::string> const& names,
+            bool reset = false);
 
         /// Add more performance counters to the set based on the given name,
         /// possibly containing wild-card characters
-        void add_counters(std::string const& names, error_code& ec = throws);
-        void add_counters(std::vector<std::string> const& names,
+        void add_counters(std::string const& names, bool reset = false,
             error_code& ec = throws);
+        void add_counters(std::vector<std::string> const& names,
+            bool reset = false, error_code& ec = throws);
 
         /// Retrieve the counter infos for all counters in this set
         std::vector<counter_info> get_counter_infos() const;
@@ -95,7 +99,7 @@ namespace hpx { namespace performance_counters
         }
 
     protected:
-        bool find_counter(counter_info const& info, error_code& ec);
+        bool find_counter(counter_info const& info, bool reset, error_code& ec);
 
         template <typename T>
         static std::vector<T> extract_values(
@@ -113,6 +117,7 @@ namespace hpx { namespace performance_counters
 
         std::vector<counter_info> infos_;     // counter instance names
         std::vector<naming::id_type> ids_;    // global ids of counter instances
+        std::vector<std::uint8_t> reset_;     // != 0 if counter should be reset
     };
 }}
 

--- a/hpx/util/query_counters.hpp
+++ b/hpx/util/query_counters.hpp
@@ -34,6 +34,7 @@ namespace hpx { namespace util
 
     public:
         query_counters(std::vector<std::string> const& names,
+            std::vector<std::string> const& reset_names,
             std::int64_t interval, std::string const& dest,
             std::string const& form, std::vector<std::string> const& shortnames,
             bool csv_header);
@@ -99,6 +100,7 @@ namespace hpx { namespace util
         mutex_type mtx_;
 
         std::vector<std::string> names_;
+        std::vector<std::string> reset_names_;
         performance_counters::performance_counter_set counters_;
 
         std::string destination_;

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -870,7 +870,7 @@ namespace hpx { namespace util
         }
 
         // if any counters have to be evaluated, always print at the end
-        if (vm.count("hpx:print-counter"))
+        if (vm.count("hpx:print-counter") || vm.count("hpx:print-counter-reset"))
         {
             if (!noshutdown_evaluate)
                 ini_config += "hpx.print_counter.shutdown!=1";

--- a/src/util/parse_command_line.cpp
+++ b/src/util/parse_command_line.cpp
@@ -343,8 +343,8 @@ namespace hpx { namespace util
                 hpx_options.add_options()
                     ("hpx:worker", "run this instance in worker mode")
                     ("hpx:console", "run this instance in console mode")
-                    ("hpx:connect", "run this instance in worker mode,\
-                         but connecting late")
+                    ("hpx:connect", "run this instance in worker mode, "
+                         "but connecting late")
                 ;
                 break;
 
@@ -357,8 +357,8 @@ namespace hpx { namespace util
                 hidden_options.add_options()
                     ("hpx:worker", "run this instance in worker mode")
                     ("hpx:console", "run this instance in console mode")
-                    ("hpx:connect", "run this instance in worker mode,\
-                        but connecting late")
+                    ("hpx:connect", "run this instance in worker mode, "
+                        "but connecting late")
                 ;
                 break;
 
@@ -515,9 +515,15 @@ namespace hpx { namespace util
                 "HPX options related to performance counters");
             counter_options.add_options()
                 ("hpx:print-counter", value<std::vector<std::string> >()->composing(),
-                  "print the specified performance counter either repeatedly or "
-                  "before shutting down the system \
-                     (see option --hpx:print-counter-interval)")
+                  "print the specified performance counter either repeatedly "
+                  "and/or at the times specified by --hpx:print-counter-at "
+                    "(see also option --hpx:print-counter-interval)")
+                ("hpx:print-counter-reset",
+                        value<std::vector<std::string> >()->composing(),
+                  "print the specified performance counter either repeatedly "
+                  "and/or at the times specified by --hpx:print-counter-at, "
+                    "reset the counter after the "
+                    "value is queried (see also option --hpx:print-counter-interval)")
                 ("hpx:print-counter-interval", value<std::size_t>(),
                   "print the performance counter(s) specified with --hpx:print-counter "
                   "repeatedly after the time interval (specified in milliseconds) "
@@ -552,10 +558,11 @@ namespace hpx { namespace util
                 ("hpx:print-counter-at",
                     value<std::vector<std::string> >()->composing(),
                   "print the performance counter(s) specified with "
-                  "--hpx:print-counter at the given point in time, possible "
+                  "--hpx:print-counter (or --hpx:print-counter-reset) at the given "
+                  "point in time, possible "
                   "argument values: 'startup', 'shutdown' (default), 'noshutdown'")
                 ("hpx:reset-counters",
-                  "reset the performance counter(s) specified with --hpx:print-counter "
+                  "reset all performance counter(s) specified with --hpx:print-counter "
                   "after they have been evaluated")
             ;
 

--- a/src/util/query_counters.cpp
+++ b/src/util/query_counters.cpp
@@ -74,23 +74,12 @@ namespace hpx { namespace util
             typedef std::map<std::string, util::itt::counter>::value_type
                 value_type;
 
-            for (auto const& name : names_)
+            for (auto const& info : counters_.get_counter_infos())
             {
                 std::string real_name =
-                    performance_counters::remove_counter_prefix(name);
+                    performance_counters::remove_counter_prefix(info.fullname_);
                 itt_counters_.insert(
-                    value_type(name, util::itt::counter(
-                        real_name.c_str(), hpx::get_thread_name().c_str(),
-                        __itt_metadata_double
-                    ))
-                );
-            }
-            for (auto const& name : reset_names_)
-            {
-                std::string real_name =
-                    performance_counters::remove_counter_prefix(name);
-                itt_counters_.insert(
-                    value_type(name, util::itt::counter(
+                    value_type(info.fullname_, util::itt::counter(
                         real_name.c_str(), hpx::get_thread_name().c_str(),
                         __itt_metadata_double
                     ))

--- a/src/util/query_counters.cpp
+++ b/src/util/query_counters.cpp
@@ -10,6 +10,7 @@
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/runtime/agas/interface.hpp>
 #include <hpx/runtime/config_entry.hpp>
+#include <hpx/runtime/get_thread_name.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
 #include <hpx/util/apex.hpp>
@@ -39,9 +40,11 @@
 namespace hpx { namespace util
 {
     query_counters::query_counters(std::vector<std::string> const& names,
+            std::vector<std::string> const& reset_names,
             std::int64_t interval, std::string const& dest, std::string const& form,
             std::vector<std::string> const& shortnames, bool csv_header)
-      : names_(names), destination_(dest), format_(form),
+      : names_(names), reset_names_(reset_names),
+        destination_(dest), format_(form),
         counter_shortnames_(shortnames), csv_header_(csv_header),
         timer_(util::bind(&query_counters::evaluate, this_()),
             util::bind(&query_counters::terminate, this_()),
@@ -52,11 +55,18 @@ namespace hpx { namespace util
         {
             performance_counters::ensure_counter_prefix(name);
         }
+        for (std::string& name : reset_names_)
+        {
+            performance_counters::ensure_counter_prefix(name);
+        }
     }
 
     void query_counters::find_counters()
     {
-        counters_.add_counters(names_);
+        if (!names_.empty())
+            counters_.add_counters(names_);
+        if (!reset_names_.empty())
+            counters_.add_counters(reset_names_, true);
 
 #if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
         if (use_ittnotify_api)
@@ -70,7 +80,18 @@ namespace hpx { namespace util
                     performance_counters::remove_counter_prefix(name);
                 itt_counters_.insert(
                     value_type(name, util::itt::counter(
-                        real_name.c_str(), "evaluate_counters",
+                        real_name.c_str(), hpx::get_thread_name().c_str(),
+                        __itt_metadata_double
+                    ))
+                );
+            }
+            for (auto const& name : reset_names_)
+            {
+                std::string real_name =
+                    performance_counters::remove_counter_prefix(name);
+                itt_counters_.insert(
+                    value_type(name, util::itt::counter(
+                        real_name.c_str(), hpx::get_thread_name().c_str(),
                         __itt_metadata_double
                     ))
                 );


### PR DESCRIPTION
- this is similar to `--hpx:print-counter` except that it additionally resets the counter after it was queried
- flyby: fix ITT domain for itt-counter