### PR TITLE
Speed up local action execution

### DIFF
--- a/hpx/runtime/actions/basic_action.hpp
+++ b/hpx/runtime/actions/basic_action.hpp
@@ -185,7 +185,6 @@ namespace hpx { namespace actions
         static R invoke(naming::address::address_type /*lva*/,
             naming::address::component_type /*comptype*/, Ts&&... /*vs*/);
 
-    protected:
         struct invoker
         {
             typedef
@@ -221,6 +220,7 @@ namespace hpx { namespace actions
             }
         };
 
+    protected:
         /// The \a thread_function will be registered as the thread
         /// function of a thread. It encapsulates the execution of the
         /// original function (given by \a func).


### PR DESCRIPTION
- this patch significantly speeds up local action execution (both,
  direct and non-direct) by avoiding to construct a (remote) promise
  but instead directly scheduling the function bound to the action
  as a local thread, while using a simple (local-only) future.
- direct actions are executed by directly invoking the function bound to 
  the function