### PR TITLE
Fixing errors generated by mixing different attribute syntaxes

### DIFF
--- a/hpx/hpx_finalize.hpp
+++ b/hpx/hpx_finalize.hpp
@@ -112,7 +112,7 @@ namespace hpx
     ///          all localities associated with this application. If the function
     ///          is called not from an HPX thread it will fail and return an error
     ///          using the argument \a ec.
-    HPX_EXPORT HPX_NORETURN void terminate();
+    HPX_NORETURN HPX_EXPORT void terminate();
 
     /// \brief Disconnect this locality from the application.
     ///


### PR DESCRIPTION
Clang will generate a compiler error if an attribute using the C++11 syntax is preceded by another attribute using the GCC syntax.

This PR reorders the attributes to fix this issue.

This fixes #2956.