### PR TITLE
Inhibit direct conversion from future<future<T>> --> future<void>

### DIFF
--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -24,6 +24,7 @@
 #include <hpx/traits/is_executor_v1.hpp>
 #endif
 #include <hpx/traits/is_executor.hpp>
+#include <hpx/traits/is_future.hpp>
 #include <hpx/traits/is_launch_policy.hpp>
 #include <hpx/util/always_void.hpp>
 #include <hpx/util/bind.hpp>
@@ -885,7 +886,9 @@ namespace hpx { namespace lcos
         //   - other.valid() == false.
         template <typename T>
         future(future<T>&& other,
-            typename std::enable_if<std::is_void<R>::value, T>::type* = nullptr
+            typename std::enable_if<
+                std::is_void<R>::value && !traits::is_future<T>::value, T
+            >::type* = nullptr
         ) : base_type(other.valid() ?
                 detail::downcast_to_void(other, false) : nullptr)
         {
@@ -1216,7 +1219,9 @@ namespace hpx { namespace lcos
         //     constructor invocation.
         template <typename T>
         shared_future(shared_future<T> const& other,
-            typename std::enable_if<std::is_void<R>::value, T>::type* = nullptr
+            typename std::enable_if<
+                std::is_void<R>::value && !traits::is_future<T>::value, T
+            >::type* = nullptr
         ) : base_type(other.valid() ?
                 detail::downcast_to_void(other, true) : nullptr)
         {}

--- a/tests/regressions/lcos/CMakeLists.txt
+++ b/tests/regressions/lcos/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2007-2015 Hartmut Kaiser
+# Copyright (c) 2007-2017 Hartmut Kaiser
 # Copyright (c) 2011-2012 Bryce Adelstein-Lelbach
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -21,6 +21,7 @@ set(tests
     dataflow_recursion_1613
     dataflow_using_774
     exception_from_continuation_1613
+    future_2667
     future_790
     future_hang_on_get_629
     future_hang_on_then_629
@@ -110,23 +111,27 @@ add_hpx_test(
   THREADS_PER_LOCALITY 4)
 
 # compile only tests
-set(compile_tests
-    future_range_ambiguity_2032
-    wait_all_std_array_2035
-   )
+if(HPX_WITH_COMPILE_ONLY_TESTS)
+  set(compile_tests
+      fail_future_2667
+      future_range_ambiguity_2032
+      wait_all_std_array_2035
+     )
 
-foreach(compile_test ${compile_tests})
-  set(sources
-      ${compile_test}.cpp)
+  set(fail_future_2667_FLAGS FAILURE_EXPECTED)
 
-  source_group("Source Files" FILES ${sources})
+  foreach(compile_test ${compile_tests})
+    set(sources
+        ${compile_test}.cpp)
 
-  add_hpx_regression_compile_test(
-    "lcos_dir"
-    ${compile_test}
-    SOURCES ${sources}
-    ${${compile_test}_FLAGS}
-    FOLDER "Tests/Regressions/LCOs/CompileOnly")
+    source_group("Source Files" FILES ${sources})
+
+    add_hpx_regression_compile_test(
+      "lcos_dir"
+      ${compile_test}
+      SOURCES ${sources}
+      ${${compile_test}_FLAGS}
+      FOLDER "Tests/Regressions/LCOs/CompileOnly")
 
     # add a custom target for this example
     add_hpx_pseudo_target(tests.regressions.lcos_dir.${compile_test})
@@ -139,4 +144,5 @@ foreach(compile_test ${compile_tests})
     add_hpx_pseudo_dependencies(tests.regressions.lcos_dir.${compile_test}
       "tests.regressions.lcos_dir.${compile_test}")
 
-endforeach()
+  endforeach()
+endif()

--- a/tests/regressions/lcos/fail_future_2667.cpp
+++ b/tests/regressions/lcos/fail_future_2667.cpp
@@ -1,0 +1,32 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This test case demonstrates the issue described in #2667: Ambiguity of
+// nested hpx::future<void>'s.
+//
+// This test is supposed to fail compiling.
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_main.hpp>
+
+#include <chrono>
+#include <utility>
+
+int main()
+{
+    hpx::future<hpx::future<int> > fut =
+        hpx::async(
+            []() -> hpx::future<int> {
+                return hpx::async(
+                    []() -> int {
+                        return 42;
+                    });
+            });
+
+    hpx::future<void> fut2 = std::move(fut);
+    fut2.get();
+
+    return 0;
+}

--- a/tests/regressions/lcos/future_2667.cpp
+++ b/tests/regressions/lcos/future_2667.cpp
@@ -1,0 +1,46 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This test case demonstrates the issue described in #2667: Ambiguity of
+// nested hpx::future<void>'s
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_main.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <chrono>
+#include <utility>
+
+#include <boost/atomic.hpp>
+
+boost::atomic<bool> was_run(false);
+
+void do_more_work()
+{
+    hpx::this_thread::sleep_for(std::chrono::seconds(1));
+    was_run = true;
+}
+
+int main()
+{
+    hpx::future<hpx::future<void> > fut =
+        hpx::async(
+            []() -> hpx::future<void> {
+                return hpx::async(
+                    []() -> void {
+                        do_more_work();
+                    });
+            });
+
+    hpx::util::high_resolution_timer t;
+
+    hpx::future<void> fut2 = std::move(fut);
+    fut2.get();
+
+    HPX_TEST(t.elapsed() > 1.0);
+    HPX_TEST(was_run.load());
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
- adding corresponding tests

- this fixes #2667