### PR TITLE
Fixing code supporting co_await

### DIFF
--- a/examples/transpose/transpose_await.cpp
+++ b/examples/transpose/transpose_await.cpp
@@ -209,7 +209,7 @@ hpx::future<sub_block> transpose_phase(
         transpose(co_await from, co_await to, block_order, tile_size);
     }
 
-    return sub_block();
+    co_return sub_block();
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hpx/lcos/detail/future_await_traits.hpp
+++ b/hpx/lcos/detail/future_await_traits.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2017 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -12,14 +12,16 @@
 #include <hpx/lcos/detail/future_data.hpp>
 #include <hpx/traits/future_access.hpp>
 
-#include <boost/intrusive_ptr.hpp>
-
 #if defined(HPX_HAVE_EMULATE_COROUTINE_SUPPORT_LIBRARY)
 #include <hpx/util/await_traits.hpp>
 #else
 #include <experimental/coroutine>
 #endif
 
+#include <boost/exception_ptr.hpp>
+#include <boost/intrusive_ptr.hpp>
+
+#include <exception>
 #include <type_traits>
 #include <utility>
 
@@ -39,7 +41,14 @@ namespace hpx { namespace lcos { namespace detail
         std::experimental::coroutine_handle<Promise> rh)
     {
         // f.then([=](future<T> result) {});
-        traits::detail::get_shared_state(f)->set_on_completed(rh);
+        auto st = traits::detail::get_shared_state(f);
+        st->set_on_completed(
+            [=]() mutable
+            {
+                if (st->has_exception())
+                    rh.promise().set_exception(st->get_exception_ptr());
+                rh();
+            });
     }
 
     template <typename T>
@@ -74,7 +83,14 @@ namespace hpx { namespace lcos { namespace detail
         std::experimental::coroutine_handle<Promise> rh)
     {
         // f.then([=](shared_future<T> result) {})
-        traits::detail::get_shared_state(f)->set_on_completed(rh);
+        auto st = traits::detail::get_shared_state(f);
+        st->set_on_completed(
+            [=]() mutable
+            {
+                if (st->has_exception())
+                    rh.promise().set_exception(st->get_exception_ptr());
+                rh();
+            });
     }
 
     template <typename T>
@@ -82,6 +98,63 @@ namespace hpx { namespace lcos { namespace detail
     {
         return f.get();
     }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // derive from future shared state as this will be combined with the
+    // necessary stack frame for the resumable function
+    template <typename T, typename Derived>
+    struct coroutine_promise_base : hpx::lcos::detail::future_data<T>
+    {
+        typedef hpx::lcos::detail::future_data<T> base_type;
+
+        coroutine_promise_base()
+        {
+            // the shared state is held alive by the coroutine
+            hpx::lcos::detail::intrusive_ptr_add_ref(this);
+        }
+
+        hpx::lcos::future<T> get_return_object()
+        {
+            boost::intrusive_ptr<base_type> shared_state(this);
+            return hpx::traits::future_access<hpx::lcos::future<T> >::
+                create(std::move(shared_state));
+        }
+
+        std::experimental::suspend_never initial_suspend()
+        {
+            return std::experimental::suspend_never{};
+        }
+
+        std::experimental::suspend_if final_suspend()
+        {
+            // This gives up the coroutine's reference count on the shared
+            // state. If this was the last reference count, the coroutine
+            // should not suspend before exiting.
+            return std::experimental::suspend_if{
+                !this->base_type::requires_delete()};
+        }
+
+        void set_exception(std::exception_ptr e)
+        {
+            try {
+                std::rethrow_exception(std::move(e));
+            }
+            catch (...) {
+                this->base_type::set_exception(boost::current_exception());
+            }
+        }
+
+        void set_exception(boost::exception_ptr e)
+        {
+            this->base_type::set_exception(std::move(e));
+        }
+
+        void destroy()
+        {
+            std::experimental::coroutine_handle<Derived>::
+                from_promise(*static_cast<Derived*>(this)).destroy();
+        }
+    };
 }}}
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -91,66 +164,32 @@ namespace std { namespace experimental
     template <typename T, typename ...Ts>
     struct coroutine_traits<hpx::lcos::future<T>, Ts...>
     {
-        // derive from future shared state as this will be combined with the
-        // necessary stack frame for the resumable function
-        struct promise_type : hpx::lcos::detail::future_data<T>
+        struct promise_type
+          : hpx::lcos::detail::coroutine_promise_base<T, promise_type>
         {
-            typedef hpx::lcos::detail::future_data<T> base_type;
+            using base_type =
+                hpx::lcos::detail::coroutine_promise_base<T, promise_type>;
 
-            promise_type()
-            {
-                // the shared state is held alive by the coroutine
-                hpx::lcos::detail::intrusive_ptr_add_ref(this);
-            }
-
-            hpx::lcos::future<T> get_return_object()
-            {
-                boost::intrusive_ptr<base_type> shared_state(this);
-                return hpx::traits::future_access<hpx::lcos::future<T> >::
-                    create(std::move(shared_state));
-            }
-
-            std::experimental::suspend_never initial_suspend()
-            {
-                return std::experimental::suspend_never{};
-            }
-
-            std::experimental::suspend_if final_suspend()
-            {
-                // This gives up the coroutine's reference count on the shared
-                // state. If this was the last reference count, the coroutine
-                // should not suspend before exiting.
-                return std::experimental::suspend_if{
-                    !this->base_type::requires_delete()};
-            }
-
-            template <typename U, typename U2 = T, typename V =
-                typename std::enable_if<!std::is_void<U2>::value>::type>
+            template <typename U>
             void return_value(U && value)
             {
                 this->base_type::set_value(std::forward<U>(value));
             }
+        };
+    };
 
-            template <typename U = T, typename V =
-                typename std::enable_if<std::is_void<U>::value>::type>
-            void return_value()
+    template <typename ...Ts>
+    struct coroutine_traits<hpx::lcos::future<void>, Ts...>
+    {
+        struct promise_type
+          : hpx::lcos::detail::coroutine_promise_base<void, promise_type>
+        {
+            using base_type =
+                hpx::lcos::detail::coroutine_promise_base<void, promise_type>;
+
+            void return_void()
             {
                 this->base_type::set_value();
-            }
-
-            void set_exception(std::exception_ptr e)
-            {
-                try {
-                    std::rethrow_exception(e);
-                }
-                catch (...) {
-                    this->base_type::set_exception(boost::current_exception());
-                }
-            }
-
-            void destroy()
-            {
-                coroutine_handle<promise_type>::from_promise(*this).destroy();
             }
         };
     };

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -289,6 +289,7 @@ namespace detail
         virtual void wait(error_code& = throws) = 0;
         virtual future_status wait_until(util::steady_clock::time_point const&,
             error_code& = throws) = 0;
+        virtual boost::exception_ptr get_exception_ptr() const = 0;
 
         enum state
         {
@@ -787,6 +788,12 @@ namespace detail
                 ec = make_success_code();
 
             return future_status::ready; //-V110
+        }
+
+        boost::exception_ptr get_exception_ptr() const
+        {
+            HPX_ASSERT(state_ == exception);
+            return *reinterpret_cast<boost::exception_ptr const*>(&storage_);
         }
 
     protected:

--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -539,7 +539,6 @@ namespace hpx { namespace lcos { namespace detail
 
             typedef typename shared_state_type::result_type result_type;
 
-
             error_code ec(lightweight);
             detail::future_get_result<result_type>::call(this->shared_state_, ec);
             if (!ec)
@@ -782,7 +781,8 @@ namespace hpx { namespace lcos { namespace detail
             detail::await_suspend(*static_cast<Derived*>(this), rh);
         }
 
-        R await_resume()
+        auto await_resume()
+        ->  decltype(detail::await_resume(std::declval<Derived>()))
         {
             return detail::await_resume(*static_cast<Derived*>(this));
         }

--- a/hpx/util/await_traits.hpp
+++ b/hpx/util/await_traits.hpp
@@ -142,29 +142,6 @@ namespace std { namespace experimental
         {
         }
     };
-
-    struct suspend_if
-    {
-    private:
-        bool b_;
-
-    public:
-        suspend_if(bool b)
-          : b_(b)
-        {
-        }
-
-        bool await_ready() const
-        {
-            return !b_;
-        }
-        void await_suspend(coroutine_handle<>) const
-        {
-        }
-        void await_resume() const
-        {
-        }
-    };
 }}
 
 #endif    // defined(HPX_HAVE_EMULATE_COROUTINE_SUPPORT_LIBRARY)

--- a/tests/unit/lcos/await.cpp
+++ b/tests/unit/lcos/await.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2015 Hartmut Kaiser
+// Copyright (C) 2015-2017 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -24,14 +24,14 @@ hpx::future<int> fib1(int n)
 {
     if (n >= 2)
         n = co_await fib1(n - 1) + co_await fib1(n - 2);
-    return n;
+    co_return n;
 }
 
 hpx::future<int> fib2(int n)
 {
     if (n >= 2)
         n = co_await hpx::async(&fib2, n - 1) + co_await fib2(n - 2);
-    return n;
+    co_return n;
 }
 
 void simple_await_test()


### PR DESCRIPTION
- adapt specializations of coroutine_traits to latest changes
- properly propagate exceptions through co_await
- flyby: fix co_await future<future<T>>
- flyby: change return to co_return where appropriate