### PR TITLE
We need to link with boost.thread and boost.chrono if we use boost.context

### DIFF
--- a/cmake/HPX_SetupBoost.cmake
+++ b/cmake/HPX_SetupBoost.cmake
@@ -36,6 +36,29 @@ if(HPX_WITH_BOOST_CHRONO_COMPATIBILITY OR __boost_need_thread)
   set(__boost_libraries ${__boost_libraries} chrono)
 endif()
 
+# Set configuration option to use Boost.Context or not. This depends on the
+# platform.
+set(__use_generic_coroutine_context OFF)
+if(APPLE)
+  set(__use_generic_coroutine_context ON)
+endif()
+if(HPX_PLATFORM_UC STREQUAL "BLUEGENEQ" AND Boost_VERSION GREATER 105500)
+  set(__use_generic_coroutine_context ON)
+endif()
+hpx_option(
+  HPX_WITH_GENERIC_CONTEXT_COROUTINES
+  BOOL
+  "Use Boost.Context as the underlying coroutines context switch implementation."
+  ${__use_generic_coroutine_context} ADVANCED)
+
+if(HPX_WITH_GENERIC_CONTEXT_COROUTINE)
+  set(__boost_libraries ${__boost_libraries} context)
+  # if context is needed, we should still link with boost thread and chrono
+  if(NOT __boost_need_thread)
+    set(__boost_libraries ${__boost_libraries} thread chrono)
+  endif()
+endif()
+
 set(__boost_libraries
   ${__boost_libraries}
   date_time
@@ -44,11 +67,7 @@ set(__boost_libraries
   regex
   system)
 
-find_package(Boost
-  1.50
-  REQUIRED
-  COMPONENTS
-  ${__boost_libraries})
+find_package(Boost 1.51 REQUIRED COMPONENTS ${__boost_libraries})
 
 if(NOT Boost_FOUND)
   hpx_error("Could not find Boost. Please set BOOST_ROOT to point to your Boost installation.")
@@ -63,32 +82,10 @@ if(UNIX AND NOT CYGWIN)
   set(Boost_TMP_LIBRARIES ${Boost_TMP_LIBRARIES} ${BOOST_UNDERLYING_THREAD_LIBRARY})
 endif()
 
-# Set configuration option to use Boost.Context or not. This depends on the Boost
-# version (Boost.Context was included with 1.51) and the Platform
-set(use_generic_coroutine_context OFF)
-if(Boost_VERSION GREATER 105000)
-  find_package(Boost 1.50 QUIET COMPONENTS context)
-  if(Boost_CONTEXT_FOUND)
-    hpx_info("  context")
-  endif()
-  if(APPLE)
-    set(use_generic_coroutine_context ON)
-  endif()
-  if(HPX_PLATFORM_UC STREQUAL "BLUEGENEQ" AND Boost_VERSION GREATER 105500)
-    set(use_generic_coroutine_context ON)
-  endif()
-endif()
-
-hpx_option(
-  HPX_WITH_GENERIC_CONTEXT_COROUTINES
-  BOOL
-  "Use Boost.Context as the underlying coroutines context switch implementation."
-  ${use_generic_coroutine_context} ADVANCED)
-
 set(Boost_TMP_LIBRARIES ${Boost_TMP_LIBRARIES} ${Boost_LIBRARIES})
 
 if(HPX_WITH_COMPRESSION_BZIP2 OR HPX_WITH_COMPRESSION_ZLIB)
-  find_package(Boost 1.49 QUIET COMPONENTS iostreams)
+  find_package(Boost 1.51 QUIET COMPONENTS iostreams)
   if(Boost_IOSTREAMS_FOUND)
     hpx_info("  iostreams")
   else()
@@ -98,7 +95,7 @@ if(HPX_WITH_COMPRESSION_BZIP2 OR HPX_WITH_COMPRESSION_ZLIB)
 endif()
 
 # attempt to load Boost.Random (if available), it's needed for one example only
-find_package(Boost 1.49 QUIET COMPONENTS random)
+find_package(Boost 1.51 QUIET COMPONENTS random)
 if(Boost_RANDOM_FOUND)
   hpx_info("  random")
   set(Boost_TMP_LIBRARIES ${Boost_TMP_LIBRARIES} ${Boost_LIBRARIES})

--- a/docs/manual/build_system/prerequisites.qbk
+++ b/docs/manual/build_system/prerequisites.qbk
@@ -63,7 +63,7 @@ favorite compiler with __hpx__ visit __stellar_hpx_buildbot__.
     [[__cmake__                  ][3.1              ][2.8.10           ]]
 
     [[[*Required Libraries]]]
-    [[__boost_libraries__        ][1.57.0 or newer    ][1.50.0          ]
+    [[__boost_libraries__        ][1.57.0 or newer    ][1.51.0          ]
         [See below for an important limitation when using Boost V1.54.0.]]
     [[__hwloc__                  ][1.10                ][1.2 (Xeon Phi: 1.6)]
         [Used for OS-thread pinning and NUMA awareness. This library is optional on Mac OSX.]]
@@ -89,10 +89,10 @@ favorite compiler with __hpx__ visit __stellar_hpx_buildbot__.
     [[__visual_cxx__ (x64)       ][2013               ][2013            ]]
 
     [[[*Build System]]]
-    [[__cmake__                  ][3.1              ][2.8.10           ]]
+    [[__cmake__                  ][3.1                ][2.8.10           ]]
 
     [[[*Required Libraries]]]
-    [[__boost__                  ][1.57.0 or newer    ][1.49.0          ]
+    [[__boost__                  ][1.57.0 or newer    ][1.51.0          ]
      [See below for an important limitation when using Boost V1.55.0.]]
     [[__hwloc__                  ][1.10                ][1.5             ]
         [Used for OS-thread pinning and NUMA awareness.]]

--- a/hpx/config.hpp
+++ b/hpx/config.hpp
@@ -27,9 +27,9 @@
 
 #include <boost/version.hpp>
 
-#if BOOST_VERSION < 105000
+#if BOOST_VERSION < 105100
 // Please update your Boost installation (see www.boost.org for details).
-#error HPX cannot be compiled with a Boost version earlier than 1.50.0
+#error HPX cannot be compiled with a Boost version earlier than 1.51.0
 #endif
 
 #if BOOST_VERSION == 105400


### PR DESCRIPTION

- flyby: raise minimal required boost version to 1.51 to guarantee existence of boost.context