### PR TITLE
P0356 Simplified partial function application 

### DIFF
--- a/hpx/components/component_storage/server/migrate_from_storage.hpp
+++ b/hpx/components/component_storage/server/migrate_from_storage.hpp
@@ -13,7 +13,7 @@
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/throw_exception.hpp>
 #include <hpx/traits/component_supports_migration.hpp>
-#include <hpx/util/bind.hpp>
+#include <hpx/util/bind_back.hpp>
 
 #include <hpx/components/component_storage/export_definitions.hpp>
 #include <hpx/components/component_storage/server/component_storage.hpp>
@@ -70,9 +70,9 @@ namespace hpx { namespace components { namespace server
             using hpx::components::runtime_support;
             return runtime_support::migrate_component_async<Component>(
                         target_locality, ptr, to_resurrect)
-                .then(util::bind(
+                .then(util::bind_back(
                     &detail::migrate_component_cleanup<Component>,
-                    util::placeholders::_1, ptr, to_resurrect));
+                    ptr, to_resurrect));
         }
 
         template <typename Component>
@@ -159,10 +159,9 @@ namespace hpx { namespace components { namespace server
                     typedef typename server::component_storage::migrate_from_here_action
                         action_type;
                     return async<action_type>(r.first, to_resurrect.get_gid())
-                        .then(util::bind(
+                        .then(util::bind_back(
                             &detail::migrate_from_storage_here<Component>,
-                            util::placeholders::_1, to_resurrect,
-                            r.second, target_locality));
+                            to_resurrect, r.second, target_locality));
                 })
             .then(
                 [to_resurrect](future<naming::id_type> && f) -> naming::id_type

--- a/hpx/components/containers/partitioned_vector/partitioned_vector_impl.hpp
+++ b/hpx/components/containers/partitioned_vector/partitioned_vector_impl.hpp
@@ -20,7 +20,8 @@
 #include <hpx/throw_exception.hpp>
 #include <hpx/traits/is_distribution_policy.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/bind.hpp>
+#include <hpx/util/bind_back.hpp>
+#include <hpx/util/bind_front.hpp>
 
 #include <hpx/components/containers/container_distribution_policy.hpp>
 #include <hpx/components/containers/partitioned_vector/partitioned_vector_decl.hpp>
@@ -83,11 +84,10 @@ namespace hpx
         {
             if (it->locality_id_ == this_locality)
             {
-                using util::placeholders::_1;
                 ptrs.push_back(
                     get_ptr<partitioned_vector_partition_server>(it->partition_)
-                        .then(util::bind(&partitioned_vector::get_ptr_helper, l,
-                            std::ref(partitions_), _1)));
+                        .then(util::bind_front(&partitioned_vector::get_ptr_helper, l,
+                            std::ref(partitions_))));
             }
         }
         wait_all(ptrs);
@@ -100,23 +100,21 @@ namespace hpx
     HPX_PARTITIONED_VECTOR_SPECIALIZATION_EXPORT hpx::future<void>
     partitioned_vector<T, Data>::connect_to_helper(shared_future<id_type>&& f)
     {
-        using util::placeholders::_1;
         typedef typename components::server::distributed_metadata_base<
             server::partitioned_vector_config_data>::get_action act;
 
         id_type id = f.get();
         return async(act(), id).then(
-            util::bind(&partitioned_vector::get_data_helper, this, id, _1));
+            util::bind_front(&partitioned_vector::get_data_helper, this, id));
     }
 
     template <typename T, typename Data /*= std::vector<T> */>
     HPX_PARTITIONED_VECTOR_SPECIALIZATION_EXPORT hpx::future<void>
     partitioned_vector<T, Data>::connect_to(std::string const& symbolic_name)
     {
-        using util::placeholders::_1;
         this->base_type::connect_to(symbolic_name);
         return this->base_type::share().then(
-            util::bind(&partitioned_vector::connect_to_helper, this, _1));
+            util::bind_front(&partitioned_vector::connect_to_helper, this));
     }
 
     template <typename T, typename Data /*= std::vector<T> */>
@@ -178,9 +176,8 @@ namespace hpx
     HPX_PARTITIONED_VECTOR_SPECIALIZATION_EXPORT
     partitioned_vector<T, Data>::partitioned_vector(future<id_type>&& f)
     {
-        using util::placeholders::_1;
         f.share().then(
-            util::bind(&partitioned_vector::connect_to_helper, this, _1));
+            util::bind_front(&partitioned_vector::connect_to_helper, this));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -367,11 +364,10 @@ namespace hpx
 
                 if (locality == this_locality)
                 {
-                    using util::placeholders::_1;
                     ptrs.push_back(
                         get_ptr<partitioned_vector_partition_server>(id).then(
-                            util::bind(&partitioned_vector::get_ptr_helper, l,
-                                std::ref(partitions_), _1)));
+                            util::bind_front(&partitioned_vector::get_ptr_helper,
+                                l, std::ref(partitions_))));
                 }
                 ++l;
 
@@ -409,13 +405,9 @@ namespace hpx
     HPX_PARTITIONED_VECTOR_SPECIALIZATION_EXPORT void
     partitioned_vector<T, Data>::create(DistPolicy const& policy)
     {
-        using util::placeholders::_1;
-        using util::placeholders::_2;
-        using util::placeholders::_3;
-
         create(policy,
-            util::bind(
-                &partitioned_vector::create_helper1<DistPolicy>, _1, _2, _3));
+            util::bind_back(
+                &partitioned_vector::create_helper1<DistPolicy>));
     }
 
     template <typename T, typename Data /*= std::vector<T> */>
@@ -423,12 +415,8 @@ namespace hpx
     HPX_PARTITIONED_VECTOR_SPECIALIZATION_EXPORT void
     partitioned_vector<T, Data>::create(T const& val, DistPolicy const& policy)
     {
-        using util::placeholders::_1;
-        using util::placeholders::_2;
-        using util::placeholders::_3;
-
         create(policy,
-            util::bind(&partitioned_vector::create_helper2<DistPolicy>, _1, _2, _3,
+            util::bind_back(&partitioned_vector::create_helper2<DistPolicy>,
                 std::ref(val)));
     }
 
@@ -466,12 +454,11 @@ namespace hpx
 
             if (locality == this_locality)
             {
-                using util::placeholders::_1;
                 ptrs.push_back(
                     get_ptr<partitioned_vector_partition_server>(
                         partitions[i].partition_)
-                        .then(util::bind(&partitioned_vector::get_ptr_helper, i,
-                            std::ref(partitions), _1)));
+                        .then(util::bind_front(&partitioned_vector::get_ptr_helper, i,
+                            std::ref(partitions))));
             }
         }
 

--- a/hpx/components/containers/unordered/unordered_map.hpp
+++ b/hpx/components/containers/unordered/unordered_map.hpp
@@ -21,7 +21,7 @@
 #include <hpx/runtime/serialization/vector.hpp>
 #include <hpx/traits/is_distribution_policy.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/bind.hpp>
+#include <hpx/util/bind_front.hpp>
 
 #include <hpx/components/containers/container_distribution_policy.hpp>
 #include <hpx/components/containers/unordered/partition_unordered_map_component.hpp>
@@ -320,12 +320,11 @@ namespace hpx
         // available
         future<void> connect_to_helper(future<id_type> && f)
         {
-            using util::placeholders::_1;
             typedef typename base_type::server_component_type::get_action act;
 
             id_type id = f.get();
             return async(act(), id).then(
-                util::bind(&unordered_map::get_data_helper, this, id, _1));
+                util::bind_front(&unordered_map::get_data_helper, this, id));
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -374,11 +373,10 @@ namespace hpx
                     partitions_.push_back(partition_data(id, locality));
                     if (locality == this_locality)
                     {
-                        using util::placeholders::_1;
                         ptrs.push_back(
                             get_ptr<partition_unordered_map_server>(id).then(
-                                util::bind(&unordered_map::get_ptr_helper,
-                                    l, std::ref(partitions_), _1
+                                util::bind_front(&unordered_map::get_ptr_helper,
+                                    l, std::ref(partitions_)
                                 )
                             )
                         );
@@ -457,11 +455,10 @@ namespace hpx
 
                 if (locality == this_locality)
                 {
-                    using util::placeholders::_1;
                     ptrs.push_back(get_ptr<partition_unordered_map_server>(
                         partitions[i].partition_.get()).then(
-                            util::bind(&unordered_map::get_ptr_helper,
-                                i, std::ref(partitions), _1)));
+                            util::bind_front(&unordered_map::get_ptr_helper,
+                                i, std::ref(partitions))));
                 }
             }
 
@@ -473,9 +470,8 @@ namespace hpx
     public:
         future<void> connect_to(std::string const& symbolic_name)
         {
-            using util::placeholders::_1;
             return base_type::connect_to(symbolic_name,
-                util::bind(&unordered_map::connect_to_helper, this, _1));
+                util::bind_front(&unordered_map::connect_to_helper, this));
         }
 
         // Register this unordered_map with AGAS using the given symbolic name

--- a/hpx/components/iostreams/write_functions.hpp
+++ b/hpx/components/iostreams/write_functions.hpp
@@ -9,7 +9,7 @@
 #define HPX_B72D9BF0_B236_46F6_83AA_E45A70BD1FAA
 
 #include <hpx/config.hpp>
-#include <hpx/util/bind.hpp>
+#include <hpx/util/bind_back.hpp>
 #include <hpx/util/function.hpp>
 
 #include <algorithm>
@@ -37,8 +37,7 @@ inline void iterator_write_function(std::vector<char> const& in, Iterator it)
 template <typename Iterator>
 inline write_function_type make_iterator_write_function(Iterator it)
 {
-    return util::bind(iterator_write_function<Iterator>,
-        util::placeholders::_1, it);
+    return util::bind_back(iterator_write_function<Iterator>, it);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -52,8 +51,7 @@ std_ostream_write_function(std::vector<char> const& in, std::ostream& os)
 // Factory function
 inline write_function_type make_std_ostream_write_function(std::ostream& os)
 {
-    return util::bind(std_ostream_write_function,
-        util::placeholders::_1, std::ref(os));
+    return util::bind_back(std_ostream_write_function, std::ref(os));
 }
 
 }}

--- a/hpx/hpx_init_impl.hpp
+++ b/hpx/hpx_init_impl.hpp
@@ -13,7 +13,7 @@
 #include <hpx/runtime/shutdown_function.hpp>
 #include <hpx/runtime/startup_function.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/bind.hpp>
+#include <hpx/util/bind_back.hpp>
 #include <hpx/util/find_prefix.hpp>
 #include <hpx/util/function.hpp>
 
@@ -286,7 +286,7 @@ namespace hpx
             std::string("Usage: ") + app_name +  " [options]");
 
         util::function_nonser<int(boost::program_options::variables_map& vm)>
-            main_f = util::bind(detail::init_helper, util::placeholders::_1, f);
+            main_f = util::bind_back(detail::init_helper, f);
         std::vector<std::string> cfg;
         util::function_nonser<void()> const empty;
 
@@ -317,7 +317,7 @@ namespace hpx
             "Usage: " + app_name +  " [options]");
 
         util::function_nonser<int(boost::program_options::variables_map& vm)>
-            main_f = util::bind(detail::init_helper, util::placeholders::_1, f);
+            main_f = util::bind_back(detail::init_helper, f);
 
         HPX_ASSERT(argc != 0 && argv != nullptr);
 

--- a/hpx/hpx_start_impl.hpp
+++ b/hpx/hpx_start_impl.hpp
@@ -12,7 +12,7 @@
 #include <hpx/runtime/shutdown_function.hpp>
 #include <hpx/runtime/startup_function.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/bind.hpp>
+#include <hpx/util/bind_back.hpp>
 #include <hpx/util/find_prefix.hpp>
 #include <hpx/util/function.hpp>
 
@@ -284,7 +284,7 @@ namespace hpx
             "Usage: " + app_name +  " [options]");
 
         util::function_nonser<int(boost::program_options::variables_map& vm)>
-            main_f = util::bind(detail::init_helper, util::placeholders::_1, f);
+            main_f = util::bind_back(detail::init_helper, f);
         std::vector<std::string> cfg;
 
         HPX_ASSERT(argc != 0 && argv != nullptr);
@@ -312,7 +312,7 @@ namespace hpx
             "Usage: " + app_name +  " [options]");
 
         util::function_nonser<int(boost::program_options::variables_map& vm)>
-            main_f = util::bind(detail::init_helper, util::placeholders::_1, f);
+            main_f = util::bind_back(detail::init_helper, f);
 
         HPX_ASSERT(argc != 0 && argv != nullptr);
 

--- a/hpx/lcos/gather.hpp
+++ b/hpx/lcos/gather.hpp
@@ -204,6 +204,9 @@ namespace hpx { namespace lcos
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime/naming/unmanaged.hpp>
 #include <hpx/util/assert.hpp>
+#include <hpx/util/bind.hpp>
+#include <hpx/util/bind_back.hpp>
+#include <hpx/util/bind_front.hpp>
 #include <hpx/util/decay.hpp>
 #include <hpx/util/detail/pp/cat.hpp>
 #include <hpx/util/detail/pp/expand.hpp>
@@ -263,9 +266,8 @@ namespace hpx { namespace lcos
             {
                 std::unique_lock<mutex_type> l(mtx_);
 
-                using util::placeholders::_1;
                 hpx::future<std::vector<T> > f = gate_.get_future().then(
-                        util::bind(&gather_server::on_ready, this, _1));
+                        util::bind_front(&gather_server::on_ready, this));
 
                 set_result_locked(which, std::move(t), l);
 
@@ -381,8 +383,8 @@ namespace hpx { namespace lcos
 
         // register the gatherer's id using the given basename
         using util::placeholders::_1;
-        return id.then(util::bind(
-                &detail::register_gather_name, _1, std::move(name), this_site
+        return id.then(util::bind_back(
+                &detail::register_gather_name, std::move(name), this_site
             ));
     }
 

--- a/hpx/lcos/packaged_action.hpp
+++ b/hpx/lcos/packaged_action.hpp
@@ -19,7 +19,7 @@
 #include <hpx/traits/component_type_is_compatible.hpp>
 #include <hpx/traits/extract_action.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/bind.hpp>
+#include <hpx/util/bind_front.hpp>
 #include <hpx/util/protect.hpp>
 
 #include <exception>
@@ -111,11 +111,8 @@ namespace lcos {
                         << hpx::actions::detail::get_action_name<action_type>()
                         << ", " << id << ") args(" << sizeof...(Ts) << ")";
 
-            using util::placeholders::_1;
-            using util::placeholders::_2;
-
-            auto f = util::bind(&packaged_action::parcel_write_handler,
-                this->shared_state_, _1, _2);
+            auto f = util::bind_front(&packaged_action::parcel_write_handler,
+                this->shared_state_);
 
             naming::address addr_(this->resolve());
             naming::id_type cont_id(this->get_id(false));
@@ -148,11 +145,8 @@ namespace lcos {
                         << hpx::actions::detail::get_action_name<action_type>()
                         << ", " << id << ") args(" << sizeof...(Ts) << ")";
 
-            using util::placeholders::_1;
-            using util::placeholders::_2;
-
-            auto f = util::bind(&packaged_action::parcel_write_handler,
-                this->shared_state_, _1, _2);
+            auto f = util::bind_front(&packaged_action::parcel_write_handler,
+                this->shared_state_);
 
             naming::address addr_(this->resolve());
             naming::id_type cont_id(this->get_id(false));
@@ -176,13 +170,9 @@ namespace lcos {
 
             typedef typename util::decay<Callback>::type callback_type;
 
-            using util::placeholders::_1;
-            using util::placeholders::_2;
-
-            auto f = util::bind(
+            auto f = util::bind_front(
                 &packaged_action::parcel_write_handler_cb<callback_type>,
-                util::protect(std::forward<Callback>(cb)), this->shared_state_,
-                _1, _2);
+                util::protect(std::forward<Callback>(cb)), this->shared_state_);
 
             naming::address addr_(this->resolve());
             naming::id_type cont_id(this->get_id(false));
@@ -218,13 +208,9 @@ namespace lcos {
 
             typedef typename util::decay<Callback>::type callback_type;
 
-            using util::placeholders::_1;
-            using util::placeholders::_2;
-
-            auto f = util::bind(
+            auto f = bind_front(
                 &packaged_action::parcel_write_handler_cb<callback_type>,
-                util::protect(std::forward<Callback>(cb)), this->shared_state_,
-                _1, _2);
+                util::protect(std::forward<Callback>(cb)), this->shared_state_);
 
             naming::address addr_(this->resolve());
             naming::id_type cont_id(this->get_id(false));
@@ -318,11 +304,8 @@ namespace lcos {
                         << hpx::actions::detail::get_action_name<action_type>()
                         << ", " << id << ") args(" << sizeof...(Ts) << ")";
 
-            using util::placeholders::_1;
-            using util::placeholders::_2;
-
-            auto cb = util::bind(&packaged_action::parcel_write_handler,
-                this->shared_state_, _1, _2);
+            auto cb = util::bind_front(&packaged_action::parcel_write_handler,
+                this->shared_state_);
 
             naming::id_type cont_id(this->get_id(false));
             naming::detail::set_dont_store_in_cache(cont_id);
@@ -344,13 +327,9 @@ namespace lcos {
 
             typedef typename util::decay<Callback>::type callback_type;
 
-            using util::placeholders::_1;
-            using util::placeholders::_2;
-
-            auto cb_ = util::bind(
+            auto cb_ = util::bind_front(
                 &packaged_action::parcel_write_handler_cb<callback_type>,
-                util::protect(std::forward<Callback>(cb)), this->shared_state_,
-                _1, _2);
+                util::protect(std::forward<Callback>(cb)), this->shared_state_);
 
             naming::id_type cont_id(this->get_id(false));
             naming::detail::set_dont_store_in_cache(cont_id);

--- a/hpx/lcos/when_each.hpp
+++ b/hpx/lcos/when_each.hpp
@@ -431,8 +431,7 @@ namespace hpx { namespace lcos
             traits::acquire_future_disp());
 
         return lcos::when_each(std::forward<F>(f), lazy_values_).then(
-            util::bind(&detail::return_iterator<Iterator>,
-                util::placeholders::_1, end));
+            util::bind_back(&detail::return_iterator<Iterator>, end));
     }
 
     template <typename F, typename Iterator>
@@ -451,8 +450,7 @@ namespace hpx { namespace lcos
             lazy_values_.push_back(func(*begin++));
 
         return lcos::when_each(std::forward<F>(f), lazy_values_).then(
-            util::bind(&detail::return_iterator<Iterator>,
-                util::placeholders::_1, begin));
+            util::bind_back(&detail::return_iterator<Iterator>, begin));
     }
 
     template <typename F>

--- a/hpx/parallel/algorithms/count.hpp
+++ b/hpx/parallel/algorithms/count.hpp
@@ -11,7 +11,7 @@
 #include <hpx/config.hpp>
 #include <hpx/traits/is_iterator.hpp>
 #include <hpx/traits/segmented_iterator_traits.hpp>
-#include <hpx/util/bind.hpp>
+#include <hpx/util/bind_back.hpp>
 #include <hpx/util/range.hpp>
 #include <hpx/util/unwrap.hpp>
 
@@ -76,11 +76,10 @@ namespace hpx { namespace parallel { inline namespace v1
             typename std::iterator_traits<Iter>::difference_type
             operator()(Iter part_begin, std::size_t part_size)
             {
-                using hpx::util::placeholders::_1;
                 typename std::iterator_traits<Iter>::difference_type ret = 0;
                 util::loop_n<execution_policy_type>(
                     part_begin, part_size,
-                    hpx::util::bind(*this, _1, std::ref(ret))
+                    hpx::util::bind_back(*this, std::ref(ret))
                 );
                 return ret;
             }
@@ -113,12 +112,11 @@ namespace hpx { namespace parallel { inline namespace v1
                     count_iteration<ExPolicy, detail::compare_to<T> >(
                         detail::compare_to<T>(value));
 
-                using hpx::util::placeholders::_1;
                 typename std::iterator_traits<InIter>::difference_type ret = 0;
 
                 util::loop(
                     policy, first, last,
-                    hpx::util::bind(std::move(f1), _1, std::ref(ret)));
+                    hpx::util::bind_back(std::move(f1), std::ref(ret)));
 
                 return ret;
             }
@@ -283,12 +281,11 @@ namespace hpx { namespace parallel { inline namespace v1
             {
                 auto f1 = count_iteration<ExPolicy, Pred>(op);
 
-                using hpx::util::placeholders::_1;
                 typename std::iterator_traits<InIter>::difference_type ret = 0;
 
                 util::loop(
                     policy, first, last,
-                    hpx::util::bind(std::move(f1), _1, std::ref(ret)));
+                    hpx::util::bind_back(std::move(f1), std::ref(ret)));
 
                 return ret;
             }

--- a/hpx/parallel/executors/execution.hpp
+++ b/hpx/parallel/executors/execution.hpp
@@ -22,6 +22,7 @@
 #include <hpx/traits/is_executor.hpp>
 #include <hpx/traits/executor_traits.hpp>
 #include <hpx/util/bind.hpp>
+#include <hpx/util/bind_back.hpp>
 #include <hpx/util/deferred_call.hpp>
 #include <hpx/util/detail/pack.hpp>
 #include <hpx/util/invoke.hpp>
@@ -175,9 +176,9 @@ namespace hpx { namespace parallel { namespace execution
                         F, Future, Ts...
                     >::type result_type;
 
-                auto func = hpx::util::bind(
+                auto func = hpx::util::bind_back(
                     hpx::util::one_shot(std::forward<F>(f)),
-                    hpx::util::placeholders::_1, std::forward<Ts>(ts)...);
+                    std::forward<Ts>(ts)...);
 
                 typename hpx::traits::detail::shared_state_ptr<result_type>::type
                     p = lcos::detail::make_continuation_exec<result_type>(
@@ -431,9 +432,9 @@ namespace hpx { namespace parallel { namespace execution
                         F, Future, Ts...
                     >::type result_type;
 
-                auto func = hpx::util::bind(
+                auto func = hpx::util::bind_back(
                     hpx::util::one_shot(std::forward<F>(f)),
-                    hpx::util::placeholders::_1, std::forward<Ts>(ts)...);
+                    std::forward<Ts>(ts)...);
 
                 typename hpx::traits::detail::shared_state_ptr<result_type>::type
                     p = lcos::detail::make_continuation_exec<result_type>(

--- a/hpx/parallel/executors/thread_execution.hpp
+++ b/hpx/parallel/executors/thread_execution.hpp
@@ -16,6 +16,7 @@
 #include <hpx/traits/is_launch_policy.hpp>
 #include <hpx/traits/future_access.hpp>
 #include <hpx/util/bind.hpp>
+#include <hpx/util/bind_back.hpp>
 #include <hpx/util/detail/pack.hpp>
 #include <hpx/util/deferred_call.hpp>
 #include <hpx/util/range.hpp>
@@ -81,9 +82,9 @@ namespace hpx { namespace threads
                 F, Future, Ts...
             >::type result_type;
 
-        auto func = hpx::util::bind(
+        auto func = hpx::util::bind_back(
             hpx::util::one_shot(std::forward<F>(f)),
-            hpx::util::placeholders::_1, std::forward<Ts>(ts)...);
+            std::forward<Ts>(ts)...);
 
         typename hpx::traits::detail::shared_state_ptr<result_type>::type
             p = hpx::lcos::detail::make_continuation_thread_exec<result_type>(

--- a/hpx/parallel/executors/timed_executors.hpp
+++ b/hpx/parallel/executors/timed_executors.hpp
@@ -16,6 +16,7 @@
 #include <hpx/traits/is_launch_policy.hpp>
 #include <hpx/util/steady_clock.hpp>
 #include <hpx/util/bind.hpp>
+#include <hpx/util/bind_back.hpp>
 #include <hpx/util/decay.hpp>
 
 #include <hpx/parallel/execution_policy.hpp>
@@ -63,9 +64,9 @@ namespace hpx { namespace parallel { namespace execution
             {
                 auto predecessor = make_ready_future_at(abs_time);
                 return execution::then_execute(sequenced_executor(),
-                    hpx::util::bind(
+                    hpx::util::bind_back(
                         hpx::util::one_shot(sync_execute_at_helper()),
-                        hpx::util::placeholders::_1, std::ref(exec),
+                        std::ref(exec),
                         hpx::util::deferred_call(
                             std::forward<F>(f), std::forward<Ts>(ts)...)),
                     predecessor).get();
@@ -171,9 +172,9 @@ namespace hpx { namespace parallel { namespace execution
             {
                 auto predecessor = make_ready_future_at(abs_time);
                 return execution::then_execute(sequenced_executor(),
-                    hpx::util::bind(
+                    hpx::util::bind_back(
                         hpx::util::one_shot(async_execute_at_helper()),
-                        hpx::util::placeholders::_1, std::forward<Executor>(exec),
+                        std::forward<Executor>(exec),
                         hpx::util::deferred_call(
                             std::forward<F>(f), std::forward<Ts>(ts)...)),
                     predecessor);
@@ -270,9 +271,9 @@ namespace hpx { namespace parallel { namespace execution
             {
                 auto predecessor = make_ready_future_at(abs_time);
                 execution::then_execute(sequenced_executor(),
-                    hpx::util::bind(
+                    hpx::util::bind_back(
                         hpx::util::one_shot(post_at_helper()),
-                        hpx::util::placeholders::_1, std::forward<Executor>(exec),
+                        std::forward<Executor>(exec),
                         hpx::util::deferred_call(std::forward<F>(f),
                             std::forward<Ts>(ts)...)),
                     predecessor);

--- a/hpx/parallel/task_block.hpp
+++ b/hpx/parallel/task_block.hpp
@@ -16,6 +16,8 @@
 #include <hpx/lcos/local/spinlock.hpp>
 #include <hpx/lcos/when_all.hpp>
 #include <hpx/traits/is_future.hpp>
+#include <hpx/util/bind.hpp>
+#include <hpx/util/bind_back.hpp>
 #include <hpx/util/decay.hpp>
 
 #include <hpx/parallel/exception_list.hpp>
@@ -192,9 +194,9 @@ namespace hpx { namespace parallel { inline namespace v2
             return
                 result::get(
                     hpx::dataflow(
-                        hpx::util::bind(hpx::
-                            util::one_shot(&task_block::on_ready),
-                            hpx::util::placeholders::_1, std::move(errors)),
+                        hpx::util::bind_back(
+                            hpx::util::one_shot(&task_block::on_ready),
+                            std::move(errors)),
                         std::move(tasks)
                     ));
         }

--- a/hpx/performance_counters/performance_counter.hpp
+++ b/hpx/performance_counters/performance_counter.hpp
@@ -10,6 +10,7 @@
 #include <hpx/lcos/future.hpp>
 #include <hpx/runtime/components/client_base.hpp>
 #include <hpx/runtime/launch_policy.hpp>
+#include <hpx/util/bind_front.hpp>
 
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/stubs/performance_counter.hpp>
@@ -153,9 +154,8 @@ namespace hpx { namespace performance_counters
         future<T> get_value(bool reset = false)
         {
             return get_counter_value(reset).then(
-                util::bind(
-                    &performance_counter::extract_value<T>,
-                    util::placeholders::_1));
+                util::bind_front(
+                    &performance_counter::extract_value<T>));
         }
         template <typename T>
         T get_value(launch::sync_policy, bool reset = false,
@@ -168,9 +168,8 @@ namespace hpx { namespace performance_counters
         future<T> get_value() const
         {
             return get_counter_value().then(
-                util::bind(
-                    &performance_counter::extract_value<T>,
-                    util::placeholders::_1));
+                util::bind_front(
+                    &performance_counter::extract_value<T>));
         }
         template <typename T>
         T get_value(launch::sync_policy, error_code& ec = throws) const

--- a/hpx/runtime/components/binpacking_distribution_policy.hpp
+++ b/hpx/runtime/components/binpacking_distribution_policy.hpp
@@ -21,6 +21,7 @@
 #include <hpx/runtime/serialization/vector.hpp>
 #include <hpx/traits/is_distribution_policy.hpp>
 #include <hpx/util/assert.hpp>
+#include <hpx/util/bind_back.hpp>
 #include <hpx/util/unwrap.hpp>
 
 #include <algorithm>
@@ -245,10 +246,9 @@ namespace hpx { namespace components
                     get_component_name<Component>(),
                     counter_name_, localities_);
 
-            using hpx::util::placeholders::_1;
-            return values.then(hpx::util::bind(
+            return values.then(hpx::util::bind_back(
                 detail::create_helper<Component>(localities_),
-                _1, std::forward<Ts>(vs)...));
+                std::forward<Ts>(vs)...));
         }
 
         /// \cond NOINTERNAL
@@ -280,11 +280,10 @@ namespace hpx { namespace components
                     get_component_name<Component>(),
                     counter_name_, localities_);
 
-                using hpx::util::placeholders::_1;
                 return values.then(
-                    hpx::util::bind(
+                    hpx::util::bind_back(
                         detail::create_bulk_helper<Component>(localities_),
-                        _1, count, std::forward<Ts>(vs)...));
+                        count, std::forward<Ts>(vs)...));
             }
 
             // handle special cases

--- a/hpx/runtime/components/client_base.hpp
+++ b/hpx/runtime/components/client_base.hpp
@@ -23,6 +23,7 @@
 #include <hpx/traits/is_future.hpp>
 #include <hpx/util/always_void.hpp>
 #include <hpx/util/assert.hpp>
+#include <hpx/util/bind_back.hpp>
 
 #include <boost/intrusive_ptr.hpp>
 
@@ -576,9 +577,8 @@ namespace hpx { namespace components
             typename hpx::traits::detail::shared_state_ptr<void>::type p =
                 lcos::detail::make_continuation<void>(
                     *this, launch::sync,
-                    util::bind(&client_base::register_as_helper,
-                        util::placeholders::_1, symbolic_name, manage_lifetime
-                    ));
+                    util::bind_back(&client_base::register_as_helper,
+                        symbolic_name, manage_lifetime));
             return hpx::traits::future_access<future<void> >::
                 create(std::move(p));
         }

--- a/hpx/runtime/components/server/copy_component.hpp
+++ b/hpx/runtime/components/server/copy_component.hpp
@@ -12,6 +12,7 @@
 #include <hpx/runtime/get_ptr.hpp>
 #include <hpx/runtime/naming/name.hpp>
 #include <hpx/traits/get_remote_result.hpp>
+#include <hpx/util/bind_back.hpp>
 
 #include <memory>
 
@@ -77,8 +78,8 @@ namespace hpx { namespace components { namespace server
     {
         future<std::shared_ptr<Component> > f =
             get_ptr<Component>(to_copy);
-        return f.then(util::bind(&detail::copy_component_postproc<Component>,
-            util::placeholders::_1, target_locality));
+        return f.then(util::bind_back(&detail::copy_component_postproc<Component>,
+            target_locality));
     }
 
     template <typename Component>

--- a/hpx/runtime/components/server/locking_hook.hpp
+++ b/hpx/runtime/components/server/locking_hook.hpp
@@ -12,6 +12,7 @@
 #include <hpx/runtime/threads/coroutines/coroutine.hpp>
 #include <hpx/traits/action_decorate_function.hpp>
 #include <hpx/util/bind.hpp>
+#include <hpx/util/bind_front.hpp>
 #include <hpx/util/register_locks.hpp>
 #include <hpx/util/unlock_guard.hpp>
 
@@ -103,8 +104,7 @@ namespace hpx { namespace components
             {
                 // register our yield decorator
                 decorate_wrapper yield_decorator(
-                    util::bind(&locking_hook::yield_function, this,
-                        util::placeholders::_1));
+                    util::bind_front(&locking_hook::yield_function, this));
 
                 result = f(state);
 

--- a/hpx/runtime/components/server/migrate_component.hpp
+++ b/hpx/runtime/components/server/migrate_component.hpp
@@ -14,6 +14,7 @@
 #include <hpx/runtime/naming/name.hpp>
 #include <hpx/traits/component_supports_migration.hpp>
 #include <hpx/traits/is_component.hpp>
+#include <hpx/util/bind_back.hpp>
 
 #include <cstdint>
 #include <memory>
@@ -155,9 +156,9 @@ namespace hpx { namespace components { namespace server
 
             return runtime_support::migrate_component_async<Component>(
                         policy, ptr, to_migrate)
-                .then(util::bind(
+                .then(util::bind_back(
                     &detail::migrate_component_cleanup<Component>,
-                    util::placeholders::_1, ptr, to_migrate));
+                    ptr, to_migrate));
         }
     }
 

--- a/hpx/runtime/get_ptr.hpp
+++ b/hpx/runtime/get_ptr.hpp
@@ -20,7 +20,7 @@
 #include <hpx/throw_exception.hpp>
 #include <hpx/traits/component_type_is_compatible.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/bind.hpp>
+#include <hpx/util/bind_back.hpp>
 
 #include <memory>
 
@@ -151,11 +151,9 @@ namespace hpx
     hpx::future<std::shared_ptr<Component> >
     get_ptr(naming::id_type const& id)
     {
-        using util::placeholders::_1;
         hpx::future<naming::address> f = agas::resolve(id);
-        return f.then(util::bind(
-            &detail::get_ptr_postproc<Component, detail::get_ptr_deleter>,
-            _1, id));
+        return f.then(util::bind_back(
+            &detail::get_ptr_postproc<Component, detail::get_ptr_deleter>, id));
     }
 
     /// \brief Returns a future referring to the pointer to the

--- a/hpx/runtime/parcelset/parcelhandler.hpp
+++ b/hpx/runtime/parcelset/parcelhandler.hpp
@@ -18,7 +18,7 @@
 #include <hpx/runtime/parcelset/parcelport.hpp>
 #include <hpx/runtime_fwd.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/bind.hpp>
+#include <hpx/util/bind_front.hpp>
 #include <hpx/util/high_resolution_timer.hpp>
 #include <hpx/util/logging.hpp>
 #include <hpx/util_fwd.hpp>
@@ -206,10 +206,8 @@ namespace hpx { namespace parcelset
         ///                 id (if not already set).
         HPX_FORCEINLINE void put_parcel(parcel p)
         {
-            using util::placeholders::_1;
-            using util::placeholders::_2;
-            put_parcel(std::move(p), util::bind(
-                &parcelhandler::invoke_write_handler, this, _1, _2));
+            put_parcel(std::move(p), util::bind_front(
+                &parcelhandler::invoke_write_handler, this));
         }
 
         /// A parcel is submitted for transport at the source locality site to
@@ -244,10 +242,8 @@ namespace hpx { namespace parcelset
         ///                 id (if not already set).
         void put_parcels(std::vector<parcel> parcels)
         {
-            using util::placeholders::_1;
-            using util::placeholders::_2;
             std::vector<write_handler_type> handlers(parcels.size(),
-                util::bind(&parcelhandler::invoke_write_handler, this, _1, _2));
+                util::bind_front(&parcelhandler::invoke_write_handler, this));
 
             put_parcels(std::move(parcels), std::move(handlers));
         }

--- a/hpx/runtime/serialization/serialize_buffer.hpp
+++ b/hpx/runtime/serialization/serialize_buffer.hpp
@@ -12,7 +12,7 @@
 #include <hpx/runtime/serialization/serialize.hpp>
 #include <hpx/throw_exception.hpp>
 #include <hpx/traits/supports_streaming_with_any.hpp>
-#include <hpx/util/bind.hpp>
+#include <hpx/util/bind_back.hpp>
 
 #include <boost/shared_array.hpp>
 
@@ -60,10 +60,9 @@ namespace hpx { namespace serialization
           , size_(size)
           , alloc_(alloc)
         {
-            using util::placeholders::_1;
             data_.reset(alloc_.allocate(size),
-                        util::bind(&serialize_buffer::deleter<allocator_type>,
-                                   _1, alloc_, size_));
+                        util::bind_back(&serialize_buffer::deleter<allocator_type>,
+                                   alloc_, size_));
         }
 
         // The default mode is 'copy' which is consistent with the constructor
@@ -75,10 +74,9 @@ namespace hpx { namespace serialization
           , alloc_(alloc)
         {
             if (mode == copy) {
-                using util::placeholders::_1;
                 data_.reset(alloc_.allocate(size),
-                    util::bind(&serialize_buffer::deleter<allocator_type>,
-                        _1, alloc_, size_));
+                    util::bind_back(&serialize_buffer::deleter<allocator_type>,
+                        alloc_, size_));
                 if (size != 0)
                     std::copy(data, data + size, data_.get());
             }
@@ -88,10 +86,9 @@ namespace hpx { namespace serialization
             }
             else {
                 // take ownership
-                using util::placeholders::_1;
                 data_ = boost::shared_array<T>(data,
-                    util::bind(&serialize_buffer::deleter<allocator_type>,
-                        _1, alloc_, size_));
+                    util::bind_back(&serialize_buffer::deleter<allocator_type>,
+                        alloc_, size_));
             }
         }
 
@@ -103,10 +100,9 @@ namespace hpx { namespace serialization
           , alloc_(alloc)
         {
             // if 2 allocators are specified we assume mode 'take'
-            using util::placeholders::_1;
             data_ = boost::shared_array<T>(data,
-                util::bind(&serialize_buffer::deleter<Deallocator>,
-                    _1, dealloc, size_));
+                util::bind_back(&serialize_buffer::deleter<Deallocator>,
+                    dealloc, size_));
         }
 
         template <typename Deleter>
@@ -173,10 +169,9 @@ namespace hpx { namespace serialization
           , alloc_(alloc)
         {
             // create from const data implies 'copy' mode
-            using util::placeholders::_1;
             data_.reset(alloc_.allocate(size),
-                util::bind(&serialize_buffer::deleter<allocator_type>,
-                    _1, alloc_, size_));
+                util::bind_back(&serialize_buffer::deleter<allocator_type>,
+                    alloc_, size_));
             if (size != 0)
                 std::copy(data, data + size, data_.get());
         }
@@ -202,10 +197,9 @@ namespace hpx { namespace serialization
           , alloc_(alloc)
         {
             if (mode == copy) {
-                using util::placeholders::_1;
                 data_.reset(alloc_.allocate(size),
-                    util::bind(&serialize_buffer::deleter<allocator_type>,
-                        _1, alloc_, size_));
+                    util::bind_back(&serialize_buffer::deleter<allocator_type>,
+                        alloc_, size_));
                 if (size != 0)
                     std::copy(data, data + size, data_.get());
             }
@@ -256,11 +250,10 @@ namespace hpx { namespace serialization
         template <typename Archive>
         void load(Archive& ar, const unsigned int version)
         {
-            using util::placeholders::_1;
             ar >> size_ >> alloc_; //-V128
 
             data_.reset(alloc_.allocate(size_),
-                util::bind(&serialize_buffer::deleter<allocator_type>, _1,
+                util::bind_back(&serialize_buffer::deleter<allocator_type>,
                     alloc_, size_));
 
             if (size_ != 0)

--- a/hpx/util/bind_back.hpp
+++ b/hpx/util/bind_back.hpp
@@ -1,0 +1,253 @@
+//  Copyright (c) 2011-2012 Thomas Heller
+//  Copyright (c) 2013-2017 Agustin Berge
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_UTIL_BIND_BACK_HPP
+#define HPX_UTIL_BIND_BACK_HPP
+
+#include <hpx/config.hpp>
+#include <hpx/traits/get_function_address.hpp>
+#include <hpx/traits/get_function_annotation.hpp>
+#include <hpx/util/decay.hpp>
+#include <hpx/util/detail/pack.hpp>
+#include <hpx/util/invoke.hpp>
+#include <hpx/util/result_of.hpp>
+#include <hpx/util/tuple.hpp>
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace util
+{
+    namespace detail
+    {
+        ///////////////////////////////////////////////////////////////////////
+        template <typename F, typename Ts, typename ...Us>
+        struct invoke_bound_back_result;
+
+        template <typename F, typename ...Ts, typename ...Us>
+        struct invoke_bound_back_result<F&, util::tuple<Ts...>&, Us...>
+          : util::invoke_result<F&, Us..., Ts&...>
+        {};
+
+        template <typename F, typename ...Ts, typename ...Us>
+        struct invoke_bound_back_result<F const&, util::tuple<Ts...> const&, Us...>
+          : util::invoke_result<F const&, Us..., Ts const&...>
+        {};
+
+        template <typename F, typename ...Ts, typename ...Us>
+        struct invoke_bound_back_result<F&&, util::tuple<Ts...>&&, Us...>
+          : util::invoke_result<F, Us..., Ts...>
+        {};
+
+        template <typename F, typename ...Ts, typename ...Us>
+        struct invoke_bound_back_result<F const&&, util::tuple<Ts...> const&&, Us...>
+          : util::invoke_result<F const, Us..., Ts const...>
+        {};
+
+        template <typename F, std::size_t ...Is, typename Ts, typename ...Us>
+        HPX_HOST_DEVICE
+        typename invoke_bound_back_result<F&&, Ts&&, Us...>::type
+        bound_back_impl(F&& f, pack_c<std::size_t, Is...>, Ts&& bound,
+            Us&&... unbound)
+        {
+            return util::invoke(std::forward<F>(f),
+                std::forward<Us>(unbound)...,
+                util::get<Is>(std::forward<Ts>(bound))...);
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename T>
+        struct bound_back;
+
+        template <typename F, typename ...Ts>
+        struct bound_back<F(Ts...)>
+        {
+        public:
+            bound_back() {} // needed for serialization
+
+            explicit bound_back(F&& f, Ts&&... vs)
+              : _f(std::forward<F>(f))
+              , _args(std::forward<Ts>(vs)...)
+            {}
+
+#if !defined(__NVCC__) && !defined(__CUDACC__)
+            bound_back(bound_back const&) = default;
+            bound_back(bound_back&&) = default;
+#else
+            HPX_HOST_DEVICE bound_back(bound_back const& other)
+              : _f(other._f)
+              , _args(other._args)
+            {}
+
+            HPX_HOST_DEVICE bound_back(bound_back&& other)
+              : _f(std::move(other._f))
+              , _args(std::move(other._args))
+            {}
+#endif
+
+            bound_back& operator=(bound_back const&) = delete;
+
+            template <typename ...Us>
+            HPX_HOST_DEVICE inline
+            typename invoke_bound_back_result<
+                typename std::decay<F>::type&,
+                util::tuple<typename util::decay_unwrap<Ts>::type...>&,
+                Us...
+            >::type operator()(Us&&... vs) &
+            {
+                return detail::bound_back_impl(_f,
+                    typename detail::make_index_pack<sizeof...(Ts)>::type(),
+                    _args, std::forward<Us>(vs)...);
+            }
+
+            template <typename ...Us>
+            HPX_HOST_DEVICE inline
+            typename invoke_bound_back_result<
+                typename std::decay<F>::type const&,
+                util::tuple<typename util::decay_unwrap<Ts>::type...> const&,
+                Us...
+            >::type operator()(Us&&... vs) const&
+            {
+                return detail::bound_back_impl(_f,
+                    typename detail::make_index_pack<sizeof...(Ts)>::type(),
+                    _args, std::forward<Us>(vs)...);
+            }
+
+            template <typename ...Us>
+            HPX_HOST_DEVICE inline
+            typename invoke_bound_back_result<
+                typename std::decay<F>::type&&,
+                util::tuple<typename util::decay_unwrap<Ts>::type...>&&,
+                Us...
+            >::type operator()(Us&&... vs) &&
+            {
+                return detail::bound_back_impl(std::move(_f),
+                    typename detail::make_index_pack<sizeof...(Ts)>::type(),
+                    std::move(_args), std::forward<Us>(vs)...);
+            }
+
+            template <typename ...Us>
+            HPX_HOST_DEVICE inline
+            typename invoke_bound_back_result<
+                typename std::decay<F>::type const&&,
+                util::tuple<typename util::decay_unwrap<Ts>::type...> const&&,
+                Us...
+            >::type operator()(Us&&... vs) const&&
+            {
+                return detail::bound_back_impl(std::move(_f),
+                    typename detail::make_index_pack<sizeof...(Ts)>::type(),
+                    std::move(_args), std::forward<Us>(vs)...);
+            }
+
+            template <typename Archive>
+            void serialize(Archive& ar, unsigned int const /*version*/)
+            {
+                ar & _f;
+                ar & _args;
+            }
+
+            std::size_t get_function_address() const
+            {
+                return traits::get_function_address<
+                        typename std::decay<F>::type
+                    >::call(_f);
+            }
+
+            char const* get_function_annotation() const
+            {
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+                return traits::get_function_annotation<
+                        typename std::decay<F>::type
+                    >::call(_f);
+#else
+                return nullptr;
+#endif
+            }
+
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+            util::itt::string_handle get_function_annotation_itt() const
+            {
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+                return traits::get_function_annotation_itt<
+                        typename std::decay<F>::type
+                    >::call(_f);
+#else
+                static util::itt::string_handle sh("bound_back");
+                return sh;
+#endif
+            }
+#endif
+
+        private:
+            typename std::decay<F>::type _f;
+            util::tuple<typename util::decay_unwrap<Ts>::type...> _args;
+        };
+    }
+
+    template <typename F, typename ...Ts>
+    detail::bound_back<F(Ts&&...)>
+    bind_back(F&& f, Ts&&... vs) {
+        return detail::bound_back<F(Ts&&...)>(
+            std::forward<F>(f), std::forward<Ts>(vs)...);
+    }
+}}
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace traits
+{
+    ///////////////////////////////////////////////////////////////////////////
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+    template <typename Sig>
+    struct get_function_address<util::detail::bound_back<Sig> >
+    {
+        static std::size_t
+            call(util::detail::bound_back<Sig> const& f) noexcept
+        {
+            return f.get_function_address();
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Sig>
+    struct get_function_annotation<util::detail::bound_back<Sig> >
+    {
+        static char const*
+            call(util::detail::bound_back<Sig> const& f) noexcept
+        {
+            return f.get_function_annotation();
+        }
+    };
+
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+    template <typename Sig>
+    struct get_function_annotation_itt<util::detail::bound_back<Sig> >
+    {
+        static util::itt::string_handle
+            call(util::detail::bound_back<Sig> const& f) noexcept
+        {
+            return f.get_function_annotation_itt();
+        }
+    };
+#endif
+#endif
+}}
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace serialization
+{
+    // serialization of the bound_back object
+    template <typename Archive, typename T>
+    void serialize(
+        Archive& ar
+      , ::hpx::util::detail::bound_back<T>& bound
+      , unsigned int const version = 0)
+    {
+        bound.serialize(ar, version);
+    }
+}}
+
+#endif

--- a/hpx/util/bind_back.hpp
+++ b/hpx/util/bind_back.hpp
@@ -24,6 +24,9 @@ namespace hpx { namespace util
 {
     namespace detail
     {
+        template <typename F>
+        class one_shot_wrapper;
+
         ///////////////////////////////////////////////////////////////////////
         template <typename F, typename Ts, typename ...Us>
         struct invoke_bound_back_result;
@@ -46,6 +49,17 @@ namespace hpx { namespace util
         template <typename F, typename ...Ts, typename ...Us>
         struct invoke_bound_back_result<F const&&, util::tuple<Ts...> const&&, Us...>
           : util::invoke_result<F const, Us..., Ts const...>
+        {};
+
+        // one-shot wrapper is not const callable
+        template <typename F, typename ...Ts, typename ...Us>
+        struct invoke_bound_back_result<
+            one_shot_wrapper<F> const&, util::tuple<Ts...> const&, Us...>
+        {};
+
+        template <typename F, typename ...Ts, typename ...Us>
+        struct invoke_bound_back_result<
+            one_shot_wrapper<F> const&&, util::tuple<Ts...> const&&, Us...>
         {};
 
         template <typename F, std::size_t ...Is, typename Ts, typename ...Us>

--- a/hpx/util/bind_front.hpp
+++ b/hpx/util/bind_front.hpp
@@ -1,0 +1,253 @@
+//  Copyright (c) 2011-2012 Thomas Heller
+//  Copyright (c) 2013-2017 Agustin Berge
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_UTIL_BIND_FRONT_HPP
+#define HPX_UTIL_BIND_FRONT_HPP
+
+#include <hpx/config.hpp>
+#include <hpx/traits/get_function_address.hpp>
+#include <hpx/traits/get_function_annotation.hpp>
+#include <hpx/util/decay.hpp>
+#include <hpx/util/detail/pack.hpp>
+#include <hpx/util/invoke.hpp>
+#include <hpx/util/result_of.hpp>
+#include <hpx/util/tuple.hpp>
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace util
+{
+    namespace detail
+    {
+        ///////////////////////////////////////////////////////////////////////
+        template <typename F, typename Ts, typename ...Us>
+        struct invoke_bound_front_result;
+
+        template <typename F, typename ...Ts, typename ...Us>
+        struct invoke_bound_front_result<F&, util::tuple<Ts...>&, Us...>
+          : util::invoke_result<F&, Ts&..., Us...>
+        {};
+
+        template <typename F, typename ...Ts, typename ...Us>
+        struct invoke_bound_front_result<F const&, util::tuple<Ts...> const&, Us...>
+          : util::invoke_result<F const&, Ts const&..., Us...>
+        {};
+
+        template <typename F, typename ...Ts, typename ...Us>
+        struct invoke_bound_front_result<F&&, util::tuple<Ts...>&&, Us...>
+          : util::invoke_result<F, Ts..., Us...>
+        {};
+
+        template <typename F, typename ...Ts, typename ...Us>
+        struct invoke_bound_front_result<F const&&, util::tuple<Ts...> const&&, Us...>
+          : util::invoke_result<F const, Ts const..., Us...>
+        {};
+
+        template <typename F, std::size_t ...Is, typename Ts, typename ...Us>
+        HPX_HOST_DEVICE
+        typename invoke_bound_front_result<F&&, Ts&&, Us...>::type
+        bound_front_impl(F&& f, pack_c<std::size_t, Is...>, Ts&& bound,
+            Us&&... unbound)
+        {
+            return util::invoke(std::forward<F>(f),
+                util::get<Is>(std::forward<Ts>(bound))...,
+                std::forward<Us>(unbound)...);
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename T>
+        struct bound_front;
+
+        template <typename F, typename ...Ts>
+        struct bound_front<F(Ts...)>
+        {
+        public:
+            bound_front() {} // needed for serialization
+
+            explicit bound_front(F&& f, Ts&&... vs)
+              : _f(std::forward<F>(f))
+              , _args(std::forward<Ts>(vs)...)
+            {}
+
+#if !defined(__NVCC__) && !defined(__CUDACC__)
+            bound_front(bound_front const&) = default;
+            bound_front(bound_front&&) = default;
+#else
+            HPX_HOST_DEVICE bound_front(bound_front const& other)
+              : _f(other._f)
+              , _args(other._args)
+            {}
+
+            HPX_HOST_DEVICE bound_front(bound_front&& other)
+              : _f(std::move(other._f))
+              , _args(std::move(other._args))
+            {}
+#endif
+
+            bound_front& operator=(bound_front const&) = delete;
+
+            template <typename ...Us>
+            HPX_HOST_DEVICE inline
+            typename invoke_bound_front_result<
+                typename std::decay<F>::type&,
+                util::tuple<typename util::decay_unwrap<Ts>::type...>&,
+                Us...
+            >::type operator()(Us&&... vs) &
+            {
+                return detail::bound_front_impl(_f,
+                    typename detail::make_index_pack<sizeof...(Ts)>::type(),
+                    _args, std::forward<Us>(vs)...);
+            }
+
+            template <typename ...Us>
+            HPX_HOST_DEVICE inline
+            typename invoke_bound_front_result<
+                typename std::decay<F>::type const&,
+                util::tuple<typename util::decay_unwrap<Ts>::type...> const&,
+                Us...
+            >::type operator()(Us&&... vs) const&
+            {
+                return detail::bound_front_impl(_f,
+                    typename detail::make_index_pack<sizeof...(Ts)>::type(),
+                    _args, std::forward<Us>(vs)...);
+            }
+
+            template <typename ...Us>
+            HPX_HOST_DEVICE inline
+            typename invoke_bound_front_result<
+                typename std::decay<F>::type&&,
+                util::tuple<typename util::decay_unwrap<Ts>::type...>&&,
+                Us...
+            >::type operator()(Us&&... vs) &&
+            {
+                return detail::bound_front_impl(std::move(_f),
+                    typename detail::make_index_pack<sizeof...(Ts)>::type(),
+                    std::move(_args), std::forward<Us>(vs)...);
+            }
+
+            template <typename ...Us>
+            HPX_HOST_DEVICE inline
+            typename invoke_bound_front_result<
+                typename std::decay<F>::type const&&,
+                util::tuple<typename util::decay_unwrap<Ts>::type...> const&&,
+                Us...
+            >::type operator()(Us&&... vs) const&&
+            {
+                return detail::bound_front_impl(std::move(_f),
+                    typename detail::make_index_pack<sizeof...(Ts)>::type(),
+                    std::move(_args), std::forward<Us>(vs)...);
+            }
+
+            template <typename Archive>
+            void serialize(Archive& ar, unsigned int const /*version*/)
+            {
+                ar & _f;
+                ar & _args;
+            }
+
+            std::size_t get_function_address() const
+            {
+                return traits::get_function_address<
+                        typename std::decay<F>::type
+                    >::call(_f);
+            }
+
+            char const* get_function_annotation() const
+            {
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+                return traits::get_function_annotation<
+                        typename std::decay<F>::type
+                    >::call(_f);
+#else
+                return nullptr;
+#endif
+            }
+
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+            util::itt::string_handle get_function_annotation_itt() const
+            {
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+                return traits::get_function_annotation_itt<
+                        typename std::decay<F>::type
+                    >::call(_f);
+#else
+                static util::itt::string_handle sh("bound_front");
+                return sh;
+#endif
+            }
+#endif
+
+        private:
+            typename std::decay<F>::type _f;
+            util::tuple<typename util::decay_unwrap<Ts>::type...> _args;
+        };
+    }
+
+    template <typename F, typename ...Ts>
+    detail::bound_front<F(Ts&&...)>
+    bind_front(F&& f, Ts&&... vs) {
+        return detail::bound_front<F(Ts&&...)>(
+            std::forward<F>(f), std::forward<Ts>(vs)...);
+    }
+}}
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace traits
+{
+    ///////////////////////////////////////////////////////////////////////////
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+    template <typename Sig>
+    struct get_function_address<util::detail::bound_front<Sig> >
+    {
+        static std::size_t
+            call(util::detail::bound_front<Sig> const& f) noexcept
+        {
+            return f.get_function_address();
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Sig>
+    struct get_function_annotation<util::detail::bound_front<Sig> >
+    {
+        static char const*
+            call(util::detail::bound_front<Sig> const& f) noexcept
+        {
+            return f.get_function_annotation();
+        }
+    };
+
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+    template <typename Sig>
+    struct get_function_annotation_itt<util::detail::bound_front<Sig> >
+    {
+        static util::itt::string_handle
+            call(util::detail::bound_front<Sig> const& f) noexcept
+        {
+            return f.get_function_annotation_itt();
+        }
+    };
+#endif
+#endif
+}}
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace serialization
+{
+    // serialization of the bound_front object
+    template <typename Archive, typename T>
+    void serialize(
+        Archive& ar
+      , ::hpx::util::detail::bound_front<T>& bound
+      , unsigned int const version = 0)
+    {
+        bound.serialize(ar, version);
+    }
+}}
+
+#endif

--- a/hpx/util/bind_front.hpp
+++ b/hpx/util/bind_front.hpp
@@ -24,6 +24,9 @@ namespace hpx { namespace util
 {
     namespace detail
     {
+        template <typename F>
+        class one_shot_wrapper;
+
         ///////////////////////////////////////////////////////////////////////
         template <typename F, typename Ts, typename ...Us>
         struct invoke_bound_front_result;
@@ -46,6 +49,17 @@ namespace hpx { namespace util
         template <typename F, typename ...Ts, typename ...Us>
         struct invoke_bound_front_result<F const&&, util::tuple<Ts...> const&&, Us...>
           : util::invoke_result<F const, Ts const..., Us...>
+        {};
+
+        // one-shot wrapper is not const callable
+        template <typename F, typename ...Ts, typename ...Us>
+        struct invoke_bound_front_result<
+            one_shot_wrapper<F> const&, util::tuple<Ts...> const&, Us...>
+        {};
+
+        template <typename F, typename ...Ts, typename ...Us>
+        struct invoke_bound_front_result<
+            one_shot_wrapper<F> const&&, util::tuple<Ts...> const&&, Us...>
         {};
 
         template <typename F, std::size_t ...Is, typename Ts, typename ...Us>

--- a/hpx/util/deferred_call.hpp
+++ b/hpx/util/deferred_call.hpp
@@ -94,6 +94,7 @@ namespace hpx { namespace util
             {}
 #endif
 
+            deferred(deferred const&) = delete;
             deferred& operator=(deferred const&) = delete;
 
             HPX_HOST_DEVICE HPX_FORCEINLINE

--- a/plugins/parcel/coalescing/coalescing_message_handler.cpp
+++ b/plugins/parcel/coalescing/coalescing_message_handler.cpp
@@ -14,6 +14,8 @@
 #include <hpx/util/get_and_reset_value.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/bind.hpp>
+#include <hpx/util/bind_back.hpp>
+#include <hpx/util/bind_front.hpp>
 
 #include <hpx/plugins/message_handler_factory.hpp>
 #include <hpx/plugins/parcel/coalescing_message_handler.hpp>
@@ -107,8 +109,8 @@ namespace hpx { namespace plugins { namespace parcel
         interval_(detail::get_interval(interval)),
         buffer_(num_coalesced_parcels_),
         timer_(
-            util::bind(&coalescing_message_handler::timer_flush, this_()),
-            util::bind(&coalescing_message_handler::flush_terminate, this_()),
+            util::bind_back(&coalescing_message_handler::timer_flush, this_()),
+            util::bind_back(&coalescing_message_handler::flush_terminate, this_()),
             std::string(action_name) + "_timer"),
         stopped_(false),
         allow_background_flush_(detail::get_background_flush()),
@@ -125,19 +127,15 @@ namespace hpx { namespace plugins { namespace parcel
         histogram_num_buckets_(-1)
     {
         // register performance counter functions
-        using util::placeholders::_1;
-        using util::placeholders::_2;
-        using util::placeholders::_3;
-        using util::placeholders::_4;
         coalescing_counter_registry::instance().register_action(action_name,
-            util::bind(&coalescing_message_handler::get_parcels_count, this, _1),
-            util::bind(&coalescing_message_handler::get_messages_count, this, _1),
-            util::bind(&coalescing_message_handler::
-                get_parcels_per_message_count, this, _1),
-            util::bind(&coalescing_message_handler::
-                get_average_time_between_parcels, this, _1),
-            util::bind(&coalescing_message_handler::
-                get_time_between_parcels_histogram_creator, this, _1, _2, _3, _4));
+            util::bind_front(&coalescing_message_handler::get_parcels_count, this),
+            util::bind_front(&coalescing_message_handler::get_messages_count, this),
+            util::bind_front(&coalescing_message_handler::
+                get_parcels_per_message_count, this),
+            util::bind_front(&coalescing_message_handler::
+                get_average_time_between_parcels, this),
+            util::bind_front(&coalescing_message_handler::
+                get_time_between_parcels_histogram_creator, this));
 
         // register parameter update callbacks
         set_config_entry_callback(
@@ -406,8 +404,8 @@ namespace hpx { namespace plugins { namespace parcel
         std::lock_guard<mutex_type> l(mtx_);
         if (time_between_parcels_)
         {
-            result = util::bind(&coalescing_message_handler::
-                get_time_between_parcels_histogram, this, util::placeholders::_1);
+            result = util::bind_front(&coalescing_message_handler::
+                get_time_between_parcels_histogram, this);
             return;
         }
 
@@ -421,8 +419,8 @@ namespace hpx { namespace plugins { namespace parcel
             hpx::util::tag::histogram::max_range = double(max_boundary)));
         last_parcel_time_ = util::high_resolution_clock::now();
 
-        result = util::bind(&coalescing_message_handler::
-            get_time_between_parcels_histogram, this, util::placeholders::_1);
+        result = util::bind_front(&coalescing_message_handler::
+            get_time_between_parcels_histogram, this);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/plugins/parcelport/libfabric/pinned_memory_vector.hpp
+++ b/plugins/parcelport/libfabric/pinned_memory_vector.hpp
@@ -42,7 +42,7 @@ namespace libfabric
 
         typedef pinned_memory_vector<T, Offset, region_type, allocator_type> vector_type;
 
-        typedef std::function<void(void)> deleter_callback;
+        typedef std::function<void()> deleter_callback;
 
         // internal vars
         T                   *m_array_;

--- a/plugins/parcelport/verbs/parcelport_verbs.cpp
+++ b/plugins/parcelport/verbs/parcelport_verbs.cpp
@@ -11,7 +11,9 @@
 #include <hpx/lcos/local/condition_variable.hpp>
 #include <hpx/runtime/threads/thread_data.hpp>
 #include <hpx/util/assert.hpp>
+#include <hpx/util/bind_front.hpp>
 #include <hpx/util/command_line_handling.hpp>
+#include <hpx/util/deferred_call.hpp>
 #include <hpx/util/detail/pp/stringize.hpp>
 #include <hpx/util/format.hpp>
 #include <hpx/util/high_resolution_timer.hpp>
@@ -369,20 +371,19 @@ namespace verbs
             chunk_pool_ = rdma_controller_->get_memory_pool();
 
             LOG_DEBUG_MSG("Setting Connection function");
-            auto connection_function = std::bind(
-                &parcelport::handle_verbs_connection, this, std::placeholders::_1);
+            auto connection_function = hpx::util::bind_front(
+                &parcelport::handle_verbs_connection, this);
             rdma_controller_->setConnectionFunction(connection_function);
 
             LOG_DEBUG_MSG("Setting Completion function");
-            auto completion_function = std::bind(
-                &parcelport::handle_verbs_completion, this,
-                std::placeholders::_1, std::placeholders::_2);
+            auto completion_function = hpx::util::bind_front(
+                &parcelport::handle_verbs_completion, this);
             rdma_controller_->setCompletionFunction(completion_function);
 
             if (HPX_PARCELPORT_VERBS_HAVE_BOOTSTRAPPING() && bootstrap_enabled_) {
                 for (std::size_t i=0; i!=io_service_pool_.size(); ++i) {
                     io_service_pool_.get_io_service(int(i)).post(
-                        hpx::util::bind(
+                        hpx::util::deferred_call(
                             &parcelport::io_service_work, this
                         )
                     );
@@ -395,7 +396,8 @@ namespace verbs
             //
             hpx::error_code ec(hpx::lightweight);
             parcelport_scheduler.register_thread_nullary(
-                    util::bind(&parcelport::background_work_scheduler_thread, this),
+                    util::deferred_call(
+                        &parcelport::background_work_scheduler_thread, this),
                     "background_work_scheduler_thread",
                     threads::pending, true,
                     threads::thread_priority_high_recursive,
@@ -824,7 +826,8 @@ namespace verbs
             if (piggy_back) {
                 if (parcel_complete) {
                     rcv_data_type wrapped_pointer(piggy_back, h->size(),
-                        util::bind(&parcelport::delete_recv_data, this, current_recv),
+                        util::deferred_call(
+                            &parcelport::delete_recv_data, this, current_recv),
                         chunk_pool_.get(), nullptr);
                     rcv_buffer_type buffer(std::move(wrapped_pointer), chunk_pool_.get());
                     LOG_DEBUG_MSG("calling parcel decode for complete NORMAL parcel");
@@ -1028,7 +1031,8 @@ namespace verbs
                 LOG_DEBUG_MSG("Creating a release buffer callback for tag "
                     << hexuint32(recv_data.tag));
                 rcv_data_type wrapped_pointer(message, message_length,
-                        util::bind(&parcelport::delete_recv_data, this, current_recv),
+                        util::deferred_call(
+                            &parcelport::delete_recv_data, this, current_recv),
                         chunk_pool_.get(), nullptr);
                 rcv_buffer_type buffer(std::move(wrapped_pointer), chunk_pool_.get());
                 LOG_DEBUG_MSG("calling parcel decode for complete ZEROCOPY parcel");
@@ -1047,7 +1051,8 @@ namespace verbs
                 //buffer.data_.resize(static_cast<std::size_t>(h->size()));
                 //buffer.data_size_ = h->size();
                 buffer.chunks_.resize(recv_data.chunks.size());
-                decode_message_with_chunks(*this, std::move(buffer), 0, recv_data.chunks);
+                decode_message_with_chunks(
+                    *this, std::move(buffer), 0, recv_data.chunks);
                 LOG_DEBUG_MSG("parcel decode called for ZEROCOPY complete parcel");
             }
             else {

--- a/plugins/parcelport/verbs/pinned_memory_vector.hpp
+++ b/plugins/parcelport/verbs/pinned_memory_vector.hpp
@@ -38,7 +38,7 @@ namespace verbs
         typedef typename std::vector<T>::size_type size_type;
         typedef Allocator allocator_type;
 
-        typedef std::function<void(void)> deleter_callback;
+        typedef std::function<void()> deleter_callback;
         T *m_array_;
         int m_size_;
         deleter_callback m_cb_;

--- a/src/components/iostreams/standard_streams.cpp
+++ b/src/components/iostreams/standard_streams.cpp
@@ -11,6 +11,7 @@
 #include <hpx/runtime/components/server/component.hpp>
 #include <hpx/runtime/components/server/create_component.hpp>
 #include <hpx/runtime/runtime_fwd.hpp>
+#include <hpx/util/bind_back.hpp>
 
 #include <hpx/components/iostreams/ostream.hpp>
 #include <hpx/components/iostreams/standard_streams.hpp>
@@ -52,7 +53,7 @@ namespace hpx { namespace iostreams { namespace detail
                 naming::id_type::managed);
 
             return agas::register_name(cout_name, cout_id).then(
-                util::bind(&return_id_type, util::placeholders::_1, cout_id));
+                util::bind_back(&return_id_type, cout_id));
         }
 
         // the console locality will create the ostream during startup

--- a/src/performance_counters/server/per_action_data_counters.cpp
+++ b/src/performance_counters/server/per_action_data_counters.cpp
@@ -10,6 +10,7 @@
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/runtime/parcelset/detail/per_action_data_counter_registry.hpp>
 #include <hpx/util/function.hpp>
+#include <hpx/util/bind_front.hpp>
 
 #include <cstdint>
 #include <string>
@@ -76,9 +77,8 @@ namespace hpx { namespace performance_counters
                 if (paths.parameters_.empty()) {
                     // if no parameters (action name) is given assume that this
                     // counter should report the overall value for all actions
-                    using util::placeholders::_1;
                     auto const& f =
-                        util::bind(counter_func, paths.parameters_, _1);
+                        util::bind_front(counter_func, paths.parameters_);
                     return performance_counters::locality_raw_counter_creator(
                         info, f,ec);
                 }

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -31,6 +31,7 @@
 #include <hpx/runtime/find_localities.hpp>
 #include <hpx/runtime/naming/split_gid.hpp>
 #include <hpx/util/bind.hpp>
+#include <hpx/util/bind_back.hpp>
 #include <hpx/util/format.hpp>
 #include <hpx/util/logging.hpp>
 #include <hpx/util/runtime_configuration.hpp>
@@ -1644,10 +1645,9 @@ lcos::future<bool> addressing_service::register_name_async(
     std::int64_t new_credit = naming::detail::get_credit_from_gid(new_gid);
     if (new_credit != 0)
     {
-        using util::placeholders::_1;
-        return f.then(util::bind(
+        return f.then(util::bind_back(
                 util::one_shot(&correct_credit_on_failure),
-                _1, id, std::int64_t(HPX_GLOBALCREDIT_INITIAL), new_credit
+                id, std::int64_t(HPX_GLOBALCREDIT_INITIAL), new_credit
             ));
     }
 
@@ -2218,46 +2218,43 @@ std::uint64_t addressing_service::get_cache_erase_entry_time(bool reset)
 /// Install performance counter types exposing properties from the local cache.
 void addressing_service::register_counter_types()
 { // {{{
-    using util::placeholders::_1;
-    using util::placeholders::_2;
-
     // install
     util::function_nonser<std::int64_t(bool)> cache_entries(
-        util::bind(&addressing_service::get_cache_entries, this, _1));
+        util::bind_front(&addressing_service::get_cache_entries, this));
     util::function_nonser<std::int64_t(bool)> cache_hits(
-        util::bind(&addressing_service::get_cache_hits, this, _1));
+        util::bind_front(&addressing_service::get_cache_hits, this));
     util::function_nonser<std::int64_t(bool)> cache_misses(
-        util::bind(&addressing_service::get_cache_misses, this, _1));
+        util::bind_front(&addressing_service::get_cache_misses, this));
     util::function_nonser<std::int64_t(bool)> cache_evictions(
-        util::bind(&addressing_service::get_cache_evictions, this, _1));
+        util::bind_front(&addressing_service::get_cache_evictions, this));
     util::function_nonser<std::int64_t(bool)> cache_insertions(
-        util::bind(&addressing_service::get_cache_insertions, this, _1));
+        util::bind_front(&addressing_service::get_cache_insertions, this));
 
     util::function_nonser<std::int64_t(bool)> cache_get_entry_count(
-        util::bind(
-            &addressing_service::get_cache_get_entry_count, this, _1));
+        util::bind_front(
+            &addressing_service::get_cache_get_entry_count, this));
     util::function_nonser<std::int64_t(bool)> cache_insertion_count(
-        util::bind(
-            &addressing_service::get_cache_insertion_entry_count, this, _1));
+        util::bind_front(
+            &addressing_service::get_cache_insertion_entry_count, this));
     util::function_nonser<std::int64_t(bool)> cache_update_entry_count(
-        util::bind(
-            &addressing_service::get_cache_update_entry_count, this, _1));
+        util::bind_front(
+            &addressing_service::get_cache_update_entry_count, this));
     util::function_nonser<std::int64_t(bool)> cache_erase_entry_count(
-        util::bind(
-            &addressing_service::get_cache_erase_entry_count, this, _1));
+        util::bind_front(
+            &addressing_service::get_cache_erase_entry_count, this));
 
     util::function_nonser<std::int64_t(bool)> cache_get_entry_time(
-        util::bind(
-            &addressing_service::get_cache_get_entry_time, this, _1));
+        util::bind_front(
+            &addressing_service::get_cache_get_entry_time, this));
     util::function_nonser<std::int64_t(bool)> cache_insertion_time(
-        util::bind(
-            &addressing_service::get_cache_insertion_entry_time, this, _1));
+        util::bind_front(
+            &addressing_service::get_cache_insertion_entry_time, this));
     util::function_nonser<std::int64_t(bool)> cache_update_entry_time(
-        util::bind(
-            &addressing_service::get_cache_update_entry_time, this, _1));
+        util::bind_front(
+            &addressing_service::get_cache_update_entry_time, this));
     util::function_nonser<std::int64_t(bool)> cache_erase_entry_time(
-        util::bind(
-            &addressing_service::get_cache_erase_entry_time, this, _1));
+        util::bind_front(
+            &addressing_service::get_cache_erase_entry_time, this));
 
     performance_counters::generic_counter_type_data const counter_types[] =
     {

--- a/src/runtime/agas/server/component_namespace_server.cpp
+++ b/src/runtime/agas/server/component_namespace_server.cpp
@@ -16,7 +16,8 @@
 #include <hpx/runtime/agas/server/component_namespace.hpp>
 #include <hpx/runtime/naming/resolver_client.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/bind.hpp>
+#include <hpx/util/bind_back.hpp>
+#include <hpx/util/bind_front.hpp>
 #include <hpx/util/format.hpp>
 #include <hpx/util/get_and_reset_value.hpp>
 #include <hpx/util/insert_checked.hpp>
@@ -53,10 +54,8 @@ void component_namespace::register_counter_types(
     error_code& ec
     )
 {
-    using hpx::util::placeholders::_1;
-    using hpx::util::placeholders::_2;
     performance_counters::create_counter_func creator(
-        util::bind(&performance_counters::agas_raw_counter_creator, _1, _2
+        util::bind_back(&performance_counters::agas_raw_counter_creator
       , agas::server::component_namespace_service_name));
 
     for (std::size_t i = 0;
@@ -101,10 +100,8 @@ void component_namespace::register_global_counter_types(
     error_code& ec
     )
 {
-    using util::placeholders::_1;
-    using util::placeholders::_2;
     performance_counters::create_counter_func creator(
-        util::bind(&performance_counters::agas_raw_counter_creator, _1, _2
+        util::bind_back(&performance_counters::agas_raw_counter_creator
       , agas::server::component_namespace_service_name));
 
     for (std::size_t i = 0;
@@ -556,42 +553,41 @@ naming::gid_type component_namespace::statistics_counter(
 
     typedef component_namespace::counter_data cd;
 
-    using util::placeholders::_1;
     util::function_nonser<std::int64_t(bool)> get_data_func;
     if (target == detail::counter_target_count)
     {
         switch (code) {
         case component_ns_bind_prefix:
-            get_data_func = util::bind(&cd::get_bind_prefix_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_bind_prefix_count,
+                &counter_data_);
             break;
         case component_ns_bind_name:
-            get_data_func = util::bind(&cd::get_bind_name_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_bind_name_count,
+                &counter_data_);
             break;
         case component_ns_resolve_id:
-            get_data_func = util::bind(&cd::get_resolve_id_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_resolve_id_count,
+                &counter_data_);
             break;
         case component_ns_unbind_name:
-            get_data_func = util::bind(&cd::get_unbind_name_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_unbind_name_count,
+                &counter_data_);
             break;
         case component_ns_iterate_types:
-            get_data_func = util::bind(&cd::get_iterate_types_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_iterate_types_count,
+                &counter_data_);
             break;
         case component_ns_get_component_type_name:
-            get_data_func = util::bind(&cd::get_component_type_name_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_component_type_name_count,
+                &counter_data_);
             break;
         case component_ns_num_localities:
-            get_data_func = util::bind(&cd::get_num_localities_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_num_localities_count,
+                &counter_data_);
             break;
         case component_ns_statistics_counter:
-            get_data_func = util::bind(&cd::get_overall_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_overall_count,
+                &counter_data_);
             break;
         default:
             HPX_THROW_EXCEPTION(bad_parameter
@@ -604,32 +600,36 @@ naming::gid_type component_namespace::statistics_counter(
         HPX_ASSERT(detail::counter_target_time == target);
         switch (code) {
         case component_ns_bind_prefix:
-            get_data_func = util::bind(&cd::get_bind_prefix_time,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_bind_prefix_time,
+                &counter_data_);
             break;
         case component_ns_bind_name:
-            get_data_func = util::bind(&cd::get_bind_name_time, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_bind_name_time,
+                &counter_data_);
             break;
         case component_ns_resolve_id:
-            get_data_func = util::bind(&cd::get_resolve_id_time, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_resolve_id_time,
+                &counter_data_);
             break;
         case component_ns_unbind_name:
-            get_data_func = util::bind(&cd::get_unbind_name_time, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_unbind_name_time,
+                &counter_data_);
             break;
         case component_ns_iterate_types:
-            get_data_func = util::bind(&cd::get_iterate_types_time,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_iterate_types_time,
+                &counter_data_);
             break;
         case component_ns_get_component_type_name:
-            get_data_func = util::bind(&cd::get_component_type_name_time,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_component_type_name_time,
+                &counter_data_);
             break;
         case component_ns_num_localities:
-            get_data_func = util::bind(&cd::get_num_localities_time,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_num_localities_time,
+                &counter_data_);
             break;
         case component_ns_statistics_counter:
-            get_data_func = util::bind(&cd::get_overall_time, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_overall_time,
+                &counter_data_);
             break;
         default:
             HPX_THROW_EXCEPTION(bad_parameter

--- a/src/runtime/agas/server/locality_namespace_server.cpp
+++ b/src/runtime/agas/server/locality_namespace_server.cpp
@@ -18,7 +18,8 @@
 #include <hpx/runtime/components/component_type.hpp>
 #include <hpx/runtime/serialization/vector.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/bind.hpp>
+#include <hpx/util/bind_back.hpp>
+#include <hpx/util/bind_front.hpp>
 #include <hpx/util/format.hpp>
 #include <hpx/util/get_and_reset_value.hpp>
 #include <hpx/util/insert_checked.hpp>
@@ -43,10 +44,8 @@ void locality_namespace::register_counter_types(
     error_code& ec
     )
 {
-    using util::placeholders::_1;
-    using util::placeholders::_2;
     performance_counters::create_counter_func creator(
-        util::bind(&performance_counters::agas_raw_counter_creator, _1, _2
+        util::bind_back(&performance_counters::agas_raw_counter_creator
       , agas::server::locality_namespace_service_name));
 
     for (std::size_t i = 0;
@@ -91,10 +90,8 @@ void locality_namespace::register_global_counter_types(
     error_code& ec
     )
 {
-    using util::placeholders::_1;
-    using util::placeholders::_2;
     performance_counters::create_counter_func creator(
-        util::bind(&performance_counters::agas_raw_counter_creator, _1, _2
+        util::bind_back(&performance_counters::agas_raw_counter_creator
       , agas::server::locality_namespace_service_name));
 
     for (std::size_t i = 0;
@@ -484,37 +481,37 @@ naming::gid_type locality_namespace::statistics_counter(std::string name)
 
     typedef locality_namespace::counter_data cd;
 
-    using util::placeholders::_1;
     util::function_nonser<std::int64_t(bool)> get_data_func;
     if (target == detail::counter_target_count)
     {
         switch (code) {
         case locality_ns_allocate:
-            get_data_func = util::bind(&cd::get_allocate_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_allocate_count,
+                &counter_data_);
             break;
         case locality_ns_resolve_locality:
-            get_data_func = util::bind(&cd::get_resolve_locality_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_resolve_locality_count,
+                &counter_data_);
             break;
         case locality_ns_free:
-            get_data_func = util::bind(&cd::get_free_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_free_count,
+                &counter_data_);
             break;
         case locality_ns_localities:
-            get_data_func = util::bind(&cd::get_localities_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_localities_count,
+                &counter_data_);
             break;
         case locality_ns_num_localities:
-            get_data_func = util::bind(&cd::get_num_localities_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_num_localities_count,
+                &counter_data_);
             break;
         case locality_ns_num_threads:
-            get_data_func = util::bind(&cd::get_num_threads_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_num_threads_count,
+                &counter_data_);
             break;
         case locality_ns_statistics_counter:
-            get_data_func = util::bind(&cd::get_overall_count, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_overall_count,
+                &counter_data_);
             break;
         default:
             HPX_THROW_EXCEPTION(bad_parameter
@@ -526,29 +523,32 @@ naming::gid_type locality_namespace::statistics_counter(std::string name)
         HPX_ASSERT(detail::counter_target_time == target);
         switch (code) {
         case locality_ns_allocate:
-            get_data_func = util::bind(&cd::get_allocate_time,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_allocate_time,
+                &counter_data_);
             break;
         case locality_ns_resolve_locality:
-            get_data_func = util::bind(&cd::get_resolve_locality_time,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_resolve_locality_time,
+                &counter_data_);
             break;
         case locality_ns_free:
-            get_data_func = util::bind(&cd::get_free_time, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_free_time,
+                &counter_data_);
             break;
         case locality_ns_localities:
-            get_data_func = util::bind(&cd::get_localities_time,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_localities_time,
+                &counter_data_);
             break;
         case locality_ns_num_localities:
-            get_data_func = util::bind(&cd::get_num_localities_time,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_num_localities_time,
+                &counter_data_);
             break;
         case locality_ns_num_threads:
-            get_data_func = util::bind(&cd::get_num_threads_time, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_num_threads_time,
+                &counter_data_);
             break;
         case locality_ns_statistics_counter:
-            get_data_func = util::bind(&cd::get_overall_time, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_overall_time,
+                &counter_data_);
             break;
         default:
             HPX_THROW_EXCEPTION(bad_parameter

--- a/src/runtime/agas/server/primary_namespace_server.cpp
+++ b/src/runtime/agas/server/primary_namespace_server.cpp
@@ -22,7 +22,8 @@
 #include <hpx/runtime/components/server/destroy_component.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/assert_owns_lock.hpp>
-#include <hpx/util/bind.hpp>
+#include <hpx/util/bind_back.hpp>
+#include <hpx/util/bind_front.hpp>
 #include <hpx/util/format.hpp>
 #include <hpx/util/get_and_reset_value.hpp>
 #include <hpx/util/insert_checked.hpp>
@@ -65,10 +66,8 @@ void primary_namespace::register_counter_types(
     error_code& ec
     )
 {
-    using util::placeholders::_1;
-    using util::placeholders::_2;
     performance_counters::create_counter_func creator(
-        util::bind(&performance_counters::agas_raw_counter_creator, _1, _2
+        util::bind_back(&performance_counters::agas_raw_counter_creator
       , agas::server::primary_namespace_service_name));
 
     for (std::size_t i = 0;
@@ -112,10 +111,8 @@ void primary_namespace::register_global_counter_types(
     error_code& ec
     )
 {
-    using util::placeholders::_1;
-    using util::placeholders::_2;
     performance_counters::create_counter_func creator(
-        util::bind(&performance_counters::agas_raw_counter_creator, _1, _2
+        util::bind_back(&performance_counters::agas_raw_counter_creator
       , agas::server::primary_namespace_service_name));
 
     for (std::size_t i = 0;
@@ -1224,48 +1221,49 @@ naming::gid_type primary_namespace::statistics_counter(std::string const& name)
 
     typedef primary_namespace::counter_data cd;
 
-    using util::placeholders::_1;
     util::function_nonser<std::int64_t(bool)> get_data_func;
     if (target == detail::counter_target_count)
     {
         switch (code) {
         case primary_ns_route:
-            get_data_func = util::bind(&cd::get_route_count, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_route_count,
+                &counter_data_);
             break;
         case primary_ns_bind_gid:
-            get_data_func = util::bind(&cd::get_bind_gid_count, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_bind_gid_count,
+                &counter_data_);
             break;
         case primary_ns_resolve_gid:
-            get_data_func = util::bind(&cd::get_resolve_gid_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_resolve_gid_count,
+                &counter_data_);
             break;
         case primary_ns_unbind_gid:
-            get_data_func = util::bind(&cd::get_unbind_gid_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_unbind_gid_count,
+                &counter_data_);
             break;
         case primary_ns_increment_credit:
-            get_data_func = util::bind(&cd::get_increment_credit_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_increment_credit_count,
+                &counter_data_);
             break;
         case primary_ns_decrement_credit:
-            get_data_func = util::bind(&cd::get_decrement_credit_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_decrement_credit_count,
+                &counter_data_);
             break;
         case primary_ns_allocate:
-            get_data_func = util::bind(&cd::get_allocate_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_allocate_count,
+                &counter_data_);
             break;
         case primary_ns_begin_migration:
-            get_data_func = util::bind(&cd::get_begin_migration_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_begin_migration_count,
+                &counter_data_);
             break;
         case primary_ns_end_migration:
-            get_data_func = util::bind(&cd::get_end_migration_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_end_migration_count,
+                &counter_data_);
             break;
         case primary_ns_statistics_counter:
-            get_data_func = util::bind(&cd::get_overall_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_overall_count,
+                &counter_data_);
             break;
         default:
             HPX_THROW_EXCEPTION(bad_parameter
@@ -1277,39 +1275,44 @@ naming::gid_type primary_namespace::statistics_counter(std::string const& name)
         HPX_ASSERT(detail::counter_target_time == target);
         switch (code) {
         case primary_ns_route:
-            get_data_func = util::bind(&cd::get_route_time, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_route_time,
+                &counter_data_);
             break;
         case primary_ns_bind_gid:
-            get_data_func = util::bind(&cd::get_bind_gid_time, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_bind_gid_time,
+                &counter_data_);
             break;
         case primary_ns_resolve_gid:
-            get_data_func = util::bind(&cd::get_resolve_gid_time, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_resolve_gid_time,
+                &counter_data_);
             break;
         case primary_ns_unbind_gid:
-            get_data_func = util::bind(&cd::get_unbind_gid_time, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_unbind_gid_time,
+                &counter_data_);
             break;
         case primary_ns_increment_credit:
-            get_data_func = util::bind(&cd::get_increment_credit_time,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_increment_credit_time,
+                &counter_data_);
             break;
         case primary_ns_decrement_credit:
-            get_data_func = util::bind(&cd::get_decrement_credit_time,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_decrement_credit_time,
+                &counter_data_);
             break;
         case primary_ns_allocate:
-            get_data_func = util::bind(&cd::get_allocate_time, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_allocate_time,
+                &counter_data_);
             break;
         case primary_ns_begin_migration:
-            get_data_func = util::bind(&cd::get_begin_migration_time,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_begin_migration_time,
+                &counter_data_);
             break;
         case primary_ns_end_migration:
-            get_data_func = util::bind(&cd::get_end_migration_time,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_end_migration_time,
+                &counter_data_);
             break;
         case primary_ns_statistics_counter:
-            get_data_func = util::bind(&cd::get_overall_time,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_overall_time,
+                &counter_data_);
             break;
         default:
             HPX_THROW_EXCEPTION(bad_parameter

--- a/src/runtime/agas/server/symbol_namespace_server.cpp
+++ b/src/runtime/agas/server/symbol_namespace_server.cpp
@@ -18,7 +18,8 @@
 #include <hpx/runtime/agas/namespace_action_code.hpp>
 #include <hpx/runtime/agas/server/symbol_namespace.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/bind.hpp>
+#include <hpx/util/bind_back.hpp>
+#include <hpx/util/bind_front.hpp>
 #include <hpx/util/format.hpp>
 #include <hpx/util/get_and_reset_value.hpp>
 #include <hpx/util/insert_checked.hpp>
@@ -56,10 +57,8 @@ void symbol_namespace::register_counter_types(
     error_code& ec
     )
 {
-    using util::placeholders::_1;
-    using util::placeholders::_2;
     performance_counters::create_counter_func creator(
-        util::bind(&performance_counters::agas_raw_counter_creator, _1, _2
+        util::bind_back(&performance_counters::agas_raw_counter_creator
       , agas::server::symbol_namespace_service_name));
 
     for (std::size_t i = 0;
@@ -106,7 +105,7 @@ void symbol_namespace::register_global_counter_types(
     using util::placeholders::_1;
     using util::placeholders::_2;
     performance_counters::create_counter_func creator(
-        util::bind(&performance_counters::agas_raw_counter_creator, _1, _2
+        util::bind_back(&performance_counters::agas_raw_counter_creator
       , agas::server::symbol_namespace_service_name));
 
     for (std::size_t i = 0;
@@ -485,29 +484,33 @@ naming::gid_type symbol_namespace::statistics_counter(std::string const& name)
 
     typedef symbol_namespace::counter_data cd;
 
-    using util::placeholders::_1;
     util::function_nonser<std::int64_t(bool)> get_data_func;
     if (target == detail::counter_target_count)
     {
         switch (code) {
         case symbol_ns_bind:
-            get_data_func = util::bind(&cd::get_bind_count, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_bind_count,
+                &counter_data_);
             break;
         case symbol_ns_resolve:
-            get_data_func = util::bind(&cd::get_resolve_count, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_resolve_count,
+                &counter_data_);
             break;
         case symbol_ns_unbind:
-            get_data_func = util::bind(&cd::get_unbind_count, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_unbind_count,
+                &counter_data_);
             break;
         case symbol_ns_iterate_names:
-            get_data_func = util::bind(&cd::get_iterate_names_count,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_iterate_names_count,
+                &counter_data_);
             break;
         case symbol_ns_on_event:
-            get_data_func = util::bind(&cd::get_on_event_count, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_on_event_count,
+                &counter_data_);
             break;
         case symbol_ns_statistics_counter:
-            get_data_func = util::bind(&cd::get_overall_count, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_overall_count,
+                &counter_data_);
             break;
         default:
             HPX_THROW_EXCEPTION(bad_parameter
@@ -519,23 +522,28 @@ naming::gid_type symbol_namespace::statistics_counter(std::string const& name)
         HPX_ASSERT(detail::counter_target_time == target);
         switch (code) {
         case symbol_ns_bind:
-            get_data_func = util::bind(&cd::get_bind_time, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_bind_time,
+                &counter_data_);
             break;
         case symbol_ns_resolve:
-            get_data_func = util::bind(&cd::get_resolve_time, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_resolve_time,
+                &counter_data_);
             break;
         case symbol_ns_unbind:
-            get_data_func = util::bind(&cd::get_unbind_time, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_unbind_time,
+                &counter_data_);
             break;
         case symbol_ns_iterate_names:
-            get_data_func = util::bind(&cd::get_iterate_names_time,
-                &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_iterate_names_time,
+                &counter_data_);
             break;
         case symbol_ns_on_event:
-            get_data_func = util::bind(&cd::get_on_event_time, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_on_event_time,
+                &counter_data_);
             break;
         case symbol_ns_statistics_counter:
-            get_data_func = util::bind(&cd::get_overall_time, &counter_data_, _1);
+            get_data_func = util::bind_front(&cd::get_overall_time,
+                &counter_data_);
             break;
         default:
             HPX_THROW_EXCEPTION(bad_parameter

--- a/src/runtime/parcelset/detail/per_action_data_counter_registry.cpp
+++ b/src/runtime/parcelset/detail/per_action_data_counter_registry.cpp
@@ -10,6 +10,7 @@
 #include <hpx/runtime/parcelset/detail/per_action_data_counter_registry.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/registry.hpp>
+#include <hpx/util/bind_front.hpp>
 #include <hpx/util/format.hpp>
 
 #include <cstdint>
@@ -58,7 +59,7 @@ namespace hpx { namespace parcelset { namespace detail
                 "unknown action type");
             return nullptr;
         }
-        return util::bind(f, name, util::placeholders::_1);
+        return util::bind_front(f, name);
     }
 
     bool per_action_data_counter_registry::counter_discoverer(

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -28,6 +28,7 @@
 #include <hpx/util/apex.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/bind.hpp>
+#include <hpx/util/bind_front.hpp>
 #include <hpx/util/deferred_call.hpp>
 #include <hpx/util/detail/pp/stringize.hpp>
 #include <hpx/util/format.hpp>
@@ -202,7 +203,6 @@ namespace hpx { namespace parcelset
 
     void parcelhandler::attach_parcelport(std::shared_ptr<parcelport> const& pp)
     {
-        using util::placeholders::_1;
 #if defined(HPX_HAVE_NETWORKING)
 
         if(!pp) return;
@@ -485,10 +485,8 @@ namespace hpx { namespace parcelset
         }
 #endif
 
-        using util::placeholders::_1;
-        using util::placeholders::_2;
         write_handler_type wrapped_f =
-            util::bind(&detail::parcel_sent_handler, std::move(f), _1, _2);
+            util::bind_front(&detail::parcel_sent_handler, std::move(f));
 
         // If we were able to resolve the address(es) locally we send the
         // parcel directly to the destination.
@@ -616,10 +614,8 @@ namespace hpx { namespace parcelset
                     p.destination(), addr);
             }
 
-            using util::placeholders::_1;
-            using util::placeholders::_2;
-            write_handler_type f = util::bind(&detail::parcel_sent_handler,
-                std::move(handlers[i]), _1, _2);
+            write_handler_type f = util::bind_front(&detail::parcel_sent_handler,
+                std::move(handlers[i]));
 
             // If we were able to resolve the address(es) locally we would send
             // the parcel directly to the destination.
@@ -1053,11 +1049,11 @@ namespace hpx { namespace parcelset
 
         // register common counters
         util::function_nonser<std::int64_t(bool)> incoming_queue_length(
-            util::bind(&parcelhandler::get_incoming_queue_length, this, _1));
+            util::bind_front(&parcelhandler::get_incoming_queue_length, this));
         util::function_nonser<std::int64_t(bool)> outgoing_queue_length(
-            util::bind(&parcelhandler::get_outgoing_queue_length, this, _1));
+            util::bind_front(&parcelhandler::get_outgoing_queue_length, this));
         util::function_nonser<std::int64_t(bool)> outgoing_routed_count(
-            util::bind(&parcelhandler::get_parcel_routed_count, this, _1));
+            util::bind_front(&parcelhandler::get_parcel_routed_count, this));
 
         performance_counters::generic_counter_type_data const counter_types[] =
         {
@@ -1104,101 +1100,89 @@ namespace hpx { namespace parcelset
 
 #if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
         util::function_nonser<std::int64_t(std::string const&, bool)>
-            num_parcel_sends(util::bind(
+            num_parcel_sends(util::bind_front(
                 &parcelhandler::get_action_parcel_send_count, this,
-                pp_type, _1, _2
-            ));
+                pp_type));
         util::function_nonser<std::int64_t(std::string const&, bool)>
-            num_parcel_receives(util::bind(
+            num_parcel_receives(util::bind_front(
                 &parcelhandler::get_action_parcel_receive_count, this,
-                pp_type, _1, _2
-            ));
+                pp_type));
 #else
         util::function_nonser<std::int64_t(bool)>
-            num_parcel_sends(util::bind(
+            num_parcel_sends(util::bind_front(
                 &parcelhandler::get_parcel_send_count, this,
-                pp_type, _1
-            ));
+                pp_type));
         util::function_nonser<std::int64_t(bool)>
-            num_parcel_receives(util::bind(
+            num_parcel_receives(util::bind_front(
                 &parcelhandler::get_parcel_receive_count, this,
-                pp_type, _1
-            ));
+                pp_type));
 #endif
 
         util::function_nonser<std::int64_t(bool)> num_message_sends(
-            util::bind(&parcelhandler::get_message_send_count, this,
-                pp_type, _1));
+            util::bind_front(&parcelhandler::get_message_send_count, this,
+                pp_type));
         util::function_nonser<std::int64_t(bool)> num_message_receives(
-            util::bind(&parcelhandler::get_message_receive_count, this,
-                pp_type, _1));
+            util::bind_front(&parcelhandler::get_message_receive_count, this,
+                pp_type));
 
         util::function_nonser<std::int64_t(bool)> sending_time(
-            util::bind(&parcelhandler::get_sending_time, this,
-                pp_type, _1));
+            util::bind_front(&parcelhandler::get_sending_time, this,
+                pp_type));
         util::function_nonser<std::int64_t(bool)> receiving_time(
-            util::bind(&parcelhandler::get_receiving_time, this,
-                pp_type, _1));
+            util::bind_front(&parcelhandler::get_receiving_time, this,
+                pp_type));
 
 #if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
         util::function_nonser<std::int64_t(std::string const&, bool)>
-            sending_serialization_time(util::bind(
+            sending_serialization_time(util::bind_front(
                 &parcelhandler::get_action_sending_serialization_time, this,
-                pp_type, _1, _2
-            ));
+                pp_type));
         util::function_nonser<std::int64_t(std::string const&, bool)>
-            receiving_serialization_time(util::bind(
+            receiving_serialization_time(util::bind_front(
                 &parcelhandler::get_action_receiving_serialization_time, this,
-                pp_type, _1, _2
-            ));
+                pp_type));
 #else
         util::function_nonser<std::int64_t(bool)>
-            sending_serialization_time(util::bind(
+            sending_serialization_time(util::bind_front(
                 &parcelhandler::get_sending_serialization_time, this,
-                pp_type, _1
-            ));
+                pp_type));
         util::function_nonser<std::int64_t(bool)>
-            receiving_serialization_time(util::bind(
+            receiving_serialization_time(util::bind_front(
                 &parcelhandler::get_receiving_serialization_time, this,
-                pp_type, _1
-            ));
+                pp_type));
 #endif
 
 #if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
         util::function_nonser<std::int64_t(std::string const&, bool)>
-            data_sent(util::bind(
+            data_sent(util::bind_front(
                 &parcelhandler::get_action_data_sent, this,
-                pp_type, _1, _2
-            ));
+                pp_type));
         util::function_nonser<std::int64_t(std::string const&, bool)>
-            data_received(util::bind(
+            data_received(util::bind_front(
                 &parcelhandler::get_action_data_received, this,
-                pp_type, _1, _2
-            ));
+                pp_type));
 #else
         util::function_nonser<std::int64_t(bool)>
-            data_sent(util::bind(
-                &parcelhandler::get_data_sent, this, pp_type, _1
-            ));
+            data_sent(util::bind_front(
+                &parcelhandler::get_data_sent, this, pp_type));
         util::function_nonser<std::int64_t(bool)>
-            data_received(util::bind(
-                &parcelhandler::get_data_received, this, pp_type, _1
-            ));
+            data_received(util::bind_front(
+                &parcelhandler::get_data_received, this, pp_type));
 #endif
 
         util::function_nonser<std::int64_t(bool)> data_raw_sent(
-            util::bind(&parcelhandler::get_raw_data_sent, this,
-                pp_type, _1));
+            util::bind_front(&parcelhandler::get_raw_data_sent, this,
+                pp_type));
         util::function_nonser<std::int64_t(bool)> data_raw_received(
-            util::bind(&parcelhandler::get_raw_data_received, this,
-                pp_type, _1));
+            util::bind_front(&parcelhandler::get_raw_data_received, this,
+                pp_type));
 
         util::function_nonser<std::int64_t(bool)> buffer_allocate_time_sent(
-            util::bind(&parcelhandler::get_buffer_allocate_time_sent, this,
-                pp_type, _1));
+            util::bind_front(&parcelhandler::get_buffer_allocate_time_sent, this,
+                pp_type));
         util::function_nonser<std::int64_t(bool)> buffer_allocate_time_received(
-            util::bind(&parcelhandler::get_buffer_allocate_time_received, this,
-                pp_type, _1));
+            util::bind_front(&parcelhandler::get_buffer_allocate_time_received, this,
+                pp_type));
 
         performance_counters::generic_counter_type_data const counter_types[] =
         {
@@ -1436,20 +1420,20 @@ namespace hpx { namespace parcelset
 
 #if defined(HPX_HAVE_NETWORKING)
         util::function_nonser<std::int64_t(bool)> cache_insertions(
-            util::bind(&parcelhandler::get_connection_cache_statistics,
-                this, pp_type, parcelport::connection_cache_insertions, _1));
+            util::bind_front(&parcelhandler::get_connection_cache_statistics,
+                this, pp_type, parcelport::connection_cache_insertions));
         util::function_nonser<std::int64_t(bool)> cache_evictions(
-            util::bind(&parcelhandler::get_connection_cache_statistics,
-                this, pp_type, parcelport::connection_cache_evictions, _1));
+            util::bind_front(&parcelhandler::get_connection_cache_statistics,
+                this, pp_type, parcelport::connection_cache_evictions));
         util::function_nonser<std::int64_t(bool)> cache_hits(
-            util::bind(&parcelhandler::get_connection_cache_statistics,
-                this, pp_type, parcelport::connection_cache_hits, _1));
+            util::bind_front(&parcelhandler::get_connection_cache_statistics,
+                this, pp_type, parcelport::connection_cache_hits));
         util::function_nonser<std::int64_t(bool)> cache_misses(
-            util::bind(&parcelhandler::get_connection_cache_statistics,
-                this, pp_type, parcelport::connection_cache_misses, _1));
+            util::bind_front(&parcelhandler::get_connection_cache_statistics,
+                this, pp_type, parcelport::connection_cache_misses));
         util::function_nonser<std::int64_t(bool)> cache_reclaims(
-            util::bind(&parcelhandler::get_connection_cache_statistics,
-                this, pp_type, parcelport::connection_cache_reclaims, _1));
+            util::bind_front(&parcelhandler::get_connection_cache_statistics,
+                this, pp_type, parcelport::connection_cache_reclaims));
 
         performance_counters::generic_counter_type_data const
             connection_cache_types[] =

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -27,7 +27,8 @@
 #include <hpx/runtime/threads/threadmanager.hpp>
 #include <hpx/runtime/threads/topology.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/bind.hpp>
+#include <hpx/util/bind_back.hpp>
+#include <hpx/util/bind_front.hpp>
 #include <hpx/util/block_profiler.hpp>
 #include <hpx/util/hardware/timestamp.hpp>
 #include <hpx/util/itt_notify.hpp>
@@ -1167,15 +1168,13 @@ namespace hpx { namespace threads
             return naming::invalid_gid;
         }
 
-        using hpx::util::placeholders::_1;
-
         detail::thread_pool_base& pool = default_pool();
         if (paths.instancename_ == "total" && paths.instanceindex_ == -1)
         {
             // overall counter
             using performance_counters::detail::create_raw_counter;
             util::function_nonser<std::int64_t(bool)> f =
-                util::bind(total_func, this, _1);
+                util::bind_front(total_func, this);
             return create_raw_counter(info, std::move(f), ec);
         }
         else if (paths.instancename_ == "pool")
@@ -1190,8 +1189,8 @@ namespace hpx { namespace threads
 
                 using performance_counters::detail::create_raw_counter;
                 util::function_nonser<std::int64_t(bool)> f =
-                    util::bind(pool_func, &pool_instance,
-                        static_cast<std::size_t>(paths.subinstanceindex_), _1);
+                    util::bind_front(pool_func, &pool_instance,
+                        static_cast<std::size_t>(paths.subinstanceindex_));
                 return create_raw_counter(info, std::move(f), ec);
             }
         }
@@ -1201,8 +1200,8 @@ namespace hpx { namespace threads
         {
             // specific counter from default
             using performance_counters::detail::create_raw_counter;
-            util::function_nonser<std::int64_t(bool)> f = util::bind(pool_func,
-                &pool, static_cast<std::size_t>(paths.instanceindex_), _1);
+            util::function_nonser<std::int64_t(bool)> f = util::bind_front(
+                pool_func, &pool, static_cast<std::size_t>(paths.instanceindex_));
             return create_raw_counter(info, std::move(f), ec);
         }
 
@@ -1238,7 +1237,7 @@ namespace hpx { namespace threads
         {
             // overall counter
             using performance_counters::detail::create_raw_counter;
-            util::function_nonser<std::int64_t()> f = util::bind(
+            util::function_nonser<std::int64_t()> f = util::bind_back(
                 &detail::thread_pool_base::get_scheduler_utilization, &pool);
             return create_raw_counter(info, std::move(f), ec);
         }
@@ -1273,8 +1272,6 @@ namespace hpx { namespace threads
             return naming::invalid_gid;
         }
 
-        using hpx::util::placeholders::_1;
-
         detail::thread_pool_base& pool = default_pool();
         if (paths.instancename_ == "total" && paths.instanceindex_ == -1)
         {
@@ -1296,8 +1293,8 @@ namespace hpx { namespace threads
 
                 using performance_counters::detail::create_raw_counter;
                 util::function_nonser<std::int64_t(bool)> f =
-                    util::bind(pool_func, &pool_instance,
-                        static_cast<std::size_t>(paths.subinstanceindex_), _1);
+                    util::bind_front(pool_func, &pool_instance,
+                        static_cast<std::size_t>(paths.subinstanceindex_));
                 return create_raw_counter(info, std::move(f), ec);
             }
         }
@@ -1308,8 +1305,8 @@ namespace hpx { namespace threads
             // specific counter
             using performance_counters::detail::create_raw_counter;
             util::function_nonser<std::int64_t(bool)> f =
-                util::bind(pool_func, &pool,
-                    static_cast<std::size_t>(paths.instanceindex_), _1);
+                util::bind_front(pool_func, &pool,
+                    static_cast<std::size_t>(paths.instanceindex_));
             return create_raw_counter(info, std::move(f), ec);
         }
 
@@ -1454,27 +1451,25 @@ namespace hpx { namespace threads
             std::size_t individual_count;
         };
 
-        using util::placeholders::_1;
-
         creator_data data[] = {
             // /threads{locality#%d/total}/count/stack-recycles
             {"count/stack-recycles",
-                util::bind(
-                    &coroutine_type::impl_type::get_stack_recycle_count, _1),
+                util::bind_front(
+                    &coroutine_type::impl_type::get_stack_recycle_count),
                 util::function_nonser<std::uint64_t(bool)>(), "", 0},
 #if !defined(HPX_WINDOWS) && !defined(HPX_HAVE_GENERIC_CONTEXT_COROUTINES)
             // /threads{locality#%d/total}/count/stack-unbinds
             {"count/stack-unbinds",
-                util::bind(
-                    &coroutine_type::impl_type::get_stack_unbind_count, _1),
+                util::bind_front(
+                    &coroutine_type::impl_type::get_stack_unbind_count),
                 util::function_nonser<std::uint64_t(bool)>(), "", 0},
 #endif
             // /threads{locality#%d/total}/count/objects
             // /threads{locality#%d/allocator%d}/count/objects
             {"count/objects",
                 &coroutine_type::impl_type::get_allocation_count_all,
-                util::bind(&coroutine_type::impl_type::get_allocation_count,
-                    static_cast<std::size_t>(paths.instanceindex_), _1),
+                util::bind_front(&coroutine_type::impl_type::get_allocation_count,
+                    static_cast<std::size_t>(paths.instanceindex_)),
                 "allocator", HPX_COROUTINE_NUM_ALL_HEAPS},
         };
         std::size_t const data_size = sizeof(data)/sizeof(data[0]);
@@ -1497,20 +1492,17 @@ namespace hpx { namespace threads
     ///////////////////////////////////////////////////////////////////////////
     void threadmanager::register_counter_types()
     {
-        using util::placeholders::_1;
-        using util::placeholders::_2;
-
-        performance_counters::create_counter_func counts_creator(util::bind(
-            &threadmanager::thread_counts_counter_creator, this, _1, _2));
+        performance_counters::create_counter_func counts_creator(util::bind_front(
+            &threadmanager::thread_counts_counter_creator, this));
 
         performance_counters::generic_counter_type_data counter_types[] = {
             // length of thread queue(s)
             {"/threadqueue/length", performance_counters::counter_raw,
                 "returns the current queue length for the referenced queue",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::get_queue_length,
-                    &detail::thread_pool_base::get_queue_length, _1, _2),
+                    &detail::thread_pool_base::get_queue_length),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 ""},
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
@@ -1519,9 +1511,9 @@ namespace hpx { namespace threads
                 "returns the average wait time of pending threads for the "
                 "referenced queue",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::queue_wait_time_counter_creator,
+                util::bind_front(&threadmanager::queue_wait_time_counter_creator,
                     this, &threadmanager::get_average_thread_wait_time,
-                    &detail::thread_pool_base::get_average_thread_wait_time, _1, _2),
+                    &detail::thread_pool_base::get_average_thread_wait_time),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 "ns"},
             // average task wait time for queue(s)
@@ -1529,9 +1521,9 @@ namespace hpx { namespace threads
                 "returns the average wait time of staged threads (task "
                 "descriptions) for the referenced queue",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::queue_wait_time_counter_creator,
+                util::bind_front(&threadmanager::queue_wait_time_counter_creator,
                     this, &threadmanager::get_average_task_wait_time,
-                    &detail::thread_pool_base::get_average_task_wait_time, _1, _2),
+                    &detail::thread_pool_base::get_average_task_wait_time),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 "ns"},
 #endif
@@ -1540,9 +1532,9 @@ namespace hpx { namespace threads
             {"/threads/idle-rate", performance_counters::counter_raw,
                 "returns the idle rate for the referenced object",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::avg_idle_rate,
-                    &detail::thread_pool_base::avg_idle_rate, _1, _2),
+                    &detail::thread_pool_base::avg_idle_rate),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 "0.01%"},
 #ifdef HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES
@@ -1550,18 +1542,18 @@ namespace hpx { namespace threads
                 "returns the % of idle-rate spent creating HPX-threads for the "
                 "referenced object",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::avg_creation_idle_rate,
-                    &detail::thread_pool_base::avg_creation_idle_rate, _1, _2),
+                    &detail::thread_pool_base::avg_creation_idle_rate),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 "0.01%"},
             {"/threads/cleanup-idle-rate", performance_counters::counter_raw,
                 "returns the % of time spent cleaning up terminated "
                 "HPX-threads for the referenced object",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::avg_cleanup_idle_rate,
-                    &detail::thread_pool_base::avg_cleanup_idle_rate, _1, _2),
+                    &detail::thread_pool_base::avg_cleanup_idle_rate),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 "0.01%"},
 #endif
@@ -1572,9 +1564,9 @@ namespace hpx { namespace threads
                 "returns the overall number of executed (retired) HPX-threads "
                 "for the referenced locality",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::get_executed_threads,
-                    &detail::thread_pool_base::get_executed_threads, _1, _2),
+                    &detail::thread_pool_base::get_executed_threads),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 ""},
             {"/threads/count/cumulative-phases",
@@ -1582,52 +1574,52 @@ namespace hpx { namespace threads
                 "returns the overall number of HPX-thread phases executed for "
                 "the referenced locality",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::get_executed_thread_phases,
-                    &detail::thread_pool_base::get_executed_thread_phases, _1, _2),
+                    &detail::thread_pool_base::get_executed_thread_phases),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 ""},
 #ifdef HPX_HAVE_THREAD_IDLE_RATES
             {"/threads/time/average", performance_counters::counter_raw,
                 "returns the average time spent executing one HPX-thread",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::get_thread_duration,
-                    &detail::thread_pool_base::get_thread_duration, _1, _2),
+                    &detail::thread_pool_base::get_thread_duration),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 "ns"},
             {"/threads/time/average-phase", performance_counters::counter_raw,
                 "returns the average time spent executing one HPX-thread phase",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::get_thread_phase_duration,
-                    &detail::thread_pool_base::get_thread_phase_duration, _1, _2),
+                    &detail::thread_pool_base::get_thread_phase_duration),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 "ns"},
             {"/threads/time/average-overhead",
                 performance_counters::counter_raw,
                 "returns average overhead time executing one HPX-thread",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::get_thread_overhead,
-                    &detail::thread_pool_base::get_thread_overhead, _1, _2),
+                    &detail::thread_pool_base::get_thread_overhead),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 "ns"},
             {"/threads/time/average-phase-overhead",
                 performance_counters::counter_raw,
                 "returns average overhead time executing one HPX-thread phase",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::get_thread_phase_overhead,
-                    &detail::thread_pool_base::get_thread_phase_overhead, _1, _2),
+                    &detail::thread_pool_base::get_thread_phase_overhead),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 "ns"},
             {"/threads/time/cumulative", performance_counters::counter_raw,
                 "returns the cumulative time spent executing HPX-threads",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::get_cumulative_thread_duration,
-                    &detail::thread_pool_base::get_cumulative_thread_duration, _1, _2),
+                    &detail::thread_pool_base::get_cumulative_thread_duration),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 "ns"},
             {"/threads/time/cumulative-overhead",
@@ -1635,9 +1627,9 @@ namespace hpx { namespace threads
                 "returns the cumulative overhead time incurred by executing "
                 "HPX threads",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::get_cumulative_thread_overhead,
-                    &detail::thread_pool_base::get_cumulative_thread_overhead, _1, _2),
+                    &detail::thread_pool_base::get_cumulative_thread_overhead),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 "ns"},
 #endif
@@ -1646,9 +1638,9 @@ namespace hpx { namespace threads
                 "returns the overall time spent running the scheduler on a "
                 "core",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::get_cumulative_duration,
-                    &detail::thread_pool_base::get_cumulative_duration, _1, _2),
+                    &detail::thread_pool_base::get_cumulative_duration),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 "ns"},
             {"/threads/count/instantaneous/all",
@@ -1656,9 +1648,9 @@ namespace hpx { namespace threads
                 "returns the overall current number of HPX-threads "
                 "instantiated at the referenced locality",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::get_thread_count_unknown,
-                    &detail::thread_pool_base::get_thread_count_unknown, _1, _2),
+                    &detail::thread_pool_base::get_thread_count_unknown),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 ""},
             {"/threads/count/instantaneous/active",
@@ -1666,9 +1658,9 @@ namespace hpx { namespace threads
                 "returns the current number of active HPX-threads "
                 "at the referenced locality",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::get_thread_count_active,
-                    &detail::thread_pool_base::get_thread_count_active, _1, _2),
+                    &detail::thread_pool_base::get_thread_count_active),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 ""},
             {"/threads/count/instantaneous/pending",
@@ -1676,9 +1668,9 @@ namespace hpx { namespace threads
                 "returns the current number of pending HPX-threads "
                 "at the referenced locality",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::get_thread_count_pending,
-                    &detail::thread_pool_base::get_thread_count_pending, _1, _2),
+                    &detail::thread_pool_base::get_thread_count_pending),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 ""},
             {"/threads/count/instantaneous/suspended",
@@ -1686,9 +1678,9 @@ namespace hpx { namespace threads
                 "returns the current number of suspended HPX-threads "
                 "at the referenced locality",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::get_thread_count_suspended,
-                    &detail::thread_pool_base::get_thread_count_suspended, _1, _2),
+                    &detail::thread_pool_base::get_thread_count_suspended),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 ""},
             {"/threads/count/instantaneous/terminated",
@@ -1696,9 +1688,9 @@ namespace hpx { namespace threads
                 "returns the current number of terminated HPX-threads "
                 "at the referenced locality",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::get_thread_count_terminated,
-                    &detail::thread_pool_base::get_thread_count_terminated, _1, _2),
+                    &detail::thread_pool_base::get_thread_count_terminated),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 ""},
             {"/threads/count/instantaneous/staged",
@@ -1707,9 +1699,9 @@ namespace hpx { namespace threads
                 "descriptions) "
                 "at the referenced locality",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::get_thread_count_staged,
-                    &detail::thread_pool_base::get_thread_count_staged, _1, _2),
+                    &detail::thread_pool_base::get_thread_count_staged),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 ""},
             {"/threads/count/stack-recycles", performance_counters::counter_raw,
@@ -1735,9 +1727,9 @@ namespace hpx { namespace threads
                 "on the referenced locality failed to find pending HPX-threads "
                 "in its associated queue",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::get_num_pending_misses,
-                    &detail::thread_pool_base::get_num_pending_misses, _1, _2),
+                    &detail::thread_pool_base::get_num_pending_misses),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 ""},
             {"/threads/count/pending-accesses",
@@ -1746,9 +1738,9 @@ namespace hpx { namespace threads
                 "on the referenced locality looked for pending HPX-threads "
                 "in its associated queue",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::get_num_pending_accesses,
-                    &detail::thread_pool_base::get_num_pending_accesses, _1, _2),
+                    &detail::thread_pool_base::get_num_pending_accesses),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 ""},
             {"/threads/count/stolen-from-pending",
@@ -1757,9 +1749,9 @@ namespace hpx { namespace threads
                 "neighboring"
                 "schedulers from this scheduler for the referenced locality",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::get_num_stolen_from_pending,
-                    &detail::thread_pool_base::get_num_stolen_from_pending, _1, _2),
+                    &detail::thread_pool_base::get_num_stolen_from_pending),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 ""},
             {"/threads/count/stolen-from-staged",
@@ -1768,9 +1760,9 @@ namespace hpx { namespace threads
                 "neighboring"
                 "schedulers from this scheduler for the referenced locality",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::get_num_stolen_from_staged,
-                    &detail::thread_pool_base::get_num_stolen_from_staged, _1, _2),
+                    &detail::thread_pool_base::get_num_stolen_from_staged),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 ""},
             {"/threads/count/stolen-to-pending",
@@ -1779,9 +1771,9 @@ namespace hpx { namespace threads
                 "neighboring"
                 "schedulers for the referenced locality",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::get_num_stolen_to_pending,
-                    &detail::thread_pool_base::get_num_stolen_to_pending, _1, _2),
+                    &detail::thread_pool_base::get_num_stolen_to_pending),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 ""},
             {"/threads/count/stolen-to-staged",
@@ -1790,9 +1782,9 @@ namespace hpx { namespace threads
                 "neighboring"
                 "schedulers for the referenced locality",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::locality_pool_thread_counter_creator,
+                util::bind_front(&threadmanager::locality_pool_thread_counter_creator,
                     this, &threadmanager::get_num_stolen_to_staged,
-                    &detail::thread_pool_base::get_num_stolen_to_staged, _1, _2),
+                    &detail::thread_pool_base::get_num_stolen_to_staged),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 ""},
 #endif
@@ -1801,18 +1793,17 @@ namespace hpx { namespace threads
                 performance_counters::counter_raw,
                 "returns the current scheduler utilization",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(
-                    &threadmanager::scheduler_utilization_counter_creator, this,
-                    _1, _2),
+                util::bind_front(
+                    &threadmanager::scheduler_utilization_counter_creator, this),
                 &performance_counters::locality_pool_counter_discoverer, "%"},
             // idle-loop count
             {"/threads/idle-loop-count/instantaneous",
                 performance_counters::counter_raw,
                 "returns the current value of the scheduler idle-loop count",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::
+                util::bind_front(&threadmanager::
                                locality_pool_thread_no_total_counter_creator,
-                    this, &detail::thread_pool_base::get_idle_loop_count, _1, _2),
+                    this, &detail::thread_pool_base::get_idle_loop_count),
                 &performance_counters::
                     locality_pool_thread_no_total_counter_discoverer,
                 ""},
@@ -1821,9 +1812,9 @@ namespace hpx { namespace threads
                 performance_counters::counter_raw,
                 "returns the current value of the scheduler busy-loop count",
                 HPX_PERFORMANCE_COUNTER_V1,
-                util::bind(&threadmanager::
+                util::bind_front(&threadmanager::
                                locality_pool_thread_no_total_counter_creator,
-                    this, &detail::thread_pool_base::get_busy_loop_count, _1, _2),
+                    this, &detail::thread_pool_base::get_busy_loop_count),
                 &performance_counters::
                     locality_pool_thread_no_total_counter_discoverer,
                 ""}

--- a/src/util/activate_counters.cpp
+++ b/src/util/activate_counters.cpp
@@ -10,6 +10,7 @@
 #include <hpx/runtime/threads/thread_helpers.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/activate_counters.hpp>
+#include <hpx/util/bind_front.hpp>
 #include <hpx/util/format.hpp>
 #include <hpx/util/high_resolution_clock.hpp>
 #include <hpx/util/apex.hpp>
@@ -68,11 +69,8 @@ namespace hpx { namespace util
         names_.reserve(names.size());
         if (ids_.empty())
         {
-            using util::placeholders::_1;
-            using util::placeholders::_2;
-
             performance_counters::discover_counter_func func(
-                util::bind(&activate_counters::find_counter, this, _1, _2));
+                util::bind_front(&activate_counters::find_counter, this));
 
             ids_.reserve(names.size());
             uoms_.reserve(names.size());

--- a/src/util/interval_timer.cpp
+++ b/src/util/interval_timer.cpp
@@ -9,9 +9,10 @@
 #include <hpx/runtime/shutdown_function.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
 #include <hpx/util/assert.hpp>
+#include <hpx/util/bind_front.hpp>
+#include <hpx/util/deferred_call.hpp>
 #include <hpx/util/interval_timer.hpp>
 #include <hpx/util/unlock_guard.hpp>
-#include <hpx/util/bind.hpp>
 
 #include <chrono>
 #include <cstddef>
@@ -60,13 +61,13 @@ namespace hpx { namespace util { namespace detail
                 if (pre_shutdown_)
                 {
                     register_pre_shutdown_function(
-                        util::bind(&interval_timer::terminate,
+                        util::deferred_call(&interval_timer::terminate,
                             this->shared_from_this()));
                 }
                 else
                 {
                     register_shutdown_function(
-                        util::bind(&interval_timer::terminate,
+                        util::deferred_call(&interval_timer::terminate,
                             this->shared_from_this()));
                 }
             }
@@ -242,8 +243,8 @@ namespace hpx { namespace util { namespace detail
             // at shutdown.
             //util::unlock_guard<std::unique_lock<mutex_type> > ul(l);
             id = hpx::applier::register_thread_plain(
-                util::bind(&interval_timer::evaluate,
-                    this->shared_from_this(), util::placeholders::_1),
+                util::bind_front(&interval_timer::evaluate,
+                    this->shared_from_this()),
                 description_.c_str(), threads::suspended, true,
                 threads::thread_priority_boost, std::size_t(-1),
                 threads::thread_stacksize_default, ec);

--- a/src/util/pool_timer.cpp
+++ b/src/util/pool_timer.cpp
@@ -9,7 +9,8 @@
 #include <hpx/runtime/applier/applier.hpp>
 #include <hpx/runtime/shutdown_function.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/bind.hpp>
+#include <hpx/util/bind_front.hpp>
+#include <hpx/util/deferred_call.hpp>
 #include <hpx/util/function.hpp>
 #include <hpx/util/io_service_pool.hpp>
 #include <hpx/util/pool_timer.hpp>
@@ -122,21 +123,21 @@ namespace hpx { namespace util { namespace detail
                 if (pre_shutdown_)
                 {
                     register_pre_shutdown_function(
-                        util::bind(&pool_timer::terminate,
+                        util::deferred_call(&pool_timer::terminate,
                             this->shared_from_this()));
                 }
                 else
                 {
                     register_shutdown_function(
-                        util::bind(&pool_timer::terminate,
+                        util::deferred_call(&pool_timer::terminate,
                             this->shared_from_this()));
                 }
             }
 
             HPX_ASSERT(timer_ != nullptr);
             timer_->expires_from_now(time_duration.value());
-            timer_->async_wait(util::bind(&pool_timer::timer_handler,
-                this->shared_from_this(), util::placeholders::_1));
+            timer_->async_wait(util::bind_front(&pool_timer::timer_handler,
+                this->shared_from_this()));
 
             return true;
         }

--- a/tests/regressions/multiple_init_2918.cpp
+++ b/tests/regressions/multiple_init_2918.cpp
@@ -4,6 +4,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
+#include <hpx/util/bind.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <string>

--- a/tests/regressions/util/set_config_entry_deadlock.cpp
+++ b/tests/regressions/util/set_config_entry_deadlock.cpp
@@ -5,6 +5,7 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/runtime/config_entry.hpp>
+#include <hpx/util/bind.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <atomic>


### PR DESCRIPTION
- Add implementations of `bind_front`/`bind_back`
- Replace some uses of `bind` by `bind_front`/`bind_back`

See http://open-std.org/JTC1/SC22/WG21/docs/papers/2017/p0356r2.html