### PR TITLE
Take advantage of C++14 lambda capture initialization syntax, where possible

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -575,7 +575,8 @@ endmacro()
 macro(hpx_check_for_cxx14_lambdas)
   add_hpx_config_test(HPX_WITH_CXX14_LAMBDAS
     SOURCE cmake/tests/cxx14_lambdas.cpp
-    FILE ${ARGN})
+    FILE ${ARGN}
+    CMAKECXXFEATURE cxx_lambda_init_captures)
 endmacro()
 
 ###############################################################################

--- a/hpx/config.hpp
+++ b/hpx/config.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //  Copyright (c) 2011 Bryce Lelbach
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -22,6 +22,7 @@
 #include <hpx/config/emulate_deleted.hpp>
 #include <hpx/config/export_definitions.hpp>
 #include <hpx/config/forceinline.hpp>
+#include <hpx/config/lambda_capture.hpp>
 #include <hpx/config/manual_profiling.hpp>
 #include <hpx/config/version.hpp>
 

--- a/hpx/config/lambda_capture.hpp
+++ b/hpx/config/lambda_capture.hpp
@@ -1,0 +1,21 @@
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_CONFIG_LAMBDA_CAPTURE_HPP
+#define HPX_CONFIG_LAMBDA_CAPTURE_HPP
+
+#include <hpx/config/defines.hpp>
+
+#include <utility>
+
+#if defined(HPX_HAVE_CXX14_LAMBDAS)
+#define HPX_CAPTURE_FORWARD(var, type)  var = std::forward<type>(var)
+#define HPX_CAPTURE_MOVE(var)           var = std::move(var)
+#else
+#define HPX_CAPTURE_FORWARD(var, type)  var
+#define HPX_CAPTURE_MOVE(var)           var
+#endif
+
+#endif

--- a/hpx/config/lambda_capture.hpp
+++ b/hpx/config/lambda_capture.hpp
@@ -11,11 +11,11 @@
 #include <utility>
 
 #if defined(HPX_HAVE_CXX14_LAMBDAS)
-#define HPX_CAPTURE_FORWARD(var, type)  var = std::forward<type>(var)
-#define HPX_CAPTURE_MOVE(var)           var = std::move(var)
+#define HPX_CAPTURE_FORWARD(var)  var = std::forward<decltype(var)>(var)
+#define HPX_CAPTURE_MOVE(var)     var = std::move(var)
 #else
-#define HPX_CAPTURE_FORWARD(var, type)  var
-#define HPX_CAPTURE_MOVE(var)           var
+#define HPX_CAPTURE_FORWARD(var)  var
+#define HPX_CAPTURE_MOVE(var)     var
 #endif
 
 #endif

--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //  Copyright (c) 2013 Agustin Berge
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -1125,7 +1125,7 @@ namespace hpx { namespace lcos
         convert_future_helper(Future && f, Conv && conv) //-V659
         {
             return f.then(
-                [conv](Future && f) -> T
+                [HPX_CAPTURE_FORWARD(conv, Conv)](Future && f) -> T
                 {
                     return hpx::util::invoke(conv, f.get());
                 });
@@ -1426,7 +1426,7 @@ namespace hpx { namespace lcos
             "result type by using the supplied conversion function");
 
         return f.then(
-            [conv](hpx::shared_future<U> const& f)
+            [HPX_CAPTURE_FORWARD(conv, Conv)](hpx::shared_future<U> const& f)
             {
                 return hpx::util::invoke(conv, f.get());
             });

--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -1125,7 +1125,7 @@ namespace hpx { namespace lcos
         convert_future_helper(Future && f, Conv && conv) //-V659
         {
             return f.then(
-                [HPX_CAPTURE_FORWARD(conv, Conv)](Future && f) -> T
+                [HPX_CAPTURE_FORWARD(conv)](Future && f) -> T
                 {
                     return hpx::util::invoke(conv, f.get());
                 });
@@ -1426,7 +1426,7 @@ namespace hpx { namespace lcos
             "result type by using the supplied conversion function");
 
         return f.then(
-            [HPX_CAPTURE_FORWARD(conv, Conv)](hpx::shared_future<U> const& f)
+            [HPX_CAPTURE_FORWARD(conv)](hpx::shared_future<U> const& f)
             {
                 return hpx::util::invoke(conv, f.get());
             });

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //  Copyright (c) 2014-2015 Agustin Berge
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -497,8 +497,10 @@ namespace hpx { namespace lcos { namespace detail
             }
 
             ptr->execute_deferred();
+
             ptr->set_on_completed(util::deferred_call(
-                    [this_](shared_state_ptr && f, launch policy)
+                    [HPX_CAPTURE_MOVE(this_)](
+                        shared_state_ptr && f, launch policy)
                     {
                         if (hpx::detail::has_async_policy(policy))
                             this_->async(std::move(f), policy.priority());

--- a/hpx/parallel/algorithms/adjacent_difference.hpp
+++ b/hpx/parallel/algorithms/adjacent_difference.hpp
@@ -78,7 +78,7 @@ namespace hpx { namespace parallel { inline namespace v1
                 }
 
                 auto f1 =
-                    [HPX_CAPTURE_FORWARD(op, Op)](
+                    [HPX_CAPTURE_FORWARD(op)](
                         zip_iterator part_begin, std::size_t part_size) mutable
                 {
                     // VS2015RC bails out when op is captured by ref

--- a/hpx/parallel/algorithms/adjacent_difference.hpp
+++ b/hpx/parallel/algorithms/adjacent_difference.hpp
@@ -78,22 +78,17 @@ namespace hpx { namespace parallel { inline namespace v1
                 }
 
                 auto f1 =
-                    [op, policy](
-                        zip_iterator part_begin, std::size_t part_size
-                    ) mutable
-                    {
-                        HPX_UNUSED(policy);
-
-                        // VS2015RC bails out when op is captured by ref
-                        using hpx::util::get;
-                        util::loop_n<ExPolicy>(
-                            part_begin, part_size,
-                            [op](zip_iterator it)
-                            {
-                                get<2>(*it) = hpx::util::invoke(
-                                    op, get<0>(*it), get<1>(*it));
-                            });
-                    };
+                    [HPX_CAPTURE_FORWARD(op, Op)](
+                        zip_iterator part_begin, std::size_t part_size) mutable
+                {
+                    // VS2015RC bails out when op is captured by ref
+                    using hpx::util::get;
+                    util::loop_n<ExPolicy>(
+                        part_begin, part_size, [op](zip_iterator it) {
+                            get<2>(*it) =
+                                hpx::util::invoke(op, get<0>(*it), get<1>(*it));
+                        });
+                };
 
                 using hpx::util::make_zip_iterator;
                 return util::partitioner<ExPolicy, Iter, void>::call(

--- a/hpx/parallel/algorithms/adjacent_find.hpp
+++ b/hpx/parallel/algorithms/adjacent_find.hpp
@@ -76,7 +76,7 @@ namespace hpx { namespace parallel { inline namespace v1
                     call_with_index(
                         std::forward<ExPolicy>(policy),
                         hpx::util::make_zip_iterator(first, next), count-1, 1,
-                        [HPX_CAPTURE_FORWARD(op, Pred), tok](
+                        [HPX_CAPTURE_FORWARD(op), tok](
                             zip_iterator it, std::size_t part_size,
                             std::size_t base_idx) mutable
                         {

--- a/hpx/parallel/algorithms/adjacent_find.hpp
+++ b/hpx/parallel/algorithms/adjacent_find.hpp
@@ -76,7 +76,8 @@ namespace hpx { namespace parallel { inline namespace v1
                     call_with_index(
                         std::forward<ExPolicy>(policy),
                         hpx::util::make_zip_iterator(first, next), count-1, 1,
-                        [op, tok](zip_iterator it, std::size_t part_size,
+                        [HPX_CAPTURE_FORWARD(op, Pred), tok](
+                            zip_iterator it, std::size_t part_size,
                             std::size_t base_idx) mutable
                         {
                             util::loop_idx_n(

--- a/hpx/parallel/algorithms/all_any_none.hpp
+++ b/hpx/parallel/algorithms/all_any_none.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -72,22 +72,22 @@ namespace hpx { namespace parallel { inline namespace v1
 
                 util::cancellation_token<> tok;
                 auto f1 =
-                    [op, tok, policy, proj](
-                        FwdIter part_begin, std::size_t part_count
-                    ) mutable -> bool
-                    {
-                        HPX_UNUSED(policy);
-
-                        util::loop_n<ExPolicy>(
-                            part_begin, part_count, tok,
-                            [&op, &tok, &proj](FwdIter const& curr)
+                    [HPX_CAPTURE_FORWARD(op, F), tok,
+                        HPX_CAPTURE_FORWARD(proj, Proj)
+                    ](FwdIter part_begin, std::size_t part_count) mutable -> bool
+                {
+                    util::loop_n<ExPolicy>(part_begin, part_count, tok,
+                        [&op, &tok, &proj](FwdIter const& curr)
+                        {
+                            if (hpx::util::invoke(op,
+                                    hpx::util::invoke(proj, *curr)))
                             {
-                                if (op(proj(*curr)))
-                                    tok.cancel();
-                            });
+                                tok.cancel();
+                            }
+                        });
 
-                        return !tok.was_cancelled();
-                    };
+                    return !tok.was_cancelled();
+                };
 
                 return util::partitioner<ExPolicy, bool>::call(
                     std::forward<ExPolicy>(policy),
@@ -247,18 +247,19 @@ namespace hpx { namespace parallel { inline namespace v1
 
                 util::cancellation_token<> tok;
                 auto f1 =
-                    [op, tok, policy, proj](
-                        FwdIter part_begin, std::size_t part_count
-                    ) mutable -> bool
+                    [HPX_CAPTURE_FORWARD(op, F), tok,
+                        HPX_CAPTURE_FORWARD(proj, Proj)
+                    ](FwdIter part_begin, std::size_t part_count) mutable -> bool
                     {
-                        HPX_UNUSED(policy);
-
                         util::loop_n<ExPolicy>(
                             part_begin, part_count, tok,
                             [&op, &tok, &proj](FwdIter const& curr)
                             {
-                                if (op(proj(*curr)))
+                                if (hpx::util::invoke(op,
+                                        hpx::util::invoke(proj, *curr)))
+                                {
                                     tok.cancel();
+                                }
                             });
 
                         return tok.was_cancelled();
@@ -422,18 +423,19 @@ namespace hpx { namespace parallel { inline namespace v1
 
                 util::cancellation_token<> tok;
                 auto f1 =
-                    [op, tok, policy, proj](
-                        FwdIter part_begin, std::size_t part_count
-                    ) mutable -> bool
+                    [HPX_CAPTURE_FORWARD(op, F), tok,
+                        HPX_CAPTURE_FORWARD(proj, Proj)
+                    ](FwdIter part_begin, std::size_t part_count) mutable -> bool
                     {
-                        HPX_UNUSED(policy);
-
                         util::loop_n<ExPolicy>(
                             part_begin, part_count, tok,
                             [&op, &tok, &proj](FwdIter const& curr)
                             {
-                                if (!op(proj(*curr)))
+                                if (!hpx::util::invoke(op,
+                                        hpx::util::invoke(proj, *curr)))
+                                {
                                     tok.cancel();
+                                }
                             });
 
                         return !tok.was_cancelled();

--- a/hpx/parallel/algorithms/all_any_none.hpp
+++ b/hpx/parallel/algorithms/all_any_none.hpp
@@ -72,8 +72,8 @@ namespace hpx { namespace parallel { inline namespace v1
 
                 util::cancellation_token<> tok;
                 auto f1 =
-                    [HPX_CAPTURE_FORWARD(op, F), tok,
-                        HPX_CAPTURE_FORWARD(proj, Proj)
+                    [HPX_CAPTURE_FORWARD(op), tok,
+                        HPX_CAPTURE_FORWARD(proj)
                     ](FwdIter part_begin, std::size_t part_count) mutable -> bool
                 {
                     util::loop_n<ExPolicy>(part_begin, part_count, tok,
@@ -247,8 +247,8 @@ namespace hpx { namespace parallel { inline namespace v1
 
                 util::cancellation_token<> tok;
                 auto f1 =
-                    [HPX_CAPTURE_FORWARD(op, F), tok,
-                        HPX_CAPTURE_FORWARD(proj, Proj)
+                    [HPX_CAPTURE_FORWARD(op), tok,
+                        HPX_CAPTURE_FORWARD(proj)
                     ](FwdIter part_begin, std::size_t part_count) mutable -> bool
                     {
                         util::loop_n<ExPolicy>(
@@ -423,8 +423,8 @@ namespace hpx { namespace parallel { inline namespace v1
 
                 util::cancellation_token<> tok;
                 auto f1 =
-                    [HPX_CAPTURE_FORWARD(op, F), tok,
-                        HPX_CAPTURE_FORWARD(proj, Proj)
+                    [HPX_CAPTURE_FORWARD(op), tok,
+                        HPX_CAPTURE_FORWARD(proj)
                     ](FwdIter part_begin, std::size_t part_count) mutable -> bool
                     {
                         util::loop_n<ExPolicy>(

--- a/hpx/parallel/algorithms/copy.hpp
+++ b/hpx/parallel/algorithms/copy.hpp
@@ -1,6 +1,6 @@
 //  Copyright (c) 2014 Grant Mercer
 //  Copyright (c) 2015 Daniel Bourgeois
-//  Copyright (c) 2016-2017 Hartmut Kaiser
+//  Copyright (c) 2016-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -423,14 +423,11 @@ namespace hpx { namespace parallel { inline namespace v1
                     > scan_partitioner_type;
 
                 auto f1 =
-                    [pred, proj, flags, policy]
-                    (
-                       zip_iterator part_begin, std::size_t part_size
-                    )   -> std::size_t
+                    [HPX_CAPTURE_FORWARD(pred, Pred),
+                        HPX_CAPTURE_FORWARD(proj, Proj)
+                    ](zip_iterator part_begin, std::size_t part_size)
+                    ->  std::size_t
                     {
-                        HPX_UNUSED(flags);
-                        HPX_UNUSED(policy);
-
                         std::size_t curr = 0;
 
                         // MSVC complains if proj is captured by ref below
@@ -438,8 +435,8 @@ namespace hpx { namespace parallel { inline namespace v1
                             part_begin, part_size,
                             [&pred, proj, &curr](zip_iterator it) mutable
                             {
-                                using hpx::util::invoke;
-                                bool f = invoke(pred, invoke(proj, get<0>(*it)));
+                                bool f = hpx::util::invoke(pred,
+                                    hpx::util::invoke(proj, get<0>(*it)));
 
                                 if ((get<1>(*it) = f))
                                     ++curr;
@@ -448,14 +445,13 @@ namespace hpx { namespace parallel { inline namespace v1
                         return curr;
                     };
                 auto f3 =
-                    [dest, flags, policy](
+                    [dest, flags](
                         zip_iterator part_begin, std::size_t part_size,
                         hpx::shared_future<std::size_t> curr,
                         hpx::shared_future<std::size_t> next
                     ) mutable
                     {
                         HPX_UNUSED(flags);
-                        HPX_UNUSED(policy);
 
                         next.get();     // rethrow exceptions
 
@@ -464,7 +460,7 @@ namespace hpx { namespace parallel { inline namespace v1
                             part_begin, part_size,
                             [&dest](zip_iterator it) mutable
                             {
-                                if(get<1>(*it))
+                                if (get<1>(*it))
                                     *dest++ = get<0>(*it);
                             });
                     };

--- a/hpx/parallel/algorithms/copy.hpp
+++ b/hpx/parallel/algorithms/copy.hpp
@@ -423,8 +423,8 @@ namespace hpx { namespace parallel { inline namespace v1
                     > scan_partitioner_type;
 
                 auto f1 =
-                    [HPX_CAPTURE_FORWARD(pred, Pred),
-                        HPX_CAPTURE_FORWARD(proj, Proj)
+                    [HPX_CAPTURE_FORWARD(pred),
+                        HPX_CAPTURE_FORWARD(proj)
                     ](zip_iterator part_begin, std::size_t part_size)
                     ->  std::size_t
                     {

--- a/hpx/parallel/algorithms/equal.hpp
+++ b/hpx/parallel/algorithms/equal.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -111,20 +111,20 @@ namespace hpx { namespace parallel { inline namespace v1
 
                 util::cancellation_token<> tok;
                 auto f1 =
-                    [f, tok, policy](
+                    [f, tok](
                         zip_iterator it, std::size_t part_count
                     ) mutable -> bool
                     {
-                        HPX_UNUSED(policy);
-
                         util::loop_n<ExPolicy>(
                             it, part_count, tok,
                             [&f, &tok](zip_iterator const& curr)
                             {
-                                using hpx::util::get;
                                 reference t = *curr;
-                                if (!f(get<0>(t), get<1>(t)))
+                                if (!hpx::util::invoke(f, hpx::util::get<0>(t),
+                                        hpx::util::get<1>(t)))
+                                {
                                     tok.cancel();
+                                }
                             });
                         return !tok.was_cancelled();
                     };
@@ -299,20 +299,20 @@ namespace hpx { namespace parallel { inline namespace v1
 
                 util::cancellation_token<> tok;
                 auto f1 =
-                    [f, tok, policy](
+                    [f, tok](
                         zip_iterator it, std::size_t part_count
                     ) mutable -> bool
                     {
-                        HPX_UNUSED(policy);
-
                         util::loop_n<ExPolicy>(
                             it, part_count, tok,
                             [&f, &tok](zip_iterator const& curr)
                             {
                                 reference t = *curr;
-                                using hpx::util::get;
-                                if (!f(get<0>(t), get<1>(t)))
+                                if (!hpx::util::invoke(f, hpx::util::get<0>(t),
+                                        hpx::util::get<1>(t)))
+                                {
                                     tok.cancel();
+                                }
                             });
                         return !tok.was_cancelled();
                     };

--- a/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -148,7 +148,7 @@ namespace hpx { namespace parallel { inline namespace v1
                     std::forward<ExPolicy>(policy),
                     make_zip_iterator(first, dest), count, init,
                     // step 1 performs first part of scan algorithm
-                    [op, HPX_CAPTURE_FORWARD(conv, Conv), last](
+                    [op, HPX_CAPTURE_FORWARD(conv), last](
                         zip_iterator part_begin, std::size_t part_size) -> T
                     {
                         T part_init = hpx::util::invoke(

--- a/hpx/parallel/algorithms/find.hpp
+++ b/hpx/parallel/algorithms/find.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2014 Grant Mercer
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -224,8 +224,10 @@ namespace hpx { namespace parallel { inline namespace v1
                 return util::partitioner<ExPolicy, FwdIter, void>::
                     call_with_index(
                         std::forward<ExPolicy>(policy), first, count, 1,
-                        [f, tok](FwdIter it, std::size_t part_size,
-                            std::size_t base_idx) mutable -> void
+                        [HPX_CAPTURE_FORWARD(f, F), tok](
+                            FwdIter it, std::size_t part_size,
+                            std::size_t base_idx
+                        ) mutable -> void
                         {
                             util::loop_idx_n(
                                 base_idx, it, part_size, tok,
@@ -398,8 +400,10 @@ namespace hpx { namespace parallel { inline namespace v1
                 return util::partitioner<ExPolicy, FwdIter, void>::
                     call_with_index(
                         std::forward<ExPolicy>(policy), first, count, 1,
-                        [f, tok](FwdIter it, std::size_t part_size,
-                            std::size_t base_idx) mutable -> void
+                        [HPX_CAPTURE_FORWARD(f, F), tok](
+                            FwdIter it, std::size_t part_size,
+                            std::size_t base_idx
+                        ) mutable -> void
                         {
                             util::loop_idx_n(
                                 base_idx, it, part_size, tok,
@@ -573,16 +577,18 @@ namespace hpx { namespace parallel { inline namespace v1
                 > tok(-1);
 
                 return util::partitioner<ExPolicy, FwdIter, void>::
-                    call_with_index(
-                        std::forward<ExPolicy>(policy), first1, count-(diff-1), 1,
-                        [=](FwdIter it, std::size_t part_size,
-                            std::size_t base_idx) mutable -> void
+                    call_with_index(std::forward<ExPolicy>(policy),
+                        first1, count - diff + 1, 1,
+                        [=, HPX_CAPTURE_FORWARD(op, Pred)](
+                            FwdIter it, std::size_t part_size,
+                            std::size_t base_idx
+                        ) mutable -> void
                         {
                             FwdIter curr = it;
 
                             util::loop_idx_n(
                                 base_idx, it, part_size, tok,
-                                [=, &tok, &curr](
+                                [=, &tok, &curr, &op](
                                     reference t, std::size_t i
                                 ) -> void
                                 {
@@ -778,7 +784,7 @@ namespace hpx { namespace parallel { inline namespace v1
                 return util::partitioner<ExPolicy, FwdIter, void>::
                     call_with_index(
                         std::forward<ExPolicy>(policy), first, count, 1,
-                        [s_first, s_last, tok, op](
+                        [s_first, s_last, tok, HPX_CAPTURE_FORWARD(op, Pred)](
                             FwdIter it, std::size_t part_size,
                             std::size_t base_idx
                         ) mutable -> void

--- a/hpx/parallel/algorithms/find.hpp
+++ b/hpx/parallel/algorithms/find.hpp
@@ -224,7 +224,7 @@ namespace hpx { namespace parallel { inline namespace v1
                 return util::partitioner<ExPolicy, FwdIter, void>::
                     call_with_index(
                         std::forward<ExPolicy>(policy), first, count, 1,
-                        [HPX_CAPTURE_FORWARD(f, F), tok](
+                        [HPX_CAPTURE_FORWARD(f), tok](
                             FwdIter it, std::size_t part_size,
                             std::size_t base_idx
                         ) mutable -> void
@@ -400,7 +400,7 @@ namespace hpx { namespace parallel { inline namespace v1
                 return util::partitioner<ExPolicy, FwdIter, void>::
                     call_with_index(
                         std::forward<ExPolicy>(policy), first, count, 1,
-                        [HPX_CAPTURE_FORWARD(f, F), tok](
+                        [HPX_CAPTURE_FORWARD(f), tok](
                             FwdIter it, std::size_t part_size,
                             std::size_t base_idx
                         ) mutable -> void
@@ -579,7 +579,7 @@ namespace hpx { namespace parallel { inline namespace v1
                 return util::partitioner<ExPolicy, FwdIter, void>::
                     call_with_index(std::forward<ExPolicy>(policy),
                         first1, count - diff + 1, 1,
-                        [=, HPX_CAPTURE_FORWARD(op, Pred)](
+                        [=, HPX_CAPTURE_FORWARD(op)](
                             FwdIter it, std::size_t part_size,
                             std::size_t base_idx
                         ) mutable -> void
@@ -784,7 +784,7 @@ namespace hpx { namespace parallel { inline namespace v1
                 return util::partitioner<ExPolicy, FwdIter, void>::
                     call_with_index(
                         std::forward<ExPolicy>(policy), first, count, 1,
-                        [s_first, s_last, tok, HPX_CAPTURE_FORWARD(op, Pred)](
+                        [s_first, s_last, tok, HPX_CAPTURE_FORWARD(op)](
                             FwdIter it, std::size_t part_size,
                             std::size_t base_idx
                         ) mutable -> void

--- a/hpx/parallel/algorithms/generate.hpp
+++ b/hpx/parallel/algorithms/generate.hpp
@@ -58,7 +58,7 @@ namespace hpx { namespace parallel { inline namespace v1
                 return for_each_n<FwdIter>().call(
                         std::forward<ExPolicy>(policy), std::false_type(),
                         first, std::distance(first, last),
-                        [f](type& v) mutable
+                        [HPX_CAPTURE_FORWARD(f, F)](type& v) mutable
                         {
                             v = f();
                         },
@@ -192,7 +192,7 @@ namespace hpx { namespace parallel { inline namespace v1
                     for_each_n<FwdIter>().call(
                         std::forward<ExPolicy>(policy),
                         std::false_type(), first, count,
-                        [f](type& v) mutable
+                        [HPX_CAPTURE_FORWARD(f, F)](type& v) mutable
                         {
                             v = f();
                         },

--- a/hpx/parallel/algorithms/generate.hpp
+++ b/hpx/parallel/algorithms/generate.hpp
@@ -58,7 +58,7 @@ namespace hpx { namespace parallel { inline namespace v1
                 return for_each_n<FwdIter>().call(
                         std::forward<ExPolicy>(policy), std::false_type(),
                         first, std::distance(first, last),
-                        [HPX_CAPTURE_FORWARD(f, F)](type& v) mutable
+                        [HPX_CAPTURE_FORWARD(f)](type& v) mutable
                         {
                             v = f();
                         },
@@ -192,7 +192,7 @@ namespace hpx { namespace parallel { inline namespace v1
                     for_each_n<FwdIter>().call(
                         std::forward<ExPolicy>(policy),
                         std::false_type(), first, count,
-                        [HPX_CAPTURE_FORWARD(f, F)](type& v) mutable
+                        [HPX_CAPTURE_FORWARD(f)](type& v) mutable
                         {
                             v = f();
                         },

--- a/hpx/parallel/algorithms/includes.hpp
+++ b/hpx/parallel/algorithms/includes.hpp
@@ -152,9 +152,10 @@ namespace hpx { namespace parallel { inline namespace v1
                 return util::partitioner<ExPolicy, bool>::call(
                     std::forward<ExPolicy>(policy),
                     first2, std::distance(first2, last2),
-                    [first1, last1, first2, last2, f, tok](
-                            FwdIter2 part_begin, std::size_t part_count
-                        ) mutable -> bool
+                    [first1, last1, first2, last2, tok,
+                        HPX_CAPTURE_FORWARD(f, F)
+                    ](FwdIter2 part_begin, std::size_t part_count) mutable
+                    ->  bool
                     {
                         FwdIter2 part_end = detail::next(part_begin, part_count);
                         if (first2 != part_begin)

--- a/hpx/parallel/algorithms/includes.hpp
+++ b/hpx/parallel/algorithms/includes.hpp
@@ -153,7 +153,7 @@ namespace hpx { namespace parallel { inline namespace v1
                     std::forward<ExPolicy>(policy),
                     first2, std::distance(first2, last2),
                     [first1, last1, first2, last2, tok,
-                        HPX_CAPTURE_FORWARD(f, F)
+                        HPX_CAPTURE_FORWARD(f)
                     ](FwdIter2 part_begin, std::size_t part_count) mutable
                     ->  bool
                     {

--- a/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -144,7 +144,7 @@ namespace hpx { namespace parallel { inline namespace v1
                     std::forward<ExPolicy>(policy),
                     make_zip_iterator(first, dest), count, init,
                     // step 1 performs first part of scan algorithm
-                    [op, last, HPX_CAPTURE_FORWARD(conv, Conv)](
+                    [op, last, HPX_CAPTURE_FORWARD(conv)](
                         zip_iterator part_begin, std::size_t part_size) -> T
                     {
                         T part_init = hpx::util::invoke(conv, get<0>(*part_begin));

--- a/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -144,20 +144,20 @@ namespace hpx { namespace parallel { inline namespace v1
                     std::forward<ExPolicy>(policy),
                     make_zip_iterator(first, dest), count, init,
                     // step 1 performs first part of scan algorithm
-                    [op, conv, last](zip_iterator part_begin,
-                        std::size_t part_size) -> T
+                    [op, last, HPX_CAPTURE_FORWARD(conv, Conv)](
+                        zip_iterator part_begin, std::size_t part_size) -> T
                     {
                         T part_init = hpx::util::invoke(conv, get<0>(*part_begin));
                         get<1>(*part_begin++) = part_init;
+
                         auto iters = part_begin.get_iterator_tuple();
                         if(get<0>(iters) != last)
-                            return sequential_inclusive_scan_n(
-                                get<0>(iters),
-                                part_size-1,
-                                get<1>(iters),
-                                part_init, op, conv);
-                        else
-                            return part_init;
+                        {
+                            return sequential_inclusive_scan_n(get<0>(iters),
+                                part_size - 1, get<1>(iters), part_init, op,
+                                conv);
+                        }
+                        return part_init;
                     },
                     // step 2 propagates the partition results from left
                     // to right

--- a/hpx/parallel/algorithms/is_heap.hpp
+++ b/hpx/parallel/algorithms/is_heap.hpp
@@ -85,8 +85,8 @@ namespace hpx { namespace parallel { inline namespace v1
                     call_with_index(
                         std::forward<ExPolicy>(policy), second, count, 1,
                         [tok, first,
-                            HPX_CAPTURE_FORWARD(comp, Comp),
-                            HPX_CAPTURE_FORWARD(proj, Proj)
+                            HPX_CAPTURE_FORWARD(comp),
+                            HPX_CAPTURE_FORWARD(proj)
                         ](RandIter it, std::size_t part_size,
                             std::size_t base_idx
                         ) mutable -> void
@@ -284,8 +284,8 @@ namespace hpx { namespace parallel { inline namespace v1
                     call_with_index(
                         std::forward<ExPolicy>(policy), second, count, 1,
                         [tok, first,
-                            HPX_CAPTURE_FORWARD(comp, Comp),
-                            HPX_CAPTURE_FORWARD(proj, Proj)
+                            HPX_CAPTURE_FORWARD(comp),
+                            HPX_CAPTURE_FORWARD(proj)
                         ](RandIter it, std::size_t part_size,
                             std::size_t base_idx) mutable
                         {

--- a/hpx/parallel/algorithms/is_heap.hpp
+++ b/hpx/parallel/algorithms/is_heap.hpp
@@ -84,20 +84,25 @@ namespace hpx { namespace parallel { inline namespace v1
                 return util::partitioner<ExPolicy, bool, void>::
                     call_with_index(
                         std::forward<ExPolicy>(policy), second, count, 1,
-                        [tok, first, comp, proj](RandIter it,
-                            std::size_t part_size, std::size_t base_idx
+                        [tok, first,
+                            HPX_CAPTURE_FORWARD(comp, Comp),
+                            HPX_CAPTURE_FORWARD(proj, Proj)
+                        ](RandIter it, std::size_t part_size,
+                            std::size_t base_idx
                         ) mutable -> void
                         {
                             util::loop_idx_n(
                                 base_idx, it, part_size, tok,
-                                [&tok, first, &comp, proj](
+                                [&tok, first, &comp, &proj](
                                     type const& v, std::size_t i
                                 ) -> void
                                 {
                                     if (hpx::util::invoke(comp,
                                         hpx::util::invoke(proj, *(first + i / 2)),
                                         hpx::util::invoke(proj, v)))
+                                    {
                                         tok.cancel(0);
+                                    }
                                 });
                         },
                         [tok](std::vector<hpx::future<void> > &&) mutable
@@ -278,8 +283,11 @@ namespace hpx { namespace parallel { inline namespace v1
                 return util::partitioner<ExPolicy, RandIter, void>::
                     call_with_index(
                         std::forward<ExPolicy>(policy), second, count, 1,
-                        [tok, first, comp, proj](RandIter it,
-                            std::size_t part_size, std::size_t base_idx) mutable
+                        [tok, first,
+                            HPX_CAPTURE_FORWARD(comp, Comp),
+                            HPX_CAPTURE_FORWARD(proj, Proj)
+                        ](RandIter it, std::size_t part_size,
+                            std::size_t base_idx) mutable
                         {
                             util::loop_idx_n(
                                 base_idx, it, part_size, tok,
@@ -290,7 +298,9 @@ namespace hpx { namespace parallel { inline namespace v1
                                     if (hpx::util::invoke(comp,
                                         hpx::util::invoke(proj, *(first + i / 2)),
                                         hpx::util::invoke(proj, v)))
+                                    {
                                         tok.cancel(i);
+                                    }
                                 });
                         },
                         [tok, second](std::vector<hpx::future<void> > &&) mutable

--- a/hpx/parallel/algorithms/is_partitioned.hpp
+++ b/hpx/parallel/algorithms/is_partitioned.hpp
@@ -89,7 +89,7 @@ namespace hpx { namespace parallel { inline namespace v1
 
                 util::cancellation_token<> tok;
                 auto f1 =
-                    [tok, HPX_CAPTURE_FORWARD(pred, Pred)](
+                    [tok, HPX_CAPTURE_FORWARD(pred)](
                         Iter part_begin, std::size_t part_count) mutable -> bool
                     {
                         bool fst_bool = hpx::util::invoke(pred, *part_begin);

--- a/hpx/parallel/algorithms/is_partitioned.hpp
+++ b/hpx/parallel/algorithms/is_partitioned.hpp
@@ -89,12 +89,9 @@ namespace hpx { namespace parallel { inline namespace v1
 
                 util::cancellation_token<> tok;
                 auto f1 =
-                    [pred, tok, policy](
-                        Iter part_begin, std::size_t part_count
-                    ) mutable -> bool
+                    [tok, HPX_CAPTURE_FORWARD(pred, Pred)](
+                        Iter part_begin, std::size_t part_count) mutable -> bool
                     {
-                        HPX_UNUSED(policy);
-
                         bool fst_bool = hpx::util::invoke(pred, *part_begin);
                         if (part_count == 1)
                             return fst_bool;

--- a/hpx/parallel/algorithms/is_sorted.hpp
+++ b/hpx/parallel/algorithms/is_sorted.hpp
@@ -65,7 +65,7 @@ namespace hpx { namespace parallel { inline namespace v1
 
                 util::cancellation_token<> tok;
                 auto f1 =
-                    [tok, last, HPX_CAPTURE_FORWARD(pred, Pred)](
+                    [tok, last, HPX_CAPTURE_FORWARD(pred)](
                         FwdIter part_begin, std::size_t part_size
                     ) mutable -> bool
                     {
@@ -226,7 +226,7 @@ namespace hpx { namespace parallel { inline namespace v1
                 return util::partitioner<ExPolicy, FwdIter, void>::
                 call_with_index(
                     std::forward<ExPolicy>(policy), first, count, 1,
-                    [tok, last, HPX_CAPTURE_FORWARD(pred, Pred)](
+                    [tok, last, HPX_CAPTURE_FORWARD(pred)](
                         FwdIter part_begin, std::size_t part_size,
                         std::size_t base_idx
                     ) mutable -> void

--- a/hpx/parallel/algorithms/is_sorted.hpp
+++ b/hpx/parallel/algorithms/is_sorted.hpp
@@ -65,12 +65,10 @@ namespace hpx { namespace parallel { inline namespace v1
 
                 util::cancellation_token<> tok;
                 auto f1 =
-                    [tok, pred, last, policy](
+                    [tok, last, HPX_CAPTURE_FORWARD(pred, Pred)](
                         FwdIter part_begin, std::size_t part_size
                     ) mutable -> bool
                     {
-                        HPX_UNUSED(policy);
-
                         FwdIter trail = part_begin++;
                         util::loop_n<ExPolicy>(
                             part_begin, part_size - 1,
@@ -228,8 +226,10 @@ namespace hpx { namespace parallel { inline namespace v1
                 return util::partitioner<ExPolicy, FwdIter, void>::
                 call_with_index(
                     std::forward<ExPolicy>(policy), first, count, 1,
-                    [tok, pred, last](FwdIter part_begin, std::size_t part_size,
-                        std::size_t base_idx) mutable -> void
+                    [tok, last, HPX_CAPTURE_FORWARD(pred, Pred)](
+                        FwdIter part_begin, std::size_t part_size,
+                        std::size_t base_idx
+                    ) mutable -> void
                     {
                         FwdIter trail = part_begin++;
                         util::loop_idx_n(++base_idx, part_begin,

--- a/hpx/parallel/algorithms/lexicographical_compare.hpp
+++ b/hpx/parallel/algorithms/lexicographical_compare.hpp
@@ -87,8 +87,10 @@ namespace hpx { namespace parallel { inline namespace v1
                     call_with_index(
                         std::forward<ExPolicy>(policy),
                         make_zip_iterator(first1, first2), count, 1,
-                        [pred, tok](zip_iterator it, std::size_t part_count,
-                            std::size_t base_idx) mutable -> void
+                        [tok, pred](
+                            zip_iterator it, std::size_t part_count,
+                            std::size_t base_idx
+                        ) mutable -> void
                         {
                             util::loop_idx_n(
                                 base_idx, it, part_count, tok,

--- a/hpx/parallel/algorithms/merge.hpp
+++ b/hpx/parallel/algorithms/merge.hpp
@@ -680,8 +680,8 @@ namespace hpx { namespace parallel { inline namespace v1
         {
             return execution::async_execute(
                 policy.executor(),
-                [=, HPX_CAPTURE_FORWARD(comp, Comp),
-                    HPX_CAPTURE_FORWARD(proj, Proj)
+                [=, HPX_CAPTURE_FORWARD(comp),
+                    HPX_CAPTURE_FORWARD(proj)
                 ]() mutable -> RandIter
                 {
                     try {

--- a/hpx/parallel/algorithms/minmax.hpp
+++ b/hpx/parallel/algorithms/minmax.hpp
@@ -133,8 +133,10 @@ namespace hpx { namespace parallel { inline namespace v1
                             policy, it, part_count, f, proj);
                     };
                 auto f2 =
-                    [f, proj, policy](std::vector<FwdIter> && positions)
-                    ->  FwdIter
+                    [policy,
+                        HPX_CAPTURE_FORWARD(f, F),
+                        HPX_CAPTURE_FORWARD(proj, Proj)
+                    ](std::vector<FwdIter> && positions) -> FwdIter
                     {
                         return min_element::sequential_minmax_element_ind(
                             policy, positions.begin(), positions.size(),
@@ -144,8 +146,7 @@ namespace hpx { namespace parallel { inline namespace v1
                 return util::partitioner<ExPolicy, FwdIter, FwdIter>::call(
                         std::forward<ExPolicy>(policy),
                         first, std::distance(first, last),
-                        std::move(f1), hpx::util::unwrapping(std::move(f2))
-                    );
+                        std::move(f1), hpx::util::unwrapping(std::move(f2)));
             }
         };
 
@@ -366,8 +367,10 @@ namespace hpx { namespace parallel { inline namespace v1
                             policy, it, part_count, f, proj);
                     };
                 auto f2 =
-                    [f, proj, policy](std::vector<FwdIter> && positions)
-                    ->  FwdIter
+                    [policy,
+                        HPX_CAPTURE_FORWARD(f, F),
+                        HPX_CAPTURE_FORWARD(proj, Proj)
+                    ](std::vector<FwdIter> && positions) -> FwdIter
                     {
                         return max_element::sequential_minmax_element_ind(
                             policy, positions.begin(), positions.size(),
@@ -377,8 +380,7 @@ namespace hpx { namespace parallel { inline namespace v1
                 return util::partitioner<ExPolicy, FwdIter, FwdIter>::call(
                         std::forward<ExPolicy>(policy),
                         first, std::distance(first, last),
-                        std::move(f1), hpx::util::unwrapping(std::move(f2))
-                    );
+                        std::move(f1), hpx::util::unwrapping(std::move(f2)));
             }
         };
 
@@ -621,8 +623,10 @@ namespace hpx { namespace parallel { inline namespace v1
                             policy, it, part_count, f, proj);
                     };
                 auto f2 =
-                    [f, proj, policy](std::vector<result_type> && positions)
-                    ->  result_type
+                    [policy,
+                        HPX_CAPTURE_FORWARD(f, F),
+                        HPX_CAPTURE_FORWARD(proj, Proj)
+                    ](std::vector<result_type> && positions) -> result_type
                     {
                         return minmax_element::sequential_minmax_element_ind(
                             policy, positions.begin(), positions.size(),
@@ -633,8 +637,7 @@ namespace hpx { namespace parallel { inline namespace v1
                     call(
                         std::forward<ExPolicy>(policy),
                         result.first, std::distance(result.first, last),
-                        std::move(f1), hpx::util::unwrapping(std::move(f2))
-                    );
+                        std::move(f1), hpx::util::unwrapping(std::move(f2)));
             }
         };
 

--- a/hpx/parallel/algorithms/minmax.hpp
+++ b/hpx/parallel/algorithms/minmax.hpp
@@ -134,8 +134,8 @@ namespace hpx { namespace parallel { inline namespace v1
                     };
                 auto f2 =
                     [policy,
-                        HPX_CAPTURE_FORWARD(f, F),
-                        HPX_CAPTURE_FORWARD(proj, Proj)
+                        HPX_CAPTURE_FORWARD(f),
+                        HPX_CAPTURE_FORWARD(proj)
                     ](std::vector<FwdIter> && positions) -> FwdIter
                     {
                         return min_element::sequential_minmax_element_ind(
@@ -368,8 +368,8 @@ namespace hpx { namespace parallel { inline namespace v1
                     };
                 auto f2 =
                     [policy,
-                        HPX_CAPTURE_FORWARD(f, F),
-                        HPX_CAPTURE_FORWARD(proj, Proj)
+                        HPX_CAPTURE_FORWARD(f),
+                        HPX_CAPTURE_FORWARD(proj)
                     ](std::vector<FwdIter> && positions) -> FwdIter
                     {
                         return max_element::sequential_minmax_element_ind(
@@ -624,8 +624,8 @@ namespace hpx { namespace parallel { inline namespace v1
                     };
                 auto f2 =
                     [policy,
-                        HPX_CAPTURE_FORWARD(f, F),
-                        HPX_CAPTURE_FORWARD(proj, Proj)
+                        HPX_CAPTURE_FORWARD(f),
+                        HPX_CAPTURE_FORWARD(proj)
                     ](std::vector<result_type> && positions) -> result_type
                     {
                         return minmax_element::sequential_minmax_element_ind(

--- a/hpx/parallel/algorithms/mismatch.hpp
+++ b/hpx/parallel/algorithms/mismatch.hpp
@@ -105,16 +105,21 @@ namespace hpx { namespace parallel { inline namespace v1
                     call_with_index(
                         std::forward<ExPolicy>(policy),
                         hpx::util::make_zip_iterator(first1, first2), count1, 1,
-                        [f, tok](zip_iterator it, std::size_t part_count,
-                            std::size_t base_idx) mutable -> void
+                        [tok, HPX_CAPTURE_FORWARD(f, F)](
+                            zip_iterator it, std::size_t part_count,
+                            std::size_t base_idx
+                        ) mutable -> void
                         {
                             util::loop_idx_n(
                                 base_idx, it, part_count, tok,
                                 [&f, &tok](reference t, std::size_t i)
                                 {
-                                    using hpx::util::get;
-                                    if (!f(get<0>(t), get<1>(t)))
+                                    if (!hpx::util::invoke(f,
+                                            hpx::util::get<0>(t),
+                                            hpx::util::get<1>(t)))
+                                    {
                                         tok.cancel(i);
+                                    }
                                 });
                         },
                         [=](std::vector<hpx::future<void> > &&) mutable
@@ -299,16 +304,21 @@ namespace hpx { namespace parallel { inline namespace v1
                     call_with_index(
                         std::forward<ExPolicy>(policy),
                         hpx::util::make_zip_iterator(first1, first2), count, 1,
-                        [f, tok](zip_iterator it, std::size_t part_count,
-                            std::size_t base_idx) mutable -> void
+                        [tok, HPX_CAPTURE_FORWARD(f, F)](
+                            zip_iterator it, std::size_t part_count,
+                            std::size_t base_idx
+                        ) mutable -> void
                         {
                             util::loop_idx_n(
                                 base_idx, it, part_count, tok,
                                 [&f, &tok](reference t, std::size_t i)
                                 {
-                                    using hpx::util::get;
-                                    if (!f(get<0>(t), get<1>(t)))
+                                    if (!hpx::util::invoke(f,
+                                            hpx::util::get<0>(t),
+                                            hpx::util::get<1>(t)))
+                                    {
                                         tok.cancel(i);
+                                    }
                                 });
                         },
                         [=](std::vector<hpx::future<void> > &&) mutable ->

--- a/hpx/parallel/algorithms/mismatch.hpp
+++ b/hpx/parallel/algorithms/mismatch.hpp
@@ -105,7 +105,7 @@ namespace hpx { namespace parallel { inline namespace v1
                     call_with_index(
                         std::forward<ExPolicy>(policy),
                         hpx::util::make_zip_iterator(first1, first2), count1, 1,
-                        [tok, HPX_CAPTURE_FORWARD(f, F)](
+                        [tok, HPX_CAPTURE_FORWARD(f)](
                             zip_iterator it, std::size_t part_count,
                             std::size_t base_idx
                         ) mutable -> void
@@ -304,7 +304,7 @@ namespace hpx { namespace parallel { inline namespace v1
                     call_with_index(
                         std::forward<ExPolicy>(policy),
                         hpx::util::make_zip_iterator(first1, first2), count, 1,
-                        [tok, HPX_CAPTURE_FORWARD(f, F)](
+                        [tok, HPX_CAPTURE_FORWARD(f)](
                             zip_iterator it, std::size_t part_count,
                             std::size_t base_idx
                         ) mutable -> void

--- a/hpx/parallel/algorithms/partition.hpp
+++ b/hpx/parallel/algorithms/partition.hpp
@@ -67,8 +67,8 @@ namespace hpx { namespace parallel { inline namespace v1
                     return execution::async_execute(
                         policy.executor(),
                         [first, last,
-                            HPX_CAPTURE_FORWARD(f, F),
-                            HPX_CAPTURE_FORWARD(proj, Proj)
+                            HPX_CAPTURE_FORWARD(f),
+                            HPX_CAPTURE_FORWARD(proj)
                         ]() -> RandIter
                         {
                             return std::stable_partition(
@@ -1156,11 +1156,9 @@ namespace hpx { namespace parallel { inline namespace v1
                     > scan_partitioner_type;
 
                 auto f1 =
-                    [HPX_CAPTURE_FORWARD(pred, Pred),
-                        HPX_CAPTURE_FORWARD(proj, Proj)]
-                    (
-                       zip_iterator part_begin, std::size_t part_size
-                    )   -> output_iterator_offset
+                    [HPX_CAPTURE_FORWARD(pred), HPX_CAPTURE_FORWARD(proj)](
+                       zip_iterator part_begin, std::size_t part_size)
+                    -> output_iterator_offset
                     {
                         std::size_t true_count = 0;
 

--- a/hpx/parallel/algorithms/partition.hpp
+++ b/hpx/parallel/algorithms/partition.hpp
@@ -60,13 +60,16 @@ namespace hpx { namespace parallel { inline namespace v1
             template <typename ExPolicy, typename RandIter, typename F, typename Proj>
             hpx::future<RandIter>
             operator()(ExPolicy && policy, RandIter first, RandIter last,
-                std::size_t size, F f, Proj proj, std::size_t chunks)
+                std::size_t size, F && f, Proj && proj, std::size_t chunks)
             {
                 if (chunks < 2)
                 {
                     return execution::async_execute(
                         policy.executor(),
-                        [first, last, f, proj]() -> RandIter
+                        [first, last,
+                            HPX_CAPTURE_FORWARD(f, F),
+                            HPX_CAPTURE_FORWARD(proj, Proj)
+                        ]() -> RandIter
                         {
                             return std::stable_partition(
                                 first, last,
@@ -98,14 +101,18 @@ namespace hpx { namespace parallel { inline namespace v1
                             if (left.has_exception() || right.has_exception())
                             {
                                 std::list<std::exception_ptr> errors;
-                                if(left.has_exception())
+                                if (left.has_exception())
+                                {
                                     hpx::parallel::util::detail::
                                     handle_local_exceptions<ExPolicy>::call(
                                         left.get_exception_ptr(), errors);
-                                if(right.has_exception())
+                                }
+                                if (right.has_exception())
+                                {
                                     hpx::parallel::util::detail::
                                     handle_local_exceptions<ExPolicy>::call(
                                         right.get_exception_ptr(), errors);
+                                }
 
                                 if (!errors.empty())
                                 {
@@ -845,7 +852,7 @@ namespace hpx { namespace parallel { inline namespace v1
                 std::vector<hpx::future<block<FwdIter>>>
                     remaining_block_futures(cores);
 
-                // Main parallel phrase: perform sub-partitioning in each thread.
+                // Main parallel phase: perform sub-partitioning in each thread.
                 for (std::size_t i = 0; i < remaining_block_futures.size(); ++i)
                 {
                     remaining_block_futures[i] = execution::async_execute(
@@ -1149,14 +1156,12 @@ namespace hpx { namespace parallel { inline namespace v1
                     > scan_partitioner_type;
 
                 auto f1 =
-                    [pred, proj, flags, policy]
+                    [HPX_CAPTURE_FORWARD(pred, Pred),
+                        HPX_CAPTURE_FORWARD(proj, Proj)]
                     (
                        zip_iterator part_begin, std::size_t part_size
                     )   -> output_iterator_offset
                     {
-                        HPX_UNUSED(flags);
-                        HPX_UNUSED(policy);
-
                         std::size_t true_count = 0;
 
                         // MSVC complains if pred or proj is captured by ref below
@@ -1175,14 +1180,13 @@ namespace hpx { namespace parallel { inline namespace v1
                             true_count, part_size - true_count);
                     };
                 auto f3 =
-                    [dest_true, dest_false, flags, policy](
+                    [dest_true, dest_false, flags](
                         zip_iterator part_begin, std::size_t part_size,
                         hpx::shared_future<output_iterator_offset> curr,
                         hpx::shared_future<output_iterator_offset> next
                     ) mutable -> void
                     {
                         HPX_UNUSED(flags);
-                        HPX_UNUSED(policy);
 
                         next.get();     // rethrow exceptions
 
@@ -1222,7 +1226,7 @@ namespace hpx { namespace parallel { inline namespace v1
                     // step 3 runs final accumulation on each partition
                     std::move(f3),
                     // step 4 use this return value
-                    [last, dest_true, dest_false, count, flags](
+                    [last, dest_true, dest_false, flags](
                         std::vector<
                             hpx::shared_future<output_iterator_offset>
                         > && items,
@@ -1230,7 +1234,6 @@ namespace hpx { namespace parallel { inline namespace v1
                     ->  hpx::util::tuple<FwdIter1, FwdIter2, FwdIter3>
                     {
                         HPX_UNUSED(flags);
-                        HPX_UNUSED(count);
 
                         output_iterator_offset count_pair = items.back().get();
                         std::size_t count_true = get<0>(count_pair);

--- a/hpx/parallel/algorithms/reduce.hpp
+++ b/hpx/parallel/algorithms/reduce.hpp
@@ -76,8 +76,8 @@ namespace hpx { namespace parallel { inline namespace v1
                     first, std::distance(first, last),
                     std::move(f1),
                     hpx::util::unwrapping(
-                        [HPX_CAPTURE_FORWARD(init, T_),
-                            HPX_CAPTURE_FORWARD(r, Reduce)
+                        [HPX_CAPTURE_FORWARD(init),
+                            HPX_CAPTURE_FORWARD(r)
                         ](std::vector<T> && results) -> T
                         {
                             return util::accumulate_n(hpx::util::begin(results),

--- a/hpx/parallel/algorithms/reduce.hpp
+++ b/hpx/parallel/algorithms/reduce.hpp
@@ -63,17 +63,22 @@ namespace hpx { namespace parallel { inline namespace v1
                         std::forward<T_>(init));
                 }
 
-                return util::partitioner<ExPolicy, T>::call(
-                    std::forward<ExPolicy>(policy),
-                    first, std::distance(first, last),
+                auto f1 =
                     [r](FwdIter part_begin, std::size_t part_size) -> T
                     {
                         T val = *part_begin;
                         return util::accumulate_n(++part_begin, --part_size,
                             std::move(val), r);
-                    },
+                    };
+
+                return util::partitioner<ExPolicy, T>::call(
+                    std::forward<ExPolicy>(policy),
+                    first, std::distance(first, last),
+                    std::move(f1),
                     hpx::util::unwrapping(
-                        [init, r](std::vector<T> && results) -> T
+                        [HPX_CAPTURE_FORWARD(init, T_),
+                            HPX_CAPTURE_FORWARD(r, Reduce)
+                        ](std::vector<T> && results) -> T
                         {
                             return util::accumulate_n(hpx::util::begin(results),
                                 hpx::util::size(results), init, r);

--- a/hpx/parallel/algorithms/remove.hpp
+++ b/hpx/parallel/algorithms/remove.hpp
@@ -108,14 +108,11 @@ namespace hpx { namespace parallel { inline namespace v1
                     > scan_partitioner_type;
 
                 auto f1 =
-                    [pred, proj, flags, policy]
-                    (
-                       zip_iterator part_begin, std::size_t part_size
-                    )   -> std::size_t
+                    [HPX_CAPTURE_FORWARD(pred, Pred),
+                        HPX_CAPTURE_FORWARD(proj, Proj)
+                    ](zip_iterator part_begin, std::size_t part_size)
+                    ->  std::size_t
                     {
-                        HPX_UNUSED(flags);
-                        HPX_UNUSED(policy);
-
                         // MSVC complains if pred or proj is captured by ref below
                         util::loop_n<ExPolicy>(
                             part_begin, part_size,
@@ -136,14 +133,13 @@ namespace hpx { namespace parallel { inline namespace v1
                 std::shared_ptr<FwdIter> dest_ptr =
                     std::make_shared<FwdIter>(first);
                 auto f3 =
-                    [dest_ptr, flags, policy](
+                    [dest_ptr, flags](
                         zip_iterator part_begin, std::size_t part_size,
                         hpx::shared_future<std::size_t> curr,
                         hpx::shared_future<std::size_t> next
                     ) mutable -> void
                     {
                         HPX_UNUSED(flags);
-                        HPX_UNUSED(policy);
 
                         curr.get();     // rethrow exceptions
                         next.get();     // rethrow exceptions
@@ -200,11 +196,12 @@ namespace hpx { namespace parallel { inline namespace v1
                     // step 3 runs final accumulation on each partition
                     std::move(f3),
                     // step 4 use this return value
-                    [dest_ptr, first, count, flags](
+                    [dest_ptr, flags](
                         std::vector<hpx::shared_future<std::size_t> > &&,
                         std::vector<hpx::future<void> > &&) mutable
                     ->  FwdIter
                     {
+                        HPX_UNUSED(flags);
                         return *dest_ptr;
                     });
             }

--- a/hpx/parallel/algorithms/remove.hpp
+++ b/hpx/parallel/algorithms/remove.hpp
@@ -108,8 +108,8 @@ namespace hpx { namespace parallel { inline namespace v1
                     > scan_partitioner_type;
 
                 auto f1 =
-                    [HPX_CAPTURE_FORWARD(pred, Pred),
-                        HPX_CAPTURE_FORWARD(proj, Proj)
+                    [HPX_CAPTURE_FORWARD(pred),
+                        HPX_CAPTURE_FORWARD(proj)
                     ](zip_iterator part_begin, std::size_t part_size)
                     ->  std::size_t
                     {

--- a/hpx/parallel/algorithms/remove_copy.hpp
+++ b/hpx/parallel/algorithms/remove_copy.hpp
@@ -80,9 +80,8 @@ namespace hpx { namespace parallel { inline namespace v1
                 return copy_if<IterPair>().call(
                     std::forward<ExPolicy>(policy), std::false_type(),
                     first, last, dest,
-                    [val, proj](T const& a) -> bool
+                    [val](T const& a) -> bool
                     {
-                        HPX_UNUSED(proj);
                         return !(a == val);
                     },
                     std::forward<Proj>(proj));
@@ -260,7 +259,7 @@ namespace hpx { namespace parallel { inline namespace v1
                 return copy_if<IterPair>().call(
                     std::forward<ExPolicy>(policy), std::false_type(),
                     first, last, dest,
-                    [f](value_type const& a) -> bool
+                    [HPX_CAPTURE_FORWARD(f, F)](value_type const& a) -> bool
                     {
                         return !hpx::util::invoke(f, a);
                     },

--- a/hpx/parallel/algorithms/remove_copy.hpp
+++ b/hpx/parallel/algorithms/remove_copy.hpp
@@ -259,7 +259,7 @@ namespace hpx { namespace parallel { inline namespace v1
                 return copy_if<IterPair>().call(
                     std::forward<ExPolicy>(policy), std::false_type(),
                     first, last, dest,
-                    [HPX_CAPTURE_FORWARD(f, F)](value_type const& a) -> bool
+                    [HPX_CAPTURE_FORWARD(f)](value_type const& a) -> bool
                     {
                         return !hpx::util::invoke(f, a);
                     },

--- a/hpx/parallel/algorithms/replace.hpp
+++ b/hpx/parallel/algorithms/replace.hpp
@@ -83,7 +83,9 @@ namespace hpx { namespace parallel { inline namespace v1
                 return for_each_n<FwdIter>().call(
                     std::forward<ExPolicy>(policy), std::false_type(),
                     first, std::distance(first, last),
-                    [old_value, new_value, proj](type& t) -> void
+                    [old_value, new_value,
+                        HPX_CAPTURE_FORWARD(proj, Proj)
+                    ](type& t) -> void
                     {
                         if (hpx::util::invoke(proj, t) == old_value)
                         {
@@ -226,7 +228,10 @@ namespace hpx { namespace parallel { inline namespace v1
                 return for_each_n<FwdIter>().call(
                     std::forward<ExPolicy>(policy), std::false_type(),
                     first, std::distance(first, last),
-                    [f, new_value, proj](type& t) -> void
+                    [new_value,
+                        HPX_CAPTURE_FORWARD(f, F),
+                        HPX_CAPTURE_FORWARD(proj, Proj)
+                    ](type& t) -> void
                     {
                         using hpx::util::invoke;
                         if (invoke(f, invoke(proj, t)))
@@ -390,7 +395,9 @@ namespace hpx { namespace parallel { inline namespace v1
                         std::forward<ExPolicy>(policy), std::false_type(),
                         hpx::util::make_zip_iterator(first, dest),
                         std::distance(first, last),
-                        [old_value, new_value, proj](reference t) -> void
+                        [old_value, new_value,
+                            HPX_CAPTURE_FORWARD(proj, Proj)
+                        ](reference t) -> void
                         {
                             using hpx::util::get;
                             if (hpx::util::invoke(proj, get<0>(t)) == old_value)
@@ -576,7 +583,10 @@ namespace hpx { namespace parallel { inline namespace v1
                         std::forward<ExPolicy>(policy), std::false_type(),
                         hpx::util::make_zip_iterator(first, dest),
                         std::distance(first, last),
-                        [f, new_value, proj](reference t) -> void
+                        [new_value,
+                            HPX_CAPTURE_FORWARD(f, F),
+                            HPX_CAPTURE_FORWARD(proj, Proj)
+                        ](reference t) -> void
                         {
                             using hpx::util::get;
                             using hpx::util::invoke;

--- a/hpx/parallel/algorithms/replace.hpp
+++ b/hpx/parallel/algorithms/replace.hpp
@@ -84,7 +84,7 @@ namespace hpx { namespace parallel { inline namespace v1
                     std::forward<ExPolicy>(policy), std::false_type(),
                     first, std::distance(first, last),
                     [old_value, new_value,
-                        HPX_CAPTURE_FORWARD(proj, Proj)
+                        HPX_CAPTURE_FORWARD(proj)
                     ](type& t) -> void
                     {
                         if (hpx::util::invoke(proj, t) == old_value)
@@ -229,8 +229,8 @@ namespace hpx { namespace parallel { inline namespace v1
                     std::forward<ExPolicy>(policy), std::false_type(),
                     first, std::distance(first, last),
                     [new_value,
-                        HPX_CAPTURE_FORWARD(f, F),
-                        HPX_CAPTURE_FORWARD(proj, Proj)
+                        HPX_CAPTURE_FORWARD(f),
+                        HPX_CAPTURE_FORWARD(proj)
                     ](type& t) -> void
                     {
                         using hpx::util::invoke;
@@ -396,7 +396,7 @@ namespace hpx { namespace parallel { inline namespace v1
                         hpx::util::make_zip_iterator(first, dest),
                         std::distance(first, last),
                         [old_value, new_value,
-                            HPX_CAPTURE_FORWARD(proj, Proj)
+                            HPX_CAPTURE_FORWARD(proj)
                         ](reference t) -> void
                         {
                             using hpx::util::get;
@@ -584,8 +584,8 @@ namespace hpx { namespace parallel { inline namespace v1
                         hpx::util::make_zip_iterator(first, dest),
                         std::distance(first, last),
                         [new_value,
-                            HPX_CAPTURE_FORWARD(f, F),
-                            HPX_CAPTURE_FORWARD(proj, Proj)
+                            HPX_CAPTURE_FORWARD(f),
+                            HPX_CAPTURE_FORWARD(proj)
                         ](reference t) -> void
                         {
                             using hpx::util::get;

--- a/hpx/parallel/algorithms/sort.hpp
+++ b/hpx/parallel/algorithms/sort.hpp
@@ -48,7 +48,8 @@ namespace hpx { namespace parallel { inline namespace v1
         ///////////////////////////////////////////////////////////////////////
         // std::is_sorted is not available on all supported platforms yet
         template <typename Iter, typename Compare>
-        inline bool is_sorted_sequential(Iter first, Iter last, Compare comp)
+        inline bool
+        is_sorted_sequential(Iter first, Iter last, Compare const& comp)
         {
             bool sorted = true;
             if (first != last)
@@ -81,7 +82,7 @@ namespace hpx { namespace parallel { inline namespace v1
             {
                 return execution::async_execute(
                     policy.executor(),
-                    [first, last, comp]() -> RandomIt
+                    [first, last, HPX_CAPTURE_MOVE(comp)]() -> RandomIt
                     {
                         std::sort(first, last, comp);
                         return last;

--- a/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -121,13 +121,11 @@ namespace hpx { namespace parallel { inline namespace v1
                 using hpx::util::make_zip_iterator;
 
                 auto f3 =
-                    [op, policy](
+                    [op](
                         zip_iterator part_begin, std::size_t part_size,
                         hpx::shared_future<T> curr, hpx::shared_future<T> next
                     ) -> void
                     {
-                        HPX_UNUSED(policy);
-
                         next.get();     // rethrow exceptions
 
                         T val = curr.get();

--- a/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -118,13 +118,11 @@ namespace hpx { namespace parallel { inline namespace v1
                 using hpx::util::make_zip_iterator;
 
                 auto f3 =
-                    [op, policy](
+                    [op](
                         zip_iterator part_begin, std::size_t part_size,
                         hpx::shared_future<T> curr, hpx::shared_future<T> next
                     ) -> void
                     {
-                        HPX_UNUSED(policy);
-
                         next.get();     // rethrow exceptions
 
                         T val = curr.get();

--- a/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/hpx/parallel/algorithms/transform_reduce.hpp
@@ -82,7 +82,7 @@ namespace hpx { namespace parallel { inline namespace v1
                     reference;
 
                 auto f1 =
-                    [r, HPX_CAPTURE_FORWARD(conv, Convert)](
+                    [r, HPX_CAPTURE_FORWARD(conv)](
                         FwdIter part_begin, std::size_t part_size) -> T
                     {
                         T val = hpx::util::invoke(conv, *part_begin);
@@ -102,8 +102,8 @@ namespace hpx { namespace parallel { inline namespace v1
                     first, std::distance(first, last),
                     std::move(f1),
                     hpx::util::unwrapping(
-                        [HPX_CAPTURE_FORWARD(init, T_),
-                            HPX_CAPTURE_FORWARD(r, Reduce)
+                        [HPX_CAPTURE_FORWARD(init),
+                            HPX_CAPTURE_FORWARD(r)
                         ](std::vector<T> && results) -> T
                         {
                             return util::accumulate_n(hpx::util::begin(results),

--- a/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/hpx/parallel/algorithms/transform_reduce.hpp
@@ -81,10 +81,9 @@ namespace hpx { namespace parallel { inline namespace v1
                 typedef typename std::iterator_traits<FwdIter>::reference
                     reference;
 
-                return util::partitioner<ExPolicy, T>::call(
-                    std::forward<ExPolicy>(policy),
-                    first, std::distance(first, last),
-                    [r, conv](FwdIter part_begin, std::size_t part_size) -> T
+                auto f1 =
+                    [r, HPX_CAPTURE_FORWARD(conv, Convert)](
+                        FwdIter part_begin, std::size_t part_size) -> T
                     {
                         T val = hpx::util::invoke(conv, *part_begin);
                         return util::accumulate_n(++part_begin, --part_size,
@@ -96,9 +95,16 @@ namespace hpx { namespace parallel { inline namespace v1
                                 return hpx::util::invoke(r, res,
                                     hpx::util::invoke(conv, next));
                             });
-                    },
+                    };
+
+                return util::partitioner<ExPolicy, T>::call(
+                    std::forward<ExPolicy>(policy),
+                    first, std::distance(first, last),
+                    std::move(f1),
                     hpx::util::unwrapping(
-                        [init, r](std::vector<T> && results) -> T
+                        [HPX_CAPTURE_FORWARD(init, T_),
+                            HPX_CAPTURE_FORWARD(r, Reduce)
+                        ](std::vector<T> && results) -> T
                         {
                             return util::accumulate_n(hpx::util::begin(results),
                                 hpx::util::size(results), init, r);

--- a/hpx/parallel/algorithms/transform_reduce_binary.hpp
+++ b/hpx/parallel/algorithms/transform_reduce_binary.hpp
@@ -157,7 +157,7 @@ namespace hpx { namespace parallel { inline namespace v1
                 difference_type count = std::distance(first1, last1);
 
                 auto f1 =
-                    [op1, HPX_CAPTURE_FORWARD(op2, Op2)](
+                    [op1, HPX_CAPTURE_FORWARD(op2)](
                         zip_iterator part_begin, std::size_t part_size
                     ) mutable -> T
                     {
@@ -225,8 +225,8 @@ namespace hpx { namespace parallel { inline namespace v1
                     std::forward<ExPolicy>(policy),
                     make_zip_iterator(first1, first2), count,
                     std::move(f1),
-                    [HPX_CAPTURE_FORWARD(init, T_),
-                        HPX_CAPTURE_FORWARD(op1, Op1)
+                    [HPX_CAPTURE_FORWARD(init),
+                        HPX_CAPTURE_FORWARD(op1)
                     ](std::vector<hpx::future<T> > && results) -> T
                     {
                         T ret = init;

--- a/hpx/parallel/algorithms/transform_reduce_binary.hpp
+++ b/hpx/parallel/algorithms/transform_reduce_binary.hpp
@@ -157,12 +157,10 @@ namespace hpx { namespace parallel { inline namespace v1
                 difference_type count = std::distance(first1, last1);
 
                 auto f1 =
-                    [op1, op2, policy](
+                    [op1, HPX_CAPTURE_FORWARD(op2, Op2)](
                         zip_iterator part_begin, std::size_t part_size
                     ) mutable -> T
                     {
-                        HPX_UNUSED(policy);
-
                         auto iters = part_begin.get_iterator_tuple();
                         FwdIter1 it1 = hpx::util::get<0>(iters);
                         FwdIter2 it2 = hpx::util::get<1>(iters);
@@ -227,7 +225,9 @@ namespace hpx { namespace parallel { inline namespace v1
                     std::forward<ExPolicy>(policy),
                     make_zip_iterator(first1, first2), count,
                     std::move(f1),
-                    [init, op1](std::vector<hpx::future<T> > && results) -> T
+                    [HPX_CAPTURE_FORWARD(init, T_),
+                        HPX_CAPTURE_FORWARD(op1, Op1)
+                    ](std::vector<hpx::future<T> > && results) -> T
                     {
                         T ret = init;
                         for(auto && fut : results)

--- a/hpx/parallel/algorithms/unique.hpp
+++ b/hpx/parallel/algorithms/unique.hpp
@@ -110,14 +110,11 @@ namespace hpx { namespace parallel { inline namespace v1
                     > scan_partitioner_type;
 
                 auto f1 =
-                    [pred, proj, flags, policy]
-                    (
-                       zip_iterator part_begin, std::size_t part_size
-                    )   -> std::size_t
+                    [HPX_CAPTURE_FORWARD(pred, Pred),
+                        HPX_CAPTURE_FORWARD(proj, Proj)
+                    ](zip_iterator part_begin, std::size_t part_size)
+                    -> std::size_t
                     {
-                        HPX_UNUSED(flags);
-                        HPX_UNUSED(policy);
-
                         FwdIter base = get<0>(part_begin.get_iterator_tuple());
 
                         // MSVC complains if pred or proj is captured by ref below
@@ -144,14 +141,13 @@ namespace hpx { namespace parallel { inline namespace v1
                 std::shared_ptr<FwdIter> dest_ptr =
                     std::make_shared<FwdIter>(first);
                 auto f3 =
-                    [dest_ptr, flags, policy](
+                    [dest_ptr, flags](
                         zip_iterator part_begin, std::size_t part_size,
                         hpx::shared_future<std::size_t> curr,
                         hpx::shared_future<std::size_t> next
                     ) mutable -> void
                     {
                         HPX_UNUSED(flags);
-                        HPX_UNUSED(policy);
 
                         curr.get();     // rethrow exceptions
                         next.get();     // rethrow exceptions
@@ -196,8 +192,7 @@ namespace hpx { namespace parallel { inline namespace v1
                     // step 2 propagates the partition results from left
                     // to right
                     hpx::util::unwrapping(
-                        [](std::size_t, std::size_t)
-                            -> std::size_t
+                        [](std::size_t, std::size_t) -> std::size_t
                         {
                             // There is no need to propagate the partition
                             // results. But, the scan_partitioner doesn't
@@ -208,7 +203,7 @@ namespace hpx { namespace parallel { inline namespace v1
                     // step 3 runs final accumulation on each partition
                     std::move(f3),
                     // step 4 use this return value
-                    [dest_ptr, first, count, flags](
+                    [HPX_CAPTURE_MOVE(dest_ptr), first, count, flags](
                         std::vector<hpx::shared_future<std::size_t> > &&,
                         std::vector<hpx::future<void> > &&) mutable
                     ->  FwdIter
@@ -449,14 +444,11 @@ namespace hpx { namespace parallel { inline namespace v1
                     > scan_partitioner_type;
 
                 auto f1 =
-                    [pred, proj, flags, policy]
-                    (
-                        zip_iterator part_begin, std::size_t part_size
-                    )   -> std::size_t
+                    [HPX_CAPTURE_FORWARD(pred, Pred),
+                        HPX_CAPTURE_FORWARD(proj, Proj)
+                    ](zip_iterator part_begin, std::size_t part_size)
+                    -> std::size_t
                     {
-                        HPX_UNUSED(flags);
-                        HPX_UNUSED(policy);
-
                         FwdIter1 base = get<0>(part_begin.get_iterator_tuple());
                         std::size_t curr = 0;
 
@@ -481,14 +473,13 @@ namespace hpx { namespace parallel { inline namespace v1
                         return curr;
                     };
                 auto f3 =
-                    [dest, flags, policy](
+                    [dest, flags](
                         zip_iterator part_begin, std::size_t part_size,
                         hpx::shared_future<std::size_t> curr,
                         hpx::shared_future<std::size_t> next
                     ) mutable -> void
                     {
                         HPX_UNUSED(flags);
-                        HPX_UNUSED(policy);
 
                         next.get();     // rethrow exceptions
 

--- a/hpx/parallel/algorithms/unique.hpp
+++ b/hpx/parallel/algorithms/unique.hpp
@@ -110,8 +110,8 @@ namespace hpx { namespace parallel { inline namespace v1
                     > scan_partitioner_type;
 
                 auto f1 =
-                    [HPX_CAPTURE_FORWARD(pred, Pred),
-                        HPX_CAPTURE_FORWARD(proj, Proj)
+                    [HPX_CAPTURE_FORWARD(pred),
+                        HPX_CAPTURE_FORWARD(proj)
                     ](zip_iterator part_begin, std::size_t part_size)
                     -> std::size_t
                     {
@@ -444,8 +444,8 @@ namespace hpx { namespace parallel { inline namespace v1
                     > scan_partitioner_type;
 
                 auto f1 =
-                    [HPX_CAPTURE_FORWARD(pred, Pred),
-                        HPX_CAPTURE_FORWARD(proj, Proj)
+                    [HPX_CAPTURE_FORWARD(pred),
+                        HPX_CAPTURE_FORWARD(proj)
                     ](zip_iterator part_begin, std::size_t part_size)
                     -> std::size_t
                     {

--- a/hpx/parallel/util/foreach_partitioner.hpp
+++ b/hpx/parallel/util/foreach_partitioner.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -162,10 +162,12 @@ namespace hpx { namespace parallel { namespace util
 
                 // wait for all tasks to finish
                 return hpx::dataflow(
-                    [last, errors, scoped_param, f2](
-                            std::vector<hpx::future<Result> > && r1,
-                            std::vector<hpx::future<Result> > && r2) mutable
-                    ->  FwdIter
+                    [last, errors,
+                        HPX_CAPTURE_MOVE(scoped_param),
+                        HPX_CAPTURE_FORWARD(f2, F2)
+                    ](std::vector<hpx::future<Result> > && r1,
+                        std::vector<hpx::future<Result> > && r2
+                    ) mutable ->  FwdIter
                     {
                         HPX_UNUSED(scoped_param);
                         handle_local_exceptions<ExPolicy>::call(r1, errors);

--- a/hpx/parallel/util/foreach_partitioner.hpp
+++ b/hpx/parallel/util/foreach_partitioner.hpp
@@ -164,7 +164,7 @@ namespace hpx { namespace parallel { namespace util
                 return hpx::dataflow(
                     [last, errors,
                         HPX_CAPTURE_MOVE(scoped_param),
-                        HPX_CAPTURE_FORWARD(f2, F2)
+                        HPX_CAPTURE_FORWARD(f2)
                     ](std::vector<hpx::future<Result> > && r1,
                         std::vector<hpx::future<Result> > && r2
                     ) mutable ->  FwdIter

--- a/hpx/parallel/util/partitioner.hpp
+++ b/hpx/parallel/util/partitioner.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -312,8 +312,10 @@ namespace hpx { namespace parallel { namespace util
 
                 // wait for all tasks to finish
                 return hpx::dataflow(
-                    [f2, errors, scoped_param](
-                        std::vector<hpx::future<Result> > && r) mutable -> R
+                    [errors,
+                        HPX_CAPTURE_MOVE(scoped_param),
+                        HPX_CAPTURE_FORWARD(f2, F2)
+                    ](std::vector<hpx::future<Result> > && r) mutable -> R
                     {
                         HPX_UNUSED(scoped_param);
 
@@ -399,8 +401,10 @@ namespace hpx { namespace parallel { namespace util
 
                 // wait for all tasks to finish
                 return hpx::dataflow(
-                    [f2, errors, scoped_param](
-                        std::vector<hpx::future<Result> > && r) mutable -> R
+                    [errors,
+                        HPX_CAPTURE_MOVE(scoped_param),
+                        HPX_CAPTURE_FORWARD(f2, F2)
+                    ](std::vector<hpx::future<Result> > && r) mutable -> R
                     {
                         // inform parameter traits
                         handle_local_exceptions<ExPolicy>::call(r, errors);
@@ -465,9 +469,12 @@ namespace hpx { namespace parallel { namespace util
 
                 // wait for all tasks to finish
                 return hpx::dataflow(
-                    [f2, errors, scoped_param](
-                        std::vector<hpx::future<Result> > && r,
-                        typename hpx::util::decay<Args>::type&&... args) mutable -> R
+                    [errors,
+                        HPX_CAPTURE_MOVE(scoped_param),
+                        HPX_CAPTURE_FORWARD(f2, F2)
+                    ](std::vector<hpx::future<Result> > && r,
+                        typename hpx::util::decay<Args>::type&&... args
+                    ) mutable -> R
                     {
                         HPX_UNUSED(scoped_param);
 

--- a/hpx/parallel/util/partitioner.hpp
+++ b/hpx/parallel/util/partitioner.hpp
@@ -314,7 +314,7 @@ namespace hpx { namespace parallel { namespace util
                 return hpx::dataflow(
                     [errors,
                         HPX_CAPTURE_MOVE(scoped_param),
-                        HPX_CAPTURE_FORWARD(f2, F2)
+                        HPX_CAPTURE_FORWARD(f2)
                     ](std::vector<hpx::future<Result> > && r) mutable -> R
                     {
                         HPX_UNUSED(scoped_param);
@@ -403,7 +403,7 @@ namespace hpx { namespace parallel { namespace util
                 return hpx::dataflow(
                     [errors,
                         HPX_CAPTURE_MOVE(scoped_param),
-                        HPX_CAPTURE_FORWARD(f2, F2)
+                        HPX_CAPTURE_FORWARD(f2)
                     ](std::vector<hpx::future<Result> > && r) mutable -> R
                     {
                         // inform parameter traits
@@ -471,7 +471,7 @@ namespace hpx { namespace parallel { namespace util
                 return hpx::dataflow(
                     [errors,
                         HPX_CAPTURE_MOVE(scoped_param),
-                        HPX_CAPTURE_FORWARD(f2, F2)
+                        HPX_CAPTURE_FORWARD(f2)
                     ](std::vector<hpx::future<Result> > && r,
                         typename hpx::util::decay<Args>::type&&... args
                     ) mutable -> R

--- a/hpx/parallel/util/partitioner_with_cleanup.hpp
+++ b/hpx/parallel/util/partitioner_with_cleanup.hpp
@@ -170,8 +170,8 @@ namespace hpx { namespace parallel { namespace util
                 return hpx::dataflow(
                     [errors,
                         HPX_CAPTURE_MOVE(scoped_param),
-                        HPX_CAPTURE_FORWARD(f2, F2),
-                        HPX_CAPTURE_FORWARD(f3, F3)
+                        HPX_CAPTURE_FORWARD(f2),
+                        HPX_CAPTURE_FORWARD(f3)
                     ](std::vector<hpx::future<Result> > && r) mutable -> R
                     {
                         HPX_UNUSED(scoped_param);

--- a/hpx/parallel/util/partitioner_with_cleanup.hpp
+++ b/hpx/parallel/util/partitioner_with_cleanup.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -168,8 +168,11 @@ namespace hpx { namespace parallel { namespace util
 
                 // wait for all tasks to finish
                 return hpx::dataflow(
-                    [f2, f3, errors, scoped_param](
-                        std::vector<hpx::future<Result> > && r) mutable -> R
+                    [errors,
+                        HPX_CAPTURE_MOVE(scoped_param),
+                        HPX_CAPTURE_FORWARD(f2, F2),
+                        HPX_CAPTURE_FORWARD(f3, F3)
+                    ](std::vector<hpx::future<Result> > && r) mutable -> R
                     {
                         HPX_UNUSED(scoped_param);
 

--- a/hpx/parallel/util/scan_partitioner.hpp
+++ b/hpx/parallel/util/scan_partitioner.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //  Copyright (c)      2015 Daniel Bourgeois
 //  Copyright (c)      2017 Taeguk Kwon
 //
@@ -341,7 +341,14 @@ namespace hpx { namespace parallel { namespace util
             {
                 hpx::future<R> f = execution::async_execute(
                     policy.executor(),
-                    [=]() mutable -> R
+                    [first, count,
+                        HPX_CAPTURE_FORWARD(policy, ExPolicy),
+                        HPX_CAPTURE_FORWARD(init, T),
+                        HPX_CAPTURE_FORWARD(f1, F1),
+                        HPX_CAPTURE_FORWARD(f2, F2),
+                        HPX_CAPTURE_FORWARD(f3, F3),
+                        HPX_CAPTURE_FORWARD(f4, F4)
+                    ]() mutable -> R
                     {
                         return static_scan_partitioner_helper<
                                 R, Result1, Result2, ScanPartTag

--- a/hpx/parallel/util/scan_partitioner.hpp
+++ b/hpx/parallel/util/scan_partitioner.hpp
@@ -342,12 +342,12 @@ namespace hpx { namespace parallel { namespace util
                 hpx::future<R> f = execution::async_execute(
                     policy.executor(),
                     [first, count,
-                        HPX_CAPTURE_FORWARD(policy, ExPolicy),
-                        HPX_CAPTURE_FORWARD(init, T),
-                        HPX_CAPTURE_FORWARD(f1, F1),
-                        HPX_CAPTURE_FORWARD(f2, F2),
-                        HPX_CAPTURE_FORWARD(f3, F3),
-                        HPX_CAPTURE_FORWARD(f4, F4)
+                        HPX_CAPTURE_FORWARD(policy),
+                        HPX_CAPTURE_FORWARD(init),
+                        HPX_CAPTURE_FORWARD(f1),
+                        HPX_CAPTURE_FORWARD(f2),
+                        HPX_CAPTURE_FORWARD(f3),
+                        HPX_CAPTURE_FORWARD(f4)
                     ]() mutable -> R
                     {
                         return static_scan_partitioner_helper<

--- a/hpx/runtime/basename_registration.hpp
+++ b/hpx/runtime/basename_registration.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -49,8 +49,8 @@ namespace hpx
     ///         This is important in order to reliably retrieve ids from a
     ///         name, even if the name was already registered.
     ///
-    HPX_API_EXPORT std::vector<hpx::future<hpx::id_type> >
-        find_all_from_basename(std::string const& base_name, std::size_t num_ids);
+    HPX_API_EXPORT std::vector<hpx::future<hpx::id_type>>
+    find_all_from_basename(std::string base_name, std::size_t num_ids);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Return all registered clients from all localities from the given base
@@ -76,10 +76,10 @@ namespace hpx
     ///
     template <typename Client>
     std::vector<Client>
-    find_all_from_basename(std::string const& base_name, std::size_t num_ids)
+    find_all_from_basename(std::string base_name, std::size_t num_ids)
     {
         return components::make_clients<Client>(
-            find_all_from_basename(base_name, num_ids));
+            find_all_from_basename(std::move(base_name), num_ids));
     }
 
     /// Return registered ids from the given base name and sequence numbers.
@@ -100,9 +100,8 @@ namespace hpx
     ///         This is important in order to reliably retrieve ids from a
     ///         name, even if the name was already registered.
     ///
-    HPX_API_EXPORT std::vector<hpx::future<hpx::id_type> >
-        find_from_basename(std::string const& base_name,
-            std::vector<std::size_t> const& ids);
+    HPX_API_EXPORT std::vector<hpx::future<hpx::id_type>> find_from_basename(
+        std::string base_name, std::vector<std::size_t> const& ids);
 
     /// Return registered clients from the given base name and sequence numbers.
     ///
@@ -126,12 +125,11 @@ namespace hpx
     ///         name, even if the name was already registered.
     ///
     template <typename Client>
-    std::vector<Client>
-        find_from_basename(std::string const& base_name,
-            std::vector<std::size_t> const& ids)
+    std::vector<Client> find_from_basename(std::string base_name,
+        std::vector<std::size_t> const& ids)
     {
         return components::make_clients<Client>(
-            find_from_basename(base_name, ids));
+            find_from_basename(std::move(base_name), ids));
     }
 
     /// \brief Return registered id from the given base name and sequence number.
@@ -152,9 +150,8 @@ namespace hpx
     ///         This is important in order to reliably retrieve ids from a
     ///         name, even if the name was already registered.
     ///
-    HPX_API_EXPORT hpx::future<hpx::id_type>
-        find_from_basename(std::string const& base_name,
-            std::size_t sequence_nr = ~0U);
+    HPX_API_EXPORT hpx::future<hpx::id_type> find_from_basename(
+        std::string base_name, std::size_t sequence_nr = ~0U);
 
     /// \brief Return registered id from the given base name and sequence number.
     ///
@@ -207,8 +204,7 @@ namespace hpx
     ///          unique.
     ///
     HPX_API_EXPORT hpx::future<bool> register_with_basename(
-        std::string const& base_name, hpx::id_type id,
-        std::size_t sequence_nr = ~0U);
+        std::string base_name, hpx::id_type id, std::size_t sequence_nr = ~0U);
 
     /// Register the id wrapped in the given future using the given base name.
     ///
@@ -232,13 +228,16 @@ namespace hpx
     /// \note    The operation will fail if the given sequence number is not
     ///          unique.
     ///
-    inline hpx::future<bool> register_with_basename(std::string const& base_name,
+    inline hpx::future<bool> register_with_basename(std::string base_name,
         hpx::future<hpx::id_type> f, std::size_t sequence_nr = ~0U)
     {
         return f.then(
-            [=](hpx::future<hpx::id_type> && f) mutable
+            [sequence_nr, HPX_CAPTURE_MOVE(base_name)](
+                hpx::future<hpx::id_type> && f
+            ) mutable -> hpx::future<bool>
             {
-                return register_with_basename(base_name, f.get(), sequence_nr);
+                return register_with_basename(
+                    std::move(base_name), f.get(), sequence_nr);
             });
     }
 
@@ -267,14 +266,17 @@ namespace hpx
     ///          unique.
     ///
     template <typename Client, typename Stub>
-    hpx::future<bool> register_with_basename(std::string const& base_name,
+    hpx::future<bool> register_with_basename(std::string base_name,
         components::client_base<Client, Stub>& client,
         std::size_t sequence_nr = ~0U)
     {
         return client.then(
-            [=](components::client_base<Client, Stub> && c)
+            [sequence_nr, HPX_CAPTURE_MOVE(base_name)](
+                components::client_base<Client, Stub> && c
+            ) mutable -> hpx::future<bool>
             {
-                return register_with_basename(base_name, c.get_id(), sequence_nr);
+                return register_with_basename(
+                    std::move(base_name), c.get_id(), sequence_nr);
             });
     }
 
@@ -293,7 +295,7 @@ namespace hpx
     ///          operation itself.
     ///
     HPX_API_EXPORT hpx::future<hpx::id_type> unregister_with_basename(
-        std::string const& base_name, std::size_t sequence_nr = ~0U);
+        std::string base_name, std::size_t sequence_nr = ~0U);
 
     /// Unregister the given base name.
     ///
@@ -313,10 +315,10 @@ namespace hpx
     ///
     template <typename Client>
     Client unregister_with_basename(
-        std::string const& base_name, std::size_t sequence_nr = ~0U)
+        std::string base_name, std::size_t sequence_nr = ~0U)
     {
         return components::make_client<Client>(
-            unregister_with_basename(base_name, sequence_nr));
+            unregister_with_basename(std::move(base_name), sequence_nr));
     }
 }
 

--- a/hpx/runtime/components/binpacking_distribution_policy.hpp
+++ b/hpx/runtime/components/binpacking_distribution_policy.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -295,8 +295,9 @@ namespace hpx { namespace components
                     id, count, std::forward<Ts>(vs)...);
 
             return f.then(hpx::launch::sync,
-                [id](hpx::future<std::vector<hpx::id_type> > && f)
-                    -> std::vector<bulk_locality_result>
+                [HPX_CAPTURE_MOVE(id)](
+                    hpx::future<std::vector<hpx::id_type> > && f
+                ) -> std::vector<bulk_locality_result>
                 {
                     std::vector<bulk_locality_result> result;
                     result.emplace_back(id, f.get());

--- a/hpx/runtime/components/colocating_distribution_policy.hpp
+++ b/hpx/runtime/components/colocating_distribution_policy.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2016 Hartmut Kaiser
+//  Copyright (c) 2014-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -134,8 +134,9 @@ namespace hpx { namespace components
             }
 
             return f.then(hpx::launch::sync,
-                [id](hpx::future<std::vector<hpx::id_type> > && f)
-                    -> std::vector<bulk_locality_result>
+                [HPX_CAPTURE_MOVE(id)](
+                    hpx::future<std::vector<hpx::id_type> > && f
+                ) -> std::vector<bulk_locality_result>
                 {
                     std::vector<bulk_locality_result> result;
                     result.emplace_back(id, f.get());

--- a/hpx/runtime/components/default_distribution_policy.hpp
+++ b/hpx/runtime/components/default_distribution_policy.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c) 2014-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -184,8 +184,9 @@ namespace hpx { namespace components
                     id, count, std::forward<Ts>(vs)...);
 
             return f.then(hpx::launch::sync,
-                [id](hpx::future<std::vector<hpx::id_type> > && f)
-                    -> std::vector<bulk_locality_result>
+                [HPX_CAPTURE_MOVE(id)](
+                    hpx::future<std::vector<hpx::id_type> > && f
+                ) -> std::vector<bulk_locality_result>
                 {
                     std::vector<bulk_locality_result> result;
                     result.emplace_back(id, f.get());

--- a/hpx/runtime/components/target_distribution_policy.hpp
+++ b/hpx/runtime/components/target_distribution_policy.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2016 Hartmut Kaiser
+//  Copyright (c) 2014-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -105,8 +105,9 @@ namespace hpx { namespace components
                     id, count, std::forward<Ts>(vs)...);
 
             return f.then(hpx::launch::sync,
-                [id](hpx::future<std::vector<hpx::id_type> > && f)
-                    -> std::vector<bulk_locality_result>
+                [HPX_CAPTURE_MOVE(id)](
+                    hpx::future<std::vector<hpx::id_type> > && f
+                ) -> std::vector<bulk_locality_result>
                 {
                     std::vector<bulk_locality_result> result;
                     result.emplace_back(id, f.get());

--- a/src/lcos/detail/barrier_node.cpp
+++ b/src/lcos/detail/barrier_node.cpp
@@ -135,7 +135,7 @@ namespace hpx { namespace lcos { namespace detail {
         if (rank_ == 0)
         {
             return future.then(hpx::launch::sync,
-                [this_](hpx::future<void>&& f)
+                [HPX_CAPTURE_MOVE(this_)](hpx::future<void>&& f)
                 {
                     // Trigger possible errors...
                     f.get();
@@ -157,7 +157,7 @@ namespace hpx { namespace lcos { namespace detail {
         }
 
         return future.then(hpx::launch::sync,
-            [this_](hpx::future<void>&& f)
+            [HPX_CAPTURE_MOVE(this_)](hpx::future<void>&& f)
             {
                 // Trigger possible errors...
                 f.get();

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
-//  Copyright (c) 2011-2017 Hartmut Kaiser
+//  Copyright (c) 2011-2018 Hartmut Kaiser
 //  Copyright (c) 2016 Parsa Amini
 //  Copyright (c) 2016 Thomas Heller
 //
@@ -2753,8 +2753,8 @@ namespace hpx
 {
     namespace detail
     {
-        std::string name_from_basename(std::string const& basename,
-            std::size_t idx)
+        std::string name_from_basename(
+            std::string const& basename, std::size_t idx)
         {
             HPX_ASSERT(!basename.empty());
 
@@ -2773,8 +2773,8 @@ namespace hpx
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    std::vector<hpx::future<hpx::id_type> >
-        find_all_from_basename(std::string const& basename, std::size_t num_ids)
+    std::vector<hpx::future<hpx::id_type>> find_all_from_basename(
+        std::string basename, std::size_t num_ids)
     {
         if (basename.empty())
         {
@@ -2793,9 +2793,8 @@ namespace hpx
         return results;
     }
 
-    std::vector<hpx::future<hpx::id_type> >
-        find_from_basename(std::string const& basename,
-            std::vector<std::size_t> const& ids)
+    std::vector<hpx::future<hpx::id_type>> find_from_basename(
+        std::string basename, std::vector<std::size_t> const& ids)
     {
         if (basename.empty())
         {
@@ -2807,14 +2806,15 @@ namespace hpx
         std::vector<hpx::future<hpx::id_type> > results;
         for (std::size_t i : ids)
         {
-            std::string name = detail::name_from_basename(basename, i); //-V106
+            std::string name =
+                detail::name_from_basename(basename, i);    //-V106
             results.push_back(agas::on_symbol_namespace_event(
                 std::move(name), true));
         }
         return results;
     }
 
-    hpx::future<hpx::id_type> find_from_basename(std::string const& basename,
+    hpx::future<hpx::id_type> find_from_basename(std::string basename,
         std::size_t sequence_nr)
     {
         if (basename.empty())
@@ -2825,13 +2825,16 @@ namespace hpx
         }
 
         if (sequence_nr == std::size_t(~0U))
-            sequence_nr = std::size_t(naming::get_locality_id_from_id(find_here()));
+        {
+            sequence_nr =
+                std::size_t(naming::get_locality_id_from_id(find_here()));
+        }
 
         std::string name = detail::name_from_basename(basename, sequence_nr);
         return agas::on_symbol_namespace_event(std::move(name), true);
     }
 
-    hpx::future<bool> register_with_basename(std::string const& basename,
+    hpx::future<bool> register_with_basename(std::string basename,
         hpx::id_type id, std::size_t sequence_nr)
     {
         if (basename.empty())
@@ -2842,14 +2845,17 @@ namespace hpx
         }
 
         if (sequence_nr == std::size_t(~0U))
-            sequence_nr = std::size_t(naming::get_locality_id_from_id(find_here()));
+        {
+            sequence_nr =
+                std::size_t(naming::get_locality_id_from_id(find_here()));
+        }
 
         std::string name = detail::name_from_basename(basename, sequence_nr);
         return agas::register_name(std::move(name), id);
     }
 
     hpx::future<hpx::id_type> unregister_with_basename(
-        std::string const& basename, std::size_t sequence_nr)
+        std::string basename, std::size_t sequence_nr)
     {
         if (basename.empty())
         {
@@ -2859,7 +2865,10 @@ namespace hpx
         }
 
         if (sequence_nr == std::size_t(~0U))
-            sequence_nr = std::size_t(naming::get_locality_id_from_id(find_here()));
+        {
+            sequence_nr =
+                std::size_t(naming::get_locality_id_from_id(find_here()));
+        }
 
         std::string name = detail::name_from_basename(basename, sequence_nr);
         return agas::unregister_name(std::move(name));

--- a/tests/unit/parallel/algorithms/reduce_by_key.cpp
+++ b/tests/unit/parallel/algorithms/reduce_by_key.cpp
@@ -138,7 +138,7 @@ void test_reduce_by_key1(ExPolicy && policy, Tkey, Tval, bool benchmark, const O
         helperkey = ho(key);
         lastkey = helperkey;
         //
-        int numkeys = static_cast<Tkey>(distrk(engk)) + 1;
+        int numkeys = static_cast<int>(distrk(engk)) + 1;
         //
         Tval sum = 0;
         for (int i = 0; i < numkeys && keysize < HPX_REDUCE_BY_KEY_TEST_SIZE; ++i) {
@@ -236,7 +236,7 @@ void test_reduce_by_key_const(ExPolicy && policy, Tkey, Tval, bool benchmark,
         helperkey = ho(key);
         lastkey = helperkey;
         //
-        int numkeys = static_cast<Tkey>(distrk(engk)) + 1;
+        int numkeys = static_cast<int>(distrk(engk)) + 1;
         //
         Tval sum = 0;
         for (int i = 0; i < numkeys && keysize < HPX_REDUCE_BY_KEY_TEST_SIZE; ++i) {


### PR DESCRIPTION

## Proposed Changes

 - utilize C++14 capture initialization syntax for lambdas wherever possible 
 - flyby: removed unneeded captures
