### PR TITLE
Fix uses of the Vc2 datapar flags; the value, not the type, should be passed to functions.

### DIFF
--- a/hpx/parallel/traits/detail/vc/vector_pack_load_store.hpp
+++ b/hpx/parallel/traits/detail/vc/vector_pack_load_store.hpp
@@ -204,7 +204,7 @@ namespace hpx { namespace parallel { namespace traits
         {
             typedef typename rebind_pack<V, ValueType>::type vector_pack_type;
             return vector_pack_type(std::addressof(*iter),
-                Vc::flags::vector_aligned_tag);
+                Vc::flags::vector_aligned);
         }
 
         template <typename Iter>
@@ -213,7 +213,7 @@ namespace hpx { namespace parallel { namespace traits
         {
             typedef typename rebind_pack<V, ValueType>::type vector_pack_type;
             return vector_pack_type(std::addressof(*iter),
-                Vc::flags::element_aligned_tag);
+                Vc::flags::element_aligned);
         }
     };
 
@@ -224,13 +224,13 @@ namespace hpx { namespace parallel { namespace traits
         template <typename Iter>
         static void aligned(V const& value, Iter const& iter)
         {
-            value.copy_to(std::addressof(*iter), Vc::flags::vector_aligned_tag);
+            value.copy_to(std::addressof(*iter), Vc::flags::vector_aligned);
         }
 
         template <typename Iter>
         static void unaligned(V const& value, Iter const& iter)
         {
-            value.copy_to(std::addressof(*iter), Vc::flags::element_aligned_tag);
+            value.copy_to(std::addressof(*iter), Vc::flags::element_aligned);
         }
     };
 }}}


### PR DESCRIPTION
Oddly, didn't catch this until compiling with Clang.