### PR TITLE
Improvements to continuation annotation

### DIFF
--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -1178,6 +1178,18 @@ namespace hpx { namespace traits
             return get_function_annotation<F1>::call(f.f1_);
         }
     };
+
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+    template <typename F1, typename F2>
+    struct get_function_annotation_itt<lcos::detail::compose_cb_impl<F1, F2> >
+    {
+        static char const*
+            call(lcos::detail::compose_cb_impl<F1, F2> const& f) noexcept
+        {
+            return get_function_annotation_itt<F1>::call(f.f1_);
+        }
+    };
+#endif
 #endif
 }}
 

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -230,11 +230,18 @@ namespace detail
                 return;
             }
 
-            f1_();
-            f2_();
+            {
+                hpx::util::annotate_function annotate(f1_);
+                (void)annotate;
+                f1_();
+            }
+            {
+                hpx::util::annotate_function annotate(f2_);
+                (void)annotate;
+                f2_();
+            }
         }
 
-    private:
         F1 f1_;
         F2 f2_;
     };
@@ -1149,13 +1156,29 @@ namespace detail
     };
 }}}
 
-namespace hpx { namespace traits { namespace detail
+namespace hpx { namespace traits
 {
-    template <typename R, typename Allocator>
-    struct shared_state_allocator<lcos::detail::future_data<R>, Allocator>
+    namespace detail
     {
-        typedef lcos::detail::future_data_allocator<R, Allocator> type;
+        template <typename R, typename Allocator>
+        struct shared_state_allocator<lcos::detail::future_data<R>, Allocator>
+        {
+            typedef lcos::detail::future_data_allocator<R, Allocator> type;
+        };
+    }
+
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename F1, typename F2>
+    struct get_function_annotation<lcos::detail::compose_cb_impl<F1, F2> >
+    {
+        static char const*
+            call(lcos::detail::compose_cb_impl<F1, F2> const& f) noexcept
+        {
+            return get_function_annotation<F1>::call(f.f1_);
+        }
     };
-}}}
+#endif
+}}
 
 #endif

--- a/hpx/parallel/algorithms/for_each.hpp
+++ b/hpx/parallel/algorithms/for_each.hpp
@@ -526,6 +526,22 @@ namespace hpx { namespace traits
                 >::call(f.f_);
         }
     };
+
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+    template <typename ExPolicy, typename F, typename Proj>
+    struct get_function_annotation_itt<
+        parallel::v1::detail::for_each_iteration<ExPolicy, F, Proj> >
+    {
+        static char const* call(
+            parallel::v1::detail::for_each_iteration<ExPolicy, F, Proj> const& f)
+                noexcept
+        {
+            return get_function_annotation_itt<
+                    typename hpx::util::decay<F>::type
+                >::call(f.f_);
+        }
+    };
+#endif
 }}
 #endif
 

--- a/hpx/parallel/algorithms/for_loop.hpp
+++ b/hpx/parallel/algorithms/for_loop.hpp
@@ -1169,6 +1169,22 @@ namespace hpx { namespace traits
                 >::call(f.f_);
         }
     };
+
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+    template <typename F, typename S, typename Tuple>
+    struct get_function_annotation_itt<
+        parallel::v2::detail::part_iterations<F, S, Tuple> >
+    {
+        static char const* call(
+            parallel::v2::detail::part_iterations<F, S, Tuple> const& f)
+                noexcept
+        {
+            return get_function_annotation_itt<
+                    typename hpx::util::decay<F>::type
+                >::call(f.f_);
+        }
+    };
+#endif
 }}
 #endif
 

--- a/hpx/parallel/algorithms/transform.hpp
+++ b/hpx/parallel/algorithms/transform.hpp
@@ -867,6 +867,22 @@ namespace hpx { namespace traits
                 >::call(f.f_);
         }
     };
+
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+    template <typename ExPolicy, typename F, typename Proj>
+    struct get_function_annotation_itt<
+        parallel::v1::detail::transform_iteration<ExPolicy, F, Proj> >
+    {
+        static char const* call(
+            parallel::v1::detail::transform_iteration<ExPolicy, F, Proj> const& f)
+                noexcept
+        {
+            return get_function_annotation_itt<
+                    typename hpx::util::decay<F>::type
+                >::call(f.f_);
+        }
+    };
+#endif
 }}
 #endif
 

--- a/hpx/parallel/util/detail/partitioner_iteration.hpp
+++ b/hpx/parallel/util/detail/partitioner_iteration.hpp
@@ -81,6 +81,22 @@ namespace hpx { namespace traits
                 >::call(f.f_);
         }
     };
+
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+    template <typename Result, typename F>
+    struct get_function_annotation_itt<
+        parallel::util::detail::partitioner_iteration<Result, F> >
+    {
+        static char const* call(
+            parallel::util::detail::partitioner_iteration<Result, F> const& f)
+                noexcept
+        {
+            return get_function_annotation_itt<
+                    typename hpx::util::decay<F>::type
+                >::call(f.f_);
+        }
+    };
+#endif
 }}
 #endif
 

--- a/hpx/util/annotated_function.hpp
+++ b/hpx/util/annotated_function.hpp
@@ -79,26 +79,27 @@ namespace hpx { namespace util
 
         explicit annotate_function(char const* name)
           : desc_(hpx::threads::get_self_ptr() ?
-                hpx::threads::set_thread_description(hpx::threads::get_self_id(),
-                    name) :
+                hpx::threads::set_thread_description(
+                    hpx::threads::get_self_id(), name) :
                 nullptr)
         {}
+
         template <typename F>
         explicit annotate_function(F && f)
           : desc_(hpx::threads::get_self_ptr() ?
                 hpx::threads::set_thread_description(
                     hpx::threads::get_self_id(),
-                    hpx::traits::get_function_annotation<
-                        typename std::decay<F>::type
-                    >::call(f)) :
+                    hpx::util::thread_description(f)) :
                 nullptr)
         {}
 
         ~annotate_function()
         {
             if (hpx::threads::get_self_ptr())
+            {
                 hpx::threads::set_thread_description(
                     hpx::threads::get_self_id(), desc_);
+            }
         }
 
         hpx::util::thread_description desc_;

--- a/hpx/util/bind.hpp
+++ b/hpx/util/bind.hpp
@@ -336,6 +336,19 @@ namespace hpx { namespace util
 #endif
             }
 
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+            char const* get_function_annotation_itt() const
+            {
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+                return traits::get_function_annotation_itt<
+                        typename std::decay<F>::type
+                    >::call(_f);
+#else
+                return nullptr;
+#endif
+            }
+#endif
+
         private:
             typename std::decay<F>::type _f;
             util::tuple<typename util::decay_unwrap<Ts>::type...> _args;
@@ -438,6 +451,17 @@ namespace hpx { namespace util
 #endif
             }
 
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+            char const* get_function_annotation_itt() const
+            {
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+                return traits::get_function_annotation_itt<F>::call(_f);
+#else
+                return nullptr;
+#endif
+            }
+#endif
+
         public: // exposition-only
             F _f;
 #           if !defined(HPX_DISABLE_ASSERTS)
@@ -474,6 +498,7 @@ namespace hpx { namespace traits
     {};
 
     ///////////////////////////////////////////////////////////////////////////
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
     template <typename Sig>
     struct get_function_address<util::detail::bound<Sig> >
     {
@@ -494,7 +519,6 @@ namespace hpx { namespace traits
         }
     };
 
-#if defined(HPX_HAVE_THREAD_DESCRIPTION)
     ///////////////////////////////////////////////////////////////////////////
     template <typename Sig>
     struct get_function_annotation<util::detail::bound<Sig> >
@@ -515,6 +539,28 @@ namespace hpx { namespace traits
             return f.get_function_annotation();
         }
     };
+
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+    template <typename Sig>
+    struct get_function_annotation_itt<util::detail::bound<Sig> >
+    {
+        static char const*
+            call(util::detail::bound<Sig> const& f) noexcept
+        {
+            return f.get_function_annotation_itt();
+        }
+    };
+
+    template <typename F>
+    struct get_function_annotation_itt<util::detail::one_shot_wrapper<F> >
+    {
+        static char const*
+            call(util::detail::one_shot_wrapper<F> const& f) noexcept
+        {
+            return f.get_function_annotation_itt();
+        }
+    };
+#endif
 #endif
 }}
 

--- a/hpx/util/deferred_call.hpp
+++ b/hpx/util/deferred_call.hpp
@@ -128,6 +128,19 @@ namespace hpx { namespace util
 #endif
             }
 
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+            char const* get_function_annotation_itt() const
+            {
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+                return traits::get_function_annotation_itt<
+                        typename util::decay_unwrap<F>::type
+                    >::call(_f);
+#else
+                return nullptr;
+#endif
+            }
+#endif
+
         private:
             typename util::decay_unwrap<F>::type _f;
             util::tuple<typename util::decay_unwrap<Ts>::type...> _args;
@@ -159,6 +172,7 @@ namespace hpx { namespace util
     }
 }}
 
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace traits
 {
@@ -173,7 +187,6 @@ namespace hpx { namespace traits
         }
     };
 
-#if defined(HPX_HAVE_THREAD_DESCRIPTION)
     ///////////////////////////////////////////////////////////////////////////
     template <typename Sig>
     struct get_function_annotation<util::detail::deferred<Sig> >
@@ -184,8 +197,20 @@ namespace hpx { namespace traits
             return f.get_function_annotation();
         }
     };
+
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+    template <typename Sig>
+    struct get_function_annotation_itt<util::detail::deferred<Sig> >
+    {
+        static char const*
+            call(util::detail::deferred<Sig> const& f) noexcept
+        {
+            return f.get_function_annotation_itt();
+        }
+    };
 #endif
 }}
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace serialization

--- a/hpx/util/detail/basic_function.hpp
+++ b/hpx/util/detail/basic_function.hpp
@@ -197,12 +197,29 @@ namespace hpx { namespace util { namespace detail
 
         std::size_t get_function_address() const
         {
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
             return vptr->get_function_address(object);
+#else
+            return nullptr;
+#endif
         }
 
         char const* get_function_annotation() const
         {
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
             return vptr->get_function_annotation(object);
+#else
+            return nullptr;
+#endif
+        }
+
+        char const* get_function_annotation_itt() const
+        {
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+            return vptr->get_function_annotation_itt(object);
+#else
+            return nullptr;
+#endif
         }
 
     private:

--- a/hpx/util/detail/vtable/callable_vtable.hpp
+++ b/hpx/util/detail/vtable/callable_vtable.hpp
@@ -21,6 +21,7 @@ namespace hpx { namespace util { namespace detail
 {
     struct callable_vtable_base
     {
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
         template <typename T>
         HPX_FORCEINLINE static std::size_t _get_function_address(void** f)
         {
@@ -31,20 +32,32 @@ namespace hpx { namespace util { namespace detail
         template <typename T>
         HPX_FORCEINLINE static char const* _get_function_annotation(void** f)
         {
-#if defined(HPX_HAVE_THREAD_DESCRIPTION)
             return traits::get_function_annotation<T>::call(vtable::get<T>(f));
-#else
-            return nullptr;
-#endif
         }
         char const* (*get_function_annotation)(void**);
 
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+        template <typename T>
+        HPX_FORCEINLINE static char const* _get_function_annotation_itt(void** f)
+        {
+            return traits::get_function_annotation_itt<T>::call(vtable::get<T>(f));
+        }
+        char const* (*get_function_annotation_itt)(void**);
+#endif
+#endif
+
         template <typename T>
         HPX_CONSTEXPR callable_vtable_base(construct_vtable<T>) noexcept
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
           : get_function_address(
                 &callable_vtable_base::template _get_function_address<T>)
           , get_function_annotation(
                 &callable_vtable_base::template _get_function_annotation<T>)
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+          , get_function_annotation_itt(
+                &callable_vtable_base::template _get_function_annotation_itt<T>)
+#endif
+#endif
         {}
     };
 

--- a/hpx/util/function.hpp
+++ b/hpx/util/function.hpp
@@ -136,6 +136,7 @@ namespace hpx { namespace util
     }
 }}
 
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace traits
 {
@@ -149,7 +150,6 @@ namespace hpx { namespace traits
         }
     };
 
-#if defined(HPX_HAVE_THREAD_DESCRIPTION)
     template <typename Sig, bool Serializable>
     struct get_function_annotation<util::function<Sig, Serializable> >
     {
@@ -159,8 +159,20 @@ namespace hpx { namespace traits
             return f.get_function_annotation();
         }
     };
+
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+    template <typename Sig, bool Serializable>
+    struct get_function_annotation_itt<util::function<Sig, Serializable> >
+    {
+        static char const*
+            call(util::function<Sig, Serializable> const& f) noexcept
+        {
+            return f.get_function_annotation_itt();
+        }
+    };
 #endif
 }}
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 #define HPX_UTIL_REGISTER_FUNCTION_DECLARATION(Sig, F, Name)                  \

--- a/hpx/util/unique_function.hpp
+++ b/hpx/util/unique_function.hpp
@@ -98,6 +98,7 @@ namespace hpx { namespace util
     }
 }}
 
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace traits
 {
@@ -111,7 +112,6 @@ namespace hpx { namespace traits
         }
     };
 
-#if defined(HPX_HAVE_THREAD_DESCRIPTION)
     template <typename Sig, bool Serializable>
     struct get_function_annotation<util::unique_function<Sig, Serializable> >
     {
@@ -121,8 +121,20 @@ namespace hpx { namespace traits
             return f.get_function_annotation();
         }
     };
+
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+    template <typename Sig, bool Serializable>
+    struct get_function_annotation_itt<util::unique_function<Sig, Serializable> >
+    {
+        static char const*
+            call(util::unique_function<Sig, Serializable> const& f) noexcept
+        {
+            return f.get_function_annotation_itt();
+        }
+    };
 #endif
 }}
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 #define HPX_UTIL_REGISTER_UNIQUE_FUNCTION_DECLARATION(Sig, F, Name)           \

--- a/src/util/thread_description.cpp
+++ b/src/util/thread_description.cpp
@@ -55,7 +55,20 @@ namespace hpx { namespace util
         if (altname == nullptr)
         {
             hpx::threads::thread_id_type id = hpx::threads::get_self_id();
-            if (id) *this = hpx::threads::get_thread_description(id);
+            if (id)
+            {
+                thread_description desc = hpx::threads::get_thread_description(id);
+                type_ = desc.kind();
+                if (type_ == data_type_description)
+                {
+                    data_.desc_ = desc.get_description();
+                }
+                else
+                {
+                    HPX_ASSERT(type_ == data_type_address);
+                    data_.addr_ = desc.get_address();
+                }
+            }
         }
 #endif
     }


### PR DESCRIPTION
This also includes some fixes to `util::annotate_function` to support a wider source of possible function names.