### PR TITLE
Remove partitioned_vector.cu from build tree when nvcc is used

### DIFF
--- a/examples/compute/cuda/CMakeLists.txt
+++ b/examples/compute/cuda/CMakeLists.txt
@@ -11,8 +11,14 @@ if(HPX_WITH_CUDA)
       cublas_matmul
       data_copy
       hello_compute
-      partitioned_vector
     )
+
+# Append example programs that only compiles with Cuda Clang
+  if(HPX_WITH_CUDA_CLANG)
+    list(APPEND example_programs
+         partitioned_vector
+        )
+  endif()
 
   include_directories(${CUDA_INCLUDE_DIRS})
 


### PR DESCRIPTION
This patch tries to remove a compilation error due to the limitations of nvcc when compiling `partitioned_vector.cu` 