### PR TITLE
Adding uintstd.h header

### DIFF
--- a/hpx/runtime/threads/coroutines/detail/context_posix.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_posix.hpp
@@ -47,6 +47,12 @@
 #include <hpx/util/get_and_reset_value.hpp>
 #include <hpx/util/unused.hpp>
 
+// include unist.d conditionally to check for POSIX version. Not all OSs have the
+// unistd header...
+#if defined(HPX_HAVE_UNISTD_H)
+#include <unistd.h>
+#endif
+
 #if defined(__FreeBSD__) || (defined(_XOPEN_UNIX) && defined(_XOPEN_VERSION) \
             && _XOPEN_VERSION >= 500)
 


### PR DESCRIPTION
Adding uintstd.h header so compiling with Clang 5.0 on ppc64le works.