### PR TITLE
Ignore build warnings round 2

### DIFF
--- a/tests/unit/component/migrate_component_to_storage.cpp
+++ b/tests/unit/component/migrate_component_to_storage.cpp
@@ -25,7 +25,10 @@ struct test_server
     // be Serializable and CopyConstructable. Components can be
     // MoveConstructable in which case the serialized data is moved into the
     // components constructor.
-    test_server(test_server const&) {}
+    test_server(test_server const& src)
+      : hpx::components::migration_support<
+            hpx::components::simple_component_base<test_server>
+        >(src) {}
     test_server(test_server &&) {}
 
     test_server& operator=(test_server const&) { return *this; }

--- a/tests/unit/util/tuple.cpp
+++ b/tests/unit/util/tuple.cpp
@@ -10,7 +10,6 @@
 //  tuple_test_bench.cpp  --------------------------------
 
 #include <hpx/config.hpp>
-#include <hpx/hpx_init.hpp>
 
 #if defined(__clang__)
 #  pragma clang diagnostic push
@@ -19,13 +18,16 @@
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wdouble-promotion"
 #endif
-#include <hpx/util/tuple.hpp>
+
+#include <hpx/hpx_init.hpp>
+
 #if defined(__clang__)
 #  pragma clang diagnostic pop
 #elif defined (__GNUC__)
 #  pragma GCC diagnostic pop
 #endif
 
+#include <hpx/util/tuple.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <array>

--- a/tests/unit/util/tuple.cpp
+++ b/tests/unit/util/tuple.cpp
@@ -9,8 +9,6 @@
 
 //  tuple_test_bench.cpp  --------------------------------
 
-#include <hpx/config.hpp>
-
 #if defined(__clang__)
 #  pragma clang diagnostic push
 #  pragma clang diagnostic ignored "-Wdouble-promotion"
@@ -19,16 +17,16 @@
 #  pragma GCC diagnostic ignored "-Wdouble-promotion"
 #endif
 
+#include <hpx/config.hpp>
 #include <hpx/hpx_init.hpp>
+#include <hpx/util/tuple.hpp>
+#include <hpx/util/lightweight_test.hpp>
 
 #if defined(__clang__)
 #  pragma clang diagnostic pop
 #elif defined (__GNUC__)
 #  pragma GCC diagnostic pop
 #endif
-
-#include <hpx/util/tuple.hpp>
-#include <hpx/util/lightweight_test.hpp>
 
 #include <array>
 #include <functional>


### PR DESCRIPTION
My previous attempt at ignoring build warnings (#3079) in the tuple test was actually no good. While it was the `tuple.hpp` header generating the warnings, it was included before that transitively by `hpx_init.hpp`. I've instead put the ignores around all hpx headers now, with the risk of silencing future warnings which might be unrelated to the current warnings (but with the benefit of still ignoring the current warnings if `hpx_init.hpp` no longer would depend on `tuple.hpp`).

Sorry for the noise.

This also adds another explicit base class initialization to get rid of a warning.