### PR TITLE
Fix stack overhead

### DIFF
--- a/hpx/config.hpp
+++ b/hpx/config.hpp
@@ -26,6 +26,7 @@
 #include <hpx/config/forceinline.hpp>
 #include <hpx/config/lambda_capture.hpp>
 #include <hpx/config/manual_profiling.hpp>
+#include <hpx/config/threads_stack.hpp>
 #include <hpx/config/version.hpp>
 
 #include <boost/version.hpp>
@@ -406,58 +407,6 @@
 #  if defined(HPX_DEBUG)
 #    define HPX_HAVE_VERIFY_LOCKS_GLOBALY
 #  endif
-#endif
-
-///////////////////////////////////////////////////////////////////////////////
-
-#if !defined(HPX_THREADS_STACK_OVERHEAD)
-#  if defined(HPX_DEBUG)
-#    if defined(HPX_GCC_VERSION)
-#      define HPX_THREADS_STACK_OVERHEAD 0x3000
-#    else
-#      define HPX_THREADS_STACK_OVERHEAD 0x2800
-#    endif
-#  else
-#    if defined(HPX_INTEL_VERSION)
-#      define HPX_THREADS_STACK_OVERHEAD 0x2800
-#    else
-#      define HPX_THREADS_STACK_OVERHEAD 0x800
-#    endif
-#  endif
-#endif
-
-#if !defined(HPX_SMALL_STACK_SIZE)
-#  if defined(__has_feature)
-#    if __has_feature(address_sanitizer)
-#      define HPX_SMALL_STACK_SIZE  0x20000       // 128kByte
-#    endif
-#  endif
-#endif
-
-#if !defined(HPX_SMALL_STACK_SIZE)
-#  if defined(HPX_WINDOWS) && !defined(HPX_HAVE_GENERIC_CONTEXT_COROUTINES)
-#    define HPX_SMALL_STACK_SIZE    0x4000        // 16kByte
-#  else
-#    if defined(HPX_DEBUG)
-#      define HPX_SMALL_STACK_SIZE  0x20000       // 128kByte
-#    else
-#      if defined(__powerpc__) || defined(__INTEL_COMPILER)
-#         define HPX_SMALL_STACK_SIZE  0x20000       // 128kByte
-#      else
-#         define HPX_SMALL_STACK_SIZE  0x10000        // 64kByte
-#      endif
-#    endif
-#  endif
-#endif
-
-#if !defined(HPX_MEDIUM_STACK_SIZE)
-#  define HPX_MEDIUM_STACK_SIZE   0x0020000       // 128kByte
-#endif
-#if !defined(HPX_LARGE_STACK_SIZE)
-#  define HPX_LARGE_STACK_SIZE    0x0200000       // 2MByte
-#endif
-#if !defined(HPX_HUGE_STACK_SIZE)
-#  define HPX_HUGE_STACK_SIZE     0x2000000       // 32MByte
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hpx/config.hpp
+++ b/hpx/config.hpp
@@ -20,6 +20,7 @@
 #include <hpx/config/compiler_native_tls.hpp>
 #include <hpx/config/compiler_specific.hpp>
 #include <hpx/config/constexpr.hpp>
+#include <hpx/config/debug.hpp>
 #include <hpx/config/defines.hpp>
 #include <hpx/config/emulate_deleted.hpp>
 #include <hpx/config/export_definitions.hpp>
@@ -43,23 +44,6 @@
 // On Windows, make sure winsock.h is not included even if windows.h is
 // included before winsock2.h
 #define _WINSOCKAPI_
-#endif
-
-///////////////////////////////////////////////////////////////////////////////
-// Make sure DEBUG macro is defined consistently across platforms
-#if defined(_DEBUG) && !defined(DEBUG)
-#  define DEBUG
-#endif
-
-///////////////////////////////////////////////////////////////////////////////
-#if defined(DEBUG) && !defined(HPX_DEBUG)
-#  define HPX_DEBUG
-#endif
-
-#if defined(HPX_DEBUG)
-#  define HPX_BUILD_TYPE debug
-#else
-#  define HPX_BUILD_TYPE release
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hpx/config/debug.hpp
+++ b/hpx/config/debug.hpp
@@ -1,0 +1,25 @@
+//  Copyright (c) 2007-2018 Hartmut Kaiser
+//  Copyright (c) 2011 Bryce Lelbach
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_CONFIG_DEBUG_HPP)
+#define HPX_CONFIG_DEBUG_HPP
+
+// Make sure DEBUG macro is defined consistently across platforms
+#if defined(_DEBUG) && !defined(DEBUG)
+#  define DEBUG
+#endif
+
+#if defined(DEBUG) && !defined(HPX_DEBUG)
+#  define HPX_DEBUG
+#endif
+
+#if defined(HPX_DEBUG)
+#  define HPX_BUILD_TYPE debug
+#else
+#  define HPX_BUILD_TYPE release
+#endif
+
+#endif

--- a/hpx/config/threads_stack.hpp
+++ b/hpx/config/threads_stack.hpp
@@ -8,6 +8,7 @@
 #ifndef HPX_CONFIG_THREADS_STACK_HPP
 #define HPX_CONFIG_THREADS_STACK_HPP
 
+#include <hpx/config/debug.hpp>
 #include <hpx/config/defines.hpp>
 #include <hpx/config/compiler_specific.hpp>
 

--- a/hpx/config/threads_stack.hpp
+++ b/hpx/config/threads_stack.hpp
@@ -1,0 +1,70 @@
+//  Copyright (c) 2007-2018 Hartmut Kaiser
+//  Copyright (c) 2018 Thomas Heller
+//  Copyright (c) 2011 Bryce Lelbach
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_CONFIG_THREADS_STACK_HPP
+#define HPX_CONFIG_THREADS_STACK_HPP
+
+#include <hpx/config/defines.hpp>
+#include <hpx/config/compiler_specific.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+
+#if !defined(HPX_THREADS_STACK_OVERHEAD)
+#  if defined(HPX_DEBUG)
+#    if defined(HPX_GCC_VERSION)
+#      define HPX_THREADS_STACK_OVERHEAD 0x3000
+#    else
+#      define HPX_THREADS_STACK_OVERHEAD 0x2800
+#    endif
+#  else
+#    if defined(HPX_INTEL_VERSION)
+#      define HPX_THREADS_STACK_OVERHEAD 0x2800
+#    else
+#      if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 40900 && HPX_GCC_VERSION < 50000
+#        define HPX_THREADS_STACK_OVERHEAD 0x1000
+#      else
+#        define HPX_THREADS_STACK_OVERHEAD 0x800
+#      endif
+#    endif
+#  endif
+#endif
+
+#if !defined(HPX_SMALL_STACK_SIZE)
+#  if defined(__has_feature)
+#    if __has_feature(address_sanitizer)
+#      define HPX_SMALL_STACK_SIZE  0x20000       // 128kByte
+#    endif
+#  endif
+#endif
+
+#if !defined(HPX_SMALL_STACK_SIZE)
+#  if defined(HPX_WINDOWS) && !defined(HPX_HAVE_GENERIC_CONTEXT_COROUTINES)
+#    define HPX_SMALL_STACK_SIZE    0x4000        // 16kByte
+#  else
+#    if defined(HPX_DEBUG)
+#      define HPX_SMALL_STACK_SIZE  0x20000       // 128kByte
+#    else
+#      if defined(__powerpc__) || defined(__INTEL_COMPILER)
+#         define HPX_SMALL_STACK_SIZE  0x20000       // 128kByte
+#      else
+#         define HPX_SMALL_STACK_SIZE  0x10000        // 64kByte
+#      endif
+#    endif
+#  endif
+#endif
+
+#if !defined(HPX_MEDIUM_STACK_SIZE)
+#  define HPX_MEDIUM_STACK_SIZE   0x0020000       // 128kByte
+#endif
+#if !defined(HPX_LARGE_STACK_SIZE)
+#  define HPX_LARGE_STACK_SIZE    0x0200000       // 2MByte
+#endif
+#if !defined(HPX_HUGE_STACK_SIZE)
+#  define HPX_HUGE_STACK_SIZE     0x2000000       // 32MByte
+#endif
+
+#endif


### PR DESCRIPTION
## Proposed Changes

- Separate debug definitions into `hpx/config/debug.hpp`
- Include `debug.hpp` in the new `threads_stack.hpp` config file

## Any background context you want to provide?

This is the same as #3097, but makes sure `HPX_DEBUG` is defined for the thread stacksize defines.