### PR TITLE
Pick up hpx.ignore_batch_env from config map

### DIFF
--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -534,7 +534,8 @@ namespace hpx { namespace util
             nodelist = vm["hpx:nodes"].as<std::vector<std::string> >();
         }
 
-        enable_batch_env = vm.count("hpx:ignore-batch-env") == 0;
+        enable_batch_env = (cfgmap.get_value<int>("hpx.ignore_batch_env", 0)
+            + vm.count("hpx:ignore-batch-env")) == 0;
 #endif
 
         util::batch_environment env(nodelist, rtcfg_, debug_clp, enable_batch_env);


### PR DESCRIPTION
This PR picks up hpx.ignore_batch_env from the config map.