### PR TITLE
Clang tidy

### DIFF
--- a/examples/1d_stencil/1d_stencil_4_checkpoint.cpp
+++ b/examples/1d_stencil/1d_stencil_4_checkpoint.cpp
@@ -151,7 +151,7 @@ struct backup
     }
     backup(backup&& old)
       : bin(std::move(old.bin))
-      , file_name_(old.file_name_)
+      , file_name_(std::move(old.file_name_))
     {
     }
     ~backup() {}

--- a/examples/quickstart/partitioned_vector_spmd_foreach.cpp
+++ b/examples/quickstart/partitioned_vector_spmd_foreach.cpp
@@ -65,7 +65,7 @@ public:
         // this view assumes that there is exactly one segment per locality
         typedef typename traits::local_segment_iterator local_segment_iterator;
         local_segment_iterator sit = segment_iterator_;
-        HPX_ASSERT(++sit == data.segment_end(hpx::get_locality_id()));
+        HPX_ASSERT(++sit == data.segment_end(hpx::get_locality_id())); // NOLINT
 #endif
     }
 

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_decl.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_decl.hpp
@@ -488,7 +488,7 @@ namespace hpx
         {
             if (this != &rhs)
             {
-                this->base_type::operator=(std::move(rhs));
+                this->base_type::operator=(std::move(static_cast<base_type&&>(rhs)));
 
                 size_ = rhs.size_;
                 partition_size_ = rhs.partition_size_;

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_segmented_iterator.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_segmented_iterator.hpp
@@ -513,7 +513,7 @@ namespace hpx
 
     public:
         segment_vector_iterator()
-          : data_(0)
+          : data_(nullptr)
         {}
 
         segment_vector_iterator(BaseIter const& it,
@@ -547,7 +547,7 @@ namespace hpx
 
     public:
         const_segment_vector_iterator()
-          : data_(0)
+          : data_(nullptr)
         {}
 
         template<typename RightBaseIter>

--- a/hpx/components/performance_counters/papi/server/papi.hpp
+++ b/hpx/components/performance_counters/papi/server/papi.hpp
@@ -184,7 +184,7 @@ namespace hpx { namespace performance_counters { namespace papi { namespace serv
 
         papi_counter():
             event_(PAPI_NULL), index_(-1), value_(0), timestamp_(-1),
-            status_(PAPI_COUNTER_STOPPED), counters_(0) { }
+            status_(PAPI_COUNTER_STOPPED), counters_(nullptr) { }
         papi_counter(hpx::performance_counters::counter_info const& info);
 
         // start the counter

--- a/hpx/components/performance_counters/papi/util/papi.hpp
+++ b/hpx/components/performance_counters/papi/util/papi.hpp
@@ -91,9 +91,9 @@ namespace hpx { namespace performance_counters { namespace papi { namespace util
 
         PAPI_event_info_t const *operator()()
         {
-            if (!active_) return 0;
+            if (!active_) return nullptr;
             while (!get_info())
-                if (!(active_ = get_next_event())) return 0;
+                if (!(active_ = get_next_event())) return nullptr;
             active_ = get_next_event();
             return &info_;
         }

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -650,7 +650,7 @@ namespace detail
 
         template <typename Target>
         future_data(Target && data, init_no_addref no_addref)
-          : future_data_base<Result>(std::move(data), no_addref)
+          : future_data_base<Result>(std::forward<Target>(data), no_addref)
         {}
 
         future_data(std::exception_ptr const& e, init_no_addref no_addref)
@@ -687,7 +687,7 @@ namespace detail
         template <typename Target>
         future_data_allocator(Target && data, init_no_addref no_addref,
                 other_allocator const& alloc)
-          : future_data<Result>(std::move(data), no_addref), alloc_(alloc)
+          : future_data<Result>(std::forward<Target>(data), no_addref), alloc_(alloc)
         {}
         future_data_allocator(std::exception_ptr const& e,
                 init_no_addref no_addref, other_allocator const& alloc)

--- a/hpx/lcos/detail/promise_base.hpp
+++ b/hpx/lcos/detail/promise_base.hpp
@@ -197,7 +197,7 @@ namespace lcos {
             }
 
             promise_base(promise_base&& other) noexcept
-                : base_type(std::move(other)),
+                : base_type(std::move(static_cast<base_type&&>(other))),
                   id_retrieved_(other.id_retrieved_),
                   id_(std::move(other.id_)),
                   addr_(std::move(other.addr_))
@@ -216,7 +216,7 @@ namespace lcos {
 
             promise_base& operator=(promise_base&& other) noexcept
             {
-                base_type::operator=(std::move(other));
+                base_type::operator=(std::move(static_cast<base_type&&>(other)));
                 id_retrieved_ = other.id_retrieved_;
                 id_ = std::move(other.id_);
                 addr_ = std::move(other.addr_);

--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -1122,7 +1122,7 @@ namespace hpx { namespace lcos
         >::type
         make_future_helper(Future && f)
         {
-            return std::move(f);
+            return std::forward<Future>(f);
         }
 
         template <typename T, typename Future>
@@ -1163,7 +1163,7 @@ namespace hpx { namespace lcos
         >::type
         convert_future_helper(Future && f, Conv && conv)
         {
-            return std::move(f);
+            return std::forward<Future>(f);
         }
 
         template <typename T, typename Future, typename Conv>

--- a/hpx/lcos/local/futures_factory.hpp
+++ b/hpx/lcos/local/futures_factory.hpp
@@ -314,7 +314,9 @@ namespace hpx { namespace lcos { namespace local
             future_obtained_(false)
         {}
 
-        template <typename F>
+        template <typename F, typename Enable = typename
+            std::enable_if<!std::is_same<typename hpx::util::decay<F>::type,
+                futures_factory>::value>::type>
         explicit futures_factory(F&& f)
           : task_(detail::create_task_object<Result, Cancelable>::call(
                 std::forward<F>(f))),

--- a/hpx/lcos/packaged_action.hpp
+++ b/hpx/lcos/packaged_action.hpp
@@ -193,7 +193,7 @@ namespace lcos {
                 hpx::apply_p_cb<action_type>(
                     actions::typed_continuation<Result, remote_result_type>(
                         std::move(cont_id), std::move(addr_)),
-                    std::move(addr), id, priority, std::move(cb),
+                    std::move(addr), id, priority, std::forward<Callback>(cb),
                     std::forward<Ts>(vs)...);
             }
             else
@@ -201,7 +201,8 @@ namespace lcos {
                 hpx::apply_p_cb<action_type>(
                     actions::typed_continuation<Result, remote_result_type>(
                         std::move(cont_id), std::move(addr_)),
-                    id, priority, std::move(cb), std::forward<Ts>(vs)...);
+                    id, priority, std::forward<Callback>(cb),
+                    std::forward<Ts>(vs)...);
             }
 
             this->shared_state_->mark_as_started();

--- a/hpx/lcos/when_each.hpp
+++ b/hpx/lcos/when_each.hpp
@@ -165,14 +165,14 @@ namespace hpx { namespace lcos
             inline static void call(F&& f, IndexType index, FutureType&& future,
                 std::true_type)
             {
-                f(index, std::move(future));
+                f(index, std::forward<FutureType>(future));
             }
 
             template<typename F, typename IndexType, typename FutureType>
             inline static void call(F&& f, IndexType index, FutureType&& future,
                 std::false_type)
             {
-                f(std::move(future));
+                f(std::forward<FutureType>(future));
             }
         };
 
@@ -387,9 +387,10 @@ namespace hpx { namespace lcos
             std::back_inserter(lazy_values_),
             traits::acquire_future_disp());
 
+        std::size_t lazy_values_size = lazy_values_.size();
         boost::intrusive_ptr<frame_type> p(new frame_type(
             util::forward_as_tuple(std::move(lazy_values_)),
-            std::forward<F>(func), lazy_values_.size()));
+            std::forward<F>(func), lazy_values_size));
 
         p->do_await();
 

--- a/hpx/parallel/algorithms/for_loop.hpp
+++ b/hpx/parallel/algorithms/for_loop.hpp
@@ -48,87 +48,66 @@ namespace hpx { namespace parallel { inline namespace v2
         /// \cond NOINTERNAL
 
         ///////////////////////////////////////////////////////////////////////
-        template <typename ... Ts, std::size_t ... Is>
+        template <typename ... Ts>
         HPX_HOST_DEVICE
-        HPX_FORCEINLINE void init_iteration(hpx::util::tuple<Ts...>& args,
-            hpx::util::detail::pack_c<std::size_t, Is...>,
-            std::size_t part_index)
+        HPX_FORCEINLINE void init_iteration(std::size_t part_index, Ts &&... args)
         {
             int const _sequencer[] =
             {
-                0, (hpx::util::get<Is>(args).init_iteration(part_index), 0)...
+                0, (std::forward<Ts>(args).init_iteration(part_index), 0)...
             };
             (void)_sequencer;
         }
 
-        template <typename ... Ts, std::size_t ... Is, typename F, typename B>
+        template <typename ... Ts>
         HPX_HOST_DEVICE
-        HPX_FORCEINLINE void invoke_iteration(hpx::util::tuple<Ts...>& args,
-            hpx::util::detail::pack_c<std::size_t, Is...>, F && f, B part_begin)
-        {
-            hpx::util::invoke_r<void>(std::forward<F>(f), part_begin,
-                hpx::util::get<Is>(args).iteration_value()...);
-        }
-
-        template <typename ... Ts, std::size_t ... Is>
-        HPX_HOST_DEVICE
-        HPX_FORCEINLINE void next_iteration(hpx::util::tuple<Ts...>& args,
-            hpx::util::detail::pack_c<std::size_t, Is...>)
+        HPX_FORCEINLINE void next_iteration(Ts&&... args)
         {
             int const _sequencer[] =
             {
-                0, (hpx::util::get<Is>(args).next_iteration(), 0)...
+                0, (std::forward<Ts>(args).next_iteration(), 0)...
             };
             (void)_sequencer;
         }
 
-        template <typename ... Ts, std::size_t ... Is>
+        template <typename ... Ts>
         HPX_HOST_DEVICE
-        HPX_FORCEINLINE void exit_iteration(hpx::util::tuple<Ts...>& args,
-            hpx::util::detail::pack_c<std::size_t, Is...>,
-            std::size_t size)
+        HPX_FORCEINLINE void exit_iteration(std::size_t size, Ts &&... args)
         {
             int const _sequencer[] =
             {
-                0, (hpx::util::get<Is>(args).exit_iteration(size), 0)...
+                0, (std::forward<Ts>(args).exit_iteration(size), 0)...
             };
             (void)_sequencer;
         }
 
         ///////////////////////////////////////////////////////////////////////
-        template <typename F, typename S, typename Tuple>
-        struct part_iterations;
-
-        template <typename F, typename S, typename ...Ts>
-        struct part_iterations<F, S, hpx::util::tuple<Ts...> >
+        template <typename F, typename S>
+        struct part_iterations
         {
             typedef typename hpx::util::decay<F>::type fun_type;
 
             fun_type f_;
             S stride_;
-            hpx::util::tuple<Ts...> args_;
 
-            template <typename F_, typename S_, typename Args>
-            part_iterations(F_&& f, S_&& stride, Args&& args)
+            template <typename F_, typename S_>
+            part_iterations(F_&& f, S_&& stride)
               : f_(std::forward<F_>(f))
               , stride_(std::forward<S_>(stride))
-              , args_(std::forward<Args>(args))
             {}
 
-            template <typename B>
+            template <typename B, typename...Args>
             HPX_HOST_DEVICE
             void execute(B part_begin, std::size_t part_steps,
-                std::size_t part_index)
+                std::size_t part_index, Args &&... args)
             {
-                auto pack = typename hpx::util::detail::make_index_pack<
-                    sizeof...(Ts)>::type();
-                detail::init_iteration(args_, pack, part_index);
+                detail::init_iteration(part_index, std::forward<Args>(args)...);
 
                 while (part_steps != 0)
                 {
-                    detail::invoke_iteration(args_, pack, f_, part_begin);
+                    f_(part_begin, std::forward<Args>(args).iteration_value()...);
 
-                    detail::next_iteration(args_, pack);
+                    detail::next_iteration(std::forward<Args>(args)...);
 
                     // NVCC seems to have a bug with std::min...
                     std::size_t chunk =
@@ -141,13 +120,14 @@ namespace hpx { namespace parallel { inline namespace v2
                 }
             }
 
-            template <typename B>
+            template <typename B, typename...Args>
             HPX_HOST_DEVICE
             void operator()(B part_begin, std::size_t part_steps,
-                std::size_t part_index)
+                std::size_t part_index, Args &&... args)
             {
                 hpx::util::annotate_function annotate(f_);
-                execute(part_begin, part_steps, part_index);
+                execute(part_begin, part_steps, part_index,
+                    std::forward<Args>(args)...);
             }
         };
 
@@ -206,28 +186,18 @@ namespace hpx { namespace parallel { inline namespace v2
                 if (size == 0)
                     return util::detail::algorithm_result<ExPolicy>::get();
 
-                // we need to decay copy here to properly transport everything
-                // to a GPU device
-                typedef
-                    hpx::util::tuple<typename hpx::util::decay<Ts>::type...>
-                    args_type;
-
-                args_type args =
-                    hpx::util::forward_as_tuple(std::forward<Ts>(ts)...);
-
                 return util::partitioner<ExPolicy>::call_with_index(
                     policy, first, size, stride,
-                    part_iterations<F, S, args_type>{
-                        std::forward<F>(f), stride, args
+                    part_iterations<F, S>{
+                        std::forward<F>(f), stride
                     },
-                    [=] (std::vector<hpx::future<void> > &&) mutable -> void
+                    [size] (std::vector<hpx::future<void> > &&,
+                        typename hpx::util::decay<Ts>::type... ts) -> void
                     {
-                        auto pack = typename hpx::util::detail::make_index_pack<
-                            sizeof...(Ts)>::type();
                         // make sure live-out variables are properly set on
                         // return
-                        detail::exit_iteration(args, pack, size);
-                    });
+                        detail::exit_iteration(size, std::move(ts)...);
+                    }, std::forward<Ts>(ts)...);
             }
         };
 
@@ -1145,12 +1115,12 @@ namespace hpx { namespace parallel { inline namespace v2
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
 namespace hpx { namespace traits
 {
-    template <typename F, typename S, typename Tuple>
+    template <typename F, typename S>
     struct get_function_address<
-        parallel::v2::detail::part_iterations<F, S, Tuple> >
+        parallel::v2::detail::part_iterations<F, S> >
     {
         static std::size_t call(
-            parallel::v2::detail::part_iterations<F, S, Tuple> const& f)
+            parallel::v2::detail::part_iterations<F, S> const& f)
                 noexcept
         {
             return get_function_address<
@@ -1159,12 +1129,12 @@ namespace hpx { namespace traits
         }
     };
 
-    template <typename F, typename S, typename Tuple>
+    template <typename F, typename S>
     struct get_function_annotation<
-        parallel::v2::detail::part_iterations<F, S, Tuple> >
+        parallel::v2::detail::part_iterations<F, S> >
     {
         static char const* call(
-            parallel::v2::detail::part_iterations<F, S, Tuple> const& f)
+            parallel::v2::detail::part_iterations<F, S> const& f)
                 noexcept
         {
             return get_function_annotation<
@@ -1174,12 +1144,12 @@ namespace hpx { namespace traits
     };
 
 #if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
-    template <typename F, typename S, typename Tuple>
+    template <typename F, typename S>
     struct get_function_annotation_itt<
-        parallel::v2::detail::part_iterations<F, S, Tuple> >
+        parallel::v2::detail::part_iterations<F, S> >
     {
         static util::itt::string_handle call(
-            parallel::v2::detail::part_iterations<F, S, Tuple> const& f)
+            parallel::v2::detail::part_iterations<F, S> const& f)
                 noexcept
         {
             return get_function_annotation_itt<

--- a/hpx/parallel/algorithms/for_loop.hpp
+++ b/hpx/parallel/algorithms/for_loop.hpp
@@ -206,19 +206,19 @@ namespace hpx { namespace parallel { inline namespace v2
                 if (size == 0)
                     return util::detail::algorithm_result<ExPolicy>::get();
 
-                auto && args =
-                    hpx::util::forward_as_tuple(std::forward<Ts>(ts)...);
-
                 // we need to decay copy here to properly transport everything
                 // to a GPU device
                 typedef
                     hpx::util::tuple<typename hpx::util::decay<Ts>::type...>
                     args_type;
 
+                args_type args =
+                    hpx::util::forward_as_tuple(std::forward<Ts>(ts)...);
+
                 return util::partitioner<ExPolicy>::call_with_index(
                     policy, first, size, stride,
                     part_iterations<F, S, args_type>{
-                        std::forward<F>(f), stride, std::move(args)
+                        std::forward<F>(f), stride, args
                     },
                     [=] (std::vector<hpx::future<void> > &&) mutable -> void
                     {

--- a/hpx/parallel/algorithms/merge.hpp
+++ b/hpx/parallel/algorithms/merge.hpp
@@ -240,6 +240,7 @@ namespace hpx { namespace parallel { inline namespace v1
 
                 // Not reachable.
                 HPX_ASSERT(false);
+                return;
             }
 
             fut.get();
@@ -585,8 +586,8 @@ namespace hpx { namespace parallel { inline namespace v1
                     // Not reachable.
                     HPX_ASSERT(false);
                 }
-
-                fut.get();
+                if (fut.valid()) // NOLINT
+                    fut.get();
             }
             else /* left_size < right_size */
             {
@@ -640,7 +641,8 @@ namespace hpx { namespace parallel { inline namespace v1
                     HPX_ASSERT(false);
                 }
 
-                fut.get();
+                if (fut.valid()) // NOLINT
+                    fut.get();
             }
         }
 

--- a/hpx/parallel/algorithms/partition.hpp
+++ b/hpx/parallel/algorithms/partition.hpp
@@ -168,21 +168,23 @@ namespace hpx { namespace parallel { inline namespace v1
                     {
                         result = hpx::make_ready_future(std::move(last));
                     }
+                    else
+                    {
+                        typedef typename
+                            hpx::util::decay<ExPolicy>::type::executor_parameters_type
+                            parameters_type;
 
-                    typedef typename
-                        hpx::util::decay<ExPolicy>::type::executor_parameters_type
-                        parameters_type;
+                        std::size_t const cores =
+                            execution::processing_units_count(policy.executor(),
+                                    policy.parameters());
+                        std::size_t max_chunks = execution::maximal_number_of_chunks(
+                            policy.parameters(), policy.executor(), cores, size);
 
-                    std::size_t const cores =
-                        execution::processing_units_count(policy.executor(),
-                                policy.parameters());
-                    std::size_t max_chunks = execution::maximal_number_of_chunks(
-                        policy.parameters(), policy.executor(), cores, size);
-
-                    result = stable_partition_helper()(
-                        std::forward<ExPolicy>(policy), first, last, size,
-                        std::forward<F>(f), std::forward<Proj>(proj),
-                        size == 1 ? 1 : (std::min)(std::size_t(size), max_chunks));
+                        result = stable_partition_helper()(
+                            std::forward<ExPolicy>(policy), first, last, size,
+                            std::forward<F>(f), std::forward<Proj>(proj),
+                            size == 1 ? 1 : (std::min)(std::size_t(size), max_chunks));
+                    }
                 }
                 catch (...) {
                     result = hpx::make_exceptional_future<RandIter>(

--- a/hpx/parallel/executors/distribution_policy_executor.hpp
+++ b/hpx/parallel/executors/distribution_policy_executor.hpp
@@ -125,7 +125,9 @@ namespace hpx { namespace parallel { namespace execution
         ///
         /// \param policy   The distribution_policy to create an executor from
         ///
-        template <typename DistPolicy_>
+        template <typename DistPolicy_, typename Enable =
+            typename std::enable_if<!std::is_same<distribution_policy_executor,
+                typename hpx::util::decay<DistPolicy_>::type>::value>::type>
         distribution_policy_executor(DistPolicy_ && policy)
           : policy_(std::forward<DistPolicy_>(policy))
         {}
@@ -220,7 +222,9 @@ namespace hpx { namespace parallel { inline namespace v3
     struct distribution_policy_executor
       : execution::distribution_policy_executor<DistPolicy>
     {
-        template <typename DistPolicy_>
+        template <typename DistPolicy_, typename Enable =
+            typename std::enable_if<!std::is_same<distribution_policy_executor,
+                typename hpx::util::decay<DistPolicy_>::type>::value>::type>
         distribution_policy_executor(DistPolicy_ && policy)
           : execution::distribution_policy_executor<DistPolicy>(
                 std::forward<DistPolicy_>(policy))

--- a/hpx/parallel/executors/execution_parameters.hpp
+++ b/hpx/parallel/executors/execution_parameters.hpp
@@ -366,7 +366,9 @@ namespace hpx { namespace parallel { namespace execution
             unwrapper() : T() {}
 
             // generic poor-man's forwarding constructor
-            template <typename U>
+            template <typename U, typename Enable = typename
+                std::enable_if<!std::is_same<typename hpx::util::decay<U>::type,
+                unwrapper>::value>::type>
             unwrapper(U && u) : T(std::forward<U>(u)) {}
         };
 

--- a/hpx/parallel/util/detail/partitioner_iteration.hpp
+++ b/hpx/parallel/util/detail/partitioner_iteration.hpp
@@ -25,11 +25,13 @@ namespace hpx { namespace parallel { namespace util
         {
             typename hpx::util::decay<F>::type f_;
 
-            template <typename T>
+            template <typename T, typename...Ts>
             HPX_HOST_DEVICE HPX_FORCEINLINE
-            Result operator()(T && t)
+            Result operator()(T && t, Ts &&... ts)
             {
-                return hpx::util::invoke_fused(f_, std::forward<T>(t));
+                return hpx::util::invoke_fused(f_,
+                    hpx::util::tuple_cat(std::forward<T>(t),
+                        hpx::util::forward_as_tuple(std::forward<Ts>(ts)...)));
             }
         };
 
@@ -38,11 +40,13 @@ namespace hpx { namespace parallel { namespace util
         {
             typename hpx::util::decay<F>::type f_;
 
-            template <typename T>
+            template <typename T, typename...Ts>
             HPX_HOST_DEVICE HPX_FORCEINLINE
-            void operator()(T && t)
+            void operator()(T && t, Ts &&... ts)
             {
-                hpx::util::invoke_fused(f_, std::forward<T>(t));
+                hpx::util::invoke_fused(f_,
+                    hpx::util::tuple_cat(std::forward<T>(t),
+                        hpx::util::forward_as_tuple(std::forward<Ts>(ts)...)));
             }
         };
     }

--- a/hpx/parallel/util/partitioner.hpp
+++ b/hpx/parallel/util/partitioner.hpp
@@ -192,9 +192,9 @@ namespace hpx { namespace parallel { namespace util
             }
 
             template <typename ExPolicy, typename FwdIter, typename Stride,
-                typename F1, typename F2>
+                typename F1, typename F2, typename...Args>
             static R call_with_index(ExPolicy && policy, FwdIter first,
-                std::size_t count, Stride stride, F1 && f1, F2 && f2)
+                std::size_t count, Stride stride, F1 && f1, F2 && f2, Args &&...args)
             {
                 typedef typename
                     hpx::util::decay<ExPolicy>::type::executor_parameters_type
@@ -219,13 +219,14 @@ namespace hpx { namespace parallel { namespace util
 
                     auto shapes =
                         get_bulk_iteration_shape_idx(policy, inititems, f1,
-                            first, count, stride, has_variable_chunk_size());
+                            first, count, stride, has_variable_chunk_size(),
+                            std::forward<Args>(args)...);
 
                     std::vector<hpx::future<Result> > workitems =
                         execution::bulk_async_execute(
                             policy.executor(),
                             partitioner_iteration<Result, F1>{std::forward<F1>(f1)},
-                            std::move(shapes));
+                            std::move(shapes), std::forward<Args>(args)...);
 
                     inititems.reserve(inititems.size() + workitems.size());
                     std::move(workitems.begin(), workitems.end(),
@@ -244,7 +245,7 @@ namespace hpx { namespace parallel { namespace util
                 handle_local_exceptions<ExPolicy>::call(inititems, errors);
 
                 try {
-                    return f2(std::move(inititems));
+                    return f2(std::move(inititems), std::forward<Args>(args)...);
                 }
                 catch (...) {
                     // rethrow either bad_alloc or exception_list
@@ -409,10 +410,10 @@ namespace hpx { namespace parallel { namespace util
             }
 
             template <typename ExPolicy, typename FwdIter, typename Stride,
-                typename F1, typename F2>
+                typename F1, typename F2, typename...Args>
             static hpx::future<R> call_with_index(ExPolicy && policy,
                 FwdIter first, std::size_t count, Stride stride,
-                F1 && f1, F2 && f2)
+                F1 && f1, F2 && f2, Args &&...args)
             {
                 typedef typename
                     hpx::util::decay<ExPolicy>::type::executor_parameters_type
@@ -442,13 +443,14 @@ namespace hpx { namespace parallel { namespace util
 
                     auto shapes =
                         get_bulk_iteration_shape_idx(policy, inititems, f1,
-                            first, count, stride, has_variable_chunk_size());
+                            first, count, stride, has_variable_chunk_size(),
+                            std::forward<Args>(args)...);
 
                     std::vector<hpx::future<Result> > workitems =
                         execution::bulk_async_execute(
                             policy.executor(),
                             partitioner_iteration<Result, F1>{std::forward<F1>(f1)},
-                            std::move(shapes));
+                            std::move(shapes), std::forward<Args>(args)...);
 
                     std::move(workitems.begin(), workitems.end(),
                         std::back_inserter(inititems));
@@ -464,15 +466,16 @@ namespace hpx { namespace parallel { namespace util
                 // wait for all tasks to finish
                 return hpx::dataflow(
                     [f2, errors, scoped_param](
-                        std::vector<hpx::future<Result> > && r) mutable -> R
+                        std::vector<hpx::future<Result> > && r,
+                        typename hpx::util::decay<Args>::type&&... args) mutable -> R
                     {
                         HPX_UNUSED(scoped_param);
 
                         // inform parameter traits
                         handle_local_exceptions<ExPolicy>::call(r, errors);
-                        return f2(std::move(r));
+                        return f2(std::move(r), std::move(args)...);
                     },
-                    std::move(inititems));
+                    std::move(inititems), std::forward<Args>(args)...);
             }
         };
 
@@ -523,15 +526,16 @@ namespace hpx { namespace parallel { namespace util
             }
 
             template <typename ExPolicy, typename FwdIter, typename Stride, typename F1,
-                typename F2>
+                typename F2, typename...Args>
             static R call_with_index(ExPolicy && policy, FwdIter first,
-                std::size_t count, Stride stride, F1 && f1, F2 && f2)
+                std::size_t count, Stride stride, F1 && f1, F2 && f2, Args &&... args)
             {
                 return static_partitioner<
                         typename hpx::util::decay<ExPolicy>::type, R, Result
                     >::call_with_index(
                         std::forward<ExPolicy>(policy), first, count, stride,
-                        std::forward<F1>(f1), std::forward<F2>(f2));
+                        std::forward<F1>(f1), std::forward<F2>(f2),
+                        std::forward<Args>(args)...);
             }
         };
 
@@ -566,16 +570,17 @@ namespace hpx { namespace parallel { namespace util
             }
 
             template <typename ExPolicy, typename FwdIter, typename Stride,
-                typename F1, typename F2>
+                typename F1, typename F2, typename... Args>
             static hpx::future<R> call_with_index(ExPolicy && policy,
                 FwdIter first, std::size_t count, Stride stride,
-                F1 && f1, F2 && f2)
+                F1 && f1, F2 && f2, Args &&... args)
             {
                 return static_partitioner<
                         typename hpx::util::decay<ExPolicy>::type, R, Result
                     >::call_with_index(
                         std::forward<ExPolicy>(policy), first, count, stride,
-                        std::forward<F1>(f1), std::forward<F2>(f2));
+                        std::forward<F1>(f1), std::forward<F2>(f2),
+                        std::forward<Args>(args)...);
             }
         };
 
@@ -611,16 +616,17 @@ namespace hpx { namespace parallel { namespace util
             }
 
             template <typename ExPolicy, typename FwdIter, typename Stride,
-                typename F1, typename F2>
+                typename F1, typename F2, typename... Args>
             static hpx::future<R> call_with_index(ExPolicy && policy,
                 FwdIter first, std::size_t count, Stride stride,
-                F1 && f1, F2 && f2)
+                F1 && f1, F2 && f2, Args &&... args)
             {
                 return static_partitioner<
                         execution::parallel_task_policy, R, Result
                     >::call_with_index(
                         std::forward<ExPolicy>(policy), first, count, stride,
-                        std::forward<F1>(f1), std::forward<F2>(f2));
+                        std::forward<F1>(f1), std::forward<F2>(f2),
+                        std::forward<Args>(args)...);
             }
         };
 #endif

--- a/hpx/runtime/actions/continuation.hpp
+++ b/hpx/runtime/actions/continuation.hpp
@@ -163,7 +163,7 @@ namespace hpx { namespace actions
 
         typed_continuation& operator=(typed_continuation&& o)
         {
-            continuation::operator=(std::move(o));
+            continuation::operator=(std::move(static_cast<continuation&&>(o)));
             f_ = std::move(o.f_);
             return *this;
         }
@@ -392,7 +392,7 @@ namespace hpx { namespace actions
 
         typed_continuation& operator=(typed_continuation&& o)
         {
-            continuation::operator=(std::move(o));
+            continuation::operator=(std::move(static_cast<continuation&&>(o)));
             f_ = std::move(o.f_);
             return *this;
         }

--- a/hpx/runtime/actions/set_lco_value_continuation.hpp
+++ b/hpx/runtime/actions/set_lco_value_continuation.hpp
@@ -25,7 +25,7 @@ namespace hpx { namespace actions
 
             // Yep, 't' is a zombie, however we don't use the returned value
             // anyways. We need it for result type calculation, though.
-            return std::move(t);
+            return std::forward<T>(t);
         }
     };
 
@@ -39,7 +39,7 @@ namespace hpx { namespace actions
 
             // Yep, 't' is a zombie, however we don't use the returned value
             // anyways. We need it for result type calculation, though.
-            return std::move(t);
+            return std::forward<T>(t);
         }
     };
 }}

--- a/hpx/runtime/applier/apply_helper.hpp
+++ b/hpx/runtime/applier/apply_helper.hpp
@@ -114,7 +114,8 @@ namespace hpx { namespace applier { namespace detail
 
             // now, schedule the thread
             data.func = Action::construct_thread_function(target,
-                std::move(cont), lva, comptype, std::forward<Ts>(vs)...);
+                std::forward<Continuation>(cont), lva, comptype,
+                std::forward<Ts>(vs)...);
 
 #if defined(HPX_HAVE_THREAD_TARGET_ADDRESS)
             data.lva = lva;

--- a/hpx/runtime/components/client_base.hpp
+++ b/hpx/runtime/components/client_base.hpp
@@ -175,7 +175,7 @@ namespace hpx { namespace lcos { namespace detail
 
         template <typename Target>
         future_data(Target && data, init_no_addref no_addref)
-          : future_data_base<id_type>(std::move(data), no_addref)
+          : future_data_base<id_type>(std::forward<Target>(data), no_addref)
         {}
 
         future_data(std::exception_ptr const& e, init_no_addref no_addref)

--- a/hpx/runtime/components/server/locking_hook.hpp
+++ b/hpx/runtime/components/server/locking_hook.hpp
@@ -17,6 +17,7 @@
 
 #include <mutex>
 #include <utility>
+#include <type_traits>
 
 namespace hpx { namespace components
 {
@@ -66,7 +67,9 @@ namespace hpx { namespace components
 
         struct decorate_wrapper
         {
-            template <typename F>
+            template <typename F, typename Enable = typename
+                std::enable_if<!std::is_same<typename hpx::util::decay<F>::type,
+                    decorate_wrapper>::value>::type>
             decorate_wrapper(F && f)
             {
                 threads::get_self().decorate_yield(std::forward<F>(f));

--- a/hpx/runtime/parcelset/parcel_buffer.hpp
+++ b/hpx/runtime/parcelset/parcel_buffer.hpp
@@ -58,7 +58,7 @@ namespace hpx { namespace parcelset
           : data_(std::move(other.data_))
           , chunks_(std::move(other.chunks_))
           , transmission_chunks_(std::move(other.transmission_chunks_))
-          , num_chunks_(other.num_chunks_)
+          , num_chunks_(std::move(other.num_chunks_))
           , size_(other.size_)
           , data_size_(other.data_size_)
           , header_size_(other.header_size_)

--- a/hpx/runtime/threads/coroutines/coroutine.hpp
+++ b/hpx/runtime/threads/coroutines/coroutine.hpp
@@ -73,7 +73,7 @@ namespace hpx { namespace threads { namespace coroutines
         }
 
         coroutine(coroutine && src)
-          : m_pimpl(src.m_pimpl)
+          : m_pimpl(std::move(src.m_pimpl))
         {
             src.m_pimpl = nullptr;
         }

--- a/hpx/runtime/threads/thread.hpp
+++ b/hpx/runtime/threads/thread.hpp
@@ -20,6 +20,7 @@
 #include <iosfwd>
 #include <mutex>
 #include <utility>
+#include <type_traits>
 
 #include <hpx/config/warnings_prefix.hpp>
 
@@ -38,9 +39,10 @@ namespace hpx
 
         thread() noexcept;
 
-        template <typename F>
+        template <typename F, typename Enable = typename
+            std::enable_if<!std::is_same<typename hpx::util::decay<F>::type,
+                thread>::value>::type>
         explicit thread(F&& f)
-          : id_(threads::invalid_thread_id)
         {
             start_thread(util::deferred_call(std::forward<F>(f)));
         }
@@ -135,7 +137,7 @@ namespace hpx
         friend class thread;
 
     public:
-        id() noexcept : id_(threads::invalid_thread_id) {}
+        id() noexcept {}
         explicit id(threads::thread_id_type const& i) noexcept
           : id_(i)
         {}

--- a/hpx/util/bind.hpp
+++ b/hpx/util/bind.hpp
@@ -251,7 +251,7 @@ namespace hpx { namespace util
         >::type bound_impl(one_shot_wrapper<F>& f, Ts& bound, Us&& /*unbound*/,
             pack_c<std::size_t, Is...>)
         {
-            return util::invoke(std::move(f), util::get<Is>(std::move(bound))...);
+            return util::invoke(std::move(f), std::move(util::get<Is>(bound))...);
         }
 
         template <typename T>

--- a/hpx/util/detail/yield_k.hpp
+++ b/hpx/util/detail/yield_k.hpp
@@ -65,7 +65,7 @@ namespace hpx { namespace util { namespace detail
                 rqtp.tv_sec = 0;
                 rqtp.tv_nsec = 1000;
 
-                nanosleep( &rqtp, 0 );
+                nanosleep( &rqtp, nullptr );
 #else
 #endif
             }

--- a/hpx/util/functional/colocated_helpers.hpp
+++ b/hpx/util/functional/colocated_helpers.hpp
@@ -21,6 +21,7 @@
 
 #include <memory>
 #include <utility>
+#include <type_traits>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace util { namespace functional
@@ -121,7 +122,9 @@ namespace hpx { namespace util { namespace functional
             apply_continuation_impl()
               : bound_() {}
 
-            template <typename Bound_>
+            template <typename Bound_, typename Enable = typename
+                std::enable_if<!std::is_same<typename hpx::util::decay<Bound_>::type,
+                    apply_continuation_impl>::value>::type>
             explicit apply_continuation_impl(Bound_ && bound)
               : bound_(std::forward<Bound_>(bound))
             {}
@@ -264,7 +267,9 @@ namespace hpx { namespace util { namespace functional
               : bound_()
             {}
 
-            template <typename Bound_>
+            template <typename Bound_, typename Enable = typename
+                std::enable_if<!std::is_same<typename hpx::util::decay<Bound_>::type,
+                    async_continuation_impl>::value>::type>
             explicit async_continuation_impl(Bound_ && bound)
               : bound_(std::forward<Bound_>(bound))
             {}

--- a/hpx/util/transform_iterator.hpp
+++ b/hpx/util/transform_iterator.hpp
@@ -83,7 +83,7 @@ namespace hpx { namespace util
                 typename std::enable_if<
                     std::is_convertible<OtherIterator, Iterator>::value &&
                     std::is_convertible<OtherTransformer, Transformer>::value
-                >::type* = 0)
+                >::type* = nullptr)
           : base_type(t.base()), transformer_(t.transformer())
         {}
 

--- a/src/components/iostreams/standard_streams.cpp
+++ b/src/components/iostreams/standard_streams.cpp
@@ -111,7 +111,7 @@ namespace hpx { namespace iostreams
 
     std::stringstream const& get_consolestream()
     {
-        if (get_runtime_ptr() != 0 && !agas::is_console())
+        if (get_runtime_ptr() != nullptr && !agas::is_console())
         {
             HPX_THROW_EXCEPTION(service_unavailable,
                 "hpx::iostreams::get_consolestream",

--- a/src/components/performance_counters/papi/papi_startup.cpp
+++ b/src/components/performance_counters/papi/papi_startup.cpp
@@ -131,7 +131,7 @@ namespace hpx { namespace performance_counters { namespace papi
     {
         typename boost::generator_iterator_generator<T>::type gi =
             boost::make_generator_iterator(gen);
-        for ( ; *gi != 0; ++gi)
+        for ( ; *gi != nullptr; ++gi)
         {
             std::set<std::string>::const_iterator it;
             // iterate over known thread names

--- a/src/components/performance_counters/papi/util/papi.cpp
+++ b/src/components/performance_counters/papi/util/papi.cpp
@@ -202,7 +202,7 @@ namespace hpx { namespace performance_counters { namespace papi { namespace util
         // collect available events and print their descriptions
         avail_preset_info_gen gen;
         boost::generator_iterator_generator<avail_preset_info_gen>::type it;
-        for (it = boost::make_generator_iterator(gen); *it != 0; ++it)
+        for (it = boost::make_generator_iterator(gen); *it != nullptr; ++it)
         {
             hpx::util::format_to(std::cout,
                 "Event        : %s\n"
@@ -271,7 +271,7 @@ namespace hpx { namespace performance_counters { namespace papi { namespace util
             native_info_gen gen(ci);
             boost::generator_iterator_generator<native_info_gen>::type it =
                 boost::make_generator_iterator(gen);
-            for ( ; *it != 0; ++it)
+            for ( ; *it != nullptr; ++it)
                 print_native_info(**it);
         }
     }

--- a/src/performance_counters/performance_counter_set.cpp
+++ b/src/performance_counters/performance_counter_set.cpp
@@ -142,7 +142,7 @@ namespace hpx { namespace performance_counters
             util::expand(n);
 
             // find matching counter types
-            discover_counter_type(n, std::move(func), discover_counters_full, ec);
+            discover_counter_type(n, func, discover_counters_full, ec);
             if (ec) return;
         }
 

--- a/src/runtime/agas/server/route.cpp
+++ b/src/runtime/agas/server/route.cpp
@@ -91,6 +91,7 @@ namespace hpx { namespace agas { namespace server
             addr.address_ = g.lva();
         }
 
+        naming::id_type source = p.source_id();
         // either send the parcel on its way or execute actions locally
         if (addr.locality_ == get_locality())
         {
@@ -110,8 +111,6 @@ namespace hpx { namespace agas { namespace server
             naming::gid_type const& id = hpx::util::get<0>(cache_address);
             if (id && naming::detail::store_in_cache(id))
             {
-                naming::id_type source = p.source_id();
-
                 gva const& g = hpx::util::get<1>(cache_address);
                 naming::address addr(g.prefix, g.type, g.lva());
 

--- a/src/runtime/agas/server/symbol_namespace_server.cpp
+++ b/src/runtime/agas/server/symbol_namespace_server.cpp
@@ -437,21 +437,11 @@ bool symbol_namespace::on_event(
         on_event_data_map_type::iterator it = on_event_data_.insert(
             on_event_data_map_type::value_type(std::move(name), lco));
 
-        l.unlock();
-
-        if (it == on_event_data_.end())
-        {
-            LAGAS_(info) << hpx::util::format(
-                "symbol_namespace::on_event, name(%1%), response(no_success)",
-                name);
-
-            return false;
-        }
+        // This overload of insert always returns the iterator pointing
+        // to the inserted value. It should never point to end
+        HPX_ASSERT(it != on_event_data_.end());
     }
-    else
-    {
-        l.unlock();
-    }
+    l.unlock();
 
     LAGAS_(info) << "symbol_namespace::on_event";
 

--- a/src/runtime/resource/detail/detail_partitioner.cpp
+++ b/src/runtime/resource/detail/detail_partitioner.cpp
@@ -506,7 +506,6 @@ namespace hpx { namespace resource { namespace detail
         affinity_data_.set_num_threads(new_pu_nums.size());
         affinity_data_.set_pu_nums(std::move(new_pu_nums));
         affinity_data_.set_affinity_masks(std::move(new_affinity_masks));
-        affinity_data_.init_cached_pu_nums(new_pu_nums.size());
     }
 
     // Returns true if any of the pools defined by the user is empty of resources

--- a/src/runtime/threads/thread.cpp
+++ b/src/runtime/threads/thread.cpp
@@ -51,11 +51,9 @@ namespace hpx
 
     ///////////////////////////////////////////////////////////////////////////
     thread::thread() noexcept
-      : id_(threads::invalid_thread_id)
     {}
 
     thread::thread(thread&& rhs) noexcept
-      : id_(threads::invalid_thread_id)   // the rhs needs to end up with an invalid_id
     {
         std::lock_guard<mutex_type> l(rhs.mtx_);
         id_ = rhs.id_;
@@ -246,7 +244,6 @@ namespace hpx
 
         public:
             thread_task_base(threads::thread_id_type const& id)
-              : id_(threads::invalid_thread_id)
             {
                 if (threads::add_thread_exit_callback(id,
                         util::bind(&thread_task_base::thread_exit_function,

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -286,7 +286,7 @@ namespace hpx { namespace threads
             "default",
             "low",
             "normal",
-            "high (recursive)"
+            "high (recursive)",
             "boost",
             "high (non-recursive)",
         };

--- a/tests/regressions/actions/async_deferred_1523.cpp
+++ b/tests/regressions/actions/async_deferred_1523.cpp
@@ -91,7 +91,7 @@ int main()
         for (hpx::id_type const& loc : hpx::find_all_localities())
         {
             hpx::id_type id = hpx::async(
-                hpx::launch::deferred, std::move(gl), loc).get();
+                hpx::launch::deferred, gl, loc).get();
             HPX_TEST_EQ(loc, id);
         }
     }

--- a/tests/regressions/actions/components/movable_objects.cpp
+++ b/tests/regressions/actions/components/movable_objects.cpp
@@ -45,7 +45,7 @@ namespace hpx { namespace test
         return *this;
     }
 
-    std::size_t movable_object::get_count() const
+    std::size_t movable_object::get_count()
     {
         return count;
     }
@@ -92,7 +92,7 @@ namespace hpx { namespace test
         return *this;
     }
 
-    std::size_t non_movable_object::get_count() const
+    std::size_t non_movable_object::get_count()
     {
         return count;
     }

--- a/tests/regressions/actions/components/movable_objects.hpp
+++ b/tests/regressions/actions/components/movable_objects.hpp
@@ -43,7 +43,7 @@ namespace hpx { namespace test
         // Move assignment.
         movable_object& operator=(movable_object && other);
 
-        std::size_t get_count() const;
+        static std::size_t get_count();
         void reset_count();
 
         template <typename Archive>
@@ -70,7 +70,7 @@ namespace hpx { namespace test
         // Copy assignment.
         non_movable_object& operator=(non_movable_object const& other);
 
-        std::size_t get_count() const;
+        static std::size_t get_count();
         void reset_count();
 
         template <typename Archive>

--- a/tests/regressions/actions/plain_action_move_semantics.cpp
+++ b/tests/regressions/actions/plain_action_move_semantics.cpp
@@ -199,7 +199,7 @@ std::size_t pass_object_void()
     Object obj;
     async<Action>(find_here(), obj).get();
 
-    return obj.get_count();
+    return Object::get_count();
 }
 
 template <typename Action, typename Object>
@@ -216,7 +216,7 @@ std::size_t move_object_void()
     Object obj;
     async<Action>(find_here(), std::move(obj)).get();
 
-    return obj.get_count();
+    return Object::get_count();
 }
 
 template <typename Action, typename Object>
@@ -231,7 +231,7 @@ template <typename Action, typename Object>
 std::size_t return_object(id_type id)
 {
     Object obj(async<Action>(id).get());
-    return obj.get_count();
+    return Object::get_count();
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/regressions/performance_counters/papi_counters_active_interface.cpp
+++ b/tests/regressions/performance_counters/papi_counters_active_interface.cpp
@@ -134,7 +134,7 @@ int main(int argc, char* argv[])
     char copt[256];
     snprintf(copt, 256, "--hpx:print-counter=%s", counter_name);
     opt[argc] = copt;
-    opt[argc+1] = 0;
+    opt[argc+1] = nullptr;
 
     // Run test in HPX domain.
     hpx::start(argc+1, opt);

--- a/tests/unit/lcos/future.cpp
+++ b/tests/unit/lcos/future.cpp
@@ -467,7 +467,7 @@ void test_packaged_task_can_be_moved()
     HPX_TEST(!fi.is_ready());
 
     try {
-        pt();
+        pt(); // NOLINT
         HPX_TEST(!"Can invoke moved task!");
     }
     catch (hpx::exception const& e) {

--- a/tests/unit/lcos/shared_future.cpp
+++ b/tests/unit/lcos/shared_future.cpp
@@ -385,7 +385,7 @@ void test_shared_future_can_be_move_assigned_from_shared_future()
 
     hpx::lcos::shared_future<int> sf;
     sf = std::move(fi);
-    HPX_TEST(!fi.valid());
+    HPX_TEST(!fi.valid()); // NOLINT
 
     HPX_TEST(!sf.is_ready());
     HPX_TEST(!sf.has_value());
@@ -398,7 +398,7 @@ void test_shared_future_void()
     hpx::lcos::shared_future<void> fi = pt.get_future();
 
     hpx::lcos::shared_future<void> sf(std::move(fi));
-    HPX_TEST(!fi.valid());
+    HPX_TEST(!fi.valid()); // NOLINT
 
     pt();
 
@@ -532,7 +532,7 @@ void test_packaged_task_can_be_moved()
     HPX_TEST(!fi.is_ready());
 
     try {
-        pt();
+        pt(); // NOLINT
         HPX_TEST(!"Can invoke moved task!");
     }
     catch (hpx::exception const& e) {

--- a/tests/unit/lcos/test_allocator.hpp
+++ b/tests/unit/lcos/test_allocator.hpp
@@ -74,7 +74,7 @@ public:
     pointer address(reference x) const { return &x; }
     const_pointer address(const_reference x) const { return &x; }
 
-    pointer allocate(size_type n, const void* = 0)
+    pointer allocate(size_type n, const void* = nullptr)
     {
         if (count >= throw_after)
             throw std::bad_alloc();

--- a/tests/unit/lcos/when_any.cpp
+++ b/tests/unit/lcos/when_any.cpp
@@ -379,11 +379,11 @@ void test_wait_for_either_of_five_futures_1_from_list()
 
     Container t = std::move(raw.futures);
 
-    HPX_TEST(!f1.valid());
-    HPX_TEST(!f2.valid());
-    HPX_TEST(!f3.valid());
-    HPX_TEST(!f4.valid());
-    HPX_TEST(!f5.valid());
+    HPX_TEST(!f1.valid()); // NOLINT
+    HPX_TEST(!f2.valid()); // NOLINT
+    HPX_TEST(!f3.valid()); // NOLINT
+    HPX_TEST(!f4.valid()); // NOLINT
+    HPX_TEST(!f5.valid()); // NOLINT
 
     HPX_TEST(t.front().is_ready());
     HPX_TEST_EQ(t.front().get(), 42);
@@ -423,11 +423,11 @@ void test_wait_for_either_of_five_futures_1_from_list_iterators()
 
     Container t = std::move(raw.futures);
 
-    HPX_TEST(!f1.valid());
-    HPX_TEST(!f2.valid());
-    HPX_TEST(!f3.valid());
-    HPX_TEST(!f4.valid());
-    HPX_TEST(!f5.valid());
+    HPX_TEST(!f1.valid()); // NOLINT
+    HPX_TEST(!f2.valid()); // NOLINT
+    HPX_TEST(!f3.valid()); // NOLINT
+    HPX_TEST(!f4.valid()); // NOLINT
+    HPX_TEST(!f5.valid()); // NOLINT
 
     HPX_TEST(t.front().is_ready());
     HPX_TEST_EQ(t.front().get(), 42);

--- a/tests/unit/lcos/when_each.cpp
+++ b/tests/unit/lcos/when_each.cpp
@@ -262,8 +262,8 @@ void test_when_each_one_future()
     HPX_TEST_EQ(call_count, count);
     HPX_TEST_EQ(call_with_index_count, count);
 
-    HPX_TEST(!f.valid());
-    HPX_TEST(!g.valid());
+    HPX_TEST(!f.valid()); // NOLINT
+    HPX_TEST(!g.valid()); // NOLINT
 }
 
 void test_when_each_two_futures()
@@ -312,10 +312,10 @@ void test_when_each_two_futures()
     HPX_TEST_EQ(call_count, count);
     HPX_TEST_EQ(call_with_index_count, count);
 
-    HPX_TEST(!f1.valid());
-    HPX_TEST(!f2.valid());
-    HPX_TEST(!g1.valid());
-    HPX_TEST(!g2.valid());
+    HPX_TEST(!f1.valid()); // NOLINT
+    HPX_TEST(!f2.valid()); // NOLINT
+    HPX_TEST(!g1.valid()); // NOLINT
+    HPX_TEST(!g2.valid()); // NOLINT
 }
 
 void test_when_each_three_futures()
@@ -366,12 +366,12 @@ void test_when_each_three_futures()
     HPX_TEST_EQ(call_count, count);
     HPX_TEST_EQ(call_with_index_count, count);
 
-    HPX_TEST(!f1.valid());
-    HPX_TEST(!f2.valid());
-    HPX_TEST(!f3.valid());
-    HPX_TEST(!g1.valid());
-    HPX_TEST(!g2.valid());
-    HPX_TEST(!g3.valid());
+    HPX_TEST(!f1.valid()); // NOLINT
+    HPX_TEST(!f2.valid()); // NOLINT
+    HPX_TEST(!f3.valid()); // NOLINT
+    HPX_TEST(!g1.valid()); // NOLINT
+    HPX_TEST(!g2.valid()); // NOLINT
+    HPX_TEST(!g3.valid()); // NOLINT
 }
 
 void test_when_each_four_futures()
@@ -424,14 +424,14 @@ void test_when_each_four_futures()
     HPX_TEST_EQ(call_count, count);
     HPX_TEST_EQ(call_with_index_count, count);
 
-    HPX_TEST(!f1.valid());
-    HPX_TEST(!f2.valid());
-    HPX_TEST(!f3.valid());
-    HPX_TEST(!f4.valid());
-    HPX_TEST(!g1.valid());
-    HPX_TEST(!g2.valid());
-    HPX_TEST(!g3.valid());
-    HPX_TEST(!g4.valid());
+    HPX_TEST(!f1.valid()); // NOLINT
+    HPX_TEST(!f2.valid()); // NOLINT
+    HPX_TEST(!f3.valid()); // NOLINT
+    HPX_TEST(!f4.valid()); // NOLINT
+    HPX_TEST(!g1.valid()); // NOLINT
+    HPX_TEST(!g2.valid()); // NOLINT
+    HPX_TEST(!g3.valid()); // NOLINT
+    HPX_TEST(!g4.valid()); // NOLINT
 }
 
 void test_when_each_five_futures()
@@ -486,16 +486,16 @@ void test_when_each_five_futures()
     HPX_TEST_EQ(call_count, count);
     HPX_TEST_EQ(call_with_index_count, count);
 
-    HPX_TEST(!f1.valid());
-    HPX_TEST(!f2.valid());
-    HPX_TEST(!f3.valid());
-    HPX_TEST(!f4.valid());
-    HPX_TEST(!f5.valid());
-    HPX_TEST(!g1.valid());
-    HPX_TEST(!g2.valid());
-    HPX_TEST(!g3.valid());
-    HPX_TEST(!g4.valid());
-    HPX_TEST(!g5.valid());
+    HPX_TEST(!f1.valid()); // NOLINT
+    HPX_TEST(!f2.valid()); // NOLINT
+    HPX_TEST(!f3.valid()); // NOLINT
+    HPX_TEST(!f4.valid()); // NOLINT
+    HPX_TEST(!f5.valid()); // NOLINT
+    HPX_TEST(!g1.valid()); // NOLINT
+    HPX_TEST(!g2.valid()); // NOLINT
+    HPX_TEST(!g3.valid()); // NOLINT
+    HPX_TEST(!g4.valid()); // NOLINT
+    HPX_TEST(!g5.valid()); // NOLINT
 }
 
 void test_when_each_late_future()
@@ -545,8 +545,8 @@ void test_when_each_late_future()
 
     r.get();
 
-    HPX_TEST(!f1.valid());
-    HPX_TEST(!f2.valid());
+    HPX_TEST(!f1.valid()); // NOLINT
+    HPX_TEST(!f2.valid()); // NOLINT
 
     hpx::future<unsigned> g1 = pt2.get_future();
     pt2.apply();
@@ -563,8 +563,8 @@ void test_when_each_late_future()
     HPX_TEST_EQ(call_count, count);
     HPX_TEST_EQ(call_with_index_count, count);
 
-    HPX_TEST(!g1.valid());
-    HPX_TEST(!g2.valid());
+    HPX_TEST(!g1.valid()); // NOLINT
+    HPX_TEST(!g2.valid()); // NOLINT
 }
 
 void test_when_each_deferred_futures()
@@ -619,11 +619,11 @@ void test_when_each_deferred_futures()
     HPX_TEST_EQ(call_count, count);
     HPX_TEST_EQ(call_with_index_count, count);
 
-    HPX_TEST(!f1.valid());
-    HPX_TEST(!f2.valid());
+    HPX_TEST(!f1.valid()); // NOLINT
+    HPX_TEST(!f2.valid()); // NOLINT
 
-    HPX_TEST(!g1.valid());
-    HPX_TEST(!g2.valid());
+    HPX_TEST(!g1.valid()); // NOLINT
+    HPX_TEST(!g2.valid()); // NOLINT
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/lcos/when_some.cpp
+++ b/tests/unit/lcos/when_some.cpp
@@ -272,11 +272,11 @@ void test_wait_for_either_of_five_futures_1_from_list()
 
     Container t = std::move(raw.futures);
 
-    HPX_TEST(!f1.valid());
-    HPX_TEST(!f2.valid());
-    HPX_TEST(!f3.valid());
-    HPX_TEST(!f4.valid());
-    HPX_TEST(!f5.valid());
+    HPX_TEST(!f1.valid()); // NOLINT
+    HPX_TEST(!f2.valid()); // NOLINT
+    HPX_TEST(!f3.valid()); // NOLINT
+    HPX_TEST(!f4.valid()); // NOLINT
+    HPX_TEST(!f5.valid()); // NOLINT
 
     HPX_TEST(t.front().is_ready());
     HPX_TEST_EQ(t.front().get(), 42);
@@ -320,11 +320,11 @@ void test_wait_for_either_of_five_futures_1_from_list_iterators()
 
     Container t = std::move(raw.futures);
 
-    HPX_TEST(!f1.valid());
-    HPX_TEST(!f2.valid());
-    HPX_TEST(!f3.valid());
-    HPX_TEST(!f4.valid());
-    HPX_TEST(!f5.valid());
+    HPX_TEST(!f1.valid()); // NOLINT
+    HPX_TEST(!f2.valid()); // NOLINT
+    HPX_TEST(!f3.valid()); // NOLINT
+    HPX_TEST(!f4.valid()); // NOLINT
+    HPX_TEST(!f5.valid()); // NOLINT
 
     HPX_TEST(t.front().is_ready());
     HPX_TEST_EQ(t.front().get(), 42);

--- a/tests/unit/parallel/algorithms/foreach_prefetching.cpp
+++ b/tests/unit/parallel/algorithms/foreach_prefetching.cpp
@@ -96,7 +96,7 @@ void for_each_prefetching_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::time(0);
+    unsigned int seed = (unsigned int)std::time(nullptr);
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/tests/unit/parallel/spmd_block.cpp
+++ b/tests/unit/parallel/spmd_block.cpp
@@ -103,12 +103,12 @@ int main()
     }
 
     hpx::parallel::v2::define_spmd_block(
-        num_images, std::move(bulk_test), c1.data() );
+        num_images, bulk_test, c1.data() );
 
     std::vector<hpx::future<void>> join =
         hpx::parallel::v2::define_spmd_block(
             par(task),
-                num_images, std::move(bulk_test), c2.data() );
+                num_images, bulk_test, c2.data() );
 
     hpx::wait_all(join);
 

--- a/tests/unit/util/checkpoint.cpp
+++ b/tests/unit/util/checkpoint.cpp
@@ -100,10 +100,18 @@ int main()
 
     HPX_TEST(test_vec == test_vec2);
 
+    checkpoint archive5(archive2);
+
+    // Test 6
+    //  test the operator= constructor
+    checkpoint archive6;
+    archive6 = archive5;
+
+    HPX_TEST(archive6 == archive5);
+
     // Test 5
     //  test creation of a checkpoint from a checkpoint
     //  test proper handling of futures
-    checkpoint archive5(archive2);
     hpx::future<std::vector<int>> test_vec2_future =
         hpx::make_ready_future(test_vec2);
     hpx::future<checkpoint> f_check =
@@ -112,13 +120,6 @@ int main()
     restore_checkpoint(f_check.get(), test_vec3_future);
 
     HPX_TEST(test_vec2 == test_vec3_future.get());
-
-    // Test 6
-    //  test the operator= constructor
-    checkpoint archive6;
-    archive6 = std::move(archive5);
-
-    HPX_TEST(archive6 == archive5);
 
     // Test 7
     //  test writing to a file

--- a/tests/unit/util/iterator/iterator_adaptor.cpp
+++ b/tests/unit/util/iterator/iterator_adaptor.cpp
@@ -122,7 +122,7 @@ public:
     ptr_iterator(const ptr_iterator<V2>& x,
             typename std::enable_if<
                 std::is_convertible<V2*, V*>::value
-            >::type* = 0)
+            >::type* = nullptr)
       : base_adaptor_type(x.base())
     {
     }

--- a/tools/clang-tidy.sh
+++ b/tools/clang-tidy.sh
@@ -5,7 +5,7 @@
 #  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 
-FILES=$(grep '"file":' compile_commands.json | awk '{print $2}' | tr -d '"')
+FILES=$(grep '"file":' compile_commands.json | awk '{print $2}' | tr -d '"' | sort)
 
 if [[ x"${1}" == x"-diff-master" ]]
 then
@@ -22,7 +22,7 @@ then
     fi
     cd ${SRC_PATH}
     CHANGED_FILES=$(git diff --name-only origin/master | grep ".cpp$")
-    CHANGED_FILES=$(echo ${CHANGED_FILES} | awk -v var=${PWD} '{printf("%s/%s\n", var, $1)}')
+    CHANGED_FILES=$(echo ${CHANGED_FILES} | awk -v var=${PWD} '{printf("%s/%s\n", var, $1)}' | sort)
     FILES=$(comm -12 <(echo "${FILES}") <(echo "${CHANGED_FILES}"))
     cd -
 fi
@@ -38,15 +38,67 @@ NUM_FILES=$(echo "${FILES}" | wc -l)
 echo "Checking ${NUM_FILES} files"
 
 RESULT=0
-CHECKS="-*,modernize-use-nullptr"
+CHECKS="-*"
+CHECKS="$CHECKS,modernize-use-nullptr"
+CHECKS="$CHECKS,misc-use-after-move"
+CHECKS="$CHECKS,misc-virtual-near-miss"
+CHECKS="$CHECKS,misc-multiple-statement-macro"
+CHECKS="$CHECKS,misc-move-constructor-init"
+CHECKS="$CHECKS,misc-move-forwarding-reference"
+CHECKS="$CHECKS,misc-assert-side-effect"
+CHECKS="$CHECKS,misc-dangling-handle"
+CHECKS="$CHECKS,misc-non-copyable-objects"
+CHECKS="$CHECKS,misc-forwarding-reference-overload"
+#CHECKS="$CHECKS,bugprone-integer-division"
+#CHECKS="$CHECKS,bugprone-suspicious-memset-usage"
+#CHECKS="$CHECKS,bugprone-undefined-memory-manipulation"
+#CHECKS="$CHECKS,cert-err34-c"
+#CHECKS="$CHECKS,cert-err52-cpp"
+#CHECKS="$CHECKS,cert-err58-cpp"
+#CHECKS="$CHECKS,cert-err60-cpp"
+#CHECKS="$CHECKS,cppcoreguidelines-interfaces-global-init"
+#CHECKS="$CHECKS,cppcoreguidelines-pro-bounds-constant-array-index"
+#CHECKS="$CHECKS,cppcoreguidelines-pro-bounds-pointer-arithmetic"
+#CHECKS="$CHECKS,cppcoreguidelines-pro-type-member-init"
+#CHECKS="$CHECKS,cppcoreguidelines-pro-type-reinterpret-cast"
+#CHECKS="$CHECKS,cppcoreguidelines-slicing"
+#CHECKS="$CHECKS,hicpp-signed-bitwise"
+#CHECKS="$CHECKS,misc-definitions-in-headers"
+#CHECKS="$CHECKS,misc-fold-init-type"
+#CHECKS="$CHECKS,misc-forward-declaration-namespace"
+#CHECKS="$CHECKS,misc-inaccurate-erase"
+#CHECKS="$CHECKS,misc-incorrect-roundings"
+#CHECKS="$CHECKS,misc-inefficient-algorithm"
+#CHECKS="$CHECKS,misc-misplaced-widening-cast"
+#CHECKS="$CHECKS,misc-redundant-expression"
+#CHECKS="$CHECKS,misc-sizeof-container"
+#CHECKS="$CHECKS,misc-sizeof-expression"
+#CHECKS="$CHECKS,misc-string-compare"
+#CHECKS="$CHECKS,misc-string-constructor"
+#CHECKS="$CHECKS,misc-string-integer-assignment"
+#CHECKS="$CHECKS,misc-string-literal-with-embedded-nul"
+#CHECKS="$CHECKS,misc-suspicious-enum-usage"
+#CHECKS="$CHECKS,misc-suspicious-missing-comma"
+#CHECKS="$CHECKS,misc-suspicious-semicolon"
+#CHECKS="$CHECKS,misc-suspicious-string-compare"
+#CHECKS="$CHECKS,misc-swapped-arguments"
+#CHECKS="$CHECKS,misc-undelegated-constructor"
+#CHECKS="$CHECKS,misc-unused-raii"
+# CHECKS="$CHECKS,"
 
 i=1
 for file in $FILES
 do
-    percentage=$(echo "scale=2; ${i}/${NUM_FILES} * 100" | bc | cut -d '.' -f 1)
-    echo -n "[${i}/${NUM_FILES} ${percentage}%] ${file}:"
-    OUT=$(clang-tidy -header-filter=".*hpx.*" -p . -checks="${CHECKS}" ${file} 2>&1);
-    echo ${OUT} | grep -vq "warning:"
+    which bc > /dev/null
+    if [[ $? == 0 ]]
+    then
+        percentage=$(echo "scale=2; ${i}/${NUM_FILES} * 100" | bc | cut -d '.' -f 1)
+        percentage=" ${percentage}%"
+    else
+        percentage=""
+    fi
+    echo -n "[${i}/${NUM_FILES}${percentage}] ${file}:"
+    OUT=$(clang-tidy -header-filter=".*hpx.*" -p . -warnings-as-errors="*" -checks="${CHECKS}" ${file} 2>&1);
     if [[ $? != 0 ]]
     then
         echo ""


### PR DESCRIPTION
Fixes as reported by clang-tidy after enabling the following checks:

    modernize-use-nullptr
    misc-use-after-move
    misc-virtual-near-miss
    misc-multiple-statement-macro
    misc-move-constructor-init
    misc-move-forwarding-reference
    misc-assert-side-effect
    misc-dangling-handle
    misc-move-constructor-init
    misc-move-forwarding-reference
    misc-non-copyable-objects
    misc-forwarding-reference-overload