### PR TITLE
Fixing #2931

### DIFF
--- a/hpx/runtime/resource/detail/partitioner.hpp
+++ b/hpx/runtime/resource/detail/partitioner.hpp
@@ -158,9 +158,9 @@ namespace hpx { namespace resource { namespace detail
             return numa_domains_;
         }
 
-        bool terminate_after_parse()
+        int parse_result() const
         {
-            return cfg_.parse_terminate_;
+            return cfg_.parse_result_;
         }
 
         std::size_t assign_cores(std::size_t first_core);

--- a/hpx/util/command_line_handling.hpp
+++ b/hpx/util/command_line_handling.hpp
@@ -39,7 +39,7 @@ namespace hpx { namespace util
             cmd_line_parsed_(false),
             info_printed_(false),
             version_printed_(false),
-            parse_terminate_(false)
+            parse_result_(0)
         {}
 
         int call(boost::program_options::options_description const& desc_cmdline,
@@ -66,7 +66,7 @@ namespace hpx { namespace util
         bool cmd_line_parsed_;
         bool info_printed_;
         bool version_printed_;
-        bool parse_terminate_;
+        int parse_result_;
 
     protected:
         bool handle_arguments(util::manage_config& cfgmap,

--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -620,7 +620,6 @@ namespace hpx
                     desc_cmdline, argc, argv, std::move(ini_config),
                     resource::mode_default, mode, false);
 
-
                 // Setup all internal parameters of the resource_partitioner
                 rp.configure_pools();
 
@@ -636,13 +635,17 @@ namespace hpx
 
                 // Build and configure this runtime instance.
                 typedef hpx::runtime_impl runtime_type;
-                std::unique_ptr<hpx::runtime> rt(
-                    new runtime_type(cms.rtcfg_));
+                std::unique_ptr<hpx::runtime> rt(new runtime_type(cms.rtcfg_));
+
+                result = rp.parse_result();
 
                 // check whether HPX should be exited at this point
-                // (if the program options contain --hpx:help or --hpx:version)
-                if (rp.terminate_after_parse())
+                // (parse_result is returning a result > 0, if the program options
+                // contain --hpx:help or --hpx:version, on error result is < 0)
+                if (result != 0)
                 {
+                    if (result > 0)
+                        result = 0;
                     return result;
                 }
 

--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -620,14 +620,6 @@ namespace hpx
                     desc_cmdline, argc, argv, std::move(ini_config),
                     resource::mode_default, mode, false);
 
-                // check whether HPX should be exited at this point
-                // (if the program options contain --hpx:help or --hpx:version)
-                if (rp.terminate_after_parse())
-                {
-                    if (result > 0)
-                        result = 0;
-                    return result;
-                }
 
                 // Setup all internal parameters of the resource_partitioner
                 rp.configure_pools();
@@ -646,6 +638,13 @@ namespace hpx
                 typedef hpx::runtime_impl runtime_type;
                 std::unique_ptr<hpx::runtime> rt(
                     new runtime_type(cms.rtcfg_));
+
+                // check whether HPX should be exited at this point
+                // (if the program options contain --hpx:help or --hpx:version)
+                if (rp.terminate_after_parse())
+                {
+                    return result;
+                }
 
                 result = run_or_start(blocking, std::move(rt),
                     cms, std::move(startup), std::move(shutdown));

--- a/src/runtime/resource/detail/detail_partitioner.cpp
+++ b/src/runtime/resource/detail/detail_partitioner.cpp
@@ -891,7 +891,7 @@ namespace hpx { namespace resource { namespace detail
 
         // parse command line and set options
         // terminate set if program options contain --hpx:help or --hpx:version ...
-        cfg_.parse_terminate_ = cfg_.call(desc_cmdline, argc, argv);
+        cfg_.parse_result_ = cfg_.call(desc_cmdline, argc, argv);
 
         // set all parameters related to affinity data
         cores_needed_ = affinity_data_.init(cfg_);
@@ -902,7 +902,7 @@ namespace hpx { namespace resource { namespace detail
             fill_topology_vectors();
         }
 
-        return cfg_.parse_terminate_;
+        return cfg_.parse_result_;
     }
 
     scheduler_function partitioner::get_pool_creator(


### PR DESCRIPTION
runtime termination in the presence of --hpx:help or --hpx:version needs to
happen after the runtime has been initialized.