### PR TITLE
Disable command-line aliasing for applications that use user_main

### DIFF
--- a/cmake/templates/hpxrun.py.in
+++ b/cmake/templates/hpxrun.py.in
@@ -99,10 +99,10 @@ def build_cmd(options, args):
     if options.localities > 1:
         # Selecting the parcelport for hpx via hpx ini confifuration
         select_parcelport = (lambda pp:
-            ['-Ihpx.parcel.verbs.enable=1'] if pp == 'verbs'
-            else ['-Ihpx.parcel.ipc.enable=1'] if pp == 'ipc'
-            else ['-Ihpx.parcel.mpi.enable=1', '-Ihpx.parcel.bootstrap=mpi'] if pp == 'mpi'
-            else ['-Ihpx.parcel.tcp.enable=1'] if pp == 'tcp'
+            ['--hpx:ini=hpx.parcel.verbs.enable=1'] if pp == 'verbs'
+            else ['--hpx:ini=hpx.parcel.ipc.enable=1'] if pp == 'ipc'
+            else ['--hpx:ini=hpx.parcel.mpi.enable=1', '--hpx:ini=hpx.parcel.bootstrap=mpi'] if pp == 'mpi'
+            else ['--hpx:ini=hpx.parcel.tcp.enable=1'] if pp == 'tcp'
             else [])
         cmd += select_parcelport(options.parcelport)
 

--- a/hpx/hpx_main_impl.hpp
+++ b/hpx/hpx_main_impl.hpp
@@ -27,9 +27,10 @@
 //
 int HPX_CDECL main(int argc, char** argv)
 {
-    // allow for unknown options
+    // allow for unknown options and inhibit aliasing of short options
     std::vector<std::string> const cfg = {
-        "hpx.commandline.allow_unknown=1"
+        "hpx.commandline.allow_unknown=1",
+        "hpx.commandline.aliasing=0"
     };
 
     return hpx::init(argc, argv, cfg);

--- a/python/scripts/hpx_run_test.py
+++ b/python/scripts/hpx_run_test.py
@@ -9,12 +9,12 @@
 
 # hpx_run_test.py is a script that is designed to manage the execution of HPX
 # tests. It is designed to:
-# 
+#
 # * Robustly clean up failed tests by killing them and all their subprocesses.
 # * Robustly enforce user-specified timeouts for tests with minimal overheads.
 # * Control the output of tests.
 #
-# hpx_run_test.py takes a number of command line arguments, described in 
+# hpx_run_test.py takes a number of command line arguments, described in
 # --help. Additionally, it takes a positional argument that describes
 # the test. This argument should be formatted as a python list. Its format is
 # described in --help.
@@ -114,10 +114,10 @@ if __name__ == '__main__':
 
   (options, files) = parser.parse_args()
 
-  if 'HPX_TEST_ARGUMENTS' in os.environ: 
+  if 'HPX_TEST_ARGUMENTS' in os.environ:
     options.args += os.environ['HPX_TEST_ARGUMENTS']
 
-  if 'HPX_TEST_LAUNCHER' in os.environ: 
+  if 'HPX_TEST_LAUNCHER' in os.environ:
     options.launcher += os.environ['HPX_TEST_LAUNCHER']
 
   if not (lambda x: "always" == x or "never" == x or "fail" == x)(options.log):


### PR DESCRIPTION
- those applications most likely will do their own command line handling,
  disabling hpx short options will prevent for the user to run into
  surprises.