### PR TITLE
Disable default executor compatibility with V1 executors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -940,24 +940,24 @@ endif()
 
 # HPX_WITH_EXECUTOR_COMPATIBILITY: introduced in V1.0.0
 hpx_option(HPX_WITH_EXECUTOR_COMPATIBILITY BOOL
-    "Enable old (pre-concurrency TS) executor API (default: ON)"
-    ON ADVANCED)
+    "Enable old (pre-concurrency TS) executor API (default: OFF)"
+    OFF ADVANCED)
 if(HPX_WITH_EXECUTOR_COMPATIBILITY)
   hpx_add_config_define(HPX_HAVE_EXECUTOR_COMPATIBILITY)
 endif()
 
 # HPX_WITH_EXECUTION_POLICY_COMPATIBILITY: introduced in V1.0.0
 hpx_option(HPX_WITH_EXECUTION_POLICY_COMPATIBILITY BOOL
-    "Enable old execution policy names in API (default: ON)"
-    ON ADVANCED)
+    "Enable old execution policy names in API (default: OFF)"
+    OFF ADVANCED)
 if(HPX_WITH_EXECUTION_POLICY_COMPATIBILITY)
   hpx_add_config_define(HPX_HAVE_EXECUTION_POLICY_COMPATIBILITY)
 endif()
 
 # HPX_WITH_TRANSFORM_REDUCE_COMPATIBILITY: introduced in V1.0.0
 hpx_option(HPX_WITH_TRANSFORM_REDUCE_COMPATIBILITY BOOL
-    "Enable old overloads for transform_reduce and inner_product (default: ON)"
-    ON ADVANCED)
+    "Enable old overloads for transform_reduce and inner_product (default: OFF)"
+    OFF ADVANCED)
 if(HPX_WITH_TRANSFORM_REDUCE_COMPATIBILITY)
   hpx_add_config_define(HPX_HAVE_TRANSFORM_REDUCE_COMPATIBILITY)
 endif()

--- a/docs/hpx.idx
+++ b/docs/hpx.idx
@@ -114,7 +114,7 @@ parallel::is_executor                      "is_executor"                   "hpx\
 
 parallel::execution::sequenced_execution_tag          "sequenced_execution_tag"       "hpx\.parallel\.execution\.sequenced_execution_tag.*"
 parallel::execution::parallel_execution_tag           "parallel_execution_tag"        "hpx\.parallel\.execution\.parallel_execution_tag.*"
-parallel::execution::vector_execution_tag             "vector_execution_tag"          "hpx\.parallel\.execution\.vector_execution_tag.*"
+parallel::execution::unsequenced_execution_tag        "unsequenced_execution_tag"     "hpx\.parallel\.execution\.unsequenced_execution_tag.*"
 
 # hpx/parallel/executors/sequential_executor.hpp
 parallel::execution::sequenced_executor              "sequenced_executor"           "hpx\.parallel\.execution\.sequenced_executor.*"

--- a/examples/quickstart/component_with_executor.cpp
+++ b/examples/quickstart/component_with_executor.cpp
@@ -15,10 +15,10 @@
 // Define a base component which exposes the required interface
 struct hello_world_server
   : hpx::components::executor_component<
-        hpx::parallel::local_priority_queue_executor,
+        hpx::parallel::execution::local_priority_queue_executor,
         hpx::components::component_base<hello_world_server> >
 {
-    typedef hpx::parallel::local_priority_queue_executor executor_type;
+    typedef hpx::parallel::execution::local_priority_queue_executor executor_type;
     typedef hpx::components::executor_component<
             executor_type, hpx::components::component_base<hello_world_server>
         > base_type;

--- a/examples/resource_partitioner/oversubscribing_resource_partitioner.cpp
+++ b/examples/resource_partitioner/oversubscribing_resource_partitioner.cpp
@@ -151,7 +151,7 @@ int hpx_main(boost::program_options::variables_map& vm)
     std::set<std::thread::id> thread_set;
 
     // test a parallel algorithm on custom pool with high priority
-    hpx::parallel::static_chunk_size fixed(1);
+    hpx::parallel::execution::static_chunk_size fixed(1);
     hpx::parallel::for_loop_strided(
         hpx::parallel::execution::par.with(fixed).on(high_priority_executor), 0,
         loop_count, 1, [&](std::size_t i) {

--- a/examples/resource_partitioner/simple_resource_partitioner.cpp
+++ b/examples/resource_partitioner/simple_resource_partitioner.cpp
@@ -153,7 +153,7 @@ int hpx_main(boost::program_options::variables_map& vm)
     std::set<std::thread::id> thread_set;
 
     // test a parallel algorithm on custom pool with high priority
-    hpx::parallel::static_chunk_size fixed(1);
+    hpx::parallel::execution::static_chunk_size fixed(1);
     hpx::parallel::for_loop_strided(
         hpx::parallel::execution::par.with(fixed).on(high_priority_executor), 0,
         loop_count, 1, [&](std::size_t i) {

--- a/hpx/compute/host/block_executor.hpp
+++ b/hpx/compute/host/block_executor.hpp
@@ -137,16 +137,16 @@ namespace hpx { namespace compute { namespace host
 
         template <typename F, typename Shape, typename ... Ts>
         std::vector<hpx::future<
-            typename hpx::parallel::v3::detail::bulk_async_execute_result<
+            typename parallel::execution::detail::bulk_function_result<
                 F, Shape, Ts...
-            >::type>
-        >
+            >::type
+        > >
         bulk_async_execute(F && f, Shape const& shape, Ts &&... ts)
         {
             std::vector<hpx::future<
-                typename hpx::parallel::v3::detail::bulk_async_execute_result<
-                        F, Shape, Ts...
-                    >::type
+                typename parallel::execution::detail::bulk_function_result<
+                    F, Shape, Ts...
+                >::type
             > > results;
             std::size_t cnt = util::size(shape);
             std::size_t part_size = cnt / executors_.size();
@@ -181,13 +181,13 @@ namespace hpx { namespace compute { namespace host
             }
         }
 
-        template <typename F, typename Shape, typename ... Ts>
-        typename hpx::parallel::v3::detail::bulk_execute_result<
+        template <typename F, typename Shape, typename... Ts>
+        typename parallel::execution::detail::bulk_execute_result<
             F, Shape, Ts...
         >::type
-        bulk_sync_execute(F && f, Shape const& shape, Ts &&... ts)
+        bulk_sync_execute(F&& f, Shape const& shape, Ts&&... ts)
         {
-            typename hpx::parallel::v3::detail::bulk_execute_result<
+            typename parallel::execution::detail::bulk_execute_result<
                     F, Shape, Ts...
                 >::type results;
             std::size_t cnt = util::size(shape);

--- a/hpx/lcos/spmd_block.hpp
+++ b/hpx/lcos/spmd_block.hpp
@@ -10,7 +10,7 @@
 #include <hpx/lcos/future.hpp>
 #include <hpx/lcos/barrier.hpp>
 #include <hpx/lcos/broadcast.hpp>
-#include <hpx/parallel/execution_policy.hpp>
+#include <hpx/parallel/execution.hpp>
 #include <hpx/runtime/get_locality_id.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/runtime/serialization/serialize.hpp>
@@ -289,15 +289,13 @@ namespace hpx { namespace lcos
                 std::size_t offset = hpx::get_locality_id();
                 offset *= images_per_locality;
 
-                hpx::parallel::executor_traits<
-                    executor_type
-                    >::bulk_execute(
-                        exec,
-                        detail::spmd_block_helper<F>{
-                            name,images_per_locality, num_images},
-                        boost::irange(
-                            offset, offset + images_per_locality),
-                        args...);
+                hpx::parallel::execution::bulk_sync_execute(
+                    exec,
+                    detail::spmd_block_helper<F>{
+                        name,images_per_locality, num_images},
+                    boost::irange(
+                        offset, offset + images_per_locality),
+                    args...);
             }
         };
     }

--- a/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -289,7 +289,7 @@ namespace hpx { namespace parallel { inline namespace v1
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2, typename Op,
         typename T,
     HPX_CONCEPT_REQUIRES_(
-        is_execution_policy<ExPolicy>::value &&
+        execution::is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<FwdIter1>::value &&
         hpx::traits::is_iterator<FwdIter2>::value &&
         hpx::traits::is_invocable<Op,
@@ -330,7 +330,7 @@ namespace hpx { namespace parallel { inline namespace v1
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2, typename T,
         typename Op,
     HPX_CONCEPT_REQUIRES_(
-        is_execution_policy<ExPolicy>::value &&
+        execution::is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<FwdIter1>::value &&
         hpx::traits::is_iterator<FwdIter2>::value &&
         hpx::traits::is_invocable<Op,
@@ -429,7 +429,7 @@ namespace hpx { namespace parallel { inline namespace v1
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2, typename T,
     HPX_CONCEPT_REQUIRES_(
-        is_execution_policy<ExPolicy>::value &&
+        execution::is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<FwdIter1>::value &&
         hpx::traits::is_iterator<FwdIter2>::value &&
        !hpx::traits::is_invocable<T,
@@ -542,7 +542,7 @@ namespace hpx { namespace parallel { inline namespace v1
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2, typename Op,
     HPX_CONCEPT_REQUIRES_(
-        is_execution_policy<ExPolicy>::value &&
+        execution::is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<FwdIter1>::value &&
         hpx::traits::is_iterator<FwdIter2>::value &&
         hpx::traits::is_invocable<Op,

--- a/hpx/parallel/algorithms/inner_product.hpp
+++ b/hpx/parallel/algorithms/inner_product.hpp
@@ -71,8 +71,9 @@ namespace hpx { namespace parallel { inline namespace v1
     ///       of \a transform_reduce.
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2, typename T>
+    HPX_DEPRECATED(HPX_DEPRECATED_MSG)
     inline typename std::enable_if<
-        is_execution_policy<ExPolicy>::value,
+        execution::is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, T>::type
     >::type
     inner_product(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
@@ -166,8 +167,9 @@ namespace hpx { namespace parallel { inline namespace v1
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2, typename T,
         typename Op1, typename Op2>
+    HPX_DEPRECATED(HPX_DEPRECATED_MSG)
     inline typename std::enable_if<
-        is_execution_policy<ExPolicy>::value,
+        execution::is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, T>::type
     >::type
     inner_product(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,

--- a/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -186,7 +186,7 @@ namespace hpx { namespace parallel { inline namespace v1
                 "Requires at least output iterator.");
 
             typedef std::integral_constant<bool,
-                    is_sequenced_execution_policy<ExPolicy>::value ||
+                    execution::is_sequenced_execution_policy<ExPolicy>::value ||
                    !hpx::traits::is_forward_iterator<FwdIter1>::value ||
                    !hpx::traits::is_forward_iterator<FwdIter2>::value
                 > is_seq;
@@ -198,7 +198,7 @@ namespace hpx { namespace parallel { inline namespace v1
                 (hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            typedef is_sequenced_execution_policy<ExPolicy> is_seq;
+            typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
 #endif
 
             return detail::transform_exclusive_scan<FwdIter2>().call(
@@ -315,7 +315,7 @@ namespace hpx { namespace parallel { inline namespace v1
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename T, typename Op, typename Conv,
     HPX_CONCEPT_REQUIRES_(
-        is_execution_policy<ExPolicy>::value &&
+        execution::is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<FwdIter1>::value &&
         hpx::traits::is_iterator<FwdIter2>::value &&
         hpx::traits::is_invocable<Conv,
@@ -344,7 +344,7 @@ namespace hpx { namespace parallel { inline namespace v1
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename T, typename Op, typename Conv,
     HPX_CONCEPT_REQUIRES_(
-        is_execution_policy<ExPolicy>::value &&
+        execution::is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<FwdIter1>::value &&
         hpx::traits::is_iterator<FwdIter2>::value &&
         hpx::traits::is_invocable<Conv,

--- a/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -185,7 +185,7 @@ namespace hpx { namespace parallel { inline namespace v1
                 "Requires at least output iterator.");
 
             typedef std::integral_constant<bool,
-                    is_sequenced_execution_policy<ExPolicy>::value ||
+                    execution::is_sequenced_execution_policy<ExPolicy>::value ||
                    !hpx::traits::is_forward_iterator<FwdIter1>::value ||
                    !hpx::traits::is_forward_iterator<FwdIter2>::value
                 > is_seq;
@@ -197,7 +197,7 @@ namespace hpx { namespace parallel { inline namespace v1
                 (hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            typedef is_sequenced_execution_policy<ExPolicy> is_seq;
+            typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
 #endif
             return detail::transform_inclusive_scan<FwdIter2>().call(
                 std::forward<ExPolicy>(policy), is_seq(),
@@ -374,7 +374,7 @@ namespace hpx { namespace parallel { inline namespace v1
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename T, typename Op, typename Conv,
     HPX_CONCEPT_REQUIRES_(
-        is_execution_policy<ExPolicy>::value &&
+        execution::is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<FwdIter1>::value &&
         hpx::traits::is_iterator<FwdIter2>::value &&
         hpx::traits::is_invocable<Conv,
@@ -533,7 +533,7 @@ namespace hpx { namespace parallel { inline namespace v1
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Conv, typename Op,
     HPX_CONCEPT_REQUIRES_(
-        is_execution_policy<ExPolicy>::value &&
+        execution::is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<FwdIter1>::value &&
         hpx::traits::is_iterator<FwdIter2>::value &&
         hpx::traits::is_invocable<Conv,

--- a/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/hpx/parallel/algorithms/transform_reduce.hpp
@@ -288,7 +288,7 @@ namespace hpx { namespace parallel { inline namespace v1
     template <typename ExPolicy, typename FwdIter, typename T, typename Reduce,
         typename Convert,
     HPX_CONCEPT_REQUIRES_(
-        is_execution_policy<ExPolicy>::value &&
+        execution::is_execution_policy<ExPolicy>::value &&
         hpx::traits::is_iterator<FwdIter>::value &&
         hpx::traits::is_invocable<Convert,
                 typename std::iterator_traits<FwdIter>::value_type

--- a/hpx/parallel/executors/timed_executors.hpp
+++ b/hpx/parallel/executors/timed_executors.hpp
@@ -196,7 +196,7 @@ namespace hpx { namespace parallel { namespace execution
         };
 
         template <>
-        struct async_execute_at_helper<sequential_execution_tag>
+        struct async_execute_at_helper<sequenced_execution_tag>
         {
             template <typename Executor, typename F, typename ... Ts>
             static auto
@@ -294,7 +294,7 @@ namespace hpx { namespace parallel { namespace execution
         };
 
         template <>
-        struct post_at_helper<sequential_execution_tag>
+        struct post_at_helper<sequenced_execution_tag>
         {
             template <typename Executor, typename F, typename ... Ts>
             static void

--- a/hpx/parallel/spmd_block.hpp
+++ b/hpx/parallel/spmd_block.hpp
@@ -31,8 +31,10 @@ namespace hpx { namespace parallel { inline namespace v2
     // Asynchronous version
     template <typename ExPolicy, typename F, typename ... Args,
         typename = typename std::enable_if<
-            hpx::parallel::v1::is_async_execution_policy<ExPolicy>::value>::type
-        >
+            hpx::parallel::execution::is_async_execution_policy<
+                ExPolicy
+            >::value
+        >::type>
     std::vector<hpx::future<void>>
     define_spmd_block(ExPolicy && policy,
         std::size_t num_images, F && f, Args && ... args)
@@ -45,8 +47,10 @@ namespace hpx { namespace parallel { inline namespace v2
     // Synchronous version
     template <typename ExPolicy, typename F, typename ... Args,
         typename = typename std::enable_if<
-            !hpx::parallel::v1::is_async_execution_policy<ExPolicy>::value>::type
-        >
+           !hpx::parallel::execution::is_async_execution_policy<
+                ExPolicy
+            >::value
+        >::type>
     void define_spmd_block(ExPolicy && policy,
         std::size_t num_images, F && f, Args && ... args)
     {

--- a/hpx/traits/is_timed_executor.hpp
+++ b/hpx/traits/is_timed_executor.hpp
@@ -15,8 +15,6 @@
 namespace hpx { namespace parallel { namespace execution
 {
     ///////////////////////////////////////////////////////////////////////////
-    struct timed_executor_tag : executor_tag {};
-
     namespace detail
     {
         /// \cond NOINTERNAL

--- a/tests/performance/local/transform_reduce_scaling.cpp
+++ b/tests/performance/local/transform_reduce_scaling.cpp
@@ -34,15 +34,14 @@ void measure_transform_reduce(std::size_t size)
     // invoke transform_reduce
     double result =
         hpx::parallel::transform_reduce(hpx::parallel::execution::par,
-        std::begin(data_representation),
-        std::end(data_representation),
-        0.0,
-        [](Point r)
-        {
-            return r.x * r.y;
-        },
-        std::plus<double>()
-    );
+            std::begin(data_representation),
+            std::end(data_representation),
+            0.0,
+            std::plus<double>(),
+            [](Point r)
+            {
+                return r.x * r.y;
+            });
     HPX_UNUSED(result);
 }
 

--- a/tests/regressions/parallel/executors/is_executor_1691.cpp
+++ b/tests/regressions/parallel/executors/is_executor_1691.cpp
@@ -13,15 +13,25 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-struct my_executor : hpx::parallel::parallel_executor {};
+struct my_executor : hpx::parallel::execution::parallel_executor {};
 
-namespace hpx { namespace parallel { inline namespace v3 { namespace detail
+namespace hpx { namespace parallel { namespace execution
 {
     template <>
-    struct is_executor<my_executor>
+    struct is_one_way_executor<my_executor>
       : std::true_type
     {};
-}}}}
+
+    template <>
+    struct is_two_way_executor<my_executor>
+      : std::true_type
+    {};
+
+    template <>
+    struct is_bulk_two_way_executor<my_executor>
+      : std::true_type
+    {};
+}}}
 
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
@@ -33,8 +43,7 @@ int hpx_main(int argc, char* argv[])
 
     std::vector<int> v(100);
 
-    for_each(par.on(exec),
-        v.begin(), v.end(), [](int x){ });
+    for_each(par.on(exec), v.begin(), v.end(), [](int x) {});
 
     return hpx::finalize();
 }

--- a/tests/regressions/parallel/scan_different_inits.cpp
+++ b/tests/regressions/parallel/scan_different_inits.cpp
@@ -38,14 +38,14 @@ void test_zero()
         [](int bar, int baz){ return bar*baz; });
     Iter i_transform_inc =
         transform_inclusive_scan(execution::par, a.begin(), a.end(), f.begin(),
-        10,
-        [](int bar, int baz){ return 2*bar+2*baz; },
-        [](int foo){ return foo - 3; });
+            [](int bar, int baz){ return 2*bar+2*baz; },
+            [](int foo){ return foo - 3; },
+            10);
     Iter i_transform_exc =
         transform_exclusive_scan(execution::par, a.begin(), a.end(), g.begin(),
-        10,
-        [](int bar, int baz){ return 2*bar+2*baz; },
-        [](int foo){ return foo - 3; });
+            10,
+            [](int bar, int baz){ return 2*bar+2*baz; },
+            [](int foo){ return foo - 3; });
 
     HPX_TEST(i_inc_add == b.begin());
     HPX_TEST(i_inc_mult == c.begin());
@@ -79,13 +79,13 @@ void test_async_zero()
             a.begin(), a.end(), e.begin(), 10,
             [](int bar, int baz){ return bar*baz; });
     Fut_Iter f_transform_inc =
-        transform_inclusive_scan(par(execution::task),
+        transform_inclusive_scan(execution::par(execution::task),
             a.begin(), a.end(), f.begin(),
-            10,
             [](int bar, int baz){ return 2*bar+2*baz; },
-            [](int foo){ return foo - 3; });
+            [](int foo){ return foo - 3; },
+            10);
     Fut_Iter f_transform_exc =
-        transform_exclusive_scan(par(execution::task),
+        transform_exclusive_scan(execution::par(execution::task),
             a.begin(), a.end(), g.begin(),
             10,
             [](int bar, int baz){ return 2*bar+2*baz; },
@@ -123,7 +123,7 @@ void test_one(std::vector<int> a)
         exclusive_scan(execution::par, a.begin(), a.end(), e.begin(), 10, fun_mult);
     Iter f_transform_inc =
         transform_inclusive_scan(execution::par, a.begin(), a.end(), f.begin(),
-        10, fun_add, fun_conv);
+        fun_add, fun_conv, 10);
     Iter f_transform_exc =
         transform_exclusive_scan(execution::par, a.begin(), a.end(), g.begin(),
         10, fun_add, fun_conv);
@@ -184,11 +184,11 @@ void test_async_one(std::vector<int> a)
         exclusive_scan(execution::par(execution::task),
             a.begin(), a.end(), e.begin(), 10, fun_mult);
     Fut_Iter f_transform_inc =
-        transform_inclusive_scan(par(execution::task),
+        transform_inclusive_scan(execution::par(execution::task),
             a.begin(), a.end(), f.begin(),
-            10, fun_add, fun_conv);
+            fun_add, fun_conv, 10);
     Fut_Iter f_transform_exc =
-        transform_exclusive_scan(par(execution::task),
+        transform_exclusive_scan(execution::par(execution::task),
             a.begin(), a.end(), g.begin(),
             10, fun_add, fun_conv);
 

--- a/tests/unit/parallel/segmented_algorithms/partitioned_vector_transform_scan.cpp
+++ b/tests/unit/parallel/segmented_algorithms/partitioned_vector_transform_scan.cpp
@@ -40,7 +40,7 @@ void test_transform_inclusive_scan(ExPolicy && policy,
     hpx::partitioned_vector<T> & xvalues, hpx::partitioned_vector<T> & out)
 {
     hpx::parallel::transform_inclusive_scan(policy, xvalues.begin(),
-        xvalues.end(), out.begin(), conv(), T(0), op());
+        xvalues.end(), out.begin(), op(), conv(), T(0));
 }
 
 template <typename ExPolicy, typename T>
@@ -50,7 +50,7 @@ test_transform_inclusive_scan_async(ExPolicy && policy,
 {
     hpx::parallel::transform_inclusive_scan(policy,
         xvalues.begin(), xvalues.end(), out.begin(),
-        conv(), T(0), op()).get();
+        op(), conv(), T(0)).get();
 }
 
 template <typename ExPolicy, typename T>
@@ -58,7 +58,7 @@ void test_transform_exclusive_scan(ExPolicy && policy,
     hpx::partitioned_vector<T> & xvalues, hpx::partitioned_vector<T> & out)
 {
     hpx::parallel::transform_exclusive_scan(policy, xvalues.begin(),
-        xvalues.end(), out.begin(), conv(), T(0), op());
+        xvalues.end(), out.begin(), T(0), op(), conv());
 }
 
 template <typename ExPolicy, typename T>
@@ -68,7 +68,7 @@ test_transform_exclusive_scan_async(ExPolicy && policy,
 {
     hpx::parallel::transform_exclusive_scan(policy,
         xvalues.begin(), xvalues.end(), out.begin(),
-        conv(), T(0), op()).get();
+        T(0), op(), conv()).get();
 }
 
 template <typename T>

--- a/tests/unit/parallel/spmd_block.cpp
+++ b/tests/unit/parallel/spmd_block.cpp
@@ -20,16 +20,15 @@
 std::size_t num_images = 10;
 std::size_t iterations = 20;
 
-void bulk_test_function(hpx::parallel::v2::spmd_block block,
-        std::atomic<std::size_t> * c)
+void bulk_test_function(hpx::parallel::spmd_block block,
+    std::atomic<std::size_t>* c)
 {
     HPX_TEST_EQ(block.get_num_images(), num_images);
     HPX_TEST_EQ(block.this_image() < num_images, true);
 
     // Test sync_all()
-    for(std::size_t i=0, test_count = num_images;
-        i<iterations;
-        i++, test_count+=num_images)
+    for (std::size_t i = 0, test_count = num_images; i < iterations;
+         i++, test_count += num_images)
     {
         ++c[0];
         block.sync_all();
@@ -40,47 +39,51 @@ void bulk_test_function(hpx::parallel::v2::spmd_block block,
     // Test sync_images() with individual values
     std::size_t image_id = block.this_image();
 
-    if((image_id == 0) || (image_id == 1))
+    if ((image_id == 0) || (image_id == 1))
     {
         ++c[1];
     }
-    block.sync_images(0,1);
-    if((image_id == 0) || (image_id == 1))
+    block.sync_images(0, 1);
+    if ((image_id == 0) || (image_id == 1))
     {
-        HPX_TEST_EQ(c[1],(std::size_t)2);
+        HPX_TEST_EQ(c[1], (std::size_t) 2);
     }
 
-    if((image_id == 2) || (image_id == 3) || (image_id == 4))
+    if ((image_id == 2) || (image_id == 3) || (image_id == 4))
     {
         ++c[2];
     }
-    block.sync_images(2,3,4);
-    if((image_id == 2) || (image_id == 3) || (image_id == 4))
+    block.sync_images(2, 3, 4);
+    if ((image_id == 2) || (image_id == 3) || (image_id == 4))
     {
-        HPX_TEST_EQ(c[2],(std::size_t)3);
+        HPX_TEST_EQ(c[2], (std::size_t) 3);
     }
 
     // Test sync_images() with vector of values
-    std::vector<std::size_t> vec_images = {5,6,7,8};
+    std::vector<std::size_t> vec_images = {5, 6, 7, 8};
 
-    if((image_id == 5) || (image_id == 6) || (image_id == 7) || (image_id == 8))
+    if ((image_id == 5) || (image_id == 6) || (image_id == 7) ||
+        (image_id == 8))
     {
         ++c[3];
     }
     block.sync_images(vec_images);
-    if((image_id == 5) || (image_id == 6) || (image_id == 7) || (image_id == 8))
+    if ((image_id == 5) || (image_id == 6) || (image_id == 7) ||
+        (image_id == 8))
     {
-        HPX_TEST_EQ(c[3],(std::size_t)4);
+        HPX_TEST_EQ(c[3], (std::size_t) 4);
     }
     block.sync_images(vec_images);
-    if((image_id == 5) || (image_id == 6) || (image_id == 7) || (image_id == 8))
+    if ((image_id == 5) || (image_id == 6) || (image_id == 7) ||
+        (image_id == 8))
     {
         ++c[3];
     }
-    block.sync_images(vec_images.begin(),vec_images.end());
-    if((image_id == 5) || (image_id == 6) || (image_id == 7) || (image_id == 8))
+    block.sync_images(vec_images.begin(), vec_images.end());
+    if ((image_id == 5) || (image_id == 6) || (image_id == 7) ||
+        (image_id == 8))
     {
-        HPX_TEST_EQ(c[3],(std::size_t)8);
+        HPX_TEST_EQ(c[3], (std::size_t) 8);
     }
 }
 
@@ -90,30 +93,26 @@ int main()
     using hpx::parallel::execution::task;
 
     auto bulk_test =
-        [](hpx::parallel::v2::spmd_block block, std::atomic<std::size_t> * c)
+        [](hpx::parallel::spmd_block block, std::atomic<std::size_t> * c)
         {
             bulk_test_function(std::move(block),c);
         };
 
     std::array<std::atomic<std::size_t>,4> c1, c2, c3;
 
-    for(std::size_t i =0; i<4; i++)
+    for (std::size_t i =0; i<4; i++)
     {
         c1[i] = c2[i] = c3[i] = (std::size_t)0;
     }
 
-    hpx::parallel::v2::define_spmd_block(
-        num_images, bulk_test, c1.data() );
+    hpx::parallel::define_spmd_block(num_images, bulk_test, c1.data());
 
-    std::vector<hpx::future<void>> join =
-        hpx::parallel::v2::define_spmd_block(
-            par(task),
-                num_images, bulk_test, c2.data() );
+    std::vector<hpx::future<void>> join = hpx::parallel::define_spmd_block(
+        par(task), num_images, bulk_test, c2.data());
 
     hpx::wait_all(join);
 
-    hpx::parallel::v2::define_spmd_block(
-        num_images, bulk_test_function, c3.data() );
+    hpx::parallel::define_spmd_block(num_images, bulk_test_function, c3.data());
 
     return 0;
 }

--- a/tests/unit/parallel/task_block_executor.cpp
+++ b/tests/unit/parallel/task_block_executor.cpp
@@ -411,12 +411,12 @@ void test_executor_task_block(Executor& exec)
 int hpx_main()
 {
     {
-        hpx::parallel::sequential_executor exec;
+        hpx::parallel::execution::sequenced_executor exec;
         test_executor_task_block(exec);
     }
 
     {
-        hpx::parallel::parallel_executor exec;
+        hpx::parallel::execution::parallel_executor exec;
         test_executor_task_block(exec);
 
         define_task_block_exceptions_test3(exec);

--- a/tests/unit/resource/named_pool_executor.cpp
+++ b/tests/unit/resource/named_pool_executor.cpp
@@ -7,10 +7,12 @@
 // pool and executor
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/resource_partitioner.hpp>
+
+#include <hpx/async.hpp>
 #include <hpx/include/parallel_execution.hpp>
-#include <hpx/runtime/threads/executors/pool_executor.hpp>
+#include <hpx/include/resource_partitioner.hpp>
 #include <hpx/include/threads.hpp>
+#include <hpx/runtime/threads/executors/pool_executor.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <cstddef>
@@ -48,11 +50,11 @@ int hpx_main(int argc, char* argv[])
     // the test to fail
     hpx::threads::scheduled_executor exec_0_hp =
         hpx::threads::executors::pool_executor("default",
-        hpx::threads::thread_priority_high);
+            hpx::threads::thread_priority_high);
 
     hpx::threads::scheduled_executor exec_0 =
         hpx::threads::executors::pool_executor("default",
-        hpx::threads::thread_priority_default);
+            hpx::threads::thread_priority_default);
 
     std::vector<hpx::future<void>> lotsa_futures;
 

--- a/tests/unit/threads/resource_manager.cpp
+++ b/tests/unit/threads/resource_manager.cpp
@@ -59,8 +59,6 @@ void test_executors(std::size_t processing_units, std::size_t num_pus)
     std::atomic<std::size_t> count_invocations(0);
     std::size_t const num_tasks = 100;
 
-    typedef hpx::parallel::executor_information_traits<Executor> infotraits;
-
     std::size_t num_execs = processing_units / num_pus;
 
     {
@@ -77,7 +75,9 @@ void test_executors(std::size_t processing_units, std::size_t num_pus)
 
         for(Executor& exec : execs)
         {
-            HPX_TEST_EQ(infotraits::processing_units_count(exec, test::dummy),
+            HPX_TEST_EQ(
+                hpx::parallel::execution::processing_units_count(
+                    exec, test::dummy),
                 num_pus);
         }
 
@@ -97,7 +97,9 @@ void test_executors(std::size_t processing_units, std::size_t num_pus)
         // test again
         for(Executor& exec : execs)
         {
-            HPX_TEST_EQ(infotraits::processing_units_count(exec, test::dummy),
+            HPX_TEST_EQ(
+                hpx::parallel::execution::processing_units_count(
+                    exec, test::dummy),
                 num_pus);
         }
     }
@@ -107,7 +109,7 @@ void test_executors(std::size_t processing_units, std::size_t num_pus)
 
 void test_executors(std::size_t num_pus)
 {
-    using namespace hpx::parallel;
+    using namespace hpx::parallel::execution;
     std::size_t processing_units = hpx::get_os_thread_count();
 
     processing_units = (processing_units / num_pus) * num_pus;
@@ -131,8 +133,6 @@ void test_executors_shrink(std::size_t processing_units, std::size_t num_pus)
     std::atomic<std::size_t> count_invocations(0);
     std::size_t const num_tasks = 100;
 
-    typedef hpx::parallel::executor_information_traits<Executor> infotraits;
-
     // create one executor which can give back processing units
     Executor shrink_exec(processing_units);
 
@@ -140,7 +140,8 @@ void test_executors_shrink(std::size_t processing_units, std::size_t num_pus)
     hpx::this_thread::yield();
 
     HPX_TEST_EQ(
-        infotraits::processing_units_count(shrink_exec, test::dummy),
+        hpx::parallel::execution::processing_units_count(
+            shrink_exec, test::dummy),
         processing_units);
 
     std::size_t num_execs = (processing_units-1) / num_pus;
@@ -157,13 +158,16 @@ void test_executors_shrink(std::size_t processing_units, std::size_t num_pus)
 
         for(Executor& exec : execs)
         {
-            HPX_TEST_EQ(infotraits::processing_units_count(exec, test::dummy),
+            HPX_TEST_EQ(
+                hpx::parallel::execution::processing_units_count(
+                    exec, test::dummy),
                 num_pus);
         }
 
         // the main executor should run on a reduced amount of cores
         HPX_TEST_EQ(
-            infotraits::processing_units_count(shrink_exec, test::dummy),
+            hpx::parallel::execution::processing_units_count(
+                shrink_exec, test::dummy),
             processing_units - num_execs * num_pus);
 
         // schedule a couple of tasks on each of the executors
@@ -182,13 +186,16 @@ void test_executors_shrink(std::size_t processing_units, std::size_t num_pus)
         // test again
         for(Executor& exec : execs)
         {
-            HPX_TEST_EQ(infotraits::processing_units_count(exec, test::dummy),
+            HPX_TEST_EQ(
+                hpx::parallel::execution::processing_units_count(
+                    exec, test::dummy),
                 num_pus);
         }
 
         // the main executor should run on a reduced amount of cores
         HPX_TEST_EQ(
-            infotraits::processing_units_count(shrink_exec, test::dummy),
+            hpx::parallel::execution::processing_units_count(
+                shrink_exec, test::dummy),
             processing_units - num_execs * num_pus);
     }
 
@@ -197,7 +204,7 @@ void test_executors_shrink(std::size_t processing_units, std::size_t num_pus)
 
 void test_executors_shrink(std::size_t num_pus)
 {
-    using namespace hpx::parallel;
+    using namespace hpx::parallel::execution;
     std::size_t processing_units = hpx::get_os_thread_count();
 
     processing_units = (processing_units / num_pus) * num_pus;


### PR DESCRIPTION
- this is in preparation with the V1.1. release at which point the V1 executors
  should be disabled by default
- this also sets the default for HPX_HAVE_TRANSFORM_REDUCE_COMPATIBILITY to OFF
