### PR TITLE
Add ciso646 header to get _LIBCPP_VERSION for testing inplace merge

### DIFF
--- a/cmake/tests/stable_inplace_merge.cpp
+++ b/cmake/tests/stable_inplace_merge.cpp
@@ -1,12 +1,14 @@
 ////////////////////////////////////////////////////////////////////////////////
-//  Copyright (c) 2017 Mikael Simberg
+//  Copyright (c) 2017-2018 Mikael Simberg
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ////////////////////////////////////////////////////////////////////////////////
 
-#if defined(_LIBCPP_VERSION) && (_LIBCPP_VERSION < 6)
-#  error "libc++ inplace_merge implementation is broken"
+#include <ciso646>
+
+#if defined(_LIBCPP_VERSION) && (_LIBCPP_VERSION < 6000)
+#  error "libc++ inplace_merge implementation is not stable"
 #endif
 
 int main()


### PR DESCRIPTION
Fixes #2964 

## Proposed Changes

- Add include to `stable_inplace_merge` cmake test so that `_LIBCPP_VERSION` is defined
- Fix version comparison

## Any background context you want to provide?

I left out out some crucial parts in #3078. This fixes them.