### PR TITLE
Add sync_images() method to spmd_block class

### DIFF
--- a/hpx/lcos/local/spmd_block.hpp
+++ b/hpx/lcos/local/spmd_block.hpp
@@ -10,13 +10,19 @@
 #include <hpx/lcos/local/barrier.hpp>
 #include <hpx/parallel/execution_policy.hpp>
 #include <hpx/traits/is_execution_policy.hpp>
+#include <hpx/traits/is_iterator.hpp>
+#include <hpx/util/detail/pack.hpp>
 #include <hpx/util/first_argument.hpp>
 
 #include <boost/range/irange.hpp>
 
 #include <cstddef>
 #include <functional>
+#include <map>
 #include <memory>
+#include <mutex>
+#include <set>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -33,9 +39,17 @@ namespace hpx { namespace lcos { namespace local
     /// first parameter.
     struct spmd_block
     {
+    private:
+        using barrier_type = hpx::lcos::local::barrier;
+        using table_type =
+            std::map<std::set<std::size_t>,std::shared_ptr<barrier_type>>;
+        using mutex_type = hpx::lcos::local::mutex;
+
+    public:
         explicit spmd_block(std::size_t num_images, std::size_t image_id,
-            hpx::lcos::local::barrier & barrier)
-        : num_images_(num_images), image_id_(image_id), barrier_(barrier)
+            barrier_type & barrier,table_type & barriers, mutex_type & mtx)
+        : num_images_(num_images), image_id_(image_id), barrier_(barrier),
+            barriers_(barriers), mtx_(mtx)
         {}
 
         // Note: spmd_block class is movable/move-assignable
@@ -62,10 +76,65 @@ namespace hpx { namespace lcos { namespace local
            barrier_.get().wait();
         }
 
+        void sync_images(std::set<std::size_t> const & images) const
+        {
+            using lock_type = std::lock_guard<mutex_type>;
+
+            table_type & brs = barriers_.get();
+            typename table_type::iterator it;
+
+            // Critical section
+            {
+                lock_type lk(mtx_);
+                it = brs.find(images);
+
+                if(it == brs.end())
+                {
+                    it = brs.insert({images,
+                        std::make_shared<barrier_type>(images.size())}).first;
+                }
+            }
+
+            if( images.find(image_id_) != images.end() )
+            {
+                it->second->wait();
+            }
+        }
+
+        void sync_images(std::vector<std::size_t> const & input_images) const
+        {
+            std::set<std::size_t> images(
+                input_images.begin(),input_images.end());
+            sync_images(images);
+        }
+
+        template<typename Iterator>
+        typename std::enable_if<
+            traits::is_input_iterator<Iterator>::value
+        >::type
+        sync_images(Iterator begin, Iterator end) const
+        {
+            std::set<std::size_t> images(begin,end);
+            sync_images(images);
+        }
+
+        template<typename ... I>
+        typename std::enable_if<
+            util::detail::all_of<
+                typename std::is_integral<I>::type ... >::value
+        >::type
+        sync_images(I ... i) const
+        {
+            std::set<std::size_t> images = {(std::size_t)i...};
+            sync_images(images);
+        }
+
     private:
         std::size_t num_images_;
         std::size_t image_id_;
-        mutable std::reference_wrapper<hpx::lcos::local::barrier> barrier_;
+        mutable std::reference_wrapper<barrier_type> barrier_;
+        mutable std::reference_wrapper<table_type> barriers_;
+        mutable std::reference_wrapper<mutex_type> mtx_;
     };
 
     namespace detail
@@ -73,14 +142,24 @@ namespace hpx { namespace lcos { namespace local
         template <typename F>
         struct spmd_block_helper
         {
-            mutable std::shared_ptr<hpx::lcos::local::barrier> barrier_;
+        private:
+            using barrier_type = hpx::lcos::local::barrier;
+            using table_type =
+                std::map<std::set<std::size_t>,std::shared_ptr<barrier_type>>;
+            using mutex_type = hpx::lcos::local::mutex;
+
+        public:
+            std::shared_ptr<barrier_type> barrier_;
+            std::shared_ptr<table_type> barriers_;
+            std::shared_ptr<mutex_type> mtx_;
             typename std::decay<F>::type f_;
             std::size_t num_images_;
 
             template <typename ... Ts>
             void operator()(std::size_t image_id, Ts && ... ts) const
             {
-                spmd_block block(num_images_, image_id, *barrier_);
+                spmd_block block(num_images_, image_id, *barrier_,
+                    *barriers_, *mtx_);
                 hpx::util::invoke(
                     f_, std::move(block), std::forward<Ts>(ts)...);
             }
@@ -101,19 +180,26 @@ namespace hpx { namespace lcos { namespace local
             "parallel::execution::is_execution_policy<ExPolicy>::value");
 
         using ftype = typename std::decay<F>::type;
-
         using first_type =
             typename hpx::util::first_argument<ftype>::type;
-
         using executor_type =
             typename hpx::util::decay<ExPolicy>::type::executor_type;
+
+        using barrier_type = hpx::lcos::local::barrier;
+        using table_type =
+            std::map<std::set<std::size_t>,std::shared_ptr<barrier_type>>;
+        using mutex_type = hpx::lcos::local::mutex;
 
         static_assert(std::is_same<spmd_block, first_type>::value,
             "define_spmd_block() needs a function or lambda that " \
             "has at least a local spmd_block as 1st argument");
 
-        std::shared_ptr<hpx::lcos::local::barrier> barrier
-            = std::make_shared<hpx::lcos::local::barrier>(num_images);
+        std::shared_ptr<barrier_type> barrier
+            = std::make_shared<barrier_type>(num_images);
+        std::shared_ptr<table_type> barriers
+            = std::make_shared<table_type>();
+        std::shared_ptr<mutex_type> mtx
+            = std::make_shared<mutex_type>();
 
         return
             hpx::parallel::executor_traits<
@@ -121,7 +207,7 @@ namespace hpx { namespace lcos { namespace local
                 >::bulk_async_execute(
                     policy.executor(),
                     detail::spmd_block_helper<F>{
-                        barrier, std::forward<F>(f), num_images
+                        barrier,barriers,mtx,std::forward<F>(f),num_images
                     },
                     boost::irange(std::size_t(0), num_images),
                         std::forward<Args>(args)...);
@@ -141,26 +227,33 @@ namespace hpx { namespace lcos { namespace local
             "parallel::execution::is_execution_policy<ExPolicy>::value");
 
         using ftype = typename std::decay<F>::type;
-
         using first_type =
             typename hpx::util::first_argument<ftype>::type;
-
         using executor_type =
             typename hpx::util::decay<ExPolicy>::type::executor_type;
+
+        using barrier_type = hpx::lcos::local::barrier;
+        using table_type =
+            std::map<std::set<std::size_t>,std::shared_ptr<barrier_type>>;
+        using mutex_type = hpx::lcos::local::mutex;
 
         static_assert(std::is_same<spmd_block, first_type>::value,
             "define_spmd_block() needs a lambda that " \
             "has at least a spmd_block as 1st argument");
 
-        std::shared_ptr<hpx::lcos::local::barrier> barrier
-            = std::make_shared<hpx::lcos::local::barrier>(num_images);
+        std::shared_ptr<barrier_type> barrier
+            = std::make_shared<barrier_type>(num_images);
+        std::shared_ptr<table_type> barriers
+            = std::make_shared<table_type>();
+        std::shared_ptr<mutex_type> mtx
+            = std::make_shared<mutex_type>();
 
         hpx::parallel::executor_traits<
                 typename std::decay<executor_type>::type
             >::bulk_execute(
                 policy.executor(),
                 detail::spmd_block_helper<F>{
-                    barrier, std::forward<F>(f), num_images
+                    barrier,barriers,mtx,std::forward<F>(f),num_images
                 },
                 boost::irange(std::size_t(0), num_images),
                     std::forward<Args>(args)...);

--- a/hpx/lcos/local/spmd_block.hpp
+++ b/hpx/lcos/local/spmd_block.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/lcos/future.hpp>
 #include <hpx/lcos/local/barrier.hpp>
+#include <hpx/lcos/local/mutex.hpp>
 #include <hpx/parallel/execution_policy.hpp>
 #include <hpx/traits/is_execution_policy.hpp>
 #include <hpx/traits/is_iterator.hpp>

--- a/hpx/lcos/spmd_block.hpp
+++ b/hpx/lcos/spmd_block.hpp
@@ -16,14 +16,18 @@
 #include <hpx/runtime/serialization/serialize.hpp>
 #include <hpx/traits/concepts.hpp>
 #include <hpx/traits/is_action.hpp>
+#include <hpx/traits/is_iterator.hpp>
+#include <hpx/util/detail/pack.hpp>
 #include <hpx/util/first_argument.hpp>
 
 #include <boost/range/irange.hpp>
 
 #include <cstddef>
 #include <functional>
+#include <map>
 #include <memory>
 #include <string>
+#include <set>
 #include <type_traits>
 #include <utility>
 
@@ -38,6 +42,11 @@ namespace hpx { namespace lcos
     /// define_spmd_block function is to accept a spmd_block as first parameter.
     struct spmd_block
     {
+    private:
+        using barrier_type = hpx::lcos::barrier;
+        using table_type =
+            std::map<std::set<std::size_t>,std::shared_ptr<barrier_type>>;
+    public:
         spmd_block(){}
 
         explicit spmd_block(std::string name, std::size_t images_per_locality,
@@ -76,6 +85,136 @@ namespace hpx { namespace lcos
            return barrier_->wait(hpx::launch::async);
         }
 
+        // Synchronous versions of sync_images()
+
+        void sync_images(std::set<std::size_t> const & images) const
+        {
+            using list_type = std::set<std::size_t>;
+
+            typename table_type::iterator table_it(barriers_.find(images));
+            typename list_type::iterator image_it(images.find(image_id_));
+
+            // Is current image in the input list?
+            if(image_it != images.end())
+            {
+                // Does the barrier for the input list non-exist?
+                if(table_it == barriers_.end())
+                {
+                    std::size_t rank = std::distance(images.begin(),image_it);
+                    std::string suffix;
+
+                    for(std::size_t s : images)
+                        suffix += ("_" + std::to_string(s));
+
+                    table_it = barriers_.insert({images,
+                        std::make_shared<barrier_type>(
+                            name_ + "_barrier" + suffix,
+                            images.size(),
+                            rank)}).first;
+                }
+
+                table_it->second->wait();
+            }
+        }
+
+        void sync_images(std::vector<std::size_t> const & input_images) const
+        {
+            std::set<std::size_t> images(
+                input_images.begin(),input_images.end());
+            sync_images(images);
+        }
+
+        template<typename Iterator>
+        typename std::enable_if<
+            traits::is_input_iterator<Iterator>::value
+        >::type
+        sync_images(Iterator begin, Iterator end) const
+        {
+            std::set<std::size_t> images(begin,end);
+            sync_images(images);
+        }
+
+        template<typename ... I>
+        typename std::enable_if<
+            util::detail::all_of<
+                typename std::is_integral<I>::type ... >::value
+        >::type
+        sync_images(I... i)
+        {
+            std::set<std::size_t> images = {(std::size_t)i...};
+            sync_images(images);
+        }
+
+        // Asynchronous versions of sync_images()
+
+        hpx::future<void>
+        sync_images(hpx::launch::async_policy const & policy,
+            std::set<std::size_t> const & images) const
+        {
+            using list_type = std::set<std::size_t>;
+
+            typename table_type::iterator table_it(barriers_.find(images));
+            typename list_type::iterator image_it(images.find(image_id_));
+
+            // Is current image in the input list?
+            if(image_it != images.end())
+            {
+                // Does the barrier for the input list exist?
+                if(table_it == barriers_.end())
+                {
+                    std::size_t rank = std::distance(images.begin(),image_it);
+                    std::string suffix;
+
+                    for(std::size_t s : images)
+                        suffix += ("_" + std::to_string(s));
+
+                    table_it = barriers_.insert({images,
+                        std::make_shared<barrier_type>(
+                            name_ + "_barrier" + suffix,
+                            images.size(),
+                            rank)}).first;
+                }
+
+                return table_it->second->wait(hpx::launch::async);
+            }
+
+            return hpx::make_ready_future();
+        }
+
+        hpx::future<void>
+        sync_images(hpx::launch::async_policy const & policy,
+            std::vector<std::size_t> const & input_images) const
+        {
+            std::set<std::size_t> images(
+                input_images.begin(),input_images.end());
+            return sync_images(policy,images);
+        }
+
+        template<typename Iterator>
+        typename std::enable_if<
+            traits::is_input_iterator<Iterator>::value,
+            hpx::future<void>
+        >::type
+        sync_images(hpx::launch::async_policy const & policy,
+            Iterator begin, Iterator end) const
+        {
+            std::set<std::size_t> images(begin,end);
+            return sync_images(images);
+        }
+
+        template<typename ... I>
+        typename std::enable_if<
+            util::detail::all_of<
+                typename std::is_integral<I>::type ... >::value,
+            hpx::future<void>
+        >::type
+        sync_images(hpx::launch::async_policy const & policy,
+            I ... i) const
+        {
+            std::set<std::size_t> images = {(std::size_t)i...};
+            return sync_images(policy,images);
+        }
+
     private:
         std::string name_;
         std::size_t images_per_locality_;
@@ -86,6 +225,7 @@ namespace hpx { namespace lcos
         // default constructor does not exist (Needed by
         // spmd_block::spmd_block())
         mutable std::shared_ptr<hpx::lcos::barrier> barrier_;
+        mutable table_type barriers_;
 
     private:
         friend class hpx::serialization::access;

--- a/hpx/lcos/spmd_block.hpp
+++ b/hpx/lcos/spmd_block.hpp
@@ -31,6 +31,7 @@
 #include <set>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 namespace hpx { namespace lcos
 {

--- a/hpx/lcos/spmd_block.hpp
+++ b/hpx/lcos/spmd_block.hpp
@@ -19,6 +19,7 @@
 #include <hpx/traits/is_iterator.hpp>
 #include <hpx/util/detail/pack.hpp>
 #include <hpx/util/first_argument.hpp>
+#include <hpx/util/jenkins_hash.hpp>
 
 #include <boost/range/irange.hpp>
 
@@ -108,7 +109,7 @@ namespace hpx { namespace lcos
 
                     table_it = barriers_.insert({images,
                         std::make_shared<barrier_type>(
-                            name_ + "_barrier" + suffix,
+                            name_ + "_barrier_" + std::to_string(hash_(suffix)),
                             images.size(),
                             rank)}).first;
                 }
@@ -159,7 +160,7 @@ namespace hpx { namespace lcos
             // Is current image in the input list?
             if(image_it != images.end())
             {
-                // Does the barrier for the input list exist?
+                // Does the barrier for the input list non-exist?
                 if(table_it == barriers_.end())
                 {
                     std::size_t rank = std::distance(images.begin(),image_it);
@@ -170,7 +171,7 @@ namespace hpx { namespace lcos
 
                     table_it = barriers_.insert({images,
                         std::make_shared<barrier_type>(
-                            name_ + "_barrier" + suffix,
+                            name_ + "_barrier_" + std::to_string(hash_(suffix)),
                             images.size(),
                             rank)}).first;
                 }
@@ -199,7 +200,7 @@ namespace hpx { namespace lcos
             Iterator begin, Iterator end) const
         {
             std::set<std::size_t> images(begin,end);
-            return sync_images(images);
+            return sync_images(policy,images);
         }
 
         template<typename ... I>
@@ -220,6 +221,7 @@ namespace hpx { namespace lcos
         std::size_t images_per_locality_;
         std::size_t num_images_;
         std::size_t image_id_;
+        hpx::util::jenkins_hash hash_;
 
         // Note : barrier is stored as a pointer because hpx::lcos::barrier
         // default constructor does not exist (Needed by

--- a/tests/unit/lcos/global_spmd_block.cpp
+++ b/tests/unit/lcos/global_spmd_block.cpp
@@ -13,6 +13,7 @@
 #include <array>
 #include <cstddef>
 #include <utility>
+#include <vector>
 
 std::size_t images_per_locality = 7;
 std::size_t iterations = 20;

--- a/tests/unit/lcos/global_spmd_block.cpp
+++ b/tests/unit/lcos/global_spmd_block.cpp
@@ -10,13 +10,14 @@
 
 #include <boost/atomic.hpp>
 
+#include <array>
 #include <cstddef>
 #include <utility>
 
-std::size_t images_per_locality = 4;
+std::size_t images_per_locality = 7;
 std::size_t iterations = 20;
 std::size_t test_value = 4;
-boost::atomic<std::size_t> c(0);
+std::array<boost::atomic<std::size_t>,4> c;
 
 void bulk_test_function(hpx::lcos::spmd_block block, std::size_t arg)
 {
@@ -32,10 +33,58 @@ void bulk_test_function(hpx::lcos::spmd_block block, std::size_t arg)
         i<iterations;
         i++, test_count+=images_per_locality)
     {
-        ++c;
+        ++c[0];
         block.sync_all();
-        HPX_TEST_EQ(c, test_count);
+        HPX_TEST_EQ(c[0], test_count);
         block.sync_all();
+    }
+
+    // Test sync_images() with individual values
+    std::size_t image_id = block.this_image();
+    std::size_t o =
+        (block.this_image() / images_per_locality) * images_per_locality;
+
+    if((image_id == o+0) || (image_id == o+1))
+    {
+        ++c[1];
+    }
+    block.sync_images(o+0,o+1);
+    if((image_id == o+0) || (image_id == o+1))
+    {
+        HPX_TEST_EQ(c[1],(std::size_t)2);
+    }
+
+    if((image_id == o+2) || (image_id == o+3))
+    {
+        ++c[2];
+    }
+    block.sync_images(o+2,o+3);
+    if((image_id == o+2) || (image_id == o+3))
+    {
+        HPX_TEST_EQ(c[2],(std::size_t)2);
+    }
+
+    // Test sync_images() with vector of values
+    std::vector<std::size_t> vec_images = {o+4,o+5,o+6};
+
+    if((image_id == o+4) || (image_id == o+5) || (image_id == o+6))
+    {
+        ++c[3];
+    }
+    block.sync_images(vec_images);
+    if((image_id == o+4) || (image_id == o+5) || (image_id == o+6))
+    {
+        HPX_TEST_EQ(c[3],(std::size_t)3);
+    }
+    block.sync_images(vec_images);
+    if((image_id == o+4) || (image_id == o+5) || (image_id == o+6))
+    {
+        ++c[3];
+    }
+    block.sync_images(vec_images.begin(),vec_images.end());
+    if((image_id == o+4) || (image_id == o+5) || (image_id == o+6))
+    {
+        HPX_TEST_EQ(c[3],(std::size_t)6);
     }
 }
 HPX_PLAIN_ACTION(bulk_test_function, bulk_test_action);
@@ -44,8 +93,13 @@ HPX_PLAIN_ACTION(bulk_test_function, bulk_test_action);
 int main()
 {
     std::size_t arg = test_value * 10;
-
     bulk_test_action act;
+
+    //Initialize our atomics
+    for(std::size_t i =0; i<4; i++)
+    {
+        c[i] = (std::size_t)0;
+    }
 
     hpx::future<void> join =
         hpx::lcos::define_spmd_block(

--- a/tests/unit/parallel/spmd_block.cpp
+++ b/tests/unit/parallel/spmd_block.cpp
@@ -11,31 +11,77 @@
 
 #include <boost/atomic.hpp>
 
+#include <array>
 #include <cstddef>
 #include <functional>
+#include <set>
 #include <utility>
 #include <vector>
 
 std::size_t num_images = 10;
 std::size_t iterations = 20;
 
-
 void bulk_test_function(hpx::parallel::v2::spmd_block block,
-        boost::atomic<std::size_t> * cptr)
+        boost::atomic<std::size_t> * c)
 {
-    boost::atomic<std::size_t> & c = *cptr;
-
     HPX_TEST_EQ(block.get_num_images(), num_images);
     HPX_TEST_EQ(block.this_image() < num_images, true);
 
+    // Test sync_all()
     for(std::size_t i=0, test_count = num_images;
         i<iterations;
         i++, test_count+=num_images)
     {
-        ++c;
+        ++c[0];
         block.sync_all();
-        HPX_TEST_EQ(c, test_count);
+        HPX_TEST_EQ(c[0], test_count);
         block.sync_all();
+    }
+
+    // Test sync_images() with individual values
+    std::size_t image_id = block.this_image();
+
+    if((image_id == 0) || (image_id == 1))
+    {
+        ++c[1];
+    }
+    block.sync_images(0,1);
+    if((image_id == 0) || (image_id == 1))
+    {
+        HPX_TEST_EQ(c[1],(std::size_t)2);
+    }
+
+    if((image_id == 2) || (image_id == 3) || (image_id == 4))
+    {
+        ++c[2];
+    }
+    block.sync_images(2,3,4);
+    if((image_id == 2) || (image_id == 3) || (image_id == 4))
+    {
+        HPX_TEST_EQ(c[2],(std::size_t)3);
+    }
+
+    // Test sync_images() with vector of values
+    std::vector<std::size_t> vec_images = {5,6,7,8};
+
+    if((image_id == 5) || (image_id == 6) || (image_id == 7) || (image_id == 8))
+    {
+        ++c[3];
+    }
+    block.sync_images(vec_images);
+    if((image_id == 5) || (image_id == 6) || (image_id == 7) || (image_id == 8))
+    {
+        HPX_TEST_EQ(c[3],(std::size_t)4);
+    }
+    block.sync_images(vec_images);
+    if((image_id == 5) || (image_id == 6) || (image_id == 7) || (image_id == 8))
+    {
+        ++c[3];
+    }
+    block.sync_images(vec_images.begin(),vec_images.end());
+    if((image_id == 5) || (image_id == 6) || (image_id == 7) || (image_id == 8))
+    {
+        HPX_TEST_EQ(c[3],(std::size_t)8);
     }
 }
 
@@ -44,73 +90,31 @@ int main()
     using hpx::parallel::execution::par;
     using hpx::parallel::execution::task;
 
-    // FIXME : the atomic variable is passed by pointer in place of by
-    // reference because of some issue related to std::ref when using certain
-    // stdlib versions
-/*
     auto bulk_test =
-        [](hpx::parallel::v2::spmd_block block, boost::atomic<std::size_t> & c)
+        [](hpx::parallel::v2::spmd_block block, boost::atomic<std::size_t> * c)
         {
-            HPX_TEST_EQ(block.get_num_images(), num_images);
-            HPX_TEST_EQ(block.this_image() < num_images, true);
-
-            for(std::size_t i=0, test_count = num_images;
-                i<iterations;
-                i++, test_count+=num_images)
-            {
-                ++c;
-                block.sync_all();
-                HPX_TEST_EQ(c, test_count);
-                block.sync_all();
-            }
+            bulk_test_function(std::move(block),c);
         };
 
-    boost::atomic<std::size_t> c1(0), c2(0);
+    std::array<boost::atomic<std::size_t>,4> c1, c2, c3;
+
+    for(std::size_t i =0; i<4; i++)
+    {
+        c1[i] = c2[i] = c3[i] = (std::size_t)0;
+    }
 
     hpx::parallel::v2::define_spmd_block(
-        num_images, std::move(bulk_test), std::ref(c1));
+        num_images, std::move(bulk_test), c1.data() );
 
     std::vector<hpx::future<void>> join =
         hpx::parallel::v2::define_spmd_block(
             par(task),
-                num_images, std::move(bulk_test), std::ref(c2));
-
-    hpx::wait_all(join);
-*/
-
-    auto bulk_test =
-        [](hpx::parallel::v2::spmd_block block, boost::atomic<std::size_t> * cptr)
-        {
-            boost::atomic<std::size_t> & c = *cptr;
-
-            HPX_TEST_EQ(block.get_num_images(), num_images);
-            HPX_TEST_EQ(block.this_image() < num_images, true);
-
-            for(std::size_t i=0, test_count = num_images;
-                i<iterations;
-                i++, test_count+=num_images)
-            {
-                ++c;
-                block.sync_all();
-                HPX_TEST_EQ(c, test_count);
-                block.sync_all();
-            }
-        };
-
-    boost::atomic<std::size_t> c1(0), c2(0), c3(0);
-
-    hpx::parallel::v2::define_spmd_block(
-        num_images, std::move(bulk_test), &c1);
-
-    std::vector<hpx::future<void>> join =
-        hpx::parallel::v2::define_spmd_block(
-            par(task),
-                num_images, std::move(bulk_test), &c2);
+                num_images, std::move(bulk_test), c2.data() );
 
     hpx::wait_all(join);
 
     hpx::parallel::v2::define_spmd_block(
-        num_images, bulk_test_function, &c3);
+        num_images, bulk_test_function, c3.data() );
 
     return 0;
 }


### PR DESCRIPTION
This patch adds a new method for `spmd_block` class called `sync_images()` to synchronize only a subset of images as opposed to `sync_all()`. The chosen approach is to manage concurrentlly a `map` of barriers that is expanded each time a new combination of _image ids_ is given via a `sync_images()` call. Local and distributed versions have been implemented and unit tests have been changed to test those features.
