### PR TITLE
Add `hpx::start` nullptr overloads

### DIFF
--- a/hpx/hpx_start.hpp
+++ b/hpx/hpx_start.hpp
@@ -734,125 +734,18 @@ namespace hpx
         int argc, char** argv, std::vector<std::string> const& cfg,
         hpx::runtime_mode mode = hpx::runtime_mode_default);
 
-    /// \brief Main non-blocking entry point for launching the HPX runtime system.
-    ///
-    /// This is a simplified main, non-blocking entry point, which can be used
-    /// to set up the runtime for an HPX application without a main function
-    /// (the runtime system will be set up in console mode or worker mode
-    /// depending on the command line settings). It will return immediately
-    /// after that. Use `hpx::wait` and `hpx::stop` to synchronize with the
-    /// runtime system's execution.
-    ///
-    /// \param f            [in] The function to be scheduled as an HPX
-    ///                     thread. Usually this function represents the main
-    ///                     entry point of any HPX application.
-    /// \param app_name     [in] The name of the application.
-    /// \param argc         [in] The number of command line arguments passed
-    ///                     in \p argv. This is usually the unchanged value as
-    ///                     passed by the operating system (to `main()`).
-    /// \param argv         [in] The command line arguments for this
-    ///                     application, usually that is the value as passed
-    ///                     by the operating system (to `main()`).
-    /// \param mode         [in] The mode the created runtime environment
-    ///                     should be initialized in. There has to be exactly
-    ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
-    ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
-    ///                     set up automatically, but sometimes it is necessary
-    ///                     to explicitly specify the mode.
-    ///
-    /// \returns            The function returns \a true if command line processing
-    ///                     succeeded and the runtime system was started successfully.
-    ///                     It will return \a false otherwise.
-    ///
-    /// \note               The created runtime system instance will be
-    ///                     executed in console or worker mode depending on the
-    ///                     command line arguments passed in `argc`/`argv`.
+/// \cond NOINTERNAL
     inline bool start(std::nullptr_t f,
         std::string const& app_name, int argc, char** argv,
         hpx::runtime_mode mode = hpx::runtime_mode_default);
 
-    /// \brief Main non-blocking entry point for launching the HPX runtime system.
-    ///
-    /// This is a simplified main, non-blocking entry point, which can be used
-    /// to set up the runtime for an HPX application without a main function
-    /// (the runtime system will be set up in console mode or worker mode
-    /// depending on the command line settings). It will return immediately
-    /// after that. Use `hpx::wait` and `hpx::stop` to synchronize with the
-    /// runtime system's execution.
-    ///
-    /// \param f            [in] The function to be scheduled as an HPX
-    ///                     thread. Usually this function represents the main
-    ///                     entry point of any HPX application.
-    /// \param argc         [in] The number of command line arguments passed
-    ///                     in \p argv. This is usually the unchanged value as
-    ///                     passed by the operating system (to `main()`).
-    /// \param argv         [in] The command line arguments for this
-    ///                     application, usually that is the value as passed
-    ///                     by the operating system (to `main()`).
-    /// \param mode         [in] The mode the created runtime environment
-    ///                     should be initialized in. There has to be exactly
-    ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
-    ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
-    ///                     set up automatically, but sometimes it is necessary
-    ///                     to explicitly specify the mode.
-    ///
-    /// \returns            The function returns \a true if command line processing
-    ///                     succeeded and the runtime system was started successfully.
-    ///                     It will return \a false otherwise.
-    ///
-    /// \note               The created runtime system instance will be
-    ///                     executed in console or worker mode depending on the
-    ///                     command line arguments passed in `argc`/`argv`.
     inline bool start(std::nullptr_t f, int argc, char** argv,
         hpx::runtime_mode mode = hpx::runtime_mode_default);
 
-    /// \brief Main non-blocking entry point for launching the HPX runtime system.
-    ///
-    /// This is a simplified main, non-blocking entry point, which can be used
-    /// to set up the runtime for an HPX application without a main function
-    /// (the runtime system will be set up in console mode or worker mode
-    /// depending on the command line settings). It will return immediately
-    /// after that. Use `hpx::wait` and `hpx::stop` to synchronize with the
-    /// runtime system's execution.
-    ///
-    /// \param f            [in] The function to be scheduled as an HPX
-    ///                     thread. Usually this function represents the main
-    ///                     entry point of any HPX application.
-    /// \param argc         [in] The number of command line arguments passed
-    ///                     in \p argv. This is usually the unchanged value as
-    ///                     passed by the operating system (to `main()`).
-    /// \param argv         [in] The command line arguments for this
-    ///                     application, usually that is the value as passed
-    ///                     by the operating system (to `main()`).
-    /// \param cfg          A list of configuration settings which will be added
-    ///                     to the system configuration before the runtime
-    ///                     instance is run. Each of the entries in this list
-    ///                     must have the format of a fully defined key/value
-    ///                     pair from an ini-file (for instance
-    ///                     'hpx.component.enabled=1')
-    /// \param mode         [in] The mode the created runtime environment
-    ///                     should be initialized in. There has to be exactly
-    ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
-    ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
-    ///                     set up automatically, but sometimes it is necessary
-    ///                     to explicitly specify the mode.
-    ///
-    /// \returns            The function returns \a true if command line processing
-    ///                     succeeded and the runtime system was started successfully.
-    ///                     It will return \a false otherwise.
-    ///
-    /// \note               The created runtime system instance will be
-    ///                     executed in console or worker mode depending on the
-    ///                     command line arguments passed in `argc`/`argv`.
     inline bool start(std::nullptr_t f,
         int argc, char** argv, std::vector<std::string> const& cfg,
         hpx::runtime_mode mode = hpx::runtime_mode_default);
+/// \endcond
 }
 
 #ifndef DOXYGEN

--- a/hpx/hpx_start.hpp
+++ b/hpx/hpx_start.hpp
@@ -18,6 +18,7 @@
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/variables_map.hpp>
 
+#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -726,6 +727,126 @@ namespace hpx
     ///                     executed in console or worker mode depending on the
     ///                     command line arguments passed in `argc`/`argv`.
     inline bool start(util::function_nonser<int(int, char**)> const& f,
+        int argc, char** argv, std::vector<std::string> const& cfg,
+        hpx::runtime_mode mode = hpx::runtime_mode_default);
+
+    /// \brief Main non-blocking entry point for launching the HPX runtime system.
+    ///
+    /// This is a simplified main, non-blocking entry point, which can be used
+    /// to set up the runtime for an HPX application without a main function
+    /// (the runtime system will be set up in console mode or worker mode
+    /// depending on the command line settings). It will return immediately
+    /// after that. Use `hpx::wait` and `hpx::stop` to synchronize with the
+    /// runtime system's execution.
+    ///
+    /// \param f            [in] The function to be scheduled as an HPX
+    ///                     thread. Usually this function represents the main
+    ///                     entry point of any HPX application.
+    /// \param app_name     [in] The name of the application.
+    /// \param argc         [in] The number of command line arguments passed
+    ///                     in \p argv. This is usually the unchanged value as
+    ///                     passed by the operating system (to `main()`).
+    /// \param argv         [in] The command line arguments for this
+    ///                     application, usually that is the value as passed
+    ///                     by the operating system (to `main()`).
+    /// \param mode         [in] The mode the created runtime environment
+    ///                     should be initialized in. There has to be exactly
+    ///                     one locality in each HPX application which is
+    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     all other localities have to be run in worker mode
+    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     set up automatically, but sometimes it is necessary
+    ///                     to explicitly specify the mode.
+    ///
+    /// \returns            The function returns \a true if command line processing
+    ///                     succeeded and the runtime system was started successfully.
+    ///                     It will return \a false otherwise.
+    ///
+    /// \note               The created runtime system instance will be
+    ///                     executed in console or worker mode depending on the
+    ///                     command line arguments passed in `argc`/`argv`.
+    inline bool start(std::nullptr_t f,
+        std::string const& app_name, int argc, char** argv,
+        hpx::runtime_mode mode = hpx::runtime_mode_default);
+
+    /// \brief Main non-blocking entry point for launching the HPX runtime system.
+    ///
+    /// This is a simplified main, non-blocking entry point, which can be used
+    /// to set up the runtime for an HPX application without a main function
+    /// (the runtime system will be set up in console mode or worker mode
+    /// depending on the command line settings). It will return immediately
+    /// after that. Use `hpx::wait` and `hpx::stop` to synchronize with the
+    /// runtime system's execution.
+    ///
+    /// \param f            [in] The function to be scheduled as an HPX
+    ///                     thread. Usually this function represents the main
+    ///                     entry point of any HPX application.
+    /// \param argc         [in] The number of command line arguments passed
+    ///                     in \p argv. This is usually the unchanged value as
+    ///                     passed by the operating system (to `main()`).
+    /// \param argv         [in] The command line arguments for this
+    ///                     application, usually that is the value as passed
+    ///                     by the operating system (to `main()`).
+    /// \param mode         [in] The mode the created runtime environment
+    ///                     should be initialized in. There has to be exactly
+    ///                     one locality in each HPX application which is
+    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     all other localities have to be run in worker mode
+    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     set up automatically, but sometimes it is necessary
+    ///                     to explicitly specify the mode.
+    ///
+    /// \returns            The function returns \a true if command line processing
+    ///                     succeeded and the runtime system was started successfully.
+    ///                     It will return \a false otherwise.
+    ///
+    /// \note               The created runtime system instance will be
+    ///                     executed in console or worker mode depending on the
+    ///                     command line arguments passed in `argc`/`argv`.
+    inline bool start(std::nullptr_t f, int argc, char** argv,
+        hpx::runtime_mode mode = hpx::runtime_mode_default);
+
+    /// \brief Main non-blocking entry point for launching the HPX runtime system.
+    ///
+    /// This is a simplified main, non-blocking entry point, which can be used
+    /// to set up the runtime for an HPX application without a main function
+    /// (the runtime system will be set up in console mode or worker mode
+    /// depending on the command line settings). It will return immediately
+    /// after that. Use `hpx::wait` and `hpx::stop` to synchronize with the
+    /// runtime system's execution.
+    ///
+    /// \param f            [in] The function to be scheduled as an HPX
+    ///                     thread. Usually this function represents the main
+    ///                     entry point of any HPX application.
+    /// \param argc         [in] The number of command line arguments passed
+    ///                     in \p argv. This is usually the unchanged value as
+    ///                     passed by the operating system (to `main()`).
+    /// \param argv         [in] The command line arguments for this
+    ///                     application, usually that is the value as passed
+    ///                     by the operating system (to `main()`).
+    /// \param cfg          A list of configuration settings which will be added
+    ///                     to the system configuration before the runtime
+    ///                     instance is run. Each of the entries in this list
+    ///                     must have the format of a fully defined key/value
+    ///                     pair from an ini-file (for instance
+    ///                     'hpx.component.enabled=1')
+    /// \param mode         [in] The mode the created runtime environment
+    ///                     should be initialized in. There has to be exactly
+    ///                     one locality in each HPX application which is
+    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     all other localities have to be run in worker mode
+    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     set up automatically, but sometimes it is necessary
+    ///                     to explicitly specify the mode.
+    ///
+    /// \returns            The function returns \a true if command line processing
+    ///                     succeeded and the runtime system was started successfully.
+    ///                     It will return \a false otherwise.
+    ///
+    /// \note               The created runtime system instance will be
+    ///                     executed in console or worker mode depending on the
+    ///                     command line arguments passed in `argc`/`argv`.
+    inline bool start(std::nullptr_t f,
         int argc, char** argv, std::vector<std::string> const& cfg,
         hpx::runtime_mode mode = hpx::runtime_mode_default);
 }

--- a/hpx/hpx_start.hpp
+++ b/hpx/hpx_start.hpp
@@ -550,6 +550,7 @@ namespace hpx
     /// to set up the runtime for an HPX application (the runtime system will
     /// be set up in console mode or worker mode depending on the command line
     /// settings). It will return immediately after that. Use `hpx::wait` and
+    /// `hpx::stop` to synchronize with the runtime system's execution.
     ///
     /// \param f            [in] The function to be scheduled as an HPX
     ///                     thread. Usually this function represents the main
@@ -587,6 +588,7 @@ namespace hpx
     /// to set up the runtime for an HPX application (the runtime system will
     /// be set up in console mode or worker mode depending on the command line
     /// settings). It will return immediately after that. Use `hpx::wait` and
+    /// `hpx::stop` to synchronize with the runtime system's execution.
     ///
     /// \param f            [in] The function to be scheduled as an HPX
     ///                     thread. Usually this function represents the main
@@ -624,6 +626,7 @@ namespace hpx
     /// to set up the runtime for an HPX application (the runtime system will
     /// be set up in console mode or worker mode depending on the command line
     /// settings). It will return immediately after that. Use `hpx::wait` and
+    /// `hpx::stop` to synchronize with the runtime system's execution.
     ///
     /// \param f            [in] The function to be scheduled as an HPX
     ///                     thread. Usually this function represents the main
@@ -659,6 +662,7 @@ namespace hpx
     /// to set up the runtime for an HPX application (the runtime system will
     /// be set up in console mode or worker mode depending on the command line
     /// settings). It will return immediately after that. Use `hpx::wait` and
+    /// `hpx::stop` to synchronize with the runtime system's execution.
     ///
     /// \param f            [in] The function to be scheduled as an HPX
     ///                     thread. Usually this function represents the main

--- a/hpx/hpx_start_impl.hpp
+++ b/hpx/hpx_start_impl.hpp
@@ -19,6 +19,7 @@
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/variables_map.hpp>
 
+#include <cstddef>
 #include <string>
 #include <utility>
 #include <vector>
@@ -313,6 +314,49 @@ namespace hpx
 
         util::function_nonser<int(boost::program_options::variables_map& vm)>
             main_f = util::bind_back(detail::init_helper, f);
+
+        HPX_ASSERT(argc != 0 && argv != nullptr);
+
+        return start(main_f, desc_commandline, argc, argv, cfg,
+            startup_function_type(), shutdown_function_type(), mode);
+    }
+
+    inline bool start(std::nullptr_t f, std::string const& app_name, int argc,
+        char** argv, hpx::runtime_mode mode)
+    {
+        using boost::program_options::options_description;
+
+        options_description desc_commandline(
+            "Usage: " + app_name +  " [options]");
+
+        util::function_nonser<int(boost::program_options::variables_map& vm)>
+            main_f;
+        std::vector<std::string> cfg;
+
+        HPX_ASSERT(argc != 0 && argv != nullptr);
+
+        return start(main_f, desc_commandline, argc, argv, cfg,
+            startup_function_type(), shutdown_function_type(), mode);
+    }
+
+    inline bool start(std::nullptr_t f, int argc, char** argv,
+        hpx::runtime_mode mode)
+    {
+        std::string app_name(HPX_APPLICATION_STRING);
+        return start(f, app_name, argc, argv, mode);
+    }
+
+    inline bool start(std::nullptr_t f, int argc, char** argv,
+        std::vector<std::string> const& cfg, hpx::runtime_mode mode)
+    {
+        std::string app_name(HPX_APPLICATION_STRING);
+        using boost::program_options::options_description;
+
+        options_description desc_commandline(
+            "Usage: " + app_name +  " [options]");
+
+        util::function_nonser<int(boost::program_options::variables_map& vm)>
+            main_f;
 
         HPX_ASSERT(argc != 0 && argv != nullptr);
 


### PR DESCRIPTION
## Proposed Changes

Adds overloads so that passing `nullptr` to `hpx::start` will only start up the runtime.

This also adds a missing line to the docstrings of some `hpx::start` overloads.