### PR TITLE
Properly support [[noreturn]] attribute if available

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -511,6 +511,13 @@ macro(hpx_check_for_cxx11_std_unordered_set)
 endmacro()
 
 ###############################################################################
+macro(hpx_check_for_cxx11_noreturn_attribute)
+  add_hpx_config_test(HPX_WITH_CXX11_NORETURN_ATTRIBUTE
+    SOURCE cmake/tests/cxx11_noreturn_attribute.cpp
+    FILE ${ARGN})
+endmacro()
+
+###############################################################################
 macro(hpx_check_for_cxx14_constexpr)
   add_hpx_config_test(HPX_WITH_CXX14_CONSTEXPR
     SOURCE cmake/tests/cxx14_constexpr.cpp

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -136,6 +136,9 @@ macro(hpx_perform_cxx_feature_tests)
   hpx_check_for_cxx11_std_unordered_set(
     REQUIRED "HPX needs support for C++11 std::unordered_set")
 
+  hpx_check_for_cxx11_noreturn_attribute(
+    DEFINITIONS HPX_HAVE_CXX11_NORETURN_ATTRIBUTE)
+
   if(HPX_WITH_CXX1Y OR HPX_WITH_CXX14 OR HPX_WITH_CXX1Z OR HPX_WITH_CXX17)
     # Check the availability of certain C++14 language features
     hpx_check_for_cxx14_constexpr(

--- a/cmake/tests/cxx11_noreturn_attribute.cpp
+++ b/cmake/tests/cxx11_noreturn_attribute.cpp
@@ -1,0 +1,19 @@
+////////////////////////////////////////////////////////////////////////////////
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+////////////////////////////////////////////////////////////////////////////////
+
+#if !defined(__has_cpp_attribute)
+#  error "__has_cpp_attribute not supported, assume [[noreturn]] is not supported"
+#else
+#  if !__has_cpp_attribute(noreturn)
+#    error "__has_cpp_attribute(noreturn) not supported"
+#  endif
+#endif
+
+int main()
+{
+    return 0;
+}

--- a/hpx/config.hpp
+++ b/hpx/config.hpp
@@ -32,10 +32,6 @@
 #error HPX cannot be compiled with a Boost version earlier than 1.55.0
 #endif
 
-#if BOOST_VERSION < 105600
-#include <boost/exception/detail/attribute_noreturn.hpp>
-#endif
-
 #include <hpx/util/detail/pp/cat.hpp>
 #include <hpx/util/detail/pp/stringize.hpp>
 
@@ -480,31 +476,6 @@
 #else
 #define HPX_CONTINUATION_MAX_RECURSION_DEPTH 20
 #endif
-#endif
-
-///////////////////////////////////////////////////////////////////////////////
-#if defined(HPX_MSVC)
-#   define HPX_NOINLINE __declspec(noinline)
-#elif defined(__GNUC__)
-#   if defined(__NVCC__) || defined(__CUDACC__)
-        // nvcc doesn't always parse __noinline
-#       define HPX_NOINLINE __attribute__ ((noinline))
-#   else
-#       define HPX_NOINLINE __attribute__ ((__noinline__))
-#   endif
-#else
-#   define HPX_NOINLINE
-#endif
-
-///////////////////////////////////////////////////////////////////////////////
-#if !defined(HPX_ATTRIBUTE_NORETURN)
-#  if defined(_MSC_VER)
-#    define HPX_ATTRIBUTE_NORETURN __declspec(noreturn)
-#  elif defined(__GNUC__)
-#    define HPX_ATTRIBUTE_NORETURN __attribute__ ((__noreturn__))
-#  else
-#    define HPX_ATTRIBUTE_NORETURN
-#  endif
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hpx/config/attributes.hpp
+++ b/hpx/config/attributes.hpp
@@ -7,14 +7,37 @@
 #define HPX_CONFIG_ATTRIBUTES_HPP
 
 #include <hpx/config/defines.hpp>
+#include <hpx/config/compiler_specific.hpp>
 
-// handle [[fallthrough]]
-#if defined(HPX_HAVE_CXX17_FALLTHROUGH_ATTRIBUTE)
-#   define HPX_FALLTHROUGH [[fallthrough]]
+///////////////////////////////////////////////////////////////////////////////
+#if defined(HPX_MSVC)
+#   define HPX_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__)
+#   if defined(__NVCC__) || defined(__CUDACC__)
+        // nvcc doesn't always parse __noinline
+#       define HPX_NOINLINE __attribute__ ((noinline))
+#   else
+#       define HPX_NOINLINE __attribute__ ((__noinline__))
+#   endif
 #else
-#   define HPX_FALLTHROUGH
+#   define HPX_NOINLINE
 #endif
 
+///////////////////////////////////////////////////////////////////////////////
+// handle [[noreturn]]
+#if defined(HPX_HAVE_CXX11_NORETURN_ATTRIBUTE)
+#   define HPX_NORETURN [[noreturn]]
+#else
+#  if defined(_MSC_VER)
+#    define HPX_NORETURN __declspec(noreturn)
+#  elif defined(__GNUC__)
+#    define HPX_NORETURN __attribute__ ((__noreturn__))
+#  else
+#    define HPX_NORETURN
+#  endif
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
 // handle [[deprecated]]
 #if defined(HPX_HAVE_DEPRECATION_WARNINGS)
 #  define HPX_DEPRECATED_MSG \
@@ -29,7 +52,15 @@
 #endif
 
 #if !defined(HPX_DEPRECATED)
-#  define HPX_DEPRECATED(x)  /**/
+#  define HPX_DEPRECATED(x)
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+// handle [[fallthrough]]
+#if defined(HPX_HAVE_CXX17_FALLTHROUGH_ATTRIBUTE)
+#   define HPX_FALLTHROUGH [[fallthrough]]
+#else
+#   define HPX_FALLTHROUGH
 #endif
 
 #endif

--- a/hpx/exception.hpp
+++ b/hpx/exception.hpp
@@ -348,12 +348,12 @@ namespace hpx
             construct_lightweight_exception(Exception const& e);
 
         // HPX_ASSERT handler
-        HPX_ATTRIBUTE_NORETURN HPX_EXPORT
+        HPX_NORETURN HPX_EXPORT
         void assertion_failed(char const* expr, char const* function,
             char const* file, long line);
 
         // HPX_ASSERT_MSG handler
-        HPX_ATTRIBUTE_NORETURN HPX_EXPORT
+        HPX_NORETURN HPX_EXPORT
         void assertion_failed_msg(char const* msg, char const* expr,
             char const* function, char const* file, long line);
 
@@ -369,8 +369,10 @@ namespace hpx
 
         // Report an early or late exception and locally abort execution. There
         // isn't anything more we could do.
-        HPX_EXPORT void report_exception_and_terminate(std::exception_ptr const&);
-        HPX_EXPORT void report_exception_and_terminate(hpx::exception const&);
+        HPX_NORETURN HPX_EXPORT void report_exception_and_terminate(
+            std::exception_ptr const&);
+        HPX_NORETURN HPX_EXPORT void report_exception_and_terminate(
+            hpx::exception const&);
 
         // Report an early or late exception and locally exit execution. There
         // isn't anything more we could do. The exception will be re-thrown
@@ -1058,12 +1060,12 @@ namespace hpx
     ///////////////////////////////////////////////////////////////////////////
     // \cond NOINTERNAL
     // forwarder for HPX_ASSERT handler
-    HPX_ATTRIBUTE_NORETURN HPX_EXPORT
+    HPX_NORETURN HPX_EXPORT
     void assertion_failed(char const* expr, char const* function,
         char const* file, long line);
 
     // forwarder for HPX_ASSERT_MSG handler
-    HPX_ATTRIBUTE_NORETURN HPX_EXPORT
+    HPX_NORETURN HPX_EXPORT
     void assertion_failed_msg(char const* msg, char const* expr,
         char const* function, char const* file, long line);
 

--- a/hpx/exception_info.hpp
+++ b/hpx/exception_info.hpp
@@ -185,7 +185,7 @@ namespace hpx
         };
     }
 
-    template <typename E> HPX_ATTRIBUTE_NORETURN
+    template <typename E> HPX_NORETURN
     void throw_with_info(E&& e, exception_info&& xi = exception_info())
     {
         using ED = typename std::decay<E>::type;
@@ -203,7 +203,7 @@ namespace hpx
         throw detail::exception_with_info<ED>(std::forward<E>(e), std::move(xi));
     }
 
-    template <typename E> HPX_ATTRIBUTE_NORETURN
+    template <typename E> HPX_NORETURN
     void throw_with_info(E&& e, exception_info const& xi)
     {
         throw_with_info(std::forward<E>(e), exception_info(xi));

--- a/hpx/hpx_finalize.hpp
+++ b/hpx/hpx_finalize.hpp
@@ -112,7 +112,7 @@ namespace hpx
     ///          all localities associated with this application. If the function
     ///          is called not from an HPX thread it will fail and return an error
     ///          using the argument \a ec.
-    HPX_EXPORT HPX_ATTRIBUTE_NORETURN void terminate();
+    HPX_EXPORT HPX_NORETURN void terminate();
 
     /// \brief Disconnect this locality from the application.
     ///

--- a/hpx/parallel/exception_list.hpp
+++ b/hpx/parallel/exception_list.hpp
@@ -28,7 +28,7 @@ namespace hpx { namespace parallel { inline namespace v1
         {
             typedef Result type;
 
-            HPX_ATTRIBUTE_NORETURN static Result call()
+            HPX_NORETURN static Result call()
             {
                 try {
                     throw; //-V667
@@ -174,20 +174,20 @@ namespace hpx { namespace parallel { inline namespace v1
         {
             typedef Result type;
 
-            HPX_ATTRIBUTE_NORETURN static Result call()
+            HPX_NORETURN static Result call()
             {
                 // any exceptions thrown by algorithms executed with the
                 // parallel_unsequenced_policy are to call terminate.
                 hpx::terminate();
             }
 
-            HPX_ATTRIBUTE_NORETURN
+            HPX_NORETURN
             static hpx::future<Result> call(hpx::future<Result> &&)
             {
                 hpx::terminate();
             }
 
-            HPX_ATTRIBUTE_NORETURN
+            HPX_NORETURN
             static hpx::future<Result> call(std::exception_ptr const&)
             {
                 hpx::terminate();

--- a/hpx/parallel/util/detail/handle_local_exceptions.hpp
+++ b/hpx/parallel/util/detail/handle_local_exceptions.hpp
@@ -26,7 +26,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail
     {
         ///////////////////////////////////////////////////////////////////////
         // std::bad_alloc has to be handled separately
-        HPX_ATTRIBUTE_NORETURN static void call(std::exception_ptr const& e)
+        HPX_NORETURN static void call(std::exception_ptr const& e)
         {
             try {
                 std::rethrow_exception(e);
@@ -130,12 +130,12 @@ namespace hpx { namespace parallel { namespace util { namespace detail
     struct handle_local_exceptions<execution::parallel_unsequenced_policy>
     {
         ///////////////////////////////////////////////////////////////////////
-        HPX_ATTRIBUTE_NORETURN static void call(std::exception_ptr const&)
+        HPX_NORETURN static void call(std::exception_ptr const&)
         {
             hpx::terminate();
         }
 
-        HPX_ATTRIBUTE_NORETURN static void call(
+        HPX_NORETURN static void call(
             std::exception_ptr const&, std::list<std::exception_ptr>&)
         {
             hpx::terminate();

--- a/hpx/parallel/util/detail/handle_remote_exceptions.hpp
+++ b/hpx/parallel/util/detail/handle_remote_exceptions.hpp
@@ -75,7 +75,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail
     template <>
     struct handle_remote_exceptions<execution::parallel_unsequenced_policy>
     {
-        HPX_ATTRIBUTE_NORETURN static void call(
+        HPX_NORETURN static void call(
             std::exception_ptr const&, std::list<std::exception_ptr>&)
         {
             hpx::terminate();

--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -194,13 +194,13 @@ namespace hpx { namespace components { namespace server
         void shutdown_all(double timeout);
 
         /// \brief Shutdown this runtime system instance
-        HPX_ATTRIBUTE_NORETURN void terminate(
+        HPX_NORETURN void terminate(
             naming::id_type const& respond_to);
 
         void terminate_act(naming::id_type const& id) { terminate(id); }
 
         /// \brief Shutdown runtime system instances on all localities
-        HPX_ATTRIBUTE_NORETURN void terminate_all();
+        HPX_NORETURN void terminate_all();
 
         void terminate_all_act() { terminate_all(); }
 

--- a/hpx/runtime/threads/coroutines/detail/context_base.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_base.hpp
@@ -430,7 +430,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 
         // Always throw exit_exception.
         // Never returns from standard control flow.
-        HPX_ATTRIBUTE_NORETURN void exit_self()
+        HPX_NORETURN void exit_self()
         {
             HPX_ASSERT(!pending());
             HPX_ASSERT(running());

--- a/hpx/runtime/threads/coroutines/detail/coroutine_self.hpp
+++ b/hpx/runtime/threads/coroutines/detail/coroutine_self.hpp
@@ -128,7 +128,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
             return tmp;
         }
 
-        HPX_ATTRIBUTE_NORETURN void exit()
+        HPX_NORETURN void exit()
         {
             m_pimpl->exit_self();
             std::terminate(); // FIXME: replace with hpx::terminate();

--- a/hpx/throw_exception.hpp
+++ b/hpx/throw_exception.hpp
@@ -25,15 +25,15 @@
 namespace hpx { namespace detail
 {
     template <typename Exception>
-    HPX_ATTRIBUTE_NORETURN HPX_EXPORT
+    HPX_NORETURN HPX_EXPORT
     void throw_exception(Exception const& e,
         std::string const& func, std::string const& file, long line);
 
-    HPX_ATTRIBUTE_NORETURN HPX_EXPORT void throw_exception(
+    HPX_NORETURN HPX_EXPORT void throw_exception(
         error errcode, std::string const& msg,
         std::string const& func, std::string const& file, long line);
 
-    HPX_ATTRIBUTE_NORETURN HPX_EXPORT void rethrow_exception(
+    HPX_NORETURN HPX_EXPORT void rethrow_exception(
         exception const& e, std::string const& func);
 
     template <typename Exception>
@@ -64,7 +64,7 @@ namespace hpx { namespace detail
     HPX_EXPORT void rethrows_if(
         hpx::error_code& ec, exception const& e, std::string const& func);
 
-    HPX_ATTRIBUTE_NORETURN HPX_EXPORT
+    HPX_NORETURN HPX_EXPORT
     void throw_thread_interrupted_exception();
 }}
 /// \endcond
@@ -74,7 +74,7 @@ namespace hpx
     /// \cond NOINTERNAL
 
     /// \brief throw an hpx::exception initialized from the given arguments
-    HPX_ATTRIBUTE_NORETURN inline
+    HPX_NORETURN inline
     void throw_exception(error e, std::string const& msg,
         std::string const& func, std::string const& file = "", long line = -1)
     {

--- a/hpx/util/assert.hpp
+++ b/hpx/util/assert.hpp
@@ -44,7 +44,7 @@
 
 namespace hpx
 {
-    HPX_ATTRIBUTE_NORETURN HPX_EXPORT void assertion_failed(char const * expr,
+    HPX_NORETURN HPX_EXPORT void assertion_failed(char const * expr,
         char const * function, char const * file, long line);  // user defined
 } // namespace hpx
 
@@ -85,7 +85,7 @@ namespace hpx
 
 namespace hpx
 {
-    HPX_ATTRIBUTE_NORETURN HPX_EXPORT void assertion_failed_msg(
+    HPX_NORETURN HPX_EXPORT void assertion_failed_msg(
         char const * expr, char const * msg,
         char const * function, char const * file, long line); // user defined
 } // namespace hpx
@@ -116,7 +116,7 @@ namespace hpx { namespace assertion { namespace detail
     // Note: The template is needed to make the function non-inline and
     // avoid linking errors
     template <typename CharT>
-    HPX_ATTRIBUTE_NORETURN HPX_NOINLINE void assertion_failed_msg(
+    HPX_NORETURN HPX_NOINLINE void assertion_failed_msg(
         CharT const * expr, char const * msg, char const * function,
         char const * file, long line)
     {

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -382,58 +382,58 @@ namespace hpx { namespace detail
     ///////////////////////////////////////////////////////////////////////////
     template HPX_EXPORT std::exception_ptr
         get_exception(hpx::exception const&, std::string const&,
-        std::string const&, long, std::string const&);
+            std::string const&, long, std::string const&);
 
-    template HPX_ATTRIBUTE_NORETURN HPX_EXPORT void
+    template HPX_EXPORT void
         throw_exception(hpx::exception const&,
-        std::string const&, std::string const&, long);
+            std::string const&, std::string const&, long);
 
-    template HPX_ATTRIBUTE_NORETURN HPX_EXPORT void
+    template HPX_EXPORT void
         throw_exception(boost::system::system_error const&,
-        std::string const&, std::string const&, long);
+            std::string const&, std::string const&, long);
 
-    template HPX_ATTRIBUTE_NORETURN HPX_EXPORT void
+    template HPX_EXPORT void
         throw_exception(std::exception const&,
-        std::string const&, std::string const&, long);
-    template HPX_ATTRIBUTE_NORETURN HPX_EXPORT void
+            std::string const&, std::string const&, long);
+    template HPX_EXPORT void
         throw_exception(hpx::detail::std_exception const&,
-        std::string const&, std::string const&, long);
-    template HPX_ATTRIBUTE_NORETURN HPX_EXPORT void
+            std::string const&, std::string const&, long);
+    template HPX_EXPORT void
         throw_exception(std::bad_exception const&,
-        std::string const&, std::string const&, long);
-    template HPX_ATTRIBUTE_NORETURN HPX_EXPORT void
+            std::string const&, std::string const&, long);
+    template HPX_EXPORT void
         throw_exception(hpx::detail::bad_exception const&,
-        std::string const&, std::string const&, long);
-    template HPX_ATTRIBUTE_NORETURN HPX_EXPORT void
+            std::string const&, std::string const&, long);
+    template HPX_EXPORT void
         throw_exception(std::bad_typeid const&,
-        std::string const&, std::string const&, long);
-    template HPX_ATTRIBUTE_NORETURN HPX_EXPORT void
+            std::string const&, std::string const&, long);
+    template HPX_EXPORT void
         throw_exception(hpx::detail::bad_typeid const&,
-        std::string const&, std::string const&, long);
-    template HPX_ATTRIBUTE_NORETURN HPX_EXPORT void
+            std::string const&, std::string const&, long);
+    template HPX_EXPORT void
         throw_exception(std::bad_cast const&,
-        std::string const&, std::string const&, long);
-    template HPX_ATTRIBUTE_NORETURN HPX_EXPORT void
+            std::string const&, std::string const&, long);
+    template HPX_EXPORT void
         throw_exception(hpx::detail::bad_cast const&,
-        std::string const&, std::string const&, long);
-    template HPX_ATTRIBUTE_NORETURN HPX_EXPORT void
+            std::string const&, std::string const&, long);
+    template HPX_EXPORT void
         throw_exception(std::bad_alloc const&,
-        std::string const&, std::string const&, long);
-    template HPX_ATTRIBUTE_NORETURN HPX_EXPORT void
+            std::string const&, std::string const&, long);
+    template HPX_EXPORT void
         throw_exception(hpx::detail::bad_alloc const&,
-        std::string const&, std::string const&, long);
-    template HPX_ATTRIBUTE_NORETURN HPX_EXPORT void
+            std::string const&, std::string const&, long);
+    template HPX_EXPORT void
         throw_exception(std::logic_error const&,
-        std::string const&, std::string const&, long);
-    template HPX_ATTRIBUTE_NORETURN HPX_EXPORT void
+            std::string const&, std::string const&, long);
+    template HPX_EXPORT void
         throw_exception(std::runtime_error const&,
-        std::string const&, std::string const&, long);
-    template HPX_ATTRIBUTE_NORETURN HPX_EXPORT void
+            std::string const&, std::string const&, long);
+    template HPX_EXPORT void
         throw_exception(std::out_of_range const&,
-        std::string const&, std::string const&, long);
-    template HPX_ATTRIBUTE_NORETURN HPX_EXPORT void
+            std::string const&, std::string const&, long);
+    template HPX_EXPORT void
         throw_exception(std::invalid_argument const&,
-        std::string const&, std::string const&, long);
+            std::string const&, std::string const&, long);
 
     ///////////////////////////////////////////////////////////////////////////
     void assertion_failed(char const* expr, char const* function,

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -56,7 +56,7 @@
 namespace hpx
 {
     ///////////////////////////////////////////////////////////////////////////
-    HPX_ATTRIBUTE_NORETURN void handle_termination(char const* reason)
+    HPX_NORETURN void handle_termination(char const* reason)
     {
         if (get_config_entry("hpx.attach_debugger", "") == "exception")
         {
@@ -112,7 +112,7 @@ namespace hpx
 namespace hpx
 {
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT HPX_ATTRIBUTE_NORETURN void termination_handler(int signum)
+    HPX_EXPORT HPX_NORETURN void termination_handler(int signum)
     {
         if (signum != SIGINT &&
             get_config_entry("hpx.attach_debugger", "") == "exception")

--- a/src/throw_exception.cpp
+++ b/src/throw_exception.cpp
@@ -16,7 +16,7 @@
 
 namespace hpx { namespace detail
 {
-    HPX_ATTRIBUTE_NORETURN void throw_exception(
+    HPX_NORETURN void throw_exception(
         error errcode, std::string const& msg,
         std::string const& func, std::string const& file, long line)
     {
@@ -26,7 +26,7 @@ namespace hpx { namespace detail
             func, p.string(), line);
     }
 
-    HPX_ATTRIBUTE_NORETURN void rethrow_exception(
+    HPX_NORETURN void rethrow_exception(
         exception const& e, std::string const& func)
     {
         hpx::detail::throw_exception(
@@ -83,7 +83,7 @@ namespace hpx { namespace detail
         }
     }
 
-    HPX_ATTRIBUTE_NORETURN void throw_thread_interrupted_exception()
+    HPX_NORETURN void throw_thread_interrupted_exception()
     {
         throw hpx::thread_interrupted();
     }


### PR DESCRIPTION
- flyby: remove #include <boost/exception/detail/attribute_noreturn.hpp>