### PR TITLE
Fixing wrong condition in wrapper_heap

### DIFF
--- a/src/runtime/components/server/wrapper_heap.cpp
+++ b/src/runtime/components/server/wrapper_heap.cpp
@@ -287,11 +287,13 @@ namespace hpx { namespace components { namespace detail
         std::size_t const total_num_bytes =
             parameters_.capacity * parameters_.element_size;
 
-        if (first_free_ < pool_ + total_num_bytes)
+        if (first_free_ < pool_ + total_num_bytes ||
+            free_size_ < parameters_.capacity)
         {
             return false;
         }
 
+        HPX_ASSERT(free_size_ == parameters_.capacity);
         HPX_ASSERT(first_free_ == pool_ + total_num_bytes);
 
         // unbind in AGAS service


### PR DESCRIPTION
This fixes a problem with a wrong condition (which had been in there before) which
led to wrapper heaps being deallocated too early.