### PR TITLE
Make HPX_WITH_MALLOC easier to use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,8 @@ endif()
 hpx_option(HPX_WITH_MALLOC
   STRING
   "Define which allocator should be linked in. Options are: system, tcmalloc, jemalloc, tbbmalloc, and custom (default is: tcmalloc)"
-  ${DEFAULT_MALLOC} ADVANCED)
+  ${DEFAULT_MALLOC} ADVANCED
+  STRINGS "system;tcmalloc;jemalloc;tbbmalloc;custom")
 
 hpx_option(HPX_WITH_HWLOC
   BOOL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ endif()
 hpx_option(HPX_WITH_MALLOC
   STRING
   "Define which allocator should be linked in. Options are: system, tcmalloc, jemalloc, tbbmalloc, and custom (default is: tcmalloc)"
-  ${DEFAULT_MALLOC} ADVANCED
+  ${DEFAULT_MALLOC}
   STRINGS "system;tcmalloc;jemalloc;tbbmalloc;custom")
 
 hpx_option(HPX_WITH_HWLOC

--- a/cmake/HPX_Option.cmake
+++ b/cmake/HPX_Option.cmake
@@ -20,7 +20,7 @@ set(HPX_OPTION_CATEGORIES
 function(hpx_option option type description default)
   set(options ADVANCED)
   set(one_value_args CATEGORY)
-  set(multi_value_args)
+  set(multi_value_args STRINGS)
   cmake_parse_arguments(HPX_OPTION "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
 
   if(NOT DEFINED ${option})
@@ -31,6 +31,14 @@ function(hpx_option option type description default)
   else()
     set_property(CACHE "${option}" PROPERTY HELPSTRING "${description}")
     set_property(CACHE "${option}" PROPERTY TYPE "${type}")
+  endif()
+  
+  if(HPX_OPTION_STRINGS)
+    if("${type}" STREQUAL "STRING")
+      set_property(CACHE "${option}" PROPERTY STRINGS "${HPX_OPTION_STRINGS}")
+    else()
+      message(FATAL_ERROR "hpx_option(): STRINGS can only be used if type is STRING !")
+    endif()
   endif()
 
   set(_category "Generic")


### PR DESCRIPTION
This branch does two things:
- it makes HPX_WITH_MALLOC non-advanced, so it is eaier to find e.g. in cmake-gui, which is good since probably most users have to modify this settings
- it adds an STRINGS keyword to hpx_option(), and uses this to set the STRINGS cache property, so that the options are presented in a combobox in cmake-gui (and so really easy to select). Use this for HPX_WITH_MALLOC.