### PR TITLE
  Enable returning future<R> from actions where R is not default-constructible

### DIFF
--- a/hpx/lcos/base_lco_with_value.hpp
+++ b/hpx/lcos/base_lco_with_value.hpp
@@ -17,6 +17,7 @@
 #include <hpx/runtime/components_fwd.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/traits/is_component.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/util/detail/pp/cat.hpp>
 #include <hpx/util/detail/pp/expand.hpp>
 #include <hpx/util/detail/pp/nargs.hpp>
@@ -81,6 +82,17 @@ namespace hpx { namespace lcos
         virtual ~base_lco_with_value() noexcept {}
 
         virtual void set_event()
+        {
+            set_event_nonvirt(std::is_default_constructible<RemoteResult>());
+        }
+
+        void set_event_nonvirt(std::false_type)
+        {
+            // this shouldn't ever be called
+            HPX_ASSERT(false);
+        }
+
+        void set_event_nonvirt(std::true_type)
         {
             set_value(RemoteResult());
         }

--- a/hpx/lcos/base_lco_with_value.hpp
+++ b/hpx/lcos/base_lco_with_value.hpp
@@ -7,6 +7,7 @@
 #define HPX_LCOS_BASE_LCO_WITH_VALUE_HPP
 
 #include <hpx/config.hpp>
+#include <hpx/throw_exception.hpp>
 #include <hpx/lcos/base_lco.hpp>
 #include <hpx/plugins/parcel/coalescing_message_handler_registration.hpp>
 #include <hpx/runtime/actions/basic_action.hpp>
@@ -89,7 +90,11 @@ namespace hpx { namespace lcos
         void set_event_nonvirt(std::false_type)
         {
             // this shouldn't ever be called
-            HPX_ASSERT(false);
+            HPX_THROW_EXCEPTION(invalid_status,
+                "base_lco_with_value::set_event_nonvirt",
+                "attempt to use a non-default-constructible return type with "
+                "an action in a context where default-construction would be "
+                "required");
         }
 
         void set_event_nonvirt(std::true_type)

--- a/hpx/lcos/detail/async_implementations.hpp
+++ b/hpx/lcos/detail/async_implementations.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2017 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -108,23 +108,6 @@ namespace hpx { namespace detail
         }
     };
 
-    template <typename Action, typename Result>
-    struct sync_local_invoke<Action, lcos::future<Result> >
-    {
-        template <typename ...Ts>
-        HPX_FORCEINLINE static lcos::future<Result>
-        call(naming::id_type const&, naming::address && addr, Ts &&... vs)
-        {
-            HPX_ASSERT(!!addr);
-            HPX_ASSERT(traits::component_type_is_compatible<
-                    typename Action::component_type
-                >::call(addr));
-
-            return Action::execute_function(addr.address_, addr.type_,
-                std::forward<Ts>(vs)...);
-        }
-    };
-
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Result>
     struct sync_local_invoke_cb
@@ -148,33 +131,10 @@ namespace hpx { namespace detail
         }
     };
 
-    template <typename Action, typename Result>
-    struct sync_local_invoke_cb<Action, lcos::future<Result> >
-    {
-        template <typename Callback, typename ...Ts>
-        HPX_FORCEINLINE static lcos::future<Result>
-        call(naming::id_type const&, naming::address && addr, Callback && cb,
-            Ts &&... vs)
-        {
-            HPX_ASSERT(!!addr);
-            HPX_ASSERT(traits::component_type_is_compatible<
-                    typename Action::component_type
-                >::call(addr));
-
-            lcos::future<Result> f = Action::execute_function(
-                addr.address_, addr.type_, std::forward<Ts>(vs)...);
-
-            // invoke callback
-            cb(boost::system::error_code(), parcelset::parcel());
-
-            return f;
-        }
-    };
-
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename ...Ts>
     hpx::future<
-        typename hpx::traits::extract_action<Action>::local_result_type
+        typename hpx::traits::extract_action<Action>::type::local_result_type
     >
     async_impl(launch policy, hpx::id_type const& id, Ts&&... vs)
     {
@@ -237,7 +197,7 @@ namespace hpx { namespace detail
 
     template <typename Action, typename ...Ts>
     hpx::future<
-        typename hpx::traits::extract_action<Action>::local_result_type
+        typename hpx::traits::extract_action<Action>::type::local_result_type
     >
     async_impl(hpx::detail::sync_policy, hpx::id_type const& id, Ts&&... vs)
     {
@@ -281,7 +241,7 @@ namespace hpx { namespace detail
 
     template <typename Action, typename ...Ts>
     hpx::future<
-        typename hpx::traits::extract_action<Action>::local_result_type
+        typename hpx::traits::extract_action<Action>::type::local_result_type
     >
     async_impl(hpx::detail::async_policy, hpx::id_type const& id, Ts&&... vs)
     {
@@ -304,7 +264,7 @@ namespace hpx { namespace detail
 
     template <typename Action, typename ...Ts>
     hpx::future<
-        typename hpx::traits::extract_action<Action>::local_result_type
+        typename hpx::traits::extract_action<Action>::type::local_result_type
     >
     async_impl(hpx::detail::deferred_policy, hpx::id_type const& id, Ts&&... vs)
     {
@@ -332,7 +292,7 @@ namespace hpx { namespace detail
     ///
     template <typename Action, typename Callback, typename ...Ts>
     hpx::future<
-        typename hpx::traits::extract_action<Action>::local_result_type
+        typename hpx::traits::extract_action<Action>::type::local_result_type
     >
     async_cb_impl(launch policy, hpx::id_type const& id, Callback&& cb, Ts&&... vs)
     {
@@ -400,7 +360,7 @@ namespace hpx { namespace detail
 
     template <typename Action, typename Callback, typename ...Ts>
     hpx::future<
-        typename hpx::traits::extract_action<Action>::local_result_type
+        typename hpx::traits::extract_action<Action>::type::local_result_type
     >
     async_cb_impl(hpx::detail::sync_policy, hpx::id_type const& id, Callback&& cb,
         Ts&&... vs)
@@ -450,7 +410,7 @@ namespace hpx { namespace detail
 
     template <typename Action, typename Callback, typename ...Ts>
     hpx::future<
-        typename hpx::traits::extract_action<Action>::local_result_type
+        typename hpx::traits::extract_action<Action>::type::local_result_type
     >
     async_cb_impl(hpx::detail::async_policy, hpx::id_type const& id, Callback&& cb,
         Ts&&... vs)
@@ -475,7 +435,7 @@ namespace hpx { namespace detail
 
     template <typename Action, typename Callback, typename ...Ts>
     hpx::future<
-        typename hpx::traits::extract_action<Action>::local_result_type
+        typename hpx::traits::extract_action<Action>::type::local_result_type
     >
     async_cb_impl(hpx::detail::deferred_policy, hpx::id_type const& id,
         Callback&& cb, Ts&&... vs)

--- a/hpx/lcos/detail/async_implementations_fwd.hpp
+++ b/hpx/lcos/detail/async_implementations_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2017 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -18,28 +18,28 @@ namespace hpx { namespace detail
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename ...Ts>
     hpx::future<
-        typename hpx::traits::extract_action<Action>::local_result_type
+        typename hpx::traits::extract_action<Action>::type::local_result_type
     >
     async_impl(launch policy, hpx::id_type const& id,
         Ts&&... vs);
 
     template <typename Action, typename ...Ts>
     hpx::future<
-        typename hpx::traits::extract_action<Action>::local_result_type
+        typename hpx::traits::extract_action<Action>::type::local_result_type
     >
     async_impl(hpx::detail::sync_policy, hpx::id_type const& id,
         Ts&&... vs);
 
     template <typename Action, typename ...Ts>
     hpx::future<
-        typename hpx::traits::extract_action<Action>::local_result_type
+        typename hpx::traits::extract_action<Action>::type::local_result_type
     >
     async_impl(hpx::detail::async_policy, hpx::id_type const& id,
         Ts&&... vs);
 
     template <typename Action, typename ...Ts>
     hpx::future<
-        typename hpx::traits::extract_action<Action>::local_result_type
+        typename hpx::traits::extract_action<Action>::type::local_result_type
     >
     async_impl(hpx::detail::deferred_policy, hpx::id_type const& id,
         Ts&&... vs);
@@ -47,28 +47,28 @@ namespace hpx { namespace detail
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Callback, typename ...Ts>
     hpx::future<
-        typename hpx::traits::extract_action<Action>::local_result_type
+        typename hpx::traits::extract_action<Action>::type::local_result_type
     >
     async_cb_impl(launch policy, hpx::id_type const& id,
         Callback&& cb, Ts&&... vs);
 
     template <typename Action, typename Callback, typename ...Ts>
     hpx::future<
-        typename hpx::traits::extract_action<Action>::local_result_type
+        typename hpx::traits::extract_action<Action>::type::local_result_type
     >
     async_cb_impl(hpx::detail::sync_policy, hpx::id_type const& id,
         Callback&& cb, Ts&&... vs);
 
     template <typename Action, typename Callback, typename ...Ts>
     hpx::future<
-        typename hpx::traits::extract_action<Action>::local_result_type
+        typename hpx::traits::extract_action<Action>::type::local_result_type
     >
     async_cb_impl(hpx::detail::async_policy, hpx::id_type const& id,
         Callback&& cb, Ts&&... vs);
 
     template <typename Action, typename Callback, typename ...Ts>
     hpx::future<
-        typename hpx::traits::extract_action<Action>::local_result_type
+        typename hpx::traits::extract_action<Action>::type::local_result_type
     >
     async_cb_impl(hpx::detail::deferred_policy, hpx::id_type const& id,
         Callback&& cb, Ts&&... vs);

--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -12,6 +12,7 @@
 #include <hpx/lcos/detail/future_data.hpp>
 #include <hpx/lcos_fwd.hpp>
 #include <hpx/runtime/actions/continuation_fwd.hpp>
+#include <hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/throw_exception.hpp>
 #include <hpx/traits/acquire_shared_state.hpp>
@@ -46,6 +47,7 @@
 
 #include <exception>
 #include <iterator>
+#include <memory>
 #include <type_traits>
 #include <utility>
 
@@ -60,6 +62,38 @@ namespace hpx { namespace lcos { namespace detail
     };
 
     template <typename Archive, typename Future>
+    void serialize_future_load(Archive& ar, Future& f, std::true_type)
+    {
+        typedef typename hpx::traits::future_traits<Future>::type value_type;
+        typedef lcos::detail::future_data<value_type> shared_state;
+        typedef typename shared_state::init_no_addref init_no_addref;
+
+        value_type value;
+        ar >> value;
+
+        boost::intrusive_ptr<shared_state> p(
+            new shared_state(std::move(value), init_no_addref()), false);
+
+        f = hpx::traits::future_access<Future>::create(std::move(p));
+    }
+
+    template <typename Archive, typename Future>
+    void serialize_future_load(Archive& ar, Future& f, std::false_type)
+    {
+        typedef typename hpx::traits::future_traits<Future>::type value_type;
+        typedef lcos::detail::future_data<value_type> shared_state;
+        typedef typename shared_state::init_no_addref init_no_addref;
+
+        std::unique_ptr<value_type> value(
+            serialization::detail::constructor_selector<value_type>::create(ar));
+
+        boost::intrusive_ptr<shared_state> p(
+            new shared_state(std::move(*value), init_no_addref()), false);
+
+        f = hpx::traits::future_access<Future>::create(std::move(p));
+    }
+
+    template <typename Archive, typename Future>
     typename std::enable_if<
         !std::is_void<typename hpx::traits::future_traits<Future>::type>::value
     >::type serialize_future_load(Archive& ar, Future& f)
@@ -72,13 +106,8 @@ namespace hpx { namespace lcos { namespace detail
         ar >> state;
         if (state == future_state::has_value)
         {
-            value_type value;
-            ar >> value;
-
-            boost::intrusive_ptr<shared_state> p(
-                new shared_state(std::move(value), init_no_addref()), false);
-
-            f = hpx::traits::future_access<Future>::create(std::move(p));
+            serialize_future_load(ar, f,
+                typename std::is_default_constructible<value_type>::type());
         } else if (state == future_state::has_exception) {
             std::exception_ptr exception;
             ar >> exception;

--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -162,7 +162,8 @@ namespace hpx { namespace lcos { namespace detail
     template <typename Archive, typename T>
     void serialize_future_save(Archive& ar, T const& val, std::false_type)
     {
-        serialization::detail::save_construct_data(ar, &val, 0);
+        using serialization::detail::save_construct_data;
+        save_construct_data(ar, &val, 0);
         ar << val;
     }
 

--- a/hpx/parallel/execution_policy.hpp
+++ b/hpx/parallel/execution_policy.hpp
@@ -322,6 +322,12 @@ namespace hpx { namespace parallel { namespace execution
         HPX_CONSTEXPR Parameters const& parameters() const { return params_; }
 
         /// \cond NOINTERNAL
+        template <typename Dependent = void, typename Enable =
+            typename std::enable_if<
+                std::is_constructible<Executor>::value &&
+                    std::is_constructible<Parameters>::value,
+                Dependent
+            >::type>
         HPX_CONSTEXPR sequenced_task_policy_shim() {}
 
         template <typename Executor_, typename Parameters_>
@@ -619,6 +625,12 @@ namespace hpx { namespace parallel { namespace execution
         HPX_CONSTEXPR Parameters const& parameters() const { return params_; }
 
         /// \cond NOINTERNAL
+        template <typename Dependent = void, typename Enable =
+            typename std::enable_if<
+                std::is_constructible<Executor>::value &&
+                    std::is_constructible<Parameters>::value,
+                Dependent
+            >::type>
         HPX_CONSTEXPR sequenced_policy_shim() {}
 
         template <typename Executor_, typename Parameters_>
@@ -917,6 +929,12 @@ namespace hpx { namespace parallel { namespace execution
         HPX_CONSTEXPR Parameters const& parameters() const { return params_; }
 
         /// \cond NOINTERNAL
+        template <typename Dependent = void, typename Enable =
+            typename std::enable_if<
+                std::is_constructible<Executor>::value &&
+                    std::is_constructible<Parameters>::value,
+                Dependent
+            >::type>
         HPX_CONSTEXPR parallel_task_policy_shim() {}
 
         template <typename Executor_, typename Parameters_>
@@ -1206,6 +1224,12 @@ namespace hpx { namespace parallel { namespace execution
         HPX_CONSTEXPR Parameters const& parameters() const { return params_; }
 
         /// \cond NOINTERNAL
+        template <typename Dependent = void, typename Enable =
+            typename std::enable_if<
+                std::is_constructible<Executor>::value &&
+                    std::is_constructible<Parameters>::value,
+                Dependent
+            >::type>
         HPX_CONSTEXPR parallel_policy_shim() {}
 
         template <typename Executor_, typename Parameters_>

--- a/hpx/parallel/executors/executor_parameters.hpp
+++ b/hpx/parallel/executors/executor_parameters.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2016 Marcin Copik
-//  Copyright (c) 2016 Hartmut Kaiser
+//  Copyright (c) 2016-2017 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -54,6 +54,10 @@ namespace hpx { namespace parallel { inline namespace v3
         struct unwrapper : T
         {
             // default constructor is needed for serialization purposes
+            template <typename Dependent = void, typename Enable =
+                typename std::enable_if<
+                    std::is_constructible<T>::value, Dependent
+                >::type>
             unwrapper() : T() {}
 
             // generic poor-man's forwarding constructor
@@ -310,11 +314,17 @@ namespace hpx { namespace parallel { inline namespace v3
             HPX_STATIC_ASSERT_ON_PARAMETERS_AMBIGUITY(maximal_number_of_chunks);
             HPX_STATIC_ASSERT_ON_PARAMETERS_AMBIGUITY(reset_thread_distribution);
 
+            template <typename Dependent = void, typename Enable =
+                typename std::enable_if<
+                    hpx::util::detail::all_of<
+                        std::is_constructible<Params>...
+                    >::value, Dependent
+                >::type>
             executor_parameters()
               : unwrapper<Params>()...
             {}
 
-            template <typename ... Params_, typename T =
+            template <typename ... Params_, typename Enable =
                 typename std::enable_if<
                     hpx::util::detail::pack<Params...>::size ==
                         hpx::util::detail::pack<Params_...>::size

--- a/hpx/runtime/actions/action_support.hpp
+++ b/hpx/runtime/actions/action_support.hpp
@@ -11,7 +11,6 @@
 #define HPX_RUNTIME_ACTIONS_ACTION_SUPPORT_NOV_14_2008_0711PM
 
 #include <hpx/config.hpp>
-#include <hpx/lcos/future.hpp>
 #include <hpx/runtime/actions_fwd.hpp>
 #include <hpx/runtime/components/pinned_ptr.hpp>
 #include <hpx/runtime/parcelset_fwd.hpp>
@@ -83,35 +82,11 @@ namespace hpx { namespace traits
     namespace detail
     {
         ///////////////////////////////////////////////////////////////////////
-        // If an action returns a future, we need to do special things
+        // If an action returns void, we need to do special things
         template <>
         struct action_remote_result_customization_point<void>
         {
             typedef util::unused_type type;
-        };
-
-        template <typename Result>
-        struct action_remote_result_customization_point<lcos::future<Result> >
-        {
-            typedef Result type;
-        };
-
-        template <>
-        struct action_remote_result_customization_point<lcos::future<void> >
-        {
-            typedef hpx::util::unused_type type;
-        };
-
-        template <typename Result>
-        struct action_remote_result_customization_point<lcos::shared_future<Result> >
-        {
-            typedef Result type;
-        };
-
-        template <>
-        struct action_remote_result_customization_point<lcos::shared_future<void> >
-        {
-            typedef hpx::util::unused_type type;
         };
     }
 }}

--- a/hpx/runtime/actions/basic_action.hpp
+++ b/hpx/runtime/actions/basic_action.hpp
@@ -43,7 +43,6 @@
 #include <hpx/util/get_and_reset_value.hpp>
 #include <hpx/util/logging.hpp>
 #include <hpx/util/tuple.hpp>
-#include <hpx/util/void_guard.hpp>
 #if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
 #include <hpx/util/itt_notify.hpp>
 #endif
@@ -350,26 +349,15 @@ namespace hpx { namespace actions
 
     private:
         ///////////////////////////////////////////////////////////////////////
-        typedef traits::is_future<result_type> is_future_pred;
-
         struct sync_invoke
         {
             template <typename IdOrPolicy, typename Policy, typename ...Ts>
             HPX_FORCEINLINE static result_type call(
-                std::false_type, Policy policy, IdOrPolicy const& id_or_policy,
+                Policy const& policy, IdOrPolicy const& id_or_policy,
                 error_code& ec, Ts&&... vs)
             {
                 return hpx::async<basic_action>(policy, id_or_policy,
                     std::forward<Ts>(vs)...).get(ec);
-            }
-
-            template <typename IdOrPolicy, typename Policy, typename ...Ts>
-            HPX_FORCEINLINE static result_type call(
-                std::true_type, Policy policy,
-                IdOrPolicy const& id_or_policy, error_code& /*ec*/, Ts&&... vs)
-            {
-                return hpx::async<basic_action>(policy, id_or_policy,
-                    std::forward<Ts>(vs)...);
             }
         };
 
@@ -380,18 +368,15 @@ namespace hpx { namespace actions
             launch policy, naming::id_type const& id,
             error_code& ec, Ts&&... vs) const
         {
-            return util::void_guard<result_type>(),
-                sync_invoke::call(
-                    is_future_pred(), policy, id, ec, std::forward<Ts>(vs)...);
+            return sync_invoke::call(policy, id, ec, std::forward<Ts>(vs)...);
         }
 
         template <typename ...Ts>
         HPX_FORCEINLINE result_type operator()(
             naming::id_type const& id, error_code& ec, Ts&&... vs) const
         {
-            return util::void_guard<result_type>(),
-                sync_invoke::call(is_future_pred(), launch::sync, id, ec,
-                    std::forward<Ts>(vs)...);
+            return sync_invoke::call(
+                launch::sync, id, ec, std::forward<Ts>(vs)...);
         }
 
         template <typename ...Ts>
@@ -399,18 +384,16 @@ namespace hpx { namespace actions
             launch policy, naming::id_type const& id,
             Ts&&... vs) const
         {
-            return util::void_guard<result_type>(),
-                sync_invoke::call(is_future_pred(), launch::sync, id, throws,
-                    std::forward<Ts>(vs)...);
+            return sync_invoke::call(
+                launch::sync, id, throws, std::forward<Ts>(vs)...);
         }
 
         template <typename ...Ts>
         HPX_FORCEINLINE result_type operator()(
             naming::id_type const& id, Ts&&... vs) const
         {
-            return util::void_guard<result_type>(),
-                sync_invoke::call(is_future_pred(), launch::sync, id, throws,
-                    std::forward<Ts>(vs)...);
+            return sync_invoke::call(
+                launch::sync, id, throws, std::forward<Ts>(vs)...);
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -423,11 +406,8 @@ namespace hpx { namespace actions
         operator()(launch policy,
             DistPolicy const& dist_policy, error_code& ec, Ts&&... vs) const
         {
-            return util::void_guard<result_type>(),
-                sync_invoke::call(
-                    is_future_pred(), policy, dist_policy, ec,
-                    std::forward<Ts>(vs)...
-                );
+            return sync_invoke::call(
+                policy, dist_policy, ec, std::forward<Ts>(vs)...);
         }
 
         template <typename DistPolicy, typename ...Ts>

--- a/hpx/runtime/actions/transfer_action.hpp
+++ b/hpx/runtime/actions/transfer_action.hpp
@@ -213,13 +213,13 @@ namespace hpx { namespace actions
 
         if (deferred_schedule)
         {
-            // If this is a direct action and deferred schedule was requested, that
-            // is we are not the last parcel, return immediately
+            // If this is a direct action and deferred schedule was requested,
+            // that is we are not the last parcel, return immediately
             if (base_type::direct_execution::value)
                 return;
 
-            // If this is not a direct action, we can safely set deferred_schedule
-            // to false
+            // If this is not a direct action, we can safely set
+            // deferred_schedule to false
             deferred_schedule = false;
         }
 

--- a/hpx/runtime/actions/transfer_base_action.hpp
+++ b/hpx/runtime/actions/transfer_base_action.hpp
@@ -68,6 +68,29 @@ namespace hpx { namespace actions
                 ar & data_;
             }
 
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            Args& data()
+            {
+                HPX_ASSERT(!!data_);
+                return *data_;
+            }
+
+#if defined(HPX_DISABLE_ASSERTS) || defined(BOOST_DISABLE_ASSERTS) || defined(NDEBUG)
+            HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
+            Args const& data() const
+            {
+                return *data_;
+            }
+#else
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+            Args const& data() const
+            {
+                HPX_ASSERT(!!data_);
+                return *data_;
+            }
+#endif
+
+        private:
             std::unique_ptr<Args> data_;
         };
     }
@@ -78,40 +101,36 @@ namespace hpx { namespace util
     template <std::size_t I, typename Args>
     HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
     typename util::tuple_element<I, Args>::type&
-    get(hpx::actions::detail::argument_holder<Args>& t) noexcept
+    get(hpx::actions::detail::argument_holder<Args>& t)
     {
-        HPX_ASSERT(!!t.data_);
-        return util::tuple_element<I, Args>::get(*t.data_);
+        return util::tuple_element<I, Args>::get(t.data());
     }
 
     template <std::size_t I, typename Args>
     HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
     typename util::tuple_element<I, Args>::type const&
-    get(hpx::actions::detail::argument_holder<Args> const& t) noexcept
+    get(hpx::actions::detail::argument_holder<Args> const& t)
     {
-        HPX_ASSERT(!!t.data_);
-        return util::tuple_element<I, Args>::get(*t.data_);
+        return util::tuple_element<I, Args>::get(t.data());
     }
 
     template <std::size_t I, typename Args>
     HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
     typename util::tuple_element<I, Args>::type&&
-    get(hpx::actions::detail::argument_holder<Args>&& t) noexcept
+    get(hpx::actions::detail::argument_holder<Args>&& t)
     {
-        HPX_ASSERT(!!t.data_);
         return std::forward<typename util::tuple_element<I, Args>::type>(
-            util::get<I>(*t.data_));
+            util::get<I>(t.data()));
     }
 
     template <std::size_t I, typename Args>
     HPX_CONSTEXPR HPX_HOST_DEVICE HPX_FORCEINLINE
     typename util::tuple_element<I, Args>::type const&&
-    get(hpx::actions::detail::argument_holder<Args> const&& t) noexcept
+    get(hpx::actions::detail::argument_holder<Args> const&& t)
     {
-        HPX_ASSERT(!!t.data_);
         return std::forward<
                 typename util::tuple_element<I, Args>::type const
-            >(util::get<I>(*t.data_));
+            >(util::get<I>(t.data()));
     }
 }}
 

--- a/hpx/runtime/actions/transfer_continuation_action.hpp
+++ b/hpx/runtime/actions/transfer_continuation_action.hpp
@@ -37,6 +37,7 @@ namespace hpx { namespace actions
 
         typedef transfer_base_action<Action> base_type;
         typedef typename base_type::continuation_type continuation_type;
+
     public:
         // construct an empty transfer_continuation_action to avoid serialization
         // overhead

--- a/hpx/runtime/components/client_base.hpp
+++ b/hpx/runtime/components/client_base.hpp
@@ -132,14 +132,6 @@ namespace hpx { namespace traits
                 typename std::enable_if<is_client<Derived>::value>::type>
           : shared_state_ptr<typename traits::future_traits<Derived>::type>
         {};
-
-        ///////////////////////////////////////////////////////////////////////
-        template <typename Derived>
-        struct action_remote_result_customization_point<Derived,
-            typename std::enable_if<is_client<Derived>::value>::type>
-        {
-            typedef id_type type;
-        };
     }
 }}
 

--- a/hpx/runtime/serialization/detail/non_default_constructible.hpp
+++ b/hpx/runtime/serialization/detail/non_default_constructible.hpp
@@ -1,0 +1,31 @@
+//  Copyright (c) 2017 Anton Bikineev
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//  See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_SERIALIZATION_NON_DEFAULT_CONSTRUCTIBLE_HPP
+#define HPX_SERIALIZATION_NON_DEFAULT_CONSTRUCTIBLE_HPP
+
+#include <hpx/config.hpp>
+
+#include <memory>
+
+namespace hpx { namespace serialization { namespace detail
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // default fall-backs for serializing non-default-constructible types
+    template <typename Archive, typename T>
+    void save_construct_data(Archive&, T const*, unsigned)
+    {
+    }
+
+    // by default fall back to in-place default construction
+    template <typename Archive, typename T>
+    void load_construct_data(Archive& ar, T* t, unsigned)
+    {
+        ::new (t) T;
+    }
+}}}
+
+#endif

--- a/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
+++ b/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
@@ -85,8 +85,7 @@ namespace hpx { namespace serialization { namespace detail
     public:
         static T* create(input_archive& ar)
         {
-            return create(
-                ar, typename std::is_default_constructible<T>::type());
+            return create(ar, std::is_default_constructible<T>());
         }
 
         // is default-constructible

--- a/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
+++ b/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
@@ -11,6 +11,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/runtime/serialization/serialization_fwd.hpp>
+#include <hpx/runtime/serialization/detail/non_default_constructible.hpp>
 #include <hpx/throw_exception.hpp>
 #include <hpx/traits/needs_automatic_registration.hpp>
 #include <hpx/traits/polymorphic_traits.hpp>
@@ -31,22 +32,6 @@
 
 namespace hpx { namespace serialization { namespace detail
 {
-    ///////////////////////////////////////////////////////////////////////////
-    // default fall-backs for constructing non-default-constructable types
-    template <class Archive, class T>
-    void save_construct_data(Archive&, T*, unsigned)
-    {
-        // a user is not required to provide their own adl-overload
-    }
-
-    template <class Archive, class T>
-    void load_construct_data(Archive& ar, T* t, unsigned)
-    {
-        // this function is never supposed to be called
-        HPX_ASSERT(false);
-        ::new (t) T;
-    }
-
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
     struct get_serialization_name

--- a/hpx/runtime/serialization/serialization_fwd.hpp
+++ b/hpx/runtime/serialization/serialization_fwd.hpp
@@ -30,7 +30,6 @@ namespace hpx { namespace serialization
 
     template <typename T>
     input_archive & operator&(input_archive & ar, T & t);
-
 }}
 
 #define HPX_SERIALIZATION_SPLIT_MEMBER()                                      \

--- a/tests/regressions/actions/CMakeLists.txt
+++ b/tests/regressions/actions/CMakeLists.txt
@@ -7,11 +7,12 @@ add_subdirectory(components)
 
 set(tests
     async_deferred_1523
+    component_action_move_semantics
     make_continuation_1615
     plain_action_1330
     plain_action_1550
     plain_action_move_semantics
-    component_action_move_semantics
+    return_future_2847
    )
 
 set(plain_action_1330_FLAGS
@@ -28,6 +29,8 @@ set(component_action_move_semantics_FLAGS
 set(component_action_move_semantics_PARAMETERS
     LOCALITIES 2
     THREADS_PER_LOCALITY 1)
+
+set(return_future_2847_PARAMETERS LOCALITIES 2)
 
 foreach(test ${tests})
   set(sources

--- a/tests/regressions/actions/CMakeLists.txt
+++ b/tests/regressions/actions/CMakeLists.txt
@@ -13,6 +13,7 @@ set(tests
     plain_action_1550
     plain_action_move_semantics
     return_future_2847
+    return_non_default_constructible_2847
    )
 
 set(plain_action_1330_FLAGS
@@ -31,6 +32,7 @@ set(component_action_move_semantics_PARAMETERS
     THREADS_PER_LOCALITY 1)
 
 set(return_future_2847_PARAMETERS LOCALITIES 2)
+set(return_non_default_constructible_2847_PARAMETERS LOCALITIES 2)
 
 foreach(test ${tests})
   set(sources

--- a/tests/regressions/actions/return_future_2847.cpp
+++ b/tests/regressions/actions/return_future_2847.cpp
@@ -1,0 +1,77 @@
+//  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c) 2017 Igor Krivenko
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/actions.hpp>
+#include <hpx/include/components.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstddef>
+#include <vector>
+
+struct non_default_ctor
+{
+    int i;
+    non_default_ctor() = delete;
+    non_default_ctor(int i)
+      : i(i)
+    {
+    }
+
+    template <typename Archive>
+    void serialize(Archive& ar, const unsigned int)
+    {
+        ar & i;
+    }
+
+    template <class Archive>
+    void friend load_construct_data(
+        Archive& ar, non_default_ctor* p, const unsigned int)
+    {
+        ::new (p) non_default_ctor(0);
+    }
+};
+
+hpx::future<non_default_ctor> plain_future_non_default_ctor()
+{
+    return hpx::make_ready_future(non_default_ctor(42));
+}
+
+HPX_PLAIN_ACTION(
+    plain_future_non_default_ctor, plain_future_non_default_ctor_action);
+
+void test_plain_call_future_non_default_ctor(hpx::id_type id)
+{
+    // test apply
+    for (std::size_t i = 0; i != 100; ++i)
+    {
+        hpx::apply<plain_future_non_default_ctor_action>(id);
+    }
+
+    // test async
+    std::vector<hpx::future<non_default_ctor>> calls;
+    for (std::size_t i = 0; i != 100; ++i)
+    {
+        calls.push_back(hpx::async<plain_future_non_default_ctor_action>(id));
+    }
+    hpx::wait_all(calls);
+
+    for (auto && f : calls)
+    {
+        HPX_TEST_EQ(f.get().i, 42);
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main()
+{
+    for (hpx::id_type id : hpx::find_all_localities())
+    {
+        test_plain_call_future_non_default_ctor(id);
+    }
+    return hpx::util::report_errors();
+}

--- a/tests/regressions/actions/return_non_default_constructible_2847.cpp
+++ b/tests/regressions/actions/return_non_default_constructible_2847.cpp
@@ -1,0 +1,77 @@
+//  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c) 2017 Igor Krivenko
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/actions.hpp>
+#include <hpx/include/components.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstddef>
+#include <vector>
+
+struct non_default_ctor
+{
+    int i;
+
+    non_default_ctor() = delete;
+    non_default_ctor(int i)
+      : i(i)
+    {
+    }
+
+    template <typename Archive>
+    void serialize(Archive& ar, const unsigned int)
+    {
+        ar & i;
+    }
+
+    template <typename Archive>
+    void friend load_construct_data(
+        Archive& ar, non_default_ctor* p, const unsigned int)
+    {
+        ::new (p) non_default_ctor(0);
+    }
+};
+
+non_default_ctor plain_non_default_ctor()
+{
+    return non_default_ctor(42);
+}
+
+HPX_PLAIN_ACTION(plain_non_default_ctor, plain_non_default_ctor_action);
+
+void test_plain_call_non_default_ctor(hpx::id_type id)
+{
+    // test apply
+    for (std::size_t i = 0; i != 100; ++i)
+    {
+        hpx::apply<plain_non_default_ctor_action>(id);
+    }
+
+    // test async
+    std::vector<hpx::future<non_default_ctor>> calls;
+    for (std::size_t i = 0; i != 100; ++i)
+    {
+        calls.push_back(hpx::async<plain_non_default_ctor_action>(id));
+    }
+    hpx::wait_all(calls);
+
+    for (auto && f : calls)
+    {
+        HPX_TEST_EQ(f.get().i, 42);
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main()
+{
+    for (hpx::id_type id : hpx::find_all_localities())
+    {
+        test_plain_call_non_default_ctor(id);
+    }
+    return hpx::util::report_errors();
+}

--- a/tests/unit/serialization/polymorphic/polymorphic_nonintrusive.cpp
+++ b/tests/unit/serialization/polymorphic/polymorphic_nonintrusive.cpp
@@ -92,7 +92,7 @@ void serialize(Archive& ar, C<T>& c, unsigned)
 }
 
 template<typename T>
-C<T> *c_factory(hpx::serialization::input_archive& ar, C<T> */*unused*/)
+C<T> *c_factory(hpx::serialization::input_archive& ar, C<T> * /*unused*/)
 {
     C<T> *c = new C<T>(999);
     serialize(ar, *c, 0);
@@ -129,7 +129,7 @@ namespace hpx { namespace serialization {
 } }
 
 template<typename T>
-E<T> *e_factory(hpx::serialization::input_archive& ar, E<T> */*unused*/)
+E<T> *e_factory(hpx::serialization::input_archive& ar, E<T> * /*unused*/)
 {
     E<T> *e = new E<T>(99, 9999);
     serialize(ar, *e, 0);

--- a/tests/unit/serialization/serialization_array.cpp
+++ b/tests/unit/serialization/serialization_array.cpp
@@ -236,7 +236,7 @@ void test_plain_array()
     T oarray[N];
 
     for(std::size_t i = 0; i < N; ++i) {
-        iarray[i] = i * i;
+        iarray[i] = static_cast<T>(i * i);
         oarray[i] = -1;
     }
 
@@ -261,7 +261,7 @@ void test_array_of_vectors()
 
     for(std::size_t i = 0; i < N; ++i) {
         for (std::size_t j = 0; j < i; ++j) {
-            iarray[i].push_back(i * i);
+            iarray[i].push_back(static_cast<T>(i * i));
         }
     }
 

--- a/tests/unit/serialization/serialize_buffer.cpp
+++ b/tests/unit/serialization/serialize_buffer.cpp
@@ -90,7 +90,7 @@ void test_fixed_size_initialization_for_persistent_buffers(std::size_t max_size)
         std::vector<T> recv_vec;
         send_vec.reserve(size);
         for (std::size_t i = 0; i < size; ++i) {
-            send_vec.push_back(size - i);
+            send_vec.push_back(static_cast<int>(size - i));
         }
 
         hpx::serialization::serialize_buffer<T> send_buffer(size);


### PR DESCRIPTION
This fixes #2847.

@krivenko: please verify whether this solves the issue you reported.

Note: this requires #2849 to be merged first