### PR TITLE
Revert "fix detection of cxx11_std_atomic"

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -9,8 +9,6 @@
 
 set(HPX_ADDCONFIGTEST_LOADED TRUE)
 
-include(CheckLibraryExists)
-
 macro(add_hpx_config_test variable)
   set(options FILE EXECUTE)
   set(one_value_args SOURCE ROOT CMAKECXXFEATURE)
@@ -389,20 +387,15 @@ macro(hpx_check_for_cxx11_std_atomic)
   # Sometimes linking against libatomic is required for atomic ops, if
   # the platform doesn't support lock-free atomics.
 
-  # remove REQUIRED so that we don't generate a failure too early
-  # need to copy ARGN to list in order to remove REQUIRED
-  set (extra_macro_args ${ARGN})
-  list(REMOVE_ITEM extra_macro_args REQUIRED)
-
   # First check if atomics work without the library.
   add_hpx_config_test(HPX_WITH_CXX11_ATOMIC
-    SOURCE cmake/tests/cxx11_std_atomic.cpp FILE extra_macro_args)
+    SOURCE cmake/tests/cxx11_std_atomic.cpp
+    FILE ${ARGN})
 
   # If not, check if the library exists, and atomics work with it.
   if(NOT HPX_WITH_CXX11_ATOMIC)
     check_library_exists(atomic __atomic_fetch_add_4 "" HPX_HAVE_LIBATOMIC)
     if(HPX_HAVE_LIBATOMIC)
-      unset(HPX_WITH_CXX11_ATOMIC CACHE)
       add_hpx_config_test(HPX_WITH_CXX11_ATOMIC
         SOURCE cmake/tests/cxx11_std_atomic.cpp
         LIBRARIES "atomic"

--- a/cmake/tests/cxx11_std_atomic.cpp
+++ b/cmake/tests/cxx11_std_atomic.cpp
@@ -7,10 +7,6 @@
 
 #include <atomic>
 
-struct P {
-    long long x; long long y;
-};
-
 int main()
 {
     std::atomic_flag af = ATOMIC_FLAG_INIT;
@@ -20,9 +16,6 @@ int main()
     std::atomic<int> ai;
     ai.store(0);
     int i = ai.load();
-
-    std::atomic<P> p0;
-    P p1 = atomic_load(&p0);
 
     std::memory_order mo;
     mo = std::memory_order_relaxed;


### PR DESCRIPTION
Reverts STEllAR-GROUP/hpx#3096 because of cmake tests failing e.g. [here](http://rostam.cct.lsu.edu/builders/hpx_clang_3_8_boost_1_59_centos_x86_64_debug/builds/186/steps/configure/logs/stdio).

Reverting so that we can keep merging other PRs to master and see the test results.