### PR TITLE
Classify chunk_size_iterator to input iterator tag. (Fix #2866)

### DIFF
--- a/hpx/parallel/util/detail/chunk_size_iterator.hpp
+++ b/hpx/parallel/util/detail/chunk_size_iterator.hpp
@@ -25,13 +25,13 @@ namespace hpx { namespace parallel { namespace util { namespace detail
       : public hpx::util::iterator_facade<
             chunk_size_iterator<Iterator>,
             hpx::util::tuple<Iterator, std::size_t> const,
-            std::forward_iterator_tag>
+            std::input_iterator_tag>
     {
     private:
         typedef hpx::util::iterator_facade<
                 chunk_size_iterator<Iterator>,
                 hpx::util::tuple<Iterator, std::size_t> const,
-                std::forward_iterator_tag
+                std::input_iterator_tag
             > base_type;
 
     public:
@@ -90,13 +90,13 @@ namespace hpx { namespace parallel { namespace util { namespace detail
       : public hpx::util::iterator_facade<
             chunk_size_idx_iterator<Iterator>,
             hpx::util::tuple<Iterator, std::size_t, std::size_t> const,
-            std::forward_iterator_tag>
+            std::input_iterator_tag>
     {
     private:
         typedef hpx::util::iterator_facade<
                 chunk_size_idx_iterator<Iterator>,
                 hpx::util::tuple<Iterator, std::size_t, std::size_t> const,
-                std::forward_iterator_tag
+                std::input_iterator_tag
             > base_type;
 
     public:


### PR DESCRIPTION
This PR fixes #2866 .

Now, I classify ```chunk_size_iterator``` to input_iterator_tag, not forward_iterator_tag.
What I worry is that if ```chunk_size_iterator``` will be used incorrectly in any place, he/she may not know what is incorrect and wander with mistery bug.
https://github.com/STEllAR-GROUP/hpx/blob/954818a2202aec118b6dd00a81e96bb18e8c9e9c/hpx/parallel/executors/execution_fwd.hpp#L193-L201
For example, in above code, there is a nothing which explicitly notices that ```chunk_size_iterator``` is input iterator.
So, an user who utilizes ```chunk_size_iterator``` "indirectly" can make a mistake which violates multi-pass gaurantee.