### PR TITLE
Speeding up accessing the resource partitioner and the topology info

### DIFF
--- a/hpx/runtime/resource/detail/partitioner.hpp
+++ b/hpx/runtime/resource/detail/partitioner.hpp
@@ -233,6 +233,9 @@ namespace hpx { namespace resource { namespace detail
         // store policy flags determining the general behavior of the
         // resource_partitioner
         resource::partitioner_mode mode_;
+
+        // topology information
+        threads::topology& topo_;
     };
 }}}
 

--- a/hpx/runtime/threads/policies/affinity_data.hpp
+++ b/hpx/runtime/threads/policies/affinity_data.hpp
@@ -51,7 +51,8 @@ namespace hpx { namespace threads { namespace policies { namespace detail
             return num_threads_;
         }
 
-        mask_cref_type get_pu_mask(std::size_t num_thread) const;
+        mask_cref_type get_pu_mask(threads::topology const& topo,
+            std::size_t num_thread) const;
 
         mask_type get_used_pus_mask(std::size_t pu_num) const;
         std::size_t get_thread_occupancy(std::size_t pid) const;
@@ -86,7 +87,7 @@ namespace hpx { namespace threads { namespace policies { namespace detail
         std::vector<mask_type> affinity_masks_;
         std::vector<std::size_t> pu_nums_;
         mask_type no_affinity_;                             ///< mask of processing units which have no affinity
-        static std::atomic<int> instance_number_counter_; ///< counter for instance numbers
+        static std::atomic<int> instance_number_counter_;   ///< counter for instance numbers
     };
 }}}}
 

--- a/src/runtime/resource/detail/detail_partitioner.cpp
+++ b/src/runtime/resource/detail/detail_partitioner.cpp
@@ -213,9 +213,10 @@ namespace hpx { namespace resource { namespace detail
 
     ////////////////////////////////////////////////////////////////////////
     partitioner::partitioner()
-        : first_core_(std::size_t(-1))
-        , cores_needed_(std::size_t(-1))
-        , mode_(mode_default)
+      : first_core_(std::size_t(-1))
+      , cores_needed_(std::size_t(-1))
+      , mode_(mode_default)
+      , topo_(threads::create_topology())
     {
         // allow only one partitioner instance
         if (++instance_number_counter_ > 1)
@@ -771,7 +772,7 @@ namespace hpx { namespace resource { namespace detail
 
     threads::topology &partitioner::get_topology() const
     {
-        return threads::create_topology();
+        return topo_;
     }
 
     util::command_line_handling &
@@ -865,7 +866,7 @@ namespace hpx { namespace resource { namespace detail
     threads::mask_cref_type partitioner::get_pu_mask(
         std::size_t global_thread_num) const
     {
-        return affinity_data_.get_pu_mask(global_thread_num);
+        return affinity_data_.get_pu_mask(topo_, global_thread_num);
     }
 
     bool partitioner::cmd_line_parsed() const

--- a/src/runtime/threads/policies/affinity_data.cpp
+++ b/src/runtime/threads/policies/affinity_data.cpp
@@ -5,9 +5,10 @@
 
 #include <hpx/error_code.hpp>
 #include <hpx/runtime/config_entry.hpp>
+#include <hpx/runtime/resource/detail/partitioner.hpp>
 #include <hpx/runtime/threads/cpu_mask.hpp>
 #include <hpx/runtime/threads/policies/affinity_data.hpp>
-#include <hpx/runtime/resource/detail/partitioner.hpp>
+#include <hpx/runtime/threads/policies/topology.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/command_line_handling.hpp>
 #include <hpx/util/format.hpp>
@@ -113,7 +114,6 @@ namespace hpx { namespace threads { namespace policies { namespace detail
     {
         num_threads_ = cfg_.num_threads_;
         std::size_t num_system_pus = hardware_concurrency();
-        auto& topo = resource::get_partitioner().get_topology();
 
         // initialize from command line
         std::size_t pu_offset = get_pu_offset(cfg_);
@@ -138,6 +138,8 @@ namespace hpx { namespace threads { namespace policies { namespace detail
                 get_config_entry("hpx.cores", 0), 0);
 
         init_cached_pu_nums(num_system_pus);
+
+        auto const& topo = threads::create_topology();
 
 #if defined(HPX_HAVE_HWLOC)
         std::string affinity_desc;
@@ -206,11 +208,9 @@ namespace hpx { namespace threads { namespace policies { namespace detail
         return (std::max)(num_unique_cores, max_cores);
     }
 
-    mask_cref_type affinity_data::get_pu_mask(std::size_t global_thread_num) const
+    mask_cref_type affinity_data::get_pu_mask(threads::topology const& topo,
+        std::size_t global_thread_num) const
     {
-        // get a topology instance
-        topology const& topology = resource::get_partitioner().get_topology();
-
         // --hpx:bind=none disables all affinity
         if (threads::test(no_affinity_, global_thread_num))
         {
@@ -228,27 +228,27 @@ namespace hpx { namespace threads { namespace policies { namespace detail
         {
             // The affinity domain is 'processing unit', just convert the
             // pu-number into a bit-mask.
-            return topology.get_thread_affinity_mask(pu_num);
+            return topo.get_thread_affinity_mask(pu_num);
         }
         if (0 == std::string("core").find(affinity_domain_))
         {
             // The affinity domain is 'core', return a bit mask corresponding
             // to all processing units of the core containing the given
             // pu_num.
-            return topology.get_core_affinity_mask(pu_num);
+            return topo.get_core_affinity_mask(pu_num);
         }
         if (0 == std::string("numa").find(affinity_domain_))
         {
             // The affinity domain is 'numa', return a bit mask corresponding
             // to all processing units of the NUMA domain containing the
             // given pu_num.
-            return topology.get_numa_node_affinity_mask(pu_num);
+            return topo.get_numa_node_affinity_mask(pu_num);
         }
 
         // The affinity domain is 'machine', return a bit mask corresponding
         // to all processing units of the machine.
         HPX_ASSERT(0 == std::string("machine").find(affinity_domain_));
-        return topology.get_machine_affinity_mask();
+        return topo.get_machine_affinity_mask();
     }
 
     mask_type affinity_data::get_used_pus_mask(std::size_t pu_num) const


### PR DESCRIPTION
- this reduces the overheads in the scheduler significantly