### PR TITLE
Documentation: Extract all entities in order to autolink functions co…

### DIFF
--- a/cmake/templates/autodoc.doxy.in
+++ b/cmake/templates/autodoc.doxy.in
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+EXTRACT_ALL = YES
 EXPAND_ONLY_PREDEF = YES
 GENERATE_HTML = NO
 GENERATE_XML = YES


### PR DESCRIPTION
…rrectly

* Closes #2615 

The current result seems good (no additional entities were added but instead some references got resolved).

**A diff of before/after is provided [here](https://gist.github.com/Naios/f9c9878a609e38925980804bd87a41c6).**

This also fixes the issues with `\copydoc` described in #2611.