### PR TITLE
Avoid completion handler allocation

### DIFF
--- a/hpx/lcos/detail/future_transforms.hpp
+++ b/hpx/lcos/detail/future_transforms.hpp
@@ -30,7 +30,7 @@ namespace lcos {
                 typename std::decay<T>::type>::value>::type* = nullptr>
         bool async_visit_future(T&& current)
         {
-            auto state =
+            auto const& state =
                 traits::detail::get_shared_state(std::forward<T>(current));
 
             if ((state.get() == nullptr) || state->is_ready())
@@ -51,7 +51,7 @@ namespace lcos {
                 typename std::decay<T>::type>::value>::type* = nullptr>
         void async_detach_future(T&& current, N&& next)
         {
-            auto state =
+            auto const& state =
                 traits::detail::get_shared_state(std::forward<T>(current));
 
             // Attach a continuation to this future which will


### PR DESCRIPTION
## Proposed Changes

This patch removes `compose_cb` in favor of `boost::container::small_vector<callback_type, 3>`. The main motivation is to avoid memory allocations for cases where two or more completion handlers are attached to a future.

Flyby: avoid reference counting for pack traversals.