### PR TITLE
Hide the `detail` namespace in doxygen per default

### DIFF
--- a/cmake/templates/autodoc.doxy.in
+++ b/cmake/templates/autodoc.doxy.in
@@ -13,4 +13,5 @@ XML_OUTPUT = @doxygen_output_file@
 OUTPUT_DIRECTORY = @doxygen_output_dir@
 GENERATE_LATEX = NO
 INPUT = @doxygen_inputs@
+EXCLUDE_SYMBOLS = detail
 


### PR DESCRIPTION
I tested this through wrapping the `when_all_n` function inside a namespace called `detail` -> the function disappeared from the documentation.