### PR TITLE
Fixing #3121

### DIFF
--- a/hpx/config/compiler_fence.hpp
+++ b/hpx/config/compiler_fence.hpp
@@ -26,7 +26,17 @@ extern "C" void _mm_pause();
 #elif defined(__GNUC__)
 
 #define HPX_COMPILER_FENCE __asm__ __volatile__( "" : : : "memory" )
+
+#if defined(__i386__) || defined(__x86_64__)
 #define HPX_SMT_PAUSE __asm__ __volatile__( "rep; nop" : : : "memory" )
+#elif defined(__ppc__)
+// According to: https://stackoverflow.com/questions/5425506/equivalent-of-x86-pause-instruction-for-ppc
+#define HPX_SMT_PAUSE __asm__ __volatile__("or 27,27,27")
+#elif defined(__arm__)
+#define HPX_SMT_PAUSE __asm__ __volatile__("yield")
+#else
+#define HPX_SMT_PAUSE HPX_COMPILER_FENCE
+#endif
 
 #else
 


### PR DESCRIPTION
Fixes #3121 

## Proposed Changes

This patch fixes #3121 by adding the proper instructions for SMT_PAUSE for the "big three", for everything else, the fence instruction is used.
