### PR TITLE
Replacing nullptr with hpx::threads::invalid_thread_id

### DIFF
--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -870,7 +870,8 @@ namespace detail
         static threads::thread_result_type run_impl(future_base_type this_)
         {
             this_->do_run();
-            return threads::thread_result_type(threads::terminated, nullptr);
+            return threads::thread_result_type(
+                threads::terminated, threads::invalid_thread_id);
         }
 
     public:
@@ -946,7 +947,8 @@ namespace detail
         {
             reset_id r(*this_);
             this_->do_run();
-            return threads::thread_result_type(threads::terminated, nullptr);
+            return threads::thread_result_type(
+                threads::terminated, threads::invalid_thread_id);
         }
 
     public:

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -281,7 +281,8 @@ namespace hpx { namespace lcos { namespace detail
 
             Future future = traits::future_access<Future>::create(std::move(f));
             invoke_continuation(f_, std::move(future), *this);
-            return threads::thread_result_type(threads::terminated, nullptr);
+            return threads::thread_result_type(threads::terminated,
+                    threads::invalid_thread_id);
         }
 
         threads::thread_result_type
@@ -298,7 +299,8 @@ namespace hpx { namespace lcos { namespace detail
 
             Future future = traits::future_access<Future>::create(std::move(f));
             invoke_continuation(f_, std::move(future), *this, is_void());
-            return threads::thread_result_type(threads::terminated, nullptr);
+            return threads::thread_result_type(threads::terminated,
+                threads::invalid_thread_id);
         }
 
     public:

--- a/hpx/runtime/actions/basic_action.hpp
+++ b/hpx/runtime/actions/basic_action.hpp
@@ -104,7 +104,8 @@ namespace hpx { namespace actions
                     << " with continuation(" << cont_.get_id() << ")";
 
                 actions::trigger(std::move(cont_), f_);
-                return threads::thread_result_type(threads::terminated, nullptr);
+                return threads::thread_result_type(threads::terminated,
+                    threads::invalid_thread_id);
             }
 
         private:
@@ -271,7 +272,8 @@ namespace hpx { namespace actions
                 // OS-thread. This will throw if there are still any locks
                 // held.
                 util::force_error_on_lock();
-                return threads::thread_result_type(threads::terminated, nullptr);
+                return threads::thread_result_type(threads::terminated,
+                    threads::invalid_thread_id);
             }
 
             // This holds the target alive, if necessary.

--- a/hpx/runtime/components/server/locking_hook.hpp
+++ b/hpx/runtime/components/server/locking_hook.hpp
@@ -89,7 +89,8 @@ namespace hpx { namespace components
         threads::thread_result_type thread_function(
             threads::thread_arg_type state, threads::thread_function_type f)
         {
-            threads::thread_result_type result(threads::unknown, nullptr);
+            threads::thread_result_type result(threads::unknown,
+                threads::invalid_thread_id);
 
             // now lock the mutex and execute the action
             std::unique_lock<mutex_type> l(mtx_);

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -311,7 +311,7 @@ namespace hpx { namespace threads { namespace detail
                         "background_work");
                 }
 
-                return thread_result_type(terminated, nullptr);
+                return thread_result_type(terminated, invalid_thread_id);
             },
             hpx::util::thread_description("background_work"),
             0,

--- a/hpx/runtime/threads/detail/set_thread_state.hpp
+++ b/hpx/runtime/threads/detail/set_thread_state.hpp
@@ -49,7 +49,7 @@ namespace hpx { namespace threads { namespace detail
             HPX_THROW_EXCEPTION(null_thread_id,
                 "threads::detail::set_active_state",
                 "null thread id encountered");
-            return thread_result_type(terminated, nullptr);
+            return thread_result_type(terminated, invalid_thread_id);
         }
 
         // make sure that the thread has not been suspended and set active again
@@ -66,7 +66,7 @@ namespace hpx { namespace threads { namespace detail
                 << thrd << "), description("
                 << thrd->get_description() << "), new state("
                 << get_thread_state_name(newstate) << ")";
-            return thread_result_type(terminated, nullptr);
+            return thread_result_type(terminated, invalid_thread_id);
         }
 
         // just retry, set_state will create new thread if target is still active
@@ -74,7 +74,7 @@ namespace hpx { namespace threads { namespace detail
         detail::set_thread_state(thrd, newstate, newstate_ex, priority,
             std::size_t(-1), ec);
 
-        return thread_result_type(terminated, nullptr);
+        return thread_result_type(terminated, invalid_thread_id);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -250,13 +250,13 @@ namespace hpx { namespace threads { namespace detail
             HPX_THROW_EXCEPTION(null_thread_id,
                 "threads::detail::wake_timer_thread",
                 "null thread id encountered (id)");
-            return thread_result_type(terminated, nullptr);
+            return thread_result_type(terminated, invalid_thread_id);
         }
         if (HPX_UNLIKELY(!timer_id)) {
             HPX_THROW_EXCEPTION(null_thread_id,
                 "threads::detail::wake_timer_thread",
                 "null thread id encountered (timer_id)");
-            return thread_result_type(terminated, nullptr);
+            return thread_result_type(terminated, invalid_thread_id);
         }
 
         bool oldvalue = false;
@@ -271,7 +271,7 @@ namespace hpx { namespace threads { namespace detail
         detail::set_thread_state(timer_id, pending, wait_timeout,
             thread_priority_boost, std::size_t(-1), ec);
 
-        return thread_result_type(terminated, nullptr);
+        return thread_result_type(terminated, invalid_thread_id);
     }
 
     /// This thread function initiates the required set_state action (on
@@ -286,7 +286,7 @@ namespace hpx { namespace threads { namespace detail
             HPX_THROW_EXCEPTION(null_thread_id,
                 "threads::detail::at_timer",
                 "null thread id encountered");
-            return thread_result_type(terminated, nullptr);
+            return thread_result_type(terminated, invalid_thread_id);
         }
 
         // create a new thread in suspended state, which will execute the
@@ -322,7 +322,7 @@ namespace hpx { namespace threads { namespace detail
         // if it returns signaled the timer has been canceled, otherwise
         // the timer fired and the wake_timer_thread above has been executed
         thread_state_ex_enum statex =
-            get_self().yield(thread_result_type(suspended, nullptr));
+            get_self().yield(thread_result_type(suspended, invalid_thread_id));
 
         if (wait_timeout != statex) //-V601
         {
@@ -337,7 +337,7 @@ namespace hpx { namespace threads { namespace detail
                 priority, std::size_t(-1), ec);
         }
 
-        return thread_result_type(terminated, nullptr);
+        return thread_result_type(terminated, invalid_thread_id);
     }
 
     /// Set a timer to set the state of the given \a thread to the given

--- a/hpx/runtime/threads/thread_id_type.hpp
+++ b/hpx/runtime/threads/thread_id_type.hpp
@@ -94,25 +94,25 @@ namespace threads {
             return lhs.thrd_ != rhs.thrd_;
         }
 
-        friend constexpr bool operator<(
+        friend HPX_CXX14_CONSTEXPR bool operator<(
             thread_id_type const& lhs, thread_id_type const& rhs)
         {
             return std::less<void const*>{}(lhs.thrd_, rhs.thrd_);
         }
 
-        friend constexpr bool operator>(
+        friend HPX_CXX14_CONSTEXPR bool operator>(
             thread_id_type const& lhs, thread_id_type const& rhs)
         {
             return std::less<void const*>{}(rhs.thrd_, lhs.thrd_);
         }
 
-        friend constexpr bool operator<=(
+        friend HPX_CXX14_CONSTEXPR bool operator<=(
             thread_id_type const& lhs, thread_id_type const& rhs)
         {
             return !(rhs > lhs);
         }
 
-        friend constexpr bool operator>=(
+        friend HPX_CXX14_CONSTEXPR bool operator>=(
             thread_id_type const& lhs, thread_id_type const& rhs)
         {
             return !(rhs < lhs);

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -855,7 +855,8 @@ namespace hpx { namespace components { namespace server
         // give the scheduler some time to work on remaining tasks
         {
             util::unlock_guard<Lock> ul(l);
-            self->yield(threads::thread_result_type(threads::pending, nullptr));
+            self->yield(threads::thread_result_type(threads::pending,
+                threads::invalid_thread_id));
         }
 
         // get rid of all terminated threads

--- a/src/runtime/threads/executors/current_executor.cpp
+++ b/src/runtime/threads/executors/current_executor.cpp
@@ -45,7 +45,8 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         // held.
         util::force_error_on_lock();
 
-        return threads::thread_result_type(threads::terminated, nullptr);
+        return threads::thread_result_type(threads::terminated,
+            threads::invalid_thread_id);
     }
 
     // Schedule the specified function for execution in this executor.

--- a/src/runtime/threads/executors/pool_executor.cpp
+++ b/src/runtime/threads/executors/pool_executor.cpp
@@ -44,7 +44,8 @@ namespace hpx { namespace threads { namespace executors
         {
             // execute the actual thread function
             func();
-            return threads::thread_result_type(threads::terminated, nullptr);
+            return threads::thread_result_type(threads::terminated,
+                threads::invalid_thread_id);
         }
 
         // Return the requested policy element

--- a/src/runtime/threads/executors/this_thread_executors.cpp
+++ b/src/runtime/threads/executors/this_thread_executors.cpp
@@ -121,7 +121,8 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         // held.
         util::force_error_on_lock();
 
-        return threads::thread_result_type(threads::terminated, nullptr);
+        return threads::thread_result_type(threads::terminated,
+            threads::invalid_thread_id);
     }
 
     // Schedule the specified function for execution in this executor.

--- a/src/runtime/threads/executors/thread_pool_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_executors.cpp
@@ -149,7 +149,8 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         // held.
         util::force_error_on_lock();
 
-        return threads::thread_result_type(threads::terminated, nullptr);
+        return threads::thread_result_type(threads::terminated,
+            threads::invalid_thread_id);
     }
 
     // Schedule the specified function for execution in this executor.

--- a/src/runtime/threads/executors/thread_pool_os_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_os_executors.cpp
@@ -131,7 +131,8 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         // execute the actual thread function
         func();
 
-        return threads::thread_result_type(threads::terminated, nullptr);
+        return threads::thread_result_type(threads::terminated,
+            threads::invalid_thread_id);
     }
 
     // Return the requested policy element

--- a/src/runtime/threads/thread.cpp
+++ b/src/runtime/threads/thread.cpp
@@ -137,7 +137,8 @@ namespace hpx
         // run all callbacks attached to the exit event for this thread
         run_thread_exit_callbacks();
 
-        return threads::thread_result_type(threads::terminated, nullptr);
+        return threads::thread_result_type(threads::terminated,
+            threads::invalid_thread_id);
     }
 
     thread::id thread::get_id() const noexcept

--- a/src/runtime/threads/thread_helpers.cpp
+++ b/src/runtime/threads/thread_helpers.cpp
@@ -568,7 +568,8 @@ namespace hpx { namespace this_thread
                 nextid->get_scheduler_base()->schedule_thread(
                     nextid.get(), std::size_t(-1));
                 statex = self.yield(
-                    threads::thread_result_type(threads::suspended, nullptr));
+                    threads::thread_result_type(threads::suspended,
+                        threads::invalid_thread_id));
             }
             else
             {

--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -252,7 +252,8 @@ namespace hpx {
         if (result) {
             lbt_ << "runtime_impl::run_helper: bootstrap "
                     "aborted, bailing out";
-            return threads::thread_result_type(threads::terminated, nullptr);
+            return threads::thread_result_type(threads::terminated,
+                threads::invalid_thread_id);
         }
 
         lbt_ << "(4th stage) runtime_impl::run_helper: bootstrap complete";
@@ -302,7 +303,8 @@ namespace hpx {
             // Call hpx_main
             result = func();
         }
-        return threads::thread_result_type(threads::terminated, nullptr);
+        return threads::thread_result_type(threads::terminated,
+            threads::invalid_thread_id);
     }
 
     int runtime_impl::start(

--- a/src/util/interval_timer.cpp
+++ b/src/util/interval_timer.cpp
@@ -187,13 +187,15 @@ namespace hpx { namespace util { namespace detail
                 statex == threads::wait_abort || 0 == microsecs_)
             {
                 // object has been finalized, exit
-                return threads::thread_result_type(threads::terminated, nullptr);
+                return threads::thread_result_type(threads::terminated,
+                    threads::invalid_thread_id);
             }
 
             if (id_ != nullptr && id_ != threads::get_self_id())
             {
                 // obsolete timer thread
-                return threads::thread_result_type(threads::terminated, nullptr);
+                return threads::thread_result_type(threads::terminated,
+                    threads::invalid_thread_id);
             }
 
             id_.reset();
@@ -222,7 +224,8 @@ namespace hpx { namespace util { namespace detail
         }
 
         // do not re-schedule this thread
-        return threads::thread_result_type(threads::terminated, nullptr);
+        return threads::thread_result_type(threads::terminated,
+            threads::invalid_thread_id);
     }
 
     // schedule a high priority task after a given time interval

--- a/tests/performance/local/coroutines_call_overhead.cpp
+++ b/tests/performance/local/coroutines_call_overhead.cpp
@@ -143,7 +143,8 @@ struct kernel
     {
         worker_timed(payload * 1000);
 
-        return hpx::threads::thread_result_type(hpx::threads::pending, nullptr);
+        return hpx::threads::thread_result_type(hpx::threads::pending,
+            hpx::threads::invalid_thread_id);
     }
 
     bool operator!() const { return true; }

--- a/tests/performance/local/htts_v2/htts2_hpx.cpp
+++ b/tests/performance/local/htts_v2/htts2_hpx.cpp
@@ -66,7 +66,8 @@ struct hpx_driver : htts2::driver
     {
         htts2::payload<BaseClock>(this->payload_duration_ /* = p */);
         //++count_;
-        return hpx::threads::thread_result_type(hpx::threads::terminated, nullptr);
+        return hpx::threads::thread_result_type(hpx::threads::terminated,
+            hpx::threads::invalid_thread_id);
     }
 
     void stage_tasks(std::uint64_t target_osthread)

--- a/tests/performance/local/timed_task_spawn.cpp
+++ b/tests/performance/local/timed_task_spawn.cpp
@@ -202,7 +202,8 @@ hpx::threads::thread_result_type invoke_worker_timed_no_suspension(
     )
 {
     worker_timed(delay * 1000);
-    return hpx::threads::thread_result_type(hpx::threads::terminated, nullptr);
+    return hpx::threads::thread_result_type(hpx::threads::terminated,
+        hpx::threads::invalid_thread_id);
 }
 
 hpx::threads::thread_result_type invoke_worker_timed_suspension(
@@ -214,7 +215,8 @@ hpx::threads::thread_result_type invoke_worker_timed_suspension(
     hpx::error_code ec(hpx::lightweight);
     hpx::this_thread::suspend(hpx::threads::suspended, "suspend", ec);
 
-    return hpx::threads::thread_result_type(hpx::threads::terminated, nullptr);
+    return hpx::threads::thread_result_type(hpx::threads::terminated,
+        hpx::threads::invalid_thread_id);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/agas/components/managed_refcnt_checker.hpp
+++ b/tests/unit/agas/components/managed_refcnt_checker.hpp
@@ -100,7 +100,8 @@ struct managed_refcnt_monitor
 
         // Suspend this pxthread.
         threads::get_self().yield(
-            threads::thread_result_type(threads::suspended, nullptr)
+            threads::thread_result_type(threads::suspended,
+                hpx::threads::invalid_thread_id)
         );
 
         return flag_.is_ready();

--- a/tests/unit/agas/components/simple_refcnt_checker.hpp
+++ b/tests/unit/agas/components/simple_refcnt_checker.hpp
@@ -100,7 +100,8 @@ struct simple_refcnt_monitor
 
         // Suspend this thread.
         threads::get_self().yield(
-            threads::thread_result_type(threads::suspended, nullptr)
+            threads::thread_result_type(threads::suspended,
+                threads::invalid_thread_id)
         );
 
         return flag_.is_ready();


### PR DESCRIPTION
This change was neceessary after #3120 was merged. It was working with clang 5 and
gcc 6 and up for some reason.
