### PR TITLE
Fixing #3044

### DIFF
--- a/hpx/lcos/detail/async_implementations.hpp
+++ b/hpx/lcos/detail/async_implementations.hpp
@@ -12,6 +12,8 @@
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/runtime/naming/address.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
+#include <hpx/runtime/threads/thread.hpp>
+#include <hpx/runtime/threads/thread_init_data.hpp>
 #include <hpx/throw_exception.hpp>
 #include <hpx/traits/action_was_object_migrated.hpp>
 #include <hpx/traits/component_supports_migration.hpp>
@@ -152,6 +154,19 @@ namespace hpx { namespace detail
     };
 
     template <typename Action>
+    bool can_invoke_locally()
+    {
+        return !traits::action_decorate_function<Action>::value &&
+            this_thread::get_priority() ==
+                static_cast<threads::thread_priority>(
+                    traits::action_priority<Action>::value) &&
+            this_thread::get_stack_size() ==
+                threads::get_stack_size(
+                    static_cast<threads::thread_stacksize>(
+                        traits::action_stacksize<Action>::value));
+    }
+
+    template <typename Action>
     struct sync_local_invoke<Action, void>
     {
         template <typename ...Ts>
@@ -209,7 +224,8 @@ namespace hpx { namespace detail
         std::pair<bool, components::pinned_ptr> r;
 
         naming::address addr;
-        if (agas::is_local_address_cached(id, addr))
+        if (agas::is_local_address_cached(id, addr) &&
+            can_invoke_locally<action_type>())
         {
             if (traits::component_supports_migration<component_type>::call())
             {
@@ -272,7 +288,8 @@ namespace hpx { namespace detail
         std::pair<bool, components::pinned_ptr> r;
 
         naming::address addr;
-        if (agas::is_local_address_cached(id, addr))
+        if (agas::is_local_address_cached(id, addr) &&
+            can_invoke_locally<action_type>())
         {
             if (traits::component_supports_migration<component_type>::call())
             {
@@ -335,7 +352,8 @@ namespace hpx { namespace detail
         std::pair<bool, components::pinned_ptr> r;
 
         naming::address addr;
-        if (agas::is_local_address_cached(id, addr))
+        if (agas::is_local_address_cached(id, addr) &&
+            can_invoke_locally<action_type>())
         {
             if (traits::component_supports_migration<component_type>::call())
             {
@@ -452,7 +470,8 @@ namespace hpx { namespace detail
         std::pair<bool, components::pinned_ptr> r;
 
         naming::address addr;
-        if (agas::is_local_address_cached(id, addr))
+        if (agas::is_local_address_cached(id, addr) &&
+            can_invoke_locally<action_type>())
         {
             if (traits::component_supports_migration<component_type>::call())
             {

--- a/hpx/runtime/actions/action_invoke_no_more_than.hpp
+++ b/hpx/runtime/actions/action_invoke_no_more_than.hpp
@@ -64,6 +64,7 @@ namespace hpx { namespace actions { namespace detail
     template <typename Action, int N>
     struct action_decorate_function
     {
+        static constexpr bool value = true;
         // This wrapper is needed to stop infinite recursion when
         // trying to get the possible additional function decoration
         // from the component

--- a/hpx/runtime/components/server/locking_hook.hpp
+++ b/hpx/runtime/components/server/locking_hook.hpp
@@ -45,6 +45,8 @@ namespace hpx { namespace components
           : base_type(std::move(rhs))
         {}
 
+        typedef void decorates_action;
+
         /// This is the hook implementation for decorate_action which locks
         /// the component ensuring that only one action is executed at a time
         /// for this component instance.

--- a/hpx/runtime/components/server/migration_support.hpp
+++ b/hpx/runtime/components/server/migration_support.hpp
@@ -155,6 +155,8 @@ namespace hpx { namespace components
         /// has been finished
         void on_migrated() {}
 
+        typedef void decorates_action;
+
         /// This is the hook implementation for decorate_action which makes
         /// sure that the object becomes pinned during the execution of an
         /// action.

--- a/hpx/traits/action_decorate_function.hpp
+++ b/hpx/traits/action_decorate_function.hpp
@@ -9,6 +9,7 @@
 #include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/runtime/threads/thread_data_fwd.hpp>
 #include <hpx/traits/detail/wrap_int.hpp>
+#include <hpx/traits/has_xxx.hpp>
 #include <hpx/util/unique_function.hpp>
 
 #include <utility>
@@ -50,11 +51,14 @@ namespace hpx { namespace traits
             return decorate_function_helper::template call<Action>(
                 0, lva, std::forward<F>(f));
         }
+
+        HPX_HAS_XXX_TRAIT_DEF(decorates_action);
     }
 
     template <typename Action, typename Enable = void>
     struct action_decorate_function
     {
+        static constexpr bool value = detail::has_decorates_action<Action>::value;
         template <typename F>
         static threads::thread_function_type
         call(naming::address_type lva, F && f)


### PR DESCRIPTION
 - Fixing local function invocations:
   - Only invoke functions locally (sync or asyn) if the calling context is the same as requested and if the action has not been decorated.
   - Fixes tests:
      - tests.unit.components.distributed.*.action_invoke_no_more_than (#3043)
      -  tests.unit.threads.distributed.*.thread_stacksize
      