### PR TITLE
Adding hpx::launch::lazy and support for async, dataflow, and future::then

### DIFF
--- a/hpx/async.hpp
+++ b/hpx/async.hpp
@@ -39,7 +39,7 @@ namespace hpx { namespace detail
         >::value
       , lcos::future<typename util::detail::invoke_deferred_result<F>::type>
     >::type
-    call_sync(F&& f, std::false_type)
+    call_sync(F && f, std::false_type)
     {
         typedef typename util::detail::invoke_deferred_result<F>::type result_type;
         try
@@ -59,7 +59,7 @@ namespace hpx { namespace detail
         >::value
       , lcos::future<typename util::detail::invoke_deferred_result<F>::type>
     >::type
-    call_sync(F&& f, std::false_type) //-V659
+    call_sync(F && f, std::false_type) //-V659
     {
         typedef typename util::detail::invoke_deferred_result<F>::type result_type;
         try
@@ -74,7 +74,7 @@ namespace hpx { namespace detail
     template <typename F>
     HPX_FORCEINLINE
     lcos::future<typename util::detail::invoke_deferred_result<F>::type>
-    call_sync(F&& f, std::true_type)
+    call_sync(F && f, std::true_type)
     {
         try
         {
@@ -125,6 +125,21 @@ namespace hpx { namespace detail
             }
             return p.get_future();
         }
+
+//         template <typename Pred, typename F, typename ...Ts>
+//         HPX_FORCEINLINE static
+//         typename std::enable_if<
+//             traits::detail::is_deferred_invocable<F, Ts...>::value,
+//             hpx::future<
+//                 typename util::detail::invoke_deferred_result<F, Ts...>::type
+//             >
+//         >::type
+//         call(hpx::detail::lazy_policy<Pred> const& policy, F && f,
+//             Ts&&... ts)
+//         {
+//             return call(policy.policy(), std::forward<F>(f),
+//                 std::forward<Ts>(ts)...);
+//         }
 
         template <typename F, typename ...Ts>
         HPX_FORCEINLINE static
@@ -194,7 +209,7 @@ namespace hpx { namespace detail
                 typename util::detail::invoke_deferred_result<F, Ts...>::type
             >
         >::type
-        call(hpx::detail::deferred_policy, F && f, Ts&&... ts)
+        call(hpx::detail::deferred_policy, F && f, Ts &&... ts)
         {
             typedef typename util::detail::invoke_deferred_result<F, Ts...>::type
                 result_type;
@@ -219,7 +234,7 @@ namespace hpx { namespace detail
                 typename util::detail::invoke_deferred_result<F, Ts...>::type
             >
         >::type
-        call(F&& f, Ts&&... ts)
+        call(F && f, Ts &&... ts)
         {
             return async_dispatch<hpx::detail::async_policy>::call(
                 launch::async, std::forward<F>(f), std::forward<Ts>(ts)...);
@@ -241,7 +256,7 @@ namespace hpx { namespace detail
                 typename util::detail::invoke_deferred_result<F, Ts...>::type
             >
         >::type
-        call(Executor_ && sched, F&& f, Ts&&... ts)
+        call(Executor_ && sched, F && f, Ts &&... ts)
         {
             typedef typename util::detail::invoke_deferred_result<F, Ts...>::type
                 result_type;
@@ -270,7 +285,7 @@ namespace hpx { namespace detail
                 typename util::detail::invoke_deferred_result<F, Ts...>::type
             >
         >::type
-        call(Executor& exec, F&& f, Ts&&... ts)
+        call(Executor& exec, F && f, Ts &&... ts)
         {
             return parallel::executor_traits<Executor>::async_execute(
                 exec, std::forward<F>(f), std::forward<Ts>(ts)...);

--- a/hpx/lcos/async.hpp
+++ b/hpx/lcos/async.hpp
@@ -32,14 +32,19 @@ namespace hpx { namespace detail
     template <typename Action>
     struct async_action_client_dispatch
     {
-        template <typename Client, typename Stub, typename ...Ts>
-        HPX_FORCEINLINE lcos::future<
-            typename traits::promise_local_result<
-                typename traits::extract_action<
-                    Action
-                >::remote_result_type
-            >::type>
-        operator()(launch launch_policy,
+        template <typename Policy, typename Client, typename Stub, typename ...Ts>
+        HPX_FORCEINLINE
+        typename std::enable_if<
+            traits::is_launch_policy<Policy>::value,
+            lcos::future<
+                typename traits::promise_local_result<
+                    typename traits::extract_action<
+                        Action
+                    >::remote_result_type
+                >::type
+            >
+        >::type
+        operator()(Policy const& launch_policy,
             components::client_base<Client, Stub> const& c, Ts &&... ts) const
         {
             HPX_ASSERT(c.is_ready());
@@ -57,7 +62,7 @@ namespace hpx { namespace detail
         >::type>
     {
         // id_type
-        template <typename ...Ts>
+        template <typename Policy_, typename ...Ts>
         HPX_FORCEINLINE static
         lcos::future<
             typename traits::promise_local_result<
@@ -65,13 +70,14 @@ namespace hpx { namespace detail
                     Action
                 >::remote_result_type
             >::type>
-        call(Policy launch_policy, naming::id_type const& id, Ts&&... ts)
+        call(Policy_ && launch_policy, naming::id_type const& id, Ts&&... ts)
         {
-            return hpx::detail::async_impl<Action>(launch_policy, id,
+            return hpx::detail::async_impl<Action>(
+                std::forward<Policy_>(launch_policy), id,
                 std::forward<Ts>(ts)...);
         }
 
-        template <typename Client, typename Stub, typename ...Ts>
+        template <typename Policy_, typename Client, typename Stub, typename ...Ts>
         HPX_FORCEINLINE static
         lcos::future<
             typename traits::promise_local_result<
@@ -79,7 +85,7 @@ namespace hpx { namespace detail
                     Action
                 >::remote_result_type
             >::type>
-        call(Policy launch_policy,
+        call(Policy_ && launch_policy,
             components::client_base<Client, Stub> c, Ts&&... ts)
         {
             // make sure the action is compatible with the component type
@@ -95,18 +101,19 @@ namespace hpx { namespace detail
             if (c.is_ready())
             {
                 return hpx::detail::async_impl<Action>(
-                    launch_policy, c.get_id(), std::forward<Ts>(ts)...);
+                    std::forward<Policy_>(launch_policy), c.get_id(),
+                    std::forward<Ts>(ts)...);
             }
 
             // defer invocation otherwise
             return c.then(util::bind(
                 util::one_shot(async_action_client_dispatch<Action>()),
-                launch_policy, c, std::forward<Ts>(ts)...
+                std::forward<Policy_>(launch_policy), c, std::forward<Ts>(ts)...
             ));
         }
 
         // distribution policy
-        template <typename DistPolicy, typename ...Ts>
+        template <typename Policy_, typename DistPolicy, typename ...Ts>
         HPX_FORCEINLINE static
         typename std::enable_if<
             traits::is_distribution_policy<DistPolicy>::value,
@@ -118,10 +125,10 @@ namespace hpx { namespace detail
                 >::type
             >
         >::type
-        call(Policy launch_policy,
-            DistPolicy const& policy, Ts&&... ts)
+        call(Policy_ && launch_policy, DistPolicy const& policy, Ts&&... ts)
         {
-            return policy.template async<Action>(launch_policy,
+            return policy.template async<Action>(
+                std::forward<Policy>(launch_policy),
                 std::forward<Ts>(ts)...);
         }
     };
@@ -208,11 +215,15 @@ namespace hpx { namespace detail
         template <typename Policy, typename ...Ts>
         HPX_FORCEINLINE static
         lcos::future<result_type>
-        call(Policy launch_policy, Action const&, Ts &&... ts)
+        call(Policy && launch_policy, Action const&, Ts &&... ts)
         {
-            static_assert(traits::is_launch_policy<Policy>::value,
+            static_assert(
+                traits::is_launch_policy<
+                    typename std::decay<Policy>::type
+                >::value,
                 "Policy must be a valid launch policy");
-            return async<Action>(launch_policy, std::forward<Ts>(ts)...);
+            return async<Action>(
+                std::forward<Policy>(launch_policy), std::forward<Ts>(ts)...);
         }
     };
 }}
@@ -305,20 +316,22 @@ namespace hpx { namespace detail
             traits::is_launch_policy<Policy>::value
         >::type>
     {
-        template <typename F, typename ...Ts>
+        template <typename Policy_, typename F, typename ...Ts>
         HPX_FORCEINLINE static auto
-        call(Policy launch_policy, F && f, Ts &&... ts)
+        call(Policy_ && launch_policy, F && f, Ts &&... ts)
         ->  decltype(detail::async_launch_policy_dispatch<
                 typename util::decay<F>::type
-            >::call(launch_policy, std::forward<F>(f), std::forward<Ts>(ts)...))
+            >::call(std::forward<Policy_>(launch_policy), std::forward<F>(f),
+                std::forward<Ts>(ts)...))
         {
             return detail::async_launch_policy_dispatch<
                 typename util::decay<F>::type
-            >::call(launch_policy, std::forward<F>(f), std::forward<Ts>(ts)...);
+            >::call(std::forward<Policy_>(launch_policy), std::forward<F>(f),
+                std::forward<Ts>(ts)...);
         }
 
-        template <typename Component, typename Signature, typename Derived,
-            typename Client, typename Stub, typename ...Ts>
+        template <typename Policy_, typename Component, typename Signature,
+            typename Derived, typename Client, typename Stub, typename ...Ts>
         HPX_FORCEINLINE static
         lcos::future<
             typename traits::promise_local_result<
@@ -326,7 +339,7 @@ namespace hpx { namespace detail
                     Derived
                 >::remote_result_type
             >::type>
-        call(Policy launch_policy,
+        call(Policy_ && launch_policy,
             hpx::actions::basic_action<Component, Signature, Derived> const&,
             components::client_base<Client, Stub> const& c, Ts&&... ts)
         {
@@ -338,12 +351,12 @@ namespace hpx { namespace detail
             static_assert(is_valid::value,
                 "The action to invoke is not supported by the target");
 
-            return async<Derived>(launch_policy, c.get_id(),
-                std::forward<Ts>(ts)...);
+            return async<Derived>(std::forward<Policy_>(launch_policy),
+                c.get_id(), std::forward<Ts>(ts)...);
         }
 
-        template <typename Component, typename Signature, typename Derived,
-            typename DistPolicy, typename ...Ts>
+        template <typename Policy_, typename Component, typename Signature,
+            typename Derived, typename DistPolicy, typename ...Ts>
         HPX_FORCEINLINE static
         typename std::enable_if<
             traits::is_distribution_policy<DistPolicy>::value,
@@ -354,11 +367,11 @@ namespace hpx { namespace detail
                     >::remote_result_type
                 >::type>
         >::type
-        call(Policy launch_policy,
+        call(Policy_ && launch_policy,
             hpx::actions::basic_action<Component, Signature, Derived> const&,
             DistPolicy const& policy, Ts&&... ts)
         {
-            return async<Derived>(launch_policy, policy,
+            return async<Derived>(std::forward<Policy_>(launch_policy), policy,
                 std::forward<Ts>(ts)...);
         }
     };

--- a/hpx/lcos/async.hpp
+++ b/hpx/lcos/async.hpp
@@ -128,7 +128,7 @@ namespace hpx { namespace detail
         call(Policy_ && launch_policy, DistPolicy const& policy, Ts&&... ts)
         {
             return policy.template async<Action>(
-                std::forward<Policy>(launch_policy),
+                std::forward<Policy_>(launch_policy),
                 std::forward<Ts>(ts)...);
         }
     };

--- a/hpx/lcos/async_callback.hpp
+++ b/hpx/lcos/async_callback.hpp
@@ -33,7 +33,7 @@ namespace hpx { namespace detail
         >::type>
     {
         // id_type
-        template <typename Callback, typename ...Ts>
+        template <typename Policy_, typename Callback, typename ...Ts>
         HPX_FORCEINLINE static
         lcos::future<
             typename traits::promise_local_result<
@@ -41,15 +41,16 @@ namespace hpx { namespace detail
                     Action
                 >::remote_result_type
             >::type>
-        call(Policy launch_policy,
+        call(Policy_ && launch_policy,
             naming::id_type const& id, Callback&& cb, Ts&&... ts)
         {
-            return hpx::detail::async_cb_impl<Action>(launch_policy, id,
+            return hpx::detail::async_cb_impl<Action>(
+                std::forward<Policy_>(launch_policy), id,
                 std::forward<Callback>(cb), std::forward<Ts>(ts)...);
         }
 
-        template <typename Client, typename Stub, typename Callback,
-            typename ...Ts>
+        template <typename Policy_, typename Client, typename Stub,
+            typename Callback, typename ...Ts>
         HPX_FORCEINLINE static
         lcos::future<
             typename traits::promise_local_result<
@@ -57,7 +58,7 @@ namespace hpx { namespace detail
                     Action
                 >::remote_result_type
             >::type>
-        call(Policy launch_policy,
+        call(Policy_ && launch_policy,
             components::client_base<Client, Stub> const& c, Callback&& cb,
             Ts&&... ts)
         {
@@ -69,13 +70,14 @@ namespace hpx { namespace detail
             static_assert(is_valid::value,
                 "The action to invoke is not supported by the target");
 
-            return hpx::detail::async_cb_impl<Action>(launch_policy,
-                c.get_id(), std::forward<Callback>(cb),
-                std::forward<Ts>(ts)...);
+            return hpx::detail::async_cb_impl<Action>(
+                std::forward<Policy_>(launch_policy), c.get_id(),
+                std::forward<Callback>(cb), std::forward<Ts>(ts)...);
         }
 
         // distribution policy
-        template <typename DistPolicy, typename Callback, typename ...Ts>
+        template <typename Policy_, typename DistPolicy, typename Callback,
+            typename ...Ts>
         HPX_FORCEINLINE static
         typename std::enable_if<
             traits::is_distribution_policy<DistPolicy>::value,
@@ -87,10 +89,11 @@ namespace hpx { namespace detail
                 >::type
             >
         >::type
-        call(Policy launch_policy,
+        call(Policy_ && launch_policy,
             DistPolicy const& policy, Callback&& cb, Ts&&... ts)
         {
-            return policy.template async_cb<Action>(launch_policy,
+            return policy.template async_cb<Action>(
+                std::forward<Policy_>(launch_policy),
                 std::forward<Callback>(cb), std::forward<Ts>(ts)...);
         }
     };
@@ -264,8 +267,8 @@ namespace hpx { namespace detail
             traits::is_launch_policy<Policy>::value
         >::type>
     {
-        template <typename Component, typename Signature, typename Derived,
-            typename Callback, typename ...Ts>
+        template <typename Policy_, typename Component, typename Signature,
+            typename Derived, typename Callback, typename ...Ts>
         HPX_FORCEINLINE static
         lcos::future<
             typename traits::promise_local_result<
@@ -273,15 +276,15 @@ namespace hpx { namespace detail
                     Derived
                 >::remote_result_type
             >::type>
-        call(Policy launch_policy,
+        call(Policy_ && launch_policy,
             hpx::actions::basic_action<Component, Signature, Derived> const&,
             naming::id_type const& id, Callback&& cb, Ts&&... ts)
         {
-            return async_cb<Derived>(launch_policy, id,
+            return async_cb<Derived>(std::forward<Policy_>(launch_policy), id,
                 std::forward<Callback>(cb), std::forward<Ts>(ts)...);
         }
 
-        template <
+        template <typename Policy_,
             typename Component, typename Signature, typename Derived,
             typename Client, typename Stub, typename Callback, typename ...Ts>
         HPX_FORCEINLINE static
@@ -291,7 +294,7 @@ namespace hpx { namespace detail
                     Derived
                 >::remote_result_type
             >::type>
-        call(Policy launch_policy,
+        call(Policy_ && launch_policy,
             hpx::actions::basic_action<Component, Signature, Derived> const&,
             components::client_base<Client, Stub> const& c, Callback&& cb,
             Ts&&... ts)
@@ -304,11 +307,12 @@ namespace hpx { namespace detail
             static_assert(is_valid::value,
                 "The action to invoke is not supported by the target");
 
-            return async_cb<Derived>(launch_policy, c.get_id(),
-                std::forward<Callback>(cb), std::forward<Ts>(ts)...);
+            return async_cb<Derived>(std::forward<Policy_>(launch_policy),
+                c.get_id(), std::forward<Callback>(cb),
+                std::forward<Ts>(ts)...);
         }
 
-        template <
+        template <typename Policy_,
             typename Component, typename Signature, typename Derived,
             typename DistPolicy, typename Callback, typename ...Ts>
         HPX_FORCEINLINE static
@@ -318,12 +322,12 @@ namespace hpx { namespace detail
                     Derived
                 >::remote_result_type
             >::type>
-        call(Policy launch_policy,
+        call(Policy_ && launch_policy,
             hpx::actions::basic_action<Component, Signature, Derived> const&,
             DistPolicy const& policy, Callback&& cb, Ts&&... ts)
         {
-            return async_cb<Derived>(launch_policy, policy,
-                std::forward<Callback>(cb), std::forward<Ts>(ts)...);
+            return async_cb<Derived>(std::forward<Policy_>(launch_policy),
+                policy, std::forward<Callback>(cb), std::forward<Ts>(ts)...);
         }
     };
 }}

--- a/hpx/lcos/local/dataflow.hpp
+++ b/hpx/lcos/local/dataflow.hpp
@@ -34,20 +34,23 @@ namespace hpx { namespace lcos { namespace detail
         template <typename Policy, typename F, typename ...Ts>
         HPX_FORCEINLINE static
         typename dataflow_frame<
-            Policy
+            typename std::decay<Policy>::type
           , typename std::decay<F>::type
           , util::tuple<
                 typename traits::acquire_future<Ts>::type...
             >
         >::type
-        call(Policy policy, F && f, Ts &&... ts)
+        call(Policy && policy, F && f, Ts &&... ts)
         {
-            static_assert(traits::is_launch_policy<Policy>::value,
+            static_assert(
+                traits::is_launch_policy<
+                    typename std::decay<Policy>::type
+                >::value,
                 "Policy must be a valid launch policy");
 
             typedef
                 dataflow_frame<
-                    Policy
+                    typename std::decay<Policy>::type
                   , typename std::decay<F>::type
                   , util::tuple<
                         typename traits::acquire_future<Ts>::type...
@@ -57,7 +60,7 @@ namespace hpx { namespace lcos { namespace detail
             typedef typename frame_type::init_no_addref init_no_addref;
 
             boost::intrusive_ptr<frame_type> p(new frame_type(
-                    policy
+                    std::forward<Policy>(policy)
                   , std::forward<F>(f)
                   , util::forward_as_tuple(
                         traits::acquire_future_disp()(
@@ -77,18 +80,22 @@ namespace hpx { namespace lcos { namespace detail
     // launch
     template <typename Policy>
     struct dataflow_dispatch<Policy,
-        typename std::enable_if<traits::is_launch_policy<Policy>::value>::type>
+        typename std::enable_if<
+            traits::is_launch_policy<typename std::decay<Policy>::type>::value
+        >::type>
     {
-        template <typename F, typename ...Ts>
+        template <typename Policy_, typename F, typename ...Ts>
         HPX_FORCEINLINE static auto
-        call(Policy policy, F && f, Ts &&... ts)
+        call(Policy_ && policy, F && f, Ts &&... ts)
         ->  decltype(dataflow_launch_policy_dispatch<
                     typename std::decay<F>::type
-                >::call(policy, std::forward<F>(f), std::forward<Ts>(ts)...))
+                >::call(std::forward<Policy_>(policy), std::forward<F>(f),
+                    std::forward<Ts>(ts)...))
         {
             return dataflow_launch_policy_dispatch<
                     typename std::decay<F>::type
-                >::call(policy, std::forward<F>(f), std::forward<Ts>(ts)...);
+                >::call(std::forward<Policy_>(policy), std::forward<F>(f),
+                    std::forward<Ts>(ts)...);
         }
     };
 
@@ -99,7 +106,7 @@ namespace hpx { namespace lcos { namespace detail
         template <typename F, typename ...Ts>
         HPX_FORCEINLINE static
         typename detail::dataflow_frame<
-            launch
+            hpx::detail::async_policy
           , typename std::decay<F>::type
           , util::tuple<
                 typename traits::acquire_future<Ts>::type...

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -525,7 +525,7 @@ namespace hpx { namespace lcos { namespace detail
 
             ptr->execute_deferred();
             ptr->set_on_completed(util::deferred_call(
-                    [this_](shared_state_ptr && f, Policy && policy)
+                    [this_](shared_state_ptr && f, launch policy)
                     {
                         if (hpx::detail::has_async_policy(policy))
                             this_->async(std::move(f), policy.priority());

--- a/hpx/runtime/launch_policy.hpp
+++ b/hpx/runtime/launch_policy.hpp
@@ -196,15 +196,15 @@ namespace hpx
         };
 
         template <typename Pred>
-        struct lazy_policy : policy_holder<lazy_policy<Pred> >
+        struct select_policy : policy_holder<select_policy<Pred> >
         {
             template <typename F, typename U =
                 typename std::enable_if<!std::is_same<
-                    lazy_policy<Pred>, typename std::decay<F>::type
+                    select_policy<Pred>, typename std::decay<F>::type
                 >::value>::type>
-            explicit lazy_policy(F && f, threads::thread_priority priority =
+            explicit select_policy(F && f, threads::thread_priority priority =
                         threads::thread_priority_default)
-              : policy_holder<lazy_policy<Pred> >(launch_policy::async, priority)
+              : policy_holder<select_policy<Pred> >(launch_policy::async, priority)
               , pred_(std::forward<F>(f))
             {}
 
@@ -222,7 +222,7 @@ namespace hpx
             Pred pred_;
         };
 
-        struct lazy_policy_generator
+        struct select_policy_generator
         {
             HPX_CONSTEXPR async_policy operator()(
                 threads::thread_priority priority) const noexcept
@@ -231,11 +231,11 @@ namespace hpx
             }
 
             template <typename F>
-            lazy_policy<typename std::decay<F>::type> operator()(F && f,
+            select_policy<typename std::decay<F>::type> operator()(F && f,
                 threads::thread_priority priority =
                     threads::thread_priority_default) const
             {
-                return lazy_policy<typename std::decay<F>::type>(
+                return select_policy<typename std::decay<F>::type>(
                     std::forward<F>(f), priority);
             }
         };
@@ -377,7 +377,7 @@ namespace hpx
 
         /// Create a launch policy representing fire and forget execution
         template <typename F>
-        HPX_CONSTEXPR launch(detail::lazy_policy<F> const& p) noexcept
+        HPX_CONSTEXPR launch(detail::select_policy<F> const& p) noexcept
           : detail::policy_holder<>{p.policy()}
         {}
 
@@ -389,7 +389,7 @@ namespace hpx
         using deferred_policy = detail::deferred_policy;
         using apply_policy = detail::apply_policy;
         template <typename F>
-        using lazy_policy = detail::lazy_policy<F>;
+        using select_policy = detail::select_policy<F>;
         /// \endcond
 
         ///////////////////////////////////////////////////////////////////////
@@ -409,9 +409,8 @@ namespace hpx
         /// Predefined launch policy representing fire and forget execution
         HPX_EXPORT static const detail::apply_policy apply;
 
-        /// Predefined launch policy representing conditionally asynchronous
-        /// execution
-        HPX_EXPORT static const detail::lazy_policy_generator lazy;
+        /// Predefined launch policy representing delayed policy selection
+        HPX_EXPORT static const detail::select_policy_generator select;
 
         /// \cond NOINTERNAL
         HPX_EXPORT static const detail::policy_holder<> all;

--- a/hpx/traits/is_launch_policy.hpp
+++ b/hpx/traits/is_launch_policy.hpp
@@ -25,7 +25,7 @@ namespace hpx { namespace traits
     {
         template <typename Policy>
         struct is_launch_policy
-          : std::is_base_of<hpx::detail::policy_holder, Policy>
+          : std::is_base_of<hpx::detail::policy_holder_base, Policy>
         {};
 
         template <typename Policy>

--- a/src/runtime/launch_policy.cpp
+++ b/src/runtime/launch_policy.cpp
@@ -20,8 +20,8 @@ namespace hpx
     const detail::deferred_policy launch::deferred = detail::deferred_policy{};
     const detail::apply_policy launch::apply = detail::apply_policy{};
 
-    const detail::lazy_policy_generator launch::lazy =
-        detail::lazy_policy_generator{};
+    const detail::select_policy_generator launch::select =
+        detail::select_policy_generator{};
 
     const detail::policy_holder<> launch::all =
         detail::policy_holder<>{detail::launch_policy::all};

--- a/src/runtime/launch_policy.cpp
+++ b/src/runtime/launch_policy.cpp
@@ -20,17 +20,21 @@ namespace hpx
     const detail::deferred_policy launch::deferred = detail::deferred_policy{};
     const detail::apply_policy launch::apply = detail::apply_policy{};
 
-    const detail::policy_holder launch::all =
-        detail::policy_holder{detail::launch_policy::all};
-    const detail::policy_holder launch::sync_policies =
-        detail::policy_holder{detail::launch_policy::sync_policies};
-    const detail::policy_holder launch::async_policies =
-        detail::policy_holder{detail::launch_policy::async_policies};
+    const detail::lazy_policy_generator launch::lazy =
+        detail::lazy_policy_generator{};
+
+    const detail::policy_holder<> launch::all =
+        detail::policy_holder<>{detail::launch_policy::all};
+    const detail::policy_holder<> launch::sync_policies =
+        detail::policy_holder<>{detail::launch_policy::sync_policies};
+    const detail::policy_holder<> launch::async_policies =
+        detail::policy_holder<>{detail::launch_policy::async_policies};
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail
     {
-        void policy_holder::load(serialization::input_archive& ar, unsigned)
+        void policy_holder_base::load(
+            serialization::input_archive& ar, unsigned)
         {
             int value = 0;
             ar & value;
@@ -39,7 +43,8 @@ namespace hpx
             priority_ = static_cast<threads::thread_priority>(value);
         }
 
-        void policy_holder::save(serialization::output_archive& ar, unsigned) const
+        void policy_holder_base::save(
+            serialization::output_archive& ar, unsigned) const
         {
             int value = static_cast<int>(policy_);
             ar & value;

--- a/tests/unit/lcos/async_local.cpp
+++ b/tests/unit/lcos/async_local.cpp
@@ -260,7 +260,7 @@ int hpx_main()
         using hpx::util::placeholders::_1;
 
         auto policy1 =
-            hpx::launch::lazy([]()
+            hpx::launch::select([]()
             {
                 return hpx::launch::sync;
             });
@@ -275,7 +275,7 @@ int hpx_main()
 
         boost::atomic<int> count(0);
         auto policy2 =
-            hpx::launch::lazy([&count]() -> hpx::launch
+            hpx::launch::select([&count]() -> hpx::launch
             {
                 if (count++ == 0)
                     return hpx::launch::async;

--- a/tests/unit/lcos/async_local.cpp
+++ b/tests/unit/lcos/async_local.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2017 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +9,8 @@
 #include <hpx/include/apply.hpp>
 #include <hpx/include/async.hpp>
 #include <hpx/util/lightweight_test.hpp>
+
+#include <boost/atomic.hpp>
 
 #include <cstdint>
 
@@ -252,6 +254,41 @@ int hpx_main()
         hpx::future<void> f6 = hpx::async(hpx::launch::sync,
             hpx::util::bind(&do_nothing_member::call, dnm, _1), 42);
         f6.get();
+    }
+
+    {
+        using hpx::util::placeholders::_1;
+
+        auto policy1 =
+            hpx::launch::lazy([]()
+            {
+                return hpx::launch::sync;
+            });
+
+        hpx::future<std::int32_t> f1 =
+            hpx::async(policy1, hpx::util::bind(&increment, 42));
+        HPX_TEST_EQ(f1.get(), 43);
+
+        hpx::future<std::int32_t> f2 =
+            hpx::async(policy1, hpx::util::bind(&increment, _1), 42);
+        HPX_TEST_EQ(f2.get(), 43);
+
+        boost::atomic<int> count(0);
+        auto policy2 =
+            hpx::launch::lazy([&count]() -> hpx::launch
+            {
+                if (count++ == 0)
+                    return hpx::launch::async;
+                return hpx::launch::sync;
+            });
+
+        hpx::future<void> f3 =
+            hpx::async(policy2, hpx::util::bind(&do_nothing, _1), 42);
+        f3.get();
+
+        hpx::future<void> f4 =
+            hpx::async(policy2, hpx::util::bind(&do_nothing, 42));
+        f4.get();
     }
 
     return hpx::finalize();

--- a/tests/unit/lcos/async_remote.cpp
+++ b/tests/unit/lcos/async_remote.cpp
@@ -159,7 +159,7 @@ void test_remote_async(hpx::id_type const& target)
 
     {
         auto policy1 =
-            hpx::launch::lazy([]()
+            hpx::launch::select([]()
             {
                 return hpx::launch::deferred;
             });
@@ -170,7 +170,7 @@ void test_remote_async(hpx::id_type const& target)
 
         boost::atomic<int> count(0);
         auto policy2 =
-            hpx::launch::lazy([&count]() -> hpx::launch
+            hpx::launch::select([&count]() -> hpx::launch
             {
                 if (count++ == 0)
                     return hpx::launch::async;

--- a/tests/unit/lcos/future_then.cpp
+++ b/tests/unit/lcos/future_then.cpp
@@ -161,7 +161,7 @@ void test_complex_then()
 void test_complex_then_launch()
 {
     auto policy =
-        hpx::launch::lazy([]()
+        hpx::launch::select([]()
         {
             return hpx::launch::async;
         });
@@ -184,7 +184,7 @@ void test_complex_then_chain_one_launch()
 {
     boost::atomic<int> count(0);
     auto policy =
-        hpx::launch::lazy(
+        hpx::launch::select(
             [&count]() -> hpx::launch
             {
                 if (count++ == 0)

--- a/tests/unit/lcos/local_dataflow.cpp
+++ b/tests/unit/lcos/local_dataflow.cpp
@@ -321,6 +321,69 @@ void plain_deferred_arguments()
     }
 }
 
+void plain_arguments_lazy()
+{
+    void_f4_count.store(0);
+    int_f4_count.store(0);
+
+    auto policy1 =
+        hpx::launch::lazy([]()
+        {
+            return hpx::launch::sync;
+        });
+
+    {
+        future<void> f1 = dataflow(policy1, &void_f4, 42);
+        future<int> f2 = dataflow(policy1, &int_f4, 42);
+
+        f1.wait();
+        HPX_TEST_EQ(void_f4_count, 1u);
+
+        HPX_TEST_EQ(f2.get(), 84);
+        HPX_TEST_EQ(int_f4_count, 1u);
+    }
+
+    auto policy2 =
+        hpx::launch::lazy([]()
+        {
+            return hpx::launch::async;
+        });
+
+    {
+        future<void> f1 = dataflow(policy2, &void_f4, 42);
+        future<int> f2 = dataflow(policy2, &int_f4, 42);
+
+        f1.wait();
+        HPX_TEST_EQ(void_f4_count, 2u);
+
+        HPX_TEST_EQ(f2.get(), 84);
+        HPX_TEST_EQ(int_f4_count, 2u);
+    }
+
+    void_f5_count.store(0);
+    int_f5_count.store(0);
+
+    boost::atomic<int> count(0);
+    auto policy3 =
+        hpx::launch::lazy([&count]() -> hpx::launch
+        {
+            if (count++ == 0)
+                return hpx::launch::async;
+            return hpx::launch::sync;
+        });
+
+    {
+        future<void> f1 = dataflow(policy3, &void_f5, 42, async(&int_f));
+        future<int> f2 = dataflow(policy3, &int_f5, 42, async(&int_f));
+
+        f1.wait();
+        HPX_TEST_EQ(void_f5_count, 1u);
+
+        HPX_TEST_EQ(f2.get(), 126);
+        HPX_TEST_EQ(int_f5_count, 1u);
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(variables_map&)
 {
@@ -328,6 +391,7 @@ int hpx_main(variables_map&)
     future_function_pointers();
     plain_arguments();
     plain_deferred_arguments();
+    plain_arguments_lazy();
 
     return hpx::finalize();
 }

--- a/tests/unit/lcos/local_dataflow.cpp
+++ b/tests/unit/lcos/local_dataflow.cpp
@@ -327,7 +327,7 @@ void plain_arguments_lazy()
     int_f4_count.store(0);
 
     auto policy1 =
-        hpx::launch::lazy([]()
+        hpx::launch::select([]()
         {
             return hpx::launch::sync;
         });
@@ -344,7 +344,7 @@ void plain_arguments_lazy()
     }
 
     auto policy2 =
-        hpx::launch::lazy([]()
+        hpx::launch::select([]()
         {
             return hpx::launch::async;
         });
@@ -365,7 +365,7 @@ void plain_arguments_lazy()
 
     boost::atomic<int> count(0);
     auto policy3 =
-        hpx::launch::lazy([&count]() -> hpx::launch
+        hpx::launch::select([&count]() -> hpx::launch
         {
             if (count++ == 0)
                 return hpx::launch::async;

--- a/tests/unit/lcos/remote_dataflow.cpp
+++ b/tests/unit/lcos/remote_dataflow.cpp
@@ -85,7 +85,7 @@ void plain_actions(hpx::id_type const& there)
     }
 
     auto policy1 =
-        hpx::launch::lazy([]()
+        hpx::launch::select([]()
         {
             return hpx::launch::sync;
         });
@@ -106,7 +106,7 @@ void plain_actions(hpx::id_type const& there)
 
     boost::atomic<int> count(0);
     auto policy2 =
-        hpx::launch::lazy([&count]() -> hpx::launch
+        hpx::launch::select([&count]() -> hpx::launch
         {
             if (count++ == 0)
                 return hpx::launch::async;


### PR DESCRIPTION
- this new policy allows to dynamically generate the required launch policy
- adding tests
- this fixes #2800

The name of the new facility is still up in the air. Please add suggestions.