### PR TITLE
Change existing symbol_namespace::iterate to return all data instead of invoking a callback

### DIFF
--- a/hpx/performance_counters/registry.hpp
+++ b/hpx/performance_counters/registry.hpp
@@ -166,12 +166,6 @@ namespace hpx { namespace performance_counters
     private:
         counter_type_map_type countertypes_;
     };
-
-    namespace detail
-    {
-        HPX_EXPORT std::string regex_from_pattern(std::string const& pattern,
-            error_code& ec);
-    }
 }}
 
 #endif

--- a/hpx/runtime/agas/addressing_service.hpp
+++ b/hpx/runtime/agas/addressing_service.hpp
@@ -61,9 +61,8 @@ public:
     // {{{ types
     typedef components::component_type component_id_type;
 
-    typedef hpx::util::function<
-        void(std::string const&, naming::gid_type const&)
-    > iterate_names_function_type;
+    typedef std::map<std::string, naming::id_type>
+        iterate_names_return_type;
 
     typedef hpx::util::function<
         void(std::string const&, components::component_type)
@@ -1184,25 +1183,15 @@ public:
     ///        name.
     ///
     /// This function iterates over all registered global ids and
-    /// unconditionally invokes the supplied hpx#function for ever found entry.
+    /// returns every found entry matching the given name pattern.
     /// Any error results in an exception thrown (or reported) from this
     /// function.
     ///
-    /// \param f          [in] a \a hpx#function encapsulating an action to be
-    ///                   invoked for every currently registered global name.
-    /// \param ec         [in,out] this represents the error status on exit,
-    ///                   if this is pre-initialized to \a hpx#throws
-    ///                   the function will throw on error instead.
+    /// \param pattern    [in] pattern (poosibly using wildcards) to match
+    ///                   all existing entries against
     ///
-    /// \note             As long as \a ec is not pre-initialized to
-    ///                   \a hpx#throws this function doesn't
-    ///                   throw but returns the result code using the
-    ///                   parameter \a ec. Otherwise it throws an instance
-    ///                   of hpx#exception.
-    bool iterate_ids(
-        iterate_names_function_type const& f
-      , error_code& ec = throws
-        );
+    hpx::future<iterate_names_return_type> iterate_ids(
+        std::string const& pattern);
 
     /// \brief Register a global name with a global address (id)
     ///

--- a/hpx/runtime/agas/interface.hpp
+++ b/hpx/runtime/agas/interface.hpp
@@ -23,6 +23,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <map>
 #include <string>
 #include <utility>
 #include <vector>
@@ -494,6 +495,11 @@ HPX_API_EXPORT std::pair<bool, components::pinned_ptr>
         util::unique_function_nonser<components::pinned_ptr()> && f);
 
 HPX_API_EXPORT void unmark_as_migrated(naming::gid_type const& gid);
+
+HPX_API_EXPORT hpx::future<std::map<std::string, hpx::id_type> >
+    find_symbols(std::string const& pattern = "*");
+HPX_API_EXPORT std::map<std::string, hpx::id_type> find_symbols(
+    hpx::launch::sync_policy, std::string const& pattern = "*");
 }}
 
 #endif // HPX_A55506A4_4AC7_4FD0_AB0D_ED0D1368FCC5

--- a/hpx/runtime/agas/server/symbol_namespace.hpp
+++ b/hpx/runtime/agas/server/symbol_namespace.hpp
@@ -44,11 +44,7 @@ struct HPX_EXPORT symbol_namespace
     // {{{ nested types
     typedef lcos::local::spinlock mutex_type;
     typedef components::fixed_component_base<symbol_namespace> base_type;
-
-    // FIXME: This signature should use id_type, not gid_type
-    typedef hpx::util::function<
-        void(std::string const&, naming::gid_type const&)
-    > iterate_names_function_type;
+    typedef std::map<std::string, naming::gid_type> iterate_names_return_type;
 
     typedef std::map<std::string, std::shared_ptr<naming::gid_type> >
         gid_table_type;
@@ -154,7 +150,7 @@ struct HPX_EXPORT symbol_namespace
 
     naming::gid_type unbind(std::string const& key);
 
-    void iterate(iterate_names_function_type const& f);
+    iterate_names_return_type iterate(std::string const& pattern);
 
     bool on_event(
         std::string const& name

--- a/hpx/runtime/agas/symbol_namespace.hpp
+++ b/hpx/runtime/agas/symbol_namespace.hpp
@@ -17,6 +17,7 @@
 #include <hpx/util/function.hpp>
 
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -30,10 +31,7 @@ struct symbol_namespace
 {
     // {{{ nested types
     typedef server::symbol_namespace server_type;
-
-    typedef hpx::util::function<
-        void(std::string const&, naming::gid_type const&)
-    > iterate_names_function_type;
+    typedef std::map<std::string, naming::id_type> iterate_names_return_type;
     // }}}
 
     static naming::gid_type get_service_instance(std::uint32_t service_locality_id);
@@ -65,8 +63,8 @@ struct symbol_namespace
     hpx::future<bool> bind_async(std::string key, naming::gid_type gid);
     bool bind(std::string key, naming::gid_type gid);
 
-    hpx::future<naming::id_type> resolve_async(std::string key);
-    naming::id_type resolve(std::string key);
+    hpx::future<naming::id_type> resolve_async(std::string key) const;
+    naming::id_type resolve(std::string key) const;
 
     hpx::future<naming::id_type> unbind_async(std::string key);
     naming::id_type unbind(std::string key);
@@ -76,6 +74,10 @@ struct symbol_namespace
       , bool call_for_past_events
       , hpx::id_type lco
         );
+
+    hpx::future<iterate_names_return_type> iterate_async(
+        std::string const& pattern) const;
+    iterate_names_return_type iterate(std::string const& pattern) const;
 
     void register_counter_types();
     void register_server_instance(std::uint32_t locality_id);

--- a/hpx/util/regex_from_pattern.hpp
+++ b/hpx/util/regex_from_pattern.hpp
@@ -1,0 +1,20 @@
+//  Copyright (c) 2007-2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_UTIL_REGEX_FROM_PATTERN_DEC_13_2017_1016AM)
+#define HPX_UTIL_REGEX_FROM_PATTERN_DEC_13_2017_1016AM
+
+#include <hpx/config.hpp>
+#include <hpx/error_code.hpp>
+
+#include <string>
+
+namespace hpx { namespace util
+{
+    HPX_EXPORT std::string regex_from_pattern(std::string const& pattern,
+        error_code& ec = throws);
+}}
+
+#endif

--- a/plugins/parcel/coalescing/coalescing_counter_registry.cpp
+++ b/plugins/parcel/coalescing/coalescing_counter_registry.cpp
@@ -8,6 +8,7 @@
 #if defined(HPX_HAVE_PARCEL_COALESCING)
 #include <hpx/performance_counters/registry.hpp>
 #include <hpx/util/format.hpp>
+#include <hpx/util/regex_from_pattern.hpp>
 
 #include <hpx/plugins/parcel/coalescing_counter_registry.hpp>
 
@@ -256,9 +257,7 @@ namespace hpx { namespace plugins { namespace parcel
 
         if (parameters.find_first_of("*?[]") != std::string::npos)
         {
-            std::string str_rx(
-                performance_counters::detail::regex_from_pattern(
-                    parameters, ec));
+            std::string str_rx(util::regex_from_pattern(parameters, ec));
             if (ec) return false;
 
             bool found_one = false;

--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -14,7 +14,7 @@
 #include <hpx/hpx_user_main_config.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/runtime/actions/plain_action.hpp>
-#include <hpx/runtime/agas/addressing_service.hpp>
+#include <hpx/runtime/agas/interface.hpp>
 #include <hpx/runtime/components/runtime_support.hpp>
 #include <hpx/runtime/config_entry.hpp>
 #include <hpx/runtime/find_localities.hpp>
@@ -51,6 +51,7 @@
 #include <exception>
 #include <functional>
 #include <iostream>
+#include <map>
 #include <memory>
 #include <new>
 #include <sstream>
@@ -80,37 +81,14 @@ namespace hpx { namespace detail
 {
     // forward declarations only
     void console_print(std::string const&);
-    void list_symbolic_name(std::string const&, naming::gid_type const&);
+    void list_symbolic_name(std::string const&, hpx::id_type const&);
     void list_component_type(std::string const&, components::component_type);
 }}
 
 HPX_PLAIN_ACTION_ID(hpx::detail::console_print,
     console_print_action, hpx::actions::console_print_action_id)
-HPX_PLAIN_ACTION_ID(hpx::detail::list_symbolic_name,
-    list_symbolic_name_action, hpx::actions::list_symbolic_name_action_id)
 HPX_PLAIN_ACTION_ID(hpx::detail::list_component_type,
     list_component_type_action, hpx::actions::list_component_type_action_id)
-
-typedef
-    hpx::util::detail::bound_action<
-        list_symbolic_name_action
-      , hpx::util::tuple<
-            hpx::naming::id_type
-          , hpx::util::detail::placeholder<1>
-          , hpx::util::detail::placeholder<2>
-        >
-    >
-    bound_list_symbolic_name_action;
-
-HPX_UTIL_REGISTER_FUNCTION_DECLARATION(
-    void(std::string const&, const hpx::naming::gid_type&)
-  , bound_list_symbolic_name_action
-  , list_symbolic_name_function)
-
-HPX_UTIL_REGISTER_FUNCTION(
-    void(std::string const&, const hpx::naming::gid_type&)
-  , bound_list_symbolic_name_action
-  , list_symbolic_name_function)
 
 typedef
     hpx::util::detail::bound_action<
@@ -245,12 +223,13 @@ namespace hpx { namespace detail
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    void list_symbolic_name(std::string const& name, naming::gid_type const& gid)
+    void list_symbolic_name(std::string const& name, hpx::id_type const& id)
     {
         std::ostringstream strm;
 
-        strm << name << ", " << gid << ", "
-             << (naming::detail::has_credits(gid) ? "managed" : "unmanaged");
+        strm << name << ", " << id << ", "
+             << (id.get_management_type() == id_type::managed ? "managed" :
+                                                                "unmanaged");
 
         print(strm.str());
     }
@@ -260,12 +239,13 @@ namespace hpx { namespace detail
         print(std::string("List of all registered symbolic names:"));
         print(std::string("--------------------------------------"));
 
-        using hpx::util::placeholders::_1;
-        using hpx::util::placeholders::_2;
+        std::map<std::string, hpx::id_type> entries =
+            agas::find_symbols(hpx::launch::sync);
 
-        naming::id_type console(agas::get_console_locality());
-        naming::get_agas_client().iterate_ids(
-            hpx::util::bind<list_symbolic_name_action>(console, _1, _2));
+        for (auto const& e : entries)
+        {
+            list_symbolic_name(e.first, e.second);
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/runtime/actions/detail/invocation_count_registry.cpp
+++ b/src/runtime/actions/detail/invocation_count_registry.cpp
@@ -9,6 +9,7 @@
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/registry.hpp>
 #include <hpx/util/format.hpp>
+#include <hpx/util/regex_from_pattern.hpp>
 
 #include <string>
 
@@ -100,9 +101,7 @@ namespace hpx { namespace actions { namespace detail
 
         if (p.parameters_.find_first_of("*?[]") != std::string::npos)
         {
-            std::string str_rx(
-                performance_counters::detail::regex_from_pattern(
-                    p.parameters_, ec));
+            std::string str_rx(util::regex_from_pattern(p.parameters_, ec));
             if (ec) return false;
 
             bool found_one = false;

--- a/src/runtime/agas/interface.cpp
+++ b/src/runtime/agas/interface.cpp
@@ -517,5 +517,18 @@ void unmark_as_migrated(naming::gid_type const& gid)
     return resolver.unmark_as_migrated(gid);
 }
 
+hpx::future<symbol_namespace::iterate_names_return_type> find_symbols(
+    std::string const& pattern)
+{
+    naming::resolver_client& resolver = naming::get_agas_client();
+    return resolver.iterate_ids(pattern);
+}
+
+symbol_namespace::iterate_names_return_type find_symbols(
+    hpx::launch::sync_policy, std::string const& pattern)
+{
+    return find_symbols(pattern).get();
+}
+
 }}
 

--- a/src/runtime/parcelset/detail/per_action_data_counter_registry.cpp
+++ b/src/runtime/parcelset/detail/per_action_data_counter_registry.cpp
@@ -12,6 +12,7 @@
 #include <hpx/performance_counters/registry.hpp>
 #include <hpx/util/bind_front.hpp>
 #include <hpx/util/format.hpp>
+#include <hpx/util/regex_from_pattern.hpp>
 
 #include <cstdint>
 #include <string>
@@ -94,9 +95,7 @@ namespace hpx { namespace parcelset { namespace detail
 
         if (p.parameters_.find_first_of("*?[]") != std::string::npos)
         {
-            std::string str_rx(
-                performance_counters::detail::regex_from_pattern(
-                    p.parameters_, ec));
+            std::string str_rx(util::regex_from_pattern(p.parameters_, ec));
             if (ec) return false;
 
             bool found_one = false;

--- a/src/util/regex_from_pattern.cpp
+++ b/src/util/regex_from_pattern.cpp
@@ -1,0 +1,98 @@
+//  Copyright (c) 2007-2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/error_code.hpp>
+#include <hpx/util/regex_from_pattern.hpp>
+
+#include <string>
+
+#include <boost/regex.hpp>
+
+namespace hpx { namespace util
+{
+    namespace detail
+    {
+        ///////////////////////////////////////////////////////////////////////
+        inline std::string
+        regex_from_character_set(std::string::const_iterator& it,
+            std::string::const_iterator end, error_code& ec)
+        {
+            std::string::const_iterator start = it;
+            std::string result(1, *it);  // copy '['
+            if (*++it == '!') {
+                result.append(1, '^');   // negated character set
+            }
+            else if (*it == ']') {
+                HPX_THROWS_IF(ec, bad_parameter, "regex_from_character_set",
+                    "Invalid pattern (empty character set) at: " +
+                        std::string(start, end));
+                return "";
+            }
+            else {
+                result.append(1, *it);   // append this character
+            }
+
+            // copy while in character set
+            while (++it != end) {
+                result.append(1, *it);
+                if (*it == ']')
+                    break;
+            }
+
+            if (it == end || *it != ']') {
+                HPX_THROWS_IF(ec, bad_parameter, "regex_from_character_set",
+                    "Invalid pattern (missing closing ']') at: " +
+                        std::string(start, end));
+                return "";
+            }
+
+            return result;
+        }
+    }
+
+    std::string regex_from_pattern(std::string const& pattern, error_code& ec)
+    {
+        std::string result;
+        std::string::const_iterator end = pattern.end();
+        for (std::string::const_iterator it = pattern.begin(); it != end; ++it)
+        {
+            char c = *it;
+            switch (c) {
+            case '*':
+                result.append(".*");
+                break;
+
+            case '?':
+                result.append(1, '.');
+                break;
+
+            case '[':
+                {
+                    std::string r =
+                        detail::regex_from_character_set(it, end, ec);
+                    if (ec) return "";
+                    result.append(r);
+                }
+                break;
+
+            case '\\':
+                if (++it == end) {
+                    HPX_THROWS_IF(ec, bad_parameter,
+                        "regex_from_pattern",
+                        "Invalid escape sequence at: " + pattern);
+                    return "";
+                }
+                result.append(1, *it);
+                break;
+
+            default:
+                result.append(1, c);
+                break;
+            }
+        }
+        return result;
+    }
+}}


### PR DESCRIPTION
This API was never used anywhere and required some face-lifting after being half-way abandoned. It is now needed on one of our projects.