### PR TITLE
Fix computeapi unit tests

### DIFF
--- a/examples/compute/cuda/hello_compute.cu
+++ b/examples/compute/cuda/hello_compute.cu
@@ -60,7 +60,7 @@ int hpx_main(boost::program_options::variables_map& vm)
             int i = blockDim.x * blockIdx.x + threadIdx.x;
             if(i < N)
                 C[i] = A[i] + B[i];
-        }, d_A.device_data(), d_B.device_data(), d_C.device_data());
+        }, d_A.data(), d_B.data(), d_C.data());
 
 
     hpx::parallel::copy(

--- a/hpx/compute/cuda/default_executor.hpp
+++ b/hpx/compute/cuda/default_executor.hpp
@@ -72,7 +72,7 @@ namespace hpx { namespace compute { namespace cuda
                     [] HPX_DEVICE
                         (F f, value_type* p, std::size_t count, Ts&... ts)
                     {
-                        int idx = blockIdx.x * blockDim.x + threadIdx.x;
+                        std::size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
                         if (idx < count)
                         {
                             hpx::util::invoke_r<void>(f, *(p + idx), ts...);
@@ -117,7 +117,8 @@ namespace hpx { namespace compute { namespace cuda
                         [begin, chunk_size]
                         HPX_DEVICE (F f, Ts&... ts)
                         {
-                            int idx = blockIdx.x * blockDim.x + threadIdx.x;
+                            std::size_t idx
+                                = blockIdx.x * blockDim.x + threadIdx.x;
                             if(idx < chunk_size)
                             {
                                 hpx::util::invoke_r<void>(f,

--- a/hpx/compute/cuda/target_ptr.hpp
+++ b/hpx/compute/cuda/target_ptr.hpp
@@ -110,16 +110,21 @@ namespace hpx { namespace compute { namespace cuda
         }
 
     public:
+
 #if defined(__CUDA_ARCH__)
         HPX_DEVICE operator T*() const
         {
             return this->base();
         }
 #else
-        explicit operator T*() const
-        {
-            return this->base();
-        }
+    // Note : need to define implicit cast at host_side because of invoke()
+    //        which is defined host_device. This function should never be
+    //        executed.
+    HPX_HOST operator T*() const
+    {
+        HPX_ASSERT(false);
+        return nullptr;
+    }
 
     private:
         friend class hpx::util::iterator_core_access;

--- a/hpx/compute/cuda/target_ptr.hpp
+++ b/hpx/compute/cuda/target_ptr.hpp
@@ -117,14 +117,14 @@ namespace hpx { namespace compute { namespace cuda
             return this->base();
         }
 #else
-    // Note : need to define implicit cast at host_side because of invoke()
-    //        which is defined host_device. This function should never be
-    //        executed.
-    HPX_HOST operator T*() const
-    {
-        HPX_ASSERT(false);
-        return nullptr;
-    }
+        // Note : need to define implicit cast at host_side because of invoke()
+        //        which is defined host_device. This function should never be
+        //        executed.
+        HPX_HOST operator T*() const
+        {
+            HPX_ASSERT(false);
+            return nullptr;
+        }
 
     private:
         friend class hpx::util::iterator_core_access;

--- a/hpx/compute/cuda/value_proxy.hpp
+++ b/hpx/compute/cuda/value_proxy.hpp
@@ -65,7 +65,28 @@ namespace hpx { namespace compute { namespace cuda
 #else
         operator T() const
         {
-            return access_target::read(*target_, p_);
+            HPX_ASSERT(false);
+            return T();
+        }
+#endif
+
+
+        // Note: The code duplication below allows Cuda Clang to not see
+        //       the host side implicit cast during the device code
+        //       compilation. Without this, wrong template parameter
+        //       deduction can occur if a value_proxy is given in the arg
+        //       list of invoke()
+
+#if defined(__CUDA_ARCH__)
+        HPX_DEVICE operator T&()
+        {
+            return *p_;
+        }
+#else
+        HPX_HOST operator T&()
+        {
+            HPX_ASSERT(false);
+            return *p_;
         }
 #endif
 

--- a/hpx/compute/cuda/value_proxy.hpp
+++ b/hpx/compute/cuda/value_proxy.hpp
@@ -51,44 +51,18 @@ namespace hpx { namespace compute { namespace cuda
             return *this;
         }
 
-        // Note: The code duplication below allows Cuda Clang to not see
-        //       the host side implicit cast during the device code
-        //       compilation. Without this, wrong template parameter
-        //       deduction can occur if a value_proxy is given in the arg
-        //       list of invoke()
+        // Note: The difference of signature allows to define proper
+        //       implicit casts for device code and host code
 
-#if defined(__CUDA_ARCH__)
-        HPX_DEVICE operator T() const
-        {
-            return access_target::read(*target_, p_);
-        }
-#else
-        operator T() const
-        {
-            HPX_ASSERT(false);
-            return T();
-        }
-#endif
-
-
-        // Note: The code duplication below allows Cuda Clang to not see
-        //       the host side implicit cast during the device code
-        //       compilation. Without this, wrong template parameter
-        //       deduction can occur if a value_proxy is given in the arg
-        //       list of invoke()
-
-#if defined(__CUDA_ARCH__)
         HPX_DEVICE operator T&()
         {
             return *p_;
         }
-#else
-        HPX_HOST operator T&()
+
+        HPX_HOST operator T() const
         {
-            HPX_ASSERT(false);
-            return *p_;
+            return access_target::read(*target_, p_);
         }
-#endif
 
         T* operator &() const
         {
@@ -129,23 +103,10 @@ namespace hpx { namespace compute { namespace cuda
           , target_(other.target())
         {}
 
-        // Note: The code duplication below allows Cuda Clang to not see
-        //       the host side implicit cast during the device code
-        //       compilation. Without this, wrong template parameter
-        //       deduction can occur if a value_proxy is given in the arg
-        //       list of invoke()
-
-#if defined(__CUDA_ARCH__)
-        HPX_DEVICE operator T() const
+        HPX_HOST_DEVICE operator T() const
         {
             return access_target::read(target_, p_);
         }
-#else
-        operator T() const
-        {
-            return access_target::read(target_, p_);
-        }
-#endif
 
         T* device_ptr() const HPX_NOEXCEPT
         {

--- a/hpx/compute/serialization/vector.hpp
+++ b/hpx/compute/serialization/vector.hpp
@@ -101,7 +101,7 @@ namespace hpx { namespace serialization
             compute::vector<T, Allocator> const& vs, std::false_type)
         {
             // normal save ...
-            for(auto v : vs)
+            for(auto const & v : vs)
             {
                 ar << v;
             }

--- a/hpx/compute/serialization/vector.hpp
+++ b/hpx/compute/serialization/vector.hpp
@@ -91,6 +91,8 @@ namespace hpx { namespace serialization
         detail::load_impl(ar, v, use_optimized());
     }
 
+
+
     // save compute::vector<T>
     namespace detail
     {
@@ -99,9 +101,7 @@ namespace hpx { namespace serialization
             compute::vector<T, Allocator> const& vs, std::false_type)
         {
             // normal save ...
-            typedef typename compute::vector<T, Allocator>::value_type
-                value_type;
-            for(value_type const& v : vs)
+            for(auto v : vs)
             {
                 ar << v;
             }

--- a/hpx/lcos/base_lco.hpp
+++ b/hpx/lcos/base_lco.hpp
@@ -58,11 +58,7 @@ namespace hpx { namespace lcos
         /// \a set_event_action is applied on a instance of a LCO. This function
         /// just forwards to the virtual function \a set_event, which is
         /// overloaded by the derived concrete LCO.
-#if defined(__NVCC__) || defined(__CUDACC__)
-        HPX_DEVICE void set_event_nonvirt() {}
-#else
         void set_event_nonvirt();
-#endif
 
         /// The \a function set_exception is called whenever a
         /// \a set_exception_action is applied on a instance of a LCO. This function
@@ -71,11 +67,7 @@ namespace hpx { namespace lcos
         ///
         /// \param e      [in] The exception encapsulating the error to report
         ///               to this LCO instance.
-#if defined(__NVCC__) || defined(__CUDACC__)
-        HPX_DEVICE void set_exception_nonvirt(boost::exception_ptr const&) {}
-#else
         void set_exception_nonvirt(boost::exception_ptr const& e);
-#endif
 
         /// The \a function connect_nonvirt is called whenever a
         /// \a connect_action is applied on a instance of a LCO. This function
@@ -83,22 +75,15 @@ namespace hpx { namespace lcos
         /// overloaded by the derived concrete LCO.
         ///
         /// \param id [in] target id
-#if defined(__NVCC__) || defined(__CUDACC__)
-        HPX_DEVICE void connect_nonvirt(naming::id_type const & id) {}
-#else
         void connect_nonvirt(naming::id_type const & id);
-#endif
+
         /// The \a function disconnect_nonvirt is called whenever a
         /// \a disconnect_action is applied on a instance of a LCO. This function
         /// just forwards to the virtual function \a disconnect, which is
         /// overloaded by the derived concrete LCO.
         ///
         /// \param id [in] target id
-#if defined(__NVCC__) || defined(__CUDACC__)
-        HPX_DEVICE void disconnect_nonvirt(naming::id_type const & id) {}
-#else
         void disconnect_nonvirt(naming::id_type const & id);
-#endif
 
     public:
         /// Each of the exposed functions needs to be encapsulated into an action

--- a/hpx/lcos/base_lco_with_value.hpp
+++ b/hpx/lcos/base_lco_with_value.hpp
@@ -85,27 +85,21 @@ namespace hpx { namespace lcos
         ///
         /// \param result [in] The result value to be transferred from the
         ///               remote operation back to this LCO instance.
-#if defined(__NVCC__)
-        HPX_DEVICE void set_value_nonvirt (RemoteResult&&) {}
-#else
+
         void set_value_nonvirt (RemoteResult&& result)
         {
             set_value(std::move(result));
         }
-#endif
 
-        /// The \a function get_result_nonvirt is called whenever a
+   /// The \a function get_result_nonvirt is called whenever a
         /// \a get_result_action is applied on this LCO instance. This
         /// function just forwards to the virtual function \a get_result, which
         /// is overloaded by the derived concrete LCO.
-#if defined(__NVCC__)
-        HPX_DEVICE Result get_value_nonvirt() { return Result(); }
-#else
+
         Result get_value_nonvirt()
         {
             return util::void_guard<Result>(), get_value();
         }
-#endif
 
     public:
         /// The \a set_value_action may be used to trigger any LCO instances
@@ -169,13 +163,6 @@ namespace hpx { namespace traits
     };
 }}
 
-#if defined(__NVCC__)
-#define HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(...)
-#define HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION2(...)
-#define HPX_REGISTER_BASE_LCO_WITH_VALUE(...)
-#define HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(...)
-#define HPX_REGISTER_BASE_LCO_WITH_VALUE_ID2(...)
-#else
 #define HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(Value, Name)               \
     HPX_REGISTER_ACTION_DECLARATION(                                            \
         hpx::lcos::base_lco_with_value<Value>::set_value_action,                \
@@ -240,7 +227,6 @@ namespace hpx { namespace traits
         BOOST_PP_CAT(base_lco_with_value_, Name)::set_value_action,             \
         "lco_set_value_action", std::size_t(-1), std::size_t(-1))               \
 /**/
-#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(hpx::naming::gid_type, gid_type)

--- a/hpx/lcos/server/latch.hpp
+++ b/hpx/lcos/server/latch.hpp
@@ -114,7 +114,7 @@ namespace hpx { namespace lcos { namespace server
             > create_component_action;
 
         // additional functionality
-        HPX_HOST_DEVICE void wait() const
+        void wait() const
         {
             latch_.wait();
         }

--- a/hpx/parallel/algorithms/detail/predicates.hpp
+++ b/hpx/parallel/algorithms/detail/predicates.hpp
@@ -22,14 +22,14 @@
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
 {
-    template<class InputIterator, class Distance>
+    template<typename InputIterator, typename Distance>
     HPX_HOST_DEVICE void advance_impl(InputIterator& i, Distance n,
         std::random_access_iterator_tag)
     {
         i += n;
     }
 
-    template<class InputIterator, class Distance>
+    template<typename InputIterator, typename Distance>
     HPX_HOST_DEVICE void advance_impl(InputIterator& i, Distance n,
         std::bidirectional_iterator_tag)
     {
@@ -43,7 +43,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         }
     }
 
-    template<class InputIterator, class Distance>
+    template<typename InputIterator, typename Distance>
     HPX_HOST_DEVICE void advance_impl(InputIterator& i, Distance n,
         std::input_iterator_tag)
     {
@@ -51,7 +51,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         while (n--) ++i;
     }
 
-    template<class InputIterator, class Distance>
+    template<typename InputIterator, typename Distance>
     HPX_HOST_DEVICE void advance (InputIterator& i, Distance n)
     {
         advance_impl(i, n,

--- a/hpx/parallel/algorithms/detail/predicates.hpp
+++ b/hpx/parallel/algorithms/detail/predicates.hpp
@@ -20,6 +20,45 @@
 #include <type_traits>
 #include <utility>
 
+
+namespace hpx { namespace detail
+{
+    template<class InputIterator, class Distance>
+    HPX_HOST_DEVICE void advance_impl(InputIterator& i, Distance n,
+        std::random_access_iterator_tag)
+    {
+        i += n;
+    }
+
+    template<class InputIterator, class Distance>
+    HPX_HOST_DEVICE void advance_impl(InputIterator& i, Distance n,
+        std::bidirectional_iterator_tag)
+    {
+        if (n < 0) {
+        while (n++) --i;
+        } else {
+        while (n--) ++i;
+        }
+    }
+
+    template<class InputIterator, class Distance>
+    HPX_HOST_DEVICE void advance_impl(InputIterator& i, Distance n,
+        std::input_iterator_tag)
+    {
+        HPX_ASSERT(n >= 0);
+        while (n--) ++i;
+    }
+
+    template<class InputIterator, class Distance>
+    HPX_HOST_DEVICE void advance (InputIterator& i, Distance n)
+    {
+        advance_impl(i, n,
+        typename std::iterator_traits<InputIterator>::iterator_category());
+    }
+
+}}
+
+
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
 {
     ///////////////////////////////////////////////////////////////////////////
@@ -116,7 +155,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         HPX_HOST_DEVICE
         HPX_FORCEINLINE static Iter call(Iter iter, Stride offset)
         {
+#if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
+            hpx::detail::advance(iter, offset);
+#else
             std::advance(iter, offset);
+#endif
             return iter;
         }
 
@@ -152,7 +195,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         HPX_HOST_DEVICE
         HPX_FORCEINLINE static Iter call(Iter iter, Stride offset)
         {
+#if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
+            hpx::detail::advance(iter, offset);
+#else
             std::advance(iter, offset);
+#endif
             return iter;
         }
 
@@ -166,7 +213,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
             {
                 // NVCC seems to have a bug with std::min...
                 offset = Stride(max_count < std::size_t(offset) ? max_count : offset);
+#if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
+                hpx::detail::advance(iter, offset);
+#else
                 std::advance(iter, offset);
+#endif
             }
             else
             {
@@ -174,7 +225,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
                         // NVCC seems to have a bug with std::min...
                         max_count < negate(offset) ? max_count : negate(offset)
                     ));
+#if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
+                hpx::detail::advance(iter, offset);
+#else
                 std::advance(iter, offset);
+#endif
             }
             return iter;
         }
@@ -187,7 +242,11 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
             // advance through the end or max number of elements
             // NVCC seems to have a bug with std::min...
             offset = Stride(max_count < std::size_t(offset) ? max_count : offset);
+#if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
+            hpx::detail::advance(iter, offset);
+#else
             std::advance(iter, offset);
+#endif
             return iter;
         }
 

--- a/hpx/parallel/algorithms/detail/predicates.hpp
+++ b/hpx/parallel/algorithms/detail/predicates.hpp
@@ -20,8 +20,7 @@
 #include <type_traits>
 #include <utility>
 
-
-namespace hpx { namespace detail
+namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
 {
     template<class InputIterator, class Distance>
     HPX_HOST_DEVICE void advance_impl(InputIterator& i, Distance n,
@@ -34,10 +33,13 @@ namespace hpx { namespace detail
     HPX_HOST_DEVICE void advance_impl(InputIterator& i, Distance n,
         std::bidirectional_iterator_tag)
     {
-        if (n < 0) {
-        while (n++) --i;
-        } else {
-        while (n--) ++i;
+        if (n < 0)
+        {
+            while (n++) --i;
+        }
+        else
+        {
+            while (n--) ++i;
         }
     }
 
@@ -56,11 +58,6 @@ namespace hpx { namespace detail
         typename std::iterator_traits<InputIterator>::iterator_category());
     }
 
-}}
-
-
-namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
-{
     ///////////////////////////////////////////////////////////////////////////
     template <typename Iterable, typename Enable = void>
     struct calculate_distance
@@ -156,7 +153,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         HPX_FORCEINLINE static Iter call(Iter iter, Stride offset)
         {
 #if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
-            hpx::detail::advance(iter, offset);
+            hpx::parallel::v1::detail::advance(iter, offset);
 #else
             std::advance(iter, offset);
 #endif
@@ -196,7 +193,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
         HPX_FORCEINLINE static Iter call(Iter iter, Stride offset)
         {
 #if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
-            hpx::detail::advance(iter, offset);
+            hpx::parallel::v1::detail::advance(iter, offset);
 #else
             std::advance(iter, offset);
 #endif
@@ -214,7 +211,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
                 // NVCC seems to have a bug with std::min...
                 offset = Stride(max_count < std::size_t(offset) ? max_count : offset);
 #if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
-                hpx::detail::advance(iter, offset);
+                hpx::parallel::v1::detail::advance(iter, offset);
 #else
                 std::advance(iter, offset);
 #endif
@@ -226,7 +223,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
                         max_count < negate(offset) ? max_count : negate(offset)
                     ));
 #if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
-                hpx::detail::advance(iter, offset);
+                hpx::parallel::v1::detail::advance(iter, offset);
 #else
                 std::advance(iter, offset);
 #endif
@@ -243,7 +240,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1) { namespace detail
             // NVCC seems to have a bug with std::min...
             offset = Stride(max_count < std::size_t(offset) ? max_count : offset);
 #if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
-            hpx::detail::advance(iter, offset);
+            hpx::parallel::v1::detail::advance(iter, offset);
 #else
             std::advance(iter, offset);
 #endif

--- a/hpx/parallel/algorithms/for_loop.hpp
+++ b/hpx/parallel/algorithms/for_loop.hpp
@@ -61,7 +61,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
         HPX_FORCEINLINE void invoke_iteration(hpx::util::tuple<Ts...>& args,
             hpx::util::detail::pack_c<std::size_t, Is...>, F && f, B part_begin)
         {
-            hpx::util::invoke(std::forward<F>(f), part_begin,
+            hpx::util::invoke_r<void>(std::forward<F>(f), part_begin,
                 hpx::util::get<Is>(args).iteration_value()...);
         }
 

--- a/tests/unit/computeapi/cuda/default_executor.cu
+++ b/tests/unit/computeapi/cuda/default_executor.cu
@@ -46,7 +46,12 @@ void test_async()
 ///////////////////////////////////////////////////////////////////////////////
 struct bulk_test
 {
-    __device__ void operator()(int) {}
+    // FIXME : call operator of bulk_test is momentarily defined as
+    //         HPX_HOST_DEVICE in place of HPX_DEVICE to allow the host_side
+    //         result_of<> (used in traits::bulk_execute()) to get the return
+    //         type
+
+    HPX_HOST_DEVICE void operator()(int) {}
 };
 
 void test_bulk_sync()

--- a/tests/unit/computeapi/cuda/for_each_compute.cu
+++ b/tests/unit/computeapi/cuda/for_each_compute.cu
@@ -32,6 +32,11 @@ void test_for_each(executor_type& exec, target_vector& d_A)
         hpx::parallel::execution::par,
         d_A.begin(), d_A.end(), h_C.begin());
 
+    // FIXME : Lambda function given to for_each() is momentarily defined as
+    //         HPX_HOST_DEVICE in place of HPX_DEVICE to allow the host_side
+    //         result_of<> (used inside for_each()) to get the return
+    //         type
+
     hpx::parallel::for_each(
         hpx::parallel::execution::par.on(exec),
         d_A.begin(), d_A.end(),

--- a/tests/unit/computeapi/cuda/for_each_compute.cu
+++ b/tests/unit/computeapi/cuda/for_each_compute.cu
@@ -35,7 +35,7 @@ void test_for_each(executor_type& exec, target_vector& d_A)
     hpx::parallel::for_each(
         hpx::parallel::execution::par.on(exec),
         d_A.begin(), d_A.end(),
-        [] HPX_DEVICE (int & i)
+        [] HPX_HOST_DEVICE (int & i)
         {
              i += 5;
         });

--- a/tests/unit/computeapi/cuda/for_loop_compute.cu
+++ b/tests/unit/computeapi/cuda/for_loop_compute.cu
@@ -29,6 +29,11 @@ void test_for_loop(executor_type& exec,
     target_vector& d_A, target_vector& d_B, target_vector& d_C,
     std::vector<int> const& ref)
 {
+    // FIXME : Lambda function given to for_loop_n() is momentarily defined as
+    //         HPX_HOST_DEVICE in place of HPX_DEVICE to allow the host_side
+    //         result_of<> (used inside for_each()) to get the return
+    //         type
+
     hpx::parallel::for_loop_n(
         hpx::parallel::execution::par.on(exec),
         d_A.data(), d_A.size(),

--- a/tests/unit/computeapi/cuda/for_loop_compute.cu
+++ b/tests/unit/computeapi/cuda/for_loop_compute.cu
@@ -34,7 +34,7 @@ void test_for_loop(executor_type& exec,
         d_A.data(), d_A.size(),
         hpx::parallel::induction(d_B.data()),
         hpx::parallel::induction(d_C.data()),
-        [] HPX_DEVICE (int* A, int* B, int* C)
+        [] HPX_HOST_DEVICE (int* A, int* B, int* C)
         {
             *C = *A + 3.0 * *B;
         });

--- a/tests/unit/computeapi/cuda/transform_compute.cu
+++ b/tests/unit/computeapi/cuda/transform_compute.cu
@@ -25,6 +25,16 @@ typedef hpx::compute::cuda::default_executor executor_type;
 typedef hpx::compute::cuda::allocator<int> target_allocator;
 typedef hpx::compute::vector<int, target_allocator> target_vector;
 
+struct transform_test
+{
+    template< typename T >
+    HPX_HOST_DEVICE int operator()(T A, T B)
+    {
+        return A + 3.0 * B;
+    }
+};
+
+
 void test_transform(executor_type& exec,
     target_vector& d_A, target_vector& d_B, target_vector& d_C,
     std::vector<int> const& ref)
@@ -32,10 +42,7 @@ void test_transform(executor_type& exec,
     hpx::parallel::transform(
         hpx::parallel::execution::par.on(exec),
         d_A.begin(), d_A.end(), d_B.begin(), d_C.begin(),
-        [] HPX_DEVICE (int A, int B) -> int
-        {
-            return A + 3.0 * B;
-        });
+        transform_test());
 
     std::vector<int> h_C(d_C.size());
     hpx::parallel::copy(

--- a/tests/unit/computeapi/cuda/transform_compute.cu
+++ b/tests/unit/computeapi/cuda/transform_compute.cu
@@ -27,10 +27,15 @@ typedef hpx::compute::vector<int, target_allocator> target_vector;
 
 struct transform_test
 {
-    template< typename T >
-    HPX_HOST_DEVICE int operator()(T A, T B)
+    // FIXME : call operator of transform_test() is momentarily defined as
+    //         HPX_HOST_DEVICE in place of HPX_DEVICE to allow the host_side
+    //         result_of<> (used inside transform()) to get the return
+    //         type
+
+    template <typename T>
+    HPX_HOST_DEVICE int operator()(T const & a, T const & b)
     {
-        return A + 3.0 * B;
+        return a + 3.0 * b;
     }
 };
 

--- a/tests/unit/computeapi/host/CMakeLists.txt
+++ b/tests/unit/computeapi/host/CMakeLists.txt
@@ -7,9 +7,14 @@ set(tests
     block_allocator
    )
 
+include_directories(${CUDA_INCLUDE_DIRS})
+
 foreach(test ${tests})
   set(sources
       ${test}.cpp)
+
+  set(${test}_FLAGS
+    DEPENDENCIES ${CUDA_LIBRARIES} ${CUDA_CUBLAS_LIBRARIES})
 
   source_group("Source Files" FILES ${sources})
 


### PR DESCRIPTION
This patch tries to fix some compilation errors that come from both nvcc and cuda-clang for computeapi unit tests