### PR TITLE
Remove warnings related to unused captured variables

### DIFF
--- a/examples/1d_stencil/1d_stencil_6.cpp
+++ b/examples/1d_stencil/1d_stencil_6.cpp
@@ -11,6 +11,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <boost/shared_array.hpp>
 
@@ -282,6 +283,9 @@ struct stepper
                 [left, middle, right](partition_data const& l, partition_data const& m,
                     partition_data const& r)
                 {
+                    HPX_UNUSED(left);
+                    HPX_UNUSED(right);
+
                     // The new partition_data will be allocated on the same locality
                     // as 'middle'.
                     return partition(middle.get_id(), heat_part_data(l, m, r));

--- a/examples/1d_stencil/1d_stencil_7.cpp
+++ b/examples/1d_stencil/1d_stencil_7.cpp
@@ -11,6 +11,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <boost/shared_array.hpp>
 
@@ -268,6 +269,8 @@ struct stepper
             unwrapped(
                 [middle](partition_data const& m) -> partition_data
                 {
+                    HPX_UNUSED(middle);
+
                     // All local operations are performed once the middle data of
                     // the previous time step becomes available.
                     std::size_t size = m.size();
@@ -285,6 +288,9 @@ struct stepper
                 [left, middle, right](partition_data next, partition_data const& l,
                     partition_data const& m, partition_data const& r) -> partition
                 {
+                    HPX_UNUSED(left);
+                    HPX_UNUSED(right);
+
                     // Calculate the missing boundary elements once the
                     // corresponding data has become available.
                     std::size_t size = m.size();

--- a/examples/1d_stencil/1d_stencil_8.cpp
+++ b/examples/1d_stencil/1d_stencil_8.cpp
@@ -12,6 +12,7 @@
 #include <hpx/hpx.hpp>
 #include <hpx/lcos/gather.hpp>
 #include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <boost/shared_array.hpp>
 
@@ -487,6 +488,8 @@ partition stepper_server::heat_part(partition const& left,
         hpx::util::unwrapped(
             [middle](partition_data const& m) -> partition_data
             {
+                HPX_UNUSED(middle);
+
                 // All local operations are performed once the middle data of
                 // the previous time step becomes available.
                 std::size_t size = m.size();
@@ -504,6 +507,9 @@ partition stepper_server::heat_part(partition const& left,
             [left, middle, right](partition_data next, partition_data const& l,
                 partition_data const& m, partition_data const& r) -> partition
             {
+                HPX_UNUSED(left);
+                HPX_UNUSED(right);
+
                 // Calculate the missing boundary elements once the
                 // corresponding data has become available.
                 std::size_t size = m.size();

--- a/examples/quickstart/shared_mutex.cpp
+++ b/examples/quickstart/shared_mutex.cpp
@@ -10,6 +10,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/threads.hpp>
 #include <hpx/include/iostreams.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <boost/atomic.hpp>
 #include <boost/random.hpp>
@@ -65,6 +66,7 @@ int main()
         threads.emplace_back(
             [&ready, &stm, k, i]
             {
+                HPX_UNUSED(k);
                 boost::random::mt19937 urng(
                     static_cast<std::uint32_t>(std::time(nullptr)));
                 boost::random::uniform_int_distribution<int> dist(1, 1000);

--- a/hpx/lcos/gather.hpp
+++ b/hpx/lcos/gather.hpp
@@ -144,6 +144,7 @@ namespace hpx { namespace lcos
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime/naming/unmanaged.hpp>
 #include <hpx/util/decay.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <boost/preprocessor/cat.hpp>
 
@@ -251,6 +252,7 @@ namespace hpx { namespace lcos
             return async(action_type(), id, site, result.get()).then(
                 [id](hpx::future<std::vector<T> > && f)
                 {
+                    HPX_UNUSED(id);
                     return f.get();
                 });
         }

--- a/hpx/parallel/util/foreach_partitioner.hpp
+++ b/hpx/parallel/util/foreach_partitioner.hpp
@@ -13,6 +13,7 @@
 #include <hpx/util/decay.hpp>
 #include <hpx/util/deferred_call.hpp>
 #include <hpx/util/tuple.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <hpx/parallel/algorithms/detail/predicates.hpp>
 #include <hpx/parallel/execution_policy.hpp>
@@ -171,6 +172,7 @@ namespace hpx { namespace parallel { namespace util
                             std::vector<hpx::future<Result> > && r2) mutable
                     ->  FwdIter
                     {
+                        HPX_UNUSED(scoped_param);
                         handle_local_exceptions<ExPolicy>::call(r1, errors);
                         handle_local_exceptions<ExPolicy>::call(r2, errors);
 

--- a/hpx/runtime/parcelset/put_parcel.hpp
+++ b/hpx/runtime/parcelset/put_parcel.hpp
@@ -21,6 +21,7 @@
 #include <hpx/util/bind.hpp>
 #include <hpx/util/decay.hpp>
 #include <hpx/util/detail/pack.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <cstddef>
 #include <memory>
@@ -134,6 +135,7 @@ namespace hpx { namespace parcelset {
                                  naming::address&& addr_,
                                  typename util::decay<Args>::type&&... args_)
                                 {
+                                    HPX_UNUSED(dest);
                                     pp_(detail::create_parcel::call(
                                         is_continuation,
                                         f.get(), std::move(addr_),

--- a/src/lcos/barrier.cpp
+++ b/src/lcos/barrier.cpp
@@ -11,6 +11,7 @@
 #include <hpx/runtime/basename_registration.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/util/runtime_configuration.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <boost/intrusive_ptr.hpp>
 
@@ -107,6 +108,7 @@ namespace hpx { namespace lcos {
                     hpx::launch::sync,
                     [node](hpx::future<void> f)
                     {
+                        HPX_UNUSED(node);
                         f.get();
                     }
                 ).get();


### PR DESCRIPTION
This patch tries to remove some warnings related to unused captured variables detected by Clang 5.0. Because most of those variables are copied via lambda capture for lifetime purpose, `HPX_UNUSED()` has been used.