### PR TITLE
Changing the coroutine implementations to do a lazy init

### DIFF
--- a/hpx/runtime/threads/coroutines/detail/context_base.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_base.hpp
@@ -94,16 +94,15 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
     apex_task_wrapper rebind_base_apex(thread_id_type id);
 #endif
 
-    class context_base : public default_context_impl
+    template <typename CoroutineImpl>
+    class context_base : public default_context_impl<CoroutineImpl>
     {
     public:
         typedef void deleter_type(context_base const*);
         typedef hpx::threads::thread_id_type thread_id_type;
 
-        template <typename Derived>
-        context_base(
-            Derived& derived, std::ptrdiff_t stack_size, thread_id_type id)
-          : default_context_impl(derived, stack_size)
+        context_base(std::ptrdiff_t stack_size, thread_id_type id)
+          : default_context_impl<CoroutineImpl>(stack_size)
           , m_caller()
           , m_state(ctx_ready)
           , m_exit_state(ctx_exit_not_requested)
@@ -180,6 +179,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         // on return.
         void invoke()
         {
+            this->init();
             HPX_ASSERT(is_ready());
             do_invoke();
             // TODO: could use a binary or here to eliminate
@@ -393,7 +393,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
             swap_context(m_caller, *this, detail::invoke_hint());
         }
 
-        typedef default_context_impl::context_impl_base ctx_type;
+        typedef typename default_context_impl<CoroutineImpl>::context_impl_base ctx_type;
         ctx_type m_caller;
 
         static HPX_EXPORT allocation_counters m_allocation_counters;

--- a/hpx/runtime/threads/coroutines/detail/context_generic_context.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_generic_context.hpp
@@ -219,6 +219,10 @@ namespace hpx { namespace threads { namespace coroutines
                 if (stack_pointer_ != nullptr) return;
 
                 stack_pointer_ = alloc_.allocate(stack_size_);
+                if (stack_pointer_ == nullptr)
+                {
+                    throw std::runtime_error("could not allocate memory for stack");
+                }
 #if BOOST_VERSION < 106100
                 ctx_ =
                     boost::context::make_fcontext(stack_pointer_, stack_size_, funp_);

--- a/hpx/runtime/threads/coroutines/detail/context_impl.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_impl.hpp
@@ -110,7 +110,8 @@
 #include <hpx/runtime/threads/coroutines/detail/context_generic_context.hpp>
 namespace hpx { namespace threads { namespace coroutines { namespace detail
 {
-    typedef generic_context::context_impl default_context_impl;
+    template <typename CoroutineImpl>
+    using default_context_impl = generic_context::fcontext_context_impl<CoroutineImpl>;
 }}}}
 
 #elif (defined(__linux) || defined(linux) || defined(__linux__)) &&            \
@@ -119,7 +120,8 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 #include <hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp>
 namespace hpx { namespace threads { namespace coroutines { namespace detail
 {
-    typedef lx::context_impl default_context_impl;
+    template <typename CoroutineImpl>
+    using default_context_impl = lx::x86_linux_context_impl<CoroutineImpl>;
 }}}}
 
 #elif defined(_POSIX_VERSION) || defined(__bgq__) || defined(__powerpc__) ||   \
@@ -128,7 +130,8 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 #include <hpx/runtime/threads/coroutines/detail/context_posix.hpp>
 namespace hpx { namespace threads { namespace coroutines { namespace detail
 {
-    typedef posix::context_impl default_context_impl;
+    template <typename CoroutineImpl>
+    using default_context_impl = posix::ucontext_context_impl<CoroutineImpl>;
 }}}}
 
 #elif defined(HPX_HAVE_FIBER_BASED_COROUTINES)
@@ -136,7 +139,8 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 #include <hpx/runtime/threads/coroutines/detail/context_windows_fibers.hpp>
 namespace hpx { namespace threads { namespace coroutines { namespace detail
 {
-    typedef windows::context_impl default_context_impl;
+    template <typename CoroutineImpl>
+    using default_context_impl = windows::fibers_context_impl<CoroutineImpl>;
 }}}}
 
 #else

--- a/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
@@ -93,15 +93,13 @@ namespace hpx { namespace threads { namespace coroutines
         }
 
         template<typename T>
-        HPX_FORCEINLINE void trampoline(T* fun);
-
-        template<typename T>
-        void trampoline(T* fun)
+        HPX_FORCEINLINE void trampoline(void* fun)
         {
-            (*fun)();
+            (*static_cast<T*>(fun))();
             std::abort();
         }
 
+        template <typename CoroutineImpl>
         class x86_linux_context_impl;
 
         class x86_linux_context_impl_base : detail::context_impl_base
@@ -146,6 +144,7 @@ namespace hpx { namespace threads { namespace coroutines
             void ** m_sp;
         };
 
+        template <typename CoroutineImpl>
         class x86_linux_context_impl : public x86_linux_context_impl_base
         {
         public:
@@ -153,41 +152,22 @@ namespace hpx { namespace threads { namespace coroutines
 
             typedef x86_linux_context_impl_base context_impl_base;
 
-            x86_linux_context_impl()
-                : m_stack(nullptr)
-            {
-#if defined(HPX_HAVE_STACKOVERFLOW_DETECTION)
-                // concept inspired by the following links:
-                //
-                // https://rethinkdb.com/blog/handling-stack-overflow-on-custom-stacks/
-                // http://www.evanjones.ca/software/threading.html
-                //
-                segv_stack.ss_sp = valloc(SEGV_STACK_SIZE);
-                segv_stack.ss_flags = 0;
-                segv_stack.ss_size = SEGV_STACK_SIZE;
-
-                std::memset(&action, '\0', sizeof(action));
-                action.sa_flags = SA_SIGINFO|SA_ONSTACK;
-                action.sa_sigaction = &x86_linux_context_impl::sigsegv_handler;
-
-                sigaltstack(&segv_stack, nullptr);
-                sigemptyset(&action.sa_mask);
-                sigaddset(&action.sa_mask, SIGSEGV);
-                sigaction(SIGSEGV, &action, nullptr);
-#endif
-            }
-
             /**
              * Create a context that on restore invokes Functor on
              *  a new stack. The stack size can be optionally specified.
              */
-            template<typename Functor>
-            x86_linux_context_impl(Functor& cb, std::ptrdiff_t stack_size = -1)
+            explicit x86_linux_context_impl(std::ptrdiff_t stack_size = -1)
               : m_stack_size(stack_size == -1
                   ? static_cast<std::ptrdiff_t>(default_stack_size)
                   : stack_size),
                 m_stack(nullptr)
             {
+            }
+
+            void init()
+            {
+                if (m_stack != nullptr) return;
+
                 if (0 != (m_stack_size % EXEC_PAGESIZE))
                 {
                     throw std::runtime_error(
@@ -207,15 +187,15 @@ namespace hpx { namespace threads { namespace coroutines
                 HPX_ASSERT(m_stack);
                 posix::watermark_stack(m_stack, static_cast<std::size_t>(m_stack_size));
 
-                typedef void fun(Functor*);
-                fun * funp = trampoline;
+                typedef void fun(void*);
+                fun * funp = trampoline<CoroutineImpl>;
 
                 m_sp = (static_cast<void**>(m_stack)
                     + static_cast<std::size_t>(m_stack_size) / sizeof(void*))
                     - context_size;
 
-                m_sp[backup_cb_idx] = m_sp[cb_idx] = &cb;
-                m_sp[backup_funp_idx] = m_sp[funp_idx] = nasty_cast<void*>(funp);
+                m_sp[cb_idx] = this;
+                m_sp[funp_idx] = nasty_cast<void*>(funp);
 
 #if defined(HPX_HAVE_VALGRIND) && !defined(NVALGRIND)
                 {
@@ -311,28 +291,26 @@ namespace hpx { namespace threads { namespace coroutines
 
             void reset_stack()
             {
-                if (m_stack)
-                {
-                    if (posix::reset_stack(
-                        m_stack, static_cast<std::size_t>(m_stack_size)))
-                        increment_stack_unbind_count();
-                }
+                HPX_ASSERT(m_stack);
+                if (posix::reset_stack(
+                    m_stack, static_cast<std::size_t>(m_stack_size)))
+                    increment_stack_unbind_count();
             }
 
             void rebind_stack()
             {
-                if (m_stack)
-                {
-                    increment_stack_recycle_count();
+                HPX_ASSERT(m_stack);
+                increment_stack_recycle_count();
 
-                    // On rebind, we initialize our stack to ensure a virgin stack
-                    m_sp = (static_cast<void**>(m_stack)
-                        + static_cast<std::size_t>(m_stack_size) / sizeof(void*))
-                        - context_size;
+                // On rebind, we initialize our stack to ensure a virgin stack
+                m_sp = (static_cast<void**>(m_stack)
+                    + static_cast<std::size_t>(m_stack_size) / sizeof(void*))
+                    - context_size;
 
-                    m_sp[cb_idx] = m_sp[backup_cb_idx];
-                    m_sp[funp_idx] = m_sp[backup_funp_idx];
-                }
+                    typedef void fun(void*);
+                    fun * funp = trampoline<CoroutineImpl>;
+                    m_sp[cb_idx] = this;
+                    m_sp[funp_idx] = nasty_cast<void*>(funp);
             }
 
             std::ptrdiff_t get_available_stack_space()
@@ -384,8 +362,6 @@ namespace hpx { namespace threads { namespace coroutines
         private:
 #if defined(__x86_64__)
             /** structure of context_data:
-             * 13: backup address of function to execute
-             * 12: backup address of trampoline
              * 11: additional alignment (or valgrind_id if enabled)
              * 10: parm 0 of trampoline
              * 9:  dummy return address for trampoline
@@ -403,16 +379,12 @@ namespace hpx { namespace threads { namespace coroutines
             static const std::size_t valgrind_id_idx = 11;
 #endif
 
-            static const std::size_t context_size = 14;
-            static const std::size_t backup_cb_idx = 13;
-            static const std::size_t backup_funp_idx = 12;
+            static const std::size_t context_size = 12;
             static const std::size_t cb_idx = 10;
             static const std::size_t funp_idx = 8;
 #else
             /** structure of context_data:
-             * 9: valgrind_id (if enabled)
-             * 8: backup address of function to execute
-             * 7: backup address of trampoline
+             * 7: valgrind_id (if enabled)
              * 6: parm 0 of trampoline
              * 5: dummy return address for trampoline
              * 4: return addr (here: start addr)
@@ -422,14 +394,12 @@ namespace hpx { namespace threads { namespace coroutines
              * 0: edi
              **/
 #if defined(HPX_HAVE_VALGRIND) && !defined(NVALGRIND)
-            static const std::size_t context_size = 10;
-            static const std::size_t valgrind_id_idx = 9;
+            static const std::size_t context_size = 8;
+            static const std::size_t valgrind_id_idx = 7;
 #else
-            static const std::size_t context_size = 9;
+            static const std::size_t context_size = 7;
 #endif
 
-            static const std::size_t backup_cb_idx = 8;
-            static const std::size_t backup_funp_idx = 7;
             static const std::size_t cb_idx = 6;
             static const std::size_t funp_idx = 4;
 #endif
@@ -442,8 +412,6 @@ namespace hpx { namespace threads { namespace coroutines
             stack_t segv_stack;
 #endif
         };
-
-        typedef x86_linux_context_impl context_impl;
 
         /**
          * Free function. Saves the current context in @p from

--- a/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
@@ -184,7 +184,11 @@ namespace hpx { namespace threads { namespace coroutines
                 }
 
                 m_stack = posix::alloc_stack(static_cast<std::size_t>(m_stack_size));
-                HPX_ASSERT(m_stack);
+                if (m_stack == nullptr)
+                {
+                    throw std::runtime_error("could not allocate memory for stack");
+                }
+
                 posix::watermark_stack(m_stack, static_cast<std::size_t>(m_stack_size));
 
                 typedef void fun(void*);

--- a/hpx/runtime/threads/coroutines/detail/context_posix.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_posix.hpp
@@ -215,6 +215,7 @@ namespace hpx { namespace threads { namespace coroutines
             HPX_COROUTINE_DECLARE_CONTEXT(m_ctx);
         };
 
+        template <typename CoroutineImpl>
         class ucontext_context_impl
           : public ucontext_context_impl_base
         {
@@ -230,8 +231,7 @@ namespace hpx { namespace threads { namespace coroutines
              * Create a context that on restore invokes Functor on
              *  a new stack. The stack size can be optionally specified.
              */
-            template<typename Functor>
-            explicit ucontext_context_impl(Functor & cb, std::ptrdiff_t stack_size)
+            explicit ucontext_context_impl(std::ptrdiff_t stack_size)
               : m_stack_size(stack_size == -1 ? (std::ptrdiff_t)default_stack_size
                     : stack_size),
                 m_stack(alloc_stack(m_stack_size)),

--- a/hpx/runtime/threads/coroutines/detail/coroutine_impl.hpp
+++ b/hpx/runtime/threads/coroutines/detail/coroutine_impl.hpp
@@ -53,7 +53,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
     // This type augments the context_base type with the type of the stored
     // functor.
     class coroutine_impl
-      : public context_base
+      : public context_base<coroutine_impl>
     {
     public:
         HPX_NON_COPYABLE(coroutine_impl);
@@ -69,7 +69,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 
         coroutine_impl(functor_type&& f, thread_id_type id,
             std::ptrdiff_t stack_size)
-          : context_base(*this, stack_size, id)
+          : context_base(stack_size, id)
           , m_result(unknown, invalid_thread_id)
           , m_arg(nullptr)
           , m_fun(std::move(f))

--- a/src/runtime/threads/coroutines/detail/context_base.cpp
+++ b/src/runtime/threads/coroutines/detail/context_base.cpp
@@ -19,11 +19,11 @@
 
 namespace hpx { namespace threads { namespace coroutines { namespace detail
 {
+    template class context_base<coroutine_impl>;
+
     // initialize static allocation counter
     template <typename CoroutineImpl>
     allocation_counters context_base<CoroutineImpl>::m_allocation_counters;
-
-    template struct context_base<coroutine_impl>;
 
 #if defined(HPX_HAVE_APEX)
     // adding this here, because the thread_id_type and thread_data types

--- a/src/runtime/threads/coroutines/detail/context_base.cpp
+++ b/src/runtime/threads/coroutines/detail/context_base.cpp
@@ -9,6 +9,7 @@
 #include <hpx/config.hpp>
 
 #include <hpx/runtime/threads/coroutines/detail/context_base.hpp>
+#include <hpx/runtime/threads/coroutines/detail/coroutine_impl.hpp>
 
 #if defined(HPX_HAVE_APEX)
 #include <hpx/runtime/threads/thread_id_type.hpp>
@@ -19,7 +20,10 @@
 namespace hpx { namespace threads { namespace coroutines { namespace detail
 {
     // initialize static allocation counter
-    allocation_counters context_base::m_allocation_counters;
+    template <typename CoroutineImpl>
+    allocation_counters context_base<CoroutineImpl>::m_allocation_counters;
+
+    template struct context_base<coroutine_impl>;
 
 #if defined(HPX_HAVE_APEX)
     // adding this here, because the thread_id_type and thread_data types


### PR DESCRIPTION
This changes the context implementations to perform a lazy initialization
of their respective contexts. This potentially leads to less resource usage.
