### PR TITLE
Remove some other warnings and errors detected by clang 5.0

### DIFF
--- a/hpx/parallel/algorithms/transform.hpp
+++ b/hpx/parallel/algorithms/transform.hpp
@@ -129,10 +129,8 @@ namespace hpx { namespace parallel { inline namespace v1
             operator()(Iter part_begin, std::size_t part_size,
                 std::size_t /*part_index*/)
             {
-#if !defined(__NVCC__) && !defined(__CUDACC__)
                 hpx::util::annotate_function annotate(f_);
                 (void)annotate;     // suppress warning about unused variable
-#endif
                 return execute(part_begin, part_size);
             }
         };

--- a/hpx/parallel/algorithms/transform.hpp
+++ b/hpx/parallel/algorithms/transform.hpp
@@ -129,8 +129,10 @@ namespace hpx { namespace parallel { inline namespace v1
             operator()(Iter part_begin, std::size_t part_size,
                 std::size_t /*part_index*/)
             {
+#if !defined(__NVCC__) && !defined(__CUDACC__)
                 hpx::util::annotate_function annotate(f_);
                 (void)annotate;     // suppress warning about unused variable
+#endif
                 return execute(part_begin, part_size);
             }
         };

--- a/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
@@ -421,8 +421,10 @@ namespace hpx { namespace threads { namespace coroutines
             std::ptrdiff_t m_stack_size;
             void* m_stack;
 
+#if defined(HPX_HAVE_THREAD_STACKOVERFLOW_DETECTION)
             struct sigaction action;
             stack_t segv_stack;
+#endif
         };
 
         typedef x86_linux_context_impl context_impl;

--- a/hpx/util/annotated_function.hpp
+++ b/hpx/util/annotated_function.hpp
@@ -35,7 +35,13 @@ namespace hpx { namespace util
 {
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
     ///////////////////////////////////////////////////////////////////////////
-#if HPX_HAVE_ITTNOTIFY != 0
+#if (!defined(__NVCC__) && !defined(__CUDACC__))
+    struct annotate_function
+    {
+        template <typename F>
+        explicit HPX_HOST_DEVICE annotate_function(F && f){}
+    };
+#elif HPX_HAVE_ITTNOTIFY != 0
     struct annotate_function
     {
         HPX_NON_COPYABLE(annotate_function);
@@ -170,7 +176,8 @@ namespace hpx { namespace util
         HPX_NON_COPYABLE(annotate_function);
 
         explicit annotate_function(char const* name) {}
-        template <typename F> explicit annotate_function(F && f) {}
+        template <typename F>
+        explicit HPX_HOST_DEVICE annotate_function(F && f) {}
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/tests/unit/computeapi/cuda/default_executor.cu
+++ b/tests/unit/computeapi/cuda/default_executor.cu
@@ -65,7 +65,7 @@ void test_bulk_sync()
     hpx::compute::cuda::target target;
     executor exec(target);
 //    traits::bulk_execute(exec, hpx::util::bind(&bulk_test, _1), v);
-    hpx::parallel::execution::sync_bulk_execute(exec, bulk_test(), v);
+    hpx::parallel::execution::bulk_sync_execute(exec, bulk_test(), v);
 }
 
 void test_bulk_async()
@@ -84,7 +84,7 @@ void test_bulk_async()
 //        exec, hpx::util::bind(&bulk_test, _1), v)
 //    ).get();
     hpx::when_all(
-        hpx::parallel::execution::async_bulk_execute(exec, bulk_test(), v)
+        hpx::parallel::execution::bulk_async_execute(exec, bulk_test(), v)
     ).get();
 }
 


### PR DESCRIPTION
This patch tries to remove some other warnings and errors detected by clang 5.0 (Cuda Clang being enabled)