### PR TITLE
Pre-include defines.hpp to get the macro HPX_HAVE_CUDA value

### DIFF
--- a/hpx/config/compiler_specific.hpp
+++ b/hpx/config/compiler_specific.hpp
@@ -6,6 +6,8 @@
 #if !defined(HPX_COMPILER_SPECIFIC_201204261048)
 #define HPX_COMPILER_SPECIFIC_201204261048
 
+#include <hpx/config/defines.hpp>
+
 #if defined(__GNUC__)
 
 // macros to facilitate handling of compiler-specific issues


### PR DESCRIPTION
This patch tries to solve the issue because `HPX_HAVE_CUDA` is tested in compiler_specific.hpp