### PR TITLE
Fix examples in Action documentation

### DIFF
--- a/docs/manual/applying_actions.qbk
+++ b/docs/manual/applying_actions.qbk
@@ -368,8 +368,8 @@ to the original invocation site:
     action1_type act1;     // define an instance of 'action1_type'
     action2_type act2;     // define an instance of 'action2_type'
     hpx::future<int> f =
-        hpx::async_continue(act1, hpx::find_here(), 42,
-            hpx::make_continuation(act2));
+        hpx::async_continue(act1, hpx::make_continuation(act2),
+            hpx::find_here(), 42);
     hpx::cout << f.get() << "\n";   // will print: 86 ((42 + 1) * 2)
 
 By default, the continuation is executed on the same locality as
@@ -382,8 +382,8 @@ the continuation should be executed, the code above has to be written as:
     action1_type act1;     // define an instance of 'action1_type'
     action2_type act2;     // define an instance of 'action2_type'
     hpx::future<int> f =
-        hpx::async_continue(act1, hpx::find_here(), 42,
-            hpx::make_continuation(act2, hpx::find_here()));
+        hpx::async_continue(act1, hpx::make_continuation(act2, hpx::find_here()),
+            hpx::find_here(), 42);
     hpx::cout << f.get() << "\n";   // will print: 86 ((42 + 1) * 2)
 
 Similarly, it is possible to chain more than 2 operations:
@@ -391,9 +391,9 @@ Similarly, it is possible to chain more than 2 operations:
     action1_type act1;     // define an instance of 'action1_type'
     action2_type act2;     // define an instance of 'action2_type'
     hpx::future<int> f =
-        hpx::async_continue(act1, hpx::find_here(), 42,
-            hpx::make_continuation(act2,
-                hpx::make_continuation(act1)));
+        hpx::async_continue(act1,
+            hpx::make_continuation(act2, hpx::make_continuation(act1)),
+            hpx::find_here(), 42);
     hpx::cout << f.get() << "\n";   // will print: 87 ((42 + 1) * 2 + 1)
 
 The function `hpx::make_continuation` creates a special function object
@@ -456,7 +456,7 @@ executed:
         void some_function_with_error(int arg)
         {
             if (arg < 0) {
-                ``[macroref HPX_THROW_EXCEPTION `HPX_THROW_EXCEPTION`]``(bad_argument, "some_function_with_error",
+                ``[macroref HPX_THROW_EXCEPTION `HPX_THROW_EXCEPTION`]``(bad_parameter, "some_function_with_error",
                     "some really bad error happened");
             }
             // do something else...

--- a/docs/manual/build_system/using_hpx_pkgconfig.qbk
+++ b/docs/manual/build_system/using_hpx_pkgconfig.qbk
@@ -131,7 +131,7 @@ we do:
     export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$HPX_LOCATION/lib/pkgconfig
     c++ -o hello_world_client hello_world_client.cpp \
         `pkg-config --cflags --libs hpx_application` \
-        -L${HOME}/my_hpx_libs -lhello_world -lhpx_iostreams
+        -L${HOME}/my_hpx_libs -lhpx_hello_world -lhpx_iostreams
 ``
 
 [important When using pkg-config with __hpx__, the pkg-config flags must go after


### PR DESCRIPTION
Several examples in the documentation of Action were using incorrect (old ?) syntax.

Notably, arguments to `hpx::async_continue` were passed in the wrong order in section _Applying an Action with a Continuation and with Synchronization_, and `bad_argument` should have been `bad_parameter` in _Action Error Handling_.

I have tested all the updated examples, however I have not rebuilt the documentation, so feel free to make any necessary changes.