### PR TITLE
Fixing service_executor

### DIFF
--- a/hpx/runtime/threads/executors/service_executors.hpp
+++ b/hpx/runtime/threads/executors/service_executors.hpp
@@ -8,7 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/exception_fwd.hpp>
-#include <hpx/lcos/local/counting_semaphore.hpp>
+#include <hpx/lcos/local/condition_variable.hpp>
 #include <hpx/runtime/threads/thread_enums.hpp>
 #include <hpx/runtime/threads/thread_executor.hpp>
 #include <hpx/throw_exception.hpp>
@@ -73,8 +73,10 @@ namespace hpx { namespace threads { namespace executors
 
         private:
             util::io_service_pool* pool_;
+            typedef hpx::lcos::local::spinlock mutex_type;
+            mutex_type mtx_;
             std::atomic<std::uint64_t> task_count_;
-            lcos::local::counting_semaphore shutdown_sem_;
+            lcos::local::condition_variable_any shutdown_cv_;
         };
     }
 

--- a/src/runtime/threads/executors/service_executor.cpp
+++ b/src/runtime/threads/executors/service_executor.cpp
@@ -10,6 +10,7 @@
 #include <hpx/throw_exception.hpp>
 #include <hpx/runtime_fwd.hpp>
 #include <hpx/runtime/threads/thread_enums.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/util/bind.hpp>
 #include <hpx/util/io_service_pool.hpp>
 #include <hpx/util/steady_clock.hpp>


### PR DESCRIPTION
The destructor and thread_wrapper of the service_executor might race for
completion. This patch ensures that the thread_wrapper always completes
before the destructor