### PR TITLE
Adding non-blocking (on destruction) service executors

### DIFF
--- a/hpx/runtime/threads/executors/service_executors.hpp
+++ b/hpx/runtime/threads/executors/service_executors.hpp
@@ -68,6 +68,9 @@ namespace hpx { namespace threads { namespace executors
             void add_no_count(closure_type&& f);
             void thread_wrapper(closure_type&& f);
 
+            // detaches this object from the underlying thread pool object
+            void detach();
+
         protected:
             // Return the requested policy element
             std::size_t get_policy_element(
@@ -79,6 +82,7 @@ namespace hpx { namespace threads { namespace executors
             mutex_type mtx_;
             hpx::util::atomic_count task_count_;
             compat::condition_variable shutdown_cv_;
+            bool blocking_;
         };
     }
 
@@ -179,4 +183,4 @@ namespace hpx { namespace threads { namespace executors
 
 #include <hpx/config/warnings_suffix.hpp>
 
-#endif /*HPX_RUNTIME_THREADS_EXECUTORS_SERVICE_EXECUTOR_HPP*/
+#endif /* HPX_RUNTIME_THREADS_EXECUTORS_SERVICE_EXECUTOR_HPP */

--- a/hpx/runtime/threads/run_as_os_thread.hpp
+++ b/hpx/runtime/threads/run_as_os_thread.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016 Hartmut Kaiser
+//  Copyright (c) 2016-2017 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -27,8 +27,10 @@ namespace hpx { namespace threads
         HPX_ASSERT(get_self_ptr() != nullptr);
 
         parallel::execution::io_pool_executor scheduler;
-        return parallel::execution::async_execute(scheduler,
+        auto result = parallel::execution::async_execute(scheduler,
             std::forward<F>(f), std::forward<Ts>(vs)...);
+        scheduler.detach();
+        return result;
     }
 }}
 

--- a/hpx/runtime/threads/thread_executor.hpp
+++ b/hpx/runtime/threads/thread_executor.hpp
@@ -196,6 +196,11 @@ namespace hpx { namespace threads
                 return create_id(reinterpret_cast<std::size_t>(this));
             }
 
+            virtual void detach()
+            {
+                // by default, do nothing
+            }
+
         protected:
             static executor_id create_id(std::size_t id)
             {
@@ -427,6 +432,11 @@ namespace hpx { namespace threads
         {
             return add_after(rel_time.value(), std::move(f), desc,
                 stacksize, ec);
+        }
+
+        void detach()
+        {
+            executor_data_->detach();
         }
 
         /// Return a reference to the default executor for this process.

--- a/tests/regressions/threads/CMakeLists.txt
+++ b/tests/regressions/threads/CMakeLists.txt
@@ -7,6 +7,7 @@
 set(tests
     block_os_threads_1036
     resume_priority
+    run_as_os_thread_lockup_2991
     thread_data_1111
     thread_pool_executor_1112
     thread_rescheduling

--- a/tests/regressions/threads/run_as_os_thread_lockup_2991.cpp
+++ b/tests/regressions/threads/run_as_os_thread_lockup_2991.cpp
@@ -1,0 +1,43 @@
+//  Copyright (c) 2017 Maciej Brodowicz
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/runtime/threads/run_as_os_thread.hpp>
+
+#include <iostream>
+#include <mutex>
+#include <thread>
+
+std::mutex mtx;
+
+void locker()
+{
+    std::cout << std::this_thread::get_id() << ": about to lock mutex\n";
+    std::lock_guard<std::mutex> lock(mtx);
+    std::cout << std::this_thread::get_id() << ": mutex locked\n";
+}
+
+int hpx_main()
+{
+    {
+        std::cout << std::this_thread::get_id() << ": about to lock mutex\n";
+        std::lock_guard<std::mutex> lock(mtx);
+        std::cout << std::this_thread::get_id() << ": mutex locked\n";
+
+        std::cout << std::this_thread::get_id() << ": about to run on io thread\n";
+        hpx::threads::run_as_os_thread(locker);
+        //sleep(2);
+    }
+    std::cout << std::this_thread::get_id() << ": exiting\n";
+
+    return hpx::finalize();
+}
+
+int main(int argc, char **argv)
+{
+    return hpx::init(argc, argv);
+}
+


### PR DESCRIPTION
- implement run_as_os_thread in terms of non-blocking io_pool executor

this fixes #2991