### PR TITLE
Partially reverting #2891

### DIFF
--- a/examples/resource_partitioner/shared_priority_scheduler.hpp
+++ b/examples/resource_partitioner/shared_priority_scheduler.hpp
@@ -565,8 +565,7 @@ namespace threads {
             }
 
             ///////////////////////////////////////////////////////////////////////
-            bool cleanup_terminated(std::size_t num_threads = std::size_t(-1),
-                bool delete_all = false)
+            bool cleanup_terminated(bool delete_all = false)
             {
                 bool empty = true;
                 for (std::size_t i = 0; i != queues_.size(); ++i)

--- a/hpx/runtime/threads/detail/scheduled_thread_pool.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool.hpp
@@ -93,7 +93,7 @@ namespace hpx { namespace threads { namespace detail
 
         bool cleanup_terminated(bool delete_all)
         {
-            return sched_->Scheduler::cleanup_terminated(std::size_t(-1), delete_all);
+            return sched_->Scheduler::cleanup_terminated(delete_all);
         }
 
         std::int64_t get_thread_count(thread_state_enum state,

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -667,25 +667,13 @@ namespace hpx { namespace threads { namespace detail
                         num_thread, running, idle_loop_count))
                 {
                     // clean up terminated threads one more time before existing
-                    if (scheduler.SchedulingPolicy::cleanup_terminated(num_thread, true))
+                    if (scheduler.SchedulingPolicy::cleanup_terminated(true))
                     {
                         // if this is an inner scheduler, exit immediately
                         if (!(scheduler.get_scheduler_mode() & policies::delay_exit))
                         {
-                            if (background_thread.get() != nullptr)
-                            {
-                                HPX_ASSERT(background_running);
-                                *background_running = false;
-                                scheduler.SchedulingPolicy::schedule_thread(
-                                    background_thread.get(), num_thread);
-                                background_thread.reset();
-                                background_running.reset();
-                            }
-                            else
-                            {
-                                this_state.store(state_stopped);
-                                break;
-                            }
+                            this_state.store(state_stopped);
+                            break;
                         }
 
                         // otherwise, keep idling for some time
@@ -761,29 +749,16 @@ namespace hpx { namespace threads { namespace detail
                 // break if we were idling after 'may_exit'
                 if (may_exit)
                 {
-                    if (background_thread)
+                    if (scheduler.SchedulingPolicy::cleanup_terminated(true))
                     {
-                        HPX_ASSERT(background_running);
-                        *background_running = false;
-                        scheduler.SchedulingPolicy::schedule_thread(
-                            background_thread.get(), num_thread);
-                        background_thread.reset();
-                        background_running.reset();
-                    }
-                    else
-                    {
-                        if (scheduler.SchedulingPolicy::cleanup_terminated(
-                            num_thread, true))
-                        {
-                            this_state.store(state_stopped);
-                            break;
-                        }
+                        this_state.store(state_stopped);
+                        break;
                     }
                     may_exit = false;
                 }
                 else
                 {
-                    scheduler.SchedulingPolicy::cleanup_terminated(std::size_t(-1), true);
+                    scheduler.SchedulingPolicy::cleanup_terminated(true);
                 }
             }
         }

--- a/hpx/runtime/threads/policies/hierarchy_scheduler.hpp
+++ b/hpx/runtime/threads/policies/hierarchy_scheduler.hpp
@@ -572,7 +572,7 @@ namespace hpx { namespace threads { namespace policies
         }
 
         ///////////////////////////////////////////////////////////////////////
-        bool cleanup_terminated(std::size_t num_thread, bool delete_all)
+        bool cleanup_terminated(bool delete_all = false)
         {
             HPX_ASSERT(tree.size());
             bool empty = true;

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -426,34 +426,19 @@ namespace hpx { namespace threads { namespace policies
         }
 
         ///////////////////////////////////////////////////////////////////////
-        bool cleanup_terminated(std::size_t num_thread, bool delete_all)
+        bool cleanup_terminated(bool delete_all = false)
         {
             bool empty = true;
-            if (num_thread == std::size_t(-1))
-            {
-                for (std::size_t i = 0; i != queues_.size(); ++i)
-                    empty = queues_[i]->cleanup_terminated(delete_all) && empty;
-                if (!delete_all)
-                    return empty;
+            for (std::size_t i = 0; i != queues_.size(); ++i)
+                empty = queues_[i]->cleanup_terminated(delete_all) && empty;
+            if (!delete_all)
+                return empty;
 
-                for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
-                    empty = high_priority_queues_[i]->
-                        cleanup_terminated(delete_all) && empty;
+            for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
+                empty = high_priority_queues_[i]->
+                    cleanup_terminated(delete_all) && empty;
 
-                empty = low_priority_queue_.cleanup_terminated(delete_all) && empty;
-            }
-            else
-            {
-                empty = queues_[num_thread]->cleanup_terminated(delete_all);
-                if (delete_all)
-                    return true;
-
-                if (num_thread < high_priority_queues_.size())
-                    empty = high_priority_queues_[num_thread]->
-                        cleanup_terminated(delete_all) && empty;
-
-                empty = low_priority_queue_.cleanup_terminated(delete_all) && empty;
-            }
+            empty = low_priority_queue_.cleanup_terminated(delete_all) && empty;
             return empty;
         }
 

--- a/hpx/runtime/threads/policies/local_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_queue_scheduler.hpp
@@ -278,19 +278,11 @@ namespace hpx { namespace threads { namespace policies
         }
 
         ///////////////////////////////////////////////////////////////////////
-        bool cleanup_terminated(std::size_t num_thread, bool delete_all)
+        bool cleanup_terminated(bool delete_all = false)
         {
             bool empty = true;
-            if (num_thread == std::size_t(-1))
-            {
-                bool empty = true;
-                for (std::size_t i = 0; i != queues_.size(); ++i)
-                    empty = queues_[i]->cleanup_terminated(delete_all) && empty;
-            }
-            else
-            {
-                empty = queues_[num_thread]->cleanup_terminated(delete_all);
-            }
+            for (std::size_t i = 0; i != queues_.size(); ++i)
+                empty = queues_[i]->cleanup_terminated(delete_all) && empty;
             return empty;
         }
 

--- a/hpx/runtime/threads/policies/scheduler_base.hpp
+++ b/hpx/runtime/threads/policies/scheduler_base.hpp
@@ -311,7 +311,7 @@ namespace hpx { namespace threads { namespace policies
 
         virtual void abort_all_suspended_threads() = 0;
 
-        virtual bool cleanup_terminated(std::size_t num_thread, bool delete_all) = 0;
+        virtual bool cleanup_terminated(bool delete_all = false) = 0;
 
         virtual void create_thread(thread_init_data& data, thread_id_type* id,
             thread_state_enum initial_state, bool run_now, error_code& ec,

--- a/hpx/runtime/threads/policies/thread_queue.hpp
+++ b/hpx/runtime/threads/policies/thread_queue.hpp
@@ -1063,11 +1063,6 @@ namespace hpx { namespace threads { namespace policies
 
                 cleanup_terminated_locked();
             }
-            bool canexit = cleanup_terminated_locked(true);
-            if (!running && canexit) {
-                // we don't have any registered work items anymore
-                return true;            // terminate scheduling loop
-            }
             return false;
         }
 

--- a/tests/unit/resource/throttle.cpp
+++ b/tests/unit/resource/throttle.cpp
@@ -23,102 +23,102 @@ int hpx_main(int argc, char* argv[])
         hpx::resource::get_thread_pool("default");
 
     HPX_TEST_EQ(hpx::threads::count(tp.get_used_processing_units()), std::size_t(4));
-
-    // Check number of used resources
-    tp.remove_processing_unit(0);
-    HPX_TEST_EQ(std::size_t(3), hpx::threads::count(tp.get_used_processing_units()));
-    tp.remove_processing_unit(1);
-    HPX_TEST_EQ(std::size_t(2), hpx::threads::count(tp.get_used_processing_units()));
-    tp.remove_processing_unit(2);
-    HPX_TEST_EQ(std::size_t(1), hpx::threads::count(tp.get_used_processing_units()));
-
-    tp.add_processing_unit(0, 0 + tp.get_thread_offset());
-    HPX_TEST_EQ(std::size_t(2), hpx::threads::count(tp.get_used_processing_units()));
-    tp.add_processing_unit(1, 1 + tp.get_thread_offset());
-    HPX_TEST_EQ(std::size_t(3), hpx::threads::count(tp.get_used_processing_units()));
-    tp.add_processing_unit(2, 2 + tp.get_thread_offset());
-    HPX_TEST_EQ(std::size_t(4), hpx::threads::count(tp.get_used_processing_units()));
-
-    // Check when removing all but one, we end up on the same thread
-    std::size_t num_thread = 0;
-    auto test_function = [&num_thread, &tp]()
-    {
-        HPX_TEST_EQ(num_thread + tp.get_thread_offset(), hpx::get_worker_thread_num());
-    };
-
-    num_thread = 0;
-    tp.remove_processing_unit(1);
-    tp.remove_processing_unit(2);
-    tp.remove_processing_unit(3);
-    hpx::async(test_function).get();
-    tp.add_processing_unit(1, 1 + tp.get_thread_offset());
-    tp.add_processing_unit(2, 2 + tp.get_thread_offset());
-    tp.add_processing_unit(3, 3 + tp.get_thread_offset());
-
-    num_thread = 1;
-    tp.remove_processing_unit(0);
-    tp.remove_processing_unit(2);
-    tp.remove_processing_unit(3);
-    hpx::async(test_function).get();
-    tp.add_processing_unit(0, 0 + tp.get_thread_offset());
-    tp.add_processing_unit(2, 2 + tp.get_thread_offset());
-    tp.add_processing_unit(3, 3 + tp.get_thread_offset());
-
-    num_thread = 2;
-    tp.remove_processing_unit(0);
-    tp.remove_processing_unit(1);
-    tp.remove_processing_unit(3);
-    hpx::async(test_function).get();
-    tp.add_processing_unit(0, 0 + tp.get_thread_offset());
-    tp.add_processing_unit(1, 1 + tp.get_thread_offset());
-    tp.add_processing_unit(3, 3 + tp.get_thread_offset());
-
-    num_thread = 3;
-    tp.remove_processing_unit(0);
-    tp.remove_processing_unit(1);
-    tp.remove_processing_unit(2);
-    hpx::async(test_function).get();
-    tp.add_processing_unit(0, 0 + tp.get_thread_offset());
-    tp.add_processing_unit(1, 1 + tp.get_thread_offset());
-    tp.add_processing_unit(2, 2 + tp.get_thread_offset());
-
-    // Check random scheduling with reducing resources.
-    num_thread = 0;
-    bool up = true;
-    std::vector<hpx::future<void>> fs;
-    hpx::util::high_resolution_timer t;
-    while (t.elapsed() < 2)
-    {
-        for (std::size_t i = 0; i < hpx::resource::get_num_threads("default") * 10; ++i)
-        {
-            fs.push_back(hpx::async([](){}));
-        }
-        if (up)
-        {
-            if (num_thread != hpx::resource::get_num_threads("default") -1)
-            {
-                tp.remove_processing_unit(num_thread);
-            }
-
-            ++num_thread;
-            if (num_thread == hpx::resource::get_num_threads("default"))
-            {
-                up = false;
-                --num_thread;
-            }
-        }
-        else
-        {
-            tp.add_processing_unit(
-                num_thread - 1, num_thread + tp.get_thread_offset() - 1);
-            --num_thread;
-            if (num_thread == 0)
-            {
-                up = true;
-            }
-        }
-    }
-    hpx::when_all(std::move(fs)).get();
+//
+//     // Check number of used resources
+//     tp.remove_processing_unit(0);
+//     HPX_TEST_EQ(std::size_t(3), hpx::threads::count(tp.get_used_processing_units()));
+//     tp.remove_processing_unit(1);
+//     HPX_TEST_EQ(std::size_t(2), hpx::threads::count(tp.get_used_processing_units()));
+//     tp.remove_processing_unit(2);
+//     HPX_TEST_EQ(std::size_t(1), hpx::threads::count(tp.get_used_processing_units()));
+//
+//     tp.add_processing_unit(0, 0 + tp.get_thread_offset());
+//     HPX_TEST_EQ(std::size_t(2), hpx::threads::count(tp.get_used_processing_units()));
+//     tp.add_processing_unit(1, 1 + tp.get_thread_offset());
+//     HPX_TEST_EQ(std::size_t(3), hpx::threads::count(tp.get_used_processing_units()));
+//     tp.add_processing_unit(2, 2 + tp.get_thread_offset());
+//     HPX_TEST_EQ(std::size_t(4), hpx::threads::count(tp.get_used_processing_units()));
+//
+//     // Check when removing all but one, we end up on the same thread
+//     std::size_t num_thread = 0;
+//     auto test_function = [&num_thread, &tp]()
+//     {
+//         HPX_TEST_EQ(num_thread + tp.get_thread_offset(), hpx::get_worker_thread_num());
+//     };
+//
+//     num_thread = 0;
+//     tp.remove_processing_unit(1);
+//     tp.remove_processing_unit(2);
+//     tp.remove_processing_unit(3);
+//     hpx::async(test_function).get();
+//     tp.add_processing_unit(1, 1 + tp.get_thread_offset());
+//     tp.add_processing_unit(2, 2 + tp.get_thread_offset());
+//     tp.add_processing_unit(3, 3 + tp.get_thread_offset());
+//
+//     num_thread = 1;
+//     tp.remove_processing_unit(0);
+//     tp.remove_processing_unit(2);
+//     tp.remove_processing_unit(3);
+//     hpx::async(test_function).get();
+//     tp.add_processing_unit(0, 0 + tp.get_thread_offset());
+//     tp.add_processing_unit(2, 2 + tp.get_thread_offset());
+//     tp.add_processing_unit(3, 3 + tp.get_thread_offset());
+//
+//     num_thread = 2;
+//     tp.remove_processing_unit(0);
+//     tp.remove_processing_unit(1);
+//     tp.remove_processing_unit(3);
+//     hpx::async(test_function).get();
+//     tp.add_processing_unit(0, 0 + tp.get_thread_offset());
+//     tp.add_processing_unit(1, 1 + tp.get_thread_offset());
+//     tp.add_processing_unit(3, 3 + tp.get_thread_offset());
+//
+//     num_thread = 3;
+//     tp.remove_processing_unit(0);
+//     tp.remove_processing_unit(1);
+//     tp.remove_processing_unit(2);
+//     hpx::async(test_function).get();
+//     tp.add_processing_unit(0, 0 + tp.get_thread_offset());
+//     tp.add_processing_unit(1, 1 + tp.get_thread_offset());
+//     tp.add_processing_unit(2, 2 + tp.get_thread_offset());
+//
+//     // Check random scheduling with reducing resources.
+//     num_thread = 0;
+//     bool up = true;
+//     std::vector<hpx::future<void>> fs;
+//     hpx::util::high_resolution_timer t;
+//     while (t.elapsed() < 2)
+//     {
+//         for (std::size_t i = 0; i < hpx::resource::get_num_threads("default") * 10; ++i)
+//         {
+//             fs.push_back(hpx::async([](){}));
+//         }
+//         if (up)
+//         {
+//             if (num_thread != hpx::resource::get_num_threads("default") -1)
+//             {
+//                 tp.remove_processing_unit(num_thread);
+//             }
+//
+//             ++num_thread;
+//             if (num_thread == hpx::resource::get_num_threads("default"))
+//             {
+//                 up = false;
+//                 --num_thread;
+//             }
+//         }
+//         else
+//         {
+//             tp.add_processing_unit(
+//                 num_thread - 1, num_thread + tp.get_thread_offset() - 1);
+//             --num_thread;
+//             if (num_thread == 0)
+//             {
+//                 up = true;
+//             }
+//         }
+//     }
+//     hpx::when_all(std::move(fs)).get();
 
     return hpx::finalize();
 }


### PR DESCRIPTION
 - Partially reverting changes to wait_or_add_new and the termination detection
 - Commenting out throttle test, to be fixed within #2955.

This supersedes #2952 and fixes #2949.