### PR TITLE
Making sure any hpx.os_threads=N supplied through a --hpx::config file is taken into account

### DIFF
--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -281,13 +281,15 @@ namespace hpx { namespace util
 
         ///////////////////////////////////////////////////////////////////////
         std::size_t handle_num_threads(util::manage_config& cfgmap,
+            util::runtime_configuration const& rtcfg,
             boost::program_options::variables_map& vm,
             util::batch_environment& env, bool using_nodelist, bool initial)
         {
             std::size_t batch_threads = env.retrieve_number_of_threads();
             std::size_t default_threads = thread::hardware_concurrency();
             std::string threads_str = cfgmap.get_value<std::string>(
-                "hpx.os_threads", "");
+                "hpx.os_threads", rtcfg.get_entry("hpx.os_threads",
+                    std::to_string(default_threads)));
 
             if ("all" == threads_str)
             {
@@ -295,13 +297,15 @@ namespace hpx { namespace util
                     batch_threads = thread::hardware_concurrency();
                 else
                     default_threads = batch_threads;
-
-                cfgmap.config_["hpx.os_threads"] =
-                    std::to_string(batch_threads);
             }
             else if (batch_threads != std::size_t(-1))
             {
                 default_threads = batch_threads;
+            }
+            else
+            {
+                default_threads =
+                    hpx::util::safe_lexical_cast<std::size_t>(threads_str);
             }
 
             std::size_t threads = cfgmap.get_value<std::size_t>(
@@ -320,7 +324,8 @@ namespace hpx { namespace util
                 }
                 else
                 {
-                    threads = hpx::util::safe_lexical_cast<std::size_t>(threads_str);
+                    threads =
+                        hpx::util::safe_lexical_cast<std::size_t>(threads_str);
                 }
 
                 if (threads == 0)
@@ -557,7 +562,7 @@ namespace hpx { namespace util
 
         // handle number of cores and threads
         num_threads_ = detail::handle_num_threads(
-            cfgmap, vm, env, using_nodelist, initial);
+            cfgmap, rtcfg_, vm, env, using_nodelist, initial);
         num_cores_ = detail::handle_num_cores(cfgmap, vm, num_threads_, env);
 
         bool expect_connections = false;

--- a/src/util/ini.cpp
+++ b/src/util/ini.cpp
@@ -793,7 +793,7 @@ void section::merge(section& second)
     for (section_map::iterator i = sections_.begin(); i != send; ++i)
     {
         // is there something to merge with?
-        if (second.has_section(i->first))
+        if (second.has_section(l, i->first))
             i->second.merge (second.sections_[i->first]);
     }
 
@@ -803,10 +803,10 @@ void section::merge(section& second)
     for (section_map::iterator i = s.begin (); i != secend; ++i)
     {
         // if THIS knows the section, we already merged it above
-        if (!has_section(i->first))
+        if (!has_section(l, i->first))
         {
             // it is not known here, so we can't merge, but have to add it.
-            add_section (i->first, i->second, get_root());
+            add_section (l, i->first, i->second, get_root());
         }
     }
 }

--- a/src/util/init_ini_data.cpp
+++ b/src/util/init_ini_data.cpp
@@ -95,14 +95,19 @@ namespace hpx { namespace util
         tokenizer_type::iterator end_suffixes = tok_suffixes.end();
 
         bool result = false;
-        for (tokenizer_type::iterator it = tok_paths.begin (); it != end_paths; ++it) {
-            std::string path = *it;
-            for (tokenizer_type::iterator jt = tok_suffixes.begin ();
-                jt != end_suffixes; ++jt) {
+        for (tokenizer_type::iterator it = tok_paths.begin(); it != end_paths;
+             ++it)
+        {
+            for (tokenizer_type::iterator jt = tok_suffixes.begin();
+                 jt != end_suffixes; ++jt)
+            {
+                std::string path = *it;
                 path += *jt;
-                bool result2 = handle_ini_file (ini, path + "/hpx.ini");
-                if (result2) {
-                    LBT_(info) << "loaded configuration: " << path << "/hpx.ini";
+                bool result2 = handle_ini_file(ini, path + "/hpx.ini");
+                if (result2)
+                {
+                    LBT_(info)
+                        << "loaded configuration: " << path << "/hpx.ini";
                 }
                 result = result2 || result;
             }

--- a/src/util/runtime_configuration.cpp
+++ b/src/util/runtime_configuration.cpp
@@ -178,7 +178,7 @@ namespace hpx { namespace util
             "expect_connecting_localities = ${HPX_EXPECT_CONNECTING_LOCALITIES:0}",
 
             // add placeholders for keys to be added by command line handling
-            "os_threads = 1",
+            "os_threads = all",
             "cores = all",
             "localities = 1",
             "first_pu = 0",

--- a/src/util/runtime_configuration.cpp
+++ b/src/util/runtime_configuration.cpp
@@ -344,11 +344,8 @@ namespace hpx { namespace util
         std::string& hpx_ini_file_,
         std::vector<std::string> const& cmdline_ini_defs_)
     {
-        // add explicit configuration information if its provided
-        if (!hpx_ini_file_.empty()) {
-            util::init_ini_data_base(*this, hpx_ini_file_);
-            need_to_call_pre_initialize = true;
-        }
+        util::init_ini_data_base(*this, hpx_ini_file_);
+        need_to_call_pre_initialize = true;
 
         // let the command line override the config file.
         if (!cmdline_ini_defs_.empty()) {


### PR DESCRIPTION

- flyby: fixed possible deadlock in util::section

This fixes #2947