### PR TITLE
Distributed define_spmd_block

### DIFF
--- a/hpx/lcos/local/spmd_block.hpp
+++ b/hpx/lcos/local/spmd_block.hpp
@@ -145,7 +145,8 @@ namespace hpx { namespace lcos { namespace local
                     detail::spmd_block_helper<F>{
                         barrier, std::forward<F>(f), num_images
                     },
-                    boost::irange(std::size_t(0), num_images), std::forward<Args>(args)...);
+                    boost::irange(std::size_t(0), num_images),
+                        std::forward<Args>(args)...);
     }
 
     // Synchronous version
@@ -184,7 +185,8 @@ namespace hpx { namespace lcos { namespace local
                 detail::spmd_block_helper<F>{
                     barrier, std::forward<F>(f), num_images
                 },
-                boost::irange(std::size_t(0), num_images), std::forward<Args>(args)...);
+                boost::irange(std::size_t(0), num_images),
+                    std::forward<Args>(args)...);
     }
 
     template <typename F, typename ... Args>

--- a/hpx/lcos/local/spmd_block.hpp
+++ b/hpx/lcos/local/spmd_block.hpp
@@ -26,10 +26,11 @@ namespace hpx { namespace lcos { namespace local
     /// The class spmd_block defines an interface for launching
     /// multiple images while giving handles to each image to interact with
     /// the remaining images. The \a define_spmd_block function templates create
-    /// multiple images of a user-defined lambda and launches them in a possibly
-    /// separate thread. A temporary spmd block object is created and diffused
-    /// to each image. The constraint for the lambda given to the
-    /// define_spmd_block function is to accept a spmd_block as first parameter.
+    /// multiple images of a user-defined function (or lambda) and launches them
+    /// in a possibly separate thread. A temporary spmd block object is created
+    /// and diffused to each image. The constraint for the function (or lambda)
+    /// given to the define_spmd_block function is to accept a spmd_block as
+    /// first parameter.
     struct spmd_block
     {
         explicit spmd_block(std::size_t num_images, std::size_t image_id,

--- a/hpx/lcos/local/spmd_block.hpp
+++ b/hpx/lcos/local/spmd_block.hpp
@@ -1,0 +1,198 @@
+//  Copyright (c) 2017 Antoine Tran Tan
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_LCOS_LOCAL_SPMD_BLOCK_HPP)
+#define HPX_LCOS_LOCAL_SPMD_BLOCK_HPP
+
+#include <hpx/lcos/future.hpp>
+#include <hpx/lcos/local/barrier.hpp>
+#include <hpx/parallel/execution_policy.hpp>
+#include <hpx/traits/is_execution_policy.hpp>
+
+#include <boost/range/irange.hpp>
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx { namespace lcos { namespace local
+{
+    namespace detail
+    {
+        template <typename T>
+        struct extract_first_parameter
+        {};
+
+        // Specialization for lambdas
+        template <typename ClassType, typename ReturnType>
+        struct extract_first_parameter<ReturnType(ClassType::*)() const>
+        {
+            using type = std::false_type;
+        };
+
+        // Specialization for lambdas
+        template <typename ClassType,
+            typename ReturnType, typename Arg0, typename... Args>
+        struct extract_first_parameter<
+            ReturnType(ClassType::*)(Arg0, Args...) const>
+        {
+            using type = typename std::decay<Arg0>::type;
+        };
+    }
+
+    /// The class spmd_block defines an interface for launching
+    /// multiple images while giving handles to each image to interact with
+    /// the remaining images. The \a define_spmd_block function templates create
+    /// multiple images of a user-defined lambda and launches them in a possibly
+    /// separate thread. A temporary spmd block object is created and diffused
+    /// to each image. The constraint for the lambda given to the
+    /// define_spmd_block function is to accept a spmd_block as first parameter.
+    struct spmd_block
+    {
+        explicit spmd_block(std::size_t num_images, std::size_t image_id,
+            hpx::lcos::local::barrier & barrier)
+        : num_images_(num_images), image_id_(image_id), barrier_(barrier)
+        {}
+
+        // Note: spmd_block class is movable/move-assignable
+        // but not copyable/copy-assignable
+
+        spmd_block(spmd_block &&) = default;
+        spmd_block(spmd_block const &) = delete;
+
+        spmd_block & operator=(spmd_block &&) = default;
+        spmd_block & operator=(spmd_block const &) = delete;
+
+        std::size_t get_num_images() const
+        {
+            return num_images_;
+        }
+
+        std::size_t this_image() const
+        {
+            return image_id_;
+        }
+
+        void sync_all() const
+        {
+           barrier_.get().wait();
+        }
+
+    private:
+        std::size_t num_images_;
+        std::size_t image_id_;
+        mutable std::reference_wrapper<hpx::lcos::local::barrier> barrier_;
+    };
+
+    namespace detail
+    {
+        template <typename F>
+        struct spmd_block_helper
+        {
+            mutable std::shared_ptr<hpx::lcos::local::barrier> barrier_;
+            typename std::decay<F>::type f_;
+            std::size_t num_images_;
+
+            template <typename ... Ts>
+            void operator()(std::size_t image_id, Ts && ... ts) const
+            {
+                spmd_block block(num_images_, image_id, *barrier_);
+                hpx::util::invoke(
+                    f_, std::move(block), std::forward<Ts>(ts)...);
+            }
+        };
+    }
+
+    // Asynchronous version
+    template <typename ExPolicy, typename F, typename ... Args,
+        typename = typename std::enable_if<
+            hpx::parallel::v1::is_async_execution_policy<ExPolicy>::value>::type
+        >
+    std::vector<hpx::future<void>>
+    define_spmd_block(ExPolicy && policy,
+        std::size_t num_images, F && f, Args && ... args)
+    {
+        static_assert(
+            parallel::execution::is_execution_policy<ExPolicy>::value,
+            "parallel::execution::is_execution_policy<ExPolicy>::value");
+
+        using ftype = typename std::decay<F>::type;
+
+        using first_type =
+            typename hpx::lcos::local::detail::extract_first_parameter<
+                        decltype(&ftype::operator())>::type;
+
+        using executor_type =
+            typename hpx::util::decay<ExPolicy>::type::executor_type;
+
+        static_assert(std::is_same<spmd_block, first_type>::value,
+            "define_spmd_block() needs a lambda that " \
+            "has at least a spmd_block as 1st argument");
+
+        std::shared_ptr<hpx::lcos::local::barrier> barrier
+            = std::make_shared<hpx::lcos::local::barrier>(num_images);
+
+        return
+            hpx::parallel::executor_traits<
+                    typename std::decay<executor_type>::type
+                >::bulk_async_execute(
+                    policy.executor(),
+                    detail::spmd_block_helper<F>{
+                        barrier, std::forward<F>(f), num_images
+                    },
+                    boost::irange(std::size_t(0), num_images), std::forward<Args>(args)...);
+    }
+
+    // Synchronous version
+    template <typename ExPolicy, typename F, typename ... Args,
+        typename = typename std::enable_if<
+            !hpx::parallel::v1::is_async_execution_policy<ExPolicy>::value>::type
+        >
+    void
+    define_spmd_block(ExPolicy && policy,
+        std::size_t num_images, F && f, Args && ... args)
+    {
+        static_assert(
+            parallel::execution::is_execution_policy<ExPolicy>::value,
+            "parallel::execution::is_execution_policy<ExPolicy>::value");
+
+        using ftype = typename std::decay<F>::type;
+
+        using first_type =
+            typename hpx::lcos::local::detail::extract_first_parameter<
+                        decltype(&ftype::operator())>::type;
+
+        using executor_type =
+            typename hpx::util::decay<ExPolicy>::type::executor_type;
+
+        static_assert(std::is_same<spmd_block, first_type>::value,
+            "define_spmd_block() needs a lambda that " \
+            "has at least a spmd_block as 1st argument");
+
+        std::shared_ptr<hpx::lcos::local::barrier> barrier
+            = std::make_shared<hpx::lcos::local::barrier>(num_images);
+
+        hpx::parallel::executor_traits<
+                typename std::decay<executor_type>::type
+            >::bulk_execute(
+                policy.executor(),
+                detail::spmd_block_helper<F>{
+                    barrier, std::forward<F>(f), num_images
+                },
+                boost::irange(std::size_t(0), num_images), std::forward<Args>(args)...);
+    }
+
+    template <typename F, typename ... Args>
+    void define_spmd_block(std::size_t num_images, F && f, Args && ... args)
+    {
+        define_spmd_block(parallel::execution::par,
+            num_images, std::forward<F>(f), std::forward<Args>(args)...);
+    }
+}}}
+
+#endif

--- a/hpx/lcos/spmd_block.hpp
+++ b/hpx/lcos/spmd_block.hpp
@@ -26,6 +26,7 @@
 #include <cstdio>
 #include <functional>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <type_traits>
 #include <utility>

--- a/hpx/lcos/spmd_block.hpp
+++ b/hpx/lcos/spmd_block.hpp
@@ -1,0 +1,260 @@
+//  Copyright (c) 2017 Antoine Tran Tan
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_LCOS_SPMD_BLOCK_HPP)
+#define HPX_LCOS_SPMD_BLOCK_HPP
+
+#include <hpx/lcos/future.hpp>
+#include <hpx/lcos/barrier.hpp>
+#include <hpx/lcos/broadcast.hpp>
+#include <hpx/parallel/execution_policy.hpp>
+#include <hpx/runtime/actions/lambda_to_action.hpp>
+#include <hpx/runtime/get_locality_id.hpp>
+#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/runtime/naming/name.hpp>
+#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/traits/is_action.hpp>
+#include <hpx/traits/is_execution_policy.hpp>
+#include <hpx/util/unused.hpp>
+
+#include <boost/range/irange.hpp>
+
+#include <cstddef>
+#include <cstdio>
+#include <functional>
+#include <iostream>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace lcos
+{
+    namespace detail
+    {
+        template <typename T>
+        struct extract_first_parameter
+        {};
+
+        // Specialization for lambdas
+        template <typename ClassType, typename ReturnType>
+        struct extract_first_parameter<ReturnType(ClassType::*)() const>
+        {
+            using type = std::false_type;
+        };
+
+        // Specialization for actions
+        template <>
+        struct extract_first_parameter< hpx::util::tuple<> >
+        {
+            using type = std::false_type;
+        };
+
+        // Specialization for lambdas
+        template <typename ClassType,
+            typename ReturnType, typename Arg0, typename... Args>
+        struct extract_first_parameter<
+            ReturnType(ClassType::*)(Arg0, Args...) const>
+        {
+            using type = typename std::decay<Arg0>::type;
+        };
+
+        // Specialization for actions
+        template <typename Arg0, typename... Args>
+        struct extract_first_parameter< hpx::util::tuple<Arg0, Args...> >
+        {
+            using type = typename std::decay<Arg0>::type;
+        };
+    }
+
+    /// The class spmd_block defines an interface for launching
+    /// multiple images while giving handles to each image to interact with
+    /// the remaining images. The \a define_spmd_block function templates create
+    /// multiple images of a user-defined lambda and launches them in a possibly
+    /// separate thread. A temporary spmd block object is created and diffused
+    /// to each image. The constraint for the lambda given to the
+    /// define_spmd_block function is to accept a spmd_block as first parameter.
+    struct spmd_block
+    {
+        spmd_block(){}
+
+        explicit spmd_block(std::string name, std::size_t num_images)
+        : name_(name), num_images_(num_images), image_id_(hpx::get_locality_id())
+        {}
+
+        explicit spmd_block(std::string name, std::size_t num_images,
+            std::size_t image_id)
+        : name_(name), num_images_(num_images), image_id_(image_id)
+        , barrier_(
+            std::make_shared<hpx::lcos::barrier>(
+                name_ + "_barrier", num_images_, image_id_))
+        {}
+
+        std::size_t get_num_images() const
+        {
+            return num_images_;
+        }
+
+        std::size_t this_image() const
+        {
+            return image_id_;
+        }
+
+        void sync_all() const
+        {
+            if(!barrier_)
+            {
+                barrier_ =
+                    std::make_shared<hpx::lcos::barrier>(
+                    name_ + "_barrier", num_images_, image_id_);
+            }
+
+           barrier_->wait();
+        }
+
+        hpx::future<void> sync_all(hpx::launch::async_policy const &) const
+        {
+            if(!barrier_)
+            {
+                barrier_ =
+                    std::make_shared<hpx::lcos::barrier>(
+                    name_ + "_barrier", num_images_, image_id_);
+            }
+
+           return barrier_->wait(hpx::launch::async);
+        }
+
+    private:
+        std::string name_;
+        std::size_t num_images_;
+        std::size_t image_id_;
+        mutable std::shared_ptr<hpx::lcos::barrier> barrier_;
+
+    private:
+        friend class hpx::serialization::access;
+
+        template <typename Archive>
+        void save(Archive& ar, unsigned const) const
+        {
+            ar << name_ << num_images_;
+        }
+
+        template <typename Archive>
+        void load(Archive& ar, const unsigned int)
+        {
+            ar >> name_ >> num_images_;
+            image_id_ = hpx::get_locality_id();
+        }
+
+        HPX_SERIALIZATION_SPLIT_MEMBER()
+    };
+
+    // Helper for the lambda version of define_spmd_block()
+    namespace detail
+    {
+        template <typename F>
+        struct spmd_block_helper
+        {
+            std::string name_;
+            std::size_t num_images_;
+
+            template <typename ... Ts>
+            void operator()(std::size_t image_id, Ts && ... ts) const
+            {
+                spmd_block block(name_, num_images_, image_id);
+
+                int * dummy = nullptr;
+                hpx::util::invoke(
+                    reinterpret_cast<const F&>(*dummy),
+                    std::move(block),
+                    std::forward<Ts>(ts)...);
+            }
+        };
+    }
+
+    // Overload for lambdas (Note : it implies some undefined behaviour)
+    template <typename F, typename ... Args>
+    typename std::enable_if_t<!hpx::traits::is_action<F>::value,
+        hpx::future<void> >
+    define_spmd_block(std::string && name, std::size_t images_per_locality,
+        F && f, Args && ... args)
+    {
+        using ftype = typename std::decay<F>::type;
+
+        using first_type =
+            typename hpx::lcos::detail::extract_first_parameter<
+                        decltype(&ftype::operator())>::type;
+
+        using executor_type =
+            hpx::parallel::execution::parallel_executor;
+
+        static_assert(std::is_same<spmd_block, first_type>::value,
+            "define_spmd_block() needs a lambda that " \
+            "has at least a spmd_block as 1st argument");
+
+        std::size_t num_images
+            = hpx::get_num_localities(hpx::launch::sync) * images_per_locality;
+
+        // Force f to be initialized at compile-time
+        auto dummy = hpx::actions::lambda_to_action(f);
+        HPX_UNUSED(dummy);
+
+        auto act = hpx::actions::lambda_to_action(
+            []( std::string name,
+                std::size_t images_per_locality,
+                std::size_t num_images,
+                Args... args)
+            {
+                executor_type exec;
+                std::size_t offset = hpx::get_locality_id();
+                offset *= images_per_locality;
+
+                hpx::parallel::executor_traits<
+                    executor_type
+                    >::bulk_execute(
+                        exec,
+                        detail::spmd_block_helper<ftype>{name,num_images},
+                        boost::irange(
+                            offset, offset + images_per_locality),
+                        args...);
+            });
+
+        return
+            hpx::lcos::broadcast(
+                act, hpx::find_all_localities(),
+                    std::forward<std::string>(name), images_per_locality,
+                        num_images, std::forward<Args>(args)...);
+    }
+
+    // Overload for actions
+    // Note : images_per_locality is fixed to 1 even if a different value is
+    // given by the user.
+    template <typename F, typename ... Args>
+    typename std::enable_if_t<hpx::traits::is_action<F>::value,
+        hpx::future<void> >
+    define_spmd_block(std::string && name, std::size_t,
+        F && f, Args && ... args)
+    {
+        using action_type = typename std::decay<F>::type;
+
+        using first_type =
+            typename hpx::lcos::detail::extract_first_parameter<
+                        typename action_type::arguments_type>::type;
+
+        static_assert(std::is_same<spmd_block, first_type>::value,
+            "define_spmd_block() needs an action that " \
+            "has at least a spmd_block as 1st argument");
+
+        std::size_t num_images
+            = hpx::get_num_localities(hpx::launch::sync);
+
+        spmd_block block(name, num_images);
+
+        return
+            hpx::lcos::broadcast(f, hpx::find_all_localities(),
+                    std::move(block), std::forward<Args>(args)...);
+    }
+}}
+
+#endif

--- a/hpx/lcos/spmd_block.hpp
+++ b/hpx/lcos/spmd_block.hpp
@@ -16,6 +16,7 @@
 #include <hpx/runtime/serialization/serialize.hpp>
 #include <hpx/traits/concepts.hpp>
 #include <hpx/traits/is_action.hpp>
+#include <hpx/util/first_argument.hpp>
 
 #include <boost/range/irange.hpp>
 
@@ -28,25 +29,6 @@
 
 namespace hpx { namespace lcos
 {
-    namespace detail
-    {
-        template <typename T>
-        struct extract_first_parameter
-        {};
-
-        template <>
-        struct extract_first_parameter< hpx::util::tuple<> >
-        {
-            using type = std::false_type;
-        };
-
-        template <typename Arg0, typename... Args>
-        struct extract_first_parameter< hpx::util::tuple<Arg0, Args...> >
-        {
-            using type = typename std::decay<Arg0>::type;
-        };
-    }
-
     /// The class spmd_block defines an interface for launching
     /// multiple images while giving handles to each image to interact with
     /// the remaining images. The \a define_spmd_block function templates create
@@ -127,8 +109,7 @@ namespace hpx { namespace lcos
             void operator()(std::size_t image_id, Ts && ... ts) const
             {
                 using first_type =
-                    typename hpx::lcos::detail::extract_first_parameter<
-                                typename F::arguments_type>::type;
+                    typename hpx::util::first_argument<F>::type;
 
                 static_assert(std::is_same<hpx::lcos::spmd_block,
                     first_type>::value,

--- a/hpx/lcos/spmd_block.hpp
+++ b/hpx/lcos/spmd_block.hpp
@@ -120,11 +120,12 @@ namespace hpx { namespace lcos
                     typename hpx::lcos::detail::extract_first_parameter<
                                 typename F::arguments_type>::type;
 
-                static_assert(std::is_same<spmd_block, first_type>::value,
-                    "define_spmd_block() needs an action that " \
-                    "has at least a spmd_block as 1st argument");
+                static_assert(std::is_same<hpx::lcos::spmd_block,
+                    first_type>::value,
+                        "define_spmd_block() needs an action that " \
+                        "has at least a spmd_block as 1st argument");
 
-                spmd_block block(name_, num_images_, image_id);
+                hpx::lcos::spmd_block block(name_, num_images_, image_id);
 
                 F()(hpx::launch::sync,
                     hpx::find_here(),

--- a/hpx/lcos/spmd_block.hpp
+++ b/hpx/lcos/spmd_block.hpp
@@ -11,22 +11,16 @@
 #include <hpx/lcos/barrier.hpp>
 #include <hpx/lcos/broadcast.hpp>
 #include <hpx/parallel/execution_policy.hpp>
-#include <hpx/runtime/actions/lambda_to_action.hpp>
 #include <hpx/runtime/get_locality_id.hpp>
 #include <hpx/runtime/launch_policy.hpp>
-#include <hpx/runtime/naming/name.hpp>
 #include <hpx/runtime/serialization/serialize.hpp>
 #include <hpx/traits/concepts.hpp>
 #include <hpx/traits/is_action.hpp>
-#include <hpx/traits/is_execution_policy.hpp>
-#include <hpx/util/unused.hpp>
 
 #include <boost/range/irange.hpp>
 
 #include <cstddef>
-#include <cstdio>
 #include <functional>
-#include <iostream>
 #include <memory>
 #include <string>
 #include <type_traits>

--- a/hpx/lcos/spmd_block.hpp
+++ b/hpx/lcos/spmd_block.hpp
@@ -56,9 +56,9 @@ namespace hpx { namespace lcos
     /// The class spmd_block defines an interface for launching
     /// multiple images while giving handles to each image to interact with
     /// the remaining images. The \a define_spmd_block function templates create
-    /// multiple images of a user-defined lambda and launches them in a possibly
+    /// multiple images of a user-defined action and launches them in a possibly
     /// separate thread. A temporary spmd block object is created and diffused
-    /// to each image. The constraint for the lambda given to the
+    /// to each image. The constraint for the action given to the
     /// define_spmd_block function is to accept a spmd_block as first parameter.
     struct spmd_block
     {

--- a/hpx/parallel/spmd_block.hpp
+++ b/hpx/parallel/spmd_block.hpp
@@ -13,6 +13,7 @@
 
 #include <cstddef>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace hpx { namespace parallel { inline namespace v2

--- a/hpx/parallel/spmd_block.hpp
+++ b/hpx/parallel/spmd_block.hpp
@@ -7,44 +7,16 @@
 #define HPX_PARALLEL_SPMD_BLOCK_HPP
 
 #include <hpx/lcos/future.hpp>
-#include <hpx/lcos/local/barrier.hpp>
+#include <hpx/lcos/local/spmd_block.hpp>
 #include <hpx/parallel/execution_policy.hpp>
 #include <hpx/traits/is_execution_policy.hpp>
 
-#include <boost/range/irange.hpp>
-
 #include <cstddef>
-#include <functional>
-#include <memory>
 #include <type_traits>
-#include <utility>
 #include <vector>
 
 namespace hpx { namespace parallel { inline namespace v2
 {
-    namespace detail
-    {
-        template <typename T>
-        struct extract_first_parameter
-        {};
-
-        // Specialization for lambdas
-        template <typename ClassType, typename ReturnType>
-        struct extract_first_parameter<ReturnType(ClassType::*)() const>
-        {
-            using type = std::false_type;
-        };
-
-        // Specialization for lambdas
-        template <typename ClassType,
-            typename ReturnType, typename Arg0, typename... Args>
-        struct extract_first_parameter<
-            ReturnType(ClassType::*)(Arg0, Args...) const>
-        {
-            using type = typename std::decay<Arg0>::type;
-        };
-    }
-
     /// The class spmd_block defines an interface for launching
     /// multiple images while giving handles to each image to interact with
     /// the remaining images. The \a define_spmd_block function templates create
@@ -52,101 +24,20 @@ namespace hpx { namespace parallel { inline namespace v2
     /// separate thread. A temporary spmd block object is created and diffused
     /// to each image. The constraint for the lambda given to the
     /// define_spmd_block function is to accept a spmd_block as first parameter.
-    struct spmd_block
-    {
-        explicit spmd_block(std::size_t num_images, std::size_t image_id,
-            hpx::lcos::local::barrier & barrier)
-        : num_images_(num_images), image_id_(image_id), barrier_(barrier)
-        {}
-
-        // Note: spmd_block class is movable/move-assignable
-        // but not copyable/copy-assignable
-
-        spmd_block(spmd_block &&) = default;
-        spmd_block(spmd_block const &) = delete;
-
-        spmd_block & operator=(spmd_block &&) = default;
-        spmd_block & operator=(spmd_block const &) = delete;
-
-        std::size_t get_num_images() const
-        {
-            return num_images_;
-        }
-
-        std::size_t this_image() const
-        {
-            return image_id_;
-        }
-
-        void sync_all() const
-        {
-           barrier_.get().wait();
-        }
-
-    private:
-        std::size_t num_images_;
-        std::size_t image_id_;
-        mutable std::reference_wrapper<hpx::lcos::local::barrier> barrier_;
-    };
-
-    namespace detail
-    {
-        template <typename F>
-        struct spmd_block_helper
-        {
-            mutable std::shared_ptr<hpx::lcos::local::barrier> barrier_;
-            typename std::decay<F>::type f_;
-            std::size_t num_images_;
-
-            template <typename ... Ts>
-            void operator()(std::size_t image_id, Ts && ... ts) const
-            {
-                spmd_block block(num_images_, image_id, *barrier_);
-                hpx::util::invoke(
-                    f_, std::move(block), std::forward<Ts>(ts)...);
-            }
-        };
-    }
+    using spmd_block = hpx::lcos::local::spmd_block;
 
     // Asynchronous version
     template <typename ExPolicy, typename F, typename ... Args,
         typename = typename std::enable_if<
             hpx::parallel::v1::is_async_execution_policy<ExPolicy>::value>::type
         >
-    std::vector<hpx::future<void>>
+    inline std::vector<hpx::future<void>>
     define_spmd_block(ExPolicy && policy,
         std::size_t num_images, F && f, Args && ... args)
     {
-        static_assert(
-            parallel::execution::is_execution_policy<ExPolicy>::value,
-            "parallel::execution::is_execution_policy<ExPolicy>::value");
-
-        using ftype = typename std::decay<F>::type;
-
-        using first_type =
-            typename hpx::parallel::v2::detail::extract_first_parameter<
-                        decltype(&ftype::operator())>::type;
-
-        using executor_type =
-            typename hpx::util::decay<ExPolicy>::type::executor_type;
-
-        static_assert(std::is_same<spmd_block, first_type>::value,
-            "define_spmd_block() needs a lambda that " \
-            "has at least a spmd_block as 1st argument");
-
-        std::shared_ptr<hpx::lcos::local::barrier> barrier
-            = std::make_shared<hpx::lcos::local::barrier>(num_images);
-
-        return
-            hpx::parallel::executor_traits<
-                    typename std::decay<executor_type>::type
-                >::bulk_async_execute(
-                    policy.executor(),
-                    detail::spmd_block_helper<F>{
-                        barrier, std::forward<F>(f), num_images
-                    },
-                    boost::irange(std::size_t(0), num_images),
-                    std::forward<Args>(args)...);
+        return hpx::lcos::local::define_spmd_block(
+            std::forward<ExPolicy>(policy), num_images,
+                std::forward<F>(f), std::forward<Args>(args)...);
     }
 
     // Synchronous version
@@ -154,45 +45,20 @@ namespace hpx { namespace parallel { inline namespace v2
         typename = typename std::enable_if<
             !hpx::parallel::v1::is_async_execution_policy<ExPolicy>::value>::type
         >
-    void
+    inline void
     define_spmd_block(ExPolicy && policy,
         std::size_t num_images, F && f, Args && ... args)
     {
-        static_assert(
-            parallel::execution::is_execution_policy<ExPolicy>::value,
-            "parallel::execution::is_execution_policy<ExPolicy>::value");
-
-        using ftype = typename std::decay<F>::type;
-
-        using first_type =
-            typename hpx::parallel::v2::detail::extract_first_parameter<
-                        decltype(&ftype::operator())>::type;
-
-        using executor_type =
-            typename hpx::util::decay<ExPolicy>::type::executor_type;
-
-        static_assert(std::is_same<spmd_block, first_type>::value,
-            "define_spmd_block() needs a lambda that " \
-            "has at least a spmd_block as 1st argument");
-
-        std::shared_ptr<hpx::lcos::local::barrier> barrier
-            = std::make_shared<hpx::lcos::local::barrier>(num_images);
-
-        hpx::parallel::executor_traits<
-                typename std::decay<executor_type>::type
-            >::bulk_execute(
-                policy.executor(),
-                detail::spmd_block_helper<F>{
-                    barrier, std::forward<F>(f), num_images
-                },
-                boost::irange(std::size_t(0), num_images),
-                std::forward<Args>(args)...);
+        hpx::lcos::local::define_spmd_block(
+            std::forward<ExPolicy>(policy), num_images,
+                std::forward<F>(f), std::forward<Args>(args)...);
     }
 
     template <typename F, typename ... Args>
-    void define_spmd_block(std::size_t num_images, F && f, Args && ... args)
+    inline void define_spmd_block(std::size_t num_images,
+        F && f, Args && ... args)
     {
-        define_spmd_block(parallel::execution::par,
+        hpx::lcos::local::define_spmd_block(parallel::execution::par,
             num_images, std::forward<F>(f), std::forward<Args>(args)...);
     }
 }}}

--- a/hpx/parallel/spmd_block.hpp
+++ b/hpx/parallel/spmd_block.hpp
@@ -32,7 +32,7 @@ namespace hpx { namespace parallel { inline namespace v2
         typename = typename std::enable_if<
             hpx::parallel::v1::is_async_execution_policy<ExPolicy>::value>::type
         >
-    inline std::vector<hpx::future<void>>
+    std::vector<hpx::future<void>>
     define_spmd_block(ExPolicy && policy,
         std::size_t num_images, F && f, Args && ... args)
     {
@@ -46,8 +46,7 @@ namespace hpx { namespace parallel { inline namespace v2
         typename = typename std::enable_if<
             !hpx::parallel::v1::is_async_execution_policy<ExPolicy>::value>::type
         >
-    inline void
-    define_spmd_block(ExPolicy && policy,
+    void define_spmd_block(ExPolicy && policy,
         std::size_t num_images, F && f, Args && ... args)
     {
         hpx::lcos::local::define_spmd_block(
@@ -56,7 +55,7 @@ namespace hpx { namespace parallel { inline namespace v2
     }
 
     template <typename F, typename ... Args>
-    inline void define_spmd_block(std::size_t num_images,
+    void define_spmd_block(std::size_t num_images,
         F && f, Args && ... args)
     {
         hpx::lcos::local::define_spmd_block(parallel::execution::par,

--- a/hpx/parallel/spmd_block.hpp
+++ b/hpx/parallel/spmd_block.hpp
@@ -21,10 +21,11 @@ namespace hpx { namespace parallel { inline namespace v2
     /// The class spmd_block defines an interface for launching
     /// multiple images while giving handles to each image to interact with
     /// the remaining images. The \a define_spmd_block function templates create
-    /// multiple images of a user-defined lambda and launches them in a possibly
-    /// separate thread. A temporary spmd block object is created and diffused
-    /// to each image. The constraint for the lambda given to the
-    /// define_spmd_block function is to accept a spmd_block as first parameter.
+    /// multiple images of a user-defined function (or lambda) and launches them
+    /// in a possibly separate thread. A temporary spmd block object is created
+    /// and diffused to each image. The constraint for the function (or lambda)
+    /// given to the define_spmd_block function is to accept a spmd_block as
+    /// first parameter.
     using spmd_block = hpx::lcos::local::spmd_block;
 
     // Asynchronous version

--- a/hpx/util/first_argument.hpp
+++ b/hpx/util/first_argument.hpp
@@ -1,0 +1,98 @@
+//  Copyright (c) 2017 Antoine Tran Tan
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(FIRST_ARGUMENT_HPP)
+#define FIRST_ARGUMENT_HPP
+
+#include <hpx/traits/is_action.hpp>
+#include <hpx/util/tuple.hpp>
+#include <type_traits>
+
+namespace hpx { namespace util
+{
+    namespace detail {
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Tuple>
+        struct tuple_first_argument;
+
+        template <>
+        struct tuple_first_argument<hpx::util::tuple<>>
+        {
+            using type = std::false_type;
+        };
+
+        template <typename Arg0, typename... Args>
+        struct tuple_first_argument<hpx::util::tuple<Arg0, Args...>>
+        {
+            using type = typename std::decay<Arg0>::type;
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename F>
+        struct function_first_argument;
+
+        template <typename ReturnType>
+        struct function_first_argument<ReturnType(*)()>
+        {
+            using type = std::false_type;
+        };
+
+        template <typename ReturnType, typename Arg0, typename... Args>
+        struct function_first_argument< ReturnType(*)(Arg0, Args...) >
+        {
+            using type = typename std::decay<Arg0>::type;
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename F>
+        struct lambda_first_argument;
+
+        template <typename ClassType, typename ReturnType>
+        struct lambda_first_argument<ReturnType(ClassType::*)() const>
+        {
+            using type = std::false_type;
+        };
+
+        template <typename ClassType,
+            typename ReturnType, typename Arg0, typename... Args>
+        struct lambda_first_argument<
+            ReturnType(ClassType::*)(Arg0, Args...) const>
+        {
+            using type = typename std::decay<Arg0>::type;
+        };
+    }
+
+    template <typename F, typename Enable = void>
+    struct first_argument
+    {};
+
+    // Specialization for actions
+    template <typename F>
+    struct first_argument<F,
+         typename std::enable_if<hpx::traits::is_action<F>::value>::type>
+    : detail::tuple_first_argument<typename F::arguments_type>
+    {};
+
+    // Specialization for functions
+    template <typename F>
+    struct first_argument<F,
+         typename std::enable_if<!hpx::traits::is_action<F>::value
+            && std::is_function<
+                typename std::remove_pointer<F>::type>::value >::type>
+    : detail::function_first_argument<F>
+    {};
+
+    // Specialization for lambdas
+    template <typename F>
+    struct first_argument<F,
+         typename std::enable_if<!hpx::traits::is_action<F>::value
+            && !std::is_function<
+                typename std::remove_pointer<F>::type>::value >::type>
+    : detail::lambda_first_argument<decltype(&F::operator())>
+    {};
+}}
+
+#endif

--- a/tests/unit/lcos/CMakeLists.txt
+++ b/tests/unit/lcos/CMakeLists.txt
@@ -34,6 +34,7 @@ set(tests
     future_then
     future_then_executor
     future_wait
+    global_spmd_block
     local_latch
     local_barrier
     local_dataflow

--- a/tests/unit/lcos/global_spmd_block.cpp
+++ b/tests/unit/lcos/global_spmd_block.cpp
@@ -22,14 +22,14 @@ boost::atomic<std::size_t> c1(0), c2(0);
 void bulk_test_function(hpx::lcos::spmd_block block)
 {
     std::size_t num_images
-        = hpx::get_num_localities(hpx::launch::sync);
+        = hpx::get_num_localities(hpx::launch::sync) * images_per_locality;
 
     HPX_TEST_EQ(block.get_num_images(), num_images);
     HPX_TEST_EQ(block.this_image() < num_images, true);
 
-    for(std::size_t i=0, test_count = 1;
+    for(std::size_t i=0, test_count = images_per_locality;
         i<iterations;
-        i++, test_count++)
+        i++, test_count+=images_per_locality)
     {
         ++c2;
         block.sync_all();

--- a/tests/unit/lcos/global_spmd_block.cpp
+++ b/tests/unit/lcos/global_spmd_block.cpp
@@ -1,0 +1,78 @@
+//  Copyright (c) 2017 Antoine Tran Tan
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_main.hpp>
+#include <hpx/lcos/spmd_block.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <boost/atomic.hpp>
+
+#include <cstddef>
+#include <cstdio>
+#include <iostream>
+#include <utility>
+
+std::size_t images_per_locality = 4;
+std::size_t iterations = 20;
+boost::atomic<std::size_t> c1(0), c2(0);
+
+void bulk_test_function(hpx::lcos::spmd_block block)
+{
+    std::size_t num_images
+        = hpx::get_num_localities(hpx::launch::sync);
+
+    HPX_TEST_EQ(block.get_num_images(), num_images);
+    HPX_TEST_EQ(block.this_image() < num_images, true);
+
+    for(std::size_t i=0, test_count = 1;
+        i<iterations;
+        i++, test_count++)
+    {
+        ++c2;
+        block.sync_all();
+        HPX_TEST_EQ(c2, test_count);
+        block.sync_all();
+    }
+}
+HPX_PLAIN_ACTION(bulk_test_function, bulk_test_action);
+
+
+int main()
+{
+    bulk_test_action act;
+
+    auto bulk_test =
+        [](hpx::lcos::spmd_block block)
+        {
+            std::size_t num_images
+                = hpx::get_num_localities(hpx::launch::sync) * images_per_locality;
+
+            HPX_TEST_EQ(block.get_num_images(), num_images);
+            HPX_TEST_EQ(block.this_image() < num_images, true);
+
+            for(std::size_t i=0, test_count = images_per_locality;
+                i<iterations;
+                i++, test_count+=images_per_locality)
+            {
+                ++c1;
+                block.sync_all();
+                HPX_TEST_EQ(c1, test_count);
+                block.sync_all();
+            }
+        };
+
+    hpx::future<void> join1 =
+        hpx::lcos::define_spmd_block(
+            "block1", images_per_locality, std::move(bulk_test));
+
+    hpx::future<void> join2 =
+        hpx::lcos::define_spmd_block(
+            "block2", images_per_locality, std::move(act));
+
+    hpx::wait_all(join1,join2);
+
+    return 0;
+}

--- a/tests/unit/lcos/global_spmd_block.cpp
+++ b/tests/unit/lcos/global_spmd_block.cpp
@@ -11,8 +11,6 @@
 #include <boost/atomic.hpp>
 
 #include <cstddef>
-#include <cstdio>
-#include <iostream>
 #include <utility>
 
 std::size_t images_per_locality = 4;

--- a/tests/unit/lcos/global_spmd_block.cpp
+++ b/tests/unit/lcos/global_spmd_block.cpp
@@ -15,15 +15,17 @@
 
 std::size_t images_per_locality = 4;
 std::size_t iterations = 20;
+std::size_t test_value = 4;
 boost::atomic<std::size_t> c(0);
 
-void bulk_test_function(hpx::lcos::spmd_block block)
+void bulk_test_function(hpx::lcos::spmd_block block, std::size_t arg)
 {
     std::size_t num_images
         = hpx::get_num_localities(hpx::launch::sync) * images_per_locality;
 
     HPX_TEST_EQ(block.get_num_images(), num_images);
     HPX_TEST_EQ(block.this_image() < num_images, true);
+    HPX_TEST_EQ(arg, test_value * 10);
 
     for(std::size_t i=0, test_count = images_per_locality;
         i<iterations;
@@ -40,11 +42,13 @@ HPX_PLAIN_ACTION(bulk_test_function, bulk_test_action);
 
 int main()
 {
+    std::size_t arg = test_value * 10;
+
     bulk_test_action act;
 
     hpx::future<void> join =
         hpx::lcos::define_spmd_block(
-            "block1", images_per_locality, std::move(act));
+            "block1", images_per_locality, std::move(act), arg );
 
     hpx::wait_all(join);
 

--- a/tests/unit/lcos/global_spmd_block.cpp
+++ b/tests/unit/lcos/global_spmd_block.cpp
@@ -23,6 +23,7 @@ void bulk_test_function(hpx::lcos::spmd_block block, std::size_t arg)
     std::size_t num_images
         = hpx::get_num_localities(hpx::launch::sync) * images_per_locality;
 
+    HPX_TEST_EQ(block.get_images_per_locality(), images_per_locality);
     HPX_TEST_EQ(block.get_num_images(), num_images);
     HPX_TEST_EQ(block.this_image() < num_images, true);
     HPX_TEST_EQ(arg, test_value * 10);

--- a/tests/unit/parallel/spmd_block.cpp
+++ b/tests/unit/parallel/spmd_block.cpp
@@ -19,6 +19,26 @@
 std::size_t num_images = 10;
 std::size_t iterations = 20;
 
+
+void bulk_test_function(hpx::parallel::v2::spmd_block block,
+        boost::atomic<std::size_t> * cptr)
+{
+    boost::atomic<std::size_t> & c = *cptr;
+
+    HPX_TEST_EQ(block.get_num_images(), num_images);
+    HPX_TEST_EQ(block.this_image() < num_images, true);
+
+    for(std::size_t i=0, test_count = num_images;
+        i<iterations;
+        i++, test_count+=num_images)
+    {
+        ++c;
+        block.sync_all();
+        HPX_TEST_EQ(c, test_count);
+        block.sync_all();
+    }
+}
+
 int main()
 {
     using hpx::parallel::execution::par;
@@ -77,7 +97,7 @@ int main()
             }
         };
 
-    boost::atomic<std::size_t> c1(0), c2(0);
+    boost::atomic<std::size_t> c1(0), c2(0), c3(0);
 
     hpx::parallel::v2::define_spmd_block(
         num_images, std::move(bulk_test), &c1);
@@ -88,6 +108,9 @@ int main()
                 num_images, std::move(bulk_test), &c2);
 
     hpx::wait_all(join);
+
+    hpx::parallel::v2::define_spmd_block(
+        num_images, bulk_test_function, &c3);
 
     return 0;
 }


### PR DESCRIPTION
This patch tries to implement a distributed version of `define_spmd_block()`.Here are the following changes:
- local `define_spmd_block()` and local `spmd_block()` have been moved to `hpx::lcos::local`
- `hpx::parallel::v2::spmd_block` is now defined as a type alias
- `hpx::parallel::v2::define_spmd_block()` is now wrapping a call to `hpx::lcos::local::define_spmd_block()`
- global `define_spmd_block()` and global `spmd_block()`  (based on `broadcast` and `hpx::lcos::barrier` ) added and located in `hpx::lcos`