### PR TITLE
Support ARM64 in timestamps

### DIFF
--- a/hpx/util/hardware/timestamp.hpp
+++ b/hpx/util/hardware/timestamp.hpp
@@ -29,7 +29,9 @@
     #else
         #include <hpx/util/hardware/timestamp/linux_generic.hpp>
     #endif
-#elif (defined(__ANDROID__) && defined(ANDROID)) || defined(__arm__)
+#elif (defined(__ANDROID__) && defined(ANDROID))
+    #include <hpx/util/hardware/timestamp/linux_generic.hpp>
+#elif defined(__arm__) || defined(__arm64__) || defined(__aarch64__)
     #include <hpx/util/hardware/timestamp/linux_generic.hpp>
 #elif defined(__powerpc__)
     #include <hpx/util/hardware/timestamp/linux_generic.hpp>


### PR DESCRIPTION
My ARMv8 debian gcc doesn't know of `"__arm__"` define, add `"__arm64__"` and `"__aarch64__"`

supporting link: https://reviews.llvm.org/D4379

this fixes #2852