### PR TITLE
New thread priority names

### DIFF
--- a/docs/manual/vector.qbk
+++ b/docs/manual/vector.qbk
@@ -212,3 +212,5 @@ Which is equivalent to:
     }
 
 [endsect]
+
+[endsect]

--- a/examples/quickstart/customize_async.cpp
+++ b/examples/quickstart/customize_async.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[])
     // run a thread with high priority
     {
         hpx::parallel::execution::default_executor high_priority_executor(
-            hpx::threads::thread_priority_critical);
+            hpx::threads::thread_priority_high);
 
         hpx::future<void> f =
             hpx::async(high_priority_executor, &run_with_high_priority);
@@ -71,7 +71,7 @@ int main(int argc, char* argv[])
     // combine both
     {
         hpx::parallel::execution::default_executor fancy_executor(
-            hpx::threads::thread_priority_critical,
+            hpx::threads::thread_priority_high,
             hpx::threads::thread_stacksize_large);
 
         hpx::future<void> f =

--- a/examples/throttle/throttle/server/throttle.cpp
+++ b/examples/throttle/throttle/server/throttle.cpp
@@ -116,7 +116,7 @@ namespace throttle { namespace server
             hpx::util::bind(&throttle::throttle_controller, this, shepherd),
             description.c_str(),
             hpx::threads::pending, true,
-            hpx::threads::thread_priority_critical,
+            hpx::threads::thread_priority_high,
             shepherd);
     }
 
@@ -130,7 +130,7 @@ namespace throttle { namespace server
             hpx::util::bind(&throttle::suspend, this, shepherd),
             description.c_str(),
             hpx::threads::pending, true,
-            hpx::threads::thread_priority_critical,
+            hpx::threads::thread_priority_high,
             shepherd);
     }
 }}

--- a/hpx/runtime/actions/action_priority.hpp
+++ b/hpx/runtime/actions/action_priority.hpp
@@ -21,8 +21,10 @@ namespace hpx { namespace actions
         threads::thread_priority priority =
             static_cast<threads::thread_priority>(
                 traits::action_priority<action_type_>::value);
-        if (priority == threads::thread_priority_default)
-            priority = threads::thread_priority_normal;
+//         The mapping to 'normal' is now done at the last possible moment in
+//         the scheduler.
+//         if (priority == threads::thread_priority_default)
+//             priority = threads::thread_priority_normal;
         return priority;
     }
 }}

--- a/hpx/runtime/actions/action_support.hpp
+++ b/hpx/runtime/actions/action_support.hpp
@@ -195,8 +195,10 @@ namespace hpx { namespace actions
             static threads::thread_priority
             call(threads::thread_priority priority)
             {
-                if (priority == threads::thread_priority_default)
-                    return threads::thread_priority_normal;
+//              The mapping to 'normal' is now done at the last possible moment
+//              in the scheduler.
+//                 if (priority == threads::thread_priority_default)
+//                     return threads::thread_priority_normal;
                 return priority;
             }
         };

--- a/hpx/runtime/actions/basic_action.hpp
+++ b/hpx/runtime/actions/basic_action.hpp
@@ -985,8 +985,16 @@ namespace hpx { namespace serialization
 #define HPX_ACTION_HAS_NORMAL_PRIORITY(action)                                \
     HPX_ACTION_HAS_PRIORITY(action, threads::thread_priority_normal)          \
 /**/
+#define HPX_ACTION_HAS_HIGH_PRIORITY(action)                                  \
+    HPX_ACTION_HAS_PRIORITY(action, threads::thread_priority_high)            \
+/**/
+#define HPX_ACTION_HAS_HIGH_RECURSIVE_PRIORITY(action)                        \
+    HPX_ACTION_HAS_PRIORITY(action, threads::thread_priority_high_recursive)  \
+/**/
+
+// obsolete, kept for compatibility
 #define HPX_ACTION_HAS_CRITICAL_PRIORITY(action)                              \
-    HPX_ACTION_HAS_PRIORITY(action, threads::thread_priority_critical)        \
+    HPX_ACTION_HAS_PRIORITY(action, threads::thread_priority_high_recursive)  \
 /**/
 
 /// \endcond

--- a/hpx/runtime/threads/detail/create_thread.hpp
+++ b/hpx/runtime/threads/detail/create_thread.hpp
@@ -70,15 +70,20 @@ namespace hpx { namespace threads { namespace detail
         if (nullptr == data.scheduler_base)
             data.scheduler_base = scheduler;
 
-        // Pass critical priority from parent to child.
+        // Pass critical priority from parent to child (but only if there is
+        // none is explicitly specified).
         if (self)
         {
-            if (thread_priority_high_recursive ==
-                threads::get_self_id()->get_priority())
+            if (data.priority == thread_priority_default &&
+                thread_priority_high_recursive ==
+                    threads::get_self_id()->get_priority())
             {
                 data.priority = thread_priority_high_recursive;
             }
         }
+
+        if (data.priority == thread_priority_default)
+            data.priority == thread_priority_normal;
 
         // create the new thread
         std::size_t num_thread = data.num_os_thread;

--- a/hpx/runtime/threads/detail/create_thread.hpp
+++ b/hpx/runtime/threads/detail/create_thread.hpp
@@ -73,8 +73,11 @@ namespace hpx { namespace threads { namespace detail
         // Pass critical priority from parent to child.
         if (self)
         {
-            if (thread_priority_critical == threads::get_self_id()->get_priority())
-                data.priority = thread_priority_critical;
+            if (thread_priority_high_recursive ==
+                threads::get_self_id()->get_priority())
+            {
+                data.priority = thread_priority_high_recursive;
+            }
         }
 
         // create the new thread

--- a/hpx/runtime/threads/detail/create_work.hpp
+++ b/hpx/runtime/threads/detail/create_work.hpp
@@ -81,12 +81,16 @@ namespace hpx { namespace threads { namespace detail
         // Pass critical priority from parent to child.
         if (self)
         {
-            if (thread_priority_high_recursive ==
-                threads::get_self_id()->get_priority())
+            if (data.priority == thread_priority_default &&
+                thread_priority_high_recursive ==
+                    threads::get_self_id()->get_priority())
             {
                 data.priority = thread_priority_high_recursive;
             }
         }
+
+        if (data.priority == thread_priority_default)
+            data.priority == thread_priority_normal;
 
         // create the new thread
         if (thread_priority_high == data.priority ||

--- a/hpx/runtime/threads/detail/create_work.hpp
+++ b/hpx/runtime/threads/detail/create_work.hpp
@@ -81,12 +81,16 @@ namespace hpx { namespace threads { namespace detail
         // Pass critical priority from parent to child.
         if (self)
         {
-            if (thread_priority_critical == threads::get_self_id()->get_priority())
-                data.priority = thread_priority_critical;
+            if (thread_priority_high_recursive ==
+                threads::get_self_id()->get_priority())
+            {
+                data.priority = thread_priority_high_recursive;
+            }
         }
 
         // create the new thread
-        if (thread_priority_critical == data.priority ||
+        if (thread_priority_high == data.priority ||
+            thread_priority_high_recursive == data.priority ||
             thread_priority_boost == data.priority)
         {
             // For critical priority threads, create the thread immediately.

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -315,7 +315,7 @@ namespace hpx { namespace threads { namespace detail
             },
             hpx::util::thread_description("background_work"),
             0,
-            thread_priority_critical,
+            thread_priority_high_recursive,
             num_thread,
             get_stack_size(thread_stacksize_large),
             &scheduler);

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -469,14 +469,17 @@ namespace hpx { namespace threads { namespace policies
                 num_thread %= queue_size;
 
             // now create the thread
-            if (data.priority == thread_priority_critical) {
+            if (data.priority == thread_priority_high_recursive ||
+                data.priority == thread_priority_high)
+            {
                 std::size_t num = num_thread % high_priority_queues_.size();
                 high_priority_queues_[num]->create_thread(data, id,
                     initial_state, run_now, ec);
                 return;
             }
 
-            if (data.priority == thread_priority_boost) {
+            if (data.priority == thread_priority_boost)
+            {
                 data.priority = thread_priority_normal;
                 std::size_t num = num_thread % high_priority_queues_.size();
                 high_priority_queues_[num]->create_thread(data, id,
@@ -484,7 +487,8 @@ namespace hpx { namespace threads { namespace policies
                 return;
             }
 
-            if (data.priority == thread_priority_low) {
+            if (data.priority == thread_priority_low)
+            {
                 low_priority_queue_.create_thread(data, id, initial_state,
                     run_now, ec);
                 return;
@@ -571,16 +575,19 @@ namespace hpx { namespace threads { namespace policies
             if (std::size_t(-1) == num_thread)
                 num_thread = curr_queue_++ % queues_.size();
 
-            if (priority == thread_priority_critical ||
+            if (priority == thread_priority_high_recursive ||
+                priority == thread_priority_high ||
                 priority == thread_priority_boost)
             {
                 std::size_t num = num_thread % high_priority_queues_.size();
                 high_priority_queues_[num]->schedule_thread(thrd);
             }
-            else if (priority == thread_priority_low) {
+            else if (priority == thread_priority_low)
+            {
                 low_priority_queue_.schedule_thread(thrd);
             }
-            else {
+            else
+            {
                 HPX_ASSERT(num_thread < queues_.size());
                 queues_[num_thread]->schedule_thread(thrd);
             }
@@ -593,16 +600,19 @@ namespace hpx { namespace threads { namespace policies
             if (std::size_t(-1) == num_thread)
                 num_thread = curr_queue_++ % queues_.size();
 
-            if (priority == thread_priority_critical ||
+            if (priority == thread_priority_high_recursive ||
+                priority == thread_priority_high ||
                 priority == thread_priority_boost)
             {
                 std::size_t num = num_thread % high_priority_queues_.size();
                 high_priority_queues_[num]->schedule_thread(thrd, true);
             }
-            else if (priority == thread_priority_low) {
+            else if (priority == thread_priority_low)
+            {
                 low_priority_queue_.schedule_thread(thrd, true);
             }
-            else {
+            else
+            {
                 HPX_ASSERT(num_thread < queues_.size());
                 queues_[num_thread]->schedule_thread(thrd, true);
             }
@@ -698,11 +708,12 @@ namespace hpx { namespace threads { namespace policies
                     return queues_[num_thread]->get_thread_count(state);
 
                 case thread_priority_boost:
-                case thread_priority_critical:
+                case thread_priority_high:
+                case thread_priority_high_recursive:
                     {
                         if (num_thread < high_priority_queues_.size())
                             return high_priority_queues_[num_thread]->
-                            get_thread_count(state);
+                                get_thread_count(state);
                         break;
                     }
 
@@ -744,7 +755,8 @@ namespace hpx { namespace threads { namespace policies
                 }
 
             case thread_priority_boost:
-            case thread_priority_critical:
+            case thread_priority_high:
+            case thread_priority_high_recursive:
                 {
                     for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
                         count += high_priority_queues_[i]->get_thread_count(state);

--- a/hpx/runtime/threads/policies/local_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_queue_scheduler.hpp
@@ -502,7 +502,8 @@ namespace hpx { namespace threads { namespace policies
                 case thread_priority_low:
                 case thread_priority_normal:
                 case thread_priority_boost:
-                case thread_priority_critical:
+                case thread_priority_high:
+                case thread_priority_high_recursive:
                     return queues_[num_thread]->get_thread_count(state);
 
                 default:
@@ -523,7 +524,8 @@ namespace hpx { namespace threads { namespace policies
             case thread_priority_low:
             case thread_priority_normal:
             case thread_priority_boost:
-            case thread_priority_critical:
+            case thread_priority_high:
+            case thread_priority_high_recursive:
                 {
                     for (std::size_t i = 0; i != queues_.size(); ++i)
                         count += queues_[i]->get_thread_count(state);

--- a/hpx/runtime/threads/thread_enums.hpp
+++ b/hpx/runtime/threads/thread_enums.hpp
@@ -68,17 +68,17 @@ namespace hpx { namespace threads
             taken from the normal priority queue, this is usually a first
             in-first-out ordering of tasks (depending on scheduler choice).
             This is the default priority. */
-        thread_priority_high = 3,         /*!< Task goes onto a special high
-            priority queue and will be executed before normal/low priority
-            tasks are taken (some schedulers modify the behavior slightly and
-            the documentation for those should be consulted). */
-        thread_priority_boost = 4,        /*!< Same as \a thread_priorit_highy
-            except that the thread will fall back to \a thread_priority_normal
-            if resumed after being suspended. */
-        thread_priority_high_recursive = 5, /*!< The task is a high priority
+        thread_priority_high_recursive = 3, /*!< The task is a high priority
             task and any child tasks spawned by this task will be made high
             priority as well - unless they are specifically flagged as non
             default priority. */
+        thread_priority_boost = 4,        /*!< Same as \a thread_priority_high
+            except that the thread will fall back to \a thread_priority_normal
+            if resumed after being suspended. */
+        thread_priority_high = 5,         /*!< Task goes onto a special high
+            priority queue and will be executed before normal/low priority
+            tasks are taken (some schedulers modify the behavior slightly and
+            the documentation for those should be consulted). */
 
         /// \cond NOINTERNAL
         // obsolete, kept for compatibility only

--- a/hpx/runtime/threads/thread_enums.hpp
+++ b/hpx/runtime/threads/thread_enums.hpp
@@ -61,9 +61,15 @@ namespace hpx { namespace threads
         thread_priority_default = 0,      ///< use default priority
         thread_priority_low = 1,          ///< low thread priority
         thread_priority_normal = 2,       ///< normal thread priority (default)
-        thread_priority_critical = 3,     ///< high thread priority
-        thread_priority_boost = 4         ///< high thread priority for first
+        thread_priority_high = 3,         ///< high thread priority,
+                                          ///< child threads don't inherit high
+                                          ///< priority
+        thread_priority_boost = 4,        ///< high thread priority for first
                                           ///< invocation, normal afterwards
+        thread_priority_high_recursive = 5, ///< high thread priority
+
+        // obsolete, kept for compatibility only
+        thread_priority_critical = thread_priority_high_recursive,
     };
 
     /// Get the readable string representing the name of the given thread_priority

--- a/hpx/runtime/threads/thread_enums.hpp
+++ b/hpx/runtime/threads/thread_enums.hpp
@@ -58,18 +58,32 @@ namespace hpx { namespace threads
     enum thread_priority
     {
         thread_priority_unknown = -1,
-        thread_priority_default = 0,      ///< use default priority
-        thread_priority_low = 1,          ///< low thread priority
-        thread_priority_normal = 2,       ///< normal thread priority (default)
-        thread_priority_high = 3,         ///< high thread priority,
-                                          ///< child threads don't inherit high
-                                          ///< priority
-        thread_priority_boost = 4,        ///< high thread priority for first
-                                          ///< invocation, normal afterwards
-        thread_priority_high_recursive = 5, ///< high thread priority
+        thread_priority_default = 0,      /*!< Will assign the priority of the
+            task to the default (normal) priority. */
+        thread_priority_low = 1,          /*!< Task goes onto a special low
+            priority queue and will not be executed until all high/normal
+            priority tasks are done, even if they are added after the low
+            priority task. */
+        thread_priority_normal = 2,       /*!< Task will be executed when it is
+            taken from the normal priority queue, this is usually a first
+            in-first-out ordering of tasks (depending on scheduler choice).
+            This is the default priority. */
+        thread_priority_high = 3,         /*!< Task goes onto a special high
+            priority queue and will be executed before normal/low priority
+            tasks are taken (some schedulers modify the behavior slightly and
+            the documentation for those should be consulted). */
+        thread_priority_boost = 4,        /*!< Same as \a thread_priorit_highy
+            except that the thread will fall back to \a thread_priority_normal
+            if resumed after being suspended. */
+        thread_priority_high_recursive = 5, /*!< The task is a high priority
+            task and any child tasks spawned by this task will be made high
+            priority as well - unless they are specifically flagged as non
+            default priority. */
 
+        /// \cond NOINTERNAL
         // obsolete, kept for compatibility only
         thread_priority_critical = thread_priority_high_recursive,
+        /// \endcond
     };
 
     /// Get the readable string representing the name of the given thread_priority

--- a/plugins/parcelport/verbs/parcelport_verbs.cpp
+++ b/plugins/parcelport/verbs/parcelport_verbs.cpp
@@ -393,7 +393,8 @@ namespace verbs
             parcelport_scheduler.register_thread_nullary(
                     util::bind(&parcelport::background_work_scheduler_thread, this),
                     "background_work_scheduler_thread",
-                    threads::pending, true, threads::thread_priority_critical,
+                    threads::pending, true,
+                    threads::thread_priority_high_recursive,
                     std::size_t(-1), threads::thread_stacksize_default, ec);
 
             FUNC_END_DEBUG_MSG;

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -117,7 +117,7 @@ namespace hpx { namespace threads
 
     char const* get_thread_priority_name(thread_priority priority)
     {
-        if (priority < thread_priority_default || priority > thread_priority_boost)
+        if (priority < thread_priority_default || priority > thread_priority_high)
             return "unknown";
         return strings::thread_priority_names[priority];
     }

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -63,7 +63,9 @@ namespace hpx { namespace threads
             "suspended",
             "depleted",
             "terminated",
-            "staged"
+            "staged",
+            "pending_do_not_schedule",
+            "pending_boost"
         };
     }
 
@@ -107,8 +109,9 @@ namespace hpx { namespace threads
             "default",
             "low",
             "normal",
-            "critical",
-            "boost"
+            "high (non-recursive)",
+            "boost",
+            "high (recursive)"
         };
     }
 

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -109,9 +109,9 @@ namespace hpx { namespace threads
             "default",
             "low",
             "normal",
-            "high (non-recursive)",
-            "boost",
             "high (recursive)"
+            "boost",
+            "high (non-recursive)",
         };
     }
 

--- a/tests/regressions/threads/resume_priority.cpp
+++ b/tests/regressions/threads/resume_priority.cpp
@@ -33,21 +33,34 @@ HPX_PLAIN_ACTION(normal_priority);
 
 void high_priority()
 {
-    HPX_TEST_EQ(hpx::threads::thread_priority_critical,
+    HPX_TEST_EQ(hpx::threads::thread_priority_high,
         hpx::this_thread::get_priority());
     hpx::this_thread::yield();
-    HPX_TEST_EQ(hpx::threads::thread_priority_critical,
+    HPX_TEST_EQ(hpx::threads::thread_priority_high,
         hpx::this_thread::get_priority());
 }
 HPX_DECLARE_ACTION(high_priority);
-HPX_ACTION_HAS_CRITICAL_PRIORITY(high_priority_action);
+HPX_ACTION_HAS_HIGH_PRIORITY(high_priority_action);
 HPX_PLAIN_ACTION(high_priority);
+
+void high_recursive_priority()
+{
+    HPX_TEST_EQ(hpx::threads::thread_priority_high_recursive,
+        hpx::this_thread::get_priority());
+    hpx::this_thread::yield();
+    HPX_TEST_EQ(hpx::threads::thread_priority_high_recursive,
+        hpx::this_thread::get_priority());
+}
+HPX_DECLARE_ACTION(high_recursive_priority);
+HPX_ACTION_HAS_HIGH_RECURSIVE_PRIORITY(high_recursive_priority_action);
+HPX_PLAIN_ACTION(high_recursive_priority);
 
 int hpx_main(int argc, char ** argv)
 {
     low_priority_action()(hpx::find_here());
     normal_priority_action()(hpx::find_here());
     high_priority_action()(hpx::find_here());
+    high_recursive_priority_action()(hpx::find_here());
     return hpx::finalize();
 }
 


### PR DESCRIPTION
Introducing explicit high priority and high priority (recursive) as thread priorities, deprecating `thread_priority_critical` (replaced by `thread_priority_high_recursive`).

This fixes #2747

@biddisco Please review.



