### PR TITLE
Support C++11 in benchmark codes of parallel::partition and parallel::partition_copy.

### DIFF
--- a/tests/performance/parallel_algorithms/local/CMakeLists.txt
+++ b/tests/performance/parallel_algorithms/local/CMakeLists.txt
@@ -8,15 +8,9 @@ set(
   benchmarks
   benchmark_is_heap
   benchmark_is_heap_until
+  benchmark_partition
+  benchmark_partition_copy
   benchmark_unique_copy)
-
-if(HPX_WITH_CXX14)
-  set(
-    benchmarks
-    ${benchmarks}
-    benchmark_partition
-    benchmark_partition_copy)
-endif()
 
 foreach(benchmark ${benchmarks})
   set(sources

--- a/tests/performance/parallel_algorithms/local/benchmark_partition.cpp
+++ b/tests/performance/parallel_algorithms/local/benchmark_partition.cpp
@@ -119,7 +119,7 @@ void run_benchmark(std::size_t vector_size, int test_count, int base_num,
 
     std::cout << "* Running Benchmark..." << std::endl;
 
-    auto pred = [base_num](auto const& t) {
+    auto pred = [base_num](int t) {
         return t < base_num;
     };
 

--- a/tests/performance/parallel_algorithms/local/benchmark_partition_copy.cpp
+++ b/tests/performance/parallel_algorithms/local/benchmark_partition_copy.cpp
@@ -109,7 +109,7 @@ void run_benchmark(std::size_t vector_size, int test_count, IteratorTag)
 
     int rand_base = std::rand();
 
-    auto pred = [rand_base](auto const& t) {
+    auto pred = [rand_base](int t) {
         return t < rand_base;
     };
 


### PR DESCRIPTION
Avoid generic lambda of C++14.

Reverted from https://github.com/STEllAR-GROUP/hpx/commit/fadd999212a12107e577f32e9650bdfd90f11541