### PR TITLE
Add support of std::array to hpx::util::tuple_size and tuple_element

### DIFF
--- a/hpx/util/tuple.hpp
+++ b/hpx/util/tuple.hpp
@@ -21,6 +21,10 @@
 #include <type_traits>
 #include <utility>
 
+#if defined(HPX_HAVE_CXX11_STD_ARRAY)
+#include <array>
+#endif
+
 #if defined(HPX_MSVC_WARNING_PRAGMA)
 #pragma warning(push)
 #pragma warning(disable: 4520) // multiple default constructors specified
@@ -532,6 +536,13 @@ namespace hpx { namespace util
       : boost::integral_constant<std::size_t, Size>
     {};
 
+#if defined(HPX_HAVE_CXX11_STD_ARRAY)
+    template <typename Type, std::size_t Size>
+    struct tuple_size<std::array<Type, Size> >
+      : boost::integral_constant<std::size_t, Size>
+    {};
+#endif
+
     // template <size_t I, class Tuple>
     // class tuple_element
     template <std::size_t I, typename T>
@@ -624,6 +635,26 @@ namespace hpx { namespace util
             return tuple[I];
         }
     };
+
+#if defined(HPX_HAVE_CXX11_STD_ARRAY)
+    template <std::size_t I, typename Type, std::size_t Size>
+    struct tuple_element<I, std::array<Type, Size> >
+    {
+        typedef Type type;
+
+        static HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE type&
+        get(std::array<Type, Size>& tuple) noexcept
+        {
+            return tuple[I];
+        }
+
+        static HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE type const&
+        get(std::array<Type, Size> const& tuple) noexcept
+        {
+            return tuple[I];
+        }
+    };
+#endif
 
     // 20.4.2.6, element access
 

--- a/tests/unit/util/tuple.cpp
+++ b/tests/unit/util/tuple.cpp
@@ -9,6 +9,7 @@
 
 //  tuple_test_bench.cpp  --------------------------------
 
+#include <hpx/config.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/util/tuple.hpp>
 #include <hpx/util/lightweight_test.hpp>
@@ -17,6 +18,10 @@
 #include <string>
 #include <type_traits>
 #include <utility>
+
+#if defined(HPX_HAVE_CXX11_STD_ARRAY)
+#include <array>
+#endif
 
 // ----------------------------------------------------------------------------
 // helpers
@@ -188,6 +193,11 @@ void element_access_test()
         float> >::type>::value != true));
     HPX_TEST((std::is_const<hpx::util::tuple_element<1, const hpx::util::tuple<int,
         float> >::type>::value));
+
+#if defined(HPX_HAVE_CXX11_STD_ARRAY)
+    HPX_TEST((std::is_same<hpx::util::tuple_element<1,
+                           std::array<float, 4>>::type, float>::value));
+#endif
 
     dummy(i); dummy(i2); dummy(j); dummy(e); // avoid warns for unused variables
 }
@@ -377,6 +387,12 @@ void tuple_length_test()
     HPX_TEST(hpx::util::tuple_size<t1>::value == 3);
     HPX_TEST(hpx::util::tuple_size<t2>::value == 0);
 
+#if defined(HPX_HAVE_CXX11_STD_ARRAY)
+    {
+        using t3 = std::array<int, 4>;
+        HPX_TEST(hpx::util::tuple_size<t3>::value == 4);
+    }
+#endif
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Didn't run the test suite on it yet, let's see how it goes.