### PR TITLE
MPI Parcelport improvements and fixes related to the background work changes

### DIFF
--- a/hpx/plugins/parcelport/mpi/receiver.hpp
+++ b/hpx/plugins/parcelport/mpi/receiver.hpp
@@ -49,60 +49,36 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
 
         bool background_work()
         {
-            // We accept as many connections as we can ...
-            connection_list connections;
+            // We first try to accept a new connection
+            connection_ptr connection = accept();
+
+            // If we don't have a new connection, try to handle one of the
+            // already accepted ones.
+            if (!connection)
             {
                 std::unique_lock<mutex_type> l(connections_mtx_, std::try_to_lock);
                 if(l && !connections_.empty())
                 {
-                    connections.push_back(connections_.front());
+                    connection = std::move(connections_.front());
                     connections_.pop_front();
                 }
             }
 
-            connection_ptr rcv;
-//             do
-//             {
-                rcv = accept();
-                if(rcv && !rcv->receive())
-                {
-                    connections.push_back(rcv);
-                }
-//             } while(rcv);
-            rcv.reset();
-
-            if(!connections.empty())
+            if(connection)
             {
-                receive_messages(std::move(connections));
+                receive_messages(std::move(connection));
                 return true;
             }
 
             return false;
         }
 
-        void receive_messages(
-            connection_list connections
-        )
+        void receive_messages(connection_ptr connection)
         {
-            // We try to handle all receives
-            typename connection_list::iterator end = std::remove_if(
-                connections.begin()
-              , connections.end()
-              , [](connection_ptr & rcv) -> bool
-              {
-                    return rcv->receive();
-              }
-            );
-
-            // If some are still in progress, give them back
-            if(connections.begin() != end)
+            if (!connection->receive())
             {
                 std::unique_lock<mutex_type> l(connections_mtx_);
-                connections_.insert(
-                    connections_.end()
-                  , std::make_move_iterator(connections.begin())
-                  , std::make_move_iterator(end)
-                );
+                connections_.push_back(std::move(connection));
             }
         }
 

--- a/hpx/plugins/parcelport/mpi/sender.hpp
+++ b/hpx/plugins/parcelport/mpi/sender.hpp
@@ -63,52 +63,38 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
         }
 
         void send_messages(
-            connection_list connections
+            connection_ptr connection
         )
         {
-            // We try to handle all sends
-            connection_list::iterator end = std::remove_if(
-                connections.begin()
-              , connections.end()
-              , [](connection_ptr sender) -> bool
-              {
-                    if(sender->send())
-                    {
-                        error_code ec;
-                        sender->postprocess_handler_(ec, sender->destination(), sender);
-                        return true;
-                    }
-                    return false;
-              }
-            );
-
-            // If some are still in progress, give them back
-            if(connections.begin() != end)
+            // Check if sending has been completed....
+            if (connection->send())
+            {
+                error_code ec;
+                connection->postprocess_handler_(
+                    ec, connection->destination(), connection);
+            }
+            else
             {
                 std::unique_lock<mutex_type> l(connections_mtx_);
-                connections_.insert(
-                    connections_.end()
-                  , std::make_move_iterator(connections.begin())
-                  , std::make_move_iterator(end)
-                );
+                connections_.push_back(std::move(connection));
             }
         }
 
         bool background_work()
         {
-            connection_list connections;
+            connection_ptr connection;
             {
                 std::unique_lock<mutex_type> l(connections_mtx_, std::try_to_lock);
                 if(l && !connections_.empty())
                 {
-                    connections.push_back(connections_.front());
+                    connection = std::move(connections_.front());
                     connections_.pop_front();
                 }
             }
             bool has_work = false;
-            if(!connections.empty())
+            if(connection)
             {
-                send_messages(std::move(connections));
+                send_messages(std::move(connection));
                 has_work = true;
             }
             next_free_tag();

--- a/hpx/runtime/parcelset/parcelport_impl.hpp
+++ b/hpx/runtime/parcelset/parcelport_impl.hpp
@@ -44,7 +44,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx
 {
-    bool is_starting();
     bool is_stopped();
 }
 
@@ -809,31 +808,10 @@ namespace hpx { namespace parcelset
                 }
 
                 // send parcels if they didn't get sent by another connection
-                if (!hpx::is_starting())
-                {
-                    // Re-schedule if this is not executed by an HPX thread
-                    hpx::applier::register_thread_nullary(
-                        hpx::util::bind(
-                            hpx::util::one_shot(&parcelport_impl
-                                ::send_pending_parcels)
-                          , this
-                          , locality_id
-                          , sender_connection
-                          , std::move(parcels)
-                          , std::move(handlers)
-                        )
-                      , "parcelport_impl::send_pending_parcels"
-                      , threads::pending, true, threads::thread_priority_boost,
-                        get_next_num_thread(), threads::thread_stacksize_default
-                    );
-                }
-                else
-                {
-                    send_pending_parcels(
-                        locality_id,
-                        sender_connection, std::move(parcels),
-                        std::move(handlers));
-                }
+                send_pending_parcels(
+                    locality_id,
+                    sender_connection, std::move(parcels),
+                    std::move(handlers));
 
                 // We yield here for a short amount of time to give another
                 // HPX thread the chance to put a subsequent parcel which

--- a/src/lcos/barrier.cpp
+++ b/src/lcos/barrier.cpp
@@ -18,6 +18,12 @@
 #include <string>
 #include <utility>
 
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx
+{
+    bool is_stopped_or_shutting_down();
+}
+
 namespace hpx { namespace lcos {
     barrier::barrier(std::string const& base_name)
       : node_(new wrapping_type(new wrapped_type(
@@ -86,7 +92,8 @@ namespace hpx { namespace lcos {
         if (node_)
         {
             if (hpx::get_runtime_ptr() != nullptr &&
-                hpx::threads::threadmanager_is(state_running))
+                hpx::threads::threadmanager_is(state_running) &&
+                !hpx::is_stopped_or_shutting_down())
             {
                 hpx::future<void> f;
                 if ((*node_)->num_ >= (*node_)->cut_off_ || (*node_)->rank_ == 0)

--- a/tests/performance/network/CMakeLists.txt
+++ b/tests/performance/network/CMakeLists.txt
@@ -22,3 +22,34 @@ foreach(subdir ${subdirs})
   add_hpx_pseudo_dependencies(tests.performance.network tests.performance.network.${subdir}_perf)
 endforeach()
 
+set(benchmarks
+    pingpong_performance)
+
+foreach(benchmark ${benchmarks})
+
+  set(sources
+      ${benchmark}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  # add example executable
+  add_hpx_executable(${benchmark}
+                     SOURCES ${sources}
+                     ${${benchmark}_FLAGS}
+                     COMPONENT_DEPENDENCIES iostreams
+                     EXCLUDE_FROM_ALL
+                     HPX_PREFIX ${HPX_BUILD_PREFIX}
+                     FOLDER "Benchmarks/Network/${benchmark}")
+
+  # add a custom target for this example
+  add_hpx_pseudo_target(tests.performance.network.${benchmark})
+
+  # make pseudo-targets depend on master pseudo-target
+  add_hpx_pseudo_dependencies(tests.performance.network
+                              tests.performance.network.${benchmark})
+
+  # add dependencies to pseudo-target
+  add_hpx_pseudo_dependencies(tests.performance.network.${benchmark}
+                              ${benchmark}_exe)
+endforeach()
+

--- a/tests/performance/network/pingpong_performance.cpp
+++ b/tests/performance/network/pingpong_performance.cpp
@@ -1,0 +1,89 @@
+//  Copyright (c) 2017 Bibek Wagle
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/include/iostreams.hpp>
+#include <hpx/include/async.hpp>
+#include <hpx/include/serialization.hpp>
+
+#include <cstddef>
+#include <complex>
+#include <string>
+#include <vector>
+
+namespace pingpong
+{
+    namespace server
+    {
+        std::complex<double> get_element()
+        {
+            return std::complex<double>(13.3,-23.8);
+        }
+    }
+}
+
+HPX_PLAIN_ACTION(pingpong::server::get_element, pingpong_get_element_action);
+//HPX_ACTION_USES_MESSAGE_COALESCING(pingpong_get_element_action);
+
+
+int hpx_main(boost::program_options::variables_map& vm)
+{
+   //Commandline specific code
+    std::size_t const n = vm["nparcels"].as<std::size_t>();
+
+    if (0 == hpx::get_locality_id())
+    {
+        hpx::cout << "Running With nparcel = " << n << "\n" << hpx::flush;
+    }
+
+    //Create instance of the actions
+    pingpong_get_element_action act;
+    std::vector<hpx::future<std::complex<double>>> vec;
+    std::vector<std::complex<double>> recieved;
+    vec.reserve(n);
+    recieved.reserve(n);
+    //Find the other locality
+    std::vector<hpx::naming::id_type> dummy = hpx::find_remote_localities();
+    hpx::naming::id_type other_locality = dummy[0];
+
+
+    for(std::size_t i=0; i<n; ++i)
+    {
+        vec.push_back(hpx::async(act,other_locality));
+    }
+
+    hpx::when_all(vec).then(
+        [&recieved, n](hpx::future<std::vector<hpx::future<std::complex<double>>>> dummy)
+        {
+            std::vector<hpx::future<std::complex<double>>> number = dummy.get();
+            for (std::size_t i = 0; i < n; ++i)
+            {
+                recieved.push_back(number[i].get());
+            }
+            hpx::evaluate_active_counters(false, " All Futures Done");
+            hpx::cout << "Now Done With Lambda and the last recieved value is "
+                      <<recieved[n-1]<< "\n" << hpx::flush;
+        }
+    ).get();
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // Configure application-specific options
+    boost::program_options::options_description cmdline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    cmdline.add_options()
+        ("nparcels,n",
+         boost::program_options::value<std::size_t>()->default_value(100),
+         "the number of parcels to create")
+        ;
+    // Initialize and run HPX
+    std::vector<std::string> cfg;
+    cfg.push_back("hpx.run_hpx_main!=1");
+    return hpx::init(cmdline,argc, argv, cfg);
+}


### PR DESCRIPTION
This PR fixes:
 - Performance problems with the MPI Parcelport
 - Locks held during suspension for condition_variable and during migration
 - Scheduling of the background work threads