### PR TITLE
Fixing serialization of classes with incompatible serialize signature

### DIFF
--- a/hpx/util/tuple.hpp
+++ b/hpx/util/tuple.hpp
@@ -306,7 +306,7 @@ namespace hpx { namespace util
             }
 
             template <typename Archive>
-            void serialize(Archive& ar, unsigned int const version)
+            void serialize(Archive& ar, unsigned int const)
             {
                 int const _sequencer[] = {
                     ((ar & this->get<Is>()), 0)...

--- a/tests/unit/serialization/CMakeLists.txt
+++ b/tests/unit/serialization/CMakeLists.txt
@@ -21,6 +21,7 @@ set(tests
     serialization_partitioned_vector
     serialization_variant
     serialize_buffer
+    serialize_with_incompatible_signature
     zero_copy_serialization
 )
 

--- a/tests/unit/serialization/serialize_with_incompatible_signature.cpp
+++ b/tests/unit/serialization/serialize_with_incompatible_signature.cpp
@@ -1,0 +1,45 @@
+//  Copyright (c) 2018 Anton Bikineev
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <vector>
+
+struct A
+{
+    double a;
+    int p;
+
+    void serialize(int, unsigned) {
+        // 3rd-party logic...
+    }
+};
+
+template <class Ar>
+void serialize(Ar& ar, A& a, unsigned) {
+    ar & a.a;
+    ar & a.p;
+}
+
+int main()
+{
+    std::vector<char> vector;
+    {
+        hpx::serialization::output_archive oar(vector);
+        A a{2., 4};
+        oar << a;
+    }
+
+    {
+        A a;
+        hpx::serialization::input_archive iar(vector);
+        iar >> a;
+        HPX_TEST_EQ(a.a, 2.);
+        HPX_TEST_EQ(a.p, 4);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This fixes #3134 
