### PR TITLE
Adding `hpx::local_new`

### DIFF
--- a/docs/hpx.idx
+++ b/docs/hpx.idx
@@ -345,6 +345,7 @@ binpacked                             '' "hpx\.components\.binpacked.*"
 
 # hpx/runtime/components/new.hpp
 new_                                  "" "hpx\.new_id.*"
+local_new                             "" "hpx\.local_new.*"
 
 # hpx/runtime/components/copy_component.hpp
 copy                                  "" "hpx\.components\.copy.*"

--- a/hpx/runtime/components/server/create_component_fwd.hpp
+++ b/hpx/runtime/components/server/create_component_fwd.hpp
@@ -30,6 +30,9 @@ namespace hpx { namespace components { namespace server
     template <typename Component>
     naming::gid_type create(naming::gid_type const& gid,
         util::unique_function_nonser<void(void*)> const& ctor);
+
+    template <typename Component, typename ...Ts>
+    naming::gid_type create_with_args(Ts&&... ts);
 }}}
 
 #endif

--- a/hpx/runtime/components/server/managed_component_base.hpp
+++ b/hpx/runtime/components/server/managed_component_base.hpp
@@ -619,6 +619,9 @@ namespace hpx { namespace components
         template <typename Component_>
         friend naming::gid_type server::create(naming::gid_type const& gid,
             util::unique_function_nonser<void(void*)> const& ctor);
+
+        template <typename Component_, typename ...Ts>
+        friend naming::gid_type server::create_with_args(Ts&&... ts);
 #endif
 
         naming::gid_type get_base_gid(

--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -446,7 +446,7 @@ namespace hpx { namespace components { namespace server
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    // Functions wrapped by creat_component actions below
+    // Functions wrapped by create_component actions below
 #if defined(__NVCC__)
     template <typename Component>
     naming::gid_type runtime_support::create_component()

--- a/hpx/runtime/components/server/simple_component_base.hpp
+++ b/hpx/runtime/components/server/simple_component_base.hpp
@@ -117,6 +117,8 @@ namespace hpx { namespace components
                 std::uint64_t(static_cast<this_component_type const*>(this)));
         }
 
+#if defined(HPX_HAVE_CXX11_EXTENDED_FRIEND_DECLARATIONS) && !defined(__NVCC__) && \
+    !defined(__CUDACC__)
     protected:
         // declare friends which are allowed to access get_base_gid()
         template <typename Component_>
@@ -129,6 +131,10 @@ namespace hpx { namespace components
         template <typename Component_>
         friend naming::gid_type server::create(naming::gid_type const& gid,
             util::unique_function_nonser<void(void*)> const& ctor);
+
+        template <typename Component_, typename ...Ts>
+        friend naming::gid_type server::create_with_args(Ts&&... ts);
+#endif
 
         // Create a new GID (if called for the first time), assign this
         // GID to this instance of a component and register this gid

--- a/tests/unit/component/CMakeLists.txt
+++ b/tests/unit/component/CMakeLists.txt
@@ -18,6 +18,7 @@ set(tests
     inheritance_3_classes_2_abstract
     inheritance_3_classes_concrete
     launch_process
+    local_new
     migrate_component
     migrate_component_to_storage
     new_

--- a/tests/unit/component/local_new.cpp
+++ b/tests/unit/component/local_new.cpp
@@ -1,0 +1,86 @@
+//  Copyright (c) 2015-2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/components.hpp>
+#include <hpx/include/actions.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+struct A
+{
+    A() = default;
+
+    HPX_NON_COPYABLE(A);
+};
+
+///////////////////////////////////////////////////////////////////////////////
+struct test_server : hpx::components::simple_component_base<test_server>
+{
+    test_server() = default;
+    test_server(A const&) {}
+
+    hpx::id_type call() const { return hpx::find_here(); }
+
+    HPX_DEFINE_COMPONENT_ACTION(test_server, call);
+};
+
+typedef hpx::components::simple_component<test_server> server_type;
+HPX_REGISTER_COMPONENT(server_type, test_server);
+
+typedef test_server::call_action call_action;
+HPX_REGISTER_ACTION(call_action);
+
+struct test_client : hpx::components::client_base<test_client, test_server>
+{
+    typedef hpx::components::client_base<test_client, test_server> base_type;
+
+    test_client(hpx::id_type const& id)
+      : base_type(id)
+    {}
+    test_client(hpx::future<hpx::id_type> && id)
+      : base_type(std::move(id))
+    {}
+
+    hpx::id_type call() const
+    {
+        return hpx::async<call_action>(this->get_id()).get();
+    }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+void test_create_single_instance()
+{
+    hpx::id_type id = hpx::local_new<test_server>().get();
+    HPX_TEST(hpx::async<call_action>(id).get() == hpx::find_here());
+
+    test_client t1 = hpx::local_new<test_client>();
+    HPX_TEST(t1.call() == hpx::find_here());
+}
+
+void test_create_single_instance_non_copyable_arg()
+{
+    A a;
+
+    hpx::id_type id = hpx::local_new<test_server>(a).get();
+    HPX_TEST(hpx::async<call_action>(id).get() == hpx::find_here());
+
+    test_client t1 = hpx::local_new<test_client>(a);
+    HPX_TEST(t1.call() == hpx::find_here());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main()
+{
+    test_create_single_instance();
+    test_create_single_instance_non_copyable_arg();
+
+    return 0;
+}
+


### PR DESCRIPTION
- this is equivalent to `hpx::new_<>(find_here(), ...)`, except that it allows
  for non-copyable and non-movable argument types and guarantees purely local
  operation
- also adding test
- flyby: #ifdef extended friend declarations in simple_component_base
- flyby: fix destruction of components if id couldn't be assigned
- flyby: fixing error messages generated if id couldn't be assigned