### PR TITLE
Add #include files needed to set _POSIX_VERSION for debug check

### DIFF
--- a/src/util/debugging.cpp
+++ b/src/util/debugging.cpp
@@ -9,9 +9,17 @@
 
 #include <iostream>
 
+#if defined(HPX_HAVE_UNISTD_H)
+#include <unistd.h>
+#endif
+
 #if defined(HPX_WINDOWS)
 #include <Windows.h>
 #endif    // HPX_WINDOWS
+
+#if defined(_POSIX_VERSION)
+#include <boost/asio/ip/host_name.hpp>
+#endif
 
 namespace hpx {
 namespace util {


### PR DESCRIPTION
Debugger was not being attached because the relevant code was #ifdef'ed
out and therefore being skipped completely on some linux flavours

fix #2924 problem seems to have been caused by changes introduced in #2830 