### PR TITLE
Fixing refcount for async traversal frame

### DIFF
--- a/tests/unit/util/pack_traversal_async.cpp
+++ b/tests/unit/util/pack_traversal_async.cpp
@@ -1,15 +1,15 @@
 //  Copyright (c) 2017 Denis Blank
+//  Copyright Andrey Semashev 2007 - 2013.
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/util/atomic_count.hpp>
 #include <hpx/util/lightweight_test.hpp>
 #include <hpx/util/pack_traversal_async.hpp>
 #include <hpx/util/tuple.hpp>
 #include <hpx/util/unused.hpp>
-
-#include <boost/smart_ptr/intrusive_ref_counter.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -36,13 +36,87 @@ struct not_accepted_tag
 {
 };
 
+struct thread_safe_counter
+{
+    typedef hpx::util::atomic_count type;
+
+    static unsigned int load(hpx::util::atomic_count const& counter) noexcept
+    {
+        return static_cast<unsigned int>(static_cast<long>(counter));
+    }
+
+    static void increment(hpx::util::atomic_count& counter) noexcept
+    {
+        ++counter;
+    }
+
+    static unsigned int decrement(hpx::util::atomic_count& counter) noexcept
+    {
+        return static_cast<unsigned int>(--counter);
+    }
+};
+
+template <typename Derived, typename CounterPolicy = thread_safe_counter>
+class intrusive_ref_counter;
+
+template <typename Derived, typename CounterPolicy>
+void intrusive_ptr_add_ref(
+    intrusive_ref_counter<Derived, CounterPolicy> const* p) noexcept;
+
+template <typename Derived, typename CounterPolicy>
+void intrusive_ptr_release(
+    intrusive_ref_counter<Derived, CounterPolicy> const* p) noexcept;
+
+template <typename Derived, typename CounterPolicy>
+class intrusive_ref_counter
+{
+private:
+    typedef typename CounterPolicy::type counter_type;
+
+    mutable counter_type ref_counter;
+
+public:
+    intrusive_ref_counter() noexcept : ref_counter(1) {}
+
+    unsigned int use_count() const noexcept
+    {
+        return CounterPolicy::load(ref_counter);
+    }
+
+protected:
+    ~intrusive_ref_counter() = default;
+
+    friend void intrusive_ptr_add_ref<Derived, CounterPolicy>(
+        intrusive_ref_counter<Derived, CounterPolicy> const* p)
+        noexcept;
+
+    friend void intrusive_ptr_release<Derived, CounterPolicy>(
+        intrusive_ref_counter<Derived, CounterPolicy> const* p)
+        noexcept;
+};
+
+template <typename Derived, typename CounterPolicy>
+inline void intrusive_ptr_add_ref(
+    intrusive_ref_counter<Derived, CounterPolicy> const* p) noexcept
+{
+    CounterPolicy::increment(p->ref_counter);
+}
+
+template <typename Derived, typename CounterPolicy>
+inline void intrusive_ptr_release(
+    intrusive_ref_counter<Derived, CounterPolicy> const* p) noexcept
+{
+    if (CounterPolicy::decrement(p->ref_counter) == 0)
+        delete static_cast<Derived const*>(p);
+}
+
 template <typename Child>
-class async_counter_base : public boost::intrusive_ref_counter<Child>
+class async_counter_base : public intrusive_ref_counter<Child>
 {
     std::size_t counter_ = 0;
 
 public:
-    explicit async_counter_base() = default;
+    async_counter_base() = default;
 
     virtual ~async_counter_base() {}
 
@@ -61,6 +135,8 @@ template <std::size_t ArgCount>
 struct async_increasing_int_sync_visitor
   : async_counter_base<async_increasing_int_sync_visitor<ArgCount>>
 {
+    explicit async_increasing_int_sync_visitor(int dummy) {}
+
     bool operator()(async_traverse_visit_tag, std::size_t i)
     {
         HPX_TEST_EQ(i, this->counter());
@@ -92,6 +168,8 @@ template <std::size_t ArgCount>
 struct async_increasing_int_visitor
   : async_counter_base<async_increasing_int_visitor<ArgCount>>
 {
+    explicit async_increasing_int_visitor(int dummy) {}
+
     bool operator()(async_traverse_visit_tag, std::size_t i) const
     {
         HPX_TEST_EQ(i, this->counter());
@@ -124,7 +202,9 @@ void test_async_traversal_base(Args&&... args)
     // when we detach the control flow on every visit.
     {
         auto result = traverse_pack_async(
-            async_increasing_int_sync_visitor<ArgCount>{}, args...);
+            hpx::util::async_traverse_in_place_tag<
+                async_increasing_int_sync_visitor<ArgCount>>{},
+            42, args...);
         HPX_TEST_EQ(result->counter(), ArgCount + 1U);
     }
 
@@ -132,7 +212,9 @@ void test_async_traversal_base(Args&&... args)
     // when we detach the control flow on every visit.
     {
         auto result = traverse_pack_async(
-            async_increasing_int_visitor<ArgCount>{}, args...);
+            hpx::util::async_traverse_in_place_tag<
+                async_increasing_int_visitor<ArgCount>>{},
+            42, args...);
         HPX_TEST_EQ(result->counter(), ArgCount + 1U);
     }
 }
@@ -248,6 +330,8 @@ template <std::size_t ArgCount>
 struct async_unique_sync_visitor
   : async_counter_base<async_unique_sync_visitor<ArgCount>>
 {
+    explicit async_unique_sync_visitor(int dummy) {}
+
     bool operator()(async_traverse_visit_tag, std::unique_ptr<std::size_t>& i)
     {
         HPX_TEST_EQ(*i, this->counter());
@@ -280,6 +364,8 @@ struct async_unique_sync_visitor
 template <std::size_t ArgCount>
 struct async_unique_visitor : async_counter_base<async_unique_visitor<ArgCount>>
 {
+    explicit async_unique_visitor(int dummy) {}
+
     bool operator()(async_traverse_visit_tag,
         std::unique_ptr<std::size_t>& i) const
     {
@@ -316,19 +402,25 @@ static void test_async_move_only_traversal()
 
     {
         auto result = traverse_pack_async(
-            async_unique_sync_visitor<4>{}, of(0), of(1), of(2), of(3));
+            hpx::util::async_traverse_in_place_tag<
+                async_unique_sync_visitor<4>>{},
+            42, of(0), of(1), of(2), of(3));
         HPX_TEST_EQ(result->counter(), 5U);
     }
 
     {
         auto result = traverse_pack_async(
-            async_unique_visitor<4>{}, of(0), of(1), of(2), of(3));
+            hpx::util::async_traverse_in_place_tag<
+                async_unique_visitor<4>>{},
+            42, of(0), of(1), of(2), of(3));
         HPX_TEST_EQ(result->counter(), 5U);
     }
 }
 
 struct invalidate_visitor : async_counter_base<invalidate_visitor>
 {
+    explicit invalidate_visitor(int dummy) {}
+
     bool operator()(async_traverse_visit_tag, std::shared_ptr<int>& i) const
     {
         HPX_TEST_EQ(*i, 22);
@@ -361,7 +453,9 @@ static void test_async_complete_invalidation()
 {
     auto value = std::make_shared<int>(22);
 
-    auto frame = traverse_pack_async(invalidate_visitor{}, value);
+    auto frame = traverse_pack_async(
+        hpx::util::async_traverse_in_place_tag<invalidate_visitor>{},
+        42, value);
 
     HPX_TEST_EQ(value.use_count(), 1U);
 }


### PR DESCRIPTION
This patch fixes a problem with the refcount of the async pack traversal visitor
dropping to zero too early.

## Proposed Changes

  - Have an initial increase of the refcount when constructing the intrusive_ptr for the frame
  - move the frame into the resumable traversal
  - return the frame from this resumer

## Any background context you want to provide?

This bug has been detected by running the pack_traversal_async test under address sanitizer which gave this diagnostic:
```
==15221==ERROR: AddressSanitizer: heap-use-after-free on address 0x6040000149e0 at pc 0x0000006877ab bp 0x7ffea7bb1050 sp 0x7ffea7bb1048
READ of size 8 at 0x6040000149e0 thread T0
    #0 0x6877aa in bool hpx::util::detail::fixture::check_equal<unsigned long, unsigned long>(char const*, int, char const*, hpx::util::counter_type, unsigned long const&, unsigned long const&, char const*) /home/inf3/heller/programming/hpx/hpx/util/lightweight_test.hpp:88:15
    #1 0x68711c in void test_async_traversal_base<4ul, not_accepted_tag, unsigned int, unsigned int, not_accepted_tag, unsigned int, unsigned int, not_accepted_tag>(not_accepted_tag&&, unsigned int&&, unsigned int&&, not_accepted_tag&&, unsigned int&&, unsigned int&&, not_accepted_tag&&) /home/inf3/heller/programming/hpx/tests/unit/util/pack_traversal_async.cpp:128:9
    #2 0x681806 in test_async_traversal() /home/inf3/heller/programming/hpx/tests/unit/util/pack_traversal_async.cpp:143:5
    #3 0x68152a in main /home/inf3/heller/programming/hpx/tests/unit/util/pack_traversal_async.cpp:371:5
    #4 0x7f03b9db6b44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b44)
    #5 0x589624 in _start (/scratch/heller/build/clang-5.0.0/boost-1.65.1-cxx14-libc++/openmpi-3.0.0/debug-address/hpx/bin/pack_traversal_async_test+0x589624)

0x6040000149e0 is located 16 bytes inside of 48-byte region [0x6040000149d0,0x604000014a00)
freed by thread T0 here:
    #0 0x67df40 in operator delete(void*) /opt/apps/source/llvm-5.0.0/projects/compiler-rt/lib/asan/asan_new_delete.cc:137
    #1 0x689e31 in hpx::util::detail::async_traversal_frame<async_increasing_int_sync_visitor<4ul>, not_accepted_tag, unsigned int, unsigned int, not_accepted_tag, unsigned int, unsigned int, not_accepted_tag>::~async_traversal_frame() /home/inf3/heller/programming/hpx/hpx/util/detail/pack_traversal_async_impl.hpp:130:13
    #2 0x69480a in void boost::sp_adl_block::intrusive_ptr_release<async_increasing_int_sync_visitor<4ul>, boost::sp_adl_block::thread_safe_counter>(boost::sp_adl_block::intrusive_ref_counter<async_increasing_int_sync_visitor<4ul>, boost::sp_adl_block::thread_safe_counter> const*) /opt/apps/x86_64/clang-5.0.0/boost/1.65.1-cxx14-libc++-asan/include/boost/smart_ptr/intrusive_ref_counter.hpp:173:9
    #3 0x6899f1 in boost::intrusive_ptr<hpx::util::detail::async_traversal_frame<async_increasing_int_sync_visitor<4ul>, not_accepted_tag, unsigned int, unsigned int, not_accepted_tag, unsigned int, unsigned int, not_accepted_tag> >::~intrusive_ptr() /opt/apps/x86_64/clang-5.0.0/boost/1.65.1-cxx14-libc++-asan/include/boost/smart_ptr/intrusive_ptr.hpp:98:23
    #4 0x688784 in hpx::util::detail::async_traversal_types<async_increasing_int_sync_visitor<4ul>, not_accepted_tag&, unsigned int&, unsigned int&, not_accepted_tag&, unsigned int&, unsigned int&, not_accepted_tag&>::visitor_pointer_type hpx::util::detail::apply_pack_transform_async<async_increasing_int_sync_visitor<4ul>, not_accepted_tag&, unsigned int&, unsigned int&, not_accepted_tag&, unsigned int&, unsigned int&, not_accepted_tag&, hpx::util::detail::async_traversal_types<async_increasing_int_sync_visitor<4ul>, not_accepted_tag&, unsigned int&, unsigned int&, not_accepted_tag&, unsigned int&, unsigned int&, not_accepted_tag&> >(async_increasing_int_sync_visitor<4ul>&&, not_accepted_tag&, unsigned int&, unsigned int&, not_accepted_tag&, unsigned int&, unsigned int&, not_accepted_tag&) /home/inf3/heller/programming/hpx/hpx/util/detail/pack_traversal_async_impl.hpp:617:9
    #5 0x687519 in _ZN3hpx4util19traverse_pack_asyncI33async_increasing_int_sync_visitorILm4EEJR16not_accepted_tagRjS6_S5_S6_S6_S5_EEEDTclsr6detailE26apply_pack_transform_asyncclsr3stdE7forwardIT_Efp_Espclsr3stdE7forwardIT0_Efp0_EEEOS7_DpOS8_ /home/inf3/heller/programming/hpx/hpx/util/pack_traversal_async.hpp:91:16
    #6 0x687072 in void test_async_traversal_base<4ul, not_accepted_tag, unsigned int, unsigned int, not_accepted_tag, unsigned int, unsigned int, not_accepted_tag>(not_accepted_tag&&, unsigned int&&, unsigned int&&, not_accepted_tag&&, unsigned int&&, unsigned int&&, not_accepted_tag&&) /home/inf3/heller/programming/hpx/tests/unit/util/pack_traversal_async.cpp:126:23
    #7 0x681806 in test_async_traversal() /home/inf3/heller/programming/hpx/tests/unit/util/pack_traversal_async.cpp:143:5
    #8 0x68152a in main /home/inf3/heller/programming/hpx/tests/unit/util/pack_traversal_async.cpp:371:5
    #9 0x7f03b9db6b44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b44)

previously allocated by thread T0 here:
    #0 0x67d1c8 in operator new(unsigned long) /opt/apps/source/llvm-5.0.0/projects/compiler-rt/lib/asan/asan_new_delete.cc:92
    #1 0x68844a in hpx::util::detail::async_traversal_types<async_increasing_int_sync_visitor<4ul>, not_accepted_tag&, unsigned int&, unsigned int&, not_accepted_tag&, unsigned int&, unsigned int&, not_accepted_tag&>::visitor_pointer_type hpx::util::detail::apply_pack_transform_async<async_increasing_int_sync_visitor<4ul>, not_accepted_tag&, unsigned int&, unsigned int&, not_accepted_tag&, unsigned int&, unsigned int&, not_accepted_tag&, hpx::util::detail::async_traversal_types<async_increasing_int_sync_visitor<4ul>, not_accepted_tag&, unsigned int&, unsigned int&, not_accepted_tag&, unsigned int&, unsigned int&, not_accepted_tag&> >(async_increasing_int_sync_visitor<4ul>&&, not_accepted_tag&, unsigned int&, unsigned int&, not_accepted_tag&, unsigned int&, unsigned int&, not_accepted_tag&) /home/inf3/heller/programming/hpx/hpx/util/detail/pack_traversal_async_impl.hpp:604:61
    #2 0x687519 in _ZN3hpx4util19traverse_pack_asyncI33async_increasing_int_sync_visitorILm4EEJR16not_accepted_tagRjS6_S5_S6_S6_S5_EEEDTclsr6detailE26apply_pack_transform_asyncclsr3stdE7forwardIT_Efp_Espclsr3stdE7forwardIT0_Efp0_EEEOS7_DpOS8_ /home/inf3/heller/programming/hpx/hpx/util/pack_traversal_async.hpp:91:16
    #3 0x687072 in void test_async_traversal_base<4ul, not_accepted_tag, unsigned int, unsigned int, not_accepted_tag, unsigned int, unsigned int, not_accepted_tag>(not_accepted_tag&&, unsigned int&&, unsigned int&&, not_accepted_tag&&, unsigned int&&, unsigned int&&, not_accepted_tag&&) /home/inf3/heller/programming/hpx/tests/unit/util/pack_traversal_async.cpp:126:23
    #4 0x681806 in test_async_traversal() /home/inf3/heller/programming/hpx/tests/unit/util/pack_traversal_async.cpp:143:5
    #5 0x68152a in main /home/inf3/heller/programming/hpx/tests/unit/util/pack_traversal_async.cpp:371:5
    #6 0x7f03b9db6b44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b44)
```