### PR TITLE
Revert "Make sure the function vtables are initialized before use"

### DIFF
--- a/hpx/util/detail/basic_function.hpp
+++ b/hpx/util/detail/basic_function.hpp
@@ -60,7 +60,7 @@ namespace hpx { namespace util { namespace detail
     {
         // make sure the empty table instance is initialized in time, even
         // during early startup
-        static VTable const* get_empty_table() noexcept
+        static VTable const* get_empty_table()
         {
             static VTable const empty_table =
                 detail::construct_vtable<detail::empty_function<R(Ts...)> >();

--- a/hpx/util/detail/vtable/vtable.hpp
+++ b/hpx/util/detail/vtable/vtable.hpp
@@ -25,12 +25,11 @@ namespace hpx { namespace util { namespace detail
     template <typename VTable, typename T>
     struct vtables
     {
-        static VTable const* get_vtable_instance() noexcept
-        {
-            static VTable const instance = construct_vtable<T>();
-            return &instance;
-        }
+        static VTable const instance;
     };
+
+    template <typename VTable, typename T>
+    VTable const vtables<VTable, T>::instance = construct_vtable<T>();
 
     template <typename VTable, typename T>
     HPX_CONSTEXPR inline VTable const* get_vtable() noexcept
@@ -39,7 +38,7 @@ namespace hpx { namespace util { namespace detail
             std::is_same<T, typename std::decay<T>::type>::value,
             "T shall have no cv-ref-qualifiers");
 
-        return vtables<VTable, T>::get_vtable_instance();
+        return &vtables<VTable, T>::instance;
     }
 
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Reverts STEllAR-GROUP/hpx#2945

The original patch has caused issues during de-serialization of functions.