### PR TITLE
Add output of a Bazel Skylark extension for paths and compile options

### DIFF
--- a/cmake/templates/hpx_bazel_defs.bzl.in
+++ b/cmake/templates/hpx_bazel_defs.bzl.in
@@ -1,0 +1,36 @@
+# Macros for building HPX code.
+def hpx_component_copts(component_name):
+    """Shorthand for needed HPX component compile options
+        Returns the needed HPX component compile options.
+    """
+    return ['-DHPX_COMPONENT_NAME=' + component_name, '-DHPX_COMPONENT_STRING=\\"' + component_name + '\\"', '-fPIC', '-DHPX_COMPONENT_EXPORTS', '-DHPX_ENABLE_ASSERT_HANDLER']
+
+def hpx_application_copts():
+    """Shorthand for needed HPX application compile options
+        Returns the needed HPX application compile options.
+    """
+    return ["-DHPX_APPLICATION_EXPORTS", "-DHPX_ENABLE_ASSERT_HANDLER"]          
+
+def hpx_copts():
+    """Shorthand for needed HPX compile options
+        Returns the needed HPX compile options.
+    """
+    return "@CXX_FLAG@".replace("  ", " ").replace(hpx_path(), "hpx").replace(boost_path(), "boost").split(" ")
+
+def hpx_link_opts():
+    """Shorthand for needed HPX link options
+        Returns the needed HPX link options
+    """
+    return "@CXX_FLAG@ -L@HPX_CONF_PREFIX@ @HPX_PKG_LIBRARY_DIR@ @HPX_PKG_LIBRARIES_BAZEL@".replace("  ", " ").replace(hpx_path(), "hpx").replace(boost_path(), "boost").split(" ")
+
+def hpx_path():
+    """Shorthand for the Boost path
+        Returns the Boost path
+    """
+    return "@HPX_CONF_PREFIX@"
+
+def boost_path():
+    """Shorthand for the Boost path
+        Returns the Boost path
+    """
+    return "@BOOST_ROOT@"

--- a/cmake/templates/hpx_bazel_defs.bzl.in
+++ b/cmake/templates/hpx_bazel_defs.bzl.in
@@ -19,18 +19,18 @@ def hpx_copts():
 
 def hpx_link_opts():
     """Shorthand for needed HPX link options
-        Returns the needed HPX link options
+        Returns the needed HPX link options.
     """
     return "@CXX_FLAG@ -L@HPX_CONF_PREFIX@ @HPX_PKG_LIBRARY_DIR@ @HPX_PKG_LIBRARIES_BAZEL@".replace("  ", " ").replace(hpx_path(), "hpx").replace(boost_path(), "boost").split(" ")
 
 def hpx_path():
-    """Shorthand for the Boost path
-        Returns the Boost path
+    """Shorthand for the HPX path
+        Returns the HPX path.
     """
     return "@HPX_CONF_PREFIX@"
 
 def boost_path():
     """Shorthand for the Boost path
-        Returns the Boost path
+        Returns the Boost path.
     """
     return "@BOOST_ROOT@"

--- a/cmake/templates/hpx_bazel_defs_debug.bzl.in
+++ b/cmake/templates/hpx_bazel_defs_debug.bzl.in
@@ -27,7 +27,7 @@ def hpx_path():
     """Shorthand for the Boost path
         Returns the Boost path
     """
-    return "@HPX_CONF_PREFIX@
+    return "@HPX_CONF_PREFIX@"
 
 def boost_path():
     """Shorthand for the Boost path

--- a/cmake/templates/hpx_bazel_defs_debug.bzl.in
+++ b/cmake/templates/hpx_bazel_defs_debug.bzl.in
@@ -19,18 +19,18 @@ def hpx_copts():
 
 def hpx_link_opts():
     """Shorthand for needed HPX link options
-        Returns the needed HPX link options
+        Returns the needed HPX link options.
     """
     return "@CXX_FLAG@ -L@HPX_CONF_PREFIX@ @HPX_PKG_LIBRARY_DIR@ @HPX_PKG_DEBUG_LIBRARIES_BAZEL@".replace("  ", " ").replace(hpx_path(), "hpx").replace(boost_path(), "boost").split(" ")
 
 def hpx_path():
-    """Shorthand for the Boost path
-        Returns the Boost path
+    """Shorthand for the HPX path
+        Returns the HPX path.
     """
     return "@HPX_CONF_PREFIX@"
 
 def boost_path():
     """Shorthand for the Boost path
-        Returns the Boost path
+        Returns the Boost path.
     """
     return "@BOOST_ROOT@"

--- a/cmake/templates/hpx_bazel_defs_debug.bzl.in
+++ b/cmake/templates/hpx_bazel_defs_debug.bzl.in
@@ -1,0 +1,36 @@
+# Macros for building HPX code.
+def hpx_component_copts(component_name):
+    """Shorthand for needed HPX component compile options
+        Returns the needed HPX component compile options.
+    """
+    return ['-DHPX_COMPONENT_NAME=' + component_name, '-DHPX_COMPONENT_STRING=\\"' + component_name + '\\"', '-fPIC', '-DHPX_COMPONENT_EXPORTS', '-DHPX_ENABLE_ASSERT_HANDLER']
+
+def hpx_application_copts():
+    """Shorthand for needed HPX application compile options
+        Returns the needed HPX application compile options.
+    """
+    return ["-DHPX_APPLICATION_EXPORTS", "-DHPX_ENABLE_ASSERT_HANDLER"]          
+
+def hpx_copts():
+    """Shorthand for needed HPX compile options
+        Returns the needed HPX compile options.
+    """
+    return "@CXX_FLAG@ -DHPX_DEBUG".replace("  ", " ").replace(hpx_path(), "hpx").replace(boost_path(), "boost").split(" ")
+
+def hpx_link_opts():
+    """Shorthand for needed HPX link options
+        Returns the needed HPX link options
+    """
+    return "@CXX_FLAG@ -L@HPX_CONF_PREFIX@ @HPX_PKG_LIBRARY_DIR@ @HPX_PKG_DEBUG_LIBRARIES_BAZEL@".replace("  ", " ").replace(hpx_path(), "hpx").replace(boost_path(), "boost").split(" ")
+
+def hpx_path():
+    """Shorthand for the Boost path
+        Returns the Boost path
+    """
+    return "@HPX_CONF_PREFIX@
+
+def boost_path():
+    """Shorthand for the Boost path
+        Returns the Boost path
+    """
+    return "@BOOST_ROOT@"


### PR DESCRIPTION
This PR adds the output of a Bazel Skylark extension for all relevant HPX compile options and paths to be able to use them from inside a Bazel project.