### PR TITLE
Fix HPX-Qt interaction in Qt example.

### DIFF
--- a/examples/qt/qt.cpp
+++ b/examples/qt/qt.cpp
@@ -36,8 +36,8 @@ void run(widget * w, std::size_t num_threads)
         futures[i] = hpx::async(a, hpx::find_here(), high_resolution_timer::now());
     }
 
-    hpx::lcos::wait(futures, [w](std::size_t i, double t){ w->add_label(i, t); });
-    w->run_finished();
+    hpx::lcos::wait(futures, [w](std::size_t i, double t){ w->threadsafe_add_label(i, t); });
+    w->threadsafe_run_finished();
 }
 
 void qt_main(int argc, char ** argv)

--- a/examples/qt/qt.cpp
+++ b/examples/qt/qt.cpp
@@ -33,10 +33,15 @@ void run(widget * w, std::size_t num_threads)
     for(std::size_t i = 0; i < num_threads; ++i)
     {
         runner_action a;
-        futures[i] = hpx::async(a, hpx::find_here(), high_resolution_timer::now());
+        futures[i] = hpx::async(a,
+                                hpx::find_here(),
+                                high_resolution_timer::now());
     }
 
-    hpx::lcos::wait(futures, [w](std::size_t i, double t){ w->threadsafe_add_label(i, t); });
+    hpx::lcos::wait(
+                futures,
+                [w](std::size_t i, double t){ w->threadsafe_add_label(i, t); }
+    );
     w->threadsafe_run_finished();
 }
 

--- a/examples/qt/widget.cpp
+++ b/examples/qt/widget.cpp
@@ -50,7 +50,7 @@ widget::widget(std::function<void(widget *, std::size_t)> callback, QWidget *par
 
 void widget::threadsafe_add_label(std::size_t i, double t)
 {
-    // may be called from any thread, does not interact directly with GUI objects
+    // may be called from any thread, doesn't interact directly with GUI objects
     QString txt("Thread ");
     txt.append(QString::number(i))
        .append(" finished in ")
@@ -58,7 +58,8 @@ void widget::threadsafe_add_label(std::size_t i, double t)
        .append(" seconds");
 
     QGenericArgument arg("const QString&", &txt);
-    QMetaObject::invokeMethod(this, "add_label", arg);
+    // Qt::QueuedConnection makes sure 'add_label' is called in the GUI thread
+    QMetaObject::invokeMethod(this, "add_label", Qt::QueuedConnection, arg);
 }
 
 void widget::threadsafe_run_finished()
@@ -66,7 +67,9 @@ void widget::threadsafe_run_finished()
     // may be called from any thread, does not interact directly with GUI objects
     bool value = true;
     QGenericArgument arg("bool",&value);
-    QMetaObject::invokeMethod(run_button, "setEnabled", arg);
+    // Qt::QueuedConnection makes sure 'setEnabled' is called in the GUI thread
+    QMetaObject::invokeMethod(
+                run_button, "setEnabled", Qt::QueuedConnection, arg);
 }
 
 void widget::set_threads(int no)

--- a/examples/qt/widget.cpp
+++ b/examples/qt/widget.cpp
@@ -48,22 +48,25 @@ widget::widget(std::function<void(widget *, std::size_t)> callback, QWidget *par
     setLayout(main_layout);
 }
 
-void widget::add_label(std::size_t i, double t)
+void widget::threadsafe_add_label(std::size_t i, double t)
 {
-    std::lock_guard<hpx::lcos::local::spinlock> l(mutex);
+    // may be called from any thread, does not interact directly with GUI objects
     QString txt("Thread ");
     txt.append(QString::number(i))
        .append(" finished in ")
        .append(QString::number(t))
        .append(" seconds");
-    list->addItem(txt);
+
+    QGenericArgument arg("const QString&", &txt);
+    QMetaObject::invokeMethod(this, "add_label", arg);
 }
 
-void widget::run_finished()
+void widget::threadsafe_run_finished()
 {
-  bool value = true;
-  QGenericArgument arg("bool",&value);
-  QMetaObject::invokeMethod(run_button, "setEnabled", arg);
+    // may be called from any thread, does not interact directly with GUI objects
+    bool value = true;
+    QGenericArgument arg("bool",&value);
+    QMetaObject::invokeMethod(run_button, "setEnabled", arg);
 }
 
 void widget::set_threads(int no)
@@ -76,4 +79,9 @@ void widget::run_clicked(bool)
     run_button->setEnabled(false);
     list->clear();
     hpx::apply(callback_, this, no_threads);
+}
+
+void widget::add_label(const QString &text)
+{
+    list->addItem(text);
 }

--- a/examples/qt/widget.hpp
+++ b/examples/qt/widget.hpp
@@ -25,14 +25,16 @@ class widget
         widget(std::function<void(widget *, std::size_t)> callback,
             QWidget *parent = nullptr);
 
-        void add_label(std::size_t i, double t);
+        void threadsafe_add_label(std::size_t i, double t);
 
-        void run_finished();
+        void threadsafe_run_finished();
 
     public slots:
         void set_threads(int no);
 
         void run_clicked(bool);
+
+        void add_label(const QString& text);
 
     private:
         std::size_t no_threads;


### PR DESCRIPTION
GUI objects must not be manipulated from threads other than the GUI thread. This rule was violated in the qt example. Now it is fixed.