### PR TITLE
Fix FreeBSD 11

### DIFF
--- a/hpx/hpx_init_impl.hpp
+++ b/hpx/hpx_init_impl.hpp
@@ -24,6 +24,11 @@
 #include <utility>
 #include <vector>
 
+#if defined(__FreeBSD__)
+extern HPX_EXPORT char** freebsd_environ;
+extern char** environ;
+#endif
+
 namespace hpx
 {
     /// \cond NOINTERNAL
@@ -63,6 +68,9 @@ namespace hpx
         detail::init_winsocket();
 #endif
         util::set_hpx_prefix(HPX_PREFIX);
+#if defined(__FreeBSD__)
+        freebsd_environ = environ;
+#endif
         return detail::run_or_start(f, desc_cmdline, argc, argv,
             hpx_startup::user_main_config(cfg),
             std::move(startup), std::move(shutdown), mode, true);

--- a/hpx/hpx_start_impl.hpp
+++ b/hpx/hpx_start_impl.hpp
@@ -23,6 +23,11 @@
 #include <utility>
 #include <vector>
 
+#if defined(__FreeBSD__)
+extern HPX_EXPORT char** freebsd_environ;
+extern char** environ;
+#endif
+
 namespace hpx
 {
     /// \cond NOINTERNAL
@@ -64,6 +69,9 @@ namespace hpx
         detail::init_winsocket();
 #endif
         util::set_hpx_prefix(HPX_PREFIX);
+#if defined(__FreeBSD__)
+        freebsd_environ = environ;
+#endif
         return 0 == detail::run_or_start(f, desc_cmdline, argc, argv,
             hpx_startup::user_main_config(cfg),
             std::move(startup), std::move(shutdown), mode, false);

--- a/hpx/runtime/threads/coroutines/detail/posix_utility.hpp
+++ b/hpx/runtime/threads/coroutines/detail/posix_utility.hpp
@@ -87,6 +87,8 @@ namespace posix
             PROT_EXEC | PROT_READ | PROT_WRITE,
 #if defined(__APPLE__)
             MAP_PRIVATE | MAP_ANON | MAP_NORESERVE,
+#elif defined(__FreeBSD__)
+            MAP_PRIVATE | MAP_ANON,
 #else
             MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE,
 #endif

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -47,6 +47,8 @@
 #ifdef __APPLE__
 #include <crt_externs.h>
 #define environ (*_NSGetEnviron())
+#elif defined(__FreeBSD__)
+HPX_EXPORT char** freebsd_environ = nullptr;
 #elif !defined(HPX_WINDOWS)
 extern char **environ;
 #endif
@@ -188,11 +190,15 @@ namespace hpx { namespace detail
         std::size_t len = get_arraylen(_environ);
         env.reserve(len);
         std::copy(&_environ[0], &_environ[len], std::back_inserter(env));
-#elif defined(linux) || defined(__linux) || defined(__linux__) \
-                     || defined(__FreeBSD__) || defined(__AIX__)
+#elif defined(linux) || defined(__linux) || defined(__linux__) || defined(__AIX__)
         std::size_t len = get_arraylen(environ);
         env.reserve(len);
         std::copy(&environ[0], &environ[len], std::back_inserter(env));
+#elif defined(__FreeBSD__)
+        std::size_t len = get_arraylen(freebsd_environ);
+        env.reserve(len);
+        std::copy(&freebsd_environ[0], &freebsd_environ[len],
+            std::back_inserter(env));
 #elif defined(__APPLE__)
         std::size_t len = get_arraylen(environ);
         env.reserve(len);

--- a/tests/unit/component/launch_process.cpp
+++ b/tests/unit/component/launch_process.cpp
@@ -35,7 +35,7 @@ std::vector<std::string> get_environment()
     int len = get_arraylen(_environ);
     std::copy(&_environ[0], &_environ[len], std::back_inserter(env));
 #elif defined(linux) || defined(__linux) || defined(__linux__) || \
-      defined(__AIX__) || defined(__APPLE__)
+      defined(__AIX__) || defined(__APPLE__) || defined(__FreeBSD__)
     int len = get_arraylen(environ);
     std::copy(&environ[0], &environ[len], std::back_inserter(env));
 #else


### PR DESCRIPTION
This pull request introduces a workaround for an unavailable `environ` in shared libraries by initializing a `freebsd_environ` in HPX startup for use in the runtime system.
We also remove `MAP_NORESERVE` from `mmap` code for FreeBSD, as the parameter previously was unimplemented and now is completely removed from FreeBSD 11.0.