### PR TITLE
Suspend thread cleanup

### DIFF
--- a/hpx/runtime/threads/policies/hierarchy_scheduler.hpp
+++ b/hpx/runtime/threads/policies/hierarchy_scheduler.hpp
@@ -207,6 +207,18 @@ namespace hpx { namespace threads { namespace policies
             return "hierarchy_scheduler";
         }
 
+        void suspend(std::size_t)
+        {
+            HPX_ASSERT_MSG(false, "hierarchy_scheduler does not support"
+                " suspending");
+        }
+
+        void resume(std::size_t)
+        {
+            HPX_ASSERT_MSG(false, "hierarchy_scheduler does not support"
+                " resuming");
+        }
+
         ///////////////////////////////////////////////////////////////////////
         // Queries the current length of the queues (work items and new items).
         std::int64_t get_queue_length(std::size_t num_thread = std::size_t(-1)) const

--- a/hpx/runtime/threads/policies/periodic_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/periodic_priority_queue_scheduler.hpp
@@ -16,6 +16,7 @@
 #include <hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp>
 #include <hpx/runtime/threads/policies/lockfree_queue_backends.hpp>
 #include <hpx/runtime/threads_fwd.hpp>
+#include <hpx/util/assert.hpp>
 
 #include <atomic>
 #include <cstddef>
@@ -72,6 +73,18 @@ namespace hpx { namespace threads { namespace policies
         static std::string get_scheduler_name()
         {
             return "periodic_priority_queue_scheduler";
+        }
+
+        void suspend(std::size_t)
+        {
+            HPX_ASSERT_MSG(false, "periodic_priority_queue_scheduler does not"
+                " support suspending");
+        }
+
+        void resume(std::size_t)
+        {
+            HPX_ASSERT_MSG(false, "periodic_priority_queue_scheduler does not"
+                " support resuming");
         }
 
         bool periodic_maintenance(bool running)

--- a/hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp
@@ -62,6 +62,18 @@ namespace hpx { namespace threads { namespace policies
             return "static_priority_queue_scheduler";
         }
 
+        void suspend(std::size_t)
+        {
+            HPX_ASSERT_MSG(false, "static_priority_queue_scheduler does not"
+                " support suspending");
+        }
+
+        void resume(std::size_t)
+        {
+            HPX_ASSERT_MSG(false, "static_priority_queue_scheduler does not"
+                " support resuming");
+        }
+
         /// Return the next thread to be executed, return false if non is
         /// available
         bool get_next_thread(std::size_t num_thread, bool running,

--- a/hpx/runtime/threads/policies/static_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/static_queue_scheduler.hpp
@@ -70,6 +70,18 @@ namespace hpx { namespace threads { namespace policies
             return "static_queue_scheduler";
         }
 
+        void suspend(std::size_t)
+        {
+            HPX_ASSERT_MSG(false, "static_queue_scheduler does not support"
+                " suspending");
+        }
+
+        void resume(std::size_t)
+        {
+            HPX_ASSERT_MSG(false, "static_queue_scheduler does not support"
+                " resuming");
+        }
+
         /// Return the next thread to be executed, return false if none is
         /// available
         virtual bool get_next_thread(std::size_t num_thread, bool,

--- a/tests/unit/resource/CMakeLists.txt
+++ b/tests/unit/resource/CMakeLists.txt
@@ -7,6 +7,7 @@ set(tests
     named_pool_executor
     resource_partitioner
     shutdown_suspended_pus
+    suspend_disabled
     throttle
     throttle_timed
     used_pus
@@ -15,6 +16,7 @@ set(tests
 set(named_pool_executor_PARAMETERS THREADS_PER_LOCALITY 4)
 set(resource_partitioner_PARAMETERS THREADS_PER_LOCALITY 4)
 set(shutdown_suspended_pus_PARAMETERS THREADS_PER_LOCALITY 4)
+set(suspend_disabled_PARAMETERS THREADS_PER_LOCALITY 4)
 set(throttle_PARAMETERS THREADS_PER_LOCALITY 4)
 set(throttle_timed_PARAMETERS THREADS_PER_LOCALITY 4)
 set(used_pus_PARAMETERS THREADS_PER_LOCALITY 4)

--- a/tests/unit/resource/shutdown_suspended_pus.cpp
+++ b/tests/unit/resource/shutdown_suspended_pus.cpp
@@ -14,6 +14,7 @@
 #include <hpx/util/lightweight_test.hpp>
 
 #include <cstddef>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>

--- a/tests/unit/resource/shutdown_suspended_pus.cpp
+++ b/tests/unit/resource/shutdown_suspended_pus.cpp
@@ -9,6 +9,8 @@
 #include <hpx/include/async.hpp>
 #include <hpx/include/resource_partitioner.hpp>
 #include <hpx/include/threads.hpp>
+#include <hpx/runtime/threads/policies/scheduler_mode.hpp>
+#include <hpx/runtime/threads/policies/schedulers.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <cstddef>
@@ -27,14 +29,6 @@ int hpx_main(int argc, char* argv[])
 
     HPX_TEST_EQ(tp.get_active_os_thread_count(), std::size_t(4));
 
-    // Enable elasticity
-    tp.set_scheduler_mode(
-        hpx::threads::policies::scheduler_mode(
-            hpx::threads::policies::do_background_work |
-            hpx::threads::policies::reduce_thread_priority |
-            hpx::threads::policies::delay_exit |
-            hpx::threads::policies::enable_elasticity));
-
     // Remove all but one pu
     for (std::size_t thread_num = 0; thread_num < num_threads - 1; ++thread_num)
     {
@@ -51,37 +45,52 @@ int hpx_main(int argc, char* argv[])
     return hpx::finalize();
 }
 
-int main(int argc, char* argv[])
+template <typename Scheduler>
+void test_scheduler(int argc, char* argv[])
 {
     std::vector<std::string> cfg =
     {
         "hpx.os_threads=4"
     };
 
-    using hpx::resource::scheduling_policy;
+    hpx::resource::partitioner rp(argc, argv, std::move(cfg));
 
-    std::vector<scheduling_policy> const policies =
-    {
-        scheduling_policy::local,
-        scheduling_policy::local_priority_fifo,
-        scheduling_policy::local_priority_lifo,
-        // NOTE: Static scheduling policies do not support suspending the own
-        // worker thread because they do not steal work.
-        //scheduling_policy::static_,
-        //scheduling_policy::static_priority,
-        scheduling_policy::abp_priority,
-        scheduling_policy::hierarchy,
-        //scheduling_policy::periodic_priority,
-    };
+    rp.create_thread_pool("default",
+        [](hpx::threads::policies::callback_notifier& notifier,
+            std::size_t num_threads, std::size_t thread_offset,
+            std::size_t pool_index, std::string const& pool_name)
+        -> std::unique_ptr<hpx::threads::detail::thread_pool_base>
+        {
+            typename Scheduler::init_parameter_type init(num_threads);
+            std::unique_ptr<Scheduler> scheduler(new Scheduler(init));
 
-    for (auto policy : policies)
-    {
-        // Set up the resource partitioner
-        hpx::resource::partitioner rp(argc, argv, std::move(cfg));
-        rp.create_thread_pool("default", policy);
+            auto mode = hpx::threads::policies::scheduler_mode(
+                hpx::threads::policies::do_background_work |
+                hpx::threads::policies::reduce_thread_priority |
+                hpx::threads::policies::delay_exit |
+                hpx::threads::policies::enable_elasticity);
 
-        HPX_TEST_EQ(hpx::init(argc, argv), 0);
-    }
+            std::unique_ptr<hpx::threads::detail::thread_pool_base> pool(
+                new hpx::threads::detail::scheduled_thread_pool<Scheduler>(
+                    std::move(scheduler), notifier, pool_index, pool_name, mode,
+                    thread_offset));
+
+            return pool;
+        });
+
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+}
+
+int main(int argc, char* argv[])
+{
+    // NOTE: Static schedulers do not support suspending the own worker thread
+    // because they do not steal work. Periodic priority scheduler not tested
+    // because it does not take into account scheduler states when scheduling
+    // work.
+
+    test_scheduler<hpx::threads::policies::local_queue_scheduler<>>(argc, argv);
+    test_scheduler<hpx::threads::policies::local_priority_queue_scheduler<>>(argc,
+        argv);
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/resource/suspend_disabled.cpp
+++ b/tests/unit/resource/suspend_disabled.cpp
@@ -1,0 +1,47 @@
+//  Copyright (c) 2017 Mikael Simberg
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Simple test verifying basic resource_partitioner functionality.
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/resource_partitioner.hpp>
+#include <hpx/include/threads.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+int hpx_main(int argc, char* argv[])
+{
+    // Try suspending without elasticity enabled, should throw an exception
+    try
+    {
+        hpx::threads::detail::thread_pool_base& tp =
+            hpx::resource::get_thread_pool("default");
+
+        tp.suspend_processing_unit(0);
+        HPX_TEST_MSG(false, "Suspending should not be allowed with "
+                     "elasticity disabled");
+    }
+    catch (std::runtime_error const&)
+    {
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg =
+    {
+        "hpx.os_threads=4"
+    };
+
+    hpx::resource::partitioner rp(argc, argv, std::move(cfg));
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+}

--- a/tests/unit/resource/suspend_disabled.cpp
+++ b/tests/unit/resource/suspend_disabled.cpp
@@ -19,6 +19,8 @@
 int hpx_main(int argc, char* argv[])
 {
     // Try suspending without elasticity enabled, should throw an exception
+    bool exception_thrown = false;
+
     try
     {
         hpx::threads::detail::thread_pool_base& tp =
@@ -26,11 +28,14 @@ int hpx_main(int argc, char* argv[])
 
         tp.suspend_processing_unit(0);
         HPX_TEST_MSG(false, "Suspending should not be allowed with "
-                     "elasticity disabled");
+            "elasticity disabled");
     }
-    catch (std::runtime_error const&)
+    catch (hpx::exception const&)
     {
+        exception_thrown = true;
     }
+
+    HPX_TEST(exception_thrown);
 
     return hpx::finalize();
 }

--- a/tests/unit/resource/throttle.cpp
+++ b/tests/unit/resource/throttle.cpp
@@ -14,6 +14,7 @@
 #include <hpx/util/lightweight_test.hpp>
 
 #include <cstddef>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <utility>

--- a/tests/unit/resource/throttle.cpp
+++ b/tests/unit/resource/throttle.cpp
@@ -9,6 +9,8 @@
 #include <hpx/include/async.hpp>
 #include <hpx/include/resource_partitioner.hpp>
 #include <hpx/include/threads.hpp>
+#include <hpx/runtime/threads/policies/scheduler_mode.hpp>
+#include <hpx/runtime/threads/policies/schedulers.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <cstddef>
@@ -27,27 +29,6 @@ int hpx_main(int argc, char* argv[])
         hpx::resource::get_thread_pool("default");
 
     HPX_TEST_EQ(tp.get_active_os_thread_count(), std::size_t(4));
-
-    {
-        // Try suspending without elasticity enabled, should throw an exception
-        try
-        {
-            tp.suspend_processing_unit(0);
-            HPX_TEST_MSG(false, "Suspending should not be allowed with "
-                 "elasticity disabled");
-        }
-        catch (std::runtime_error const&)
-        {
-        }
-    }
-
-    // Enable elasticity
-    tp.set_scheduler_mode(
-        hpx::threads::policies::scheduler_mode(
-            hpx::threads::policies::do_background_work |
-            hpx::threads::policies::reduce_thread_priority |
-            hpx::threads::policies::delay_exit |
-            hpx::threads::policies::enable_elasticity));
 
     {
         // Check number of used resources
@@ -165,37 +146,52 @@ int hpx_main(int argc, char* argv[])
     return hpx::finalize();
 }
 
-int main(int argc, char* argv[])
+template <typename Scheduler>
+void test_scheduler(int argc, char* argv[])
 {
     std::vector<std::string> cfg =
     {
         "hpx.os_threads=4"
     };
 
-    using hpx::resource::scheduling_policy;
+    hpx::resource::partitioner rp(argc, argv, std::move(cfg));
 
-    std::vector<scheduling_policy> const policies =
-    {
-        scheduling_policy::local,
-        scheduling_policy::local_priority_fifo,
-        scheduling_policy::local_priority_lifo,
-        // NOTE: Static scheduling policies do not support suspending the own
-        // worker thread because they do not steal work.
-        //scheduling_policy::static_,
-        //scheduling_policy::static_priority,
-        scheduling_policy::abp_priority,
-        scheduling_policy::hierarchy,
-        //scheduling_policy::periodic_priority,
-    };
+    rp.create_thread_pool("default",
+        [](hpx::threads::policies::callback_notifier& notifier,
+            std::size_t num_threads, std::size_t thread_offset,
+            std::size_t pool_index, std::string const& pool_name)
+        -> std::unique_ptr<hpx::threads::detail::thread_pool_base>
+        {
+            typename Scheduler::init_parameter_type init(num_threads);
+            std::unique_ptr<Scheduler> scheduler(new Scheduler(init));
 
-    for (auto policy : policies)
-    {
-        // Set up the resource partitioner
-        hpx::resource::partitioner rp(argc, argv, std::move(cfg));
-        rp.create_thread_pool("default", policy);
+            auto mode = hpx::threads::policies::scheduler_mode(
+                hpx::threads::policies::do_background_work |
+                hpx::threads::policies::reduce_thread_priority |
+                hpx::threads::policies::delay_exit |
+                hpx::threads::policies::enable_elasticity);
 
-        HPX_TEST_EQ(hpx::init(argc, argv), 0);
-    }
+            std::unique_ptr<hpx::threads::detail::thread_pool_base> pool(
+                new hpx::threads::detail::scheduled_thread_pool<Scheduler>(
+                    std::move(scheduler), notifier, pool_index, pool_name, mode,
+                    thread_offset));
+
+            return pool;
+        });
+
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+}
+
+int main(int argc, char* argv[])
+{
+    // NOTE: Static schedulers do not support suspending the own worker thread
+    // because they do not steal work. Periodic priority scheduler not tested
+    // because it does not take into account scheduler states when scheduling
+    // work.
+
+    test_scheduler<hpx::threads::policies::local_queue_scheduler<>>(argc, argv);
+    test_scheduler<hpx::threads::policies::local_priority_queue_scheduler<>>(argc,
+        argv);
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/resource/throttle_timed.cpp
+++ b/tests/unit/resource/throttle_timed.cpp
@@ -16,6 +16,7 @@
 
 #include <chrono>
 #include <cstddef>
+#include <memory>
 #include <random>
 #include <string>
 #include <utility>

--- a/tests/unit/resource/throttle_timed.cpp
+++ b/tests/unit/resource/throttle_timed.cpp
@@ -10,6 +10,8 @@
 #include <hpx/include/resource_partitioner.hpp>
 #include <hpx/include/threads.hpp>
 #include <hpx/runtime/threads/executors/pool_executor.hpp>
+#include <hpx/runtime/threads/policies/scheduler_mode.hpp>
+#include <hpx/runtime/threads/policies/schedulers.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <chrono>
@@ -27,14 +29,6 @@ int hpx_main(int argc, char* argv[])
 
     hpx::threads::detail::thread_pool_base& tp =
         hpx::resource::get_thread_pool("default");
-
-    // Enable elasticity
-    tp.set_scheduler_mode(
-        hpx::threads::policies::scheduler_mode(
-            hpx::threads::policies::do_background_work |
-            hpx::threads::policies::reduce_thread_priority |
-            hpx::threads::policies::delay_exit |
-            hpx::threads::policies::enable_elasticity));
 
     {
         // Check random scheduling with reducing resources.
@@ -100,37 +94,52 @@ int hpx_main(int argc, char* argv[])
     return hpx::finalize();
 }
 
-int main(int argc, char* argv[])
+template <typename Scheduler>
+void test_scheduler(int argc, char* argv[])
 {
     std::vector<std::string> cfg =
     {
         "hpx.os_threads=4"
     };
 
-    using hpx::resource::scheduling_policy;
+    hpx::resource::partitioner rp(argc, argv, std::move(cfg));
 
-    std::vector<scheduling_policy> const policies =
-    {
-        scheduling_policy::local,
-        scheduling_policy::local_priority_fifo,
-        scheduling_policy::local_priority_lifo,
-        // NOTE: Static scheduling policies do not support suspending the own
-        // worker thread because they do not steal work.
-        //scheduling_policy::static_,
-        //scheduling_policy::static_priority,
-        scheduling_policy::abp_priority,
-        scheduling_policy::hierarchy,
-        //scheduling_policy::periodic_priority,
-    };
+    rp.create_thread_pool("default",
+        [](hpx::threads::policies::callback_notifier& notifier,
+            std::size_t num_threads, std::size_t thread_offset,
+            std::size_t pool_index, std::string const& pool_name)
+        -> std::unique_ptr<hpx::threads::detail::thread_pool_base>
+        {
+            typename Scheduler::init_parameter_type init(num_threads);
+            std::unique_ptr<Scheduler> scheduler(new Scheduler(init));
 
-    for (auto policy : policies)
-    {
-        // Set up the resource partitioner
-        hpx::resource::partitioner rp(argc, argv, std::move(cfg));
-        rp.create_thread_pool("default", policy);
+            auto mode = hpx::threads::policies::scheduler_mode(
+                hpx::threads::policies::do_background_work |
+                hpx::threads::policies::reduce_thread_priority |
+                hpx::threads::policies::delay_exit |
+                hpx::threads::policies::enable_elasticity);
 
-        HPX_TEST_EQ(hpx::init(argc, argv), 0);
-    }
+            std::unique_ptr<hpx::threads::detail::thread_pool_base> pool(
+                new hpx::threads::detail::scheduled_thread_pool<Scheduler>(
+                    std::move(scheduler), notifier, pool_index, pool_name, mode,
+                    thread_offset));
+
+            return pool;
+        });
+
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+}
+
+int main(int argc, char* argv[])
+{
+    // NOTE: Static schedulers do not support suspending the own worker thread
+    // because they do not steal work. Periodic priority scheduler not tested
+    // because it does not take into account scheduler states when scheduling
+    // work.
+
+    test_scheduler<hpx::threads::policies::local_queue_scheduler<>>(argc, argv);
+    test_scheduler<hpx::threads::policies::local_priority_queue_scheduler<>>(argc,
+        argv);
 
     return hpx::util::report_errors();
 }


### PR DESCRIPTION
This moves enabling elasticity to the test setup before calling `hpx::init`, and creates a separate test to check that suspending is only allowed if elasticity is enabled.