### PR TITLE
Refactoring component_base and base_action/transfer_base_action 

### DIFF
--- a/hpx/runtime/actions/action_support.hpp
+++ b/hpx/runtime/actions/action_support.hpp
@@ -20,7 +20,6 @@
 #include <hpx/runtime/threads/thread_helpers.hpp>
 #include <hpx/runtime/threads/thread_init_data.hpp>
 #include <hpx/traits/action_remote_result.hpp>
-#include <hpx/traits/is_bitwise_serializable.hpp>
 #include <hpx/util/detail/pp/cat.hpp>
 #include <hpx/util/detail/pp/nargs.hpp>
 #include <hpx/util/tuple.hpp>
@@ -36,47 +35,6 @@
 #include <hpx/config/warnings_prefix.hpp>
 
 /// \cond NOINTERNAL
-namespace hpx { namespace actions { namespace detail
-{
-    struct action_serialization_data
-    {
-        action_serialization_data()
-          : parent_locality_(naming::invalid_locality_id)
-          , parent_id_(static_cast<std::uint64_t>(0))
-          , parent_phase_(0)
-          , priority_(static_cast<threads::thread_priority>(0))
-          , stacksize_(static_cast<threads::thread_stacksize>(0))
-        {}
-
-        action_serialization_data(std::uint32_t parent_locality,
-                threads::thread_id_type parent_id,
-                std::uint64_t parent_phase,
-                threads::thread_priority priority,
-                threads::thread_stacksize stacksize)
-          : parent_locality_(parent_locality)
-          , parent_id_(reinterpret_cast<std::uint64_t>(parent_id.get()))
-          , parent_phase_(parent_phase)
-          , priority_(priority)
-          , stacksize_(stacksize)
-        {}
-
-        std::uint32_t parent_locality_;
-        std::uint64_t parent_id_;
-        std::uint64_t parent_phase_;
-        threads::thread_priority priority_;
-        threads::thread_stacksize stacksize_;
-
-        template <class Archive>
-        void serialize(Archive& ar, unsigned)
-        {
-            ar & parent_id_ & parent_phase_ & parent_locality_
-               & priority_ & stacksize_;
-        }
-    };
-}}}
-
-HPX_IS_BITWISE_SERIALIZABLE(hpx::actions::detail::action_serialization_data)
-
 namespace hpx { namespace traits
 {
     namespace detail
@@ -90,7 +48,6 @@ namespace hpx { namespace traits
         };
     }
 }}
-
 /// \endcond
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/actions/base_action.hpp
+++ b/hpx/runtime/actions/base_action.hpp
@@ -15,11 +15,16 @@
 #include <hpx/runtime/actions_fwd.hpp>
 #include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/runtime/parcelset_fwd.hpp>
+#include <hpx/runtime/threads/thread_data_fwd.hpp>
+
+#include <hpx/runtime/actions/action_support.hpp>
 #include <hpx/runtime/actions/detail/action_factory.hpp>
 #include <hpx/runtime/components/pinned_ptr.hpp>
-#include <hpx/runtime/threads/thread_data_fwd.hpp>
+#include <hpx/runtime/naming/name.hpp>
 #include <hpx/runtime/threads/thread_enums.hpp>
+#include <hpx/runtime/threads/thread_id_type.hpp>
 #include <hpx/traits/polymorphic_traits.hpp>
+
 #if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
 #include <hpx/util/itt_notify.hpp>
 #endif
@@ -29,6 +34,8 @@
 #include <memory>
 #include <utility>
 
+#include <hpx/config/warnings_prefix.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace actions
 {
@@ -36,7 +43,7 @@ namespace hpx { namespace actions
     /// The \a base_action class is an abstract class used as the base class
     /// for all action types. It's main purpose is to allow polymorphic
     /// serialization of action instances through a unique_ptr.
-    struct HPX_API_EXPORT base_action
+    struct HPX_EXPORT base_action
     {
         /// The type of an action defines whether this action will be executed
         /// directly or by a HPX-threads
@@ -47,7 +54,7 @@ namespace hpx { namespace actions
         };
 
         /// Destructor
-        virtual ~base_action() {}
+        virtual ~base_action();
 
         /// The function \a get_component_type returns the \a component_type
         /// of the component this action belongs to.
@@ -133,8 +140,53 @@ namespace hpx { namespace actions
         virtual util::itt::string_handle const& get_action_name_itt() const = 0;
 #endif
     };
+
+    ///////////////////////////////////////////////////////////////////////////
+    struct HPX_EXPORT base_action_data : base_action
+    {
+        base_action_data() = default;
+
+        base_action_data(threads::thread_priority priority,
+                threads::thread_stacksize stacksize);
+
+        /// Return the locality of the parent thread
+        std::uint32_t get_parent_locality_id() const override;
+
+        /// Return the thread id of the parent thread
+        threads::thread_id_type get_parent_thread_id() const override;
+
+        /// Return the phase of the parent thread
+        std::uint64_t get_parent_thread_phase() const override;
+
+        /// Return the thread priority this action has to be executed with
+        threads::thread_priority get_thread_priority() const override;
+
+        /// Return the thread stacksize this action has to be executed with
+        threads::thread_stacksize get_thread_stacksize() const override;
+
+    private:
+        static std::uint32_t get_locality_id();
+
+    protected:
+        // serialization support
+        void load_base(hpx::serialization::input_archive & ar);
+        void save_base(hpx::serialization::output_archive & ar);
+
+    protected:
+        threads::thread_priority priority_;
+        threads::thread_stacksize stacksize_;
+
+#if defined(HPX_HAVE_THREAD_PARENT_REFERENCE)
+        std::uint32_t parent_locality_;
+        threads::thread_id_type parent_id_;
+        std::uint64_t parent_phase_;
+#endif
+    };
 }}
 
+#include <hpx/config/warnings_suffix.hpp>
+
 HPX_TRAITS_SERIALIZED_WITH_ID(hpx::actions::base_action)
+HPX_TRAITS_SERIALIZED_WITH_ID(hpx::actions::base_action_data)
 
 #endif

--- a/hpx/runtime/actions/detail/action_factory.hpp
+++ b/hpx/runtime/actions/detail/action_factory.hpp
@@ -85,9 +85,9 @@ namespace hpx { namespace actions { namespace detail
     base_action* register_action<Action>::create(bool has_continuation)
     {
         if (has_continuation)
-            return new transfer_continuation_action<Action>();
+            return new transfer_continuation_action<Action>{};
 
-        return new transfer_action<Action>();
+        return new transfer_action<Action>{};
     }
 
     template <typename Action>

--- a/hpx/runtime/actions/transfer_action.hpp
+++ b/hpx/runtime/actions/transfer_action.hpp
@@ -14,6 +14,8 @@
 #include <hpx/runtime/actions/transfer_base_action.hpp>
 #include <hpx/runtime/applier/apply_helper.hpp>
 #include <hpx/runtime/parcelset/detail/per_action_data_counter_registry.hpp>
+#include <hpx/runtime/serialization/input_archive.hpp>
+#include <hpx/runtime/serialization/output_archive.hpp>
 #include <hpx/runtime/serialization/serialization_fwd.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
 #include <hpx/runtime/threads/thread_init_data.hpp>
@@ -40,7 +42,7 @@ namespace hpx { namespace actions
 
     public:
         // construct an empty transfer_action to avoid serialization overhead
-        transfer_action();
+        transfer_action() = default;
 
         // construct an action from its arguments
         template <typename ...Ts>
@@ -49,7 +51,7 @@ namespace hpx { namespace actions
         template <typename ...Ts>
         transfer_action(threads::thread_priority priority, Ts&&... vs);
 
-        bool has_continuation() const;
+        bool has_continuation() const override;
 
         /// The \a get_thread_function constructs a proper thread function for
         /// a \a thread, encapsulating the functionality and the arguments
@@ -73,7 +75,7 @@ namespace hpx { namespace actions
         threads::thread_function_type
         get_thread_function(naming::id_type&& target,
             naming::address::address_type lva,
-            naming::address::component_type comptype);
+            naming::address::component_type comptype) override;
 
         template <std::size_t ...Is>
         void
@@ -87,25 +89,21 @@ namespace hpx { namespace actions
         void schedule_thread(naming::gid_type const& target_gid,
             naming::address::address_type lva,
             naming::address::component_type comptype,
-            std::size_t num_thread);
+            std::size_t num_thread) override;
 
         // serialization support
         // loading ...
-        void load(hpx::serialization::input_archive & ar);
+        void load(hpx::serialization::input_archive & ar) override;
 
         // saving ...
-        void save(hpx::serialization::output_archive & ar);
+        void save(hpx::serialization::output_archive & ar) override;
 
         void load_schedule(serialization::input_archive& ar,
             naming::gid_type&& target, naming::address_type lva,
             naming::component_type comptype, std::size_t num_thread,
-            bool& deferred_schedule);
+            bool& deferred_schedule) override;
     };
     /// \endcond
-
-    template <typename Action>
-    transfer_action<Action>::transfer_action()
-    {}
 
     template <typename Action>
     template <typename ...Ts>

--- a/hpx/runtime/actions/transfer_continuation_action.hpp
+++ b/hpx/runtime/actions/transfer_continuation_action.hpp
@@ -15,6 +15,8 @@
 #include <hpx/runtime/actions/transfer_base_action.hpp>
 #include <hpx/runtime/applier/apply_helper.hpp>
 #include <hpx/runtime/parcelset/detail/per_action_data_counter_registry.hpp>
+#include <hpx/runtime/serialization/input_archive.hpp>
+#include <hpx/runtime/serialization/output_archive.hpp>
 #include <hpx/runtime/serialization/serialization_fwd.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
 #include <hpx/runtime/threads/thread_init_data.hpp>
@@ -43,7 +45,7 @@ namespace hpx { namespace actions
     public:
         // construct an empty transfer_continuation_action to avoid serialization
         // overhead
-        transfer_continuation_action();
+        transfer_continuation_action() = default;
 
         // construct an action from its arguments
         template <typename ...Ts>
@@ -54,7 +56,7 @@ namespace hpx { namespace actions
             threads::thread_priority priority, continuation_type&& cont,
             Ts&&... vs);
 
-        bool has_continuation() const;
+        bool has_continuation() const override;
 
         /// The \a get_thread_function constructs a proper thread function for
         /// a \a thread, encapsulating the functionality and the arguments
@@ -78,9 +80,9 @@ namespace hpx { namespace actions
         threads::thread_function_type
         get_thread_function(naming::id_type&& target,
             naming::address::address_type lva,
-            naming::address::component_type comptype);
+            naming::address::component_type comptype) override;
 
-        template <std::size_t ...Is>
+        template <std::size_t... Is>
         void schedule_thread(util::detail::pack_c<std::size_t, Is...>,
             naming::gid_type const& target_gid,
             naming::address::address_type lva,
@@ -89,28 +91,25 @@ namespace hpx { namespace actions
         // schedule a new thread
         void schedule_thread(naming::gid_type const& target_gid,
             naming::address::address_type lva,
-            naming::address::component_type comptype, std::size_t num_thread);
+            naming::address::component_type comptype,
+            std::size_t num_thread) override;
 
         // serialization support
         // loading ...
-        void load(hpx::serialization::input_archive & ar);
+        void load(hpx::serialization::input_archive & ar) override;
 
         // saving ...
-        void save(hpx::serialization::output_archive & ar);
+        void save(hpx::serialization::output_archive & ar) override;
 
         void load_schedule(serialization::input_archive& ar,
             naming::gid_type&& target, naming::address_type lva,
             naming::component_type comptype, std::size_t num_thread,
-            bool& deferred_schedule);
+            bool& deferred_schedule) override;
 
     private:
         continuation_type cont_;
     };
     /// \endcond
-
-    template <typename Action>
-    transfer_continuation_action<Action>::transfer_continuation_action()
-    {}
 
     template <typename Action>
     template <typename ...Ts>

--- a/hpx/runtime/components/component_registry.hpp
+++ b/hpx/runtime/components/component_registry.hpp
@@ -119,7 +119,7 @@ namespace hpx { namespace components
         {
             typedef typename Component::type_holder type_holder;
 
-            const char* name = components::get_component_name<type_holder>();
+            char const* name = components::get_component_name<type_holder>();
             bool enabled = true;
             hpx::util::runtime_configuration const& config = hpx::get_config();
             std::string enabled_entry = config.get_entry(

--- a/hpx/runtime/components/component_type.hpp
+++ b/hpx/runtime/components/component_type.hpp
@@ -174,12 +174,12 @@ namespace hpx { namespace components
 
     // Returns the (unique) name for a given component
     template <typename Component, typename Enable = void>
-    const char* get_component_name();
+    HPX_CONSTEXPR char const* get_component_name();
 
     // Returns the (unique) name of the base component. If there is none,
     // nullptr is returned
     template <typename Component, typename Enable = void>
-    const char* get_component_base_name();
+    HPX_CONSTEXPR const char* get_component_base_name();
 
     template <typename Component>
     inline void set_component_type(component_type type)
@@ -253,13 +253,13 @@ namespace hpx { namespace components
 
 #define HPX_DEFINE_COMPONENT_NAME_2(Component, name)                          \
 namespace hpx { namespace components {                                        \
-    template <> HPX_ALWAYS_EXPORT                                             \
-    const char* get_component_name< Component, void>()                        \
+    template <> HPX_CONSTEXPR                                                 \
+    char const* get_component_name< Component, void>()                        \
     {                                                                         \
         return HPX_PP_STRINGIZE(name);                                        \
     }                                                                         \
-    template <> HPX_ALWAYS_EXPORT                                             \
-    const char* get_component_base_name< Component, void>()                   \
+    template <> HPX_CONSTEXPR                                                 \
+    char const* get_component_base_name< Component, void>()                   \
     {                                                                         \
         return nullptr;                                                       \
     }                                                                         \
@@ -268,13 +268,13 @@ namespace hpx { namespace components {                                        \
 
 #define HPX_DEFINE_COMPONENT_NAME_3(Component, name, base_name)               \
 namespace hpx { namespace components {                                        \
-    template <> HPX_ALWAYS_EXPORT                                             \
-    const char* get_component_name< Component, void>()                        \
+    template <> HPX_CONSTEXPR                                                 \
+    char const* get_component_name< Component, void>()                        \
     {                                                                         \
         return HPX_PP_STRINGIZE(name);                                        \
     }                                                                         \
-    template <> HPX_ALWAYS_EXPORT                                             \
-    const char* get_component_base_name< Component, void>()                   \
+    template <> HPX_CONSTEXPR                                                 \
+    char const* get_component_base_name< Component, void>()                   \
     {                                                                         \
         return base_name;                                                     \
     }                                                                         \

--- a/hpx/runtime/components/server/component_base.hpp
+++ b/hpx/runtime/components/server/component_base.hpp
@@ -7,10 +7,6 @@
 #define HPX_RUNTIME_COMPONENTS_SERVER_COMPONENT_BASE_HPP
 
 #include <hpx/config.hpp>
-#include <hpx/runtime/agas/interface.hpp>
-#include <hpx/runtime/applier/applier.hpp>
-#include <hpx/runtime/applier/bind_naming_wrappers.hpp>
-#include <hpx/runtime/applier_fwd.hpp>
 #include <hpx/runtime/components/component_type.hpp>
 #include <hpx/runtime/components/server/create_component_fwd.hpp>
 #include <hpx/runtime/components_fwd.hpp>
@@ -30,32 +26,120 @@
 #include <utility>
 #include <vector>
 
-namespace hpx {
-namespace detail {
+namespace hpx { namespace detail
+{
     HPX_API_EXPORT naming::gid_type get_next_id(std::size_t count = 1);
-}
-}
+}}
 
-namespace hpx { namespace components {
+namespace hpx { namespace components
+{
+    namespace detail
+    {
+        struct base_component : traits::detail::component_tag
+        {
+            base_component() = default;
+
+            HPX_EXPORT ~base_component();
+
+            // Copy construction and copy assignment should not copy the gid_.
+            base_component(base_component const& rhs)
+            {
+            }
+
+            base_component& operator=(base_component const& rhs)
+            {
+                return *this;
+            }
+
+            // just move our gid_
+            base_component(base_component&& rhs)
+              : gid_(std::move(rhs.gid_))
+            {
+            }
+
+            base_component& operator=(base_component&& rhs)
+            {
+                if (this != &rhs)
+                {
+                    gid_ = std::move(rhs.gid_);
+                }
+                return *this;
+            }
+
+            /// \brief finalize() will be called just before the instance gets
+            ///        destructed
+            HPX_CONSTEXPR static void finalize()
+            {
+            }
+
+            HPX_EXPORT naming::id_type get_id(naming::gid_type gid) const;
+            HPX_EXPORT naming::id_type get_unmanaged_id(
+                naming::gid_type const& gid) const;
+
+            // Pinning functionality
+            HPX_CONSTEXPR static void pin()
+            {
+            }
+            HPX_CONSTEXPR static void unpin()
+            {
+            }
+            HPX_CONSTEXPR static std::uint32_t pin_count()
+            {
+                return 0;
+            }
+
+#if defined(HPX_DISABLE_ASSERTS) || defined(BOOST_DISABLE_ASSERTS) || defined(NDEBUG)
+            HPX_CONSTEXPR static void mark_as_migrated()
+            {
+            }
+            HPX_CONSTEXPR static void on_migrated()
+            {
+            }
+#else
+            static void mark_as_migrated()
+            {
+                // If this assertion is triggered then this component instance is
+                // being migrated even if the component type has not been enabled
+                // to support migration.
+                HPX_ASSERT(false);
+            }
+
+            static void on_migrated()
+            {
+                // If this assertion is triggered then this component instance is being
+                // migrated even if the component type has not been enabled to support
+                // migration.
+                HPX_ASSERT(false);
+            }
+#endif
+
+        protected:
+            // Create a new GID (if called for the first time), assign this
+            // GID to this instance of a component and register this gid
+            // with the AGAS service
+            //
+            // Returns he global id (GID) assigned to this instance of a component
+            HPX_EXPORT naming::gid_type get_base_gid(
+                naming::gid_type const& assign_gid,
+                naming::address const& addr) const;
+
+        protected:
+            mutable naming::gid_type gid_;
+        };
+    }
+
     template <typename Component>
     class component;
 
     template <typename Component>
-    class component_base : public traits::detail::component_tag
+    class component_base : public detail::base_component
     {
     protected:
         typedef typename std::conditional<
-            std::is_same<Component, detail::this_type>::value, component_base,
-            Component>::type this_component_type;
-
-        Component& derived()
-        {
-            return static_cast<Component&>(*this);
-        }
-        Component const& derived() const
-        {
-            return static_cast<Component const&>(*this);
-        }
+                std::is_same<Component, detail::this_type>::value,
+                component_base,
+                Component
+            >::type this_component_type;
 
     public:
         typedef this_component_type wrapped_type;
@@ -63,55 +147,10 @@ namespace hpx { namespace components {
         typedef component<this_component_type> wrapping_type;
 
         /// \brief Construct an empty component
-        component_base()
-        {
-        }
+        component_base() = default;
 
         /// \brief Destruct a component
-        ~component_base()
-        {
-            if (gid_)
-            {
-                error_code ec;
-                agas::unbind(launch::sync, gid_, 1, ec);
-            }
-        }
-
-        // Copy construction and copy assignment should not copy the gid_.
-        component_base(component_base const&)
-        {
-        }
-
-        component_base& operator=(component_base const&)
-        {
-            return *this;
-        }
-
-        // just move our gid_
-        component_base(component_base&& rhs)
-          : gid_(std::move(rhs.gid_))
-        {
-        }
-
-        component_base& operator=(component_base&& rhs)
-        {
-            if (this != &rhs)
-                gid_ = std::move(rhs.gid_);
-            return *this;
-        }
-
-        /// \brief finalize() will be called just before the instance gets
-        ///        destructed
-        void finalize()
-        {
-        }
-
-        naming::address get_current_address() const
-        {
-            return naming::address(get_locality(),
-                components::get_component_type<wrapped_type>(),
-                std::uint64_t(static_cast<this_component_type const*>(this)));
-        }
+        ~component_base() = default;
 
 #if defined(HPX_HAVE_CXX11_EXTENDED_FRIEND_DECLARATIONS) &&                    \
     !defined(__NVCC__) && !defined(__CUDACC__)
@@ -124,98 +163,30 @@ namespace hpx { namespace components {
         friend naming::gid_type server::create_migrated(
             naming::gid_type const& gid, void** p, Ts&&...ts);
 
-        template <typename Component_, typename...Ts>
-        friend std::vector<naming::gid_type> bulk_create(std::size_t count, Ts&&...ts);
+        template <typename Component_, typename... Ts>
+        friend std::vector<naming::gid_type> bulk_create(
+            std::size_t count, Ts&&... ts);
 #endif
 
-        // Create a new GID (if called for the first time), assign this
-        // GID to this instance of a component and register this gid
-        // with the AGAS service
-        //
-        // Returns he global id (GID) assigned to this instance of a component
-        naming::gid_type get_base_gid(
-            naming::gid_type const& assign_gid = naming::invalid_gid) const
+    public:
+        naming::address get_current_address() const
         {
-            if (!gid_)
-            {
-                naming::address addr(get_current_address());
-                if (!assign_gid)
-                {
-                    gid_ = hpx::detail::get_next_id();
-                    if (!applier::bind_gid_local(gid_, addr))
-                    {
-                        std::ostringstream strm;
-                        strm << "failed to bind id " << gid_
-                             << "to locality: " << hpx::get_locality();
-
-                        gid_ = naming::invalid_gid;    // invalidate GID
-
-                        HPX_THROW_EXCEPTION(duplicate_component_address,
-                            "component_base<Component>::get_base_gid",
-                            strm.str());
-                    }
-                }
-                else
-                {
-                    applier::applier& appl = hpx::applier::get_applier();
-                    gid_ = assign_gid;
-                    naming::detail::strip_credits_from_gid(gid_);
-
-                    if (!agas::bind(
-                            launch::sync, gid_, addr, appl.get_locality_id()))
-                    {
-                        std::ostringstream strm;
-                        strm << "failed to rebind id " << gid_
-                             << "to locality: " << hpx::get_locality();
-
-                        gid_ = naming::invalid_gid;    // invalidate GID
-
-                        HPX_THROW_EXCEPTION(duplicate_component_address,
-                            "component_base<Component>::get_base_gid",
-                            strm.str());
-                    }
-                }
-            }
-
-            std::unique_lock<naming::gid_type::mutex_type> l(gid_.get_mutex());
-
-            if (!naming::detail::has_credits(gid_))
-            {
-                naming::gid_type gid = gid_;
-                return gid;
-            }
-
-            // on first invocation take all credits to avoid a self reference
-            naming::gid_type gid = gid_;
-
-            naming::detail::strip_credits_from_gid(
-                const_cast<naming::gid_type&>(gid_));
-
-            HPX_ASSERT(naming::detail::has_credits(gid));
-
-            // We have to assume this credit was split as otherwise the gid
-            // returned at this point will control the lifetime of the
-            // component.
-            naming::detail::set_credit_split_mask_for_gid(gid);
-            return gid;
+            return naming::address(hpx::get_locality(),
+                components::get_component_type<wrapped_type>(),
+                std::uint64_t(static_cast<this_component_type const*>(this)));
         }
 
-    public:
         naming::id_type get_id() const
         {
             // all credits should have been taken already
-            naming::gid_type gid = derived().get_base_gid();
-            HPX_ASSERT(!naming::detail::has_credits(gid));
-
-            // any (subsequent) invocation causes the credits to be replenished
-            naming::detail::replenish_credits(gid);
-            return naming::id_type(gid, naming::id_type::managed);
+            return this->detail::base_component::get_id(
+                static_cast<Component const&>(*this).get_base_gid());
         }
 
         naming::id_type get_unmanaged_id() const
         {
-            return naming::id_type(
-                derived().get_base_gid(), naming::id_type::managed);
+            return this->detail::base_component::get_unmanaged_id(
+                static_cast<Component const&>(*this).get_base_gid());
         }
 
 #if defined(HPX_HAVE_COMPONENT_GET_GID_COMPATIBILITY)
@@ -225,37 +196,13 @@ namespace hpx { namespace components {
             return get_id();
         }
 #endif
-
-        // Pinning functionality
-        void pin()
-        {
-        }
-        void unpin()
-        {
-        }
-        std::uint32_t pin_count() const
-        {
-            return 0;
-        }
-
-        void mark_as_migrated()
-        {
-            // If this assertion is triggered then this component instance is
-            // being migrated even if the component type has not been enabled
-            // to support migration.
-            HPX_ASSERT(false);
-        }
-
-        void on_migrated()
-        {
-            // If this assertion is triggered then this component instance is being
-            // migrated even if the component type has not been enabled to support
-            // migration.
-            HPX_ASSERT(false);
-        }
-
     protected:
-        mutable naming::gid_type gid_;
+        naming::gid_type get_base_gid(
+            naming::gid_type const& assign_gid = naming::invalid_gid) const
+        {
+            return this->detail::base_component::get_base_gid(assign_gid,
+                static_cast<Component const&>(*this).get_current_address());
+        }
     };
 }}
 

--- a/hpx/runtime/components/server/managed_component_base.hpp
+++ b/hpx/runtime/components/server/managed_component_base.hpp
@@ -45,7 +45,7 @@ namespace hpx { namespace components
         struct init<traits::construct_with_back_ptr>
         {
             template <typename Component, typename Managed>
-            static void call(Component* component, Managed* this_)
+            HPX_CONSTEXPR static void call(Component* component, Managed* this_)
             {
             }
 
@@ -99,7 +99,7 @@ namespace hpx { namespace components
         struct destroy_backptr<traits::managed_object_controls_lifetime>
         {
             template <typename BackPtr>
-            static void call(BackPtr*)
+            HPX_CONSTEXPR static void call(BackPtr*)
             {
                 // The managed_component's lifetime is controlled by the
                 // component implementation. Do nothing.
@@ -116,7 +116,7 @@ namespace hpx { namespace components
         struct manage_lifetime<traits::managed_object_is_lifetime_controlled>
         {
             template <typename Component>
-            static void call(Component*)
+            HPX_CONSTEXPR static void call(Component*)
             {
                 // The managed_component's lifetime is controlled by the
                 // component implementation. Do nothing.
@@ -148,35 +148,65 @@ namespace hpx { namespace components
             }
 
             template <typename Component>
-            static void addref(Component*)
+            HPX_CONSTEXPR static void addref(Component*)
             {
             }
 
             template <typename Component>
-            static void release(Component*)
+            HPX_CONSTEXPR static void release(Component*)
             {
             }
         };
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        struct base_managed_component
+          : public traits::detail::managed_component_tag
+        {
+            /// \brief finalize() will be called just before the instance gets
+            ///        destructed
+            HPX_CONSTEXPR static void finalize() {}
+
+            // Pinning functionality
+            HPX_CONSTEXPR static void pin() {}
+            HPX_CONSTEXPR static void unpin() {}
+            HPX_CONSTEXPR static std::uint32_t pin_count() { return 0; }
+
+#if defined(HPX_DISABLE_ASSERTS) || defined(BOOST_DISABLE_ASSERTS) || defined(NDEBUG)
+            HPX_CONSTEXPR static void mark_as_migrated()
+            {
+            }
+            HPX_CONSTEXPR static void on_migrated()
+            {
+            }
+#else
+            static void mark_as_migrated()
+            {
+                // If this assertion is triggered then this component instance is
+                // being migrated even if the component type has not been enabled
+                // to support migration.
+                HPX_ASSERT(false);
+            }
+
+            static void on_migrated()
+            {
+                // If this assertion is triggered then this component instance is being
+                // migrated even if the component type has not been enabled to support
+                // migration.
+                HPX_ASSERT(false);
+            }
+#endif
+        };
+    }
+
     template <typename Component, typename Wrapper,
         typename CtorPolicy, typename DtorPolicy>
-    class managed_component_base
-      : public traits::detail::managed_component_tag
+    class managed_component_base : public detail::base_managed_component
     {
     public:
         HPX_NON_COPYABLE(managed_component_base);
-
-    private:
-        Component& derived()
-        {
-            return static_cast<Component&>(*this);
-        }
-        Component const& derived() const
-        {
-            return static_cast<Component const&>(*this);
-        }
 
     public:
         typedef typename std::conditional<
@@ -223,10 +253,6 @@ namespace hpx { namespace components
         typedef managed_component<Component, Wrapper> wrapping_type;
         typedef Component base_type_holder;
 
-        /// \brief finalize() will be called just before the instance gets
-        ///        destructed
-        void finalize() {}
-
         naming::id_type get_unmanaged_id() const;
         naming::id_type get_id() const;
 
@@ -240,28 +266,6 @@ namespace hpx { namespace components
 
     protected:
         naming::gid_type get_base_gid() const;
-
-    public:
-        // Pinning functionality
-        void pin() {}
-        void unpin() {}
-        std::uint32_t pin_count() const { return 0; }
-
-        void mark_as_migrated()
-        {
-            // If this assertion is triggered then this component instance is
-            // being migrated even if the component type has not been enabled
-            // to support migration.
-            HPX_ASSERT(false);
-        }
-
-        void on_migrated()
-        {
-            // If this assertion is triggered then this component instance is being
-            // migrated even if the component type has not been enabled to support
-            // migration.
-            HPX_ASSERT(false);
-        }
 
     protected:
         template <typename>
@@ -377,7 +381,8 @@ namespace hpx { namespace components
 
         /// \brief finalize() will be called just before the instance gets
         ///        destructed
-        void finalize() {}  // finalize the wrapped component in our destructor
+        ///
+        HPX_CONSTEXPR static void finalize() {}
 
         /// \brief Return a pointer to the wrapped instance
         /// \note  Caller must check validity of returned pointer
@@ -524,7 +529,8 @@ namespace hpx { namespace components
         get_id() const
     {
         // all credits should have been taken already
-        naming::gid_type gid = derived().get_base_gid();
+        naming::gid_type gid =
+            static_cast<Component const&>(*this).get_base_gid();
 
         // The underlying heap will always give us a full set of credits, but
         // those are valid for the first invocation of get_base_gid() only.

--- a/src/runtime/actions/base_action.cpp
+++ b/src/runtime/actions/base_action.cpp
@@ -1,0 +1,175 @@
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/runtime/threads/thread_data_fwd.hpp>
+
+#include <hpx/runtime/actions/base_action.hpp>
+#include <hpx/runtime/get_locality_id.hpp>
+#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/runtime/serialization/input_archive.hpp>
+#include <hpx/runtime/serialization/output_archive.hpp>
+#include <hpx/traits/is_bitwise_serializable.hpp>
+
+#include <cstdint>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace actions { namespace detail
+{
+    ///////////////////////////////////////////////////////////////////////////
+    struct action_serialization_data
+    {
+        action_serialization_data()
+          : parent_locality_(naming::invalid_locality_id)
+          , parent_id_(static_cast<std::uint64_t>(0))
+          , parent_phase_(0)
+          , priority_(static_cast<threads::thread_priority>(0))
+          , stacksize_(static_cast<threads::thread_stacksize>(0))
+        {}
+
+        action_serialization_data(std::uint32_t parent_locality,
+                threads::thread_id_type parent_id,
+                std::uint64_t parent_phase,
+                threads::thread_priority priority,
+                threads::thread_stacksize stacksize)
+          : parent_locality_(parent_locality)
+          , parent_id_(reinterpret_cast<std::uint64_t>(parent_id.get()))
+          , parent_phase_(parent_phase)
+          , priority_(priority)
+          , stacksize_(stacksize)
+        {}
+
+        std::uint32_t parent_locality_;
+        std::uint64_t parent_id_;
+        std::uint64_t parent_phase_;
+        threads::thread_priority priority_;
+        threads::thread_stacksize stacksize_;
+
+        template <typename Archive>
+        void serialize(Archive& ar, unsigned)
+        {
+            ar & parent_id_ & parent_phase_ & parent_locality_
+               & priority_ & stacksize_;
+        }
+    };
+}}}
+
+HPX_IS_BITWISE_SERIALIZABLE(hpx::actions::detail::action_serialization_data)
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace actions
+{
+    ///////////////////////////////////////////////////////////////////////////
+    base_action::~base_action()
+    {
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    base_action_data::base_action_data(threads::thread_priority priority,
+            threads::thread_stacksize stacksize)
+      : priority_(priority)
+      , stacksize_(stacksize)
+#if defined(HPX_HAVE_THREAD_PARENT_REFERENCE)
+      , parent_locality_(base_action_data::get_locality_id())
+      , parent_id_(threads::get_parent_id())
+      , parent_phase_(threads::get_parent_phase())
+#endif
+    {
+    }
+
+    // serialization support
+    // loading ...
+    void base_action_data::load_base(hpx::serialization::input_archive & ar)
+    {
+        // Always serialize the parent information to maintain binary
+        // compatibility on the wire.
+
+        detail::action_serialization_data data;
+        ar >> data;
+
+#if defined(HPX_HAVE_THREAD_PARENT_REFERENCE)
+        parent_locality_ = data.parent_locality_;
+        parent_id_ = threads::thread_id_type(
+            reinterpret_cast<threads::thread_data*>(data.parent_id_));
+        parent_phase_ = data.parent_phase_;
+#endif
+        priority_ = data.priority_;
+        stacksize_ = data.stacksize_;
+    }
+
+    // saving ...
+    void base_action_data::save_base(hpx::serialization::output_archive & ar)
+    {
+        // Always serialize the parent information to maintain binary
+        // compatibility on the wire.
+
+#if !defined(HPX_HAVE_THREAD_PARENT_REFERENCE)
+        std::uint32_t parent_locality_ = naming::invalid_locality_id;
+        threads::thread_id_type parent_id_;
+        std::uint64_t parent_phase_ = 0;
+#endif
+        detail::action_serialization_data data(parent_locality_,
+            parent_id_, parent_phase_, priority_, stacksize_);
+        ar << data;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    std::uint32_t base_action_data::get_locality_id()
+    {
+        error_code ec(lightweight);      // ignore any errors
+        return hpx::get_locality_id(ec);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+#if !defined(HPX_HAVE_THREAD_PARENT_REFERENCE)
+    /// Return the locality of the parent thread
+    std::uint32_t base_action_data::get_parent_locality_id() const
+    {
+        return naming::invalid_locality_id;
+    }
+
+    /// Return the thread id of the parent thread
+    threads::thread_id_type base_action_data::get_parent_thread_id() const
+    {
+        return threads::invalid_thread_id;
+    }
+
+    /// Return the phase of the parent thread
+    std::uint64_t base_action_data::get_parent_thread_phase() const
+    {
+        return 0;
+    }
+#else
+    /// Return the locality of the parent thread
+    std::uint32_t base_action_data::get_parent_locality_id() const
+    {
+        return parent_locality_;
+    }
+
+    /// Return the thread id of the parent thread
+    threads::thread_id_type base_action_data::get_parent_thread_id() const
+    {
+        return parent_id_;
+    }
+
+    /// Return the phase of the parent thread
+    std::uint64_t base_action_data::get_parent_thread_phase() const
+    {
+        return parent_phase_;
+    }
+#endif
+
+    /// Return the thread priority this action has to be executed with
+    threads::thread_priority base_action_data::get_thread_priority() const
+    {
+        return priority_;
+    }
+
+    /// Return the thread stacksize this action has to be executed with
+    threads::thread_stacksize base_action_data::get_thread_stacksize() const
+    {
+        return stacksize_;
+    }
+}}

--- a/src/runtime/components/server/component_base.cpp
+++ b/src/runtime/components/server/component_base.cpp
@@ -1,0 +1,117 @@
+//  Copyright (c) 2015 Thomas Heller
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/error_code.hpp>
+#include <hpx/runtime/agas/interface.hpp>
+#include <hpx/runtime/applier/applier.hpp>
+#include <hpx/runtime/applier/bind_naming_wrappers.hpp>
+#include <hpx/runtime/components/component_type.hpp>
+#include <hpx/runtime/components/server/component_base.hpp>
+#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/runtime/naming/address.hpp>
+#include <hpx/runtime/naming/name.hpp>
+#include <hpx/runtime_fwd.hpp>
+#include <hpx/throw_exception.hpp>
+#include <hpx/util/assert.hpp>
+
+#include <mutex>
+#include <sstream>
+
+namespace hpx { namespace components { namespace detail
+{
+    base_component::~base_component()
+    {
+        if (gid_)
+        {
+            error_code ec;
+            agas::unbind(launch::sync, gid_, 1, ec);
+        }
+    }
+
+    naming::gid_type base_component::get_base_gid(
+        naming::gid_type const& assign_gid, naming::address const& addr) const
+    {
+        if (!gid_)
+        {
+            if (!assign_gid)
+            {
+                gid_ = hpx::detail::get_next_id();
+                if (!applier::bind_gid_local(gid_, addr))
+                {
+                    std::ostringstream strm;
+                    strm << "failed to bind id " << gid_
+                            << "to locality: " << hpx::get_locality();
+
+                    gid_ = naming::invalid_gid;    // invalidate GID
+
+                    HPX_THROW_EXCEPTION(duplicate_component_address,
+                        "component_base<Component>::get_base_gid",
+                        strm.str());
+                }
+            }
+            else
+            {
+                applier::applier& appl = hpx::applier::get_applier();
+                gid_ = assign_gid;
+                naming::detail::strip_credits_from_gid(gid_);
+
+                if (!agas::bind(
+                        launch::sync, gid_, addr, appl.get_locality_id()))
+                {
+                    std::ostringstream strm;
+                    strm << "failed to rebind id " << gid_
+                            << "to locality: " << hpx::get_locality();
+
+                    gid_ = naming::invalid_gid;    // invalidate GID
+
+                    HPX_THROW_EXCEPTION(duplicate_component_address,
+                        "component_base<Component>::get_base_gid",
+                        strm.str());
+                }
+            }
+        }
+
+        std::unique_lock<naming::gid_type::mutex_type> l(gid_.get_mutex());
+
+        if (!naming::detail::has_credits(gid_))
+        {
+            naming::gid_type gid = gid_;
+            return gid;
+        }
+
+        // on first invocation take all credits to avoid a self reference
+        naming::gid_type gid = gid_;
+
+        naming::detail::strip_credits_from_gid(
+            const_cast<naming::gid_type&>(gid_));
+
+        HPX_ASSERT(naming::detail::has_credits(gid));
+
+        // We have to assume this credit was split as otherwise the gid
+        // returned at this point will control the lifetime of the
+        // component.
+        naming::detail::set_credit_split_mask_for_gid(gid);
+        return gid;
+    }
+
+    naming::id_type base_component::get_id(naming::gid_type gid) const
+    {
+        // all credits should have been taken already
+        HPX_ASSERT(!naming::detail::has_credits(gid));
+
+        // any (subsequent) invocation causes the credits to be replenished
+        naming::detail::replenish_credits(gid);
+        return naming::id_type(gid, naming::id_type::managed);
+    }
+
+    naming::id_type base_component::get_unmanaged_id(
+        naming::gid_type const& gid) const
+    {
+        return naming::id_type(gid, naming::id_type::managed);
+    }
+}}}
+


### PR DESCRIPTION
This allows to reduce the number of instantiated functions and exported symbols, especially for external modules that contain components.
