### PR TITLE
Adding test to trigger problem reported in #2916

### DIFF
--- a/hpx/lcos/channel.hpp
+++ b/hpx/lcos/channel.hpp
@@ -290,20 +290,20 @@ namespace hpx { namespace lcos
             typedef typename lcos::server::channel<T>::close_action action_type;
             hpx::apply(action_type(), this->get_id(), force_delete_entries);
         }
-        hpx::future<void> close(
+        hpx::future<std::size_t> close(
             launch::async_policy, bool force_delete_entries = false)
         {
             typedef typename lcos::server::channel<T>::close_action action_type;
             return hpx::async(action_type(), this->get_id(), force_delete_entries);
         }
-        void close(launch::sync_policy, bool force_delete_entries = false)
+        std::size_t close(launch::sync_policy, bool force_delete_entries = false)
         {
             typedef typename lcos::server::channel<T>::close_action action_type;
-            action_type()(this->get_id(), force_delete_entries);
+            return action_type()(this->get_id(), force_delete_entries);
         }
-        void close(bool force_delete_entries = false)
+        std::size_t close(bool force_delete_entries = false)
         {
-            close(launch::sync, force_delete_entries);
+            return close(launch::sync, force_delete_entries);
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -528,20 +528,20 @@ namespace hpx { namespace lcos
             typedef typename lcos::server::channel<T>::close_action action_type;
             hpx::apply(action_type(), this->get_id(), force_delete_entries);
         }
-        hpx::future<void> close(
+        hpx::future<std::size_t> close(
             launch::async_policy, bool force_delete_entries = false)
         {
             typedef typename lcos::server::channel<T>::close_action action_type;
             return hpx::async(action_type(), this->get_id(), force_delete_entries);
         }
-        void close(launch::sync_policy, bool force_delete_entries = false)
+        std::size_t close(launch::sync_policy, bool force_delete_entries = false)
         {
             typedef typename lcos::server::channel<T>::close_action action_type;
-            action_type()(this->get_id(), force_delete_entries);
+            return action_type()(this->get_id(), force_delete_entries);
         }
-        void close(bool force_delete_entries = false)
+        std::size_t close(bool force_delete_entries = false)
         {
-            close(launch::sync, force_delete_entries);
+            return close(launch::sync, force_delete_entries);
         }
     };
 }}

--- a/hpx/lcos/local/receive_buffer.hpp
+++ b/hpx/lcos/local/receive_buffer.hpp
@@ -198,11 +198,13 @@ namespace hpx { namespace lcos { namespace local
             return buffer_map_.empty();
         }
 
-        void cancel_waiting(std::exception_ptr const& e,
+        // return the number of deleted buffer entries
+        std::size_t cancel_waiting(std::exception_ptr const& e,
             bool force_delete_entries = false)
         {
             std::lock_guard<mutex_type> l(mtx_);
 
+            std::size_t count = 0;
             iterator end = buffer_map_.end();
             for (iterator it = buffer_map_.begin(); it != end; /**/)
             {
@@ -210,8 +212,10 @@ namespace hpx { namespace lcos { namespace local
                 if (to_delete->second->cancel(e) || force_delete_entries)
                 {
                     buffer_map_.erase(to_delete);
+                    ++count;
                 }
             }
+            return count;
         }
 
     protected:
@@ -412,11 +416,13 @@ namespace hpx { namespace lcos { namespace local
             return buffer_map_.empty();
         }
 
-        void cancel_waiting(std::exception_ptr const& e,
+        // return the number of deleted buffer entries
+        std::size_t cancel_waiting(std::exception_ptr const& e,
             bool force_delete_entries = false)
         {
             std::lock_guard<mutex_type> l(mtx_);
 
+            std::size_t count = 0;
             iterator end = buffer_map_.end();
             for (iterator it = buffer_map_.begin(); it != end; /**/)
             {
@@ -424,8 +430,10 @@ namespace hpx { namespace lcos { namespace local
                 if (to_delete->second->cancel(e) || force_delete_entries)
                 {
                     buffer_map_.erase(to_delete);
+                    ++count;
                 }
             }
+            return count;
         }
 
     protected:

--- a/hpx/lcos/server/channel.hpp
+++ b/hpx/lcos/server/channel.hpp
@@ -104,9 +104,9 @@ namespace hpx { namespace lcos { namespace server
         }
         HPX_DEFINE_COMPONENT_ACTION(channel, set_generation);
 
-        void close(bool force_delete_entries)
+        std::size_t close(bool force_delete_entries)
         {
-            channel_.close(force_delete_entries);
+            return channel_.close(force_delete_entries);
         }
         HPX_DEFINE_COMPONENT_ACTION(channel, close);
 

--- a/tests/regressions/lcos/CMakeLists.txt
+++ b/tests/regressions/lcos/CMakeLists.txt
@@ -14,6 +14,7 @@ set(tests
     broadcast_unwrap_future_2885
     broadcast_wait_for_2822
     call_promise_get_gid_more_than_once
+    channel_2916
     channel_not_empty_2890
     channel_register_as_2722
     dataflow_791
@@ -64,6 +65,8 @@ set(async_callback_with_bound_callback_PARAMETERS LOCALITIES 2)
 set(async_callback_non_deduced_context_PARAMETERS THREADS_PER_LOCALITY 4)
 set(broadcast_unwrap_future_2885_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 4)
 set(broadcast_wait_for_2822_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 4)
+set(channel_2916_FLAGS DEPENDENCIES iostreams_component)
+set(channel_2916_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 4)
 set(future_hang_on_get_629_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 2)
 set(dataflow_future_swap2_FLAGS DEPENDENCIES iostreams_component)
 set(dataflow_launch_775_PARAMETERS THREADS_PER_LOCALITY 2)

--- a/tests/regressions/lcos/channel_2916.cpp
+++ b/tests/regressions/lcos/channel_2916.cpp
@@ -1,0 +1,69 @@
+//  Copyright (c) 2017 Igor Krivenko
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstddef>
+
+typedef hpx::naming::id_type locality_id_t;
+HPX_REGISTER_CHANNEL(locality_id_t);
+
+std::atomic<std::size_t> count(0);
+
+int hpx_main()
+{
+    // List of currently available resources
+    hpx::lcos::channel<locality_id_t> free_resources(hpx::find_here());
+
+    std::size_t os_thread_count = hpx::get_os_thread_count();
+
+    // At the beginning all threads on all localities are free
+    for (locality_id_t id : hpx::find_all_localities())
+    {
+        for (std::size_t i = 0; i != os_thread_count; ++i)
+        {
+            free_resources.set(id);
+            ++count;
+        }
+    }
+
+    for (int i = 0; i < 1000; ++i)
+    {
+        // Ask for resources
+        hpx::shared_future<locality_id_t> target = free_resources.get();
+
+        // Do some work, once we have acquired resources
+        hpx::shared_future<int> result = target.then(
+            [](hpx::shared_future<locality_id_t> t)
+            ->  hpx::shared_future<int>
+            {
+                --count;
+                return hpx::make_ready_future(0);
+            });
+
+        // Free resources
+        result.then(
+            [free_resources, target](hpx::shared_future<int>) mutable
+            {
+                ++count;
+                free_resources.set(target.get());
+            });
+
+        result.get();
+    }
+
+    std::size_t remaining_count = free_resources.close(true);
+    HPX_TEST_EQ(remaining_count, count.load());
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(0, hpx::init(argc, argv));
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
- flyby: channel::close() now returns the number of elements left in the channel