### PR TITLE
Add lcos::local::one_element_channel

### DIFF
--- a/examples/quickstart/local_channel.cpp
+++ b/examples/quickstart/local_channel.cpp
@@ -3,7 +3,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// This example demonstrates the use a a channel which is very similar to the
+// This example demonstrates the use of a channel which is very similar to the
 // equally named feature in the Go language.
 
 #include <hpx/hpx_main.hpp>
@@ -63,6 +63,48 @@ void pingpong()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+void pingpong1()
+{
+    hpx::lcos::local::one_element_channel<std::string> pings;
+    hpx::lcos::local::one_element_channel<std::string> pongs;
+
+    for (int i = 0; i != 10; ++i)
+    {
+        ping(pings, "passed message");
+        pong(pings, pongs);
+        pongs.get(hpx::launch::sync);
+    }
+
+    hpx::cout << "ping-ponged 10 times\n";
+}
+
+void pingpong2()
+{
+    hpx::lcos::local::one_element_channel<std::string> pings;
+    hpx::lcos::local::one_element_channel<std::string> pongs;
+
+    ping(pings, "passed message");
+    hpx::future<void> f1 = hpx::async(
+        [=]() {
+            pong(pings, pongs);
+        });
+
+    ping(pings, "passed message");
+    hpx::future<void> f2 = hpx::async(
+        [=]() {
+            pong(pings, pongs);
+        });
+
+    pongs.get(hpx::launch::sync);
+    pongs.get(hpx::launch::sync);
+
+    f1.get();
+    f2.get();
+
+    hpx::cout << "ping-ponged with waiting\n";
+}
+
+///////////////////////////////////////////////////////////////////////////////
 void dispatch_work()
 {
     hpx::lcos::local::channel<int> jobs;
@@ -118,6 +160,8 @@ int main(int argc, char* argv[])
 {
     calculate_sum();
     pingpong();
+    pingpong1();
+    pingpong2();
     dispatch_work();
     channel_range();
 

--- a/hpx/lcos/detail/future_await_traits.hpp
+++ b/hpx/lcos/detail/future_await_traits.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2017 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -12,14 +12,16 @@
 #include <hpx/lcos/detail/future_data.hpp>
 #include <hpx/traits/future_access.hpp>
 
-#include <boost/intrusive_ptr.hpp>
-
 #if defined(HPX_HAVE_EMULATE_COROUTINE_SUPPORT_LIBRARY)
 #include <hpx/util/await_traits.hpp>
 #else
 #include <experimental/coroutine>
 #endif
 
+#include <boost/exception_ptr.hpp>
+#include <boost/intrusive_ptr.hpp>
+
+#include <exception>
 #include <type_traits>
 #include <utility>
 
@@ -39,7 +41,14 @@ namespace hpx { namespace lcos { namespace detail
         std::experimental::coroutine_handle<Promise> rh)
     {
         // f.then([=](future<T> result) {});
-        traits::detail::get_shared_state(f)->set_on_completed(rh);
+        auto st = traits::detail::get_shared_state(f);
+        st->set_on_completed(
+            [=]() mutable
+            {
+                if (st->has_exception())
+                    rh.promise().set_exception(st->get_exception_ptr());
+                rh();
+            });
     }
 
     template <typename T>
@@ -74,7 +83,14 @@ namespace hpx { namespace lcos { namespace detail
         std::experimental::coroutine_handle<Promise> rh)
     {
         // f.then([=](shared_future<T> result) {})
-        traits::detail::get_shared_state(f)->set_on_completed(rh);
+        auto st = traits::detail::get_shared_state(f);
+        st->set_on_completed(
+            [=]() mutable
+            {
+                if (st->has_exception())
+                    rh.promise().set_exception(st->get_exception_ptr());
+                rh();
+            });
     }
 
     template <typename T>
@@ -82,6 +98,63 @@ namespace hpx { namespace lcos { namespace detail
     {
         return f.get();
     }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // derive from future shared state as this will be combined with the
+    // necessary stack frame for the resumable function
+    template <typename T, typename Derived>
+    struct coroutine_promise_base : hpx::lcos::detail::future_data<T>
+    {
+        typedef hpx::lcos::detail::future_data<T> base_type;
+
+        coroutine_promise_base()
+        {
+            // the shared state is held alive by the coroutine
+            hpx::lcos::detail::intrusive_ptr_add_ref(this);
+        }
+
+        hpx::lcos::future<T> get_return_object()
+        {
+            boost::intrusive_ptr<base_type> shared_state(this);
+            return hpx::traits::future_access<hpx::lcos::future<T> >::
+                create(std::move(shared_state));
+        }
+
+        std::experimental::suspend_never initial_suspend()
+        {
+            return std::experimental::suspend_never{};
+        }
+
+        std::experimental::suspend_if final_suspend()
+        {
+            // This gives up the coroutine's reference count on the shared
+            // state. If this was the last reference count, the coroutine
+            // should not suspend before exiting.
+            return std::experimental::suspend_if{
+                !this->base_type::requires_delete()};
+        }
+
+        void set_exception(std::exception_ptr e)
+        {
+            try {
+                std::rethrow_exception(std::move(e));
+            }
+            catch (...) {
+                this->base_type::set_exception(boost::current_exception());
+            }
+        }
+
+        void set_exception(boost::exception_ptr e)
+        {
+            this->base_type::set_exception(std::move(e));
+        }
+
+        void destroy()
+        {
+            std::experimental::coroutine_handle<Derived>::
+                from_promise(*static_cast<Derived*>(this)).destroy();
+        }
+    };
 }}}
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -91,66 +164,32 @@ namespace std { namespace experimental
     template <typename T, typename ...Ts>
     struct coroutine_traits<hpx::lcos::future<T>, Ts...>
     {
-        // derive from future shared state as this will be combined with the
-        // necessary stack frame for the resumable function
-        struct promise_type : hpx::lcos::detail::future_data<T>
+        struct promise_type
+          : hpx::lcos::detail::coroutine_promise_base<T, promise_type>
         {
-            typedef hpx::lcos::detail::future_data<T> base_type;
+            using base_type =
+                hpx::lcos::detail::coroutine_promise_base<T, promise_type>;
 
-            promise_type()
-            {
-                // the shared state is held alive by the coroutine
-                hpx::lcos::detail::intrusive_ptr_add_ref(this);
-            }
-
-            hpx::lcos::future<T> get_return_object()
-            {
-                boost::intrusive_ptr<base_type> shared_state(this);
-                return hpx::traits::future_access<hpx::lcos::future<T> >::
-                    create(std::move(shared_state));
-            }
-
-            std::experimental::suspend_never initial_suspend()
-            {
-                return std::experimental::suspend_never{};
-            }
-
-            std::experimental::suspend_if final_suspend()
-            {
-                // This gives up the coroutine's reference count on the shared
-                // state. If this was the last reference count, the coroutine
-                // should not suspend before exiting.
-                return std::experimental::suspend_if{
-                    !this->base_type::requires_delete()};
-            }
-
-            template <typename U, typename U2 = T, typename V =
-                typename std::enable_if<!std::is_void<U2>::value>::type>
+            template <typename U>
             void return_value(U && value)
             {
                 this->base_type::set_value(std::forward<U>(value));
             }
+        };
+    };
 
-            template <typename U = T, typename V =
-                typename std::enable_if<std::is_void<U>::value>::type>
-            void return_value()
+    template <typename ...Ts>
+    struct coroutine_traits<hpx::lcos::future<void>, Ts...>
+    {
+        struct promise_type
+          : hpx::lcos::detail::coroutine_promise_base<void, promise_type>
+        {
+            using base_type =
+                hpx::lcos::detail::coroutine_promise_base<void, promise_type>;
+
+            void return_void()
             {
                 this->base_type::set_value();
-            }
-
-            void set_exception(std::exception_ptr e)
-            {
-                try {
-                    std::rethrow_exception(e);
-                }
-                catch (...) {
-                    this->base_type::set_exception(boost::current_exception());
-                }
-            }
-
-            void destroy()
-            {
-                coroutine_handle<promise_type>::from_promise(*this).destroy();
             }
         };
     };

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -289,6 +289,7 @@ namespace detail
         virtual void wait(error_code& = throws) = 0;
         virtual future_status wait_until(util::steady_clock::time_point const&,
             error_code& = throws) = 0;
+        virtual boost::exception_ptr get_exception_ptr() const = 0;
 
         enum state
         {
@@ -787,6 +788,12 @@ namespace detail
                 ec = make_success_code();
 
             return future_status::ready; //-V110
+        }
+
+        boost::exception_ptr get_exception_ptr() const
+        {
+            HPX_ASSERT(state_ == exception);
+            return *reinterpret_cast<boost::exception_ptr const*>(&storage_);
         }
 
     protected:

--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -539,7 +539,6 @@ namespace hpx { namespace lcos { namespace detail
 
             typedef typename shared_state_type::result_type result_type;
 
-
             error_code ec(lightweight);
             detail::future_get_result<result_type>::call(this->shared_state_, ec);
             if (!ec)
@@ -782,7 +781,8 @@ namespace hpx { namespace lcos { namespace detail
             detail::await_suspend(*static_cast<Derived*>(this), rh);
         }
 
-        R await_resume()
+        auto await_resume()
+        ->  decltype(detail::await_resume(std::declval<Derived>()))
         {
             return detail::await_resume(*static_cast<Derived*>(this));
         }

--- a/hpx/lcos/local/channel.hpp
+++ b/hpx/lcos/local/channel.hpp
@@ -10,12 +10,14 @@
 #include <hpx/exception.hpp>
 #include <hpx/lcos/future.hpp>
 #include <hpx/lcos/local/no_mutex.hpp>
+#include <hpx/lcos/local/futures_factory.hpp>
 #include <hpx/lcos/local/receive_buffer.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/atomic_count.hpp>
 #include <hpx/util/iterator_facade.hpp>
+#include <hpx/util/register_locks.hpp>
 #include <hpx/util/scoped_unlock.hpp>
 #include <hpx/util/unused.hpp>
 
@@ -35,20 +37,29 @@ namespace hpx { namespace lcos { namespace local
     {
         ///////////////////////////////////////////////////////////////////////
         template <typename T>
-        struct channel_base
+        struct channel_impl_base
         {
-            channel_base()
+            channel_impl_base()
               : count_(0)
             {}
 
-            virtual ~channel_base() {}
+            virtual ~channel_impl_base() {}
 
             virtual hpx::future<T> get(std::size_t generation,
                 bool blocking = false) = 0;
             virtual bool try_get(std::size_t generation,
                 hpx::future<T>* f = nullptr) = 0;
-            virtual void set(std::size_t generation, T && t) = 0;
+            virtual hpx::future<void> set(std::size_t generation, T && t) = 0;
             virtual void close() = 0;
+
+            virtual bool requires_delete()
+            {
+                return 0 == release();
+            }
+            virtual void destroy()
+            {
+                delete this;
+            }
 
             long use_count() const { return count_; }
             long addref() { return ++count_; }
@@ -58,22 +69,23 @@ namespace hpx { namespace lcos { namespace local
             hpx::util::atomic_count count_;
         };
 
+        // support functions for boost::intrusive_ptr
         template <typename T>
-        void intrusive_ptr_add_ref(channel_base<T>* p)
+        void intrusive_ptr_add_ref(channel_impl_base<T>* p)
         {
             p->addref();
         }
 
         template <typename T>
-        void intrusive_ptr_release(channel_base<T>* p)
+        void intrusive_ptr_release(channel_impl_base<T>* p)
         {
-            if (0 == p->release())
-                delete p;
+            if (p->requires_delete())
+                p->destroy();
         }
 
         ///////////////////////////////////////////////////////////////////////
         template <typename T>
-        class unlimited_channel : public channel_base<T>
+        class unlimited_channel : public channel_impl_base<T>
         {
             typedef hpx::lcos::local::spinlock mutex_type;
 
@@ -152,16 +164,16 @@ namespace hpx { namespace lcos { namespace local
                 return true;
             }
 
-            void set(std::size_t generation, T && t)
+            hpx::future<void> set(std::size_t generation, T && t)
             {
                 std::unique_lock<mutex_type> l(mtx_);
                 if(closed_)
                 {
                     l.unlock();
-                    HPX_THROW_EXCEPTION(hpx::invalid_status,
-                        "hpx::lcos::local::channel::set",
-                        "attempting to write to a closed channel");
-                    return;
+                    return hpx::make_exceptional_future<void>(
+                        HPX_GET_EXCEPTION(hpx::invalid_status,
+                            "hpx::lcos::local::channel::set",
+                            "attempting to write to a closed channel"));
                 }
 
                 ++set_generation_;
@@ -169,6 +181,7 @@ namespace hpx { namespace lcos { namespace local
                     generation = set_generation_;
 
                 buffer_.store_received(generation, std::move(t), &l);
+                return hpx::make_ready_future();
             }
 
             void close()
@@ -209,10 +222,264 @@ namespace hpx { namespace lcos { namespace local
             std::size_t set_generation_;
             bool closed_;
         };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename T>
+        class one_element_queue_async
+        {
+            HPX_NON_COPYABLE(one_element_queue_async);
+
+            template <typename T1>
+            void set(T1 && val)
+            {
+                val_ = std::forward<T1>(val);
+                empty_ = false;
+                push_active_ = false;
+            }
+            void set_deferred(T && val)
+            {
+                val_ = std::move(val);
+                empty_ = false;
+                push_active_ = false;
+            }
+
+            T get()
+            {
+                empty_ = true;
+                pop_active_ = false;
+                return std::move(val_);
+            }
+
+            template <typename T1>
+            local::futures_factory<void()> push_ff(T1 && val)
+            {
+                return local::futures_factory<void()>(
+                    util::deferred_call(
+                        &one_element_queue_async::set_deferred, this,
+                        std::forward<T1>(val)));
+            }
+            local::futures_factory<T()> pop_ff()
+            {
+                return local::futures_factory<T()>(
+                    util::deferred_call(&one_element_queue_async::get, this));
+            }
+
+        public:
+            one_element_queue_async()
+              : empty_(true), push_active_(false), pop_active_(false)
+            {}
+
+            template <typename T1, typename Lock>
+            hpx::future<void> push(T1 && val, Lock& l)
+            {
+                if (!empty_)
+                {
+                    if (push_active_)
+                    {
+                        // error!
+                    }
+
+                    push_ = push_ff(std::forward<T1>(val));
+                    push_active_ = true;
+                    return push_.get_future();
+                }
+
+                set(std::forward<T1>(val));
+                if (pop_active_)
+                {
+                    util::scoped_unlock<Lock> ul(l);
+                    pop_();                          // trigger waiting pop
+                }
+                return hpx::make_ready_future();
+            }
+
+            void cancel(boost::exception_ptr const& e)
+            {
+                if (pop_active_)
+                {
+                    pop_.set_exception(e);
+                    pop_active_ = false;
+                }
+            }
+
+            template <typename Lock>
+            hpx::future<T> pop(Lock& l)
+            {
+                if (empty_)
+                {
+                    if (pop_active_)
+                    {
+                        // error!
+                    }
+
+                    pop_ = pop_ff();
+                    pop_active_ = true;
+                    return pop_.get_future();
+                }
+
+                T val = get();
+                if (push_active_)
+                {
+                    util::scoped_unlock<Lock> ul(l);
+                    push_();                        // trigger waiting push
+                }
+                return hpx::make_ready_future(val);
+            }
+
+            bool is_empty() const
+            {
+                return empty_;
+            }
+
+            bool has_pending_request() const
+            {
+                return push_active_;
+            }
+
+        private:
+            T val_;
+            local::futures_factory<void()> push_;
+            local::futures_factory<T()> pop_;
+            bool empty_;
+            bool push_active_;
+            bool pop_active_;
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename T>
+        class one_element_channel : public channel_impl_base<T>
+        {
+            typedef hpx::lcos::local::spinlock mutex_type;
+
+            HPX_NON_COPYABLE(one_element_channel);
+
+        public:
+            one_element_channel()
+              : closed_(false)
+            {}
+
+        protected:
+            hpx::future<T> get(std::size_t, bool blocking)
+            {
+                std::unique_lock<mutex_type> l(mtx_);
+
+                if (buffer_.is_empty() && !buffer_.has_pending_request())
+                {
+                    if (closed_)
+                    {
+                        l.unlock();
+                        return hpx::make_exceptional_future<T>(
+                            HPX_GET_EXCEPTION(hpx::invalid_status,
+                                "hpx::lcos::local::channel::get",
+                                "this channel is empty and was closed"));
+                    }
+
+                    if (blocking && this->use_count() == 1)
+                    {
+                        l.unlock();
+                        return hpx::make_exceptional_future<T>(
+                            HPX_GET_EXCEPTION(hpx::invalid_status,
+                                "hpx::lcos::local::channel::get",
+                                "this channel is empty and is not accessible "
+                                "by any other thread causing a deadlock"));
+                    }
+                }
+
+                hpx::future<T> f = buffer_.pop(l);
+                if (closed_ && !f.is_ready())
+                {
+                    // the requested item must be available, otherwise this
+                    // would create a deadlock
+                    l.unlock();
+                    return hpx::make_exceptional_future<T>(
+                        HPX_GET_EXCEPTION(hpx::invalid_status,
+                            "hpx::lcos::local::channel::get",
+                            "this channel is closed and the requested value"
+                            "has not been received yet"));
+                }
+
+                return f;
+            }
+
+            bool try_get(std::size_t, hpx::future<T>* f = nullptr)
+            {
+                std::unique_lock<mutex_type> l(mtx_);
+
+                if (buffer_.is_empty() && !buffer_.has_pending_request() && closed_)
+                    return false;
+
+                if (f != nullptr)
+                {
+                    *f = buffer_.pop(l);
+                }
+                return true;
+            }
+
+            hpx::future<void> set(std::size_t, T && t)
+            {
+                std::unique_lock<mutex_type> l(mtx_);
+
+                if (closed_)
+                {
+                    l.unlock();
+                    return hpx::make_exceptional_future<void>(
+                        HPX_GET_EXCEPTION(hpx::invalid_status,
+                            "hpx::lcos::local::channel::set",
+                            "attempting to write to a closed channel"));
+                }
+
+                return buffer_.push(std::move(t), l);
+            }
+
+            void close()
+            {
+                std::unique_lock<mutex_type> l(mtx_);
+
+                if (closed_)
+                {
+                    l.unlock();
+                    HPX_THROW_EXCEPTION(hpx::invalid_status,
+                        "hpx::lcos::local::channel::close",
+                        "attempting to close an already closed channel");
+                    return;
+                }
+
+                closed_ = true;
+
+                if (buffer_.is_empty() || !buffer_.has_pending_request())
+                    return;
+
+                // all pending requests which can't be satisfied have to be
+                // canceled at this point
+                buffer_.cancel(boost::exception_ptr(
+                        HPX_GET_EXCEPTION(hpx::future_cancelled,
+                            "hpx::lcos::local::close",
+                            "canceled waiting on this entry")
+                    ));
+            }
+
+            void set_exception(boost::exception_ptr e)
+            {
+                std::unique_lock<mutex_type> l(mtx_);
+                closed_ = true;
+
+                if (!buffer_.is_empty())
+                    buffer_.cancel(e);
+            }
+
+        private:
+            mutable mutex_type mtx_;
+            one_element_queue_async<T> buffer_;
+            bool closed_;
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename T> class channel_base;
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T = void> class channel;
+    template <typename T = void> class one_element_channel;
     template <typename T = void> class receive_channel;
     template <typename T = void> class send_channel;
 
@@ -231,7 +498,7 @@ namespace hpx { namespace lcos { namespace local
           : channel_(nullptr), data_(T(), false)
         {}
 
-        inline explicit channel_iterator(channel<T> const* c);
+        inline explicit channel_iterator(detail::channel_base<T> const* c);
         inline explicit channel_iterator(receive_channel<T> const* c);
 
     private:
@@ -267,172 +534,291 @@ namespace hpx { namespace lcos { namespace local
         }
 
     private:
-        boost::intrusive_ptr<detail::channel_base<T> > channel_;
+        boost::intrusive_ptr<detail::channel_impl_base<T> > channel_;
         std::pair<T, bool> data_;
     };
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    class channel
+    class channel_async_iterator
+      : public hpx::util::iterator_facade<
+            channel_async_iterator<T>, hpx::future<T>, std::input_iterator_tag,
+            hpx::future<T>>
     {
+        typedef hpx::util::iterator_facade<
+                channel_async_iterator<T>, hpx::future<T>,
+                std::input_iterator_tag, hpx::future<T>
+            > base_type;
+
     public:
-        channel()
-          : channel_(new detail::unlimited_channel<T>())
+        channel_async_iterator()
+          : channel_(nullptr), data_(hpx::future<T>(), false)
         {}
 
-        ///////////////////////////////////////////////////////////////////////
-        hpx::future<T> get(launch::async_policy,
-            std::size_t generation = std::size_t(-1)) const
+        inline explicit channel_async_iterator(detail::channel_base<T> const* c);
+
+    private:
+        std::pair<hpx::future<T>, bool> get_checked() const
         {
-            return channel_->get(generation);
-        }
-        hpx::future<T> get(std::size_t generation = std::size_t(-1)) const
-        {
-            return get(launch::async, generation);
-        }
-        T get(launch::sync_policy, std::size_t generation = std::size_t(-1),
-            error_code& ec = throws) const
-        {
-            return channel_->get(generation, true).get(ec);
-        }
-        T get(launch::sync_policy, error_code& ec,
-            std::size_t generation = std::size_t(-1)) const
-        {
-            return channel_->get(generation, true).get(ec);
+            hpx::future<T> f;
+            if (channel_->try_get(std::size_t(-1), &f))
+            {
+                return std::make_pair(std::move(f), true);
+            }
+            return std::make_pair(hpx::future<T>(), false);
         }
 
-        ///////////////////////////////////////////////////////////////////////
-        void set(T val, std::size_t generation = std::size_t(-1))
+        friend class hpx::util::iterator_core_access;
+
+        bool equal(channel_async_iterator const& rhs) const
         {
-            channel_->set(generation, std::move(val));
+            return (channel_ == rhs.channel_ && data_.second == rhs.data_.second) ||
+                (!data_.second && rhs.channel_ == nullptr) ||
+                (channel_ == nullptr && !rhs.data_.second);
         }
 
-        void close()
+        void increment()
         {
-            channel_->close();
+            if (channel_)
+                data_ = get_checked();
         }
 
-        ///////////////////////////////////////////////////////////////////////
-        channel_iterator<T> begin() const
+        typename base_type::reference dereference() const
         {
-            return channel_iterator<T>(this);
-        }
-        channel_iterator<T> end() const
-        {
-            return channel_iterator<T>();
+            HPX_ASSERT(data_.second);
+            return std::move(data_.first);
         }
 
-        channel_iterator<T> rbegin() const
+    private:
+        boost::intrusive_ptr<detail::channel_impl_base<T> > channel_;
+        mutable std::pair<hpx::future<T>, bool> data_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        template <typename T>
+        class channel_async_range
         {
-            return channel_iterator<T>(this);
-        }
-        channel_iterator<T> rend() const
+        public:
+            explicit channel_async_range(channel_base<T> const& c)
+              : channel_(c)
+            {}
+
+            ///////////////////////////////////////////////////////////////////
+            channel_async_iterator<T> begin() const
+            {
+                return channel_async_iterator<T>(&channel_);
+            }
+            channel_async_iterator<T> end() const
+            {
+                return channel_async_iterator<T>();
+            }
+
+        private:
+            channel_base<T> const& channel_;
+        };
+
+        template <typename T>
+        class channel_base
         {
-            return channel_iterator<T>();
-        }
+        protected:
+            explicit channel_base(channel_impl_base<T>* impl)
+              : channel_(impl)
+            {}
+
+        public:
+            ///////////////////////////////////////////////////////////////////
+            hpx::future<T> get(launch::async_policy,
+                std::size_t generation = std::size_t(-1)) const
+            {
+                return channel_->get(generation);
+            }
+            hpx::future<T> get(std::size_t generation = std::size_t(-1)) const
+            {
+                return get(launch::async, generation);
+            }
+
+            T get(launch::sync_policy, std::size_t generation = std::size_t(-1),
+                error_code& ec = throws) const
+            {
+                return channel_->get(generation, true).get(ec);
+            }
+            T get(launch::sync_policy, error_code& ec,
+                std::size_t generation = std::size_t(-1)) const
+            {
+                return channel_->get(generation, true).get(ec);
+            }
+
+            ///////////////////////////////////////////////////////////////////
+            void set(T val, std::size_t generation = std::size_t(-1))
+            {
+                channel_->set(generation, std::move(val)).get();
+            }
+            void set(launch::sync_policy, T val,
+                std::size_t generation = std::size_t(-1))
+            {
+                channel_->set(generation, std::move(val)).get();
+            }
+            hpx::future<void> set(launch::async_policy, T val,
+                std::size_t generation = std::size_t(-1))
+            {
+                return channel_->set(generation, std::move(val));
+            }
+
+            void close()
+            {
+                channel_->close();
+            }
+
+            ///////////////////////////////////////////////////////////////////
+            channel_iterator<T> begin() const
+            {
+                return channel_iterator<T>(this);
+            }
+            channel_iterator<T> end() const
+            {
+                return channel_iterator<T>();
+            }
+
+            channel_base const& range() const
+            {
+                return *this;
+            }
+            channel_base const& range(launch::sync_policy) const
+            {
+                return *this;
+            }
+            channel_async_range<T> range(launch::async_policy) const
+            {
+                return channel_async_range<T>(*this);
+            }
+
+            ///////////////////////////////////////////////////////////////////
+            channel_impl_base<T>* get_channel_impl() const
+            {
+                return channel_.get();
+            }
+
+        protected:
+            boost::intrusive_ptr<channel_impl_base<T> > channel_;
+        };
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // channel with unlimited buffer
+    template <typename T>
+    class channel : protected detail::channel_base<T>
+    {
+        typedef detail::channel_base<T> base_type;
 
     private:
         friend class channel_iterator<T>;
         friend class receive_channel<T>;
         friend class send_channel<T>;
 
+    public:
+        typedef T value_type;
+
+        channel()
+          : base_type(new detail::unlimited_channel<T>())
+        {}
+
+        using base_type::get;
+        using base_type::set;
+        using base_type::close;
+        using base_type::begin;
+        using base_type::end;
+        using base_type::range;
+    };
+
+    // channel with a one-element buffer
+    template <typename T>
+    class one_element_channel : protected detail::channel_base<T>
+    {
+        typedef detail::channel_base<T> base_type;
+
     private:
-        boost::intrusive_ptr<detail::channel_base<T> > channel_;
+        friend class channel_iterator<T>;
+        friend class receive_channel<T>;
+        friend class send_channel<T>;
+
+    public:
+        typedef T value_type;
+
+        one_element_channel()
+          : base_type(new detail::one_element_channel<T>())
+        {}
+
+        using base_type::get;
+        using base_type::set;
+        using base_type::close;
+        using base_type::begin;
+        using base_type::end;
+        using base_type::range;
     };
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    class receive_channel
+    class receive_channel : protected detail::channel_base<T>
     {
+        typedef detail::channel_base<T> base_type;
+
+    private:
+        friend class channel_iterator<T>;
+        friend class receive_channel<T>;
+        friend class send_channel<T>;
+
     public:
         receive_channel(channel<T> const& c)
-          : channel_(c.channel_)
+          : base_type(c.get_channel_impl())
+        {}
+        receive_channel(one_element_channel<T> const& c)
+          : base_type(c.get_channel_impl())
         {}
 
-        ///////////////////////////////////////////////////////////////////////
-        hpx::future<T> get(launch::async_policy,
-            std::size_t generation = std::size_t(-1)) const
-        {
-            return channel_->get(generation);
-        }
-        hpx::future<T> get(std::size_t generation = std::size_t(-1)) const
-        {
-            return get(launch::async, generation);
-        }
-        T get(launch::sync_policy, std::size_t generation = std::size_t(-1),
-            error_code& ec = throws) const
-        {
-            return channel_->get(generation, true).get(ec);
-        }
-        T get(launch::sync_policy, error_code& ec,
-            std::size_t generation = std::size_t(-1)) const
-        {
-            return channel_->get(generation, true).get(ec);
-        }
-
-        ///////////////////////////////////////////////////////////////////////
-        channel_iterator<T> begin() const
-        {
-            return channel_iterator<T>(this);
-        }
-        channel_iterator<T> end() const
-        {
-            return channel_iterator<T>();
-        }
-
-        channel_iterator<T> rbegin() const
-        {
-            return channel_iterator<T>(this);
-        }
-        channel_iterator<T> rend() const
-        {
-            return channel_iterator<T>();
-        }
-
-    private:
-        friend class channel_iterator<T>;
-
-    private:
-        boost::intrusive_ptr<detail::channel_base<T> > channel_;
+        using base_type::get;
+        using base_type::begin;
+        using base_type::end;
+        using base_type::range;
     };
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    class send_channel
+    class send_channel : private detail::channel_base<T>
     {
+        typedef detail::channel_base<T> base_type;
+
     public:
         send_channel(channel<T> const& c)
-          : channel_(c.channel_)
+          : base_type(c.get_channel_impl())
+        {}
+        send_channel(one_element_channel<T> const& c)
+          : base_type(c.get_channel_impl())
         {}
 
-        void set(T val, std::size_t generation = std::size_t(-1))
-        {
-            channel_->set(generation, std::move(val));
-        }
-
-        void close()
-        {
-            channel_->close();
-        }
-
-    private:
-        friend class channel_iterator<T>;
-
-    private:
-        boost::intrusive_ptr<detail::channel_base<T> > channel_;
+        using base_type::set;
+        using base_type::close;
     };
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    inline channel_iterator<T>::channel_iterator(channel<T> const* c)
-      : channel_(c ? c->channel_ : nullptr),
+    inline channel_iterator<T>::channel_iterator(detail::channel_base<T> const* c)
+      : channel_(c ? c->get_channel_impl() : nullptr),
         data_(c ? get_checked() : std::make_pair(T(), false))
     {}
 
     template <typename T>
     inline channel_iterator<T>::channel_iterator(receive_channel<T> const* c)
-      : channel_(c ? c->channel_ : nullptr),
+      : channel_(c ? c->get_channel_impl() : nullptr),
         data_(c ? get_checked() : std::make_pair(T(), false))
+    {}
+
+    template <typename T>
+    inline channel_async_iterator<T>::channel_async_iterator(
+            detail::channel_base<T> const* c)
+      : channel_(c ? c->get_channel_impl() : nullptr),
+        data_(c ? get_checked() : std::make_pair(hpx::future<T>(), false))
     {}
 
     ///////////////////////////////////////////////////////////////////////////
@@ -457,7 +843,7 @@ namespace hpx { namespace lcos { namespace local
           : channel_(nullptr), data_(false)
         {}
 
-        inline explicit channel_iterator(channel<void> const* c);
+        inline explicit channel_iterator(detail::channel_base<void> const* c);
         inline explicit channel_iterator(receive_channel<void> const* c);
 
     private:
@@ -494,169 +880,199 @@ namespace hpx { namespace lcos { namespace local
         }
 
     private:
-        boost::intrusive_ptr<detail::channel_base<util::unused_type> > channel_;
+        boost::intrusive_ptr<detail::channel_impl_base<util::unused_type> > channel_;
         bool data_;
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    template <>
-    class channel<void>
+    namespace detail
     {
-    public:
-        channel()
-          : channel_(new detail::unlimited_channel<util::unused_type>())
-        {}
+        template <>
+        class channel_base<void>
+        {
+        public:
+            explicit channel_base(detail::channel_impl_base<util::unused_type>* impl)
+              : channel_(impl)
+            {}
 
-        ///////////////////////////////////////////////////////////////////////
-        hpx::future<void> get(launch::async_policy,
-            std::size_t generation = std::size_t(-1)) const
-        {
-            return channel_->get(generation);
-        }
-        hpx::future<void> get(std::size_t generation = std::size_t(-1)) const
-        {
-            return get(launch::async, generation);
-        }
-        void get(launch::sync_policy, std::size_t generation = std::size_t(-1),
-            error_code& ec = throws) const
-        {
-            channel_->get(generation, true).get(ec);
-        }
-        void get(launch::sync_policy, error_code& ec,
-            std::size_t generation = std::size_t(-1)) const
-        {
-            channel_->get(generation, true).get(ec);
-        }
+            ///////////////////////////////////////////////////////////////////////
+            hpx::future<void> get(launch::async_policy,
+                std::size_t generation = std::size_t(-1)) const
+            {
+                return channel_->get(generation);
+            }
+            hpx::future<void> get(std::size_t generation = std::size_t(-1)) const
+            {
+                return get(launch::async, generation);
+            }
+            void get(launch::sync_policy, std::size_t generation = std::size_t(-1),
+                error_code& ec = throws) const
+            {
+                channel_->get(generation, true).get(ec);
+            }
+            void get(launch::sync_policy, error_code& ec,
+                std::size_t generation = std::size_t(-1)) const
+            {
+                channel_->get(generation, true).get(ec);
+            }
 
-        ///////////////////////////////////////////////////////////////////////
-        void set(std::size_t generation = std::size_t(-1))
-        {
-            channel_->set(generation, hpx::util::unused_type());
-        }
+            ///////////////////////////////////////////////////////////////////////
+            void set(std::size_t generation = std::size_t(-1))
+            {
+                channel_->set(generation, hpx::util::unused_type()).get();
+            }
+            void set(launch::sync_policy,
+                std::size_t generation = std::size_t(-1))
+            {
+                channel_->set(generation, hpx::util::unused_type()).get();
+            }
+            hpx::future<void> set(launch::async_policy,
+                std::size_t generation = std::size_t(-1))
+            {
+                return channel_->set(generation, hpx::util::unused_type());
+            }
 
-        void close()
-        {
-            channel_->close();
-        }
+            void close()
+            {
+                channel_->close();
+            }
 
-        channel_iterator<void> begin() const
-        {
-            return channel_iterator<void>(this);
-        }
-        channel_iterator<void> end() const
-        {
-            return channel_iterator<void>();
-        }
+            ///////////////////////////////////////////////////////////////////
+            channel_iterator<void> begin() const
+            {
+                return channel_iterator<void>(this);
+            }
+            channel_iterator<void> end() const
+            {
+                return channel_iterator<void>();
+            }
 
-        channel_iterator<void> rbegin() const
-        {
-            return channel_iterator<void>(this);
-        }
-        channel_iterator<void> rend() const
-        {
-            return channel_iterator<void>();
-        }
+            channel_base const& range() const
+            {
+                return *this;
+            }
+            channel_base const& range(launch::sync_policy) const
+            {
+                return *this;
+            }
+            channel_async_range<void> range(launch::async_policy) const
+            {
+                return channel_async_range<void>(*this);
+            }
+
+            ///////////////////////////////////////////////////////////////////
+            channel_impl_base<util::unused_type>* get_channel_impl() const
+            {
+                return channel_.get();
+            }
+
+        protected:
+            boost::intrusive_ptr<channel_impl_base<util::unused_type> > channel_;
+        };
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <>
+    class channel<void> : protected detail::channel_base<void>
+    {
+        typedef detail::channel_base<void> base_type;
 
     private:
         friend class channel_iterator<void>;
         friend class receive_channel<void>;
         friend class send_channel<void>;
 
+    public:
+        typedef void value_type;
+
+        channel()
+          : base_type(new detail::unlimited_channel<util::unused_type>())
+        {}
+
+        using base_type::get;
+        using base_type::set;
+        using base_type::close;
+        using base_type::begin;
+        using base_type::end;
+        using base_type::range;
+    };
+
+    template <>
+    class one_element_channel<void> : protected detail::channel_base<void>
+    {
+        typedef detail::channel_base<void> base_type;
+
     private:
-        boost::intrusive_ptr<detail::channel_base<util::unused_type> > channel_;
+        friend class channel_iterator<void>;
+        friend class receive_channel<void>;
+        friend class send_channel<void>;
+
+    public:
+        typedef void value_type;
+
+        one_element_channel()
+          : base_type(new detail::one_element_channel<util::unused_type>())
+        {}
+
+        using base_type::get;
+        using base_type::set;
+        using base_type::close;
+        using base_type::begin;
+        using base_type::end;
+        using base_type::range;
     };
 
     ///////////////////////////////////////////////////////////////////////////
     template <>
-    class receive_channel<void>
+    class receive_channel<void> : protected detail::channel_base<void>
     {
+        typedef detail::channel_base<void> base_type;
+
+    private:
+        friend class channel_iterator<void>;
+        friend class receive_channel<void>;
+        friend class send_channel<void>;
+
     public:
         receive_channel(channel<void> const& c)
-          : channel_(c.channel_)
+          : base_type(c.get_channel_impl())
+        {}
+        receive_channel(one_element_channel<void> const& c)
+          : base_type(c.get_channel_impl())
         {}
 
-        ///////////////////////////////////////////////////////////////////////
-        hpx::future<void> get(launch::async_policy,
-            std::size_t generation = std::size_t(-1)) const
-        {
-            return channel_->get(generation);
-        }
-        hpx::future<void> get(std::size_t generation = std::size_t(-1)) const
-        {
-            return get(launch::async, generation);
-        }
-        void get(launch::sync_policy,
-            std::size_t generation = std::size_t(-1),
-            error_code& ec = throws) const
-        {
-            channel_->get(generation, true).get(ec);
-        }
-        void get(launch::sync_policy, error_code& ec,
-            std::size_t generation = std::size_t(-1)) const
-        {
-            channel_->get(generation, true).get(ec);
-        }
-
-        ///////////////////////////////////////////////////////////////////////
-        channel_iterator<void> begin() const
-        {
-            return channel_iterator<void>(this);
-        }
-        channel_iterator<void> end() const
-        {
-            return channel_iterator<void>();
-        }
-
-        channel_iterator<void> rbegin() const
-        {
-            return channel_iterator<void>(this);
-        }
-        channel_iterator<void> rend() const
-        {
-            return channel_iterator<void>();
-        }
-
-    private:
-        friend class channel_iterator<void>;
-
-    private:
-        boost::intrusive_ptr<detail::channel_base<util::unused_type> > channel_;
+        using base_type::get;
+        using base_type::begin;
+        using base_type::end;
+        using base_type::range;
     };
 
     ///////////////////////////////////////////////////////////////////////////
     template <>
-    class send_channel<void>
+    class send_channel<void> : private detail::channel_base<void>
     {
+        typedef detail::channel_base<void> base_type;
+
     public:
         send_channel(channel<void> const& c)
-          : channel_(c.channel_)
+          : base_type(c.get_channel_impl())
+        {}
+        send_channel(one_element_channel<void> const& c)
+          : base_type(c.get_channel_impl())
         {}
 
-        void set(std::size_t generation = std::size_t(-1))
-        {
-            channel_->set(generation, util::unused_type());
-        }
-
-        void close()
-        {
-            channel_->close();
-        }
-
-    private:
-        friend class channel_iterator<void>;
-
-    private:
-        boost::intrusive_ptr<detail::channel_base<util::unused_type> > channel_;
+        using base_type::set;
+        using base_type::close;
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    inline channel_iterator<void>::channel_iterator(channel<void> const* c)
-      : channel_(c ? c->channel_ : nullptr),
+    inline channel_iterator<void>::channel_iterator(detail::channel_base<void> const* c)
+      : channel_(c ? c->get_channel_impl() : nullptr),
         data_(c ? get_checked() : false)
     {}
 
     inline channel_iterator<void>::channel_iterator(receive_channel<void> const* c)
-      : channel_(c ? c->channel_ : nullptr),
+      : channel_(c ? c->get_channel_impl() : nullptr),
         data_(c ? get_checked() : false)
     {}
 }}}

--- a/hpx/lcos/local/futures_factory.hpp
+++ b/hpx/lcos/local/futures_factory.hpp
@@ -407,6 +407,17 @@ namespace hpx { namespace lcos { namespace local
             return !!task_;
         }
 
+        void set_exception(boost::exception_ptr const& e)
+        {
+            if (!task_) {
+                HPX_THROW_EXCEPTION(task_moved,
+                    "futures_factory<Result()>::set_exception",
+                    "futures_factory invalid (has it been moved?)");
+                return;
+            }
+            task_->set_exception(e);
+        }
+
     protected:
         boost::intrusive_ptr<task_impl_type> task_;
         bool future_obtained_;

--- a/hpx/lcos/local/packaged_task.hpp
+++ b/hpx/lcos/local/packaged_task.hpp
@@ -132,6 +132,12 @@ namespace hpx { namespace lcos { namespace local
             promise_ = local::promise<R>();
         }
 
+        // extension
+        void set_exception(boost::exception_ptr const& e)
+        {
+            promise_.set_exception(e);
+        }
+
     private:
         // synchronous execution
         template <typename ...Vs>

--- a/tests/unit/lcos/await.cpp
+++ b/tests/unit/lcos/await.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2015 Hartmut Kaiser
+// Copyright (C) 2015-2017 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -24,14 +24,14 @@ hpx::future<int> fib1(int n)
 {
     if (n >= 2)
         n = co_await fib1(n - 1) + co_await fib1(n - 2);
-    return n;
+    co_return n;
 }
 
 hpx::future<int> fib2(int n)
 {
     if (n >= 2)
         n = co_await hpx::async(&fib2, n - 1) + co_await fib2(n - 2);
-    return n;
+    co_return n;
 }
 
 void simple_await_test()


### PR DESCRIPTION
- refactored local channel implementation
- channel::set is now optionally asynchronous
- adding asynchronous iterator support to channel