### PR TITLE
Improving destruction of threads

### DIFF
--- a/examples/resource_partitioner/shared_priority_scheduler.hpp
+++ b/examples/resource_partitioner/shared_priority_scheduler.hpp
@@ -859,7 +859,7 @@ namespace threads {
             }
 
             /// Destroy the passed thread - as it has been terminated
-            bool destroy_thread(
+            void destroy_thread(
                 threads::thread_data* thrd, std::int64_t& busy_count)
             {
                 LOG_CUSTOM_MSG("destroy thread " << THREAD_DESC(thrd)
@@ -867,26 +867,8 @@ namespace threads {
                                                  << decnumber(busy_count));
                 HPX_ASSERT(thrd->get_scheduler_base() == this);
 
-                for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
-                {
-                    if (high_priority_queues_[i]->destroy_thread(
-                            thrd, busy_count))
-                        return true;
-                }
-
-                for (std::size_t i = 0; i != queues_.size(); ++i)
-                {
-                    if (queues_[i]->destroy_thread(thrd, busy_count))
-                        return true;
-                }
-
-                if (low_priority_queue_.destroy_thread(thrd, busy_count))
-                    return true;
-
-                // the thread has to belong to one of the queues, always
-                HPX_ASSERT(false);
-
-                return false;
+                HPX_ASSERT(thrd->get_scheduler_base() == this);
+                thrd->get_queue<thread_queue_type>().destroy_thread(thrd, busy_count);
             }
 
             ///////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/threads/policies/hierarchy_scheduler.hpp
+++ b/hpx/runtime/threads/policies/hierarchy_scheduler.hpp
@@ -710,17 +710,10 @@ namespace hpx { namespace threads { namespace policies
         }
 
         /// Destroy the passed thread as it has been terminated
-        bool destroy_thread(threads::thread_data* thrd, std::int64_t& busy_count)
+        void destroy_thread(threads::thread_data* thrd, std::int64_t& busy_count)
         {
-            for(size_type i = 0; i < tree.size(); ++i)
-            {
-                for(size_type j = 0; j < tree[i].size(); ++j)
-                {
-                    if(tree[i][j]->destroy_thread(thrd, busy_count))
-                        return true;
-                }
-            }
-            return false;
+            HPX_ASSERT(thrd->get_scheduler_base() == this);
+            thrd->get_queue<thread_queue_type>().destroy_thread(thrd, busy_count);
         }
 
         void transfer_tasks(

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -649,27 +649,10 @@ namespace hpx { namespace threads { namespace policies
         }
 
         /// Destroy the passed thread as it has been terminated
-        bool destroy_thread(threads::thread_data* thrd, std::int64_t& busy_count)
+        void destroy_thread(threads::thread_data* thrd, std::int64_t& busy_count)
         {
-            for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
-            {
-                if (high_priority_queues_[i]->destroy_thread(thrd, busy_count))
-                    return true;
-            }
-
-            for (std::size_t i = 0; i != queues_.size(); ++i)
-            {
-                if (queues_[i]->destroy_thread(thrd, busy_count))
-                    return true;
-            }
-
-            if (low_priority_queue_.destroy_thread(thrd, busy_count))
-                return true;
-
-            // the thread has to belong to one of the queues, always
-            HPX_ASSERT(false);
-
-            return false;
+            HPX_ASSERT(thrd->get_scheduler_base() == this);
+            thrd->get_queue<thread_queue_type>().destroy_thread(thrd, busy_count);
         }
 
         ///////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/threads/policies/local_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_queue_scheduler.hpp
@@ -480,20 +480,10 @@ namespace hpx { namespace threads { namespace policies
         }
 
         /// Destroy the passed thread as it has been terminated
-        bool destroy_thread(threads::thread_data* thrd, std::int64_t& busy_count)
+        void destroy_thread(threads::thread_data* thrd, std::int64_t& busy_count)
         {
             HPX_ASSERT(thrd->get_scheduler_base() == this);
-
-            for (std::size_t i = 0; i != queues_.size(); ++i)
-            {
-                if (queues_[i]->destroy_thread(thrd, busy_count))
-                    return true;
-            }
-
-            // the thread has to belong to one of the queues, always
-            HPX_ASSERT(false);
-
-            return false;
+            thrd->get_queue<thread_queue_type>().destroy_thread(thrd, busy_count);
         }
 
         ///////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/threads/policies/scheduler_base.hpp
+++ b/hpx/runtime/threads/policies/scheduler_base.hpp
@@ -387,7 +387,7 @@ namespace hpx { namespace threads { namespace policies
             std::size_t num_thread,
             thread_priority priority = thread_priority_normal) = 0;
 
-        virtual bool destroy_thread(threads::thread_data* thrd,
+        virtual void destroy_thread(threads::thread_data* thrd,
             std::int64_t& busy_count) = 0;
 
         virtual bool wait_or_add_new(std::size_t num_thread, bool running,

--- a/hpx/runtime/threads/policies/thread_queue.hpp
+++ b/hpx/runtime/threads/policies/thread_queue.hpp
@@ -268,7 +268,7 @@ namespace hpx { namespace threads { namespace policies
 
                 // Allocate a new thread object.
                 thrd = thread_id_type(
-                    threads::thread_data::create(data, memory_pool_, state));
+                    new threads::thread_data(data, this, state));
             }
         }
 
@@ -331,7 +331,7 @@ namespace hpx { namespace threads { namespace policies
 
                 // this thread has to be in the map now
                 HPX_ASSERT(thread_map_.find(thrd) != thread_map_.end());
-                HPX_ASSERT(thrd->get_pool() == &memory_pool_);
+                HPX_ASSERT(&thrd->get_queue<thread_queue>() == this);
             }
 
             if (added) {
@@ -549,7 +549,6 @@ namespace hpx { namespace threads { namespace policies
             new_tasks_wait_(0),
             new_tasks_wait_count_(0),
 #endif
-            memory_pool_(64),
             thread_heap_small_(),
             thread_heap_medium_(),
             thread_heap_large_(),
@@ -744,7 +743,7 @@ namespace hpx { namespace threads { namespace policies
 
                     // this thread has to be in the map now
                     HPX_ASSERT(thread_map_.find(thrd) != thread_map_.end());
-                    HPX_ASSERT(thrd->get_pool() == &memory_pool_);
+                    HPX_ASSERT(&thrd->get_queue<thread_queue>() == this);
 
                     // push the new thread in the pending queue thread
                     if (initial_state == pending)
@@ -882,20 +881,16 @@ namespace hpx { namespace threads { namespace policies
         }
 
         /// Destroy the passed thread as it has been terminated
-        bool destroy_thread(threads::thread_data* thrd, std::int64_t& busy_count)
+        void destroy_thread(threads::thread_data* thrd, std::int64_t& busy_count)
         {
-            if (thrd->get_pool() == &memory_pool_)
-            {
-                terminated_items_.push(thrd);
+            HPX_ASSERT(&thrd->get_queue<thread_queue>() == this);
+            terminated_items_.push(thrd);
 
-                std::int64_t count = ++terminated_items_count_;
-                if (count > max_terminated_threads)
-                {
-                    cleanup_terminated(true);   // clean up all terminated threads
-                }
-                return true;
+            std::int64_t count = ++terminated_items_count_;
+            if (count > max_terminated_threads)
+            {
+                cleanup_terminated(true);   // clean up all terminated threads
             }
-            return false;
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -1127,9 +1122,6 @@ namespace hpx { namespace threads { namespace policies
         std::atomic<std::int64_t> new_tasks_wait_count_;
         ///< overall number tasks waited
 #endif
-
-        threads::thread_pool memory_pool_;          ///< OS thread local memory pools for
-                                                    ///< HPX-threads
 
         std::list<thread_id_type> thread_heap_small_;
         std::list<thread_id_type> thread_heap_medium_;


### PR DESCRIPTION
## Proposed Changes

Instead of having to loop over the available queues, this patch stores the queue
in which the thread has been allocated.
In addition, we completely avoid going over an additional memory pool as the
queues cache and reuse the allocated threads.