### PR TITLE
Break the debugger when a test failed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -823,6 +823,14 @@ hpx_option(HPX_WITH_THREAD_DESCRIPTION_FULL BOOL
   OFF
   CATEGORY "Debugging" ADVANCED)
 
+hpx_option(HPX_WITH_ATTACH_DEBUGGER_ON_TEST_FAILURE BOOL
+  "Break the debugger if a test has failed  (default: OFF)"
+  OFF
+  CATEGORY "Debugging" ADVANCED)
+if(HPX_WITH_ATTACH_DEBUGGER_ON_TEST_FAILURE)
+  hpx_add_config_define(HPX_HAVE_ATTACH_DEBUGGER_ON_TEST_FAILURE)
+endif()
+
 # If APEX is defined, the action timers need thread debug info.
 if(HPX_WITH_APEX)
     hpx_add_config_define(HPX_HAVE_THREAD_DESCRIPTION)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -183,6 +183,7 @@ set(doxygen_dependencies
     "${PROJECT_SOURCE_DIR}/hpx/lcos/wait_each.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/lcos/when_each.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/traits/is_execution_policy.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/util/debugging.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/util/invoke.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/util/invoke_fused.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/util/pack_traversal.hpp"

--- a/docs/hpx.idx
+++ b/docs/hpx.idx
@@ -526,6 +526,9 @@ when_each_n                           "" "header\.hpx\.lcos\.when_each.*"
 wait_each                             "" "header\.hpx\.lcos\.wait_each.*"
 wait_each_n                           "" "header\.hpx\.lcos\.wait_each.*"
 
+# hpx/util/debugging.hpp
+attach_debugger                       "" "header\.hpx\.util\.attach_debugger.*"
+
 # hpx/util/invoke.hpp
 invoke                                "" "header\.hpx\.util\.invoke.*"
 invoke_r                              "" "header\.hpx\.util\.invoke_r.*"

--- a/hpx/util/command_line_handling.hpp
+++ b/hpx/util/command_line_handling.hpp
@@ -90,8 +90,6 @@ namespace hpx { namespace util
 #endif
 
     void handle_list_parcelports();
-
-    void HPX_EXPORT attach_debugger();
 }}
 
 #endif /*HPX_UTIL_COMMAND_LINE_HANDLING_HPP*/

--- a/hpx/util/debugging.hpp
+++ b/hpx/util/debugging.hpp
@@ -1,0 +1,20 @@
+//  Copyright (c) 2007-2012 Hartmut Kaiser
+//  Copyright (c) 2017      Denis Blank
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_UTIL_DEBUGGING_HPP
+#define HPX_UTIL_DEBUGGING_HPP
+
+#include <hpx/config.hpp>
+
+namespace hpx {
+namespace util {
+    /// Tries to break an attached debugger, if not supported a loop is
+    /// invoked which gives enough time to attach a debugger manually.
+    void HPX_EXPORT attach_debugger();
+}    // end namespace util
+}    // end namespace hpx
+
+#endif    // HPX_UTIL_DEBUGGING_HPP

--- a/hpx/util/lightweight_test.hpp
+++ b/hpx/util/lightweight_test.hpp
@@ -59,31 +59,9 @@ struct fixture
     {
     }
 
-    void increment(counter_type c)
-    {
-        switch (c)
-        {
-            case counter_sanity:
-                ++sanity_failures_; return;
-            case counter_test:
-                ++test_failures_; return;
-            default:
-                { HPX_ASSERT(false); return; }
-        }
-    }
+    void increment(counter_type c);
 
-    std::size_t get(counter_type c) const
-    {
-        switch (c)
-        {
-            case counter_sanity:
-                return sanity_failures_;
-            case counter_test:
-                return test_failures_;
-            default:
-                { HPX_ASSERT(false); return 0; }
-        }
-    }
+    std::size_t get(counter_type c) const;
 
     template <typename T>
     bool check(char const* file, int line, char const* function,

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -21,6 +21,7 @@
 #include <hpx/util/assert.hpp>
 #include <hpx/util/backtrace.hpp>
 #include <hpx/util/command_line_handling.hpp>
+#include <hpx/util/debugging.hpp>
 #include <hpx/util/filesystem_compatibility.hpp>
 #include <hpx/util/logging.hpp>
 

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -27,6 +27,7 @@
 #include <hpx/state.hpp>
 #include <hpx/util/backtrace.hpp>
 #include <hpx/util/command_line_handling.hpp>
+#include <hpx/util/debugging.hpp>
 #include <hpx/util/high_resolution_clock.hpp>
 #include <hpx/util/logging.hpp>
 #include <hpx/util/query_counters.hpp>

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -1044,12 +1044,12 @@ namespace hpx { namespace util
         if(vm_.count("hpx:attach-debugger"))
         {
             std::string option = vm_["hpx:attach-debugger"].as<std::string>();
-            if (option != "startup" && option != "exception" &&
-                option != "test-failure") {
+            if (option != "off" && option != "startup" &&
+                option != "exception" && option != "test-failure") {
                 std::cerr <<
                     "hpx::init: command line warning: --hpx:attach-debugger: "
                     "invalid option: " << option << ". Allowed values are "
-                    "'startup', 'exception' or 'test-failure'" << std::endl;
+                    "'off', 'startup', 'exception' or 'test-failure'" << std::endl;
             }
             else {
                 if (option == "startup")

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -16,6 +16,7 @@
 #include <hpx/runtime/threads/topology.hpp>
 #include <hpx/util/asio_util.hpp>
 #include <hpx/util/batch_environment.hpp>
+#include <hpx/util/debugging.hpp>
 #include <hpx/util/detail/pp/stringize.hpp>
 #include <hpx/util/detail/reset_function.hpp>
 #include <hpx/util/manage_config.hpp>
@@ -1037,34 +1038,18 @@ namespace hpx { namespace util
         return false;
     }
 
-    void attach_debugger()
-    {
-#if defined(_POSIX_VERSION)
-        volatile int i = 0;
-        std::cerr
-            << "PID: " << getpid() << " on " << boost::asio::ip::host_name()
-            << " ready for attaching debugger. Once attached set i = 1 and continue"
-            << std::endl;
-        while(i == 0)
-        {
-            sleep(1);
-        }
-#elif defined(HPX_WINDOWS)
-        DebugBreak();
-#endif
-    }
-
     void command_line_handling::handle_attach_debugger()
     {
 #if defined(_POSIX_VERSION) || defined(HPX_WINDOWS)
         if(vm_.count("hpx:attach-debugger"))
         {
             std::string option = vm_["hpx:attach-debugger"].as<std::string>();
-            if (option != "startup" && option != "exception") {
+            if (option != "startup" && option != "exception" &&
+                option != "test-failure") {
                 std::cerr <<
                     "hpx::init: command line warning: --hpx:attach-debugger: "
                     "invalid option: " << option << ". Allowed values are "
-                    "'startup' or 'exception'" << std::endl;
+                    "'startup', 'exception' or 'test-failure'" << std::endl;
             }
             else {
                 if (option == "startup")

--- a/src/util/debugging.cpp
+++ b/src/util/debugging.cpp
@@ -1,0 +1,36 @@
+//  Copyright (c) 2007-2012 Hartmut Kaiser
+//  Copyright (c) 2017      Denis Blank
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/util/debugging.hpp>
+
+#include <iostream>
+
+#if defined(HPX_WINDOWS)
+#include <Windows.h>
+#endif    // HPX_WINDOWS
+
+namespace hpx {
+namespace util {
+    void attach_debugger()
+    {
+#if defined(_POSIX_VERSION)
+        volatile int i = 0;
+        std::cerr << "PID: " << getpid() << " on "
+                  << boost::asio::ip::host_name()
+                  << " ready for attaching debugger. Once attached set i = 1 "
+                     "and continue"
+                  << std::endl;
+        while (i == 0)
+        {
+            sleep(1);
+        }
+#elif defined(HPX_WINDOWS)
+        DebugBreak();
+#endif
+    }
+}    // end namespace util
+}    // end namespace hpx

--- a/src/util/lightweight_test.cpp
+++ b/src/util/lightweight_test.cpp
@@ -1,15 +1,57 @@
 //  Copyright (c) 2013 Hartmut Kaiser
+//  Copyright (c) 2017 Denis Blank
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #define HPX_NO_VERSION_CHECK
 
+#include <hpx/runtime/config_entry.hpp>
+#include <hpx/util/debugging.hpp>
 #include <hpx/util/lightweight_test.hpp>
+
+#include <cstddef>
 #include <iostream>
 
 namespace hpx { namespace util { namespace detail
 {
+    /// Attach the debugger if this is enabled in the config
+    static void may_attach_debugger()
+    {
+        if (get_config_entry("hpx.attach-debugger", "") == "test-failure")
+        {
+            attach_debugger();
+        }
+    }
+
+    void fixture::increment(counter_type c)
+    {
+        may_attach_debugger();
+
+        switch (c)
+        {
+            case counter_sanity:
+                ++sanity_failures_; return;
+            case counter_test:
+                ++test_failures_; return;
+            default:
+                { HPX_ASSERT(false); return; }
+        }
+    }
+
+    std::size_t fixture::get(counter_type c) const
+    {
+        switch (c)
+        {
+            case counter_sanity:
+                return sanity_failures_;
+            case counter_test:
+                return test_failures_;
+            default:
+                { HPX_ASSERT(false); return 0; }
+        }
+    }
+
     fixture global_fixture{std::cerr};
 }}}
 

--- a/src/util/parse_command_line.cpp
+++ b/src/util/parse_command_line.cpp
@@ -507,7 +507,7 @@ namespace hpx { namespace util
                 ("hpx:attach-debugger",
                   value<std::string>()->implicit_value("startup"),
                   "wait for a debugger to be attached, possible values: "
-                  "startup, exception or test-failure (default: startup)")
+                  "off, startup, exception or test-failure (default: startup)")
 #endif
                 ("hpx:list-parcel-ports", "list all available parcel-ports")
             ;

--- a/src/util/parse_command_line.cpp
+++ b/src/util/parse_command_line.cpp
@@ -507,7 +507,7 @@ namespace hpx { namespace util
                 ("hpx:attach-debugger",
                   value<std::string>()->implicit_value("startup"),
                   "wait for a debugger to be attached, possible values: "
-                  "startup or exception (default: startup)")
+                  "startup, exception or test-failure (default: startup)")
 #endif
                 ("hpx:list-parcel-ports", "list all available parcel-ports")
             ;

--- a/src/util/runtime_configuration.cpp
+++ b/src/util/runtime_configuration.cpp
@@ -195,6 +195,14 @@ namespace hpx { namespace util
             "max_busy_loop_count = ${HPX_MAX_BUSY_LOOP_COUNT:"
                 HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_BUSY_LOOP_COUNT_MAX)) "}",
 
+            /// If HPX_HAVE_ATTACH_DEBUGGER_ON_TEST_FAILURE is set,
+            /// then apply the test-failure value as default.
+#if defined(HPX_HAVE_ATTACH_DEBUGGER_ON_TEST_FAILURE)
+            "attach-debugger = ${HPX_ATTACH_DEBUGGER:test-failure}",
+#else
+            "attach-debugger = ${HPX_ATTACH_DEBUGGER}",
+#endif
+
             // arity for collective operations implemented in a tree fashion
             "[hpx.lcos.collectives]",
             "arity = ${HPX_LCOS_COLLECTIVES_ARITY:32}",


### PR DESCRIPTION
* Currently only implemented for the MSVC debugger if attached

The main idea is that we instantly see which test failed if we execute a test inside a debugger.

I would like to hear your opinion about this:
* Maybe we could allow to enable/disable this from CMake.
* Maybe we could move this up to the test macros which could yield a better stack trace