### PR TITLE
Integrate spmd multidimensionnal views for partitioned_vectors

### DIFF
--- a/hpx/components/containers/partitioned_vector/detail/make_index_sequence.hpp
+++ b/hpx/components/containers/partitioned_vector/detail/make_index_sequence.hpp
@@ -1,0 +1,111 @@
+//  Copyright (c) 2017 Antoine Tran Tan
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file hpx/components/partitioned_vector/detail/make_index_sequence.hpp
+
+#ifndef HPX_PARTITIONED_VECTOR_DETAIL_MAKE_INDEX_SEQUENCE_HPP
+#define HPX_PARTITIONED_VECTOR_DETAIL_MAKE_INDEX_SEQUENCE_HPP
+
+namespace hpx {  namespace detail {
+
+    // Unrolled recursive version of make_index_sequence
+
+    template< class T, T... I>
+    class integer_sequence
+    {};
+
+    template< std::size_t N,
+        std::size_t Start = 0,
+        class previous_sequence = integer_sequence<std::size_t>,
+        bool = (N > 8)>
+    struct make_index_sequence;
+
+    template<std::size_t Start, std::size_t... I>
+    struct make_index_sequence<0, Start,
+        integer_sequence<std::size_t, I...>, false>
+    {
+        using type = integer_sequence<std::size_t, I...>;
+    };
+
+    template<std::size_t Start, std::size_t... I>
+    struct make_index_sequence<1, Start,
+        integer_sequence<std::size_t, I...>, false>
+    {
+        using type = integer_sequence<std::size_t, I..., Start>;
+    };
+
+    template<std::size_t Start, std::size_t... I>
+    struct make_index_sequence<2, Start,
+        integer_sequence<std::size_t, I...>, false>
+    {
+        using type = integer_sequence<std::size_t, I..., Start, Start+1>;
+    };
+
+    template<std::size_t Start, std::size_t... I>
+    struct make_index_sequence<3, Start,
+        integer_sequence<std::size_t, I...>, false>
+    {
+        using type
+            = integer_sequence<std::size_t, I..., Start, Start+1, Start+2>;
+    };
+
+    template<std::size_t Start, std::size_t... I>
+    struct make_index_sequence<4, Start,
+        integer_sequence<std::size_t, I...>, false>
+    {
+        using type
+            = integer_sequence<std::size_t, I..., Start, Start+1, Start+2,
+                Start+3>;
+    };
+
+    template<std::size_t Start, std::size_t... I>
+    struct make_index_sequence<5, Start,
+        integer_sequence<std::size_t, I...>, false>
+    {
+        using type
+            = integer_sequence<std::size_t, I..., Start, Start+1, Start+2,
+                Start+3, Start+4>;
+    };
+
+    template<std::size_t Start, std::size_t... I>
+    struct make_index_sequence<6, Start,
+        integer_sequence<std::size_t, I...>, false>
+    {
+        using type
+            = integer_sequence<std::size_t, I..., Start, Start+1, Start+2,
+                Start+3, Start+4, Start+5>;
+    };
+
+    template<std::size_t Start, std::size_t... I>
+    struct make_index_sequence<7, Start,
+        integer_sequence<std::size_t, I...>, false>
+    {
+        using type
+            = integer_sequence<std::size_t, I..., Start, Start+1, Start+2,
+                Start+3, Start+4, Start+5, Start+6>;
+    };
+
+    template<std::size_t Start, std::size_t... I>
+    struct make_index_sequence<8, Start,
+        integer_sequence<std::size_t, I...>, false>
+    {
+        using type
+            = integer_sequence<std::size_t, I..., Start, Start+1,Start+2,
+                Start+3, Start+4, Start+5, Start+6, Start+7>;
+    };
+
+    template<std::size_t Start, std::size_t N, std::size_t... I>
+    struct make_index_sequence<N, Start,
+        integer_sequence<std::size_t, I...>, true>
+    {
+        using type
+            = typename make_index_sequence<N-8, Start+8,
+                integer_sequence<std::size_t, I..., Start, Start+1, Start+2,
+                    Start+3, Start+4, Start+5, Start+6, Start+7>>::type;
+    };
+
+}}
+
+#endif

--- a/hpx/components/containers/partitioned_vector/detail/make_index_sequence.hpp
+++ b/hpx/components/containers/partitioned_vector/detail/make_index_sequence.hpp
@@ -8,6 +8,8 @@
 #ifndef HPX_PARTITIONED_VECTOR_DETAIL_MAKE_INDEX_SEQUENCE_HPP
 #define HPX_PARTITIONED_VECTOR_DETAIL_MAKE_INDEX_SEQUENCE_HPP
 
+#include <cstddef>
+
 namespace hpx {  namespace detail {
 
     // Unrolled recursive version of make_index_sequence

--- a/hpx/components/containers/partitioned_vector/detail/view_element.hpp
+++ b/hpx/components/containers/partitioned_vector/detail/view_element.hpp
@@ -1,0 +1,170 @@
+//  Copyright (c) 2017 Antoine Tran Tan
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file hpx/components/partitioned_vector/partitioned_vector_view.hpp
+
+#ifndef HPX_PARTITIONED_VECTOR_DETAIL_VIEW_ELEMENT_HPP
+#define HPX_PARTITIONED_VECTOR_DETAIL_VIEW_ELEMENT_HPP
+
+#include <hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp>
+#include <hpx/lcos/spmd_block.hpp>
+#include <hpx/runtime/get_locality_id.hpp>
+#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/runtime/naming/name.hpp>
+
+#include <utility>
+#include <cstdint>
+#include <cstdio>
+
+///////////////////////////////////////////////////////////////////////////////
+/// \cond NOINTERNAL
+
+namespace hpx { namespace detail
+{
+    template<typename T, typename Data>
+    struct view_element
+    : public hpx::partitioned_vector_partition<T,Data>
+    {
+        using pvector_iterator = hpx::vector_iterator<T,Data>;
+        using segment_iterator
+            = typename pvector_iterator::segment_iterator;
+        using local_segment_iterator
+            = typename pvector_iterator::local_segment_iterator;
+        using traits
+            = typename hpx::traits::segmented_iterator_traits<pvector_iterator>;
+
+    public:
+        explicit view_element(
+            hpx::lcos::spmd_block const & block,
+                segment_iterator begin, segment_iterator end, segment_iterator it)
+
+        : hpx::partitioned_vector_partition<T,Data>( it->get_id() ), it_(it)
+        {
+            std::uint32_t here = hpx::get_locality_id();
+
+            is_data_here_
+            = ( here == hpx::naming::get_locality_id_from_id(it_->get_id()) );
+
+            is_owned_by_current_thread_ =
+                is_data_here_ && (
+                    (std::distance(
+                        local_segment_iterator(begin.base(),end.base(),here)
+                        ,local_segment_iterator(it_.base(),end.base(),here)
+                        )  %  block.get_images_per_locality() )
+                    == (block.this_image() %  block.get_images_per_locality()) );
+        }
+
+        view_element(view_element const &) = default;
+
+        // Not copy-assygnable
+        view_element& operator=(view_element const &) = delete;
+
+        // But movable
+        view_element(view_element && other) = default;
+
+        // Explicit conversion allows to perform Get operations
+        explicit operator Data() const { return const_data(); }
+
+        // operator overloading (Useful for manual view definition)
+        segment_iterator && operator&()
+        {
+            return std::move(it_);
+
+        }
+
+    private:
+        template<typename, typename>
+        friend class partitioned_vector_local_view_iterator;
+
+        bool is_data_here() const
+        {
+            return is_data_here_;
+        }
+
+        Data const_data() const
+        {
+            if ( is_data_here() )
+            {
+                return this->get_ptr()->get_data();
+            }
+            else
+                return this->get_copied_data(hpx::launch::sync) ;
+        }
+
+        Data & data()
+        {
+            return this->get_ptr()->get_data();
+        }
+
+        Data const & data() const
+        {
+            return this->get_ptr()->get_data();
+        }
+
+        bool is_owned_by_current_thread() const
+        {
+            return is_owned_by_current_thread_;
+        }
+
+    public:
+        // Note: Put operation. Race condition may occur, be sure that
+        // operator=() is called by only one thread at a time.
+        void operator=(Data && other)
+        {
+            if ( is_data_here() )
+            {
+                Data & ref = data();
+
+                HPX_ASSERT_MSG( ref.size() == other.size(), \
+                    "r-value vector has invalid size");
+
+                ref = other;
+            }
+            else
+            {
+                this->set_data(hpx::launch::sync, std::move(other) );
+            }
+        }
+
+        // Note: Put operation. Free of race conditions.
+        void operator=(view_element<T,Data> && other)
+        {
+            if(other.is_owned_by_current_thread())
+            {
+                if( is_data_here() )
+                {
+                    Data & ref = data();
+
+                    HPX_ASSERT_MSG( ref.size() == other.size(),
+                        "Indexed r-value element has " \
+                        "invalid size");
+
+                    ref = other.data();
+                }
+
+                else
+                    this->set_data(hpx::launch::sync, other.const_data() );
+            }
+        }
+
+        T operator[](std::size_t i) const
+        {
+            if( is_data_here() )
+            {
+                return data()[i];
+            }
+
+            else
+                return this->get_value(hpx::launch::sync,i);
+        }
+
+    private:
+        bool is_data_here_;
+        bool is_owned_by_current_thread_;
+        segment_iterator it_;
+    };
+}}
+
+#endif // HPX_PARTITIONED_VECTOR_DETAIL_VIEW_ELEMENT_HPP

--- a/hpx/components/containers/partitioned_vector/detail/view_element.hpp
+++ b/hpx/components/containers/partitioned_vector/detail/view_element.hpp
@@ -9,6 +9,7 @@
 #define HPX_PARTITIONED_VECTOR_DETAIL_VIEW_ELEMENT_HPP
 
 #include <hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp>
+#include <hpx/components/containers/partitioned_vector/partitioned_vector_segmented_iterator.hpp>
 #include <hpx/lcos/spmd_block.hpp>
 #include <hpx/runtime/get_locality_id.hpp>
 #include <hpx/runtime/launch_policy.hpp>
@@ -16,7 +17,7 @@
 
 #include <utility>
 #include <cstdint>
-#include <cstdio>
+#include <cstddef>
 
 ///////////////////////////////////////////////////////////////////////////////
 /// \cond NOINTERNAL

--- a/hpx/components/containers/partitioned_vector/detail/view_element.hpp
+++ b/hpx/components/containers/partitioned_vector/detail/view_element.hpp
@@ -75,9 +75,6 @@ namespace hpx { namespace detail
         }
 
     private:
-        template<typename, typename>
-        friend class partitioned_vector_local_view_iterator;
-
         bool is_data_here() const
         {
             return is_data_here_;
@@ -93,6 +90,7 @@ namespace hpx { namespace detail
                 return this->get_copied_data(hpx::launch::sync) ;
         }
 
+    public:
         Data & data()
         {
             return this->get_ptr()->get_data();
@@ -108,7 +106,6 @@ namespace hpx { namespace detail
             return is_owned_by_current_thread_;
         }
 
-    public:
         // Note: Put operation. Race condition may occur, be sure that
         // operator=() is called by only one thread at a time.
         void operator=(Data && other)

--- a/hpx/components/containers/partitioned_vector/detail/view_element.hpp
+++ b/hpx/components/containers/partitioned_vector/detail/view_element.hpp
@@ -109,7 +109,7 @@ namespace hpx { namespace detail
 
         // Note: Put operation. Race condition may occur, be sure that
         // operator=() is called by only one thread at a time.
-        void operator=(Data && other)
+        view_element && operator=(Data && other)
         {
             if ( is_data_here() )
             {
@@ -124,10 +124,12 @@ namespace hpx { namespace detail
             {
                 this->set_data(hpx::launch::sync, std::move(other) );
             }
+
+            return std::move(*this);
         }
 
         // Note: Put operation. Free of race conditions.
-        void operator=(view_element<T,Data> && other)
+        view_element && operator=(view_element<T,Data> && other)
         {
             if(other.is_owned_by_current_thread())
             {
@@ -145,6 +147,8 @@ namespace hpx { namespace detail
                 else
                     this->set_data(hpx::launch::sync, other.const_data() );
             }
+
+            return std::move(*this);
         }
 
         T operator[](std::size_t i) const

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_local_view.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_local_view.hpp
@@ -1,0 +1,60 @@
+//  Copyright (c) 2017 Antoine Tran Tan
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file hpx/components/partitioned_vector/partitioned_vector_view.hpp
+
+#ifndef HPX_PARTITIONED_VECTOR_LOCAL_VIEW_HPP
+#define HPX_PARTITIONED_VECTOR_LOCAL_VIEW_HPP
+
+#include <hpx/components/containers/partitioned_vector/partitioned_vector_view.hpp>
+#include <hpx/components/containers/partitioned_vector/partitioned_vector_local_view_iterator.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+/// \cond NOINTERNAL
+
+namespace hpx
+{
+    template<typename T, std::size_t N, typename Data>
+    struct partitioned_vector_local_view
+    : public hpx::partitioned_vector_view<T,N,Data>
+    {
+    private:
+        using base_type = hpx::partitioned_vector_view<T,N,Data>;
+        using base_iterator = typename base_type::iterator;
+
+    public:
+        using value_type = T;
+        using iterator = typename
+            hpx::partitioned_vector_local_view_iterator<Data, base_iterator>;
+
+        explicit partitioned_vector_local_view(base_type const & global_pview )
+        : base_type(global_pview)
+        {}
+
+    // Iterator interfaces
+        iterator begin()
+        {
+            base_type & base(*this);
+            return iterator(base.begin(), base.end());
+        }
+
+        iterator end()
+        {
+            base_type & base(*this);
+            return iterator( base.end(), base.end() );
+        }
+
+    };
+
+    template<typename T, std::size_t N, typename Data>
+    partitioned_vector_local_view<T,N,Data>
+    local_view(hpx::partitioned_vector_view<T,N,Data> const & base)
+    {
+        return partitioned_vector_local_view<T,N,Data>( base );
+    }
+
+}
+
+#endif // PARTITIONED_VECTOR_LOCAL_VIEW_HPP

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_local_view.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_local_view.hpp
@@ -11,6 +11,8 @@
 #include <hpx/components/containers/partitioned_vector/partitioned_vector_view.hpp>
 #include <hpx/components/containers/partitioned_vector/partitioned_vector_local_view_iterator.hpp>
 
+#include <cstddef>
+
 ///////////////////////////////////////////////////////////////////////////////
 /// \cond NOINTERNAL
 

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_local_view_iterator.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_local_view_iterator.hpp
@@ -11,6 +11,8 @@
 #include <hpx/components/containers/partitioned_vector/detail/view_element.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 
+#include <utility>
+
 namespace hpx {
 
     template <typename DataType, typename BaseIter>

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_local_view_iterator.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_local_view_iterator.hpp
@@ -1,0 +1,80 @@
+//  Copyright (c) 2017 Antoine Tran Tan
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file hpx/components/partitioned_vector/partitioned_vector_local_view_iterator.hpp
+
+#ifndef PARTITIONED_VECTOR_LOCAL_VIEW_ITERATOR_HPP
+#define PARTITIONED_VECTOR_LOCAL_VIEW_ITERATOR_HPP
+
+#include <hpx/components/containers/partitioned_vector/detail/view_element.hpp>
+#include <boost/iterator/iterator_adaptor.hpp>
+
+namespace hpx {
+
+    template <typename DataType, typename BaseIter>
+    class partitioned_vector_local_view_iterator
+      : public boost::iterator_adaptor<
+            partitioned_vector_local_view_iterator<DataType, BaseIter>,
+            BaseIter,
+            DataType,
+            std::forward_iterator_tag>
+    {
+    private:
+        using base_type
+            = boost::iterator_adaptor<
+                partitioned_vector_local_view_iterator<DataType, BaseIter>,
+                BaseIter,
+                DataType,
+                std::forward_iterator_tag>;
+
+    public:
+        partitioned_vector_local_view_iterator()
+        {}
+
+        explicit partitioned_vector_local_view_iterator(
+            BaseIter && it, BaseIter && end)
+        : base_type( std::forward<BaseIter>(it) ),
+          end_( std::forward<BaseIter>(end) )
+        {
+            satisfy_predicate();
+        }
+
+        bool is_at_end() const
+        {
+            return this->base_reference() == end_;
+        }
+
+    private:
+        friend class boost::iterator_core_access;
+
+        DataType & dereference() const
+        {
+            HPX_ASSERT(!is_at_end());
+            return this->base_reference()->data();
+        }
+
+        void increment()
+        {
+            ++(this->base_reference());
+            satisfy_predicate();
+        }
+
+        void satisfy_predicate()
+        {
+            while(this->base_reference() != end_ &&
+                !this->base_reference()-> is_owned_by_current_thread())
+            {
+                ++( this->base_reference() );
+            }
+        }
+
+    private:
+        BaseIter end_;
+    };
+
+
+}
+
+#endif

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_view.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_view.hpp
@@ -15,10 +15,13 @@
 #include <hpx/lcos/spmd_block.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 
+#include <array>
+#include <cstddef>
 #include <functional>
 #include <initializer_list>
 #include <type_traits>
 #include <vector>
+#include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
 /// \cond NOINTERNAL

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_view.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_view.hpp
@@ -1,0 +1,194 @@
+//  Copyright (c) 2017 Antoine Tran Tan
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file hpx/components/partitioned_vector/partitioned_vector_view.hpp
+
+#ifndef HPX_PARTITIONED_VECTOR_VIEW_HPP
+#define HPX_PARTITIONED_VECTOR_VIEW_HPP
+
+#include <hpx/components/containers/partitioned_vector/detail/make_index_sequence.hpp>
+#include <hpx/components/containers/partitioned_vector/partitioned_vector.hpp>
+#include <hpx/components/containers/partitioned_vector/partitioned_vector_segmented_iterator.hpp>
+#include <hpx/components/containers/partitioned_vector/partitioned_vector_view_iterator.hpp>
+#include <hpx/lcos/spmd_block.hpp>
+#include <hpx/runtime/launch_policy.hpp>
+
+#include <functional>
+#include <initializer_list>
+#include <type_traits>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+/// \cond NOINTERNAL
+
+namespace hpx
+{
+    template<typename T, std::size_t N, typename Data = std::vector<T> >
+    struct partitioned_vector_view
+    {
+    private:
+        // Type aliases
+        using pvector_iterator = hpx::vector_iterator<T,Data>;
+        using segment_iterator = typename pvector_iterator::segment_iterator;
+        using traits
+            = typename hpx::traits::segmented_iterator_traits<pvector_iterator>;
+        using list_type = std::initializer_list<std::size_t>;
+
+        // Small utilities needed for partitioned_vector_view subscripts
+        template<bool ...>
+        struct bools;
+
+        template<typename ... I>
+        struct are_integral
+        : public std::integral_constant< bool,
+            std::is_same<
+                bools<true, std::is_integral<I>::value ...>,
+                bools<std::is_integral<I>::value ...,true > >::value >
+        {};
+
+    public:
+        using iterator
+            = typename hpx::partitioned_vector_view_iterator<T,N,Data>;
+
+        explicit partitioned_vector_view(
+            hpx::lcos::spmd_block const & block,
+            pvector_iterator && v_begin,
+            pvector_iterator && v_last,
+            list_type && sw_sizes,
+            list_type && hw_sizes = {})
+        : partitioned_vector_view(
+            block,
+            traits::segment(std::forward<pvector_iterator>(v_begin)),
+            traits::segment(std::forward<pvector_iterator>(v_last)),
+            std::forward<list_type>(sw_sizes),
+            std::forward<list_type>(hw_sizes))
+        {}
+
+        explicit partitioned_vector_view(
+            hpx::lcos::spmd_block const & block,
+            segment_iterator && begin,
+            segment_iterator && last,
+            list_type sw_sizes,
+            list_type hw_sizes = {})
+        : begin_( begin ), end_( begin ), block_( block )
+        {
+            using indices = typename hpx::detail::make_index_sequence<N>::type;
+
+            // Physical sizes is equal to logical sizes if physical sizes are
+            // not defined
+            list_type & hw_sizes_ = hw_sizes.size() ? hw_sizes : sw_sizes;
+
+            // Check that sizes of the view are valid regarding its dimension
+            HPX_ASSERT_MSG(sw_sizes.size() == N, \
+                "Defined co-sizes must match the partitioned_vector_view " \
+                "dimension");
+
+            // Generate two mixed radix basis
+            fill_basis(hw_sizes_, hw_basis_, indices() );
+            fill_basis(sw_sizes, sw_basis_, indices() );
+
+            // Compute the needed size for the described view
+            std::ptrdiff_t limit = 0;
+            std::size_t idx = 0;
+            for(std::size_t const & i : sw_sizes)
+            {
+                limit += (i-1) * hw_basis_[idx];
+                idx++;
+            }
+
+            // Check that combined sizes doesn't overflow the used space
+            HPX_ASSERT_MSG(limit <= std::distance(begin,last), \
+                "Space dedicated to the described partitioned_vector_view " \
+                "is too small");
+
+            // Update end_
+            end_ += sw_basis_.back();
+        }
+
+    private:
+        // Update view basis from the partitioned_vector_view sizes
+        template<std::size_t... I>
+        void fill_basis(
+            list_type const & sizes,
+            std::array<std::size_t,N+1> & basis,
+            hpx::detail::integer_sequence<std::size_t, I...>) const
+        {
+            basis[0] = 1;
+
+            std::size_t  tmp = 1;
+            auto in  = sizes.begin();
+
+            (void)std::initializer_list<int>{
+                (static_cast<void>( basis[I+1] = tmp *= (*in), in++)
+                , 0)... };
+        }
+
+        template<typename... I>
+        std::size_t offset_solver(I ... index) const
+        {
+            // Check that the subscript is valid regarding the view dimension
+            static_assert( sizeof...(I) == N, \
+                "Subscript must match the partitioned_vector_view " \
+                "dimension");
+
+            // Check that all the elements are of integral type
+            static_assert(
+                partitioned_vector_view::are_integral<I...>::value,
+                "One or more elements in subscript is not integral");
+
+            std::size_t  offset = 0;
+            std::size_t  i = 0;
+
+            (void)std::initializer_list<int>
+            { ( static_cast<void>(
+                    offset +=  ((std::size_t)index) * hw_basis_[i++])
+              , 0 )...
+            };
+
+            // Check that the solved index doesn't overflow the used space
+            HPX_ASSERT_MSG( offset< hw_basis_.back(), \
+                "*Invalid partitioned_vector_view subscript");
+
+            return offset;
+        }
+
+    public:
+        // Subsrcript operator
+        template<typename... I>
+        hpx::detail::view_element<T,Data>
+        operator()(I... index) const
+        {
+            std::size_t offset = offset_solver( index... );
+            return
+                hpx::detail::view_element<T,Data>(
+                    block_, begin_, end_, begin_ + offset);
+        }
+
+        // Iterator interfaces
+        iterator begin()
+        {
+            return iterator( block_
+                           , begin_, end_
+                           , sw_basis_,hw_basis_
+                           , 0);
+        }
+
+        iterator end()
+        {
+            return iterator( block_
+                           , begin_, end_
+                           , sw_basis_, hw_basis_
+                           , sw_basis_.back());
+        }
+
+
+    private:
+        std::array< std::size_t, N+1 > sw_basis_, hw_basis_;
+        segment_iterator begin_, end_;
+        std::reference_wrapper<const hpx::lcos::spmd_block> block_;
+    };
+}
+
+#endif // PARTITIONED_VECTOR_VIEW_HPP

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_view_iterator.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_view_iterator.hpp
@@ -15,6 +15,7 @@
 #include <boost/iterator/iterator_facade.hpp>
 
 #include <array>
+#include <cstddef>
 #include <functional>
 #include <iterator>
 

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_view_iterator.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_view_iterator.hpp
@@ -1,0 +1,131 @@
+//  Copyright (c) 2017 Antoine Tran Tan
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file hpx/components/partitioned_vector/partitioned_vector_view_iterator.hpp
+
+#if !defined(PARTITIONED_VECTOR_VIEW_ITERATOR_HPP)
+#define PARTITIONED_VECTOR_VIEW_ITERATOR_HPP
+
+#include <hpx/components/containers/partitioned_vector/detail/make_index_sequence.hpp>
+#include <hpx/components/containers/partitioned_vector/detail/view_element.hpp>
+#include <hpx/components/containers/partitioned_vector/partitioned_vector_segmented_iterator.hpp>
+
+#include <boost/iterator/iterator_facade.hpp>
+
+#include <array>
+#include <functional>
+#include <iterator>
+
+namespace hpx {
+
+    template<typename T, std::size_t N, typename Data>
+    class partitioned_vector_view_iterator
+    : public boost::iterator_facade<
+                partitioned_vector_view_iterator<T,N,Data>,
+                hpx::detail::view_element<T,Data>,
+                std::random_access_iterator_tag,
+                hpx::detail::view_element<T,Data> >
+    {
+    private:
+        using pvector_iterator = hpx::vector_iterator<T,Data>;
+        using segment_iterator = typename pvector_iterator::segment_iterator;
+        using indices = typename hpx::detail::make_index_sequence<N>::type;
+
+    template<std::size_t... I>
+    std::size_t  increment_solver( std::size_t dist,
+        hpx::detail::integer_sequence<std::size_t, I...> ) const
+    {
+        std::size_t max = N-1;
+        std::size_t offset = 0;
+        std::size_t carry = dist;
+        std::size_t tmp;
+
+        // More expensive than a usual incrementation but did not find another
+        // solution
+        (void)std::initializer_list<int>
+        { ( static_cast<void>(
+                carry   -= tmp = (carry/sw_basis_[max-I]) * sw_basis_[max-I],
+                offset  += (tmp/sw_basis_[max-I]) * hw_basis_[max-I]),
+            0 )...
+        };
+
+        return offset;
+    }
+
+    public:
+        using element_type = hpx::detail::view_element<T,Data>;
+
+        explicit partitioned_vector_view_iterator(
+              hpx::lcos::spmd_block const & block
+            , segment_iterator const & begin
+            , segment_iterator const & end
+            , std::array<std::size_t, N+1> const & sw_basis
+            , std::array<std::size_t, N+1> const & hw_basis
+            , std::size_t count
+            )
+        : block_(block), t_(begin), begin_(begin), end_(end), count_(count)
+        , sw_basis_(sw_basis), hw_basis_(hw_basis)
+        {}
+
+        partitioned_vector_view_iterator(
+            partitioned_vector_view_iterator const &) = default;
+
+        partitioned_vector_view_iterator(
+            partitioned_vector_view_iterator &&) = default;
+
+        // Note : partitioned_vector_view_iterator is not assignable
+        // because it owns references members
+        partitioned_vector_view_iterator
+        operator=(partitioned_vector_view_iterator const &) = delete;
+
+        partitioned_vector_view_iterator
+        operator=(partitioned_vector_view_iterator &&) = delete;
+
+    private:
+        friend class boost::iterator_core_access;
+
+        void increment()
+        {
+            std::size_t offset = increment_solver(++count_, indices() );
+            t_ = begin_ + offset;
+        }
+
+        void decrement()
+        {
+            std::size_t offset = increment_solver(--count_, indices() );
+            t_ = begin_ + offset;
+        }
+
+        void advance(std::size_t n)
+        {
+            std::size_t offset = increment_solver(count_+=n, indices() );
+            t_ = begin_ + offset;
+        }
+
+        bool equal(partitioned_vector_view_iterator const& other) const
+        {
+            return this->count_ == other.count_;
+        }
+
+        // Will not return a datatype but a view_element type
+        element_type dereference() const
+        {
+            return hpx::detail::view_element<T,Data>(block_,begin_,end_,t_);
+        }
+
+        std::ptrdiff_t distance_to(partitioned_vector_view_iterator const& other) const
+        {
+            return other.count_ - count_;
+        }
+
+        hpx::lcos::spmd_block const & block_;
+        segment_iterator t_, begin_, end_;
+        std::size_t count_;
+        std::array< std::size_t, N+1 > const & sw_basis_;
+        std::array< std::size_t, N+1 > const & hw_basis_;
+    };
+}
+
+#endif

--- a/tests/unit/component/CMakeLists.txt
+++ b/tests/unit/component/CMakeLists.txt
@@ -35,6 +35,9 @@ set(tests
     partitioned_vector_fill
     partitioned_vector_inclusive_scan
     partitioned_vector_exclusive_scan
+    partitioned_vector_view
+    partitioned_vector_view_iterator
+    partitioned_vector_subview
    )
 
 if(HPX_WITH_EXECUTOR_COMPATIBILITY)
@@ -130,10 +133,19 @@ set(partitioned_vector_inclusive_scan_PARAMETERS
     LOCALITIES 2
     THREADS_PER_LOCALITY 4)
 
-set(partitioned_vector_exclusive_sacn_FLAGS DEPENDENCIES partitioned_vector_component)
+set(partitioned_vector_exclusive_scan_FLAGS DEPENDENCIES partitioned_vector_component)
 set(partitioned_vector_exclusive_scan_PARAMETERS
     LOCALITIES 2
     THREADS_PER_LOCALITY 4)
+
+set(partitioned_vector_view_FLAGS DEPENDENCIES partitioned_vector_component)
+set(partitioned_vector_view_PARAMETERS THREADS_PER_LOCALITY 4)
+
+set(partitioned_vector_view_iterator_FLAGS DEPENDENCIES partitioned_vector_component)
+set(partitioned_vector_view_iterator_PARAMETERS THREADS_PER_LOCALITY 4)
+
+set(partitioned_vector_subview_FLAGS DEPENDENCIES partitioned_vector_component)
+set(partitioned_vector_subview_PARAMETERS THREADS_PER_LOCALITY 4)
 
 foreach(test ${tests})
   set(sources

--- a/tests/unit/component/partitioned_vector_subview.cpp
+++ b/tests/unit/component/partitioned_vector_subview.cpp
@@ -12,6 +12,7 @@
 #include <hpx/util/lightweight_test.hpp>
 
 #include <cstddef>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/tests/unit/component/partitioned_vector_subview.cpp
+++ b/tests/unit/component/partitioned_vector_subview.cpp
@@ -1,0 +1,119 @@
+//  Copyright (c) 2017 Antoine Tran Tan
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/components/containers/partitioned_vector/partitioned_vector_view.hpp>
+#include <hpx/components/containers/partitioned_vector/partitioned_vector_local_view.hpp>
+#include <hpx/include/partitioned_vector.hpp>
+#include <hpx/lcos/spmd_block.hpp>
+
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+// Define the vector types to be used.
+HPX_REGISTER_PARTITIONED_VECTOR(double);
+
+void bulk_test( hpx::lcos::spmd_block block,
+                std::size_t N,
+                std::size_t tile,
+                std::size_t elt_size,
+                std::string vec_name)
+{
+    using const_iterator
+        = typename std::vector<double>::const_iterator;
+    using vector_type
+        = hpx::partitioned_vector<double>;
+    using view_type
+        = hpx::partitioned_vector_view<double,2>;
+
+    vector_type my_vector;
+    my_vector.connect_to(hpx::launch::sync, vec_name);
+
+    view_type my_view(block,
+        my_vector.begin(), my_vector.end(), {N,N});
+
+    std::size_t idx = 0;
+
+    for (std::size_t j = 0; j<N; j+=tile)
+    for (std::size_t i = 0; i<N; i+=tile)
+    {
+        view_type my_subview ( block,
+            & my_view(i,j), & my_view(i+tile-1,j+tile-1),
+            {tile,tile},
+            {N,N} );
+
+        for ( auto & v : hpx::local_view(my_subview) )
+        {
+            v = std::vector<double>( elt_size, double(idx) );
+        }
+
+        idx++;
+    }
+
+    block.sync_all();
+
+    if(block.this_image() == 0)
+    {
+        int idx = 0;
+
+        for (std::size_t j = 0; j<N; j+=tile)
+        for (std::size_t i = 0; i<N; i+=tile)
+        {
+            std::vector<double> result( elt_size, double(idx) );
+
+            for (std::size_t jj = j, jj_end = j+tile; jj< jj_end; jj++)
+            for (std::size_t ii = i, ii_end = i+tile; ii< ii_end; ii++)
+            {
+                // It's a Get operation
+                std::vector<double> value =
+                    (std::vector<double>)my_view(ii,jj);
+
+                const_iterator it1 = result.begin(),
+                    it2 = value.begin();
+
+                const_iterator end1 = result.end(),
+                    end2 = value.end();
+
+                for (; it1 != end1 && it2 != end2; ++it1, ++it2)
+                {
+                    HPX_TEST_EQ(*it1, *it2);
+                }
+            }
+            idx++;
+        }
+    }
+
+}
+HPX_PLAIN_ACTION(bulk_test, bulk_test_action);
+
+int main()
+{
+    using vector_type
+        = hpx::partitioned_vector<double>;
+
+    std::size_t N        = 40;
+    std::size_t tile     = 10;
+    std::size_t elt_size = 8;
+
+    std::size_t raw_size = N*N*elt_size;
+
+    vector_type my_vector(raw_size,
+        hpx::container_layout( N*N, hpx::find_all_localities() ));
+
+    std::string vec_name("my_vector");
+    my_vector.register_as(hpx::launch::sync, vec_name);
+
+    hpx::future<void> join =
+        hpx::lcos::define_spmd_block("block", 4, bulk_test_action(),
+            N, tile, elt_size, vec_name);
+
+    join.get();
+
+    return 0;
+}

--- a/tests/unit/component/partitioned_vector_view.cpp
+++ b/tests/unit/component/partitioned_vector_view.cpp
@@ -13,6 +13,7 @@
 #include <hpx/util/lightweight_test.hpp>
 
 #include <cstddef>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/tests/unit/component/partitioned_vector_view.cpp
+++ b/tests/unit/component/partitioned_vector_view.cpp
@@ -1,0 +1,332 @@
+//  Copyright (c) 2017 Antoine Tran Tan
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/components/containers/partitioned_vector/partitioned_vector_view.hpp>
+#include <hpx/components/containers/partitioned_vector/partitioned_vector_local_view.hpp>
+#include <hpx/include/partitioned_vector.hpp>
+#include <hpx/lcos/spmd_block.hpp>
+#include <hpx/parallel/execution_policy.hpp>
+
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+// Define the vector types to be used.
+HPX_REGISTER_PARTITIONED_VECTOR(double);
+
+void bulk_test( hpx::lcos::spmd_block block,
+                std::size_t height,
+                std::size_t width,
+                std::size_t local_height,
+                std::size_t local_width,
+                std::size_t local_leading_dimension,
+                std::string in_name,
+                std::string out_name
+              )
+{
+    using const_iterator
+        = typename std::vector<double>::const_iterator;
+
+    using vector_type
+        = hpx::partitioned_vector<double>;
+
+    using view_type
+        = hpx::partitioned_vector_view<double,2>;
+
+    vector_type vector_in;
+    vector_type vector_out;
+
+    vector_in.connect_to(hpx::launch::sync, in_name);
+    vector_out.connect_to(hpx::launch::sync, out_name);
+
+    view_type in(block, vector_in.begin(), vector_in.end(), {height,width});
+    view_type out(block, vector_out.begin(), vector_out.end(), {height,width});
+
+    // Ensure that only one image is doing put operations
+    if(block.this_image() == 0)
+    {
+        std::size_t idx = 0;
+
+        // traverse all the indexed elements
+        for (auto && v : in)
+        {
+            std::vector<double> data(local_height * local_width);
+            std::size_t local_idx = 0;
+
+            for( double & d : data)
+            {
+                d = idx + local_idx++;
+            }
+
+            // Put operation
+            v = std::move(data);
+            idx ++;
+        }
+    }
+
+    block.sync_all();
+
+    // Outer Transpose operation
+    for (std::size_t j = 0; j<width; j++)
+    for (std::size_t i = 0; i<height; i++)
+    {
+        // Put operation
+        out(j,i) =  in(i,j);
+    }
+
+    block.sync_all();
+
+    // Inner Transpose operation
+    for ( auto & v : hpx::local_view(out) )
+    {
+        for (std::size_t jj = 0; jj<local_width-1;  jj++)
+        for (std::size_t ii = jj+1; ii<local_height; ii++)
+        {
+            std::swap( v[jj + ii*local_leading_dimension]
+                     , v[ii + jj*local_leading_dimension]
+                     );
+        }
+    }
+
+    block.sync_all();
+
+    // Test the result of the computation
+    if(block.this_image() == 0)
+    {
+        int idx = 0;
+        std::vector<double> result(local_height * local_width);
+
+        for (std::size_t j = 0; j<width; j++)
+        for (std::size_t i = 0; i<height; i++)
+        {
+            std::size_t local_idx = 0;
+
+            for( double & r : result)
+            {
+                r = idx + local_idx++;
+            }
+
+            // transpose the guess result
+            for (std::size_t jj = 0; jj<local_width-1;  jj++)
+            for (std::size_t ii = jj+1; ii<local_height; ii++)
+            {
+                std::swap( result[jj + ii*local_leading_dimension]
+                         , result[ii + jj*local_leading_dimension]
+                         );
+            }
+
+            // It's a Get operation
+            std::vector<double> value = (std::vector<double>)out(j,i);
+
+            const_iterator it1 = result.begin(), it2 = value.begin();
+            const_iterator end1 = result.end(), end2 = value.end();
+
+            for (; it1 != end1 && it2 != end2; ++it1, ++it2)
+            {
+                HPX_TEST_EQ(*it1, *it2);
+            }
+
+            idx++;
+        }
+
+    }
+}
+HPX_PLAIN_ACTION(bulk_test, bulk_test_action);
+
+void async_bulk_test( hpx::lcos::spmd_block block,
+                      std::size_t height,
+                      std::size_t width,
+                      std::size_t local_height,
+                      std::size_t local_width,
+                      std::size_t local_leading_dimension,
+                      std::string in_name,
+                      std::string out_name
+                    )
+{
+    using const_iterator
+        = typename std::vector<double>::const_iterator;
+
+    using vector_type
+        = hpx::partitioned_vector<double>;
+
+    using view_type
+        = hpx::partitioned_vector_view<double,2,std::vector<double>>;
+
+    vector_type vector_in;
+    vector_type vector_out;
+
+    vector_in.connect_to(hpx::launch::sync, in_name);
+    vector_out.connect_to(hpx::launch::sync, out_name);
+
+    view_type in(block, vector_in.begin(), vector_in.end(), {height,width});
+    view_type out(block, vector_out.begin(), vector_out.end(), {height,width});
+
+    // Ensure that only one image is doing put operations
+    if(block.this_image() == 0)
+    {
+        std::size_t idx = 0;
+
+        // traverse all the indexed elements
+        for (auto && v : in)
+        {
+            std::vector<double> data(local_height * local_width);
+            std::size_t local_idx = 0;
+
+            for( double & d : data)
+            {
+                d = idx + local_idx++;
+            }
+
+            // Put operation
+            v = std::move(data);
+            idx ++;
+        }
+    }
+
+    block.sync_all(hpx::launch::async)
+    .then(
+        [&block, &in, &out, width, height, local_width, local_height,
+            local_leading_dimension] (hpx::future<void> event)
+        {
+            event.get();
+
+            // Outer Transpose operation
+            for (std::size_t j = 0; j<width; j++)
+            for (std::size_t i = 0; i<height; i++)
+            {
+                // It's a Put operation
+                out(j,i) = in(i,j);
+            }
+
+            return block.sync_all(hpx::launch::async);
+        })
+    .then(
+        [&block, &in, &out, width, height, local_width, local_height,
+            local_leading_dimension] (hpx::future<void> event)
+        {
+            event.get();
+
+            // Inner Transpose operation
+            for ( auto & v : hpx::local_view(out) )
+            {
+                for (std::size_t jj = 0; jj<local_width-1;  jj++)
+                for (std::size_t ii = jj+1; ii<local_height; ii++)
+                {
+                    std::swap( v[jj + ii*local_leading_dimension]
+                             , v[ii + jj*local_leading_dimension]
+                             );
+                }
+            }
+
+            return block.sync_all(hpx::launch::async);
+        })
+    .then(
+        [&block, &in, &out, width, height, local_width, local_height,
+            local_leading_dimension] (hpx::future<void> event)
+        {
+            event.get();
+
+            // Test the result of the computation
+            if(block.this_image() == 0)
+            {
+                int idx = 0;
+                std::vector<double> result(local_height * local_width);
+
+                for (std::size_t j = 0; j<width; j++)
+                for (std::size_t i = 0; i<height; i++)
+                {
+                    std::size_t local_idx = 0;
+
+                    for( double & r : result)
+                    {
+                        r = idx + local_idx++;
+                    }
+
+                    // transpose the guess result
+                    for (std::size_t jj = 0; jj<local_width-1;  jj++)
+                    for (std::size_t ii = jj+1; ii<local_height; ii++)
+                    {
+                        std::swap( result[jj + ii*local_leading_dimension]
+                                 , result[ii + jj*local_leading_dimension]
+                                 );
+                    }
+
+                    // It's a Get operation
+                    std::vector<double> value =
+                        (std::vector<double>)out(j,i);
+
+                    const_iterator it1 = result.begin(), it2 = value.begin();
+                    const_iterator end1 = result.end(), end2 = value.end();
+
+                    for (; it1 != end1 && it2 != end2; ++it1, ++it2)
+                    {
+                        HPX_TEST_EQ(*it1, *it2);
+                    }
+
+                    idx++;
+                }
+
+            }
+        })
+    .get();
+}
+HPX_PLAIN_ACTION(async_bulk_test, async_bulk_test_action);
+
+int main()
+{
+    using vector_type
+        = hpx::partitioned_vector<double>;
+
+    const std::size_t height = 16;
+    const std::size_t width  = 16;
+
+    std::size_t local_height = 16;
+    std::size_t local_width  = 16;
+    std::size_t local_leading_dimension  = local_height;
+
+    std::size_t raw_size = (height*width)*(local_height*local_width);
+
+    auto layout =
+        hpx::container_layout( height*width, hpx::find_all_localities() );
+
+    // Vector instanciations for test 1
+    vector_type in1(raw_size, layout);
+    vector_type out1(raw_size, layout);
+
+    std::string in1_name("in1");
+    std::string out1_name("out1");
+
+    in1.register_as(hpx::launch::sync, in1_name);
+    out1.register_as(hpx::launch::sync, out1_name);
+
+    // Vector instanciations for test 2
+    vector_type in2(raw_size, layout);
+    vector_type out2(raw_size, layout);
+
+    std::string in2_name("in2");
+    std::string out2_name("out2");
+
+    in2.register_as(hpx::launch::sync, in2_name);
+    out2.register_as(hpx::launch::sync, out2_name);
+
+    // Launch tests
+    hpx::future<void> join1 =
+        hpx::lcos::define_spmd_block("block1", 4, bulk_test_action(),
+            height, width, local_height, local_width, local_leading_dimension,
+                in1_name, out1_name);
+
+    hpx::future<void> join2 =
+        hpx::lcos::define_spmd_block("block2", 4, async_bulk_test_action(),
+            height, width, local_height, local_width, local_leading_dimension,
+                in2_name, out2_name);
+
+    hpx::wait_all(join1,join2);
+
+    return 0;
+}

--- a/tests/unit/component/partitioned_vector_view_iterator.cpp
+++ b/tests/unit/component/partitioned_vector_view_iterator.cpp
@@ -49,7 +49,7 @@ void bulk_test( hpx::lcos::spmd_block block,
         for (auto && v : my_view)
         {
             // It's a Put operation
-            v = std::vector<double>(4,idx++);
+            v = std::vector<double>(elt_size,idx++);
         }
     }
 

--- a/tests/unit/component/partitioned_vector_view_iterator.cpp
+++ b/tests/unit/component/partitioned_vector_view_iterator.cpp
@@ -12,6 +12,7 @@
 #include <hpx/util/lightweight_test.hpp>
 
 #include <cstddef>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/tests/unit/component/partitioned_vector_view_iterator.cpp
+++ b/tests/unit/component/partitioned_vector_view_iterator.cpp
@@ -1,0 +1,116 @@
+//  Copyright (c) 2017 Antoine Tran Tan
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/components/containers/partitioned_vector/partitioned_vector_view.hpp>
+#include <hpx/components/containers/partitioned_vector/partitioned_vector_local_view.hpp>
+#include <hpx/include/partitioned_vector.hpp>
+#include <hpx/lcos/spmd_block.hpp>
+
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+// Define the vector types to be used.
+HPX_REGISTER_PARTITIONED_VECTOR(double);
+
+void bulk_test( hpx::lcos::spmd_block block,
+                std::size_t size_x,
+                std::size_t size_y,
+                std::size_t size_z,
+                std::size_t elt_size,
+                std::string vec_name)
+{
+    using const_iterator
+        = typename std::vector<double>::const_iterator;
+    using vector_type
+        = hpx::partitioned_vector<double>;
+    using view_type
+        = hpx::partitioned_vector_view<double,3>;
+
+    vector_type my_vector;
+    my_vector.connect_to(hpx::launch::sync, vec_name);
+
+    view_type my_view(block,
+        my_vector.begin(), my_vector.end(), {size_x,size_y,size_z});
+
+    int idx = 0;
+
+    // Ensure that only one image is putting data into the different
+    // partitions
+    if(block.this_image() == 0)
+    {
+        // Traverse all the co-indexed elements
+        for (auto && v : my_view)
+        {
+            // It's a Put operation
+            v = std::vector<double>(4,idx++);
+        }
+    }
+
+    block.sync_all();
+
+    if(block.this_image() == 0)
+    {
+        int idx = 0;
+
+        for (std::size_t k = 0; k<size_z; k++)
+            for (std::size_t j = 0; j<size_y; j++)
+                for (std::size_t i = 0; i<size_x; i++)
+                {
+                    std::vector<double> result(elt_size,idx);
+
+                    // It's a Get operation
+                    std::vector<double> value =
+                        (std::vector<double>)my_view(i,j,k);
+
+                    const_iterator it1 = result.begin(),
+                        it2 = value.begin();
+
+                    const_iterator end1 = result.end(),
+                        end2 = value.end();
+
+                    for (; it1 != end1 && it2 != end2; ++it1, ++it2)
+                    {
+                        HPX_TEST_EQ(*it1, *it2);
+                    }
+
+                    idx++;
+                }
+    }
+}
+HPX_PLAIN_ACTION(bulk_test, bulk_test_action);
+
+int main()
+{
+    using vector_type
+        = hpx::partitioned_vector<double>;
+
+    const std::size_t size_x = 32;
+    const std::size_t size_y = 4;
+    const std::size_t size_z = hpx::get_num_localities(hpx::launch::sync);
+
+    const std::size_t elt_size = 4;
+    const std::size_t num_partitions  = size_x*size_y*size_z;
+
+    std::size_t raw_size = num_partitions*elt_size;
+
+    vector_type my_vector(raw_size,
+        hpx::container_layout( num_partitions, hpx::find_all_localities() ));
+
+    std::string vec_name("my_vector");
+    my_vector.register_as(hpx::launch::sync, vec_name);
+
+    hpx::future<void> join =
+        hpx::lcos::define_spmd_block("block", 4, bulk_test_action(),
+            size_x, size_y, size_z, elt_size, vec_name);
+
+    join.get();
+
+    return 0;
+}


### PR DESCRIPTION
This PR proposes to add _spmd multidimensionnal view_ functionalities to manage segments of `partitioned_vector`. The added features include:
- View constructions from` partitioned_vector` iterators : 
example: `hpx::partitioned_vector_view<double,2> view (block, v.begin(), v.end(), {height,width} )`, with `block ` being a `spmd_block`, `v` being a `partitioned_vector` and height and width being integral values
- _Put_ operations (in MPI sense) allowed via the expression `a(i,j) = b(i,j)` or ` a(i,j) = some_std_vector`
- _Get_ operations (in MPI sense) allowed via an explicit conversion : 
`std::vector<T> v = ( std::vector<T> ) a(i,j)`
- _iterators_ to iterate globally (or locally) over the segments covered by the view