### PR TITLE
Make parallel unit test names match build target/folder names

### DIFF
--- a/tests/unit/parallel/algorithms/CMakeLists.txt
+++ b/tests/unit/parallel/algorithms/CMakeLists.txt
@@ -166,7 +166,7 @@ foreach(test ${tests})
                      HPX_PREFIX ${HPX_BUILD_PREFIX}
                      FOLDER ${folder_name})
 
-  add_hpx_unit_test("parallel" ${test} ${${test}_PARAMETERS})
+  add_hpx_unit_test("parallel.algorithms" ${test} ${${test}_PARAMETERS})
 
   # add a custom target for this example
   add_hpx_pseudo_target(tests.unit.parallel.algorithms.${test})

--- a/tests/unit/parallel/container_algorithms/CMakeLists.txt
+++ b/tests/unit/parallel/container_algorithms/CMakeLists.txt
@@ -55,7 +55,7 @@ foreach(test ${tests})
                      HPX_PREFIX ${HPX_BUILD_PREFIX}
                      FOLDER "Tests/Unit/Parallel/ContainerAlgorithms")
 
-  add_hpx_unit_test("parallel" ${test} ${${test}_PARAMETERS})
+  add_hpx_unit_test("parallel.container_algorithms" ${test} ${${test}_PARAMETERS})
 
   # add a custom target for this example
   add_hpx_pseudo_target(tests.unit.parallel.container_algorithms.${test})

--- a/tests/unit/parallel/datapar_algorithms/CMakeLists.txt
+++ b/tests/unit/parallel/datapar_algorithms/CMakeLists.txt
@@ -35,7 +35,7 @@ foreach(test ${tests})
                      HPX_PREFIX ${HPX_BUILD_PREFIX}
                      FOLDER "Tests/Unit/Parallel/DataParAlgorithms")
 
-  add_hpx_unit_test("parallel" ${test} ${${test}_PARAMETERS})
+  add_hpx_unit_test("parallel.datapar_algorithms" ${test} ${${test}_PARAMETERS})
 
   # add a custom target for this example
   add_hpx_pseudo_target(tests.unit.parallel.datapar_algorithms.${test})

--- a/tests/unit/parallel/executors/CMakeLists.txt
+++ b/tests/unit/parallel/executors/CMakeLists.txt
@@ -73,7 +73,7 @@ foreach(test ${tests})
                      HPX_PREFIX ${HPX_BUILD_PREFIX}
                      FOLDER ${folder_name})
 
-  add_hpx_unit_test("parallel" ${test} ${${test}_PARAMETERS})
+  add_hpx_unit_test("parallel.executors" ${test} ${${test}_PARAMETERS})
 
   # add a custom target for this example
   add_hpx_pseudo_target(tests.unit.parallel.executors.${test})

--- a/tests/unit/parallel/segmented_algorithms/CMakeLists.txt
+++ b/tests/unit/parallel/segmented_algorithms/CMakeLists.txt
@@ -48,7 +48,7 @@ foreach(test ${tests})
                      HPX_PREFIX ${HPX_BUILD_PREFIX}
                      FOLDER ${folder_name})
 
-  add_hpx_unit_test("parallel" ${test} ${${test}_PARAMETERS})
+  add_hpx_unit_test("parallel.segmented_algorithms" ${test} ${${test}_PARAMETERS})
 
   # add a custom target for this example
   add_hpx_pseudo_target(tests.unit.parallel.segmented_algorithms.${test})


### PR DESCRIPTION
This makes it possible to run all tests in subfolders of `tests/unit/parallel` with one `ctest -R` command. This is also consistent with other test categories with subfolders.