### PR TITLE
Making sure generated performance counter names are correct

### DIFF
--- a/src/performance_counters/counters.cpp
+++ b/src/performance_counters/counters.cpp
@@ -1098,20 +1098,17 @@ namespace hpx { namespace performance_counters
             // now expand "pool#*"
             if (detail::is_pool_kind(p.instancename_))
             {
+                bool expand_threads = detail::is_thread_kind(p.subinstancename_);
+
                 counter_info i = info;
                 p.instancename_ = detail::get_pool_kind(p.instancename_);
-                if (!detail::expand_counter_info_threads(i, p, f, ec))
-                    return false;
-
-                if (detail::is_thread_kind(p.subinstancename_))
+                if (expand_threads)
                 {
-                    counter_info i = info;
-                    p.subinstancename_ =
-                        detail::get_thread_kind(p.subinstancename_) + "-thread";
-                    return detail::expand_counter_info_threads(i, p, f, ec);
+                    p.subinstancename_ = detail::get_thread_kind(
+                        p.subinstancename_) + "-thread";
                 }
-
-                return true;
+                return detail::expand_counter_info_pools(
+                    expand_threads, i, p, f, ec);
             }
 
             if (detail::is_thread_kind(p.instancename_))

--- a/src/runtime/resource/detail/detail_partitioner.cpp
+++ b/src/runtime/resource/detail/detail_partitioner.cpp
@@ -368,11 +368,12 @@ namespace hpx { namespace resource { namespace detail
             }
         }
 
-        std::lock_guard<mutex_type> l(mtx_);
+        std::unique_lock<mutex_type> l(mtx_);
 
         // @TODO allow empty pools
         if (get_pool_data("default").num_threads_ == 0)
         {
+            l.unlock();
             throw_runtime_error("partitioner::setup_pools",
                 "Default pool has no threads assigned. Please rerun with "
                 "--hpx:threads=X and check the pool thread assignment");
@@ -381,6 +382,7 @@ namespace hpx { namespace resource { namespace detail
         // Check whether any of the pools defined up to now are empty
         if (check_empty_pools())
         {
+            l.unlock();
             throw_runtime_error("partitioner::setup_pools",
                 "Pools empty of resources are not allowed. Please re-run this "
                 "application with allow-empty-pool-policy (not implemented "
@@ -542,7 +544,7 @@ namespace hpx { namespace resource { namespace detail
                 "as a name.");
         }
 
-        std::lock_guard<mutex_type> l(mtx_);
+        std::unique_lock<mutex_type> l(mtx_);
 
         if (pool_name == "default")
         {
@@ -556,6 +558,7 @@ namespace hpx { namespace resource { namespace detail
         {
             if (pool_name == initial_thread_pools_[i].pool_name_)
             {
+                l.unlock();
                 throw std::invalid_argument(
                     "partitioner::create_thread_pool: "
                     "there already exists a pool named '" + pool_name + "'.\n");
@@ -585,7 +588,7 @@ namespace hpx { namespace resource { namespace detail
                 "as a name.");
         }
 
-        std::lock_guard<mutex_type> l(mtx_);
+        std::unique_lock<mutex_type> l(mtx_);
 
         if (pool_name == "default")
         {
@@ -600,6 +603,7 @@ namespace hpx { namespace resource { namespace detail
         {
             if (pool_name == initial_thread_pools_[i].pool_name_)
             {
+                l.unlock();
                 throw std::invalid_argument(
                     "partitioner::create_thread_pool: "
                     "there already exists a pool named '" + pool_name + "'.\n");
@@ -625,10 +629,11 @@ namespace hpx { namespace resource { namespace detail
                 "been started");
         }
 
-        std::lock_guard<mutex_type> l(mtx_);
+        std::unique_lock<mutex_type> l(mtx_);
 
         if (!exclusive && !(mode_ & mode_allow_dynamic_pools))
         {
+            l.unlock();
             throw std::invalid_argument(
                 "partitioner::add_resource: dynamic pools have not been "
                 "enabled for this partitioner");
@@ -659,6 +664,7 @@ namespace hpx { namespace resource { namespace detail
                     && detail::init_pool_data::num_threads_overall == cfg_.num_threads_) {
                     // then it's all fine
                 } else {*/
+                l.unlock();
                 throw std::runtime_error(
                     "partitioner::add_resource: " "Creation of " +
                     std::to_string(detail::init_pool_data::num_threads_overall) +
@@ -671,6 +677,7 @@ namespace hpx { namespace resource { namespace detail
         }
         else
         {
+            l.unlock();
             throw std::runtime_error(
                 "partitioner::add_resource: " "PU #" + std::to_string(p.id_) +
                 " can be assigned only " + std::to_string(p.thread_occupancy_) +
@@ -738,13 +745,14 @@ namespace hpx { namespace resource { namespace detail
     scheduling_policy partitioner::which_scheduler(
         std::string const& pool_name)
     {
-        std::lock_guard<mutex_type> l(mtx_);
+        std::unique_lock<mutex_type> l(mtx_);
 
         // look up which scheduler is needed
         scheduling_policy sched_type =
             get_pool_data(pool_name).scheduling_policy_;
         if (sched_type == unspecified)
         {
+            l.unlock();
             throw std::invalid_argument(
                 "partitioner::which_scheduler: " "Thread pool " + pool_name +
                 " cannot be instantiated with unspecified scheduler type.");
@@ -827,7 +835,6 @@ namespace hpx { namespace resource { namespace detail
     std::string const& partitioner::get_pool_name(
         std::size_t index) const
     {
-        std::lock_guard<mutex_type> l(mtx_);
         if (index >= initial_thread_pools_.size())
         {
             throw_invalid_argument(
@@ -891,9 +898,10 @@ namespace hpx { namespace resource { namespace detail
     scheduler_function partitioner::get_pool_creator(
         std::size_t index) const
     {
-        std::lock_guard<mutex_type> l(mtx_);
+        std::unique_lock<mutex_type> l(mtx_);
         if (index >= initial_thread_pools_.size())
         {
+            l.unlock();
             throw std::invalid_argument(
                 "partitioner::get_pool_creator: pool requested out of bounds.");
         }
@@ -1033,14 +1041,16 @@ namespace hpx { namespace resource { namespace detail
     std::size_t partitioner::get_pool_index(
         std::string const& pool_name) const
     {
-        std::lock_guard<mutex_type> l(mtx_);
-
-        std::size_t num_pools = initial_thread_pools_.size();
-        for (std::size_t i = 0; i < num_pools; i++)
         {
-            if (initial_thread_pools_[i].pool_name_ == pool_name)
+            std::lock_guard<mutex_type> l(mtx_);
+
+            std::size_t num_pools = initial_thread_pools_.size();
+            for (std::size_t i = 0; i < num_pools; i++)
             {
-                return i;
+                if (initial_thread_pools_[i].pool_name_ == pool_name)
+                {
+                    return i;
+                }
             }
         }
 


### PR DESCRIPTION
- this fixes #2905
- flyby: fixing lock held during suspension problem in resource_partitioner