### PR TITLE
Change version of pulled APEX to master

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1558,7 +1558,7 @@ if(HPX_WITH_APEX)
   include(GitExternal)
   git_external(apex
     https://github.com/khuck/xpress-apex.git
-    v1.2
+    master
     ${_hpx_apex_no_update}
     VERBOSE)
 


### PR DESCRIPTION
v1.2 is an old tag, updating APEX GitHub command to pull master instead.