### PR TITLE
chaning 7zip command to 7za in roll_release.sh

### DIFF
--- a/tools/roll_release.sh
+++ b/tools/roll_release.sh
@@ -53,12 +53,12 @@ rm -rf packages/tar.bz2/hpx_$DOT_VERSION
 echo "DONE"
 
 echo -n "Packaging $SEVENZ... "
-7zr a -xr\!.git -xr\!packages packages/$SEVENZ . > /dev/null
-(cd packages/7z/hpx_$DOT_VERSION && 7zr x ../../$SEVENZ > /dev/null)
+7za a -xr\!.git -xr\!packages packages/$SEVENZ . > /dev/null
+(cd packages/7z/hpx_$DOT_VERSION && 7za x ../../$SEVENZ > /dev/null)
 rm -f packages/$SEVENZ
-(cd packages/7z && 7zr a ../$SEVENZ hpx_$DOT_VERSION > /dev/null)
+(cd packages/7z && 7za a ../$SEVENZ hpx_$DOT_VERSION > /dev/null)
 rm -rf packages/7z/hpx_$DOT_VERSION
-(cd packages/7z && 7zr x ../$SEVENZ > /dev/null)
+(cd packages/7z && 7za x ../$SEVENZ > /dev/null)
 echo "DONE"
 
 ZIP_MD5=`md5sum packages/$ZIP | awk {'print $1'}`

--- a/tools/roll_release.sh
+++ b/tools/roll_release.sh
@@ -52,13 +52,19 @@ rm -rf packages/tar.bz2/hpx_$DOT_VERSION
 (cd packages/tar.bz2 && tar -xf ../$TARBZ2)
 echo "DONE"
 
+if type -t "7za" > /dev/null; 
+then
+	SEVENZIP=7za
+else
+	SEVENZIP=7zr
+fi
 echo -n "Packaging $SEVENZ... "
-7za a -xr\!.git -xr\!packages packages/$SEVENZ . > /dev/null
-(cd packages/7z/hpx_$DOT_VERSION && 7za x ../../$SEVENZ > /dev/null)
+$SEVENZIP a -xr\!.git -xr\!packages packages/$SEVENZ . > /dev/null
+(cd packages/7z/hpx_$DOT_VERSION && $SEVENZIP x ../../$SEVENZ > /dev/null)
 rm -f packages/$SEVENZ
-(cd packages/7z && 7za a ../$SEVENZ hpx_$DOT_VERSION > /dev/null)
+(cd packages/7z && $SEVENZIP a ../$SEVENZ hpx_$DOT_VERSION > /dev/null)
 rm -rf packages/7z/hpx_$DOT_VERSION
-(cd packages/7z && 7za x ../$SEVENZ > /dev/null)
+(cd packages/7z && $SEVENZIP x ../$SEVENZ > /dev/null)
 echo "DONE"
 
 ZIP_MD5=`md5sum packages/$ZIP | awk {'print $1'}`


### PR DESCRIPTION
Most Linux distribution don't have 7zr command, but almost all of them have 7za as well as Rostam's ContOS. 7za uses same syntax as 7zr