### PR TITLE
First attempt to introduce spmd_block in hpx

### DIFF
--- a/hpx/parallel/spmd_block.hpp
+++ b/hpx/parallel/spmd_block.hpp
@@ -18,6 +18,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <string>
 #include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
@@ -115,13 +116,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
         }*/
     };
 
-    template <typename ExPolicy, typename F, typename ... Args>
+    template <typename F, typename ... Args>
     void define_spmd_block(
-        ExPolicy && policy,
         std::string && name,
         std::size_t num_images,
         F && f, Args && ... args)
     {
+        using hpx::parallel::execution::par;
         using ftype = typename std::remove_reference<F>::type;
 
         using first_type
@@ -134,12 +135,16 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
             "has at least a spmd_block as 1st argument");
 
         auto range = boost::irange(0ul, num_images);
+        hpx::parallel::static_chunk_size cs(1);
 
 // FIXME : How to invoke images remotely?
+
 /*        auto a = hpx::actions::lambda_to_action(std::move(f));*/
 
+    // Note : par.with() ensures that each invoked image is running in a
+    // separate thread
         hpx::parallel::for_each(
-            policy, range.begin(), range.end(),
+            par.with(cs), range.begin(), range.end(),
             [=,&f](std::size_t image_id)
             {
                 spmd_block block(name,num_images,image_id);

--- a/hpx/parallel/spmd_block.hpp
+++ b/hpx/parallel/spmd_block.hpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
 {
@@ -61,8 +62,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
         : num_images_(num_images), image_id_(image_id), barrier_(barrier)
         {}
 
-    // Note: spmd_block class is movable/move-assignable
-    // but not copyable/copy-assignable
+        // Note: spmd_block class is movable/move-assignable
+        // but not copyable/copy-assignable
 
         spmd_block(spmd_block &&) = default;
         spmd_block(spmd_block const &) = delete;
@@ -115,7 +116,7 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
         typename = std::enable_if_t<
             hpx::parallel::v1::is_async_execution_policy<ExPolicy>::value>
         >
-    std::vector<hpx::future<void> >
+    std::vector<hpx::future<void>>
     define_spmd_block(ExPolicy && policy,
         std::size_t num_images, F && f, Args && ... args)
     {

--- a/hpx/parallel/spmd_block.hpp
+++ b/hpx/parallel/spmd_block.hpp
@@ -120,8 +120,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
         using ftype = typename std::decay<F>::type;
 
         using first_type =
-                typename hpx::parallel::v2::detail::extract_first_parameter<
-                            decltype(&ftype::operator())>::type;
+            typename hpx::parallel::v2::detail::extract_first_parameter<
+                        decltype(&ftype::operator())>::type;
 
         using executor_type =
             typename hpx::util::decay<ExPolicy>::type::executor_type;

--- a/hpx/parallel/spmd_block.hpp
+++ b/hpx/parallel/spmd_block.hpp
@@ -1,0 +1,149 @@
+////////////////////////////////////////////////////////////////////////////////
+//  Copyright (c) 2017 Antoine Tran Tan
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+///////////////////////////////////////////////////////////////////////////////
+#if !defined(HPX_PARALLEL_SPMD_BLOCK_HPP)
+#define HPX_PARALLEL_SPMD_BLOCK_HPP
+
+#include <hpx/include/parallel_for_each.hpp>
+#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/runtime/naming/name.hpp>
+/*#include <hpx/runtime/serialization/serialize.hpp>*/
+#include <hpx/lcos/future.hpp>
+#include <hpx/lcos/barrier.hpp>
+
+/*#include <hpx/runtime/actions/lambda_to_action.hpp>*/
+
+#include <boost/range/irange.hpp>
+
+#include <memory>
+
+namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
+{
+    namespace detail
+    {
+        template <typename T>
+        struct extract_first_parameter
+        {};
+
+        // Specialization for lambdas
+        template <typename ClassType, typename ReturnType>
+        struct extract_first_parameter<ReturnType(ClassType::*)() const>
+        {
+            using type = std::false_type;
+        };
+
+        // Specialization for lambdas
+        template <typename ClassType,
+            typename ReturnType, typename Arg0, typename... Args>
+        struct extract_first_parameter<
+            ReturnType(ClassType::*)(Arg0, Args...) const>
+        {
+            using type = Arg0;
+        };
+    }
+
+    /// The class spmd_block defines an interface for launching
+    /// multiple images while giving handles to each image to interact with
+    /// the remaining images. The \a define_spmd_block function templates create
+    /// multiple images of a user-defined lambda and launches them in a possibly
+    /// separate thread. A temporary spmd block object is created and diffused
+    /// to each image. The constraint for the lambda given to the
+    /// define_spmd_block function is to accept a spmd_block as first parameter.
+    struct spmd_block
+    {
+        spmd_block(){}
+
+        spmd_block(
+            std::string name, std::size_t num_images, std::size_t image_id)
+        : name_(name), num_images_(num_images), image_id_(image_id)
+        {}
+
+        std::size_t get_num_images() const
+        {
+            return num_images_;
+        }
+
+        std::size_t this_image() const
+        {
+            return image_id_;
+        }
+
+        void sync_all() const
+        {
+           if (!barrier_)
+           {
+               barrier_ = std::make_shared<hpx::lcos::barrier>(
+                 name_ + "_barrier"
+               , num_images_
+               );
+           }
+
+           barrier_->wait();
+        }
+
+        hpx::future<void> sync_all(hpx::launch::async_policy const &) const
+        {
+           if (!barrier_)
+           {
+               barrier_ = std::make_shared<hpx::lcos::barrier>(
+                 name_+ "_barrier"
+               , num_images_
+               );
+           }
+
+           return barrier_->wait(hpx::launch::async);
+        }
+
+    private:
+        std::string name_;
+        std::size_t num_images_;
+        std::size_t image_id_;
+        mutable std::shared_ptr<hpx::lcos::barrier> barrier_;
+
+/*    private:
+        friend class hpx::serialization::access;
+
+        template <typename Archive>
+        void serialize(Archive& ar, unsigned int const)
+        {
+            ar & name_ & num_images_ && image_id_;
+        }*/
+    };
+
+    template <typename ExPolicy, typename F, typename ... Args>
+    void define_spmd_block(
+        ExPolicy && policy,
+        std::string && name,
+        std::size_t num_images,
+        F && f, Args && ... args)
+    {
+        using ftype = typename std::remove_reference<F>::type;
+
+        using first_type
+            = typename
+                hpx::parallel::v2::detail::extract_first_parameter<
+                    decltype(&ftype::operator())>::type;
+
+        static_assert( std::is_same<spmd_block,first_type>::value,
+            "define_spmd_block() needs a lambda that " \
+            "has at least a spmd_block as 1st argument");
+
+        auto range = boost::irange(0ul, num_images);
+
+// FIXME : How to invoke images remotely?
+/*        auto a = hpx::actions::lambda_to_action(std::move(f));*/
+
+        hpx::parallel::for_each(
+            policy, range.begin(), range.end(),
+            [=,&f](std::size_t image_id)
+            {
+                spmd_block block(name,num_images,image_id);
+                f(block,args...);
+            });
+    }
+}}}
+
+#endif

--- a/hpx/parallel/spmd_block.hpp
+++ b/hpx/parallel/spmd_block.hpp
@@ -6,11 +6,9 @@
 #if !defined(HPX_PARALLEL_SPMD_BLOCK_HPP)
 #define HPX_PARALLEL_SPMD_BLOCK_HPP
 
-#include <hpx/include/parallel_for_each.hpp>
 #include <hpx/lcos/future.hpp>
 #include <hpx/lcos/local/barrier.hpp>
-#include <hpx/runtime/launch_policy.hpp>
-#include <hpx/runtime/naming/name.hpp>
+#include <hpx/parallel/execution_policy.hpp>
 #include <hpx/traits/is_execution_policy.hpp>
 
 #include <boost/range/irange.hpp>
@@ -18,7 +16,6 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
-#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>

--- a/hpx/parallel/spmd_block.hpp
+++ b/hpx/parallel/spmd_block.hpp
@@ -1,24 +1,24 @@
-////////////////////////////////////////////////////////////////////////////////
 //  Copyright (c) 2017 Antoine Tran Tan
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-///////////////////////////////////////////////////////////////////////////////
+
 #if !defined(HPX_PARALLEL_SPMD_BLOCK_HPP)
 #define HPX_PARALLEL_SPMD_BLOCK_HPP
 
 #include <hpx/include/parallel_for_each.hpp>
+#include <hpx/lcos/future.hpp>
+#include <hpx/lcos/barrier.hpp>
+/*#include <hpx/runtime/actions/lambda_to_action.hpp>*/
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/runtime/naming/name.hpp>
 /*#include <hpx/runtime/serialization/serialize.hpp>*/
-#include <hpx/lcos/future.hpp>
-#include <hpx/lcos/barrier.hpp>
-
-/*#include <hpx/runtime/actions/lambda_to_action.hpp>*/
 
 #include <boost/range/irange.hpp>
 
+#include <cstddef>
 #include <memory>
+#include <type_traits>
 
 namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
 {
@@ -71,6 +71,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
             return image_id_;
         }
 
+    // FIXME : If 2 images are scheduled in the same thread (not OS-thread)
+    // -> deadlock
         void sync_all() const
         {
            if (!barrier_)

--- a/hpx/parallel/spmd_block.hpp
+++ b/hpx/parallel/spmd_block.hpp
@@ -93,14 +93,14 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
         template <typename F>
         struct spmd_block_helper
         {
-            mutable std::reference_wrapper<hpx::lcos::local::barrier> barrier_;
+            mutable std::shared_ptr<hpx::lcos::local::barrier> barrier_;
             typename std::decay<F>::type f_;
             std::size_t num_images_;
 
             template <typename ... Ts>
             void operator()(std::size_t image_id, Ts && ... ts) const
             {
-                spmd_block block(num_images_, image_id, barrier_);
+                spmd_block block(num_images_, image_id, *barrier_);
                 hpx::util::invoke_r<void>(
                     f_, block, std::forward<Ts>(ts)...);
             }
@@ -129,7 +129,8 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v2)
             "define_spmd_block() needs a lambda that " \
             "has at least a spmd_block as 1st argument");
 
-        hpx::lcos::local::barrier barrier(num_images);
+        std::shared_ptr<hpx::lcos::local::barrier> barrier
+            = std::make_shared<hpx::lcos::local::barrier>(num_images);
 
         return hpx::parallel::executor_traits<
                 typename std::decay<executor_type>::type

--- a/tests/unit/parallel/CMakeLists.txt
+++ b/tests/unit/parallel/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 # add tests
 set(tests
+    spmd_block
     task_block
     task_block_executor
     task_block_par

--- a/tests/unit/parallel/spmd_block.cpp
+++ b/tests/unit/parallel/spmd_block.cpp
@@ -19,6 +19,9 @@ std::size_t iterations = 20;
 
 int main()
 {
+    using hpx::parallel::execution::par;
+    using hpx::parallel::execution::task;
+
     auto bulk_test =
         [](hpx::parallel::v2::spmd_block block, boost::atomic<std::size_t> & c)
         {
@@ -36,10 +39,17 @@ int main()
             }
         };
 
-    boost::atomic<std::size_t> c(0);
+    boost::atomic<std::size_t> c1(0), c2(0);
 
     hpx::parallel::v2::define_spmd_block(
-        num_images, std::move(bulk_test), std::ref(c));
+        num_images, std::move(bulk_test), std::ref(c1));
+
+    auto join =
+        hpx::parallel::v2::define_spmd_block(
+            par(task),
+                num_images, std::move(bulk_test), std::ref(c2));
+
+    hpx::wait_all(join);
 
     return 0;
 }

--- a/tests/unit/parallel/spmd_block.cpp
+++ b/tests/unit/parallel/spmd_block.cpp
@@ -10,12 +10,13 @@
 
 #include <cstddef>
 #include <iostream>
+#include <utility>
 
 std::size_t num_images = 10;
 
 int main()
 {
-    auto bulk_test = [](hpx::parallel::v2::spmd_block & block)
+    auto bulk_test = [](hpx::parallel::v2::spmd_block block)
                      {
                         std::cout<< "Welcome in image "
                             << block.this_image() << std::endl;

--- a/tests/unit/parallel/spmd_block.cpp
+++ b/tests/unit/parallel/spmd_block.cpp
@@ -9,20 +9,23 @@
 #include <hpx/util/lightweight_test.hpp>
 
 #include <cstddef>
+#include <iostream>
 
-std::size_t num_images = 1000;
+std::size_t num_images = 10;
 
 int main()
 {
-    using hpx::parallel::execution::par;
-
     auto bulk_test = [](hpx::parallel::v2::spmd_block block)
                      {
+                        std::cout<< "Welcome in image "
+                            << block.this_image() << std::endl;
+
                         HPX_TEST_EQ( block.get_num_images(), num_images );
                         HPX_TEST_EQ( block.this_image() < num_images, true );
+                        block.sync_all();
                      };
 
-    hpx::parallel::v2::define_spmd_block(par, "block1", num_images, bulk_test);
+    hpx::parallel::v2::define_spmd_block("block1", num_images, bulk_test);
 
     return 0;
 }

--- a/tests/unit/parallel/spmd_block.cpp
+++ b/tests/unit/parallel/spmd_block.cpp
@@ -1,14 +1,14 @@
-////////////////////////////////////////////////////////////////////////////////
-//  Copyright (c) 2016 Antoine Tran Tan
+//  Copyright (c) 2017 Antoine Tran Tan
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-///////////////////////////////////////////////////////////////////////////////
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_main.hpp>
 #include <hpx/parallel/spmd_block.hpp>
 #include <hpx/util/lightweight_test.hpp>
+
+#include <cstddef>
 
 std::size_t num_images = 1000;
 

--- a/tests/unit/parallel/spmd_block.cpp
+++ b/tests/unit/parallel/spmd_block.cpp
@@ -15,17 +15,18 @@ std::size_t num_images = 10;
 
 int main()
 {
-    auto bulk_test = [](hpx::parallel::v2::spmd_block block)
+    auto bulk_test = [](hpx::parallel::v2::spmd_block & block)
                      {
                         std::cout<< "Welcome in image "
                             << block.this_image() << std::endl;
 
                         HPX_TEST_EQ( block.get_num_images(), num_images );
                         HPX_TEST_EQ( block.this_image() < num_images, true );
+
                         block.sync_all();
                      };
 
-    hpx::parallel::v2::define_spmd_block("block1", num_images, bulk_test);
+    hpx::parallel::v2::define_spmd_block(num_images, std::move(bulk_test));
 
     return 0;
 }

--- a/tests/unit/parallel/spmd_block.cpp
+++ b/tests/unit/parallel/spmd_block.cpp
@@ -13,6 +13,7 @@
 #include <cstddef>
 #include <functional>
 #include <utility>
+#include <vector>
 
 std::size_t num_images = 10;
 std::size_t iterations = 20;
@@ -44,7 +45,7 @@ int main()
     hpx::parallel::v2::define_spmd_block(
         num_images, std::move(bulk_test), std::ref(c1));
 
-    auto join =
+    std::vector<hpx::future<void>> join =
         hpx::parallel::v2::define_spmd_block(
             par(task),
                 num_images, std::move(bulk_test), std::ref(c2));

--- a/tests/unit/parallel/spmd_block.cpp
+++ b/tests/unit/parallel/spmd_block.cpp
@@ -1,0 +1,28 @@
+////////////////////////////////////////////////////////////////////////////////
+//  Copyright (c) 2016 Antoine Tran Tan
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+///////////////////////////////////////////////////////////////////////////////
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_main.hpp>
+#include <hpx/parallel/spmd_block.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+std::size_t num_images = 1000;
+
+int main()
+{
+    using hpx::parallel::execution::par;
+
+    auto bulk_test = [](hpx::parallel::v2::spmd_block block)
+                     {
+                        HPX_TEST_EQ( block.get_num_images(), num_images );
+                        HPX_TEST_EQ( block.this_image() < num_images, true );
+                     };
+
+    hpx::parallel::v2::define_spmd_block(par, "block1", num_images, bulk_test);
+
+    return 0;
+}

--- a/tests/unit/parallel/spmd_block.cpp
+++ b/tests/unit/parallel/spmd_block.cpp
@@ -77,21 +77,17 @@ int main()
             }
         };
 
-    boost::atomic<std::size_t> * c1 = new boost::atomic<std::size_t>(0);
-    boost::atomic<std::size_t> * c2 = new boost::atomic<std::size_t>(0);
+    boost::atomic<std::size_t> c1(0), c2(0);
 
     hpx::parallel::v2::define_spmd_block(
-        num_images, std::move(bulk_test), c1);
+        num_images, std::move(bulk_test), &c1);
 
     std::vector<hpx::future<void>> join =
         hpx::parallel::v2::define_spmd_block(
             par(task),
-                num_images, std::move(bulk_test), c2);
+                num_images, std::move(bulk_test), &c2);
 
     hpx::wait_all(join);
-
-    delete(c1);
-    delete(c2);
 
     return 0;
 }

--- a/tests/unit/parallel/spmd_block.cpp
+++ b/tests/unit/parallel/spmd_block.cpp
@@ -6,6 +6,7 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_main.hpp>
 #include <hpx/parallel/spmd_block.hpp>
+#include <hpx/parallel/execution_policy.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <boost/atomic.hpp>


### PR DESCRIPTION
This PR tries to introduce code related to _spmd_block_ that was presented here http://stellar.cct.lsu.edu/pubs/extending_cpp_with_coarray_semantics_2016.pdf
A major difference in comparaison to what was presented in that paper is that _an image_ is no longer considered as a computation located in an _explicit_ locality. It is now a simple sequential computation able to cooperate with other ones.