### PR TITLE
Fix some listing in documentation

### DIFF
--- a/docs/manual/vector.qbk
+++ b/docs/manual/vector.qbk
@@ -371,7 +371,7 @@ By default, the `partitioned_vector` class integrates 1-D views of its segments 
     std::vector<double> v = vv[i];
 
 Our views are called "multi-dimensional" in the sense that they generalize
-to N dimensions the purpose of `segmented_iterator_traits::segments()` in the 1-D case. Note that
+to N dimensions the purpose of `segmented_iterator_traits::segment()` in the 1-D case. Note that
 in a parallel section, the 2-D expression `a(i,j) = b(i,j)` is quite confusing
 because without convention, each of the images invoked will race to execute
 the statement. For this reason, our views are not only multi-dimensional
@@ -539,14 +539,14 @@ sub-view.
 
         // Instanciate the subview
         View_2D svv(
-            block,&v(tilesize,0),&v(2*tilesize-1,tilesize-1),{tilesize,tilesize},{N,N});
+            block,&vv(tilesize,0),&vv(2*tilesize-1,tilesize-1),{tilesize,tilesize},{N,N});
 
         if(block.this_image() == 0)
         {
-            // Equivalent to 'sv(tilesize,0) = 2.0f'
+            // Equivalent to 'vv(tilesize,0) = 2.0f'
             svv(0,0) = 2.0f;
 
-            // Equivalent to 'sv(2*tilesize-1,tilesize-1) = 3.0f'
+            // Equivalent to 'vv(2*tilesize-1,tilesize-1) = 3.0f'
             svv(tilesize-1,tilesize-1) = 3.0f;
         }
 


### PR DESCRIPTION
This patch fixes some variable names in an example code contained in the documentation.