### PR TITLE
This patch makes sure that all parcels in a batch are properly handled

### DIFF
--- a/hpx/runtime/parcelset/detail/parcel_await.hpp
+++ b/hpx/runtime/parcelset/detail/parcel_await.hpp
@@ -32,9 +32,7 @@ namespace hpx { namespace parcelset { namespace detail {
 
         put_parcel_type put_parcel_;
         std::vector<parcel> parcels_;
-        hpx::serialization::detail::preprocess preprocess_;
-        hpx::serialization::output_archive archive_;
-        std::size_t overhead_;
+        int archive_flags_;
         std::size_t idx_;
     };
 }}}


### PR DESCRIPTION
- the split_gids container is not a zombie anymore for anything but the first parcel

@sithhell please verify