### PR TITLE
Implement parallel::unique_copy.

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -119,6 +119,7 @@ set(doxygen_dependencies
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/rotate.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/sort.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/transform.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/unique.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/executors/auto_chunk_size.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/executors/dynamic_chunk_size.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/executors/execution_fwd.hpp"

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -107,6 +107,7 @@ set(doxygen_dependencies
     "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/uninitialized_fill.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/uninitialized_move.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/uninitialized_value_construct.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/algorithms/unique.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/copy.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/for_each.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/generate.hpp"

--- a/docs/manual/parallel_algorithms.qbk
+++ b/docs/manual/parallel_algorithms.qbk
@@ -330,6 +330,11 @@ __hpx__ provides implementations of the following parallel algorithms:
      [`<hpx/include/parallel_transform.hpp>`]
      [[cpprefalgodocs transform]]
     ]
+	[[ [algoref unique_copy] ]
+     [Applies a function to a range of elements.]
+     [`<hpx/include/parallel_unique.hpp>`]
+     [[cpprefalgodocs unique_copy]]
+    ]
 ]
 
 [table Set operations on sorted sequences (In Header: `<hpx/include/parallel_algorithm.hpp>`)

--- a/hpx/include/parallel_unique.hpp
+++ b/hpx/include/parallel_unique.hpp
@@ -1,0 +1,12 @@
+//  Copyright (c) 2017 Taeguk Kwon
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_UNIQUE_JUL_07_2017_1631PM)
+#define HPX_PARALLEL_UNIQUE_JUL_07_2017_1631PM
+
+#include <hpx/parallel/algorithms/unique.hpp>
+
+#endif
+

--- a/hpx/include/parallel_unique.hpp
+++ b/hpx/include/parallel_unique.hpp
@@ -7,6 +7,7 @@
 #define HPX_PARALLEL_UNIQUE_JUL_07_2017_1631PM
 
 #include <hpx/parallel/algorithms/unique.hpp>
+#include <hpx/parallel/container_algorithms/unique.hpp>
 
 #endif
 

--- a/hpx/parallel/algorithms/partition.hpp
+++ b/hpx/parallel/algorithms/partition.hpp
@@ -548,9 +548,9 @@ namespace hpx { namespace parallel { inline namespace v1
     /// \a tagged_tuple<tag::in(InIter), tag::out1(OutIter1), tag::out2(OutIter2)>
     ///           otherwise.
     ///           The \a partition_copy algorithm returns the tuple of
-    ///           the input iterator \a last,
-    ///           the output iterator to the end of the \a dest_true range, and
-    ///           the output iterator to the end of the \a dest_false range.
+    ///           the source iterator \a last,
+    ///           the destination iterator to the end of the \a dest_true range, and
+    ///           the destination iterator to the end of the \a dest_false range.
     ///
     template <typename ExPolicy, typename FwdIter1,
         typename FwdIter2, typename FwdIter3,

--- a/hpx/parallel/algorithms/unique.hpp
+++ b/hpx/parallel/algorithms/unique.hpp
@@ -84,7 +84,7 @@ namespace hpx { namespace parallel { inline namespace v1
 
             auto base_val = *first;
 
-            *dest++ = *first;
+            *dest++ = base_val;
 
             while (++first != last)
             {
@@ -93,7 +93,7 @@ namespace hpx { namespace parallel { inline namespace v1
                     hpx::util::invoke(proj, *first)))
                 {
                     base_val = *first;
-                    *dest++ = *first;
+                    *dest++ = base_val;
                 }
             }
             return std::make_pair(std::move(last), std::move(dest));

--- a/hpx/parallel/algorithms/unique.hpp
+++ b/hpx/parallel/algorithms/unique.hpp
@@ -271,7 +271,7 @@ namespace hpx { namespace parallel { inline namespace v1
     /// \param dest         Refers to the beginning of the destination range.
     /// \param pred         Specifies the function (or function object) which
     ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last).This is an
+    ///                     sequence specified by [first, last). This is an
     ///                     binary predicate which returns \a true for the
     ///                     required elements. The signature of this predicate
     ///                     should be equivalent to:

--- a/hpx/parallel/algorithms/unique.hpp
+++ b/hpx/parallel/algorithms/unique.hpp
@@ -1,0 +1,367 @@
+//  Copyright (c) 2017 Taeguk Kwon
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_ALGORITHM_UNIQUE_JUL_07_2017_1805PM)
+#define HPX_PARALLEL_ALGORITHM_UNIQUE_JUL_07_2017_1805PM
+
+#include <hpx/config.hpp>
+#include <hpx/traits/concepts.hpp>
+#include <hpx/traits/is_iterator.hpp>
+#include <hpx/util/invoke.hpp>
+#include <hpx/util/tagged_pair.hpp>
+
+#include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/algorithms/detail/is_negative.hpp>
+#include <hpx/parallel/algorithms/detail/predicates.hpp>
+#include <hpx/parallel/algorithms/detail/transfer.hpp>
+#include <hpx/parallel/execution_policy.hpp>
+#include <hpx/parallel/tagspec.hpp>
+#include <hpx/parallel/traits/projected.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/foreach_partitioner.hpp>
+#include <hpx/parallel/util/loop.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+#include <hpx/parallel/util/scan_partitioner.hpp>
+#include <hpx/parallel/util/transfer.hpp>
+#include <hpx/parallel/util/zip_iterator.hpp>
+#include <hpx/util/unused.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
+#include <iterator>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <boost/shared_array.hpp>
+
+namespace hpx { namespace parallel { inline namespace v1
+{
+    /////////////////////////////////////////////////////////////////////////////
+    // unique_copy
+    namespace detail
+    {
+        /// \cond NOINTERNAL
+
+        // sequential unique_copy with projection function
+        template <typename FwdIter, typename OutIter, typename Pred, typename Proj>
+        std::pair<FwdIter, OutIter>
+        sequential_unique_copy(FwdIter first, FwdIter last, OutIter dest,
+            Pred && pred, Proj && proj, std::true_type)
+        {
+            if (first == last)
+                return std::make_pair(std::move(last), std::move(dest));
+
+            FwdIter base = first;
+
+            *dest++ = *first;
+
+            while (++first != last)
+            {
+                if (!hpx::util::invoke(pred,
+                    hpx::util::invoke(proj, *base),
+                    hpx::util::invoke(proj, *first)))
+                {
+                    base = first;
+                    *dest++ = *first;
+                }
+            }
+            return std::make_pair(std::move(last), std::move(dest));
+        }
+
+        // sequential unique_copy with projection function
+        template <typename InIter, typename OutIter, typename Pred, typename Proj>
+        std::pair<InIter, OutIter>
+        sequential_unique_copy(InIter first, InIter last, OutIter dest,
+            Pred && pred, Proj && proj, std::false_type)
+        {
+            if (first == last)
+                return std::make_pair(std::move(last), std::move(dest));
+
+            auto base_val = *first;
+
+            *dest++ = *first;
+
+            while (++first != last)
+            {
+                if (!hpx::util::invoke(pred,
+                    hpx::util::invoke(proj, base_val),
+                    hpx::util::invoke(proj, *first)))
+                {
+                    base_val = *first;
+                    *dest++ = *first;
+                }
+            }
+            return std::make_pair(std::move(last), std::move(dest));
+        }
+
+        template <typename IterPair>
+        struct unique_copy : public detail::algorithm<unique_copy<IterPair>, IterPair>
+        {
+            unique_copy()
+              : unique_copy::algorithm("unique_copy")
+            {}
+
+            template <typename ExPolicy, typename InIter, typename OutIter,
+                typename Pred, typename Proj = util::projection_identity>
+            static std::pair<InIter, OutIter>
+            sequential(ExPolicy, InIter first, InIter last, OutIter dest,
+                Pred && pred, Proj && proj/* = Proj()*/)
+            {
+                return sequential_unique_copy(first, last, dest,
+                    std::forward<Pred>(pred), std::forward<Proj>(proj),
+                    hpx::traits::is_forward_iterator<InIter>());
+            }
+
+            template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+                typename Pred, typename Proj = util::projection_identity>
+            static typename util::detail::algorithm_result<
+                ExPolicy, std::pair<FwdIter1, FwdIter2>
+            >::type
+            parallel(ExPolicy && policy, FwdIter1 first, FwdIter1 last,
+                FwdIter2 dest, Pred && pred, Proj && proj/* = Proj()*/)
+            {
+                typedef hpx::util::zip_iterator<FwdIter1, bool*> zip_iterator;
+                typedef util::detail::algorithm_result<
+                    ExPolicy, std::pair<FwdIter1, FwdIter2>
+                > result;
+                typedef typename std::iterator_traits<FwdIter1>::difference_type
+                    difference_type;
+
+                if (first == last)
+                    return result::get(
+                        std::make_pair(std::move(last), std::move(dest)));
+
+                difference_type count = std::distance(first, last);
+
+                *dest++ = *first;
+
+                if (count == 1)
+                    return result::get(
+                        std::make_pair(std::move(last), std::move(dest)));
+
+                boost::shared_array<bool> flags(new bool[count - 1]);
+                std::size_t init = 0;
+
+                using hpx::util::get;
+                using hpx::util::make_zip_iterator;
+                typedef util::scan_partitioner<
+                        ExPolicy, std::pair<FwdIter1, FwdIter2>, std::size_t
+                    > scan_partitioner_type;
+
+                auto f1 =
+                    [pred, proj, flags, policy]
+                    (
+                       zip_iterator part_begin, std::size_t part_size
+                    )   -> std::size_t
+                    {
+                        HPX_UNUSED(flags);
+                        HPX_UNUSED(policy);
+
+                        FwdIter1 base = get<0>(part_begin.get_iterator_tuple());
+                        std::size_t curr = 0;
+
+                        // MSVC complains if pred or proj is captured by ref below
+                        util::loop_n<ExPolicy>(
+                            ++part_begin, part_size,
+                            [base, pred, proj, &curr](zip_iterator it) mutable
+                            {
+                                using hpx::util::invoke;
+
+                                bool f = invoke(pred,
+                                    invoke(proj, *base),
+                                    invoke(proj, get<0>(*it)));
+
+                                if (!(get<1>(*it) = f))
+                                {
+                                    base = get<0>(it.get_iterator_tuple());
+                                    ++curr;
+                                }
+                            });
+
+                        return curr;
+                    };
+                auto f3 =
+                    [dest, flags, policy](
+                        zip_iterator part_begin, std::size_t part_size,
+                        hpx::shared_future<std::size_t> curr,
+                        hpx::shared_future<std::size_t> next
+                    ) mutable -> void
+                    {
+                        HPX_UNUSED(flags);
+                        HPX_UNUSED(policy);
+
+                        next.get();     // rethrow exceptions
+
+                        std::advance(dest, curr.get());
+                        util::loop_n<ExPolicy>(
+                            ++part_begin, part_size,
+                            [&dest](zip_iterator it) mutable
+                            {
+                                if(!get<1>(*it))
+                                    *dest++ = get<0>(*it);
+                            });
+                    };
+
+                return scan_partitioner_type::call(
+                    std::forward<ExPolicy>(policy),
+                    make_zip_iterator(first, flags.get()),
+                    count - 1, init,
+                    // step 1 performs first part of scan algorithm
+                    std::move(f1),
+                    // step 2 propagates the partition results from left
+                    // to right
+                    hpx::util::unwrapped(std::plus<std::size_t>()),
+                    // step 3 runs final accumulation on each partition
+                    std::move(f3),
+                    // step 4 use this return value
+                    [last, dest, flags](
+                        std::vector<hpx::shared_future<std::size_t> > && items,
+                        std::vector<hpx::future<void> > &&) mutable
+                    ->  std::pair<FwdIter1, FwdIter2>
+                    {
+                        HPX_UNUSED(flags);
+
+                        std::advance(dest, items.back().get());
+                        return std::make_pair(std::move(last), std::move(dest));
+                    });
+            }
+        };
+        /// \endcond
+    }
+
+    /// Copies the elements from the range [first, last),
+    /// to another range beginning at \a dest in such a way that
+    /// there are no consecutive equal elements. Only the first element of
+    /// each group of equal elements is copied.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first - 1 applications of
+    ///         the predicate \a pred.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a unique_copy requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     binary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a, const Type &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a unique_copy algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a unique_copy algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a unique_copy algorithm returns a
+    ///           \a hpx::future<tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)> >
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)>
+    ///           otherwise.
+    ///           The \a unique_copy algorithm returns the pair of
+    ///           the source iterator to \a last, and
+    ///           the destination iterator to the end of the \a dest range.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename Pred = detail::equal_to,
+        typename Proj = util::projection_identity,
+    HPX_CONCEPT_REQUIRES_(
+        execution::is_execution_policy<ExPolicy>::value &&
+        hpx::traits::is_iterator<FwdIter1>::value &&
+        hpx::traits::is_iterator<FwdIter2>::value &&
+        traits::is_projected<Proj, FwdIter1>::value &&
+        traits::is_indirect_callable<
+            ExPolicy, Pred,
+            traits::projected<Proj, FwdIter1>,
+            traits::projected<Proj, FwdIter1>
+        >::value)>
+    typename util::detail::algorithm_result<
+        ExPolicy, hpx::util::tagged_pair<
+        tag::in(FwdIter1), tag::out(FwdIter2)>
+    >::type
+    unique_copy(ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest,
+        Pred && pred = Pred(), Proj && proj = Proj())
+    {
+#if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
+        static_assert(
+            (hpx::traits::is_input_iterator<FwdIter1>::value),
+            "Required at least input iterator.");
+        static_assert(
+            (hpx::traits::is_output_iterator<FwdIter2>::value ||
+                hpx::traits::is_forward_iterator<FwdIter2>::value),
+            "Requires at least output iterator.");
+
+        typedef std::integral_constant<bool,
+                execution::is_sequenced_execution_policy<ExPolicy>::value ||
+               !hpx::traits::is_forward_iterator<FwdIter1>::value ||
+               !hpx::traits::is_forward_iterator<FwdIter2>::value
+            > is_seq;
+#else
+        static_assert(
+            (hpx::traits::is_forward_iterator<FwdIter1>::value),
+            "Required at least forward iterator.");
+        static_assert(
+            (hpx::traits::is_forward_iterator<FwdIter2>::value),
+            "Requires at least forward iterator.");
+
+        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+#endif
+
+        typedef std::pair<FwdIter1, FwdIter2> result_type;
+
+        return hpx::util::make_tagged_pair<tag::in, tag::out>(
+            detail::unique_copy<result_type>().call(
+                std::forward<ExPolicy>(policy), is_seq(),
+                first, last, dest, std::forward<Pred>(pred),
+                std::forward<Proj>(proj)));
+    }
+}}}
+
+#endif

--- a/hpx/parallel/container_algorithms/unique.hpp
+++ b/hpx/parallel/container_algorithms/unique.hpp
@@ -3,19 +3,19 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-/// \file parallel/container_algorithms/partition.hpp
+/// \file parallel/container_algorithms/unique.hpp
 
-#if !defined(HPX_PARALLEL_CONTAINER_ALGORITHM_PARTITION_JUL_09_2017_0501PM)
-#define HPX_PARALLEL_CONTAINER_ALGORITHM_PARTITION_JUL_09_2017_0501PM
+#if !defined(HPX_PARALLEL_CONTAINER_ALGORITHM_UNIQUE_JUL_11_2017_1018PM)
+#define HPX_PARALLEL_CONTAINER_ALGORITHM_UNIQUE_JUL_11_2017_1018PM
 
 #include <hpx/config.hpp>
 #include <hpx/traits/concepts.hpp>
 #include <hpx/traits/is_iterator.hpp>
 #include <hpx/traits/is_range.hpp>
 #include <hpx/util/range.hpp>
-#include <hpx/util/tagged_tuple.hpp>
+#include <hpx/util/tagged_pair.hpp>
 
-#include <hpx/parallel/algorithms/partition.hpp>
+#include <hpx/parallel/algorithms/unique.hpp>
 #include <hpx/parallel/tagspec.hpp>
 #include <hpx/parallel/traits/projected.hpp>
 #include <hpx/parallel/traits/projected_range.hpp>
@@ -27,12 +27,10 @@
 
 namespace hpx { namespace parallel { inline namespace v1
 {
-    /// Copies the elements in the range \a rng,
-    /// to two different ranges depending on the value returned by
-    /// the predicate \a pred. The elements, that satisfy the predicate \a pred,
-    /// are copied to the range beginning at \a dest_true. The rest of
-    /// the elements are copied to the range beginning at \a dest_false.
-    /// The order of the elements is preserved.
+    /// Copies the elements from the range \a rng,
+    /// to another range beginning at \a dest in such a way that
+    /// there are no consecutive equal elements. Only the first element of
+    /// each group of equal elements is copied.
     ///
     /// \note   Complexity: Performs not more than N assignments,
     ///         exactly N applications of the predicate \a pred,
@@ -46,19 +44,14 @@ namespace hpx { namespace parallel { inline namespace v1
     ///                     The iterators extracted from this range type must
     ///                     meet the requirements of an forward iterator.
     /// \tparam FwdIter2    The type of the iterator representing the
-    ///                     destination range for the elements that satisfy
-    ///                     the predicate \a pred (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter3    The type of the iterator representing the
-    ///                     destination range for the elements that don't satisfy
-    ///                     the predicate \a pred (deduced).
+    ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
     /// \tparam Pred        The type of the function/function object to use
     ///                     (deduced). Unlike its sequential form, the parallel
-    ///                     overload of \a partition_copy requires \a Pred to meet
-    ///                     the requirements of \a CopyConstructible.
+    ///                     overload of \a unique_copy requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
     /// \tparam Proj        The type of an optional projection function. This
     ///                     defaults to \a util::projection_identity
     ///
@@ -66,72 +59,72 @@ namespace hpx { namespace parallel { inline namespace v1
     ///                     the iterations.
     /// \param rng          Refers to the sequence of elements the algorithm
     ///                     will be applied to.
-    /// \param dest_true    Refers to the beginning of the destination range for
-    ///                     the elements that satisfy the predicate \a pred.
-    /// \param dest_false   Refers to the beginning of the destination range for
-    ///                     the elements that don't satisfy the predicate \a pred.
+    /// \param dest         Refers to the beginning of the destination range.
     /// \param pred         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the sequence
-    ///                     specified by the range \a rng. This is an unary predicate
-    ///                     for partitioning the source iterators. The signature of
-    ///                     this predicate should be equivalent to:
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by the range \a rng. This is an
+    ///                     binary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
     ///                     \code
-    ///                     bool pred(const Type &a);
+    ///                     bool pred(const Type &a, const Type &b);
     ///                     \endcode \n
     ///                     The signature does not need to have const&, but
     ///                     the function must not modify the objects passed to
     ///                     it. The type \a Type must be such that an object of
-    ///                     type \a InIter can be dereferenced and then
-    ///                     implicitly converted to Type.
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to \a Type.
     /// \param proj         Specifies the function (or function object) which
     ///                     will be invoked for each of the elements as a
     ///                     projection operation before the actual predicate
     ///                     \a is invoked.
     ///
-    /// The assignments in the parallel \a partition_copy algorithm invoked with
+    /// The assignments in the parallel \a unique_copy algorithm invoked with
     /// an execution policy object of type \a sequenced_policy
     /// execute in sequential order in the calling thread.
     ///
-    /// The assignments in the parallel \a partition_copy algorithm invoked with
+    /// The assignments in the parallel \a unique_copy algorithm invoked with
     /// an execution policy object of type \a parallel_policy or
     /// \a parallel_task_policy are permitted to execute in an unordered
     /// fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a partition_copy algorithm returns a
-    /// \a hpx::future<tagged_tuple<tag::in(InIter), tag::out1(OutIter1), tag::out2(OutIter2)> >
-    ///           if the execution policy is of type \a parallel_task_policy
-    ///           and returns
-    /// \a tagged_tuple<tag::in(InIter), tag::out1(OutIter1), tag::out2(OutIter2)>
+    /// \returns  The \a unique_copy algorithm returns a
+    ///           \a hpx::future<tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)> >
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)>
     ///           otherwise.
-    ///           The \a partition_copy algorithm returns the tuple of
-    ///           the source iterator \a last,
-    ///           the destination iterator to the end of the \a dest_true range, and
-    ///           the destination iterator to the end of the \a dest_false range.
+    ///           The \a unique_copy algorithm returns the pair of
+    ///           the source iterator to \a last, and
+    ///           the destination iterator to the end of the \a dest range.
     ///
-    template <typename ExPolicy, typename Rng, typename FwdIter2, typename FwdIter3,
-        typename Pred, typename Proj = util::projection_identity,
+    template <typename ExPolicy, typename Rng, typename FwdIter2,
+        typename Pred = detail::equal_to,
+        typename Proj = util::projection_identity,
     HPX_CONCEPT_REQUIRES_(
         execution::is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_range<Rng>::value &&
         hpx::traits::is_iterator<FwdIter2>::value &&
-        hpx::traits::is_iterator<FwdIter3>::value &&
         traits::is_projected_range<Proj, Rng>::value &&
         traits::is_indirect_callable<
-            ExPolicy, Pred, traits::projected_range<Proj, Rng>
+            ExPolicy, Pred,
+            traits::projected_range<Proj, Rng>,
+            traits::projected_range<Proj, Rng>
         >::value)>
     typename util::detail::algorithm_result<
         ExPolicy,
-        hpx::util::tagged_tuple<
+        hpx::util::tagged_pair<
             tag::in(typename hpx::traits::range_traits<Rng>::iterator_type),
-            tag::out1(FwdIter2), tag::out2(FwdIter3)>
+            tag::out(FwdIter2)>
     >::type
-    partition_copy(ExPolicy && policy, Rng && rng,
-        FwdIter2 dest_true, FwdIter3 dest_false, Pred && pred,
+    unique_copy(ExPolicy && policy, Rng && rng,
+        FwdIter2 dest, Pred && pred = Pred(),
         Proj && proj = Proj())
     {
-        return partition_copy(std::forward<ExPolicy>(policy),
-            std::begin(rng), std::end(rng), dest_true, dest_false,
+        return unique_copy(std::forward<ExPolicy>(policy),
+            std::begin(rng), std::end(rng), dest,
             std::forward<Pred>(pred),
             std::forward<Proj>(proj));
     }

--- a/tests/performance/parallel_algorithms/local/CMakeLists.txt
+++ b/tests/performance/parallel_algorithms/local/CMakeLists.txt
@@ -7,6 +7,7 @@ set(benchmarks
     benchmark_is_heap
     benchmark_is_heap_until
     benchmark_partition_copy
+    benchmark_unique_copy
    )
 
 foreach(benchmark ${benchmarks})

--- a/tests/performance/parallel_algorithms/local/benchmark_partition_copy.cpp
+++ b/tests/performance/parallel_algorithms/local/benchmark_partition_copy.cpp
@@ -96,10 +96,10 @@ void run_benchmark(std::size_t vector_size, int test_count, IteratorTag)
 
     std::vector<int> v(vector_size);
     std::vector<int> result_true(v.size()), result_false(v.size());
-    iterator first = iterator(boost::begin(v));
-    iterator last = iterator(boost::end(v));
-    iterator dest_true = iterator(boost::begin(result_true));
-    iterator dest_false = iterator(boost::begin(result_false));
+    iterator first = iterator(std::begin(v));
+    iterator last = iterator(std::end(v));
+    iterator dest_true = iterator(std::begin(result_true));
+    iterator dest_false = iterator(std::begin(result_false));
 
     // initialize data
     using namespace hpx::parallel;

--- a/tests/performance/parallel_algorithms/local/benchmark_unique_copy.cpp
+++ b/tests/performance/parallel_algorithms/local/benchmark_unique_copy.cpp
@@ -44,7 +44,7 @@ struct random_fill
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename InIter, typename OutIter>
-double run_unique_copy_benchmark_std(std::size_t test_count,
+double run_unique_copy_benchmark_std(int test_count,
     InIter first, InIter last, OutIter dest)
 {
     std::uint64_t time = hpx::util::high_resolution_clock::now();
@@ -61,7 +61,7 @@ double run_unique_copy_benchmark_std(std::size_t test_count,
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename ExPolicy, typename FwdIter1, typename FwdIter2>
-double run_unique_copy_benchmark_hpx(std::size_t test_count, ExPolicy policy,
+double run_unique_copy_benchmark_hpx(int test_count, ExPolicy policy,
     FwdIter1 first, FwdIter1 last, FwdIter2 dest)
 {
     std::uint64_t time = hpx::util::high_resolution_clock::now();
@@ -79,7 +79,7 @@ double run_unique_copy_benchmark_hpx(std::size_t test_count, ExPolicy policy,
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
 void run_benchmark(std::size_t vector_size, std::size_t random_range,
-    std::size_t test_count, IteratorTag)
+    int test_count, IteratorTag)
 {
     std::cout << "* Preparing Benchmark..." << std::endl;
 
@@ -156,7 +156,7 @@ int hpx_main(boost::program_options::variables_map& vm)
     // pull values from cmd
     std::size_t vector_size = vm["vector_size"].as<std::size_t>();
     std::size_t random_range = vm["random_range"].as<std::size_t>();
-    std::size_t test_count = vm["test_count"].as<int>();
+    int test_count = vm["test_count"].as<int>();
     std::string iterator_tag_str = correct_iterator_tag_str(
         vm["iterator_tag"].as<std::string>());
 

--- a/tests/performance/parallel_algorithms/local/benchmark_unique_copy.cpp
+++ b/tests/performance/parallel_algorithms/local/benchmark_unique_copy.cpp
@@ -1,0 +1,223 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright (c) 2017 Taeguk Kwon
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+///////////////////////////////////////////////////////////////////////////////
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/include/parallel_unique.hpp>
+#include <hpx/include/parallel_generate.hpp>
+#include <hpx/util/high_resolution_clock.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <boost/format.hpp>
+#include <boost/program_options.hpp>
+#include <boost/random.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+#include <algorithm>
+#include <iostream>
+#include <string>
+
+#include "test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+struct random_fill
+{
+    random_fill(std::size_t random_range)
+        : gen(std::rand()),
+        dist(0, random_range - 1)
+    {}
+
+    int operator()()
+    {
+        return dist(gen);
+    }
+
+    boost::random::mt19937 gen;
+    boost::random::uniform_int_distribution<> dist;
+};
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename InIter, typename OutIter>
+double run_unique_copy_benchmark_std(std::size_t test_count,
+    InIter first, InIter last, OutIter dest)
+{
+    std::uint64_t time = hpx::util::high_resolution_clock::now();
+
+    for (int i = 0; i < test_count; ++i)
+    {
+        std::unique_copy(first, last, dest);
+    }
+
+    time = hpx::util::high_resolution_clock::now() - time;
+
+    return (time * 1e-9) / test_count;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename FwdIter1, typename FwdIter2>
+double run_unique_copy_benchmark_hpx(std::size_t test_count, ExPolicy policy,
+    FwdIter1 first, FwdIter1 last, FwdIter2 dest)
+{
+    std::uint64_t time = hpx::util::high_resolution_clock::now();
+
+    for (int i = 0; i < test_count; ++i)
+    {
+        hpx::parallel::unique_copy(policy, first, last, dest);
+    }
+
+    time = hpx::util::high_resolution_clock::now() - time;
+
+    return (time * 1e-9) / test_count;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void run_benchmark(std::size_t vector_size, std::size_t random_range,
+    std::size_t test_count, IteratorTag)
+{
+    std::cout << "* Preparing Benchmark..." << std::endl;
+
+    typedef typename std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> v(vector_size);
+    std::vector<int> result(v.size());
+    iterator first = iterator(boost::begin(v));
+    iterator last = iterator(boost::end(v));
+    iterator dest = iterator(boost::begin(result));
+
+    // initialize data
+    using namespace hpx::parallel;
+    generate(execution::par, std::begin(v), std::end(v),
+        random_fill(random_range));
+
+    auto dest_dist = std::distance(std::begin(result),
+        std::unique_copy(first, last, dest).base());
+
+    std::cout << "*** Destination iterator distance : "
+        << dest_dist << std::endl << std::endl;
+
+    std::cout << "* Running Benchmark..." << std::endl;
+    std::cout << "--- run_unique_copy_benchmark_std ---" << std::endl;
+    double time_std =
+        run_unique_copy_benchmark_std(test_count,
+            first, last, dest);
+
+    std::cout << "--- run_unique_copy_benchmark_seq ---" << std::endl;
+    double time_seq =
+        run_unique_copy_benchmark_hpx(test_count, execution::seq,
+            first, last, dest);
+
+    std::cout << "--- run_unique_copy_benchmark_par ---" << std::endl;
+    double time_par =
+        run_unique_copy_benchmark_hpx(test_count, execution::par,
+            first, last, dest);
+
+    std::cout << "--- run_unique_copy_benchmark_par_unseq ---" << std::endl;
+    double time_par_unseq =
+        run_unique_copy_benchmark_hpx(test_count, execution::par_unseq,
+            first, last, dest);
+
+    std::cout << "\n-------------- Benchmark Result --------------" << std::endl;
+    auto fmt = "unique_copy (%1%) : %2%(sec)";
+    std::cout << (boost::format(fmt) % "std" % time_std) << std::endl;
+    std::cout << (boost::format(fmt) % "seq" % time_seq) << std::endl;
+    std::cout << (boost::format(fmt) % "par" % time_par) << std::endl;
+    std::cout << (boost::format(fmt) % "par_unseq" % time_par_unseq) << std::endl;
+    std::cout << "----------------------------------------------" << std::endl;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+std::string correct_iterator_tag_str(std::string iterator_tag)
+{
+    if (iterator_tag != "random" &&
+        iterator_tag != "bidirectional" &&
+        iterator_tag != "forward")
+        return "random";
+    else
+        return iterator_tag;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int)std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::srand(seed);
+
+    // pull values from cmd
+    std::size_t vector_size = vm["vector_size"].as<std::size_t>();
+    std::size_t random_range = vm["random_range"].as<std::size_t>();
+    std::size_t test_count = vm["test_count"].as<int>();
+    std::string iterator_tag_str = correct_iterator_tag_str(
+        vm["iterator_tag"].as<std::string>());
+
+    std::size_t const os_threads = hpx::get_os_thread_count();
+
+    if (random_range < 1)
+        random_range = 1;
+
+    std::cout << "-------------- Benchmark Config --------------" << std::endl;
+    std::cout << "seed         : " << seed << std::endl;
+    std::cout << "vector_size  : " << vector_size << std::endl;
+    std::cout << "random_range : " << random_range << std::endl;
+    std::cout << "iterator_tag : " << iterator_tag_str << std::endl;
+    std::cout << "test_count   : " << test_count << std::endl;
+    std::cout << "os threads   : " << os_threads << std::endl;
+    std::cout << "----------------------------------------------\n" << std::endl;
+
+    if (iterator_tag_str == "random")
+        run_benchmark(vector_size, test_count, random_range,
+            std::random_access_iterator_tag());
+    else if (iterator_tag_str == "bidirectional")
+        run_benchmark(vector_size, test_count, random_range,
+            std::bidirectional_iterator_tag());
+    else // forward
+        run_benchmark(vector_size, test_count, random_range,
+            std::forward_iterator_tag());
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    using namespace boost::program_options;
+    options_description desc_commandline(
+        "usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()
+        ("vector_size",
+            boost::program_options::value<std::size_t>()->default_value(1000000),
+            "size of vector (default: 1000000)")
+        ("random_range",
+            boost::program_options::value<std::size_t>()->default_value(6),
+            "range of random numbers [0, x) (default: 6)")
+        ("iterator_tag",
+            boost::program_options::value<std::string>()->default_value("random"),
+            "the kind of iterator tag (random/bidirectional/forward)")
+        ("test_count",
+            boost::program_options::value<int>()->default_value(10),
+            "number of tests to be averaged (default: 10)")
+        ("seed,s", boost::program_options::value<unsigned int>(),
+            "the random number generator seed to use for this run")
+        ;
+
+    // initialize program
+    std::vector<std::string> const cfg = {
+        "hpx.os_threads=all"
+    };
+
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/tests/performance/parallel_algorithms/local/benchmark_unique_copy.cpp
+++ b/tests/performance/parallel_algorithms/local/benchmark_unique_copy.cpp
@@ -88,9 +88,9 @@ void run_benchmark(std::size_t vector_size, std::size_t random_range,
 
     std::vector<int> v(vector_size);
     std::vector<int> result(v.size());
-    iterator first = iterator(boost::begin(v));
-    iterator last = iterator(boost::end(v));
-    iterator dest = iterator(boost::begin(result));
+    iterator first = iterator(std::begin(v));
+    iterator last = iterator(std::end(v));
+    iterator dest = iterator(std::begin(result));
 
     // initialize data
     using namespace hpx::parallel;

--- a/tests/performance/parallel_algorithms/local/benchmark_unique_copy.cpp
+++ b/tests/performance/parallel_algorithms/local/benchmark_unique_copy.cpp
@@ -78,8 +78,8 @@ double run_unique_copy_benchmark_hpx(int test_count, ExPolicy policy,
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
-void run_benchmark(std::size_t vector_size, std::size_t random_range,
-    int test_count, IteratorTag)
+void run_benchmark(std::size_t vector_size, int test_count,
+    std::size_t random_range, IteratorTag)
 {
     std::cout << "* Preparing Benchmark..." << std::endl;
 

--- a/tests/unit/parallel/algorithms/CMakeLists.txt
+++ b/tests/unit/parallel/algorithms/CMakeLists.txt
@@ -121,6 +121,7 @@ set(tests
     uninitialized_moven
     uninitialized_value_construct
     uninitialized_value_constructn
+    unique_copy
    )
 
 if(HPX_WITH_EXECUTOR_COMPATIBILITY)

--- a/tests/unit/parallel/algorithms/is_heap.cpp
+++ b/tests/unit/parallel/algorithms/is_heap.cpp
@@ -5,10 +5,7 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/include/parallel_is_heap.hpp>
 #include <hpx/util/lightweight_test.hpp>
-
-#include <boost/range/functions.hpp>
 
 #include <iostream>
 #include <vector>

--- a/tests/unit/parallel/algorithms/is_heap_until.cpp
+++ b/tests/unit/parallel/algorithms/is_heap_until.cpp
@@ -5,10 +5,7 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/include/parallel_is_heap.hpp>
 #include <hpx/util/lightweight_test.hpp>
-
-#include <boost/range/functions.hpp>
 
 #include <iostream>
 #include <vector>

--- a/tests/unit/parallel/algorithms/unique_copy.cpp
+++ b/tests/unit/parallel/algorithms/unique_copy.cpp
@@ -1,0 +1,87 @@
+//  Copyright (c) 2017 Taeguk Kwon
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/include/parallel_partition.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <boost/range/functions.hpp>
+
+#include <iostream>
+#include <vector>
+#include <algorithm>
+#include <string>
+
+#include "unique_copy_tests.hpp"
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+void unique_copy_test()
+{
+    std::cout << "--- unique_copy_test ---" << std::endl;
+    test_unique_copy<std::random_access_iterator_tag>();
+    test_unique_copy<std::bidirectional_iterator_tag>();
+    test_unique_copy<std::forward_iterator_tag>();
+}
+
+void unique_copy_exception_test()
+{
+    std::cout << "--- unique_copy_exception_test ---" << std::endl;
+    test_unique_copy_exception<std::random_access_iterator_tag>();
+    test_unique_copy_exception<std::bidirectional_iterator_tag>();
+    test_unique_copy_exception<std::forward_iterator_tag>();
+}
+
+void unique_copy_bad_alloc_test()
+{
+    std::cout << "--- unique_copy_bad_alloc_test ---" << std::endl;
+    test_unique_copy_bad_alloc<std::random_access_iterator_tag>();
+    test_unique_copy_bad_alloc<std::bidirectional_iterator_tag>();
+    test_unique_copy_bad_alloc<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int)std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    unique_copy_test();
+    unique_copy_exception_test();
+    unique_copy_bad_alloc_test();
+
+    std::cout << "Test Finish!" << std::endl;
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace boost::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()
+        ("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run")
+        ;
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {
+        "hpx.os_threads=all"
+    };
+
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/parallel/algorithms/unique_copy.cpp
+++ b/tests/unit/parallel/algorithms/unique_copy.cpp
@@ -5,10 +5,7 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/include/parallel_partition.hpp>
 #include <hpx/util/lightweight_test.hpp>
-
-#include <boost/range/functions.hpp>
 
 #include <iostream>
 #include <vector>

--- a/tests/unit/parallel/algorithms/unique_copy_tests.hpp
+++ b/tests/unit/parallel/algorithms/unique_copy_tests.hpp
@@ -10,7 +10,6 @@
 #include <hpx/util/lightweight_test.hpp>
 
 #include <boost/random.hpp>
-#include <boost/range/functions.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -122,8 +121,8 @@ void test_unique_copy(ExPolicy policy, IteratorTag, DataType, Pred pred,
     std::generate(std::begin(c), std::end(c), random_fill(rand_base, 6));
 
     auto result = hpx::parallel::unique_copy(policy,
-        iterator(boost::begin(c)), iterator(boost::end(c)),
-        iterator(boost::begin(dest_res)),
+        iterator(std::begin(c)), iterator(std::end(c)),
+        iterator(std::begin(dest_res)),
         pred);
     auto solution = std::unique_copy(std::begin(c), std::end(c),
         std::begin(dest_sol),
@@ -154,8 +153,8 @@ void test_unique_copy_async(ExPolicy policy, IteratorTag, DataType, Pred pred,
     std::generate(std::begin(c), std::end(c), random_fill(rand_base, 6));
 
     auto f = hpx::parallel::unique_copy(policy,
-        iterator(boost::begin(c)), iterator(boost::end(c)),
-        iterator(boost::begin(dest_res)),
+        iterator(std::begin(c)), iterator(std::end(c)),
+        iterator(std::begin(dest_res)),
         pred);
     auto result = f.get();
     auto solution = std::unique_copy(std::begin(c), std::end(c),
@@ -187,8 +186,8 @@ void test_unique_copy_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try {
         auto result = hpx::parallel::unique_copy(policy,
-            iterator(boost::begin(c)), iterator(boost::end(c)),
-            iterator(boost::begin(dest)),
+            iterator(std::begin(c)), iterator(std::end(c)),
+            iterator(std::begin(dest)),
             throw_always());
 
         HPX_TEST(false);
@@ -218,8 +217,8 @@ void test_unique_copy_exception_async(ExPolicy policy, IteratorTag)
     bool returned_from_algorithm = false;
     try {
         auto f = hpx::parallel::unique_copy(policy,
-            iterator(boost::begin(c)), iterator(boost::end(c)),
-            iterator(boost::begin(dest)),
+            iterator(std::begin(c)), iterator(std::end(c)),
+            iterator(std::begin(dest)),
             throw_always());
         returned_from_algorithm = true;
         f.get();
@@ -256,8 +255,8 @@ void test_unique_copy_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try {
         auto result = hpx::parallel::unique_copy(policy,
-            iterator(boost::begin(c)), iterator(boost::end(c)),
-            iterator(boost::begin(dest)),
+            iterator(std::begin(c)), iterator(std::end(c)),
+            iterator(std::begin(dest)),
             throw_bad_alloc());
 
         HPX_TEST(false);
@@ -286,8 +285,8 @@ void test_unique_copy_bad_alloc_async(ExPolicy policy, IteratorTag)
     bool returned_from_algorithm = false;
     try {
         auto f = hpx::parallel::unique_copy(policy,
-            iterator(boost::begin(c)), iterator(boost::end(c)),
-            iterator(boost::begin(dest)),
+            iterator(std::begin(c)), iterator(std::end(c)),
+            iterator(std::begin(dest)),
             throw_bad_alloc());
         returned_from_algorithm = true;
         f.get();
@@ -327,8 +326,8 @@ void test_unique_copy_etc(ExPolicy policy, IteratorTag,
         typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
         auto result = hpx::parallel::unique_copy(policy,
-            iterator(boost::begin(c)), iterator(boost::end(c)),
-            iterator(boost::begin(dest_res)));
+            iterator(std::begin(c)), iterator(std::end(c)),
+            iterator(std::begin(dest_res)));
         auto solution = std::unique_copy(std::begin(c), std::end(c),
             std::begin(dest_sol));
 
@@ -345,8 +344,8 @@ void test_unique_copy_etc(ExPolicy policy, IteratorTag,
 
         DataType val;
         auto result = hpx::parallel::unique_copy(policy,
-            iterator(boost::begin(c)), iterator(boost::end(c)),
-            iterator(boost::begin(dest_res)),
+            iterator(std::begin(c)), iterator(std::end(c)),
+            iterator(std::begin(dest_res)),
             [](DataType const& a, DataType const& b) -> bool {
                 return a == b;
             },
@@ -365,7 +364,7 @@ void test_unique_copy_etc(ExPolicy policy, IteratorTag,
             std::input_iterator_tag> iterator;
 
         auto result = hpx::parallel::v1::detail::sequential_unique_copy(
-            iterator(boost::begin(c)), iterator(boost::end(c)),
+            iterator(std::begin(c)), iterator(std::end(c)),
             std::begin(dest_res),
             [](DataType const& a, DataType const& b) -> bool {
                 return a == b;

--- a/tests/unit/parallel/algorithms/unique_copy_tests.hpp
+++ b/tests/unit/parallel/algorithms/unique_copy_tests.hpp
@@ -1,0 +1,497 @@
+//  Copyright (c) 2017 Taeguk Kwon
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_TEST_UNIQUE_JUL_07_2017_1940PM)
+#define HPX_PARALLEL_TEST_UNIQUE_JUL_07_2017_1940PM
+
+#include <hpx/include/parallel_unique.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <boost/random.hpp>
+#include <boost/range/functions.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include "test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+
+struct throw_always
+{
+    template <typename T>
+    bool operator()(T const&, T const&) const
+    {
+        throw std::runtime_error("test");
+    }
+};
+
+struct throw_bad_alloc
+{
+    template <typename T>
+    bool operator()(T const&, T const&) const
+    {
+        throw std::bad_alloc();
+    }
+};
+
+struct user_defined_type
+{
+    user_defined_type() = default;
+    user_defined_type(int rand_no) : val(rand_no) {}
+
+    bool operator<(user_defined_type const& t) const
+    {
+        if (this->name < t.name)
+            return true;
+        else if (this->name > t.name)
+            return false;
+        else
+            return this->val < t.val;
+    }
+
+    bool operator>(user_defined_type const& t) const
+    {
+        if (this->name > t.name)
+            return true;
+        else if (this->name < t.name)
+            return false;
+        else
+            return this->val > t.val;
+    }
+
+    bool operator==(user_defined_type const& t) const
+    {
+        return this->name == t.name && this->val == t.val;
+    }
+
+    user_defined_type const& operator++()
+    {
+        static const std::vector<std::string> name_list = {
+            "ABB", "ABC", "ACB", "BCA", "CAA", "CAAA", "CAAB"
+        };
+        name = name_list[std::rand() % name_list.size()];
+        ++val;
+        return *this;
+    }
+
+    std::string name;
+    int val;
+};
+
+struct random_fill
+{
+    random_fill() = default;
+    random_fill(int rand_base, int range)
+        : gen(std::rand()),
+        dist(rand_base - range / 2, rand_base + range / 2)
+    {}
+
+    int operator()()
+    {
+        return dist(gen);
+    }
+
+    boost::random::mt19937 gen;
+    boost::random::uniform_int_distribution<> dist;
+};
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag, typename DataType, typename Pred>
+void test_unique_copy(ExPolicy policy, IteratorTag, DataType, Pred pred,
+    int rand_base)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef typename std::vector<DataType>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    using hpx::util::get;
+
+    std::size_t const size = 10007;
+    std::vector<DataType> c(size), dest_res(size), dest_sol(size);
+    std::generate(std::begin(c), std::end(c), random_fill(rand_base, 6));
+
+    auto result = hpx::parallel::unique_copy(policy,
+        iterator(boost::begin(c)), iterator(boost::end(c)),
+        iterator(boost::begin(dest_res)),
+        pred);
+    auto solution = std::unique_copy(std::begin(c), std::end(c),
+        std::begin(dest_sol),
+        pred);
+
+    bool equality = std::equal(
+        std::begin(dest_res), get<1>(result).base(),
+        std::begin(dest_sol), solution);
+
+    HPX_TEST(equality);
+}
+
+template <typename ExPolicy, typename IteratorTag, typename DataType, typename Pred>
+void test_unique_copy_async(ExPolicy policy, IteratorTag, DataType, Pred pred,
+    int rand_base)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef typename std::vector<DataType>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    using hpx::util::get;
+
+    std::size_t const size = 10007;
+    std::vector<DataType> c(size), dest_res(size), dest_sol(size);
+    std::generate(std::begin(c), std::end(c), random_fill(rand_base, 6));
+
+    auto f = hpx::parallel::unique_copy(policy,
+        iterator(boost::begin(c)), iterator(boost::end(c)),
+        iterator(boost::begin(dest_res)),
+        pred);
+    auto result = f.get();
+    auto solution = std::unique_copy(std::begin(c), std::end(c),
+        std::begin(dest_sol),
+        pred);
+
+    bool equality = std::equal(
+        std::begin(dest_res), get<1>(result).base(),
+        std::begin(dest_sol), solution);
+
+    HPX_TEST(equality);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_unique_copy_exception(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::size_t const size = 10007;
+    std::vector<int> c(size), dest(size);
+    std::generate(std::begin(c), std::end(c), random_fill());
+
+    bool caught_exception = false;
+    try {
+        auto result = hpx::parallel::unique_copy(policy,
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            iterator(boost::begin(dest)),
+            throw_always());
+
+        HPX_TEST(false);
+    }
+    catch(hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_unique_copy_exception_async(ExPolicy policy, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::size_t const size = 10007;
+    std::vector<int> c(size), dest(size);
+    std::generate(std::begin(c), std::end(c), random_fill());
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try {
+        auto f = hpx::parallel::unique_copy(policy,
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            iterator(boost::begin(dest)),
+            throw_always());
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(hpx::exception_list const& e) {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_unique_copy_bad_alloc(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::size_t const size = 10007;
+    std::vector<int> c(size), dest(size);
+    std::generate(std::begin(c), std::end(c), random_fill());
+
+    bool caught_bad_alloc = false;
+    try {
+        auto result = hpx::parallel::unique_copy(policy,
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            iterator(boost::begin(dest)),
+            throw_bad_alloc());
+
+        HPX_TEST(false);
+    }
+    catch(std::bad_alloc const&) {
+        caught_bad_alloc = true;
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_unique_copy_bad_alloc_async(ExPolicy policy, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::size_t const size = 10007;
+    std::vector<int> c(size), dest(size);
+    std::generate(std::begin(c), std::end(c), random_fill());
+
+    bool caught_bad_alloc = false;
+    bool returned_from_algorithm = false;
+    try {
+        auto f = hpx::parallel::unique_copy(policy,
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            iterator(boost::begin(dest)),
+            throw_bad_alloc());
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch(std::bad_alloc const&) {
+        caught_bad_alloc = true;
+    }
+    catch(...) {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+    HPX_TEST(returned_from_algorithm);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag, typename DataType>
+void test_unique_copy_etc(ExPolicy policy, IteratorTag,
+    DataType, int rand_base)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef typename std::vector<DataType>::iterator base_iterator;
+
+    using hpx::util::get;
+
+    std::size_t const size = 10007;
+    std::vector<DataType> c(size), dest_res(size), dest_sol(size);
+    std::generate(std::begin(c), std::end(c), random_fill(rand_base, size / 10));
+
+    // Test default predicate.
+    {
+        typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+        auto result = hpx::parallel::unique_copy(policy,
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            iterator(boost::begin(dest_res)));
+        auto solution = std::unique_copy(std::begin(c), std::end(c),
+            std::begin(dest_sol));
+
+        bool equality = std::equal(
+            std::begin(dest_res), get<1>(result).base(),
+            std::begin(dest_sol), solution);
+
+        HPX_TEST(equality);
+    }
+
+    // Test projection.
+    {
+        typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+        DataType val;
+        auto result = hpx::parallel::unique_copy(policy,
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            iterator(boost::begin(dest_res)),
+            [](DataType const& a, DataType const& b) -> bool {
+                return a == b;
+            },
+            [&val](DataType const&) -> DataType {
+                // This is projection.
+                return val;
+            });
+
+        auto dist = std::distance(std::begin(dest_res), get<1>(result).base());
+        HPX_TEST_EQ(dist, 1);
+    }
+
+    // Test sequential_unique_copy with input_iterator_tag.
+    {
+        typedef test::test_iterator<base_iterator,
+            std::input_iterator_tag> iterator;
+
+        auto result = hpx::parallel::v1::detail::sequential_unique_copy(
+            iterator(boost::begin(c)), iterator(boost::end(c)),
+            std::begin(dest_res),
+            [](DataType const& a, DataType const& b) -> bool {
+                return a == b;
+            },
+            [](DataType& t) -> DataType& {
+                return t;
+            },
+            std::false_type());
+        auto solution = std::unique_copy(std::begin(c), std::end(c),
+            std::begin(dest_sol));
+
+        bool equality = std::equal(
+            std::begin(dest_res), get<1>(result),
+            std::begin(dest_sol), solution);
+
+        HPX_TEST(equality);
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_unique_copy()
+{
+    using namespace hpx::parallel;
+
+    int rand_base = std::rand();
+
+    ////////// Test cases for 'int' type.
+    test_unique_copy(execution::seq, IteratorTag(), int(),
+        [](const int a, const int b) -> bool {
+            return a == b;
+        }, rand_base);
+    test_unique_copy(execution::par, IteratorTag(), int(),
+        [rand_base](const int a, const int b) -> bool {
+            return a == b && b == rand_base;
+        }, rand_base);
+    test_unique_copy(execution::par_unseq, IteratorTag(), int(),
+        [](const int a, const int b) -> bool {
+            return a == b;
+        }, rand_base);
+
+    ////////// Test cases for user defined type.
+    test_unique_copy(execution::seq, IteratorTag(), user_defined_type(),
+        [](user_defined_type const& a, user_defined_type const& b) -> bool {
+            return a == b;
+        }, rand_base);
+    test_unique_copy(execution::par, IteratorTag(), user_defined_type(),
+        [](user_defined_type const& a, user_defined_type const& b) -> bool {
+            return a == b;
+        }, rand_base);
+    test_unique_copy(execution::par_unseq, IteratorTag(), user_defined_type(),
+        [rand_base](user_defined_type const& a, user_defined_type const& b) -> bool {
+            return a == b && b == rand_base;
+        }, rand_base);
+
+    ////////// Asynchronous test cases for 'int' type.
+    test_unique_copy_async(execution::seq(execution::task), IteratorTag(), int(),
+        [rand_base](const int a, const int b) -> bool {
+            return a == b && b == rand_base;
+        }, rand_base);
+    test_unique_copy_async(execution::par(execution::task), IteratorTag(), int(),
+        [](const int a, const int b) -> bool {
+            return a == b;
+        }, rand_base);
+
+    ////////// Asynchronous test cases for user defined type.
+    test_unique_copy_async(execution::seq(execution::task), IteratorTag(),
+        user_defined_type(),
+        [](user_defined_type const& a, user_defined_type const& b) -> bool {
+            return a == b;
+        }, rand_base);
+    test_unique_copy_async(execution::par(execution::task), IteratorTag(),
+        user_defined_type(),
+        [rand_base](user_defined_type const& a, user_defined_type const& b) -> bool {
+            return a == rand_base && b == rand_base;
+        }, rand_base);
+
+    ////////// Corner test cases.
+    test_unique_copy(execution::par, IteratorTag(), int(),
+        [](const int, const int) -> bool {
+            return true;
+        }, rand_base);
+    test_unique_copy(execution::par_unseq, IteratorTag(), user_defined_type(),
+        [](user_defined_type const&, user_defined_type const&) -> bool {
+            return false;
+        }, rand_base);
+
+    ////////// Another test cases for justifying the implementation.
+    test_unique_copy_etc(execution::seq, IteratorTag(),
+        user_defined_type(), rand_base);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_unique_copy_exception()
+{
+    using namespace hpx::parallel;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_unique_copy_exception(execution::seq, IteratorTag());
+    test_unique_copy_exception(execution::par, IteratorTag());
+
+    test_unique_copy_exception_async(execution::seq(execution::task),
+        IteratorTag());
+    test_unique_copy_exception_async(execution::par(execution::task),
+        IteratorTag());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_unique_copy_bad_alloc()
+{
+    using namespace hpx::parallel;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_unique_copy_bad_alloc(execution::seq, IteratorTag());
+    test_unique_copy_bad_alloc(execution::par, IteratorTag());
+
+    test_unique_copy_bad_alloc_async(execution::seq(execution::task),
+        IteratorTag());
+    test_unique_copy_bad_alloc_async(execution::par(execution::task),
+        IteratorTag());
+}
+
+#endif

--- a/tests/unit/parallel/container_algorithms/CMakeLists.txt
+++ b/tests/unit/parallel/container_algorithms/CMakeLists.txt
@@ -27,6 +27,7 @@ set(tests
     transform_range
     transform_range_binary
     transform_range_binary2
+    unique_copy_range
    )
 
 foreach(test ${tests})

--- a/tests/unit/parallel/container_algorithms/unique_copy_range.cpp
+++ b/tests/unit/parallel/container_algorithms/unique_copy_range.cpp
@@ -1,0 +1,275 @@
+//  Copyright (c) 2017 Taeguk Kwon
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/include/parallel_unique.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <boost/random.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+struct user_defined_type
+{
+    user_defined_type() = default;
+    user_defined_type(int rand_no)
+      : val(rand_no),
+        name(name_list[std::rand() % name_list.size()])
+    {}
+
+    bool operator<(int rand_base) const
+    {
+        static std::string const base_name = "BASE";
+
+        if (this->name < base_name)
+            return true;
+        else if (this->name > base_name)
+            return false;
+        else
+            return this->val < rand_base;
+    }
+
+    bool operator==(user_defined_type const& t) const
+    {
+        return this->name == t.name && this->val == t.val;
+    }
+
+    struct user_defined_type& operator++() { return *this; };
+
+    static const std::vector<std::string> name_list;
+
+    int val;
+    std::string name;
+};
+
+const std::vector<std::string> user_defined_type::name_list{
+    "ABB", "ABC", "ACB", "BASE", "CAA", "CAAA", "CAAB"
+};
+
+struct random_fill
+{
+    random_fill(int rand_base, int range)
+      : gen(std::rand()),
+        dist(rand_base - range / 2, rand_base + range / 2)
+    {}
+
+    int operator()()
+    {
+        return dist(gen);
+    }
+
+    boost::random::mt19937 gen;
+    boost::random::uniform_int_distribution<> dist;
+};
+
+////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename DataType>
+void test_unique_copy(ExPolicy policy, DataType)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    using hpx::util::get;
+
+    std::size_t const size = 10007;
+    std::vector<DataType> c(size), dest_res(size), dest_sol(size);
+    std::generate(std::begin(c), std::end(c), random_fill(0, 6));
+
+    auto result = hpx::parallel::unique_copy(policy,
+        c, std::begin(dest_res));
+    auto solution = std::unique_copy(std::begin(c), std::end(c),
+        std::begin(dest_sol));
+
+    HPX_TEST(get<0>(result) == std::end(c));
+
+    bool equality = std::equal(
+        std::begin(dest_res), get<1>(result),
+        std::begin(dest_sol), solution);
+
+    HPX_TEST(equality);
+}
+
+template <typename ExPolicy, typename DataType>
+void test_unique_copy_async(ExPolicy policy, DataType)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    using hpx::util::get;
+
+    std::size_t const size = 10007;
+    std::vector<DataType> c(size), dest_res(size), dest_sol(size);
+    std::generate(std::begin(c), std::end(c), random_fill(0, 6));
+
+    auto f = hpx::parallel::unique_copy(policy,
+        c, std::begin(dest_res));
+    auto result = f.get();
+    auto solution = std::unique_copy(std::begin(c), std::end(c),
+        std::begin(dest_sol));
+
+    HPX_TEST(get<0>(result) == std::end(c));
+
+    bool equality = std::equal(
+        std::begin(dest_res), get<1>(result),
+        std::begin(dest_sol), solution);
+
+    HPX_TEST(equality);
+}
+
+#if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
+template <typename ExPolicy, typename DataType>
+void test_unique_copy_outiter(ExPolicy policy, DataType)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    using hpx::util::get;
+
+    std::size_t const size = 10007;
+    std::vector<DataType> c(size), dest_res(0), dest_sol(0);
+    std::generate(std::begin(c), std::end(c), random_fill(0, 6));
+
+    auto result = hpx::parallel::unique_copy(policy,
+        c, std::back_inserter(dest_res));
+    auto solution = std::unique_copy(std::begin(c), std::end(c),
+        std::back_inserter(dest_sol));
+
+    HPX_TEST(get<0>(result) == std::end(c));
+
+    bool equality = std::equal(
+        std::begin(dest_res), std::end(dest_res),
+        std::begin(dest_sol), std::end(dest_sol));
+
+    HPX_TEST(equality);
+}
+
+template <typename ExPolicy, typename DataType>
+void test_unique_copy_outiter_async(ExPolicy policy, DataType)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    using hpx::util::get;
+
+    std::size_t const size = 10007;
+    std::vector<DataType> c(size), dest_res(0), dest_sol(0);
+    std::generate(std::begin(c), std::end(c), random_fill(0, 6));
+
+    auto f = hpx::parallel::unique_copy(policy,
+        c, std::back_inserter(dest_res));
+    auto result = f.get();
+    auto solution = std::unique_copy(std::begin(c), std::end(c),
+        std::back_inserter(dest_sol));
+
+    HPX_TEST(get<0>(result) == std::end(c));
+
+    bool equality = std::equal(
+        std::begin(dest_res), std::end(dest_res),
+        std::begin(dest_sol), std::end(dest_sol));
+
+    HPX_TEST(equality);
+}
+#endif
+
+template <typename DataType>
+void test_unique_copy()
+{
+    using namespace hpx::parallel;
+
+    test_unique_copy(execution::seq, DataType());
+    test_unique_copy(execution::par, DataType());
+    test_unique_copy(execution::par_unseq, DataType());
+
+    test_unique_copy_async(execution::seq(execution::task), DataType());
+    test_unique_copy_async(execution::par(execution::task), DataType());
+
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
+    test_unique_copy(execution_policy(execution::seq), DataType());
+    test_unique_copy(execution_policy(execution::par), DataType());
+    test_unique_copy(execution_policy(execution::par_unseq), DataType());
+
+    test_unique_copy(execution_policy(execution::seq(execution::task)),
+        DataType());
+    test_unique_copy(execution_policy(execution::par(execution::task)),
+        DataType());
+#endif
+
+#if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
+    test_unique_copy_outiter(execution::seq, DataType());
+    test_unique_copy_outiter(execution::par, DataType());
+    test_unique_copy_outiter(execution::par_unseq, DataType());
+
+    test_unique_copy_outiter_async(execution::seq(execution::task), DataType());
+    test_unique_copy_outiter_async(execution::par(execution::task), DataType());
+
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
+    test_unique_copy_outiter(execution_policy(execution::seq), DataType());
+    test_unique_copy_outiter(execution_policy(execution::par), DataType());
+    test_unique_copy_outiter(execution_policy(execution::par_unseq), DataType());
+
+    test_unique_copy_outiter(execution_policy(execution::seq(execution::task)),
+        DataType());
+    test_unique_copy_outiter(execution_policy(execution::par(execution::task)),
+        DataType());
+#endif
+#endif
+}
+
+void test_unique_copy()
+{
+    test_unique_copy<int>();
+    test_unique_copy<user_defined_type>();
+}
+
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int)std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    test_unique_copy();
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace boost::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()
+        ("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run")
+        ;
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {
+        "hpx.os_threads=all"
+    };
+
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Check Box
---------------
- [x] Implementation of unique_copy.
- [x] Unit tests for unique_copy.
- [x] Benchmark codes for unique_copy.
- [x] Adapt to Ranges TS (#1668).
- [x] Benchmark with using ```policy.executor()``` instead of ```hpx::launch::sync``` in ```scan_partitioner```. (https://gist.github.com/taeguk/36f6fadce38c85096018f4df3a91d552) 
=> The parallel version is faster than the sequential version, but not satisfying.