### PR TITLE
Coroutine stackoverflow detection for linux/posix; Issue #2408

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ hpx_option(HPX_WITH_THREAD_STACKOVERFLOW_DETECTION
 if(HPX_WITH_THREAD_STACKOVERFLOW_DETECTION)
   hpx_add_config_define(HPX_HAVE_THREAD_STACKOVERFLOW_DETECTION)
 endif()
-  
+ 
 hpx_option(HPX_WITH_MALLOC
   STRING
   "Define which allocator should be linked in. Options are: system, tcmalloc, jemalloc, tbbmalloc, and custom (default is: tcmalloc)"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,14 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
 #    set(DEFAULT_MALLOC "jemalloc")
 endif()
 
+hpx_option(HPX_WITH_THREAD_STACKOVERFLOW_DETECTION
+  BOOL
+  "Enable stackoverflow detection for HPX threads/coroutines. (default: ON)"
+  ON ADVANCED)
+if(HPX_WITH_THREAD_STACKOVERFLOW_DETECTION)
+  hpx_add_config_define(HPX_HAVE_THREAD_STACKOVERFLOW_DETECTION)
+endif()
+  
 hpx_option(HPX_WITH_MALLOC
   STRING
   "Define which allocator should be linked in. Options are: system, tcmalloc, jemalloc, tbbmalloc, and custom (default is: tcmalloc)"

--- a/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
@@ -29,12 +29,16 @@
 #include <boost/atomic.hpp>
 #include <boost/format.hpp>
 
+#if defined(HPX_HAVE_THREAD_STACKOVERFLOW_DETECTION)
+
 #include <signal.h>
 #include <stdlib.h>
 #include <strings.h>
 
 #ifndef SEGV_STACK_SIZE
   #define SEGV_STACK_SIZE MINSIGSTKSZ+4096
+#endif
+
 #endif
 
 #include <iostream>

--- a/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
@@ -234,7 +234,7 @@ namespace hpx { namespace threads { namespace coroutines
 
                 std::cerr << "Stack overflow in coroutine at address "
                     << std::internal << std::hex << std::setw(sizeof(addr)*2+2) 
-                    << std::setfill('0') << static_cast<int*>(addr) << "." std::endl
+                    << std::setfill('0') << static_cast<int*>(addr) << "." <<std::endl
                     << "Configure the hpx runtime to allocate a larger "
                     << "coroutine stack size." << std::endl
                     << "Use the hpx.stacks.small_size, hpx.stacks.medium_size, " << std::endl;

--- a/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
@@ -231,11 +231,11 @@ namespace hpx { namespace threads { namespace coroutines
                 void *data) 
             {
                 void *addr = info->si_addr;
-
                 std::cerr << "Stack overflow in coroutine at address "
-                    << std::internal << std::hex << std::setw(sizeof(addr)*2+2) 
-                    << std::setfill('0') << static_cast<int*>(addr) << "." <<std::endl
-                    << "Configure the hpx runtime to allocate a larger "
+                    << std::internal << std::hex << std::setw(sizeof(addr)*2+2)
+                    << std::setfill('0') << static_cast<int*>(addr) << "." << std::endl;
+
+                std::cerr << std::endl << "Configure the hpx runtime to allocate a larger "
                     << "coroutine stack size." << std::endl
                     << "Use the hpx.stacks.small_size, hpx.stacks.medium_size, " << std::endl
                     << "hpx.stacks.large_size, or hpx.stacks.huge_size runtime " << std::endl

--- a/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
@@ -160,9 +160,9 @@ namespace hpx { namespace threads { namespace coroutines
                 action.sa_flags = SA_SIGINFO|SA_ONSTACK; //SA_STACK
                 action.sa_sigaction = &sigsegv_handler;
 
-                sigaltstack(&segv_stack, NULL);
+                sigaltstack(&segv_stack, nullptr);
                 sigfillset(&action.sa_mask);
-                sigaction(SIGSEGV, &action, NULL);
+                sigaction(SIGSEGV, &action, nullptr);
             }
 
             /**
@@ -228,18 +228,27 @@ namespace hpx { namespace threads { namespace coroutines
             }
 
             static void sigsegv_handler(int signum, siginfo_t *info,
-                void *data) 
+                void *data)
             {
                 void *addr = info->si_addr;
-                std::cerr << "Stack overflow in coroutine at address "
-                    << std::internal << std::hex << std::setw(sizeof(addr)*2+2)
-                    << std::setfill('0') << static_cast<int*>(addr) << "." << std::endl;
 
-                std::cerr << std::endl << "Configure the hpx runtime to allocate a larger "
+                std::cerr << "Stack overflow in coroutine at address "
+                    << std::internal << std::hex
+                    << std::setw(sizeof(addr)*2+2)
+                    << std::setfill('0') << static_cast<int*>(addr)
+                    << "." << std::endl;
+
+                std::cerr << std::endl << "Configure the hpx runtime to "
+                    << "allocate a larger "
                     << "coroutine stack size." << std::endl
-                    << "Use the hpx.stacks.small_size, hpx.stacks.medium_size, " << std::endl
-                    << "hpx.stacks.large_size, or hpx.stacks.huge_size runtime " << std::endl
-                    << "flags to configure coroutine heap sizes." << std::endl;
+                    << "Use the hpx.stacks.small_size, "
+                    << "hpx.stacks.medium_size, "
+                    << std::endl
+                    << "hpx.stacks.large_size, "
+                    << "or hpx.stacks.huge_size runtime "
+                    << std::endl
+                    << "flags to configure coroutine heap sizes." 
+                    << std::endl << std::endl;
 
                 std::exit(EXIT_FAILURE);
             }

--- a/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
@@ -231,9 +231,9 @@ namespace hpx { namespace threads { namespace coroutines
                 action.sa_flags = SA_SIGINFO|SA_ONSTACK; //SA_STACK
                 action.sa_sigaction = &sigsegv_handler;
 
-                sigaltstack(&segv_stack, NULL);
+                sigaltstack(&segv_stack, nullptr);
                 sigfillset(&action.sa_mask);
-                sigaction(SIGSEGV, &action, NULL);
+                sigaction(SIGSEGV, &action, nullptr);
 #endif
             }
 
@@ -258,7 +258,7 @@ namespace hpx { namespace threads { namespace coroutines
                     << "hpx.stacks.large_size, "
                     << "or hpx.stacks.huge_size runtime "
                     << std::endl
-                    << "flags to configure coroutine heap sizes." 
+                    << "flags to configure coroutine heap sizes."
                     << std::endl << std::endl;
 
                 std::exit(EXIT_FAILURE);

--- a/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
@@ -34,6 +34,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <strings.h>
+#include <cstring>
 
 #ifndef SEGV_STACK_SIZE
   #define SEGV_STACK_SIZE MINSIGSTKSZ+4096
@@ -161,7 +162,7 @@ namespace hpx { namespace threads { namespace coroutines
                 segv_stack.ss_flags = 0;
                 segv_stack.ss_size = SEGV_STACK_SIZE;
 
-                bzero(&action, sizeof(action));
+                std::memset(&action, '\0', sizeof(action));
                 action.sa_flags = SA_SIGINFO|SA_ONSTACK; //SA_STACK
                 action.sa_sigaction = &sigsegv_handler;
 
@@ -226,7 +227,7 @@ namespace hpx { namespace threads { namespace coroutines
                 segv_stack.ss_flags = 0;
                 segv_stack.ss_size = SEGV_STACK_SIZE;
 
-                bzero(&action, sizeof(action));
+                std::memset(&action, '\0', sizeof(action));
                 action.sa_flags = SA_SIGINFO|SA_ONSTACK; //SA_STACK
                 action.sa_sigaction = &sigsegv_handler;
 

--- a/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
@@ -3,6 +3,7 @@
 //  Copyright (c) 2007-2016 Hartmut Kaiser
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
 //  Copyright (c) 2013-2016 Thomas Heller
+//  Copyright (c) 2017 Christopher Taylor
 //
 //  Distributed under the Boost Software License, Version 1.0.
 //  (See accompanying file LICENSE_1_0.txt or copy at
@@ -158,6 +159,12 @@ namespace hpx { namespace threads { namespace coroutines
                 : m_stack(nullptr)
 #if defined(HPX_HAVE_THREAD_STACKOVERFLOW_DETECTION)
             {
+
+                // concept inspired by the following links:
+                //
+                // https://rethinkdb.com/blog/handling-stack-overflow-on-custom-stacks/
+                // http://www.evanjones.ca/software/threading.html
+                //
                 segv_stack.ss_sp = valloc(SEGV_STACK_SIZE);
                 segv_stack.ss_flags = 0;
                 segv_stack.ss_size = SEGV_STACK_SIZE;

--- a/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
@@ -237,8 +237,8 @@ namespace hpx { namespace threads { namespace coroutines
                     << std::setfill('0') << static_cast<int*>(addr) << "." <<std::endl
                     << "Configure the hpx runtime to allocate a larger "
                     << "coroutine stack size." << std::endl
-                    << "Use the hpx.stacks.small_size, hpx.stacks.medium_size, " << std::endl;
-                    << "hpx.stacks.large_size, or hpx.stacks.huge_size runtime " << std::endl;
+                    << "Use the hpx.stacks.small_size, hpx.stacks.medium_size, " << std::endl
+                    << "hpx.stacks.large_size, or hpx.stacks.huge_size runtime " << std::endl
                     << "flags to configure coroutine heap sizes." << std::endl;
 
                 std::exit(EXIT_FAILURE);

--- a/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
@@ -151,6 +151,7 @@ namespace hpx { namespace threads { namespace coroutines
 
             x86_linux_context_impl()
                 : m_stack(nullptr)
+#if defined(HPX_HAVE_THREAD_STACKOVERFLOW_DETECTION)
             {
                 segv_stack.ss_sp = valloc(SEGV_STACK_SIZE);
                 segv_stack.ss_flags = 0;
@@ -164,6 +165,9 @@ namespace hpx { namespace threads { namespace coroutines
                 sigfillset(&action.sa_mask);
                 sigaction(SIGSEGV, &action, nullptr);
             }
+#else
+            {}
+#endif
 
             /**
              * Create a context that on restore invokes Functor on
@@ -213,6 +217,7 @@ namespace hpx { namespace threads { namespace coroutines
                 }
 #endif
 
+#if defined(HPX_HAVE_THREAD_STACKOVERFLOW_DETECTION)
                 segv_stack.ss_sp = valloc(SEGV_STACK_SIZE);
                 segv_stack.ss_flags = 0;
                 segv_stack.ss_size = SEGV_STACK_SIZE;
@@ -224,9 +229,10 @@ namespace hpx { namespace threads { namespace coroutines
                 sigaltstack(&segv_stack, NULL);
                 sigfillset(&action.sa_mask);
                 sigaction(SIGSEGV, &action, NULL);
-
+#endif
             }
 
+#if defined(HPX_HAVE_THREAD_STACKOVERFLOW_DETECTION)
             static void sigsegv_handler(int signum, siginfo_t *info,
                 void *data)
             {
@@ -252,7 +258,7 @@ namespace hpx { namespace threads { namespace coroutines
 
                 std::exit(EXIT_FAILURE);
             }
-
+#endif
             ~x86_linux_context_impl()
             {
                 if (m_stack)

--- a/hpx/runtime/threads/coroutines/detail/context_posix.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_posix.hpp
@@ -105,12 +105,16 @@ namespace posix { namespace pth
 #include <cstddef>                  // ptrdiff_t
 #include <ucontext.h>
 
+#if defined(HPX_HAVE_THREAD_STACKOVERFLOW_DETECTION)
+
 #include <signal.h>
 #include <stdlib.h>
 #include <strings.h>
 
 #ifndef SEGV_STACK_SIZE
   #define SEGV_STACK_SIZE MINSIGSTKSZ+4096
+#endif
+
 #endif
 
 #include <iostream>

--- a/hpx/runtime/threads/coroutines/detail/context_posix.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_posix.hpp
@@ -235,6 +235,7 @@ namespace hpx { namespace threads { namespace coroutines
                 HPX_UNUSED(error);
                 HPX_ASSERT(error == 0);
 
+#if defined(HPX_HAVE_THREAD_STACKOVERFLOW_DETECTION)
                 segv_stack.ss_sp = valloc(SEGV_STACK_SIZE);
                 segv_stack.ss_flags = 0;
                 segv_stack.ss_size = SEGV_STACK_SIZE;
@@ -246,8 +247,10 @@ namespace hpx { namespace threads { namespace coroutines
                 sigaltstack(&segv_stack, nullptr);
                 sigfillset(&action.sa_mask);
                 sigaction(SIGSEGV, &action, nullptr);
+#endif
             }
 
+#if defined(HPX_HAVE_THREAD_STACKOVERFLOW_DETECTION)
             static void sigsegv_handler(int signum, siginfo_t *info,
                 void *data)
             {
@@ -273,6 +276,7 @@ namespace hpx { namespace threads { namespace coroutines
 
                 std::exit(EXIT_FAILURE);
             }
+#endif
 
             ~ucontext_context_impl()
             {

--- a/hpx/runtime/threads/coroutines/detail/context_posix.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_posix.hpp
@@ -105,6 +105,17 @@ namespace posix { namespace pth
 #include <cstddef>                  // ptrdiff_t
 #include <ucontext.h>
 
+#include <signal.h>
+#include <stdlib.h>
+#include <strings.h>
+
+#ifndef SEGV_STACK_SIZE
+  #define SEGV_STACK_SIZE MINSIGSTKSZ+4096
+#endif
+
+#include <iostream>
+#include <iomanip>
+
 namespace hpx { namespace threads { namespace coroutines { namespace detail {
 namespace posix { namespace ucontext
 {
@@ -223,6 +234,35 @@ namespace hpx { namespace threads { namespace coroutines
                     &m_ctx, m_stack, m_stack_size, funp_, cb_, nullptr);
                 HPX_UNUSED(error);
                 HPX_ASSERT(error == 0);
+
+                segv_stack.ss_sp = valloc(SEGV_STACK_SIZE);
+                segv_stack.ss_flags = 0;
+                segv_stack.ss_size = SEGV_STACK_SIZE;
+
+                bzero(&action, sizeof(action));
+                action.sa_flags = SA_SIGINFO|SA_ONSTACK; //SA_STACK
+                action.sa_sigaction = &sigsegv_handler;
+
+                sigaltstack(&segv_stack, NULL);
+                sigfillset(&action.sa_mask);
+                sigaction(SIGSEGV, &action, NULL);
+            }
+
+            static void sigsegv_handler(int signum, siginfo_t *info,
+                void *data)
+            {
+                void *addr = info->si_addr;
+
+                std::cerr << "Stack overflow in coroutine at address "
+                    << std::internal << std::hex << std::setw(sizeof(addr)*2+2)
+                    << std::setfill('0') << static_cast<int*>(addr) << "." std::endl
+                    << "Configure the hpx runtime to allocate a larger "
+                    << "coroutine stack size." << std::endl
+                    << "Use the hpx.stacks.small_size, hpx.stacks.medium_size, " << std::endl;
+                    << "hpx.stacks.large_size, or hpx.stacks.huge_size runtime " << std::endl;
+                    << "flags to configure coroutine heap sizes." << std::endl;
+
+                std::exit(EXIT_FAILURE);
             }
 
             ~ucontext_context_impl()
@@ -316,6 +356,9 @@ namespace hpx { namespace threads { namespace coroutines
             void * m_stack;
             void * cb_;
             void(*funp_)(void*);
+
+            struct sigaction action;
+            stack_t segv_stack;
         };
 
         typedef ucontext_context_impl context_impl;

--- a/hpx/runtime/threads/coroutines/detail/context_posix.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_posix.hpp
@@ -276,7 +276,7 @@ namespace hpx { namespace threads { namespace coroutines
                     << "hpx.stacks.large_size, "
                     << "or hpx.stacks.huge_size runtime "
                     << std::endl
-                    << "flags to configure coroutine heap sizes." 
+                    << "flags to configure coroutine heap sizes."
                     << std::endl << std::endl;
 
                 std::exit(EXIT_FAILURE);

--- a/hpx/runtime/threads/coroutines/detail/context_posix.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_posix.hpp
@@ -258,8 +258,8 @@ namespace hpx { namespace threads { namespace coroutines
                     << std::setfill('0') << static_cast<int*>(addr) << "." << std::endl
                     << "Configure the hpx runtime to allocate a larger "
                     << "coroutine stack size." << std::endl
-                    << "Use the hpx.stacks.small_size, hpx.stacks.medium_size, " << std::endl;
-                    << "hpx.stacks.large_size, or hpx.stacks.huge_size runtime " << std::endl;
+                    << "Use the hpx.stacks.small_size, hpx.stacks.medium_size, " << std::endl
+                    << "hpx.stacks.large_size, or hpx.stacks.huge_size runtime " << std::endl
                     << "flags to configure coroutine heap sizes." << std::endl;
 
                 std::exit(EXIT_FAILURE);

--- a/hpx/runtime/threads/coroutines/detail/context_posix.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_posix.hpp
@@ -241,6 +241,11 @@ namespace hpx { namespace threads { namespace coroutines
                 HPX_ASSERT(error == 0);
 
 #if defined(HPX_HAVE_THREAD_STACKOVERFLOW_DETECTION)
+                // concept inspired by the following links:
+                //
+                // https://rethinkdb.com/blog/handling-stack-overflow-on-custom-stacks/
+                // http://www.evanjones.ca/software/threading.html
+                //
                 segv_stack.ss_sp = valloc(SEGV_STACK_SIZE);
                 segv_stack.ss_flags = 0;
                 segv_stack.ss_size = SEGV_STACK_SIZE;

--- a/hpx/runtime/threads/coroutines/detail/context_posix.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_posix.hpp
@@ -243,9 +243,9 @@ namespace hpx { namespace threads { namespace coroutines
                 action.sa_flags = SA_SIGINFO|SA_ONSTACK; //SA_STACK
                 action.sa_sigaction = &sigsegv_handler;
 
-                sigaltstack(&segv_stack, NULL);
+                sigaltstack(&segv_stack, nullptr);
                 sigfillset(&action.sa_mask);
-                sigaction(SIGSEGV, &action, NULL);
+                sigaction(SIGSEGV, &action, nullptr);
             }
 
             static void sigsegv_handler(int signum, siginfo_t *info,
@@ -254,13 +254,22 @@ namespace hpx { namespace threads { namespace coroutines
                 void *addr = info->si_addr;
 
                 std::cerr << "Stack overflow in coroutine at address "
-                    << std::internal << std::hex << std::setw(sizeof(addr)*2+2)
-                    << std::setfill('0') << static_cast<int*>(addr) << "." << std::endl
-                    << "Configure the hpx runtime to allocate a larger "
+                    << std::internal << std::hex
+                    << std::setw(sizeof(addr)*2+2)
+                    << std::setfill('0') << static_cast<int*>(addr)
+                    << "." << std::endl;
+
+                std::cerr << std::endl << "Configure the hpx runtime to "
+                    << "allocate a larger "
                     << "coroutine stack size." << std::endl
-                    << "Use the hpx.stacks.small_size, hpx.stacks.medium_size, " << std::endl
-                    << "hpx.stacks.large_size, or hpx.stacks.huge_size runtime " << std::endl
-                    << "flags to configure coroutine heap sizes." << std::endl;
+                    << "Use the hpx.stacks.small_size, "
+                    << "hpx.stacks.medium_size, "
+                    << std::endl
+                    << "hpx.stacks.large_size, "
+                    << "or hpx.stacks.huge_size runtime "
+                    << std::endl
+                    << "flags to configure coroutine heap sizes." 
+                    << std::endl << std::endl;
 
                 std::exit(EXIT_FAILURE);
             }

--- a/hpx/runtime/threads/coroutines/detail/context_posix.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_posix.hpp
@@ -110,6 +110,7 @@ namespace posix { namespace pth
 #include <signal.h>
 #include <stdlib.h>
 #include <strings.h>
+#include <cstring>
 
 #ifndef SEGV_STACK_SIZE
   #define SEGV_STACK_SIZE MINSIGSTKSZ+4096
@@ -244,7 +245,7 @@ namespace hpx { namespace threads { namespace coroutines
                 segv_stack.ss_flags = 0;
                 segv_stack.ss_size = SEGV_STACK_SIZE;
 
-                bzero(&action, sizeof(action));
+                std::memset(&action, '\0', sizeof(action));
                 action.sa_flags = SA_SIGINFO|SA_ONSTACK; //SA_STACK
                 action.sa_sigaction = &sigsegv_handler;
 

--- a/hpx/runtime/threads/coroutines/detail/context_posix.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_posix.hpp
@@ -255,7 +255,7 @@ namespace hpx { namespace threads { namespace coroutines
 
                 std::cerr << "Stack overflow in coroutine at address "
                     << std::internal << std::hex << std::setw(sizeof(addr)*2+2)
-                    << std::setfill('0') << static_cast<int*>(addr) << "." std::endl
+                    << std::setfill('0') << static_cast<int*>(addr) << "." << std::endl
                     << "Configure the hpx runtime to allocate a larger "
                     << "coroutine stack size." << std::endl
                     << "Use the hpx.stacks.small_size, hpx.stacks.medium_size, " << std::endl;

--- a/tests/unit/threads/CMakeLists.txt
+++ b/tests/unit/threads/CMakeLists.txt
@@ -14,9 +14,9 @@ set(tests
     thread_launching
     thread_mf
     thread_stacksize
+    thread_stacksize_overflow
     thread_suspension_executor
     thread_yield
-    thread_stacksize
    )
 
 if(HPX_WITH_THREAD_LOCAL_STORAGE)

--- a/tests/unit/threads/CMakeLists.txt
+++ b/tests/unit/threads/CMakeLists.txt
@@ -16,6 +16,7 @@ set(tests
     thread_stacksize
     thread_suspension_executor
     thread_yield
+    thread_stacksize
    )
 
 if(HPX_WITH_THREAD_LOCAL_STORAGE)

--- a/tests/unit/threads/thread_stacksize.cpp
+++ b/tests/unit/threads/thread_stacksize.cpp
@@ -22,7 +22,11 @@ void test_small_stacksize()
             hpx::threads::thread_stacksize_small));
 
     // allocate HPX_SMALL_STACK_SIZE - HPX_THREADS_STACK_OVERHEAD memory on the stack
-    char array[HPX_SMALL_STACK_SIZE-HPX_THREADS_STACK_OVERHEAD];
+    //char array[HPX_SMALL_STACK_SIZE-HPX_THREADS_STACK_OVERHEAD];
+    char array[HPX_SMALL_STACK_SIZE*HPX_THREADS_STACK_OVERHEAD];
+
+std::cout << HPX_SMALL_STACK_SIZE << '\t' << (HPX_SMALL_STACK_SIZE*HPX_THREADS_STACK_OVERHEAD) << std::endl;
+std::cout.flush();
 
     // do something to that array
     std::memset(array, '\0', sizeof(array));
@@ -95,12 +99,16 @@ int main()
 
     for (hpx::id_type const& id : localities)
     {
-        if(id != hpx::find_here())
+std::cout << id << '\t' << hpx::find_here() << std::endl;
+
+        if(id == hpx::find_here())
         {
+std::cout << "running" << std::endl;
             test_small_stacksize_action test_action;
             test_action(id);
         }
 
+/*
         {
             test_medium_stacksize_action test_action;
             test_action(id);
@@ -115,6 +123,7 @@ int main()
             test_huge_stacksize_action test_action;
             test_action(id);
         }
+*/
     }
 
     return hpx::util::report_errors();

--- a/tests/unit/threads/thread_stacksize_overflow.cpp
+++ b/tests/unit/threads/thread_stacksize_overflow.cpp
@@ -32,64 +32,6 @@ HPX_DECLARE_ACTION(test_small_stacksize, test_small_stacksize_action)
 HPX_ACTION_USES_SMALL_STACK(test_small_stacksize_action)
 HPX_PLAIN_ACTION(test_small_stacksize, test_small_stacksize_action)
 
-///////////////////////////////////////////////////////////////////////////////
-void test_medium_stacksize()
-{
-    HPX_TEST(hpx::threads::get_self_ptr());
-    // verify that sufficient stack has been allocated
-    HPX_TEST_EQ(hpx::threads::get_ctx_ptr()->get_stacksize(),
-        hpx::get_runtime().get_config().get_stack_size(
-            hpx::threads::thread_stacksize_medium));
-
-    // allocate HPX_MEDIUM_STACK_SIZE - HPX_THREADS_STACK_OVERHEAD memory on the stack
-    char array[HPX_MEDIUM_STACK_SIZE*HPX_THREADS_STACK_OVERHEAD];
-
-    // do something to that array
-    std::memset(array, '\0', sizeof(array));
-}
-HPX_DECLARE_ACTION(test_medium_stacksize, test_medium_stacksize_action)
-HPX_ACTION_USES_MEDIUM_STACK(test_medium_stacksize_action)
-HPX_PLAIN_ACTION(test_medium_stacksize, test_medium_stacksize_action)
-
-///////////////////////////////////////////////////////////////////////////////
-void test_large_stacksize()
-{
-    HPX_TEST(hpx::threads::get_self_ptr());
-    // verify that sufficient stack has been allocated
-    HPX_TEST(hpx::threads::get_ctx_ptr()->get_stacksize() >=
-        hpx::get_runtime().get_config().get_stack_size(
-            hpx::threads::thread_stacksize_large));
-
-    // allocate HPX_LARGE_STACK_SIZE - HPX_THREADS_STACK_OVERHEAD memory on the stack
-    char array[HPX_LARGE_STACK_SIZE*HPX_THREADS_STACK_OVERHEAD];
-
-    // do something to that array
-    std::memset(array, '\0', sizeof(array));
-}
-HPX_DECLARE_ACTION(test_large_stacksize, test_large_stacksize_action)
-HPX_ACTION_USES_LARGE_STACK(test_large_stacksize_action)
-HPX_PLAIN_ACTION(test_large_stacksize, test_large_stacksize_action)
-
-///////////////////////////////////////////////////////////////////////////////
-void test_huge_stacksize()
-{
-    HPX_TEST(hpx::threads::get_self_ptr());
-    // verify that sufficient stack has been allocated
-    HPX_TEST(hpx::threads::get_ctx_ptr()->get_stacksize() >=
-        hpx::get_runtime().get_config().get_stack_size(
-            hpx::threads::thread_stacksize_huge));
-
-    // allocate HPX_LARGE_STACK_SIZE - HPX_THREADS_STACK_OVERHEAD memory on the stack
-    char array[HPX_HUGE_STACK_SIZE*HPX_THREADS_STACK_OVERHEAD];
-
-    // do something to that array
-    std::memset(array, '\0', sizeof(array));
-}
-HPX_DECLARE_ACTION(test_huge_stacksize, test_huge_stacksize_action)
-HPX_ACTION_USES_HUGE_STACK(test_huge_stacksize_action)
-HPX_PLAIN_ACTION(test_huge_stacksize, test_huge_stacksize_action)
-
-///////////////////////////////////////////////////////////////////////////////
 int main()
 {
     std::vector<hpx::id_type> localities = hpx::find_all_localities();
@@ -101,20 +43,6 @@ int main()
             test_action(id);
         }
 
-        {
-            test_medium_stacksize_action test_action;
-            test_action(id);
-        }
-
-        {
-            test_large_stacksize_action test_action;
-            test_action(id);
-        }
-
-        {
-            test_huge_stacksize_action test_action;
-            test_action(id);
-        }
     }
 
     return hpx::util::report_errors();

--- a/tests/unit/threads/thread_stacksize_overflow.cpp
+++ b/tests/unit/threads/thread_stacksize_overflow.cpp
@@ -1,4 +1,5 @@
 // Copyright (C) 2012 Hartmut Kaiser
+// Copyright (C) 2017 Christopher Taylor 
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -22,7 +23,7 @@ void test_small_stacksize()
             hpx::threads::thread_stacksize_small));
 
     // allocate HPX_SMALL_STACK_SIZE - HPX_THREADS_STACK_OVERHEAD memory on the stack
-    char array[HPX_SMALL_STACK_SIZE-HPX_THREADS_STACK_OVERHEAD];
+    char array[HPX_SMALL_STACK_SIZE*HPX_THREADS_STACK_OVERHEAD];
 
     // do something to that array
     std::memset(array, '\0', sizeof(array));
@@ -41,7 +42,7 @@ void test_medium_stacksize()
             hpx::threads::thread_stacksize_medium));
 
     // allocate HPX_MEDIUM_STACK_SIZE - HPX_THREADS_STACK_OVERHEAD memory on the stack
-    char array[HPX_MEDIUM_STACK_SIZE-HPX_THREADS_STACK_OVERHEAD];
+    char array[HPX_MEDIUM_STACK_SIZE*HPX_THREADS_STACK_OVERHEAD];
 
     // do something to that array
     std::memset(array, '\0', sizeof(array));
@@ -60,7 +61,7 @@ void test_large_stacksize()
             hpx::threads::thread_stacksize_large));
 
     // allocate HPX_LARGE_STACK_SIZE - HPX_THREADS_STACK_OVERHEAD memory on the stack
-    char array[HPX_LARGE_STACK_SIZE-HPX_THREADS_STACK_OVERHEAD];
+    char array[HPX_LARGE_STACK_SIZE*HPX_THREADS_STACK_OVERHEAD];
 
     // do something to that array
     std::memset(array, '\0', sizeof(array));
@@ -79,7 +80,7 @@ void test_huge_stacksize()
             hpx::threads::thread_stacksize_huge));
 
     // allocate HPX_LARGE_STACK_SIZE - HPX_THREADS_STACK_OVERHEAD memory on the stack
-    char array[HPX_HUGE_STACK_SIZE-HPX_THREADS_STACK_OVERHEAD];
+    char array[HPX_HUGE_STACK_SIZE*HPX_THREADS_STACK_OVERHEAD];
 
     // do something to that array
     std::memset(array, '\0', sizeof(array));
@@ -95,7 +96,6 @@ int main()
 
     for (hpx::id_type const& id : localities)
     {
-        if(id != hpx::find_here())
         {
             test_small_stacksize_action test_action;
             test_action(id);

--- a/tests/unit/threads/thread_stacksize_overflow.cpp
+++ b/tests/unit/threads/thread_stacksize_overflow.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2012 Hartmut Kaiser
-// Copyright (C) 2017 Christopher Taylor 
+// Copyright (C) 2017 Christopher Taylor
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)


### PR DESCRIPTION
Initial implementation of stackoverflow detection for coroutines issue tracker [#2408](https://github.com/STEllAR-GROUP/hpx/issues/2408) . The source was derived from posix/linux system man pages, the [rethinkdb link](https://rethinkdb.com/blog/handling-stack-overflow-on-custom-stacks/) provided in the issue conversation thread, and a [blog post](http://evanjones.ca/software/threading.html) about coroutine implementations.