### PR TITLE
Fixing transfer_(continuation)_action::schedule

### DIFF
--- a/hpx/runtime/actions/transfer_action.hpp
+++ b/hpx/runtime/actions/transfer_action.hpp
@@ -170,7 +170,7 @@ namespace hpx { namespace actions
 #endif
         applier::detail::apply_helper<typename base_type::derived_type>::call(
             std::move(data), target, lva, this->priority_,
-            util::get<Is>(std::move(this->arguments_))...);
+            std::move(util::get<Is>(this->arguments_))...);
     }
 
     template <typename Action>

--- a/hpx/runtime/actions/transfer_continuation_action.hpp
+++ b/hpx/runtime/actions/transfer_continuation_action.hpp
@@ -170,7 +170,7 @@ namespace hpx { namespace actions
 #endif
         applier::detail::apply_helper<typename base_type::derived_type>::call(
             std::move(data), std::move(cont_), target, lva, this->priority_,
-            util::get<Is>(std::move(this->arguments_))...);
+            std::move(util::get<Is>(this->arguments_))...);
     }
 
     template <typename Action>


### PR DESCRIPTION
Instead of moving the argument in the pack expansion, we should rather move
the argument element we expanded...