### PR TITLE
Enable controlling amount of pending threads which must be available to allow thread stealing

### DIFF
--- a/docs/manual/config_defaults.qbk
+++ b/docs/manual/config_defaults.qbk
@@ -175,7 +175,8 @@ by section basis below.
 [teletype]
 ``
     [hpx.thread_queue]
-    min_tasks_to_steal = ${HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL:10}
+    min_tasks_to_steal_pending = ${HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_PENDING:0}
+    min_tasks_to_steal_staged = ${HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_STAGED:10}
     min_add_new_count = ${HPX_THREAD_QUEUE_MIN_ADD_NEW_COUNT:10}
     max_add_new_count = ${HPX_THREAD_QUEUE_MAX_ADD_NEW_COUNT:10}
     max_delete_count = ${HPX_THREAD_QUEUE_MAX_DELETE_COUNT:1000}
@@ -184,9 +185,15 @@ by section basis below.
 
 [table:ini_hpx_thread_queue
     [[Property]                 [Description]]
-    [[`hpx.thread_queue.min_tasks_to_steal`]
-     [The value of this property defines the number __hpx__ tasks have to be
-      available before neighboring cores are allowed to steal work.]]
+    [[`hpx.thread_queue.min_tasks_to_steal_pending`]
+     [The value of this property defines the number of pending __hpx__ threads
+      which have to be available before neighboring cores are allowed to steal
+      work. The default is to allow stealing always.]]
+    [[`hpx.thread_queue.min_tasks_to_steal_staged`]
+     [The value of this property defines the number of staged __hpx__ tasks have
+      which to be available before neighboring cores are allowed to steal work.
+      The default is to allow stealing only if there are more tan 10 tasks
+      available.]]
     [[`hpx.thread_queue.min_add_new_count`]
      [The value of this property defines the minimal number tasks to be
       converted into __hpx__ threads whenever the thread queues for a core have

--- a/hpx/runtime/threads/policies/hierarchy_scheduler.hpp
+++ b/hpx/runtime/threads/policies/hierarchy_scheduler.hpp
@@ -650,7 +650,7 @@ namespace hpx { namespace threads { namespace policies
 
         /// Return the next thread to be executed, return false if none is
         /// available
-        bool get_next_thread(std::size_t num_thread,
+        bool get_next_thread(std::size_t num_thread, bool running,
             std::int64_t& idle_loop_count, threads::thread_data*& thrd)
         {
             HPX_ASSERT(tree.size());

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -490,7 +490,7 @@ namespace hpx { namespace threads { namespace policies
 
         /// Return the next thread to be executed, return false if none is
         /// available
-        virtual bool get_next_thread(std::size_t num_thread,
+        virtual bool get_next_thread(std::size_t num_thread, bool running,
             std::int64_t& idle_loop_count, threads::thread_data*& thrd)
         {
             std::size_t queues_size = queues_.size();
@@ -503,7 +503,8 @@ namespace hpx { namespace threads { namespace policies
             if (num_thread < high_priority_queues)
             {
                 this_high_priority_queue = high_priority_queues_[num_thread];
-                bool result = this_high_priority_queue->get_next_thread(thrd);
+                bool result =
+                    this_high_priority_queue->get_next_thread(thrd);
 
                 this_high_priority_queue->increment_num_pending_accesses();
                 if (result)
@@ -535,7 +536,7 @@ namespace hpx { namespace threads { namespace policies
                     num_thread < high_priority_queues)
                 {
                     thread_queue_type* q = high_priority_queues_[idx];
-                    if (q->get_next_thread(thrd))
+                    if (q->get_next_thread(thrd, running))
                     {
                         q->increment_num_stolen_from_pending();
                         this_high_priority_queue->
@@ -544,7 +545,7 @@ namespace hpx { namespace threads { namespace policies
                     }
                 }
 
-                if (queues_[idx]->get_next_thread(thrd))
+                if (queues_[idx]->get_next_thread(thrd, running))
                 {
                     queues_[idx]->increment_num_stolen_from_pending();
                     this_queue->increment_num_stolen_to_pending();

--- a/hpx/runtime/threads/policies/local_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_queue_scheduler.hpp
@@ -319,7 +319,7 @@ namespace hpx { namespace threads { namespace policies
 
         /// Return the next thread to be executed, return false if none is
         /// available
-        virtual bool get_next_thread(std::size_t num_thread,
+        virtual bool get_next_thread(std::size_t num_thread, bool running,
             std::int64_t& idle_loop_count, threads::thread_data*& thrd)
         {
             std::size_t queues_size = queues_.size();
@@ -368,7 +368,7 @@ namespace hpx { namespace threads { namespace policies
                             continue;
 
                         thread_queue_type* q = queues_[idx];
-                        if (q->get_next_thread(thrd))
+                        if (q->get_next_thread(thrd, running))
                         {
                             q->increment_num_stolen_from_pending();
                             queues_[num_thread]->increment_num_stolen_to_pending();
@@ -397,7 +397,7 @@ namespace hpx { namespace threads { namespace policies
                             continue;
 
                         thread_queue_type* q = queues_[idx];
-                        if (q->get_next_thread(thrd))
+                        if (q->get_next_thread(thrd, running))
                         {
                             q->increment_num_stolen_from_pending();
                             queues_[num_thread]->increment_num_stolen_to_pending();
@@ -418,7 +418,7 @@ namespace hpx { namespace threads { namespace policies
                     HPX_ASSERT(idx != num_thread);
 
                     thread_queue_type* q = queues_[idx];
-                    if (q->get_next_thread(thrd))
+                    if (q->get_next_thread(thrd, running))
                     {
                         q->increment_num_stolen_from_pending();
                         queues_[num_thread]->increment_num_stolen_to_pending();

--- a/hpx/runtime/threads/policies/scheduler_base.hpp
+++ b/hpx/runtime/threads/policies/scheduler_base.hpp
@@ -272,7 +272,7 @@ namespace hpx { namespace threads { namespace policies
             thread_state_enum initial_state, bool run_now, error_code& ec,
             std::size_t num_thread) = 0;
 
-        virtual bool get_next_thread(std::size_t num_thread,
+        virtual bool get_next_thread(std::size_t num_thread, bool running,
             std::int64_t& idle_loop_count, threads::thread_data*& thrd) = 0;
 
         virtual void schedule_thread(threads::thread_data* thrd,

--- a/hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp
@@ -65,7 +65,7 @@ namespace hpx { namespace threads { namespace policies
 
         /// Return the next thread to be executed, return false if non is
         /// available
-        bool get_next_thread(std::size_t num_thread,
+        bool get_next_thread(std::size_t num_thread, bool running,
             std::int64_t& idle_loop_count, threads::thread_data*& thrd)
         {
             std::size_t queues_size = this->queues_.size();

--- a/hpx/runtime/threads/policies/static_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/static_queue_scheduler.hpp
@@ -74,7 +74,7 @@ namespace hpx { namespace threads { namespace policies
 
         /// Return the next thread to be executed, return false if none is
         /// available
-        virtual bool get_next_thread(std::size_t num_thread,
+        virtual bool get_next_thread(std::size_t num_thread, bool,
             std::int64_t& idle_loop_count, threads::thread_data*& thrd)
         {
             typedef typename base_type::thread_queue_type thread_queue_type;

--- a/hpx/runtime/threads/policies/throttle_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/throttle_queue_scheduler.hpp
@@ -122,7 +122,7 @@ namespace hpx { namespace threads { namespace policies
 
         /// Return the next thread to be executed, return false if none is
         /// available
-        virtual bool get_next_thread(std::size_t num_thread,
+        virtual bool get_next_thread(std::size_t num_thread, bool running,
             std::int64_t& idle_loop_count, threads::thread_data*& thrd)
         {
             bool ret = throttle(num_thread, apex_current_threads_ <
@@ -131,7 +131,7 @@ namespace hpx { namespace threads { namespace policies
 
             // grab work if available
             return this->base_type::get_next_thread(
-                num_thread, idle_loop_count, thrd);
+                num_thread, running, idle_loop_count, thrd);
         }
 
     protected:

--- a/src/util/runtime_configuration.cpp
+++ b/src/util/runtime_configuration.cpp
@@ -219,7 +219,10 @@ namespace hpx { namespace util
                 BOOST_PP_STRINGIZE(HPX_NUM_TIMER_POOL_SIZE) "}",
 
             "[hpx.thread_queue]",
-            "min_tasks_to_steal = ${HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL:10}",
+            "min_tasks_to_steal_pending = "
+                "${HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_PENDING:0}",
+            "min_tasks_to_steal_staged = "
+                "${HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_STAGED:10}",
             "min_add_new_count = ${HPX_THREAD_QUEUE_MIN_ADD_NEW_COUNT:10}",
             "max_add_new_count = ${HPX_THREAD_QUEUE_MAX_ADD_NEW_COUNT:10}",
             "max_delete_count = ${HPX_THREAD_QUEUE_MAX_DELETE_COUNT:1000}",


### PR DESCRIPTION
- this value is exposed as `hpx.thread_queue.min_tasks_to_steal_pending`, default is zero
- flyby: renamed the same value for staged tasks to `hpx.thread_queue.min_tasks_to_steal_staged`
