### PR TITLE
Fix incorrect handling of compile definition with value 0

### DIFF
--- a/cmake/HPX_AddDefinitions.cmake
+++ b/cmake/HPX_AddDefinitions.cmake
@@ -15,7 +15,10 @@ set_property(GLOBAL PROPERTY HPX_CONFIG_COND_DEFINITIONS "")
 
 function(hpx_add_config_define definition)
 
-  if(ARGN)
+  # if(ARGN) ignores an argument "0"
+  set(Args ${ARGN})
+  list(LENGTH Args ArgsLen)
+  if(ArgsLen GREATER 0)
     set_property(GLOBAL APPEND PROPERTY HPX_CONFIG_DEFINITIONS "${definition} ${ARGN}")
   else()
     set_property(GLOBAL APPEND PROPERTY HPX_CONFIG_DEFINITIONS "${definition}")
@@ -25,7 +28,10 @@ endfunction()
 
 function(hpx_add_config_cond_define definition)
 
-  if(ARGN)
+  # if(ARGN) ignores an argument "0"
+  set(Args ${ARGN})
+  list(LENGTH Args ArgsLen)
+  if(ArgsLen GREATER 0)
     set_property(GLOBAL APPEND PROPERTY HPX_CONFIG_COND_DEFINITIONS "${definition} ${ARGN}")
   else()
     set_property(GLOBAL APPEND PROPERTY HPX_CONFIG_COND_DEFINITIONS "${definition}")


### PR DESCRIPTION
With the current version, adding a compile definition with value "0" does not work. Calling:
```
hpx_add_config_define(MY_DEFINITION 0)
```
creates
```
#define MY_DEFINITION
```
in hpx/config/defines.hpp. The PR fixes it.