### PR TITLE
Alloc membind

### DIFF
--- a/hpx/runtime/resource/partitioner_fwd.hpp
+++ b/hpx/runtime/resource/partitioner_fwd.hpp
@@ -25,11 +25,6 @@ namespace hpx
 
         class partitioner;
 
-        struct hpx_hwloc_bitmap_wrapper;
-        typedef std::shared_ptr<hpx_hwloc_bitmap_wrapper> hwloc_bitmap_ptr;
-
-        enum hpx_membind_policy  : int;
-
         namespace detail
         {
             class HPX_EXPORT partitioner;

--- a/hpx/runtime/resource/partitioner_fwd.hpp
+++ b/hpx/runtime/resource/partitioner_fwd.hpp
@@ -25,6 +25,11 @@ namespace hpx
 
         class partitioner;
 
+        struct hpx_hwloc_bitmap_wrapper;
+        typedef std::shared_ptr<hpx_hwloc_bitmap_wrapper> hwloc_bitmap_ptr;
+
+        enum hpx_membind_policy  : int;
+
         namespace detail
         {
             class HPX_EXPORT partitioner;

--- a/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
@@ -29,6 +29,8 @@
 
 #include <boost/system/system_error.hpp>
 
+#include <hpx/runtime/threads/policies/hwloc_topology_info.hpp>
+
 #include <algorithm>
 #include <atomic>
 #include <numeric>
@@ -127,6 +129,7 @@ namespace hpx { namespace threads { namespace detail
            << "\n"
            << "is running on PUs : \n";
         os << std::hex << HPX_CPU_MASK_PREFIX << used_processing_units_ << '\n';
+        os << "on numa domains : \n" << used_numa_domains_ << '\n';
     }
 
     template <typename Scheduler>

--- a/hpx/runtime/threads/detail/thread_pool_base.hpp
+++ b/hpx/runtime/threads/detail/thread_pool_base.hpp
@@ -120,6 +120,7 @@ namespace hpx { namespace threads { namespace detail
         }
 
         mask_cref_type get_used_processing_units() const;
+        hpx::resource::hwloc_bitmap_ptr get_numa_domain_bitmap() const;
 
         // performance counters
 #if defined(HPX_HAVE_THREAD_CUMULATIVE_COUNTS)
@@ -290,6 +291,7 @@ namespace hpx { namespace threads { namespace detail
         typedef hpx::lcos::local::spinlock pu_mutex_type;
         mutable pu_mutex_type used_processing_units_mtx_;
         threads::mask_type used_processing_units_;
+        hpx::resource::hwloc_bitmap_ptr used_numa_domains_;
 
         // Mode of operation of the pool
         policies::scheduler_mode mode_;

--- a/hpx/runtime/threads/detail/thread_pool_base.hpp
+++ b/hpx/runtime/threads/detail/thread_pool_base.hpp
@@ -119,8 +119,8 @@ namespace hpx { namespace threads { namespace detail
             return nullptr;
         }
 
-        mask_cref_type get_used_processing_units() const;
-        hpx::resource::hwloc_bitmap_ptr get_numa_domain_bitmap() const;
+        mask_cref_type   get_used_processing_units() const;
+        hwloc_bitmap_ptr get_numa_domain_bitmap() const;
 
         // performance counters
 #if defined(HPX_HAVE_THREAD_CUMULATIVE_COUNTS)
@@ -290,8 +290,8 @@ namespace hpx { namespace threads { namespace detail
         // thread pool.
         typedef hpx::lcos::local::spinlock pu_mutex_type;
         mutable pu_mutex_type used_processing_units_mtx_;
-        threads::mask_type used_processing_units_;
-        hpx::resource::hwloc_bitmap_ptr used_numa_domains_;
+        mask_type used_processing_units_;
+        hwloc_bitmap_ptr used_numa_domains_;
 
         // Mode of operation of the pool
         policies::scheduler_mode mode_;

--- a/hpx/runtime/threads/policies/hwloc_topology_info.hpp
+++ b/hpx/runtime/threads/policies/hwloc_topology_info.hpp
@@ -38,7 +38,10 @@
 namespace hpx { namespace resource
 {
     class resource_partitioner;
+}}
 
+namespace hpx { namespace threads
+{
     struct hpx_hwloc_bitmap_wrapper {
         hpx_hwloc_bitmap_wrapper(void *bmp) {
             bmp_ = reinterpret_cast<hwloc_bitmap_t >(bmp);
@@ -49,12 +52,18 @@ namespace hpx { namespace resource
         hwloc_bitmap_t bmp_;
     };
 
-    typedef std::shared_ptr<hpx_hwloc_bitmap_wrapper> hwloc_bitmap_ptr;
+    /// \brief Please see hwloc documentation for the corresponding
+    /// enums HWLOC_MEMBIND_XXX
+    enum hpx_hwloc_membind_policy : int {
+        HPX_MEMBIND_DEFAULT = 0,
+        HPX_MEMBIND_FIRSTTOUCH = 1,
+        HPX_MEMBIND_BIND = 2,
+        HPX_MEMBIND_INTERLEAVE = 3,
+        HPX_MEMBIND_REPLICATE =	4,
+        HPX_MEMBIND_NEXTTOUCH =	5,
+        HPX_MEMBIND_MIXED = -1
+    };
 
-}}
-
-namespace hpx { namespace threads
-{
     struct HPX_EXPORT hwloc_topology_info : topology
     {
         friend resource::resource_partitioner;
@@ -177,7 +186,8 @@ namespace hpx { namespace threads
             std::size_t numa_node
             ) const;
 
-        hpx::resource::hwloc_bitmap_ptr cpuset_to_nodeset(mask_cref_type cpuset) const;
+        /// convert a cpu mask into a numa node mask in hwloc bitmap form
+        hwloc_bitmap_ptr cpuset_to_nodeset(mask_cref_type cpuset) const;
 
         void print_affinity_mask(std::ostream& os, std::size_t num_thread,
             mask_cref_type m, const std::string &pool_name) const;
@@ -191,8 +201,8 @@ namespace hpx { namespace threads
         void* allocate(std::size_t len) const;
 
         void* allocate_membind(std::size_t len,
-            hpx::resource::hwloc_bitmap_ptr bitmap,
-            hpx::resource::hpx_membind_policy policy, int flags) const;
+            hwloc_bitmap_ptr bitmap,
+            hpx_hwloc_membind_policy policy, int flags) const;
 
         /// Free memory that was previously allocated by allocate
         void deallocate(void* addr, std::size_t len) const;

--- a/hpx/runtime/threads/policies/hwloc_topology_info.hpp
+++ b/hpx/runtime/threads/policies/hwloc_topology_info.hpp
@@ -43,12 +43,19 @@ namespace hpx { namespace resource
 namespace hpx { namespace threads
 {
     struct hpx_hwloc_bitmap_wrapper {
+        // take ownership of the hwloc allocated bitmap
         hpx_hwloc_bitmap_wrapper(void *bmp) {
             bmp_ = reinterpret_cast<hwloc_bitmap_t >(bmp);
         }
+        // frees the hwloc allocated bitmap
         ~hpx_hwloc_bitmap_wrapper() {
             hwloc_bitmap_free(bmp_);
         }
+        // stringify the bitmp using hwloc
+        friend HPX_EXPORT std::ostream& operator<<(std::ostream& os,
+            hpx_hwloc_bitmap_wrapper const* bmp);
+
+        // the raw bitmap object
         hwloc_bitmap_t bmp_;
     };
 

--- a/hpx/runtime/threads/policies/hwloc_topology_info.hpp
+++ b/hpx/runtime/threads/policies/hwloc_topology_info.hpp
@@ -66,8 +66,8 @@ namespace hpx { namespace threads
         HPX_MEMBIND_FIRSTTOUCH = 1,
         HPX_MEMBIND_BIND = 2,
         HPX_MEMBIND_INTERLEAVE = 3,
-        HPX_MEMBIND_REPLICATE =	4,
-        HPX_MEMBIND_NEXTTOUCH =	5,
+        HPX_MEMBIND_REPLICATE = 4,
+        HPX_MEMBIND_NEXTTOUCH = 5,
         HPX_MEMBIND_MIXED = -1
     };
 

--- a/hpx/runtime/threads/policies/hwloc_topology_info.hpp
+++ b/hpx/runtime/threads/policies/hwloc_topology_info.hpp
@@ -214,6 +214,14 @@ namespace hpx { namespace threads
         /// Free memory that was previously allocated by allocate
         void deallocate(void* addr, std::size_t len) const;
 
+        threads::mask_type get_area_membind_nodeset(
+            const void *addr, std::size_t len, void *nodeset) const;
+
+        bool set_area_membind_nodeset(
+            const void *addr, std::size_t len, void *nodeset) const;
+
+        int get_numa_domain(const void *addr, void *nodeset) const;
+
         void print_vector(
             std::ostream& os, std::vector<std::size_t> const& v) const;
         void print_mask_vector(

--- a/hpx/runtime/threads/policies/hwloc_topology_info.hpp
+++ b/hpx/runtime/threads/policies/hwloc_topology_info.hpp
@@ -42,7 +42,10 @@ namespace hpx { namespace resource
 
 namespace hpx { namespace threads
 {
-    struct hpx_hwloc_bitmap_wrapper {
+    struct hpx_hwloc_bitmap_wrapper
+    {
+        HPX_NON_COPYABLE(hpx_hwloc_bitmap_wrapper);
+
         // take ownership of the hwloc allocated bitmap
         hpx_hwloc_bitmap_wrapper(void *bmp) {
             bmp_ = reinterpret_cast<hwloc_bitmap_t >(bmp);
@@ -51,10 +54,16 @@ namespace hpx { namespace threads
         ~hpx_hwloc_bitmap_wrapper() {
             hwloc_bitmap_free(bmp_);
         }
+
+        hwloc_bitmap_t get_bmp() const {
+            return bmp_;
+        }
+
         // stringify the bitmp using hwloc
         friend HPX_EXPORT std::ostream& operator<<(std::ostream& os,
             hpx_hwloc_bitmap_wrapper const* bmp);
 
+    private:
         // the raw bitmap object
         hwloc_bitmap_t bmp_;
     };

--- a/hpx/runtime/threads/policies/hwloc_topology_info.hpp
+++ b/hpx/runtime/threads/policies/hwloc_topology_info.hpp
@@ -71,13 +71,13 @@ namespace hpx { namespace threads
     /// \brief Please see hwloc documentation for the corresponding
     /// enums HWLOC_MEMBIND_XXX
     enum hpx_hwloc_membind_policy : int {
-        HPX_MEMBIND_DEFAULT = 0,
-        HPX_MEMBIND_FIRSTTOUCH = 1,
-        HPX_MEMBIND_BIND = 2,
-        HPX_MEMBIND_INTERLEAVE = 3,
-        HPX_MEMBIND_REPLICATE = 4,
-        HPX_MEMBIND_NEXTTOUCH = 5,
-        HPX_MEMBIND_MIXED = -1
+        membind_default    = HWLOC_MEMBIND_DEFAULT,
+        membind_firsttouch = HWLOC_MEMBIND_FIRSTTOUCH,
+        membind_bind       = HWLOC_MEMBIND_BIND,
+        membind_interleave = HWLOC_MEMBIND_INTERLEAVE,
+        membind_replicate  = HWLOC_MEMBIND_REPLICATE,
+        membind_nexttouch  = HWLOC_MEMBIND_NEXTTOUCH,
+        membind_mixed      = HWLOC_MEMBIND_MIXED
     };
 
     struct HPX_EXPORT hwloc_topology_info : topology

--- a/hpx/runtime/threads/policies/noop_topology.hpp
+++ b/hpx/runtime/threads/policies/noop_topology.hpp
@@ -213,7 +213,7 @@ public:
     }
 
     void print_affinity_mask(std::ostream& os, std::size_t num_thread,
-        mask_type const& m, std::string pool_name) const
+        mask_cref_type m, const std::string &pool_name) const
     {
     }
 

--- a/hpx/runtime/threads/thread_data_fwd.hpp
+++ b/hpx/runtime/threads/thread_data_fwd.hpp
@@ -37,6 +37,9 @@ namespace hpx { namespace threads
 
     class HPX_EXPORT executor;
 
+    struct hpx_hwloc_bitmap_wrapper;
+    typedef std::shared_ptr<hpx_hwloc_bitmap_wrapper> hwloc_bitmap_ptr;
+
     typedef coroutines::coroutine coroutine_type;
 
     typedef coroutines::detail::coroutine_self thread_self;

--- a/hpx/runtime/threads/thread_data_fwd.hpp
+++ b/hpx/runtime/threads/thread_data_fwd.hpp
@@ -21,6 +21,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <utility>
+#include <memory>
 
 namespace hpx
 {

--- a/hpx/runtime/threads/threadmanager.hpp
+++ b/hpx/runtime/threads/threadmanager.hpp
@@ -268,6 +268,12 @@ namespace hpx { namespace threads
             return total_used_processing_punits;
         }
 
+        hpx::resource::hwloc_bitmap_ptr get_pool_numa_bitmap(
+            const std::string &pool_name) const
+        {
+            return get_pool(pool_name).get_numa_domain_bitmap();
+        }
+
         void set_scheduler_mode(threads::policies::scheduler_mode mode)
         {
             for (auto& pool_iter : pools_)

--- a/hpx/runtime/threads/threadmanager.hpp
+++ b/hpx/runtime/threads/threadmanager.hpp
@@ -268,7 +268,7 @@ namespace hpx { namespace threads
             return total_used_processing_punits;
         }
 
-        hpx::resource::hwloc_bitmap_ptr get_pool_numa_bitmap(
+        hwloc_bitmap_ptr get_pool_numa_bitmap(
             const std::string &pool_name) const
         {
             return get_pool(pool_name).get_numa_domain_bitmap();

--- a/hpx/runtime/threads/topology.hpp
+++ b/hpx/runtime/threads/topology.hpp
@@ -16,7 +16,6 @@
 #include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/runtime/threads/cpu_mask.hpp>
 #include <hpx/runtime/threads/thread_data_fwd.hpp>
-#include <hpx/runtime/resource/partitioner_fwd.hpp>
 
 #include <cstddef>
 #include <iosfwd>
@@ -32,7 +31,6 @@
 
 namespace hpx { namespace threads
 {
-
     /// forward declare membind enum type as int
     enum hpx_hwloc_membind_policy  : int;
 

--- a/hpx/runtime/threads/topology.hpp
+++ b/hpx/runtime/threads/topology.hpp
@@ -207,6 +207,14 @@ namespace hpx { namespace threads
             hwloc_bitmap_ptr bitmap,
             hpx_hwloc_membind_policy policy, int flags) const = 0;
 
+        virtual threads::mask_type get_area_membind_nodeset(
+            const void *addr, std::size_t len, void *nodeset) const = 0;
+
+        virtual bool set_area_membind_nodeset(
+            const void *addr, std::size_t len, void *nodeset) const = 0;
+
+        virtual int get_numa_domain(const void *addr, void *nodeset) const = 0;
+
         /// Free memory that was previously allocated by allocate
         virtual void deallocate(void* addr, std::size_t len) const = 0;
 

--- a/hpx/runtime/threads/topology.hpp
+++ b/hpx/runtime/threads/topology.hpp
@@ -32,6 +32,10 @@
 
 namespace hpx { namespace threads
 {
+
+    /// forward declare membind enum type as int
+    enum hpx_hwloc_membind_policy  : int;
+
     struct topology
     {
         virtual ~topology() {}
@@ -189,7 +193,8 @@ namespace hpx { namespace threads
         virtual mask_type get_cpubind_mask(compat::thread & handle,
             error_code& ec = throws) const = 0;
 
-        virtual hpx::resource::hwloc_bitmap_ptr cpuset_to_nodeset(
+        /// convert a cpu mask into a numa node mask in hwloc bitmap form
+        virtual hwloc_bitmap_ptr cpuset_to_nodeset(
             mask_cref_type cpuset) const = 0;
 
         virtual void write_to_log() const = 0;
@@ -197,9 +202,12 @@ namespace hpx { namespace threads
         /// This is equivalent to malloc(), except that it tries to allocate
         /// page-aligned memory from the OS.
         virtual void* allocate(std::size_t len) const = 0;
+
+        /// allocate memory with binding to a numa node set as
+        /// specified by the policy and flags (see hwloc docs)
         virtual void* allocate_membind(std::size_t len,
-            hpx::resource::hwloc_bitmap_ptr bitmap,
-            hpx::resource::hpx_membind_policy policy, int flags) const = 0;
+            hwloc_bitmap_ptr bitmap,
+            hpx_hwloc_membind_policy policy, int flags) const = 0;
 
         /// Free memory that was previously allocated by allocate
         virtual void deallocate(void* addr, std::size_t len) const = 0;

--- a/hpx/runtime/threads/topology.hpp
+++ b/hpx/runtime/threads/topology.hpp
@@ -16,6 +16,7 @@
 #include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/runtime/threads/cpu_mask.hpp>
 #include <hpx/runtime/threads/thread_data_fwd.hpp>
+#include <hpx/runtime/resource/partitioner_fwd.hpp>
 
 #include <cstddef>
 #include <iosfwd>
@@ -147,8 +148,8 @@ namespace hpx { namespace threads
 
         /// \brief Prints the \param m to os in a human readable form
         virtual void print_affinity_mask(std::ostream& os,
-            std::size_t num_thread, mask_type const& m,
-            std::string pool_name) const = 0;
+            std::size_t num_thread, mask_cref_type m,
+            const std::string &pool_name) const = 0;
 
         /// \brief Reduce thread priority of the current thread.
         ///
@@ -188,11 +189,17 @@ namespace hpx { namespace threads
         virtual mask_type get_cpubind_mask(compat::thread & handle,
             error_code& ec = throws) const = 0;
 
+        virtual hpx::resource::hwloc_bitmap_ptr cpuset_to_nodeset(
+            mask_cref_type cpuset) const = 0;
+
         virtual void write_to_log() const = 0;
 
         /// This is equivalent to malloc(), except that it tries to allocate
         /// page-aligned memory from the OS.
         virtual void* allocate(std::size_t len) const = 0;
+        virtual void* allocate_membind(std::size_t len,
+            hpx::resource::hwloc_bitmap_ptr bitmap,
+            hpx::resource::hpx_membind_policy policy, int flags) const = 0;
 
         /// Free memory that was previously allocated by allocate
         virtual void deallocate(void* addr, std::size_t len) const = 0;

--- a/src/runtime/threads/detail/thread_pool_base.cpp
+++ b/src/runtime/threads/detail/thread_pool_base.cpp
@@ -51,6 +51,11 @@ namespace hpx { namespace threads { namespace detail
         return used_processing_units_;
     }
 
+    hpx::resource::hwloc_bitmap_ptr thread_pool_base::get_numa_domain_bitmap() const
+    {
+        return used_numa_domains_;
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     std::size_t thread_pool_base::get_worker_thread_num() const
     {
@@ -106,6 +111,7 @@ namespace hpx { namespace threads { namespace detail
             else
                 threads::set(used_processing_units_, threads_offset + i);
         }
+        used_numa_domains_ = rp.get_topology().cpuset_to_nodeset(used_processing_units_);
     }
 }}}
 

--- a/src/runtime/threads/detail/thread_pool_base.cpp
+++ b/src/runtime/threads/detail/thread_pool_base.cpp
@@ -51,7 +51,7 @@ namespace hpx { namespace threads { namespace detail
         return used_processing_units_;
     }
 
-    hpx::resource::hwloc_bitmap_ptr thread_pool_base::get_numa_domain_bitmap() const
+    hwloc_bitmap_ptr thread_pool_base::get_numa_domain_bitmap() const
     {
         return used_numa_domains_;
     }

--- a/src/runtime/threads/policies/hwloc_topology_info.cpp
+++ b/src/runtime/threads/policies/hwloc_topology_info.cpp
@@ -1144,7 +1144,7 @@ namespace hpx { namespace threads
         hwloc_bitmap_ptr bitmap,
         hpx_hwloc_membind_policy policy, int flags) const
     {
-        return hwloc_alloc_membind_nodeset(topo, len, bitmap->bmp_,
+        return hwloc_alloc_membind_nodeset(topo, len, bitmap->get_bmp(),
             (hwloc_membind_policy_t)(policy), flags);
     }
 

--- a/src/runtime/threads/policies/hwloc_topology_info.cpp
+++ b/src/runtime/threads/policies/hwloc_topology_info.cpp
@@ -29,6 +29,7 @@
 #include <mutex>
 #include <string>
 #include <vector>
+#include <memory>
 
 #include <hwloc.h>
 
@@ -1174,10 +1175,10 @@ namespace hpx { namespace threads
                     static_cast<unsigned int>(pu_obj->os_index));
             }
         }
-        std::cout << "mask_to_bitmap mask_cref is " << mask;
-        char strp[256];
-        hwloc_bitmap_snprintf((char*)(strp), 256, (const hwloc_bitmap_s*)(bitmap));
-        std::cout << "\n" << "bitmap is " << strp << std::endl;
+//        std::cout << "mask_to_bitmap mask_cref is " << mask;
+//        char strp[256];
+//        hwloc_bitmap_snprintf((char*)(strp), 256, (const hwloc_bitmap_s*)(bitmap));
+//        std::cout << "\n" << "bitmap is " << strp << std::endl;
         return bitmap;
     }
 
@@ -1196,10 +1197,10 @@ namespace hpx { namespace threads
             if (hwloc_bitmap_isset(bitmap, idx) != 0)
                 set(mask, detail::get_index(pu_obj));
         }
-        std::cout << "bitmap_to_mask mask_cref is " << mask;
-        char strp[256];
-        hwloc_bitmap_snprintf((char*)(strp), 256, (const hwloc_bitmap_s*)(bitmap));
-        std::cout << "\n" << "bitmap is " << strp << std::endl;
+//        std::cout << "bitmap_to_mask mask_cref is " << mask;
+//        char strp[256];
+//        hwloc_bitmap_snprintf((char*)(strp), 256, (const hwloc_bitmap_s*)(bitmap));
+//        std::cout << "\n" << "bitmap is " << strp << std::endl;
         return mask;
     }
 

--- a/src/runtime/threads/policies/hwloc_topology_info.cpp
+++ b/src/runtime/threads/policies/hwloc_topology_info.cpp
@@ -737,13 +737,13 @@ namespace hpx { namespace threads
         return get_number_of_cores();
     }
 
-    hpx::resource::hwloc_bitmap_ptr hwloc_topology_info::cpuset_to_nodeset(
+    hwloc_bitmap_ptr hwloc_topology_info::cpuset_to_nodeset(
         mask_cref_type mask) const
     {
         hwloc_bitmap_t cpuset  = mask_to_bitmap(mask, HWLOC_OBJ_PU);
         hwloc_bitmap_t nodeset = hwloc_bitmap_alloc();
         hwloc_cpuset_to_nodeset_strict(topo, cpuset, nodeset);
-        return std::make_shared<hpx::resource::hpx_hwloc_bitmap_wrapper>(nodeset);
+        return std::make_shared<hpx::threads::hpx_hwloc_bitmap_wrapper>(nodeset);
     }
 
     namespace detail
@@ -1131,8 +1131,8 @@ namespace hpx { namespace threads
     /// Allocate some memory on NUMA memory nodes specified by nodeset
     /// as specified by the hwloc hwloc_alloc_membind_nodeset call
     void* hwloc_topology_info::allocate_membind(std::size_t len,
-        hpx::resource::hwloc_bitmap_ptr bitmap,
-        hpx::resource::hpx_membind_policy policy, int flags) const
+        hwloc_bitmap_ptr bitmap,
+        hpx_hwloc_membind_policy policy, int flags) const
     {
         char strp[256];
         hwloc_bitmap_snprintf((char*)(strp), 256, bitmap->bmp_);

--- a/src/runtime/threads/policies/hwloc_topology_info.cpp
+++ b/src/runtime/threads/policies/hwloc_topology_info.cpp
@@ -428,7 +428,7 @@ namespace hpx { namespace threads
         if (&ec != &throws)
             ec = make_success_code();
 
-        hwloc_membind_policy_t policy = HWLOC_MEMBIND_DEFAULT;
+        hwloc_membind_policy_t policy = ::HWLOC_MEMBIND_DEFAULT;
         hwloc_nodeset_t nodeset = hwloc_bitmap_alloc();
 
         {
@@ -1151,7 +1151,7 @@ namespace hpx { namespace threads
     bool hwloc_topology_info::set_area_membind_nodeset(
         const void *addr, std::size_t len, void *nodeset) const
     {
-        hwloc_membind_policy_t policy = HWLOC_MEMBIND_BIND;
+        hwloc_membind_policy_t policy = ::HWLOC_MEMBIND_BIND;
         hwloc_nodeset_t ns = reinterpret_cast<hwloc_nodeset_t>(nodeset);
         int ret = hwloc_set_area_membind_nodeset(topo, addr, len, ns, policy, 0);
         if (ret<0) {

--- a/src/runtime/threads/policies/hwloc_topology_info.cpp
+++ b/src/runtime/threads/policies/hwloc_topology_info.cpp
@@ -92,6 +92,15 @@ namespace hpx { namespace threads
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    std::ostream& operator<<(std::ostream& os, hpx_hwloc_bitmap_wrapper const* bmp)
+    {
+        char buffer[256];
+        hwloc_bitmap_snprintf(buffer, 256, bmp->bmp_);
+        os << buffer;
+        return os;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     mask_type hwloc_topology_info::empty_mask = mask_type();
 
     hwloc_topology_info::hwloc_topology_info()
@@ -1134,10 +1143,7 @@ namespace hpx { namespace threads
         hwloc_bitmap_ptr bitmap,
         hpx_hwloc_membind_policy policy, int flags) const
     {
-        char strp[256];
-        hwloc_bitmap_snprintf((char*)(strp), 256, bitmap->bmp_);
-        std::cout << "Calling hwloc_alloc_membind with bitmap "
-                  << strp << std::endl;
+        std::cout << "Calling hwloc_alloc_membind with bitmap " << bitmap << std::endl;
 
         return hwloc_alloc_membind_nodeset(topo, len, bitmap->bmp_,
             (hwloc_membind_policy_t)(policy), flags);


### PR DESCRIPTION
This provides an interface to the hwloc_alloc_membind function and requires a numa nodeset to be passed that the memory is bound to. 
This in turn requires a nodeset and rather than using a mask and converting to and from hwloc types, it is less error prone to use an hwloc bitmap object wrapped in a c++ holder to manage deletion.