### PR TITLE
Adding apex data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1380,7 +1380,7 @@ if(HPX_WITH_APEX)
   include(GitExternal)
   git_external(apex
     https://github.com/khuck/xpress-apex.git
-    v1.1
+    v1.2
     ${_hpx_apex_no_update}
     VERBOSE)
 

--- a/hpx/lcos/dataflow.hpp
+++ b/hpx/lcos/dataflow.hpp
@@ -245,7 +245,7 @@ namespace hpx { namespace lcos { namespace detail
             char const* name = traits::get_function_annotation<Func>::call(func_);
             if (name != nullptr)
             {
-                util::apex_wrapper apex_profiler(name, (uint64_t)this);
+                util::apex_wrapper apex_profiler(name);
                 execute(indices_type(), is_void());
             }
             else

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -525,7 +525,7 @@ namespace detail
                     >::call(on_completed);
                 if (name != nullptr)
                 {
-                    util::apex_wrapper apex_profiler(name, (uint64_t)this);
+                    util::apex_wrapper apex_profiler(name);
                     on_completed();
                 }
                 else

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -123,7 +123,7 @@ namespace hpx { namespace lcos { namespace detail
         char const* name = traits::get_function_annotation<Func>::call(func);
         if (name != nullptr)
         {
-            util::apex_wrapper apex_profiler(name, (uint64_t)&future);
+            util::apex_wrapper apex_profiler(name);
             invoke_continuation(func, future, cont, is_void());
         }
         else

--- a/hpx/lcos/local/packaged_task.hpp
+++ b/hpx/lcos/local/packaged_task.hpp
@@ -104,7 +104,7 @@ namespace hpx { namespace lcos { namespace local
                 >::call(function_);
             if (name != nullptr)
             {
-                util::apex_wrapper apex_profiler(name, (uint64_t)this);
+                util::apex_wrapper apex_profiler(name);
                 invoke_impl(std::is_void<R>(), std::forward<Ts>(vs)...);
             }
             else

--- a/hpx/runtime/serialization/detail/vc.hpp
+++ b/hpx/runtime/serialization/detail/vc.hpp
@@ -16,7 +16,7 @@
 #include <cstddef>
 #include <type_traits>
 
-#include <Vc/version.h>
+#include <Vc/global.h>
 
 #if defined(Vc_IS_VERSION_1) && Vc_IS_VERSION_1
 

--- a/hpx/runtime/threads/coroutines/coroutine.hpp
+++ b/hpx/runtime/threads/coroutines/coroutine.hpp
@@ -120,14 +120,9 @@ namespace hpx { namespace threads { namespace coroutines
         }
 
 #if defined(HPX_HAVE_APEX)
-        std::size_t get_apex_data() const
+        void** get_apex_data() const
         {
             return m_pimpl.get() ? m_pimpl->get_apex_data() : 0ull;
-        }
-
-        std::size_t set_apex_data(std::size_t data)
-        {
-            return m_pimpl.get() ? m_pimpl->set_apex_data(data) : 0ull;
         }
 #endif
 

--- a/hpx/runtime/threads/coroutines/detail/context_base.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_base.hpp
@@ -654,8 +654,8 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         mutable std::size_t m_thread_data;
 #endif
 #if defined(HPX_HAVE_APEX)
-	// This is a pointer that APEX will use to maintain state
-	// when an HPX thread is pre-empted.
+        // This is a pointer that APEX will use to maintain state
+        // when an HPX thread is pre-empted.
         void* m_apex_data;
 #endif
 

--- a/hpx/runtime/threads/coroutines/detail/context_base.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_base.hpp
@@ -484,16 +484,15 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         }
 
 #if defined(HPX_HAVE_APEX)
-        std::size_t get_apex_data() const
+        void** get_apex_data() const
         {
-            return m_apex_data;
-        }
-
-        std::size_t set_apex_data(std::size_t data)
-        {
-            std::size_t olddata = m_apex_data;
-            m_apex_data = data;
-            return olddata;
+            // APEX wants the ADDRESS of a location to store
+            // data.  This storage could be updated asynchronously,
+            // so APEX stores this address, and uses it as a way
+            // to remember state for the HPX thread in-betweeen
+            // calls to apex::start/stop/yield/resume().
+            // APEX will change the value pointed to by the address.
+            return const_cast<void**>(&m_apex_data);
         }
 #endif
 
@@ -655,7 +654,9 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         mutable std::size_t m_thread_data;
 #endif
 #if defined(HPX_HAVE_APEX)
-        std::size_t m_apex_data;
+	// This is a pointer that APEX will use to maintain state
+	// when an HPX thread is pre-empted.
+        void* m_apex_data;
 #endif
 
         // This is used to generate a meaningful exception trace.

--- a/hpx/runtime/threads/coroutines/detail/coroutine_self.hpp
+++ b/hpx/runtime/threads/coroutines/detail/coroutine_self.hpp
@@ -205,7 +205,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         static HPX_EXPORT void init_self();
         static HPX_EXPORT void reset_self();
 
-#if defined(HPX_HAVE_APEX)
+#if defined(HPX_HAVE_APEX_DISABLED)
         std::size_t get_apex_data() const
         {
             HPX_ASSERT(m_pimpl);

--- a/hpx/runtime/threads/coroutines/detail/coroutine_self.hpp
+++ b/hpx/runtime/threads/coroutines/detail/coroutine_self.hpp
@@ -205,6 +205,19 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         static HPX_EXPORT void init_self();
         static HPX_EXPORT void reset_self();
 
+#if defined(HPX_HAVE_APEX)
+        std::size_t get_apex_data() const
+        {
+            HPX_ASSERT(m_pimpl);
+            return m_pimpl->get_apex_data();
+        }
+        std::size_t set_apex_data(std::size_t data)
+        {
+            HPX_ASSERT(m_pimpl);
+            return m_pimpl->set_apex_data(data);
+        }
+#endif
+
     private:
         yield_decorator_type yield_decorator_;
 

--- a/hpx/runtime/threads/coroutines/detail/coroutine_self.hpp
+++ b/hpx/runtime/threads/coroutines/detail/coroutine_self.hpp
@@ -206,15 +206,10 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         static HPX_EXPORT void reset_self();
 
 #if defined(HPX_HAVE_APEX)
-        std::size_t get_apex_data() const
+        void** get_apex_data() const
         {
             HPX_ASSERT(m_pimpl);
             return m_pimpl->get_apex_data();
-        }
-        std::size_t set_apex_data(std::size_t data)
-        {
-            HPX_ASSERT(m_pimpl);
-            return m_pimpl->set_apex_data(data);
         }
 #endif
 

--- a/hpx/runtime/threads/coroutines/detail/coroutine_self.hpp
+++ b/hpx/runtime/threads/coroutines/detail/coroutine_self.hpp
@@ -205,7 +205,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         static HPX_EXPORT void init_self();
         static HPX_EXPORT void reset_self();
 
-#if defined(HPX_HAVE_APEX_DISABLED)
+#if defined(HPX_HAVE_APEX)
         std::size_t get_apex_data() const
         {
             HPX_ASSERT(m_pimpl);

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -354,9 +354,17 @@ namespace hpx { namespace threads { namespace detail
                             thrd_stat.get_previous() == pending))
                     {
 #if defined(HPX_HAVE_APEX)
+#if 1
+                        std::size_t tmp_data = background_thread->get_apex_data();
                         util::apex_wrapper apex_profiler(
                             background_thread->get_description(),
-                            reinterpret_cast<std::uint64_t>(background_thread.get()));
+                            &(tmp_data));
+                        background_thread->set_apex_data(tmp_data);
+#else
+                        util::apex_wrapper apex_profiler(
+                            background_thread->get_description(),
+                            &(background_thread->apex_data_));
+#endif
 
                         thrd_stat = (*background_thread)();
 
@@ -506,9 +514,18 @@ namespace hpx { namespace threads { namespace detail
                                 exec_time_wrapper exec_time_collector(idle_rate);
 
 #if defined(HPX_HAVE_APEX)
+#if 1
+                                std::size_t tmp_data = thrd->get_apex_data();
+                                // tmp_data is getting updated during this call
                                 util::apex_wrapper apex_profiler(
                                     thrd->get_description(),
-                                    reinterpret_cast<std::uint64_t>(thrd));
+                                    &(tmp_data));
+                                background_thread->set_apex_data(tmp_data);
+#else
+                                util::apex_wrapper apex_profiler(
+                                    thrd->get_description(),
+                                    &(thrd->apex_data_));
+#endif
 
                                 thrd_stat = (*thrd)();
 

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -354,11 +354,15 @@ namespace hpx { namespace threads { namespace detail
                             thrd_stat.get_previous() == pending))
                     {
 #if defined(HPX_HAVE_APEX)
+			// get the APEX data pointer, in case we are resuming the
+			// thread and have to restore any leaf timers from
+			// direct actions, etc.
                         std::size_t tmp_data = background_thread->get_apex_data();
+                        // the address of tmp_data is getting stored 
+                        // by APEX during this call
                         util::apex_wrapper apex_profiler(
                             background_thread->get_description(),
                             &(tmp_data));
-                        background_thread->set_apex_data(tmp_data);
 
                         thrd_stat = (*background_thread)();
 
@@ -370,6 +374,8 @@ namespace hpx { namespace threads { namespace detail
                         {
                             apex_profiler.yield();
                         }
+			// APEX may have saved some data
+                        background_thread->set_apex_data(tmp_data);
 #else
                         thrd_stat = (*background_thread)();
 #endif
@@ -508,12 +514,15 @@ namespace hpx { namespace threads { namespace detail
                                 exec_time_wrapper exec_time_collector(idle_rate);
 
 #if defined(HPX_HAVE_APEX)
+                                // get the APEX data pointer, in case we are resuming the
+                                // thread and have to restore any leaf timers from
+                                // direct actions, etc.
                                 std::size_t tmp_data = thrd->get_apex_data();
-                                // tmp_data is getting updated during this call
+                                // the address of tmp_data is getting stored 
+                                // by APEX during this call
                                 util::apex_wrapper apex_profiler(
                                     thrd->get_description(),
                                     &(tmp_data));
-                                thrd->set_apex_data(tmp_data);
 
                                 thrd_stat = (*thrd)();
 
@@ -525,6 +534,8 @@ namespace hpx { namespace threads { namespace detail
                                 {
                                     apex_profiler.yield();
                                 }
+				// APEX may have saved some data
+                                thrd->set_apex_data(tmp_data);
 #else
                                 thrd_stat = (*thrd)();
 #endif

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -354,17 +354,11 @@ namespace hpx { namespace threads { namespace detail
                             thrd_stat.get_previous() == pending))
                     {
 #if defined(HPX_HAVE_APEX)
-#if 1
                         std::size_t tmp_data = background_thread->get_apex_data();
                         util::apex_wrapper apex_profiler(
                             background_thread->get_description(),
                             &(tmp_data));
                         background_thread->set_apex_data(tmp_data);
-#else
-                        util::apex_wrapper apex_profiler(
-                            background_thread->get_description(),
-                            &(background_thread->apex_data_));
-#endif
 
                         thrd_stat = (*background_thread)();
 
@@ -514,18 +508,12 @@ namespace hpx { namespace threads { namespace detail
                                 exec_time_wrapper exec_time_collector(idle_rate);
 
 #if defined(HPX_HAVE_APEX)
-#if 1
                                 std::size_t tmp_data = thrd->get_apex_data();
                                 // tmp_data is getting updated during this call
                                 util::apex_wrapper apex_profiler(
                                     thrd->get_description(),
                                     &(tmp_data));
                                 background_thread->set_apex_data(tmp_data);
-#else
-                                util::apex_wrapper apex_profiler(
-                                    thrd->get_description(),
-                                    &(thrd->apex_data_));
-#endif
 
                                 thrd_stat = (*thrd)();
 

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -357,12 +357,12 @@ namespace hpx { namespace threads { namespace detail
 			// get the APEX data pointer, in case we are resuming the
 			// thread and have to restore any leaf timers from
 			// direct actions, etc.
-                        std::size_t tmp_data = background_thread->get_apex_data();
+
                         // the address of tmp_data is getting stored 
                         // by APEX during this call
                         util::apex_wrapper apex_profiler(
                             background_thread->get_description(),
-                            &(tmp_data));
+                            background_thread->get_apex_data());
 
                         thrd_stat = (*background_thread)();
 
@@ -374,8 +374,6 @@ namespace hpx { namespace threads { namespace detail
                         {
                             apex_profiler.yield();
                         }
-			// APEX may have saved some data
-                        background_thread->set_apex_data(tmp_data);
 #else
                         thrd_stat = (*background_thread)();
 #endif
@@ -517,12 +515,12 @@ namespace hpx { namespace threads { namespace detail
                                 // get the APEX data pointer, in case we are resuming the
                                 // thread and have to restore any leaf timers from
                                 // direct actions, etc.
-                                std::size_t tmp_data = thrd->get_apex_data();
+                                
                                 // the address of tmp_data is getting stored 
                                 // by APEX during this call
                                 util::apex_wrapper apex_profiler(
                                     thrd->get_description(),
-                                    &(tmp_data));
+                                    thrd->get_apex_data());
 
                                 thrd_stat = (*thrd)();
 
@@ -534,8 +532,6 @@ namespace hpx { namespace threads { namespace detail
                                 {
                                     apex_profiler.yield();
                                 }
-				// APEX may have saved some data
-                                thrd->set_apex_data(tmp_data);
 #else
                                 thrd_stat = (*thrd)();
 #endif

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -513,7 +513,7 @@ namespace hpx { namespace threads { namespace detail
                                 util::apex_wrapper apex_profiler(
                                     thrd->get_description(),
                                     &(tmp_data));
-                                background_thread->set_apex_data(tmp_data);
+                                thrd->set_apex_data(tmp_data);
 
                                 thrd_stat = (*thrd)();
 

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -354,11 +354,11 @@ namespace hpx { namespace threads { namespace detail
                             thrd_stat.get_previous() == pending))
                     {
 #if defined(HPX_HAVE_APEX)
-			// get the APEX data pointer, in case we are resuming the
-			// thread and have to restore any leaf timers from
-			// direct actions, etc.
+                        // get the APEX data pointer, in case we are resuming the
+                        // thread and have to restore any leaf timers from
+                        // direct actions, etc.
 
-                        // the address of tmp_data is getting stored 
+                        // the address of tmp_data is getting stored
                         // by APEX during this call
                         util::apex_wrapper apex_profiler(
                             background_thread->get_description(),
@@ -515,8 +515,8 @@ namespace hpx { namespace threads { namespace detail
                                 // get the APEX data pointer, in case we are resuming the
                                 // thread and have to restore any leaf timers from
                                 // direct actions, etc.
-                                
-                                // the address of tmp_data is getting stored 
+
+                                // the address of tmp_data is getting stored
                                 // by APEX during this call
                                 util::apex_wrapper apex_profiler(
                                     thrd->get_description(),

--- a/hpx/runtime/threads/thread_data.hpp
+++ b/hpx/runtime/threads/thread_data.hpp
@@ -545,6 +545,20 @@ namespace hpx { namespace threads
             return coroutine_.set_thread_data(data);
         }
 
+#if defined(HPX_HAVE_APEX)
+        std::size_t get_apex_data() const
+        {
+            return apex_data_;
+        }
+
+        std::size_t set_apex_data(std::size_t data)
+        {
+            std::size_t apex_data = apex_data_;
+            apex_data_ = 0ull;
+            return apex_data;
+        }
+#endif
+
         void rebind(thread_init_data& init_data,
             thread_state_enum newstate)
         {
@@ -598,6 +612,9 @@ namespace hpx { namespace threads
             coroutine_(std::move(init_data.func),
                 this_(), init_data.stacksize),
             pool_(pool)
+#if defined(HPX_WITH_APEX)
+          , apex_data_(0ull)
+#endif
         {
             LTM_(debug) << "thread::thread(" << this << "), description("
                         << get_description() << ")";
@@ -671,6 +688,9 @@ namespace hpx { namespace threads
             if (0 == parent_locality_id_)
                 parent_locality_id_ = get_locality_id();
 #endif
+#if defined(HPX_HAVE_APEX)
+            apex_data_ = 0ull;
+#endif
         }
 
         mutable boost::atomic<thread_state> current_state_;
@@ -718,13 +738,17 @@ namespace hpx { namespace threads
         // reference to scheduler which created/manages this thread
         policies::scheduler_base* scheduler_base_;
 
-        //reference count
+        // reference count
         util::atomic_count count_;
 
         std::ptrdiff_t stacksize_;
 
         coroutine_type coroutine_;
         pool_type* pool_;
+
+#if defined(HPX_HAVE_APEX)
+        std::size_t apex_data_;
+#endif
     };
 
     typedef thread_data::pool_type thread_pool;

--- a/hpx/runtime/threads/thread_data.hpp
+++ b/hpx/runtime/threads/thread_data.hpp
@@ -546,14 +546,9 @@ namespace hpx { namespace threads
         }
 
 #if defined(HPX_HAVE_APEX)
-        std::size_t get_apex_data() const
+        void** get_apex_data() const
         {
             return coroutine_.get_apex_data();
-        }
-
-        std::size_t set_apex_data(std::size_t data)
-        {
-            return coroutine_.set_apex_data(data);
         }
 #endif
 

--- a/hpx/runtime/threads/thread_data_fwd.hpp
+++ b/hpx/runtime/threads/thread_data_fwd.hpp
@@ -165,6 +165,11 @@ namespace hpx { namespace threads
     HPX_API_EXPORT bool enumerate_threads(
         util::function_nonser<bool(thread_id_type)> const& f,
         thread_state_enum state = unknown);
+
+#if defined(HPX_HAVE_APEX)
+    HPX_API_EXPORT std::size_t get_self_apex_data();
+    HPX_API_EXPORT std::size_t set_self_apex_data(std::size_t);
+#endif
 }}
 
 #endif

--- a/hpx/runtime/threads/thread_data_fwd.hpp
+++ b/hpx/runtime/threads/thread_data_fwd.hpp
@@ -167,8 +167,7 @@ namespace hpx { namespace threads
         thread_state_enum state = unknown);
 
 #if defined(HPX_HAVE_APEX)
-    HPX_API_EXPORT std::size_t get_self_apex_data();
-    HPX_API_EXPORT std::size_t set_self_apex_data(std::size_t);
+    HPX_API_EXPORT void** get_self_apex_data();
 #endif
 }}
 

--- a/hpx/util/apex.hpp
+++ b/hpx/util/apex.hpp
@@ -50,17 +50,21 @@ namespace hpx { namespace util
                     apex_function_address(name_.get_address()));
             }
         }
-        apex_wrapper(thread_description const& name, uint64_t id)
+        apex_wrapper(thread_description const& name, std::size_t* data_ptr)
           : name_(name), stopped(false)
         {
             if (name_.kind() == thread_description::data_type_description)
             {
-                profiler_ = apex::start(name_.get_description(), id);
+                // not a mistake... we need to pass in the address of this
+                // pointer, so that we can assign it in apex...
+                profiler_ = apex::start(name_.get_description(), (void**)(data_ptr));
             }
             else
             {
+                // not a mistake... we need to pass in the address of this
+                // pointer, so that we can assign it in apex...
                 profiler_ = apex::start(
-                    apex_function_address(name_.get_address()), id);
+                    apex_function_address(name_.get_address()), (void**)(data_ptr));
             }
         }
         ~apex_wrapper()

--- a/hpx/util/apex.hpp
+++ b/hpx/util/apex.hpp
@@ -50,21 +50,21 @@ namespace hpx { namespace util
                     apex_function_address(name_.get_address()));
             }
         }
-        apex_wrapper(thread_description const& name, std::size_t* data_ptr)
+        apex_wrapper(thread_description const& name, void** const data_ptr)
           : name_(name), stopped(false)
         {
             if (name_.kind() == thread_description::data_type_description)
             {
                 // not a mistake... we need to pass in the address of this
-                // pointer, so that we can assign it in apex...
-                profiler_ = apex::start(name_.get_description(), (void**)(data_ptr));
+                // pointer, so that we can assign data to it in apex...
+                profiler_ = apex::start(name_.get_description(), data_ptr);
             }
             else
             {
                 // not a mistake... we need to pass in the address of this
-                // pointer, so that we can assign it in apex...
+                // pointer, so that we can assign data to it in apex...
                 profiler_ = apex::start(
-                    apex_function_address(name_.get_address()), (void**)(data_ptr));
+                    apex_function_address(name_.get_address()), data_ptr);
             }
         }
         ~apex_wrapper()

--- a/src/runtime/threads/thread_data.cpp
+++ b/src/runtime/threads/thread_data.cpp
@@ -236,7 +236,7 @@ namespace hpx { namespace threads
 #endif
     }
 
-#if defined(HPX_HAVE_APEX)
+#if defined(HPX_HAVE_APEX_DISABLED)
     std::size_t get_self_apex_data()
     {
         thread_self* self = get_self_ptr();

--- a/src/runtime/threads/thread_data.cpp
+++ b/src/runtime/threads/thread_data.cpp
@@ -235,4 +235,22 @@ namespace hpx { namespace threads
         return get_self_id()->get_component_id();
 #endif
     }
+
+#if defined(HPX_HAVE_APEX)
+    std::size_t get_self_apex_data()
+    {
+        thread_self* self = get_self_ptr();
+        if (nullptr == self)
+            return 0ull;
+        return self->get_apex_data();
+    }
+
+    std::size_t set_self_apex_data(std::size_t data)
+    {
+        thread_self* self = get_self_ptr();
+        if (nullptr == self)
+            return 0ull;
+        return self->set_apex_data(data);
+    }
+#endif
 }}

--- a/src/runtime/threads/thread_data.cpp
+++ b/src/runtime/threads/thread_data.cpp
@@ -237,20 +237,12 @@ namespace hpx { namespace threads
     }
 
 #if defined(HPX_HAVE_APEX)
-    std::size_t get_self_apex_data()
+    void** get_self_apex_data()
     {
         thread_self* self = get_self_ptr();
         if (nullptr == self)
             return 0ull;
         return self->get_apex_data();
-    }
-
-    std::size_t set_self_apex_data(std::size_t data)
-    {
-        thread_self* self = get_self_ptr();
-        if (nullptr == self)
-            return 0ull;
-        return self->set_apex_data(data);
     }
 #endif
 }}

--- a/src/runtime/threads/thread_data.cpp
+++ b/src/runtime/threads/thread_data.cpp
@@ -236,7 +236,7 @@ namespace hpx { namespace threads
 #endif
     }
 
-#if defined(HPX_HAVE_APEX_DISABLED)
+#if defined(HPX_HAVE_APEX)
     std::size_t get_self_apex_data()
     {
         thread_self* self = get_self_ptr();


### PR DESCRIPTION
This branch adds the APEX data pointer, and matches up with APEX release 1.2, tagged in the APEX git repo as v1.2.

Hartmut - for the APEX release "blurb" text: This release includes OTF2 support, updated TAU integration, enhanced support for HPX threads calling direct actions, updated policy support, updated HPX counter integration, HPX send/recv measurement, new scatterplot output, and performance optimizations and bug fixes.