### PR TITLE
Making sure --hpx:help does not throw for required (but missing) arguments

### DIFF
--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -1163,6 +1163,13 @@ namespace hpx { namespace util
         for (std::string const& e : ini_config_)
             rtcfg_.parse("<user supplied config>", e, true, false);
 
+        // support re-throwing command line exceptions for testing purposes
+        int error_mode = util::allow_unregistered;
+        if (cfgmap.get_value("hpx.commandline.rethrow_errors", 0) != 0)
+        {
+            error_mode |= util::rethrow_on_error;
+        }
+
         // Initial analysis of the command line options. This is
         // preliminary as it will not take into account any aliases as
         // defined in any of the runtime configuration files.
@@ -1173,7 +1180,7 @@ namespace hpx { namespace util
             // command line handling.
             boost::program_options::variables_map prevm;
             if (!util::parse_commandline(rtcfg_, desc_cmdline, argc,
-                    argv, prevm, std::size_t(-1), util::allow_unregistered,
+                    argv, prevm, std::size_t(-1), error_mode,
                     rtcfg_.mode_))
             {
                 return -1;
@@ -1224,7 +1231,7 @@ namespace hpx { namespace util
         std::vector<std::string> unregistered_options;
 
         if (!util::parse_commandline(rtcfg_, desc_cmdline,
-                argc, argv, vm_, node_, util::allow_unregistered, rtcfg_.mode_,
+                argc, argv, vm_, node_, error_mode, rtcfg_.mode_,
                 &help, &unregistered_options))
         {
             return -1;

--- a/src/util/parse_command_line.cpp
+++ b/src/util/parse_command_line.cpp
@@ -649,24 +649,28 @@ namespace hpx { namespace util
                 store(opts, vm);
             }
 
+            if (vm.count("hpx:help"))
+            {
+                // collect help information
+                if (visible) {
+                    (*visible)
+                        .add(app_options).add(cmdline_options)
+                        .add(hpx_options).add(counter_options)
+                        .add(debugging_options).add(config_options)
+                    ;
+                }
+                return true;
+            }
+
             notify(vm);
 
             detail::handle_generic_config_options(
                 argv[0], vm, desc_cfgfile, rtcfg, node, error_mode);
             detail::handle_config_options(
                 vm, desc_cfgfile, rtcfg, node, error_mode);
-
-            // collect help information
-            if (visible && vm.count("hpx:help")) {
-                (*visible)
-                    .add(app_options).add(cmdline_options)
-                    .add(hpx_options).add(counter_options)
-                    .add(debugging_options).add(config_options)
-                ;
-            }
         }
         catch (std::exception const& e) {
-            if (error_mode == rethrow_on_error)
+            if (error_mode & rethrow_on_error)
                 throw;
 
             std::cerr << "hpx::init: exception caught: "

--- a/tests/regressions/util/CMakeLists.txt
+++ b/tests/regressions/util/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 set(tests
     command_line_arguments_706
+    command_line_required_arguments_2990
     configuration_1572
     function_argument
     function_serialization_728

--- a/tests/regressions/util/command_line_required_arguments_2990.cpp
+++ b/tests/regressions/util/command_line_required_arguments_2990.cpp
@@ -1,0 +1,50 @@
+//  Copyright (c) 2017 Igor Krivenko
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace boost::program_options;
+
+int hpx_main(variables_map& vm)
+{
+    std::cout << "Value of reqopt1: " << vm["reqopt1"].as<int>() << std::endl;
+    std::cout << "Value of reqopt2: " << vm["reqopt2"].as<double>()
+              << std::endl;
+    std::cout << "Value of reqopt3: " << vm["reqopt3"].as<std::string>()
+              << std::endl;
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = {
+        "hpx.commandline.rethrow_errors!=1"
+    };
+
+    char help_option[] = "--hpx:help";
+
+    std::vector<char*> newargv;
+    for (int i = 0; i != argc; ++i)
+    {
+        newargv.push_back(argv[i]);
+    }
+    newargv.push_back(help_option);
+    newargv.push_back(nullptr);
+
+    options_description op("Issue #2990\n\nUsage: issue2990 [options]");
+
+    op.add_options()
+        ("reqopt1", value<int>()->required(), "Required option 1")
+        ("reqopt2", value<double>()->required(), "Required option 2")
+        ("reqopt3", value<std::string>()->required(), "Required option 3");
+
+    return hpx::init(op, argc + 1, newargv.data(), cfg);
+}


### PR DESCRIPTION
this fixes #2990 

@krivenko please make sure that this fixes the problem you reported, thanks!