### PR TITLE
bump minimum required cmake to 3.0 in test

### DIFF
--- a/tests/unit/build/src/CMakeLists.txt
+++ b/tests/unit/build/src/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 project(test CXX)
 

--- a/tests/unit/build/src/CMakeLists.txt
+++ b/tests/unit/build/src/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.3.2)
 
 project(test CXX)
 


### PR DESCRIPTION
On MacOS with cmake 3.9.0 on the current master the test

`tests/unit/build/CMakeFiles/cmake_build_dir_test.make_configure`

fails to compile with the error
```
  ERROR: Compilers do not match.  In order to compile HPX application it is
  recommended to use the same compiler as you did for HPX.
  HPX_CXX_COMPILER=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++,
  CMAKE_CXX_COMPILER=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++.
  HPX_CXX_COMPILER_ID=AppleClang, CMAKE_CXX_COMPILER_ID=Clang.  To disable
  this message set HPX_IGNORE_COMPILER_COMPATIBILITY to On.
Call Stack (most recent call first):
  /Users/Joseph/Documents/umich/research/libraries/hpx/build/lib/cmake/HPX/HPXMacros.cmake:26 (hpx_error)
  /Users/Joseph/Documents/umich/research/libraries/hpx/build/lib/cmake/HPX/HPXConfig.cmake:64 (hpx_check_compiler_compatibility)
  CMakeLists.txt:12 (find_package)
```

This is because `cmake_minimum_required(VERSION 2.8)` sets the cmake policies so that the compiler id is set to `Clang` instead of `AppleClang`. This behavior was changed in cmake version 3.0. See https://cmake.org/cmake/help/v3.0/policy/CMP0025.html

This commit bumps the required cmake version in the test to 3.0 to fix this error.