### PR TITLE
Fix setting of default build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE_Fortran
 # Build type (needs to be handled before project command below)
 ################################################################################
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Configuration type (one of Debug, RelWithDebInfo, Release, MinSizeRel)")
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Configuration type (one of Debug, RelWithDebInfo, Release, MinSizeRel)" FORCE)
 endif()
 
 ################################################################################


### PR DESCRIPTION
We just ran into a strange issue with the AllScale project. Investigating it, I found that setting the default build type in HPX does not work. This should be fixed by this PR.

Even if no `CMAKE_BUILD_TYPE` is specified by the user, CMake still creates a cache entry. This entry is empty, yet present -- therefore `FORCE` is required.