### PR TITLE
Avoiding more stack overflows

### DIFF
--- a/hpx/lcos/detail/async_implementations.hpp
+++ b/hpx/lcos/detail/async_implementations.hpp
@@ -157,10 +157,13 @@ namespace hpx { namespace detail
     template <typename Action>
     bool can_invoke_locally()
     {
-        return !traits::action_decorate_function<Action>::value &&
-            this_thread::get_stack_size() >= threads::get_stack_size(
+        std::ptrdiff_t requested_stack_size =
+            threads::get_stack_size(
                 static_cast<threads::thread_stacksize>(
                     traits::action_stacksize<Action>::value));
+        return !traits::action_decorate_function<Action>::value &&
+            this_thread::get_stack_size() >= requested_stack_size &&
+            this_thread::has_sufficient_stack_space(requested_stack_size);
     }
 
     template <typename Action>

--- a/tests/unit/threads/thread_stacksize.cpp
+++ b/tests/unit/threads/thread_stacksize.cpp
@@ -15,19 +15,19 @@
 ///////////////////////////////////////////////////////////////////////////////
 void test_small_stacksize()
 {
-    HPX_TEST(hpx::threads::get_self_ptr());
-
-    // verify that sufficient stack has been allocated
-    HPX_TEST(hpx::threads::get_ctx_ptr()->get_stacksize() >=
-        hpx::get_runtime().get_config().get_stack_size(
-            hpx::threads::thread_stacksize_small));
-
     // allocate HPX_SMALL_STACK_SIZE - HPX_THREADS_STACK_OVERHEAD memory on
     // the stack
     char array[HPX_SMALL_STACK_SIZE-HPX_THREADS_STACK_OVERHEAD];
 
     // do something to that array
     std::memset(array, '\0', sizeof(array));
+
+    HPX_TEST(hpx::threads::get_self_ptr());
+
+    // verify that sufficient stack has been allocated
+    HPX_TEST(hpx::threads::get_ctx_ptr()->get_stacksize() >=
+        hpx::get_runtime().get_config().get_stack_size(
+            hpx::threads::thread_stacksize_small));
 }
 HPX_DECLARE_ACTION(test_small_stacksize, test_small_stacksize_action)
 HPX_ACTION_USES_SMALL_STACK(test_small_stacksize_action)
@@ -36,19 +36,18 @@ HPX_PLAIN_ACTION(test_small_stacksize, test_small_stacksize_action)
 ///////////////////////////////////////////////////////////////////////////////
 void test_medium_stacksize()
 {
+    // allocate HPX_MEDIUM_STACK_SIZE - HPX_THREADS_STACK_OVERHEAD memory on
+    // the stack
+    char array[HPX_MEDIUM_STACK_SIZE-HPX_THREADS_STACK_OVERHEAD];
+    // do something to that array
+    std::memset(array, '\0', sizeof(array));
+
     HPX_TEST(hpx::threads::get_self_ptr());
 
     // verify that sufficient stack has been allocated
     HPX_TEST(hpx::threads::get_ctx_ptr()->get_stacksize() >=
         hpx::get_runtime().get_config().get_stack_size(
             hpx::threads::thread_stacksize_medium));
-
-    // allocate HPX_MEDIUM_STACK_SIZE - HPX_THREADS_STACK_OVERHEAD memory on
-    // the stack
-    char array[HPX_MEDIUM_STACK_SIZE-HPX_THREADS_STACK_OVERHEAD];
-
-    // do something to that array
-    std::memset(array, '\0', sizeof(array));
 }
 HPX_DECLARE_ACTION(test_medium_stacksize, test_medium_stacksize_action)
 HPX_ACTION_USES_MEDIUM_STACK(test_medium_stacksize_action)
@@ -57,19 +56,18 @@ HPX_PLAIN_ACTION(test_medium_stacksize, test_medium_stacksize_action)
 ///////////////////////////////////////////////////////////////////////////////
 void test_large_stacksize()
 {
+    // allocate HPX_LARGE_STACK_SIZE - HPX_THREADS_STACK_OVERHEAD memory on
+    // the stack
+    char array[HPX_LARGE_STACK_SIZE-HPX_THREADS_STACK_OVERHEAD];
+    // do something to that array
+    std::memset(array, '\0', sizeof(array));
+
     HPX_TEST(hpx::threads::get_self_ptr());
 
     // verify that sufficient stack has been allocated
     HPX_TEST(hpx::threads::get_ctx_ptr()->get_stacksize() >=
         hpx::get_runtime().get_config().get_stack_size(
             hpx::threads::thread_stacksize_large));
-
-    // allocate HPX_LARGE_STACK_SIZE - HPX_THREADS_STACK_OVERHEAD memory on
-    // the stack
-    char array[HPX_LARGE_STACK_SIZE-HPX_THREADS_STACK_OVERHEAD];
-
-    // do something to that array
-    std::memset(array, '\0', sizeof(array));
 }
 HPX_DECLARE_ACTION(test_large_stacksize, test_large_stacksize_action)
 HPX_ACTION_USES_LARGE_STACK(test_large_stacksize_action)
@@ -78,19 +76,19 @@ HPX_PLAIN_ACTION(test_large_stacksize, test_large_stacksize_action)
 ///////////////////////////////////////////////////////////////////////////////
 void test_huge_stacksize()
 {
-    HPX_TEST(hpx::threads::get_self_ptr());
-
-    // verify that sufficient stack has been allocated
-    HPX_TEST(hpx::threads::get_ctx_ptr()->get_stacksize() >=
-        hpx::get_runtime().get_config().get_stack_size(
-            hpx::threads::thread_stacksize_huge));
-
     // allocate HPX_LARGE_STACK_SIZE - HPX_THREADS_STACK_OVERHEAD memory on
     // the stack
     char array[HPX_HUGE_STACK_SIZE-HPX_THREADS_STACK_OVERHEAD];
 
     // do something to that array
     std::memset(array, '\0', sizeof(array));
+
+    HPX_TEST(hpx::threads::get_self_ptr());
+
+    // verify that sufficient stack has been allocated
+    HPX_TEST(hpx::threads::get_ctx_ptr()->get_stacksize() >=
+        hpx::get_runtime().get_config().get_stack_size(
+            hpx::threads::thread_stacksize_huge));
 }
 HPX_DECLARE_ACTION(test_huge_stacksize, test_huge_stacksize_action)
 HPX_ACTION_USES_HUGE_STACK(test_huge_stacksize_action)
@@ -103,7 +101,6 @@ int main()
 
     for (hpx::id_type const& id : localities)
     {
-        if (id != hpx::find_here())
         {
             test_small_stacksize_action test_action;
             test_action(id);


### PR DESCRIPTION
This patch makes sure that action invocations always have at least as much
stack space available as they requested.
