### PR TITLE
Fixing bit-wise (zero-copy) serialization

### DIFF
--- a/hpx/compute/serialization/vector.hpp
+++ b/hpx/compute/serialization/vector.hpp
@@ -82,7 +82,9 @@ namespace hpx { namespace serialization
     {
         typedef std::integral_constant<bool,
             hpx::traits::is_bitwise_serializable<
-                typename compute::vector<T, Allocator>::value_type
+                typename std::remove_const<
+                    typename compute::vector<T, Allocator>::value_type
+                >::type
             >::value> use_optimized;
 
         v.clear();
@@ -129,7 +131,9 @@ namespace hpx { namespace serialization
     {
         typedef std::integral_constant<bool,
             hpx::traits::is_bitwise_serializable<
-                typename compute::vector<T, Allocator>::value_type
+                typename std::remove_const<
+                    typename compute::vector<T, Allocator>::value_type
+                >::type
             >::value> use_optimized;
 
         ar << v.size(); //-V128

--- a/hpx/runtime/serialization/array.hpp
+++ b/hpx/runtime/serialization/array.hpp
@@ -66,7 +66,9 @@ namespace hpx { namespace serialization
         void serialize(Archive& ar, unsigned int v)
         {
             typedef std::integral_constant<bool,
-                hpx::traits::is_bitwise_serializable<T>::value> use_optimized;
+                hpx::traits::is_bitwise_serializable<
+                    typename std::remove_const<T>::type
+                >::value> use_optimized;
 
 #ifdef BOOST_BIG_ENDIAN
             bool archive_endianess_differs = ar.endian_little();

--- a/hpx/runtime/serialization/complex.hpp
+++ b/hpx/runtime/serialization/complex.hpp
@@ -10,6 +10,7 @@
 #include <hpx/traits/is_bitwise_serializable.hpp>
 
 #include <complex>
+#include <type_traits>
 
 namespace hpx { namespace serialization
 {
@@ -33,7 +34,7 @@ namespace hpx { namespace traits
 {
     template <typename T>
     struct is_bitwise_serializable<std::complex<T> >
-      : is_bitwise_serializable<T>
+      : is_bitwise_serializable<typename std::remove_const<T>::type>
     {};
 }}
 

--- a/hpx/runtime/serialization/detail/boost_simd.hpp
+++ b/hpx/runtime/serialization/detail/boost_simd.hpp
@@ -14,6 +14,7 @@
 #include <hpx/traits/is_bitwise_serializable.hpp>
 
 #include <cstddef>
+#include <type_traits>
 
 #include <boost/simd.hpp>
 
@@ -39,7 +40,7 @@ namespace hpx { namespace traits
 {
     template <typename T, std::size_t N, typename Abi>
     struct is_bitwise_serializable<boost::simd::pack<T, N, Abi> >
-      : is_bitwise_serializable<T>
+      : is_bitwise_serializable<typename std::remove_const<T>::type>
     {};
 }}
 

--- a/hpx/runtime/serialization/detail/libflatarray.hpp
+++ b/hpx/runtime/serialization/detail/libflatarray.hpp
@@ -15,6 +15,7 @@
 
 #include <array>
 #include <cstddef>
+#include <type_traits>
 
 #include <libflatarray/flat_array.hpp>
 
@@ -45,7 +46,7 @@ namespace hpx { namespace traits
 {
     template <typename T, std::size_t N>
     struct is_bitwise_serializable<LibFlatArray::short_vec<T, N> >
-      : is_bitwise_serializable<T>
+      : is_bitwise_serializable<typename std::remove_const<T>::type>
     {};
 }}
 #endif

--- a/hpx/runtime/serialization/detail/vc.hpp
+++ b/hpx/runtime/serialization/detail/vc.hpp
@@ -14,6 +14,7 @@
 #include <hpx/traits/is_bitwise_serializable.hpp>
 
 #include <cstddef>
+#include <type_traits>
 
 #include <Vc/Vc>
 
@@ -91,17 +92,17 @@ namespace hpx { namespace traits
 {
     template <typename T, typename Abi>
     struct is_bitwise_serializable<Vc::Vector<T, Abi> >
-      : is_bitwise_serializable<T>
+      : is_bitwise_serializable<typename std::remove_const<T>::type>
     {};
 
     template <typename T>
     struct is_bitwise_serializable<Vc::Scalar::Vector<T> >
-      : is_bitwise_serializable<T>
+      : is_bitwise_serializable<typename std::remove_const<T>::type>
     {};
 
     template <typename T, std::size_t N, typename V, std::size_t W>
     struct is_bitwise_serializable<Vc::SimdArray<T, N, V, W> >
-      : is_bitwise_serializable<T>
+      : is_bitwise_serializable<typename std::remove_const<T>::type>
     {};
 }}
 

--- a/hpx/runtime/serialization/map.hpp
+++ b/hpx/runtime/serialization/map.hpp
@@ -23,8 +23,8 @@ namespace hpx
         struct is_bitwise_serializable<std::pair<Key, Value> >
           : std::integral_constant<
                 bool,
-                is_bitwise_serializable<Key>::value
-             && is_bitwise_serializable<Value>::value
+                is_bitwise_serializable<typename std::remove_const<Key>::type>::value
+             && is_bitwise_serializable<typename std::remove_const<Value>::type>::value
             >
         {};
     }

--- a/hpx/runtime/serialization/vector.hpp
+++ b/hpx/runtime/serialization/vector.hpp
@@ -83,7 +83,9 @@ namespace hpx { namespace serialization
     {
         typedef std::integral_constant<bool,
             hpx::traits::is_bitwise_serializable<
-                typename std::vector<T, Allocator>::value_type
+                typename std::remove_const<
+                    typename std::vector<T, Allocator>::value_type
+                >::type
             >::value> use_optimized;
 
         v.clear();
@@ -142,7 +144,9 @@ namespace hpx { namespace serialization
     {
         typedef std::integral_constant<bool,
             hpx::traits::is_bitwise_serializable<
-                typename std::vector<T, Allocator>::value_type
+                typename std::remove_const<
+                    typename std::vector<T, Allocator>::value_type
+                >::type
             >::value> use_optimized;
 
         ar << v.size(); //-V128

--- a/hpx/util/tuple.hpp
+++ b/hpx/util/tuple.hpp
@@ -1012,7 +1012,9 @@ namespace hpx { namespace traits
     struct is_bitwise_serializable<
         ::hpx::util::detail::tuple_impl<Is, Ts...>
     > : ::hpx::util::detail::all_of<
-            hpx::traits::is_bitwise_serializable<Ts>...
+            hpx::traits::is_bitwise_serializable<
+                typename std::remove_const<Ts>::type
+            >...
         >
     {};
 }}

--- a/src/runtime/naming/address.cpp
+++ b/src/runtime/naming/address.cpp
@@ -8,7 +8,6 @@
 #include <hpx/throw_exception.hpp>
 #include <hpx/runtime/components/component_type.hpp>
 #include <hpx/runtime/serialization/serialize.hpp>
-#include <hpx/traits/is_bitwise_serializable.hpp>
 
 #include <boost/io/ios_state.hpp>
 


### PR DESCRIPTION
This fixes a whole set of problems we were seeing lately. This is an important patch which should be merged as soon as possible.