### PR TITLE
Prevent -Wundef warnings on Vc version checks.

### DIFF
--- a/hpx/parallel/traits/detail/vc/vector_pack_alignment_size.hpp
+++ b/hpx/parallel/traits/detail/vc/vector_pack_alignment_size.hpp
@@ -15,7 +15,7 @@
 
 #include <Vc/global.h>
 
-#if Vc_IS_VERSION_1
+#if defined(Vc_IS_VERSION_1) && Vc_IS_VERSION_1
 
 #include <Vc/Vc>
 

--- a/hpx/parallel/traits/detail/vc/vector_pack_count_bits.hpp
+++ b/hpx/parallel/traits/detail/vc/vector_pack_count_bits.hpp
@@ -14,7 +14,7 @@
 
 #include <Vc/global.h>
 
-#if Vc_IS_VERSION_1
+#if defined(Vc_IS_VERSION_1) && Vc_IS_VERSION_1
 
 #include <Vc/Vc>
 

--- a/hpx/parallel/traits/detail/vc/vector_pack_load_store.hpp
+++ b/hpx/parallel/traits/detail/vc/vector_pack_load_store.hpp
@@ -17,7 +17,7 @@
 
 #include <Vc/global.h>
 
-#if Vc_IS_VERSION_1
+#if defined(Vc_IS_VERSION_1) && Vc_IS_VERSION_1
 
 #include <Vc/Vc>
 

--- a/hpx/parallel/traits/detail/vc/vector_pack_type.hpp
+++ b/hpx/parallel/traits/detail/vc/vector_pack_type.hpp
@@ -16,7 +16,7 @@
 
 #include <Vc/global.h>
 
-#if Vc_IS_VERSION_1
+#if defined(Vc_IS_VERSION_1) && Vc_IS_VERSION_1
 
 #include <Vc/Vc>
 

--- a/hpx/runtime/serialization/detail/vc.hpp
+++ b/hpx/runtime/serialization/detail/vc.hpp
@@ -18,7 +18,7 @@
 
 #include <Vc/version.h>
 
-#if Vc_IS_VERSION_1
+#if defined(Vc_IS_VERSION_1) && Vc_IS_VERSION_1
 
 #include <Vc/Vc>
 


### PR DESCRIPTION
Change the Vc preprocessor version check from #if Vc_IS_VERSION_1 to #if defined(Vc_IS_VERSION_1) && Vc_IS_VERSION_1; otherwise we would get warnings under -Wundef.

See STEllAR-Group/octotiger/#48 for more info.