### PR TITLE
Making sure UNICODE on Windows does not break by default

### DIFF
--- a/hpx/components/iostreams/ostream.hpp
+++ b/hpx/components/iostreams/ostream.hpp
@@ -38,7 +38,7 @@ namespace hpx { namespace iostreams
         struct buffer_sink;
     }
 
-    template <typename Char = char, typename Sink = detail::buffer_sink<char> >
+    template <typename Char = char, typename Sink = detail::buffer_sink<Char> >
     struct ostream;
 
     ///////////////////////////////////////////////////////////////////////////

--- a/hpx/util/logging/defaults.hpp
+++ b/hpx/util/logging/defaults.hpp
@@ -66,15 +66,6 @@ Example:
 
 */
 
-// define HPX_LOG_USE_WCHAR_T if you want your char type to be 'wchar_t'
-
-#if defined(HPX_WINDOWS) && !defined(HPX_LOG_DONOT_USE_WCHAR_T)
-#if defined( UNICODE) || defined(_UNICODE)
-#undef HPX_LOG_USE_WCHAR_T
-#define HPX_LOG_USE_WCHAR_T
-#endif
-#endif
-
     // forward defines
 
     namespace filter {
@@ -94,11 +85,8 @@ Example:
 
     struct default_types
     {
-#ifdef HPX_LOG_USE_WCHAR_T
-        typedef wchar_t char_type;
-#else
         typedef char char_type;
-#endif
+
         // this is the type we use to hold a string, internally
         typedef std::basic_string<char_type> hold_string_type;
 

--- a/hpx/util/logging/detail/scoped_log.hpp
+++ b/hpx/util/logging/detail/scoped_log.hpp
@@ -28,31 +28,15 @@
 namespace hpx { namespace util { namespace logging {
 
 
-#ifndef HPX_LOG_USE_WCHAR_T
-
-#define BOOST_SCOPED_LOG_WITH_CLASS_NAME(logger, msg, class_name) \
+#define HPX_SCOPED_LOG_WITH_CLASS_NAME(logger, msg, class_name) \
 struct class_name { \
     class_name()  { logger ( "start of " msg ) ;} \
     ~class_name() { logger ( "  end of " msg ) ; } \
 } HPX_LOG_CONCATENATE(log_, __LINE__);
 
-#define BOOST_SCOPED_LOG(logger, msg) \
- BOOST_SCOPED_LOG_WITH_CLASS_NAME(logger, msg, \
- HPX_LOG_CONCATENATE(boost_scoped_log,__LINE__) )
-
-#else
-// unicode
-#define BOOST_SCOPED_LOG_WITH_CLASS_NAME(logger, msg, class_name) \
-struct class_name { \
-    class_name()  { logger ( L"start of " msg ) ;} \
-    ~class_name() { logger ( L"  end of " msg ) ; } \
-} HPX_LOG_CONCATENATE(log_, __LINE__);
-
-#define BOOST_SCOPED_LOG(logger, msg) \
- BOOST_SCOPED_LOG_WITH_CLASS_NAME(logger, msg, \
- HPX_LOG_CONCATENATE(boost_scoped_log,__LINE__) )
-
-#endif
+#define HPX_SCOPED_LOG(logger, msg) \
+ HPX_SCOPED_LOG_WITH_CLASS_NAME(logger, msg, \
+ HPX_LOG_CONCATENATE(hpx_scoped_log,__LINE__) )
 
 // default scoped write - in case your gather
 //    class .read_msg().out() returns an STL ostream
@@ -110,7 +94,7 @@ namespace detail {
 
 
 
-#define BOOST_SCOPED_LOG_CTX_IMPL(logger_macro, operator_, class_name) \
+#define HPX_SCOPED_LOG_CTX_IMPL(logger_macro, operator_, class_name) \
 struct class_name : ::hpx::util::logging::detail::scoped_gather_base<> { \
     class_name() : m_is_enabled(false) { } \
     ~class_name() {  if ( m_is_enabled) \
@@ -123,11 +107,11 @@ struct class_name : ::hpx::util::logging::detail::scoped_gather_base<> { \
 
 
 
-// note: to use BOOST_SCOPED_LOG_CTX, you need to #include
+// note: to use HPX_SCOPED_LOG_CTX, you need to #include
 // <hpx/util/logging/gather/ostream_like.hpp>
 //       This is included by default, in #include <hpx/util/logging/format_fwd.hpp>
-#define BOOST_SCOPED_LOG_CTX(logger) \
-BOOST_SCOPED_LOG_CTX_IMPL(logger, << , HPX_LOG_CONCATENATE(boost_scoped_log,__LINE__) )
+#define HPX_SCOPED_LOG_CTX(logger) \
+HPX_SCOPED_LOG_CTX_IMPL(logger, << , HPX_LOG_CONCATENATE(hpx_scoped_log,__LINE__) )
 
 
 }}}

--- a/hpx/util/logging/detail/time_format_holder.hpp
+++ b/hpx/util/logging/detail/time_format_holder.hpp
@@ -153,13 +153,8 @@ public:
 
         // ignore value at index 0
         // - it's there so that I don't have to test for an index being -1
-    #ifdef HPX_LOG_USE_WCHAR_T
-        swprintf( buffer, m_format.c_str(), vals[1], vals[2], vals[3],
-            vals[4], vals[5], vals[6], vals[7], vals[8], vals[9], vals[10] );
-    #else
         sprintf( buffer, m_format.c_str(), vals[1], vals[2], vals[3],
             vals[4], vals[5], vals[6], vals[7], vals[8], vals[9], vals[10] );
-    #endif
     }
 
     void write_time(char_type buffer[], int day, int month, int year,
@@ -175,13 +170,8 @@ public:
 
         // ignore value at index 0
         // - it's there so that I don't have to test for an index being -1
-    #ifdef HPX_LOG_USE_WCHAR_T
-        swprintf( buffer, m_format.c_str(), vals[1], vals[2], vals[3],
-            vals[4], vals[5], vals[6], vals[7]);
-    #else
         sprintf( buffer, m_format.c_str(), vals[1], vals[2], vals[3],
             vals[4], vals[5], vals[6], vals[7] );
-    #endif
     }
 
 private:

--- a/hpx/util/logging/format/destination/defaults.hpp
+++ b/hpx/util/logging/format/destination/defaults.hpp
@@ -38,11 +38,7 @@ template<class convert_dest = do_convert_destination > struct cout_t : is_generi
 hpx::util::logging::op_equal::always_equal {
 
     template<class msg_type> void operator()(const msg_type & msg) const {
-#ifndef HPX_LOG_USE_WCHAR_T
         convert_dest::write(msg, std::cout);
-#else
-        convert_dest::write(msg, std::wcout);
-#endif
     }
 };
 
@@ -54,11 +50,7 @@ template<class convert_dest = do_convert_destination > struct cerr_t : is_generi
 hpx::util::logging::op_equal::always_equal {
 
     template<class msg_type> void operator()(const msg_type & msg) const {
-#ifndef HPX_LOG_USE_WCHAR_T
         convert_dest::write(msg, std::cerr);
-#else
-        convert_dest::write(msg, std::wcerr);
-#endif
     }
 };
 
@@ -115,11 +107,7 @@ hpx::util::logging::op_equal::always_equal {
 
     template<class msg_type> void operator()(const msg_type & msg) const {
 #ifdef HPX_WINDOWS
-#ifndef HPX_LOG_USE_WCHAR_T
     ::OutputDebugStringA( convert_dest::do_convert(msg, into<const char*>() ) );
-#else
-    ::OutputDebugStringW( convert_dest::do_convert(msg, into<const wchar_t*>() ) );
-#endif
 #else
         // non windows - dump to console
         std::cout << msg;

--- a/hpx/util/logging/format/formatter/time_strf.hpp
+++ b/hpx/util/logging/format/formatter/time_strf.hpp
@@ -58,11 +58,7 @@ template<class convert = do_convert_format::prepend> struct time_strf_t : is_gen
         char_type buffer[64];
         ::time_t t = ::time (nullptr);
         ::tm t_details = m_localtime ? *localtime( &t) : *gmtime( &t);
-    #ifdef HPX_LOG_USE_WCHAR_T
-        if (0 != wcsftime (buffer, sizeof (buffer), m_format.c_str (), &t_details))
-    #else
         if (0 != strftime (buffer, sizeof (buffer), m_format.c_str (), &t_details))
-    #endif
             convert::write(buffer, msg);
     }
 

--- a/hpx/util/plugin/detail/dll_windows.hpp
+++ b/hpx/util/plugin/detail/dll_windows.hpp
@@ -162,7 +162,7 @@ namespace hpx { namespace util { namespace plugin {
             // a symbol, the LoadLibrary function increases the refcnt of the dll
             // so in the end the dll class holds one refcnt and so does every
             // symbol.
-            HMODULE handle = ::LoadLibrary(dll_name.c_str());
+            HMODULE handle = ::LoadLibraryA(dll_name.c_str());
             if (!handle) {
                 std::ostringstream str;
                 str << "Hpx.Plugin: Could not open shared library '"
@@ -191,11 +191,11 @@ namespace hpx { namespace util { namespace plugin {
                 if (dll_name.empty()) {
                 // load main module
                     char buffer[_MAX_PATH];
-                    ::GetModuleFileName(nullptr, buffer, sizeof(buffer));
+                    ::GetModuleFileNameA(nullptr, buffer, sizeof(buffer));
                     dll_name = buffer;
                 }
 
-                dll_handle = ::LoadLibrary(dll_name.c_str());
+                dll_handle = ::LoadLibraryA(dll_name.c_str());
                 if (!dll_handle) {
                     std::ostringstream str;
                     str << "Hpx.Plugin: Could not open shared library '"
@@ -222,7 +222,7 @@ namespace hpx { namespace util { namespace plugin {
             if (ec) return buffer;
 
             DWORD name_length =
-                GetModuleFileName(dll_handle, buffer, sizeof(buffer));
+                GetModuleFileNameA(dll_handle, buffer, sizeof(buffer));
 
             if (name_length <= 0) {
                 std::ostringstream str;
@@ -235,7 +235,7 @@ namespace hpx { namespace util { namespace plugin {
             }
 
             // extract the directory name
-            PathRemoveFileSpec(buffer);
+            PathRemoveFileSpecA(buffer);
 
             if (&ec != &throws)
                 ec = make_success_code();

--- a/src/util/find_prefix.cpp
+++ b/src/util/find_prefix.cpp
@@ -128,7 +128,7 @@ namespace hpx { namespace util
         HPX_UNUSED(argv0);
 
         char exe_path[MAX_PATH + 1] = { '\0' };
-        if (!GetModuleFileName(nullptr, exe_path, sizeof(exe_path)))
+        if (!GetModuleFileNameA(nullptr, exe_path, sizeof(exe_path)))
         {
             HPX_THROW_EXCEPTION(hpx::dynamic_link_failure,
                 "get_executable_filename",


### PR DESCRIPTION
- flyby: Fixed typo in iostreams type declaration
- flyby: rename leftover BOOST_ names in logging library