### PR TITLE
Fix cmake soft errors due to failing creation of links on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ include(HPX_Libraries)
 include(HPX_LibraryDir)
 include(HPX_AddConfigTest)
 include(HPX_AddDefinitions)
+include(HPX_CreateSymbolicLink)
 
 hpx_force_out_of_tree_build("This project requires an out-of-source-tree build. See README.rst. Clean your CMake cache and CMakeFiles if this message persists.")
 
@@ -1871,9 +1872,8 @@ endif()
 include(HPX_GeneratePackage)
 
 # Create a symlink in share pointing to the latest HPX installation
-execute_process(COMMAND
-  "${CMAKE_COMMAND}" -E create_symlink "hpx-${HPX_VERSION}" "hpx"
-  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/share")
+create_symbolic_link("${CMAKE_BINARY_DIR}/share/hpx-${HPX_VERSION}"
+                     "${CMAKE_BINARY_DIR}/share/hpx")
 
 message("")
 message("HPX will be installed to ${CMAKE_INSTALL_PREFIX}")

--- a/cmake/HPX_CreateSymbolicLink.cmake
+++ b/cmake/HPX_CreateSymbolicLink.cmake
@@ -1,0 +1,21 @@
+# Copyright (c) 2017 Denis Blank
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# Creates a symbolic link from the destination to the target,
+# if the link doesn't exist yet.
+# Since `create_symlink` is only available for unix derivates,
+# we work around that in this macro.
+macro(create_symbolic_link SYM_TARGET SYM_DESTINATION)
+  if(WIN32)
+    if(NOT EXISTS ${SYM_DESTINATION})
+      # Create a junction for windows links
+      execute_process(COMMAND cmd /C "${CMAKE_SOURCE_DIR}/cmake/scripts/create_symbolic_link.bat"
+                                     ${SYM_DESTINATION} ${SYM_TARGET})
+    endif()
+  else()
+    # Only available on unix derivates
+    execute_process(COMMAND "${CMAKE_COMMAND}" -E create_symlink ${SYM_TARGET} ${SYM_DESTINATION})
+  endif()
+endmacro(create_symbolic_link)

--- a/cmake/scripts/create_symbolic_link.bat
+++ b/cmake/scripts/create_symbolic_link.bat
@@ -1,0 +1,6 @@
+:: Copyright (c) 2017 Denis Blank
+::
+:: Distributed under the Boost Software License, Version 1.0. (See accompanying
+:: file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+mklink /J "%1" "%2"

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -381,20 +381,22 @@ endif()
 
 # Create links to properly view the docs in the build directory
 set(DOCS_OUTPUT_DIR "${CMAKE_BINARY_DIR}/share/hpx-${HPX_VERSION}/docs/html")
+
 execute_process(COMMAND "${CMAKE_COMMAND}" -E make_directory "${DOCS_OUTPUT_DIR}" )
 execute_process(COMMAND "${CMAKE_COMMAND}" -E make_directory "${DOCS_OUTPUT_DIR}/code" )
-execute_process(
-  COMMAND "${CMAKE_COMMAND}" -E create_symlink "${PROJECT_SOURCE_DIR}/docs/html/src" "${DOCS_OUTPUT_DIR}/src")
-execute_process(
-  COMMAND "${CMAKE_COMMAND}" -E create_symlink "${PROJECT_SOURCE_DIR}/docs/html/images" "${DOCS_OUTPUT_DIR}/images")
-execute_process(
-  COMMAND "${CMAKE_COMMAND}" -E create_symlink "${PROJECT_SOURCE_DIR}/hpx" "${DOCS_OUTPUT_DIR}/code/hpx")
-execute_process(
-  COMMAND "${CMAKE_COMMAND}" -E create_symlink "${PROJECT_SOURCE_DIR}/src" "${DOCS_OUTPUT_DIR}/code/src")
-execute_process(
-  COMMAND "${CMAKE_COMMAND}" -E create_symlink "${PROJECT_SOURCE_DIR}/examples" "${DOCS_OUTPUT_DIR}/code/examples")
-execute_process(
-  COMMAND "${CMAKE_COMMAND}" -E create_symlink "${PROJECT_SOURCE_DIR}/tests" "${DOCS_OUTPUT_DIR}/code/tests")
+
+create_symbolic_link("${PROJECT_SOURCE_DIR}/docs/html/src"
+                     "${DOCS_OUTPUT_DIR}/src")
+create_symbolic_link("${PROJECT_SOURCE_DIR}/docs/html/images"
+                     "${DOCS_OUTPUT_DIR}/images")
+create_symbolic_link("${PROJECT_SOURCE_DIR}/hpx"
+                     "${DOCS_OUTPUT_DIR}/code/hpx")
+create_symbolic_link("${PROJECT_SOURCE_DIR}/src"
+                     "${DOCS_OUTPUT_DIR}/code/src")
+create_symbolic_link("${PROJECT_SOURCE_DIR}/examples"
+                     "${DOCS_OUTPUT_DIR}/code/examples")
+create_symbolic_link("${PROJECT_SOURCE_DIR}/tests"
+                     "${DOCS_OUTPUT_DIR}/code/tests")
 
 source_group(Documentation FILES ${base_files})
 source_group("Documentation\\Manual" FILES ${manual_files})


### PR DESCRIPTION
Use cmd under windows to create links
* Prevents errors when generating the documentation
  on windows since cmake doesn't provide the
  `create_symlink` there.

See the following screenshot:
![screenshot_2](https://cloud.githubusercontent.com/assets/1146834/26280414/18751004-3dd3-11e7-9138-55cf4ba7bf23.png)

Further reference of `create_symlink <old> <new>`: https://cmake.org/cmake/help/v3.2/manual/cmake.1.html#unix-specific-command-line-tools

