### PR TITLE
Remove warnings due to some captured variables

### DIFF
--- a/hpx/parallel/algorithms/adjacent_difference.hpp
+++ b/hpx/parallel/algorithms/adjacent_difference.hpp
@@ -18,6 +18,7 @@
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -82,6 +83,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         zip_iterator part_begin, std::size_t part_size
                     ) mutable
                     {
+                        HPX_UNUSED(policy);
+
                         // VS2015RC bails out when op is captured by ref
                         using hpx::util::get;
                         util::loop_n<ExPolicy>(

--- a/hpx/parallel/algorithms/all_any_none.hpp
+++ b/hpx/parallel/algorithms/all_any_none.hpp
@@ -18,6 +18,7 @@
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <boost/range/functions.hpp>
 
@@ -68,6 +69,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         FwdIter part_begin, std::size_t part_count
                     ) mutable -> bool
                     {
+                        HPX_UNUSED(policy);
+
                         util::loop_n<ExPolicy>(
                             part_begin, part_count, tok,
                             [&op, &tok](FwdIter const& curr)
@@ -214,6 +217,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         FwdIter part_begin, std::size_t part_count
                     ) mutable -> bool
                     {
+                        HPX_UNUSED(policy);
+
                         util::loop_n<ExPolicy>(
                             part_begin, part_count, tok,
                             [&op, &tok](FwdIter const& curr)
@@ -359,6 +364,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         FwdIter part_begin, std::size_t part_count
                     ) mutable -> bool
                     {
+                        HPX_UNUSED(policy);
+
                         util::loop_n<ExPolicy>(
                             part_begin, part_count, tok,
                             [&op, &tok](FwdIter const& curr)

--- a/hpx/parallel/algorithms/copy.hpp
+++ b/hpx/parallel/algorithms/copy.hpp
@@ -30,6 +30,7 @@
 #include <hpx/parallel/util/scan_partitioner.hpp>
 #include <hpx/parallel/util/transfer.hpp>
 #include <hpx/parallel/util/zip_iterator.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -416,6 +417,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                        zip_iterator part_begin, std::size_t part_size
                     )   -> std::size_t
                     {
+                        HPX_UNUSED(flags);
+                        HPX_UNUSED(policy);
+
                         std::size_t curr = 0;
 
                         // MSVC complains if proj is captured by ref below
@@ -439,6 +443,9 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         hpx::shared_future<std::size_t> next
                     ) mutable
                     {
+                        HPX_UNUSED(flags);
+                        HPX_UNUSED(policy);
+
                         next.get();     // rethrow exceptions
 
                         std::advance(dest, curr.get());
@@ -467,6 +474,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         std::vector<hpx::future<void> > &&) mutable
                     ->  std::pair<FwdIter, OutIter>
                     {
+                        HPX_UNUSED(flags);
+
                         std::advance(dest, items.back().get());
                         return std::make_pair(last, dest);
                     });

--- a/hpx/parallel/algorithms/equal.hpp
+++ b/hpx/parallel/algorithms/equal.hpp
@@ -19,6 +19,7 @@
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/zip_iterator.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <boost/range/functions.hpp>
 
@@ -115,6 +116,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         zip_iterator it, std::size_t part_count
                     ) mutable -> bool
                     {
+                        HPX_UNUSED(policy);
+
                         util::loop_n<ExPolicy>(
                             it, part_count, tok,
                             [&f, &tok](zip_iterator const& curr)
@@ -290,6 +293,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         zip_iterator it, std::size_t part_count
                     ) mutable -> bool
                     {
+                        HPX_UNUSED(policy);
+
                         util::loop_n<ExPolicy>(
                             it, part_count, tok,
                             [&f, &tok](zip_iterator const& curr)

--- a/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -23,6 +23,7 @@
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/scan_partitioner.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -124,6 +125,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         hpx::shared_future<T> curr, hpx::shared_future<T> next
                     )
                     {
+                        HPX_UNUSED(policy);
+
                         next.get();     // rethrow exceptions
 
                         T val = curr.get();

--- a/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -22,6 +22,7 @@
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/scan_partitioner.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -119,6 +120,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         hpx::shared_future<T> curr, hpx::shared_future<T> next
                     )
                     {
+                        HPX_UNUSED(policy);
+
                         next.get();     // rethrow exceptions
 
                         T val = curr.get();

--- a/hpx/parallel/algorithms/is_partitioned.hpp
+++ b/hpx/parallel/algorithms/is_partitioned.hpp
@@ -19,6 +19,7 @@
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -93,6 +94,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         Iter part_begin, std::size_t part_count
                     ) mutable -> bool
                     {
+                        HPX_UNUSED(policy);
+
                         bool fst_bool = pred(*part_begin);
                         if (part_count == 1)
                             return fst_bool;

--- a/hpx/parallel/algorithms/is_sorted.hpp
+++ b/hpx/parallel/algorithms/is_sorted.hpp
@@ -19,6 +19,7 @@
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <boost/range/functions.hpp>
 
@@ -71,6 +72,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         FwdIter part_begin, std::size_t part_size
                     ) mutable -> bool
                     {
+                        HPX_UNUSED(policy);
+
                         FwdIter trail = part_begin++;
                         util::loop_n<ExPolicy>(
                             part_begin, part_size - 1,

--- a/hpx/parallel/algorithms/remove_copy.hpp
+++ b/hpx/parallel/algorithms/remove_copy.hpp
@@ -20,6 +20,7 @@
 #include <hpx/parallel/tagspec.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <algorithm>
 #include <iterator>
@@ -81,6 +82,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     first, last, dest,
                     [val, proj](T const& a)
                     {
+                        HPX_UNUSED(proj);
                         return !(a == val);
                     },
                     std::forward<Proj>(proj));

--- a/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -23,6 +23,7 @@
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/scan_partitioner.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -128,6 +129,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         hpx::shared_future<T> curr, hpx::shared_future<T> next
                     )
                     {
+                        HPX_UNUSED(policy);
+
                         next.get();     // rethrow exceptions
 
                         T val = curr.get();

--- a/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -23,6 +23,7 @@
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/scan_partitioner.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -125,6 +126,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         hpx::shared_future<T> curr, hpx::shared_future<T> next
                     )
                     {
+                        HPX_UNUSED(policy);
+
                         next.get();     // rethrow exceptions
 
                         T val = curr.get();

--- a/hpx/parallel/algorithms/transform_reduce_binary.hpp
+++ b/hpx/parallel/algorithms/transform_reduce_binary.hpp
@@ -22,6 +22,7 @@
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -160,6 +161,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                         zip_iterator part_begin, std::size_t part_size
                     ) mutable -> T
                     {
+                        HPX_UNUSED(policy);
+
                         auto iters = part_begin.get_iterator_tuple();
                         FwdIter1 it1 = hpx::util::get<0>(iters);
                         FwdIter2 it2 = hpx::util::get<1>(iters);

--- a/hpx/parallel/segmented_algorithms/detail/scan.hpp
+++ b/hpx/parallel/segmented_algorithms/detail/scan.hpp
@@ -87,6 +87,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     first, std::distance(first, last),
                     [op, policy](FwdIter part_begin, std::size_t part_size) -> T
                     {
+                        HPX_UNUSED(policy);
+
                         T ret = *part_begin;
                         if(part_size > 1)
                         {
@@ -103,6 +105,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
                     hpx::util::unwrapped(
                         [op, policy](std::vector<T>&& results) -> T
                         {
+                            HPX_UNUSED(policy);
+
                             T ret = *results.begin();
                             if(results.size() > 1)
                             {

--- a/hpx/parallel/util/partitioner.hpp
+++ b/hpx/parallel/util/partitioner.hpp
@@ -22,6 +22,7 @@
 #include <hpx/parallel/util/detail/handle_local_exceptions.hpp>
 #include <hpx/parallel/util/detail/partitioner_iteration.hpp>
 #include <hpx/parallel/util/detail/scoped_executor_parameters.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <boost/exception_ptr.hpp>
 #include <boost/range/functions.hpp>
@@ -320,6 +321,8 @@ namespace hpx { namespace parallel { namespace util
                     [f2, errors, scoped_param](
                         std::vector<hpx::future<Result> > && r) mutable -> R
                     {
+                        HPX_UNUSED(scoped_param);
+
                         // inform parameter traits
                         handle_local_exceptions<ExPolicy>::call(r, errors);
                         return f2(std::move(r));
@@ -472,6 +475,8 @@ namespace hpx { namespace parallel { namespace util
                     [f2, errors, scoped_param](
                         std::vector<hpx::future<Result> > && r) mutable -> R
                     {
+                        HPX_UNUSED(scoped_param);
+
                         // inform parameter traits
                         handle_local_exceptions<ExPolicy>::call(r, errors);
                         return f2(std::move(r));

--- a/hpx/parallel/util/partitioner_with_cleanup.hpp
+++ b/hpx/parallel/util/partitioner_with_cleanup.hpp
@@ -21,6 +21,7 @@
 #include <hpx/parallel/util/detail/handle_local_exceptions.hpp>
 #include <hpx/parallel/util/detail/partitioner_iteration.hpp>
 #include <hpx/parallel/util/detail/scoped_executor_parameters.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <boost/exception_ptr.hpp>
 
@@ -175,6 +176,8 @@ namespace hpx { namespace parallel { namespace util
                     [f2, f3, errors, scoped_param](
                         std::vector<hpx::future<Result> > && r) mutable -> R
                     {
+                        HPX_UNUSED(scoped_param);
+
                         detail::handle_local_exceptions<ExPolicy>::call(
                             r, errors, std::forward<F3>(f3));
                         return f2(std::move(r));

--- a/hpx/parallel/util/scan_partitioner.hpp
+++ b/hpx/parallel/util/scan_partitioner.hpp
@@ -23,6 +23,7 @@
 #include <hpx/parallel/util/detail/chunk_size.hpp>
 #include <hpx/parallel/util/detail/handle_local_exceptions.hpp>
 #include <hpx/parallel/util/detail/scoped_executor_parameters.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <boost/exception_ptr.hpp>
 #include <boost/range/functions.hpp>
@@ -267,6 +268,8 @@ namespace hpx { namespace parallel { namespace util
                         std::vector<hpx::future<Result2> >&& fitems
                     ) mutable -> R
                     {
+                        HPX_UNUSED(scoped_param);
+
                         handle_local_exceptions<ExPolicy>::call(witems, errors);
                         handle_local_exceptions<ExPolicy>::call(fitems, errors);
 

--- a/tests/unit/parallel/algorithms/exclusive_scan.cpp
+++ b/tests/unit/parallel/algorithms/exclusive_scan.cpp
@@ -28,7 +28,7 @@ void exclusive_scan_benchmark()
 
       double const val(0);
       auto op =
-        [val](double v1, double v2) {
+        [](double v1, double v2) {
           return v1 + v2;
       };
 
@@ -72,7 +72,7 @@ void test_exclusive_scan1(ExPolicy policy, IteratorTag)
 
     std::size_t const val(0);
     auto op =
-        [val](std::size_t v1, std::size_t v2) {
+        [](std::size_t v1, std::size_t v2) {
             return v1 + v2;
         };
 
@@ -100,7 +100,7 @@ void test_exclusive_scan1_async(ExPolicy p, IteratorTag)
 
     std::size_t const val(0);
     auto op =
-        [val](std::size_t v1, std::size_t v2) {
+        [](std::size_t v1, std::size_t v2) {
             return v1 + v2;
         };
 

--- a/tests/unit/parallel/algorithms/inclusive_scan_tests.hpp
+++ b/tests/unit/parallel/algorithms/inclusive_scan_tests.hpp
@@ -31,7 +31,7 @@ void inclusive_scan_benchmark()
 
       double const val(0);
       auto op =
-          [val](double v1, double v2) {
+          [](double v1, double v2) {
               return v1 + v2;
           };
 
@@ -76,7 +76,7 @@ void test_inclusive_scan1(ExPolicy && policy, IteratorTag)
 
     std::size_t const val(0);
     auto op =
-        [val](std::size_t v1, std::size_t v2) {
+        [](std::size_t v1, std::size_t v2) {
             return v1 + v2;
         };
 
@@ -104,7 +104,7 @@ void test_inclusive_scan1_async(ExPolicy && p, IteratorTag)
 
     std::size_t const val(0);
     auto op =
-        [val](std::size_t v1, std::size_t v2) {
+        [](std::size_t v1, std::size_t v2) {
             return v1 + v2;
         };
 

--- a/tests/unit/parallel/algorithms/reduce_.cpp
+++ b/tests/unit/parallel/algorithms/reduce_.cpp
@@ -32,7 +32,7 @@ void test_reduce1(ExPolicy policy, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::iota(boost::begin(c), boost::end(c), std::rand());
 
-    std::size_t const val(42);
+    std::size_t val(42);
     auto op =
         [val](std::size_t v1, std::size_t v2) {
             return v1 + v2 + val;
@@ -55,7 +55,7 @@ void test_reduce1_async(ExPolicy p, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::iota(boost::begin(c), boost::end(c), std::rand());
 
-    std::size_t const val(42);
+    std::size_t val(42);
     auto op =
         [val](std::size_t v1, std::size_t v2) {
             return v1 + v2 + val;

--- a/tests/unit/parallel/algorithms/transform_exclusive_scan.cpp
+++ b/tests/unit/parallel/algorithms/transform_exclusive_scan.cpp
@@ -33,7 +33,7 @@ void test_transform_exclusive_scan(ExPolicy policy, IteratorTag)
     std::fill(boost::begin(c), boost::end(c), std::size_t(1));
 
     std::size_t const val(0);
-    auto op = [val](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
     auto conv = [](std::size_t val) { return 2*val; };
 
     hpx::parallel::transform_exclusive_scan(policy,
@@ -59,7 +59,7 @@ void test_transform_exclusive_scan_async(ExPolicy p, IteratorTag)
     std::fill(boost::begin(c), boost::end(c), std::size_t(1));
 
     std::size_t const val(0);
-    auto op = [val](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
     auto conv = [](std::size_t val) { return 2*val; };
 
     hpx::future<void> f =

--- a/tests/unit/parallel/algorithms/transform_inclusive_scan.cpp
+++ b/tests/unit/parallel/algorithms/transform_inclusive_scan.cpp
@@ -33,7 +33,7 @@ void test_transform_inclusive_scan1(ExPolicy policy, IteratorTag)
     std::fill(boost::begin(c), boost::end(c), std::size_t(1));
 
     std::size_t const val(0);
-    auto op = [val](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
     auto conv = [](std::size_t val) { return 2*val; };
 
     hpx::parallel::transform_inclusive_scan(policy,
@@ -59,7 +59,7 @@ void test_transform_inclusive_scan1_async(ExPolicy p, IteratorTag)
     std::fill(boost::begin(c), boost::end(c), std::size_t(1));
 
     std::size_t const val(0);
-    auto op = [val](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
     auto conv = [](std::size_t val) { return 2*val; };
 
     hpx::future<void> f =
@@ -129,8 +129,7 @@ void test_transform_inclusive_scan2(ExPolicy policy, IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::fill(boost::begin(c), boost::end(c), std::size_t(1));
 
-    std::size_t const val(0);
-    auto op = [val](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
     auto conv = [](std::size_t val) { return 2*val; };
 
     hpx::parallel::transform_inclusive_scan(policy,
@@ -155,8 +154,7 @@ void test_transform_inclusive_scan2_async(ExPolicy p, IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::fill(boost::begin(c), boost::end(c), std::size_t(1));
 
-    std::size_t const val(0);
-    auto op = [val](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
     auto conv = [](std::size_t val) { return 2*val; };
 
     hpx::future<void> f =

--- a/tests/unit/parallel/algorithms/transform_reduce.cpp
+++ b/tests/unit/parallel/algorithms/transform_reduce.cpp
@@ -79,7 +79,7 @@ void test_transform_reduce_async(ExPolicy p, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::iota(boost::begin(c), boost::end(c), std::rand());
 
-    std::size_t const val(42);
+    std::size_t val(42);
     auto op =
         [val](std::size_t v1, std::size_t v2) {
             return v1 + v2 + val;


### PR DESCRIPTION
This patch tries to remove some warnings related to unused captured variables detected by Clang 5.0. Because most of those variables are copied via lambda capture for lifetime purpose, HPX_UNUSED() has been used. Also warnings are generated when local const variables are captured by value;  some of those variables are then declared non-const in place of const.