### PR TITLE
Unify serialization of non-default-constructable types

### DIFF
--- a/tests/unit/serialization/polymorphic/polymorphic_nonintrusive.cpp
+++ b/tests/unit/serialization/polymorphic/polymorphic_nonintrusive.cpp
@@ -92,7 +92,7 @@ void serialize(Archive& ar, C<T>& c, unsigned)
 }
 
 template<typename T>
-C<T> *c_factory(hpx::serialization::input_archive& ar, C<T> */*unused*/)
+C<T> *c_factory(hpx::serialization::input_archive& ar, C<T> * /*unused*/)
 {
     C<T> *c = new C<T>(999);
     serialize(ar, *c, 0);
@@ -129,7 +129,7 @@ namespace hpx { namespace serialization {
 } }
 
 template<typename T>
-E<T> *e_factory(hpx::serialization::input_archive& ar, E<T> */*unused*/)
+E<T> *e_factory(hpx::serialization::input_archive& ar, E<T> * /*unused*/)
 {
     E<T> *e = new E<T>(99, 9999);
     serialize(ar, *e, 0);

--- a/tests/unit/serialization/serialization_array.cpp
+++ b/tests/unit/serialization/serialization_array.cpp
@@ -236,7 +236,7 @@ void test_plain_array()
     T oarray[N];
 
     for(std::size_t i = 0; i < N; ++i) {
-        iarray[i] = i * i;
+        iarray[i] = static_cast<T>(i * i);
         oarray[i] = -1;
     }
 
@@ -261,7 +261,7 @@ void test_array_of_vectors()
 
     for(std::size_t i = 0; i < N; ++i) {
         for (std::size_t j = 0; j < i; ++j) {
-            iarray[i].push_back(i * i);
+            iarray[i].push_back(static_cast<T>(i * i));
         }
     }
 

--- a/tests/unit/serialization/serialize_buffer.cpp
+++ b/tests/unit/serialization/serialize_buffer.cpp
@@ -90,7 +90,7 @@ void test_fixed_size_initialization_for_persistent_buffers(std::size_t max_size)
         std::vector<T> recv_vec;
         send_vec.reserve(size);
         for (std::size_t i = 0; i < size; ++i) {
-            send_vec.push_back(size - i);
+            send_vec.push_back(static_cast<int>(size - i));
         }
 
         hpx::serialization::serialize_buffer<T> send_buffer(size);


### PR DESCRIPTION
- this fixes #2846
- flyby: fixed a couple of warnings in tests
