### PR TITLE
Implement an API for asynchronous pack traversal

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -190,6 +190,7 @@ set(doxygen_dependencies
     "${PROJECT_SOURCE_DIR}/hpx/util/invoke.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/util/invoke_fused.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/util/pack_traversal.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/util/pack_traversal_async.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/util/unwrap.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/util/unwrapped.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/performance_counters/manage_counter_type.hpp")

--- a/docs/hpx.idx
+++ b/docs/hpx.idx
@@ -549,6 +549,9 @@ map_pack                              "" "header\.hpx\.util\.pack_traversal.*"
 spread_this                           "" "header\.hpx\.util\.pack_traversal.*"
 traverse_pack                         "" "header\.hpx\.util\.pack_traversal.*"
 
+# hpx/util/pack_traversal_async.hpp
+traverse_pack_async                   "" "header\.hpx\.util\.pack_traversal_async.*"
+
 # hpx/util/unwrap.hpp
 unwrap                                "" "header\.hpx\.util\.unwrap.*"
 unwrap_n                              "" "header\.hpx\.util\.unwrap_n.*"

--- a/hpx/lcos/dataflow.hpp
+++ b/hpx/lcos/dataflow.hpp
@@ -11,13 +11,13 @@
 
 #include <hpx/config.hpp>
 #include <hpx/apply.hpp>
+#include <hpx/lcos/detail/future_transforms.hpp>
 #include <hpx/lcos/future.hpp>
 #include <hpx/runtime/get_worker_thread_num.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/traits/acquire_future.hpp>
 #include <hpx/traits/extract_action.hpp>
 #include <hpx/traits/future_access.hpp>
-#include <hpx/traits/future_traits.hpp>
 #include <hpx/traits/is_action.hpp>
 #include <hpx/traits/is_distribution_policy.hpp>
 #include <hpx/traits/is_executor.hpp>
@@ -27,12 +27,11 @@
 #include <hpx/traits/promise_local_result.hpp>
 #include <hpx/util/annotated_function.hpp>
 #include <hpx/util/deferred_call.hpp>
-#include <hpx/util/detail/pack.hpp>
 #include <hpx/util/invoke_fused.hpp>
-#include <hpx/util/range.hpp>
+#include <hpx/util/pack_traversal.hpp>
+#include <hpx/util/pack_traversal_async.hpp>
 #include <hpx/util/thread_description.hpp>
 #include <hpx/util/tuple.hpp>
-#include <hpx/util/unwrap_ref.hpp>
 
 #if defined(HPX_HAVE_EXECUTOR_COMPATIBILITY)
 #include <hpx/traits/v1/is_executor.hpp>
@@ -104,6 +103,16 @@ namespace hpx { namespace lcos { namespace detail
         {}
     };
 
+    /// Helper to invalidate the futures contained in the given pack in order
+    /// to break cycles.
+    template<typename T>
+    void invalidate_futures(T&& futures)
+    {
+        // Invalidate all futures which are contained recursively inside
+        // the given tuple of futures and non futures.
+        util::traverse_pack(reset_dataflow_future{}, std::forward<T>(futures));
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename F, typename Args, typename Enable = void>
     struct dataflow_return;
@@ -135,25 +144,7 @@ namespace hpx { namespace lcos { namespace detail
 
         typedef hpx::lcos::future<result_type> type;
 
-        typedef typename util::detail::make_index_pack<
-                util::tuple_size<Futures>::value
-            >::type indices_type;
-
         typedef std::is_void<result_type> is_void;
-
-        template <std::size_t I>
-        struct is_end
-          : std::integral_constant<
-                bool,
-                util::tuple_size<Futures>::value == I
-            >
-        {};
-
-        typedef typename std::conditional<
-                is_void::value
-              , void(dataflow_frame::*)(indices_type, std::true_type)
-              , void(dataflow_frame::*)(indices_type, std::false_type)
-            >::type execute_function_type;
 
     private:
         // workaround gcc regression wrongly instantiating constructors
@@ -163,45 +154,40 @@ namespace hpx { namespace lcos { namespace detail
     public:
         typedef typename base_type::init_no_addref init_no_addref;
 
-        template <typename Policy_, typename FFunc, typename FFutures>
-        dataflow_frame(
-            Policy_ && policy
-          , FFunc && func
-          , FFutures && futures)
-              : policy_(std::forward<Policy_>(policy))
-              , func_(std::forward<FFunc>(func))
-              , futures_(std::forward<FFutures>(futures))
-              , done_(false)
-        {}
+        /// A struct to construct the dataflow_frame in-place
+        struct construction_data
+        {
+            Policy policy_;
+            Func func_;
+        };
 
-        template <typename Policy_, typename FFunc, typename FFutures>
-        dataflow_frame(
-            Policy_ && policy
-          , FFunc && func
-          , FFutures && futures
-          , init_no_addref no_addref)
-              : base_type(no_addref)
-              , policy_(std::forward<Policy_>(policy))
-              , func_(std::forward<FFunc>(func))
-              , futures_(std::forward<FFutures>(futures))
-              , done_(false)
-        {}
+        /// Construct the dataflow_frame from the given policy
+        /// and callable object.
+        static construction_data construct_from(Policy policy, Func func)
+        {
+            return construction_data{std::move(policy), std::move(func)};
+        }
 
-    protected:
+        explicit dataflow_frame(construction_data data)
+          : base_type(init_no_addref{})
+          , policy_(std::move(data.policy_))
+          , func_(std::move(data.func_))
+        {
+        }
+
+    private:
         ///////////////////////////////////////////////////////////////////////
-        template <std::size_t ...Is>
+        /// Passes the futures into the evaluation function and
+        /// sets the result future.
         HPX_FORCEINLINE
-        void execute(util::detail::pack_c<std::size_t, Is...>, std::false_type)
+        void execute(std::false_type, Futures&& futures)
         {
             try {
-                result_type res = util::invoke_fused(func_, std::move(futures_));
+                result_type res =
+                    util::invoke_fused(func_, std::move(futures));
 
-                // reset futures
-                reset_dataflow_future reset;
-                int const _sequencer[] = {
-                    ((reset(util::get<Is>(futures_))), 0)...
-                };
-                (void)_sequencer;
+                // Reassigning a moved value isn't UB
+                invalidate_futures(std::move(futures));
 
                 this->set_data(std::move(res));
             }
@@ -210,19 +196,16 @@ namespace hpx { namespace lcos { namespace detail
             }
         }
 
-        template <std::size_t ...Is>
+        /// Passes the futures into the evaluation function and
+        /// sets the result future.
         HPX_FORCEINLINE
-        void execute(util::detail::pack_c<std::size_t, Is...>, std::true_type)
+        void execute(std::true_type, Futures&& futures)
         {
             try {
-                util::invoke_fused(func_, std::move(futures_));
+                util::invoke_fused(func_, std::move(futures));
 
-                // reset futures
-                reset_dataflow_future reset;
-                int const _sequencer[] = {
-                    ((reset(util::get<Is>(futures_))), 0)...
-                };
-                (void)_sequencer;
+                // Reassigning a moved value isn't UB
+                invalidate_futures(std::move(futures));
 
                 this->set_data(util::unused_type());
             }
@@ -231,14 +214,15 @@ namespace hpx { namespace lcos { namespace detail
             }
         }
 
-        HPX_FORCEINLINE void done()
+        HPX_FORCEINLINE void done(Futures futures)
         {
             hpx::util::annotate_function annotate(func_);
-            execute(indices_type(), is_void());
+
+            execute(is_void{}, std::move(futures));
         }
 
         ///////////////////////////////////////////////////////////////////////
-        void finalize(hpx::detail::async_policy policy)
+        void finalize(hpx::detail::async_policy policy, Futures&& futures)
         {
             // schedule the final function invocation with high priority
             util::thread_description desc(func_, "dataflow_frame::finalize");
@@ -246,7 +230,8 @@ namespace hpx { namespace lcos { namespace detail
 
             // simply schedule new thread
             threads::register_thread_nullary(
-                util::deferred_call(&dataflow_frame::done, std::move(this_))
+                util::deferred_call(&dataflow_frame::done, std::move(this_),
+                                    std::move(futures))
               , desc
               , threads::pending
               , true
@@ -256,19 +241,20 @@ namespace hpx { namespace lcos { namespace detail
         }
 
         HPX_FORCEINLINE
-        void finalize(hpx::detail::sync_policy)
+        void finalize(hpx::detail::sync_policy, Futures&& futures)
         {
-            done();
+            done(std::move(futures));
         }
 
-        void finalize(hpx::detail::fork_policy policy)
+        void finalize(hpx::detail::fork_policy policy, Futures&& futures)
         {
             // schedule the final function invocation with high priority
             util::thread_description desc(func_, "dataflow_frame::finalize");
             boost::intrusive_ptr<dataflow_frame> this_(this);
 
             threads::thread_id_type tid = threads::register_thread_nullary(
-                util::deferred_call(&dataflow_frame::done, std::move(this_))
+                util::deferred_call(&dataflow_frame::done, std::move(this_),
+                                    std::move(futures))
               , desc
               , threads::pending_do_not_schedule
               , true
@@ -283,27 +269,28 @@ namespace hpx { namespace lcos { namespace detail
             }
         }
 
-        void finalize(launch policy)
+        void finalize(launch policy, Futures&& futures)
         {
             if (policy == launch::sync)
             {
-                finalize(launch::sync);
+                finalize(launch::sync, std::move(futures));
             }
             else if (policy == launch::fork)
             {
-                finalize(launch::fork);
+                finalize(launch::fork, std::move(futures));
             }
             else
             {
-                finalize(launch::async);
+                finalize(launch::async, std::move(futures));
             }
         }
 
         HPX_FORCEINLINE
-        void finalize(threads::executor& sched)
+        void finalize(threads::executor& sched, Futures&& futures)
         {
             boost::intrusive_ptr<dataflow_frame> this_(this);
-            hpx::apply(sched, &dataflow_frame::done, std::move(this_));
+            hpx::apply(sched, &dataflow_frame::done, std::move(this_),
+                std::move(futures));
         }
 
 #if defined(HPX_HAVE_EXECUTOR_COMPATIBILITY)
@@ -313,11 +300,11 @@ namespace hpx { namespace lcos { namespace detail
         typename std::enable_if<
             traits::is_executor<Executor>::value
         >::type
-        finalize(Executor& exec)
+        finalize(Executor& exec, Futures&& futures)
         {
             boost::intrusive_ptr<dataflow_frame> this_(this);
             parallel::executor_traits<Executor>::apply_execute(exec,
-                &dataflow_frame::done, std::move(this_));
+                &dataflow_frame::done, std::move(this_), std::move(futures));
         }
 #endif
 
@@ -327,201 +314,51 @@ namespace hpx { namespace lcos { namespace detail
             traits::is_one_way_executor<Executor>::value ||
             traits::is_two_way_executor<Executor>::value
         >::type
-        finalize(Executor& exec)
+        finalize(Executor& exec, Futures&& futures)
         {
+            using execute_function_type =
+                typename std::conditional<
+                    is_void::value,
+                    void (dataflow_frame::*)(std::true_type, Futures&&),
+                    void (dataflow_frame::*)(std::false_type, Futures&&)
+                >::type;
+
             execute_function_type f = &dataflow_frame::execute;
             boost::intrusive_ptr<dataflow_frame> this_(this);
 
             parallel::execution::post(exec,
-                f, std::move(this_), indices_type(), is_void());
-        }
-
-        ///////////////////////////////////////////////////////////////////////
-        template <std::size_t I>
-        HPX_FORCEINLINE
-        void do_await(std::true_type)
-        {
-            done_ = true;
-        }
-
-        // Current element is a not a future or future range, e.g. a just plain
-        // value.
-        template <std::size_t I, typename IsFuture, typename IsRange>
-        HPX_FORCEINLINE
-        void await_next_respawn(IsFuture is_future, IsRange is_range)
-        {
-            await_next<I>(is_future, is_range);
-
-            // avoid finalizing more than once
-            bool expected = true;
-            if (done_.compare_exchange_strong(expected, false))
-                finalize(policy_);
-        }
-
-        template <std::size_t I>
-        HPX_FORCEINLINE
-        void await_next(std::false_type, std::false_type)
-        {
-            do_await<I + 1>(is_end<I + 1>());
-        }
-
-        template <std::size_t I, typename Iter>
-        void await_range_respawn(Iter next, Iter end)
-        {
-            await_range<I>(next, end);
-
-            // avoid finalizing more than once
-            bool expected = true;
-            if (done_.compare_exchange_strong(expected, false))
-                finalize(policy_);
-        }
-
-        template <std::size_t I, typename Iter>
-        void await_range(Iter next, Iter end)
-        {
-            void (dataflow_frame::*f)(Iter, Iter) =
-                &dataflow_frame::await_range_respawn<I>;
-
-            for (/**/; next != end; ++next)
-            {
-                typedef
-                    typename std::iterator_traits<Iter>::value_type
-                    future_type;
-                typedef
-                    typename traits::future_traits<future_type>::type
-                    future_result_type;
-
-                typename traits::detail::shared_state_ptr<
-                        future_result_type
-                    >::type next_future_data =
-                        traits::detail::get_shared_state(*next);
-
-                if (next_future_data.get() != nullptr &&
-                    !next_future_data->is_ready())
-                {
-                    next_future_data->execute_deferred();
-
-                    // execute_deferred might have made the future ready
-                    if (!next_future_data->is_ready())
-                    {
-                        boost::intrusive_ptr<dataflow_frame> this_(this);
-                        next_future_data->set_on_completed(
-                            util::deferred_call(
-                                f
-                              , std::move(this_)
-                              , std::move(next)
-                              , std::move(end)
-                            )
-                        );
-                        return;
-                    }
-                }
-            }
-
-            do_await<I + 1>(is_end<I + 1>());
-        }
-
-        // Current element is a range (vector) of futures
-        template <std::size_t I>
-        HPX_FORCEINLINE
-        void await_next(std::false_type, std::true_type)
-        {
-            typedef
-                typename util::tuple_element<I, Futures>::type
-                future_type;
-            future_type & f_ = util::get<I>(futures_);
-
-            await_range<I>(
-                util::begin(util::unwrap_ref(f_))
-              , util::end(util::unwrap_ref(f_))
-            );
-        }
-
-        // Current element is a simple future
-        template <std::size_t I>
-        HPX_FORCEINLINE
-        void await_next(std::true_type, std::false_type)
-        {
-            typedef
-                typename util::tuple_element<I, Futures>::type
-                future_type;
-            future_type & f_ = util::get<I>(futures_);
-
-            typedef
-                typename traits::future_traits<future_type>::type
-                future_result_type;
-
-            typename traits::detail::shared_state_ptr<
-                    future_result_type
-                >::type next_future_data =
-                    traits::detail::get_shared_state(f_);
-
-            if (next_future_data.get() != nullptr &&
-                !next_future_data->is_ready())
-            {
-                next_future_data->execute_deferred();
-
-                // execute_deferred might have made the future ready
-                if (!next_future_data->is_ready())
-                {
-                    void (dataflow_frame::*f)(
-                            std::true_type, std::false_type
-                        ) = &dataflow_frame::await_next_respawn<I>;
-
-                    boost::intrusive_ptr<dataflow_frame> this_(this);
-                    next_future_data->set_on_completed(
-                        util::deferred_call(
-                            f
-                          , std::move(this_)
-                          , std::true_type()
-                          , std::false_type()
-                        )
-                    );
-                    return;
-                }
-            }
-
-            do_await<I + 1>(is_end<I + 1>());
-        }
-
-        ///////////////////////////////////////////////////////////////////////
-        template <std::size_t I>
-        HPX_FORCEINLINE
-        void do_await(std::false_type)
-        {
-            typedef
-                typename util::tuple_element<I, Futures>::type
-                future_type;
-
-            typedef util::detail::any_of<
-                    traits::is_future<future_type>,
-                    traits::is_ref_wrapped_future<future_type>
-                > is_future;
-
-            typedef util::detail::any_of<
-                    traits::is_future_range<future_type>,
-                    traits::is_ref_wrapped_future_range<future_type>
-                > is_range;
-
-            await_next<I>(is_future(), is_range());
+                f, std::move(this_), is_void{}, std::move(futures));
         }
 
     public:
-        HPX_FORCEINLINE void do_await()
+        /// Check whether the current future is ready
+        template <typename T>
+        auto operator()(util::async_traverse_visit_tag, T&& current)
+            -> decltype(async_visit_future(std::forward<T>(current)))
         {
-            do_await<0>(is_end<0>());
+            return async_visit_future(std::forward<T>(current));
+        }
 
-            // avoid finalizing more than once
-            bool expected = true;
-            if (done_.compare_exchange_strong(expected, false))
-                finalize(policy_);
+        /// Detach the current execution context and continue when the
+        /// current future was set to be ready.
+        template <typename T, typename N>
+        auto operator()(util::async_traverse_detach_tag, T&& current, N&& next)
+            -> decltype(async_detach_future(
+                std::forward<T>(current), std::forward<N>(next)))
+        {
+            return async_detach_future(
+                std::forward<T>(current), std::forward<N>(next));
+        }
+
+        /// Finish the dataflow when the traversal has finished
+        void operator()(util::async_traverse_complete_tag, Futures futures)
+        {
+            finalize(policy_, std::move(futures));
         }
 
     private:
         Policy policy_;
         Func func_;
-        Futures futures_;
-        std::atomic<bool> done_;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -561,21 +398,21 @@ namespace hpx { namespace lcos { namespace detail
                     >
                 >
                 frame_type;
-            typedef typename frame_type::init_no_addref init_no_addref;
 
-            boost::intrusive_ptr<frame_type> p(new frame_type(
-                    std::forward<Policy>(launch_policy)
-                  , Derived()
-                  , util::forward_as_tuple(
-                        id
-                      , traits::acquire_future_disp()(std::forward<Ts>(ts))...
-                    )
-                  , init_no_addref()
-                ), false);
-            p->do_await();
+            // Create the data which is used to construct the dataflow_frame
+            auto data = frame_type::construct_from(
+                std::forward<Policy>(launch_policy), Derived{});
+
+            // Construct the dataflow_frame and traverse
+            // the arguments asynchronously
+            boost::intrusive_ptr<frame_type> p = util::traverse_pack_async(
+                util::async_traverse_in_place_tag<frame_type>{},
+                std::move(data), id,
+                traits::acquire_future_disp()(std::forward<Ts>(ts))...);
 
             using traits::future_access;
-            return future_access<typename frame_type::type>::create(std::move(p));
+            return future_access<typename frame_type::type>::create(
+                std::move(p));
         }
 
         template <

--- a/hpx/lcos/detail/future_transforms.hpp
+++ b/hpx/lcos/detail/future_transforms.hpp
@@ -1,0 +1,101 @@
+//  Copyright (c) 2017 Denis Blank
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_LCOS_DETAIL_FUTURE_TRANSFORMS_HPP
+#define HPX_LCOS_DETAIL_FUTURE_TRANSFORMS_HPP
+
+#include <hpx/lcos/future.hpp>
+#include <hpx/traits/acquire_future.hpp>
+#include <hpx/traits/acquire_shared_state.hpp>
+#include <hpx/traits/detail/reserve.hpp>
+#include <hpx/traits/is_future.hpp>
+#include <hpx/util/deferred_call.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx {
+namespace lcos {
+    namespace detail {
+        /// Returns true when the given future is ready,
+        /// the future is deferred executed if possible first.
+        template <typename T,
+            typename std::enable_if<traits::is_future<
+                typename std::decay<T>::type>::value>::type* = nullptr>
+        bool async_visit_future(T&& current)
+        {
+            auto state =
+                traits::detail::get_shared_state(std::forward<T>(current));
+
+            if ((state.get() == nullptr) || state->is_ready())
+            {
+                return true;
+            }
+
+            // Execute_deferred might have made the future ready
+            state->execute_deferred();
+
+            // Detach the context if the future isn't ready
+            return state->is_ready();
+        }
+
+        /// Attach the continuation next to the given future
+        template <typename T, typename N,
+            typename std::enable_if<traits::is_future<
+                typename std::decay<T>::type>::value>::type* = nullptr>
+        void async_detach_future(T&& current, N&& next)
+        {
+            auto state =
+                traits::detail::get_shared_state(std::forward<T>(current));
+
+            // Attach a continuation to this future which will
+            // re-evaluate it and continue to the next argument (if any).
+            state->set_on_completed(util::deferred_call(std::forward<N>(next)));
+        }
+
+        /// Acquire a future range from the given begin and end iterator
+        template <typename Iterator,
+            typename Container =
+                std::vector<typename future_iterator_traits<Iterator>::type>>
+        Container acquire_future_iterators(Iterator begin, Iterator end)
+        {
+            Container lazy_values;
+
+            auto difference = std::distance(begin, end);
+            if (difference > 0)
+                traits::detail::reserve_if_reservable(
+                    lazy_values, static_cast<std::size_t>(difference));
+
+            std::transform(begin, end, std::back_inserter(lazy_values),
+                traits::acquire_future_disp());
+
+            return lazy_values;    // Should be optimized by RVO
+        }
+
+        /// Acquire a future range from the given
+        /// begin iterator and count
+        template <typename Iterator,
+            typename Container =
+                std::vector<typename future_iterator_traits<Iterator>::type>>
+        Container acquire_future_n(Iterator begin, std::size_t count)
+        {
+            Container values;
+            traits::detail::reserve_if_reservable(values, count);
+
+            traits::acquire_future_disp func;
+            for (std::size_t i = 0; i != count; ++i)
+                values.push_back(func(*begin++));
+
+            return values;    // Should be optimized by RVO
+        }
+    }    // end namespace detail
+}    // end namespace lcos
+}    // end namespace hpx
+
+#endif    // HPX_LCOS_DETAIL_FUTURE_TRANSFORMS_HPP

--- a/hpx/lcos/local/dataflow.hpp
+++ b/hpx/lcos/local/dataflow.hpp
@@ -57,19 +57,17 @@ namespace hpx { namespace lcos { namespace detail
                     >
                 >
                 frame_type;
-            typedef typename frame_type::init_no_addref init_no_addref;
 
-            boost::intrusive_ptr<frame_type> p(new frame_type(
-                    std::forward<Policy>(policy)
-                  , std::forward<F>(f)
-                  , util::forward_as_tuple(
-                        traits::acquire_future_disp()(
-                            std::forward<Ts>(ts)
-                        )...
-                    )
-                  , init_no_addref()
-                ), false);
-            p->do_await();
+            // Create the data which is used to construct the dataflow_frame
+            auto data = frame_type::construct_from(
+                std::forward<Policy>(policy), std::forward<F>(f));
+
+            // Construct the dataflow_frame and traverse
+            // the arguments asynchronously
+            boost::intrusive_ptr<frame_type> p = util::traverse_pack_async(
+                util::async_traverse_in_place_tag<frame_type>{},
+                std::move(data),
+                traits::acquire_future_disp()(std::forward<Ts>(ts))...);
 
             using traits::future_access;
             return future_access<typename frame_type::type>::create(std::move(p));
@@ -144,19 +142,16 @@ namespace hpx { namespace lcos { namespace detail
                     >
                 >
                 frame_type;
-            typedef typename frame_type::init_no_addref init_no_addref;
 
-            boost::intrusive_ptr<frame_type> p(new frame_type(
-                    sched
-                  , std::forward<F>(f)
-                  , util::forward_as_tuple(
-                        traits::acquire_future_disp()(
-                            std::forward<Ts>(ts)
-                        )...
-                    )
-                  , init_no_addref()
-                ), false);
-            p->do_await();
+            // Create the data which is used to construct the dataflow_frame
+            auto data = frame_type::construct_from(sched, std::forward<F>(f));
+
+            // Construct the dataflow_frame and traverse
+            // the arguments asynchronously
+            boost::intrusive_ptr<frame_type> p = util::traverse_pack_async(
+                util::async_traverse_in_place_tag<frame_type>{},
+                std::move(data),
+                traits::acquire_future_disp()(std::forward<Ts>(ts))...);
 
             using traits::future_access;
             return future_access<typename frame_type::type>::create(std::move(p));
@@ -197,17 +192,17 @@ namespace hpx { namespace lcos { namespace detail
                     >
                 >
                 frame_type;
-            typedef typename frame_type::init_no_addref init_no_addref;
 
-            boost::intrusive_ptr<frame_type> p(new frame_type(
-                    std::forward<Executor_>(exec)
-                  , std::forward<F>(f)
-                  , util::forward_as_tuple(
-                        traits::acquire_future_disp()(std::forward<Ts>(ts))...
-                    )
-                  , init_no_addref()
-                ), false);
-            p->do_await();
+            // Create the data which is used to construct the dataflow_frame
+            auto data = frame_type::construct_from(
+                std::forward<Executor_>(exec), std::forward<F>(f));
+
+            // Construct the dataflow_frame and traverse
+            // the arguments asynchronously
+            boost::intrusive_ptr<frame_type> p = util::traverse_pack_async(
+                util::async_traverse_in_place_tag<frame_type>{},
+                std::move(data),
+                traits::acquire_future_disp()(std::forward<Ts>(ts))...);
 
             using traits::future_access;
             return future_access<typename frame_type::type>::create(std::move(p));

--- a/hpx/util/detail/container_category.hpp
+++ b/hpx/util/detail/container_category.hpp
@@ -1,0 +1,32 @@
+//  Copyright (c) 2017 Denis Blank
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_UTIL_DETAIL_CONTAINER_CATEGORY_HPP
+#define HPX_UTIL_DETAIL_CONTAINER_CATEGORY_HPP
+
+#include <hpx/config.hpp>
+#include <hpx/traits/is_range.hpp>
+#include <hpx/traits/is_tuple_like.hpp>
+
+namespace hpx {
+namespace util {
+    namespace detail {
+        /// A tag for dispatching based on the tuple like
+        /// or container properties of a type.
+        template <bool IsContainer, bool IsTupleLike>
+        struct container_category_tag
+        {
+        };
+
+        /// Deduces to the container_category_tag of the given type T.
+        template <typename T>
+        using container_category_of_t =
+            container_category_tag<traits::is_range<T>::value,
+                traits::is_tuple_like<T>::value>;
+    }    // end namespace detail
+}    // end namespace util
+}    // end namespace hpx
+
+#endif    // HPX_UTIL_DETAIL_CONTAINER_CATEGORY_HPP

--- a/hpx/util/detail/pack_traversal_async_impl.hpp
+++ b/hpx/util/detail/pack_traversal_async_impl.hpp
@@ -118,6 +118,9 @@ namespace util {
             {
             }
 
+            /// We require a virtual base
+            ~async_traversal_frame() noexcept override {}
+
             template <typename MapperArg>
             explicit async_traversal_frame(async_traverse_in_place_tag<Visitor>,
                 MapperArg&& mapper_arg, Args... args)

--- a/hpx/util/detail/pack_traversal_async_impl.hpp
+++ b/hpx/util/detail/pack_traversal_async_impl.hpp
@@ -1,0 +1,479 @@
+//  Copyright (c) 2017 Denis Blank
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_UTIL_DETAIL_PACK_TRAVERSAL_ASYNC_IMPL_HPP
+#define HPX_UTIL_DETAIL_PACK_TRAVERSAL_ASYNC_IMPL_HPP
+
+#include <hpx/config.hpp>
+#include <hpx/util/always_void.hpp>
+#include <hpx/util/detail/container_category.hpp>
+#include <hpx/util/detail/pack.hpp>
+#include <hpx/util/invoke.hpp>
+#include <hpx/util/invoke_fused.hpp>
+#include <hpx/util/iterator_range.hpp>
+#include <hpx/util/tuple.hpp>
+
+#include <cstddef>
+#include <exception>
+#include <iterator>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+namespace hpx {
+namespace util {
+    namespace detail {
+        /// Relocates the given pack with the given offset
+        template <std::size_t Offset, typename Pack>
+        struct relocate_index_pack;
+        template <std::size_t Offset, std::size_t... Sequence>
+        struct relocate_index_pack<Offset, pack_c<std::size_t, Sequence...>>
+          : std::common_type<pack_c<std::size_t, (Sequence + Offset)...>>
+        {
+        };
+
+        /// Creates a sequence from begin to end explicitly
+        template <std::size_t Begin, std::size_t End>
+        using explicit_range_sequence_of_t = typename relocate_index_pack<Begin,
+            typename make_index_pack<End - Begin>::type>::type;
+
+        /// Continues the traversal when the object is called
+        template <typename Frame, typename State>
+        class resume_traversal_callable
+        {
+            Frame frame_;
+            State state_;
+
+        public:
+            explicit resume_traversal_callable(Frame frame, State state)
+              : frame_(std::move(frame))
+              , state_(std::move(state))
+            {
+            }
+
+            /// The callable operator for resuming
+            /// the asynchronous pack traversal
+            void operator()();
+        };
+
+        /// Creates a resume_traversal_callable from the given frame and the
+        /// given iterator tuple.
+        template <typename Frame, typename State>
+        auto make_resume_traversal_callable(Frame&& frame, State&& state)
+            -> resume_traversal_callable<typename std::decay<Frame>::type,
+                typename std::decay<State>::type>
+        {
+            return resume_traversal_callable<typename std::decay<Frame>::type,
+                typename std::decay<State>::type>(
+                std::forward<Frame>(frame), std::forward<State>(state));
+        }
+
+        /// Stores the visitor and the arguments to traverse
+        template <typename Visitor, typename... Args>
+        class async_traversal_frame
+          : public std::enable_shared_from_this<
+                async_traversal_frame<Visitor, Args...>>
+        {
+            Visitor visitor_;
+            tuple<Args...> args_;
+
+        public:
+            explicit HPX_CONSTEXPR async_traversal_frame(Visitor visitor,
+                Args... args)
+              : visitor_(std::move(visitor))
+              , args_(util::make_tuple(std::move(args)...))
+            {
+            }
+
+            /// Returns the arguments of the frame
+            tuple<Args...>& head() noexcept
+            {
+                return args_;
+            }
+
+            /// Calls the visitor with the given element
+            template <typename T>
+            auto traverse(T&& value)
+                -> decltype(util::invoke(visitor_, std::forward<T>(value)))
+            {
+                return util::invoke(visitor_, std::forward<T>(value));
+            }
+
+            /// Calls the visitor with the given element and a continuation
+            /// which is capable of continuing the asynchrone traversal
+            /// when it's called later.
+            template <typename T, typename Hierarchy>
+            void async_continue(T&& value, Hierarchy&& hierarchy)
+            {
+                auto resumable =
+                    make_resume_traversal_callable(this->shared_from_this(),
+                        std::forward<Hierarchy>(hierarchy));
+                util::invoke(
+                    visitor_, std::forward<T>(value), std::move(resumable));
+            }
+
+            /// Calls the visitor with no arguments to signalize that the
+            /// asynchrnous traversal was finished.
+            void async_complete()
+            {
+                util::invoke(visitor_);
+            }
+        };
+
+        /// An internally used exception to detach the current execution context
+        struct async_traversal_detached_exception : std::exception
+        {
+            explicit async_traversal_detached_exception() {}
+
+            char const* what() const noexcept override
+            {
+                return "The execution context was detached!";
+            }
+        };
+
+        template <typename Target, std::size_t Begin, std::size_t End>
+        struct static_async_range
+        {
+            Target* target_;
+
+            HPX_CONSTEXPR auto operator*() const noexcept
+                -> decltype(util::get<Begin>(*target_))
+            {
+                return util::get<Begin>(*target_);
+            }
+
+            template <std::size_t Position>
+            HPX_CONSTEXPR static_async_range<Target, Position, End> relocate()
+                const noexcept
+            {
+                return static_async_range<Target, Position, End>{target_};
+            }
+
+            HPX_CONSTEXPR static_async_range<Target, Begin + 1, End> next()
+                const noexcept
+            {
+                return static_async_range<Target, Begin + 1, End>{target_};
+            }
+
+            HPX_CONSTEXPR bool is_finished() const noexcept
+            {
+                return false;
+            }
+        };
+        /// Specialization for the end marker which doesn't provide
+        /// a particular element dereference
+        template <typename Target, std::size_t Begin>
+        struct static_async_range<Target, Begin, Begin>
+        {
+            explicit static_async_range(Target*) {}
+
+            HPX_CONSTEXPR bool is_finished() const noexcept
+            {
+                return true;
+            }
+        };
+
+        /// Returns a static range for the given type
+        template <typename T,
+            typename Range = static_async_range<typename std::decay<T>::type,
+                0U, util::tuple_size<typename std::decay<T>::type>::value>>
+        Range make_static_range(T&& element)
+        {
+            auto pointer = std::addressof(element);
+            return Range{pointer};
+        }
+
+        template <typename Begin, typename Sentinel>
+        struct dynamic_async_range
+        {
+            Begin begin_;
+            Sentinel sentinel_;
+
+            dynamic_async_range& operator++() noexcept
+            {
+                ++begin_;
+                return *this;
+            }
+
+            auto operator*() const noexcept
+                -> decltype(*std::declval<Begin const&>())
+            {
+                return *begin_;
+            }
+
+            dynamic_async_range next() const
+            {
+                dynamic_async_range other = *this;
+                ++other;
+                return other;
+            }
+
+            bool is_finished() const
+            {
+                return begin_ == sentinel_;
+            }
+        };
+
+        template <typename T>
+        using dynamic_async_range_of_t = dynamic_async_range<
+            typename std::decay<decltype(std::begin(std::declval<T>()))>::type,
+            typename std::decay<decltype(std::end(std::declval<T>()))>::type>;
+
+        /// Returns a dynamic range for the given type
+        template <typename T, typename Range = dynamic_async_range_of_t<T>>
+        Range make_dynamic_async_range(T&& element)
+        {
+            return Range{std::begin(element), std::end(element)};
+        }
+
+        /// Represents a particular point in a asynchronous traversal hierarchy
+        template <typename Frame, typename... Hierarchy>
+        class async_traversal_point
+        {
+            Frame frame_;
+            tuple<Hierarchy...> hierarchy_;
+
+        public:
+            explicit async_traversal_point(
+                Frame frame, tuple<Hierarchy...> hierarchy)
+              : frame_(std::move(frame))
+              , hierarchy_(std::move(hierarchy))
+            {
+            }
+
+            /// Creates a new traversal point which
+            template <typename Parent>
+            auto push(Parent&& parent) -> async_traversal_point<Frame,
+                typename std::decay<Parent>::type, Hierarchy...>
+            {
+                // Create a new hierarchy which contains the
+                // the parent (the last traversed element).
+                auto hierarchy = util::tuple_cat(
+                    util::make_tuple(std::forward<Parent>(parent)), hierarchy_);
+
+                return async_traversal_point<Frame,
+                    typename std::decay<Parent>::type, Hierarchy...>(
+                    frame_, std::move(hierarchy));
+            }
+
+            /// Forks the current traversal point and continues the child
+            /// of the given parent.
+            template <typename Child, typename Parent>
+            void fork(Child&& child, Parent&& parent)
+            {
+                // Push the parent on top of the hierarchy
+                auto point = push(std::forward<Parent>(parent));
+
+                // Continue the traversal with the current element
+                point.async_traverse(std::forward<Child>(child));
+            }
+
+            /// Async traverse a single element, and do nothing.
+            /// This function is matched last.
+            template <typename Matcher, typename Current>
+            void async_traverse_one_impl(Matcher, Current&& current)
+            {
+                // Do nothing if the visitor does't accept the type
+            }
+
+            /// Async traverse a single element which isn't a container or
+            /// tuple like type. This function is SFINAEd out if the element
+            /// isn't accepted by the visitor.
+            ///
+            /// \throws async_traversal_detached_exception If the execution
+            ///         context was detached, an exception is thrown to
+            ///         stop the traversal.
+            template <typename Current>
+            auto async_traverse_one_impl(container_category_tag<false, false>,
+                Current&& current)
+                /// SFINAE this out, if the visitor doesn't accept
+                /// the given element
+                -> typename always_void<decltype(
+                    std::declval<Frame>()->traverse(*current))>::type
+            {
+                if (!frame_->traverse(*current))
+                {
+                    // Store the current call hierarchy into a tuple for
+                    // later reentrance.
+                    auto state =
+                        util::tuple_cat(util::make_tuple(current.next()),
+                            std::move(hierarchy_));
+
+                    // If the traversal method returns false, we detach the
+                    // current execution context and call the visitor with the
+                    // element and a continue callable object again.
+                    frame_->async_continue(*current, std::move(state));
+
+                    // Then detach the current execution context through throwing
+                    // an async_traversal_detached_exception which is catched
+                    // below the traversal call hierarchy.
+                    throw async_traversal_detached_exception{};
+                }
+            }
+
+            /// Async traverse a single element which is a container or
+            /// tuple like type.
+            template <bool IsTupleLike, typename Current>
+            void async_traverse_one_impl(
+                container_category_tag<true, IsTupleLike>,
+                Current&& current)
+            {
+                fork(make_dynamic_async_range(*current),
+                    std::forward<Current>(current));
+            }
+
+            /// Async traverse a single element which is a tuple like type only.
+            template <typename Current>
+            void async_traverse_one_impl(container_category_tag<false, true>,
+                Current&& current)
+            {
+                fork(make_static_range(*current),
+                    std::forward<Current>(current));
+            }
+
+            /// Async traverse the current iterator
+            template <typename Current>
+            void async_traverse_one(Current&& current)
+            {
+                using ElementType =
+                    typename std::decay<decltype(*current)>::type;
+                return async_traverse_one_impl(
+                    container_category_of_t<ElementType>{},
+                    std::forward<Current>(current));
+            }
+
+            template <std::size_t... Sequence, typename Current>
+            void async_traverse_static_async_range(
+                pack_c<std::size_t, Sequence...>,
+                Current&& current)
+            {
+                int dummy[] = {0,
+                    ((void) async_traverse_one(
+                         current.template relocate<Sequence>()),
+                        0)...};
+                (void) dummy;
+            }
+
+            /// Traverse a static range
+            template <typename Target, std::size_t Begin, std::size_t End>
+            void async_traverse(static_async_range<Target, Begin, End> current)
+            {
+                async_traverse_static_async_range(
+                    explicit_range_sequence_of_t<Begin, End>{}, current);
+            }
+
+            /// Traverse a dynamic range
+            template <typename Begin, typename Sentinel>
+            void async_traverse(dynamic_async_range<Begin, Sentinel> range)
+            {
+                for (; !range.is_finished(); ++range)
+                {
+                    async_traverse_one(range);
+                }
+            }
+        };
+
+        /// Deduces to the traversal point class of the
+        /// given frame and hierarchy
+        template <typename Frame, typename... Hierarchy>
+        using traversal_point_of_t =
+            async_traversal_point<typename std::decay<Frame>::type,
+                typename std::decay<Hierarchy>::type...>;
+
+        /// A callable object which is cabale of resuming an asynchronous
+        /// pack traversal.
+        struct resume_state_callable
+        {
+            /// Reenter an asynchronous iterator pack and continue
+            /// its traversal.
+            template <typename Frame, typename Current>
+            void operator()(Frame&& frame, Current&& current) const
+            {
+                // Only process the next element if the current iterator
+                // hasn't reached its end.
+                if (!current.is_finished())
+                {
+                    traversal_point_of_t<Frame> point(
+                        std::forward<Frame>(frame), util::make_tuple());
+
+                    point.async_traverse(std::forward<Current>(current));
+                }
+            }
+
+            /// Reenter an asynchronous iterator pack and continue
+            /// its traversal.
+            template <typename Frame, typename Current, typename Parent,
+                typename... Hierarchy>
+            void operator()(Frame&& frame, Current&& current, Parent&& parent,
+                Hierarchy&&... hierarchy) const
+            {
+                // Only process element if the current iterator
+                // hasn't reached its end.
+                if (!current.is_finished())
+                {
+                    // Don't forward the arguments here, since we still need
+                    // the objects in a valid state later.
+                    traversal_point_of_t<Frame, Parent, Hierarchy...> point(
+                        frame, util::make_tuple(parent, hierarchy...));
+
+                    point.async_traverse(std::forward<Current>(current));
+                }
+
+                // Pop the top element from the hierarchy, and shift the
+                // parent element one to the right
+                (*this)(std::forward<Frame>(frame),
+                    std::forward<Parent>(parent).next(),
+                    std::forward<Hierarchy>(hierarchy)...);
+            }
+        };
+
+        template <typename Frame, typename State>
+        void resume_traversal_callable<Frame, State>::operator()()
+        {
+            try
+            {
+                auto hierarchy = util::tuple_cat(
+                    util::make_tuple(frame_), std::move(state_));
+                util::invoke_fused(
+                    resume_state_callable{}, std::move(hierarchy));
+
+                // Complete the asynchrnous traversal when the last iterator
+                // was processed to its end.
+                frame_->async_complete();
+            }
+            catch (async_traversal_detached_exception const&)
+            {
+                // Do nothing here since the exception was just meant
+                // for terminating the control flow.
+            }
+        }
+
+        /// Traverses the given pack with the given mapper
+        template <typename Mapper, typename... T>
+        void apply_pack_transform_async(Mapper&& mapper, T&&... pack)
+        {
+            using frame_type =
+                async_traversal_frame<typename std::decay<Mapper>::type,
+                    typename std::decay<T>::type...>;
+
+            // Create the frame on the heap which stores the arguments
+            // to traverse asynchronous.
+            auto frame = std::make_shared<frame_type>(
+                std::forward<Mapper>(mapper), std::forward<T>(pack)...);
+
+            // Create a static range for the top level tuple
+            auto range = make_static_range(frame->head());
+
+            auto resumer = make_resume_traversal_callable(
+                std::move(frame), util::make_tuple(std::move(range)));
+
+            // Start the asynchronous traversal
+            resumer();
+        }
+    }    // end namespace detail
+}    // end namespace util
+}    // end namespace hpx
+
+#endif    // HPX_UTIL_DETAIL_PACK_TRAVERSAL_ASYNC_IMPL_HPP

--- a/hpx/util/detail/pack_traversal_async_impl.hpp
+++ b/hpx/util/detail/pack_traversal_async_impl.hpp
@@ -12,25 +12,31 @@
 #include <hpx/util/detail/pack.hpp>
 #include <hpx/util/invoke.hpp>
 #include <hpx/util/invoke_fused.hpp>
-#include <hpx/util/iterator_range.hpp>
 #include <hpx/util/tuple.hpp>
+
+#include <boost/intrusive_ptr.hpp>
 
 #include <cstddef>
 #include <exception>
 #include <iterator>
-#include <memory>
 #include <type_traits>
 #include <utility>
 
 namespace hpx {
 namespace util {
     namespace detail {
+        /// A tag which is passed to the `operator()` of the visitor
+        /// if an element is visited synchronously.
         struct async_traverse_visit_tag
         {
         };
+        /// A tag which is passed to the `operator()` of the visitor
+        /// if an element is visited after the traversal was detached.
         struct async_traverse_detach_tag
         {
         };
+        /// A tag which is passed to the `operator()` of the visitor
+        /// if the asynchronous pack traversal was finished.
         struct async_traverse_complete_tag
         {
         };
@@ -82,10 +88,7 @@ namespace util {
 
         /// Stores the visitor and the arguments to traverse
         template <typename Visitor, typename... Args>
-        class async_traversal_frame
-          : public Visitor
-          , public std::enable_shared_from_this<
-                async_traversal_frame<Visitor, Args...>>
+        class async_traversal_frame : public Visitor
         {
             tuple<Args...> args_;
 
@@ -128,9 +131,16 @@ namespace util {
             template <typename T, typename Hierarchy>
             void async_continue(T&& value, Hierarchy&& hierarchy)
             {
-                auto resumable =
-                    make_resume_traversal_callable(this->shared_from_this(),
-                        std::forward<Hierarchy>(hierarchy));
+                // Create a self reference
+                boost::intrusive_ptr<async_traversal_frame> self(this);
+
+                // Create a callable object which resumes the current
+                // traversal when it's called.
+                auto resumable = make_resume_traversal_callable(
+                    std::move(self), std::forward<Hierarchy>(hierarchy));
+
+                // Invoke the visitor with the current value and the
+                // callable object to resume the control flow.
                 util::invoke(visitor(), async_traverse_detach_tag{},
                     std::forward<T>(value), std::move(resumable));
             }
@@ -326,6 +336,7 @@ namespace util {
                     // If the traversal method returns false, we detach the
                     // current execution context and call the visitor with the
                     // element and a continue callable object again.
+
                     frame_->async_continue(*current, std::move(state));
 
                     // Then detach the current execution context through throwing
@@ -474,7 +485,8 @@ namespace util {
 
         /// Traverses the given pack with the given mapper
         template <typename Mapper, typename... T>
-        void apply_pack_transform_async(Mapper&& mapper, T&&... pack)
+        auto apply_pack_transform_async(Mapper&& mapper, T&&... pack)
+            -> boost::intrusive_ptr<typename std::decay<Mapper>::type>
         {
             using frame_type =
                 async_traversal_frame<typename std::decay<Mapper>::type,
@@ -482,17 +494,23 @@ namespace util {
 
             // Create the frame on the heap which stores the arguments
             // to traverse asynchronous.
-            auto frame = std::make_shared<frame_type>(
-                std::forward<Mapper>(mapper), std::forward<T>(pack)...);
+            auto frame = [&] {
+                auto ptr = new frame_type(
+                    std::forward<Mapper>(mapper), std::forward<T>(pack)...);
+
+                /// Create a intrusive_ptr from the heap object
+                return boost::intrusive_ptr<frame_type>(ptr);
+            }();
 
             // Create a static range for the top level tuple
             auto range = make_static_range(frame->head());
 
             auto resumer = make_resume_traversal_callable(
-                std::move(frame), util::make_tuple(std::move(range)));
+                frame, util::make_tuple(std::move(range)));
 
             // Start the asynchronous traversal
             resumer();
+            return frame;
         }
     }    // end namespace detail
 }    // end namespace util

--- a/hpx/util/pack_traversal_async.hpp
+++ b/hpx/util/pack_traversal_async.hpp
@@ -63,11 +63,27 @@ namespace util {
     ///    };
     ///    ```
     ///
-    /// See `traverse_pack` for a detailed description.
+    /// \param   visitor A visitor object which provides the three `operator()`
+    ///                  overloads that were described above.
+    ///                  Additionally the visitor must be compatible
+    ///                  for referencing it from a `boost::intrusive_ptr`.
+    ///
+    /// \param   pack    The arbitrary parameter pack which is traversed
+    ///                  asynchronously. Nested objects inside containers and
+    ///                  tuple like types are traversed recursively.
+    ///
+    /// \returns         A boost::intrusive_ptr that references an instance of
+    ///                  the given visitor object.
+    ///
+    /// See `traverse_pack` for a detailed description about the
+    /// traversal behaviour and capabilities.
+    ///
     template <typename Visitor, typename... T>
-    void traverse_pack_async(Visitor&& visitor, T&&... pack)
+    auto traverse_pack_async(Visitor&& visitor, T&&... pack)
+        -> decltype(detail::apply_pack_transform_async(
+            std::forward<Visitor>(visitor), std::forward<T>(pack)...))
     {
-        detail::apply_pack_transform_async(
+        return detail::apply_pack_transform_async(
             std::forward<Visitor>(visitor), std::forward<T>(pack)...);
     }
 }    // end namespace util

--- a/hpx/util/pack_traversal_async.hpp
+++ b/hpx/util/pack_traversal_async.hpp
@@ -1,0 +1,64 @@
+//  Copyright (c) 2017 Denis Blank
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_UTIL_PACK_TRAVERSAL_ASYNC_HPP
+#define HPX_UTIL_PACK_TRAVERSAL_ASYNC_HPP
+
+#include <hpx/util/detail/pack_traversal_async_impl.hpp>
+
+#include <utility>
+
+namespace hpx {
+namespace util {
+    /// Traverses the pack with the given visitor in an asynchronous way.
+    ///
+    /// This function works in the same way as `traverse_pack`,
+    /// however, we are able to suspend and continue the traversal at
+    /// later time.
+    /// Thus we require a visitor callable object which provides three
+    /// `operator()` overloads as depicted by the code sample below:
+    ///    ```cpp
+    ///    struct my_async_visitor
+    ///    {
+    ///        /// The synchronous overload is called for each object,
+    ///        /// it may return false to suspend the current control.
+    ///        /// In that case the overload below is called.
+    ///        template <typename T>
+    ///        bool operator()(T&& element)
+    ///        {
+    ///            return true;
+    ///        }
+    ///
+    ///        /// The asynchronous overload this is called when the
+    ///        /// synchronous overload returned false.
+    ///        /// In addition to the current visited element the overload is
+    ///        /// called with a contnuation callable object which resumes the
+    ///        /// traversal when it's called later.
+    ///        /// The continuation next may be stored and called later or
+    ///        /// dropped completely to abort the traversal early.
+    ///        template <typename T, typename N>
+    ///        void operator()(T&& element, N&& next)
+    ///        {
+    ///        }
+    ///
+    ///        /// The overload with no parameters is called when the traversal
+    ///        /// was finished.
+    ///        void operator()()
+    ///        {
+    ///        }
+    ///    };
+    ///    ```
+    ///
+    /// See `traverse_pack` for a detailed description.
+    template <typename Visitor, typename... T>
+    void traverse_pack_async(Visitor&& visitor, T&&... pack)
+    {
+        detail::apply_pack_transform_async(
+            std::forward<Visitor>(visitor), std::forward<T>(pack)...);
+    }
+}    // end namespace util
+}    // end namespace hpx
+
+#endif    // HPX_UTIL_PACK_TRAVERSAL_ASYNC_HPP

--- a/hpx/util/pack_traversal_async.hpp
+++ b/hpx/util/pack_traversal_async.hpp
@@ -71,6 +71,7 @@ namespace util {
     ///                  overloads that were described above.
     ///                  Additionally the visitor must be compatible
     ///                  for referencing it from a `boost::intrusive_ptr`.
+    ///                  The visitor should must have a virtual destructor!
     ///
     /// \param   pack    The arbitrary parameter pack which is traversed
     ///                  asynchronously. Nested objects inside containers and

--- a/hpx/util/pack_traversal_async.hpp
+++ b/hpx/util/pack_traversal_async.hpp
@@ -22,6 +22,10 @@ namespace util {
     /// if the asynchronous pack traversal was finished.
     using detail::async_traverse_complete_tag;
 
+    /// A tag to identify that a mapper shall be constructed in-place
+    /// from the first argument passed.
+    using detail::async_traverse_in_place_tag;
+
     /// Traverses the pack with the given visitor in an asynchronous way.
     ///
     /// This function works in the same way as `traverse_pack`,

--- a/hpx/util/pack_traversal_async.hpp
+++ b/hpx/util/pack_traversal_async.hpp
@@ -12,6 +12,16 @@
 
 namespace hpx {
 namespace util {
+    /// A tag which is passed to the `operator()` of the visitor
+    /// if an element is visited synchronously.
+    using detail::async_traverse_visit_tag;
+    /// A tag which is passed to the `operator()` of the visitor
+    /// if an element is visited after the traversal was detached.
+    using detail::async_traverse_detach_tag;
+    /// A tag which is passed to the `operator()` of the visitor
+    /// if the asynchronous pack traversal was finished.
+    using detail::async_traverse_complete_tag;
+
     /// Traverses the pack with the given visitor in an asynchronous way.
     ///
     /// This function works in the same way as `traverse_pack`,
@@ -26,7 +36,7 @@ namespace util {
     ///        /// it may return false to suspend the current control.
     ///        /// In that case the overload below is called.
     ///        template <typename T>
-    ///        bool operator()(T&& element)
+    ///        bool operator()(async_traverse_visit_tag, T&& element)
     ///        {
     ///            return true;
     ///        }
@@ -39,13 +49,15 @@ namespace util {
     ///        /// The continuation next may be stored and called later or
     ///        /// dropped completely to abort the traversal early.
     ///        template <typename T, typename N>
-    ///        void operator()(T&& element, N&& next)
+    ///        void operator()(async_traverse_detach_tag, T&& element, N&& next)
     ///        {
     ///        }
     ///
-    ///        /// The overload with no parameters is called when the traversal
-    ///        /// was finished.
-    ///        void operator()()
+    ///        /// The overload is called when the traversal was finished.
+    ///        /// As argument the whole pack is passed over which we
+    ///        /// traversed asynchrnously.
+    ///        template <typename T>
+    ///        void operator()(async_traverse_complete_tag, T&& pack)
     ///        {
     ///        }
     ///    };

--- a/tests/unit/lcos/CMakeLists.txt
+++ b/tests/unit/lcos/CMakeLists.txt
@@ -62,6 +62,7 @@ set(tests
     when_all_std_array
     when_any
     when_any_std_array
+    when_each
     when_some
     when_some_std_array
    )

--- a/tests/unit/util/CMakeLists.txt
+++ b/tests/unit/util/CMakeLists.txt
@@ -12,6 +12,7 @@ set(tests
     config_entry
     function
     pack_traversal
+    pack_traversal_async
     parse_slurm_nodelist
     range
     tagged

--- a/tests/unit/util/pack_traversal_async.cpp
+++ b/tests/unit/util/pack_traversal_async.cpp
@@ -1,0 +1,376 @@
+//  Copyright (c) 2017 Denis Blank
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/util/pack_traversal_async.hpp>
+#include <hpx/util/tuple.hpp>
+#include <hpx/util/unused.hpp>
+#include "hpx/util/lightweight_test.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <list>
+#include <memory>
+#include <set>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#if defined(HPX_HAVE_CXX11_STD_ARRAY)
+#include <array>
+#endif
+
+using hpx::util::make_tuple;
+using hpx::util::traverse_pack_async;
+using hpx::util::tuple;
+
+template <std::size_t ArgCount>
+class async_increasing_int_sync_visitor
+{
+    std::reference_wrapper<std::size_t> counter_;
+
+public:
+    explicit async_increasing_int_sync_visitor(
+        std::reference_wrapper<std::size_t>
+            counter)
+      : counter_(counter)
+    {
+    }
+
+    bool operator()(std::size_t i) const
+    {
+        HPX_TEST_EQ(i, counter_.get());
+        ++counter_.get();
+        return true;
+    }
+
+    template <typename N>
+    void operator()(std::size_t i, N&& next)
+    {
+        HPX_UNUSED(i);
+        HPX_UNUSED(next);
+
+        // Should never be called!
+        HPX_TEST(false);
+    }
+
+    void operator()() const
+    {
+        HPX_TEST_EQ(counter_.get(), ArgCount);
+        ++counter_.get();
+    }
+};
+
+template <std::size_t ArgCount>
+class async_increasing_int_visitor
+{
+    std::reference_wrapper<std::size_t> counter_;
+
+public:
+    explicit async_increasing_int_visitor(std::reference_wrapper<std::size_t>
+            counter)
+      : counter_(counter)
+    {
+    }
+
+    bool operator()(std::size_t i) const
+    {
+        HPX_TEST_EQ(i, counter_.get());
+        return false;
+    }
+
+    template <typename N>
+    void operator()(std::size_t i, N&& next)
+    {
+        HPX_UNUSED(i);
+
+        ++counter_.get();
+        std::forward<N>(next)();
+    }
+
+    void operator()() const
+    {
+        HPX_TEST_EQ(counter_.get(), ArgCount);
+        ++counter_.get();
+    }
+};
+
+template <std::size_t ArgCount>
+class async_increasing_int_interrupted_visitor
+{
+    std::reference_wrapper<std::size_t> counter_;
+
+public:
+    explicit async_increasing_int_interrupted_visitor(
+        std::reference_wrapper<std::size_t>
+            counter)
+      : counter_(counter)
+    {
+    }
+
+    bool operator()(std::size_t i) const
+    {
+        HPX_TEST_EQ(i, counter_.get());
+        ++counter_.get();
+
+        // Detach the control flow at the second step
+        return i == 0;
+    }
+
+    template <typename N>
+    void operator()(std::size_t i, N&& next)
+    {
+        HPX_TEST_EQ(i, 1U);
+        HPX_TEST_EQ(counter_.get(), 2U);
+
+        // Don't call next here
+        HPX_UNUSED(next);
+    }
+
+    void operator()() const
+    {
+        // Will never be called
+        HPX_TEST(false);
+    }
+};
+
+template <std::size_t ArgCount, typename... Args>
+void test_async_traversal_base(Args&&... args)
+{
+    // Test that every element is traversed in the correct order
+    // when we detach the control flow on every visit.
+    {
+        std::size_t counter = 0U;
+        traverse_pack_async(
+            async_increasing_int_sync_visitor<ArgCount>(std::ref(counter)),
+            args...);
+        HPX_TEST_EQ(counter, ArgCount + 1U);
+    }
+
+    // Test that every element is traversed in the correct order
+    // when we detach the control flow on every visit.
+    {
+        std::size_t counter = 0U;
+        traverse_pack_async(
+            async_increasing_int_visitor<ArgCount>(std::ref(counter)), args...);
+        HPX_TEST_EQ(counter, ArgCount + 1U);
+    }
+
+    // Test that the first element is traversed only,
+    // if we don't call the resume continuation.
+    {
+        std::size_t counter = 0U;
+        traverse_pack_async(async_increasing_int_interrupted_visitor<ArgCount>(
+                                std::ref(counter)),
+            args...);
+        HPX_TEST_EQ(counter, 2U);
+    }
+}
+
+static void test_async_traversal()
+{
+    // Just test everything using a casual int pack
+    test_async_traversal_base<4U>(0U, 1U, 2U, 3U);
+}
+
+template <typename ContainerFactory>
+void test_async_container_traversal_impl(ContainerFactory&& container_of)
+{
+    // Test by passing a containers in the middle
+    test_async_traversal_base<4U>(0U, container_of(1U, 2U), 3U);
+    // Test by splitting the pack in two containers
+    test_async_traversal_base<4U>(container_of(0U, 1U), container_of(2U, 3U));
+    // Test by passing a huge containers to the traversal
+    test_async_traversal_base<4U>(container_of(0U, 1U, 2U, 3U));
+}
+
+template <typename T>
+struct common_container_factory
+{
+    template <typename... Args>
+    T operator()(Args&&... args)
+    {
+        return T{std::forward<Args>(args)...};
+    }
+};
+
+#if defined(HPX_HAVE_CXX11_STD_ARRAY)
+template <typename T>
+struct array_container_factory
+{
+    template <typename... Args, typename Array = std::array<T, sizeof...(Args)>>
+    Array operator()(Args&&... args)
+    {
+        return Array{{std::forward<Args>(args)...}};
+    }
+};
+#endif
+
+static void test_async_container_traversal()
+{
+    {
+        common_container_factory<std::vector<std::size_t>> factory;
+        test_async_container_traversal_impl(factory);
+    }
+
+    {
+        common_container_factory<std::list<std::size_t>> factory;
+        test_async_container_traversal_impl(factory);
+    }
+
+    {
+        common_container_factory<std::set<std::size_t>> factory;
+        test_async_container_traversal_impl(factory);
+    }
+
+#if defined(HPX_HAVE_CXX11_STD_ARRAY)
+    {
+        array_container_factory<std::size_t> factory;
+        test_async_container_traversal_impl(factory);
+    }
+#endif
+}
+
+static void test_async_tuple_like_traversal()
+{
+    // Test by passing a tuple in the middle
+    test_async_traversal_base<4U>(0U, make_tuple(1U, 2U), 3U);
+    // Test by splitting the pack in two tuples
+    test_async_traversal_base<4U>(make_tuple(0U, 1U), make_tuple(2U, 3U));
+    // Test by passing a huge tuple to the traversal
+    test_async_traversal_base<4U>(make_tuple(0U, 1U, 2U, 3U));
+}
+
+template <typename T,
+    typename... Args,
+    typename Vector = std::vector<typename std::decay<T>::type>>
+Vector vector_of(T&& first, Args&&... args)
+{
+    return Vector{std::forward<T>(first), std::forward<Args>(args)...};
+}
+
+static void test_async_mixed_traversal()
+{
+    using container_t = std::vector<std::size_t>;
+
+    // Test hierarchies where container and tuple like types are mixed
+    test_async_traversal_base<4U>(
+        0U, hpx::util::make_tuple(container_t{1U, 2U}), 3U);
+
+    test_async_traversal_base<4U>(
+        hpx::util::make_tuple(0U, vector_of(vector_of(1U))),
+        make_tuple(2U, 3U));
+
+    test_async_traversal_base<4U>(
+        vector_of(vector_of(make_tuple(0U, 1U, 2U, 3U))));
+}
+
+template <std::size_t ArgCount>
+class async_unique_sync_visitor
+{
+    std::reference_wrapper<std::size_t> counter_;
+
+public:
+    explicit async_unique_sync_visitor(std::reference_wrapper<std::size_t>
+            counter)
+      : counter_(counter)
+    {
+    }
+
+    bool operator()(std::unique_ptr<std::size_t>& i) const
+    {
+        HPX_TEST_EQ(*i, counter_.get());
+        ++counter_.get();
+        return true;
+    }
+
+    template <typename N>
+    void operator()(std::unique_ptr<std::size_t>& i, N&& next)
+    {
+        HPX_UNUSED(i);
+        HPX_UNUSED(next);
+
+        // Should never be called!
+        HPX_TEST(false);
+    }
+
+    void operator()() const
+    {
+        HPX_TEST_EQ(counter_.get(), ArgCount);
+        ++counter_.get();
+    }
+};
+
+template <std::size_t ArgCount>
+class async_unique_visitor
+{
+    std::reference_wrapper<std::size_t> counter_;
+
+public:
+    explicit async_unique_visitor(std::reference_wrapper<std::size_t> counter)
+      : counter_(counter)
+    {
+    }
+
+    bool operator()(std::unique_ptr<std::size_t>& i) const
+    {
+        HPX_TEST_EQ(*i, counter_.get());
+        return false;
+    }
+
+    template <typename N>
+    void operator()(std::unique_ptr<std::size_t>& i, N&& next)
+    {
+        HPX_UNUSED(i);
+
+        ++counter_.get();
+        std::forward<N>(next)();
+    }
+
+    void operator()() const
+    {
+        HPX_TEST_EQ(counter_.get(), ArgCount);
+        ++counter_.get();
+    }
+};
+
+static void test_async_move_only_traversal()
+{
+    auto const of = [](std::size_t i) {
+        return std::unique_ptr<std::size_t>(new std::size_t(i));
+    };
+
+    {
+        std::size_t counter = 0U;
+        traverse_pack_async(async_unique_sync_visitor<4>(std::ref(counter)),
+            of(0),
+            of(1),
+            of(2),
+            of(3));
+        HPX_TEST_EQ(counter, 5U);
+    }
+
+    {
+        std::size_t counter = 0U;
+        traverse_pack_async(async_unique_visitor<4>(std::ref(counter)),
+            of(0),
+            of(1),
+            of(2),
+            of(3));
+        HPX_TEST_EQ(counter, 5U);
+    }
+}
+
+int main(int, char**)
+{
+    test_async_traversal();
+    test_async_container_traversal();
+    test_async_tuple_like_traversal();
+    test_async_mixed_traversal();
+    test_async_move_only_traversal();
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/util/pack_traversal_async.cpp
+++ b/tests/unit/util/pack_traversal_async.cpp
@@ -44,6 +44,8 @@ class async_counter_base : public boost::intrusive_ref_counter<Child>
 public:
     explicit async_counter_base() = default;
 
+    virtual ~async_counter_base() {}
+
     std::size_t const& counter() const noexcept
     {
         return counter_;

--- a/tests/unit/util/pack_traversal_async.cpp
+++ b/tests/unit/util/pack_traversal_async.cpp
@@ -31,6 +31,11 @@ using hpx::util::make_tuple;
 using hpx::util::traverse_pack_async;
 using hpx::util::tuple;
 
+/// A tag which isn't accepted by any mapper
+struct not_accepted_tag
+{
+};
+
 template <typename Child>
 class async_counter_base : public boost::intrusive_ref_counter<Child>
 {
@@ -174,7 +179,13 @@ void test_async_traversal_base(Args&&... args)
 static void test_async_traversal()
 {
     // Just test everything using a casual int pack
-    test_async_traversal_base<4U>(0U, 1U, 2U, 3U);
+    test_async_traversal_base<4U>(not_accepted_tag{},
+        0U,
+        1U,
+        not_accepted_tag{},
+        2U,
+        3U,
+        not_accepted_tag{});
 }
 
 template <typename ContainerFactory>
@@ -238,9 +249,11 @@ static void test_async_container_traversal()
 static void test_async_tuple_like_traversal()
 {
     // Test by passing a tuple in the middle
-    test_async_traversal_base<4U>(0U, make_tuple(1U, 2U), 3U);
+    test_async_traversal_base<4U>(
+        not_accepted_tag{}, 0U, make_tuple(1U, not_accepted_tag{}, 2U), 3U);
     // Test by splitting the pack in two tuples
-    test_async_traversal_base<4U>(make_tuple(0U, 1U), make_tuple(2U, 3U));
+    test_async_traversal_base<4U>(
+        make_tuple(0U, not_accepted_tag{}, 1U), make_tuple(2U, 3U));
     // Test by passing a huge tuple to the traversal
     test_async_traversal_base<4U>(make_tuple(0U, 1U, 2U, 3U));
 }
@@ -262,7 +275,8 @@ static void test_async_mixed_traversal()
         0U, hpx::util::make_tuple(container_t{1U, 2U}), 3U);
 
     test_async_traversal_base<4U>(
-        hpx::util::make_tuple(0U, vector_of(vector_of(1U))),
+        hpx::util::make_tuple(
+            0U, vector_of(not_accepted_tag{}), vector_of(vector_of(1U))),
         make_tuple(2U, 3U));
 
     test_async_traversal_base<4U>(

--- a/tests/unit/util/pack_traversal_async.cpp
+++ b/tests/unit/util/pack_traversal_async.cpp
@@ -23,6 +23,9 @@
 #include <array>
 #endif
 
+using hpx::util::async_traverse_complete_tag;
+using hpx::util::async_traverse_detach_tag;
+using hpx::util::async_traverse_visit_tag;
 using hpx::util::make_tuple;
 using hpx::util::traverse_pack_async;
 using hpx::util::tuple;
@@ -40,7 +43,7 @@ public:
     {
     }
 
-    bool operator()(std::size_t i) const
+    bool operator()(async_traverse_visit_tag, std::size_t i) const
     {
         HPX_TEST_EQ(i, counter_.get());
         ++counter_.get();
@@ -48,7 +51,7 @@ public:
     }
 
     template <typename N>
-    void operator()(std::size_t i, N&& next)
+    void operator()(async_traverse_detach_tag, std::size_t i, N&& next)
     {
         HPX_UNUSED(i);
         HPX_UNUSED(next);
@@ -57,8 +60,11 @@ public:
         HPX_TEST(false);
     }
 
-    void operator()() const
+    template <typename T>
+    void operator()(async_traverse_complete_tag, T&& pack) const
     {
+        HPX_UNUSED(pack);
+
         HPX_TEST_EQ(counter_.get(), ArgCount);
         ++counter_.get();
     }
@@ -76,14 +82,14 @@ public:
     {
     }
 
-    bool operator()(std::size_t i) const
+    bool operator()(async_traverse_visit_tag, std::size_t i) const
     {
         HPX_TEST_EQ(i, counter_.get());
         return false;
     }
 
     template <typename N>
-    void operator()(std::size_t i, N&& next)
+    void operator()(async_traverse_detach_tag, std::size_t i, N&& next)
     {
         HPX_UNUSED(i);
 
@@ -91,8 +97,11 @@ public:
         std::forward<N>(next)();
     }
 
-    void operator()() const
+    template <typename T>
+    void operator()(async_traverse_complete_tag, T&& pack) const
     {
+        HPX_UNUSED(pack);
+
         HPX_TEST_EQ(counter_.get(), ArgCount);
         ++counter_.get();
     }
@@ -111,7 +120,7 @@ public:
     {
     }
 
-    bool operator()(std::size_t i) const
+    bool operator()(async_traverse_visit_tag, std::size_t i) const
     {
         HPX_TEST_EQ(i, counter_.get());
         ++counter_.get();
@@ -121,7 +130,7 @@ public:
     }
 
     template <typename N>
-    void operator()(std::size_t i, N&& next)
+    void operator()(async_traverse_detach_tag, std::size_t i, N&& next)
     {
         HPX_TEST_EQ(i, 1U);
         HPX_TEST_EQ(counter_.get(), 2U);
@@ -130,8 +139,11 @@ public:
         HPX_UNUSED(next);
     }
 
-    void operator()() const
+    template <typename T>
+    void operator()(async_traverse_complete_tag, T&& pack) const
     {
+        HPX_UNUSED(pack);
+
         // Will never be called
         HPX_TEST(false);
     }
@@ -280,7 +292,8 @@ public:
     {
     }
 
-    bool operator()(std::unique_ptr<std::size_t>& i) const
+    bool operator()(async_traverse_visit_tag,
+        std::unique_ptr<std::size_t>& i) const
     {
         HPX_TEST_EQ(*i, counter_.get());
         ++counter_.get();
@@ -288,7 +301,9 @@ public:
     }
 
     template <typename N>
-    void operator()(std::unique_ptr<std::size_t>& i, N&& next)
+    void operator()(async_traverse_detach_tag,
+        std::unique_ptr<std::size_t>& i,
+        N&& next)
     {
         HPX_UNUSED(i);
         HPX_UNUSED(next);
@@ -297,8 +312,11 @@ public:
         HPX_TEST(false);
     }
 
-    void operator()() const
+    template <typename T>
+    void operator()(async_traverse_complete_tag, T&& pack) const
     {
+        HPX_UNUSED(pack);
+
         HPX_TEST_EQ(counter_.get(), ArgCount);
         ++counter_.get();
     }
@@ -315,14 +333,17 @@ public:
     {
     }
 
-    bool operator()(std::unique_ptr<std::size_t>& i) const
+    bool operator()(async_traverse_visit_tag,
+        std::unique_ptr<std::size_t>& i) const
     {
         HPX_TEST_EQ(*i, counter_.get());
         return false;
     }
 
     template <typename N>
-    void operator()(std::unique_ptr<std::size_t>& i, N&& next)
+    void operator()(async_traverse_detach_tag,
+        std::unique_ptr<std::size_t>& i,
+        N&& next)
     {
         HPX_UNUSED(i);
 
@@ -330,8 +351,11 @@ public:
         std::forward<N>(next)();
     }
 
-    void operator()() const
+    template <typename T>
+    void operator()(async_traverse_complete_tag, T&& pack) const
     {
+        HPX_UNUSED(pack);
+
         HPX_TEST_EQ(counter_.get(), ArgCount);
         ++counter_.get();
     }


### PR DESCRIPTION
**This is the third PR of my GSoC :sun_with_face: project**

It implements an API for traversing a pack in an asynchronous way.

It uses exceptions for cancelling the current control flow, hoping this is available on all platforms (nvcc).

**I also added the `when_each` test to the build since it wasn't included**, also there wasn't any indication that it was excluded from the build for any reason.


- [x] Unify the shared state creation