### PR TITLE
Don't use boost::intrusive_ptr for thread_id_type

### DIFF
--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -223,7 +223,7 @@ namespace detail
             if (recurse_asynchronously)
             {
                 error_code ec;
-                threads::thread_id_type id = threads::register_thread_nullary(
+                threads::register_thread_nullary(
                     compose_cb_impl(std::move(f1_), std::move(f2_)),
                     "compose_cb",
                     threads::pending, true, threads::thread_priority_boost,

--- a/hpx/lcos/local/detail/condition_variable.hpp
+++ b/hpx/lcos/local/detail/condition_variable.hpp
@@ -40,11 +40,11 @@ namespace hpx { namespace lcos { namespace local { namespace detail
                 boost::intrusive::link_mode<boost::intrusive::normal_link>
             > hook_type;
 
-            queue_entry(threads::thread_id_repr_type const& id, void* q)
+            queue_entry(threads::thread_id_type const& id, void* q)
               : id_(id), q_(q)
             {}
 
-            threads::thread_id_repr_type id_;
+            threads::thread_id_type id_;
             void* q_;
             hook_type slist_hook_;
         };
@@ -68,7 +68,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail
 
             ~reset_queue_entry()
             {
-                if (e_.id_ != threads::invalid_thread_id_repr)
+                if (e_.id_ != threads::invalid_thread_id)
                 {
                     queue_type* q = static_cast<queue_type*>(e_.q_);
                     q->erase(last_);     // remove entry from queue

--- a/hpx/lcos/local/mutex.hpp
+++ b/hpx/lcos/local/mutex.hpp
@@ -48,7 +48,7 @@ namespace hpx { namespace lcos { namespace local
 
     protected:
         mutable mutex_type mtx_;
-        threads::thread_id_repr_type owner_id_;
+        threads::thread_id_type owner_id_;
         detail::condition_variable cond_;
     };
 

--- a/hpx/lcos/local/recursive_mutex.hpp
+++ b/hpx/lcos/local/recursive_mutex.hpp
@@ -50,7 +50,7 @@ namespace hpx { namespace lcos { namespace local
             static thread_id_type call()
             {
                 return hpx::threads::get_self_ptr() ?
-                    (thread_id_type)hpx::threads::get_self_id().get() :
+                    reinterpret_cast<thread_id_type>(hpx::threads::get_self_id().get()) :
                     thread_id_from_mutex<void>::call();
             };
         };
@@ -126,8 +126,8 @@ namespace hpx { namespace lcos { namespace local
             ///         called outside of a HPX-thread.
 //             bool timed_lock(::boost::system_time const& wait_until);
 //             {
-//                 threads::thread_id_repr_type const current_thread_id =
-//                     threads::get_self_id().get();
+//                 threads::thread_id_type const current_thread_id =
+//                     threads::get_self_id();
 //
 //                 return try_recursive_lock(current_thread_id) ||
 //                        try_timed_lock(current_thread_id, wait_until);
@@ -197,7 +197,7 @@ namespace hpx { namespace lcos { namespace local
                 return false;
             }
 
-//             bool try_timed_lock(threads::thread_id_repr_type current_thread_id,
+//             bool try_timed_lock(threads::thread_id_type current_thread_id,
 //                 ::boost::system_time const& target)
 //             {
 //                 if (mtx.timed_lock(target))

--- a/hpx/runtime/actions/action_support.hpp
+++ b/hpx/runtime/actions/action_support.hpp
@@ -42,19 +42,19 @@ namespace hpx { namespace actions { namespace detail
     {
         action_serialization_data()
           : parent_locality_(naming::invalid_locality_id)
-          , parent_id_(static_cast<std::uint64_t>(-1))
+          , parent_id_(static_cast<std::uint64_t>(0))
           , parent_phase_(0)
           , priority_(static_cast<threads::thread_priority>(0))
           , stacksize_(static_cast<threads::thread_stacksize>(0))
         {}
 
         action_serialization_data(std::uint32_t parent_locality,
-                std::uint64_t parent_id,
+                threads::thread_id_type parent_id,
                 std::uint64_t parent_phase,
                 threads::thread_priority priority,
                 threads::thread_stacksize stacksize)
           : parent_locality_(parent_locality)
-          , parent_id_(parent_id)
+          , parent_id_(reinterpret_cast<std::uint64_t>(parent_id.get()))
           , parent_phase_(parent_phase)
           , priority_(priority)
           , stacksize_(stacksize)

--- a/hpx/runtime/actions/base_action.hpp
+++ b/hpx/runtime/actions/base_action.hpp
@@ -81,7 +81,7 @@ namespace hpx { namespace actions
         virtual std::uint32_t get_parent_locality_id() const = 0;
 
         /// Return the thread id of the parent thread
-        virtual threads::thread_id_repr_type get_parent_thread_id() const = 0;
+        virtual threads::thread_id_type get_parent_thread_id() const = 0;
 
         /// Return the thread phase of the parent thread
         virtual std::uint64_t get_parent_thread_phase() const = 0;

--- a/hpx/runtime/actions/transfer_action.hpp
+++ b/hpx/runtime/actions/transfer_action.hpp
@@ -168,8 +168,7 @@ namespace hpx { namespace actions
 
         threads::thread_init_data data;
 #if defined(HPX_HAVE_THREAD_PARENT_REFERENCE)
-        data.parent_id =
-            reinterpret_cast<threads::thread_id_repr_type>(this->parent_id_);
+        data.parent_id = this->parent_id_;
         data.parent_locality_id = this->parent_locality_;
 #endif
         applier::detail::apply_helper<typename base_type::derived_type>::call(

--- a/hpx/runtime/actions/transfer_base_action.hpp
+++ b/hpx/runtime/actions/transfer_base_action.hpp
@@ -16,6 +16,8 @@
 #include <hpx/runtime/actions/detail/invocation_count_registry.hpp>
 #include <hpx/runtime/components/pinned_ptr.hpp>
 #include <hpx/runtime/get_locality_id.hpp>
+#include <hpx/runtime/threads/thread_data_fwd.hpp>
+#include <hpx/runtime/threads/thread_id_type.hpp>
 #include <hpx/runtime/serialization/base_object.hpp>
 #include <hpx/runtime/serialization/input_archive.hpp>
 #include <hpx/runtime/serialization/output_archive.hpp>
@@ -176,7 +178,7 @@ namespace hpx { namespace actions
           : arguments_(std::forward<Ts>(vs)...),
 #if defined(HPX_HAVE_THREAD_PARENT_REFERENCE)
             parent_locality_(transfer_base_action::get_locality_id()),
-            parent_id_(reinterpret_cast<std::uint64_t>(threads::get_parent_id())),
+            parent_id_(threads::get_parent_id()),
             parent_phase_(threads::get_parent_phase()),
 #endif
             priority_(
@@ -194,7 +196,7 @@ namespace hpx { namespace actions
           : arguments_(std::forward<Ts>(vs)...),
 #if defined(HPX_HAVE_THREAD_PARENT_REFERENCE)
             parent_locality_(transfer_base_action::get_locality_id()),
-            parent_id_(reinterpret_cast<std::uint64_t>(threads::get_parent_id())),
+            parent_id_(threads::get_parent_id()),
             parent_phase_(threads::get_parent_phase()),
 #endif
             priority_(
@@ -266,9 +268,9 @@ namespace hpx { namespace actions
         }
 
         /// Return the thread id of the parent thread
-        threads::thread_id_repr_type get_parent_thread_id() const
+        threads::thread_id_type get_parent_thread_id() const
         {
-            return threads::invalid_thread_id_repr;
+            return threads::invalid_thread_id;
         }
 
         /// Return the phase of the parent thread
@@ -284,9 +286,9 @@ namespace hpx { namespace actions
         }
 
         /// Return the thread id of the parent thread
-        threads::thread_id_repr_type get_parent_thread_id() const
+        threads::thread_id_type get_parent_thread_id() const
         {
-            return reinterpret_cast<threads::thread_id_repr_type>(parent_id_);
+            return parent_id_;
         }
 
         /// Return the phase of the parent thread
@@ -368,7 +370,8 @@ namespace hpx { namespace actions
 
 #if defined(HPX_HAVE_THREAD_PARENT_REFERENCE)
             parent_locality_ = data.parent_locality_;
-            parent_id_ = data.parent_id_;
+            parent_id_ = threads::thread_id_type(
+                reinterpret_cast<threads::thread_data*>(data.parent_id_));
             parent_phase_ = data.parent_phase_;
 #endif
             priority_ = data.priority_;
@@ -385,7 +388,7 @@ namespace hpx { namespace actions
 
 #if !defined(HPX_HAVE_THREAD_PARENT_REFERENCE)
             std::uint32_t parent_locality_ = naming::invalid_locality_id;
-            std::uint64_t parent_id_ = std::uint64_t(-1);
+            threads::thread_id_type parent_id_;
             std::uint64_t parent_phase_ = 0;
 #endif
             detail::action_serialization_data data(parent_locality_,
@@ -405,7 +408,7 @@ namespace hpx { namespace actions
 
 #if defined(HPX_HAVE_THREAD_PARENT_REFERENCE)
         std::uint32_t parent_locality_;
-        std::uint64_t parent_id_;
+        threads::thread_id_type parent_id_;
         std::uint64_t parent_phase_;
 #endif
         threads::thread_priority priority_;

--- a/hpx/runtime/actions/transfer_continuation_action.hpp
+++ b/hpx/runtime/actions/transfer_continuation_action.hpp
@@ -175,8 +175,7 @@ namespace hpx { namespace actions
 
         threads::thread_init_data data;
 #if defined(HPX_HAVE_THREAD_PARENT_REFERENCE)
-        data.parent_id =
-            reinterpret_cast<threads::thread_id_repr_type>(this->parent_id_);
+        data.parent_id = this->parent_id_;
         data.parent_locality_id = this->parent_locality_;
 #endif
         applier::detail::apply_helper<typename base_type::derived_type>::call(

--- a/hpx/runtime/threads/coroutines/coroutine.hpp
+++ b/hpx/runtime/threads/coroutines/coroutine.hpp
@@ -37,6 +37,7 @@
 #include <hpx/runtime/threads/coroutines/detail/coroutine_impl.hpp>
 #include <hpx/runtime/threads/coroutines/detail/coroutine_self.hpp>
 #include <hpx/runtime/threads/thread_enums.hpp>
+#include <hpx/runtime/threads/thread_id_type.hpp>
 #include <hpx/util/assert.hpp>
 
 #include <cstddef>
@@ -54,7 +55,7 @@ namespace hpx { namespace threads { namespace coroutines
 
         typedef detail::coroutine_impl impl_type;
         typedef impl_type::pointer impl_ptr;
-        typedef impl_type::thread_id_repr_type thread_id_repr_type;
+        typedef impl_type::thread_id_type thread_id_type;
 
         typedef impl_type::result_type result_type;
         typedef impl_type::arg_type arg_type;
@@ -64,7 +65,7 @@ namespace hpx { namespace threads { namespace coroutines
         coroutine() : m_pimpl(nullptr) {}
 
         coroutine(functor_type&& f,
-                thread_id_repr_type id = nullptr,
+                thread_id_type id,
                 std::ptrdiff_t stack_size = detail::default_stack_size)
           : m_pimpl(impl_type::create(
                 std::move(f), id, stack_size))
@@ -95,7 +96,7 @@ namespace hpx { namespace threads { namespace coroutines
             lhs.swap(rhs);
         }
 
-        thread_id_repr_type get_thread_id() const
+        thread_id_type get_thread_id() const
         {
             return m_pimpl->get_thread_id();
         }
@@ -124,7 +125,7 @@ namespace hpx { namespace threads { namespace coroutines
         }
 #endif
 
-        void rebind(functor_type&& f, thread_id_repr_type id = nullptr)
+        void rebind(functor_type&& f, thread_id_type id)
         {
             HPX_ASSERT(exited());
             impl_type::rebind(m_pimpl.get(), std::move(f), id);

--- a/hpx/runtime/threads/coroutines/coroutine_fwd.hpp
+++ b/hpx/runtime/threads/coroutines/coroutine_fwd.hpp
@@ -34,11 +34,6 @@
 
 namespace hpx { namespace threads
 {
-    class HPX_EXPORT thread_data;
-
-    HPX_EXPORT void intrusive_ptr_add_ref(thread_data* p);
-    HPX_EXPORT void intrusive_ptr_release(thread_data* p);
-
     namespace coroutines
     {
         namespace detail

--- a/hpx/runtime/threads/coroutines/detail/context_base.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_base.hpp
@@ -46,6 +46,7 @@
 #include <hpx/runtime/threads/coroutines/detail/swap_context.hpp> //for swap hints
 #include <hpx/runtime/threads/coroutines/detail/tss.hpp>
 #include <hpx/runtime/threads/coroutines/exception.hpp>
+#include <hpx/runtime/threads/thread_id_type.hpp>
 #include <hpx/util/assert.hpp>
 
 #include <atomic>
@@ -92,10 +93,10 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
     {
     public:
         typedef void deleter_type(context_base const*);
-        typedef void* thread_id_repr_type;
+        typedef hpx::threads::thread_id_type thread_id_type;
 
         template <typename Derived>
-        context_base(Derived& derived, std::ptrdiff_t stack_size, thread_id_repr_type id)
+        context_base(Derived& derived, std::ptrdiff_t stack_size, thread_id_type id)
           : default_context_impl(derived, stack_size),
             m_caller(),
 #if HPX_COROUTINE_IS_REFERENCE_COUNTED
@@ -183,7 +184,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 #if defined(HPX_HAVE_APEX)
             m_apex_data = 0ull;
 #endif
-            m_thread_id = nullptr;
+            m_thread_id.reset();
         }
 
 #if defined(HPX_HAVE_THREAD_OPERATIONS_COUNT)
@@ -238,7 +239,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         }
 #endif
 
-        thread_id_repr_type get_thread_id() const
+        thread_id_type get_thread_id() const
         {
             return m_thread_id;
         }
@@ -445,7 +446,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
                 if (!exited())
                     exit();
                 HPX_ASSERT(exited());
-                m_thread_id = nullptr;
+                m_thread_id.reset();
             }
             catch (...) {
                 /**/;
@@ -560,7 +561,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
             ctx_exited_abnormally // process exited uncleanly.
         };
 
-        void rebind_base(thread_id_repr_type id)
+        void rebind_base(thread_id_type id)
         {
 #if defined(HPX_HAVE_THREAD_OPERATIONS_COUNT)
             HPX_ASSERT(exited() && 0 == m_wait_counter && !pending());
@@ -660,7 +661,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 
         // This is used to generate a meaningful exception trace.
         std::exception_ptr m_type_info;
-        thread_id_repr_type m_thread_id;
+        thread_id_type m_thread_id;
 
         std::size_t continuation_recursion_count_;
     };

--- a/hpx/runtime/threads/coroutines/detail/coroutine_impl.hpp
+++ b/hpx/runtime/threads/coroutines/detail/coroutine_impl.hpp
@@ -40,6 +40,7 @@
 #include <hpx/runtime/threads/coroutines/detail/context_base.hpp>
 #include <hpx/runtime/threads/coroutines/detail/coroutine_accessor.hpp>
 #include <hpx/runtime/threads/thread_enums.hpp>
+#include <hpx/runtime/threads/thread_id_type.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/unique_function.hpp>
 
@@ -61,8 +62,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 
     public:
         typedef context_base super_type;
-        typedef context_base::thread_id_repr_type thread_id_repr_type;
-        typedef boost::intrusive_ptr<threads::thread_data> thread_id_type;
+        typedef context_base::thread_id_type thread_id_type;
 
         typedef std::pair<thread_state_enum, thread_id_type> result_type;
         typedef thread_state_ex_enum arg_type;
@@ -71,10 +71,11 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 
         typedef boost::intrusive_ptr<coroutine_impl> pointer;
 
-        coroutine_impl(functor_type&& f, thread_id_repr_type id,
+        coroutine_impl(functor_type&& f, thread_id_type id,
             std::ptrdiff_t stack_size)
           : context_base(*this, stack_size, id)
-          , m_result_last(std::make_pair(thread_state_enum::unknown, nullptr))
+          , m_result_last(std::make_pair(thread_state_enum::unknown,
+                thread_id_type(nullptr)))
           , m_arg(nullptr)
           , m_result(nullptr)
           , m_fun(std::move(f))
@@ -88,14 +89,14 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 #endif
 
         static inline coroutine_impl* create(
-            functor_type&& f, thread_id_repr_type id = nullptr,
+            functor_type&& f, thread_id_type id,
             std::ptrdiff_t stack_size = default_stack_size)
         {
             coroutine_impl* p = allocate(id, stack_size);
 
             if (!p)
             {
-                std::size_t const heap_num = std::size_t(id) / 32; //-V112
+                std::size_t const heap_num = std::size_t(id.get()) / 32; //-V112
 
                 // allocate a new coroutine object, if non is available (or all
                 // heaps are locked)
@@ -110,7 +111,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         }
 
         static inline void rebind(
-            coroutine_impl* p, functor_type&& f, thread_id_repr_type id = nullptr)
+            coroutine_impl* p, functor_type&& f, thread_id_type id)
         {
             p->rebind(std::move(f), id);
         }
@@ -167,7 +168,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
             this->super_type::reset();
         }
 
-        void rebind(functor_type && f, thread_id_repr_type id)
+        void rebind(functor_type && f, thread_id_type id)
         {
             this->rebind_stack();     // count how often a coroutines object was reused
             m_fun = std::move(f);
@@ -176,7 +177,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 
     private:
         static HPX_EXPORT coroutine_impl* allocate(
-            thread_id_repr_type id, std::ptrdiff_t stacksize);
+            thread_id_type id, std::ptrdiff_t stacksize);
 
         static HPX_EXPORT void deallocate(coroutine_impl* wrapper);
 

--- a/hpx/runtime/threads/coroutines/detail/coroutine_self.hpp
+++ b/hpx/runtime/threads/coroutines/detail/coroutine_self.hpp
@@ -33,6 +33,7 @@
 #include <hpx/runtime/threads/coroutines/detail/coroutine_accessor.hpp>
 #include <hpx/runtime/threads/coroutines/detail/coroutine_impl.hpp>
 #include <hpx/runtime/threads/thread_enums.hpp>
+#include <hpx/runtime/threads/thread_id_type.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/function.hpp>
 
@@ -71,7 +72,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 
         typedef coroutine_impl impl_type;
         typedef impl_type* impl_ptr; // Note, no reference counting here.
-        typedef impl_type::thread_id_repr_type thread_id_repr_type;
+        typedef impl_type::thread_id_type thread_id_type;
 
         typedef impl_type::result_type result_type;
         typedef impl_type::arg_type arg_type;
@@ -140,7 +141,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
             return m_pimpl->pending() != 0;
         }
 
-        thread_id_repr_type get_thread_id() const
+        thread_id_type get_thread_id() const
         {
             HPX_ASSERT(m_pimpl);
             return m_pimpl->get_thread_id();

--- a/hpx/runtime/threads/detail/create_thread.hpp
+++ b/hpx/runtime/threads/detail/create_thread.hpp
@@ -59,7 +59,7 @@ namespace hpx { namespace threads { namespace detail
         if (nullptr == data.parent_id) {
             if (self)
             {
-                data.parent_id = threads::get_self_id().get();
+                data.parent_id = threads::get_self_id();
                 data.parent_phase = self->get_thread_phase();
             }
         }

--- a/hpx/runtime/threads/detail/create_work.hpp
+++ b/hpx/runtime/threads/detail/create_work.hpp
@@ -67,7 +67,7 @@ namespace hpx { namespace threads { namespace detail
 
             if (self)
             {
-                data.parent_id = threads::get_self_id().get();
+                data.parent_id = threads::get_self_id();
                 data.parent_phase = self->get_thread_phase();
             }
         }

--- a/hpx/runtime/threads/detail/set_thread_state.hpp
+++ b/hpx/runtime/threads/detail/set_thread_state.hpp
@@ -63,7 +63,7 @@ namespace hpx { namespace threads { namespace detail
                 << "set_active_state: thread is still active, however "
                       "it was non-active since the original set_state "
                       "request was issued, aborting state change, thread("
-                << thrd.get() << "), description("
+                << thrd << "), description("
                 << thrd->get_description() << "), new state("
                 << get_thread_state_name(newstate) << ")";
             return thread_result_type(terminated, nullptr);
@@ -117,7 +117,7 @@ namespace hpx { namespace threads { namespace detail
                 LTM_(warning)
                     << "set_thread_state: old thread state is the same as new "
                        "thread state, aborting state change, thread("
-                    << thrd.get() << "), description("
+                    << thrd << "), description("
                     << thrd->get_description() << "), new state("
                     << get_thread_state_name(new_state) << ")";
 
@@ -135,7 +135,7 @@ namespace hpx { namespace threads { namespace detail
                     // schedule a new thread to set the state
                     LTM_(warning)
                         << "set_thread_state: thread is currently active, scheduling "
-                            "new thread, thread(" << thrd.get() << "), description("
+                            "new thread, thread(" << thrd << "), description("
                         << thrd->get_description() << "), new state("
                         << get_thread_state_name(new_state) << ")";
 
@@ -157,7 +157,7 @@ namespace hpx { namespace threads { namespace detail
                 {
                     LTM_(warning)
                         << "set_thread_state: thread is terminated, aborting state "
-                            "change, thread(" << thrd.get() << "), description("
+                            "change, thread(" << thrd << "), description("
                         << thrd->get_description() << "), new state("
                         << get_thread_state_name(new_state) << ")";
 
@@ -177,7 +177,7 @@ namespace hpx { namespace threads { namespace detail
                     std::ostringstream strm;
                     strm << "set_thread_state: invalid new state, can't demote a "
                             "pending thread, "
-                         << "thread(" << thrd.get() << "), description("
+                         << "thread(" << thrd << "), description("
                          << thrd->get_description() << "), new state("
                          << get_thread_state_name(new_state) << ")";
 
@@ -203,7 +203,7 @@ namespace hpx { namespace threads { namespace detail
             // at some point will ignore this thread by simply skipping it
             // (if it's not pending anymore).
 
-            LTM_(info) << "set_thread_state: thread(" << thrd.get() << "), "
+            LTM_(info) << "set_thread_state: thread(" << thrd << "), "
                           "description(" << thrd->get_description() << "), "
                           "new state(" << get_thread_state_name(new_state) << "), "
                           "old state(" << get_thread_state_name(previous_state_val)
@@ -216,7 +216,7 @@ namespace hpx { namespace threads { namespace detail
             // state has changed since we fetched it from the thread, retry
             LTM_(error)
                 << "set_thread_state: state has been changed since it was fetched, "
-                   "retrying, thread(" << thrd.get() << "), "
+                   "retrying, thread(" << thrd << "), "
                    "description(" << thrd->get_description() << "), "
                    "new state(" << get_thread_state_name(new_state) << "), "
                    "old state(" << get_thread_state_name(previous_state_val)
@@ -352,7 +352,7 @@ namespace hpx { namespace threads { namespace detail
             HPX_THROWS_IF(ec, null_thread_id,
                 "threads::detail::set_thread_state",
                 "null thread id encountered");
-            return nullptr;
+            return invalid_thread_id;
         }
 
         // this creates a new thread which creates the timer and handles the

--- a/hpx/runtime/threads/policies/local_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_queue_scheduler.hpp
@@ -460,6 +460,8 @@ namespace hpx { namespace threads { namespace policies
             if (std::size_t(-1) == num_thread)
                 num_thread = curr_queue_++ % queues_.size();
 
+            HPX_ASSERT(thrd->get_scheduler_base() == this);
+
             HPX_ASSERT(num_thread < queues_.size());
             queues_[num_thread]->schedule_thread(thrd);
         }
@@ -471,6 +473,8 @@ namespace hpx { namespace threads { namespace policies
             if (std::size_t(-1) == num_thread)
                 num_thread = curr_queue_++ % queues_.size();
 
+            HPX_ASSERT(thrd->get_scheduler_base() == this);
+
             HPX_ASSERT(num_thread < queues_.size());
             queues_[num_thread]->schedule_thread(thrd, true);
         }
@@ -478,6 +482,8 @@ namespace hpx { namespace threads { namespace policies
         /// Destroy the passed thread as it has been terminated
         bool destroy_thread(threads::thread_data* thrd, std::int64_t& busy_count)
         {
+            HPX_ASSERT(thrd->get_scheduler_base() == this);
+
             for (std::size_t i = 0; i != queues_.size(); ++i)
             {
                 if (queues_[i]->destroy_thread(thrd, busy_count))

--- a/hpx/runtime/threads/policies/queue_helpers.hpp
+++ b/hpx/runtime/threads/policies/queue_helpers.hpp
@@ -65,7 +65,7 @@ namespace detail
         typename Map::const_iterator end = tm.end();
         for (typename Map::const_iterator it = tm.begin(); it != end; ++it)
         {
-            threads::thread_data const* thrd = (*it).get();
+            threads::thread_data const* thrd = it->get();
             threads::thread_state_enum state = thrd->get_state().state();
             threads::thread_state_enum marked_state = thrd->get_marked_state();
 
@@ -89,7 +89,7 @@ namespace detail
                     LTM_(error) << "queue(" << num_thread << "): " //-V128
                                 << get_thread_state_name(state)
                                 << "(" << std::hex << std::setw(8)
-                                    << std::setfill('0') << (*it).get()
+                                    << std::setfill('0') << (*it)
                                 << "." << std::hex << std::setw(2)
                                     << std::setfill('0') << thrd->get_thread_phase()
                                 << "/" << std::hex << std::setw(8)
@@ -107,7 +107,7 @@ namespace detail
                                 << "queue(" << num_thread << "): "
                                 << get_thread_state_name(state)
                                 << "(" << std::hex << std::setw(8)
-                                    << std::setfill('0') << (*it).get()
+                                    << std::setfill('0') << (*it)
                                 << "." << std::hex << std::setw(2)
                                     << std::setfill('0') << thrd->get_thread_phase()
                                 << "/" << std::hex << std::setw(8)

--- a/hpx/runtime/threads/policies/thread_queue.hpp
+++ b/hpx/runtime/threads/policies/thread_queue.hpp
@@ -43,23 +43,6 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace std
-{
-    template <>
-    struct hash< ::hpx::threads::thread_id_type>
-    {
-        typedef ::hpx::threads::thread_id_type argument_type;
-        typedef std::size_t result_type;
-
-        std::size_t operator()(::hpx::threads::thread_id_type const& v) const
-        {
-            std::hash<std::size_t> hasher_;
-            return hasher_(reinterpret_cast<std::size_t>(v.get()));
-        }
-    };
-}
-
-///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace threads { namespace policies
 {
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
@@ -278,13 +261,14 @@ namespace hpx { namespace threads { namespace policies
                 heap->pop_front();
                 thrd->rebind(data, state);
             }
-
             else
             {
                 hpx::util::unlock_guard<Lock> ull(lk);
 
+
                 // Allocate a new thread object.
-                thrd = threads::thread_data::create(data, memory_pool_, state);
+                thrd = thread_id_type(
+                    threads::thread_data::create(data, memory_pool_, state));
             }
         }
 
@@ -346,7 +330,7 @@ namespace hpx { namespace threads { namespace policies
                 }
 
                 // this thread has to be in the map now
-                HPX_ASSERT(thread_map_.find(thrd.get()) != thread_map_.end());
+                HPX_ASSERT(thread_map_.find(thrd) != thread_map_.end());
                 HPX_ASSERT(thrd->get_pool() == &memory_pool_);
             }
 
@@ -464,14 +448,16 @@ namespace hpx { namespace threads { namespace policies
                 thread_data* todelete;
                 while (terminated_items_.pop(todelete))
                 {
+                    thread_id_type tid(todelete);
                     --terminated_items_count_;
 
                     // this thread has to be in this map
-                    HPX_ASSERT(thread_map_.find(todelete) != thread_map_.end());
+                    HPX_ASSERT(thread_map_.find(tid) != thread_map_.end());
 
-                    bool deleted = thread_map_.erase(todelete) != 0;
+                    bool deleted = thread_map_.erase(tid) != 0;
                     HPX_ASSERT(deleted);
                     if (deleted) {
+                        delete todelete;
                         --thread_map_count_;
                         HPX_ASSERT(thread_map_count_ >= 0);
                     }
@@ -487,9 +473,10 @@ namespace hpx { namespace threads { namespace policies
                 thread_data* todelete;
                 while (delete_count && terminated_items_.pop(todelete))
                 {
+                    thread_id_type tid(todelete);
                     --terminated_items_count_;
 
-                    thread_map_type::iterator it = thread_map_.find(todelete);
+                    thread_map_type::iterator it = thread_map_.find(tid);
 
                     // this thread has to be in this map
                     HPX_ASSERT(it != thread_map_.end());
@@ -581,6 +568,21 @@ namespace hpx { namespace threads { namespace policies
 #endif
             add_new_logger_("thread_queue::add_new")
         {}
+
+        ~thread_queue()
+        {
+            for(auto t: thread_heap_small_)
+                delete t.get();
+
+            for(auto t: thread_heap_medium_)
+                delete t.get();
+
+            for(auto t: thread_heap_large_)
+                delete t.get();
+
+            for(auto t: thread_heap_huge_)
+                delete t.get();
+        }
 
         void set_max_count(std::size_t max_count = max_thread_count)
         {
@@ -741,7 +743,7 @@ namespace hpx { namespace threads { namespace policies
                     ++thread_map_count_;
 
                     // this thread has to be in the map now
-                    HPX_ASSERT(thread_map_.find(thrd.get()) != thread_map_.end());
+                    HPX_ASSERT(thread_map_.find(thrd) != thread_map_.end());
                     HPX_ASSERT(thrd->get_pool() == &memory_pool_);
 
                     // push the new thread in the pending queue thread
@@ -749,7 +751,7 @@ namespace hpx { namespace threads { namespace policies
                         schedule_thread(thrd.get());
 
                     // return the thread_id of the newly created thread
-                    if (id) *id = std::move(thrd);
+                    if (id) *id = thrd;
 
                     if (&ec != &throws)
                         ec = make_success_code();

--- a/hpx/runtime/threads/thread.hpp
+++ b/hpx/runtime/threads/thread.hpp
@@ -136,7 +136,7 @@ namespace hpx
         friend class thread;
 
     public:
-        id() noexcept {}
+        id() noexcept : id_(threads::invalid_thread_id) {}
         explicit id(threads::thread_id_type const& i) noexcept
           : id_(i)
         {}

--- a/hpx/runtime/threads/thread_data_fwd.hpp
+++ b/hpx/runtime/threads/thread_data_fwd.hpp
@@ -12,11 +12,10 @@
 #include <hpx/exception_fwd.hpp>
 #include <hpx/runtime/threads/coroutines/coroutine_fwd.hpp>
 #include <hpx/runtime/threads/thread_enums.hpp>
+#include <hpx/runtime/threads/thread_id_type.hpp>
 #include <hpx/util_fwd.hpp>
 #include <hpx/util/function.hpp>
 #include <hpx/util/unique_function.hpp>
-
-#include <boost/intrusive_ptr.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -46,20 +45,13 @@ namespace hpx { namespace threads
     typedef coroutines::detail::coroutine_self thread_self;
     typedef coroutines::detail::coroutine_impl thread_self_impl_type;
 
-    typedef void * thread_id_repr_type;
-    typedef boost::intrusive_ptr<thread_data> thread_id_type;
-
     typedef std::pair<thread_state_enum, thread_id_type> thread_result_type;
     typedef thread_state_ex_enum thread_arg_type;
 
     typedef thread_result_type thread_function_sig(thread_arg_type);
     typedef util::unique_function_nonser<thread_function_sig> thread_function_type;
 
-    HPX_API_EXPORT void intrusive_ptr_add_ref(thread_data* p);
-    HPX_API_EXPORT void intrusive_ptr_release(thread_data* p);
-
-    HPX_CONSTEXPR_OR_CONST thread_id_repr_type invalid_thread_id_repr = nullptr;
-    thread_id_type const invalid_thread_id = thread_id_type();
+    HPX_CONSTEXPR_OR_CONST thread_id_type invalid_thread_id;
     /// \endcond
 
     ///////////////////////////////////////////////////////////////////////
@@ -90,7 +82,7 @@ namespace hpx { namespace threads
     /// \note This function will return a meaningful value only if the
     ///       code was compiled with HPX_HAVE_THREAD_PARENT_REFERENCE
     ///       being defined.
-    HPX_API_EXPORT thread_id_repr_type get_parent_id();
+    HPX_API_EXPORT thread_id_type get_parent_id();
 
     /// The function \a get_parent_phase returns the HPX phase of the
     /// current thread's parent (or zero if the current thread is not a

--- a/hpx/runtime/threads/thread_helpers.hpp
+++ b/hpx/runtime/threads/thread_helpers.hpp
@@ -513,7 +513,7 @@ namespace hpx { namespace this_thread
             util::thread_description("this_thread::suspend"),
         error_code& ec = throws)
     {
-        return suspend(state, nullptr, description, ec);
+        return suspend(state, threads::invalid_thread_id, description, ec);
     }
 
     /// The function \a suspend will return control to the thread manager
@@ -563,7 +563,7 @@ namespace hpx { namespace this_thread
             util::thread_description("this_thread::suspend"),
         error_code& ec = throws)
     {
-        return suspend(abs_time, nullptr, description, ec);
+        return suspend(abs_time, threads::invalid_thread_id, description, ec);
     }
 
     /// The function \a suspend will return control to the thread manager
@@ -589,7 +589,8 @@ namespace hpx { namespace this_thread
             util::thread_description("this_thread::suspend"),
         error_code& ec = throws)
     {
-        return suspend(rel_time.from_now(), nullptr, description, ec);
+        return suspend(rel_time.from_now(), threads::invalid_thread_id,
+            description, ec);
     }
 
     /// The function \a suspend will return control to the thread manager
@@ -641,7 +642,8 @@ namespace hpx { namespace this_thread
             util::thread_description("this_thread::suspend"),
         error_code& ec = throws)
     {
-        return suspend(std::chrono::milliseconds(ms), nullptr, description, ec);
+        return suspend(std::chrono::milliseconds(ms), threads::invalid_thread_id,
+            description, ec);
     }
 
     /// Returns a reference to the executor which was used to create the current
@@ -804,7 +806,8 @@ namespace hpx { namespace applier
                 // held.
                 util::force_error_on_lock();
 
-                return threads::thread_result_type(threads::terminated, nullptr);
+                return threads::thread_result_type(threads::terminated,
+                    threads::invalid_thread_id);
             }
         };
 
@@ -823,7 +826,8 @@ namespace hpx { namespace applier
                 // held.
                 util::force_error_on_lock();
 
-                return threads::thread_result_type(threads::terminated, nullptr);
+                return threads::thread_result_type(threads::terminated,
+                    threads::invalid_thread_id);
             }
         };
     }

--- a/hpx/runtime/threads/thread_id_type.hpp
+++ b/hpx/runtime/threads/thread_id_type.hpp
@@ -1,0 +1,151 @@
+//  Copyright (c) 2018 Thomas Heller
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file hpx/runtime/threads/thread_id_type.hpp
+
+#ifndef HPX_THREADS_THREAD_ID_TYPE_HPP
+#define HPX_THREADS_THREAD_ID_TYPE_HPP
+
+#include <hpx/config/constexpr.hpp>
+#include <hpx/config/export_definitions.hpp>
+
+#include <cstddef>
+#include <functional>
+#include <iosfwd>
+
+namespace hpx {
+namespace threads {
+    class HPX_EXPORT thread_data;
+
+    struct thread_id_type
+    {
+        constexpr thread_id_type()
+          : thrd_(nullptr)
+        {
+        }
+        explicit constexpr thread_id_type(thread_data* thrd)
+          : thrd_(thrd)
+        {
+        }
+
+        thread_id_type(thread_id_type const&) = default;
+        thread_id_type& operator=(thread_id_type const&) = default;
+
+        constexpr thread_data* operator->() const
+        {
+            return thrd_;
+        }
+
+        constexpr thread_data& operator*() const
+        {
+            return *thrd_;
+        }
+
+        explicit constexpr operator bool() const
+        {
+            return nullptr != thrd_;
+        }
+
+        constexpr thread_data* get() const
+        {
+            return thrd_;
+        }
+
+        HPX_CXX14_CONSTEXPR void reset()
+        {
+            thrd_ = nullptr;
+        }
+
+        friend constexpr bool operator==(
+            std::nullptr_t, thread_id_type const& rhs)
+        {
+            return nullptr == rhs.thrd_;
+        }
+
+        friend constexpr bool operator!=(
+            std::nullptr_t, thread_id_type const& rhs)
+        {
+            return nullptr != rhs.thrd_;
+        }
+
+        friend constexpr bool operator==(
+            thread_id_type const& lhs, std::nullptr_t)
+        {
+            return nullptr == lhs.thrd_;
+        }
+
+        friend constexpr bool operator!=(
+            thread_id_type const& lhs, std::nullptr_t)
+        {
+            return nullptr != lhs.thrd_;
+        }
+
+        friend constexpr bool operator==(
+            thread_id_type const& lhs, thread_id_type const& rhs)
+        {
+            return lhs.thrd_ == rhs.thrd_;
+        }
+
+        friend constexpr bool operator!=(
+            thread_id_type const& lhs, thread_id_type const& rhs)
+        {
+            return lhs.thrd_ != rhs.thrd_;
+        }
+
+        friend constexpr bool operator<(
+            thread_id_type const& lhs, thread_id_type const& rhs)
+        {
+            return std::less<void const*>{}(lhs.thrd_, rhs.thrd_);
+        }
+
+        friend constexpr bool operator>(
+            thread_id_type const& lhs, thread_id_type const& rhs)
+        {
+            return std::less<void const*>{}(rhs.thrd_, lhs.thrd_);
+        }
+
+        friend constexpr bool operator<=(
+            thread_id_type const& lhs, thread_id_type const& rhs)
+        {
+            return !(rhs > lhs);
+        }
+
+        friend constexpr bool operator>=(
+            thread_id_type const& lhs, thread_id_type const& rhs)
+        {
+            return !(rhs < lhs);
+        }
+
+        template <typename Char, typename Traits>
+        friend std::basic_ostream<Char, Traits>& operator<<(
+            std::basic_ostream<Char, Traits>& os, thread_id_type const& id)
+        {
+            os << id.get();
+            return os;
+        }
+
+    private:
+        thread_data* thrd_;
+    };
+}
+}
+
+namespace std {
+template <>
+struct hash<::hpx::threads::thread_id_type>
+{
+    typedef ::hpx::threads::thread_id_type argument_type;
+    typedef std::size_t result_type;
+
+    std::size_t operator()(::hpx::threads::thread_id_type const& v) const
+        noexcept
+    {
+        std::hash<const ::hpx::threads::thread_data*> hasher_;
+        return hasher_(v.get());
+    }
+};
+}
+
+#endif

--- a/hpx/runtime/threads/thread_init_data.hpp
+++ b/hpx/runtime/threads/thread_init_data.hpp
@@ -101,7 +101,7 @@ namespace hpx { namespace threads
 #endif
 #if defined(HPX_HAVE_THREAD_PARENT_REFERENCE)
         std::uint32_t parent_locality_id;
-        threads::thread_id_repr_type parent_id;
+        threads::thread_id_type parent_id;
         std::size_t parent_phase;
 #endif
 

--- a/src/lcos/local/mutex.cpp
+++ b/src/lcos/local/mutex.cpp
@@ -23,7 +23,7 @@ namespace hpx { namespace lcos { namespace local
 {
     ///////////////////////////////////////////////////////////////////////////
     mutex::mutex(char const* const description)
-      : owner_id_(threads::invalid_thread_id_repr)
+      : owner_id_(threads::invalid_thread_id)
     {
         HPX_ITT_SYNC_CREATE(this, "lcos::local::mutex", description);
         HPX_ITT_SYNC_RENAME(this, "lcos::local::mutex");
@@ -41,7 +41,7 @@ namespace hpx { namespace lcos { namespace local
         HPX_ITT_SYNC_PREPARE(this);
         std::unique_lock<mutex_type> l(mtx_);
 
-        threads::thread_id_repr_type self_id = threads::get_self_id().get();
+        threads::thread_id_type self_id = threads::get_self_id();
         if(owner_id_ == self_id)
         {
             HPX_ITT_SYNC_CANCEL(this);
@@ -51,7 +51,7 @@ namespace hpx { namespace lcos { namespace local
             return;
         }
 
-        while (owner_id_ != threads::invalid_thread_id_repr)
+        while (owner_id_ != threads::invalid_thread_id)
         {
             cond_.wait(l, ec);
             if (ec) { HPX_ITT_SYNC_CANCEL(this); return; }
@@ -69,13 +69,13 @@ namespace hpx { namespace lcos { namespace local
         HPX_ITT_SYNC_PREPARE(this);
         std::unique_lock<mutex_type> l(mtx_);
 
-        if (owner_id_ != threads::invalid_thread_id_repr)
+        if (owner_id_ != threads::invalid_thread_id)
         {
             HPX_ITT_SYNC_CANCEL(this);
             return false;
         }
 
-        threads::thread_id_repr_type self_id = threads::get_self_id().get();
+        threads::thread_id_type self_id = threads::get_self_id();
         util::register_lock(this);
         HPX_ITT_SYNC_ACQUIRED(this);
         owner_id_ = self_id;
@@ -89,7 +89,7 @@ namespace hpx { namespace lcos { namespace local
         HPX_ITT_SYNC_RELEASING(this);
         std::unique_lock<mutex_type> l(mtx_);
 
-        threads::thread_id_repr_type self_id = threads::get_self_id().get();
+        threads::thread_id_type self_id = threads::get_self_id();
         if (HPX_UNLIKELY(owner_id_ != self_id))
         {
             util::unregister_lock(this);
@@ -101,7 +101,7 @@ namespace hpx { namespace lcos { namespace local
 
         util::unregister_lock(this);
         HPX_ITT_SYNC_RELEASED(this);
-        owner_id_ = threads::invalid_thread_id_repr;
+        owner_id_ = threads::invalid_thread_id;
 
         cond_.notify_one(std::move(l), threads::thread_priority_boost, ec);
     }
@@ -122,8 +122,8 @@ namespace hpx { namespace lcos { namespace local
         HPX_ITT_SYNC_PREPARE(this);
         std::unique_lock<mutex_type> l(mtx_);
 
-        threads::thread_id_repr_type self_id = threads::get_self_id().get();
-        if (owner_id_ != threads::invalid_thread_id_repr)
+        threads::thread_id_type self_id = threads::get_self_id();
+        if (owner_id_ != threads::invalid_thread_id)
         {
             threads::thread_state_ex_enum const reason =
                 cond_.wait_until(l, abs_time, ec);
@@ -135,7 +135,7 @@ namespace hpx { namespace lcos { namespace local
                 return false;
             }
 
-            if (owner_id_ != threads::invalid_thread_id_repr) //-V110
+            if (owner_id_ != threads::invalid_thread_id) //-V110
             {
                 HPX_ITT_SYNC_CANCEL(this);
                 return false;

--- a/src/runtime/parcelset/parcel.cpp
+++ b/src/runtime/parcelset/parcel.cpp
@@ -453,7 +453,7 @@ namespace hpx { namespace parcelset
         // tell APEX about the received parcel
         apex::recv(data_.parcel_id_.get_lsb(), size_,
             naming::get_locality_id_from_gid(data_.source_id_),
-            reinterpret_cast<std::uint64_t>(action_->get_parent_thread_id()));
+            reinterpret_cast<std::uint64_t>(action_->get_parent_thread_id().get()));
 #endif
 
         return false;

--- a/src/runtime/threads/coroutines/detail/coroutine_impl.cpp
+++ b/src/runtime/threads/coroutines/detail/coroutine_impl.cpp
@@ -217,10 +217,10 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
     }
 
     coroutine_impl* coroutine_impl::allocate(
-        thread_id_repr_type id, std::ptrdiff_t stacksize)
+        thread_id_type id, std::ptrdiff_t stacksize)
     {
         // start looking at the matching heap
-        std::size_t const heap_num = std::size_t(id) / 32; //-V112
+        std::size_t const heap_num = std::size_t(id.get()) / 32; //-V112
         std::size_t const heap_count = get_heap_count(stacksize);
 
         // look through all heaps to find an available coroutine object
@@ -237,7 +237,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 
     void coroutine_impl::deallocate(coroutine_impl* p)
     {
-        std::size_t const heap_num = std::size_t(p->get_thread_id()) / 32; //-V112
+        std::size_t const heap_num = std::size_t(p->get_thread_id().get()) / 32; //-V112
         std::ptrdiff_t const stacksize = p->get_stacksize();
 
         get_heap(heap_num, stacksize).deallocate(p);

--- a/src/runtime/threads/thread.cpp
+++ b/src/runtime/threads/thread.cpp
@@ -51,6 +51,7 @@ namespace hpx
 
     ///////////////////////////////////////////////////////////////////////////
     thread::thread() noexcept
+      : id_(hpx::threads::invalid_thread_id)
     {}
 
     thread::thread(thread&& rhs) noexcept

--- a/src/runtime/threads/thread_data.cpp
+++ b/src/runtime/threads/thread_data.cpp
@@ -34,25 +34,6 @@ namespace hpx { namespace threads
     };
 #endif
 
-    void intrusive_ptr_add_ref(thread_data* p)
-    {
-        ++p->count_;
-    }
-    void intrusive_ptr_release(thread_data* p)
-    {
-        if (0 == --p->count_)
-        {
-            thread_data::pool_type* pool = p->get_pool();
-            if (pool == nullptr)
-                delete p;
-            else
-            {
-                p->~thread_data();
-                pool->deallocate(p);
-            }
-        }
-    }
-
     void thread_data::run_thread_exit_callbacks()
     {
         mutex_type::scoped_lock l(this);
@@ -170,9 +151,7 @@ namespace hpx { namespace threads
         if (nullptr == self)
             return threads::invalid_thread_id;
 
-        return thread_id_type(
-                reinterpret_cast<thread_data*>(self->get_thread_id())
-            );
+        return self->get_thread_id();
     }
 
     std::size_t get_self_stacksize()
@@ -182,9 +161,9 @@ namespace hpx { namespace threads
     }
 
 #ifndef HPX_HAVE_THREAD_PARENT_REFERENCE
-    thread_id_repr_type get_parent_id()
+    thread_id_type get_parent_id()
     {
-        return threads::invalid_thread_id_repr;
+        return threads::invalid_thread_id;
     }
 
     std::size_t get_parent_phase()
@@ -197,12 +176,12 @@ namespace hpx { namespace threads
         return naming::invalid_locality_id;
     }
 #else
-    thread_id_repr_type get_parent_id()
+    thread_id_type get_parent_id()
     {
         thread_self* self = get_self_ptr();
         if (nullptr == self)
-            return threads::invalid_thread_id_repr;
-        return get_self_id()->get_parent_thread_id();
+            return threads::invalid_thread_id;
+        return self->get_thread_id()->get_parent_thread_id();
     }
 
     std::size_t get_parent_phase()
@@ -210,7 +189,7 @@ namespace hpx { namespace threads
         thread_self* self = get_self_ptr();
         if (nullptr == self)
             return 0;
-        return get_self_id()->get_parent_thread_phase();
+        return self->get_thread_id()->get_parent_thread_phase();
     }
 
     std::uint32_t get_parent_locality_id()
@@ -218,7 +197,7 @@ namespace hpx { namespace threads
         thread_self* self = get_self_ptr();
         if (nullptr == self)
             return naming::invalid_locality_id;
-        return get_self_id()->get_parent_locality_id();
+        return self->get_thread_id()->get_parent_locality_id();
     }
 #endif
 
@@ -230,7 +209,7 @@ namespace hpx { namespace threads
         thread_self* self = get_self_ptr();
         if (nullptr == self)
             return 0;
-        return get_self_id()->get_component_id();
+        return self->get_thread_id()->get_component_id();
 #endif
     }
 

--- a/src/runtime/threads/thread_helpers.cpp
+++ b/src/runtime/threads/thread_helpers.cpp
@@ -499,7 +499,8 @@ namespace hpx { namespace this_thread
             {
                 nextid->get_scheduler_base()->schedule_thread(
                     nextid.get(), std::size_t(-1));
-                statex = self.yield(threads::thread_result_type(state, nullptr));
+                statex = self.yield(threads::thread_result_type(state,
+                    threads::invalid_thread_id));
             }
             else
             {

--- a/src/util/interval_timer.cpp
+++ b/src/util/interval_timer.cpp
@@ -127,7 +127,7 @@ namespace hpx { namespace util { namespace detail
                 error_code ec(lightweight);       // avoid throwing on error
                 threads::set_thread_state(id_, threads::pending,
                     threads::wait_abort, threads::thread_priority_boost, ec);
-                id_ = nullptr;
+                id_.reset();
             }
             return true;
         }
@@ -196,7 +196,7 @@ namespace hpx { namespace util { namespace detail
                 return threads::thread_result_type(threads::terminated, nullptr);
             }
 
-            id_ = nullptr;
+            id_.reset();
             is_started_ = false;
 
             bool result = false;

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -284,13 +284,13 @@ namespace hpx { namespace util
     {
         void operator()(param str) const
         {
-            threads::thread_id_repr_type parent_id = threads::get_parent_id();
+            threads::thread_id_type parent_id = threads::get_parent_id();
             if (nullptr != parent_id && threads::invalid_thread_id != parent_id) {
                 // called from inside a HPX thread
                 std::stringstream out;
                 out << std::hex << std::setw(sizeof(void*)*2)
                     << std::setfill('0')
-                    << reinterpret_cast<std::ptrdiff_t>(parent_id);
+                    << reinterpret_cast<std::ptrdiff_t>(parent_id.get());
                 str.prepend_string(out.str());
             }
             else {

--- a/tests/performance/local/coroutines_call_overhead.cpp
+++ b/tests/performance/local/coroutines_call_overhead.cpp
@@ -165,7 +165,7 @@ double perform_2n_iterations()
 
     for (std::uint64_t i = 0; i < contexts; ++i)
     {
-        coroutine_type* c = new coroutine_type(k);
+        coroutine_type* c = new coroutine_type(k, hpx::threads::invalid_thread_id);
         coroutines.push_back(c);
     }
 


### PR DESCRIPTION
This change gets rid of using boost::intrusive_ptr to refcount thread_data. The
lifetime of thread_data is perfectly managed by the scheduling policy. That is,
once a task terminates, it can be deleted/reused.

## Any background context you want to provide?

refcounting requires atomic operations which may needlessly (in this case) slow down an application.