### PR TITLE
Revert "Fixing a race with timed suspension"

### DIFF
--- a/src/runtime/threads/thread_helpers.cpp
+++ b/src/runtime/threads/thread_helpers.cpp
@@ -16,7 +16,6 @@
 #include <hpx/runtime/threads/executors/current_executor.hpp>
 #include <hpx/runtime/threads/thread_data_fwd.hpp>
 #include <hpx/runtime/threads/thread_enums.hpp>
-#include <hpx/util/assert.hpp>
 #ifdef HPX_HAVE_THREAD_BACKTRACE_ON_SUSPENSION
 #include <hpx/util/backtrace.hpp>
 #endif
@@ -580,9 +579,6 @@ namespace hpx { namespace this_thread
 
             if (statex != threads::wait_timeout)
             {
-                HPX_ASSERT(
-                    statex == threads::wait_abort ||
-                    statex == threads::wait_signaled);
                 error_code ec1(lightweight);    // do not throw
                 threads::set_thread_state(timer_id,
                     threads::pending, threads::wait_abort,

--- a/tests/regressions/lcos/wait_for_1751.cpp
+++ b/tests/regressions/lcos/wait_for_1751.cpp
@@ -35,7 +35,7 @@ int hpx_main()
             auto now = std::chrono::high_resolution_clock::now();
             std::chrono::duration<double> dif = now - start_time;
 
-            HPX_TEST_LTE(dif.count(), 1.01);
+            HPX_TEST_LTE(dif.count(), 1.0);
             break;
         }
         else


### PR DESCRIPTION
Reverts STEllAR-GROUP/hpx#3153.

There were timeouts at least in `action_invoke_no_more_than` and possibly some other tests so reverting.