### PR TITLE
Adapted parallel::{all_of|any_of|none_of} for Ranges TS (see #1668)

### DIFF
--- a/hpx/include/parallel_all_any_none_of.hpp
+++ b/hpx/include/parallel_all_any_none_of.hpp
@@ -8,6 +8,7 @@
 #define HPX_PARALLEL_ALL_ANY_NONE_OF_JUL_07_2014_1246PM
 
 #include <hpx/parallel/algorithms/all_any_none.hpp>
+#include <hpx/parallel/container_algorithms/all_any_none.hpp>
 
 #endif
 

--- a/hpx/parallel/container_algorithms/all_any_none.hpp
+++ b/hpx/parallel/container_algorithms/all_any_none.hpp
@@ -1,0 +1,276 @@
+//  Copyright (c) 2017 Bruno Pitrus
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/container_algorithms/all_any_none.hpp
+
+#if !defined(HPX_PARALLEL_CONTAINER_ALGORITHM_ALL_ANY_NONE_NOV_01_2017_1509PM)
+#define HPX_PARALLEL_CONTAINER_ALGORITHM_ALL_ANY_NONE_NOV_01_2017_1509PM
+
+#include <hpx/config.hpp>
+#include <hpx/traits/concepts.hpp>
+#include <hpx/traits/is_range.hpp>
+#include <hpx/util/range.hpp>
+
+#include <hpx/parallel/algorithms/all_any_none.hpp>
+#include <hpx/parallel/traits/projected_range.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { inline namespace v1
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // none_of
+
+    ///  Checks if unary predicate \a f returns true for no elements in the
+    ///  range \a rng.
+    ///
+    /// \note   Complexity: At most std::distance(begin(rng), end(rng))
+    ///         applications of the predicate \a f
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it applies user-provided function objects.
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a none_of requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param f            Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).
+    ///                     The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed
+    ///                     to it. The type \a Type must be such that an object
+    ///                     of type \a FwdIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified
+    /// threads, and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a none_of algorithm returns a \a hpx::future<bool> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and returns \a bool
+    ///           otherwise.
+    ///           The \a none_of algorithm returns true if the unary predicate
+    ///           \a f returns true for no elements in the range, false
+    ///           otherwise. It returns true if the range is empty.
+    ///
+    template <typename ExPolicy, typename Rng, typename F,
+        typename Proj = util::projection_identity,
+    HPX_CONCEPT_REQUIRES_(
+        execution::is_execution_policy<ExPolicy>::value &&
+        hpx::traits::is_range<Rng>::value &&
+        traits::is_projected_range<Proj, Rng>::value &&
+        traits::is_indirect_callable<
+            ExPolicy, F, traits::projected_range<Proj, Rng>
+        >::value)>
+    typename util::detail::algorithm_result<ExPolicy, bool>::type
+    none_of(ExPolicy && policy, Rng && rng, F && f,
+        Proj && proj = Proj())
+    {
+        return none_of(std::forward<ExPolicy>(policy),
+            hpx::util::begin(rng), hpx::util::end(rng), std::forward<F>(f),
+            std::forward<Proj>(proj));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // any_of
+
+    /// Checks if unary predicate \a f returns true for at least one element
+    /// in the range \a rng.
+    ///
+    /// \note   Complexity: At most std::distance(begin(rng), end(rng))
+    ///         applications of the predicate \a f
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it applies user-provided function objects.
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a none_of requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param f            Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).
+    ///                     The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed
+    ///                     to it. The type \a Type must be such that an object
+    ///                     of type \a FwdIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified
+    /// threads, and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a any_of algorithm returns a \a hpx::future<bool> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a bool otherwise.
+    ///           The \a any_of algorithm returns true if the unary predicate
+    ///           \a f returns true for at least one element in the range,
+    ///           false otherwise. It returns false if the range is empty.
+    ///
+    template <typename ExPolicy, typename Rng, typename F,
+        typename Proj = util::projection_identity,
+    HPX_CONCEPT_REQUIRES_(
+        execution::is_execution_policy<ExPolicy>::value &&
+        hpx::traits::is_range<Rng>::value &&
+        traits::is_projected_range<Proj, Rng>::value &&
+        traits::is_indirect_callable<
+            ExPolicy, F, traits::projected_range<Proj, Rng>
+        >::value)>
+    typename util::detail::algorithm_result<ExPolicy, bool>::type
+    any_of(ExPolicy && policy, Rng && rng, F && f,
+        Proj && proj = Proj())
+    {
+        return any_of(std::forward<ExPolicy>(policy),
+            hpx::util::begin(rng), hpx::util::end(rng), std::forward<F>(f),
+            std::forward<Proj>(proj));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // all_of
+
+    /// Checks if unary predicate \a f returns true for all elements in the
+    /// range \a rng.
+    ///
+    /// \note   Complexity: At most std::distance(begin(rng), end(rng))
+    ///         applications of the predicate \a f
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it applies user-provided function objects.
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a none_of requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param f            Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).
+    ///                     The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed
+    ///                     to it. The type \a Type must be such that an object
+    ///                     of type \a FwdIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified
+    /// threads, and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a all_of algorithm returns a \a hpx::future<bool> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a bool otherwise.
+    ///           The \a all_of algorithm returns true if the unary predicate
+    ///           \a f returns true for all elements in the range, false
+    ///           otherwise. It returns true if the range is empty.
+    ///
+    template <typename ExPolicy, typename Rng, typename F,
+        typename Proj = util::projection_identity,
+    HPX_CONCEPT_REQUIRES_(
+        execution::is_execution_policy<ExPolicy>::value &&
+        hpx::traits::is_range<Rng>::value &&
+        traits::is_projected_range<Proj, Rng>::value &&
+        traits::is_indirect_callable<
+            ExPolicy, F, traits::projected_range<Proj, Rng>
+        >::value)>
+    typename util::detail::algorithm_result<ExPolicy, bool>::type
+    all_of(ExPolicy && policy, Rng && rng, F && f,
+        Proj && proj = Proj())
+    {
+        return all_of(std::forward<ExPolicy>(policy),
+            hpx::util::begin(rng), hpx::util::end(rng), std::forward<F>(f),
+            std::forward<Proj>(proj));
+    }
+
+}}}
+
+#endif

--- a/tests/unit/parallel/algorithms/none_of.cpp
+++ b/tests/unit/parallel/algorithms/none_of.cpp
@@ -7,6 +7,7 @@
 #include <hpx/hpx.hpp>
 #include <hpx/include/parallel_all_any_none_of.hpp>
 #include <hpx/util/lightweight_test.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
 
 #include <cstddef>
 #include <iostream>
@@ -17,8 +18,9 @@
 #include "test_utils.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
-template <typename ExPolicy, typename IteratorTag>
-void test_none_of(ExPolicy policy, IteratorTag)
+template <typename ExPolicy, typename IteratorTag,
+    typename Proj = hpx::parallel::util::projection_identity>
+void test_none_of(ExPolicy policy, IteratorTag,Proj proj=Proj())
 {
     static_assert(
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
@@ -37,21 +39,22 @@ void test_none_of(ExPolicy policy, IteratorTag)
                 iterator(std::begin(c)), iterator(std::end(c)),
                 [](std::size_t v) {
                     return v != 0;
-                });
+                },proj);
 
         // verify values
         bool expected =
             std::none_of(std::begin(c), std::end(c),
-                [](std::size_t v) {
-                    return v != 0;
+                [proj](std::size_t v) {
+                    return proj(v)!= 0;
                 });
 
         HPX_TEST_EQ(result, expected);
     }
 }
 
-template <typename ExPolicy, typename IteratorTag>
-void test_none_of_async(ExPolicy p, IteratorTag)
+template <typename ExPolicy, typename IteratorTag,
+    typename Proj = hpx::parallel::util::projection_identity>
+void test_none_of_async(ExPolicy p, IteratorTag,Proj proj=Proj())
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -64,16 +67,16 @@ void test_none_of_async(ExPolicy p, IteratorTag)
         hpx::future<bool> f =
             hpx::parallel::none_of(p,
                 iterator(std::begin(c)), iterator(std::end(c)),
-                [](std::size_t v) {
+                [proj](std::size_t v) {
                     return v != 0;
-                });
+                },proj);
         f.wait();
 
         // verify values
         bool expected =
             std::none_of(std::begin(c), std::end(c),
-                [](std::size_t v) {
-                    return v != 0;
+                [proj](std::size_t v) {
+                    return proj(v) != 0;
                 });
 
         HPX_TEST_EQ(expected, f.get());
@@ -83,24 +86,49 @@ void test_none_of_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_none_of()
 {
+    struct proj
+    {
+        //This projection should cause tests to fail if it is not applied
+        //because it causes predicate to evaluate the opposite
+        constexpr std::size_t operator()(std::size_t x)const
+        {
+            return !static_cast<bool>(x);
+        }
+    };
     using namespace hpx::parallel;
 
     test_none_of(execution::seq, IteratorTag());
     test_none_of(execution::par, IteratorTag());
     test_none_of(execution::par_unseq, IteratorTag());
 
+    test_none_of(execution::seq, IteratorTag(), proj());
+    test_none_of(execution::par, IteratorTag(), proj());
+    test_none_of(execution::par_unseq, IteratorTag(), proj());
+
     test_none_of_async(execution::seq(execution::task), IteratorTag());
     test_none_of_async(execution::par(execution::task), IteratorTag());
+
+    test_none_of_async(execution::seq(execution::task), IteratorTag(), proj());
+    test_none_of_async(execution::par(execution::task), IteratorTag(), proj());
 
 #if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_none_of(execution_policy(execution::seq), IteratorTag());
     test_none_of(execution_policy(execution::par), IteratorTag());
     test_none_of(execution_policy(execution::par_unseq), IteratorTag());
 
+    test_none_of(execution_policy(execution::seq), IteratorTag(), proj());
+    test_none_of(execution_policy(execution::par), IteratorTag(), proj());
+    test_none_of(execution_policy(execution::par_unseq), IteratorTag(), proj());
+
     test_none_of(execution_policy(execution::seq(execution::task)),
         IteratorTag());
     test_none_of(execution_policy(execution::par(execution::task)),
         IteratorTag());
+
+    test_none_of(execution_policy(execution::seq(execution::task)),
+        IteratorTag(), proj());
+    test_none_of(execution_policy(execution::par(execution::task)),
+        IteratorTag()), proj();
 #endif
 }
 

--- a/tests/unit/parallel/container_algorithms/CMakeLists.txt
+++ b/tests/unit/parallel/container_algorithms/CMakeLists.txt
@@ -4,6 +4,8 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    all_of_range
+    any_of_range
     copy_range
     copyif_range
     foreach_range
@@ -15,6 +17,7 @@ set(tests
     merge_range
     min_element_range
     minmax_element_range
+    none_of_range
     partition_range
     partition_copy_range
     remove_copy_range

--- a/tests/unit/parallel/container_algorithms/all_of_range.cpp
+++ b/tests/unit/parallel/container_algorithms/all_of_range.cpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2014-2017 Hartmut Kaiser
-//
+//                2017 Bruno Pitrus
+
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
@@ -21,7 +22,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 template <typename ExPolicy, typename IteratorTag,
     typename Proj = hpx::parallel::util::projection_identity>
-void test_any_of(ExPolicy policy, IteratorTag,Proj proj=Proj())
+void test_all_of(ExPolicy policy, IteratorTag,Proj proj=Proj())
 {
     static_assert(
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
@@ -36,15 +37,14 @@ void test_any_of(ExPolicy policy, IteratorTag,Proj proj=Proj())
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i); //-V106
 
         bool result =
-            hpx::parallel::any_of(policy,
-                iterator(std::begin(c)), iterator(std::end(c)),
+            hpx::parallel::all_of(policy, c,
                 [](std::size_t v) {
                     return v != 0;
                 },proj);
 
         // verify values
         bool expected =
-            std::any_of(std::begin(c), std::end(c),
+            std::all_of(std::begin(c), std::end(c),
                 [proj](std::size_t v) {
                     return proj(v) != 0;
                 });
@@ -55,7 +55,7 @@ void test_any_of(ExPolicy policy, IteratorTag,Proj proj=Proj())
 
 template <typename ExPolicy, typename IteratorTag,
     typename Proj = hpx::parallel::util::projection_identity>
-void test_any_of_async(ExPolicy p, IteratorTag,Proj proj=Proj())
+void test_all_of_async(ExPolicy p, IteratorTag,Proj proj=Proj())
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -66,8 +66,7 @@ void test_any_of_async(ExPolicy p, IteratorTag,Proj proj=Proj())
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i); //-V106
 
         hpx::future<bool> f =
-            hpx::parallel::any_of(p,
-                iterator(std::begin(c)), iterator(std::end(c)),
+            hpx::parallel::all_of(p, c,
                 [](std::size_t v) {
                     return v != 0;
                 },proj);
@@ -75,7 +74,7 @@ void test_any_of_async(ExPolicy p, IteratorTag,Proj proj=Proj())
 
         // verify values
         bool expected =
-            std::any_of(std::begin(c), std::end(c),
+            std::all_of(std::begin(c), std::end(c),
                 [proj](std::size_t v) {
                     return proj(v) != 0;
                 });
@@ -85,7 +84,7 @@ void test_any_of_async(ExPolicy p, IteratorTag,Proj proj=Proj())
 }
 
 template <typename IteratorTag>
-void test_any_of()
+void test_all_of()
 {
     struct proj
     {
@@ -98,77 +97,77 @@ void test_any_of()
     };
     using namespace hpx::parallel;
 
-    test_any_of(execution::seq, IteratorTag());
-    test_any_of(execution::par, IteratorTag());
-    test_any_of(execution::par_unseq, IteratorTag());
+    test_all_of(execution::seq, IteratorTag());
+    test_all_of(execution::par, IteratorTag());
+    test_all_of(execution::par_unseq, IteratorTag());
 
-    test_any_of(execution::seq, IteratorTag(), proj());
-    test_any_of(execution::par, IteratorTag(), proj());
-    test_any_of(execution::par_unseq, IteratorTag(), proj());
+    test_all_of(execution::seq, IteratorTag(), proj());
+    test_all_of(execution::par, IteratorTag(), proj());
+    test_all_of(execution::par_unseq, IteratorTag(), proj());
 
-    test_any_of_async(execution::seq(execution::task), IteratorTag());
-    test_any_of_async(execution::par(execution::task), IteratorTag());
+    test_all_of_async(execution::seq(execution::task), IteratorTag());
+    test_all_of_async(execution::par(execution::task), IteratorTag());
 
-    test_any_of_async(execution::seq(execution::task), IteratorTag(), proj());
-    test_any_of_async(execution::par(execution::task), IteratorTag(), proj());
+    test_all_of_async(execution::seq(execution::task), IteratorTag(), proj());
+    test_all_of_async(execution::par(execution::task), IteratorTag(), proj());
 
 #if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_any_of(execution_policy(execution::seq), IteratorTag());
-    test_any_of(execution_policy(execution::par), IteratorTag());
-    test_any_of(execution_policy(execution::par_unseq), IteratorTag());
+    test_all_of(execution_policy(execution::seq), IteratorTag());
+    test_all_of(execution_policy(execution::par), IteratorTag());
+    test_all_of(execution_policy(execution::par_unseq), IteratorTag());
 
-    test_any_of(execution_policy(execution::seq), IteratorTag(), proj());
-    test_any_of(execution_policy(execution::par), IteratorTag(), proj());
-    test_any_of(execution_policy(execution::par_unseq), IteratorTag(), proj());
+    test_all_of(execution_policy(execution::seq), IteratorTag(), proj());
+    test_all_of(execution_policy(execution::par), IteratorTag(), proj());
+    test_all_of(execution_policy(execution::par_unseq), IteratorTag(), proj());
 
-    test_any_of(execution_policy(execution::seq(execution::task)),
+    test_all_of(execution_policy(execution::seq(execution::task)),
         IteratorTag());
-    test_any_of(execution_policy(execution::par(execution::task)),
+    test_all_of(execution_policy(execution::par(execution::task)),
         IteratorTag());
 
-    test_any_of(execution_policy(execution::seq(execution::task)),
+    test_all_of(execution_policy(execution::seq(execution::task)),
         IteratorTag(), proj());
-    test_any_of(execution_policy(execution::par(execution::task)),
+    test_all_of(execution_policy(execution::par(execution::task)),
         IteratorTag()), proj();
 #endif
 }
 
 // template <typename IteratorTag>
-// void test_any_of_exec()
+// void test_all_of_exec()
 // {
 //     using namespace hpx::parallel;
 //
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_any_of(execution::par(exec), IteratorTag());
+//         test_all_of(execution::par(exec), IteratorTag());
 //     }
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_any_of(task(exec), IteratorTag());
+//         test_all_of(task(exec), IteratorTag());
 //     }
 //
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_any_of(execution_policy(execution::par(exec)), IteratorTag());
+//         test_all_of(execution_policy(execution::par(exec)), IteratorTag());
 //     }
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_any_of(execution_policy(task(exec)), IteratorTag());
+//         test_all_of(execution_policy(task(exec)), IteratorTag());
 //     }
 // }
 
-void any_of_test()
+void all_of_test()
 {
-    test_any_of<std::random_access_iterator_tag>();
-    test_any_of<std::forward_iterator_tag>();
+    test_all_of<std::random_access_iterator_tag>();
+    test_all_of<std::forward_iterator_tag>();
 #if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
-    test_any_of<std::input_iterator_tag>();
+    test_all_of<std::input_iterator_tag>();
 #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename ExPolicy, typename IteratorTag>
-void test_any_of_exception(ExPolicy policy, IteratorTag)
+void test_all_of_exception(ExPolicy policy, IteratorTag)
 {
     static_assert(
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
@@ -178,14 +177,13 @@ void test_any_of_exception(ExPolicy policy, IteratorTag)
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
     std::size_t iseq[] = { 0, 23, 10007 };
-    for (std::size_t i: iseq)
+    for (std::size_t i : iseq)
     {
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i); //-V106
 
         bool caught_exception = false;
         try {
-            hpx::parallel::any_of(policy,
-                iterator(std::begin(c)), iterator(std::end(c)),
+            hpx::parallel::all_of(policy, c,
                 [](std::size_t v) {
                     return throw std::runtime_error("test"), v != 0;
                 });
@@ -205,7 +203,7 @@ void test_any_of_exception(ExPolicy policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_any_of_exception_async(ExPolicy p, IteratorTag)
+void test_all_of_exception_async(ExPolicy p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -219,8 +217,7 @@ void test_any_of_exception_async(ExPolicy p, IteratorTag)
         bool returned_from_algorithm = false;
         try {
             hpx::future<void> f =
-                hpx::parallel::any_of(p,
-                    iterator(std::begin(c)), iterator(std::end(c)),
+                hpx::parallel::all_of(p, c,
                     [](std::size_t v) {
                         return throw std::runtime_error("test"), v != 0;
                     });
@@ -243,42 +240,42 @@ void test_any_of_exception_async(ExPolicy p, IteratorTag)
 }
 
 template <typename IteratorTag>
-void test_any_of_exception()
+void test_all_of_exception()
 {
     using namespace hpx::parallel;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_any_of_exception(execution::seq, IteratorTag());
-    test_any_of_exception(execution::par, IteratorTag());
+    test_all_of_exception(execution::seq, IteratorTag());
+    test_all_of_exception(execution::par, IteratorTag());
 
-    test_any_of_exception_async(execution::seq(execution::task), IteratorTag());
-    test_any_of_exception_async(execution::par(execution::task), IteratorTag());
+    test_all_of_exception_async(execution::seq(execution::task), IteratorTag());
+    test_all_of_exception_async(execution::par(execution::task), IteratorTag());
 
 #if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_any_of_exception(execution_policy(execution::seq), IteratorTag());
-    test_any_of_exception(execution_policy(execution::par), IteratorTag());
+    test_all_of_exception(execution_policy(execution::seq), IteratorTag());
+    test_all_of_exception(execution_policy(execution::par), IteratorTag());
 
-    test_any_of_exception(execution_policy(execution::seq(execution::task)),
+    test_all_of_exception(execution_policy(execution::seq(execution::task)),
         IteratorTag());
-    test_any_of_exception(execution_policy(execution::par(execution::task)),
+    test_all_of_exception(execution_policy(execution::par(execution::task)),
         IteratorTag());
 #endif
 }
 
-void any_of_exception_test()
+void all_of_exception_test()
 {
-    test_any_of_exception<std::random_access_iterator_tag>();
-    test_any_of_exception<std::forward_iterator_tag>();
+    test_all_of_exception<std::random_access_iterator_tag>();
+    test_all_of_exception<std::forward_iterator_tag>();
 #if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
-    test_any_of_exception<std::input_iterator_tag>();
+    test_all_of_exception<std::input_iterator_tag>();
 #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename ExPolicy, typename IteratorTag>
-void test_any_of_bad_alloc(ExPolicy policy, IteratorTag)
+void test_all_of_bad_alloc(ExPolicy policy, IteratorTag)
 {
     static_assert(
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
@@ -294,8 +291,7 @@ void test_any_of_bad_alloc(ExPolicy policy, IteratorTag)
 
         bool caught_exception = false;
         try {
-            hpx::parallel::any_of(policy,
-                iterator(std::begin(c)), iterator(std::end(c)),
+            hpx::parallel::all_of(policy, c,
                 [](std::size_t v) {
                     return throw std::bad_alloc(), v != 0;
                 });
@@ -314,7 +310,7 @@ void test_any_of_bad_alloc(ExPolicy policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_any_of_bad_alloc_async(ExPolicy p, IteratorTag)
+void test_all_of_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -328,8 +324,7 @@ void test_any_of_bad_alloc_async(ExPolicy p, IteratorTag)
         bool returned_from_algorithm = false;
         try {
             hpx::future<void> f =
-                hpx::parallel::any_of(p,
-                    iterator(std::begin(c)), iterator(std::end(c)),
+                hpx::parallel::all_of(p, c,
                     [](std::size_t v) {
                         return throw std::bad_alloc(), v != 0;
                     });
@@ -351,36 +346,36 @@ void test_any_of_bad_alloc_async(ExPolicy p, IteratorTag)
 }
 
 template <typename IteratorTag>
-void test_any_of_bad_alloc()
+void test_all_of_bad_alloc()
 {
     using namespace hpx::parallel;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_any_of_bad_alloc(execution::seq, IteratorTag());
-    test_any_of_bad_alloc(execution::par, IteratorTag());
+    test_all_of_bad_alloc(execution::seq, IteratorTag());
+    test_all_of_bad_alloc(execution::par, IteratorTag());
 
-    test_any_of_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_any_of_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_all_of_bad_alloc_async(execution::seq(execution::task), IteratorTag());
+    test_all_of_bad_alloc_async(execution::par(execution::task), IteratorTag());
 
 #if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_any_of_bad_alloc(execution_policy(execution::seq), IteratorTag());
-    test_any_of_bad_alloc(execution_policy(execution::par), IteratorTag());
+    test_all_of_bad_alloc(execution_policy(execution::seq), IteratorTag());
+    test_all_of_bad_alloc(execution_policy(execution::par), IteratorTag());
 
-    test_any_of_bad_alloc(execution_policy(execution::seq(execution::task)),
+    test_all_of_bad_alloc(execution_policy(execution::seq(execution::task)),
         IteratorTag());
-    test_any_of_bad_alloc(execution_policy(execution::par(execution::task)),
+    test_all_of_bad_alloc(execution_policy(execution::par(execution::task)),
         IteratorTag());
 #endif
 }
 
-void any_of_bad_alloc_test()
+void all_of_bad_alloc_test()
 {
-    test_any_of_bad_alloc<std::random_access_iterator_tag>();
-    test_any_of_bad_alloc<std::forward_iterator_tag>();
+    test_all_of_bad_alloc<std::random_access_iterator_tag>();
+    test_all_of_bad_alloc<std::forward_iterator_tag>();
 #if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
-    test_any_of_bad_alloc<std::input_iterator_tag>();
+    test_all_of_bad_alloc<std::input_iterator_tag>();
 #endif
 }
 
@@ -394,9 +389,9 @@ int hpx_main(boost::program_options::variables_map& vm)
     std::cout << "using seed: " << seed << std::endl;
     std::srand(seed);
 
-    any_of_test();
-    any_of_exception_test();
-    any_of_bad_alloc_test();
+    all_of_test();
+    all_of_exception_test();
+    all_of_bad_alloc_test();
     return hpx::finalize();
 }
 

--- a/tests/unit/parallel/container_algorithms/any_of_range.cpp
+++ b/tests/unit/parallel/container_algorithms/any_of_range.cpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2014-2017 Hartmut Kaiser
-//
+//                2017 Bruno Pitrus
+
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
@@ -36,8 +37,7 @@ void test_any_of(ExPolicy policy, IteratorTag,Proj proj=Proj())
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i); //-V106
 
         bool result =
-            hpx::parallel::any_of(policy,
-                iterator(std::begin(c)), iterator(std::end(c)),
+            hpx::parallel::any_of(policy, c,
                 [](std::size_t v) {
                     return v != 0;
                 },proj);
@@ -66,8 +66,7 @@ void test_any_of_async(ExPolicy p, IteratorTag,Proj proj=Proj())
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i); //-V106
 
         hpx::future<bool> f =
-            hpx::parallel::any_of(p,
-                iterator(std::begin(c)), iterator(std::end(c)),
+            hpx::parallel::any_of(p, c,
                 [](std::size_t v) {
                     return v != 0;
                 },proj);
@@ -184,8 +183,7 @@ void test_any_of_exception(ExPolicy policy, IteratorTag)
 
         bool caught_exception = false;
         try {
-            hpx::parallel::any_of(policy,
-                iterator(std::begin(c)), iterator(std::end(c)),
+            hpx::parallel::any_of(policy, c,
                 [](std::size_t v) {
                     return throw std::runtime_error("test"), v != 0;
                 });
@@ -219,8 +217,7 @@ void test_any_of_exception_async(ExPolicy p, IteratorTag)
         bool returned_from_algorithm = false;
         try {
             hpx::future<void> f =
-                hpx::parallel::any_of(p,
-                    iterator(std::begin(c)), iterator(std::end(c)),
+                hpx::parallel::any_of(p, c,
                     [](std::size_t v) {
                         return throw std::runtime_error("test"), v != 0;
                     });
@@ -294,8 +291,7 @@ void test_any_of_bad_alloc(ExPolicy policy, IteratorTag)
 
         bool caught_exception = false;
         try {
-            hpx::parallel::any_of(policy,
-                iterator(std::begin(c)), iterator(std::end(c)),
+            hpx::parallel::any_of(policy, c,
                 [](std::size_t v) {
                     return throw std::bad_alloc(), v != 0;
                 });
@@ -328,8 +324,7 @@ void test_any_of_bad_alloc_async(ExPolicy p, IteratorTag)
         bool returned_from_algorithm = false;
         try {
             hpx::future<void> f =
-                hpx::parallel::any_of(p,
-                    iterator(std::begin(c)), iterator(std::end(c)),
+                hpx::parallel::any_of(p, c,
                     [](std::size_t v) {
                         return throw std::bad_alloc(), v != 0;
                     });

--- a/tests/unit/parallel/container_algorithms/none_of_range.cpp
+++ b/tests/unit/parallel/container_algorithms/none_of_range.cpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2014-2017 Hartmut Kaiser
-//
+//                2017 Bruno Pitrus
+
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
@@ -8,7 +9,6 @@
 #include <hpx/include/parallel_all_any_none_of.hpp>
 #include <hpx/util/lightweight_test.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
-
 
 #include <cstddef>
 #include <iostream>
@@ -21,7 +21,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 template <typename ExPolicy, typename IteratorTag,
     typename Proj = hpx::parallel::util::projection_identity>
-void test_any_of(ExPolicy policy, IteratorTag,Proj proj=Proj())
+void test_none_of(ExPolicy policy, IteratorTag,Proj proj=Proj())
 {
     static_assert(
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
@@ -30,23 +30,22 @@ void test_any_of(ExPolicy policy, IteratorTag,Proj proj=Proj())
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::size_t iseq[] = { 0, 23, 10007 };
+    std::size_t iseq[] = { 0, 1, 3 };
     for (std::size_t i: iseq)
     {
-        std::vector<std::size_t> c = test::fill_all_any_none(10007, i); //-V106
+        std::vector<std::size_t> c = test::fill_all_any_none(3, i); //-V106
 
         bool result =
-            hpx::parallel::any_of(policy,
-                iterator(std::begin(c)), iterator(std::end(c)),
+            hpx::parallel::none_of(policy, c,
                 [](std::size_t v) {
                     return v != 0;
                 },proj);
 
         // verify values
         bool expected =
-            std::any_of(std::begin(c), std::end(c),
+            std::none_of(std::begin(c), std::end(c),
                 [proj](std::size_t v) {
-                    return proj(v) != 0;
+                    return proj(v)!= 0;
                 });
 
         HPX_TEST_EQ(result, expected);
@@ -55,27 +54,26 @@ void test_any_of(ExPolicy policy, IteratorTag,Proj proj=Proj())
 
 template <typename ExPolicy, typename IteratorTag,
     typename Proj = hpx::parallel::util::projection_identity>
-void test_any_of_async(ExPolicy p, IteratorTag,Proj proj=Proj())
+void test_none_of_async(ExPolicy p, IteratorTag,Proj proj=Proj())
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
     std::size_t iseq[] = { 0, 23, 10007 };
-    for (std::size_t i: iseq)
+    for (std::size_t i : iseq)
     {
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i); //-V106
 
         hpx::future<bool> f =
-            hpx::parallel::any_of(p,
-                iterator(std::begin(c)), iterator(std::end(c)),
-                [](std::size_t v) {
+            hpx::parallel::none_of(p, c,
+                [proj](std::size_t v) {
                     return v != 0;
                 },proj);
         f.wait();
 
         // verify values
         bool expected =
-            std::any_of(std::begin(c), std::end(c),
+            std::none_of(std::begin(c), std::end(c),
                 [proj](std::size_t v) {
                     return proj(v) != 0;
                 });
@@ -85,7 +83,7 @@ void test_any_of_async(ExPolicy p, IteratorTag,Proj proj=Proj())
 }
 
 template <typename IteratorTag>
-void test_any_of()
+void test_none_of()
 {
     struct proj
     {
@@ -98,77 +96,77 @@ void test_any_of()
     };
     using namespace hpx::parallel;
 
-    test_any_of(execution::seq, IteratorTag());
-    test_any_of(execution::par, IteratorTag());
-    test_any_of(execution::par_unseq, IteratorTag());
+    test_none_of(execution::seq, IteratorTag());
+    test_none_of(execution::par, IteratorTag());
+    test_none_of(execution::par_unseq, IteratorTag());
 
-    test_any_of(execution::seq, IteratorTag(), proj());
-    test_any_of(execution::par, IteratorTag(), proj());
-    test_any_of(execution::par_unseq, IteratorTag(), proj());
+    test_none_of(execution::seq, IteratorTag(), proj());
+    test_none_of(execution::par, IteratorTag(), proj());
+    test_none_of(execution::par_unseq, IteratorTag(), proj());
 
-    test_any_of_async(execution::seq(execution::task), IteratorTag());
-    test_any_of_async(execution::par(execution::task), IteratorTag());
+    test_none_of_async(execution::seq(execution::task), IteratorTag());
+    test_none_of_async(execution::par(execution::task), IteratorTag());
 
-    test_any_of_async(execution::seq(execution::task), IteratorTag(), proj());
-    test_any_of_async(execution::par(execution::task), IteratorTag(), proj());
+    test_none_of_async(execution::seq(execution::task), IteratorTag(), proj());
+    test_none_of_async(execution::par(execution::task), IteratorTag(), proj());
 
 #if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_any_of(execution_policy(execution::seq), IteratorTag());
-    test_any_of(execution_policy(execution::par), IteratorTag());
-    test_any_of(execution_policy(execution::par_unseq), IteratorTag());
+    test_none_of(execution_policy(execution::seq), IteratorTag());
+    test_none_of(execution_policy(execution::par), IteratorTag());
+    test_none_of(execution_policy(execution::par_unseq), IteratorTag());
 
-    test_any_of(execution_policy(execution::seq), IteratorTag(), proj());
-    test_any_of(execution_policy(execution::par), IteratorTag(), proj());
-    test_any_of(execution_policy(execution::par_unseq), IteratorTag(), proj());
+    test_none_of(execution_policy(execution::seq), IteratorTag(), proj());
+    test_none_of(execution_policy(execution::par), IteratorTag(), proj());
+    test_none_of(execution_policy(execution::par_unseq), IteratorTag(), proj());
 
-    test_any_of(execution_policy(execution::seq(execution::task)),
+    test_none_of(execution_policy(execution::seq(execution::task)),
         IteratorTag());
-    test_any_of(execution_policy(execution::par(execution::task)),
+    test_none_of(execution_policy(execution::par(execution::task)),
         IteratorTag());
 
-    test_any_of(execution_policy(execution::seq(execution::task)),
+    test_none_of(execution_policy(execution::seq(execution::task)),
         IteratorTag(), proj());
-    test_any_of(execution_policy(execution::par(execution::task)),
+    test_none_of(execution_policy(execution::par(execution::task)),
         IteratorTag()), proj();
 #endif
 }
 
 // template <typename IteratorTag>
-// void test_any_of_exec()
+// void test_none_of_exec()
 // {
 //     using namespace hpx::parallel;
 //
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_any_of(execution::par(exec), IteratorTag());
+//         test_none_of(execution::par(exec), IteratorTag());
 //     }
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_any_of(task(exec), IteratorTag());
+//         test_none_of(task(exec), IteratorTag());
 //     }
 //
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_any_of(execution_policy(execution::par(exec)), IteratorTag());
+//         test_none_of(execution_policy(execution::par(exec)), IteratorTag());
 //     }
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_any_of(execution_policy(task(exec)), IteratorTag());
+//         test_none_of(execution_policy(task(exec)), IteratorTag());
 //     }
 // }
 
-void any_of_test()
+void none_of_test()
 {
-    test_any_of<std::random_access_iterator_tag>();
-    test_any_of<std::forward_iterator_tag>();
+    test_none_of<std::random_access_iterator_tag>();
+    test_none_of<std::forward_iterator_tag>();
 #if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
-    test_any_of<std::input_iterator_tag>();
+    test_none_of<std::input_iterator_tag>();
 #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename ExPolicy, typename IteratorTag>
-void test_any_of_exception(ExPolicy policy, IteratorTag)
+void test_none_of_exception(ExPolicy policy, IteratorTag)
 {
     static_assert(
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
@@ -178,14 +176,13 @@ void test_any_of_exception(ExPolicy policy, IteratorTag)
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
     std::size_t iseq[] = { 0, 23, 10007 };
-    for (std::size_t i: iseq)
+    for (std::size_t i : iseq)
     {
         std::vector<std::size_t> c = test::fill_all_any_none(10007, i); //-V106
 
         bool caught_exception = false;
         try {
-            hpx::parallel::any_of(policy,
-                iterator(std::begin(c)), iterator(std::end(c)),
+            hpx::parallel::none_of(policy, c,
                 [](std::size_t v) {
                     return throw std::runtime_error("test"), v != 0;
                 });
@@ -205,7 +202,7 @@ void test_any_of_exception(ExPolicy policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_any_of_exception_async(ExPolicy p, IteratorTag)
+void test_none_of_exception_async(ExPolicy p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -219,8 +216,7 @@ void test_any_of_exception_async(ExPolicy p, IteratorTag)
         bool returned_from_algorithm = false;
         try {
             hpx::future<void> f =
-                hpx::parallel::any_of(p,
-                    iterator(std::begin(c)), iterator(std::end(c)),
+                hpx::parallel::none_of(p, c,
                     [](std::size_t v) {
                         return throw std::runtime_error("test"), v != 0;
                     });
@@ -243,42 +239,42 @@ void test_any_of_exception_async(ExPolicy p, IteratorTag)
 }
 
 template <typename IteratorTag>
-void test_any_of_exception()
+void test_none_of_exception()
 {
     using namespace hpx::parallel;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_any_of_exception(execution::seq, IteratorTag());
-    test_any_of_exception(execution::par, IteratorTag());
+    test_none_of_exception(execution::seq, IteratorTag());
+    test_none_of_exception(execution::par, IteratorTag());
 
-    test_any_of_exception_async(execution::seq(execution::task), IteratorTag());
-    test_any_of_exception_async(execution::par(execution::task), IteratorTag());
+    test_none_of_exception_async(execution::seq(execution::task), IteratorTag());
+    test_none_of_exception_async(execution::par(execution::task), IteratorTag());
 
 #if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_any_of_exception(execution_policy(execution::seq), IteratorTag());
-    test_any_of_exception(execution_policy(execution::par), IteratorTag());
+    test_none_of_exception(execution_policy(execution::seq), IteratorTag());
+    test_none_of_exception(execution_policy(execution::par), IteratorTag());
 
-    test_any_of_exception(execution_policy(execution::seq(execution::task)),
+    test_none_of_exception(execution_policy(execution::seq(execution::task)),
         IteratorTag());
-    test_any_of_exception(execution_policy(execution::par(execution::task)),
+    test_none_of_exception(execution_policy(execution::par(execution::task)),
         IteratorTag());
 #endif
 }
 
-void any_of_exception_test()
+void none_of_exception_test()
 {
-    test_any_of_exception<std::random_access_iterator_tag>();
-    test_any_of_exception<std::forward_iterator_tag>();
+    test_none_of_exception<std::random_access_iterator_tag>();
+    test_none_of_exception<std::forward_iterator_tag>();
 #if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
-    test_any_of_exception<std::input_iterator_tag>();
+    test_none_of_exception<std::input_iterator_tag>();
 #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename ExPolicy, typename IteratorTag>
-void test_any_of_bad_alloc(ExPolicy policy, IteratorTag)
+void test_none_of_bad_alloc(ExPolicy policy, IteratorTag)
 {
     static_assert(
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
@@ -294,8 +290,7 @@ void test_any_of_bad_alloc(ExPolicy policy, IteratorTag)
 
         bool caught_exception = false;
         try {
-            hpx::parallel::any_of(policy,
-                iterator(std::begin(c)), iterator(std::end(c)),
+            hpx::parallel::none_of(policy, c,
                 [](std::size_t v) {
                     return throw std::bad_alloc(), v != 0;
                 });
@@ -314,7 +309,7 @@ void test_any_of_bad_alloc(ExPolicy policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_any_of_bad_alloc_async(ExPolicy p, IteratorTag)
+void test_none_of_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -328,8 +323,7 @@ void test_any_of_bad_alloc_async(ExPolicy p, IteratorTag)
         bool returned_from_algorithm = false;
         try {
             hpx::future<void> f =
-                hpx::parallel::any_of(p,
-                    iterator(std::begin(c)), iterator(std::end(c)),
+                hpx::parallel::none_of(p, c,
                     [](std::size_t v) {
                         return throw std::bad_alloc(), v != 0;
                     });
@@ -351,36 +345,36 @@ void test_any_of_bad_alloc_async(ExPolicy p, IteratorTag)
 }
 
 template <typename IteratorTag>
-void test_any_of_bad_alloc()
+void test_none_of_bad_alloc()
 {
     using namespace hpx::parallel;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_any_of_bad_alloc(execution::seq, IteratorTag());
-    test_any_of_bad_alloc(execution::par, IteratorTag());
+    test_none_of_bad_alloc(execution::seq, IteratorTag());
+    test_none_of_bad_alloc(execution::par, IteratorTag());
 
-    test_any_of_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_any_of_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_none_of_bad_alloc_async(execution::seq(execution::task), IteratorTag());
+    test_none_of_bad_alloc_async(execution::par(execution::task), IteratorTag());
 
 #if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_any_of_bad_alloc(execution_policy(execution::seq), IteratorTag());
-    test_any_of_bad_alloc(execution_policy(execution::par), IteratorTag());
+    test_none_of_bad_alloc(execution_policy(execution::seq), IteratorTag());
+    test_none_of_bad_alloc(execution_policy(execution::par), IteratorTag());
 
-    test_any_of_bad_alloc(execution_policy(execution::seq(execution::task)),
+    test_none_of_bad_alloc(execution_policy(execution::seq(execution::task)),
         IteratorTag());
-    test_any_of_bad_alloc(execution_policy(execution::par(execution::task)),
+    test_none_of_bad_alloc(execution_policy(execution::par(execution::task)),
         IteratorTag());
 #endif
 }
 
-void any_of_bad_alloc_test()
+void none_of_bad_alloc_test()
 {
-    test_any_of_bad_alloc<std::random_access_iterator_tag>();
-    test_any_of_bad_alloc<std::forward_iterator_tag>();
+    test_none_of_bad_alloc<std::random_access_iterator_tag>();
+    test_none_of_bad_alloc<std::forward_iterator_tag>();
 #if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
-    test_any_of_bad_alloc<std::input_iterator_tag>();
+    test_none_of_bad_alloc<std::input_iterator_tag>();
 #endif
 }
 
@@ -394,9 +388,9 @@ int hpx_main(boost::program_options::variables_map& vm)
     std::cout << "using seed: " << seed << std::endl;
     std::srand(seed);
 
-    any_of_test();
-    any_of_exception_test();
-    any_of_bad_alloc_test();
+    none_of_test();
+    none_of_exception_test();
+    none_of_bad_alloc_test();
     return hpx::finalize();
 }
 
@@ -411,7 +405,6 @@ int main(int argc, char* argv[])
         ("seed,s", value<unsigned int>(),
         "the random number generator seed to use for this run")
         ;
-
     // By default this test should run on all available cores
     std::vector<std::string> const cfg = {
         "hpx.os_threads=all"


### PR DESCRIPTION
- Add projection function to all_of, any_of, none_of
- Add range version of the above functions (#1668)
- corresponding tests