### PR TITLE
Fix scheduling loop exit

### DIFF
--- a/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
@@ -440,7 +440,7 @@ namespace hpx { namespace threads { namespace detail
                 // threads exist or if some other thread has terminated
                 HPX_ASSERT(
                     !sched_->Scheduler::get_thread_count(
-                        unknown, thread_priority_default, thread_num) ||
+                        suspended, thread_priority_default, thread_num) ||
                     sched_->Scheduler::get_state(thread_num) > state_stopping);
             }
             catch (hpx::exception const& e)

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -672,6 +672,7 @@ namespace hpx { namespace threads { namespace detail
                 {
                     // clean up terminated threads one more time before sleeping
                     bool can_exit =
+                        !running &&
                         scheduler.SchedulingPolicy::cleanup_terminated(
                             num_thread, true) &&
                         scheduler.SchedulingPolicy::get_thread_count(
@@ -801,6 +802,7 @@ namespace hpx { namespace threads { namespace detail
                     else
                     {
                         bool can_exit =
+                            !running &&
                             scheduler.SchedulingPolicy::cleanup_terminated(
                                 true) &&
                             scheduler.SchedulingPolicy::get_thread_count(


### PR DESCRIPTION
This fixes occasional asserts firing on throttle tests. Because the suspension/throttling changes relaxed scheduling loop exit criteria, the assert after exiting also needs to be relaxed.