### PR TITLE
Remove slashes before CMAKE_FILES_DIRECTORY variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1645,7 +1645,7 @@ set(HPX_DEFINES_PREFIX ${HPX_PREFIX})
 write_config_defines_file(
   TEMPLATE "${PROJECT_SOURCE_DIR}/cmake/templates/config_defines.hpp.in"
   NAMESPACE default
-  FILENAME "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/hpx/config/defines.hpp")
+  FILENAME "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hpx/config/defines.hpp")
 
 # Configure hpxrun.py
 configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/hpxrun.py.in"
@@ -1675,7 +1675,7 @@ install( # install all hpx header files
 # Install all HPX header that have been configured using various
 # cmake options
 install(
-  DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/hpx/"
+  DIRECTORY "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hpx/"
   DESTINATION include/hpx
   COMPONENT core
   FILES_MATCHING PATTERN "*.hpp"

--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -25,7 +25,7 @@ macro(add_hpx_config_test variable)
   endif()
 
   if(NOT DEFINED ${variable})
-    file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/config_tests")
+    file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/config_tests")
 
     string(TOLOWER "${variable}" variable_lc)
     if(${variable}_FILE)
@@ -36,11 +36,11 @@ macro(add_hpx_config_test variable)
       endif()
     else()
       set(test_source
-          "${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/config_tests/${variable_lc}.cpp")
+          "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/config_tests/${variable_lc}.cpp")
       file(WRITE "${test_source}"
            "${${variable}_SOURCE}\n")
     endif()
-    set(test_binary ${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/config_tests/${variable_lc})
+    set(test_binary ${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/config_tests/${variable_lc})
 
     get_directory_property(CONFIG_TEST_INCLUDE_DIRS INCLUDE_DIRECTORIES)
     get_directory_property(CONFIG_TEST_LINK_DIRS LINK_DIRECTORIES)
@@ -66,7 +66,7 @@ macro(add_hpx_config_test variable)
     if(${variable}_EXECUTE)
       if(NOT CMAKE_CROSSCOMPILING)
         try_run(${variable}_RUN_RESULT ${variable}_COMPILE_RESULT
-          ${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/config_tests
+          ${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/config_tests
           ${test_source}
           CMAKE_FLAGS
             "-DINCLUDE_DIRECTORIES=${CONFIG_TEST_INCLUDE_DIRS}"
@@ -85,7 +85,7 @@ macro(add_hpx_config_test variable)
       endif()
     else()
       try_compile(${variable}_RESULT
-        ${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/config_tests
+        ${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/config_tests
         ${test_source}
         CMAKE_FLAGS
           "-DINCLUDE_DIRECTORIES=${CONFIG_TEST_INCLUDE_DIRS}"

--- a/cmake/HPX_AddDefinitions.cmake
+++ b/cmake/HPX_AddDefinitions.cmake
@@ -115,7 +115,7 @@ function(write_config_defines_file)
       "#ifndef HPX_CONFIG_${NAMESPACE_UPPER}_HPP\n"
       "#define HPX_CONFIG_${NAMESPACE_UPPER}_HPP\n"
     )
-    set(TEMP_FILENAME "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/${NAMESPACE_UPPER}")
+    set(TEMP_FILENAME "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${NAMESPACE_UPPER}")
     file(WRITE ${TEMP_FILENAME}
         ${PREAMBLE}
         ${hpx_config_defines}

--- a/cmake/HPX_GeneratePackage.cmake
+++ b/cmake/HPX_GeneratePackage.cmake
@@ -119,28 +119,28 @@ set(HPX_CONF_PREFIX ${CMAKE_INSTALL_PREFIX})
 set(HPX_CONF_LIBRARY_DIR ${HPX_LIBRARY_DIR})
 
 configure_file(cmake/templates/${HPX_PACKAGE_NAME}Config.cmake.in
-  "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/${HPX_PACKAGE_NAME}Config.cmake"
+  "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${HPX_PACKAGE_NAME}Config.cmake"
   ESCAPE_QUOTES @ONLY)
 configure_file(cmake/templates/hpx_application.pc.in
-  "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/hpx_application.pc"
+  "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hpx_application.pc"
   ESCAPE_QUOTES @ONLY)
 configure_file(cmake/templates/hpx_application_debug.pc.in
-  "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/hpx_application_debug.pc"
+  "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hpx_application_debug.pc"
   ESCAPE_QUOTES @ONLY)
 configure_file(cmake/templates/hpx_component.pc.in
-  "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/hpx_component.pc"
+  "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hpx_component.pc"
   ESCAPE_QUOTES @ONLY)
 configure_file(cmake/templates/hpx_component_debug.pc.in
-  "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/hpx_component_debug.pc"
+  "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hpx_component_debug.pc"
   ESCAPE_QUOTES @ONLY)
 # Configure hpxcxx
 configure_file(cmake/templates/hpxcxx.in
-  "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/hpxcxx"
+  "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hpxcxx"
   @ONLY)
 
 # Configure bazel file
 configure_file(${hpx_bazel_file}
-  "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/hpx_bazel_defs.bzl"
+  "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hpx_bazel_defs.bzl"
   ESCAPE_QUOTES @ONLY)
 
 # ... and the build dir
@@ -180,7 +180,7 @@ configure_file(${hpx_bazel_file}
 # Configure macros for the install dir ...
 set(HPX_CMAKE_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/lib/cmake/${HPX_PACKAGE_NAME}")
 configure_file(cmake/templates/HPXMacros.cmake.in
-  "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/HPXMacros.cmake"
+  "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/HPXMacros.cmake"
   ESCAPE_QUOTES @ONLY)
 # ... and the build dir
 set(HPX_CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
@@ -197,8 +197,8 @@ install(
 
 install(
   FILES
-    "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/${HPX_PACKAGE_NAME}Config.cmake"
-    "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/HPXMacros.cmake"
+    "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${HPX_PACKAGE_NAME}Config.cmake"
+    "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/HPXMacros.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}/${HPX_PACKAGE_NAME}ConfigVersion.cmake"
     DESTINATION ${LIB}/cmake/${HPX_PACKAGE_NAME}
   COMPONENT cmake
@@ -206,17 +206,17 @@ install(
 
 install(
   FILES
-    "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/hpx_application.pc"
-    "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/hpx_application_debug.pc"
-    "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/hpx_component.pc"
-    "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/hpx_component_debug.pc"
+    "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hpx_application.pc"
+    "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hpx_application_debug.pc"
+    "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hpx_component.pc"
+    "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hpx_component_debug.pc"
   DESTINATION ${LIB}/pkgconfig
   COMPONENT pkgconfig
 )
 
 install(
   FILES
-    "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/hpxcxx"
+    "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hpxcxx"
   DESTINATION bin
   COMPONENT compiler_wrapper
   PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
@@ -226,7 +226,7 @@ install(
 
 install(
   FILES
-    "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/hpx_bazel_defs.bzl"
+    "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hpx_bazel_defs.bzl"
   DESTINATION ${LIB}/bazel
   COMPONENT bazel
 )

--- a/plugins/parcelport/CMakeLists.txt
+++ b/plugins/parcelport/CMakeLists.txt
@@ -131,5 +131,5 @@ write_config_defines_file(
   TEMPLATE ""
   NAMESPACE "parcelport"
   FILENAME
-  "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/hpx/config/parcelport_defines.hpp")
+  "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hpx/config/parcelport_defines.hpp")
 


### PR DESCRIPTION
Something I came across while working on my GSoC Project:

As stated by https://cmake.org/Wiki/CMake_Useful_Variables CMAKE_FILES_DIRECTORY contains a leading slash already, and should be used as following with the current binary directory:  `${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}`.
Otherwise this will lead to paths with double slashes.

I did find & replace, probably this should work if the CI reports green.