### PR TITLE
implement executor then interface with && forwarding reference

### DIFF
--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -726,7 +726,7 @@ namespace hpx { namespace lcos { namespace detail
     {
         // simply forward this to executor
         return parallel::execution::then_execute(exec, std::forward<F>(f),
-            predecessor);
+            std::forward<Future>(predecessor));
     }
 }}}
 

--- a/hpx/parallel/executors/execution.hpp
+++ b/hpx/parallel/executors/execution.hpp
@@ -168,7 +168,7 @@ namespace hpx { namespace parallel { namespace execution
             hpx::lcos::future<typename hpx::util::detail::invoke_deferred_result<
                 F, Future, Ts...
             >::type>
-            call(OneWayExecutor && exec, F && f, Future& predecessor,
+            call(OneWayExecutor && exec, F && f, Future&& predecessor,
                 Ts &&... ts)
             {
                 typedef typename hpx::util::detail::invoke_deferred_result<
@@ -181,7 +181,8 @@ namespace hpx { namespace parallel { namespace execution
 
                 typename hpx::traits::detail::shared_state_ptr<result_type>::type
                     p = lcos::detail::make_continuation_exec<result_type>(
-                            predecessor, std::forward<OneWayExecutor>(exec),
+                            std::forward<Future>(predecessor), 
+                            std::forward<OneWayExecutor>(exec),
                             std::move(func));
 
                 return hpx::traits::future_access<
@@ -424,7 +425,7 @@ namespace hpx { namespace parallel { namespace execution
                 >::type
             >
             call_impl(hpx::traits::detail::wrap_int,
-                    TwoWayExecutor && exec, F && f, Future& predecessor,
+                    TwoWayExecutor && exec, F && f, Future&& predecessor,
                     Ts &&... ts)
             {
                 typedef typename hpx::util::detail::invoke_deferred_result<
@@ -437,7 +438,8 @@ namespace hpx { namespace parallel { namespace execution
 
                 typename hpx::traits::detail::shared_state_ptr<result_type>::type
                     p = lcos::detail::make_continuation_exec<result_type>(
-                            predecessor, std::forward<TwoWayExecutor>(exec),
+                            std::forward<Future>(predecessor),
+                            std::forward<TwoWayExecutor>(exec),
                             std::move(func));
 
                 return hpx::traits::future_access<
@@ -449,28 +451,32 @@ namespace hpx { namespace parallel { namespace execution
                 typename ... Ts>
             HPX_FORCEINLINE static auto
             call_impl(int,
-                    TwoWayExecutor && exec, F && f, Future& predecessor,
+                    TwoWayExecutor && exec, F && f, Future&& predecessor,
                     Ts &&... ts)
             ->  decltype(exec.then_execute(
-                    std::forward<F>(f), predecessor, std::forward<Ts>(ts)...
+                    std::forward<F>(f),
+                    std::forward<Future>(predecessor),
+                    std::forward<Ts>(ts)...
                 ))
             {
                 return exec.then_execute(std::forward<F>(f),
-                    predecessor, std::forward<Ts>(ts)...);
+                    std::forward<Future>(predecessor),
+                    std::forward<Ts>(ts)...);
             }
 
             template <typename TwoWayExecutor, typename F, typename Future,
                 typename ... Ts>
             HPX_FORCEINLINE static auto
-            call(TwoWayExecutor && exec, F && f, Future& predecessor,
+            call(TwoWayExecutor && exec, F && f, Future&& predecessor,
                     Ts &&... ts)
             ->  decltype(call_impl(
                     0, std::forward<TwoWayExecutor>(exec), std::forward<F>(f),
-                    predecessor, std::forward<Ts>(ts)...
+                    std::forward<Future>(predecessor), std::forward<Ts>(ts)...
                 ))
             {
                 return call_impl(0, std::forward<TwoWayExecutor>(exec),
-                    std::forward<F>(f), predecessor, std::forward<Ts>(ts)...);
+                    std::forward<F>(f), std::forward<Future>(predecessor),
+                    std::forward<Ts>(ts)...);
             }
         };
 
@@ -1071,17 +1077,17 @@ namespace hpx { namespace parallel { namespace execution
             typename Future, std::size_t ... Is, typename ... Ts>
         HPX_FORCEINLINE auto
         fused_bulk_sync_execute(Executor && exec,
-                F && f, Shape const& shape, Future& predecessor,
+                F && f, Shape const& shape, Future&& predecessor,
                 hpx::util::detail::pack_c<std::size_t, Is...>,
                 hpx::util::tuple<Ts...> const& args)
         ->  decltype(execution::bulk_sync_execute(
                 std::forward<Executor>(exec), std::forward<F>(f), shape,
-                predecessor, hpx::util::get<Is>(args)...
+                std::forward<Future>(predecessor), hpx::util::get<Is>(args)...
             ))
         {
             return execution::bulk_sync_execute(
                 std::forward<Executor>(exec), std::forward<F>(f), shape,
-                predecessor, hpx::util::get<Is>(args)...);
+                std::forward<Future>(predecessor), hpx::util::get<Is>(args)...);
         }
 
         template <typename Executor>
@@ -1187,21 +1193,21 @@ namespace hpx { namespace parallel { namespace execution
             HPX_FORCEINLINE static auto
             call_impl(int,
                     BulkExecutor && exec, F && f, Shape const& shape,
-                    Future& predecessor, Ts &&... ts)
+                    Future&& predecessor, Ts &&... ts)
             ->  decltype(exec.bulk_then_execute(
-                    std::forward<F>(f), shape, predecessor,
+                    std::forward<F>(f), shape, std::forward<Future>(predecessor),
                     std::forward<Ts>(ts)...
                 ))
             {
                 return exec.bulk_then_execute(std::forward<F>(f),
-                    shape, predecessor, std::forward<Ts>(ts)...);
+                    shape, std::forward<Future>(predecessor), std::forward<Ts>(ts)...);
             }
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename Future, typename ... Ts>
             HPX_FORCEINLINE static auto
             call(BulkExecutor && exec, F && f, Shape const& shape,
-                    Future& predecessor, Ts &&... ts)
+                    Future&& predecessor, Ts &&... ts)
             ->  decltype(call_impl(
                     0, std::forward<BulkExecutor>(exec), std::forward<F>(f),
                     shape, hpx::lcos::make_shared_future(predecessor),
@@ -1220,17 +1226,17 @@ namespace hpx { namespace parallel { namespace execution
             typename Future, std::size_t ... Is, typename ... Ts>
         HPX_FORCEINLINE auto
         fused_bulk_async_execute(Executor && exec,
-                F && f, Shape const& shape, Future& predecessor,
+                F && f, Shape const& shape, Future&& predecessor,
                 hpx::util::detail::pack_c<std::size_t, Is...>,
                 hpx::util::tuple<Ts...> const& args)
         ->  decltype(execution::bulk_async_execute(
                 std::forward<Executor>(exec), std::forward<F>(f), shape,
-                predecessor, hpx::util::get<Is>(args)...
+                std::forward<Future>(predecessor), hpx::util::get<Is>(args)...
             ))
         {
             return execution::bulk_async_execute(
                 std::forward<Executor>(exec), std::forward<F>(f),
-                shape, predecessor, hpx::util::get<Is>(args)...);
+                shape, std::forward<Future>(predecessor), hpx::util::get<Is>(args)...);
         }
 
         template <typename Executor>
@@ -1296,21 +1302,21 @@ namespace hpx { namespace parallel { namespace execution
             HPX_FORCEINLINE static auto
             call_impl(int,
                     BulkExecutor && exec, F && f, Shape const& shape,
-                    Future& predecessor, Ts &&... ts)
+                    Future&& predecessor, Ts &&... ts)
             ->  decltype(exec.bulk_then_execute(
-                    std::forward<F>(f), shape, predecessor,
+                    std::forward<F>(f), shape, std::forward<Future>(predecessor),
                     std::forward<Ts>(ts)...
                 ))
             {
                 return exec.bulk_then_execute(std::forward<F>(f), shape,
-                    predecessor, std::forward<Ts>(ts)...);
+                    std::forward<Future>(predecessor), std::forward<Ts>(ts)...);
             }
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename Future, typename ... Ts>
             HPX_FORCEINLINE static auto
             call(BulkExecutor && exec, F && f, Shape const& shape,
-                    Future& predecessor, Ts &&... ts)
+                    Future&& predecessor, Ts &&... ts)
             ->  decltype(call_impl(
                     0, std::forward<BulkExecutor>(exec), std::forward<F>(f),
                     shape, hpx::lcos::make_shared_future(predecessor),

--- a/hpx/parallel/executors/execution_fwd.hpp
+++ b/hpx/parallel/executors/execution_fwd.hpp
@@ -105,7 +105,7 @@ namespace hpx { namespace parallel { namespace execution
             template <typename Executor, typename F, typename Future,
                 typename ... Ts>
             HPX_FORCEINLINE
-            auto operator()(Executor && exec, F && f, Future& predecessor,
+            auto operator()(Executor && exec, F && f, Future&& predecessor,
                 Ts &&... ts) const;
         };
 
@@ -136,7 +136,7 @@ namespace hpx { namespace parallel { namespace execution
                 typename Future, typename ... Ts>
             HPX_FORCEINLINE
             auto operator()(Executor && exec, F && f, Shape const& shape,
-                Future& predecessor, Ts &&... ts) const;
+                Future&& predecessor, Ts &&... ts) const;
         };
 #endif
 
@@ -263,17 +263,17 @@ namespace hpx { namespace parallel { namespace execution
             typename Future, typename ... Ts>
         HPX_FORCEINLINE auto
         bulk_then_execute(Executor && exec, F && f, Shape const& shape,
-                Future& predecessor, Ts &&... ts)
+                Future&& predecessor, Ts &&... ts)
         ->  decltype(bulk_then_execute_fn_helper<
                     typename std::decay<Executor>::type
                 >::call(std::forward<Executor>(exec), std::forward<F>(f),
-                    shape, predecessor, std::forward<Ts>(ts)...
+                    shape, std::forward<Future>(predecessor), std::forward<Ts>(ts)...
             ))
         {
             return bulk_then_execute_fn_helper<
                     typename std::decay<Executor>::type
                 >::call(std::forward<Executor>(exec), std::forward<F>(f),
-                    shape, predecessor, std::forward<Ts>(ts)...);
+                    shape, std::forward<Future>(predecessor), std::forward<Ts>(ts)...);
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -299,18 +299,18 @@ namespace hpx { namespace parallel { namespace execution
         template <typename Executor, typename F, typename Future,
             typename ... Ts>
         HPX_FORCEINLINE auto
-        then_execute(Executor && exec, F && f, Future& predecessor,
+        then_execute(Executor && exec, F && f, Future&& predecessor,
                 Ts &&... ts)
         ->  decltype(then_execute_fn_helper<
                     typename std::decay<Executor>::type
                 >::call(std::forward<Executor>(exec), std::forward<F>(f),
-                    predecessor, std::forward<Ts>(ts)...
+                    std::forward<Future>(predecessor), std::forward<Ts>(ts)...
             ))
         {
             return then_execute_fn_helper<
                     typename std::decay<Executor>::type
                 >::call(std::forward<Executor>(exec), std::forward<F>(f),
-                    predecessor, std::forward<Ts>(ts)...);
+                    std::forward<Future>(predecessor), std::forward<Ts>(ts)...);
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -374,10 +374,10 @@ namespace hpx { namespace parallel { namespace execution
             typename... Ts>
         HPX_FORCEINLINE auto customization_point<then_execute_tag>::
         operator()(
-            Executor&& exec, F&& f, Future& predecessor, Ts&&... ts) const
+            Executor&& exec, F&& f, Future&& predecessor, Ts&&... ts) const
         {
             return then_execute(std::forward<Executor>(exec),
-                std::forward<F>(f), predecessor, std::forward<Ts>(ts)...);
+                std::forward<F>(f), std::forward<Future>(predecessor), std::forward<Ts>(ts)...);
         }
 #else
         template <>
@@ -387,14 +387,14 @@ namespace hpx { namespace parallel { namespace execution
             template <typename Executor, typename F, typename Future,
                 typename... Ts>
             HPX_FORCEINLINE auto operator()(Executor&& exec, F&& f,
-                Future& predecessor, Ts&&... ts) const
+                Future&& predecessor, Ts&&... ts) const
                 -> decltype(then_execute(std::forward<Executor>(exec),
-                    std::forward<F>(f), predecessor,
+                    std::forward<F>(f), std::forward<Future>(predecessor),
                     std::forward<Ts>(ts)...))
 
             {
                 return then_execute(std::forward<Executor>(exec),
-                    std::forward<F>(f), predecessor,
+                    std::forward<F>(f), std::forward<Future>(predecessor),
                     std::forward<Ts>(ts)...);
             }
         };
@@ -494,10 +494,10 @@ namespace hpx { namespace parallel { namespace execution
             typename Future, typename... Ts>
         HPX_FORCEINLINE auto customization_point<bulk_then_execute_tag>::
         operator()(Executor&& exec, F&& f, Shape const& shape,
-            Future& predecessor, Ts&&... ts) const
+            Future&& predecessor, Ts&&... ts) const
         {
             return bulk_then_execute(std::forward<Executor>(exec),
-                std::forward<F>(f), shape, predecessor,
+                std::forward<F>(f), shape, std::forward<Future>(predecessor),
                 std::forward<Ts>(ts)...);
         }
 #else
@@ -508,13 +508,13 @@ namespace hpx { namespace parallel { namespace execution
             template <typename Executor, typename F, typename Shape,
                 typename Future, typename... Ts>
             HPX_FORCEINLINE auto operator()(Executor&& exec, F&& f,
-                Shape const& shape, Future& predecessor, Ts&&... ts) const
+                Shape const& shape, Future&& predecessor, Ts&&... ts) const
                 -> decltype(bulk_then_execute(std::forward<Executor>(exec),
-                    std::forward<F>(f), shape, predecessor,
+                    std::forward<F>(f), shape, std::forward<Future>(predecessor),
                     std::forward<Ts>(ts)...))
             {
                 return bulk_then_execute(std::forward<Executor>(exec),
-                    std::forward<F>(f), shape, predecessor,
+                    std::forward<F>(f), shape, std::forward<Future>(predecessor),
                     std::forward<Ts>(ts)...);
             }
         };

--- a/hpx/parallel/executors/thread_execution.hpp
+++ b/hpx/parallel/executors/thread_execution.hpp
@@ -75,7 +75,7 @@ namespace hpx { namespace threads
             >::type
         >
     >::type
-    then_execute(Executor && exec, F && f, Future& predecessor, Ts &&... ts)
+    then_execute(Executor && exec, F && f, Future&& predecessor, Ts &&... ts)
     {
         typedef typename hpx::util::detail::invoke_deferred_result<
                 F, Future, Ts...
@@ -87,7 +87,7 @@ namespace hpx { namespace threads
 
         typename hpx::traits::detail::shared_state_ptr<result_type>::type
             p = hpx::lcos::detail::make_continuation_thread_exec<result_type>(
-                    predecessor, std::forward<Executor>(exec),
+                    std::forward<Future>(predecessor), std::forward<Executor>(exec),
                     std::move(func));
 
         return hpx::traits::future_access<hpx::lcos::future<result_type> >::
@@ -177,7 +177,7 @@ namespace hpx { namespace threads
         >
     >::type
     bulk_then_execute(Executor && exec, F && f, Shape const& shape,
-        Future& predecessor, Ts &&... ts)
+        Future&& predecessor, Ts &&... ts)
     {
         typedef typename parallel::execution::detail::then_bulk_function_result<
                 F, Shape, Future, Ts...


### PR DESCRIPTION
P0443 executor proposal uses API of the form ...
  then_execute(Function&& f, Future&& pred) const