### PR TITLE
C++17 invoke forms

### DIFF
--- a/hpx/apply.hpp
+++ b/hpx/apply.hpp
@@ -42,7 +42,7 @@ namespace hpx { namespace detail
         template <typename F, typename ...Ts>
         HPX_FORCEINLINE static
         typename std::enable_if<
-            traits::detail::is_deferred_callable<F(Ts&&...)>::value,
+            traits::detail::is_deferred_invocable<F, Ts...>::value,
             bool
         >::type
         call(F&& f, Ts&&... ts)
@@ -65,7 +65,7 @@ namespace hpx { namespace detail
         template <typename F, typename ...Ts>
         HPX_FORCEINLINE static
         typename std::enable_if<
-            traits::detail::is_deferred_callable<F(Ts&&...)>::value,
+            traits::detail::is_deferred_invocable<F, Ts...>::value,
             bool
         >::type
         call(Executor& sched, F&& f, Ts&&... ts)
@@ -88,7 +88,7 @@ namespace hpx { namespace detail
         template <typename F, typename ...Ts>
         HPX_FORCEINLINE static
         typename std::enable_if<
-            traits::detail::is_deferred_callable<F(Ts&&...)>::value,
+            traits::detail::is_deferred_invocable<F, Ts...>::value,
             bool
         >::type
         call(Executor& exec, F&& f, Ts&&... ts)
@@ -111,7 +111,7 @@ namespace hpx { namespace detail
         template <typename F, typename ...Ts>
         HPX_FORCEINLINE static
         typename std::enable_if<
-            traits::detail::is_deferred_callable<F(Ts&&...)>::value,
+            traits::detail::is_deferred_invocable<F, Ts...>::value,
             bool
         >::type
         call(Executor& exec, F && f, Ts &&... ts)

--- a/hpx/async.hpp
+++ b/hpx/async.hpp
@@ -110,7 +110,7 @@ namespace hpx { namespace detail
         template <typename F, typename ...Ts>
         HPX_FORCEINLINE static
         typename std::enable_if<
-            traits::detail::is_deferred_callable<F&&(Ts&&...)>::value,
+            traits::detail::is_deferred_invocable<F, Ts...>::value,
             hpx::future<
                 typename util::detail::deferred_result_of<F&&(Ts&&...)>::type
             >
@@ -145,7 +145,7 @@ namespace hpx { namespace detail
         template <typename F, typename ...Ts>
         HPX_FORCEINLINE static
         typename std::enable_if<
-            traits::detail::is_deferred_callable<F&&(Ts&&...)>::value,
+            traits::detail::is_deferred_invocable<F, Ts...>::value,
             hpx::future<
                 typename util::detail::deferred_result_of<F&&(Ts&&...)>::type
             >
@@ -163,7 +163,7 @@ namespace hpx { namespace detail
         template <typename F, typename ...Ts>
         HPX_FORCEINLINE static
         typename std::enable_if<
-            traits::detail::is_deferred_callable<F&&(Ts&&...)>::value,
+            traits::detail::is_deferred_invocable<F, Ts...>::value,
             hpx::future<
                 typename util::detail::deferred_result_of<F&&(Ts&&...)>::type
             >
@@ -183,7 +183,7 @@ namespace hpx { namespace detail
         template <typename F, typename ...Ts>
         HPX_FORCEINLINE static
         typename std::enable_if<
-            traits::detail::is_deferred_callable<F&&(Ts&&...)>::value,
+            traits::detail::is_deferred_invocable<F, Ts...>::value,
             hpx::future<
                 typename util::detail::deferred_result_of<F&&(Ts&&...)>::type
             >
@@ -205,7 +205,7 @@ namespace hpx { namespace detail
         template <typename F, typename ...Ts>
         HPX_FORCEINLINE static
         typename std::enable_if<
-            traits::detail::is_deferred_callable<F&&(Ts&&...)>::value,
+            traits::detail::is_deferred_invocable<F, Ts...>::value,
             hpx::future<
                 typename util::detail::deferred_result_of<F&&(Ts&&...)>::type
             >
@@ -230,7 +230,7 @@ namespace hpx { namespace detail
         template <typename F, typename ...Ts>
         HPX_FORCEINLINE static
         typename std::enable_if<
-            traits::detail::is_deferred_callable<F&&(Ts&&...)>::value,
+            traits::detail::is_deferred_invocable<F, Ts...>::value,
             hpx::future<
                 typename util::detail::deferred_result_of<F&&(Ts&&...)>::type
             >
@@ -252,7 +252,7 @@ namespace hpx { namespace detail
         template <typename Executor_, typename F, typename ...Ts>
         HPX_FORCEINLINE static
         typename std::enable_if<
-            traits::detail::is_deferred_callable<F&&(Ts&&...)>::value,
+            traits::detail::is_deferred_invocable<F, Ts...>::value,
             hpx::future<
                 typename util::detail::deferred_result_of<F&&(Ts&&...)>::type
             >
@@ -282,7 +282,7 @@ namespace hpx { namespace detail
         template <typename F, typename ...Ts>
         HPX_FORCEINLINE static
         typename std::enable_if<
-            traits::detail::is_deferred_callable<F&&(Ts&&...)>::value,
+            traits::detail::is_deferred_invocable<F, Ts...>::value,
             hpx::future<
                 typename util::detail::deferred_result_of<F&&(Ts&&...)>::type
             >
@@ -306,7 +306,7 @@ namespace hpx { namespace detail
         template <typename Executor_, typename F, typename ...Ts>
         HPX_FORCEINLINE static
         typename std::enable_if<
-            traits::detail::is_deferred_callable<F&&(Ts&&...)>::value,
+            traits::detail::is_deferred_invocable<F, Ts...>::value,
             hpx::future<
                 typename util::detail::deferred_result_of<F&&(Ts&&...)>::type
             >

--- a/hpx/async.hpp
+++ b/hpx/async.hpp
@@ -51,13 +51,13 @@ namespace hpx { namespace detail
     HPX_FORCEINLINE
     typename util::lazy_enable_if<
         std::is_reference<
-            typename util::detail::deferred_result_of<F&&()>::type
+            typename util::detail::invoke_deferred_result<F>::type
         >::value
       , detail::create_future<F&&()>
     >::type
     call_sync(F&& f, std::false_type)
     {
-        typedef typename util::detail::deferred_result_of<F&&()>::type result_type;
+        typedef typename util::detail::invoke_deferred_result<F>::type result_type;
         try
         {
             return lcos::make_ready_future(std::ref(f()));
@@ -71,13 +71,13 @@ namespace hpx { namespace detail
     HPX_FORCEINLINE
     typename util::lazy_enable_if<
        !std::is_reference<
-            typename util::detail::deferred_result_of<F&&()>::type
+            typename util::detail::invoke_deferred_result<F>::type
         >::value
       , detail::create_future<F()>
     >::type
     call_sync(F&& f, std::false_type) //-V659
     {
-        typedef typename util::detail::deferred_result_of<F()>::type result_type;
+        typedef typename util::detail::invoke_deferred_result<F>::type result_type;
         try
         {
             return lcos::make_ready_future(f());
@@ -112,14 +112,13 @@ namespace hpx { namespace detail
         typename std::enable_if<
             traits::detail::is_deferred_invocable<F, Ts...>::value,
             hpx::future<
-                typename util::detail::deferred_result_of<F&&(Ts&&...)>::type
+                typename util::detail::invoke_deferred_result<F, Ts...>::type
             >
         >::type
         call(launch policy, F && f, Ts&&... ts)
         {
-            typedef typename util::detail::deferred_result_of<
-                    F(Ts&&...)
-                >::type result_type;
+            typedef typename util::detail::invoke_deferred_result<F, Ts...>::type
+                result_type;
 
             if (policy == launch::sync)
             {
@@ -147,12 +146,12 @@ namespace hpx { namespace detail
         typename std::enable_if<
             traits::detail::is_deferred_invocable<F, Ts...>::value,
             hpx::future<
-                typename util::detail::deferred_result_of<F&&(Ts&&...)>::type
+                typename util::detail::invoke_deferred_result<F, Ts...>::type
             >
         >::type
         call(hpx::detail::sync_policy, F && f, Ts&&... ts)
         {
-            typedef typename util::detail::deferred_result_of<F(Ts&&...)>::type
+            typedef typename util::detail::invoke_deferred_result<F, Ts...>::type
                 result_type;
 
             return detail::call_sync(
@@ -165,12 +164,12 @@ namespace hpx { namespace detail
         typename std::enable_if<
             traits::detail::is_deferred_invocable<F, Ts...>::value,
             hpx::future<
-                typename util::detail::deferred_result_of<F&&(Ts&&...)>::type
+                typename util::detail::invoke_deferred_result<F, Ts...>::type
             >
         >::type
         call(hpx::detail::async_policy policy, F && f, Ts&&... ts)
         {
-            typedef typename util::detail::deferred_result_of<F(Ts&&...)>::type
+            typedef typename util::detail::invoke_deferred_result<F, Ts...>::type
                 result_type;
 
             lcos::local::futures_factory<result_type()> p(
@@ -185,12 +184,12 @@ namespace hpx { namespace detail
         typename std::enable_if<
             traits::detail::is_deferred_invocable<F, Ts...>::value,
             hpx::future<
-                typename util::detail::deferred_result_of<F&&(Ts&&...)>::type
+                typename util::detail::invoke_deferred_result<F, Ts...>::type
             >
         >::type
         call(hpx::detail::fork_policy policy, F && f, Ts&&... ts)
         {
-            typedef typename util::detail::deferred_result_of<F(Ts&&...)>::type
+            typedef typename util::detail::invoke_deferred_result<F, Ts...>::type
                 result_type;
 
             lcos::local::futures_factory<result_type()> p(
@@ -207,12 +206,12 @@ namespace hpx { namespace detail
         typename std::enable_if<
             traits::detail::is_deferred_invocable<F, Ts...>::value,
             hpx::future<
-                typename util::detail::deferred_result_of<F&&(Ts&&...)>::type
+                typename util::detail::invoke_deferred_result<F, Ts...>::type
             >
         >::type
         call(hpx::detail::deferred_policy, F && f, Ts&&... ts)
         {
-            typedef typename util::detail::deferred_result_of<F(Ts&&...)>::type
+            typedef typename util::detail::invoke_deferred_result<F, Ts...>::type
                 result_type;
 
             lcos::local::futures_factory<result_type()> p(
@@ -232,7 +231,7 @@ namespace hpx { namespace detail
         typename std::enable_if<
             traits::detail::is_deferred_invocable<F, Ts...>::value,
             hpx::future<
-                typename util::detail::deferred_result_of<F&&(Ts&&...)>::type
+                typename util::detail::invoke_deferred_result<F, Ts...>::type
             >
         >::type
         call(F&& f, Ts&&... ts)
@@ -254,14 +253,13 @@ namespace hpx { namespace detail
         typename std::enable_if<
             traits::detail::is_deferred_invocable<F, Ts...>::value,
             hpx::future<
-                typename util::detail::deferred_result_of<F&&(Ts&&...)>::type
+                typename util::detail::invoke_deferred_result<F, Ts...>::type
             >
         >::type
         call(Executor_ && sched, F&& f, Ts&&... ts)
         {
-            typedef typename util::detail::deferred_result_of<
-                    F(Ts&&...)
-                >::type result_type;
+            typedef typename util::detail::invoke_deferred_result<F, Ts...>::type
+                result_type;
 
             lcos::local::futures_factory<result_type()> p(
                 std::forward<Executor_>(sched),
@@ -284,7 +282,7 @@ namespace hpx { namespace detail
         typename std::enable_if<
             traits::detail::is_deferred_invocable<F, Ts...>::value,
             hpx::future<
-                typename util::detail::deferred_result_of<F&&(Ts&&...)>::type
+                typename util::detail::invoke_deferred_result<F, Ts...>::type
             >
         >::type
         call(Executor& exec, F&& f, Ts&&... ts)
@@ -308,7 +306,7 @@ namespace hpx { namespace detail
         typename std::enable_if<
             traits::detail::is_deferred_invocable<F, Ts...>::value,
             hpx::future<
-                typename util::detail::deferred_result_of<F&&(Ts&&...)>::type
+                typename util::detail::invoke_deferred_result<F, Ts...>::type
             >
         >::type
         call(Executor_ && exec, F && f, Ts &&... ts)

--- a/hpx/compute/host/block_executor.hpp
+++ b/hpx/compute/host/block_executor.hpp
@@ -116,7 +116,7 @@ namespace hpx { namespace compute { namespace host
 
         template <typename F, typename ... Ts>
         hpx::future<
-            typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type>
+            typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type>
         async_execute(F && f, Ts &&... ts)
         {
             std::size_t current = ++current_ % executors_.size();
@@ -125,7 +125,7 @@ namespace hpx { namespace compute { namespace host
         }
 
         template <typename F, typename ... Ts>
-        typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
+        typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
         sync_execute(F && f, Ts &&... ts)
         {
             std::size_t current = ++current_ % executors_.size();

--- a/hpx/lcos/async_continue_fwd.hpp
+++ b/hpx/lcos/async_continue_fwd.hpp
@@ -29,12 +29,12 @@ namespace hpx
         template <typename Action, typename Cont>
         struct result_of_async_continue
             : traits::action_remote_result<
-                typename util::result_of<typename util::decay<Cont>::type(
+                typename util::invoke_result<typename util::decay<Cont>::type,
                     naming::id_type,
                     typename hpx::traits::extract_action<
                         Action
                     >::remote_result_type
-                )>::type
+                >::type
             >
         {};
 

--- a/hpx/lcos/dataflow.hpp
+++ b/hpx/lcos/dataflow.hpp
@@ -111,7 +111,7 @@ namespace hpx { namespace lcos { namespace detail
     template <typename F, typename Args>
     struct dataflow_return<F, Args,
         typename std::enable_if<!traits::is_action<F>::value>::type
-    > : util::detail::fused_result_of<F(Args &&)>
+    > : util::detail::invoke_fused_result<F, Args>
     {};
 
     template <typename Action, typename Args>

--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -1340,7 +1340,7 @@ namespace hpx { namespace lcos
     make_future(hpx::shared_future<U> const& f, Conv && conv)
     {
         static_assert(
-            hpx::traits::is_callable<Conv(U), R>::value,
+            hpx::traits::is_invocable_r<R, Conv, U>::value,
             "the argument type must be convertible to the requested "
             "result type by using the supplied conversion function");
 

--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -615,7 +615,7 @@ namespace hpx { namespace lcos { namespace detail
             }
 
             typedef
-                typename hpx::util::result_of<F(Derived)>::type
+                typename hpx::util::invoke_result<F, Derived>::type
                 continuation_result_type;
             typedef
                 typename hpx::traits::detail::shared_state_ptr<result_type>::type
@@ -645,7 +645,7 @@ namespace hpx { namespace lcos { namespace detail
             }
 
             typedef
-                typename hpx::util::result_of<F(Derived)>::type
+                typename hpx::util::invoke_result<F, Derived>::type
                 continuation_result_type;
             typedef
                 typename hpx::traits::detail::shared_state_ptr<result_type>::type
@@ -679,7 +679,7 @@ namespace hpx { namespace lcos { namespace detail
             }
 
             typedef
-                typename hpx::util::result_of<F(Derived)>::type
+                typename hpx::util::invoke_result<F, Derived>::type
                 continuation_result_type;
             typedef
                 typename hpx::traits::detail::shared_state_ptr<result_type>::type

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -102,12 +102,12 @@ namespace hpx { namespace lcos { namespace detail
     template <typename Func, typename Future, typename Continuation>
     typename std::enable_if<
         !traits::detail::is_unique_future<
-            typename util::result_of<Func(Future)>::type
+            typename util::invoke_result<Func, Future>::type
         >::value
     >::type invoke_continuation(Func& func, Future& future, Continuation& cont)
     {
         typedef std::is_void<
-            typename util::result_of<Func(Future)>::type
+            typename util::invoke_result<Func, Future>::type
         > is_void;
 
         hpx::util::annotate_function annotate(func);
@@ -118,13 +118,13 @@ namespace hpx { namespace lcos { namespace detail
     template <typename Func, typename Future, typename Continuation>
     typename std::enable_if<
         traits::detail::is_unique_future<
-            typename util::result_of<Func(Future)>::type
+            typename util::invoke_result<Func, Future>::type
         >::value
     >::type invoke_continuation(Func& func, Future& future, Continuation& cont)
     {
         try {
             typedef
-                typename util::result_of<Func(Future)>::type
+                typename util::invoke_result<Func, Future>::type
                 inner_future;
             typedef
                 typename traits::detail::shared_state_ptr_for<inner_future>::type
@@ -286,7 +286,7 @@ namespace hpx { namespace lcos { namespace detail
             Future future = traits::future_access<Future>::create(std::move(f));
 
             typedef std::is_void<
-                    typename util::result_of<F(Future)>::type
+                    typename util::invoke_result<F, Future>::type
                 > is_void;
             invoke_continuation(f_, future, *this, is_void());
 

--- a/hpx/lcos/local/packaged_task.hpp
+++ b/hpx/lcos/local/packaged_task.hpp
@@ -43,7 +43,7 @@ namespace hpx { namespace lcos { namespace local
             typename F, typename FD = typename std::decay<F>::type,
             typename Enable = typename std::enable_if<
                 !std::is_same<FD, packaged_task>::value
-             && traits::is_callable<FD&(Ts...), R>::value
+             && traits::is_invocable_r<R, FD&, Ts...>::value
             >::type
         >
         explicit packaged_task(F&& f)
@@ -56,7 +56,7 @@ namespace hpx { namespace lcos { namespace local
             typename F, typename FD = typename std::decay<F>::type,
             typename Enable = typename std::enable_if<
                 !std::is_same<FD, packaged_task>::value
-             && traits::is_callable<FD&(Ts...), R>::value
+             && traits::is_invocable_r<R, FD&, Ts...>::value
             >::type
         >
         explicit packaged_task(std::allocator_arg_t, Allocator const& a, F && f)

--- a/hpx/lcos/when_each.hpp
+++ b/hpx/lcos/when_each.hpp
@@ -253,8 +253,8 @@ namespace hpx { namespace lcos
 
                     dispatch::call(std::forward<F>(f_), count_++,
                         std::move(*next),
-                        typename traits::is_callable<
-                            F(std::size_t, future_type)
+                        typename traits::is_invocable<
+                            F, std::size_t, future_type
                         >::type()
                     );
 
@@ -319,8 +319,8 @@ namespace hpx { namespace lcos
                 }
 
                 dispatch::call(std::forward<F>(f_), count_++, std::move(fut),
-                    typename traits::is_callable<
-                        F(std::size_t, future_type)
+                    typename traits::is_invocable<
+                        F, std::size_t, future_type
                     >::type()
                 );
 

--- a/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -276,9 +276,9 @@ namespace hpx { namespace parallel { inline namespace v1
         is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<InIter>::value &&
         hpx::traits::is_iterator<OutIter>::value &&
-        hpx::traits::is_callable<
-                Op(typename std::iterator_traits<InIter>::value_type,
-                    typename std::iterator_traits<InIter>::value_type)
+        hpx::traits::is_invocable<Op,
+                typename std::iterator_traits<InIter>::value_type,
+                typename std::iterator_traits<InIter>::value_type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     inclusive_scan(ExPolicy&& policy, InIter first, InIter last, OutIter dest,
@@ -308,9 +308,9 @@ namespace hpx { namespace parallel { inline namespace v1
         is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<InIter>::value &&
         hpx::traits::is_iterator<OutIter>::value &&
-        hpx::traits::is_callable<
-                Op(typename std::iterator_traits<InIter>::value_type,
-                    typename std::iterator_traits<InIter>::value_type)
+        hpx::traits::is_invocable<Op,
+                typename std::iterator_traits<InIter>::value_type,
+                typename std::iterator_traits<InIter>::value_type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     inclusive_scan(ExPolicy&& policy, InIter first, InIter last, OutIter dest,
@@ -397,9 +397,9 @@ namespace hpx { namespace parallel { inline namespace v1
         is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<InIter>::value &&
         hpx::traits::is_iterator<OutIter>::value &&
-       !hpx::traits::is_callable<
-                T(typename std::iterator_traits<InIter>::value_type,
-                    typename std::iterator_traits<InIter>::value_type)
+       !hpx::traits::is_invocable<T,
+                typename std::iterator_traits<InIter>::value_type,
+                typename std::iterator_traits<InIter>::value_type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     inclusive_scan(ExPolicy&& policy, InIter first, InIter last, OutIter dest,
@@ -500,9 +500,9 @@ namespace hpx { namespace parallel { inline namespace v1
         is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<InIter>::value &&
         hpx::traits::is_iterator<OutIter>::value &&
-        hpx::traits::is_callable<
-                Op(typename std::iterator_traits<InIter>::value_type,
-                    typename std::iterator_traits<InIter>::value_type)
+        hpx::traits::is_invocable<Op,
+                typename std::iterator_traits<InIter>::value_type,
+                typename std::iterator_traits<InIter>::value_type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     inclusive_scan(ExPolicy&& policy, InIter first, InIter last, OutIter dest,

--- a/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -283,11 +283,11 @@ namespace hpx { namespace parallel { inline namespace v1
                 typename std::iterator_traits<InIter>::value_type
             >::value &&
         hpx::traits::is_invocable<Op,
-                typename hpx::util::result_of<
-                    Conv(typename std::iterator_traits<InIter>::value_type)
+                typename hpx::util::invoke_result<Conv,
+                    typename std::iterator_traits<InIter>::value_type
                 >::type,
-                typename hpx::util::result_of<
-                    Conv(typename std::iterator_traits<InIter>::value_type)
+                typename hpx::util::invoke_result<Conv,
+                    typename std::iterator_traits<InIter>::value_type
                 >::type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, OutIter>::type
@@ -326,11 +326,11 @@ namespace hpx { namespace parallel { inline namespace v1
                 typename std::iterator_traits<InIter>::value_type
             >::value &&
         hpx::traits::is_invocable<Op,
-                typename hpx::util::result_of<
-                    Conv(typename std::iterator_traits<InIter>::value_type)
+                typename hpx::util::invoke_result<Conv,
+                    typename std::iterator_traits<InIter>::value_type
                 >::type,
-                typename hpx::util::result_of<
-                    Conv(typename std::iterator_traits<InIter>::value_type)
+                typename hpx::util::invoke_result<Conv,
+                    typename std::iterator_traits<InIter>::value_type
                 >::type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, OutIter>::type

--- a/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -279,16 +279,16 @@ namespace hpx { namespace parallel { inline namespace v1
         execution::is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<InIter>::value &&
         hpx::traits::is_iterator<OutIter>::value &&
-        hpx::traits::is_callable<
-                Conv(typename std::iterator_traits<InIter>::value_type)
+        hpx::traits::is_invocable<Conv,
+                typename std::iterator_traits<InIter>::value_type
             >::value &&
-        hpx::traits::is_callable<
-            Op(typename hpx::util::result_of<
+        hpx::traits::is_invocable<Op,
+                typename hpx::util::result_of<
                     Conv(typename std::iterator_traits<InIter>::value_type)
                 >::type,
                 typename hpx::util::result_of<
                     Conv(typename std::iterator_traits<InIter>::value_type)
-                >::type)
+                >::type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     transform_exclusive_scan(ExPolicy && policy, InIter first, InIter last,
@@ -322,16 +322,16 @@ namespace hpx { namespace parallel { inline namespace v1
         is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<InIter>::value &&
         hpx::traits::is_iterator<OutIter>::value &&
-        hpx::traits::is_callable<
-                Conv(typename std::iterator_traits<InIter>::value_type)
+        hpx::traits::is_invocable<Conv,
+                typename std::iterator_traits<InIter>::value_type
             >::value &&
-        hpx::traits::is_callable<
-            Op(typename hpx::util::result_of<
+        hpx::traits::is_invocable<Op,
+                typename hpx::util::result_of<
                     Conv(typename std::iterator_traits<InIter>::value_type)
                 >::type,
                 typename hpx::util::result_of<
                     Conv(typename std::iterator_traits<InIter>::value_type)
-                >::type)
+                >::type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     transform_exclusive_scan(ExPolicy && policy, InIter first, InIter last,

--- a/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -286,11 +286,11 @@ namespace hpx { namespace parallel { inline namespace v1
                 typename std::iterator_traits<InIter>::value_type
             >::value &&
         hpx::traits::is_invocable<Op,
-                typename hpx::util::result_of<
-                    Conv(typename std::iterator_traits<InIter>::value_type)
+                typename hpx::util::invoke_result<Conv,
+                    typename std::iterator_traits<InIter>::value_type
                 >::type,
-                typename hpx::util::result_of<
-                    Conv(typename std::iterator_traits<InIter>::value_type)
+                typename hpx::util::invoke_result<Conv,
+                    typename std::iterator_traits<InIter>::value_type
                 >::type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, OutIter>::type
@@ -329,11 +329,11 @@ namespace hpx { namespace parallel { inline namespace v1
                 typename std::iterator_traits<InIter>::value_type
             >::value &&
         hpx::traits::is_invocable<Op,
-                typename hpx::util::result_of<
-                    Conv(typename std::iterator_traits<InIter>::value_type)
+                typename hpx::util::invoke_result<Conv,
+                    typename std::iterator_traits<InIter>::value_type
                 >::type,
-                typename hpx::util::result_of<
-                    Conv(typename std::iterator_traits<InIter>::value_type)
+                typename hpx::util::invoke_result<Conv,
+                    typename std::iterator_traits<InIter>::value_type
                 >::type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, OutIter>::type
@@ -370,11 +370,11 @@ namespace hpx { namespace parallel { inline namespace v1
                 typename std::iterator_traits<InIter>::value_type
             >::value &&
         hpx::traits::is_invocable<Op,
-                typename hpx::util::result_of<
-                    Conv(typename std::iterator_traits<InIter>::value_type)
+                typename hpx::util::invoke_result<Conv,
+                    typename std::iterator_traits<InIter>::value_type
                 >::type,
-                typename hpx::util::result_of<
-                    Conv(typename std::iterator_traits<InIter>::value_type)
+                typename hpx::util::invoke_result<Conv,
+                    typename std::iterator_traits<InIter>::value_type
                 >::type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, OutIter>::type
@@ -511,11 +511,11 @@ namespace hpx { namespace parallel { inline namespace v1
                 typename std::iterator_traits<InIter>::value_type
             >::value &&
         hpx::traits::is_invocable<Op,
-                typename hpx::util::result_of<
-                    Conv(typename std::iterator_traits<InIter>::value_type)
+                typename hpx::util::invoke_result<Conv,
+                    typename std::iterator_traits<InIter>::value_type
                 >::type,
-                typename hpx::util::result_of<
-                    Conv(typename std::iterator_traits<InIter>::value_type)
+                typename hpx::util::invoke_result<Conv,
+                    typename std::iterator_traits<InIter>::value_type
                 >::type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, OutIter>::type
@@ -556,11 +556,11 @@ namespace hpx { namespace parallel { inline namespace v1
                 typename std::iterator_traits<InIter>::value_type
             >::value &&
         hpx::traits::is_invocable<Op,
-                typename hpx::util::result_of<
-                    Conv(typename std::iterator_traits<InIter>::value_type)
+                typename hpx::util::invoke_result<Conv,
+                    typename std::iterator_traits<InIter>::value_type
                 >::type,
-                typename hpx::util::result_of<
-                    Conv(typename std::iterator_traits<InIter>::value_type)
+                typename hpx::util::invoke_result<Conv,
+                    typename std::iterator_traits<InIter>::value_type
                 >::type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, OutIter>::type

--- a/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -282,16 +282,16 @@ namespace hpx { namespace parallel { inline namespace v1
         execution::is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<InIter>::value &&
         hpx::traits::is_iterator<OutIter>::value &&
-        hpx::traits::is_callable<
-                Conv(typename std::iterator_traits<InIter>::value_type)
+        hpx::traits::is_invocable<Conv,
+                typename std::iterator_traits<InIter>::value_type
             >::value &&
-        hpx::traits::is_callable<
-            Op(typename hpx::util::result_of<
+        hpx::traits::is_invocable<Op,
+                typename hpx::util::result_of<
                     Conv(typename std::iterator_traits<InIter>::value_type)
                 >::type,
                 typename hpx::util::result_of<
                     Conv(typename std::iterator_traits<InIter>::value_type)
-                >::type)
+                >::type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     transform_inclusive_scan(ExPolicy && policy, InIter first, InIter last,
@@ -325,16 +325,16 @@ namespace hpx { namespace parallel { inline namespace v1
         execution::is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<InIter>::value &&
         hpx::traits::is_iterator<OutIter>::value &&
-        hpx::traits::is_callable<
-                Conv(typename std::iterator_traits<InIter>::value_type)
+        hpx::traits::is_invocable<Conv,
+                typename std::iterator_traits<InIter>::value_type
             >::value &&
-        hpx::traits::is_callable<
-            Op(typename hpx::util::result_of<
+        hpx::traits::is_invocable<Op,
+                typename hpx::util::result_of<
                     Conv(typename std::iterator_traits<InIter>::value_type)
                 >::type,
                 typename hpx::util::result_of<
                     Conv(typename std::iterator_traits<InIter>::value_type)
-                >::type)
+                >::type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     transform_inclusive_scan(ExPolicy && policy, InIter first, InIter last,
@@ -366,16 +366,16 @@ namespace hpx { namespace parallel { inline namespace v1
         is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<InIter>::value &&
         hpx::traits::is_iterator<OutIter>::value &&
-        hpx::traits::is_callable<
-                Conv(typename std::iterator_traits<InIter>::value_type)
+        hpx::traits::is_invocable<Conv,
+                typename std::iterator_traits<InIter>::value_type
             >::value &&
-        hpx::traits::is_callable<
-            Op(typename hpx::util::result_of<
+        hpx::traits::is_invocable<Op,
+                typename hpx::util::result_of<
                     Conv(typename std::iterator_traits<InIter>::value_type)
                 >::type,
                 typename hpx::util::result_of<
                     Conv(typename std::iterator_traits<InIter>::value_type)
-                >::type)
+                >::type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     transform_inclusive_scan(ExPolicy && policy, InIter first, InIter last,
@@ -507,16 +507,16 @@ namespace hpx { namespace parallel { inline namespace v1
         execution::is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<InIter>::value &&
         hpx::traits::is_iterator<OutIter>::value &&
-        hpx::traits::is_callable<
-                Conv(typename std::iterator_traits<InIter>::value_type)
+        hpx::traits::is_invocable<Conv,
+                typename std::iterator_traits<InIter>::value_type
             >::value &&
-        hpx::traits::is_callable<
-            Op(typename hpx::util::result_of<
+        hpx::traits::is_invocable<Op,
+                typename hpx::util::result_of<
                     Conv(typename std::iterator_traits<InIter>::value_type)
                 >::type,
                 typename hpx::util::result_of<
                     Conv(typename std::iterator_traits<InIter>::value_type)
-                >::type)
+                >::type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     transform_inclusive_scan(ExPolicy&& policy, InIter first, InIter last,
@@ -552,16 +552,16 @@ namespace hpx { namespace parallel { inline namespace v1
         is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<InIter>::value &&
         hpx::traits::is_iterator<OutIter>::value &&
-        hpx::traits::is_callable<
-                Conv(typename std::iterator_traits<InIter>::value_type)
+        hpx::traits::is_invocable<Conv,
+                typename std::iterator_traits<InIter>::value_type
             >::value &&
-        hpx::traits::is_callable<
-            Op(typename hpx::util::result_of<
+        hpx::traits::is_invocable<Op,
+                typename hpx::util::result_of<
                     Conv(typename std::iterator_traits<InIter>::value_type)
                 >::type,
                 typename hpx::util::result_of<
                     Conv(typename std::iterator_traits<InIter>::value_type)
-                >::type)
+                >::type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, OutIter>::type
     transform_inclusive_scan(ExPolicy&& policy, InIter first, InIter last,

--- a/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/hpx/parallel/algorithms/transform_reduce.hpp
@@ -241,17 +241,16 @@ namespace hpx { namespace parallel { inline namespace v1
     HPX_CONCEPT_REQUIRES_(
         execution::is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<InIter>::value &&
-        hpx::traits::is_callable<
-                Convert(typename std::iterator_traits<InIter>::value_type)
+        hpx::traits::is_invocable<Convert,
+                typename std::iterator_traits<InIter>::value_type
             >::value &&
-        hpx::traits::is_callable<
-            Reduce(
+        hpx::traits::is_invocable<Reduce,
                 typename hpx::util::result_of<
                     Convert(typename std::iterator_traits<InIter>::value_type)
                 >::type,
                 typename hpx::util::result_of<
                     Convert(typename std::iterator_traits<InIter>::value_type)
-                >::type)
+                >::type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, T>::type
     transform_reduce(ExPolicy && policy, InIter first, InIter last,
@@ -272,17 +271,16 @@ namespace hpx { namespace parallel { inline namespace v1
     HPX_CONCEPT_REQUIRES_(
         is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<InIter>::value &&
-        hpx::traits::is_callable<
-                Convert(typename std::iterator_traits<InIter>::value_type)
+        hpx::traits::is_invocable<Convert,
+                typename std::iterator_traits<InIter>::value_type
             >::value &&
-        hpx::traits::is_callable<
-            Reduce(
+        hpx::traits::is_invocable<Reduce,
                 typename hpx::util::result_of<
                     Convert(typename std::iterator_traits<InIter>::value_type)
                 >::type,
                 typename hpx::util::result_of<
                     Convert(typename std::iterator_traits<InIter>::value_type)
-                >::type)
+                >::type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, T>::type
     transform_reduce(ExPolicy && policy, InIter first, InIter last,

--- a/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/hpx/parallel/algorithms/transform_reduce.hpp
@@ -245,11 +245,11 @@ namespace hpx { namespace parallel { inline namespace v1
                 typename std::iterator_traits<InIter>::value_type
             >::value &&
         hpx::traits::is_invocable<Reduce,
-                typename hpx::util::result_of<
-                    Convert(typename std::iterator_traits<InIter>::value_type)
+                typename hpx::util::invoke_result<Convert,
+                    typename std::iterator_traits<InIter>::value_type
                 >::type,
-                typename hpx::util::result_of<
-                    Convert(typename std::iterator_traits<InIter>::value_type)
+                typename hpx::util::invoke_result<Convert,
+                    typename std::iterator_traits<InIter>::value_type
                 >::type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, T>::type
@@ -275,11 +275,11 @@ namespace hpx { namespace parallel { inline namespace v1
                 typename std::iterator_traits<InIter>::value_type
             >::value &&
         hpx::traits::is_invocable<Reduce,
-                typename hpx::util::result_of<
-                    Convert(typename std::iterator_traits<InIter>::value_type)
+                typename hpx::util::invoke_result<Convert,
+                    typename std::iterator_traits<InIter>::value_type
                 >::type,
-                typename hpx::util::result_of<
-                    Convert(typename std::iterator_traits<InIter>::value_type)
+                typename hpx::util::invoke_result<Convert,
+                    typename std::iterator_traits<InIter>::value_type
                 >::type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, T>::type

--- a/hpx/parallel/algorithms/transform_reduce_binary.hpp
+++ b/hpx/parallel/algorithms/transform_reduce_binary.hpp
@@ -407,13 +407,13 @@ namespace hpx { namespace parallel { inline namespace v1
                 typename std::iterator_traits<InIter2>::value_type
             >::value &&
         hpx::traits::is_invocable<Reduce,
-                typename hpx::util::result_of<
-                    Convert(typename std::iterator_traits<InIter1>::value_type,
-                        typename std::iterator_traits<InIter2>::value_type)
+                typename hpx::util::invoke_result<Convert,
+                    typename std::iterator_traits<InIter1>::value_type,
+                    typename std::iterator_traits<InIter2>::value_type
                 >::type,
-                typename hpx::util::result_of<
-                    Convert(typename std::iterator_traits<InIter1>::value_type,
-                        typename std::iterator_traits<InIter2>::value_type)
+                typename hpx::util::invoke_result<Convert,
+                    typename std::iterator_traits<InIter1>::value_type,
+                    typename std::iterator_traits<InIter2>::value_type
                 >::type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, T>::type

--- a/hpx/parallel/algorithms/transform_reduce_binary.hpp
+++ b/hpx/parallel/algorithms/transform_reduce_binary.hpp
@@ -402,12 +402,11 @@ namespace hpx { namespace parallel { inline namespace v1
         execution::is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<InIter1>::value &&
         hpx::traits::is_iterator<InIter2>::value &&
-        hpx::traits::is_callable<
-                Convert(typename std::iterator_traits<InIter1>::value_type,
-                    typename std::iterator_traits<InIter2>::value_type)
+        hpx::traits::is_invocable<Convert,
+                typename std::iterator_traits<InIter1>::value_type,
+                typename std::iterator_traits<InIter2>::value_type
             >::value &&
-        hpx::traits::is_callable<
-            Reduce(
+        hpx::traits::is_invocable<Reduce,
                 typename hpx::util::result_of<
                     Convert(typename std::iterator_traits<InIter1>::value_type,
                         typename std::iterator_traits<InIter2>::value_type)
@@ -415,7 +414,7 @@ namespace hpx { namespace parallel { inline namespace v1
                 typename hpx::util::result_of<
                     Convert(typename std::iterator_traits<InIter1>::value_type,
                         typename std::iterator_traits<InIter2>::value_type)
-                >::type)
+                >::type
             >::value)>
     typename util::detail::algorithm_result<ExPolicy, T>::type
     transform_reduce(ExPolicy && policy, InIter1 first1, InIter1 last1,

--- a/hpx/parallel/datapar/iterator_helpers.hpp
+++ b/hpx/parallel/datapar/iterator_helpers.hpp
@@ -12,6 +12,7 @@
 #include <hpx/parallel/traits/vector_pack_alignment_size.hpp>
 #include <hpx/parallel/traits/vector_pack_load_store.hpp>
 #include <hpx/parallel/traits/vector_pack_type.hpp>
+#include <hpx/util/result_of.hpp>
 
 #include <cstddef>
 #include <iterator>
@@ -189,7 +190,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail
 
         template <typename F>
         HPX_HOST_DEVICE HPX_FORCEINLINE
-        static typename std::result_of<F&&(V1*)>::type
+        static typename hpx::util::invoke_result<F, V1*>::type
         call1(F && f, Iter& it)
         {
             store_on_exit_unaligned<Iter, V1> tmp(it);
@@ -199,7 +200,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail
 
         template <typename F>
         HPX_HOST_DEVICE HPX_FORCEINLINE
-        static typename std::result_of<F&&(V*)>::type
+        static typename hpx::util::invoke_result<F, V*>::type
         callv(F && f, Iter& it)
         {
             store_on_exit<Iter, V> tmp(it);
@@ -213,7 +214,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail
     struct invoke_vectorized_in2
     {
         template <typename F, typename Iter1, typename Iter2>
-        static typename std::result_of<F&&(V1*, V2*)>::type
+        static typename hpx::util::invoke_result<F, V1*, V2*>::type
         call_aligned(F && f, Iter1& it1, Iter2& it2)
         {
             static_assert(
@@ -234,7 +235,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail
         }
 
         template <typename F, typename Iter1, typename Iter2>
-        static typename std::result_of<F&&(V1*, V2*)>::type
+        static typename hpx::util::invoke_result<F, V1*, V2*>::type
         call_unaligned(F && f, Iter1& it1, Iter2& it2)
         {
             static_assert(
@@ -269,7 +270,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail
 
         template <typename F>
         HPX_HOST_DEVICE HPX_FORCEINLINE
-        static typename std::result_of<F&&(V11*, V12*)>::type
+        static typename hpx::util::invoke_result<F, V11*, V12*>::type
         call1(F && f, Iter1& it1, Iter2& it2)
         {
             return invoke_vectorized_in2<V11, V12>::call_aligned(
@@ -278,7 +279,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail
 
         template <typename F>
         HPX_HOST_DEVICE HPX_FORCEINLINE
-        static typename std::result_of<F&&(V1*, V2*)>::type
+        static typename hpx::util::invoke_result<F, V1*, V2*>::type
         callv(F && f, Iter1& it1, Iter2& it2)
         {
             if (is_data_aligned(it1) || is_data_aligned(it2))

--- a/hpx/parallel/executors/distribution_policy_executor.hpp
+++ b/hpx/parallel/executors/distribution_policy_executor.hpp
@@ -32,9 +32,8 @@ namespace hpx { namespace parallel { namespace execution
         template <typename F, typename ... Ts>
         struct distribution_policy_execute_result_impl<F, false, Ts...>
         {
-            typedef typename hpx::util::detail::deferred_result_of<
-                    F(Ts...)
-                >::type type;
+            typedef typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
+                type;
         };
 
         template <typename Action, typename ... Ts>

--- a/hpx/parallel/executors/execution.hpp
+++ b/hpx/parallel/executors/execution.hpp
@@ -194,14 +194,14 @@ namespace hpx { namespace parallel { namespace execution
             template <typename OneWayExecutor, typename F, typename Future,
                 typename ... Ts>
             HPX_FORCEINLINE static
-            hpx::lcos::future<typename hpx::util::detail::deferred_result_of<
-                F(Future, Ts...)
+            hpx::lcos::future<typename hpx::util::detail::invoke_deferred_result<
+                F, Future, Ts...
             >::type>
             call(OneWayExecutor && exec, F && f, Future& predecessor,
                 Ts &&... ts)
             {
-                typedef typename hpx::util::detail::deferred_result_of<
-                        F(Future, Ts...)
+                typedef typename hpx::util::detail::invoke_deferred_result<
+                        F, Future, Ts...
                     >::type result_type;
 
                 auto func = hpx::util::bind(
@@ -363,8 +363,8 @@ namespace hpx { namespace parallel { namespace execution
                 ))
             {
                 try {
-                    typedef typename hpx::util::detail::deferred_result_of<
-                            F(Ts...)
+                    typedef typename hpx::util::detail::invoke_deferred_result<
+                            F, Ts...
                         >::type result_type;
 
                     // older versions of gcc are not able to capture parameter
@@ -430,8 +430,8 @@ namespace hpx { namespace parallel { namespace execution
                 ))
             {
                 typedef typename std::is_void<
-                        typename hpx::util::detail::deferred_result_of<
-                            F(Ts...)
+                        typename hpx::util::detail::invoke_deferred_result<
+                            F, Ts...
                         >::type
                     >::type is_void;
 
@@ -502,16 +502,16 @@ namespace hpx { namespace parallel { namespace execution
             template <typename TwoWayExecutor, typename F, typename Future,
                 typename ... Ts>
             static hpx::lcos::future<
-                typename hpx::util::detail::deferred_result_of<
-                    F(Future, Ts...)
+                typename hpx::util::detail::invoke_deferred_result<
+                    F, Future, Ts...
                 >::type
             >
             call_impl(hpx::traits::detail::wrap_int,
                     TwoWayExecutor && exec, F && f, Future& predecessor,
                     Ts &&... ts)
             {
-                typedef typename hpx::util::detail::deferred_result_of<
-                        F(Future, Ts...)
+                typedef typename hpx::util::detail::invoke_deferred_result<
+                        F, Future, Ts...
                     >::type result_type;
 
                 auto func = hpx::util::bind(
@@ -760,8 +760,8 @@ namespace hpx { namespace parallel { namespace execution
                     std::iterator_traits<iterator_type>::value_type
                 value_type;
             typedef typename
-                    hpx::util::detail::deferred_result_of<
-                        F(value_type, Ts...)
+                    hpx::util::detail::invoke_deferred_result<
+                        F, value_type, Ts...
                     >::type
                 type;
         };
@@ -1268,8 +1268,8 @@ namespace hpx { namespace parallel { namespace execution
                     std::iterator_traits<iterator_type>::value_type
                 value_type;
             typedef typename
-                    hpx::util::detail::deferred_result_of<
-                        F(value_type, Future, Ts...)
+                    hpx::util::detail::invoke_deferred_result<
+                        F, value_type, Future, Ts...
                     >::type
                 type;
         };

--- a/hpx/parallel/executors/executor_traits.hpp
+++ b/hpx/parallel/executors/executor_traits.hpp
@@ -123,8 +123,8 @@ namespace hpx { namespace parallel { inline namespace v3
                 )
             {
                 try {
-                    typedef typename hpx::util::detail::deferred_result_of<
-                            F(Ts&&...)
+                    typedef typename hpx::util::detail::invoke_deferred_result<
+                            F, Ts...
                         >::type result_type;
 
                     // older versions of gcc are not able to capture parameter
@@ -186,8 +186,8 @@ namespace hpx { namespace parallel { inline namespace v3
                 )
             {
                 typedef std::is_void<
-                        typename hpx::util::detail::deferred_result_of<
-                            F(Ts&&...)
+                        typename hpx::util::detail::invoke_deferred_result<
+                            F, Ts...
                         >::type
                     > is_void;
                 return call_impl(std::forward<Executor>(exec),
@@ -227,8 +227,8 @@ namespace hpx { namespace parallel { inline namespace v3
                     std::iterator_traits<iterator_type>::value_type
                 value_type;
             typedef typename
-                    hpx::util::detail::deferred_result_of<
-                        F(value_type, Ts...)
+                    hpx::util::detail::invoke_deferred_result<
+                        F, value_type, Ts...
                     >::type
                 type;
         };
@@ -632,7 +632,7 @@ namespace hpx { namespace parallel { inline namespace v3
     typename std::enable_if<
         hpx::traits::is_executor<Executor>::value,
         hpx::lcos::future<
-            typename hpx::util::detail::deferred_result_of<F(Ts...)>::type
+            typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
         >
     >::type
     async_execute(Executor && exec, F && f, Ts &&... ts)
@@ -648,7 +648,7 @@ namespace hpx { namespace parallel { inline namespace v3
     HPX_FORCEINLINE
     typename std::enable_if<
         hpx::traits::is_executor<Executor>::value,
-        typename hpx::util::detail::deferred_result_of<F(Ts...)>::type
+        typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
     >::type
     sync_execute(Executor && exec, F && f, Ts &&... ts)
     {

--- a/hpx/parallel/executors/parallel_executor.hpp
+++ b/hpx/parallel/executors/parallel_executor.hpp
@@ -82,7 +82,7 @@ namespace hpx { namespace parallel { namespace execution
         // TwoWayExecutor interface
         template <typename F, typename ... Ts>
         hpx::future<
-            typename hpx::util::detail::deferred_result_of<F&&(Ts&&...)>::type
+            typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
         >
         async_execute(F && f, Ts &&... ts) const
         {

--- a/hpx/parallel/executors/sequenced_executor.hpp
+++ b/hpx/parallel/executors/sequenced_executor.hpp
@@ -57,7 +57,7 @@ namespace hpx { namespace parallel { namespace execution
 
         // OneWayExecutor interface
         template <typename F, typename ... Ts>
-        static typename hpx::util::detail::deferred_result_of<F(Ts...)>::type
+        static typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
         sync_execute(F && f, Ts &&... ts)
         {
             try {
@@ -76,7 +76,7 @@ namespace hpx { namespace parallel { namespace execution
         // TwoWayExecutor interface
         template <typename F, typename ... Ts>
         static hpx::future<
-            typename hpx::util::detail::deferred_result_of<F(Ts...)>::type
+            typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
         >
         async_execute(F && f, Ts &&... ts)
         {
@@ -189,7 +189,7 @@ namespace hpx { namespace parallel { inline namespace v3
         using base_type = parallel::execution::sequenced_executor;
 
         template <typename F, typename ... Ts>
-        static typename hpx::util::detail::deferred_result_of<F(Ts...)>::type
+        static typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
         execute(F && f, Ts &&... ts)
         {
             return base_type::sync_execute(std::forward<F>(f),

--- a/hpx/parallel/executors/thread_execution.hpp
+++ b/hpx/parallel/executors/thread_execution.hpp
@@ -41,7 +41,7 @@ namespace hpx { namespace threads
     typename std::enable_if<
         hpx::traits::is_threads_executor<Executor>::value,
         hpx::lcos::future<
-            typename hpx::util::detail::deferred_result_of<F(Ts...)>::type
+            typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
         >
     >::type
     async_execute(Executor && exec, F && f, Ts &&... ts)
@@ -56,7 +56,7 @@ namespace hpx { namespace threads
     HPX_FORCEINLINE
     typename std::enable_if<
         hpx::traits::is_threads_executor<Executor>::value,
-        typename hpx::util::detail::deferred_result_of<F(Ts...)>::type
+        typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
     >::type
     sync_execute(Executor && exec, F && f, Ts &&... ts)
     {
@@ -71,15 +71,15 @@ namespace hpx { namespace threads
     typename std::enable_if<
         hpx::traits::is_threads_executor<Executor>::value,
         hpx::lcos::future<
-            typename hpx::util::detail::deferred_result_of<
-                F(Future, Ts...)
+            typename hpx::util::detail::invoke_deferred_result<
+                F, Future, Ts...
             >::type
         >
     >::type
     then_execute(Executor && exec, F && f, Future& predecessor, Ts &&... ts)
     {
-        typedef typename hpx::util::detail::deferred_result_of<
-                F(Future, Ts...)
+        typedef typename hpx::util::detail::invoke_deferred_result<
+                F, Future, Ts...
             >::type result_type;
 
         auto func = hpx::util::bind(

--- a/hpx/parallel/executors/thread_executor_traits.hpp
+++ b/hpx/parallel/executors/thread_executor_traits.hpp
@@ -94,7 +94,7 @@ namespace hpx { namespace parallel { inline namespace v3
         ///
         template <typename Executor_, typename F, typename ... Ts>
         static hpx::future<
-            typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
+            typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
         >
         async_execute(Executor_ && sched, F && f, Ts &&... ts)
         {
@@ -118,7 +118,7 @@ namespace hpx { namespace parallel { inline namespace v3
         /// \returns f(ts...)'s result through a future
         ///
         template <typename Executor_, typename F, typename ... Ts>
-        static typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
+        static typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
         execute(Executor_ && sched, F && f, Ts &&... ts)
         {
             return hpx::async(std::forward<Executor_>(sched),

--- a/hpx/parallel/executors/thread_timed_execution.hpp
+++ b/hpx/parallel/executors/thread_timed_execution.hpp
@@ -54,14 +54,14 @@ namespace hpx { namespace threads
     typename std::enable_if<
         hpx::traits::is_threads_executor<Executor>::value,
         hpx::future<
-            typename hpx::util::detail::deferred_result_of<F(Ts...)>::type
+            typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
         >
     >::type
     async_execute_at(Executor && exec,
         hpx::util::steady_time_point const& abs_time, F && f, Ts &&... ts)
     {
-        typedef typename hpx::util::detail::deferred_result_of<
-                F(Ts...)
+        typedef typename hpx::util::detail::invoke_deferred_result<
+                F, Ts...
             >::type result_type;
 
         lcos::local::packaged_task<
@@ -82,14 +82,14 @@ namespace hpx { namespace threads
     typename std::enable_if<
         hpx::traits::is_threads_executor<Executor>::value,
         hpx::future<
-            typename hpx::util::detail::deferred_result_of<F(Ts...)>::type
+            typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
         >
     >::type
     async_execute_after(Executor && exec,
         hpx::util::steady_duration const& rel_time, F && f, Ts &&... ts)
     {
-        typedef typename hpx::util::detail::deferred_result_of<
-                F(Ts...)
+        typedef typename hpx::util::detail::invoke_deferred_result<
+                F, Ts...
             >::type result_type;
 
         lcos::local::packaged_task<result_type(Ts...)>
@@ -109,7 +109,7 @@ namespace hpx { namespace threads
     template <typename Executor, typename F, typename ... Ts>
     typename std::enable_if<
         hpx::traits::is_threads_executor<Executor>::value,
-        typename hpx::util::detail::deferred_result_of<F(Ts...)>::type
+        typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
     >::type
     sync_execute_at(Executor && exec,
         hpx::util::steady_time_point const& abs_time, F && f, Ts &&... ts)
@@ -121,7 +121,7 @@ namespace hpx { namespace threads
     template <typename Executor, typename F, typename ... Ts>
     typename std::enable_if<
         hpx::traits::is_threads_executor<Executor>::value,
-        typename hpx::util::detail::deferred_result_of<F(Ts...)>::type
+        typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
     >::type
     sync_execute_after(Executor && exec,
         hpx::util::steady_duration const& rel_time, F && f, Ts &&... ts)

--- a/hpx/parallel/executors/thread_timed_executor_traits.hpp
+++ b/hpx/parallel/executors/thread_timed_executor_traits.hpp
@@ -132,13 +132,13 @@ namespace hpx { namespace parallel { inline namespace v3
         ///
         template <typename Executor_, typename F, typename ... Ts>
         static hpx::future<
-            typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
+            typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
         >
         async_execute_at(Executor_ && sched,
             hpx::util::steady_time_point const& abs_time, F && f, Ts &&... ts)
         {
-            typedef typename hpx::util::detail::deferred_result_of<
-                    F(Ts&&...)
+            typedef typename hpx::util::detail::invoke_deferred_result<
+                    F, Ts...
                 >::type result_type;
 
             lcos::local::packaged_task<result_type(Ts...)>
@@ -170,13 +170,13 @@ namespace hpx { namespace parallel { inline namespace v3
         ///
         template <typename Executor_, typename F, typename ... Ts>
         static hpx::future<
-            typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
+            typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
         >
         async_execute_after(Executor_ && sched,
             hpx::util::steady_duration const& rel_time, F && f, Ts &&... ts)
         {
-            typedef typename hpx::util::detail::deferred_result_of<
-                    F(Ts&&...)
+            typedef typename hpx::util::detail::invoke_deferred_result<
+                    F, Ts...
                 >::type result_type;
 
             lcos::local::packaged_task<result_type(Ts...)>
@@ -208,7 +208,7 @@ namespace hpx { namespace parallel { inline namespace v3
         /// \returns f(ts...)'s result
         ///
         template <typename Executor_, typename F, typename ... Ts>
-        static typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
+        static typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
         execute_at(Executor_ && sched,
             hpx::util::steady_time_point const& abs_time, F && f, Ts &&... ts)
         {
@@ -234,7 +234,7 @@ namespace hpx { namespace parallel { inline namespace v3
         /// \returns f(ts...)'s result
         ///
         template <typename Executor_, typename F, typename ... Ts>
-        static typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
+        static typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
         execute_after(Executor_ && sched,
             hpx::util::steady_duration const& rel_time, F && f, Ts &&... ts)
         {

--- a/hpx/parallel/executors/timed_executors.hpp
+++ b/hpx/parallel/executors/timed_executors.hpp
@@ -398,7 +398,7 @@ namespace hpx { namespace parallel { namespace execution
 
         // OneWayExecutor interface
         template <typename F, typename ... Ts>
-        typename hpx::util::detail::deferred_result_of<F(Ts...)>::type
+        typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
         sync_execute(F && f, Ts &&... ts)
         {
             return detail::call_sync_execute_at(exec_, execute_at_,
@@ -408,7 +408,7 @@ namespace hpx { namespace parallel { namespace execution
         // TwoWayExecutor interface
         template <typename F, typename ... Ts>
         hpx::future<
-            typename hpx::util::detail::deferred_result_of<F(Ts...)>::type
+            typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
         >
         async_execute(F && f, Ts &&... ts)
         {

--- a/hpx/parallel/traits/projected.hpp
+++ b/hpx/parallel/traits/projected.hpp
@@ -72,9 +72,9 @@ namespace hpx { namespace parallel { namespace traits
                 typename std::enable_if<
                     hpx::traits::is_iterator<Iter>::value
                 >::type>
-          : hpx::util::result_of<Proj(
+          : hpx::util::invoke_result<Proj,
                     typename std::iterator_traits<Iter>::reference
-                )>
+                >
         {};
 
         template <typename Projected>
@@ -90,14 +90,14 @@ namespace hpx { namespace parallel { namespace traits
         // with a tuple<datapar<T>...> instead of just a tuple<T...>
         template <typename Proj, typename ValueType, typename Enable = void>
         struct projected_result_of_vector_pack_
-          : hpx::util::result_of<Proj(
+          : hpx::util::invoke_result<Proj,
                     typename hpx::parallel::traits::vector_pack_load<
                         typename hpx::parallel::traits::vector_pack_type<
                             ValueType
                         >::type,
                         ValueType
                     >::value_type&
-                )>
+                >
         {};
 
         template <typename Projected, typename Enable = void>

--- a/hpx/parallel/traits/projected.hpp
+++ b/hpx/parallel/traits/projected.hpp
@@ -137,9 +137,9 @@ namespace hpx { namespace parallel { namespace traits
                 typename std::enable_if<
                     hpx::traits::is_iterator<Iter>::value
                 >::type>
-          : hpx::traits::is_callable<Proj(
-                    typename std::iterator_traits<Iter>::reference
-                )>
+          : hpx::traits::is_invocable<
+                Proj, typename std::iterator_traits<Iter>::reference
+            >
         {};
 
         template <typename Projected, typename Enable = void>
@@ -197,7 +197,7 @@ namespace hpx { namespace parallel { namespace traits
     {
         template <typename F, typename ...Args>
         struct is_indirect_callable_impl
-          : hpx::traits::is_callable<F(Args...)>
+          : hpx::traits::is_invocable<F, Args...>
         {};
 
         template <typename ExPolicy, typename F, typename ProjectedPack,

--- a/hpx/parallel/util/detail/algorithm_result.hpp
+++ b/hpx/parallel/util/detail/algorithm_result.hpp
@@ -246,7 +246,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail
     template <typename U, typename Conv,
     HPX_CONCEPT_REQUIRES_(
         hpx::traits::is_invocable<Conv, U>::value)>
-    typename hpx::util::result_of<Conv(U)>::type
+    typename hpx::util::invoke_result<Conv, U>::type
     convert_to_result(U && val, Conv && conv)
     {
         return hpx::util::invoke(conv, val);
@@ -255,10 +255,10 @@ namespace hpx { namespace parallel { namespace util { namespace detail
     template <typename U, typename Conv,
     HPX_CONCEPT_REQUIRES_(
         hpx::traits::is_invocable<Conv, U>::value)>
-    hpx::future<typename hpx::util::result_of<Conv(U)>::type>
+    hpx::future<typename hpx::util::invoke_result<Conv, U>::type>
     convert_to_result(hpx::future<U> && f, Conv && conv)
     {
-        typedef typename hpx::util::result_of<Conv(U)>::type result_type;
+        typedef typename hpx::util::invoke_result<Conv, U>::type result_type;
 
         return lcos::make_future<result_type>(
                 std::move(f), std::forward<Conv>(conv)

--- a/hpx/parallel/util/detail/algorithm_result.hpp
+++ b/hpx/parallel/util/detail/algorithm_result.hpp
@@ -245,7 +245,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail
     ///////////////////////////////////////////////////////////////////////////
     template <typename U, typename Conv,
     HPX_CONCEPT_REQUIRES_(
-        hpx::traits::is_callable<Conv(U)>::value)>
+        hpx::traits::is_invocable<Conv, U>::value)>
     typename hpx::util::result_of<Conv(U)>::type
     convert_to_result(U && val, Conv && conv)
     {
@@ -254,7 +254,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail
 
     template <typename U, typename Conv,
     HPX_CONCEPT_REQUIRES_(
-        hpx::traits::is_callable<Conv(U)>::value)>
+        hpx::traits::is_invocable<Conv, U>::value)>
     hpx::future<typename hpx::util::result_of<Conv(U)>::type>
     convert_to_result(hpx::future<U> && f, Conv && conv)
     {

--- a/hpx/parallel/util/loop.hpp
+++ b/hpx/parallel/util/loop.hpp
@@ -14,6 +14,7 @@
 #include <hpx/traits/is_execution_policy.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/invoke.hpp>
+#include <hpx/util/result_of.hpp>
 #include <hpx/util/tuple.hpp>
 
 #include <algorithm>
@@ -30,7 +31,7 @@ namespace hpx { namespace parallel { namespace util
     HPX_HOST_DEVICE HPX_FORCEINLINE
     typename std::enable_if<
        !execution::is_vectorpack_execution_policy<ExPolicy>::value,
-        typename std::result_of<F&&(Iters...)>::type
+        typename hpx::util::invoke_result<F, Iters...>::type
     >::type
     loop_step(VecOnly, F && f, Iters& ... its)
     {

--- a/hpx/runtime/actions/continuation2_impl.hpp
+++ b/hpx/runtime/actions/continuation2_impl.hpp
@@ -39,12 +39,11 @@ namespace hpx { namespace actions {
         virtual ~continuation2_impl() {}
 
         template <typename T>
-        typename util::result_of<
-            function_type(
-                hpx::naming::id_type,
-                typename util::result_of<
-                    cont_type(hpx::naming::id_type, T)
-                >::type)
+        typename util::invoke_result<function_type,
+            hpx::naming::id_type,
+            typename util::invoke_result<
+                cont_type, hpx::naming::id_type, T
+            >::type
         >::type operator()(hpx::naming::id_type const& lco, T && t) const
         {
             using hpx::util::placeholders::_2;
@@ -53,12 +52,11 @@ namespace hpx { namespace actions {
 
             // Unfortunately we need to default construct the return value,
             // this possibly imposes an additional restriction of return types.
-            typedef typename util::result_of<
-                function_type(
-                    hpx::naming::id_type,
-                    typename util::result_of<
-                        cont_type(hpx::naming::id_type, T)
-                    >::type)
+            typedef typename util::invoke_result<function_type,
+                hpx::naming::id_type,
+                typename util::invoke_result<
+                    cont_type, hpx::naming::id_type, T
+                >::type
             >::type result_type;
             return result_type();
         }

--- a/hpx/runtime/actions/continuation_impl.hpp
+++ b/hpx/runtime/actions/continuation_impl.hpp
@@ -34,15 +34,15 @@ namespace hpx { namespace actions {
         virtual ~continuation_impl() {}
 
         template <typename T>
-        typename util::result_of<cont_type(hpx::naming::id_type, T)>::type
+        typename util::invoke_result<cont_type, hpx::naming::id_type, T>::type
         operator()(hpx::naming::id_type const& lco, T && t) const
         {
             hpx::apply_c(cont_, lco, target_, std::forward<T>(t));
 
             // Unfortunately we need to default construct the return value,
             // this possibly imposes an additional restriction of return types.
-            typedef typename util::result_of<
-                cont_type(hpx::naming::id_type, T)
+            typedef typename util::invoke_result<
+                cont_type, hpx::naming::id_type, T
             >::type result_type;
             return result_type();
         }

--- a/hpx/runtime/actions/trigger.hpp
+++ b/hpx/runtime/actions/trigger.hpp
@@ -133,7 +133,7 @@ namespace hpx { namespace actions {
     void trigger(typed_continuation<Result, RemoteResult>&& cont,
         F&& f, Ts&&... vs)
     {
-        typedef typename util::result_of<F(Ts...)>::type result_type;
+        typedef typename util::invoke_result<F, Ts...>::type result_type;
         traits::is_future<result_type> is_future;
 
         detail::trigger_impl_future(is_future, std::move(cont),

--- a/hpx/runtime/components/client_base.hpp
+++ b/hpx/runtime/components/client_base.hpp
@@ -510,7 +510,7 @@ namespace hpx { namespace components
             }
 
             typedef
-                typename hpx::util::result_of<F(Derived)>::type
+                typename hpx::util::invoke_result<F, Derived>::type
                 continuation_result_type;
             typedef
                 typename hpx::traits::detail::shared_state_ptr<result_type>::type

--- a/hpx/runtime/components/server/invoke_function.hpp
+++ b/hpx/runtime/components/server/invoke_function.hpp
@@ -23,7 +23,7 @@ namespace hpx { namespace components { namespace server
         template <typename F, typename ...Ts>
         struct invoke_function
         {
-            static typename util::result_of<F(Ts...)>::type
+            static typename util::invoke_result<F, Ts...>::type
             call (F f, Ts... ts)
             {
                 return f(std::move(ts)...);
@@ -36,7 +36,7 @@ namespace hpx { namespace components { namespace server
     template <typename F, typename ...Ts>
     struct invoke_function_action
       : ::hpx::actions::action<
-            typename util::result_of<F(Ts...)>::type(*)(F, Ts...),
+            typename util::invoke_result<F, Ts...>::type(*)(F, Ts...),
             &detail::invoke_function<F, Ts...>::call,
             invoke_function_action<F, Ts...> >
     {};

--- a/hpx/runtime/threads/run_as_hpx_thread.hpp
+++ b/hpx/runtime/threads/run_as_hpx_thread.hpp
@@ -35,14 +35,14 @@ namespace hpx { namespace threads
     {
         // This is the overload for running functions which return a value.
         template <typename F, typename... Ts>
-        typename util::result_of<F&&(Ts&&...)>::type
+        typename util::invoke_result<F, Ts...>::type
         run_as_hpx_thread(std::false_type, F const& f, Ts &&... ts)
         {
             hpx::lcos::local::spinlock mtx;
             std::condition_variable_any cond;
             bool stopping = false;
 
-            typedef typename util::result_of<F&&(Ts&&...)>::type result_type;
+            typedef typename util::invoke_result<F, Ts...>::type result_type;
 
             // Using the optional for storing the returned result value
             // allows to support non-default-constructible and move-only
@@ -127,14 +127,14 @@ namespace hpx { namespace threads
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename F, typename... Ts>
-    typename util::result_of<F&&(Ts&&...)>::type
+    typename util::invoke_result<F, Ts...>::type
     run_as_hpx_thread(F const& f, Ts &&... vs)
     {
         // This shouldn't be used on a HPX-thread
         HPX_ASSERT(hpx::threads::get_self_ptr() == nullptr);
 
         typedef typename std::is_void<
-                typename util::result_of<F&&(Ts&&...)>::type
+                typename util::invoke_result<F, Ts...>::type
             >::type result_is_void;
 
         return detail::run_as_hpx_thread(result_is_void(),

--- a/hpx/runtime/threads/run_as_os_thread.hpp
+++ b/hpx/runtime/threads/run_as_os_thread.hpp
@@ -21,7 +21,7 @@ namespace hpx { namespace threads
 {
     ///////////////////////////////////////////////////////////////////////////
     template <typename F, typename ... Ts>
-    hpx::future<typename util::result_of<F&&(Ts&&...)>::type>
+    hpx::future<typename util::invoke_result<F, Ts...>::type>
     run_as_os_thread(F && f, Ts &&... vs)
     {
         HPX_ASSERT(get_self_ptr() != nullptr);

--- a/hpx/traits/future_then_result.hpp
+++ b/hpx/traits/future_then_result.hpp
@@ -98,11 +98,11 @@ namespace hpx { namespace traits
         struct future_then_result<
             Future, F, hpx::util::detail::pack<Ts...>
           , typename hpx::util::always_void<
-                typename hpx::util::result_of<F(Future, Ts...)>::type
+                typename hpx::util::invoke_result<F, Future, Ts...>::type
             >::type
         >
         {
-            typedef typename hpx::util::result_of<F(Future, Ts...)>::type
+            typedef typename hpx::util::invoke_result<F, Future, Ts...>::type
                 cont_result;
 
             // perform unwrapping of future<future<R>>
@@ -128,10 +128,10 @@ namespace hpx { namespace traits
         struct future_then_executor_result<
                 Executor, Future, F, hpx::util::detail::pack<Ts...>
               , typename hpx::util::always_void<
-                    typename hpx::util::result_of<F(Future, Ts...)>::type
+                    typename hpx::util::invoke_result<F, Future, Ts...>::type
                 >::type>
         {
-            typedef typename hpx::util::result_of<F(Future, Ts...)>::type
+            typedef typename hpx::util::invoke_result<F, Future, Ts...>::type
                 func_result_type;
 
             typedef typename traits::executor_future<

--- a/hpx/traits/is_callable.hpp
+++ b/hpx/traits/is_callable.hpp
@@ -4,6 +4,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// hpxinspect:nodeprecatedname:is_callable
+// hpxinspect:nodeprecatedname:util::result_of
+
 #ifndef HPX_TRAITS_IS_CALLABLE_HPP
 #define HPX_TRAITS_IS_CALLABLE_HPP
 

--- a/hpx/traits/is_callable.hpp
+++ b/hpx/traits/is_callable.hpp
@@ -47,6 +47,17 @@ namespace hpx { namespace traits
     struct is_callable<F(Ts...), R>
       : detail::is_callable_impl<F(Ts...), R>
     {};
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename F, typename ...Ts>
+    struct is_invocable
+      : detail::is_callable_impl<F&&(Ts&&...), void>
+    {};
+
+    template <typename R, typename F, typename ...Ts>
+    struct is_invocable_r
+      : detail::is_callable_impl<F&&(Ts&&...), R>
+    {};
 }}
 
 #endif

--- a/hpx/util/annotated_function.hpp
+++ b/hpx/util/annotated_function.hpp
@@ -125,7 +125,7 @@ namespace hpx { namespace util
 
         public:
             template <typename ... Ts>
-            typename deferred_result_of<F(Ts...)>::type
+            typename invoke_deferred_result<F, Ts...>::type
             operator()(Ts && ... ts)
             {
                 annotate_function func(name_);

--- a/hpx/util/bind.hpp
+++ b/hpx/util/bind.hpp
@@ -137,8 +137,8 @@ namespace hpx { namespace util
             >::type
         >
         {
-            typedef typename util::detail::fused_result_of<
-                T&(Us&&)
+            typedef typename util::detail::invoke_fused_result<
+                T&, Us
             >::type type;
 
             static HPX_HOST_DEVICE HPX_FORCEINLINE
@@ -176,45 +176,45 @@ namespace hpx { namespace util
 
         ///////////////////////////////////////////////////////////////////////
         template <typename F, typename Ts, typename Us>
-        struct bound_result_of_impl;
+        struct invoke_bound_result_impl;
 
         template <typename F, typename ...Ts, typename Us>
-        struct bound_result_of_impl<F, util::tuple<Ts...>, Us>
-          : util::result_of<
-                F&(typename bind_eval_impl<F, Ts, Us>::type&&...)
+        struct invoke_bound_result_impl<F, util::tuple<Ts...>, Us>
+          : util::invoke_result<
+                F&, typename bind_eval_impl<F, Ts, Us>::type...
             >
         {};
 
         template <typename F, typename Ts>
-        struct bound_result_of_simple_impl;
+        struct invoke_bound_result_simple_impl;
 
         template <typename F, typename ...Ts>
-        struct bound_result_of_simple_impl<F, util::tuple<Ts...> >
-          : util::result_of<F&(Ts&...)>
+        struct invoke_bound_result_simple_impl<F, util::tuple<Ts...> >
+          : util::invoke_result<F&, Ts&...>
         {};
 
         template <typename F, typename ...Ts>
-        struct bound_result_of_simple_impl<one_shot_wrapper<F>, util::tuple<Ts...> >
-          : util::result_of<F&&(Ts&&...)>
+        struct invoke_bound_result_simple_impl<one_shot_wrapper<F>, util::tuple<Ts...> >
+          : util::invoke_result<F&&, Ts&&...>
         {};
 
         ///////////////////////////////////////////////////////////////////////
         template <typename F, typename Ts, typename Us>
-        struct bound_result_of
+        struct invoke_bound_result
           : std::conditional<
                 !detail::is_simple_bind<Ts>::value,
-                bound_result_of_impl<F, Ts, Us>,
-                bound_result_of_simple_impl<F, Ts>
+                invoke_bound_result_impl<F, Ts, Us>,
+                invoke_bound_result_simple_impl<F, Ts>
             >::type
         {};
 
         template <typename F, typename ...Ts, typename Us>
-        struct bound_result_of<F, util::tuple<Ts...> const, Us>
-          : bound_result_of<F, util::tuple<Ts const...>, Us>
+        struct invoke_bound_result<F, util::tuple<Ts...> const, Us>
+          : invoke_bound_result<F, util::tuple<Ts const...>, Us>
         {};
 
         template <typename F, typename ...Ts, typename Us>
-        struct bound_result_of<
+        struct invoke_bound_result<
             one_shot_wrapper<F> const, util::tuple<Ts...> const, Us>
         {}; // one-shot wrapper is not const callable
 
@@ -223,7 +223,7 @@ namespace hpx { namespace util
         HPX_HOST_DEVICE
         typename std::enable_if<
             !detail::is_simple_bind<Ts>::value,
-            typename bound_result_of<F, Ts, Us>::type
+            typename invoke_bound_result<F, Ts, Us>::type
         >::type bound_impl(F& f, Ts& bound, Us&& unbound,
             pack_c<std::size_t, Is...>)
         {
@@ -236,7 +236,7 @@ namespace hpx { namespace util
         HPX_HOST_DEVICE
         typename std::enable_if<
             detail::is_simple_bind<Ts>::value,
-            typename bound_result_of<F, Ts, Us>::type
+            typename invoke_bound_result<F, Ts, Us>::type
         >::type bound_impl(F& f, Ts& bound, Us&& /*unbound*/,
             pack_c<std::size_t, Is...>)
         {
@@ -247,7 +247,7 @@ namespace hpx { namespace util
         HPX_HOST_DEVICE
         typename std::enable_if<
             detail::is_simple_bind<Ts>::value,
-            typename bound_result_of<one_shot_wrapper<F>, Ts, Us>::type
+            typename invoke_bound_result<one_shot_wrapper<F>, Ts, Us>::type
         >::type bound_impl(one_shot_wrapper<F>& f, Ts& bound, Us&& /*unbound*/,
             pack_c<std::size_t, Is...>)
         {
@@ -287,7 +287,7 @@ namespace hpx { namespace util
 
             template <typename ...Us>
             HPX_HOST_DEVICE inline
-            typename bound_result_of<
+            typename invoke_bound_result<
                 typename std::decay<F>::type,
                 util::tuple<typename util::decay_unwrap<Ts>::type...>,
                 util::tuple<Us&&...>
@@ -300,7 +300,7 @@ namespace hpx { namespace util
 
             template <typename ...Us>
             HPX_HOST_DEVICE inline
-            typename bound_result_of<
+            typename invoke_bound_result<
                 typename std::decay<F>::type const,
                 util::tuple<typename util::decay_unwrap<Ts>::type...> const,
                 util::tuple<Us&&...>
@@ -411,7 +411,7 @@ namespace hpx { namespace util
 
             template <typename ...Ts>
             HPX_HOST_DEVICE inline
-            typename util::result_of<F&&(Ts&&...)>::type
+            typename util::invoke_result<F, Ts...>::type
             operator()(Ts&&... vs)
             {
                 check_call();

--- a/hpx/util/deferred_call.hpp
+++ b/hpx/util/deferred_call.hpp
@@ -3,6 +3,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// hpxinspect:nodeprecatedname:is_callable
+// hpxinspect:nodeprecatedname:util::result_of
+
 #ifndef HPX_UTIL_DEFERRED_CALL_HPP
 #define HPX_UTIL_DEFERRED_CALL_HPP
 

--- a/hpx/util/deferred_call.hpp
+++ b/hpx/util/deferred_call.hpp
@@ -59,6 +59,14 @@ namespace hpx { namespace util
             >
         {};
 
+        template <typename F, typename ...Ts>
+        struct invoke_deferred_result
+          : util::invoke_result<
+                typename util::decay_unwrap<F>::type,
+                typename util::decay_unwrap<Ts>::type...
+            >
+        {};
+
         ///////////////////////////////////////////////////////////////////////
         template <typename T>
         class deferred;
@@ -86,7 +94,7 @@ namespace hpx { namespace util
             deferred& operator=(deferred const&) = delete;
 
             HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename deferred_result_of<F(Ts...)>::type
+            typename invoke_deferred_result<F, Ts...>::type
             operator()()
             {
                 return util::invoke_fused(std::move(_f), std::move(_args));

--- a/hpx/util/deferred_call.hpp
+++ b/hpx/util/deferred_call.hpp
@@ -32,6 +32,15 @@ namespace hpx { namespace traits { namespace detail
                 typename util::decay_unwrap<Ts>::type...)
         >
     {};
+
+    template <typename F, typename ...Ts>
+    struct is_deferred_invocable
+      : is_invocable<
+            typename util::decay_unwrap<F>::type,
+            typename util::decay_unwrap<Ts>::type...
+        >
+    {};
+
 }}}
 
 namespace hpx { namespace util

--- a/hpx/util/detail/basic_function.hpp
+++ b/hpx/util/detail/basic_function.hpp
@@ -164,7 +164,7 @@ namespace hpx { namespace util { namespace detail
             typedef typename std::remove_cv<T>::type target_type;
 
             static_assert(
-                traits::is_callable<target_type&(Ts...), R>::value
+                traits::is_invocable_r<R, target_type&, Ts...>::value
               , "T shall be Callable with the function signature");
 
             VTable const* f_vptr = get_vtable<target_type>();
@@ -180,7 +180,7 @@ namespace hpx { namespace util { namespace detail
             typedef typename std::remove_cv<T>::type target_type;
 
             static_assert(
-                traits::is_callable<target_type&(Ts...), R>::value
+                traits::is_invocable_r<R, target_type&, Ts...>::value
               , "T shall be Callable with the function signature");
 
             VTable const* f_vptr = get_vtable<target_type>();

--- a/hpx/util/function.hpp
+++ b/hpx/util/function.hpp
@@ -71,7 +71,7 @@ namespace hpx { namespace util
         template <typename F, typename FD = typename std::decay<F>::type,
             typename Enable = typename std::enable_if<
                 !std::is_same<FD, function>::value
-             && traits::is_callable<FD&(Ts...), R>::value
+             && traits::is_invocable_r<R, FD&, Ts...>::value
             >::type>
         function(F&& f)
           : base_type()
@@ -109,7 +109,7 @@ namespace hpx { namespace util
         template <typename F, typename FD = typename std::decay<F>::type,
             typename Enable = typename std::enable_if<
                 !std::is_same<FD, function>::value
-             && traits::is_callable<FD&(Ts...), R>::value
+             && traits::is_invocable_r<R, FD&, Ts...>::value
             >::type>
         function& operator=(F&& f)
         {

--- a/hpx/util/functional/colocated_helpers.hpp
+++ b/hpx/util/functional/colocated_helpers.hpp
@@ -80,11 +80,11 @@ namespace hpx { namespace util { namespace functional
             }
 
             template <typename T>
-            typename util::result_of<bound_type(naming::id_type, T)>::type
+            typename util::invoke_result<bound_type, naming::id_type, T>::type
             operator()(naming::id_type lco, T && t)
             {
-                typedef typename util::result_of<
-                    bound_type(naming::id_type, T)
+                typedef typename util::invoke_result<
+                    bound_type, naming::id_type, T
                 >::type result_type;
 
                 bound_.apply_c(std::move(cont_), lco, std::forward<T>(t));
@@ -138,11 +138,11 @@ namespace hpx { namespace util { namespace functional
             }
 
             template <typename T>
-            typename util::result_of<bound_type(naming::id_type, T)>::type
+            typename util::invoke_result<bound_type, naming::id_type, T>::type
             operator()(naming::id_type lco, T && t)
             {
-                typedef typename util::result_of<
-                    bound_type(naming::id_type, T)
+                typedef typename util::invoke_result<
+                    bound_type, naming::id_type, T
                 >::type result_type;
 
                 bound_.apply(lco, std::forward<T>(t));
@@ -221,11 +221,11 @@ namespace hpx { namespace util { namespace functional
             }
 
             template <typename T>
-            typename util::result_of<bound_type(naming::id_type, T)>::type
+            typename util::invoke_result<bound_type, naming::id_type, T>::type
             operator()(naming::id_type lco, T && t)
             {
-                typedef typename util::result_of<
-                    bound_type(naming::id_type, T)
+                typedef typename util::invoke_result<
+                    bound_type, naming::id_type, T
                 >::type result_type;
 
                 bound_.apply_c(std::move(cont_), lco, std::forward<T>(t));
@@ -280,11 +280,11 @@ namespace hpx { namespace util { namespace functional
             }
 
             template <typename T>
-            typename util::result_of<bound_type(naming::id_type, T)>::type
+            typename util::invoke_result<bound_type, naming::id_type, T>::type
             operator()(naming::id_type lco, T && t)
             {
-                typedef typename util::result_of<
-                    bound_type(naming::id_type, T)
+                typedef typename util::invoke_result<
+                    bound_type, naming::id_type, T
                 >::type result_type;
 
                 bound_.apply_c(lco, lco, std::forward<T>(t));

--- a/hpx/util/invoke.hpp
+++ b/hpx/util/invoke.hpp
@@ -145,10 +145,10 @@ namespace hpx { namespace util
     /// \note This function is similar to `std::invoke` (C++17)
     template <typename F, typename ...Ts>
     HPX_HOST_DEVICE HPX_FORCEINLINE
-    typename util::result_of<F&&(Ts&&...)>::type
+    typename util::invoke_result<F, Ts...>::type
     invoke(F&& f, Ts&&... vs)
     {
-        typedef typename util::result_of<F&&(Ts&&...)>::type R;
+        typedef typename util::invoke_result<F, Ts...>::type R;
 
         return detail::invoke_impl<R,typename std::decay<F>::type>()(
             std::forward<F>(f), std::forward<Ts>(vs)...);
@@ -174,10 +174,10 @@ namespace hpx { namespace util
         {
             template <typename F, typename... Ts>
             HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::result_of<F&&(Ts &&...)>::type
+            typename util::invoke_result<F, Ts...>::type
             operator()(F && f, Ts &&... vs)
             {
-                typedef typename util::result_of<F&&(Ts&&...)>::type R;
+                typedef typename util::invoke_result<F, Ts...>::type R;
 
                 return hpx::util::void_guard<R>(), util::invoke(std::forward<F>(f),
                     std::forward<Ts>(vs)...);

--- a/hpx/util/invoke_fused.hpp
+++ b/hpx/util/invoke_fused.hpp
@@ -4,6 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// hpxinspect:nodeprecatedname:util::result_of
+
 #ifndef HPX_UTIL_INVOKE_FUSED_HPP
 #define HPX_UTIL_INVOKE_FUSED_HPP
 

--- a/hpx/util/invoke_fused.hpp
+++ b/hpx/util/invoke_fused.hpp
@@ -56,6 +56,11 @@ namespace hpx { namespace util
           : fused_result_of_impl<F, Tuple&&, typename fused_index_pack<Tuple>::type>
         {};
 
+        template <typename F, typename Tuple>
+        struct invoke_fused_result
+          : fused_result_of_impl<F, Tuple&&, typename fused_index_pack<Tuple>::type>
+        {};
+
         ///////////////////////////////////////////////////////////////////////
         template <typename R, typename F, typename Tuple, std::size_t ...Is>
         HPX_HOST_DEVICE
@@ -87,10 +92,10 @@ namespace hpx { namespace util
     /// \note This function is similar to `std::apply` (C++17)
     template <typename F, typename Tuple>
     HPX_HOST_DEVICE HPX_FORCEINLINE
-    typename detail::fused_result_of<F&&(Tuple&&)>::type
+    typename detail::invoke_fused_result<F, Tuple>::type
     invoke_fused(F&& f, Tuple&& t)
     {
-        typedef typename detail::fused_result_of<F&&(Tuple&&)>::type R;
+        typedef typename detail::invoke_fused_result<F, Tuple>::type R;
 
         return detail::invoke_fused_impl<R>(
             std::forward<F>(f), std::forward<Tuple>(t),
@@ -117,10 +122,10 @@ namespace hpx { namespace util
         {
             template <typename F, typename Tuple>
             HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::detail::fused_result_of<F&&(Tuple&&)>::type
+            typename util::detail::invoke_fused_result<F, Tuple>::type
             operator()(F&& f, Tuple&& args)
             {
-                typedef typename util::detail::fused_result_of<F&&(Tuple&&)>::type R;
+                typedef typename util::detail::invoke_fused_result<F, Tuple>::type R;
 
                 return hpx::util::void_guard<R>(), util::invoke_fused(
                     std::forward<F>(f),

--- a/hpx/util/mem_fn.hpp
+++ b/hpx/util/mem_fn.hpp
@@ -29,7 +29,7 @@ namespace hpx { namespace util
             {}
 
             template <typename ...Ts>
-            inline typename util::result_of<MemberPointer(Ts&&...)>::type
+            inline typename util::invoke_result<MemberPointer, Ts...>::type
             operator()(Ts&&... vs) const
             {
                 return util::invoke(_pm, std::forward<Ts>(vs)...);

--- a/hpx/util/result_of.hpp
+++ b/hpx/util/result_of.hpp
@@ -182,6 +182,12 @@ namespace hpx { namespace util
     struct result_of<F(Ts...)>
       : detail::result_of_impl<typename std::decay<F>::type, F(Ts...)>
     {};
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename F, typename ...Ts>
+    struct invoke_result
+      : detail::result_of_impl<typename std::decay<F>::type, F&&(Ts&&...)>
+    {};
 }}
 
 #endif

--- a/hpx/util/transform_iterator.hpp
+++ b/hpx/util/transform_iterator.hpp
@@ -28,7 +28,7 @@ namespace hpx { namespace util
         {
             typedef typename std::conditional<
                     std::is_void<Reference>::value,
-                    typename util::result_of<Transformer(Iterator)>::type,
+                    typename util::invoke_result<Transformer, Iterator>::type,
                     Reference
                 >::type reference_type;
 

--- a/hpx/util/unique_function.hpp
+++ b/hpx/util/unique_function.hpp
@@ -57,7 +57,7 @@ namespace hpx { namespace util
         template <typename F, typename FD = typename std::decay<F>::type,
             typename Enable = typename std::enable_if<
                 !std::is_same<FD, unique_function>::value
-             && traits::is_callable<FD&(Ts...), R>::value
+             && traits::is_invocable_r<R, FD&, Ts...>::value
             >::type>
         unique_function(F&& f)
           : base_type()
@@ -74,7 +74,7 @@ namespace hpx { namespace util
         template <typename F, typename FD = typename std::decay<F>::type,
             typename Enable = typename std::enable_if<
                 !std::is_same<FD, unique_function>::value
-             && traits::is_callable<FD&(Ts...), R>::value
+             && traits::is_invocable_r<R, FD&, Ts...>::value
             >::type>
         unique_function& operator=(F&& f)
         {

--- a/hpx/util/unwrapped.hpp
+++ b/hpx/util/unwrapped.hpp
@@ -272,8 +272,8 @@ namespace hpx { namespace util
         struct unwrapped_impl_result<
             F, T, TD,
             typename std::enable_if<traits::is_future<TD>::value>::type
-        > : util::detail::fused_result_of<
-                F(typename unwrap_impl<util::tuple<TD> >::type)
+        > : util::detail::invoke_fused_result<
+                F, typename unwrap_impl<util::tuple<TD> >::type
             >
         {};
 
@@ -283,11 +283,11 @@ namespace hpx { namespace util
             typename std::enable_if<traits::is_future_range<TD>::value>::type
         > : std::conditional<
                 unwrap_impl<TD>::is_void::value
-              , util::detail::fused_result_of<
-                    F(util::tuple<>)
+              , util::detail::invoke_fused_result<
+                    F, util::tuple<>
                 >
-              , util::detail::fused_result_of<
-                    F(util::tuple<typename unwrap_impl<TD>::type>)
+              , util::detail::invoke_fused_result<
+                    F, util::tuple<typename unwrap_impl<TD>::type>
                 >
             >::type
         {};
@@ -296,8 +296,8 @@ namespace hpx { namespace util
         struct unwrapped_impl_result<
             F, T, TD,
             typename std::enable_if<traits::is_future_tuple<TD>::value>::type
-        > : util::detail::fused_result_of<
-                F(typename unwrap_impl<TD>::type)
+        > : util::detail::invoke_fused_result<
+                F, typename unwrap_impl<TD>::type
             >
         {};
 
@@ -334,7 +334,7 @@ namespace hpx { namespace util
 
             template <typename Delayed = unwrapped_impl>
             HPX_FORCEINLINE
-            typename util::result_of<Delayed()>::type
+            typename util::invoke_result<Delayed>::type
             operator()()
             {
                 return util::invoke_fused(f_,

--- a/hpx/util/zip_iterator.hpp
+++ b/hpx/util/zip_iterator.hpp
@@ -588,7 +588,7 @@ namespace hpx { namespace traits
 
         ///////////////////////////////////////////////////////////////////////
         template <typename F, typename T>
-        struct element_result_of : util::result_of<F(T)> {};
+        struct element_result_of : util::invoke_result<F, T> {};
 
         template <typename F, typename Iter>
         struct lift_zipped_iterators;

--- a/tests/performance/local/stream.cpp
+++ b/tests/performance/local/stream.cpp
@@ -229,7 +229,7 @@ struct multiply_step
     multiply_step(T factor) : factor_(factor) {}
 
     // FIXME : call operator of multiply_step is momentarily defined with
-    //         a generic parameter to allow the host_side result_of<>
+    //         a generic parameter to allow the host_side invoke_result<>
     //         (used in invoke()) to get the return type
 
     template<typename U>
@@ -245,7 +245,7 @@ template <typename T>
 struct add_step
 {
     // FIXME : call operator of add_step is momentarily defined with
-    //         generic parameters to allow the host_side result_of<>
+    //         generic parameters to allow the host_side invoke_result<>
     //         (used in invoke()) to get the return type
 
     template<typename U>
@@ -261,7 +261,7 @@ struct triad_step
     triad_step(T factor) : factor_(factor) {}
 
     // FIXME : call operator of triad_step is momentarily defined with
-    //         generic parameters to allow the host_side result_of<>
+    //         generic parameters to allow the host_side invoke_result<>
     //         (used in invoke()) to get the return type
 
     template<typename U>

--- a/tests/regressions/traits/is_callable_1179.cpp
+++ b/tests/regressions/traits/is_callable_1179.cpp
@@ -4,6 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// hpxinspect:nodeprecatedname:hpx::traits::is_callable
+
 #include <hpx/config.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/traits/is_callable.hpp>

--- a/tests/unit/parallel/executors/minimal_async_executor.cpp
+++ b/tests/unit/parallel/executors/minimal_async_executor.cpp
@@ -156,7 +156,7 @@ struct test_async_executor1
     typedef hpx::parallel::execution::parallel_execution_tag execution_category;
 
     template <typename F, typename ... Ts>
-    static hpx::future<typename hpx::util::result_of<F&&(Ts&&...)>::type>
+    static hpx::future<typename hpx::util::invoke_result<F, Ts...>::type>
     async_execute(F && f, Ts &&... ts)
     {
         ++count_async;
@@ -178,7 +178,7 @@ struct test_async_executor2 : test_async_executor1
     typedef hpx::parallel::execution::parallel_execution_tag execution_category;
 
     template <typename F, typename ... Ts>
-    static typename hpx::util::detail::deferred_result_of<F(Ts...)>::type
+    static typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
     sync_execute(F && f, Ts &&... ts)
     {
         ++count_sync;

--- a/tests/unit/parallel/executors/minimal_async_executor_v1.cpp
+++ b/tests/unit/parallel/executors/minimal_async_executor_v1.cpp
@@ -132,7 +132,7 @@ void test_executor()
 struct test_async_executor2 : hpx::parallel::executor_tag
 {
     template <typename F, typename ... Ts>
-    hpx::future<typename hpx::util::result_of<F&&(Ts&&...)>::type>
+    hpx::future<typename hpx::util::invoke_result<F, Ts...>::type>
     async_execute(F && f, Ts &&... ts)
     {
         return hpx::async(hpx::launch::async, std::forward<F>(f),
@@ -143,7 +143,7 @@ struct test_async_executor2 : hpx::parallel::executor_tag
 struct test_async_executor1 : test_async_executor2
 {
     template <typename F, typename ... Ts>
-    typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
+    typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
     execute(F && f, Ts &&... ts)
     {
         return hpx::async(hpx::launch::async, std::forward<F>(f),

--- a/tests/unit/parallel/executors/minimal_sync_executor.cpp
+++ b/tests/unit/parallel/executors/minimal_sync_executor.cpp
@@ -248,7 +248,7 @@ struct test_sync_executor1
     typedef hpx::parallel::execution::sequenced_execution_tag execution_category;
 
     template <typename F, typename ... Ts>
-    static typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
+    static typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
     sync_execute(F && f, Ts &&... ts)
     {
         ++count_sync;

--- a/tests/unit/parallel/executors/minimal_sync_executor_v1.cpp
+++ b/tests/unit/parallel/executors/minimal_sync_executor_v1.cpp
@@ -134,7 +134,7 @@ struct test_sync_executor2 : hpx::parallel::executor_tag
     typedef hpx::parallel::sequential_execution_tag execution_category;
 
     template <typename F, typename ... Ts>
-    hpx::future<typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type>
+    hpx::future<typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type>
     async_execute(F && f, Ts &&... ts)
     {
         return hpx::async(hpx::launch::sync, std::forward<F>(f),
@@ -152,7 +152,7 @@ struct test_sync_executor1 : test_sync_executor2
     typedef hpx::parallel::sequential_execution_tag execution_category;
 
     template <typename F, typename ... Ts>
-    typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
+    typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
     execute(F && f, Ts &&... ts)
     {
         return hpx::util::invoke(std::forward<F>(f), std::forward<Ts>(ts)...);

--- a/tests/unit/parallel/executors/minimal_timed_async_executor.cpp
+++ b/tests/unit/parallel/executors/minimal_timed_async_executor.cpp
@@ -167,7 +167,7 @@ struct test_async_executor1
 
     template <typename F, typename ... Ts>
     static hpx::future<
-        typename hpx::util::detail::deferred_result_of<F(Ts...)>::type
+        typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
     >
     async_execute(F && f, Ts &&... ts)
     {
@@ -181,7 +181,7 @@ struct test_timed_async_executor1 : test_async_executor1
 {
     template <typename F, typename ... Ts>
     static hpx::future<
-        typename hpx::util::detail::deferred_result_of<F(Ts...)>::type
+        typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
     >
     async_execute_at(hpx::util::steady_time_point const& abs_time, F && f,
         Ts &&... ts)
@@ -209,7 +209,7 @@ namespace hpx { namespace traits
 struct test_timed_async_executor2 : test_async_executor1
 {
     template <typename F, typename ... Ts>
-    static typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
+    static typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
     sync_execute(F && f, Ts &&... ts)
     {
         ++count_sync;
@@ -221,7 +221,7 @@ struct test_timed_async_executor2 : test_async_executor1
 struct test_timed_async_executor3 : test_timed_async_executor2
 {
     template <typename F, typename ... Ts>
-    static typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
+    static typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
     sync_execute_at(hpx::util::steady_time_point const& abs_time,
         F && f, Ts &&... ts)
     {

--- a/tests/unit/parallel/executors/minimal_timed_async_executor_v1.cpp
+++ b/tests/unit/parallel/executors/minimal_timed_async_executor_v1.cpp
@@ -126,7 +126,7 @@ struct test_timed_async_executor2 : hpx::parallel::timed_executor_tag
     typedef hpx::parallel::parallel_execution_tag execution_category;
 
     template <typename F, typename ... Ts>
-    hpx::future<typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type>
+    hpx::future<typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type>
     async_execute(F && f, Ts &&... ts)
     {
         return hpx::async(hpx::launch::async, std::forward<F>(f),
@@ -134,7 +134,7 @@ struct test_timed_async_executor2 : hpx::parallel::timed_executor_tag
     }
 
     template <typename F, typename ... Ts>
-    hpx::future<typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type>
+    hpx::future<typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type>
     async_execute_at(hpx::util::steady_time_point const& abs_time, F && f,
         Ts &&... ts)
     {
@@ -149,7 +149,7 @@ struct test_timed_async_executor1 : test_timed_async_executor2
     typedef hpx::parallel::parallel_execution_tag execution_category;
 
     template <typename F, typename ... Ts>
-    typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
+    typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
     execute_at(hpx::util::steady_time_point const& abs_time, F && f, Ts &&... ts)
     {
         hpx::this_thread::sleep_until(abs_time);

--- a/tests/unit/parallel/executors/minimal_timed_sync_executor.cpp
+++ b/tests/unit/parallel/executors/minimal_timed_sync_executor.cpp
@@ -160,7 +160,7 @@ struct test_sync_executor1
     typedef hpx::parallel::execution::sequenced_execution_tag execution_category;
 
     template <typename F, typename ... Ts>
-    typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
+    typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
     static sync_execute(F && f, Ts &&... ts)
     {
         ++count_sync;
@@ -173,7 +173,7 @@ struct test_timed_sync_executor1 : test_sync_executor1
     typedef hpx::parallel::execution::sequenced_execution_tag execution_category;
 
     template <typename F, typename ... Ts>
-    typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
+    typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
     static sync_execute_at(hpx::util::steady_time_point const& abs_time,
         F && f, Ts &&... ts)
     {

--- a/tests/unit/parallel/executors/minimal_timed_sync_executor_v1.cpp
+++ b/tests/unit/parallel/executors/minimal_timed_sync_executor_v1.cpp
@@ -126,7 +126,7 @@ struct test_timed_async_executor2 : hpx::parallel::timed_executor_tag
     typedef hpx::parallel::sequential_execution_tag execution_category;
 
     template <typename F, typename ... Ts>
-    hpx::future<typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type>
+    hpx::future<typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type>
     async_execute(F && f, Ts &&... ts)
     {
         return hpx::async(hpx::launch::sync, std::forward<F>(f),
@@ -134,7 +134,7 @@ struct test_timed_async_executor2 : hpx::parallel::timed_executor_tag
     }
 
     template <typename F, typename ... Ts>
-    hpx::future<typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type>
+    hpx::future<typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type>
     async_execute_at(hpx::util::steady_time_point const& abs_time, F && f,
         Ts &&... ts)
     {
@@ -154,7 +154,7 @@ struct test_timed_async_executor1 : test_timed_async_executor2
     typedef hpx::parallel::sequential_execution_tag execution_category;
 
     template <typename F, typename ... Ts>
-    typename hpx::util::detail::deferred_result_of<F(Ts&&...)>::type
+    typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
     execute_at(hpx::util::steady_time_point const& abs_time, F && f, Ts &&... ts)
     {
         hpx::this_thread::sleep_until(abs_time);

--- a/tests/unit/parallel/executors/shared_parallel_executor.cpp
+++ b/tests/unit/parallel/executors/shared_parallel_executor.cpp
@@ -22,7 +22,7 @@
 struct shared_parallel_executor
 {
     template <typename F, typename ... Ts>
-    hpx::shared_future<typename hpx::util::result_of<F&&(Ts &&...)>::type>
+    hpx::shared_future<typename hpx::util::invoke_result<F, Ts...>::type>
     async_execute(F && f, Ts &&... ts)
     {
         return hpx::async(std::forward<F>(f), std::forward<Ts>(ts)...);

--- a/tests/unit/parallel/executors/shared_parallel_executor_v1.cpp
+++ b/tests/unit/parallel/executors/shared_parallel_executor_v1.cpp
@@ -29,7 +29,7 @@ struct shared_parallel_executor
     };
 
     template <typename F, typename ... Ts>
-    hpx::shared_future<typename hpx::util::result_of<F&&(Ts &&...)>::type>
+    hpx::shared_future<typename hpx::util::invoke_result<F, Ts...>::type>
     async_execute(F && f, Ts &&... ts)
     {
         return hpx::async(std::forward<F>(f), std::forward<Ts>(ts)...);

--- a/tests/unit/traits/is_callable.cpp
+++ b/tests/unit/traits/is_callable.cpp
@@ -3,6 +3,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// hpxinspect:nodeprecatedname:hpx::traits::is_callable
+
 #include <hpx/config.hpp>
 #include <hpx/traits/is_callable.hpp>
 #include <hpx/util/lightweight_test.hpp>

--- a/tests/unit/util/iterator/stencil3_iterator.cpp
+++ b/tests/unit/util/iterator/stencil3_iterator.cpp
@@ -154,7 +154,7 @@ namespace test
         {
             typedef typename std::iterator_traits<Iterator>::reference
                 element_type;
-            typedef typename hpx::util::result_of<F(element_type)>::type
+            typedef typename hpx::util::invoke_result<F, element_type>::type
                 value_type;
 
             typedef hpx::util::tuple<value_type, element_type, value_type> type;

--- a/tools/inspect/deprecated_name_check.cpp
+++ b/tools/inspect/deprecated_name_check.cpp
@@ -25,6 +25,7 @@ namespace boost
   {
     deprecated_names const names[] =
     {
+      // boost::xyz
       { "(\\bboost\\s*::\\s*move\\b)", "std::move" },
       { "(\\bboost\\s*::\\s*forward\\b)", "std::forward" },
       { "(\\bboost\\s*::\\s*noncopyable\\b)", "HPX_NON_COPYABLE" },
@@ -73,6 +74,9 @@ namespace boost
       { "(\\bboost\\s*::\\s*cv_status\\b)", "hpx::compat::cv_status" },
       { "(\\bboost\\s*::\\s*condition_variable\\b)", "hpx::compat::condition_variable" },
       { "(\\bboost\\s*::\\s*barrier\\b)", "hpx::compat::barrier" },
+      /////////////////////////////////////////////////////////////////////////
+      { "((\\bhpx::\\b)?\\btraits\\s*::\\bis_callable\\b)", "\\2traits::is_invocable[_r]" },
+      { "((\\bhpx::\\b)?\\butil\\s*::\\bresult_of\\b)", "\\2util::invoke_result" },
       { "(\\bNULL\\b)", "nullptr" },
       { nullptr, nullptr }
     };


### PR DESCRIPTION
Provide (and use) C++17 `is_invocable[_r]` and `invoke_result` forms.