### PR TITLE
Config support for fallthrough attribute

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -509,6 +509,13 @@ macro(hpx_check_for_cxx17_fold_expressions)
 endmacro()
 
 ###############################################################################
+macro(hpx_check_for_cxx17_fallthrough_attribute)
+  add_hpx_config_test(HPX_WITH_CXX17_FALLTHROUGH_ATTRIBUTE
+    SOURCE cmake/tests/cxx17_fallthrough_attribute.cpp
+    FILE ${ARGN})
+endmacro()
+
+###############################################################################
 macro(hpx_check_for_mm_prefetch)
   add_hpx_config_test(HPX_WITH_MM_PREFECTH
     SOURCE cmake/tests/mm_prefetch.cpp

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -168,6 +168,9 @@ macro(hpx_perform_cxx_feature_tests)
 
     hpx_check_for_cxx17_variable_templates(
       DEFINITIONS HPX_HAVE_CXX17_VARIABLE_TEMPLATES)
+    
+    hpx_check_for_cxx17_fallthrough_attribute(
+      DEFINITIONS HPX_HAVE_CXX17_FALLTHROUGH_ATTRIBUTE)
   endif()
 endmacro()
 

--- a/cmake/tests/cxx17_fallthrough_attribute.cpp
+++ b/cmake/tests/cxx17_fallthrough_attribute.cpp
@@ -1,0 +1,21 @@
+////////////////////////////////////////////////////////////////////////////////
+//  Copyright (c) 2017 Marcin Copik
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+////////////////////////////////////////////////////////////////////////////////
+
+
+int main()
+{
+    int n = 0, m = 0;
+    switch(n)
+    {
+        case 0:
+            ++m;
+        [[fallthrough]];
+        case 1:
+            m += 2;
+        break;
+    }
+}

--- a/hpx/config.hpp
+++ b/hpx/config.hpp
@@ -14,6 +14,7 @@
 #error Boost.Config was included before the hpx config header. This might lead to subtile failures and compile errors. Please include <hpx/config.hpp> before any other boost header
 #endif
 
+#include <hpx/config/attributes.hpp>
 #include <hpx/config/branch_hints.hpp>
 #include <hpx/config/compiler_specific.hpp>
 #include <hpx/config/constexpr.hpp>

--- a/hpx/config/attributes.hpp
+++ b/hpx/config/attributes.hpp
@@ -1,0 +1,17 @@
+//  Copyright (c) 2017 Marcin Copik
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_CONFIG_ATTRIBUTES_HPP
+#define HPX_CONFIG_ATTRIBUTES_HPP
+
+#include <hpx/config/defines.hpp>
+
+#if defined(HPX_HAVE_CXX17_FALLTHROUGH_ATTRIBUTE)
+#   define HPX_FALLTHROUGH [[fallthrough]];
+#else
+#   define HPX_FALLTHROUGH
+#endif
+
+#endif

--- a/hpx/config/attributes.hpp
+++ b/hpx/config/attributes.hpp
@@ -9,7 +9,7 @@
 #include <hpx/config/defines.hpp>
 
 #if defined(HPX_HAVE_CXX17_FALLTHROUGH_ATTRIBUTE)
-#   define HPX_FALLTHROUGH [[fallthrough]];
+#   define HPX_FALLTHROUGH [[fallthrough]]
 #else
 #   define HPX_FALLTHROUGH
 #endif

--- a/hpx/util/jenkins_hash.hpp
+++ b/hpx/util/jenkins_hash.hpp
@@ -223,7 +223,6 @@ namespace hpx { namespace util
                 HPX_FALLTHROUGH
             case 1:
                 a += k[0];
-                HPX_FALLTHROUGH
                 /* case 0: nothing left to add */
             }
 

--- a/hpx/util/jenkins_hash.hpp
+++ b/hpx/util/jenkins_hash.hpp
@@ -192,35 +192,35 @@ namespace hpx { namespace util
             {
             case 11:
                 c += ((size_type)k[10] << 24);
-                HPX_FALLTHROUGH
+                HPX_FALLTHROUGH;
             case 10:
                 c += ((size_type)k[9] << 16);
-                HPX_FALLTHROUGH
+                HPX_FALLTHROUGH;
             case 9:
                 c += ((size_type)k[8] << 8);
-                HPX_FALLTHROUGH
+                HPX_FALLTHROUGH;
                 /* the first byte of c is reserved for the length */
             case 8:
                 b += ((size_type)k[7] << 24);
-                HPX_FALLTHROUGH
+                HPX_FALLTHROUGH;
             case 7:
                 b += ((size_type)k[6] << 16);
-                HPX_FALLTHROUGH
+                HPX_FALLTHROUGH;
             case 6:
                 b += ((size_type)k[5] << 8);
-                HPX_FALLTHROUGH
+                HPX_FALLTHROUGH;
             case 5:
                 b += k[4];
-                HPX_FALLTHROUGH
+                HPX_FALLTHROUGH;
             case 4:
                 a += ((size_type)k[3] << 24);
-                HPX_FALLTHROUGH
+                HPX_FALLTHROUGH;
             case 3:
                 a += ((size_type)k[2] << 16);
-                HPX_FALLTHROUGH
+                HPX_FALLTHROUGH;
             case 2:
                 a += ((size_type)k[1] << 8);
-                HPX_FALLTHROUGH
+                HPX_FALLTHROUGH;
             case 1:
                 a += k[0];
                 /* case 0: nothing left to add */

--- a/hpx/util/jenkins_hash.hpp
+++ b/hpx/util/jenkins_hash.hpp
@@ -6,12 +6,13 @@
 #if !defined(JENKINS_HASH_HPP_SEP_08_2007_0102PM)
 #define JENKINS_HASH_HPP_SEP_08_2007_0102PM
 
-#include <cstdlib>
+#include <hpx/config.hpp>
 
 #if defined(JENKINS_HASH_HAS_SERIALIZATION_SUPPORT)
 #include <hpx/runtime/serialization/serialize.hpp>
 #endif
 
+#include <cstdlib>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>

--- a/hpx/util/jenkins_hash.hpp
+++ b/hpx/util/jenkins_hash.hpp
@@ -192,27 +192,38 @@ namespace hpx { namespace util
             {
             case 11:
                 c += ((size_type)k[10] << 24);
+                HPX_FALLTHROUGH
             case 10:
                 c += ((size_type)k[9] << 16);
+                HPX_FALLTHROUGH
             case 9:
                 c += ((size_type)k[8] << 8);
+                HPX_FALLTHROUGH
                 /* the first byte of c is reserved for the length */
             case 8:
                 b += ((size_type)k[7] << 24);
+                HPX_FALLTHROUGH
             case 7:
                 b += ((size_type)k[6] << 16);
+                HPX_FALLTHROUGH
             case 6:
                 b += ((size_type)k[5] << 8);
+                HPX_FALLTHROUGH
             case 5:
                 b += k[4];
+                HPX_FALLTHROUGH
             case 4:
                 a += ((size_type)k[3] << 24);
+                HPX_FALLTHROUGH
             case 3:
                 a += ((size_type)k[2] << 16);
+                HPX_FALLTHROUGH
             case 2:
                 a += ((size_type)k[1] << 8);
+                HPX_FALLTHROUGH
             case 1:
                 a += k[0];
+                HPX_FALLTHROUGH
                 /* case 0: nothing left to add */
             }
 


### PR DESCRIPTION
Adds a feature test for C++17 `[[fallthrough]]` and removes gcc 7.1 warnings complaining about a possible fallthrough.