### PR TITLE
Facilities to create actions from lambdas

### DIFF
--- a/hpx/include/actions.hpp
+++ b/hpx/include/actions.hpp
@@ -11,6 +11,7 @@
 #include <hpx/runtime/actions/action_invoke_no_more_than.hpp>
 #include <hpx/runtime/actions/component_action.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
+#include <hpx/runtime/actions/lambda_to_action.hpp>
 #include <hpx/runtime/actions/make_continuation.hpp>
 #include <hpx/runtime/actions/manage_object_action.hpp>
 #include <hpx/runtime/actions/plain_action.hpp>

--- a/hpx/runtime/actions/lambda_to_action.hpp
+++ b/hpx/runtime/actions/lambda_to_action.hpp
@@ -102,10 +102,10 @@ namespace hpx { namespace actions
             constexpr typename hpx::actions::detail::action_from_lambda<F>::type
             operator += (F* f)
             {
-                static_assert( 
+                static_assert(
                     //!std::is_assignable<F,F>::value &&
                     std::is_empty<F>::value,
-                    "lambda_to_action() needs and only needs a lambda without " \
+                    "lambda_to_action() needs and only needs a lambda with empty " \
                     "capture list");
 
                 return typename

--- a/hpx/runtime/actions/lambda_to_action.hpp
+++ b/hpx/runtime/actions/lambda_to_action.hpp
@@ -102,7 +102,7 @@ namespace hpx { namespace actions
                 static_assert(
                     //!std::is_assignable<F,F>::value &&
                     std::is_empty<F>::value,
-                    "HPX_LAMBDA_ACTION needs and only needs a lambda with empty " \
+                    "lambda_to_action() needs and only needs a lambda with empty " \
                     "capture list");
 
                 return typename
@@ -110,9 +110,20 @@ namespace hpx { namespace actions
             }
         };
     }
-}}
 
-#define HPX_LAMBDA_ACTION hpx::actions::detail::action_maker() \
-    += true ? nullptr : hpx::actions::detail::addr_add() +
+    template<typename F>
+    auto lambda_to_action(F&& f)
+    -> decltype( hpx::actions::detail::action_maker() += true
+        ? nullptr
+        : hpx::actions::detail::addr_add() +  f)
+    {
+        HPX_CONSTEXPR auto act =
+            hpx::actions::detail::action_maker() += true
+            ? nullptr
+            : hpx::actions::detail::addr_add() +  f;
+
+        return act;
+    }
+}}
 
 #endif /*HPX_RUNTIME_ACTIONS_LAMBDA_TO_ACTION_HPP*/

--- a/hpx/runtime/actions/lambda_to_action.hpp
+++ b/hpx/runtime/actions/lambda_to_action.hpp
@@ -102,9 +102,10 @@ namespace hpx { namespace actions
             constexpr typename hpx::actions::detail::action_from_lambda<F>::type
             operator += (F* f)
             {
-                static_assert( !std::is_assignable<F,F>::value &&
+                static_assert( 
+                    //!std::is_assignable<F,F>::value &&
                     std::is_empty<F>::value,
-                    "make_action() needs and only needs a lambda without " \
+                    "lambda_to_action() needs and only needs a lambda without " \
                     "capture list");
 
                 return typename

--- a/hpx/runtime/actions/lambda_to_action.hpp
+++ b/hpx/runtime/actions/lambda_to_action.hpp
@@ -1,0 +1,128 @@
+//  Copyright (c) 2017 Antoine TRAN TAN
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file hpx/runtime/actions/make_action.hpp
+
+#ifndef HPX_RUNTIME_ACTIONS_LAMBDA_TO_ACTION_HPP
+#define HPX_RUNTIME_ACTIONS_LAMBDA_TO_ACTION_HPP
+
+#include <hpx/include/plain_actions.hpp>
+#include <type_traits>
+
+namespace hpx { namespace actions
+{
+    /// \cond NOINTERNAL
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        // Helpers to actionize a lambda
+
+        template <typename ... T>
+        struct sequence
+        {};
+
+        struct addr_add
+        {
+            template<class T>
+            friend typename std::remove_reference<T>::type *
+            operator+(addr_add, T &&t)
+            {
+                return &t;
+            }
+        };
+
+        template<typename F, typename ReturnType, typename ... Args>
+        struct caller{
+          static inline ReturnType call(Args... args)
+          {
+             int * dummy = nullptr;
+             return reinterpret_cast<const F&>(*dummy)( args... );
+          }
+        };
+
+        template<class F, typename ReturnType, typename Sequence>
+        struct make_action_using_sequence
+        {};
+
+        template<class F, typename ReturnType,
+          template <typename...> class T, typename ... Args>
+        struct make_action_using_sequence< F, ReturnType, T<Args...> >
+        {
+          using type =
+              typename hpx::actions::make_action<
+                decltype(&caller<F,ReturnType,Args...>::call),
+                &caller<F,ReturnType,Args...>::call >::type;
+        };
+
+        template <typename T>
+        struct extract_parameters
+        {};
+
+        // Specialization for lambdas
+        template <typename ClassType, typename ReturnType, typename... Args>
+        struct extract_parameters<ReturnType(ClassType::*)(Args...) const>
+        {
+            template<typename T>
+            using remove_reference_t = typename std::remove_reference<T>::type;
+            using type
+                = hpx::actions::detail::sequence< remove_reference_t<Args>... >;
+        };
+
+        template <typename T>
+        struct extract_return_type
+        {};
+
+        template <typename ClassType, typename ReturnType, typename... Args>
+        struct extract_return_type<ReturnType(ClassType::*)(Args...) const>
+        {
+            using type = ReturnType;
+        };
+
+        template <typename F>
+        struct action_from_lambda
+        {
+            using sequence_type =
+                typename hpx::actions::detail::extract_parameters<
+                    decltype(&F::operator())>::type;
+            using return_type =
+                typename hpx::actions::detail::extract_return_type<
+                    decltype(&F::operator())>::type;
+            using type =
+                typename hpx::actions::detail::make_action_using_sequence<
+                    F,return_type,sequence_type>::type;
+        };
+
+
+        template<typename F>
+        struct action_maker
+        {
+            constexpr typename hpx::actions::detail::action_from_lambda<F>::type
+            operator += (F* f)
+            {
+                static_assert( !std::is_assignable<F,F>::value &&
+                    std::is_empty<F>::value,
+                    "make_action() needs and only needs a lambda without " \
+                    "capture list");
+
+                return typename
+                    hpx::actions::detail::action_from_lambda<F>::type();
+            }
+        };
+    }
+
+    template<typename F>
+    constexpr auto lambda_to_action(F && f)
+    -> decltype(hpx::actions::detail::action_maker<F>() += true
+        ? nullptr
+        : hpx::actions::detail::addr_add() + f)
+    {
+        return hpx::actions::detail::action_maker<F>() += true
+            ? nullptr
+            : hpx::actions::detail::addr_add() + f;
+    }
+}}
+
+#endif /*HPX_RUNTIME_ACTIONS_LAMBDA_TO_ACTION_HPP*/

--- a/hpx/runtime/actions/lambda_to_action.hpp
+++ b/hpx/runtime/actions/lambda_to_action.hpp
@@ -95,17 +95,16 @@ namespace hpx { namespace actions
                     F,return_type,sequence_type>::type;
         };
 
-
-        template<typename F>
         struct action_maker
         {
+            template<typename F>
             constexpr typename hpx::actions::detail::action_from_lambda<F>::type
             operator += (F* f)
             {
                 static_assert(
                     //!std::is_assignable<F,F>::value &&
                     std::is_empty<F>::value,
-                    "lambda_to_action() needs and only needs a lambda with empty " \
+                    "HPX_LAMBDA_ACTION needs and only needs a lambda with empty " \
                     "capture list");
 
                 return typename
@@ -113,17 +112,9 @@ namespace hpx { namespace actions
             }
         };
     }
-
-    template<typename F>
-    constexpr auto lambda_to_action(F && f)
-    -> decltype(hpx::actions::detail::action_maker<F>() += true
-        ? nullptr
-        : hpx::actions::detail::addr_add() + f)
-    {
-        return hpx::actions::detail::action_maker<F>() += true
-            ? nullptr
-            : hpx::actions::detail::addr_add() + f;
-    }
 }}
+
+#define HPX_LAMBDA_ACTION hpx::actions::detail::action_maker() \
+    += true ? nullptr : hpx::actions::detail::addr_add() +
 
 #endif /*HPX_RUNTIME_ACTIONS_LAMBDA_TO_ACTION_HPP*/

--- a/hpx/runtime/actions/lambda_to_action.hpp
+++ b/hpx/runtime/actions/lambda_to_action.hpp
@@ -36,10 +36,10 @@ namespace hpx { namespace actions
 
         template<typename F, typename ReturnType, typename ... Args>
         struct caller{
-          static inline ReturnType call(Args... args)
+          static inline ReturnType call(Args && ... args)
           {
              int * dummy = nullptr;
-             return reinterpret_cast<const F&>(*dummy)( args... );
+             return reinterpret_cast<const F&>(*dummy)( std::forward<Args>(args)... );
           }
         };
 
@@ -68,7 +68,7 @@ namespace hpx { namespace actions
             template<typename T>
             using remove_reference_t = typename std::remove_reference<T>::type;
             using type
-                = hpx::actions::detail::sequence< remove_reference_t<Args>... >;
+                = hpx::actions::detail::sequence< Args... >;
         };
 
         template <typename T>

--- a/hpx/runtime/actions/lambda_to_action.hpp
+++ b/hpx/runtime/actions/lambda_to_action.hpp
@@ -10,6 +10,7 @@
 
 #include <hpx/include/plain_actions.hpp>
 #include <type_traits>
+#include <utility>
 
 namespace hpx { namespace actions
 {
@@ -65,10 +66,7 @@ namespace hpx { namespace actions
         template <typename ClassType, typename ReturnType, typename... Args>
         struct extract_parameters<ReturnType(ClassType::*)(Args...) const>
         {
-            template<typename T>
-            using remove_reference_t = typename std::remove_reference<T>::type;
-            using type
-                = hpx::actions::detail::sequence< Args... >;
+            using type = hpx::actions::detail::sequence< Args... >;
         };
 
         template <typename T>
@@ -98,7 +96,7 @@ namespace hpx { namespace actions
         struct action_maker
         {
             template<typename F>
-            constexpr typename hpx::actions::detail::action_from_lambda<F>::type
+            HPX_CONSTEXPR typename hpx::actions::detail::action_from_lambda<F>::type
             operator += (F* f)
             {
                 static_assert(

--- a/tests/regressions/actions/async_deferred_1523.cpp
+++ b/tests/regressions/actions/async_deferred_1523.cpp
@@ -57,20 +57,20 @@ int main()
 
     // Same test with lambdas
     {
-        auto nt = hpx::actions::lambda_to_action(
+        constexpr auto nt = hpx::actions::lambda_to_action(
             []()
             {
                 nt_executed = true;
             });
 
-        auto it = hpx::actions::lambda_to_action(
+        constexpr auto it = hpx::actions::lambda_to_action(
             []() -> int
             {
                 it_executed = true;
                 return 42;
             });
 
-        auto gl = hpx::actions::lambda_to_action(
+        constexpr auto gl = hpx::actions::lambda_to_action(
             []() -> hpx::id_type
             {
                 return hpx::find_here();

--- a/tests/regressions/actions/async_deferred_1523.cpp
+++ b/tests/regressions/actions/async_deferred_1523.cpp
@@ -57,14 +57,14 @@ int main()
 
     // Same test with lambdas
     {
-        constexpr auto nt =
+        HPX_CONSTEXPR auto nt =
             HPX_LAMBDA_ACTION
             []()
             {
                 nt_executed = true;
             };
 
-        constexpr auto it =
+        HPX_CONSTEXPR auto it =
             HPX_LAMBDA_ACTION
             []() -> int
             {
@@ -72,7 +72,7 @@ int main()
                 return 42;
             };
 
-        constexpr auto gl =
+        HPX_CONSTEXPR auto gl =
             HPX_LAMBDA_ACTION
             []() -> hpx::id_type
             {

--- a/tests/regressions/actions/async_deferred_1523.cpp
+++ b/tests/regressions/actions/async_deferred_1523.cpp
@@ -57,24 +57,27 @@ int main()
 
     // Same test with lambdas
     {
-        constexpr auto nt = hpx::actions::lambda_to_action(
+        constexpr auto nt =
+            HPX_LAMBDA_ACTION
             []()
             {
                 nt_executed = true;
-            });
+            };
 
-        constexpr auto it = hpx::actions::lambda_to_action(
+        constexpr auto it =
+            HPX_LAMBDA_ACTION
             []() -> int
             {
                 it_executed = true;
                 return 42;
-            });
+            };
 
-        constexpr auto gl = hpx::actions::lambda_to_action(
+        constexpr auto gl =
+            HPX_LAMBDA_ACTION
             []() -> hpx::id_type
             {
                 return hpx::find_here();
-            });
+            };
 
         hpx::async(
             hpx::launch::deferred, std::move(nt), hpx::find_here()).get();

--- a/tests/regressions/actions/async_deferred_1523.cpp
+++ b/tests/regressions/actions/async_deferred_1523.cpp
@@ -57,27 +57,27 @@ int main()
 
     // Same test with lambdas
     {
-        HPX_CONSTEXPR auto nt =
-            HPX_LAMBDA_ACTION
+        auto nt =
+            hpx::actions::lambda_to_action(
             []()
             {
                 nt_executed = true;
-            };
+            });
 
-        HPX_CONSTEXPR auto it =
-            HPX_LAMBDA_ACTION
+        auto it =
+            hpx::actions::lambda_to_action(
             []() -> int
             {
                 it_executed = true;
                 return 42;
-            };
+            });
 
-        HPX_CONSTEXPR auto gl =
-            HPX_LAMBDA_ACTION
+        auto gl =
+            hpx::actions::lambda_to_action(
             []() -> hpx::id_type
             {
                 return hpx::find_here();
-            };
+            });
 
         hpx::async(
             hpx::launch::deferred, std::move(nt), hpx::find_here()).get();

--- a/tests/regressions/actions/async_deferred_1523.cpp
+++ b/tests/regressions/actions/async_deferred_1523.cpp
@@ -10,9 +10,12 @@
 #include <hpx/include/actions.hpp>
 #include <hpx/include/async.hpp>
 #include <hpx/util/lightweight_test.hpp>
+#include <utility>
 
 bool null_action_executed = false;
 bool int_action_executed = false;
+bool nt_executed = false;
+bool it_executed = false;
 
 void null_thread()
 {
@@ -57,13 +60,13 @@ int main()
         auto nt = hpx::actions::lambda_to_action(
             []()
             {
-                null_action_executed = true;
+                nt_executed = true;
             });
 
         auto it = hpx::actions::lambda_to_action(
             []() -> int
             {
-                int_action_executed = true;
+                it_executed = true;
                 return 42;
             });
 
@@ -75,11 +78,11 @@ int main()
 
         hpx::async(
             hpx::launch::deferred, std::move(nt), hpx::find_here()).get();
-        HPX_TEST(null_action_executed);
+        HPX_TEST(nt_executed);
 
         int result = hpx::async(
             hpx::launch::deferred, std::move(it), hpx::find_here()).get();
-        HPX_TEST(int_action_executed);
+        HPX_TEST(it_executed);
         HPX_TEST_EQ(result, 42);
 
         for (hpx::id_type const& loc : hpx::find_all_localities())

--- a/tests/regressions/actions/async_deferred_1523.cpp
+++ b/tests/regressions/actions/async_deferred_1523.cpp
@@ -35,19 +35,59 @@ HPX_PLAIN_ACTION(get_locality, get_locality_action);
 
 int main()
 {
-    hpx::async<null_action>(hpx::launch::deferred, hpx::find_here()).get();
-    HPX_TEST(null_action_executed);
-
-    int result = hpx::async<int_action>(
-        hpx::launch::deferred, hpx::find_here()).get();
-    HPX_TEST(int_action_executed);
-    HPX_TEST_EQ(result, 42);
-
-    for (hpx::id_type const& loc : hpx::find_all_localities())
     {
-        hpx::id_type id = hpx::async<get_locality_action>(
-            hpx::launch::deferred, loc).get();
-        HPX_TEST_EQ(loc, id);
+        hpx::async<null_action>(hpx::launch::deferred, hpx::find_here()).get();
+        HPX_TEST(null_action_executed);
+
+        int result = hpx::async<int_action>(
+            hpx::launch::deferred, hpx::find_here()).get();
+        HPX_TEST(int_action_executed);
+        HPX_TEST_EQ(result, 42);
+
+        for (hpx::id_type const& loc : hpx::find_all_localities())
+        {
+            hpx::id_type id = hpx::async<get_locality_action>(
+                hpx::launch::deferred, loc).get();
+            HPX_TEST_EQ(loc, id);
+        }
+    }
+
+    // Same test with lambdas
+    {
+        auto nt = hpx::actions::lambda_to_action(
+            []()
+            {
+                null_action_executed = true;
+            });
+
+        auto it = hpx::actions::lambda_to_action(
+            []() -> int
+            {
+                int_action_executed = true;
+                return 42;
+            });
+
+        auto gl = hpx::actions::lambda_to_action(
+            []() -> hpx::id_type
+            {
+                return hpx::find_here();
+            });
+
+        hpx::async(
+            hpx::launch::deferred, std::move(nt), hpx::find_here()).get();
+        HPX_TEST(null_action_executed);
+
+        int result = hpx::async(
+            hpx::launch::deferred, std::move(it), hpx::find_here()).get();
+        HPX_TEST(int_action_executed);
+        HPX_TEST_EQ(result, 42);
+
+        for (hpx::id_type const& loc : hpx::find_all_localities())
+        {
+            hpx::id_type id = hpx::async(
+                hpx::launch::deferred, std::move(gl), loc).get();
+            HPX_TEST_EQ(loc, id);
+        }
     }
 
     return 0;

--- a/tests/regressions/actions/make_continuation_1615.cpp
+++ b/tests/regressions/actions/make_continuation_1615.cpp
@@ -39,14 +39,14 @@ int hpx_main(int argc, char* argv[])
 
     // Same test with lambdas
     {
-        constexpr auto t2 =
+        HPX_CONSTEXPR auto t2 =
             HPX_LAMBDA_ACTION
             [](std::int32_t i) -> std::int32_t
             {
                 return i * 2;
             };
 
-        constexpr auto ts =
+        HPX_CONSTEXPR auto ts =
             HPX_LAMBDA_ACTION
             [](std::int32_t i) -> std::string
             {

--- a/tests/regressions/actions/make_continuation_1615.cpp
+++ b/tests/regressions/actions/make_continuation_1615.cpp
@@ -13,6 +13,7 @@
 
 #include <cstdint>
 #include <string>
+#include <utility>
 
 std::int32_t times2(std::int32_t i)
 {

--- a/tests/regressions/actions/make_continuation_1615.cpp
+++ b/tests/regressions/actions/make_continuation_1615.cpp
@@ -39,13 +39,13 @@ int hpx_main(int argc, char* argv[])
 
     // Same test with lambdas
     {
-        auto t2 = hpx::actions::lambda_to_action(
+        constexpr auto t2 = hpx::actions::lambda_to_action(
             [](std::int32_t i) -> std::int32_t
             {
                 return i * 2;
             });
 
-        auto ts = hpx::actions::lambda_to_action(
+        constexpr auto ts = hpx::actions::lambda_to_action(
             [](std::int32_t i) -> std::string
             {
                 return std::to_string(i);

--- a/tests/regressions/actions/make_continuation_1615.cpp
+++ b/tests/regressions/actions/make_continuation_1615.cpp
@@ -28,11 +28,34 @@ HPX_PLAIN_ACTION(to_string);    // defines to_string_action
 
 int hpx_main(int argc, char* argv[])
 {
-    std::string result = hpx::async_continue(
-        times2_action(), hpx::make_continuation(to_string_action()),
-        hpx::find_here(), 42).get();
+    {
+        std::string result = hpx::async_continue(
+            times2_action(), hpx::make_continuation(to_string_action()),
+            hpx::find_here(), 42).get();
 
-    HPX_TEST_EQ(result, std::string("84"));
+        HPX_TEST_EQ(result, std::string("84"));
+    }
+
+    // Same test with lambdas
+    {
+        auto t2 = hpx::actions::lambda_to_action(
+            [](std::int32_t i) -> std::int32_t
+            {
+                return i * 2;
+            });
+
+        auto ts = hpx::actions::lambda_to_action(
+            [](std::int32_t i) -> std::string
+            {
+                return std::to_string(i);
+            });
+
+        std::string result = hpx::async_continue(
+            std::move(t2), hpx::make_continuation(std::move(ts)),
+            hpx::find_here(), 42).get();
+
+        HPX_TEST_EQ(result, std::string("84"));
+    }
 
     return hpx::finalize();
 }

--- a/tests/regressions/actions/make_continuation_1615.cpp
+++ b/tests/regressions/actions/make_continuation_1615.cpp
@@ -39,19 +39,19 @@ int hpx_main(int argc, char* argv[])
 
     // Same test with lambdas
     {
-        HPX_CONSTEXPR auto t2 =
-            HPX_LAMBDA_ACTION
+        auto t2 =
+            hpx::actions::lambda_to_action(
             [](std::int32_t i) -> std::int32_t
             {
                 return i * 2;
-            };
+            });
 
-        HPX_CONSTEXPR auto ts =
-            HPX_LAMBDA_ACTION
+        auto ts =
+            hpx::actions::lambda_to_action(
             [](std::int32_t i) -> std::string
             {
                 return std::to_string(i);
-            };
+            });
 
         std::string result = hpx::async_continue(
             std::move(t2), hpx::make_continuation(std::move(ts)),

--- a/tests/regressions/actions/make_continuation_1615.cpp
+++ b/tests/regressions/actions/make_continuation_1615.cpp
@@ -39,17 +39,19 @@ int hpx_main(int argc, char* argv[])
 
     // Same test with lambdas
     {
-        constexpr auto t2 = hpx::actions::lambda_to_action(
+        constexpr auto t2 =
+            HPX_LAMBDA_ACTION
             [](std::int32_t i) -> std::int32_t
             {
                 return i * 2;
-            });
+            };
 
-        constexpr auto ts = hpx::actions::lambda_to_action(
+        constexpr auto ts =
+            HPX_LAMBDA_ACTION
             [](std::int32_t i) -> std::string
             {
                 return std::to_string(i);
-            });
+            };
 
         std::string result = hpx::async_continue(
             std::move(t2), hpx::make_continuation(std::move(ts)),

--- a/tests/regressions/actions/plain_action_1330.cpp
+++ b/tests/regressions/actions/plain_action_1330.cpp
@@ -19,7 +19,7 @@ namespace mynamespace
 
     HPX_DEFINE_PLAIN_ACTION(test, test_action);
 
-    static auto t = hpx::actions::lambda_to_action(
+    static constexpr auto t = hpx::actions::lambda_to_action(
         []()
         {
             hpx::cout << "test" << hpx::endl;

--- a/tests/regressions/actions/plain_action_1330.cpp
+++ b/tests/regressions/actions/plain_action_1330.cpp
@@ -19,11 +19,12 @@ namespace mynamespace
 
     HPX_DEFINE_PLAIN_ACTION(test, test_action);
 
-    static constexpr auto t = hpx::actions::lambda_to_action(
+    static constexpr auto t =
+        HPX_LAMBDA_ACTION
         []()
         {
             hpx::cout << "test" << hpx::endl;
-        });
+        };
 }
 
 HPX_REGISTER_ACTION(mynamespace::test_action, mynamespace_test_action);

--- a/tests/regressions/actions/plain_action_1330.cpp
+++ b/tests/regressions/actions/plain_action_1330.cpp
@@ -19,12 +19,12 @@ namespace mynamespace
 
     HPX_DEFINE_PLAIN_ACTION(test, test_action);
 
-    static HPX_CONSTEXPR auto t =
-        HPX_LAMBDA_ACTION
+    static auto t =
+        hpx::actions::lambda_to_action(
         []()
         {
             hpx::cout << "test" << hpx::endl;
-        };
+        });
 }
 
 HPX_REGISTER_ACTION(mynamespace::test_action, mynamespace_test_action);

--- a/tests/regressions/actions/plain_action_1330.cpp
+++ b/tests/regressions/actions/plain_action_1330.cpp
@@ -19,7 +19,7 @@ namespace mynamespace
 
     HPX_DEFINE_PLAIN_ACTION(test, test_action);
 
-    static constexpr auto t =
+    static HPX_CONSTEXPR auto t =
         HPX_LAMBDA_ACTION
         []()
         {

--- a/tests/regressions/actions/plain_action_1330.cpp
+++ b/tests/regressions/actions/plain_action_1330.cpp
@@ -8,6 +8,7 @@
 #include <hpx/include/actions.hpp>
 #include <hpx/include/iostreams.hpp>
 #include <hpx/lcos/future.hpp>
+#include <utility>
 
 namespace mynamespace
 {

--- a/tests/regressions/actions/plain_action_1330.cpp
+++ b/tests/regressions/actions/plain_action_1330.cpp
@@ -5,6 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_start.hpp>
+#include <hpx/include/actions.hpp>
 #include <hpx/include/iostreams.hpp>
 #include <hpx/lcos/future.hpp>
 
@@ -16,6 +17,12 @@ namespace mynamespace
     }
 
     HPX_DEFINE_PLAIN_ACTION(test, test_action);
+
+    static auto t = hpx::actions::lambda_to_action(
+        []()
+        {
+            hpx::cout << "test" << hpx::endl;
+        });
 }
 
 HPX_REGISTER_ACTION(mynamespace::test_action, mynamespace_test_action);
@@ -26,6 +33,11 @@ int hpx_main(int argc, char* argv[])
     {
         typedef mynamespace::test_action func;
         hpx::async<func>(hpx::find_here());
+    }
+
+    // Same test with lambdas
+    {
+        hpx::async(std::move(mynamespace::t), hpx::find_here());
     }
 
     // End the program

--- a/tests/regressions/actions/plain_action_1550.cpp
+++ b/tests/regressions/actions/plain_action_1550.cpp
@@ -23,7 +23,7 @@ namespace mynamespace
 
     HPX_DEFINE_PLAIN_ACTION(test);
 
-    static constexpr auto t =
+    static HPX_CONSTEXPR auto t =
         HPX_LAMBDA_ACTION
         []()
         {

--- a/tests/regressions/actions/plain_action_1550.cpp
+++ b/tests/regressions/actions/plain_action_1550.cpp
@@ -11,6 +11,7 @@
 #include <hpx/util/lightweight_test.hpp>
 
 bool called_test_action = false;
+bool called_t_action = false;
 
 namespace mynamespace
 {
@@ -20,6 +21,12 @@ namespace mynamespace
     }
 
     HPX_DEFINE_PLAIN_ACTION(test);
+
+    static auto t = hpx::actions::lambda_to_action(
+        []()
+        {
+            called_t_action = true;
+        });
 }
 
 typedef mynamespace::test_action mynamespace_test_action;
@@ -29,11 +36,21 @@ HPX_REGISTER_ACTION(mynamespace_test_action);
 int hpx_main(int argc, char* argv[])
 {
     {
-        typedef mynamespace_test_action func;
-        hpx::async<func>(hpx::find_here()).get();
+        {
+            typedef mynamespace_test_action func;
+            hpx::async<func>(hpx::find_here()).get();
+        }
+
+        HPX_TEST(called_test_action);
     }
 
-    HPX_TEST(called_test_action);
+    {
+        {
+            hpx::async(std::move(mynamespace::t),hpx::find_here()).get();
+        }
+
+        HPX_TEST(called_t_action);
+    }
 
     return hpx::finalize();
 }

--- a/tests/regressions/actions/plain_action_1550.cpp
+++ b/tests/regressions/actions/plain_action_1550.cpp
@@ -23,7 +23,7 @@ namespace mynamespace
 
     HPX_DEFINE_PLAIN_ACTION(test);
 
-    static auto t = hpx::actions::lambda_to_action(
+    static constexpr auto t = hpx::actions::lambda_to_action(
         []()
         {
             called_t = true;

--- a/tests/regressions/actions/plain_action_1550.cpp
+++ b/tests/regressions/actions/plain_action_1550.cpp
@@ -9,9 +9,10 @@
 #include <hpx/include/actions.hpp>
 #include <hpx/include/async.hpp>
 #include <hpx/util/lightweight_test.hpp>
+#include <utility>
 
 bool called_test_action = false;
-bool called_t_action = false;
+bool called_t = false;
 
 namespace mynamespace
 {
@@ -25,7 +26,7 @@ namespace mynamespace
     static auto t = hpx::actions::lambda_to_action(
         []()
         {
-            called_t_action = true;
+            called_t = true;
         });
 }
 
@@ -44,12 +45,13 @@ int hpx_main(int argc, char* argv[])
         HPX_TEST(called_test_action);
     }
 
+    // Same test with lambdas
     {
         {
             hpx::async(std::move(mynamespace::t),hpx::find_here()).get();
         }
 
-        HPX_TEST(called_t_action);
+        HPX_TEST(called_t);
     }
 
     return hpx::finalize();

--- a/tests/regressions/actions/plain_action_1550.cpp
+++ b/tests/regressions/actions/plain_action_1550.cpp
@@ -23,12 +23,12 @@ namespace mynamespace
 
     HPX_DEFINE_PLAIN_ACTION(test);
 
-    static HPX_CONSTEXPR auto t =
-        HPX_LAMBDA_ACTION
+    static auto t =
+        hpx::actions::lambda_to_action(
         []()
         {
             called_t = true;
-        };
+        });
 }
 
 typedef mynamespace::test_action mynamespace_test_action;

--- a/tests/regressions/actions/plain_action_1550.cpp
+++ b/tests/regressions/actions/plain_action_1550.cpp
@@ -23,11 +23,12 @@ namespace mynamespace
 
     HPX_DEFINE_PLAIN_ACTION(test);
 
-    static constexpr auto t = hpx::actions::lambda_to_action(
+    static constexpr auto t =
+        HPX_LAMBDA_ACTION
         []()
         {
             called_t = true;
-        });
+        };
 }
 
 typedef mynamespace::test_action mynamespace_test_action;

--- a/tests/regressions/actions/plain_action_move_semantics.cpp
+++ b/tests/regressions/actions/plain_action_move_semantics.cpp
@@ -45,11 +45,11 @@ std::size_t pass_movable_object(movable_object const& obj)
     return obj.get_count();
 }
 
-constexpr auto movable_object_void_passer =
+HPX_CONSTEXPR auto movable_object_void_passer =
     HPX_LAMBDA_ACTION
     [](movable_object const&) -> void {};
 
-constexpr auto movable_object_passer =
+HPX_CONSTEXPR auto movable_object_passer =
     HPX_LAMBDA_ACTION
     [](movable_object const& obj) -> std::size_t
     {
@@ -75,11 +75,11 @@ std::size_t pass_movable_object_value(movable_object obj)
     return obj.get_count();
 }
 
-constexpr auto movable_object_value_void_passer =
+HPX_CONSTEXPR auto movable_object_value_void_passer =
     HPX_LAMBDA_ACTION
     [](movable_object) -> void {};
 
-constexpr auto movable_object_value_passer =
+HPX_CONSTEXPR auto movable_object_value_passer =
     HPX_LAMBDA_ACTION
     [](movable_object obj) -> std::size_t
     {
@@ -105,11 +105,11 @@ std::size_t pass_non_movable_object(non_movable_object const& obj)
     return obj.get_count();
 }
 
-constexpr auto non_movable_object_void_passer =
+HPX_CONSTEXPR auto non_movable_object_void_passer =
     HPX_LAMBDA_ACTION
     [](non_movable_object const&) -> void {};
 
-constexpr auto non_movable_object_passer =
+HPX_CONSTEXPR auto non_movable_object_passer =
     HPX_LAMBDA_ACTION
     [](non_movable_object const& obj) -> std::size_t
     {
@@ -134,11 +134,11 @@ std::size_t pass_non_movable_object_value(non_movable_object obj)
     return obj.get_count();
 }
 
-constexpr auto non_movable_object_value_void_passer =
+HPX_CONSTEXPR auto non_movable_object_value_void_passer =
     HPX_LAMBDA_ACTION
     [](non_movable_object) -> void {};
 
-constexpr auto non_movable_object_value_passer =
+HPX_CONSTEXPR auto non_movable_object_value_passer =
     HPX_LAMBDA_ACTION
     [](non_movable_object obj) -> std::size_t
     {
@@ -166,14 +166,14 @@ movable_object return_movable_object()
     return movable_object();
 }
 
-constexpr auto non_movable_object_returner =
+HPX_CONSTEXPR auto non_movable_object_returner =
     HPX_LAMBDA_ACTION
     []() -> non_movable_object
     {
         return non_movable_object();
     };
 
-constexpr auto movable_object_returner =
+HPX_CONSTEXPR auto movable_object_returner =
     HPX_LAMBDA_ACTION
     []() -> movable_object
     {
@@ -513,20 +513,22 @@ void test_object_actions()
             if (is_local)
             {
                 HPX_TEST_EQ((
-                    pass_object<pass_non_movable_object_value_action, non_movable_object>(id)
-                ), 3u); // bind + function + call
+                    pass_object<pass_non_movable_object_value_action,
+                    non_movable_object>(id)), 3u); // bind + function + call
 
                 HPX_TEST_EQ((
-                    move_object<pass_non_movable_object_value_action, non_movable_object>(id)
-                ), 3u); // bind + function + call
+                    move_object<pass_non_movable_object_value_action,
+                    non_movable_object>(id)), 3u); // bind + function + call
             } else {
                 HPX_TEST_EQ((
-                    pass_object<pass_non_movable_object_value_action, non_movable_object>(id)
-                ), 4u); // transfer_action + bind + function + call
+                    pass_object<pass_non_movable_object_value_action,
+                    non_movable_object>(id)),
+                    4u); // transfer_action + bind + function + call
 
                 HPX_TEST_EQ((
-                    move_object<pass_non_movable_object_value_action, non_movable_object>(id)
-                ), 4u); // transfer_action + bind + function + call
+                    move_object<pass_non_movable_object_value_action,
+                    non_movable_object>(id)),
+                    4u); // transfer_action + bind + function + call
             }
 
             // test movable_object()
@@ -596,59 +598,61 @@ void test_object_actions()
             if (is_local)
             {
                 HPX_TEST_EQ((
-                    pass_object<decltype(non_movable_object_passer), non_movable_object>(id)
-                ), 2u); // bind + function
+                    pass_object<decltype(non_movable_object_passer),
+                    non_movable_object>(id)), 2u); // bind + function
 
                 HPX_TEST_EQ((
-                    move_object<decltype(non_movable_object_passer), non_movable_object>(id)
-                ), 2u); // bind + function
+                    move_object<decltype(non_movable_object_passer),
+                    non_movable_object>(id)), 2u); // bind + function
             } else {
                 HPX_TEST_EQ((
-                    pass_object<decltype(non_movable_object_passer), non_movable_object>(id)
-                ), 3u); // transfer_action + bind + function
+                    pass_object<decltype(non_movable_object_passer),
+                    non_movable_object>(id)), 3u); // transfer_action + bind + function
 
                 HPX_TEST_EQ((
-                    move_object<decltype(non_movable_object_passer), non_movable_object>(id)
-                ), 3u); // transfer_action + bind + function
+                    move_object<decltype(non_movable_object_passer),
+                    non_movable_object>(id)), 3u); // transfer_action + bind + function
             }
 
             // test size_t(movable_object)
             if (is_local)
             {
                 HPX_TEST_EQ((
-                    pass_object<decltype(movable_object_value_passer), movable_object>(id)
-                ), 1u); // call
+                    pass_object<decltype(movable_object_value_passer),
+                    movable_object>(id)), 1u); // call
 
                 HPX_TEST_EQ((
-                    move_object<decltype(movable_object_value_passer), movable_object>(id)
-                ), 0u);
+                    move_object<decltype(movable_object_value_passer),
+                    movable_object>(id)), 0u);
             } else {
                 HPX_TEST_EQ((
-                    pass_object<decltype(movable_object_value_passer), movable_object>(id)
-                ), 1u); // transfer_action
+                    pass_object<decltype(movable_object_value_passer),
+                    movable_object>(id)), 1u); // transfer_action
 
                 HPX_TEST_EQ((
-                    move_object<decltype(movable_object_value_passer), movable_object>(id)
-                ), 0u);
+                    move_object<decltype(movable_object_value_passer),
+                    movable_object>(id)), 0u);
             }
 
             // test size_t(non_movable_object)
             if (is_local)
             {
                 HPX_TEST_EQ((
-                    pass_object<decltype(non_movable_object_value_passer), non_movable_object>(id)
-                ), 3u); // bind + function + call
+                    pass_object<decltype(non_movable_object_value_passer),
+                    non_movable_object>(id)), 3u); // bind + function + call
 
                 HPX_TEST_EQ((
-                    move_object<decltype(non_movable_object_value_passer), non_movable_object>(id)
-                ), 3u); // bind + function + call
+                    move_object<decltype(non_movable_object_value_passer),
+                    non_movable_object>(id)), 3u); // bind + function + call
             } else {
                 HPX_TEST_EQ((
-                    pass_object<decltype(non_movable_object_value_passer), non_movable_object>(id)
+                    pass_object<decltype(non_movable_object_value_passer),
+                    non_movable_object>(id)
                 ), 4u); // transfer_action + bind + function + call
 
                 HPX_TEST_EQ((
-                    move_object<decltype(non_movable_object_value_passer), non_movable_object>(id)
+                    move_object<decltype(non_movable_object_value_passer),
+                    non_movable_object>(id)
                 ), 4u); // transfer_action + bind + function + call
             }
 

--- a/tests/regressions/actions/plain_action_move_semantics.cpp
+++ b/tests/regressions/actions/plain_action_move_semantics.cpp
@@ -45,16 +45,16 @@ std::size_t pass_movable_object(movable_object const& obj)
     return obj.get_count();
 }
 
-HPX_CONSTEXPR auto movable_object_void_passer =
-    HPX_LAMBDA_ACTION
-    [](movable_object const&) -> void {};
+auto movable_object_void_passer =
+    hpx::actions::lambda_to_action(
+    [](movable_object const&) -> void {});
 
-HPX_CONSTEXPR auto movable_object_passer =
-    HPX_LAMBDA_ACTION
+auto movable_object_passer =
+    hpx::actions::lambda_to_action(
     [](movable_object const& obj) -> std::size_t
     {
         return obj.get_count();
-    };
+    });
 
 // 'normal' actions (execution is scheduled on a new thread)
 HPX_PLAIN_ACTION(pass_movable_object,
@@ -75,16 +75,16 @@ std::size_t pass_movable_object_value(movable_object obj)
     return obj.get_count();
 }
 
-HPX_CONSTEXPR auto movable_object_value_void_passer =
-    HPX_LAMBDA_ACTION
-    [](movable_object) -> void {};
+auto movable_object_value_void_passer =
+    hpx::actions::lambda_to_action(
+    [](movable_object) -> void {});
 
-HPX_CONSTEXPR auto movable_object_value_passer =
-    HPX_LAMBDA_ACTION
+auto movable_object_value_passer =
+    hpx::actions::lambda_to_action(
     [](movable_object obj) -> std::size_t
     {
        return obj.get_count();
-    };
+    });
 
 // 'normal' actions (execution is scheduled on a new thread)
 HPX_PLAIN_ACTION(pass_movable_object_value,
@@ -105,16 +105,16 @@ std::size_t pass_non_movable_object(non_movable_object const& obj)
     return obj.get_count();
 }
 
-HPX_CONSTEXPR auto non_movable_object_void_passer =
-    HPX_LAMBDA_ACTION
-    [](non_movable_object const&) -> void {};
+auto non_movable_object_void_passer =
+    hpx::actions::lambda_to_action(
+    [](non_movable_object const&) -> void {});
 
-HPX_CONSTEXPR auto non_movable_object_passer =
-    HPX_LAMBDA_ACTION
+auto non_movable_object_passer =
+    hpx::actions::lambda_to_action(
     [](non_movable_object const& obj) -> std::size_t
     {
         return obj.get_count();
-    };
+    });
 
 // 'normal' actions (execution is scheduled on a new thread)
 HPX_PLAIN_ACTION(pass_non_movable_object_void,
@@ -134,16 +134,16 @@ std::size_t pass_non_movable_object_value(non_movable_object obj)
     return obj.get_count();
 }
 
-HPX_CONSTEXPR auto non_movable_object_value_void_passer =
-    HPX_LAMBDA_ACTION
-    [](non_movable_object) -> void {};
+auto non_movable_object_value_void_passer =
+    hpx::actions::lambda_to_action(
+    [](non_movable_object) -> void {});
 
-HPX_CONSTEXPR auto non_movable_object_value_passer =
-    HPX_LAMBDA_ACTION
+auto non_movable_object_value_passer =
+    hpx::actions::lambda_to_action(
     [](non_movable_object obj) -> std::size_t
     {
        return obj.get_count();
-    };
+    });
 
 // 'normal' actions (execution is scheduled on a new thread)
 HPX_PLAIN_ACTION(pass_non_movable_object_value_void,
@@ -166,19 +166,19 @@ movable_object return_movable_object()
     return movable_object();
 }
 
-HPX_CONSTEXPR auto non_movable_object_returner =
-    HPX_LAMBDA_ACTION
+auto non_movable_object_returner =
+    hpx::actions::lambda_to_action(
     []() -> non_movable_object
     {
         return non_movable_object();
-    };
+    });
 
-HPX_CONSTEXPR auto movable_object_returner =
-    HPX_LAMBDA_ACTION
+auto movable_object_returner =
+    hpx::actions::lambda_to_action(
     []() -> movable_object
     {
         return movable_object();
-    };
+    });
 
 // 'normal' actions (execution is scheduled on a new thread)
 HPX_PLAIN_ACTION(return_movable_object,

--- a/tests/regressions/actions/plain_action_move_semantics.cpp
+++ b/tests/regressions/actions/plain_action_move_semantics.cpp
@@ -45,6 +45,17 @@ std::size_t pass_movable_object(movable_object const& obj)
     return obj.get_count();
 }
 
+constexpr auto movable_object_void_passer =
+    HPX_LAMBDA_ACTION
+    [](movable_object const&) -> void {};
+
+constexpr auto movable_object_passer =
+    HPX_LAMBDA_ACTION
+    [](movable_object const& obj) -> std::size_t
+    {
+        return obj.get_count();
+    };
+
 // 'normal' actions (execution is scheduled on a new thread)
 HPX_PLAIN_ACTION(pass_movable_object,
     pass_movable_object_action)
@@ -63,6 +74,17 @@ std::size_t pass_movable_object_value(movable_object obj)
 {
     return obj.get_count();
 }
+
+constexpr auto movable_object_value_void_passer =
+    HPX_LAMBDA_ACTION
+    [](movable_object) -> void {};
+
+constexpr auto movable_object_value_passer =
+    HPX_LAMBDA_ACTION
+    [](movable_object obj) -> std::size_t
+    {
+       return obj.get_count();
+    };
 
 // 'normal' actions (execution is scheduled on a new thread)
 HPX_PLAIN_ACTION(pass_movable_object_value,
@@ -83,6 +105,17 @@ std::size_t pass_non_movable_object(non_movable_object const& obj)
     return obj.get_count();
 }
 
+constexpr auto non_movable_object_void_passer =
+    HPX_LAMBDA_ACTION
+    [](non_movable_object const&) -> void {};
+
+constexpr auto non_movable_object_passer =
+    HPX_LAMBDA_ACTION
+    [](non_movable_object const& obj) -> std::size_t
+    {
+        return obj.get_count();
+    };
+
 // 'normal' actions (execution is scheduled on a new thread)
 HPX_PLAIN_ACTION(pass_non_movable_object_void,
     pass_non_movable_object_void_action)
@@ -100,6 +133,17 @@ std::size_t pass_non_movable_object_value(non_movable_object obj)
 {
     return obj.get_count();
 }
+
+constexpr auto non_movable_object_value_void_passer =
+    HPX_LAMBDA_ACTION
+    [](non_movable_object) -> void {};
+
+constexpr auto non_movable_object_value_passer =
+    HPX_LAMBDA_ACTION
+    [](non_movable_object obj) -> std::size_t
+    {
+       return obj.get_count();
+    };
 
 // 'normal' actions (execution is scheduled on a new thread)
 HPX_PLAIN_ACTION(pass_non_movable_object_value_void,
@@ -121,6 +165,20 @@ movable_object return_movable_object()
 {
     return movable_object();
 }
+
+constexpr auto non_movable_object_returner =
+    HPX_LAMBDA_ACTION
+    []() -> non_movable_object
+    {
+        return non_movable_object();
+    };
+
+constexpr auto movable_object_returner =
+    HPX_LAMBDA_ACTION
+    []() -> movable_object
+    {
+        return movable_object();
+    };
 
 // 'normal' actions (execution is scheduled on a new thread)
 HPX_PLAIN_ACTION(return_movable_object,
@@ -179,68 +237,137 @@ std::size_t return_object(id_type id)
 ///////////////////////////////////////////////////////////////////////////////
 void test_void_actions()
 {
-    // test the void actions locally only (there is no way to get the
-    // overall copy count back)
-
-    // test void(movable_object const&)
     {
-        HPX_TEST_EQ((
-            pass_object_void<
-                pass_movable_object_void_action, movable_object
-            >()
-        ), 1u); // bind
+        // test the void actions locally only (there is no way to get the
+        // overall copy count back)
 
-        HPX_TEST_EQ((
-            move_object_void<
-                pass_movable_object_void_action, movable_object
-            >()
-        ), 0u);
+        // test void(movable_object const&)
+        {
+            HPX_TEST_EQ((
+                pass_object_void<
+                    pass_movable_object_void_action, movable_object
+                >()
+            ), 1u); // bind
+
+            HPX_TEST_EQ((
+                move_object_void<
+                    pass_movable_object_void_action, movable_object
+                >()
+            ), 0u);
+        }
+
+        // test void(non_movable_object const&)
+        {
+            HPX_TEST_EQ((
+                pass_object_void<
+                    pass_non_movable_object_void_action, non_movable_object
+                >()
+            ), 2u); // bind + function
+
+            HPX_TEST_EQ((
+                move_object_void<
+                    pass_non_movable_object_void_action, non_movable_object
+                >()
+            ), 2u); // bind + function
+        }
+
+        // test void(movable_object)
+        {
+            HPX_TEST_EQ((
+                pass_object_void<
+                    pass_movable_object_value_void_action, movable_object
+                >()
+            ), 1u); // call
+            //! should be: -
+
+            HPX_TEST_EQ((
+                move_object_void<
+                    pass_movable_object_value_void_action, movable_object
+                >()
+            ), 0u);
+        }
+
+        // test void(non_movable_object)
+        {
+            HPX_TEST_EQ((
+                pass_object_void<
+                    pass_non_movable_object_value_void_action, non_movable_object
+                >()
+            ), 3u); // bind + function + call
+
+            HPX_TEST_EQ((
+                move_object_void<
+                    pass_non_movable_object_value_void_action, non_movable_object
+                >()
+            ), 3u); // bind + function + call
+        }
     }
 
-    // test void(non_movable_object const&)
+    // Same tests with lambdas
     {
-        HPX_TEST_EQ((
-            pass_object_void<
-                pass_non_movable_object_void_action, non_movable_object
-            >()
-        ), 2u); // bind + function
+        // test the void actions locally only (there is no way to get the
+        // overall copy count back)
 
-        HPX_TEST_EQ((
-            move_object_void<
-                pass_non_movable_object_void_action, non_movable_object
-            >()
-        ), 2u); // bind + function
-    }
+        // test void(movable_object const&)
+        {
+            HPX_TEST_EQ((
+                pass_object_void<
+                    decltype(movable_object_void_passer), movable_object
+                >()
+            ), 1u); // bind
 
-    // test void(movable_object)
-    {
-        HPX_TEST_EQ((
-            pass_object_void<
-                pass_movable_object_value_void_action, movable_object
-            >()
-        ), 1u); // call
-        //! should be: -
+            HPX_TEST_EQ((
+                move_object_void<
+                    decltype(movable_object_void_passer), movable_object
+                >()
+            ), 0u);
+        }
 
-        HPX_TEST_EQ((
-            move_object_void<
-                pass_movable_object_value_void_action, movable_object
-            >()
-        ), 0u);
-    }
+        // test void(non_movable_object const&)
+        {
+            HPX_TEST_EQ((
+                pass_object_void<
+                    decltype(non_movable_object_void_passer), non_movable_object
+                >()
+            ), 2u); // bind + function
 
-    // test void(non_movable_object)
-    {
-        HPX_TEST_EQ((
-            pass_object_void<
-                pass_non_movable_object_value_void_action, non_movable_object
-            >()
-        ), 3u); // bind + function + call
+            HPX_TEST_EQ((
+                move_object_void<
+                    decltype(non_movable_object_void_passer), non_movable_object
+                >()
+            ), 2u); // bind + function
+        }
 
-        HPX_TEST_EQ((
-            move_object_void<
-                pass_non_movable_object_value_void_action, non_movable_object
-            >()
-        ), 3u); // bind + function + call
+        // test void(movable_object)
+        {
+            HPX_TEST_EQ((
+                pass_object_void<
+                    decltype(movable_object_value_passer), movable_object
+                >()
+            ), 1u); // call
+            //! should be: -
+
+            HPX_TEST_EQ((
+                move_object_void<
+                    decltype(movable_object_value_passer), movable_object
+                >()
+            ), 0u);
+        }
+
+        // test void(non_movable_object)
+        {
+            HPX_TEST_EQ((
+                pass_object_void<
+                    decltype(non_movable_object_value_passer), non_movable_object
+                >()
+            ), 3u); // bind + function + call
+
+            HPX_TEST_EQ((
+                move_object_void<
+                    decltype(non_movable_object_value_passer), non_movable_object
+                >()
+            ), 3u); // bind + function + call
+        }
     }
 }
 
@@ -317,123 +444,248 @@ void test_object_actions()
 {
     std::vector<id_type> localities = hpx::find_all_localities();
 
-    for (id_type const& id : localities)
     {
-        bool is_local = id == find_here();
-
-        // test size_t(movable_object const&)
-        if (is_local)
+        for (id_type const& id : localities)
         {
-            HPX_TEST_EQ((
-                pass_object<pass_movable_object_action, movable_object>(id)
-            ), 1u); // bind
+            bool is_local = id == find_here();
 
-            HPX_TEST_EQ((
-                move_object<pass_movable_object_action, movable_object>(id)
-            ), 0U);
-        } else {
-            HPX_TEST_EQ((
-                pass_object<pass_movable_object_action, movable_object>(id)
-            ), 1u); // transfer_action
+            // test size_t(movable_object const&)
+            if (is_local)
+            {
+                HPX_TEST_EQ((
+                    pass_object<pass_movable_object_action, movable_object>(id)
+                ), 1u); // bind
 
-            HPX_TEST_EQ((
-                move_object<pass_movable_object_action, movable_object>(id)
-            ), 0u);
+                HPX_TEST_EQ((
+                    move_object<pass_movable_object_action, movable_object>(id)
+                ), 0U);
+            } else {
+                HPX_TEST_EQ((
+                    pass_object<pass_movable_object_action, movable_object>(id)
+                ), 1u); // transfer_action
+
+                HPX_TEST_EQ((
+                    move_object<pass_movable_object_action, movable_object>(id)
+                ), 0u);
+            }
+
+            // test size_t(non_movable_object const&)
+            if (is_local)
+            {
+                HPX_TEST_EQ((
+                    pass_object<pass_non_movable_object_action, non_movable_object>(id)
+                ), 2u); // bind + function
+
+                HPX_TEST_EQ((
+                    move_object<pass_non_movable_object_action, non_movable_object>(id)
+                ), 2u); // bind + function
+            } else {
+                HPX_TEST_EQ((
+                    pass_object<pass_non_movable_object_action, non_movable_object>(id)
+                ), 3u); // transfer_action + bind + function
+
+                HPX_TEST_EQ((
+                    move_object<pass_non_movable_object_action, non_movable_object>(id)
+                ), 3u); // transfer_action + bind + function
+            }
+
+            // test size_t(movable_object)
+            if (is_local)
+            {
+                HPX_TEST_EQ((
+                    pass_object<pass_movable_object_value_action, movable_object>(id)
+                ), 1u); // call
+
+                HPX_TEST_EQ((
+                    move_object<pass_movable_object_value_action, movable_object>(id)
+                ), 0u);
+            } else {
+                HPX_TEST_EQ((
+                    pass_object<pass_movable_object_value_action, movable_object>(id)
+                ), 1u); // transfer_action
+
+                HPX_TEST_EQ((
+                    move_object<pass_movable_object_value_action, movable_object>(id)
+                ), 0u);
+            }
+
+            // test size_t(non_movable_object)
+            if (is_local)
+            {
+                HPX_TEST_EQ((
+                    pass_object<pass_non_movable_object_value_action, non_movable_object>(id)
+                ), 3u); // bind + function + call
+
+                HPX_TEST_EQ((
+                    move_object<pass_non_movable_object_value_action, non_movable_object>(id)
+                ), 3u); // bind + function + call
+            } else {
+                HPX_TEST_EQ((
+                    pass_object<pass_non_movable_object_value_action, non_movable_object>(id)
+                ), 4u); // transfer_action + bind + function + call
+
+                HPX_TEST_EQ((
+                    move_object<pass_non_movable_object_value_action, non_movable_object>(id)
+                ), 4u); // transfer_action + bind + function + call
+            }
+
+            // test movable_object()
+            if (is_local)
+            {
+                HPX_TEST_EQ((
+                    return_object<
+                        return_movable_object_action, movable_object
+                    >(id)
+                ), 0u);
+            } else {
+                HPX_TEST_EQ((
+                    return_object<
+                        return_movable_object_action, movable_object
+                    >(id)
+                ), 0u);
+            }
+
+            // test non_movable_object()
+            if (is_local)
+            {
+                //FIXME: bumped number for intel compiler
+                HPX_TEST_RANGE((
+                    return_object<
+                        return_non_movable_object_action, non_movable_object
+                    >(id)
+                ), 1u, 5u); // ?call + set_value + ?return
+            } else {
+                //FIXME: bumped number for intel compiler
+                HPX_TEST_RANGE((
+                    return_object<
+                        return_non_movable_object_action, non_movable_object
+                    >(id)
+                ), 3u, 8u); // transfer_action + function + ?call +
+                        // set_value + ?return
+            }
         }
+    }
 
-        // test size_t(non_movable_object const&)
-        if (is_local)
+    // Same tests with lambdas
+    {
+        for (id_type const& id : localities)
         {
-            HPX_TEST_EQ((
-                pass_object<pass_non_movable_object_action, non_movable_object>(id)
-            ), 2u); // bind + function
+            bool is_local = id == find_here();
 
-            HPX_TEST_EQ((
-                move_object<pass_non_movable_object_action, non_movable_object>(id)
-            ), 2u); // bind + function
-        } else {
-            HPX_TEST_EQ((
-                pass_object<pass_non_movable_object_action, non_movable_object>(id)
-            ), 3u); // transfer_action + bind + function
+            // test size_t(movable_object const&)
+            if (is_local)
+            {
+                HPX_TEST_EQ((
+                    pass_object<decltype(movable_object_passer), movable_object>(id)
+                ), 1u); // bind
 
-            HPX_TEST_EQ((
-                move_object<pass_non_movable_object_action, non_movable_object>(id)
-            ), 3u); // transfer_action + bind + function
-        }
+                HPX_TEST_EQ((
+                    move_object<decltype(movable_object_passer), movable_object>(id)
+                ), 0U);
+            } else {
+                HPX_TEST_EQ((
+                    pass_object<decltype(movable_object_passer), movable_object>(id)
+                ), 1u); // transfer_action
 
-        // test size_t(movable_object)
-        if (is_local)
-        {
-            HPX_TEST_EQ((
-                pass_object<pass_movable_object_value_action, movable_object>(id)
-            ), 1u); // call
+                HPX_TEST_EQ((
+                    move_object<decltype(movable_object_passer), movable_object>(id)
+                ), 0u);
+            }
 
-            HPX_TEST_EQ((
-                move_object<pass_movable_object_value_action, movable_object>(id)
-            ), 0u);
-        } else {
-            HPX_TEST_EQ((
-                pass_object<pass_movable_object_value_action, movable_object>(id)
-            ), 1u); // transfer_action
+            // test size_t(non_movable_object const&)
+            if (is_local)
+            {
+                HPX_TEST_EQ((
+                    pass_object<decltype(non_movable_object_passer), non_movable_object>(id)
+                ), 2u); // bind + function
 
-            HPX_TEST_EQ((
-                move_object<pass_movable_object_value_action, movable_object>(id)
-            ), 0u);
-        }
+                HPX_TEST_EQ((
+                    move_object<decltype(non_movable_object_passer), non_movable_object>(id)
+                ), 2u); // bind + function
+            } else {
+                HPX_TEST_EQ((
+                    pass_object<decltype(non_movable_object_passer), non_movable_object>(id)
+                ), 3u); // transfer_action + bind + function
 
-        // test size_t(non_movable_object)
-        if (is_local)
-        {
-            HPX_TEST_EQ((
-                pass_object<pass_non_movable_object_value_action, non_movable_object>(id)
-            ), 3u); // bind + function + call
+                HPX_TEST_EQ((
+                    move_object<decltype(non_movable_object_passer), non_movable_object>(id)
+                ), 3u); // transfer_action + bind + function
+            }
 
-            HPX_TEST_EQ((
-                move_object<pass_non_movable_object_value_action, non_movable_object>(id)
-            ), 3u); // bind + function + call
-        } else {
-            HPX_TEST_EQ((
-                pass_object<pass_non_movable_object_value_action, non_movable_object>(id)
-            ), 4u); // transfer_action + bind + function + call
+            // test size_t(movable_object)
+            if (is_local)
+            {
+                HPX_TEST_EQ((
+                    pass_object<decltype(movable_object_value_passer), movable_object>(id)
+                ), 1u); // call
 
-            HPX_TEST_EQ((
-                move_object<pass_non_movable_object_value_action, non_movable_object>(id)
-            ), 4u); // transfer_action + bind + function + call
-        }
+                HPX_TEST_EQ((
+                    move_object<decltype(movable_object_value_passer), movable_object>(id)
+                ), 0u);
+            } else {
+                HPX_TEST_EQ((
+                    pass_object<decltype(movable_object_value_passer), movable_object>(id)
+                ), 1u); // transfer_action
 
-        // test movable_object()
-        if (is_local)
-        {
-            HPX_TEST_EQ((
-                return_object<
-                    return_movable_object_action, movable_object
-                >(id)
-            ), 0u);
-        } else {
-            HPX_TEST_EQ((
-                return_object<
-                    return_movable_object_action, movable_object
-                >(id)
-            ), 0u);
-        }
+                HPX_TEST_EQ((
+                    move_object<decltype(movable_object_value_passer), movable_object>(id)
+                ), 0u);
+            }
 
-        // test non_movable_object()
-        if (is_local)
-        {
-            //FIXME: bumped number for intel compiler
-            HPX_TEST_RANGE((
-                return_object<
-                    return_non_movable_object_action, non_movable_object
-                >(id)
-            ), 1u, 5u); // ?call + set_value + ?return
-        } else {
-            //FIXME: bumped number for intel compiler
-            HPX_TEST_RANGE((
-                return_object<
-                    return_non_movable_object_action, non_movable_object
-                >(id)
-            ), 3u, 8u); // transfer_action + function + ?call +
-                    // set_value + ?return
+            // test size_t(non_movable_object)
+            if (is_local)
+            {
+                HPX_TEST_EQ((
+                    pass_object<decltype(non_movable_object_value_passer), non_movable_object>(id)
+                ), 3u); // bind + function + call
+
+                HPX_TEST_EQ((
+                    move_object<decltype(non_movable_object_value_passer), non_movable_object>(id)
+                ), 3u); // bind + function + call
+            } else {
+                HPX_TEST_EQ((
+                    pass_object<decltype(non_movable_object_value_passer), non_movable_object>(id)
+                ), 4u); // transfer_action + bind + function + call
+
+                HPX_TEST_EQ((
+                    move_object<decltype(non_movable_object_value_passer), non_movable_object>(id)
+                ), 4u); // transfer_action + bind + function + call
+            }
+
+            // test movable_object()
+            if (is_local)
+            {
+                HPX_TEST_EQ((
+                    return_object<
+                        decltype(movable_object_returner), movable_object
+                    >(id)
+                ), 0u);
+            } else {
+                HPX_TEST_EQ((
+                    return_object<
+                        decltype(movable_object_returner), movable_object
+                    >(id)
+                ), 0u);
+            }
+
+            // test non_movable_object()
+            if (is_local)
+            {
+                //FIXME: bumped number for intel compiler
+                HPX_TEST_RANGE((
+                    return_object<
+                        decltype(non_movable_object_returner), non_movable_object
+                    >(id)
+                ), 1u, 5u); // ?call + set_value + ?return
+            } else {
+                //FIXME: bumped number for intel compiler
+                HPX_TEST_RANGE((
+                    return_object<
+                        decltype(non_movable_object_returner), non_movable_object
+                    >(id)
+                ), 3u, 8u); // transfer_action + function + ?call +
+                        // set_value + ?return
+            }
         }
     }
 }


### PR DESCRIPTION
This PR tries to give some facilities to create actions from lambdas. It is inspired from the trick explained in http://pfultz2.com/blog/2014/09/02/static-lambda/. The constraints for the lambda are :

- No captured variables (property checked via `static_assert()`)
- Parameters passed by value (similarly to global functions that are converted into actions)