### PR TITLE
Disable throttling scheduler if HWLOC is not found/used

### DIFF
--- a/hpx/parallel/executors/thread_pool_executors.hpp
+++ b/hpx/parallel/executors/thread_pool_executors.hpp
@@ -65,7 +65,7 @@ namespace hpx { namespace parallel { namespace execution
         threads::executors::static_priority_queue_executor;
 #endif
 
-#if defined(HPX_HAVE_THROTTLING_SCHEDULER)
+#if defined(HPX_HAVE_THROTTLING_SCHEDULER) && defined(HPX_HAVE_HWLOC)
     /// Creates a new throttling_executor
     ///
     /// \param max_punits   [in] The maximum number of processing units to
@@ -97,7 +97,7 @@ namespace hpx { namespace parallel { inline namespace v3
         threads::executors::static_queue_executor;
 #endif
 
-#if defined(HPX_HAVE_THROTTLING_SCHEDULER)
+#if defined(HPX_HAVE_THROTTLING_SCHEDULER) && defined(HPX_HAVE_HWLOC)
     using throttling_executor =
         threads::executors::throttling_executor;
 #endif

--- a/hpx/runtime/threads/executors/thread_pool_executors.hpp
+++ b/hpx/runtime/threads/executors/thread_pool_executors.hpp
@@ -187,8 +187,7 @@ namespace hpx { namespace threads { namespace executors
     };
 #endif
 
-
-#if defined(HPX_HAVE_THROTTLING_SCHEDULER)
+#if defined(HPX_HAVE_THROTTLING_SCHEDULER) && defined(HPX_HAVE_HWLOC)
     struct HPX_EXPORT throttling_executor : public scheduled_executor
     {
         throttling_executor();
@@ -197,9 +196,6 @@ namespace hpx { namespace threads { namespace executors
             std::size_t min_punits = 1);
     };
 #endif
-
-
-
 
 }}}
 

--- a/hpx/runtime/threads/policies/noop_topology.hpp
+++ b/hpx/runtime/threads/policies/noop_topology.hpp
@@ -31,7 +31,7 @@ namespace hpx { namespace threads
 struct noop_topology : topology
 {
 private:
-    static mask_type empty_mask;
+    HPX_EXPORT static mask_type empty_mask;
 
 public:
     std::size_t get_numa_node_number(

--- a/hpx/runtime/threads/policies/schedulers.hpp
+++ b/hpx/runtime/threads/policies/schedulers.hpp
@@ -24,7 +24,7 @@
 #if defined(HPX_HAVE_PERIODIC_PRIORITY_SCHEDULER)
 #include <hpx/runtime/threads/policies/periodic_priority_queue_scheduler.hpp>
 #endif
-#if defined(HPX_HAVE_THROTTLING_SCHEDULER)
+#if defined(HPX_HAVE_THROTTLING_SCHEDULER) && defined(HPX_HAVE_HWLOC)
 #include <hpx/runtime/threads/policies/throttling_scheduler.hpp>
 #endif
 #endif

--- a/hpx/runtime/threads/policies/throttling_scheduler.hpp
+++ b/hpx/runtime/threads/policies/throttling_scheduler.hpp
@@ -11,7 +11,7 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_THROTTLING_SCHEDULER)
+#if defined(HPX_HAVE_THROTTLING_SCHEDULER) && defined(HPX_HAVE_HWLOC)
 #include <hpx/runtime/threads/policies/local_queue_scheduler.hpp>
 #include <hpx/runtime/get_worker_thread_num.hpp>
 #include <hpx/runtime/get_os_thread_count.hpp>

--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -1054,7 +1054,7 @@ namespace hpx
             shutdown_function_type shutdown,
             util::command_line_handling& cfg, bool blocking)
         {
-#if defined(HPX_HAVE_THROTTLING_SCHEDULER)
+#if defined(HPX_HAVE_THROTTLING_SCHEDULER) && defined(HPX_HAVE_HWLOC)
             ensure_high_priority_compatibility(cfg.vm_);
             ensure_hierarchy_arity_compatibility(cfg.vm_);
 

--- a/src/runtime/threads/detail/thread_pool.cpp
+++ b/src/runtime/threads/detail/thread_pool.cpp
@@ -1481,7 +1481,7 @@ template class HPX_EXPORT hpx::threads::detail::thread_pool<
     hpx::threads::policies::periodic_priority_queue_scheduler<> >;
 #endif
 
-#if defined(HPX_HAVE_THROTTLING_SCHEDULER)
+#if defined(HPX_HAVE_THROTTLING_SCHEDULER) && defined(HPX_HAVE_HWLOC)
 #include <hpx/runtime/threads/policies/throttling_scheduler.hpp>
 template class HPX_EXPORT hpx::threads::detail::thread_pool<
     hpx::threads::policies::throttling_scheduler<> >;

--- a/src/runtime/threads/executors/thread_pool_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_executors.cpp
@@ -13,7 +13,7 @@
 #include <hpx/runtime/threads/policies/static_queue_scheduler.hpp>
 #endif
 #include <hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp>
-#if defined(HPX_HAVE_THROTTLING_SCHEDULER)
+#if defined(HPX_HAVE_THROTTLING_SCHEDULER) && defined(HPX_HAVE_HWLOC)
 #include <hpx/runtime/threads/policies/throttling_scheduler.hpp>
 #endif
 #if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
@@ -471,7 +471,6 @@ namespace hpx { namespace threads { namespace executors
     {}
 #endif
 
-
     ///////////////////////////////////////////////////////////////////////////
     local_priority_queue_executor::local_priority_queue_executor()
       : scheduled_executor(new detail::thread_pool_executor<
@@ -502,10 +501,7 @@ namespace hpx { namespace threads { namespace executors
     {}
 #endif
 
-
-
-
-#if defined(HPX_HAVE_THROTTLING_SCHEDULER)
+#if defined(HPX_HAVE_THROTTLING_SCHEDULER) && defined(HPX_HAVE_HWLOC)
     ///////////////////////////////////////////////////////////////////////////
     throttling_executor::throttling_executor()
       : scheduled_executor(new detail::thread_pool_executor<
@@ -520,8 +516,5 @@ namespace hpx { namespace threads { namespace executors
                 max_punits, min_punits))
     {}
 #endif
-
-
-
 
 }}}

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -1448,7 +1448,7 @@ template class HPX_EXPORT hpx::threads::threadmanager_impl<
     hpx::threads::policies::periodic_priority_queue_scheduler<> >;
 #endif
 
-#if defined(HPX_HAVE_THROTTLING_SCHEDULER)
+#if defined(HPX_HAVE_THROTTLING_SCHEDULER) && defined(HPX_HAVE_HWLOC)
 #include <hpx/runtime/threads/policies/throttling_scheduler.hpp>
 template class HPX_EXPORT hpx::threads::threadmanager_impl<
     hpx::threads::policies::throttling_scheduler<> >;

--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -889,7 +889,7 @@ template class HPX_EXPORT hpx::runtime_impl<
     hpx::threads::policies::periodic_priority_queue_scheduler<> >;
 #endif
 
-#if defined(HPX_HAVE_THROTTLING_SCHEDULER)
+#if defined(HPX_HAVE_THROTTLING_SCHEDULER) && defined(HPX_HAVE_HWLOC)
 #include <hpx/runtime/threads/policies/throttling_scheduler.hpp>
 template class HPX_EXPORT hpx::runtime_impl<
     hpx::threads::policies::throttling_scheduler<> >;


### PR DESCRIPTION
- this is necessary as this scheduler directly uses HWLOC.
- this fixes #2807