### PR TITLE
Fixing lock held during suspension in papi counter component

### DIFF
--- a/src/components/performance_counters/papi/server/papi.cpp
+++ b/src/components/performance_counters/papi/server/papi.cpp
@@ -213,6 +213,10 @@ namespace hpx { namespace performance_counters { namespace papi { namespace serv
         // convert event name to code and check availability
         {
             std::lock_guard<papi_counter_base::mutex_type> lk(this->get_global_mtx());
+            // papi_call might throw, leading to potential "lock held while
+            // suspending thread" errors. At this point, it is safe to ignore
+            // the lock.
+            hpx::util::ignore_all_while_checking il;
 
             papi_call(PAPI_event_name_to_code(
                 const_cast<char *>(cpe.countername_.c_str()),


### PR DESCRIPTION
Partially fixes #3044

## Proposed Changes

Fixing lock held during suspension in papi counter component

## Any background context you want to provide?

This fixes this test: http://rostam.cct.lsu.edu/builders/hpx_clang_3_8_boost_1_59_centos_x86_64_debug/builds/134/steps/run_regression_tests/logs/tests.regressions.performance_counters.papi_counters_active_interface%20%281.10%20sec%29