### PR TITLE
fix detection of cxx11_std_atomic

### DIFF
--- a/cmake/tests/cxx11_std_atomic.cpp
+++ b/cmake/tests/cxx11_std_atomic.cpp
@@ -6,9 +6,10 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <atomic>
+#include <cstdint>
 
 struct P {
-    long x; long y;
+    uint64_t x; uint64_t y;
 };
 
 int main()

--- a/cmake/tests/cxx11_std_atomic.cpp
+++ b/cmake/tests/cxx11_std_atomic.cpp
@@ -7,6 +7,10 @@
 
 #include <atomic>
 
+struct P {
+    long x; long y;
+};
+
 int main()
 {
     std::atomic_flag af = ATOMIC_FLAG_INIT;
@@ -16,6 +20,9 @@ int main()
     std::atomic<int> ai;
     ai.store(0);
     int i = ai.load();
+
+    std::atomic<P> p0;
+    P p1 = atomic_load(&p0);
 
     std::memory_order mo;
     mo = std::memory_order_relaxed;

--- a/cmake/tests/cxx11_std_atomic.cpp
+++ b/cmake/tests/cxx11_std_atomic.cpp
@@ -6,10 +6,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <atomic>
-#include <cstdint>
 
 struct P {
-    uint64_t x; uint64_t y;
+    long long x; long long y;
 };
 
 int main()


### PR DESCRIPTION
Fixes #3031 
- add some instructions to `cxx11_std_atomic.cpp` to require `__atomic_load_16` symbol
- fix cmake code for testing for `std::atomic` support

The previous cmake code is broken in several ways. First, the REQUIRED option is forwarded to the first `add_hpx_config_test` invocation so it generates at fatal error if the test doesn't compile without the library. Second the `CheckLibraryExists` module is not included so the `check_library_exists` call fails. Third the second `add_hpx_config_test` invocation does nothing because `HPX_WITH_CXX11_ATOMIC` is already set. This fixes those issues and makes the test source a little more comprehensive.