### PR TITLE
Master fixes

### DIFF
--- a/hpx/lcos/detail/promise_base.hpp
+++ b/hpx/lcos/detail/promise_base.hpp
@@ -316,6 +316,8 @@ namespace lcos {
                   : ptr_(o.ptr_.release(), &wrapping_deleter)
                 {}
 
+                keep_alive& operator=(keep_alive&& o) = default;
+
                 void operator()()
                 {
                     delete ptr_->get(); // delete wrapped_type

--- a/hpx/util/optional.hpp
+++ b/hpx/util/optional.hpp
@@ -319,7 +319,7 @@ namespace hpx { namespace util
     template <typename T>
     constexpr bool operator>(optional<T> const& lhs, optional<T> const& rhs)
     {
-        return (!bool(rhs)) ? false : (!bool(lhs)) ? true : *rhs > *lhs;
+        return (!bool(lhs)) ? false : (!bool(rhs)) ? true : *rhs > *lhs;
     }
 
     template <typename T>


### PR DESCRIPTION
Small fixes to master:
 - cosmetic addition of promise_lco<T>::keep_alive default move assignment
 - Fixing c&p errors for operator> in optional after constexpr 'fixes'