### PR TITLE
Add commandline options --hpx:print-counters-locally 

### DIFF
--- a/docs/manual/commandline.qbk
+++ b/docs/manual/commandline.qbk
@@ -170,6 +170,11 @@ described in the table below:
         `--hpx:print-counter` (or `--hpx:print-counter-reset`) at the given
         point in time, possible argument are values: 'startup',
         'shutdown' (default), 'noshutdown'.]]
+    [[`--hpx:print-counters-locally`]
+     [Each locality prints only its own local counters. If this is used with
+      `--hpx-print-counter-destination=<file>, the code will append a
+      `".<locality_id>"` to the file name in order to avoid clashes between
+      localities.]]
 ]
 
 [heading Command Line Argument Shortcuts]

--- a/hpx/performance_counters/performance_counter_set.hpp
+++ b/hpx/performance_counters/performance_counter_set.hpp
@@ -33,7 +33,9 @@ namespace hpx { namespace performance_counters
 
     public:
         /// Create an empty set of performance counters
-        performance_counter_set() {}
+        performance_counter_set(bool print_counters_locally = false)
+          : print_counters_locally_(print_counters_locally)
+        {}
 
         /// Create a set of performance counters from a name, possibly
         /// containing wild-card characters
@@ -118,6 +120,8 @@ namespace hpx { namespace performance_counters
         std::vector<counter_info> infos_;     // counter instance names
         std::vector<naming::id_type> ids_;    // global ids of counter instances
         std::vector<std::uint8_t> reset_;     // != 0 if counter should be reset
+
+        bool print_counters_locally_;         // handle only local counters
     };
 }}
 

--- a/hpx/util/query_counters.hpp
+++ b/hpx/util/query_counters.hpp
@@ -37,7 +37,7 @@ namespace hpx { namespace util
             std::vector<std::string> const& reset_names,
             std::int64_t interval, std::string const& dest,
             std::string const& form, std::vector<std::string> const& shortnames,
-            bool csv_header);
+            bool csv_header, bool print_counters_locally);
 
         void start();
         void stop_evaluating_counters();
@@ -107,6 +107,7 @@ namespace hpx { namespace util
         std::string format_;
         std::vector<std::string> counter_shortnames_;
         bool csv_header_;
+        bool print_counters_locally_;
 
         interval_timer timer_;
 

--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -333,7 +333,8 @@ namespace hpx
 
         ///////////////////////////////////////////////////////////////////////
         void handle_list_and_print_options(hpx::runtime& rt,
-            boost::program_options::variables_map& vm)
+            boost::program_options::variables_map& vm,
+            bool print_counters_locally)
         {
             if (vm.count("hpx:list-counters")) {
                 // Print the names of all registered performance counters.
@@ -430,7 +431,8 @@ namespace hpx
                 std::shared_ptr<util::query_counters> qc =
                     std::make_shared<util::query_counters>(
                         std::ref(counters), std::ref(reset_counters), interval,
-                        destination, counter_format, counter_shortnames, csv_header);
+                        destination, counter_format, counter_shortnames, csv_header,
+                        print_counters_locally);
 
                 // schedule to print counters at shutdown, if requested
                 if (get_config_entry("hpx.print_counter.shutdown", "0") == "1")
@@ -491,8 +493,10 @@ namespace hpx
 
             // Add startup function related to listing counter names or counter
             // infos (on console only).
-            if (mode == runtime_mode_console)
-                handle_list_and_print_options(rt, vm);
+            bool print_counters_locally =
+                vm.count("hpx:print-counters-locally") != 0;
+            if (mode == runtime_mode_console || print_counters_locally)
+                handle_list_and_print_options(rt, vm, print_counters_locally);
 
             // Dump the configuration before all components have been loaded.
             if (vm.count("hpx:dump-config-initial")) {

--- a/src/util/parse_command_line.cpp
+++ b/src/util/parse_command_line.cpp
@@ -565,6 +565,8 @@ namespace hpx { namespace util
                 ("hpx:reset-counters",
                   "reset all performance counter(s) specified with --hpx:print-counter "
                   "after they have been evaluated")
+                ("hpx:print-counters-locally",
+                  "each locality prints only its own local counters")
             ;
 
             hidden_options.add_options()

--- a/src/util/query_counters.cpp
+++ b/src/util/query_counters.cpp
@@ -42,10 +42,13 @@ namespace hpx { namespace util
     query_counters::query_counters(std::vector<std::string> const& names,
             std::vector<std::string> const& reset_names,
             std::int64_t interval, std::string const& dest, std::string const& form,
-            std::vector<std::string> const& shortnames, bool csv_header)
+            std::vector<std::string> const& shortnames, bool csv_header,
+            bool print_counters_locally)
       : names_(names), reset_names_(reset_names),
+        counters_(print_counters_locally),
         destination_(dest), format_(form),
         counter_shortnames_(shortnames), csv_header_(csv_header),
+        print_counters_locally_(print_counters_locally),
         timer_(util::bind(&query_counters::evaluate, this_()),
             util::bind(&query_counters::terminate, this_()),
             interval*1000, "query_counters", true)
@@ -91,6 +94,9 @@ namespace hpx { namespace util
 
     void query_counters::start()
     {
+        if (print_counters_locally_ && destination_ != "cout")
+            destination_ += "." + std::to_string(hpx::get_locality_id());
+
         find_counters();
 
         counters_.start(launch::sync);


### PR DESCRIPTION
Add commandline options `--hpx:print-counters-locally` which forces each locality to print only its own counters