### PR TITLE
Making sure any function object passed to dataflow is released after being invoked

### DIFF
--- a/hpx/lcos/dataflow.hpp
+++ b/hpx/lcos/dataflow.hpp
@@ -133,8 +133,10 @@ namespace hpx { namespace lcos { namespace detail
         void execute(std::false_type, Futures&& futures)
         {
             try {
+                Func func = std::move(func_);
+
                 result_type res =
-                    util::invoke_fused(func_, std::move(futures));
+                    util::invoke_fused(std::move(func), std::move(futures));
 
                 this->set_data(std::move(res));
             }
@@ -149,7 +151,9 @@ namespace hpx { namespace lcos { namespace detail
         void execute(std::true_type, Futures&& futures)
         {
             try {
-                util::invoke_fused(func_, std::move(futures));
+                Func func = std::move(func_);
+
+                util::invoke_fused(std::move(func), std::move(futures));
 
                 this->set_data(util::unused_type());
             }


### PR DESCRIPTION
- this fixes test problems with the executor_parameters_timer_hooks test