### PR TITLE
Adding performance_counter::reinit to allow for dynamically changing counter sets

### DIFF
--- a/hpx/include/performance_counters.hpp
+++ b/hpx/include/performance_counters.hpp
@@ -12,6 +12,7 @@
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/manage_counter.hpp>
 #include <hpx/performance_counters/manage_counter_type.hpp>
+#include <hpx/performance_counters/base_performance_counter.hpp>
 #include <hpx/performance_counters/performance_counter.hpp>
 #include <hpx/performance_counters/performance_counter_set.hpp>
 #include <hpx/util/get_and_reset_value.hpp>

--- a/hpx/performance_counters/base_performance_counter.hpp
+++ b/hpx/performance_counters/base_performance_counter.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2012 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/hpx/performance_counters/performance_counter.hpp
+++ b/hpx/performance_counters/performance_counter.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -109,6 +109,10 @@ namespace hpx { namespace performance_counters
 
         future<void> reset();
         void reset(launch::sync_policy, error_code& ec = throws);
+
+        future<void> reinit(bool reset = true);
+        void reinit(
+            launch::sync_policy, bool reset = true, error_code& ec = throws);
 
 #if defined(HPX_HAVE_ASYNC_FUNCTION_COMPATIBILITY)
         HPX_DEPRECATED(HPX_DEPRECATED_MSG)

--- a/hpx/performance_counters/performance_counter_base.hpp
+++ b/hpx/performance_counters/performance_counter_base.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -42,6 +42,9 @@ namespace hpx { namespace performance_counters
 
         // Stop the Performance Counter.
         virtual bool stop() = 0;
+
+        // Re-initialize the Performance Counter.
+        virtual void reinit(bool reset) = 0;
     };
     //]
 }}

--- a/hpx/performance_counters/performance_counter_set.hpp
+++ b/hpx/performance_counters/performance_counter_set.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016-2017 Hartmut Kaiser
+//  Copyright (c) 2016-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -79,6 +79,10 @@ namespace hpx { namespace performance_counters
         /// Stop all counters in this set
         std::vector<hpx::future<bool> > stop();
         bool stop(launch::sync_policy, error_code& ec = throws);
+
+        /// Re-initialize all counters in this set
+        std::vector<hpx::future<void> > reinit(bool reset = true);
+        void reinit(launch::sync_policy, bool reset = true, error_code& ec = throws);
 
         /// Release all references to counters in the set
         void release();

--- a/hpx/performance_counters/server/base_performance_counter.hpp
+++ b/hpx/performance_counters/server/base_performance_counter.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -26,26 +26,27 @@ namespace hpx { namespace performance_counters { namespace server
     protected:
         /// the following functions are not implemented by default, they will
         /// just throw
-        virtual void reset_counter_value()
+        virtual void reset_counter_value() override
         {
             HPX_THROW_EXCEPTION(invalid_status, "reset_counter_value",
                 "reset_counter_value is not implemented for this counter");
         }
 
-        virtual void set_counter_value(counter_value const& /*value*/)
+        virtual void set_counter_value(counter_value const& /*value*/) override
         {
             HPX_THROW_EXCEPTION(invalid_status, "set_counter_value",
                 "set_counter_value is not implemented for this counter");
         }
 
-        virtual counter_value get_counter_value(bool reset)
+        virtual counter_value get_counter_value(bool reset) override
         {
             HPX_THROW_EXCEPTION(invalid_status, "get_counter_value",
                 "get_counter_value is not implemented for this counter");
             return counter_value();
         }
 
-        virtual counter_values_array get_counter_values_array(bool reset)
+        virtual counter_values_array get_counter_values_array(
+            bool reset) override
         {
             HPX_THROW_EXCEPTION(invalid_status, "get_counter_values_array",
                 "get_counter_values_array is not implemented for this "
@@ -53,17 +54,21 @@ namespace hpx { namespace performance_counters { namespace server
             return counter_values_array();
         }
 
-        virtual bool start()
+        virtual bool start() override
         {
             return false;    // nothing to do
         }
 
-        virtual bool stop()
+        virtual bool stop() override
         {
             return false;    // nothing to do
         }
 
-        virtual counter_info get_counter_info() const
+        virtual void reinit(bool reset) override
+        {
+        }
+
+        virtual counter_info get_counter_info() const override
         {
             return info_;
         }
@@ -137,6 +142,11 @@ namespace hpx { namespace performance_counters { namespace server
             return this->stop();
         }
 
+        void reinit_nonvirt(bool reset)
+        {
+            reinit(reset);
+        }
+
         /// Each of the exposed functions needs to be encapsulated into an action
         /// type, allowing to generate all required boilerplate code for threads,
         /// serialization, etc.
@@ -172,6 +182,10 @@ namespace hpx { namespace performance_counters { namespace server
         /// The \a stop_action
         HPX_DEFINE_COMPONENT_ACTION(
             base_performance_counter, stop_nonvirt, stop_action);
+
+        /// The \a reinit_action
+        HPX_DEFINE_COMPONENT_ACTION(
+            base_performance_counter, reinit_nonvirt, reinit_action);
 
     protected:
         hpx::performance_counters::counter_info info_;

--- a/hpx/performance_counters/stubs/performance_counter.hpp
+++ b/hpx/performance_counters/stubs/performance_counter.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -67,6 +67,8 @@ namespace hpx { namespace performance_counters { namespace stubs
             naming::id_type const& targetid);
         static lcos::future<void> reset(launch::async_policy,
             naming::id_type const& targetid);
+        static lcos::future<void> reinit(launch::async_policy,
+            naming::id_type const& targetid, bool reset);
 
         static bool start(launch::sync_policy, naming::id_type const& targetid,
             error_code& ec = throws);
@@ -74,6 +76,8 @@ namespace hpx { namespace performance_counters { namespace stubs
             error_code& ec = throws);
         static void reset(launch::sync_policy, naming::id_type const& targetid,
             error_code& ec = throws);
+        static void reinit(launch::sync_policy, naming::id_type const& targetid,
+            bool reset, error_code& ec = throws);
 
 #if defined(HPX_HAVE_ASYNC_FUNCTION_COMPATIBILITY)
         HPX_DEPRECATED(HPX_DEPRECATED_MSG)

--- a/hpx/runtime.hpp
+++ b/hpx/runtime.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -289,6 +289,7 @@ namespace hpx
         void start_active_counters(error_code& ec = throws);
         void stop_active_counters(error_code& ec = throws);
         void reset_active_counters(error_code& ec = throws);
+        void reinit_active_counters(bool reset = true, error_code& ec = throws);
         void evaluate_active_counters(bool reset = false,
             char const* description = nullptr, error_code& ec = throws);
 

--- a/hpx/runtime_fwd.hpp
+++ b/hpx/runtime_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -175,6 +175,25 @@ namespace hpx
     ///           the command line while executing the application (see command
     ///           line option \--hpx:print-counter)
     HPX_API_EXPORT void reset_active_counters(error_code& ec = throws);
+
+    /// \brief Re-initialize all active performance counters.
+    ///
+    /// \param reset [in] Reset the current values before re-initializing
+    ///           counters (default: true)
+    /// \param ec [in,out] this represents the error status on exit, if this
+    ///           is pre-initialized to \a hpx#throws the function will throw
+    ///           on error instead.
+    ///
+    /// \note     As long as \a ec is not pre-initialized to \a hpx::throws this
+    ///           function doesn't throw but returns the result code using the
+    ///           parameter \a ec. Otherwise it throws an instance of
+    ///           hpx::exception.
+    ///
+    /// \note     The active counters are those which have been specified on
+    ///           the command line while executing the application (see command
+    ///           line option \--hpx:print-counter)
+    HPX_API_EXPORT void reinit_active_counters(
+        bool reset = true, error_code& ec = throws);
 
     /// \brief Stop all active performance counters.
     ///

--- a/hpx/util/query_counters.hpp
+++ b/hpx/util/query_counters.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -47,6 +47,7 @@ namespace hpx { namespace util
         void start_counters(error_code& ec = throws);
         void stop_counters(error_code& ec = throws);
         void reset_counters(error_code& ec = throws);
+        void reinit_counters(bool reset = true, error_code& ec = throws);
         bool evaluate_counters(bool reset = false,
             char const* description = nullptr, error_code& ec = throws);
 

--- a/src/performance_counters/performance_counter.cpp
+++ b/src/performance_counters/performance_counter.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -128,6 +128,16 @@ namespace hpx { namespace performance_counters
     void performance_counter::reset(launch::sync_policy, error_code& ec)
     {
         stubs::performance_counter::reset(launch::sync, get_id(), ec);
+    }
+
+    future<void> performance_counter::reinit(bool reset)
+    {
+        return stubs::performance_counter::reinit(launch::async, get_id(), reset);
+    }
+    void performance_counter::reinit(
+        launch::sync_policy, bool reset, error_code& ec)
+    {
+        stubs::performance_counter::reinit(launch::sync, get_id(), reset, ec);
     }
 
     ///

--- a/src/performance_counters/stubs/performance_counter_stub.cpp
+++ b/src/performance_counters/stubs/performance_counter_stub.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -79,6 +79,14 @@ namespace hpx { namespace performance_counters { namespace stubs
         return hpx::async<action_type>(targetid);
     }
 
+    lcos::future<void> performance_counter::reinit(launch::async_policy,
+        naming::id_type const& targetid, bool reset)
+    {
+        typedef server::base_performance_counter::reinit_action
+            action_type;
+        return hpx::async<action_type>(targetid, reset);
+    }
+
     bool performance_counter::start(launch::sync_policy,
         naming::id_type const& targetid, error_code& ec)
     {
@@ -95,5 +103,11 @@ namespace hpx { namespace performance_counters { namespace stubs
         naming::id_type const& targetid, error_code& ec)
     {
         reset(launch::async, targetid).get(ec);
+    }
+
+    void performance_counter::reinit(launch::sync_policy,
+        naming::id_type const& targetid, bool reset, error_code& ec)
+    {
+        reinit(launch::async, targetid, reset).get(ec);
     }
 }}}

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -330,7 +330,7 @@ namespace hpx
         return *thread_support_;
     }
 
-///////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
     void runtime::register_query_counters(
         std::shared_ptr<util::query_counters> const& active_counters)
     {
@@ -353,6 +353,12 @@ namespace hpx
     {
         if (active_counters_.get())
             active_counters_->reset_counters(ec);
+    }
+
+    void runtime::reinit_active_counters(bool reset, error_code& ec)
+    {
+        if (active_counters_.get())
+            active_counters_->reinit_counters(reset, ec);
     }
 
     void runtime::evaluate_active_counters(bool reset,
@@ -1283,6 +1289,18 @@ namespace hpx
         }
         else {
             HPX_THROWS_IF(ec, invalid_status, "reset_active_counters",
+                "the runtime system is not available at this time");
+        }
+    }
+
+    void reinit_active_counters(bool reset, error_code& ec)
+    {
+        runtime* rt = get_runtime_ptr();
+        if (nullptr != rt) {
+            rt->reinit_active_counters(reset, ec);
+        }
+        else {
+            HPX_THROWS_IF(ec, invalid_status, "reinit_active_counters",
                 "the runtime system is not available at this time");
         }
     }

--- a/src/util/query_counters.cpp
+++ b/src/util/query_counters.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -405,6 +405,21 @@ namespace hpx { namespace util
 
         // Reset the performance counters.
         counters_.reset(launch::sync, ec);
+    }
+
+    void query_counters::reinit_counters(bool reset, error_code& ec)
+    {
+        if (counters_.size() == 0)
+        {
+            // start has not been called yet
+            HPX_THROWS_IF(ec, invalid_status,
+                "query_counters::reinit_counters",
+                "The counters to be evaluated have not been initialized yet");
+            return;
+        }
+
+        // Reset the performance counters.
+        counters_.reinit(launch::sync, reset, ec);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/tests/unit/performance_counter/CMakeLists.txt
+++ b/tests/unit/performance_counter/CMakeLists.txt
@@ -6,7 +6,8 @@
 set(tests
     all_counters
     counter_raw_values
-    path_elements)
+    path_elements
+    reinit_counters)
 
 foreach(test ${tests})
   set(sources

--- a/tests/unit/performance_counter/reinit_counters.cpp
+++ b/tests/unit/performance_counter/reinit_counters.cpp
@@ -1,0 +1,184 @@
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/components.hpp>
+#include <hpx/include/performance_counters.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <ctime>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+std::atomic<unsigned int> value_count_;
+
+class test_counter
+  : public hpx::performance_counters::base_performance_counter<test_counter>
+{
+public:
+    test_counter() = default;
+
+    test_counter(hpx::performance_counters::counter_info const& info)
+      : hpx::performance_counters::base_performance_counter<test_counter>(info)
+      , base_counter_(0)
+    {
+        value_count_ = std::rand();
+    }
+
+    hpx::performance_counters::counter_values_array get_counter_values_array(
+        bool reset) override
+    {
+        hpx::performance_counters::counter_values_array value;
+
+        value.time_ = hpx::util::high_resolution_clock::now();
+        value.status_ = hpx::performance_counters::status_new_data;
+        value.count_ = ++invocation_count_;
+
+        std::vector<std::int64_t> result(value_count_.load());
+        std::iota(result.begin(), result.end(), base_counter_.load());
+
+        ++base_counter_;
+        if (reset)
+            base_counter_.store(0);
+
+        value.values_ = std::move(result);
+
+        return value;
+    }
+
+    void reinit(bool reset) override
+    {
+        value_count_ = std::rand();
+    }
+
+private:
+    std::atomic<std::int64_t> base_counter_;
+};
+
+typedef hpx::components::component<test_counter> test_counter_type;
+
+HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
+    test_counter_type, test_counter, "base_performance_counter");
+
+///////////////////////////////////////////////////////////////////////////////
+hpx::naming::gid_type test_counter_creator(
+    hpx::performance_counters::counter_info const& info, hpx::error_code& ec)
+{
+    hpx::performance_counters::counter_path_elements paths;
+    get_counter_path_elements(info.fullname_, paths, ec);
+    if (ec) return hpx::naming::invalid_gid;
+
+    if (paths.parentinstance_is_basename_) {
+        HPX_THROWS_IF(ec, hpx::bad_parameter,
+            "test_counter_creator",
+            "invalid counter instance parent name: " +
+                paths.parentinstancename_);
+        return hpx::naming::invalid_gid;
+    }
+
+    // create individual counter
+    if (paths.instancename_ == "total" && paths.instanceindex_ == -1)
+    {
+        // make sure parent instance name is set properly
+        hpx::performance_counters::counter_info complemented_info = info;
+        complement_counter_info(complemented_info, info, ec);
+        if (ec) return hpx::naming::invalid_gid;
+
+        // create the counter as requested
+        hpx::naming::gid_type id;
+        try {
+            id = hpx::components::server::construct<test_counter_type>(
+                complemented_info);
+        }
+        catch (hpx::exception const& e) {
+            if (&ec == &hpx::throws)
+                throw;
+            ec = make_error_code(e.get_error(), e.what());
+            return hpx::naming::invalid_gid;
+        }
+
+        if (&ec != &hpx::throws)
+            ec = hpx::make_success_code();
+        return id;
+    }
+
+    HPX_THROWS_IF(ec, hpx::bad_parameter,
+        "test_counter_creator",
+        "invalid counter instance name: " + paths.instancename_);
+    return hpx::naming::invalid_gid;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void register_counter_type()
+{
+    // Call the HPX API function to register the counter type.
+    hpx::performance_counters::install_counter_type("/test/reinit-values",
+        hpx::performance_counters::counter_raw_values,
+        "returns an array of linearly increasing counter values, supports "
+            "reinit",
+        &test_counter_creator,
+        &hpx::performance_counters::locality_counter_discoverer,
+        HPX_PERFORMANCE_COUNTER_V1);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int)std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    for (int i = 0; i != 10; ++i)
+    {
+        hpx::performance_counters::performance_counter c("/test/reinit-values");
+
+        c.reinit();
+
+        auto values = c.get_counter_values_array(hpx::launch::sync, false);
+
+        HPX_TEST_EQ(values.count_, static_cast<std::uint64_t>(i + 1));
+
+        std::vector<std::int64_t> expected(value_count_.load());
+        std::iota(expected.begin(), expected.end(), i);
+        HPX_TEST(values.values_ == expected);
+
+        std::string name = c.get_name(hpx::launch::sync);
+        HPX_TEST_EQ(name, std::string("/test{locality#0/total}/reinit-values"));
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace boost::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()
+        ("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run")
+        ;
+
+    hpx::register_startup_function(&register_counter_type);
+
+    // Initialize and run HPX.
+    std::vector<std::string> const cfg = {
+        "hpx.os_threads=1"
+    };
+    HPX_TEST_EQ(hpx::init(desc_commandline, argc, argv, cfg), 0);
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
- This change adds a new API function for performance counters that instructs a
  counter to re-initialize the set of values it refers to
- This also adds a new `hpx::reinit_active_counters()` API that triggers a
  reinit for all active counters

## Any background context you want to provide?

We will need this functionality for the new performance counters to be created for Phylanx where the list of values to be returned from a performance counter may change dynamically based on the evaluated expressions.