### PR TITLE
Adding enable_elasticity option to pool configuration

### DIFF
--- a/hpx/runtime/threads/detail/scheduled_thread_pool.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool.hpp
@@ -236,15 +236,18 @@ namespace hpx { namespace threads { namespace detail
 
         // Provide the given processing unit to the scheduler.
         void add_processing_unit(std::size_t virt_core,
-            std::size_t thread_num, error_code&);
+            std::size_t thread_num, error_code&  = hpx::throws);
 
         // Remove the given processing unit from the scheduler.
-        void remove_processing_unit(std::size_t virt_core, error_code&);
+        void remove_processing_unit(
+            std::size_t virt_core, error_code& = hpx::throws);
 
     protected:
         friend struct init_tss_helper<Scheduler>;
 
-        void add_processing_unit(std::size_t virt_core,
+        void remove_processing_unit_internal(
+            std::size_t virt_core, error_code& = hpx::throws);
+        void add_processing_unit_internal(std::size_t virt_core,
             std::size_t thread_num, std::shared_ptr<compat::barrier> startup,
             error_code& ec = hpx::throws);
 

--- a/hpx/runtime/threads/policies/scheduler_mode.hpp
+++ b/hpx/runtime/threads/policies/scheduler_mode.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015 Hartmut Kaiser
+//  Copyright (c) 2015-2017 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -10,12 +10,25 @@ namespace hpx { namespace threads { namespace policies
 {
     enum scheduler_mode
     {
-        nothing_special = 0,
-        do_background_work = 0x1,
-        reduce_thread_priority = 0x02,
-        delay_exit = 0x04,
-        fast_idle_mode = 0x08,
-        enable_elasticity = 0x10
+        nothing_special = 0,            ///< As the name suggests, this option
+            ///< can be used to disable all other options.
+        do_background_work = 0x1,       ///< The scheduler will periodically
+            ///< call a provided callback function from a special HPX thread
+            ///< to enable performing background-work, for instance driving
+            ///< networking progress or garbage-collect AGAS
+        reduce_thread_priority = 0x02,  ///< The kernel priority of the
+            ///< os-thread driving the scheduler will be reduced below normal.
+        delay_exit = 0x04,              ///< The scheduler will wait for some
+            ///< unspecified amount of time before exiting the scheduling loop
+            ///< while being terminated to make sure no other work is being
+            ///< scheduled during processing the shutdown request.
+        fast_idle_mode = 0x08,          ///< Some schedulers have the capability
+            ///< to act as 'embedded' schedulers. In this case it needs to
+            ///< periodically invoke a provided callback into the outer scheduler
+            ///< more frequently than normal. This option enables this behavior.
+        enable_elasticity = 0x10        ///< This options allows for the
+            ///< scheduler to dynamically increase and reduce the number of
+            ///< processing units it runs on.
     };
 }}}
 

--- a/hpx/runtime/threads/policies/scheduler_mode.hpp
+++ b/hpx/runtime/threads/policies/scheduler_mode.hpp
@@ -14,7 +14,8 @@ namespace hpx { namespace threads { namespace policies
         do_background_work = 0x1,
         reduce_thread_priority = 0x02,
         delay_exit = 0x04,
-        fast_idle_mode = 0x08
+        fast_idle_mode = 0x08,
+        enable_elasticity = 0x10
     };
 }}}
 

--- a/src/runtime/threads/detail/thread_pool_base.cpp
+++ b/src/runtime/threads/detail/thread_pool_base.cpp
@@ -47,6 +47,13 @@ namespace hpx { namespace threads { namespace detail
     ///////////////////////////////////////////////////////////////////////////
     mask_cref_type thread_pool_base::get_used_processing_units() const
     {
+        if (!(mode_ & threads::policies::enable_elasticity))
+        {
+            return used_processing_units_;
+        }
+
+        // FIXME: this is broken as the function returns a reference allowing
+        // to access the value of the mask without it being guarded.
         std::lock_guard<pu_mutex_type> l(used_processing_units_mtx_);
         return used_processing_units_;
     }


### PR DESCRIPTION
- fixing performance problem related to `get_used_processing_units()` for
  non-elastic pools

This specifically leaves open  the issue of `get_used_processing_units()` returning an unprotected reference to the mask. This has to be resolved separately.