### PR TITLE
Do not bind test running to cmake test build rule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1754,11 +1754,6 @@ if(HPX_WITH_TESTS)
   enable_testing()
   include(CTest)
 
-  if(NOT MSVC)
-    add_custom_command(TARGET tests POST_BUILD
-      COMMAND ctest --output-on-failure --timeout 100)
-  endif()
-
   include_directories(tests)
   add_subdirectory(tests)
 endif()


### PR DESCRIPTION
This fixes #2092