### PR TITLE
Add configuration option to disable networking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -560,44 +560,52 @@ if(HPX_WITH_AGAS_DUMP_REFCNT_ENTRIES)
   hpx_add_config_define(HPX_HAVE_AGAS_DUMP_REFCNT_ENTRIES)
 endif()
 
-## Parcelport related build options
-set(_parcel_profiling_default OFF)
-if(HPX_WITH_APEX)
-  set(_parcel_profiling_default ON)
-endif()
-
-hpx_option(HPX_WITH_PARCEL_PROFILING BOOL
-  "Enable profiling data for parcels"
-  ${_parcel_profiling_default} CATEGORY "Parcelport" ADVANCED)
-
-if(HPX_WITH_PARCEL_PROFILING)
-  hpx_add_config_define(HPX_HAVE_PARCEL_PROFILING)
-endif()
-
-## Parcelport related build options
-hpx_option(HPX_WITH_PARCELPORT_VERBS BOOL
-  "Enable the ibverbs based parcelport. This is currently an experimental feature"
-  OFF CATEGORY "Parcelport" ADVANCED)
-hpx_option(HPX_WITH_PARCELPORT_MPI BOOL
-  "Enable the MPI based parcelport."
-  OFF CATEGORY "Parcelport")
-hpx_option(HPX_WITH_PARCELPORT_TCP BOOL
-  "Enable the TCP based parcelport."
+# Should networking be supported?
+hpx_option(HPX_WITH_NETWORKING BOOL
+  "Enable support for networking and multi-node runs (default: ON)"
   ON CATEGORY "Parcelport")
-hpx_option(HPX_WITH_PARCELPORT_ACTION_COUNTERS BOOL
-  "Enable performance counters reporting parcelport statistics on a per-action basis."
-  OFF CATEGORY "Parcelport")
-if(HPX_WITH_PARCELPORT_ACTION_COUNTERS)
-  hpx_add_config_define(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
-endif()
+if(HPX_WITH_NETWORKING)
+  hpx_add_config_define(HPX_HAVE_NETWORKING)
 
-## mpi parcelport settings
-hpx_option(HPX_WITH_PARCELPORT_MPI_ENV STRING
-  "List of environment variables checked to detect MPI (default: MV2_COMM_WORLD_RANK;PMI_RANK;OMPI_COMM_WORLD_SIZE;ALPS_APP_PE)."
-  "MV2_COMM_WORLD_RANK;PMI_RANK;OMPI_COMM_WORLD_SIZE;ALPS_APP_PE" CATEGORY "Parcelport" ADVANCED)
-hpx_option(HPX_WITH_PARCELPORT_MPI_MULTITHREADED BOOL
-  "Turn on MPI multithreading support (default: ON)."
-  ON CATEGORY "Parcelport" ADVANCED)
+  ## Parcelport related build options
+  set(_parcel_profiling_default OFF)
+  if(HPX_WITH_APEX)
+    set(_parcel_profiling_default ON)
+  endif()
+
+  hpx_option(HPX_WITH_PARCEL_PROFILING BOOL
+    "Enable profiling data for parcels"
+    ${_parcel_profiling_default} CATEGORY "Parcelport" ADVANCED)
+
+  if(HPX_WITH_PARCEL_PROFILING)
+    hpx_add_config_define(HPX_HAVE_PARCEL_PROFILING)
+  endif()
+
+  ## Parcelport related build options
+  hpx_option(HPX_WITH_PARCELPORT_VERBS BOOL
+    "Enable the ibverbs based parcelport. This is currently an experimental feature"
+    OFF CATEGORY "Parcelport" ADVANCED)
+  hpx_option(HPX_WITH_PARCELPORT_MPI BOOL
+    "Enable the MPI based parcelport."
+    OFF CATEGORY "Parcelport")
+  hpx_option(HPX_WITH_PARCELPORT_TCP BOOL
+    "Enable the TCP based parcelport."
+    ON CATEGORY "Parcelport")
+  hpx_option(HPX_WITH_PARCELPORT_ACTION_COUNTERS BOOL
+    "Enable performance counters reporting parcelport statistics on a per-action basis."
+    OFF CATEGORY "Parcelport")
+  if(HPX_WITH_PARCELPORT_ACTION_COUNTERS)
+    hpx_add_config_define(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
+  endif()
+
+  ## mpi parcelport settings
+  hpx_option(HPX_WITH_PARCELPORT_MPI_ENV STRING
+    "List of environment variables checked to detect MPI (default: MV2_COMM_WORLD_RANK;PMI_RANK;OMPI_COMM_WORLD_SIZE;ALPS_APP_PE)."
+    "MV2_COMM_WORLD_RANK;PMI_RANK;OMPI_COMM_WORLD_SIZE;ALPS_APP_PE" CATEGORY "Parcelport" ADVANCED)
+  hpx_option(HPX_WITH_PARCELPORT_MPI_MULTITHREADED BOOL
+    "Turn on MPI multithreading support (default: ON)."
+    ON CATEGORY "Parcelport" ADVANCED)
+endif()
 
 ## External libraries/frameworks used by sme of the examples and benchmarks
 hpx_option(HPX_WITH_EXAMPLES_OPENMP BOOL
@@ -727,19 +735,21 @@ if(HPX_WITH_RUN_MAIN_EVERYWHERE)
   hpx_add_config_define(HPX_HAVE_RUN_MAIN_EVERYWHERE)
 endif()
 
-# Options for our plugins
-hpx_option(HPX_WITH_COMPRESSION_BZIP2 BOOL
-  "Enable bzip2 compression for parcel data (default: OFF)." OFF ADVANCED)
-hpx_option(HPX_WITH_COMPRESSION_SNAPPY BOOL
-  "Enable snappy compression for parcel data (default: OFF)." OFF ADVANCED)
-hpx_option(HPX_WITH_COMPRESSION_ZLIB BOOL
-  "Enable zlib compression for parcel data (default: OFF)." OFF ADVANCED)
+if(HPX_WITH_NETWORKING)
+  # Options for our plugins
+  hpx_option(HPX_WITH_COMPRESSION_BZIP2 BOOL
+    "Enable bzip2 compression for parcel data (default: OFF)." OFF ADVANCED)
+  hpx_option(HPX_WITH_COMPRESSION_SNAPPY BOOL
+    "Enable snappy compression for parcel data (default: OFF)." OFF ADVANCED)
+  hpx_option(HPX_WITH_COMPRESSION_ZLIB BOOL
+    "Enable zlib compression for parcel data (default: OFF)." OFF ADVANCED)
 
-# Parcel coalescing is used by the main HPX library, enable it always
-hpx_option(HPX_WITH_PARCEL_COALESCING BOOL
-  "Enable the parcel coalescing plugin (default: ON)." ON ADVANCED)
-if(HPX_WITH_PARCEL_COALESCING)
-  hpx_add_config_define(HPX_HAVE_PARCEL_COALESCING)
+  # Parcel coalescing is used by the main HPX library, enable it always
+  hpx_option(HPX_WITH_PARCEL_COALESCING BOOL
+    "Enable the parcel coalescing plugin (default: ON)." ON ADVANCED)
+  if(HPX_WITH_PARCEL_COALESCING)
+    hpx_add_config_define(HPX_HAVE_PARCEL_COALESCING)
+  endif()
 endif()
 
 ################################################################################

--- a/docs/manual/config_defaults.qbk
+++ b/docs/manual/config_defaults.qbk
@@ -374,7 +374,7 @@ The following settings relate to the TCP/IP parcelport.
 [teletype]
 ``
     [hpx.parcel.tcp]
-    enable = ${HPX_HAVE_PARCELPORT_TCP:1}
+    enable = ${HPX_HAVE_PARCELPORT_TCP:$[hpx.parcel.enabled]}
     array_optimization = ${HPX_PARCEL_TCP_ARRAY_OPTIMIZATION:$[hpx.parcel.array_optimization]}
     zero_copy_optimization = ${HPX_PARCEL_TCP_ZERO_COPY_OPTIMIZATION:$[hpx.parcel.zero_copy_optimization]}
     async_serialization = ${HPX_PARCEL_TCP_ASYNC_SERIALIZATION:$[hpx.parcel.async_serialization]}
@@ -433,144 +433,6 @@ The following settings relate to the TCP/IP parcelport.
       taken from `hpx.parcel.max_outbound_connections`.]]
 ]
 
-The following settings relate to the shared memory parcelport (which is usable
-for communication between two localities on the same node). These settings take
-effect only if the compile time constant `HPX_HAVE_PARCELPORT_IPC` is set
-(the equivalent cmake variable is `HPX_WITH_PARCELPORT_IPC`, and has to be set to `ON`).
-
-[teletype]
-``
-    [hpx.parcel.ipc]
-    enable = ${HPX_HAVE_PARCELPORT_IPC:0}
-    data_buffer_cache_size=${HPX_PARCEL_IPC_DATA_BUFFER_CACHE_SIZE:512}
-    array_optimization = ${HPX_PARCEL_IPC_ARRAY_OPTIMIZATION:$[hpx.parcel.array_optimization]}
-    async_serialization = ${HPX_PARCEL_IPC_ASYNC_SERIALIZATION:$[hpx.parcel.async_serialization]}
-    enable_security = ${HPX_PARCEL_IPC_ENABLE_SECURITY:$[hpx.parcel.enable_security]}
-    parcel_pool_size = ${HPX_PARCEL_IPC_PARCEL_POOL_SIZE:$[hpx.threadpools.parcel_pool_size]}
-    max_connections =  ${HPX_PARCEL_IPC_MAX_CONNECTIONS:$[hpx.parcel.max_connections]}
-    max_connections_per_locality = ${HPX_PARCEL_IPC_MAX_CONNECTIONS_PER_LOCALITY:$[hpx.parcel.max_connections_per_locality]}
-    max_message_size =  ${HPX_PARCEL_IPC_MAX_MESSAGE_SIZE:$[hpx.parcel.max_message_size]}
-    max_outbound_message_size =  ${HPX_PARCEL_IPC_MAX_OUTBOUND_MESSAGE_SIZE:$[hpx.parcel.max_outbound_message_size]}
-``
-[c++]
-
-[table:ini_hpx_parcel_ipc
-    [[Property]                 [Description]]
-    [[`hpx.parcel.ipc.enable`]
-     [Enable the use of the shared memory parcelport for connections between
-      localities running on the same node. Note that the initial bootstrap
-      of the overall __hpx__ application will still be performed using the
-      default ipc connections. This parcelport is disabled by default.]]
-    [[`hpx.parcel.ipc.data_buffer_cache_size`]
-     [This property specifies the number of cached data buffers used for
-      interprocess communication between localities on the same node. The
-      default depends on the compile time preprocessor constant
-      `HPX_PARCEL_IPC_DATA_BUFFER_CACHE_SIZE` (`512`).]]
-    [[`hpx.parcel.ipc.array_optimization`]
-     [This property defines whether this locality is allowed to utilize array
-      optimizations in the shared memory parcelport during serialization of parcel data.
-      The default is the same value as set for `hpx.parcel.array_optimization`.]]
-    [[`hpx.parcel.ipc.async_serialization`]
-     [This property defines whether this locality is allowed to spawn a new thread
-      for serialization in the shared memory parcelport (this is both for encoding
-      and decoding parcels). The default is the same value as set for
-      `hpx.parcel.async_serialization`.]]
-    [[`hpx.parcel.ipc.enable_security`]
-     [This property defines whether this locality is encrypting parcels in the
-      shared memory parcelport. The default is the same value as set for
-      `hpx.parcel.enable_security`.]]
-    [[`hpx.parcel.ipc.parcel_pool_size`]
-     [The value of this property defines the number of OS-threads created for
-      the internal parcel thread pool of the ipc parcel port. The default is
-      taken from `hpx.threadpools.parcel_pool_size`.]]
-    [[`hpx.parcel.ipc.max_connections`]
-     [This property defines how many network connections between different
-      localities are overall kept alive by each of locality. The default is
-      taken from `hpx.parcel.max_connections`.]]
-    [[`hpx.parcel.ipc.max_connections_per_locality`]
-     [This property defines the maximum number of network connections that one
-      locality will open to another locality. The default is
-      taken from `hpx.parcel.max_connections_per_locality`.]]
-    [[`hpx.parcel.ipc.max_message_size`]
-     [This property defines the maximum allowed message size which will be
-      transferrable through the parcel layer. The default is
-      taken from `hpx.parcel.max_message_size`.]]
-    [[`hpx.parcel.ipc.max_outbound_message_size`]
-     [This property defines the maximum allowed outbound coalesced message size which
-      will be transferrable through the parcel layer. The default is
-      taken from `hpx.parcel.max_outbound_connections`.]]
-]
-
-The following settings relate to the Infiniband parcelport. These settings take
-effect only if the compile time constant `HPX_PARCELPORT_IBVERBS` is set
-(the equivalent cmake variable is `HPX_PARCELPORT_IBVERBS`, and has to be
-set to `ON`).
-
-[teletype]
-``
-    [hpx.parcel.ibverbs]
-    enable = ${HPX_PARCELPORT_IBVERBS:0}
-    buffer_size = ${HPX_PARCEL_IBVERBS_BUFFER_SIZE:65536}
-    array_optimization = ${HPX_PARCEL_IBVERBS_ARRAY_OPTIMIZATION:$[hpx.parcel.array_optimization]}
-    async_serialization = ${HPX_PARCEL_IBVERBS_ASYNC_SERIALIZATION:$[hpx.parcel.async_serialization]}
-    enable_security = ${HPX_PARCEL_IBVERBS_ENABLE_SECURITY:$[hpx.parcel.enable_security]}
-    parcel_pool_size = ${HPX_PARCEL_IBVERBS_PARCEL_POOL_SIZE:$[hpx.threadpools.parcel_pool_size]}
-    max_connections =  ${HPX_PARCEL_IBVERBS_MAX_CONNECTIONS:$[hpx.parcel.max_connections]}
-    max_connections_per_locality = ${HPX_PARCEL_IBVERBS_MAX_CONNECTIONS_PER_LOCALITY:$[hpx.parcel.max_connections_per_locality]}
-    max_message_size =  ${HPX_PARCEL_IBVERBS_MAX_MESSAGE_SIZE:$[hpx.parcel.max_message_size]}
-    max_outbound_message_size =  ${HPX_PARCEL_IBVERBS_MAX_OUTBOUND_MESSAGE_SIZE:$[hpx.parcel.max_outbound_message_size]}
-``
-[c++]
-
-[table:ini_hpx_parcel_ibverbs
-    [[Property]                 [Description]]
-    [[`hpx.parcel.ibverbs.enable`]
-     [Enable the use of the ibverbs parcelport for connections between
-      localities running on a node with infiniband capable hardware. Note
-      that the initial bootstrap of the overall __hpx__ application will
-      still be performed using the default TCP/IP connections.
-      This parcelport is disabled by default.]]
-    [[`hpx.parcel.ibverbs.buffer_size`]
-     [This property specifies the size in bytes of the buffers registered to
-      the infiniband hardware. Parcels which are smaller than this will be
-      serialized and sent over the network in a zero-copy fashion. Parcels
-      bigger than this will be transparently copied to a big enough temporary
-      buffer.]]
-    [[`hpx.parcel.ibverbs.array_optimization`]
-     [This property defines whether this locality is allowed to utilize array
-      optimizations in the ibverbs parcelport during serialization of parcel data.
-      The default is the same value as set for `hpx.parcel.array_optimization`.]]
-    [[`hpx.parcel.ibverbs.async_serialization`]
-     [This property defines whether this locality is allowed to spawn a new thread
-      for serialization in the ibverbs parcelport (this is both for encoding
-      and decoding parcels). The default is the same value as set for
-      `hpx.parcel.async_serialization`.]]
-    [[`hpx.parcel.ibverbs.enable_security`]
-     [This property defines whether this locality is encrypting parcels in the
-      ibverbs parcelport. The default is the same value as set for
-      `hpx.parcel.enable_security`.]]
-    [[`hpx.parcel.ibverbs.parcel_pool_size`]
-     [The value of this property defines the number of OS-threads created for
-      the internal parcel thread pool of the ibverbs parcel port. The default is
-      taken from `hpx.threadpools.parcel_pool_size`.]]
-    [[`hpx.parcel.ibverbs.max_connections`]
-     [This property defines how many network connections between different
-      localities are overall kept alive by each of locality. The default is
-      taken from `hpx.parcel.max_connections`.]]
-    [[`hpx.parcel.ibverbs.max_connections_per_locality`]
-     [This property defines the maximum number of network connections that one
-      locality will open to another locality. The default is
-      taken from `hpx.parcel.max_connections_per_locality`.]]
-    [[`hpx.parcel.ibverbs.max_message_size`]
-     [This property defines the maximum allowed message size which will be
-      transferrable through the parcel layer. The default is
-      taken from `hpx.parcel.max_message_size`.]]
-    [[`hpx.parcel.ibverbs.max_outbound_message_size`]
-     [This property defines the maximum allowed outbound coalesced message size which
-      will be transferrable through the parcel layer. The default is
-      taken from `hpx.parcel.max_outbound_connections`.]]
-]
-
 The following settings relate to the MPI parcelport. These settings take
 effect only if the compile time constant `HPX_HAVE_PARCELPORT_MPI` is set
 (the equivalent cmake variable is `HPX_WITH_PARCELPORT_MPI`, and has to be set
@@ -579,7 +441,7 @@ to `ON`).
 [teletype]
 ``
     [hpx.parcel.mpi]
-    enable = ${HPX_HAVE_PARCELPORT_MPI:1}
+    enable = ${HPX_HAVE_PARCELPORT_MPI:$[hpx.parcel.enabled]}
     env = ${HPX_HAVE_PARCELPORT_MPI_ENV:MV2_COMM_WORLD_RANK,PMI_RANK,OMPI_COMM_WORLD_SIZE,ALPS_APP_PE}
     multithreaded = ${HPX_HAVE_PARCELPORT_MPI_MULTITHREADED:0}
     rank = <MPI_rank>

--- a/hpx/plugins/parcelport_factory.hpp
+++ b/hpx/plugins/parcelport_factory.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c)      2014 Thomas Heller
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2017 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -79,7 +79,7 @@ namespace hpx { namespace plugins
             fillini += "name = " HPX_PLUGIN_STRING;
             fillini += std::string("path = ") +
                 util::find_prefixes("/hpx", HPX_PLUGIN_STRING);
-            fillini += "enable = 1";
+            fillini += "enable = $[hpx.parcel.enabled]";
 
             std::string name_uc = boost::to_upper_copy(name);
             // basic parcelport configuration ...

--- a/plugins/binary_filter/CMakeLists.txt
+++ b/plugins/binary_filter/CMakeLists.txt
@@ -1,12 +1,16 @@
-# Copyright (c) 2007-2013 Hartmut Kaiser
+# Copyright (c) 2007-2017 Hartmut Kaiser
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(binary_filter_plugins
+set(binary_filter_plugins)
+
+if(HPX_WITH_NETWORKING)
+  set(binary_filter_plugins ${binary_filter_plugins}
     bzip2
     snappy
     zlib)
+endif()
 
 foreach(type ${binary_filter_plugins})
   add_hpx_pseudo_target(plugins.binary_filter.${type})
@@ -15,7 +19,9 @@ foreach(type ${binary_filter_plugins})
 endforeach()
 
 macro(add_binary_filter_modules)
-  add_bzip2_module()
-  add_snappy_module()
-  add_zlib_module()
+  if(HPX_WITH_NETWORKING)
+    add_bzip2_module()
+    add_snappy_module()
+    add_zlib_module()
+  endif()
 endmacro()

--- a/plugins/parcel/CMakeLists.txt
+++ b/plugins/parcel/CMakeLists.txt
@@ -1,10 +1,14 @@
-# Copyright (c) 2007-2013 Hartmut Kaiser
+# Copyright (c) 2007-2017 Hartmut Kaiser
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(parcel_plugins
+set(parcel_plugins)
+
+if(HPX_WITH_NETWORKING)
+  set(parcel_plugins ${parcel_plugins}
     coalescing)
+endif()
 
 foreach(type ${parcel_plugins})
   add_hpx_pseudo_target(plugins.parcel.${type})
@@ -13,5 +17,7 @@ foreach(type ${parcel_plugins})
 endforeach()
 
 macro(add_parcel_modules)
-  add_coalescing_module()
+  if(HPX_WITH_NETWORKING)
+    add_coalescing_module()
+  endif()
 endmacro()

--- a/plugins/parcelport/CMakeLists.txt
+++ b/plugins/parcelport/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2007-2013 Hartmut Kaiser
+# Copyright (c) 2007-2017 Hartmut Kaiser
 # Copyright (c) 2014-2015 Thomas Heller
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,10 +6,14 @@
 
 # We explicitly disable ibverbs and ipc for now as they don't work currently
 
-set(parcelport_plugins
-  verbs
-  mpi
-  tcp)
+set(parcelport_plugins)
+
+if(HPX_WITH_NETWORKING)
+  set(parcelport_plugins ${parcelport_plugins}
+    verbs
+    mpi
+    tcp)
+endif()
 
 set(HPX_STATIC_PARCELPORT_PLUGINS "" CACHE INTERNAL "" FORCE)
 set(HPX_STATIC_PARCELPORT_PLUGINS_SOURCES "" CACHE INTERNAL "" FORCE)
@@ -85,25 +89,26 @@ foreach(type ${parcelport_plugins})
 endforeach()
 
 macro(add_static_parcelports)
-  add_parcelport_tcp_module()
-  add_parcelport_mpi_module()
-  add_parcelport_verbs_module()
+  if(HPX_WITH_NETWORKING)
+    add_parcelport_tcp_module()
+    add_parcelport_mpi_module()
+    add_parcelport_verbs_module()
+  endif()
 endmacro()
 
 macro(add_parcelport_modules)
-  #add_parcelport_ibverbs_module()
-  #add_parcelport_ipc_module()
+  if(HPX_WITH_NETWORKING)
+    hpx_debug("creating static_parcelports.hpp: " ${HPX_STATIC_PARCELPORT_PLUGINS})
 
-  hpx_debug("creating static_parcelports.hpp: " ${HPX_STATIC_PARCELPORT_PLUGINS})
-
-  set(_parcelport_export)
-  set(_parcelport_init)
-  foreach(parcelport ${HPX_STATIC_PARCELPORT_PLUGINS})
-    set(_parcelport_export
-      "${_parcelport_export}HPX_EXPORT hpx::plugins::parcelport_factory_base *parcelport_${parcelport}_factory_init(std::vector<hpx::plugins::parcelport_factory_base *>& factories);\n")
-    set(_parcelport_init
-      "${_parcelport_init}        parcelport_${parcelport}_factory_init(factories);\n")
-  endforeach()
+    set(_parcelport_export)
+    set(_parcelport_init)
+    foreach(parcelport ${HPX_STATIC_PARCELPORT_PLUGINS})
+      set(_parcelport_export
+        "${_parcelport_export}HPX_EXPORT hpx::plugins::parcelport_factory_base *parcelport_${parcelport}_factory_init(std::vector<hpx::plugins::parcelport_factory_base *>& factories);\n")
+      set(_parcelport_init
+        "${_parcelport_init}        parcelport_${parcelport}_factory_init(factories);\n")
+    endforeach()
+  endif()
 
   configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/static_parcelports.hpp.in"
                  "${CMAKE_BINARY_DIR}/hpx/runtime/parcelset/static_parcelports.hpp"

--- a/plugins/parcelport/mpi/mpi_environment.cpp
+++ b/plugins/parcelport/mpi/mpi_environment.cpp
@@ -5,7 +5,11 @@
 
 #include <hpx/config.hpp>
 
+#if defined(HPX_HAVE_NETWORKING)
+
+#if defined(HPX_HAVE_PARCELPORT_MPI)
 #include <mpi.h>
+#endif
 
 #include <hpx/util/runtime_configuration.hpp>
 #include <hpx/util/command_line_handling.hpp>
@@ -293,3 +297,4 @@ namespace hpx { namespace util
     }
 }}
 
+#endif

--- a/plugins/parcelport/mpi/parcelport_mpi.cpp
+++ b/plugins/parcelport/mpi/parcelport_mpi.cpp
@@ -5,6 +5,8 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING)
 #include <hpx/traits/plugin_config_data.hpp>
 
 #if defined(HPX_HAVE_PARCELPORT_MPI)
@@ -286,3 +288,5 @@ namespace hpx { namespace traits
 HPX_REGISTER_PARCELPORT(
     hpx::parcelset::policies::mpi::parcelport,
     mpi);
+
+#endif

--- a/plugins/parcelport/tcp/connection_handler_tcp.cpp
+++ b/plugins/parcelport/tcp/connection_handler_tcp.cpp
@@ -11,6 +11,8 @@
 // hpxinspect:nodeprecatedname:boost::chrono
 
 #include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING)
 #include <hpx/lcos/future.hpp>
 #include <hpx/exception_list.hpp>
 #include <hpx/runtime/parcelset/locality.hpp>
@@ -337,3 +339,5 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
         }
     }
 }}}}
+
+#endif

--- a/plugins/parcelport/tcp/parcelport_tcp.cpp
+++ b/plugins/parcelport/tcp/parcelport_tcp.cpp
@@ -4,6 +4,8 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING)
 #include <hpx/traits/plugin_config_data.hpp>
 
 #include <hpx/plugins/parcelport/tcp/connection_handler.hpp>
@@ -41,3 +43,5 @@ namespace hpx { namespace traits
 HPX_REGISTER_PARCELPORT(
     hpx::parcelset::policies::tcp::connection_handler,
     tcp);
+
+#endif

--- a/plugins/parcelport/verbs/parcelport_verbs.cpp
+++ b/plugins/parcelport/verbs/parcelport_verbs.cpp
@@ -5,6 +5,8 @@
 
 // config
 #include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING)
 // util
 #include <hpx/util/command_line_handling.hpp>
 #include <hpx/util/runtime_configuration.hpp>
@@ -1685,3 +1687,4 @@ HPX_REGISTER_PARCELPORT(hpx::parcelset::policies::verbs::parcelport, verbs);
                 << decnumber(sends_posted+handled_receives+total_reads));
 */
 
+#endif

--- a/plugins/parcelport/verbs/rdma/rdma_controller.cpp
+++ b/plugins/parcelport/verbs/rdma/rdma_controller.cpp
@@ -3,6 +3,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_PARCELPORT_MPI)
 #include <hpx/config/parcelport_verbs_defines.hpp>
 //
 #include <plugins/parcelport/verbs/rdma/rdma_error.hpp>
@@ -769,3 +772,5 @@ bool rdma_controller::active()
     }
     return false;
 }
+
+#endif

--- a/src/runtime/parcelset/parcelport.cpp
+++ b/src/runtime/parcelset/parcelport.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2017 Hartmut Kaiser
 //  Copyright (c) 2013-2014 Thomas Heller
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/src/util/runtime_configuration.cpp
+++ b/src/util/runtime_configuration.cpp
@@ -203,6 +203,12 @@ namespace hpx { namespace util
             "[hpx.on_startup]",
             "wait_on_latch = ${HPX_ON_STARTUP_WAIT_ON_LATCH}",
 
+#if defined(HPX_HAVE_NETWORKING)
+            // by default, enable networking
+            "[hpx.parcel]",
+            "enable = 1",
+#endif
+
             "[hpx.stacks]",
             "small_size = ${HPX_SMALL_STACK_SIZE:"
                 BOOST_PP_STRINGIZE(HPX_SMALL_STACK_SIZE) "}",


### PR DESCRIPTION
This allows to completely disable networking which is useful either if all the user needs is a purely local solution or if HPX is to be combined with legacy MPI code. In the latter case HPX would be run on each of the ranks in console mode and all communication would be left to other solutions.