### PR TITLE
Fixing thread scheduling when yielding a thread id.

### DIFF
--- a/src/runtime/threads/thread_helpers.cpp
+++ b/src/runtime/threads/thread_helpers.cpp
@@ -493,9 +493,18 @@ namespace hpx { namespace this_thread
 #ifdef HPX_HAVE_THREAD_BACKTRACE_ON_SUSPENSION
             detail::reset_backtrace bt(id, ec);
 #endif
-
-            // suspend the HPX-thread
-            statex = self.yield(threads::thread_result_type(state, nextid));
+            // We might need to dispatch 'nextid' to it's correct scheduler
+            // only if our current scheduler is the same, we should yield the id
+            if (nextid && nextid->get_scheduler_base() != id->get_scheduler_base())
+            {
+                nextid->get_scheduler_base()->schedule_thread(
+                    nextid.get(), std::size_t(-1));
+                statex = self.yield(threads::thread_result_type(state, nullptr));
+            }
+            else
+            {
+                statex = self.yield(threads::thread_result_type(state, nextid));
+            }
         }
 
         // handle interruption, if needed
@@ -551,9 +560,20 @@ namespace hpx { namespace this_thread
                 threads::thread_priority_boost, ec);
             if (ec) return threads::wait_unknown;
 
-            // suspend the HPX-thread
-            statex = self.yield(
-                threads::thread_result_type(threads::suspended, nextid));
+            // We might need to dispatch 'nextid' to it's correct scheduler
+            // only if our current scheduler is the same, we should yield the id
+            if (nextid && nextid->get_scheduler_base() != id->get_scheduler_base())
+            {
+                nextid->get_scheduler_base()->schedule_thread(
+                    nextid.get(), std::size_t(-1));
+                statex = self.yield(
+                    threads::thread_result_type(threads::suspended, nullptr));
+            }
+            else
+            {
+                statex = self.yield(
+                    threads::thread_result_type(threads::suspended, nextid));
+            }
 
             if (statex != threads::wait_timeout)
             {


### PR DESCRIPTION
It might happen that the id that is being yielded to the scheduling loop
should be run on a different scheduler. This patch fixes that.

This might be related to the occasional failures we see with the thread executors tests.