### PR TITLE
Fix tuple serialization

### DIFF
--- a/hpx/plugins/parcelport/mpi/receiver.hpp
+++ b/hpx/plugins/parcelport/mpi/receiver.hpp
@@ -174,7 +174,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
             int ret = 0;
             ret = MPI_Test(&r, &completed, status);
             HPX_ASSERT(ret == MPI_SUCCESS);
-            if(completed)// && status->MPI_ERROR != MPI_ERR_PENDING)
+            if(completed)
             {
                 return true;
             }

--- a/hpx/plugins/parcelport/mpi/receiver_connection.hpp
+++ b/hpx/plugins/parcelport/mpi/receiver_connection.hpp
@@ -229,7 +229,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
             int ret = 0;
             ret = MPI_Test(request_ptr_, &completed, MPI_STATUS_IGNORE);
             HPX_ASSERT(ret == MPI_SUCCESS);
-            if(completed)// && status.MPI_ERROR != MPI_ERR_PENDING)
+            if(completed)
             {
                 request_ptr_ = nullptr;
                 return true;

--- a/hpx/plugins/parcelport/mpi/sender_connection.hpp
+++ b/hpx/plugins/parcelport/mpi/sender_connection.hpp
@@ -248,8 +248,6 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
                 chunks_idx_++;
             }
 
-            if(!request_done()) return false;
-
             state_ = sent_chunks;
 
             return done();
@@ -266,6 +264,8 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
             pp_->add_sent_data(buffer_.data_point_);
             buffer_.clear();
 
+            state_ = initialized;
+
             return true;
         }
 
@@ -281,7 +281,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
             int ret = 0;
             ret = MPI_Test(request_ptr_, &completed, MPI_STATUS_IGNORE);
             HPX_ASSERT(ret == MPI_SUCCESS);
-            if(completed)// && status.MPI_ERROR != MPI_ERR_PENDING)
+            if(completed)
             {
                 request_ptr_ = nullptr;
                 return true;

--- a/hpx/plugins/parcelport/mpi/tag_provider.hpp
+++ b/hpx/plugins/parcelport/mpi/tag_provider.hpp
@@ -47,9 +47,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
         {
             HPX_ASSERT(tag > 1);
             std::lock_guard<mutex_type> l(mtx_);
-            HPX_ASSERT(tag <= next_tag_);
-
-            if(tag == next_tag_) return;
+            HPX_ASSERT(tag < next_tag_);
 
             free_tags_.push_back(tag);
         }

--- a/hpx/runtime/actions/basic_action.hpp
+++ b/hpx/runtime/actions/basic_action.hpp
@@ -104,8 +104,6 @@ namespace hpx { namespace actions
                 LTM_(debug) << "Executing " << Action::get_action_name(lva_)
                     << " with continuation(" << cont_.get_id() << ")";
 
-                typedef typename Action::local_result_type local_result_type;
-
                 actions::trigger(std::move(cont_), f_);
                 return threads::thread_result_type(threads::terminated, nullptr);
             }

--- a/hpx/runtime/actions/trigger.hpp
+++ b/hpx/runtime/actions/trigger.hpp
@@ -70,8 +70,6 @@ namespace hpx { namespace actions {
             auto result = util::invoke(std::forward<F>(f),
                 std::forward<Ts>(vs)...);
 
-            typedef typename hpx::util::decay<decltype(result)>::type future_type;
-
             deferred_trigger trigger;
 
             if(result.is_ready())

--- a/hpx/runtime/agas/component_namespace.hpp
+++ b/hpx/runtime/agas/component_namespace.hpp
@@ -46,7 +46,7 @@ namespace hpx { namespace agas
         virtual lcos::future<std::uint32_t>
         get_num_localities(components::component_type type)=0;
 
-        virtual naming::gid_type statistics_counter(std::string const& name)=0;;
+        virtual naming::gid_type statistics_counter(std::string const& name)=0;
 
         virtual void register_counter_types()
         {}

--- a/hpx/traits/get_function_address.hpp
+++ b/hpx/traits/get_function_address.hpp
@@ -60,8 +60,8 @@ namespace hpx { namespace traits
 #  pragma clang diagnostic ignored "-Wstrict-aliasing"
 #endif
 
-#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__NVCC__) && \
-    !defined(__CUDACC__)
+#if defined(__GNUG__) && !defined(__INTEL_COMPILER) &&  \
+    (!defined(__NVCC__) || (__CUDACC_VER_MAJOR__ >= 8))
 #  if defined(HPX_GCC_DIAGNOSTIC_PRAGMA_CONTEXTS)
 #    pragma GCC diagnostic push
 #  endif
@@ -70,8 +70,8 @@ namespace hpx { namespace traits
 
             return reinterpret_cast<std::size_t>(*reinterpret_cast<void**>(&f));
 
-#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__NVCC__) && \
-    !defined(__CUDACC__)
+#if defined(__GNUG__) && !defined(__INTEL_COMPILER) &&  \
+    (!defined(__NVCC__) || (__CUDACC_VER_MAJOR__ >= 8))
 #if defined(HPX_GCC_DIAGNOSTIC_PRAGMA_CONTEXTS)
 #pragma GCC diagnostic pop
 #endif
@@ -93,8 +93,8 @@ namespace hpx { namespace traits
 #  pragma clang diagnostic ignored "-Wstrict-aliasing"
 #endif
 
-#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__NVCC__) && \
-    !defined(__CUDACC__)
+#if defined(__GNUG__) && !defined(__INTEL_COMPILER) &&  \
+    (!defined(__NVCC__) || (__CUDACC_VER_MAJOR__ >= 8))
 #  if defined(HPX_GCC_DIAGNOSTIC_PRAGMA_CONTEXTS)
 #    pragma GCC diagnostic push
 #  endif
@@ -103,8 +103,8 @@ namespace hpx { namespace traits
 
             return reinterpret_cast<std::size_t>(*reinterpret_cast<void**>(&f));
 
-#if defined(__GNUG__) && !defined(__INTEL_COMPILER) && !defined(__NVCC__) && \
-    !defined(__CUDACC__)
+#if defined(__GNUG__) && !defined(__INTEL_COMPILER) &&  \
+    (!defined(__NVCC__) || (__CUDACC_VER_MAJOR__ >= 8))
 #if defined(HPX_GCC_DIAGNOSTIC_PRAGMA_CONTEXTS)
 #pragma GCC diagnostic pop
 #endif

--- a/hpx/util/tuple.hpp
+++ b/hpx/util/tuple.hpp
@@ -1008,9 +1008,9 @@ namespace hpx { namespace util
 namespace hpx { namespace traits
 {
     ///////////////////////////////////////////////////////////////////////////
-    template <typename ...Ts>
+    template <typename Is, typename ...Ts>
     struct is_bitwise_serializable<
-        ::hpx::util::tuple<Ts...>
+        ::hpx::util::detail::tuple_impl<Is, Ts...>
     > : ::hpx::util::detail::all_of<
             hpx::traits::is_bitwise_serializable<Ts>...
         >
@@ -1028,7 +1028,7 @@ namespace hpx { namespace serialization
       , unsigned int const version = 0
     )
     {
-        t._impl.serialize(ar, version);
+        ar & t._impl;
     }
 
     template <typename Archive>


### PR DESCRIPTION
Only tuple_impl<Is, Ts...> should be bitwise serialized

Flyby: Cleaning up MPI parcelport.