### PR TITLE
gcc split stack support for HPX threads #620

### DIFF
--- a/hpx/components/containers/partitioned_vector/partitioned_vector.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector.hpp
@@ -242,6 +242,8 @@ namespace hpx
         friend class const_segment_vector_iterator<
             T, Data, typename partitions_vector_type::const_iterator>;
 
+        friend struct serializer::detail::partitioned_vector_segmented_serializer<T>;
+
         std::size_t get_partition_size() const
         {
             std::size_t num_parts = partitions_.size();

--- a/hpx/components/containers/partitioned_vector/partitioned_vector.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector.hpp
@@ -242,7 +242,7 @@ namespace hpx
         friend class const_segment_vector_iterator<
             T, Data, typename partitions_vector_type::const_iterator>;
 
-        friend struct serializer::detail::partitioned_vector_segmented_serializer<T>;
+        friend struct serializer::detail::partitioned_vector_segmented_serializer;
 
         std::size_t get_partition_size() const
         {

--- a/hpx/runtime/serialization/partitioned_vector.hpp
+++ b/hpx/runtime/serialization/partitioned_vector.hpp
@@ -17,9 +17,9 @@ namespace hpx { namespace serialization
 {
     namespace detail
     {
-        template<typename T>
         partitioned_vector_segmented_serializer
         {
+            template<typename T>
             static void serialize(input_archive & ar,
                 hpx::partitioned_vector<T> & v, std::false_type)
             {
@@ -29,6 +29,7 @@ namespace hpx { namespace serialization
                     "hpx::serialization::serialize requires segemented partitioned_vector");
             }
 
+            template<typename T>
             static void serialize(input_archive & ar,
                 hpx::partitioned_vector<T> & v, std::true_type)
             {
@@ -38,6 +39,7 @@ namespace hpx { namespace serialization
                 fconnect.wait();
             }
 
+            template<typename T>
             static void serialize(output_archive & ar,
                 const hpx::partitioned_vector<T> & v, std::false_type) const
             {
@@ -51,6 +53,7 @@ namespace hpx { namespace serialization
                     "hpx::serialization::serialize requires a registered partitioned_vector");
             }
 
+            template<typename T>
             static void serialize(output_archive & ar,
                 const hpx::partitioned_vector<T> & v, std::true_type) const
             {
@@ -66,7 +69,7 @@ namespace hpx { namespace serialization
         typedef hpx::traits::is_segmented_iterator<FwdIter> is_segmented;
 
         auto vitr = std::begin(v);
-        detail::partitioned_vector_segmented_serializer::serialize(
+        detail::partitioned_vector_segmented_serializer::serialize<T>(
             ar, v, is_segmented(vitr));
     }
 
@@ -77,7 +80,7 @@ namespace hpx { namespace serialization
         typedef hpx::traits::is_segmented_iterator<FwdIter> is_segmented;
 
         auto vitr = std::begin(v);
-        detail::partitioned_vector_segmented_serializer::serialize(
+        detail::partitioned_vector_segmented_serializer::serialize<T>(
             ar, v, is_segmented(vitr));
     }
 

--- a/hpx/runtime/serialization/partitioned_vector.hpp
+++ b/hpx/runtime/serialization/partitioned_vector.hpp
@@ -26,7 +26,7 @@ namespace hpx { namespace serialization
                 static_assert(
                     hpx::parallel::is_partitioned(hpx::parallel::execution::par,
                         std::begin(v), std::end(v), [](std::size_t n) { return n > 0; });
-                    "hpx::serialization::serialize requires segemented partitioned_vector");
+                    "hpx::serialization::serialize requires segmented partitioned_vector");
             }
 
             template<typename T>
@@ -46,7 +46,7 @@ namespace hpx { namespace serialization
                 static_assert(
                     hpx::parallel::is_partitioned(hpx::parallel::execution::par,
                         std::begin(v), std::end(v), [](std::size_t n) { return n > 0; });
-                    "hpx::serialization::serialize requires segemented partitioned_vector");
+                    "hpx::serialization::serialize requires segmented partitioned_vector");
 
                 static_assert(
                     v.registered_name_.size() > 0,

--- a/hpx/runtime/serialization/partitioned_vector.hpp
+++ b/hpx/runtime/serialization/partitioned_vector.hpp
@@ -10,61 +10,75 @@
 #include <hpx/runtime/serialization/serialize.hpp>
 #include <hpx/traits/is_bitwise_serializable.hpp>
 
-#include <hpx/include/parallel_is_partitioned.hpp>
+#include <hpx/traits/segmented_iterator_traits.hpp>
 #include <hpx/include/partitioned_vector.hpp>
-
-#include <cstddef>
-#include <cstdint>
-#include <type_traits>
 
 namespace hpx { namespace serialization
 {
     namespace detail
     {
         template<typename T>
-        partitioned_vector_segmented_serializer(input_archive & ar,
-            hpx::partitioned_vector<T> & v)
+        partitioned_vector_segmented_serializer
         {
-            static_assert(
-                hpx::parallel::is_partitioned(hpx::parallel::execution::par,
-                    std::begin(v), std::end(v), [](std::size_t n) { return n > 0; });
-                "hpx::serialization::serialize requires segemented partitioned_vector");
+            static void serialize(input_archive & ar,
+                hpx::partitioned_vector<T> & v, std::false_type)
+            {
+                static_assert(
+                    hpx::parallel::is_partitioned(hpx::parallel::execution::par,
+                        std::begin(v), std::end(v), [](std::size_t n) { return n > 0; });
+                    "hpx::serialization::serialize requires segemented partitioned_vector");
+            }
 
-            std::string pvec_registered_name;
-            ar >> pvec_registered_name;
-            hpx::future<void> fconnect = v.connect_to(pvec_registered_name);
-            fconnect.wait();
-        }
+            static void serialize(input_archive & ar,
+                hpx::partitioned_vector<T> & v, std::true_type)
+            {
+                std::string pvec_registered_name;
+                ar >> pvec_registered_name;
+                hpx::future<void> fconnect = v.connect_to(pvec_registered_name);
+                fconnect.wait();
+            }
 
-        template<typename T>
-        partitioned_vector_segmented_serializer(output_archive & ar,
-            hpx::partitioned_vector<T> & v)
-        {
-            static_assert(
-                hpx::parallel::is_partitioned(hpx::parallel::execution::par,
-                    std::begin(v), std::end(v), [](std::size_t n) { return n > 0; });
-                "hpx::serialization::serialize requires segemented partitioned_vector");
+            static void serialize(output_archive & ar,
+                const hpx::partitioned_vector<T> & v, std::false_type) const
+            {
+                static_assert(
+                    hpx::parallel::is_partitioned(hpx::parallel::execution::par,
+                        std::begin(v), std::end(v), [](std::size_t n) { return n > 0; });
+                    "hpx::serialization::serialize requires segemented partitioned_vector");
 
-            static_assert(
-                v.registered_name_.size() > 0,
-                "hpx::serialization::serialize requires a registered partitioned_vector");
+                static_assert(
+                    v.registered_name_.size() > 0,
+                    "hpx::serialization::serialize requires a registered partitioned_vector");
+            }
 
-            ar << v.registered_name_;
-        }
+            static void serialize(output_archive & ar,
+                const hpx::partitioned_vector<T> & v, std::true_type) const
+            {
+                ar << v.registered_name_;
+            }
+        };
     }
 
     template <typename T>
     void serialize(input_archive & ar, hpx::partitioned_vector<T> & v,
         unsigned)
     {
-        partitioned_vector_segmented_serializer(ar, v);
+        typedef hpx::traits::is_segmented_iterator<FwdIter> is_segmented;
+
+        auto vitr = std::begin(v);
+        detail::partitioned_vector_segmented_serializer::serialize(
+            ar, v, is_segmented(vitr));
     }
 
     template <typename T>
     void serialize(output_archive & ar, const hpx::partitioned_vector<T> & v,
         unsigned)
     {
-        partitioned_vector_segemented_serializer(ar, v);
+        typedef hpx::traits::is_segmented_iterator<FwdIter> is_segmented;
+
+        auto vitr = std::begin(v);
+        detail::partitioned_vector_segmented_serializer::serialize(
+            ar, v, is_segmented(vitr));
     }
 
 }}

--- a/hpx/runtime/serialization/partitioned_vector.hpp
+++ b/hpx/runtime/serialization/partitioned_vector.hpp
@@ -1,0 +1,72 @@
+//  Copyright (c) 2017 Christopher Taylor
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_SERIALIZATION_PARTITIONED_VECTOR_HPP
+#define HPX_SERIALIZATION_PARTITIONED_VECTOR_HPP
+
+#include <hpx/config.hpp>
+#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/traits/is_bitwise_serializable.hpp>
+
+#include <hpx/include/parallel_is_partitioned.hpp>
+#include <hpx/include/partitioned_vector.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+namespace hpx { namespace serialization
+{
+    namespace detail
+    {
+        template<typename T>
+        partitioned_vector_segmented_serializer(input_archive & ar,
+            hpx::partitioned_vector<T> & v)
+        {
+            static_assert(
+                hpx::parallel::is_partitioned(hpx::parallel::execution::par,
+                    std::begin(v), std::end(v), [](std::size_t n) { return n > 0; });
+                "hpx::serialization::serialize requires segemented partitioned_vector");
+
+            std::string pvec_registered_name;
+            ar >> pvec_registered_name;
+            hpx::future<void> fconnect = v.connect_to(pvec_registered_name);
+            fconnect.wait();
+        }
+
+        template<typename T>
+        partitioned_vector_segmented_serializer(output_archive & ar,
+            hpx::partitioned_vector<T> & v)
+        {
+            static_assert(
+                hpx::parallel::is_partitioned(hpx::parallel::execution::par,
+                    std::begin(v), std::end(v), [](std::size_t n) { return n > 0; });
+                "hpx::serialization::serialize requires segemented partitioned_vector");
+
+            static_assert(
+                v.registered_name_.size() > 0,
+                "hpx::serialization::serialize requires a registered partitioned_vector");
+
+            ar << v.registered_name_;
+        }
+    }
+
+    template <typename T>
+    void serialize(input_archive & ar, hpx::partitioned_vector<T> & v,
+        unsigned)
+    {
+        partitioned_vector_segmented_serializer(ar, v);
+    }
+
+    template <typename T>
+    void serialize(output_archive & ar, const hpx::partitioned_vector<T> & v,
+        unsigned)
+    {
+        partitioned_vector_segemented_serializer(ar, v);
+    }
+
+}}
+
+#endif

--- a/tests/unit/serialization/CMakeLists.txt
+++ b/tests/unit/serialization/CMakeLists.txt
@@ -17,6 +17,7 @@ set(tests
     serialization_smart_ptr
     serialization_unordered_map
     serialization_vector
+    serialization_partitioned_vector
     serialization_variant
     serialize_buffer
     zero_copy_serialization

--- a/tests/unit/serialization/serialization_partitioned_vector.cpp
+++ b/tests/unit/serialization/serialization_partitioned_vector.cpp
@@ -1,0 +1,74 @@
+//  Copyright (c) 2017 Christopher Taylor
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/runtime/serialization/partitioned_vector.hpp>
+#include <hpx/runtime/serialization/input_archive.hpp>
+#include <hpx/runtime/serialization/output_archive.hpp>
+
+#include <hpx/include/partitioned_vector.hpp>
+
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstddef>
+#include <numeric>
+
+template <typename T>
+void test(T minval, T maxval)
+{
+    {
+        std::vector<char> buffer;
+        hpx::serialization::output_archive oarchive(buffer,
+            hpx::serialization::disable_data_chunking);
+
+        std::size_t sz = static_cast<std::size_t>(maxval-minval);
+        hpx::partitioned_vector<T> os(sz);
+
+        T n = minval;
+        hpx::parallel::generate(std::begin(os), std::end(os),
+            [&n] { return ++n; });
+
+        oarchive << os;
+
+        hpx::serialization::input_archive iarchive(buffer);
+        hpx::partitioned_vector<T> is(os.size());
+        iarchive >> is;
+        HPX_TEST_EQ(os.size(), is.size());
+        for(std::size_t i = 0; i < os.size(); ++i)
+        {
+            HPX_TEST_EQ(os[i], is[i]);
+        }
+    }
+}
+
+int main()
+{
+    test<int>((std::numeric_limits<int>::min)(),
+        (std::numeric_limits<int>::min)() + 100);
+    test<int>((std::numeric_limits<int>::max)() - 100,
+        (std::numeric_limits<int>::max)());
+    test<int>(-100, 100);
+    test<unsigned>((std::numeric_limits<unsigned>::min)(),
+        (std::numeric_limits<unsigned>::min)() + 100);
+    test<unsigned>((std::numeric_limits<unsigned>::max)() - 100,
+        (std::numeric_limits<unsigned>::max)());
+    test<long>((std::numeric_limits<long>::min)(),
+        (std::numeric_limits<long>::min)() + 100);
+    test<long>((std::numeric_limits<long>::max)() - 100,
+        (std::numeric_limits<long>::max)());
+    test<long>(-100, 100);
+    test<unsigned long>((std::numeric_limits<unsigned long>::min)(),
+        (std::numeric_limits<unsigned long>::min)() + 100);
+    test<unsigned long>((std::numeric_limits<unsigned long>::max)() - 100,
+        (std::numeric_limits<unsigned long>::max)());
+    test<double>((std::numeric_limits<double>::min)(),
+        (std::numeric_limits<double>::min)() + 100);
+    test<double>(-100, 100);
+
+    return hpx::util::report_errors();
+}
+


### PR DESCRIPTION
implementation of GCC's -fsplit-stack support for HPX threads. initial import needs cmake flags and unit test.