### PR TITLE
Fix bad size during archive creation

### DIFF
--- a/hpx/runtime/serialization/container.hpp
+++ b/hpx/runtime/serialization/container.hpp
@@ -31,7 +31,7 @@ namespace hpx { namespace serialization
             naming::gid_type const & split_gid) = 0;
         virtual void set_filter(binary_filter* filter) = 0;
         virtual void save_binary(void const* address, std::size_t count) = 0;
-        virtual void save_binary_chunk(void const* address, std::size_t count) = 0;
+        virtual std::size_t save_binary_chunk(void const* address, std::size_t count) = 0;
         virtual void reset() = 0;
         virtual std::size_t get_num_chunks() const = 0;
         virtual void flush() = 0;

--- a/hpx/runtime/serialization/output_archive.hpp
+++ b/hpx/runtime/serialization/output_archive.hpp
@@ -197,6 +197,7 @@ namespace hpx { namespace serialization
 
     private:
         friend struct basic_archive<output_archive>;
+
         template <class T>
         friend class array;
 
@@ -357,11 +358,14 @@ namespace hpx { namespace serialization
         void save_binary_chunk(void const * address, std::size_t count)
         {
             if(count == 0) return;
-            size_ += count;
-            if (disable_data_chunking())
+            if (disable_data_chunking()) {
+                size_ += count;
                 buffer_->save_binary(address, count);
-            else
-                buffer_->save_binary_chunk(address, count);
+            }
+            else {
+                // the size might grow if optimizations are not used
+                size_ += buffer_->save_binary_chunk(address, count);
+            }
         }
 
         typedef std::map<const void *, std::uint64_t> pointer_tracker;

--- a/hpx/runtime/serialization/output_container.hpp
+++ b/hpx/runtime/serialization/output_container.hpp
@@ -315,12 +315,14 @@ namespace hpx { namespace serialization
             current_ = new_current;
         }
 
-        void save_binary_chunk(void const* address, std::size_t count) // override
+        std::size_t save_binary_chunk(void const* address, std::size_t count) // override
         {
             if (count < HPX_ZERO_COPY_SERIALIZATION_THRESHOLD)
             {
                 // fall back to serialization_chunk-less archive
                 this->output_container::save_binary(address, count);
+                // the container has grown by count bytes
+                return count;
             }
             else {
                 HPX_ASSERT(
@@ -339,6 +341,8 @@ namespace hpx { namespace serialization
                 // add a new serialization_chunk referring to the external
                 // buffer
                 chunker_.push_back(create_pointer_chunk(address, count));
+                // the container did not grow
+                return 0;
             }
         }
 
@@ -408,7 +412,7 @@ namespace hpx { namespace serialization
             this->current_ += count;
         }
 
-        void save_binary_chunk(void const* address, std::size_t count) // override
+        std::size_t save_binary_chunk(void const* address, std::size_t count) // override
         {
             if (count < HPX_ZERO_COPY_SERIALIZATION_THRESHOLD)
             {
@@ -416,9 +420,10 @@ namespace hpx { namespace serialization
                 HPX_ASSERT(count != 0);
                 filter_->save(address, count);
                 this->current_ += count;
+                return count;
             }
             else {
-                this->base_type::save_binary_chunk(address, count);
+                return this->base_type::save_binary_chunk(address, count);
             }
         }
 


### PR DESCRIPTION
The archive size only grows if the data is written into the container,
when chunks are added, we do not need to increment the size of the
archive itself.

This fixes a bug where the archive containter is allocated with a much
larger size than needed.