### PR TITLE
Adding missing support for throttling scheduler

### DIFF
--- a/src/runtime/threads/detail/scheduled_thread_pool.cpp
+++ b/src/runtime/threads/detail/scheduled_thread_pool.cpp
@@ -51,3 +51,9 @@ template class HPX_EXPORT hpx::threads::detail::scheduled_thread_pool<
 template class HPX_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::periodic_priority_queue_scheduler<>>;
 #endif
+
+#if defined(HPX_HAVE_THROTTLING_SCHEDULER)
+#include <hpx/runtime/threads/policies/throttling_scheduler.hpp>
+template class HPX_EXPORT hpx::threads::detail::scheduled_thread_pool<
+    hpx::threads::policies::throttling_scheduler<>>;
+#endif


### PR DESCRIPTION
This code got lost while merging the resource partitioner. Those changes enable
it again.