### PR TITLE
Fixing a race with timed suspension (second attempt)

### DIFF
--- a/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
@@ -709,7 +709,7 @@ namespace hpx { namespace threads { namespace detail
         thread_priority priority, error_code& ec)
     {
         return detail::set_thread_state_timed(*sched_, abs_time, id, newstate,
-            newstate_ex, priority, get_worker_thread_num(), ec);
+            newstate_ex, priority, get_worker_thread_num(), nullptr, ec);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/threads/thread_helpers.hpp
+++ b/hpx/runtime/threads/thread_helpers.hpp
@@ -23,6 +23,7 @@
 #include <hpx/util/steady_clock.hpp>
 #include <hpx/util/thread_description.hpp>
 
+#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -104,10 +105,22 @@ namespace hpx { namespace threads
     ///                   of hpx#exception.
     HPX_API_EXPORT thread_id_type set_thread_state(thread_id_type const& id,
         util::steady_time_point const& abs_time,
+        std::atomic<bool>* started,
         thread_state_enum state = pending,
         thread_state_ex_enum stateex = wait_timeout,
         thread_priority priority = thread_priority_normal,
         error_code& ec = throws);
+
+    inline thread_id_type set_thread_state(thread_id_type const& id,
+        util::steady_time_point const& abs_time,
+        thread_state_enum state = pending,
+        thread_state_ex_enum stateex = wait_timeout,
+        thread_priority priority = thread_priority_normal,
+        error_code& ec = throws)
+    {
+        return set_thread_state(id, abs_time, nullptr, state, stateex,
+            priority, throws);
+    }
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief  Set the thread state of the \a thread referenced by the

--- a/src/runtime/threads/executors/current_executor.cpp
+++ b/src/runtime/threads/executors/current_executor.cpp
@@ -91,7 +91,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
 
         // now schedule new thread for execution
         threads::detail::set_thread_state_timed(
-            *scheduler_base_, abs_time, id, ec);
+            *scheduler_base_, abs_time, id, nullptr, ec);
         if (ec) return;
 
         if (&ec != &throws)

--- a/src/runtime/threads/executors/this_thread_executors.cpp
+++ b/src/runtime/threads/executors/this_thread_executors.cpp
@@ -196,7 +196,8 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         ++tasks_scheduled_;
 
         // now schedule new thread for execution
-        threads::detail::set_thread_state_timed(scheduler_, abs_time, id, ec);
+        threads::detail::set_thread_state_timed(scheduler_, abs_time, id,
+            nullptr, ec);
         if (ec) {
             --tasks_scheduled_;
             return;

--- a/src/runtime/threads/executors/thread_pool_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_executors.cpp
@@ -208,7 +208,8 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         ++tasks_scheduled_;
 
         // now schedule new thread for execution
-        threads::detail::set_thread_state_timed(scheduler_, abs_time, id, ec);
+        threads::detail::set_thread_state_timed(scheduler_, abs_time, id,
+            nullptr, ec);
         if (ec) {
             --tasks_scheduled_;
             return;

--- a/src/runtime/threads/thread_helpers.cpp
+++ b/src/runtime/threads/thread_helpers.cpp
@@ -16,6 +16,7 @@
 #include <hpx/runtime/threads/thread_data_fwd.hpp>
 #include <hpx/runtime/threads/thread_enums.hpp>
 #include <hpx/runtime/threads/thread_pool_base.hpp>
+#include <hpx/util/assert.hpp>
 #ifdef HPX_HAVE_THREAD_BACKTRACE_ON_SUSPENSION
 #include <hpx/util/backtrace.hpp>
 #endif
@@ -25,7 +26,9 @@
 #include <hpx/util/steady_clock.hpp>
 #include <hpx/util/thread_description.hpp>
 #include <hpx/util/thread_specific_ptr.hpp>
+#include <hpx/util/yield_while.hpp>
 
+#include <atomic>
 #include <cstddef>
 #include <limits>
 #include <sstream>
@@ -48,11 +51,12 @@ namespace hpx { namespace threads
 
     ///////////////////////////////////////////////////////////////////////////
     thread_id_type set_thread_state(thread_id_type const& id,
-        util::steady_time_point const& abs_time, thread_state_enum state,
-        thread_state_ex_enum stateex, thread_priority priority, error_code& ec)
+        util::steady_time_point const& abs_time, std::atomic<bool>* timer_started,
+        thread_state_enum state, thread_state_ex_enum stateex,
+        thread_priority priority, error_code& ec)
     {
         return detail::set_thread_state_timed(*id->get_scheduler_base(), abs_time, id,
-            state, stateex, priority, std::size_t(-1), ec);
+            state, stateex, priority, std::size_t(-1), timer_started, ec);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -556,8 +560,9 @@ namespace hpx { namespace this_thread
 #ifdef HPX_HAVE_THREAD_BACKTRACE_ON_SUSPENSION
             detail::reset_backtrace bt(id, ec);
 #endif
+            std::atomic<bool> timer_started(false);
             threads::thread_id_type timer_id = threads::set_thread_state(id,
-                abs_time, threads::pending, threads::wait_timeout,
+                abs_time, &timer_started, threads::pending, threads::wait_timeout,
                 threads::thread_priority_boost, ec);
             if (ec) return threads::wait_unknown;
 
@@ -579,7 +584,13 @@ namespace hpx { namespace this_thread
 
             if (statex != threads::wait_timeout)
             {
+                HPX_ASSERT(
+                    statex == threads::wait_abort ||
+                    statex == threads::wait_signaled);
                 error_code ec1(lightweight);    // do not throw
+                hpx::util::yield_while(
+                    [&timer_started]() { return !timer_started.load(); },
+                    "set_thread_state_timed");
                 threads::set_thread_state(timer_id,
                     threads::pending, threads::wait_abort,
                     threads::thread_priority_boost, ec1);

--- a/tests/regressions/lcos/wait_for_1751.cpp
+++ b/tests/regressions/lcos/wait_for_1751.cpp
@@ -35,7 +35,7 @@ int hpx_main()
             auto now = std::chrono::high_resolution_clock::now();
             std::chrono::duration<double> dif = now - start_time;
 
-            HPX_TEST_LTE(dif.count(), 1.0);
+            HPX_TEST_LTE(dif.count(), 1.01);
             break;
         }
         else

--- a/tests/unit/component/CMakeLists.txt
+++ b/tests/unit/component/CMakeLists.txt
@@ -47,7 +47,6 @@ add_hpx_executable(launched_process_test
   COMPONENT_DEPENDENCIES launch_process_test_server)
 
 set(action_invoke_no_more_than_PARAMETERS
-    LOCALITIES 2
     THREADS_PER_LOCALITY 4)
 set(action_invoke_no_more_than_FLAGS
     DEPENDENCIES iostreams_component)


### PR DESCRIPTION
When doing a timed suspension on a thread, there were several race conditions
between setting the different participating thread states, which should now be
fixed. The problem was observable with the wait_for_1751 regression test.

This is the second attempt (after #3153), fixing the previous issues.