### PR TITLE
Attempt to resolve resolve_locality

### DIFF
--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -383,9 +383,7 @@ parcelset::endpoints_type const & addressing_service::resolve_locality(
                 HPX_THROWS_IF(ec, bad_parameter,
                     "addressing_service::resolve_locality",
                     strm.str());
-
-                static parcelset::endpoints_type empty_endpoints;
-                return empty_endpoints;
+                return resolved_localities_[naming::invalid_gid];
             }
         }
 

--- a/src/runtime/agas/big_boot_barrier.cpp
+++ b/src/runtime/agas/big_boot_barrier.cpp
@@ -629,6 +629,13 @@ void big_boot_barrier::spin()
     boost::unique_lock<boost::mutex> lock(mtx);
     while (connected)
         cond.wait(lock);
+
+    // pre-cache all known locality endpoints in local AGAS on locality 0 as well
+    naming::resolver_client& agas_client = get_runtime().get_agas_client();
+    if (agas_client.is_bootstrap())
+    {
+        agas_client.pre_cache_endpoints(localities);
+    }
 }
 
 inline std::size_t get_number_of_bootstrap_connections(


### PR DESCRIPTION
Attempt to resolve the miracle of `resolve_locality` being called excessively often. 

Essentially this makes sure that all locality endpoints get properly cached on locality 0 as well.
