### PR TITLE
Move yield_while out of detail namespace and into own file

### DIFF
--- a/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
@@ -30,8 +30,8 @@
 #include <hpx/state.hpp>
 #include <hpx/throw_exception.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/detail/yield_k.hpp>
 #include <hpx/util/unlock_guard.hpp>
+#include <hpx/util/yield_while.hpp>
 
 #include <boost/system/system_error.hpp>
 
@@ -384,7 +384,7 @@ namespace hpx { namespace threads { namespace detail
     template <typename Scheduler>
     void scheduled_thread_pool<Scheduler>::suspend_internal(error_code& ec)
     {
-        util::detail::yield_while([this]()
+        util::yield_while([this]()
             {
                 return this->sched_->Scheduler::get_thread_count() >
                     this->get_background_thread_count();
@@ -1589,7 +1589,7 @@ namespace hpx { namespace threads { namespace detail
         {
             std::size_t thread_num = thread_offset_ + virt_core;
 
-            util::detail::yield_while([thread_num]()
+            util::yield_while([thread_num]()
                 {
                     return thread_num == hpx::get_worker_thread_num();
                 }, "scheduled_thread_pool::remove_processing_unit_internal",
@@ -1607,7 +1607,7 @@ namespace hpx { namespace threads { namespace detail
         // deadlocks when multiple HPX threads try to resume or suspend pus.
         std::unique_lock<compat::mutex>
             l(sched_->Scheduler::get_pu_mutex(virt_core), std::try_to_lock);
-        util::detail::yield_while([&l]()
+        util::yield_while([&l]()
             {
                 if (l.owns_lock())
                 {
@@ -1646,7 +1646,7 @@ namespace hpx { namespace threads { namespace detail
 
         HPX_ASSERT(oldstate == state_running);
 
-        util::detail::yield_while([&state]()
+        util::yield_while([&state]()
             {
                 return state.load() == state_pre_sleep;
             }, "scheduled_thread_pool::suspend_processing_unit_internal",
@@ -1717,7 +1717,7 @@ namespace hpx { namespace threads { namespace detail
         // deadlocks when multiple HPX threads try to resume or suspend pus.
         std::unique_lock<compat::mutex>
             l(sched_->Scheduler::get_pu_mutex(virt_core), std::try_to_lock);
-        util::detail::yield_while([&l]()
+        util::yield_while([&l]()
             {
                 if (l.owns_lock())
                 {
@@ -1744,7 +1744,7 @@ namespace hpx { namespace threads { namespace detail
         std::atomic<hpx::state>& state =
             sched_->Scheduler::get_state(virt_core);
 
-        util::detail::yield_while([this, &state, virt_core]()
+        util::yield_while([this, &state, virt_core]()
             {
                 this->sched_->Scheduler::resume(virt_core);
                 return state.load() == state_sleeping;

--- a/hpx/util/detail/yield_k.hpp
+++ b/hpx/util/detail/yield_k.hpp
@@ -99,27 +99,6 @@ namespace hpx { namespace util { namespace detail
             }
         }
     }
-
-    template <typename Predicate>
-    inline void yield_while(Predicate && predicate, const char *thread_name,
-        hpx::threads::thread_state_enum p = hpx::threads::pending_boost,
-        bool allow_timed_suspension = true)
-    {
-        if (allow_timed_suspension)
-        {
-            for (std::size_t k = 0; predicate(); ++k)
-            {
-                yield_k(k, thread_name, p);
-            }
-        }
-        else
-        {
-            for (std::size_t k = 0; predicate(); ++k)
-            {
-                yield_k(k % 32, thread_name, p);
-            }
-        }
-    }
 }}}
 
 #endif

--- a/hpx/util/yield_while.hpp
+++ b/hpx/util/yield_while.hpp
@@ -1,0 +1,42 @@
+////////////////////////////////////////////////////////////////////////////////
+//  Copyright (c) 2013 Thomas Heller
+//  Copyright (c) 2008 Peter Dimov
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef HPX_UTIL_DETAIL_YIELD_WHILE_HPP
+#define HPX_UTIL_DETAIL_YIELD_WHILE_HPP
+
+#include <hpx/runtime/threads/thread_helpers.hpp>
+#include <hpx/util/detail/yield_k.hpp>
+
+#include <cstddef>
+
+namespace hpx { namespace util {
+    template <typename Predicate>
+    inline void yield_while(Predicate && predicate,
+        const char *thread_name = nullptr,
+        hpx::threads::thread_state_enum p = hpx::threads::pending_boost,
+        bool allow_timed_suspension = true)
+    {
+        if (allow_timed_suspension)
+        {
+            for (std::size_t k = 0; predicate(); ++k)
+            {
+                detail::yield_k(k, thread_name, p);
+            }
+        }
+        else
+        {
+            for (std::size_t k = 0; predicate(); ++k)
+            {
+                detail::yield_k(k % 32, thread_name, p);
+            }
+        }
+    }
+}}
+
+#endif

--- a/plugins/parcelport/libfabric/parcelport_libfabric.cpp
+++ b/plugins/parcelport/libfabric/parcelport_libfabric.cpp
@@ -364,7 +364,7 @@ namespace libfabric
     // --------------------------------------------------------------------
     bool parcelport::can_send_immediate()
     {
-        // hpx::util::detail::yield_while([this]()
+        // hpx::util::yield_while([this]()
         //     {
         //         this->background_work(0);
         //         return this->senders_.empty();

--- a/plugins/parcelport/libfabric/receiver.cpp
+++ b/plugins/parcelport/libfabric/receiver.cpp
@@ -16,7 +16,7 @@
 #include <hpx/runtime/parcelset/parcel_buffer.hpp>
 //
 #include <hpx/util/assert.hpp>
-#include <hpx/util/detail/yield_k.hpp>
+#include <hpx/util/yield_while.hpp>
 //
 #include <utility>
 #include <cstddef>
@@ -169,7 +169,7 @@ namespace libfabric
             << *header_region_
             << "context " << hexpointer(this));
 
-        hpx::util::detail::yield_while([this, desc]()
+        hpx::util::yield_while([this, desc]()
             {
                 // post a receive using 'this' as the context, so that this
                 // receiver object can be used to handle the incoming

--- a/plugins/parcelport/libfabric/rma_receiver.cpp
+++ b/plugins/parcelport/libfabric/rma_receiver.cpp
@@ -11,7 +11,7 @@
 #include <hpx/runtime/parcelset/parcel_buffer.hpp>
 //
 #include <hpx/util/assert.hpp>
-#include <hpx/util/detail/yield_k.hpp>
+#include <hpx/util/yield_while.hpp>
 //
 #include <cstddef>
 #include <cstdint>
@@ -306,7 +306,7 @@ namespace libfabric
         // count reads
         ++rma_reads_;
 
-        hpx::util::detail::yield_while([this, get_region]()
+        hpx::util::yield_while([this, get_region]()
             {
                 LOG_EXCLUSIVE(
                     // write a pattern and dump out data for debugging purposes
@@ -485,7 +485,7 @@ namespace libfabric
 
         ++sent_ack_;
 
-        hpx::util::detail::yield_while([this]()
+        hpx::util::yield_while([this]()
             {
                 // when we received the incoming message, the tag was already set
                 // with the sender context so that we can signal it directly

--- a/plugins/parcelport/libfabric/sender.cpp
+++ b/plugins/parcelport/libfabric/sender.cpp
@@ -12,9 +12,9 @@
 //
 #include <hpx/util/assert.hpp>
 #include <hpx/util/atomic_count.hpp>
-#include <hpx/util/detail/yield_k.hpp>
 #include <hpx/util/high_resolution_timer.hpp>
 #include <hpx/util/unique_function.hpp>
+#include <hpx/util/yield_while.hpp>
 //
 #include <rdma/fi_endpoint.h>
 //
@@ -150,7 +150,7 @@ namespace libfabric
                 "Message region (send piggyback)"));
 
             // send 2 regions as one message, goes into one receive
-            hpx::util::detail::yield_while([this]()
+            hpx::util::yield_while([this]()
                 {
                     int ret = fi_sendv(this->endpoint_, this->region_list_,
                         this->desc_, 2, this->dst_addr_, this);
@@ -187,7 +187,7 @@ namespace libfabric
                 "Message region (send for rdma fetch)"));
 
             // send just the header region - a single message
-            hpx::util::detail::yield_while([this]()
+            hpx::util::yield_while([this]()
                 {
                     int ret = fi_send(this->endpoint_,
                         this->region_list_[0].iov_base,
@@ -277,7 +277,7 @@ namespace libfabric
         if (header_->message_piggy_back())
         {
             // send 2 regions as one message, goes into one receive
-            hpx::util::detail::yield_while([this]()
+            hpx::util::yield_while([this]()
                 {
                     int ret = fi_sendv(this->endpoint_, this->region_list_,
                         this->desc_, 2, this->dst_addr_, this);
@@ -301,7 +301,7 @@ namespace libfabric
                 message_region_->get_remote_key(), message_region_->get_address());
 
             // send just the header region - a single message
-            hpx::util::detail::yield_while([this]()
+            hpx::util::yield_while([this]()
                 {
                     int ret = fi_send(this->endpoint_,
                         this->region_list_[0].iov_base,

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -51,7 +51,7 @@
 #include <hpx/util/assert.hpp>
 #include <hpx/util/parse_command_line.hpp>
 #include <hpx/util/command_line_handling.hpp>
-#include <hpx/util/detail/yield_k.hpp>
+#include <hpx/util/yield_while.hpp>
 
 #include <hpx/plugins/message_handler_factory_base.hpp>
 #include <hpx/plugins/binary_filter_factory_base.hpp>
@@ -410,7 +410,7 @@ namespace hpx { namespace components { namespace server
         // it hands over the token to machine nr.i.
         threads::threadmanager& tm = appl.get_thread_manager();
 
-        util::detail::yield_while([&tm]()
+        util::yield_while([&tm]()
             {
                 tm.cleanup_terminated(true);
                 return tm.get_thread_count() >
@@ -449,7 +449,7 @@ namespace hpx { namespace components { namespace server
             applier::applier& appl = hpx::applier::get_applier();
             threads::threadmanager& tm = appl.get_thread_manager();
 
-            util::detail::yield_while([&tm]()
+            util::yield_while([&tm]()
                 {
                     tm.cleanup_terminated(true);
                     return tm.get_thread_count() >
@@ -510,7 +510,7 @@ namespace hpx { namespace components { namespace server
         applier::applier& appl = hpx::applier::get_applier();
         threads::threadmanager& tm = appl.get_thread_manager();
 
-        util::detail::yield_while([&tm]()
+        util::yield_while([&tm]()
             {
                 tm.cleanup_terminated(true);
                 return tm.get_thread_count() >
@@ -587,7 +587,7 @@ namespace hpx { namespace components { namespace server
             applier::applier& appl = hpx::applier::get_applier();
             threads::threadmanager& tm = appl.get_thread_manager();
 
-            util::detail::yield_while([&tm]()
+            util::yield_while([&tm]()
                 {
                     tm.cleanup_terminated(true);
                     return tm.get_thread_count() >
@@ -867,7 +867,7 @@ namespace hpx { namespace components { namespace server
 
             stopped_ = true;
 
-            util::detail::yield_while(
+            util::yield_while(
                 [&tm, &l, timeout, &t, start_time, &timed_out]()
                 {
                     cleanup_threads(tm, l);
@@ -889,7 +889,7 @@ namespace hpx { namespace components { namespace server
                 // now we have to wait for all threads to be aborted
                 start_time = t.elapsed();
 
-                util::detail::yield_while([&tm, &l, timeout, &t, start_time]()
+                util::yield_while([&tm, &l, timeout, &t, start_time]()
                     {
                         tm.abort_all_suspended_threads();
                         cleanup_threads(tm, l);

--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -27,11 +27,11 @@
 #include <hpx/util/apex.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/bind.hpp>
-#include <hpx/util/detail/yield_k.hpp>
 #include <hpx/util/logging.hpp>
 #include <hpx/util/safe_lexical_cast.hpp>
 #include <hpx/util/set_thread_name.hpp>
 #include <hpx/util/thread_mapper.hpp>
+#include <hpx/util/yield_while.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -556,7 +556,7 @@ namespace hpx {
             return -1;
         }
 
-        util::detail::yield_while(
+        util::yield_while(
             [this]()
             {
                 return thread_manager_->get_thread_count() >

--- a/tests/unit/resource/suspend_runtime.cpp
+++ b/tests/unit/resource/suspend_runtime.cpp
@@ -10,8 +10,8 @@
 #include <hpx/include/async.hpp>
 #include <hpx/include/threadmanager.hpp>
 #include <hpx/include/threads.hpp>
-#include <hpx/util/detail/yield_k.hpp>
 #include <hpx/util/lightweight_test.hpp>
+#include <hpx/util/yield_while.hpp>
 
 #include <cstddef>
 #include <string>
@@ -29,10 +29,8 @@ int main(int argc, char* argv[])
 
     // Wait for runtime to start
     hpx::runtime* rt = hpx::get_runtime_ptr();
-    hpx::util::detail::yield_while([rt]()
-        {
-            return rt->get_state() < hpx::state_running;
-        }, "");
+    hpx::util::yield_while([rt]()
+        { return rt->get_state() < hpx::state_running; });
 
     hpx::suspend();
 


### PR DESCRIPTION
## Proposed Changes

- Move `yield_while` from `yield_k.hpp` in the `detail` namespace to its own file not in the `detail` namespace
- Make `nullptr` the default value for the `thread_name` parameter in `yield_while`