### PR TITLE
Barrier hang

### DIFF
--- a/plugins/parcel/coalescing/coalescing_message_handler.cpp
+++ b/plugins/parcel/coalescing/coalescing_message_handler.cpp
@@ -192,9 +192,6 @@ namespace hpx { namespace plugins { namespace parcel
             break;
 
         case detail::message_buffer::normal:
-            if (timer_.is_started())
-                break;
-
             // start deadline timer to flush buffer
             l.unlock();
             timer_.start(interval);

--- a/plugins/parcelport/verbs/parcelport_verbs.cpp
+++ b/plugins/parcelport/verbs/parcelport_verbs.cpp
@@ -1197,7 +1197,9 @@ namespace verbs
 
         bool can_send_immediate() {
             while (!immediate_send_allowed_) {
-                background_work(0);
+                // We suspend our thread, which will make progress on the network
+                hpx::this_thread::suspend(hpx::threads::pending,
+                    "verbs::parcelport::can_send_immediate");
             }
             return true;
         }

--- a/src/lcos/local/detail/condition_variable.cpp
+++ b/src/lcos/local/detail/condition_variable.cpp
@@ -137,9 +137,12 @@ namespace hpx { namespace lcos { namespace local { namespace detail
                 }
 
                 error_code local_ec;
-                threads::set_thread_state(threads::thread_id_type(
-                        reinterpret_cast<threads::thread_data*>(id)),
-                    threads::pending, threads::wait_signaled, priority, local_ec);
+                {
+                    util::ignore_while_checking<std::unique_lock<mutex_type> > il(&lock);
+                    threads::set_thread_state(threads::thread_id_type(
+                            reinterpret_cast<threads::thread_data*>(id)),
+                        threads::pending, threads::wait_signaled, priority, local_ec);
+                }
 
                 if (local_ec)
                 {

--- a/src/runtime/agas/big_boot_barrier.cpp
+++ b/src/runtime/agas/big_boot_barrier.cpp
@@ -665,15 +665,16 @@ big_boot_barrier::big_boot_barrier(
 {
     // register all not registered typenames
     if (service_type == service_mode_bootstrap)
+    {
         detail::register_unassigned_typenames();
+        // store endpoints of root locality for later
+        add_locality_endpoints(0, get_endpoints());
+    }
 }
 
 void big_boot_barrier::wait_bootstrap()
 { // {{{
     HPX_ASSERT(service_mode_bootstrap == service_type);
-
-    // store endpoints of root locality for later
-    add_locality_endpoints(0, get_runtime().endpoints());
 
     // the root just waits until all localities have connected
     spin();

--- a/src/util/pool_timer.cpp
+++ b/src/util/pool_timer.cpp
@@ -115,6 +115,9 @@ namespace hpx { namespace util { namespace detail
             return false;
 
         if (!is_started_) {
+            is_stopped_ = false;
+            is_started_ = true;
+
             if (first_start_) {
                 first_start_ = false;
 
@@ -132,9 +135,6 @@ namespace hpx { namespace util { namespace detail
                             this->shared_from_this()));
                 }
             }
-
-            is_stopped_ = false;
-            is_started_ = true;
 
             HPX_ASSERT(timer_ != nullptr);
             timer_->expires_from_now(time_duration.value());

--- a/tests/regressions/lcos/CMakeLists.txt
+++ b/tests/regressions/lcos/CMakeLists.txt
@@ -11,6 +11,7 @@ set(tests
     async_callback_non_deduced_context
     async_unwrap_1037
     call_promise_get_gid_more_than_once
+    barrier_hang
     dataflow_791
     dataflow_action_2008
     dataflow_future_swap

--- a/tests/regressions/lcos/barrier_hang.cpp
+++ b/tests/regressions/lcos/barrier_hang.cpp
@@ -1,0 +1,80 @@
+//  Copyright (c) 2017 Antoine Tran Tan
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_main.hpp>
+#include <hpx/lcos/barrier.hpp>
+#include <hpx/lcos/broadcast.hpp>
+#include <hpx/parallel/execution_policy.hpp>
+
+#include <cstddef>
+#include <cstdio>
+#include <iostream>
+#include <string>
+
+
+struct spmd_block_helper
+{
+    std::string name_;
+    std::size_t num_images_;
+
+    template <typename ... Ts>
+    void operator()(std::size_t image_id, Ts && ... ts) const
+    {
+        printf("image_id is equal to %lu and num_images is %lu\n",
+            image_id, num_images_);
+
+        std::cout << "The barrier name is "
+            << name_ + "_barrier" << std::endl;
+
+        hpx::lcos::barrier
+            barrier(name_ + "_barrier" , num_images_, image_id);
+
+        // Ensure that other images reaches that point
+        barrier.wait();
+    }
+};
+
+
+void bulk_test(
+    std::string name,
+    std::size_t images_per_locality,
+    std::size_t num_images)
+{
+
+    using hpx::parallel::execution::par;
+
+    std::size_t offset = hpx::get_locality_id();
+    offset *= images_per_locality;
+
+    return
+        hpx::parallel::executor_traits<
+            decltype(par)::executor_type
+            >::bulk_execute(
+                par.executor(),
+                spmd_block_helper{name,num_images},
+                boost::irange(
+                    offset, offset + images_per_locality));
+}
+HPX_PLAIN_ACTION(bulk_test, bulk_test_action);
+
+
+
+int main()
+{
+    std::string name = "test";
+    std::size_t images_per_locality = 4;
+    std::size_t num_images
+        = hpx::get_num_localities(hpx::launch::sync) * images_per_locality;
+
+    bulk_test_action act;
+
+    hpx::util::unwrapped(hpx::lcos::broadcast(
+        act, hpx::find_all_localities(), name, images_per_locality, num_images));
+
+    std::cout << "done...\n";
+
+    return 0;
+}


### PR DESCRIPTION
This patch fixes a hang observed with certain usages of `hpx::lcos::barrier`.

Flybys:
 - Fixing one lock held during suspension error
 - Fixing race condition for pre caching localities