### PR TITLE
Improve is_tuple_like trait

### DIFF
--- a/hpx/traits/is_tuple_like.hpp
+++ b/hpx/traits/is_tuple_like.hpp
@@ -3,7 +3,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(HPX_TRAITS_IS_TUPLE_LIKE_HPP)
+#ifndef HPX_TRAITS_IS_TUPLE_LIKE_HPP
 #define HPX_TRAITS_IS_TUPLE_LIKE_HPP
 
 #include <type_traits>
@@ -11,21 +11,28 @@
 #include <hpx/util/always_void.hpp>
 #include <hpx/util/tuple.hpp>
 
-namespace hpx {
-namespace traits {
+namespace hpx { namespace traits
+{
+    namespace detail
+    {
+        template <typename T, typename Enable = void>
+        struct is_tuple_like_impl
+          : std::false_type
+        {};
+
+        template <typename T>
+        struct is_tuple_like_impl<T, typename util::always_void<
+            decltype(util::tuple_size<T>::value)>::type
+        > : std::true_type
+        {};
+    }
+
     /// Deduces to a true type if the given parameter T
     /// has a specific tuple like size.
-    template <typename T, typename = void>
-    struct is_tuple_like : std::false_type
-    {
-    };
     template <typename T>
-    struct is_tuple_like<T,
-        typename util::always_void<decltype(util::tuple_size<T>::value)>::type>
-      : std::true_type
-    {
-    };
-}    // namespace traits
-}    // namespace hpx
+    struct is_tuple_like
+      : detail::is_tuple_like_impl<typename std::remove_cv<T>::type>
+    {};
+}}
 
-#endif
+#endif /*HPX_TRAITS_IS_TUPLE_LIKE_HPP*/


### PR DESCRIPTION
- Move SFINAE out of the lookup phase, defer to base implementation
- Ignore cv-qualified specializations of tuple_size