### PR TITLE
Making sure that all continuations of a shared_future are invoked in order

### DIFF
--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -269,7 +269,7 @@ namespace detail
 
         typedef lcos::local::spinlock mutex_type;
         typedef util::unused_type result_type;
-        typedef typename future_data_refcnt_base::init_no_addref init_no_addref;
+        typedef future_data_refcnt_base::init_no_addref init_no_addref;
 
         virtual ~future_data() HPX_NOEXCEPT {}
         virtual void execute_deferred(error_code& = throws) = 0;
@@ -748,8 +748,10 @@ namespace detail
             }
             else {
                 // store a combined callback wrapping the old and the new one
+                // make sure continuations are evaluated in the order they are
+                // attached
                 this->on_completed_ = compose_cb(
-                    std::move(data_sink), std::move(on_completed_));
+                    std::move(on_completed_), std::move(data_sink));
             }
         }
 

--- a/tests/regressions/lcos/CMakeLists.txt
+++ b/tests/regressions/lcos/CMakeLists.txt
@@ -31,6 +31,7 @@ set(tests
     receive_buffer_1733
     safely_destroy_promise_1481
     set_hpx_limit_798
+    shared_future_continuation_order
     shared_future_then_2166
     shared_mutex_1702
     shared_stated_leaked_1211

--- a/tests/regressions/lcos/shared_future_continuation_order.cpp
+++ b/tests/regressions/lcos/shared_future_continuation_order.cpp
@@ -1,0 +1,46 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Making sure the continuations of a shared_future are invoked in the same
+// order as they have been attached.
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <boost/atomic.hpp>
+
+boost::atomic<int> invocation_count(0);
+
+///////////////////////////////////////////////////////////////////////////////
+int main()
+{
+    hpx::lcos::local::promise<int> p;
+    hpx::shared_future<int> f1 = p.get_future();
+
+    hpx::future<int> f2 =
+        f1.then(
+            [](hpx::shared_future<int> && f)
+            {
+                HPX_TEST_EQ(f.get(), 42);
+                return ++invocation_count;
+            });
+
+    hpx::future<int> f3 =
+        f1.then(
+            [](hpx::shared_future<int> && f)
+            {
+                HPX_TEST_EQ(f.get(), 42);
+                return ++invocation_count;
+            });
+
+    p.set_value(42);
+
+    HPX_TEST_EQ(f1.get(), 1);
+    HPX_TEST_EQ(f2.get(), 2);
+
+    return hpx::util::report_errors();
+}
+


### PR DESCRIPTION
Continuations are now invoked in the same order as they were attached

- flyby: remove superfluous typename keyword

This fixes #2504