### PR TITLE
Adding extended arithmetic performance counters

### DIFF
--- a/docs/manual/existing_performance_counters.qbk
+++ b/docs/manual/existing_performance_counters.qbk
@@ -1434,6 +1434,51 @@ system and application performance.
          this counter is accessed. Any wildcards in the counter names will
          be expanded.]
     ]
+    [   [`/arithmetics/mean`]
+        [None]
+        [Returns the average value of all values queried from the
+         underlying counters (the ones specified as the parameters).]
+        [The parameter will be interpreted as a comma separated list of
+         full performance counter names which are queried whenever
+         this counter is accessed. Any wildcards in the counter names will
+         be expanded.]
+    ]
+    [   [`/arithmetics/variance`]
+        [None]
+        [Returns the standard deviation of all values queried from the
+         underlying counters (the ones specified as the parameters).]
+        [The parameter will be interpreted as a comma separated list of
+         full performance counter names which are queried whenever
+         this counter is accessed. Any wildcards in the counter names will
+         be expanded.]
+    ]
+    [   [`/arithmetics/median`]
+        [None]
+        [Returns the median value of all values queried from the
+         underlying counters (the ones specified as the parameters).]
+        [The parameter will be interpreted as a comma separated list of
+         full performance counter names which are queried whenever
+         this counter is accessed. Any wildcards in the counter names will
+         be expanded.]
+    ]
+    [   [`/arithmetics/min`]
+        [None]
+        [Returns the minimum value of all values queried from the
+         underlying counters (the ones specified as the parameters).]
+        [The parameter will be interpreted as a comma separated list of
+         full performance counter names which are queried whenever
+         this counter is accessed. Any wildcards in the counter names will
+         be expanded.]
+    ]
+    [   [`/arithmetics/max`]
+        [None]
+        [Returns the maximum value of all values queried from the
+         underlying counters (the ones specified as the parameters).]
+        [The parameter will be interpreted as a comma separated list of
+         full performance counter names which are queried whenever
+         this counter is accessed. Any wildcards in the counter names will
+         be expanded.]
+    ]
 ]
 
 [note The /arithmetics counters can consume an arbitrary number of other counters.

--- a/hpx/performance_counters/counters.hpp
+++ b/hpx/performance_counters/counters.hpp
@@ -710,6 +710,11 @@ namespace hpx { namespace performance_counters
         HPX_EXPORT naming::gid_type arithmetics_counter_creator(
             counter_info const&, error_code&);
 
+        // Creation function for extended aggregating performance counters; to
+        // be registered with the counter types.
+        HPX_EXPORT naming::gid_type arithmetics_counter_extended_creator(
+            counter_info const&, error_code&);
+
         // Creation function for uptime counters.
         HPX_EXPORT naming::gid_type uptime_counter_creator(
             counter_info const&, error_code&);
@@ -729,6 +734,13 @@ namespace hpx { namespace performance_counters
         // \brief Create a new arithmetics performance counter instance based on
         //        the given base counter names
         HPX_EXPORT naming::gid_type create_arithmetics_counter(
+            counter_info const& info,
+            std::vector<std::string> const& base_counter_names,
+            error_code& ec = throws);
+
+        // \brief Create a new extended arithmetics performance counter instance
+        //        based on the given base counter names
+        HPX_EXPORT naming::gid_type create_arithmetics_counter_extended(
             counter_info const& info,
             std::vector<std::string> const& base_counter_names,
             error_code& ec = throws);

--- a/hpx/performance_counters/performance_counter_set.hpp
+++ b/hpx/performance_counters/performance_counter_set.hpp
@@ -100,6 +100,8 @@ namespace hpx { namespace performance_counters
             return get_values<T>(reset).get(ec);
         }
 
+        std::size_t get_invocation_count() const;
+
     protected:
         bool find_counter(counter_info const& info, bool reset, error_code& ec);
 
@@ -121,6 +123,7 @@ namespace hpx { namespace performance_counters
         std::vector<naming::id_type> ids_;    // global ids of counter instances
         std::vector<std::uint8_t> reset_;     // != 0 if counter should be reset
 
+        mutable std::uint64_t invocation_count_;
         bool print_counters_locally_;         // handle only local counters
     };
 }}

--- a/hpx/performance_counters/registry.hpp
+++ b/hpx/performance_counters/registry.hpp
@@ -133,9 +133,15 @@ namespace hpx { namespace performance_counters
             naming::gid_type& id, error_code& ec = throws);
 
         /// \brief Create a new arithmetics performance counter instance based
-        ///        on given base counter name and given base time interval
-        ///        (milliseconds).
+        ///        on given base counter names
         counter_status create_arithmetics_counter(counter_info const& info,
+            std::vector<std::string> const& base_counter_names,
+            naming::gid_type& id, error_code& ec = throws);
+
+        /// \brief Create a new extended arithmetics performance counter
+        ///        instance based on given base counter names
+        counter_status create_arithmetics_counter_extended(
+            counter_info const& info,
             std::vector<std::string> const& base_counter_names,
             naming::gid_type& id, error_code& ec = throws);
 

--- a/hpx/performance_counters/server/arithmetics_counter_extended.hpp
+++ b/hpx/performance_counters/server/arithmetics_counter_extended.hpp
@@ -3,8 +3,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(HPX_PERFORMANCE_COUNTERS_SERVER_ARITHMETICS_COUNTER_APR_10_2013_1002AM)
-#define HPX_PERFORMANCE_COUNTERS_SERVER_ARITHMETICS_COUNTER_APR_10_2013_1002AM
+#if !defined(HPX_PERFORMANCE_COUNTERS_SERVER_ARITHMETICS_COUNTER_EXTENDED)
+#define HPX_PERFORMANCE_COUNTERS_SERVER_ARITHMETICS_COUNTER_EXTENDED
 
 #include <hpx/config.hpp>
 #include <hpx/performance_counters/performance_counter_set.hpp>
@@ -12,6 +12,7 @@
 #include <hpx/runtime/components/server/component_base.hpp>
 
 #include <cstdint>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -21,21 +22,22 @@ namespace hpx { namespace performance_counters { namespace server
     ///////////////////////////////////////////////////////////////////////////
     // This counter exposes the result of an arithmetic operation The counter
     // relies on querying two base counters.
-    template <typename Operation>
-    class arithmetics_counter
+    template <typename Statistic>
+    class arithmetics_counter_extended
       : public base_performance_counter,
-        public components::component_base<arithmetics_counter<Operation> >
+        public components::component_base<
+            arithmetics_counter_extended<Statistic> >
     {
         typedef components::component_base<
-            arithmetics_counter<Operation> > base_type;
+            arithmetics_counter_extended<Statistic> > base_type;
 
     public:
-        typedef arithmetics_counter type_holder;
+        typedef arithmetics_counter_extended type_holder;
         typedef base_performance_counter base_type_holder;
 
-        arithmetics_counter() = default;
+        arithmetics_counter_extended() = default;
 
-        arithmetics_counter(counter_info const& info,
+        arithmetics_counter_extended(counter_info const& info,
             std::vector<std::string> const& base_counter_names);
 
         /// Overloads from the base_counter base class.

--- a/src/performance_counters/counters.cpp
+++ b/src/performance_counters/counters.cpp
@@ -702,6 +702,20 @@ namespace hpx { namespace performance_counters
             return gid;
         }
 
+        // \brief Create a new aggregating extended performance counter instance
+        //        based on given base counter name and given base time interval
+        //        (milliseconds).
+        naming::gid_type create_arithmetics_counter_extended(
+            counter_info const& info,
+            std::vector<std::string> const& base_counter_names, error_code& ec)
+        {
+            naming::gid_type gid;
+            get_runtime().get_counter_registry().
+                create_arithmetics_counter_extended(info, base_counter_names,
+                    gid, ec);
+            return gid;
+        }
+
         ///////////////////////////////////////////////////////////////////////
         counter_status add_counter(naming::id_type const& id,
             counter_info const& info, error_code& ec)

--- a/src/performance_counters/performance_counter_set.cpp
+++ b/src/performance_counters/performance_counter_set.cpp
@@ -27,13 +27,15 @@
 namespace hpx { namespace performance_counters
 {
     performance_counter_set::performance_counter_set(std::string const& name,
-        bool reset)
+            bool reset)
+      : invocation_count_(0)
     {
         add_counters(name, reset);
     }
 
     performance_counter_set::performance_counter_set(
-        std::vector<std::string> const& names, bool reset)
+            std::vector<std::string> const& names, bool reset)
+      : invocation_count_(0)
     {
         add_counters(names, reset);
     }
@@ -257,6 +259,7 @@ namespace hpx { namespace performance_counters
         {
             std::unique_lock<mutex_type> l(mtx_);
             ids = ids_;
+            ++invocation_count_;
         }
 
         std::vector<hpx::future<counter_value> > v;
@@ -298,6 +301,7 @@ namespace hpx { namespace performance_counters
         {
             std::unique_lock<mutex_type> l(mtx_);
             ids = ids_;
+            ++invocation_count_;
         }
 
         std::vector<hpx::future<counter_values_array> > v;
@@ -329,6 +333,13 @@ namespace hpx { namespace performance_counters
                 "performance_counter_set::get_counter_values_aray");
             return std::vector<counter_values_array>();
         }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    std::size_t performance_counter_set::get_invocation_count() const
+    {
+        std::unique_lock<mutex_type> l(mtx_);
+        return invocation_count_;
     }
 }}
 

--- a/src/performance_counters/server/arithmetics_counter.cpp
+++ b/src/performance_counters/server/arithmetics_counter.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2017 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,6 +6,7 @@
 // make inspect happy: hpxinspect:nodeprecatedname:boost::is_any_of
 
 #include <hpx/config.hpp>
+#include <hpx/runtime/runtime_fwd.hpp>
 #include <hpx/runtime/components/derived_component_factory.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/runtime/agas/interface.hpp>
@@ -28,6 +29,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace performance_counters { namespace server
 {
+    ///////////////////////////////////////////////////////////////////////////
     namespace detail
     {
         template <typename Operation>
@@ -64,55 +66,36 @@ namespace hpx { namespace performance_counters { namespace server
             counter_info const& info,
             std::vector<std::string> const& base_counter_names)
       : base_type_holder(info),
-        base_counter_names_(base_counter_names),
-        invocation_count_(0)
+        counters_(base_counter_names)
     {
         if (info.type_ != counter_aggregating) {
             HPX_THROW_EXCEPTION(bad_parameter,
                 "arithmetics_counter<Operation>::arithmetics_counter",
                 "unexpected counter type specified");
         }
-        base_counter_ids_.resize(base_counter_names_.size());
+
+        counter_path_elements paths;
+        get_counter_path_elements(info.fullname_, paths);
+
+        if (paths.countername_ == "divide")
+        {
+            if (counters_.size() < 2)
+            {
+                HPX_THROW_EXCEPTION(bad_parameter,
+                    "arithmetics_counter<Operation>::arithmetics_counter",
+                    "the parameter specification for an arithmetic counter "
+                    "'/arithmetics/divide' has to expand to more than one "
+                    "counter name: " + paths.parameters_);
+            }
+        }
     }
 
     template <typename Operation>
     hpx::performance_counters::counter_value
         arithmetics_counter<Operation>::get_counter_value(bool reset)
     {
-        std::vector<counter_value> base_values;
-        base_values.reserve(base_counter_names_.size());
-
-        // lock here to avoid checking out multiple reference counted GIDs
-        // from AGAS
-        {
-            std::unique_lock<mutex_type> l(mtx_);
-
-            for (std::size_t i = 0; i != base_counter_names_.size(); ++i)
-            {
-                // gather current base values
-                counter_value value;
-                if (!evaluate_base_counter(base_counter_ids_[i],
-                    base_counter_names_[i], value, l))
-                {
-                    return value;
-                }
-
-                base_values.push_back(value);
-            }
-
-            // adjust local invocation count
-            base_values[0].count_ = ++invocation_count_;
-        }
-
-//         if (base_value1.scaling_ != base_value2.scaling_ ||
-//             base_value1.scale_inverse_ != base_value2.scale_inverse_)
-//         {
-//             // not supported right now
-//             HPX_THROW_EXCEPTION(not_implemented,
-//                 "arithmetics_counter<Operation>::evaluate",
-//                 "base counters should expose same scaling");
-//             return false;
-//         }
+        std::vector<counter_value> base_values =
+            counters_.get_counter_values(hpx::launch::sync);
 
         // apply arithmetic operation
         double value = detail::init_value<Operation>::call();
@@ -130,148 +113,29 @@ namespace hpx { namespace performance_counters { namespace server
             base_values[0].value_ =
                 static_cast<std::int64_t>(value / base_values[0].scaling_);
         }
+
+        base_values[0].time_ = static_cast<std::int64_t>(hpx::get_system_uptime());
+        base_values[0].count_ = counters_.get_invocation_count();
+
         return base_values[0];
     }
 
     template <typename Operation>
     bool arithmetics_counter<Operation>::start()
     {
-        std::unique_lock<mutex_type> l(mtx_);
-        for (std::size_t i = 0; i != base_counter_names_.size(); ++i)
-        {
-            if (!base_counter_ids_[i] &&
-                !ensure_base_counter(base_counter_ids_[i], base_counter_names_[i], l))
-            {
-                HPX_THROW_EXCEPTION(bad_parameter,
-                    "arithmetics_counter<Operation>::start",
-                    boost::str(boost::format(
-                        "could not get or create performance counter: '%s'") %
-                            base_counter_names_[i]));
-                return false;
-            }
-
-            {
-                util::unlock_guard<std::unique_lock<mutex_type> > ul(l);
-                using performance_counters::stubs::performance_counter;
-                if (!performance_counter::start(launch::sync, base_counter_ids_[i]))
-                {
-                    HPX_THROW_EXCEPTION(bad_parameter,
-                        "arithmetics_counter<Operation>::stop",
-                        boost::str(boost::format(
-                            "could not start performance counter: '%s'") %
-                                base_counter_names_[i]));
-                    return false;
-                }
-            }
-        }
-        return true;
+        return counters_.start(hpx::launch::sync);
     }
 
     template <typename Operation>
     bool arithmetics_counter<Operation>::stop()
     {
-        std::unique_lock<mutex_type> l(mtx_);
-        for (std::size_t i = 0; i != base_counter_names_.size(); ++i)
-        {
-            if (!base_counter_ids_[i] &&
-                !ensure_base_counter(base_counter_ids_[i], base_counter_names_[i], l))
-            {
-                HPX_THROW_EXCEPTION(bad_parameter,
-                    "arithmetics_counter<Operation>::stop",
-                    boost::str(boost::format(
-                        "could not get or create performance counter: '%s'") %
-                            base_counter_names_[i]));
-                return false;
-            }
-
-            {
-                util::unlock_guard<std::unique_lock<mutex_type> > ul(l);
-                using performance_counters::stubs::performance_counter;
-                if (!performance_counter::stop(launch::sync, base_counter_ids_[i]))
-                {
-                    HPX_THROW_EXCEPTION(bad_parameter,
-                        "arithmetics_counter<Operation>::stop",
-                        boost::str(boost::format(
-                            "could not stop performance counter: '%s'") %
-                                base_counter_names_[i]));
-                    return false;
-                }
-            }
-        }
-        return true;
+        return counters_.stop(hpx::launch::sync);
     }
 
     template <typename Operation>
     void arithmetics_counter<Operation>::reset_counter_value()
     {
-        std::unique_lock<mutex_type> l(mtx_);
-        for (std::size_t i = 0; i != base_counter_names_.size(); ++i)
-        {
-            if (!base_counter_ids_[i] &&
-                !ensure_base_counter(base_counter_ids_[i], base_counter_names_[i], l))
-            {
-                HPX_THROW_EXCEPTION(bad_parameter,
-                    "arithmetics_counter<Operation>::reset_counter_value",
-                    boost::str(boost::format(
-                        "could not get or create performance counter: '%s'") %
-                            base_counter_names_[i]));
-                return;
-            }
-
-            using performance_counters::stubs::performance_counter;
-            performance_counter::reset(launch::sync, base_counter_ids_[i]);
-        }
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename Operation>
-    bool arithmetics_counter<Operation>::ensure_base_counter(
-        naming::id_type& base_counter_id, std::string const& base_counter_name,
-        std::unique_lock<mutex_type>& l)
-    {
-        if (!base_counter_id) {
-            // get or create the base counter
-            error_code ec(lightweight);
-            hpx::id_type counter_id;
-            {
-                util::unlock_guard<std::unique_lock<mutex_type> > ul(l);
-                counter_id = get_counter(base_counter_name, ec);
-            }
-            // Since we needed to unlock to retrieve the counter id, check if
-            // no other thread came first
-            if (!base_counter_id)
-            {
-                base_counter_id = counter_id;
-            }
-            if (HPX_UNLIKELY(ec || !base_counter_id))
-            {
-                // base counter could not be retrieved
-                HPX_THROW_EXCEPTION(bad_parameter,
-                    "arithmetics_counter<Operation>::evaluate_base_counter",
-                    boost::str(boost::format(
-                        "could not get or create performance counter: '%s'") %
-                            base_counter_name));
-                return false;
-            }
-        }
-        return true;
-    }
-
-    template <typename Operation>
-    bool arithmetics_counter<Operation>::evaluate_base_counter(
-        naming::id_type& base_counter_id, std::string const& name,
-        counter_value& value, std::unique_lock<mutex_type>& l)
-    {
-        // query the actual value
-        if (!base_counter_id && !ensure_base_counter(base_counter_id, name, l))
-            return false;
-
-        hpx::id_type counter_id = base_counter_id;
-        {
-            util::unlock_guard<std::unique_lock<mutex_type> > ul(l);
-            value = stubs::performance_counter::get_value(launch::sync, counter_id);
-        }
-        return true;
+        counters_.reset(hpx::launch::sync);
     }
 }}}
 
@@ -332,29 +196,6 @@ HPX_DEFINE_GET_COMPONENT_TYPE(dividing_counter_type::wrapped_type)
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace performance_counters { namespace detail
 {
-    void expand_counter_name_wildcards(std::vector<std::string>& names, error_code& ec)
-    {
-        std::vector<counter_info> counters;
-        for (std::string const& name : names)
-        {
-            discover_counter_type(ensure_counter_prefix(name), counters,
-                discover_counters_full, ec);
-            if (ec) return;
-        }
-
-        std::vector<std::string> result;
-        result.reserve(counters.size());
-        for (counter_info const& info : counters)
-        {
-            result.push_back(info.fullname_);
-        }
-
-        if (&ec != &throws)
-            ec = make_success_code();
-
-        std::swap(names, result);
-    }
-
     /// Creation function for aggregating performance counters to be registered
     /// with the counter types.
     naming::gid_type arithmetics_counter_creator(counter_info const& info,
@@ -373,38 +214,7 @@ namespace hpx { namespace performance_counters { namespace detail
                     std::vector<std::string> names;
                     boost::split(names, paths.parameters_, boost::is_any_of(","));
 
-                    // expand all wildcards in given counter names
-                    expand_counter_name_wildcards(names, ec);
-                    if (ec) return naming::invalid_gid;
-
-                    for (std::string const& name : names)
-                    {
-                        counter_path_elements paths;
-                        if (status_valid_data != get_counter_path_elements(
-                                name, paths, ec) || ec)
-                        {
-                            HPX_THROWS_IF(ec, bad_parameter,
-                                "arithmetics_counter_creator",
-                                "the given (expanded) counter name is not \
-                                 a validly formed "
-                                "performance counter name: " + name);
-                            return naming::invalid_gid;
-                        }
-                    }
-
-                    if (paths.countername_ == "divide")
-                    {
-                        if (names.size() < 2)
-                        {
-                            HPX_THROWS_IF(ec, bad_parameter,
-                                "arithmetics_counter_creator",
-                                "the parameter specification for an arithmetic counter "
-                                "has to expand to more than one counter name: " +
-                                paths.parameters_);
-                            return naming::invalid_gid;
-                        }
-                    }
-                    else if (names.empty())
+                    if (names.empty())
                     {
                         HPX_THROWS_IF(ec, bad_parameter,
                             "arithmetics_counter_creator",
@@ -414,13 +224,28 @@ namespace hpx { namespace performance_counters { namespace detail
                         return naming::invalid_gid;
                     }
 
+                    for (std::string const& name : names)
+                    {
+                        counter_path_elements paths;
+                        if (status_valid_data != get_counter_path_elements(
+                                name, paths, ec) || ec)
+                        {
+                            HPX_THROWS_IF(ec, bad_parameter,
+                                "arithmetics_counter_creator",
+                                "the given (expanded) counter name is not "
+                                "a validly formed performance counter name: " +
+                                    name);
+                            return naming::invalid_gid;
+                        }
+                    }
+
                     return create_arithmetics_counter(info, names, ec);
                 }
                 else {
                     HPX_THROWS_IF(ec, bad_parameter,
                         "arithmetics_counter_creator",
                         "the parameter specification for an arithmetic counter "
-                        "has to be a comma separated list of two performance "
+                        "has to be a comma separated list of performance "
                         "counter names, none is given: " +
                             remove_counter_prefix(info.fullname_));
                 }

--- a/src/performance_counters/server/arithmetics_counter_extended.cpp
+++ b/src/performance_counters/server/arithmetics_counter_extended.cpp
@@ -1,0 +1,307 @@
+//  Copyright (c) 2007-2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// make inspect happy: hpxinspect:nodeprecatedname:boost::is_any_of
+
+#include <hpx/config.hpp>
+#include <hpx/runtime/runtime_fwd.hpp>
+#include <hpx/runtime/components/derived_component_factory.hpp>
+#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/performance_counters/counters.hpp>
+#include <hpx/performance_counters/counter_creators.hpp>
+#include <hpx/performance_counters/stubs/performance_counter.hpp>
+#include <hpx/performance_counters/server/arithmetics_counter_extended.hpp>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics/stats.hpp>
+#include <boost/accumulators/statistics/mean.hpp>
+#include <boost/accumulators/statistics/median.hpp>
+#include <boost/accumulators/statistics/variance.hpp>
+#include <boost/accumulators/statistics/max.hpp>
+#include <boost/accumulators/statistics/min.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace performance_counters { namespace server
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Statistic>
+    arithmetics_counter_extended<Statistic>::arithmetics_counter_extended(
+            counter_info const& info,
+            std::vector<std::string> const& base_counter_names)
+      : base_type_holder(info),
+        counters_(base_counter_names)
+    {
+        if (info.type_ != counter_aggregating) {
+            HPX_THROW_EXCEPTION(bad_parameter,
+                "arithmetics_counter_extended<Statistic>::"
+                    "arithmetics_counter_extended",
+                "unexpected counter type specified");
+        }
+    }
+
+    namespace detail
+    {
+        template <typename Statistic>
+        struct statistic_get_value;
+
+        template <>
+        struct statistic_get_value<boost::accumulators::tag::mean>
+        {
+            template <typename Accumulator>
+            static double call(Accumulator const& accum)
+            {
+                return boost::accumulators::mean(accum);
+            }
+        };
+
+        template <>
+        struct statistic_get_value<boost::accumulators::tag::variance>
+        {
+            template <typename Accumulator>
+            static double call(Accumulator const& accum)
+            {
+                return boost::accumulators::variance(accum);
+            }
+        };
+
+        template <>
+        struct statistic_get_value<boost::accumulators::tag::median>
+        {
+            template <typename Accumulator>
+            static double call(Accumulator const& accum)
+            {
+                return boost::accumulators::median(accum);
+            }
+        };
+
+        template <>
+        struct statistic_get_value<boost::accumulators::tag::min>
+        {
+            template <typename Accumulator>
+            static double call(Accumulator const& accum)
+            {
+                return (boost::accumulators::min)(accum);
+            }
+        };
+
+        template <>
+        struct statistic_get_value<boost::accumulators::tag::max>
+        {
+            template <typename Accumulator>
+            static double call(Accumulator const& accum)
+            {
+                return (boost::accumulators::max)(accum);
+            }
+        };
+    }
+
+    template <typename Statistic>
+    hpx::performance_counters::counter_value
+        arithmetics_counter_extended<Statistic>::get_counter_value(bool reset)
+    {
+        std::vector<counter_value> base_values =
+            counters_.get_counter_values(hpx::launch::sync);
+
+        // apply arithmetic Statistic
+        typedef boost::accumulators::accumulator_set<
+            double, boost::accumulators::stats<Statistic>
+        > accumulator_type;
+
+        accumulator_type accum;
+        for (counter_value const& base_value : base_values)
+        {
+            accum(base_value.get_value<double>());
+        }
+        double value = detail::statistic_get_value<Statistic>::call(accum);
+
+        if (base_values[0].scale_inverse_ && base_values[0].scaling_ != 1.0) //-V550
+        {
+            base_values[0].value_ =
+                static_cast<std::int64_t>(value * base_values[0].scaling_);
+        }
+        else {
+            base_values[0].value_ =
+                static_cast<std::int64_t>(value / base_values[0].scaling_);
+        }
+
+        base_values[0].time_ = static_cast<std::int64_t>(hpx::get_system_uptime());
+        base_values[0].count_ = counters_.get_invocation_count();
+
+        return base_values[0];
+    }
+
+    template <typename Statistic>
+    bool arithmetics_counter_extended<Statistic>::start()
+    {
+        return counters_.start(hpx::launch::sync);
+    }
+
+    template <typename Statistic>
+    bool arithmetics_counter_extended<Statistic>::stop()
+    {
+        return counters_.stop(hpx::launch::sync);
+    }
+
+    template <typename Statistic>
+    void arithmetics_counter_extended<Statistic>::reset_counter_value()
+    {
+        counters_.reset(hpx::launch::sync);
+    }
+}}}
+
+///////////////////////////////////////////////////////////////////////////////
+template class HPX_EXPORT
+hpx::performance_counters::server::arithmetics_counter_extended<
+    boost::accumulators::tag::mean>;
+template class HPX_EXPORT
+hpx::performance_counters::server::arithmetics_counter_extended<
+    boost::accumulators::tag::variance>;
+template class HPX_EXPORT
+hpx::performance_counters::server::arithmetics_counter_extended<
+    boost::accumulators::tag::median>;
+template class HPX_EXPORT
+hpx::performance_counters::server::arithmetics_counter_extended<
+    boost::accumulators::tag::min>;
+template class HPX_EXPORT
+hpx::performance_counters::server::arithmetics_counter_extended<
+    boost::accumulators::tag::max>;
+
+///////////////////////////////////////////////////////////////////////////////
+// /arithmetic/mean
+typedef hpx::components::component<
+    hpx::performance_counters::server::arithmetics_counter_extended<
+        boost::accumulators::tag::mean>
+> mean_arithmetics_counter_type;
+
+HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
+    mean_arithmetics_counter_type, mean_arithmetics_counter,
+    "base_performance_counter", hpx::components::factory_enabled)
+HPX_DEFINE_GET_COMPONENT_TYPE(mean_arithmetics_counter_type::wrapped_type)
+
+///////////////////////////////////////////////////////////////////////////////
+// /arithmetic/variance
+typedef hpx::components::component<
+    hpx::performance_counters::server::arithmetics_counter_extended<
+        boost::accumulators::tag::variance>
+> variance_arithmetics_counter_type;
+
+HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
+    variance_arithmetics_counter_type, variance_arithmetics_counter,
+    "base_performance_counter", hpx::components::factory_enabled)
+HPX_DEFINE_GET_COMPONENT_TYPE(variance_arithmetics_counter_type::wrapped_type)
+
+///////////////////////////////////////////////////////////////////////////////
+// /arithmetic/median
+typedef hpx::components::component<
+    hpx::performance_counters::server::arithmetics_counter_extended<
+        boost::accumulators::tag::median>
+> median_arithmetics_counter_type;
+
+HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
+    median_arithmetics_counter_type, median_arithmetics_counter,
+    "base_performance_counter", hpx::components::factory_enabled)
+HPX_DEFINE_GET_COMPONENT_TYPE(median_arithmetics_counter_type::wrapped_type)
+
+///////////////////////////////////////////////////////////////////////////////
+// /arithmetic/min
+typedef hpx::components::component<
+    hpx::performance_counters::server::arithmetics_counter_extended<
+        boost::accumulators::tag::min>
+> min_arithmetics_counter_type;
+
+HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
+    min_arithmetics_counter_type, min_arithmetics_counter,
+    "base_performance_counter", hpx::components::factory_enabled)
+HPX_DEFINE_GET_COMPONENT_TYPE(min_arithmetics_counter_type::wrapped_type)
+
+///////////////////////////////////////////////////////////////////////////////
+// /arithmetic/max
+typedef hpx::components::component<
+    hpx::performance_counters::server::arithmetics_counter_extended<
+        boost::accumulators::tag::max>
+> max_arithmetics_counter_type;
+
+HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
+    max_arithmetics_counter_type, max_arithmetics_counter,
+    "base_performance_counter", hpx::components::factory_enabled)
+HPX_DEFINE_GET_COMPONENT_TYPE(max_arithmetics_counter_type::wrapped_type)
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace performance_counters { namespace detail
+{
+    /// Creation function for aggregating performance counters to be registered
+    /// with the counter types.
+    naming::gid_type arithmetics_counter_extended_creator(
+        counter_info const& info, error_code& ec)
+    {
+        switch (info.type_) {
+        case counter_aggregating:
+            {
+                counter_path_elements paths;
+                get_counter_path_elements(info.fullname_, paths, ec);
+                if (ec) return naming::invalid_gid;
+
+                if (!paths.parameters_.empty()) {
+                    // try to interpret the additional parameter as a list of
+                    // two performance counter names
+                    std::vector<std::string> names;
+                    boost::split(names, paths.parameters_, boost::is_any_of(","));
+
+                    if (names.empty())
+                    {
+                        HPX_THROWS_IF(ec, bad_parameter,
+                            "arithmetics_counter_extended_creator",
+                            "the parameter specification for an arithmetic counter "
+                            "has to expand to at least one counter name: " +
+                            paths.parameters_);
+                        return naming::invalid_gid;
+                    }
+
+                    for (std::string const& name : names)
+                    {
+                        counter_path_elements paths;
+                        if (status_valid_data != get_counter_path_elements(
+                                name, paths, ec) || ec)
+                        {
+                            HPX_THROWS_IF(ec, bad_parameter,
+                                "arithmetics_counter_extended_creator",
+                                "the given (expanded) counter name is not "
+                                "a validly formed performance counter name: " +
+                                    name);
+                            return naming::invalid_gid;
+                        }
+                    }
+
+                    return create_arithmetics_counter_extended(info, names, ec);
+                }
+                else {
+                    HPX_THROWS_IF(ec, bad_parameter,
+                        "arithmetics_counter_extended_creator",
+                        "the parameter specification for an arithmetic counter "
+                        "has to be a comma separated list of performance "
+                        "counter names, none is given: " +
+                            remove_counter_prefix(info.fullname_));
+                }
+            }
+            break;
+
+        default:
+            HPX_THROWS_IF(ec, bad_parameter,
+                "arithmetics_counter_extended_creator",
+                "invalid counter type requested");
+            break;
+        }
+        return naming::invalid_gid;
+    }
+}}}
+

--- a/src/performance_counters/server/raw_counter.cpp
+++ b/src/performance_counters/server/raw_counter.cpp
@@ -1,9 +1,10 @@
-//  Copyright (c) 2007-2012 Hartmut Kaiser
+//  Copyright (c) 2007-2017 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/runtime/runtime_fwd.hpp>
 #include <hpx/runtime/components/derived_component_factory.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/util/high_resolution_clock.hpp>

--- a/src/performance_counters/server/statistics_counter.cpp
+++ b/src/performance_counters/server/statistics_counter.cpp
@@ -19,6 +19,7 @@
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/mean.hpp>
+#include <boost/accumulators/statistics/median.hpp>
 #include <boost/accumulators/statistics/variance.hpp>
 #include <boost/accumulators/statistics/max.hpp>
 #include <boost/accumulators/statistics/min.hpp>

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -584,6 +584,57 @@ namespace hpx
               &performance_counters::default_counter_discoverer,
               ""
             },
+
+            // arithmetics mean counter
+            { "/arithmetics/mean", performance_counters::counter_aggregating,
+              "returns the average value of all values of the specified "
+              "base counters; pass the required base counters as the parameters: "
+              "/arithmetics/mean@<base_counter_name1>,<base_counter_name2>",
+              HPX_PERFORMANCE_COUNTER_V1,
+              &performance_counters::detail::arithmetics_counter_extended_creator,
+              &performance_counters::default_counter_discoverer,
+              ""
+            },
+            // arithmetics variance counter
+            { "/arithmetics/variance", performance_counters::counter_aggregating,
+              "returns the standard deviation of all values of the specified "
+              "base counters; pass the required base counters as the parameters: "
+              "/arithmetics/variance@<base_counter_name1>,<base_counter_name2>",
+              HPX_PERFORMANCE_COUNTER_V1,
+              &performance_counters::detail::arithmetics_counter_extended_creator,
+              &performance_counters::default_counter_discoverer,
+              ""
+            },
+            // arithmetics median counter
+            { "/arithmetics/median", performance_counters::counter_aggregating,
+              "returns the median of all values of the specified "
+              "base counters; pass the required base counters as the parameters: "
+              "/arithmetics/median@<base_counter_name1>,<base_counter_name2>",
+              HPX_PERFORMANCE_COUNTER_V1,
+              &performance_counters::detail::arithmetics_counter_extended_creator,
+              &performance_counters::default_counter_discoverer,
+              ""
+            },
+            // arithmetics min counter
+            { "/arithmetics/min", performance_counters::counter_aggregating,
+              "returns the minimum value of all values of the specified "
+              "base counters; pass the required base counters as the parameters: "
+              "/arithmetics/min@<base_counter_name1>,<base_counter_name2>",
+              HPX_PERFORMANCE_COUNTER_V1,
+              &performance_counters::detail::arithmetics_counter_extended_creator,
+              &performance_counters::default_counter_discoverer,
+              ""
+            },
+            // arithmetics max counter
+            { "/arithmetics/max", performance_counters::counter_aggregating,
+              "returns the maximum value of all values of the specified "
+              "base counters; pass the required base counters as the parameters: "
+              "/arithmetics/max@<base_counter_name1>,<base_counter_name2>",
+              HPX_PERFORMANCE_COUNTER_V1,
+              &performance_counters::detail::arithmetics_counter_extended_creator,
+              &performance_counters::default_counter_discoverer,
+              ""
+            },
         };
         performance_counters::install_counter_types(
             arithmetic_counter_types,


### PR DESCRIPTION
- this adds 5 new performance counters:
    `/arithmetics/mean`, `/arithmetics/variance`, `/arithmetics/median`,
    `/arithmetics/min`, and `/arithmetics/max`
  all of which will calculate the given statistics over a set of
  counters specified as counter parameters, for instance:
    `/arithmetics/mean@/threadqueue{locality#0/worker-thread#*}/length`
  which calculates the average queue length for all worker threads