### PR TITLE
Fix rp hang

### DIFF
--- a/hpx/runtime/resource/detail/partitioner.hpp
+++ b/hpx/runtime/resource/detail/partitioner.hpp
@@ -213,7 +213,6 @@ namespace hpx { namespace resource { namespace detail
         std::vector<detail::init_pool_data> initial_thread_pools_;
 
         // reference to the topology and affinity data
-        threads::topology &topology_;
         hpx::threads::policies::detail::affinity_data affinity_data_;
 
         // contains the internal topology back-end used to add resources to


### PR DESCRIPTION
This makes sure that exceptions thrown during the creation of the resource_partitioner don't cause hangs at startup.

This also adds a fallback to get_num_cores() for systems which don't report a proper value from hwloc.