### PR TITLE
Added documentation for debugging with core files

### DIFF
--- a/docs/manual/build_system.qbk
+++ b/docs/manual/build_system.qbk
@@ -108,6 +108,31 @@ for more information.
 In order to enable full static linking with the __libraries, the __cmake__ variable
 `HPX_WITH_STATIC_LINKING` has to be set to `On`.
 
+[heading:debugging_core Debugging applications using core files]
+
+For __hpx__ to generate useful core files, __hpx__ has to be compiled without signal and exception handlers
+(`HPX_WITH_DISABLED_SIGNAL_EXCEPTION_HANDLERS`). If this option is not specified, the signal handlers
+change the application state. For example, after a segmentation fault the stack trace will show the signal
+handler. Similarly, unhandled exceptions are also caught by the these handlers and the stack trace will not
+point to the location where the unhandled exception was thrown.
+
+In general, core files are a helpful tool to inspect the state of the application at the moment of the crash
+(post-mortem debugging), without the need of attaching a debugger beforehand. This approach to debugging
+is especially useful if the error cannot be reliably reproduced, as only a single crashed application run
+is required to gain potentially helpful information like a stacktrace.
+
+To debug with core files, the operating system first has to be told to actually write them. On most unix systems this can be done by calling
+
+``
+    ulimit -c unlimited
+``
+in the shell. Now the debugger can be started up with:
+``
+        gdb <application> <core file name>
+``
+The debugger should now display the last state of the application. The default file name for core files is `core`.
+
+
 [include build_system/cmake_variables.qbk]
 [include build_system/cmake_toolchains.qbk]
 


### PR DESCRIPTION
Added a small paragraph to document signal and exception disable switch of the build system. And more general, how to debug an hpx application with the help of a core file.

I'm pretty sure I didn't put that into a file where it really makes sense, I'm creating this pull request to get the process started.

(Also, Circle CI will likely complain, I couldn't get the documentation creation set up on my system.)