### PR TITLE
Remove various warnings detected by clang 5.0

### DIFF
--- a/hpx/parallel/algorithms/is_heap.hpp
+++ b/hpx/parallel/algorithms/is_heap.hpp
@@ -25,6 +25,7 @@
 #include <hpx/parallel/util/projection_identity.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -80,6 +81,7 @@ namespace hpx { namespace parallel { inline namespace v1
                         [tok, second](std::vector<hpx::future<void> > &&) mutable
                             -> bool
                         {
+                            HPX_UNUSED(second);
                             difference_type find_res =
                                 static_cast<difference_type>(tok.get_data());
 

--- a/hpx/parallel/algorithms/partition.hpp
+++ b/hpx/parallel/algorithms/partition.hpp
@@ -30,6 +30,7 @@
 #include <hpx/parallel/util/projection_identity.hpp>
 #include <hpx/parallel/util/scan_partitioner.hpp>
 #include <hpx/parallel/util/zip_iterator.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -454,6 +455,7 @@ namespace hpx { namespace parallel { inline namespace v1
                     ->  hpx::util::tuple<FwdIter1, FwdIter2, FwdIter3>
                     {
                         HPX_UNUSED(flags);
+                        HPX_UNUSED(count);
 
                         output_iterator_offset count_pair = items.back().get();
                         std::size_t count_true = get<0>(count_pair);

--- a/tests/performance/local/serialization_overhead.cpp
+++ b/tests/performance/local/serialization_overhead.cpp
@@ -119,7 +119,7 @@ double benchmark_serialization(std::size_t data_size, std::size_t iterations,
     if (zerocopy)
         chunks = new std::vector<hpx::serialization::serialization_chunk>();
 
-    std::uint32_t dest_locality_id = outp.destination_locality_id();
+    //std::uint32_t dest_locality_id = outp.destination_locality_id();
     hpx::util::high_resolution_timer t;
 
     for (std::size_t i = 0; i != iterations; ++i)

--- a/tests/performance/network/network_storage/network_storage.cpp
+++ b/tests/performance/network/network_storage/network_storage.cpp
@@ -690,7 +690,7 @@ void test_write(
 static void transfer_data(general_buffer_type recv,
   hpx::future<transfer_buffer_type> &&f)
 {
-  transfer_buffer_type buffer(std::move(f.get()));
+  transfer_buffer_type buffer(f.get());
 //  if (buffer.data() != recv.data())
   {
     std::copy(buffer.data(), buffer.data() + buffer.size(), recv.data());

--- a/tests/unit/parallel/algorithms/partition_copy_tests.hpp
+++ b/tests/unit/parallel/algorithms/partition_copy_tests.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/include/parallel_partition.hpp>
 #include <hpx/util/lightweight_test.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <boost/random.hpp>
 
@@ -194,6 +195,7 @@ void test_partition_copy_exception(ExPolicy policy, IteratorTag)
             iterator(std::begin(d_true)), iterator(std::begin(d_false)),
             throw_always());
 
+        HPX_UNUSED(result);
         HPX_TEST(false);
     }
     catch(hpx::exception_list const& e) {
@@ -263,6 +265,7 @@ void test_partition_copy_bad_alloc(ExPolicy policy, IteratorTag)
             iterator(std::begin(d_true)), iterator(std::begin(d_false)),
             throw_bad_alloc());
 
+        HPX_UNUSED(result);
         HPX_TEST(false);
     }
     catch(std::bad_alloc const&) {
@@ -369,10 +372,12 @@ void test_partition_copy()
     ////////// Corner test cases.
     test_partition_copy(execution::par, IteratorTag(), int(),
         [rand_base](const int n) -> bool {
+            HPX_UNUSED(rand_base);
             return true;
         }, rand_base);
     test_partition_copy(execution::par_unseq, IteratorTag(), user_defined_type(),
         [rand_base](user_defined_type const& t) -> bool {
+            HPX_UNUSED(rand_base);
             return false;
         }, rand_base);
 }

--- a/tests/unit/parallel/algorithms/unique_copy_tests.hpp
+++ b/tests/unit/parallel/algorithms/unique_copy_tests.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/include/parallel_unique.hpp>
 #include <hpx/util/lightweight_test.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <boost/random.hpp>
 
@@ -190,6 +191,7 @@ void test_unique_copy_exception(ExPolicy policy, IteratorTag)
             iterator(std::begin(dest)),
             throw_always());
 
+        HPX_UNUSED(result);
         HPX_TEST(false);
     }
     catch(hpx::exception_list const& e) {
@@ -259,6 +261,7 @@ void test_unique_copy_bad_alloc(ExPolicy policy, IteratorTag)
             iterator(std::begin(dest)),
             throw_bad_alloc());
 
+        HPX_UNUSED(result);
         HPX_TEST(false);
     }
     catch(std::bad_alloc const&) {

--- a/tests/unit/parallel/container_algorithms/partition_copy_range.cpp
+++ b/tests/unit/parallel/container_algorithms/partition_copy_range.cpp
@@ -7,6 +7,7 @@
 #include <hpx/hpx.hpp>
 #include <hpx/include/parallel_partition.hpp>
 #include <hpx/util/lightweight_test.hpp>
+#include <hpx/util/unused.hpp>
 
 #include <boost/random.hpp>
 
@@ -104,6 +105,7 @@ void test_partition_copy(ExPolicy policy, DataType)
         std::begin(d_true_sol), std::begin(d_false_sol),
         pred);
 
+    HPX_UNUSED(solution);
     HPX_TEST(get<0>(result) == std::end(c));
 
     bool equality_true = std::equal(
@@ -147,6 +149,7 @@ void test_partition_copy_async(ExPolicy policy, DataType)
         std::begin(d_true_sol), std::begin(d_false_sol),
         pred);
 
+    HPX_UNUSED(solution);
     HPX_TEST(get<0>(result) == std::end(c));
 
     bool equality_true = std::equal(


### PR DESCRIPTION
This patch tries to remove various warnings due to unused variables or captured variables.