### PR TITLE
Make thread NICE level setting an option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,6 +317,19 @@ else()
 endif()
 
 ################################################################################
+# Threadlevel Nice option
+################################################################################
+hpx_option(HPX_WITH_NICE_THREADLEVEL BOOL
+  "Set HPX worker threads to have high NICE level (may impact performance) (default: OFF)"
+  OFF ADVANCED)
+if(HPX_WITH_NICE_THREADLEVEL)
+  hpx_info("Nice threadlevel is enabled.")
+  hpx_add_config_define(HPX_HAVE_NICE_THREADLEVEL)
+else()
+  hpx_info("Nice threadlevel is disabled.")
+endif()
+
+################################################################################
 # Utility configuration
 ################################################################################
 set(HPX_HIDDEN_VISIBILITY_DEFAULT ON)

--- a/src/runtime/threads/topology.cpp
+++ b/src/runtime/threads/topology.cpp
@@ -71,6 +71,7 @@ namespace hpx { namespace threads
 
     bool topology::reduce_thread_priority(error_code& ec) const
     {
+#ifdef HPX_HAVE_NICE_THREADLEVEL
 #if defined(__linux__) && !defined(__ANDROID__) && !defined(__bgq__)
         pid_t tid;
         tid = syscall(SYS_gettid);
@@ -89,6 +90,7 @@ namespace hpx { namespace threads
         }
 #elif defined(__bgq__)
         ThreadPriority_Low();
+#endif
 #endif
         return true;
     }


### PR DESCRIPTION
We have found that setting the thread NICE level high causes a significant performance drop. This patch sets it to OFF by default, but allows the user to turn it on.