### PR TITLE
Add inline to prevent multiple definition issue

### DIFF
--- a/hpx/parallel/task_block.hpp
+++ b/hpx/parallel/task_block.hpp
@@ -38,7 +38,7 @@ namespace hpx { namespace parallel { inline namespace v2
     {
         /// \cond NOINTERNAL
         ///////////////////////////////////////////////////////////////////////
-        void handle_task_block_exceptions(parallel::exception_list& errors)
+        inline void handle_task_block_exceptions(parallel::exception_list& errors)
         {
             try {
                 std::rethrow_exception(std::current_exception());


### PR DESCRIPTION
Prevent multiple definition issue when file is included in multiple translation units, fixes #2707 