### PR TITLE
Adding ability to statistics counters to reset base counter

### DIFF
--- a/docs/manual/existing_performance_counters.qbk
+++ b/docs/manual/existing_performance_counters.qbk
@@ -1291,9 +1291,13 @@ system and application performance.
         [Returns the current average (mean) value calculated based on the values
          queried from the underlying counter (the one specified as the instance
          name).]
-        [Any parameter will be interpreted as the time interval (in
+        [Any parameter will be interpreted as a list of up to two comma separated
+         (integer) values, where the first is the time interval (in
          milliseconds) at which the underlying counter should be queried. If
-         no value is specified, the counter will assume `1000` \[ms\] as the default.]
+         no value is specified, the counter will assume `1000` \[ms\] as the default.
+         The second value can be either `0` or `1` and specifies whether the
+         underlying counter should be reset during evaluation (`1`) or not (`0`).
+         The default value is `0`.]
     ]
     [   [`/statistics/rolling_average`]
         [Any full performance counter name. The referenced performance counter
@@ -1301,13 +1305,15 @@ system and application performance.
         [Returns the current rolling average (mean) value calculated based on the values
          queried from the underlying counter (the one specified as the instance
          name).]
-        [Any parameter will be interpreted as a list of two comma separated (integer)
+        [Any parameter will be interpreted as a list of up to three comma separated (integer)
          values, where the first is the time interval (in
          milliseconds) at which the underlying counter should be queried. If
          no value is specified, the counter will assume `1000` \[ms\] as the default.
          The second value will be interpreted as the size of the rolling window
          (the number of latest values to use to calculate the rolling average). The
-         default value for this is `10`.]
+         default value for this is `10`. The third value can be either `0` or `1`
+         and specifies whether the underlying counter should be reset during
+         evaluation (`1`) or not (`0`). The default value is `0`.]
     ]
     [   [`/statistics/stddev`]
         [Any full performance counter name. The referenced performance counter
@@ -1316,10 +1322,13 @@ system and application performance.
          on the values queried from the underlying counter (the one specified
          as the instance name). Note that this counter will be available only
          for Boost V1.56 and newer.]
-        [Any parameter will be interpreted as the time interval (in
+        [Any parameter will be interpreted as a list of up to two comma separated
+         (integer) values, where the first is the time interval (in
          milliseconds) at which the underlying counter should be queried. If
-         no value is specified, the counter will assume `1000` \[ms\] as the
-         default.]
+         no value is specified, the counter will assume `1000` \[ms\] as the default.
+         The second value can be either `0` or `1` and specifies whether the
+         underlying counter should be reset during evaluation (`1`) or not (`0`).
+         The default value is `0`.]
     ]
     [   [`/statistics/rolling_stddev`]
         [Any full performance counter name. The referenced performance counter
@@ -1327,13 +1336,15 @@ system and application performance.
         [Returns the current rolling variance (stddev) value calculated based on
          the values queried from the underlying counter (the one specified as
          the instance name).]
-        [Any parameter will be interpreted as a list of two comma separated (integer)
+        [Any parameter will be interpreted as a list of up to three comma separated (integer)
          values, where the first is the time interval (in
          milliseconds) at which the underlying counter should be queried. If
          no value is specified, the counter will assume `1000` \[ms\] as the default.
          The second value will be interpreted as the size of the rolling window
          (the number of latest values to use to calculate the rolling average). The
-         default value for this is `10`.]
+         default value for this is `10`. The third value can be either `0` or `1`
+         and specifies whether the underlying counter should be reset during
+         evaluation (`1`) or not (`0`). The default value is `0`.]
     ]
     [   [`/statistics/median`]
         [Any full performance counter name. The referenced performance counter
@@ -1341,9 +1352,13 @@ system and application performance.
         [Returns the current (statistically estimated) median value calculated
          based on the values queried from the underlying counter (the one
          specified as the instance name).]
-        [Any parameter will be interpreted as the time interval (in
+        [Any parameter will be interpreted as a list of up to two comma separated
+         (integer) values, where the first is the time interval (in
          milliseconds) at which the underlying counter should be queried. If
-         no value is specified, the counter will assume `1000` \[ms\] as the default.]
+         no value is specified, the counter will assume `1000` \[ms\] as the default.
+         The second value can be either `0` or `1` and specifies whether the
+         underlying counter should be reset during evaluation (`1`) or not (`0`).
+         The default value is `0`.]
     ]
     [   [`/statistics/max`]
         [Any full performance counter name. The referenced performance counter
@@ -1351,9 +1366,13 @@ system and application performance.
         [Returns the current maximum value calculated based on the values
          queried from the underlying counter (the one specified as the instance
          name).]
-        [Any parameter will be interpreted as the time interval (in
+        [Any parameter will be interpreted as a list of up to two comma separated
+         (integer) values, where the first is the time interval (in
          milliseconds) at which the underlying counter should be queried. If
-         no value is specified, the counter will assume `1000` \[ms\] as the default.]
+         no value is specified, the counter will assume `1000` \[ms\] as the default.
+         The second value can be either `0` or `1` and specifies whether the
+         underlying counter should be reset during evaluation (`1`) or not (`0`).
+         The default value is `0`.]
     ]
     [   [`/statistics/rolling_max`]
         [Any full performance counter name. The referenced performance counter
@@ -1361,13 +1380,15 @@ system and application performance.
         [Returns the current rolling maximum value calculated based on
          the values queried from the underlying counter (the one specified as
          the instance name).]
-        [Any parameter will be interpreted as a list of two comma separated (integer)
+        [Any parameter will be interpreted as a list of up to three comma separated (integer)
          values, where the first is the time interval (in
          milliseconds) at which the underlying counter should be queried. If
          no value is specified, the counter will assume `1000` \[ms\] as the default.
          The second value will be interpreted as the size of the rolling window
          (the number of latest values to use to calculate the rolling average). The
-         default value for this is `10`.]
+         default value for this is `10`. The third value can be either `0` or `1`
+         and specifies whether the underlying counter should be reset during
+         evaluation (`1`) or not (`0`). The default value is `0`.]
     ]
     [   [`/statistics/min`]
         [Any full performance counter name. The referenced performance counter
@@ -1375,9 +1396,13 @@ system and application performance.
         [Returns the current minimum value calculated based on the values
          queried from the underlying counter (the one specified as the instance
          name).]
-        [Any parameter will be interpreted as the time interval (in
+        [Any parameter will be interpreted as a list of up to two comma separated
+         (integer) values, where the first is the time interval (in
          milliseconds) at which the underlying counter should be queried. If
-         no value is specified, the counter will assume `1000` \[ms\] as the default.]
+         no value is specified, the counter will assume `1000` \[ms\] as the default.
+         The second value can be either `0` or `1` and specifies whether the
+         underlying counter should be reset during evaluation (`1`) or not (`0`).
+         The default value is `0`.]
     ]
     [   [`/statistics/rolling_min`]
         [Any full performance counter name. The referenced performance counter
@@ -1385,13 +1410,15 @@ system and application performance.
         [Returns the current rolling minimum value calculated based on
          the values queried from the underlying counter (the one specified as
          the instance name).]
-        [Any parameter will be interpreted as a list of two comma separated (integer)
+        [Any parameter will be interpreted as a list of up to three comma separated (integer)
          values, where the first is the time interval (in
          milliseconds) at which the underlying counter should be queried. If
          no value is specified, the counter will assume `1000` \[ms\] as the default.
          The second value will be interpreted as the size of the rolling window
          (the number of latest values to use to calculate the rolling average). The
-         default value for this is `10`.]
+         default value for this is `10`. The third value can be either `0` or `1`
+         and specifies whether the underlying counter should be reset during
+         evaluation (`1`) or not (`0`). The default value is `0`.]
     ]
 ]
 

--- a/hpx/performance_counters/server/statistics_counter.hpp
+++ b/hpx/performance_counters/server/statistics_counter.hpp
@@ -59,7 +59,8 @@ namespace hpx { namespace performance_counters { namespace server
 
         statistics_counter(counter_info const& info,
             std::string const& base_counter_name,
-            std::size_t parameter1, std::size_t parameter2);
+            std::size_t parameter1, std::size_t parameter2,
+            bool reset_base_counter);
 
         /// Overloads from the base_counter base class.
         hpx::performance_counters::counter_value
@@ -108,6 +109,7 @@ namespace hpx { namespace performance_counters { namespace server
         bool has_prev_value_;
 
         std::size_t parameter1_, parameter2_;
+        bool reset_base_counter_;
     };
 }}}
 

--- a/src/performance_counters/registry.cpp
+++ b/src/performance_counters/registry.cpp
@@ -712,6 +712,8 @@ namespace hpx { namespace performance_counters
         try {
             // extract parameters
             std::size_t sample_interval = 1000;   // default sampling interval
+            bool reset_base_counter = false;
+
             if (!parameters.empty())
                 sample_interval = parameters[0];
 
@@ -721,16 +723,26 @@ namespace hpx { namespace performance_counters
                     hpx::performance_counters::server::statistics_counter<
                         boost::accumulators::tag::mean>
                 > counter_t;
+
+                if (parameters.size() > 1)
+                    reset_base_counter = (parameters[1] != 0) ? true : false;
+
                 gid = components::server::construct<counter_t>(
-                    complemented_info, base_counter_name, sample_interval, 0);
+                    complemented_info, base_counter_name, sample_interval, 0,
+                    reset_base_counter);
             }
             else if (p.countername_ == "stddev") {
                 typedef hpx::components::component<
                     hpx::performance_counters::server::statistics_counter<
                         boost::accumulators::tag::variance>
                 > counter_t;
+
+                if (parameters.size() > 1)
+                    reset_base_counter = (parameters[1] != 0) ? true : false;
+
                 gid = components::server::construct<counter_t>(
-                    complemented_info, base_counter_name, sample_interval, 0);
+                    complemented_info, base_counter_name, sample_interval, 0,
+                    reset_base_counter);
             }
             else if (p.countername_ == "rolling_average") {
                 typedef hpx::components::component<
@@ -742,9 +754,12 @@ namespace hpx { namespace performance_counters
                 if (parameters.size() > 1)
                     window_size = parameters[1];
 
+                if (parameters.size() > 2)
+                    reset_base_counter = (parameters[2] != 0) ? true : false;
+
                 gid = components::server::construct<counter_t>(
                     complemented_info, base_counter_name, sample_interval,
-                    window_size);
+                    window_size, reset_base_counter);
             }
 #if BOOST_VERSION >= 105600
             else if (p.countername_ == "rolling_stddev") {
@@ -757,9 +772,12 @@ namespace hpx { namespace performance_counters
                 if (parameters.size() > 1)
                     window_size = parameters[1];
 
+                if (parameters.size() > 2)
+                    reset_base_counter = (parameters[2] != 0) ? true : false;
+
                 gid = components::server::construct<counter_t>(
                     complemented_info, base_counter_name, sample_interval,
-                    window_size);
+                    window_size, reset_base_counter);
             }
 #endif
             else if (p.countername_ == "median") {
@@ -767,24 +785,39 @@ namespace hpx { namespace performance_counters
                     hpx::performance_counters::server::statistics_counter<
                         boost::accumulators::tag::median>
                 > counter_t;
+
+                if (parameters.size() > 1)
+                    reset_base_counter = (parameters[1] != 0) ? true : false;
+
                 gid = components::server::construct<counter_t>(
-                    complemented_info, base_counter_name, sample_interval, 0);
+                    complemented_info, base_counter_name, sample_interval, 0,
+                    reset_base_counter);
             }
             else if (p.countername_ == "max") {
                 typedef hpx::components::component<
                     hpx::performance_counters::server::statistics_counter<
                         boost::accumulators::tag::max>
                 > counter_t;
+
+                if (parameters.size() > 1)
+                    reset_base_counter = (parameters[1] != 0) ? true : false;
+
                 gid = components::server::construct<counter_t>(
-                    complemented_info, base_counter_name, sample_interval, 0);
+                    complemented_info, base_counter_name, sample_interval, 0,
+                    reset_base_counter);
             }
             else if (p.countername_ == "min") {
                 typedef hpx::components::component<
                     hpx::performance_counters::server::statistics_counter<
                         boost::accumulators::tag::min>
                 > counter_t;
+
+                if (parameters.size() > 1)
+                    reset_base_counter = (parameters[1] != 0) ? true : false;
+
                 gid = components::server::construct<counter_t>(
-                    complemented_info, base_counter_name, sample_interval, 0);
+                    complemented_info, base_counter_name, sample_interval, 0,
+                    reset_base_counter);
             }
             else if (p.countername_ == "rolling_min") {
                 typedef hpx::components::component<
@@ -796,9 +829,12 @@ namespace hpx { namespace performance_counters
                 if (parameters.size() > 1)
                     window_size = parameters[1];
 
+                if (parameters.size() > 2)
+                    reset_base_counter = (parameters[2] != 0) ? true : false;
+
                 gid = components::server::construct<counter_t>(
                     complemented_info, base_counter_name, sample_interval,
-                    window_size);
+                    window_size, reset_base_counter);
             }
             else if (p.countername_ == "rolling_max") {
                 typedef hpx::components::component<
@@ -810,9 +846,12 @@ namespace hpx { namespace performance_counters
                 if (parameters.size() > 1)
                     window_size = parameters[1];
 
+                if (parameters.size() > 2)
+                    reset_base_counter = (parameters[2] != 0) ? true : false;
+
                 gid = components::server::construct<counter_t>(
                     complemented_info, base_counter_name, sample_interval,
-                    window_size);
+                    window_size, reset_base_counter);
             }
             else {
                 HPX_THROWS_IF(ec, bad_parameter,


### PR DESCRIPTION
- This adds an additional (optional) parameter to the statistics counter names allowing
  to specify whether the underlying counter should be reset during evaluation.
- This also improves error reporting related to the parameters specified for statistics
  counters

- this fixes #2743