### PR TITLE
Fixed build for mingw.

### DIFF
--- a/hpx/config/compiler_specific.hpp
+++ b/hpx/config/compiler_specific.hpp
@@ -72,6 +72,7 @@
 
 #if defined(__MINGW32__)
 #   define HPX_WINDOWS
+#   define HPX_MINGW
 #endif
 
 #if (defined(__NVCC__) || defined(__CUDACC__)) && defined(HPX_HAVE_CUDA)

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -178,6 +178,22 @@ namespace detail
     };
 
     ///////////////////////////////////////////////////////////////////////////
+    struct handle_continuation_recursion_count
+    {
+        handle_continuation_recursion_count()
+          : count_(threads::get_continuation_recursion_count())
+        {
+            ++count_;
+        }
+        ~handle_continuation_recursion_count()
+        {
+            --count_;
+        }
+
+        std::size_t& count_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
     template <typename F1, typename F2>
     class compose_cb_impl
     {
@@ -241,22 +257,6 @@ namespace detail
         > result_type;
         return result_type(std::forward<F1>(f1), std::forward<F2>(f2));
     }
-
-    ///////////////////////////////////////////////////////////////////////////
-    struct handle_continuation_recursion_count
-    {
-        handle_continuation_recursion_count()
-          : count_(threads::get_continuation_recursion_count())
-        {
-            ++count_;
-        }
-        ~handle_continuation_recursion_count()
-        {
-            --count_;
-        }
-
-        std::size_t& count_;
-    };
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_EXPORT bool run_on_completed_on_new_thread(

--- a/hpx/runtime/actions/basic_action.hpp
+++ b/hpx/runtime/actions/basic_action.hpp
@@ -878,7 +878,7 @@ namespace hpx { namespace serialization
     }}                                                                        \
 /**/
 
-#if defined(HPX_MSVC) || defined(HPX_WINDOWS)
+#if defined(HPX_MSVC) || defined(HPX_MINGW)
 #define HPX_REGISTER_ACTION_EXTERN_DECLARATION(action)                        \
 /**/
 #else

--- a/hpx/runtime/actions/basic_action.hpp
+++ b/hpx/runtime/actions/basic_action.hpp
@@ -878,7 +878,7 @@ namespace hpx { namespace serialization
     }}                                                                        \
 /**/
 
-#if defined(HPX_MSVC)
+#if defined(HPX_MSVC) || defined(HPX_WINDOWS)
 #define HPX_REGISTER_ACTION_EXTERN_DECLARATION(action)                        \
 /**/
 #else

--- a/hpx/util/itt_notify.hpp
+++ b/hpx/util/itt_notify.hpp
@@ -629,7 +629,7 @@ namespace hpx { namespace util { namespace itt
     //////////////////////////////////////////////////////////////////////////
     struct domain
     {
-        HPX_EXPORT domain(char const*) {}
+        domain(char const*) {}
         ~domain() {}
     };
 
@@ -674,8 +674,8 @@ namespace hpx { namespace util { namespace itt
     //////////////////////////////////////////////////////////////////////////
     struct task
     {
-        HPX_EXPORT task(domain const&, util::thread_description const&) {}
-        HPX_EXPORT task(domain const&, string_handle const&) {}
+        task(domain const&, util::thread_description const&) {}
+        task(domain const&, string_handle const&) {}
 
         ~task() {}
     };

--- a/hpx/util/plugin/detail/dll_windows.hpp
+++ b/hpx/util/plugin/detail/dll_windows.hpp
@@ -31,7 +31,7 @@
 #include <Shlwapi.h>
 #include <windows.h>
 
-#if !defined(HPX_MSVC) && !defined(HPX_WINDOWS)
+#if !defined(HPX_MSVC) && !defined(HPX_MINGW)
 #error "This file shouldn't be included directly, use the file hpx/util/plugin/dll.hpp only."
 #endif
 

--- a/hpx/util/plugin/detail/dll_windows.hpp
+++ b/hpx/util/plugin/detail/dll_windows.hpp
@@ -31,7 +31,7 @@
 #include <Shlwapi.h>
 #include <windows.h>
 
-#if !defined(HPX_MSVC)
+#if !defined(HPX_MSVC) && !defined(HPX_WINDOWS)
 #error "This file shouldn't be included directly, use the file hpx/util/plugin/dll.hpp only."
 #endif
 

--- a/hpx/util/plugin/dll.hpp
+++ b/hpx/util/plugin/dll.hpp
@@ -14,7 +14,7 @@
 # endif
 #endif
 
-#if defined(HPX_MSVC) || defined(HPX_WINDOWS)
+#if defined(HPX_MSVC) || defined(HPX_MINGW)
 #include <hpx/util/plugin/detail/dll_windows.hpp>
 #elif defined(HPX_HAS_DLOPEN)
 #include <hpx/util/plugin/detail/dll_dlopen.hpp>

--- a/hpx/util/plugin/dll.hpp
+++ b/hpx/util/plugin/dll.hpp
@@ -14,7 +14,7 @@
 # endif
 #endif
 
-#if defined(HPX_MSVC)
+#if defined(HPX_MSVC) || defined(HPX_WINDOWS)
 #include <hpx/util/plugin/detail/dll_windows.hpp>
 #elif defined(HPX_HAS_DLOPEN)
 #include <hpx/util/plugin/detail/dll_dlopen.hpp>

--- a/src/components/process/util/windows/search_path.cpp
+++ b/src/components/process/util/windows/search_path.cpp
@@ -87,7 +87,7 @@ namespace hpx { namespace components { namespace process { namespace windows
             boost::filesystem::path p = *it;
             p /= filename;
             boost::array<std::string, 4> extensions = //-V112
-                { "", ".exe", ".com", ".bat" };
+                {{ "", ".exe", ".com", ".bat" }};
             for (boost::array<std::string, 4>::iterator it2 = extensions.begin();
                 it2 != extensions.end(); ++it2)
             {

--- a/src/runtime/threads/policies/hwloc_topology_info.cpp
+++ b/src/runtime/threads/policies/hwloc_topology_info.cpp
@@ -1064,7 +1064,7 @@ namespace hpx { namespace threads
 
         {
             std::unique_lock<hpx::util::spinlock> lk(topo_mtx);
-            if (hwloc_get_thread_cpubind(topo, handle.native_handle(), cpuset,
+            if (hwloc_get_thread_cpubind(topo, (HANDLE)(handle.native_handle()), cpuset,
                     HWLOC_CPUBIND_THREAD))
             {
                 hwloc_bitmap_free(cpuset);

--- a/src/runtime/threads/policies/hwloc_topology_info.cpp
+++ b/src/runtime/threads/policies/hwloc_topology_info.cpp
@@ -1068,7 +1068,7 @@ namespace hpx { namespace threads
             if (hwloc_get_thread_cpubind(topo, pthread_gethandle(handle.native_handle()), cpuset,
                     HWLOC_CPUBIND_THREAD))
 #else
-	            if (hwloc_get_thread_cpubind(topo, handle.native_handle(), cpuset,
+	        if (hwloc_get_thread_cpubind(topo, handle.native_handle(), cpuset,
                     HWLOC_CPUBIND_THREAD))
 #endif
             {

--- a/src/runtime/threads/policies/hwloc_topology_info.cpp
+++ b/src/runtime/threads/policies/hwloc_topology_info.cpp
@@ -1064,8 +1064,13 @@ namespace hpx { namespace threads
 
         {
             std::unique_lock<hpx::util::spinlock> lk(topo_mtx);
-            if (hwloc_get_thread_cpubind(topo, (HANDLE)(handle.native_handle()), cpuset,
+#if defined(HPX_MINGW)
+            if (hwloc_get_thread_cpubind(topo, pthread_gethandle(handle.native_handle()), cpuset,
                     HWLOC_CPUBIND_THREAD))
+#else
+	            if (hwloc_get_thread_cpubind(topo, handle.native_handle(), cpuset,
+                    HWLOC_CPUBIND_THREAD))
+#endif
             {
                 hwloc_bitmap_free(cpuset);
                 HPX_THROWS_IF(ec, kernel_error

--- a/src/runtime/threads/policies/hwloc_topology_info.cpp
+++ b/src/runtime/threads/policies/hwloc_topology_info.cpp
@@ -1065,10 +1065,10 @@ namespace hpx { namespace threads
         {
             std::unique_lock<hpx::util::spinlock> lk(topo_mtx);
 #if defined(HPX_MINGW)
-            if (hwloc_get_thread_cpubind(topo, pthread_gethandle(handle.native_handle()), cpuset,
-                    HWLOC_CPUBIND_THREAD))
+            if (hwloc_get_thread_cpubind(topo, pthread_gethandle(handle.native_handle()),
+                    cpuset, HWLOC_CPUBIND_THREAD))
 #else
-	        if (hwloc_get_thread_cpubind(topo, handle.native_handle(), cpuset,
+            if (hwloc_get_thread_cpubind(topo, handle.native_handle(), cpuset,
                     HWLOC_CPUBIND_THREAD))
 #endif
             {


### PR DESCRIPTION
Tested on win7x64 with msys2, mingw-w64, gcc 6.3.0, cmake 1.8.

CMake was called with the following parameters:

```
  cmake
    -G "MSYS Makefiles"
    -DHPX_WITH_TESTS_EXTERNAL_BUILD=Off
    -DHPX_WITH_MALLOC=jemalloc
    -DCMAKE_INSTALL_PREFIX:PATH=/c/msys64/mingw64 ..
```