### PR TITLE
Fixing handling of GIDs during serialization preprocessing

### DIFF
--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -148,6 +148,7 @@ namespace hpx { namespace lcos { namespace detail
                         value_type const & value =
                             *hpx::traits::future_access<Future>::
                                 get_shared_state(f)->get_result();
+                        state = future_state::has_value;
                         ar << state << value; //-V128
                     } else if (f.has_exception()) {
                         state = future_state::has_exception;

--- a/hpx/runtime/parcelset/parcel.hpp
+++ b/hpx/runtime/parcelset/parcel.hpp
@@ -75,7 +75,7 @@ namespace hpx { namespace parcelset
     private:
 
         typedef
-            std::map<naming::gid_type, naming::gid_type>
+            std::map<const naming::gid_type*, naming::gid_type>
             split_gids_type;
 
 #if defined(HPX_DEBUG)

--- a/hpx/runtime/serialization/detail/preprocess.hpp
+++ b/hpx/runtime/serialization/detail/preprocess.hpp
@@ -31,7 +31,7 @@ namespace hpx { namespace serialization { namespace detail
     class preprocess
     {
         typedef hpx::lcos::local::spinlock mutex_type;
-        typedef std::map<naming::gid_type, naming::gid_type> split_gids_map;
+        typedef std::map<const naming::gid_type*, naming::gid_type> split_gids_map;
     public:
         preprocess()
           : size_(0)
@@ -79,14 +79,14 @@ namespace hpx { namespace serialization { namespace detail
             naming::gid_type const & split_gid)
         {
             std::lock_guard<mutex_type> l(mtx_);
-            HPX_ASSERT(split_gids_[gid] == naming::invalid_gid);
-            split_gids_[gid] = split_gid;
+            HPX_ASSERT(split_gids_[&gid] == naming::invalid_gid);
+            split_gids_[&gid] = split_gid;
         }
 
         bool has_gid(naming::gid_type const & gid)
         {
             std::lock_guard<mutex_type> l(mtx_);
-            return split_gids_.find(gid) != split_gids_.end();
+            return split_gids_.find(&gid) != split_gids_.end();
         }
 
         void reset()

--- a/hpx/runtime/serialization/output_archive.hpp
+++ b/hpx/runtime/serialization/output_archive.hpp
@@ -38,7 +38,7 @@ namespace hpx { namespace serialization
     {
         typedef basic_archive<output_archive> base_type;
 
-        typedef std::map<naming::gid_type, naming::gid_type> split_gids_type;
+        typedef std::map<const naming::gid_type*, naming::gid_type> split_gids_type;
 
         template <typename Container>
         output_archive(Container & buffer,

--- a/src/runtime/serialization/output_archive.cpp
+++ b/src/runtime/serialization/output_archive.cpp
@@ -28,7 +28,7 @@ namespace hpx { namespace serialization
     {
         if(!split_gids_) return naming::gid_type();
 
-        split_gids_type::iterator it = split_gids_->find(gid);
+        split_gids_type::iterator it = split_gids_->find(&gid);
         HPX_ASSERT(it != split_gids_->end());
         HPX_ASSERT(it->second != naming::invalid_gid);
         naming::gid_type new_gid = it->second;


### PR DESCRIPTION
Instead of looking up the gid_type by the GID, the split_gid mechanism is now
using the address of gid_type, which is owned by id_type.

Flyby: Fixing minor inconsistency during future serialization.