### PR TITLE
Update CXX14 constexpr feature test

### DIFF
--- a/cmake/tests/cxx14_constexpr.cpp
+++ b/cmake/tests/cxx14_constexpr.cpp
@@ -8,14 +8,28 @@
 
 constexpr void decrement(int& value) { --value; }
 
+struct S
+{
+    constexpr S() : ptr(nullptr) {}
+    constexpr void reset() { ptr = nullptr; }
+    constexpr void reset() const { }
+    void * ptr;
+};
+
 constexpr int zero()
 {
     int ret = 1;
     decrement(ret);
+
+    S s;
+    s.reset();
+
     return ret;
 }
 
 int main()
 {
     constexpr int i = zero();
+    S s;
+    s.reset();
 }


### PR DESCRIPTION
This patch is adding functionality to the C++14 constexpr test to cover more usecases

## Any background context you want to provide?

Our intel builders currently fail to compile master:
http://rostam.cct.lsu.edu/builders/hpx_intel_17_2_174_boost_1_59_centos_x86_64_debug/builds/203/steps/build_core/logs/stdio