### PR TITLE
Adding empty (but non-trivial) destructor to circumvent warnings

### DIFF
--- a/hpx/lcos/dataflow.hpp
+++ b/hpx/lcos/dataflow.hpp
@@ -234,7 +234,6 @@ namespace hpx { namespace lcos { namespace detail
         HPX_FORCEINLINE void done()
         {
             hpx::util::annotate_function annotate(func_);
-            (void)annotate;     // suppress warning about unused variable
             execute(indices_type(), is_void());
         }
 

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -502,7 +502,6 @@ namespace detail
         {
             try {
                 hpx::util::annotate_function annotate(on_completed);
-                (void)annotate;     // suppress warning about unused variable
                 on_completed();
             }
             catch (...) {

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -112,7 +112,6 @@ namespace hpx { namespace lcos { namespace detail
         > is_void;
 
         hpx::util::annotate_function annotate(func);
-        (void)annotate;     // suppress warning about unused variable
         invoke_continuation(func, future, cont, is_void());
     }
 

--- a/hpx/lcos/local/packaged_task.hpp
+++ b/hpx/lcos/local/packaged_task.hpp
@@ -95,7 +95,6 @@ namespace hpx { namespace lcos { namespace local
             }
 
             hpx::util::annotate_function annotate(function_);
-            (void)annotate;     // suppress warning about unused variable
             invoke_impl(std::is_void<R>(), std::forward<Ts>(vs)...);
         }
 

--- a/hpx/parallel/algorithms/for_each.hpp
+++ b/hpx/parallel/algorithms/for_each.hpp
@@ -128,10 +128,7 @@ namespace hpx { namespace parallel { inline namespace v1
             void operator()(Iter part_begin, std::size_t part_size,
                 std::size_t /*part_index*/)
             {
-#if !defined(__NVCC__) && !defined(__CUDACC__)
                 hpx::util::annotate_function annotate(f_);
-                (void)annotate;     // suppress warning about unused variable
-#endif
                 execute(part_begin, part_size);
             }
         };

--- a/hpx/parallel/algorithms/for_loop.hpp
+++ b/hpx/parallel/algorithms/for_loop.hpp
@@ -146,10 +146,7 @@ namespace hpx { namespace parallel { inline namespace v2
             void operator()(B part_begin, std::size_t part_steps,
                 std::size_t part_index)
             {
-#if !defined(__NVCC__) && !defined(__CUDACC__)
                 hpx::util::annotate_function annotate(f_);
-                (void)annotate;     // suppress warning about unused variable
-#endif
                 execute(part_begin, part_steps, part_index);
             }
         };

--- a/hpx/parallel/algorithms/transform.hpp
+++ b/hpx/parallel/algorithms/transform.hpp
@@ -130,7 +130,6 @@ namespace hpx { namespace parallel { inline namespace v1
                 std::size_t /*part_index*/)
             {
                 hpx::util::annotate_function annotate(f_);
-                (void)annotate;     // suppress warning about unused variable
                 return execute(part_begin, part_size);
             }
         };

--- a/hpx/util/annotated_function.hpp
+++ b/hpx/util/annotated_function.hpp
@@ -38,8 +38,14 @@ namespace hpx { namespace util
 #if (!defined(__NVCC__) && !defined(__CUDACC__))
     struct annotate_function
     {
+        HPX_NON_COPYABLE(annotate_function);
+
+        explicit annotate_function(char const* name) {}
         template <typename F>
-        explicit HPX_HOST_DEVICE annotate_function(F && f){}
+        explicit HPX_HOST_DEVICE annotate_function(F && f) {}
+
+        // add empty (but non-trivial) destructor to silence warnings
+        ~annotate_function() {}
     };
 #elif HPX_HAVE_ITTNOTIFY != 0
     struct annotate_function
@@ -178,6 +184,9 @@ namespace hpx { namespace util
         explicit annotate_function(char const* name) {}
         template <typename F>
         explicit HPX_HOST_DEVICE annotate_function(F && f) {}
+
+        // add empty (but non-trivial) destructor to silence warnings
+        ~annotate_function() {}
     };
 
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- cleaning up use of annotate_function