### PR TITLE
Cleaning up coroutine implementation

### DIFF
--- a/hpx/runtime/actions/action_invoke_no_more_than.hpp
+++ b/hpx/runtime/actions/action_invoke_no_more_than.hpp
@@ -15,7 +15,7 @@
 #include <hpx/traits/action_decorate_function.hpp>
 #include <hpx/traits/is_future.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/bind.hpp>
+#include <hpx/util/deferred_call.hpp>
 #include <hpx/util/static.hpp>
 
 #include <memory>
@@ -83,7 +83,6 @@ namespace hpx { namespace actions { namespace detail
         // If the action returns something which is not a future, we inject
         // a semaphore into the call graph.
         static threads::thread_result_type thread_function(
-            threads::thread_state_ex_enum state,
             threads::thread_function_type f)
         {
             typedef typename construct_semaphore_type::semaphore_type
@@ -91,16 +90,15 @@ namespace hpx { namespace actions { namespace detail
 
             signal_on_exit<semaphore_type> on_exit(
                 construct_semaphore_type::get_sem());
-            return f(state);
+            return f();
         }
 
         template <typename F>
         static threads::thread_function_type
         call(naming::address::address_type lva, F && f, std::false_type)
         {
-            return util::bind(
-                util::one_shot(&action_decorate_function::thread_function),
-                util::placeholders::_1,
+            return util::deferred_call(
+                &action_decorate_function::thread_function,
                 traits::action_decorate_function<action_wrapper>::call(
                     lva, std::forward<F>(f))
             );
@@ -109,20 +107,18 @@ namespace hpx { namespace actions { namespace detail
         // If the action returns a future we wait on the semaphore as well,
         // however it will be signaled once the future gets ready only.
         static threads::thread_result_type thread_function_future(
-            threads::thread_state_ex_enum state,
             threads::thread_function_type f)
         {
             construct_semaphore_type::get_sem().wait();
-            return f(state);
+            return f();
         }
 
         template <typename F>
         static threads::thread_function_type
         call(naming::address::address_type lva, F && f, std::true_type)
         {
-            return util::bind(
-                util::one_shot(&action_decorate_function::thread_function_future),
-                util::placeholders::_1,
+            return util::deferred_call(
+                &action_decorate_function::thread_function_future,
                 traits::action_decorate_function<action_wrapper>::call(
                     lva, std::forward<F>(f))
             );

--- a/hpx/runtime/actions/basic_action.hpp
+++ b/hpx/runtime/actions/basic_action.hpp
@@ -97,7 +97,7 @@ namespace hpx { namespace actions
             {}
 
             HPX_FORCEINLINE threads::thread_result_type
-            operator()(threads::thread_state_ex_enum)
+            operator()()
             {
                 LTM_(debug)
                     << "Executing " << Action::get_action_name(lva_)

--- a/hpx/runtime/components/server/executor_component.hpp
+++ b/hpx/runtime/components/server/executor_component.hpp
@@ -46,7 +46,7 @@ namespace hpx { namespace components
         // executor
         static void execute(hpx::threads::thread_function_type const& f)
         {
-            f(hpx::threads::wait_signaled);
+            f();
         }
 
         /// This is the default hook implementation for schedule_thread which

--- a/hpx/runtime/components/server/locking_hook.hpp
+++ b/hpx/runtime/components/server/locking_hook.hpp
@@ -11,8 +11,8 @@
 #include <hpx/runtime/get_lva.hpp>
 #include <hpx/runtime/threads/coroutines/coroutine.hpp>
 #include <hpx/traits/action_decorate_function.hpp>
-#include <hpx/util/bind.hpp>
 #include <hpx/util/bind_front.hpp>
+#include <hpx/util/deferred_call.hpp>
 #include <hpx/util/register_locks.hpp>
 #include <hpx/util/unlock_guard.hpp>
 
@@ -55,17 +55,15 @@ namespace hpx { namespace components
         static threads::thread_function_type
         decorate_action(naming::address::address_type lva, F && f)
         {
-            return util::bind(
-                util::one_shot(&locking_hook::thread_function),
+            return util::deferred_call(&locking_hook::thread_function,
                 get_lva<this_component_type>::call(lva),
-                util::placeholders::_1,
                 traits::action_decorate_function<base_type>::call(
                     lva, std::forward<F>(f)));
         }
 
     protected:
         typedef util::function_nonser<
-            threads::thread_arg_type(threads::thread_result_type)
+            void(threads::thread_result_type)
         > yield_decorator_type;
 
         struct decorate_wrapper
@@ -87,7 +85,7 @@ namespace hpx { namespace components
         // Execute the wrapped action. This locks the mutex ensuring a thread
         // safe action invocation.
         threads::thread_result_type thread_function(
-            threads::thread_arg_type state, threads::thread_function_type f)
+            threads::thread_function_type f)
         {
             threads::thread_result_type result(threads::unknown,
                 threads::invalid_thread_id);
@@ -109,7 +107,7 @@ namespace hpx { namespace components
                 decorate_wrapper yield_decorator(
                     util::bind_front(&locking_hook::yield_function, this));
 
-                result = f(state);
+                result = f();
 
                 (void)yield_decorator;       // silence gcc warnings
             }
@@ -133,24 +131,21 @@ namespace hpx { namespace components
 
         // The yield decorator unlocks the mutex and calls the system yield
         // which gives up control back to the thread manager.
-        threads::thread_arg_type yield_function(threads::thread_result_type state)
+        void yield_function(threads::thread_result_type state)
         {
             // We un-decorate the yield function as the lock handling may
             // suspend, which causes an infinite recursion otherwise.
             undecorate_wrapper yield_decorator;
-            threads::thread_arg_type result = threads::wait_unknown;
 
             {
                 util::unlock_guard<mutex_type> ul(mtx_);
-                result = threads::get_self().yield_impl(state);
+                threads::get_self().yield_impl(state);
             }
 
             // Re-enable ignoring the lock on the mutex above (this
             // information is lost in the lock tracking tables once a mutex is
             // unlocked).
             util::ignore_lock(&mtx_);
-
-            return result;
         }
 
     private:

--- a/hpx/runtime/components/server/migration_support.hpp
+++ b/hpx/runtime/components/server/migration_support.hpp
@@ -16,7 +16,7 @@
 #include <hpx/runtime/threads_fwd.hpp>
 #include <hpx/traits/action_decorate_function.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/bind.hpp>
+#include <hpx/util/deferred_call.hpp>
 
 #include <cstdint>
 #include <mutex>
@@ -167,10 +167,8 @@ namespace hpx { namespace components
             // Make sure we pin the component at construction of the bound object
             // which will also unpin it once the thread runs to completion (the
             // bound object goes out of scope).
-            return util::bind(
-                util::one_shot(&migration_support::thread_function),
+            return util::deferred_call(&migration_support::thread_function,
                 get_lva<this_component_type>::call(lva),
-                util::placeholders::_1,
                 traits::action_decorate_function<base_type>::call(
                     lva, std::forward<F>(f)),
                 components::pinned_ptr::create<this_component_type>(lva));
@@ -193,11 +191,10 @@ namespace hpx { namespace components
         // Execute the wrapped action. This function is bound in decorate_action
         // above. The bound object performs the pinning/unpinning.
         threads::thread_result_type thread_function(
-            threads::thread_state_ex_enum state,
             threads::thread_function_type && f,
             components::pinned_ptr)
         {
-            return f(state);
+            return f();
         }
 
     private:

--- a/hpx/runtime/threads/coroutines/coroutine.hpp
+++ b/hpx/runtime/threads/coroutines/coroutine.hpp
@@ -54,168 +54,84 @@ namespace hpx { namespace threads { namespace coroutines
         friend struct detail::coroutine_accessor;
 
         typedef detail::coroutine_impl impl_type;
-        typedef impl_type::pointer impl_ptr;
         typedef impl_type::thread_id_type thread_id_type;
 
         typedef impl_type::result_type result_type;
-        typedef impl_type::arg_type arg_type;
 
-        typedef util::unique_function_nonser<result_type(arg_type)> functor_type;
-
-        coroutine() : m_pimpl(nullptr) {}
+        typedef util::unique_function_nonser<result_type()> functor_type;
 
         coroutine(functor_type&& f,
                 thread_id_type id,
                 std::ptrdiff_t stack_size = detail::default_stack_size)
-          : m_pimpl(impl_type::create(
-                std::move(f), id, stack_size))
+          : impl_(std::move(f), id, stack_size)
         {
-            HPX_ASSERT(m_pimpl->is_ready());
+            HPX_ASSERT(impl_.is_ready());
         }
 
-        coroutine(coroutine && src)
-          : m_pimpl(std::move(src.m_pimpl))
-        {
-            src.m_pimpl = nullptr;
-        }
-
-        coroutine& operator=(coroutine && src)
-        {
-            coroutine(std::move(src)).swap(*this);
-            return *this;
-        }
-
-        coroutine& swap(coroutine& rhs)
-        {
-            std::swap(m_pimpl, rhs.m_pimpl);
-            return *this;
-        }
-
-        friend void swap(coroutine& lhs, coroutine& rhs)
-        {
-            lhs.swap(rhs);
-        }
+        coroutine(coroutine const& src) = delete;
+        coroutine& operator=(coroutine const& src) = delete;
+        coroutine(coroutine && src) = delete;
+        coroutine& operator=(coroutine && src) = delete;
 
         thread_id_type get_thread_id() const
         {
-            return m_pimpl->get_thread_id();
+            return impl_.get_thread_id();
         }
 
 #if defined(HPX_HAVE_THREAD_PHASE_INFORMATION)
         std::size_t get_thread_phase() const
         {
-            return m_pimpl->get_thread_phase();
+            return impl_.get_thread_phase();
         }
 #endif
 
         std::size_t get_thread_data() const
         {
-            return m_pimpl.get() ? m_pimpl->get_thread_data() : 0;
+            return impl_.get_thread_data();
         }
 
         std::size_t set_thread_data(std::size_t data)
         {
-            return m_pimpl.get() ? m_pimpl->set_thread_data(data) : 0;
+            return impl_.set_thread_data(data);
         }
 
 #if defined(HPX_HAVE_APEX)
         void** get_apex_data() const
         {
-            return m_pimpl.get() ? m_pimpl->get_apex_data() : 0ull;
+            return impl_.get_apex_data();
         }
 #endif
 
         void rebind(functor_type&& f, thread_id_type id)
         {
-            HPX_ASSERT(exited());
-            impl_type::rebind(m_pimpl.get(), std::move(f), id);
+            impl_.rebind(std::move(f), id);
         }
 
-        HPX_FORCEINLINE result_type operator()(arg_type arg = arg_type())
+        HPX_FORCEINLINE result_type operator()()
         {
-            HPX_ASSERT(m_pimpl);
-            HPX_ASSERT(m_pimpl->is_ready());
+            HPX_ASSERT(impl_.is_ready());
 
-            result_type* ptr = nullptr;
-            m_pimpl->bind_args(&arg);
-            m_pimpl->bind_result_pointer(&ptr);
+            impl_.invoke();
 
-            m_pimpl->invoke();
-
-            return std::move(*m_pimpl->result());
-        }
-
-        explicit operator bool() const
-        {
-            return good();
-        }
-
-        bool operator==(const coroutine& rhs) const
-        {
-            return m_pimpl == rhs.m_pimpl;
-        }
-
-        void exit()
-        {
-            HPX_ASSERT(m_pimpl);
-            m_pimpl->exit();
-        }
-
-        bool waiting() const
-        {
-            HPX_ASSERT(m_pimpl);
-            return m_pimpl->waiting();
-        }
-
-        bool pending() const
-        {
-            HPX_ASSERT(m_pimpl);
-            return m_pimpl->pending() != 0;
-        }
-
-        bool exited() const
-        {
-            HPX_ASSERT(m_pimpl);
-            return m_pimpl->exited();
+            return impl_.result();
         }
 
         bool is_ready() const
         {
-            HPX_ASSERT(m_pimpl);
-            return m_pimpl->is_ready();
-        }
-
-        bool empty() const
-        {
-            return m_pimpl == nullptr;
+            return impl_.is_ready();
         }
 
         std::ptrdiff_t get_available_stack_space()
         {
 #if defined(HPX_HAVE_THREADS_GET_STACK_POINTER)
-            return m_pimpl->get_available_stack_space();
+            return impl_.get_available_stack_space();
 #else
             return (std::numeric_limits<std::ptrdiff_t>::max)();
 #endif
         }
 
-    protected:
-        bool good() const
-        {
-            return !empty() && !exited() && !waiting();
-        }
-
-        impl_ptr m_pimpl;
-
-        std::uint64_t count() const
-        {
-            return m_pimpl->count();
-        }
-
-        impl_ptr get_impl()
-        {
-            return m_pimpl;
-        }
+    private:
+        impl_type impl_;
     };
 }}}
 

--- a/hpx/runtime/threads/coroutines/detail/coroutine_self.hpp
+++ b/hpx/runtime/threads/coroutines/detail/coroutine_self.hpp
@@ -75,30 +75,27 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         typedef impl_type::thread_id_type thread_id_type;
 
         typedef impl_type::result_type result_type;
-        typedef impl_type::arg_type arg_type;
 
-        typedef util::function_nonser<arg_type(result_type)>
+        typedef util::function_nonser<void(result_type)>
             yield_decorator_type;
 
-        arg_type yield(result_type arg = result_type())
+        void yield(result_type arg)
         {
-            return !yield_decorator_.empty() ?
+            !yield_decorator_.empty() ?
                 yield_decorator_(std::move(arg)) :
                 yield_impl(std::move(arg));
         }
 
-        arg_type yield_impl(result_type arg)
+        void yield_impl(result_type arg)
         {
             HPX_ASSERT(m_pimpl);
 
-            this->m_pimpl->bind_result(&arg);
+            this->m_pimpl->bind_result(arg);
 
             {
                 reset_self_on_exit on_exit(this);
                 this->m_pimpl->yield();
             }
-
-            return *m_pimpl->args();
         }
 
         template <typename F>
@@ -127,18 +124,6 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
             yield_decorator_type tmp;
             std::swap(tmp, yield_decorator_);
             return tmp;
-        }
-
-        HPX_NORETURN void exit()
-        {
-            m_pimpl->exit_self();
-            std::terminate(); // FIXME: replace with hpx::terminate();
-        }
-
-        bool pending() const
-        {
-            HPX_ASSERT(m_pimpl);
-            return m_pimpl->pending() != 0;
         }
 
         thread_id_type get_thread_id() const

--- a/hpx/runtime/threads/coroutines/exception.hpp
+++ b/hpx/runtime/threads/coroutines/exception.hpp
@@ -49,12 +49,6 @@ namespace hpx { namespace threads { namespace coroutines
     // on an already exited coroutine is undefined behavior.
     class coroutine_exited : public exception_base {};
 
-    // This exception is thrown on a coroutine invocation
-    // if a coroutine enter the wait state without
-    // returning a result. Note that calling invoke()
-    // on a waiting coroutine is undefined behavior.
-    class waiting : public exception_base {};
-
     class unknown_exception_tag {};
 
     // This exception is thrown on a coroutine invocation

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -295,7 +295,7 @@ namespace hpx { namespace threads { namespace detail
         thread_id_type background_thread;
         background_running.reset(new bool(true));
         thread_init_data background_init(
-            [&, background_running](thread_state_ex_enum) -> thread_result_type
+            [&, background_running]() -> thread_result_type
             {
                 while(*background_running)
                 {

--- a/hpx/runtime/threads/detail/set_thread_state.hpp
+++ b/hpx/runtime/threads/detail/set_thread_state.hpp
@@ -321,8 +321,9 @@ namespace hpx { namespace threads { namespace detail
         // this waits for the thread to be reactivated when the timer fired
         // if it returns signaled the timer has been canceled, otherwise
         // the timer fired and the wake_timer_thread above has been executed
+        get_self().yield(thread_result_type(suspended, invalid_thread_id));
         thread_state_ex_enum statex =
-            get_self().yield(thread_result_type(suspended, invalid_thread_id));
+            self_id->set_state_ex(thread_state_ex_enum::wait_signaled);
 
         if (wait_timeout != statex) //-V601
         {

--- a/hpx/runtime/threads/thread_data.hpp
+++ b/hpx/runtime/threads/thread_data.hpp
@@ -241,7 +241,7 @@ namespace hpx { namespace threads
                 thread_state(new_state, state_ex, tag));
         }
 
-    private:
+    public:
         /// The set_state function changes the extended state of this
         /// thread instance.
         ///
@@ -269,7 +269,6 @@ namespace hpx { namespace threads
             }
         }
 
-    public:
         /// Return the id of the component this thread is running in
         naming::address_type get_component_id() const
         {
@@ -517,7 +516,7 @@ namespace hpx { namespace threads
         coroutine_type::result_type operator()()
         {
             HPX_ASSERT(this == coroutine_.get_thread_id().get());
-            return coroutine_(set_state_ex(wait_signaled));
+            return coroutine_();
         }
 
         thread_id_type get_thread_id() const

--- a/hpx/runtime/threads/thread_data_fwd.hpp
+++ b/hpx/runtime/threads/thread_data_fwd.hpp
@@ -48,10 +48,7 @@ namespace hpx { namespace threads
     typedef std::pair<thread_state_enum, thread_id_type> thread_result_type;
     typedef thread_state_ex_enum thread_arg_type;
 
-    typedef thread_result_type thread_function_sig(thread_arg_type);
-    typedef util::unique_function_nonser<thread_function_sig> thread_function_type;
-
-    HPX_CONSTEXPR_OR_CONST thread_id_type invalid_thread_id;
+    typedef util::unique_function_nonser<thread_result_type()> thread_function_type;
     /// \endcond
 
     ///////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/threads/thread_helpers.hpp
+++ b/hpx/runtime/threads/thread_helpers.hpp
@@ -796,27 +796,7 @@ namespace hpx { namespace applier
         {
             F f;
 
-            inline threads::thread_result_type operator()(threads::thread_arg_type)
-            {
-                // execute the actual thread function
-                f(threads::wait_signaled);
-
-                // Verify that there are no more registered locks for this
-                // OS-thread. This will throw if there are still any locks
-                // held.
-                util::force_error_on_lock();
-
-                return threads::thread_result_type(threads::terminated,
-                    threads::invalid_thread_id);
-            }
-        };
-
-        template <typename F>
-        struct thread_function_nullary
-        {
-            F f;
-
-            inline threads::thread_result_type operator()(threads::thread_arg_type)
+            inline threads::thread_result_type operator()()
             {
                 // execute the actual thread function
                 f();
@@ -875,7 +855,7 @@ namespace hpx { namespace applier
         error_code& ec = throws)
     {
         threads::thread_function_type thread_func(
-            detail::thread_function_nullary<typename std::decay<F>::type>{
+            detail::thread_function<typename std::decay<F>::type>{
                 std::forward<F>(func)});
         return register_thread_plain(std::move(thread_func),
             description, initial_state, run_now, priority, os_thread, stacksize,
@@ -1008,7 +988,7 @@ namespace hpx { namespace applier
         error_code& ec = throws)
     {
         threads::thread_function_type thread_func(
-            detail::thread_function_nullary<typename std::decay<F>::type>{
+            detail::thread_function<typename std::decay<F>::type>{
                 std::forward<F>(func)});
         return register_work_plain(std::move(thread_func),
             description, 0, initial_state, priority, os_thread, stacksize,

--- a/hpx/runtime/threads/thread_id_type.hpp
+++ b/hpx/runtime/threads/thread_id_type.hpp
@@ -129,6 +129,8 @@ namespace threads {
     private:
         thread_data* thrd_;
     };
+
+    HPX_CONSTEXPR_OR_CONST thread_id_type invalid_thread_id;
 }
 }
 

--- a/hpx/util/interval_timer.hpp
+++ b/hpx/util/interval_timer.hpp
@@ -69,8 +69,7 @@ namespace hpx { namespace util { namespace detail
         // schedule a high priority task after a given time interval
         void schedule_thread(std::unique_lock<mutex_type> & l);
 
-        threads::thread_result_type
-            evaluate(threads::thread_state_ex_enum statex);
+        threads::thread_result_type evaluate();
 
         void terminate();             // handle system shutdown
         bool stop_locked();

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -845,8 +845,7 @@ namespace hpx { namespace components { namespace server
 
     // let thread manager clean up HPX threads
     template <typename Lock>
-    inline void
-    cleanup_threads(threads::threadmanager& tm, Lock& l)
+    inline void cleanup_threads(threads::threadmanager& tm, Lock& l)
     {
         // re-acquire pointer to self as it might have changed
         threads::thread_self* self = threads::get_self_ptr();

--- a/src/runtime/threads/coroutines/detail/coroutine_impl.cpp
+++ b/src/runtime/threads/coroutines/detail/coroutine_impl.cpp
@@ -34,10 +34,6 @@
 #include <hpx/runtime/threads/coroutines/detail/coroutine_self.hpp>
 #include <hpx/runtime/threads/thread_data_fwd.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/reinitializable_static.hpp>
-
-#include <boost/exception/exception.hpp>
-#include <boost/lockfree/stack.hpp>
 
 #include <cstddef>
 #include <exception>
@@ -73,173 +69,41 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
     }
 #endif
 
-    void coroutine_impl::operator()()
+    void coroutine_impl::operator()() noexcept
     {
         typedef super_type::context_exit_status context_exit_status;
         context_exit_status status = super_type::ctx_exited_return;
 
-        // loop as long this coroutine has been rebound
-        do
+        // yield value once the thread function has finished executing
+        static result_type result_last(
+            thread_state_enum::terminated, invalid_thread_id);
+
+        std::exception_ptr tinfo;
+        try
         {
-            std::exception_ptr tinfo;
-            try
             {
-                this->check_exit_state();
+                coroutine_self* old_self = coroutine_self::get_self();
+                coroutine_self self(this, old_self);
+                reset_self_on_exit on_exit(&self, old_self);
 
-                HPX_ASSERT(this->count() > 0);
+                result_last = m_fun();
+                HPX_ASSERT(result_last.first == thread_state_enum::terminated);
 
-                {
-                    coroutine_self* old_self = coroutine_self::get_self();
-                    coroutine_self self(this, old_self);
-                    reset_self_on_exit on_exit(&self, old_self);
-
-                    this->m_result_last = m_fun(*this->args());
-
-                    // if this thread returned 'terminated' we need to reset
-                    // the functor and the bound arguments
-                    if (this->m_result_last.first == terminated)
-                        this->reset();
-                }
-
-                // return value to other side of the fence
-                this->bind_result(&this->m_result_last);
-            }
-            catch (exit_exception const&) {
-                status = super_type::ctx_exited_exit;
-                tinfo = std::current_exception();
-                this->reset();            // reset functor
-            }
-            catch (boost::exception const&) {
-                status = super_type::ctx_exited_abnormally;
-                tinfo = std::current_exception();
-                this->reset();
-            }
-            catch (std::exception const&) {
-                status = super_type::ctx_exited_abnormally;
-                tinfo = std::current_exception();
-                this->reset();
-            }
-            catch (...) {
-                status = super_type::ctx_exited_abnormally;
-                tinfo = std::current_exception();
                 this->reset();
             }
 
-            this->do_return(status, std::move(tinfo));
+            // return value to other side of the fence
+            this->bind_result(result_last);
+        }
+        catch (...) {
+            status = super_type::ctx_exited_abnormally;
+            tinfo = std::current_exception();
+            this->reset();
+        }
 
-        } while (this->m_state == super_type::ctx_running);
+        this->do_return(status, std::move(tinfo));
 
         // should not get here, never
         HPX_ASSERT(this->m_state == super_type::ctx_running);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    // the memory for the threads is managed by a lockfree caching_freelist
-    struct coroutine_heap
-    {
-        coroutine_heap()
-          : heap_(128)
-        {}
-
-        ~coroutine_heap()
-        {
-            while (coroutine_impl* next = get_locked())
-                delete next;
-        }
-
-        coroutine_impl* allocate()
-        {
-            return get_locked();
-        }
-
-        void deallocate(coroutine_impl* p)
-        {
-            //p->reset();          // reset bound function
-            heap_.push(p);
-        }
-
-    private:
-        coroutine_impl* get_locked()
-        {
-            coroutine_impl* result = nullptr;
-            heap_.pop(result);
-            return result;
-        }
-
-        boost::lockfree::stack<coroutine_impl*> heap_;
-    };
-
-    ///////////////////////////////////////////////////////////////////////////
-    struct heap_tag_small {};
-    struct heap_tag_medium {};
-    struct heap_tag_large {};
-    struct heap_tag_huge {};
-
-    template <std::size_t NumHeaps, typename Tag>
-    static coroutine_heap& get_heap(std::size_t i)
-    {
-        // ensure thread-safe initialization
-        util::reinitializable_static<coroutine_heap, Tag, NumHeaps> heap;
-        return heap.get(i);
-    }
-
-    static coroutine_heap& get_heap(std::size_t i, std::ptrdiff_t stacksize)
-    {
-        // FIXME: This should check the sizes in runtime_configuration, not the
-        // default macro sizes
-        if (stacksize > HPX_MEDIUM_STACK_SIZE)
-        {
-            if (stacksize > HPX_LARGE_STACK_SIZE)
-                return get_heap<HPX_COROUTINE_NUM_HEAPS / 4,
-                heap_tag_huge>(i % (HPX_COROUTINE_NUM_HEAPS / 4)); //-V112
-
-            return get_heap<HPX_COROUTINE_NUM_HEAPS / 4,
-                heap_tag_large>(i % (HPX_COROUTINE_NUM_HEAPS / 4)); //-V112
-        }
-
-        if (stacksize > HPX_SMALL_STACK_SIZE)
-            return get_heap<HPX_COROUTINE_NUM_HEAPS / 2,
-            heap_tag_medium>(i % (HPX_COROUTINE_NUM_HEAPS / 2));
-
-        return get_heap<HPX_COROUTINE_NUM_HEAPS,
-            heap_tag_small>(i % HPX_COROUTINE_NUM_HEAPS);
-    }
-
-    static std::size_t get_heap_count(ptrdiff_t stacksize)
-    {
-        if (stacksize > HPX_MEDIUM_STACK_SIZE)
-            return HPX_COROUTINE_NUM_HEAPS / 4; //-V112
-
-        if (stacksize > HPX_SMALL_STACK_SIZE)
-            return HPX_COROUTINE_NUM_HEAPS / 2;
-
-        return HPX_COROUTINE_NUM_HEAPS;
-    }
-
-    coroutine_impl* coroutine_impl::allocate(
-        thread_id_type id, std::ptrdiff_t stacksize)
-    {
-        // start looking at the matching heap
-        std::size_t const heap_num = std::size_t(id.get()) / 32; //-V112
-        std::size_t const heap_count = get_heap_count(stacksize);
-
-        // look through all heaps to find an available coroutine object
-        coroutine_impl* p = get_heap(heap_num, stacksize).allocate();
-        if (!p)
-        {
-            for (std::size_t i = 1; i != heap_count && !p; ++i)
-            {
-                p = get_heap(heap_num + i, stacksize).allocate();
-            }
-        }
-        return p;
-    }
-
-    void coroutine_impl::deallocate(coroutine_impl* p)
-    {
-        std::size_t const heap_num = std::size_t(p->get_thread_id().get()) / 32; //-V112
-        std::ptrdiff_t const stacksize = p->get_stacksize();
-
-        get_heap(heap_num, stacksize).deallocate(p);
     }
 }}}}

--- a/src/runtime/threads/thread_helpers.cpp
+++ b/src/runtime/threads/thread_helpers.cpp
@@ -474,7 +474,7 @@ namespace hpx { namespace this_thread
     {
         // let the thread manager do other things while waiting
         threads::thread_self& self = threads::get_self();
-        threads::thread_id_type id = threads::get_self_id();
+        threads::thread_id_type id = self.get_thread_id();
 
         // handle interruption, if needed
         threads::interruption_point(id, ec);
@@ -499,13 +499,14 @@ namespace hpx { namespace this_thread
             {
                 nextid->get_scheduler_base()->schedule_thread(
                     nextid.get(), std::size_t(-1));
-                statex = self.yield(threads::thread_result_type(state,
+                self.yield(threads::thread_result_type(state,
                     threads::invalid_thread_id));
             }
             else
             {
-                statex = self.yield(threads::thread_result_type(state, nextid));
+                self.yield(threads::thread_result_type(state, nextid));
             }
+            statex = id->get_state().state_ex();
         }
 
         // handle interruption, if needed
@@ -536,7 +537,7 @@ namespace hpx { namespace this_thread
     {
         // schedule a thread waking us up at_time
         threads::thread_self& self = threads::get_self();
-        threads::thread_id_type id = threads::get_self_id();
+        threads::thread_id_type id = self.get_thread_id();
 
         // handle interruption, if needed
         threads::interruption_point(id, ec);
@@ -567,15 +568,15 @@ namespace hpx { namespace this_thread
             {
                 nextid->get_scheduler_base()->schedule_thread(
                     nextid.get(), std::size_t(-1));
-                statex = self.yield(
-                    threads::thread_result_type(threads::suspended,
-                        threads::invalid_thread_id));
+                self.yield(threads::thread_result_type(threads::suspended,
+                    threads::invalid_thread_id));
             }
             else
             {
-                statex = self.yield(
+                self.yield(
                     threads::thread_result_type(threads::suspended, nextid));
             }
+            statex = id->get_state().state_ex();
 
             if (statex != threads::wait_timeout)
             {

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -1478,13 +1478,6 @@ namespace hpx { namespace threads
                     &coroutine_type::impl_type::get_stack_unbind_count),
                 util::function_nonser<std::uint64_t(bool)>(), "", 0},
 #endif
-            // /threads{locality#%d/total}/count/objects
-            // /threads{locality#%d/allocator%d}/count/objects
-            {"count/objects",
-                &coroutine_type::impl_type::get_allocation_count_all,
-                util::bind_front(&coroutine_type::impl_type::get_allocation_count,
-                    static_cast<std::size_t>(paths.instanceindex_)),
-                "allocator", HPX_COROUTINE_NUM_ALL_HEAPS},
         };
         std::size_t const data_size = sizeof(data)/sizeof(data[0]);
 

--- a/src/util/interval_timer.cpp
+++ b/src/util/interval_timer.cpp
@@ -8,6 +8,7 @@
 #include <hpx/runtime/applier/applier.hpp>
 #include <hpx/runtime/shutdown_function.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
+#include <hpx/runtime/threads/thread_data.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/bind_front.hpp>
 #include <hpx/util/deferred_call.hpp>
@@ -76,7 +77,7 @@ namespace hpx { namespace util { namespace detail
 
             if (evaluate_) {
                 l.unlock();
-                evaluate(threads::wait_signaled);
+                evaluate();
             }
             else {
                 schedule_thread(l);
@@ -103,7 +104,7 @@ namespace hpx { namespace util { namespace detail
         // reschedule evaluation thread
         if (evaluate_) {
             l.unlock();
-            evaluate(threads::wait_signaled);
+            evaluate();
         }
         else {
             schedule_thread(l);
@@ -177,12 +178,15 @@ namespace hpx { namespace util { namespace detail
         microsecs_ = (std::max)((90 * microsecs_) / 100, min_interval);
     }
 
-    threads::thread_result_type interval_timer::evaluate(
-        threads::thread_state_ex_enum statex)
+    threads::thread_result_type interval_timer::evaluate()
     {
         try {
             std::unique_lock<mutex_type> l(mtx_);
 
+            auto self_id = threads::get_self_id();
+            threads::thread_state_ex_enum statex =
+                self_id ? self_id->get_state().state_ex() :
+                threads::wait_signaled;
             if (is_stopped_ || is_terminated_ ||
                 statex == threads::wait_abort || 0 == microsecs_)
             {
@@ -191,7 +195,7 @@ namespace hpx { namespace util { namespace detail
                     threads::invalid_thread_id);
             }
 
-            if (id_ != nullptr && id_ != threads::get_self_id())
+            if (id_ != nullptr && id_ != self_id)
             {
                 // obsolete timer thread
                 return threads::thread_result_type(threads::terminated,

--- a/tests/performance/local/coroutines_call_overhead.cpp
+++ b/tests/performance/local/coroutines_call_overhead.cpp
@@ -139,7 +139,7 @@ void print_results(
 ///////////////////////////////////////////////////////////////////////////////
 struct kernel
 {
-    hpx::threads::thread_result_type operator()(thread_state_ex_enum) const
+    hpx::threads::thread_result_type operator()() const
     {
         worker_timed(payload * 1000);
 
@@ -177,14 +177,14 @@ double perform_2n_iterations()
     // Warmup
     for (std::uint64_t i = 0; i < iterations; ++i)
     {
-        (*coroutines[indices[i]])(wait_signaled);
+        (*coroutines[indices[i]])();
     }
 
     hpx::util::high_resolution_timer t;
 
     for (std::uint64_t i = 0; i < iterations; ++i)
     {
-        (*coroutines[indices[i]])(wait_signaled);
+        (*coroutines[indices[i]])();
     }
 
     double elapsed = t.elapsed();

--- a/tests/performance/local/htts_v2/htts2_hpx.cpp
+++ b/tests/performance/local/htts_v2/htts2_hpx.cpp
@@ -60,9 +60,7 @@ struct hpx_driver : htts2::driver
         return hpx::finalize();
     }
 
-    hpx::threads::thread_result_type payload_thread_function(
-        hpx::threads::thread_state_ex_enum ex = hpx::threads::wait_signaled
-        )
+    hpx::threads::thread_result_type payload_thread_function()
     {
         htts2::payload<BaseClock>(this->payload_duration_ /* = p */);
         //++count_;
@@ -94,7 +92,7 @@ struct hpx_driver : htts2::driver
             using hpx::util::placeholders::_1;
             hpx::threads::register_thread_plain(
                 hpx::util::bind(&hpx_driver::payload_thread_function,
-                    std::ref(*this), _1)
+                    std::ref(*this))
               , nullptr // No HPX-thread name.
               , hpx::threads::pending
               , false // Do not run immediately.

--- a/tests/performance/local/timed_task_spawn.cpp
+++ b/tests/performance/local/timed_task_spawn.cpp
@@ -197,18 +197,14 @@ void wait_for_tasks(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::threads::thread_result_type invoke_worker_timed_no_suspension(
-    hpx::threads::thread_state_ex_enum ex = hpx::threads::wait_signaled
-    )
+hpx::threads::thread_result_type invoke_worker_timed_no_suspension()
 {
     worker_timed(delay * 1000);
     return hpx::threads::thread_result_type(hpx::threads::terminated,
         hpx::threads::invalid_thread_id);
 }
 
-hpx::threads::thread_result_type invoke_worker_timed_suspension(
-    hpx::threads::thread_state_ex_enum ex = hpx::threads::wait_signaled
-    )
+hpx::threads::thread_result_type invoke_worker_timed_suspension()
 {
     worker_timed(delay * 1000);
 

--- a/tests/regressions/threads/thread_rescheduling.cpp
+++ b/tests/regressions/threads/thread_rescheduling.cpp
@@ -131,22 +131,20 @@ void tree_boot(
     detail::wait(promises);
 }
 
+bool woken = false;
+
 ///////////////////////////////////////////////////////////////////////////////
 void test_dummy_thread(
     std::uint64_t
     )
 {
-    bool woken = false;
-
     while (true)
     {
         thread_state_ex_enum statex = suspend(suspended);
 
-        woken = true;
-
         if (statex == wait_terminate)
         {
-            HPX_TEST(woken);
+            woken = true;
             return;
         }
     }
@@ -202,6 +200,8 @@ int main(int argc, char* argv[])
 
     // Initialize and run HPX
     HPX_TEST_EQ(0, init(cmdline, argc, argv));
+
+    HPX_TEST(woken);
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/computeapi/host/block_allocator.cpp
+++ b/tests/unit/computeapi/host/block_allocator.cpp
@@ -80,12 +80,12 @@ int hpx_main(boost::program_options::variables_map& vm)
     std::srand(seed);
 
     {
-        std::size_t count = std::rand();
+        std::size_t count = std::rand() % 512;
         test_bulk_allocator<int>(count);
     }
 
     {
-        std::size_t count = std::rand();
+        std::size_t count = std::rand() % 512;
         test_bulk_allocator<test>(count);
         HPX_TEST_EQ(construction_count.load(), count);
         HPX_TEST_EQ(destruction_count.load(), count);

--- a/tests/unit/parallel/algorithms/partition_tests.hpp
+++ b/tests/unit/parallel/algorithms/partition_tests.hpp
@@ -187,7 +187,7 @@ void test_partition_exception(ExPolicy policy, IteratorTag)
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::size_t const size = 300007;
+    std::size_t const size = 30007;
     std::vector<int> c(size);
     std::iota(std::begin(c), std::end(c), std::rand());
 
@@ -217,7 +217,7 @@ void test_partition_exception_async(ExPolicy policy, IteratorTag)
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::size_t const size = 300007;
+    std::size_t const size = 30007;
     std::vector<int> c(size);
     std::iota(std::begin(c), std::end(c), std::rand());
 
@@ -255,7 +255,7 @@ void test_partition_bad_alloc(ExPolicy policy, IteratorTag)
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::size_t const size = 300007;
+    std::size_t const size = 30007;
     std::vector<int> c(size);
     std::iota(std::begin(c), std::end(c), std::rand());
 
@@ -284,7 +284,7 @@ void test_partition_bad_alloc_async(ExPolicy policy, IteratorTag)
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::size_t const size = 300007;
+    std::size_t const size = 30007;
     std::vector<int> c(size);
     std::iota(std::begin(c), std::end(c), std::rand());
 
@@ -314,7 +314,7 @@ template <typename ExPolicy, typename IteratorTag, typename DataType, typename P
 void test_partition(ExPolicy policy, IteratorTag, DataType, Pred pred,
     int rand_base)
 {
-    const std::size_t size = 300007u;
+    const std::size_t size = 30007;
     const int half_range = size / 10;
 
     test_partition(policy, IteratorTag(), DataType(), pred,
@@ -325,7 +325,7 @@ template <typename ExPolicy, typename IteratorTag, typename DataType, typename P
 void test_partition_async(ExPolicy policy, IteratorTag, DataType, Pred pred,
     int rand_base)
 {
-    const std::size_t size = 300007u;
+    const std::size_t size = 30007;
     const int half_range = size / 10;
 
     test_partition_async(policy, IteratorTag(), DataType(), pred,

--- a/tests/unit/parallel/algorithms/sort_by_key.cpp
+++ b/tests/unit/parallel/algorithms/sort_by_key.cpp
@@ -16,7 +16,7 @@
 #include <vector>
 //
 #if defined(HPX_DEBUG)
-#define HPX_SORT_BY_KEY_TEST_SIZE (1 << 16)
+#define HPX_SORT_BY_KEY_TEST_SIZE (1 << 8)
 #else
 #define HPX_SORT_BY_KEY_TEST_SIZE (1 << 18)
 #endif


### PR DESCRIPTION


## Proposed Changes

 - Removing dynamic memory allocation
 - Removing intrusive ptr
 - Removing unused functions
 - Simplifying thread functions to be nullary
 - Using thread_data directly to get/set the state_ex value

## Any background context you want to provide?

This patch both simplifies and cleans up current code. This patch gives a rough speedup of about 1.5x for small grain sizes leading to heavy contention in the thread scheduler.

There is a potential breaking change for third party code using thread functions directly. I think this code is minimal and should be mostly under our control.
