### PR TITLE
Ignore build warnings

### DIFF
--- a/examples/allgather/mpi_equivalent/mpiallgather.cpp
+++ b/examples/allgather/mpi_equivalent/mpiallgather.cpp
@@ -7,7 +7,19 @@
 #include <stdio.h>
 #include <time.h>
 #include <math.h>
+#if defined(__clang__)
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wcast-qual"
+#elif defined (__GNUC__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
 #include <mpi.h>
+#if defined(__clang__)
+#  pragma clang diagnostic pop
+#elif defined (__GNUC__)
+#  pragma GCC diagnostic pop
+#endif
 
 int main(int argc,char** argv)
 {

--- a/examples/allgather/mpi_equivalent/mpiallgather.cpp
+++ b/examples/allgather/mpi_equivalent/mpiallgather.cpp
@@ -3,23 +3,12 @@
 /*  Distributed under the Boost Software License, Version 1.0. (See accompanying */
 /*  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)        */
 
+#include <hpx/plugins/parcelport/mpi/mpi.hpp>
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <time.h>
 #include <math.h>
-#if defined(__clang__)
-#  pragma clang diagnostic push
-#  pragma clang diagnostic ignored "-Wcast-qual"
-#elif defined (__GNUC__)
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wcast-qual"
-#endif
-#include <mpi.h>
-#if defined(__clang__)
-#  pragma clang diagnostic pop
-#elif defined (__GNUC__)
-#  pragma GCC diagnostic pop
-#endif
 
 int main(int argc,char** argv)
 {

--- a/hpx/plugins/parcelport/mpi/header.hpp
+++ b/hpx/plugins/parcelport/mpi/header.hpp
@@ -11,7 +11,19 @@
 
 #if defined(HPX_HAVE_PARCELPORT_MPI)
 
+#if defined(__clang__)
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wcast-qual"
+#elif defined (__GNUC__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
 #include <mpi.h>
+#if defined(__clang__)
+#  pragma clang diagnostic pop
+#elif defined (__GNUC__)
+#  pragma GCC diagnostic pop
+#endif
 
 #include <hpx/runtime/parcelset/parcel_buffer.hpp>
 

--- a/hpx/plugins/parcelport/mpi/header.hpp
+++ b/hpx/plugins/parcelport/mpi/header.hpp
@@ -11,23 +11,9 @@
 
 #if defined(HPX_HAVE_PARCELPORT_MPI)
 
-#if defined(__clang__)
-#  pragma clang diagnostic push
-#  pragma clang diagnostic ignored "-Wcast-qual"
-#elif defined (__GNUC__)
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wcast-qual"
-#endif
-#include <mpi.h>
-#if defined(__clang__)
-#  pragma clang diagnostic pop
-#elif defined (__GNUC__)
-#  pragma GCC diagnostic pop
-#endif
-
-#include <hpx/runtime/parcelset/parcel_buffer.hpp>
-
+#include <hpx/plugins/parcelport/mpi/mpi.hpp>
 #include <hpx/plugins/parcelport/mpi/mpi_environment.hpp>
+#include <hpx/runtime/parcelset/parcel_buffer.hpp>
 #include <hpx/util/assert.hpp>
 
 #include <array>

--- a/hpx/plugins/parcelport/mpi/mpi.hpp
+++ b/hpx/plugins/parcelport/mpi/mpi.hpp
@@ -6,6 +6,8 @@
 #ifndef HPX_PLUGINS_PARCELPORT_MPI_MPI_HPP
 #define HPX_PLUGINS_PARCELPORT_MPI_MPI_HPP
 
+#if defined(HPX_HAVE_PARCELPORT_MPI)
+
 #if defined(__clang__)
 #  pragma clang diagnostic push
 #  pragma clang diagnostic ignored "-Wcast-qual"
@@ -20,6 +22,8 @@
 #  pragma clang diagnostic pop
 #elif defined (__GNUC__)
 #  pragma GCC diagnostic pop
+#endif
+
 #endif
 
 #endif

--- a/hpx/plugins/parcelport/mpi/mpi.hpp
+++ b/hpx/plugins/parcelport/mpi/mpi.hpp
@@ -1,0 +1,25 @@
+//  Copyright (c) 2017 Mikael Simberg
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_PLUGINS_PARCELPORT_MPI_MPI_HPP
+#define HPX_PLUGINS_PARCELPORT_MPI_MPI_HPP
+
+#if defined(__clang__)
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wcast-qual"
+#elif defined (__GNUC__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
+
+#include <mpi.h>
+
+#if defined(__clang__)
+#  pragma clang diagnostic pop
+#elif defined (__GNUC__)
+#  pragma GCC diagnostic pop
+#endif
+
+#endif

--- a/hpx/plugins/parcelport/mpi/mpi_environment.hpp
+++ b/hpx/plugins/parcelport/mpi/mpi_environment.hpp
@@ -11,21 +11,8 @@
 #if defined(HPX_HAVE_PARCELPORT_MPI)
 
 #include <hpx/lcos/local/spinlock.hpp>
+#include <hpx/plugins/parcelport/mpi/mpi.hpp>
 #include <hpx/util_fwd.hpp>
-
-#if defined(__clang__)
-#  pragma clang diagnostic push
-#  pragma clang diagnostic ignored "-Wcast-qual"
-#elif defined (__GNUC__)
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wcast-qual"
-#endif
-#include <mpi.h>
-#if defined(__clang__)
-#  pragma clang diagnostic pop
-#elif defined (__GNUC__)
-#  pragma GCC diagnostic pop
-#endif
 
 #include <cstdlib>
 #include <string>

--- a/hpx/plugins/parcelport/mpi/mpi_environment.hpp
+++ b/hpx/plugins/parcelport/mpi/mpi_environment.hpp
@@ -13,7 +13,19 @@
 #include <hpx/lcos/local/spinlock.hpp>
 #include <hpx/util_fwd.hpp>
 
+#if defined(__clang__)
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wcast-qual"
+#elif defined (__GNUC__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
 #include <mpi.h>
+#if defined(__clang__)
+#  pragma clang diagnostic pop
+#elif defined (__GNUC__)
+#  pragma GCC diagnostic pop
+#endif
 
 #include <cstdlib>
 #include <string>

--- a/plugins/parcelport/mpi/mpi_environment.cpp
+++ b/plugins/parcelport/mpi/mpi_environment.cpp
@@ -8,7 +8,19 @@
 #if defined(HPX_HAVE_NETWORKING)
 
 #if defined(HPX_HAVE_PARCELPORT_MPI)
+#  if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wcast-qual"
+#  elif defined (__GNUC__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wcast-qual"
+#  endif
 #include <mpi.h>
+#  if defined(__clang__)
+#    pragma clang diagnostic pop
+#  elif defined (__GNUC__)
+#    pragma GCC diagnostic pop
+#  endif
 #endif
 
 #include <hpx/util/runtime_configuration.hpp>

--- a/plugins/parcelport/mpi/mpi_environment.cpp
+++ b/plugins/parcelport/mpi/mpi_environment.cpp
@@ -8,19 +8,7 @@
 #if defined(HPX_HAVE_NETWORKING)
 
 #if defined(HPX_HAVE_PARCELPORT_MPI)
-#  if defined(__clang__)
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wcast-qual"
-#  elif defined (__GNUC__)
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wcast-qual"
-#  endif
-#include <mpi.h>
-#  if defined(__clang__)
-#    pragma clang diagnostic pop
-#  elif defined (__GNUC__)
-#    pragma GCC diagnostic pop
-#  endif
+#include <hpx/plugins/parcelport/mpi/mpi.hpp>
 #endif
 
 #include <hpx/util/runtime_configuration.hpp>

--- a/plugins/parcelport/mpi/parcelport_mpi.cpp
+++ b/plugins/parcelport/mpi/parcelport_mpi.cpp
@@ -10,7 +10,19 @@
 #include <hpx/traits/plugin_config_data.hpp>
 
 #if defined(HPX_HAVE_PARCELPORT_MPI)
+#  if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wcast-qual"
+#  elif defined (__GNUC__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wcast-qual"
+#  endif
 #include <mpi.h>
+#  if defined(__clang__)
+#    pragma clang diagnostic pop
+#  elif defined (__GNUC__)
+#    pragma GCC diagnostic pop
+#  endif
 #endif
 
 #include <hpx/plugins/parcelport/mpi/mpi_environment.hpp>

--- a/plugins/parcelport/mpi/parcelport_mpi.cpp
+++ b/plugins/parcelport/mpi/parcelport_mpi.cpp
@@ -10,19 +10,7 @@
 #include <hpx/traits/plugin_config_data.hpp>
 
 #if defined(HPX_HAVE_PARCELPORT_MPI)
-#  if defined(__clang__)
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wcast-qual"
-#  elif defined (__GNUC__)
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wcast-qual"
-#  endif
-#include <mpi.h>
-#  if defined(__clang__)
-#    pragma clang diagnostic pop
-#  elif defined (__GNUC__)
-#    pragma GCC diagnostic pop
-#  endif
+#include <hpx/plugins/parcelport/mpi/mpi.hpp>
 #endif
 
 #include <hpx/plugins/parcelport/mpi/mpi_environment.hpp>

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -12,19 +12,7 @@
 #if defined(HPX_HAVE_PARCELPORT_MPI)
 // Intel MPI does not like to be included after stdio.h. As such, we include mpi.h
 // as soon as possible.
-#  if defined(__clang__)
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wcast-qual"
-#  elif defined (__GNUC__)
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wcast-qual"
-#  endif
-#include <mpi.h>
-#  if defined(__clang__)
-#    pragma clang diagnostic pop
-#  elif defined (__GNUC__)
-#    pragma GCC diagnostic pop
-#  endif
+#include <hpx/plugins/parcelport/mpi/mpi.hpp>
 #endif
 
 #include <hpx/exception.hpp>

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -12,7 +12,19 @@
 #if defined(HPX_HAVE_PARCELPORT_MPI)
 // Intel MPI does not like to be included after stdio.h. As such, we include mpi.h
 // as soon as possible.
+#  if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wcast-qual"
+#  elif defined (__GNUC__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wcast-qual"
+#  endif
 #include <mpi.h>
+#  if defined(__clang__)
+#    pragma clang diagnostic pop
+#  elif defined (__GNUC__)
+#    pragma GCC diagnostic pop
+#  endif
 #endif
 
 #include <hpx/exception.hpp>

--- a/tests/unit/util/parse_affinity_options.cpp
+++ b/tests/unit/util/parse_affinity_options.cpp
@@ -90,6 +90,11 @@ namespace test
 //   thread:0-1=numanode:0.pu:0-1
 //   thread:0-1=socket:0.core:all.pu:0
 
+#if defined(__GNUC__) && __GNUC__ < 5
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
+
     data_good data[] =
     {
         {   "thread:0=socket:0;thread:1=socket:0", 2,
@@ -971,6 +976,10 @@ namespace test
 
         { "", 0,  {data_good_thread(), data_good_thread()}, {0,0} }
     };
+
+#if defined(__GNUC__) && __GNUC__ < 5
+#  pragma GCC diagnostic pop
+#endif
 
     void good_testing(data_good const* t, char const* const options)
     {

--- a/tests/unit/util/tuple.cpp
+++ b/tests/unit/util/tuple.cpp
@@ -11,7 +11,21 @@
 
 #include <hpx/config.hpp>
 #include <hpx/hpx_init.hpp>
+
+#if defined(__clang__)
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wdouble-promotion"
+#elif defined (__GNUC__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdouble-promotion"
+#endif
 #include <hpx/util/tuple.hpp>
+#if defined(__clang__)
+#  pragma clang diagnostic pop
+#elif defined (__GNUC__)
+#  pragma GCC diagnostic pop
+#endif
+
 #include <hpx/util/lightweight_test.hpp>
 
 #include <array>


### PR DESCRIPTION
This ignores build warnings that we can't fix using `#pragma diagnostic GCC/clang ignored ...`.