### PR TITLE
Don't test inplace_merge with libc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1184,6 +1184,13 @@ endif()
 hpx_check_for_mm_prefetch(
   DEFINITIONS HPX_HAVE_MM_PREFETCH)
 
+hpx_check_for_stable_inplace_merge(
+  DEFINITIONS HPX_HAVE_STABLE_INPLACE_MERGE)
+
+if(NOT HPX_WITH_STABLE_INPLACE_MERGE)
+  hpx_warn("The standard library you are using (libc++ version < 6) does not have a stable inplace_merge implementation.")
+endif()
+
 ################################################################################
 # Check for misc system headers
 ################################################################################

--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -656,3 +656,10 @@ macro(hpx_check_for_mm_prefetch)
     SOURCE cmake/tests/mm_prefetch.cpp
     FILE ${ARGN})
 endmacro()
+
+###############################################################################
+macro(hpx_check_for_stable_inplace_merge)
+  add_hpx_config_test(HPX_WITH_STABLE_INPLACE_MERGE
+    SOURCE cmake/tests/stable_inplace_merge.cpp
+    FILE ${ARGN})
+endmacro()

--- a/cmake/tests/stable_inplace_merge.cpp
+++ b/cmake/tests/stable_inplace_merge.cpp
@@ -1,0 +1,15 @@
+////////////////////////////////////////////////////////////////////////////////
+//  Copyright (c) 2017 Mikael Simberg
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+////////////////////////////////////////////////////////////////////////////////
+
+#if defined(_LIBCPP_VERSION) && (_LIBCPP_VERSION < 6)
+#  error "libc++ inplace_merge implementation is broken"
+#endif
+
+int main()
+{
+    return 0;
+}

--- a/tests/unit/parallel/algorithms/inplace_merge.cpp
+++ b/tests/unit/parallel/algorithms/inplace_merge.cpp
@@ -47,7 +47,7 @@ int hpx_main(boost::program_options::variables_map& vm)
     std::cout << "using seed: " << seed << std::endl;
     std::srand(seed);
 
-#if !defined(_LIBCPP_VERSION)
+#if !defined(_LIBCPP_VERSION) || (_LIBCPP_VERSION >= 6)
     inplace_merge_test();
     inplace_merge_exception_test();
     inplace_merge_bad_alloc_test();

--- a/tests/unit/parallel/algorithms/inplace_merge.cpp
+++ b/tests/unit/parallel/algorithms/inplace_merge.cpp
@@ -47,11 +47,9 @@ int hpx_main(boost::program_options::variables_map& vm)
     std::cout << "using seed: " << seed << std::endl;
     std::srand(seed);
 
-#if !defined(_LIBCPP_VERSION) || (_LIBCPP_VERSION >= 6)
     inplace_merge_test();
     inplace_merge_exception_test();
     inplace_merge_bad_alloc_test();
-#endif
 
     std::cout << "Test Finish!" << std::endl;
 

--- a/tests/unit/parallel/algorithms/inplace_merge.cpp
+++ b/tests/unit/parallel/algorithms/inplace_merge.cpp
@@ -47,9 +47,11 @@ int hpx_main(boost::program_options::variables_map& vm)
     std::cout << "using seed: " << seed << std::endl;
     std::srand(seed);
 
+#if !defined(_LIBCPP_VERSION)
     inplace_merge_test();
     inplace_merge_exception_test();
     inplace_merge_bad_alloc_test();
+#endif
 
     std::cout << "Test Finish!" << std::endl;
 

--- a/tests/unit/parallel/algorithms/inplace_merge_tests.hpp
+++ b/tests/unit/parallel/algorithms/inplace_merge_tests.hpp
@@ -415,6 +415,7 @@ void test_inplace_merge_etc(ExPolicy policy, IteratorTag,
 
     // Test projection.
     {
+#if defined(HPX_HAVE_STABLE_INPLACE_MERGE)
         typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
         sol = res = org;
@@ -436,6 +437,7 @@ void test_inplace_merge_etc(ExPolicy policy, IteratorTag,
             sol_first, sol_last);
 
         HPX_TEST(equality);
+#endif
     }
 }
 
@@ -444,6 +446,7 @@ template <typename ExPolicy, typename IteratorTag, typename DataType>
 void test_inplace_merge_stable(ExPolicy policy, IteratorTag,
     DataType, int rand_base)
 {
+#if defined(HPX_HAVE_STABLE_INPLACE_MERGE)
     static_assert(
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
@@ -501,6 +504,7 @@ void test_inplace_merge_stable(ExPolicy policy, IteratorTag,
 
     HPX_TEST(test_is_meaningful);
     HPX_TEST(stable);
+#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
AFAICT [this](https://git.codingcafe.org/Mirrors/llvm-mirror/libcxx/commit/25a78dcd773ce509469a2b892adbeac0c230cdb9) is not yet in any released version of libc++ so I'm ignoring the test for all versions of libc++.

I'll update this to check the version as well once the fix has been merged.

"Fixes" #2964.