### PR TITLE
Check for and optionally use [[deprecated]] attribute

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -561,6 +561,13 @@ macro(hpx_check_for_cxx14_variable_templates)
 endmacro()
 
 ###############################################################################
+macro(hpx_check_for_cxx14_deprecated_attribute)
+  add_hpx_config_test(HPX_WITH_CXX14_DEPRECATED_ATTRIBUTE
+    SOURCE cmake/tests/cxx14_deprecated_attribute.cpp
+    FILE ${ARGN})
+endmacro()
+
+###############################################################################
 macro(hpx_check_for_libfun_std_experimental_optional)
   add_hpx_config_test(HPX_WITH_LIBFUN_EXPERIMENTAL_OPTIONAL
     SOURCE cmake/tests/libfun_std_experimental_optional.cpp

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -160,6 +160,9 @@ macro(hpx_perform_cxx_feature_tests)
     hpx_check_for_cxx14_variable_templates(
       DEFINITIONS HPX_HAVE_CXX14_VARIABLE_TEMPLATES)
 
+    hpx_check_for_cxx14_deprecated_attribute(
+      DEFINITIONS HPX_HAVE_CXX14_DEPRECATED_ATTRIBUTE)
+
     # check for experimental facilities
 
     # check for Library Fundamentals TS v2's experimental/optional

--- a/cmake/tests/cxx14_deprecated_attribute.cpp
+++ b/cmake/tests/cxx14_deprecated_attribute.cpp
@@ -1,0 +1,19 @@
+////////////////////////////////////////////////////////////////////////////////
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+////////////////////////////////////////////////////////////////////////////////
+
+#if !defined(__has_cpp_attribute)
+#  error "__has_cpp_attribute not supported, assume [[deprecated]] is not supported"
+#else
+#  if !__has_cpp_attribute(deprecated)
+#    error "__has_cpp_attribute(deprecated) not supported"
+#  endif
+#endif
+
+int main()
+{
+    return 0;
+}

--- a/hpx/config.hpp
+++ b/hpx/config.hpp
@@ -539,25 +539,4 @@
 #define HPX_AGAS_LOCALITY_NS_MSB                     0x0000000100000001ULL
 #define HPX_AGAS_LOCALITY_NS_LSB                     0x0000000000000004ULL
 
-#if defined(HPX_HAVE_SODIUM)
-#  define HPX_ROOT_CERTIFICATE_AUTHORITY_MSB         0x0000000100000001ULL
-#  define HPX_ROOT_CERTIFICATE_AUTHORITY_LSB         0x0000000000000005ULL
-#  define HPX_SUBORDINATE_CERTIFICATE_AUTHORITY_MSB  0x0000000000000001ULL
-// this is made locality specific
-#  define HPX_SUBORDINATE_CERTIFICATE_AUTHORITY_LSB  0x0000000000000006ULL
-#endif
-
-#if !defined(HPX_NO_DEPRECATED)
-#  define HPX_DEPRECATED_MSG \
-   "This function is deprecated and will be removed in the future."
-#  if defined(HPX_MSVC)
-#    define HPX_DEPRECATED(x) __declspec(deprecated(x))
-#  elif defined(__GNUC__)
-#    define HPX_DEPRECATED(x) __attribute__((__deprecated__(x)))
-#  endif
-#  if !defined(HPX_DEPRECATED)
-#    define HPX_DEPRECATED(x)  /**/
-#  endif
-#endif
-
 #endif

--- a/hpx/config/attributes.hpp
+++ b/hpx/config/attributes.hpp
@@ -8,10 +8,27 @@
 
 #include <hpx/config/defines.hpp>
 
+// handle [[fallthrough]]
 #if defined(HPX_HAVE_CXX17_FALLTHROUGH_ATTRIBUTE)
 #   define HPX_FALLTHROUGH [[fallthrough]]
 #else
 #   define HPX_FALLTHROUGH
+#endif
+
+// handle [[deprecated]]
+#if !defined(HPX_NO_DEPRECATED)
+#  define HPX_DEPRECATED_MSG \
+   "This function is deprecated and will be removed in the future."
+#  if defined(HPX_HAVE_CXX14_DEPRECATED_ATTRIBUTE)
+#    define HPX_DEPRECATED(x) [[deprecated(x)]]
+#  elif defined(HPX_MSVC)
+#    define HPX_DEPRECATED(x) __declspec(deprecated(x))
+#  elif defined(__GNUC__)
+#    define HPX_DEPRECATED(x) __attribute__((__deprecated__(x)))
+#  endif
+#  if !defined(HPX_DEPRECATED)
+#    define HPX_DEPRECATED(x)  /**/
+#  endif
 #endif
 
 #endif

--- a/hpx/lcos/dataflow.hpp
+++ b/hpx/lcos/dataflow.hpp
@@ -310,7 +310,7 @@ namespace hpx { namespace lcos { namespace detail
 #if defined(HPX_HAVE_EXECUTOR_COMPATIBILITY)
         // handle executors through their executor_traits
         template <typename Executor>
-        HPX_FORCEINLINE
+        HPX_DEPRECATED(HPX_DEPRECATED_MSG) HPX_FORCEINLINE
         typename std::enable_if<
             traits::is_executor<Executor>::value
         >::type

--- a/hpx/lcos/detail/promise_base.hpp
+++ b/hpx/lcos/detail/promise_base.hpp
@@ -256,6 +256,7 @@ namespace lcos {
             }
 
 #if defined(HPX_HAVE_COMPONENT_GET_GID_COMPATIBILITY)
+            HPX_DEPRECATED(HPX_DEPRECATED_MSG)
             naming::id_type get_gid(error_code& ec = throws) const
             {
                 return get_id(ec);

--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -623,6 +623,7 @@ namespace hpx { namespace lcos { namespace detail
 
 #if defined(HPX_HAVE_EXECUTOR_COMPATIBILITY)
         template <typename Executor, typename F>
+        HPX_DEPRECATED(HPX_DEPRECATED_MSG)
         typename util::lazy_enable_if<
             hpx::traits::is_executor<Executor>::value
           , hpx::traits::future_then_result<Derived, F>
@@ -988,6 +989,7 @@ namespace hpx { namespace lcos
 
 #if defined(HPX_HAVE_EXECUTOR_COMPATIBILITY)
         template <typename Executor, typename F>
+        HPX_DEPRECATED(HPX_DEPRECATED_MSG)
         typename util::lazy_enable_if<
             hpx::traits::is_executor<Executor>::value
           , hpx::traits::future_then_result<future, F>

--- a/hpx/lcos/local/dataflow.hpp
+++ b/hpx/lcos/local/dataflow.hpp
@@ -216,7 +216,7 @@ namespace hpx
     namespace lcos { namespace local
     {
         template <typename F, typename ...Ts>
-        HPX_FORCEINLINE
+        HPX_DEPRECATED(HPX_DEPRECATED_MSG) HPX_FORCEINLINE
         auto dataflow(F && f, Ts &&... ts)
         ->  decltype(lcos::detail::dataflow_dispatch<
                 typename std::decay<F>::type>::call(

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -360,6 +360,7 @@ namespace hpx { namespace lcos { namespace detail
 
 #if defined(HPX_HAVE_EXECUTOR_COMPATIBILITY)
         template <typename Executor>
+        HPX_DEPRECATED(HPX_DEPRECATED_MSG)
         void async_exec_v1(
             typename traits::detail::shared_state_ptr_for<
                 Future
@@ -439,6 +440,7 @@ namespace hpx { namespace lcos { namespace detail
 
 #if defined(HPX_HAVE_EXECUTOR_COMPATIBILITY)
         template <typename Executor>
+        HPX_DEPRECATED(HPX_DEPRECATED_MSG)
         void async_exec_v1(
             typename traits::detail::shared_state_ptr_for<
                 Future
@@ -563,6 +565,7 @@ namespace hpx { namespace lcos { namespace detail
 
 #if defined(HPX_HAVE_EXECUTOR_COMPATIBILITY)
         template <typename Executor>
+        HPX_DEPRECATED(HPX_DEPRECATED_MSG)
         void attach_exec_v1(Future const& future, Executor& exec)
         {
             typedef
@@ -665,6 +668,7 @@ namespace hpx { namespace lcos { namespace detail
 #if defined(HPX_HAVE_EXECUTOR_COMPATIBILITY)
     template <typename ContResult, typename Future, typename Executor,
         typename F>
+    HPX_DEPRECATED(HPX_DEPRECATED_MSG)
     inline typename traits::detail::shared_state_ptr<
         typename continuation_result<ContResult>::type
     >::type

--- a/hpx/lcos/queue.hpp
+++ b/hpx/lcos/queue.hpp
@@ -111,21 +111,25 @@ namespace hpx { namespace lcos
         }
 
 #if defined(HPX_HAVE_ASYNC_FUNCTION_COMPATIBILITY)
+        HPX_DEPRECATED(HPX_DEPRECATED_MSG)
         ValueType get_value_sync()
         {
             return get_value(launch::sync);
         }
 
+        HPX_DEPRECATED(HPX_DEPRECATED_MSG)
         void set_value_sync(RemoteType const& val)
         {
             set_value(launch::sync, val);
         }
 
+        HPX_DEPRECATED(HPX_DEPRECATED_MSG)
         void set_value_sync(RemoteType && val) //-V659
         {
             set_value(launch::sync, std::move(val));
         }
 
+        HPX_DEPRECATED(HPX_DEPRECATED_MSG)
         void abort_pending_sync()
         {
             abort_pending(launch::sync);

--- a/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -328,6 +328,7 @@ namespace hpx { namespace parallel { inline namespace v1
                 typename std::iterator_traits<FwdIter1>::value_type,
                 typename std::iterator_traits<FwdIter1>::value_type
             >::value)>
+    HPX_DEPRECATED(HPX_DEPRECATED_MSG)
     typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
     inclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest,
         T init, Op && op)
@@ -426,6 +427,7 @@ namespace hpx { namespace parallel { inline namespace v1
                 typename std::iterator_traits<FwdIter1>::value_type,
                 typename std::iterator_traits<FwdIter1>::value_type
             >::value)>
+    HPX_DEPRECATED(HPX_DEPRECATED_MSG)
     typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
     inclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest,
         T init)

--- a/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -342,6 +342,7 @@ namespace hpx { namespace parallel { inline namespace v1
                     typename std::iterator_traits<FwdIter1>::value_type
                 >::type
             >::value)>
+    HPX_DEPRECATED(HPX_DEPRECATED_MSG)
     typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
     transform_exclusive_scan(ExPolicy && policy, FwdIter1 first, FwdIter1 last,
         FwdIter2 dest, Conv && conv, T init, Op && op)

--- a/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -345,6 +345,7 @@ namespace hpx { namespace parallel { inline namespace v1
                     typename std::iterator_traits<FwdIter1>::value_type
                 >::type
             >::value)>
+    HPX_DEPRECATED(HPX_DEPRECATED_MSG)
     typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
     transform_inclusive_scan(ExPolicy && policy, FwdIter1 first, FwdIter1 last,
         FwdIter2 dest, T init, Op && op, Conv && conv)
@@ -605,6 +606,7 @@ namespace hpx { namespace parallel { inline namespace v1
                     typename std::iterator_traits<FwdIter1>::value_type
                 >::type
             >::value)>
+    HPX_DEPRECATED(HPX_DEPRECATED_MSG)
     typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
     transform_inclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
         FwdIter2 dest, Conv && conv, Op && op)

--- a/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/hpx/parallel/algorithms/transform_reduce.hpp
@@ -295,6 +295,7 @@ namespace hpx { namespace parallel { inline namespace v1
                     typename std::iterator_traits<FwdIter>::value_type
                 >::type
             >::value)>
+    HPX_DEPRECATED(HPX_DEPRECATED_MSG)
     typename util::detail::algorithm_result<ExPolicy, T>::type
     transform_reduce(ExPolicy && policy, FwdIter first, FwdIter last,
         T init, Convert && conv_op, Reduce && red_op)

--- a/hpx/runtime/actions/continuation.hpp
+++ b/hpx/runtime/actions/continuation.hpp
@@ -66,6 +66,7 @@ namespace hpx { namespace actions
         void serialize(hpx::serialization::output_archive& ar, unsigned);
 
 #if defined(HPX_HAVE_COMPONENT_GET_GID_COMPATIBILITY)
+        HPX_DEPRECATED(HPX_DEPRECATED_MSG)
         naming::id_type const& get_gid() const
         {
             return gid_;

--- a/hpx/runtime/components/client_base.hpp
+++ b/hpx/runtime/components/client_base.hpp
@@ -370,6 +370,7 @@ namespace hpx { namespace components
 
         ///////////////////////////////////////////////////////////////////////
 #if defined(HPX_HAVE_COMPONENT_GET_GID_COMPATIBILITY)
+        HPX_DEPRECATED(HPX_DEPRECATED_MSG)
         id_type const& get_gid() const
         {
             return get_id();

--- a/hpx/runtime/components/runtime_support.hpp
+++ b/hpx/runtime/components/runtime_support.hpp
@@ -164,6 +164,7 @@ namespace hpx { namespace components
 
         ///////////////////////////////////////////////////////////////////////
 #if defined(HPX_HAVE_COMPONENT_GET_GID_COMPATIBILITY)
+        HPX_DEPRECATED(HPX_DEPRECATED_MSG)
         naming::id_type const& get_gid() const
         {
             return gid_;

--- a/hpx/runtime/components/server/fixed_component_base.hpp
+++ b/hpx/runtime/components/server/fixed_component_base.hpp
@@ -153,6 +153,7 @@ public:
     }
 
 #if defined(HPX_HAVE_COMPONENT_GET_GID_COMPATIBILITY)
+    HPX_DEPRECATED(HPX_DEPRECATED_MSG)
     naming::id_type get_gid() const
     {
         return get_unmanaged_id();

--- a/hpx/runtime/components/server/managed_component_base.hpp
+++ b/hpx/runtime/components/server/managed_component_base.hpp
@@ -237,6 +237,7 @@ namespace hpx { namespace components
         naming::id_type get_id() const;
 
 #if defined(HPX_HAVE_COMPONENT_GET_GID_COMPATIBILITY)
+        HPX_DEPRECATED(HPX_DEPRECATED_MSG)
         naming::id_type get_gid() const
         {
             return get_unmanaged_id();
@@ -604,6 +605,7 @@ namespace hpx { namespace components
         }
 
 #if defined(HPX_HAVE_COMPONENT_GET_GID_COMPATIBILITY)
+        HPX_DEPRECATED(HPX_DEPRECATED_MSG)
         naming::id_type get_gid() const
         {
             return get_unmanaged_id();

--- a/hpx/runtime/components/server/memory_block.hpp
+++ b/hpx/runtime/components/server/memory_block.hpp
@@ -133,6 +133,7 @@ namespace hpx { namespace components { namespace server { namespace detail
         naming::id_type get_unmanaged_id() const;
 
 #if defined(HPX_HAVE_COMPONENT_GET_GID_COMPATIBILITY)
+        HPX_DEPRECATED(HPX_DEPRECATED_MSG)
         naming::id_type get_gid() const //-V659
         {
             return get_unmanaged_id();
@@ -662,6 +663,7 @@ namespace hpx { namespace components { namespace server
         }
 
 #if defined(HPX_HAVE_COMPONENT_GET_GID_COMPATIBILITY)
+        HPX_DEPRECATED(HPX_DEPRECATED_MSG)
         naming::id_type get_gid() const
         {
             return get_checked()->get_gid();

--- a/hpx/runtime/components/server/simple_component_base.hpp
+++ b/hpx/runtime/components/server/simple_component_base.hpp
@@ -227,6 +227,7 @@ namespace hpx { namespace components
         }
 
 #if defined(HPX_HAVE_COMPONENT_GET_GID_COMPATIBILITY)
+        HPX_DEPRECATED(HPX_DEPRECATED_MSG)
         naming::id_type get_gid() const
         {
             return get_id();


### PR DESCRIPTION
- flyby: adding missing deprecated attributions to some older functions
- flyby: remove leftovers still referring to Sodium