### PR TITLE
Fix incorrect pool usage masks setup in RP/thread manager

### DIFF
--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -665,8 +665,6 @@ namespace hpx
         std::size_t cores_needed =
             hpx::resource::get_partitioner().assign_cores(first_core);
 
-        // this initializes the used_processing_units_ mask
-        get_thread_manager().init();
         return static_cast<std::uint32_t>(cores_needed);
     }
 

--- a/src/runtime/threads/detail/thread_pool_base.cpp
+++ b/src/runtime/threads/detail/thread_pool_base.cpp
@@ -95,7 +95,7 @@ namespace hpx { namespace threads { namespace detail
         auto const& rp = resource::get_partitioner();
         for (std::size_t i = 0; i != pool_threads; ++i)
         {
-            bit_or(used_processing_units_, rp.get_pu_mask(threads_offset + i));
+            used_processing_units_ |= rp.get_pu_mask(threads_offset + i);
         }
     }
 }}}

--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -170,6 +170,9 @@ namespace hpx {
         // now create all threadmanager pools
         thread_manager_->create_pools();
 
+        // this initializes the used_processing_units_ mask
+        thread_manager_->init();
+
         // now, launch AGAS and register all nodes, launch all other components
         agas_client_.initialize(
             parcel_handler_, std::uint64_t(runtime_support_.get()),

--- a/tests/unit/resource/CMakeLists.txt
+++ b/tests/unit/resource/CMakeLists.txt
@@ -5,9 +5,11 @@
 
 set(tests
     resource_partitioner
+    used_pus
 )
 
 set(resource_partitioner_PARAMETERS THREADS_PER_LOCALITY 4)
+set(used_pus_PARAMETERS THREADS_PER_LOCALITY 4)
 
 foreach(test ${tests})
   set(sources

--- a/tests/unit/resource/used_pus.cpp
+++ b/tests/unit/resource/used_pus.cpp
@@ -1,0 +1,48 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Simple test verifying basic resource_partitioner functionality.
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/resource_partitioner.hpp>
+#include <hpx/include/threads.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+int hpx_main(int argc, char* argv[])
+{
+    std::size_t num_threads = hpx::resource::get_num_threads("default");
+    hpx::threads::detail::thread_pool_base& tp =
+                hpx::resource::get_thread_pool("default");
+
+    auto used_pu_mask = tp.get_used_processing_units();
+    HPX_TEST_EQ(hpx::threads::count(used_pu_mask), num_threads);
+
+    for (std::size_t t = 0; t < num_threads; ++t)
+    {
+        auto thread_mask = hpx::resource::get_partitioner().get_pu_mask(t);
+        HPX_TEST(hpx::threads::bit_or(used_pu_mask, thread_mask));
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = {
+        "hpx.os_threads=4"
+    };
+
+    // set up the resource partitioner
+    hpx::resource::partitioner rp(argc, argv, std::move(cfg));
+
+    // now run the test
+    HPX_TEST_EQ(hpx::init(), 0);
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Just a minor tweak to get the pool_usage_mask set correctly