### PR TITLE
Support Checkpointing Components

### DIFF
--- a/docs/sphinx/manual/miscellaneous.rst
+++ b/docs/sphinx/manual/miscellaneous.rst
@@ -251,6 +251,32 @@ illustrated below.
    :language: c++
    :lines: 129-150
 
+Checkpointing Components
+------------------------
+
+``save_checkpoint`` and ``restore_checkpoint`` are also able to store components
+inside ``checkpoint``s. This can be done in one of two ways. First a client of
+the component can be passed to ``save_checkpoint``. When the user wishes to
+resurrect the component she can pass a client instance to ``restore_checkpoint``.
+
+This technique is demonstrated below:
+
+.. literalinclude:: ../../tests/unit/util/checkpoint.cpp
+   :language: c++
+   :lines: 143-144
+
+The second way a user can save a component is by passing a ``shared_ptr`` to the
+component to ``save_checkpoint``. This component can be resurrected by creating
+a new instance of the component type and passing a ``shared_ptr`` to the new
+instance to ``restore_checkpoint``. An example can be found below:
+
+This technique is demonstrated below:
+
+.. literalinclude:: ../../tests/unit/util/checkpoint.cpp
+   :language: c++
+   :lines: 113-126
+
+
 .. _iostreams:
 
 The |hpx| I/O-streams component

--- a/examples/1d_stencil/1d_stencil_4_checkpoint.cpp
+++ b/examples/1d_stencil/1d_stencil_4_checkpoint.cpp
@@ -1,6 +1,6 @@
 //  Copyright (c) 2014 Hartmut Kaiser
 //  Copyright (c) 2014 Patricia Grubel
-//  Copyright (c) 2017 Adrian Serio
+//  Copyright (c) 2018 Adrian Serio
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -167,7 +167,9 @@ struct backup
     {
         hpx::util::checkpoint archive_data =
             hpx::util::save_checkpoint(hpx::launch::sync, bin);
-        std::ofstream file_archive(file_name_);
+        // Make sure file stream is bianary for Windows/Mac machines
+        std::ofstream file_archive(
+            file_name_, std::ios::binary | std::ios::out);
         if (file_archive.is_open())
         {
             file_archive << archive_data;
@@ -183,7 +185,8 @@ struct backup
         std::size_t nx)
     {
         hpx::util::checkpoint temp_archive;
-        std::ifstream ist(file_name_);
+        // Make sure file stream is bianary for Windows/Mac machines
+        std::ifstream ist(file_name_, std::ios::binary | std::ios::in);
         ist >> temp_archive;
         hpx::util::restore_checkpoint(temp_archive, bin);
         for (std::size_t i = 0; i < U[0].size(); i++)
@@ -337,7 +340,6 @@ struct stepper
                             container[(t / cp) - 1].save(value, i);
                             partition f_value = hpx::make_ready_future(value);
                             return f_value;
-
                         });
                 }
             }

--- a/hpx/runtime/naming/name.hpp
+++ b/hpx/runtime/naming/name.hpp
@@ -811,7 +811,7 @@ namespace hpx { namespace naming
             HPX_NON_COPYABLE(id_type_impl);
 
         private:
-            typedef void (*deleter_type)(detail::id_type_impl*);
+            using deleter_type = void (*)(detail::id_type_impl*);
             static deleter_type get_deleter(id_type_management t) noexcept;
 
         public:

--- a/hpx/runtime/naming_fwd.hpp
+++ b/hpx/runtime/naming_fwd.hpp
@@ -34,6 +34,9 @@ namespace hpx
 
         HPX_CONSTEXPR_OR_CONST std::uint32_t invalid_locality_id =
             ~static_cast<std::uint32_t>(0);
+
+        // tag used to mark serialization archive during check-pointing
+        struct checkpointing_tag {};
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/hpx/util/checkpoint.hpp
+++ b/hpx/util/checkpoint.hpp
@@ -18,12 +18,16 @@
 
 #include <hpx/dataflow.hpp>
 #include <hpx/lcos/future.hpp>
-#include <hpx/serialization/serialize.hpp>
-#include <hpx/serialization/vector.hpp>
+#include <hpx/runtime/components/client_base.hpp>
 #include <hpx/runtime/components/new.hpp>
 #include <hpx/runtime/get_ptr.hpp>
+#include <hpx/runtime/naming_fwd.hpp>
+#include <hpx/serialization/serialize.hpp>
+#include <hpx/serialization/vector.hpp>
+#include <hpx/traits/is_client.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <fstream>
 #include <iosfwd>
 #include <memory>
@@ -33,18 +37,20 @@
 #include <utility>
 #include <vector>
 
-namespace hpx {
-namespace util {
+namespace hpx { namespace util {
 
+    ///////////////////////////////////////////////////////////////////////////
     // Forward declarations
     class checkpoint;
+
     std::ostream& operator<<(std::ostream& ost, checkpoint const& ckp);
     std::istream& operator>>(std::istream& ist, checkpoint& ckp);
+
     namespace detail {
         struct save_funct_obj;
     }
 
-    ///////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
     /// Checkpoint Object
     ///
     /// Checkpoint is the container object which is produced by save_checkpoint
@@ -56,41 +62,44 @@ namespace util {
     /// serialized including components.
     class checkpoint
     {
-        std::vector<char> data;
+        std::vector<char> data_;
 
         friend std::ostream& operator<<(
             std::ostream& ost, checkpoint const& ckp);
         friend std::istream& operator>>(std::istream& ist, checkpoint& ckp);
+
         // Serialization Definition
         friend class hpx::serialization::access;
         template <typename Archive>
         void serialize(Archive& arch, const unsigned int version)
         {
-            arch& data;
-        };
+            arch& data_;
+        }
+
         friend struct detail::save_funct_obj;
+
         template <typename T, typename... Ts>
         friend void restore_checkpoint(checkpoint const& c, T& t, Ts&... ts);
 
     public:
         checkpoint() = default;
         checkpoint(checkpoint const& c)
-          : data(c.data)
+          : data_(c.data_)
         {
         }
-        checkpoint(checkpoint&& c)
-          : data(std::move(c.data))
+        checkpoint(checkpoint&& c) noexcept
+          : data_(std::move(c.data_))
         {
         }
         ~checkpoint() = default;
 
         // Other Constructors
         checkpoint(std::vector<char> const& vec)
-          : data(vec)
+          : data_(vec)
         {
         }
         checkpoint(std::vector<char>&& vec)
-          : data(std::move(vec))
+          : data_(std::move(vec))
         {
         }
 
@@ -99,49 +108,51 @@ namespace util {
         {
             if (&c != this)
             {
-                data = c.data;
+                data_ = c.data_;
             }
             return *this;
         }
-        checkpoint& operator=(checkpoint&& c)
+        checkpoint& operator=(checkpoint&& c) noexcept
         {
             if (&c != this)
             {
-                data = std::move(c.data);
+                data_ = std::move(c.data_);
             }
             return *this;
         }
 
-        bool operator==(checkpoint const& c) const
+        friend bool operator==(checkpoint const& lhs, checkpoint const& rhs)
         {
-            return data == c.data;
+            return lhs.data_ == rhs.data_;
         }
-        bool operator!=(checkpoint const& c) const
+        friend bool operator!=(checkpoint const& lhs, checkpoint const& rhs)
         {
-            return !(data == c.data);
+            return !(lhs == rhs);
         }
 
         // Iterators
         //  expose iterators to access data held by checkpoint
         using const_iterator = std::vector<char>::const_iterator;
+
         const_iterator begin() const
         {
-            return data.begin();
+            return data_.begin();
         }
         const_iterator end() const
         {
-            return data.end();
+            return data_.end();
         }
 
         // Functions
         size_t size() const
         {
-            return data.size();
+            return data_.size();
         }
     };
 
-    //Stream Overloads
-    ///////////////////////////////////
+    // Stream Overloads
+
+    ///////////////////////////////////////////////////////////////////////////
     /// Operator<< Overload
     ///
     /// \param ost           Output stream to write to.
@@ -163,13 +174,15 @@ namespace util {
     inline std::ostream& operator<<(std::ostream& ost, checkpoint const& ckp)
     {
         // Write the size of the checkpoint to the file
-        int64_t size = ckp.size();
-        ost.write(reinterpret_cast<char const*>(&size), sizeof(int64_t));
+        std::int64_t size = ckp.size();
+        ost.write(reinterpret_cast<char const*>(&size), sizeof(std::int64_t));
+
         // Write the file to the stream
-        ost.write(ckp.data.data(), ckp.size());
+        ost.write(ckp.data_.data(), ckp.size());
         return ost;
     }
-    ///////////////////////////////////
+
+    ///////////////////////////////////////////////////////////////////////////
     /// Operator>> Overload
     ///
     /// \param ist           Input stream to write from.
@@ -194,16 +207,18 @@ namespace util {
     inline std::istream& operator>>(std::istream& ist, checkpoint& ckp)
     {
         // Read in the size of the next checkpoint
-        int64_t length;
-        ist.read(reinterpret_cast<char*>(&length), sizeof(int64_t));
-        ckp.data.resize(length);
+        std::int64_t length = 0;
+        ist.read(reinterpret_cast<char*>(&length), sizeof(std::int64_t));
+        ckp.data_.resize(length);
+
         // Read in the next checkpoint
-        ist.read(ckp.data.data(), length);
+        ist.read(ckp.data_.data(), length);
         return ist;
     }
 
     // Function objects for save_checkpoint
     namespace detail {
+
         // Properly handle non clients
         template <typename T,
             typename U = typename std::enable_if<!hpx::traits::is_client<
@@ -212,42 +227,44 @@ namespace util {
         {
             return std::forward<T>(t);
         }
-        // Properly handle Clients to compoents
-        template <typename T,
-            typename U = typename std::enable_if<hpx::traits::is_client<
-                typename std::decay<T>::type>::value>::type>
-        hpx::future<std::shared_ptr<
-            typename std::decay<T>::type::server_component_type>>
-        prep(T&& c)
+
+        // Properly handle Clients to components
+        template <typename Client, typename Server>
+        hpx::future<std::shared_ptr<typename hpx::components::client_base<
+            Client, Server>::server_component_type>>
+        prep(hpx::components::client_base<Client, Server> const& c)
         {
             // Use shared pointer to serialize server
-            using server_type =
-                typename std::decay<T>::type::server_component_type;
-            return c.then(
-                [](typename std::decay<T>::type && c)
-                {
-                    return hpx::get_ptr<server_type>(c.get_id());
-                });
+            using server_type = typename hpx::components::client_base<Client,
+                Server>::server_component_type;
+            return hpx::get_ptr<server_type>(c.get_id());
         }
+
         struct save_funct_obj
         {
             template <typename... Ts>
             checkpoint operator()(checkpoint&& c, Ts&&... ts) const
             {
                 // Create serialization archive from checkpoint data member
-                hpx::serialization::output_archive ar(c.data);
+                hpx::serialization::output_archive ar(c.data_);
+
+                // force check-pointing flag to be created in the archive,
+                // the serialization of id_type's checks for it
+                ar.get_extra_data<naming::checkpointing_tag>();
+
                 // Serialize data
-                int const sequencer[] = {
-                    // Trick to expand the variable pack
-                    0, (ar << ts, 0)...    // Takes advantage of the comma oper.
-                };
+
+                // Trick to expand the variable pack, akes advantage of the
+                // comma operator.
+                int const sequencer[] = {0, (ar << ts, 0)...};
                 (void) sequencer;    // Suppress unused param. warnings
+
                 return std::move(c);
             }
         };
-    }
+    }    // namespace detail
 
-    ///////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
     /// Save_checkpoint
     ///
     /// \tparam T            Containers passed to save_checkpoint to be
@@ -281,22 +298,19 @@ namespace util {
     ///          exception: if you pass hpx::launch::sync as the first
     ///          argument. In this case save_checkpoint will simply return
     ///          a checkpoint.
-
-    template <typename T,
-        typename... Ts,
+    template <typename T, typename... Ts,
         typename U =
             typename std::enable_if<!hpx::traits::is_launch_policy<T>::value &&
                 !std::is_same<typename std::decay<T>::type,
                     checkpoint>::value>::type>
     hpx::future<checkpoint> save_checkpoint(T&& t, Ts&&... ts)
     {
-        return hpx::dataflow(detail::save_funct_obj(),
-            std::move(checkpoint()),
+        return hpx::dataflow(detail::save_funct_obj{}, checkpoint{},
             detail::prep(std::forward<T>(t)),
             detail::prep(std::forward<Ts>(ts))...);
     }
 
-    ///////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
     /// Save_checkpoint - Take a pre-initialized checkpoint
     ///
     /// \tparam T            Containers passed to save_checkpoint to be
@@ -333,13 +347,12 @@ namespace util {
     template <typename T, typename... Ts>
     hpx::future<checkpoint> save_checkpoint(checkpoint&& c, T&& t, Ts&&... ts)
     {
-        return hpx::dataflow(detail::save_funct_obj(),
-            std::move(c),
+        return hpx::dataflow(detail::save_funct_obj{}, std::move(c),
             detail::prep(std::forward<T>(t)),
             detail::prep(std::forward<Ts>(ts))...);
     }
 
-    ///////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
     /// Save_checkpoint - Policy overload
     ///
     /// \tparam T            Containers passed to save_checkpoint to be
@@ -377,14 +390,12 @@ namespace util {
     template <typename T, typename... Ts>
     hpx::future<checkpoint> save_checkpoint(hpx::launch p, T&& t, Ts&&... ts)
     {
-        return hpx::dataflow(p,
-            detail::save_funct_obj(),
-            std::move(checkpoint()),
+        return hpx::dataflow(p, detail::save_funct_obj{}, checkpoint{},
             detail::prep(std::forward<T>(t)),
             detail::prep(std::forward<Ts>(ts))...);
     }
 
-    ///////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
     /// Save_checkpoint - Policy overload & pre-initialized checkpoint
     ///
     /// \tparam T            Containers passed to save_checkpoint to be
@@ -426,14 +437,12 @@ namespace util {
     hpx::future<checkpoint> save_checkpoint(
         hpx::launch p, checkpoint&& c, T&& t, Ts&&... ts)
     {
-        return hpx::dataflow(p,
-            detail::save_funct_obj(),
-            std::move(c),
+        return hpx::dataflow(p, detail::save_funct_obj{}, std::move(c),
             detail::prep(std::forward<T>(t)),
             detail::prep(std::forward<Ts>(ts))...);
     }
 
-    ///////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
     /// Save_checkpoint - Sync_policy overload
     ///
     /// \tparam T            Containers passed to save_checkpoint to be
@@ -475,15 +484,14 @@ namespace util {
     checkpoint save_checkpoint(
         hpx::launch::sync_policy sync_p, T&& t, Ts&&... ts)
     {
-        hpx::future<checkpoint> f_chk = hpx::dataflow(sync_p,
-            detail::save_funct_obj(),
-            std::move(checkpoint()),
-            detail::prep(std::forward<T>(t)),
-            detail::prep(std::forward<Ts>(ts))...);
+        hpx::future<checkpoint> f_chk =
+            hpx::dataflow(sync_p, detail::save_funct_obj{}, checkpoint{},
+                detail::prep(std::forward<T>(t)),
+                detail::prep(std::forward<Ts>(ts))...);
         return f_chk.get();
     }
 
-    ///////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
     /// Save_checkpoint - Sync_policy overload & pre-init. checkpoint
     ///
     /// \tparam T            Containers passed to save_checkpoint to be
@@ -522,15 +530,15 @@ namespace util {
         hpx::launch::sync_policy sync_p, checkpoint&& c, T&& t, Ts&&... ts)
     {
         hpx::future<checkpoint> f_chk =
-            hpx::dataflow(sync_p,
-                detail::save_funct_obj(),
-                std::move(c),
+            hpx::dataflow(sync_p, detail::save_funct_obj{}, std::move(c),
                 detail::prep(std::forward<T>(t)),
                 detail::prep(std::forward<Ts>(ts))...);
         return f_chk.get();
     }
 
+    ///////////////////////////////////////////////////////////////////////////
     namespace detail {
+
         // Properly handle non client/server restoration
         template <typename T,
             typename U = typename std::enable_if<
@@ -545,17 +553,19 @@ namespace util {
         void restore_impl(hpx::serialization::input_archive& ar,
             hpx::components::client_base<Client, Server>& c)
         {
-            hpx::future<std::shared_ptr<typename hpx::components::
-                    client_base<Client, Server>::server_component_type>>
-                f_server_ptr;
             // Revive server
+            using server_component_type =
+                typename hpx::components::client_base<Client,
+                    Server>::server_component_type;
+
+            hpx::future<std::shared_ptr<server_component_type>> f_server_ptr;
             ar >> f_server_ptr;
             c = hpx::new_<Client>(
                 hpx::find_here(), std::move(*(f_server_ptr.get())));
         }
-    }
+    }    // namespace detail
 
-    ///////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
     /// Restore_checkpoint
     ///
     /// Restore_checkpoint takes a checkpoint object as a first argument and
@@ -584,17 +594,17 @@ namespace util {
     void restore_checkpoint(checkpoint const& c, T& t, Ts&... ts)
     {
         // Create serialization archive
-        hpx::serialization::input_archive ar(c.data, c.size());
+        hpx::serialization::input_archive ar(c.data_, c.size());
 
         // De-serialize data
         detail::restore_impl(ar, t);
-        int const sequencer[] = { // Trick to exand the variable pack
-                                  // Takes advantage of the comma operator
-            0, (detail::restore_impl(ar, ts), 0)...};
-        (void) sequencer;         // Suppress unused param. warnings
+
+        // Trick to expand the variable pack, takes advantage of the comma
+        // operator
+        int const sequencer[] = {0, (detail::restore_impl(ar, ts), 0)...};
+        (void) sequencer;    // Suppress unused variable warnings
     }
 
-}    // End Util Namespace
-}    // End HPX Namespace
+}}    // namespace hpx::util
 
 #endif

--- a/hpx/util/checkpoint.hpp
+++ b/hpx/util/checkpoint.hpp
@@ -262,7 +262,7 @@ namespace util {
     ///
     /// Save_checkpoint takes any number of objects which a user may wish
     /// to store and returns a future to a checkpoint object.
-    /// This funciton can also store a component either by passing a
+    /// This function can also store a component either by passing a
     /// shared_ptr to the component or by passing a component's client
     /// instance to save_checkpoint.
     /// Additionally the function can take a policy as
@@ -307,7 +307,7 @@ namespace util {
     ///
     /// Save_checkpoint takes any number of objects which a user may wish
     /// to store and returns a future to a checkpoint object.
-    /// This funciton can also store a component either by passing a
+    /// This function can also store a component either by passing a
     /// shared_ptr to the component or by passing a component's client
     /// instance to save_checkpoint.
     /// Additionally the function can take a policy as a first object which
@@ -349,7 +349,7 @@ namespace util {
     ///
     /// Save_checkpoint takes any number of objects which a user may wish
     /// to store and returns a future to a checkpoint object.
-    /// This funciton can also store a component either by passing a
+    /// This function can also store a component either by passing a
     /// shared_ptr to the component or by passing a component's client
     /// instance to save_checkpoint.
     /// Additionally the function can take a policy as a first object which
@@ -395,7 +395,7 @@ namespace util {
     ///
     /// Save_checkpoint takes any number of objects which a user may wish
     /// to store and returns a future to a checkpoint object.
-    /// This funciton can also store a component either by passing a
+    /// This function can also store a component either by passing a
     /// shared_ptr to the component or by passing a component's client
     /// instance to save_checkpoint.
     /// Additionally the function can take a policy as a first object which
@@ -440,7 +440,7 @@ namespace util {
     ///
     /// Save_checkpoint takes any number of objects which a user may wish
     /// to store and returns a future to a checkpoint object.
-    /// This funciton can also store a component either by passing a
+    /// This function can also store a component either by passing a
     /// shared_ptr to the component or by passing a component's client
     /// instance to save_checkpoint.
     /// Additionally the function can take a policy as a first object which
@@ -487,7 +487,7 @@ namespace util {
     ///
     /// Save_checkpoint takes any number of objects which a user may wish
     /// to store and returns a future to a checkpoint object.
-    /// This funciton can also store a component either by passing a
+    /// This function can also store a component either by passing a
     /// shared_ptr to the component or by passing a component's client
     /// instance to save_checkpoint.
     /// Additionally the function can take a policy as a first object which

--- a/tests/unit/util/CMakeLists.txt
+++ b/tests/unit/util/CMakeLists.txt
@@ -32,6 +32,7 @@ if(HWLOC_FOUND)
   set(parse_affinity_options_PARAMETERS THREADS_PER_LOCALITY 2)
 endif()
 
+set(checkpoint_component_FLAGS COMPONENT_DEPENDENCIES iostreams)
 set(serialize_buffer_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 2)
 
 foreach(test ${tests})

--- a/tests/unit/util/CMakeLists.txt
+++ b/tests/unit/util/CMakeLists.txt
@@ -8,6 +8,7 @@ set(tests
     any_serialization
     bind_action
     checkpoint
+    checkpoint_component
     config_entry
     pack_traversal
     pack_traversal_async

--- a/tests/unit/util/checkpoint.cpp
+++ b/tests/unit/util/checkpoint.cpp
@@ -8,14 +8,14 @@
 // restore_checkpoint.
 //
 
+#include <hpx/hpx_main.hpp>
+#include <hpx/testing.hpp>
+#include <hpx/util/checkpoint.hpp>
+
 #include <fstream>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <hpx/hpx_main.hpp>
-#include <hpx/util/checkpoint.hpp>
-#include <hpx/testing.hpp>
 
 using hpx::util::checkpoint;
 using hpx::util::restore_checkpoint;
@@ -142,7 +142,7 @@ int main()
     if (test_file_7_1)
     {
         test_file_7_1.seekg(0, test_file_7_1.end);
-        int length = test_file_7_1.tellg();
+        auto length = test_file_7_1.tellg();
         test_file_7_1.seekg(0, test_file_7_1.beg);
         char_vec.resize(length);
         test_file_7_1.read(char_vec.data(), length);
@@ -211,7 +211,7 @@ int main()
     if (test_file_10_1)
     {
         test_file_10_1.seekg(0, test_file_10_1.end);
-        int length = test_file_10_1.tellg();
+        auto length = test_file_10_1.tellg();
         test_file_10_1.seekg(0, test_file_10_1.beg);
         char_vec_10.resize(length);
         test_file_10_1.read(char_vec_10.data(), length);

--- a/tests/unit/util/checkpoint.cpp
+++ b/tests/unit/util/checkpoint.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Adrian Serio
+// Copyright (c) 2018 Adrian Serio
 //
 //  SPDX-License-Identifier: BSL-1.0
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -131,9 +131,9 @@ int main()
     std::vector<float> vec7{1.02f, 1.03f, 1.04f, 1.05f};
     hpx::future<checkpoint> fut_7 = save_checkpoint(vec7);
     checkpoint archive7 = fut_7.get();
-    std::copy(archive7.begin()    // Write data to ofstream
-        , archive7.end()    // ie. the file
-        , std::ostream_iterator<char>(test_file_7));
+    std::copy(archive7.begin(),    // Write data to ofstream
+        archive7.end(),            // ie. the file
+        std::ostream_iterator<char>(test_file_7));
     test_file_7.close();
 
     std::vector<float> vec7_1;
@@ -147,7 +147,7 @@ int main()
         char_vec.resize(length);
         test_file_7_1.read(char_vec.data(), length);
     }
-    checkpoint archive7_1(std::move(char_vec));  // Write data to checkpoint
+    checkpoint archive7_1(std::move(char_vec));    // Write data to checkpoint
     restore_checkpoint(archive7_1, vec7_1);
     //]
 
@@ -200,9 +200,9 @@ int main()
     std::vector<float> vec10{1.02f, 1.03f, 1.04f, 1.05f};
     hpx::future<checkpoint> fut_10 = save_checkpoint(vec10);
     checkpoint archive10 = fut_10.get();
-    std::copy(archive10.begin()    // Write data to ofstream
-        , archive10.end()    // ie. the file
-        , std::ostream_iterator<char>(test_file_10));
+    std::copy(archive10.begin(),    // Write data to ofstream
+        archive10.end(),            // ie. the file
+        std::ostream_iterator<char>(test_file_10));
     test_file_10.close();
 
     std::vector<float> vec10_1;
@@ -216,7 +216,7 @@ int main()
         char_vec_10.resize(length);
         test_file_10_1.read(char_vec_10.data(), length);
     }
-    checkpoint archive10_1(char_vec_10);  // Write data to checkpoint
+    checkpoint archive10_1(char_vec_10);    // Write data to checkpoint
     restore_checkpoint(archive10_1, vec10_1);
 
     HPX_TEST(vec10 == vec10_1);

--- a/tests/unit/util/checkpoint_component.cpp
+++ b/tests/unit/util/checkpoint_component.cpp
@@ -134,7 +134,7 @@ int main()
     data_client B(std::move(old_id));
 
     HPX_TEST(A.get_data().get() == B.get_data().get());
-    
+
     // Test 2
     // Try to checkpoint and restore a component with a client
     //[comp_test_1

--- a/tests/unit/util/checkpoint_component.cpp
+++ b/tests/unit/util/checkpoint_component.cpp
@@ -1,18 +1,18 @@
 // Copyright (c) 2018 Adrian Serio
 //
+//  SPDX-License-Identifier: BSL-1.0
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-//
-// This example tests the interoperablility of save_checkpoint and
+
+// This example tests the interoperability of save_checkpoint and
 // restore_checkpoint with components.
-//
 
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/components.hpp>
 #include <hpx/include/iostreams.hpp>
-#include <hpx/runtime/serialization/shared_ptr.hpp>
+#include <hpx/serialization/shared_ptr.hpp>
+#include <hpx/testing.hpp>
 #include <hpx/util/checkpoint.hpp>
-#include <hpx/util/lightweight_test.hpp>
 
 #include <fstream>
 #include <iostream>
@@ -63,9 +63,10 @@ struct data_server : hpx::components::component_base<data_server>
     void serialize(Archive& arch, const unsigned int version)
     {
         arch& data_;
-    };
+    }
 };
-typedef hpx::components::component<data_server> data_server_type;
+
+using data_server_type = hpx::components::component<data_server>;
 HPX_REGISTER_COMPONENT(data_server_type, data_server);
 
 HPX_REGISTER_ACTION(data_server::get_data_action);
@@ -73,7 +74,7 @@ HPX_REGISTER_ACTION(data_server::print_action);
 
 struct data_client : hpx::components::client_base<data_client, data_server>
 {
-    typedef hpx::components::client_base<data_client, data_server> base_type;
+    using base_type = hpx::components::client_base<data_client, data_server>;
     data_client() = default;
     ~data_client() = default;
 
@@ -109,14 +110,12 @@ int main()
 {
     // Test 1
     //  test checkpoint a component using a shared_ptr
-    //[comp_test_2
     std::vector<int> vec{1, 2, 3, 4, 5};
     data_client A(hpx::find_here(), std::move(vec));
 
     // Checkpoint Server
-    //]
     hpx::id_type old_id = A.get_id();
-    //[comp_test_3
+
     hpx::future<std::shared_ptr<data_server>> f_a_ptr =
         hpx::get_ptr<data_server>(A.get_id());
     std::shared_ptr<data_server> a_ptr = f_a_ptr.get();
@@ -126,7 +125,6 @@ int main()
     // Create a new server instance
     std::shared_ptr<data_server> b_server;
     restore_checkpoint(f.get(), b_server);
-    //]
 
     HPX_TEST(A.get_data().get() == b_server->get_data());
 
@@ -137,17 +135,17 @@ int main()
 
     // Test 2
     // Try to checkpoint and restore a component with a client
-    //[comp_test_1
     std::vector<int> vec3{10, 10, 10, 10, 10};
+
     // Create a component instance through client constructor
     data_client D(hpx::find_here(), std::move(vec3));
     hpx::future<checkpoint> f3 = save_checkpoint(D);
 
     // Create a new client
     data_client E;
+
     // Restore server inside client instance
     restore_checkpoint(f3.get(), E);
-    //]
 
     HPX_TEST(D.get_data().get() == E.get_data().get());
 

--- a/tests/unit/util/checkpoint_component.cpp
+++ b/tests/unit/util/checkpoint_component.cpp
@@ -1,0 +1,165 @@
+// Copyright (c) 2018 Adrian Serio
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// This example tests the interoperablility of save_checkpoint and
+// restore_checkpoint with components.
+//
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/components.hpp>
+#include <hpx/include/iostreams.hpp>
+#include <hpx/runtime/serialization/shared_ptr.hpp>
+#include <hpx/util/checkpoint.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <fstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+using hpx::util::checkpoint;
+using hpx::util::restore_checkpoint;
+using hpx::util::save_checkpoint;
+
+struct data_server : hpx::components::component_base<data_server>
+{
+    data_server() = default;
+    ~data_server() = default;
+
+    data_server(std::vector<int>&& data)
+      : data_(std::move(data))
+    {
+    }
+
+    std::vector<int> get_data()
+    {
+        return data_;
+    }
+    HPX_DEFINE_COMPONENT_ACTION(data_server, get_data, get_data_action);
+
+    void print()
+    {
+        for (size_t i = 0; i < data_.size(); i++)
+        {
+            std::cout << data_[i];
+            if (data_.size() - 1 != i)
+            {
+                std::cout << ",";
+            }
+        }
+        std::cout << std::endl;
+    }
+    HPX_DEFINE_COMPONENT_ACTION(data_server, print, print_action);
+
+    std::vector<int> data_;
+
+    // Serialization Definition
+    friend class hpx::serialization::access;
+    template <typename Archive>
+    void serialize(Archive& arch, const unsigned int version)
+    {
+        arch& data_;
+    };
+};
+typedef hpx::components::component<data_server> data_server_type;
+HPX_REGISTER_COMPONENT(data_server_type, data_server);
+
+HPX_REGISTER_ACTION(data_server::get_data_action);
+HPX_REGISTER_ACTION(data_server::print_action);
+
+struct data_client : hpx::components::client_base<data_client, data_server>
+{
+    typedef hpx::components::client_base<data_client, data_server> base_type;
+    data_client() = default;
+    ~data_client() = default;
+
+    data_client(hpx::id_type where, std::vector<int>&& data)
+      : base_type(hpx::new_<data_server>(hpx::colocated(where), data))
+    {
+    }
+
+    data_client(hpx::id_type&& id)
+      : base_type(std::move(id))
+    {
+    }
+
+    data_client(hpx::shared_future<hpx::id_type> const& id)
+      : base_type(id)
+    {
+    }
+
+    hpx::future<std::vector<int>> get_data()
+    {
+        data_server::get_data_action get_act;
+        return hpx::async(get_act, get_id());
+    }
+
+    hpx::future<void> print()
+    {
+        data_server::print_action print_act;
+        return hpx::async(print_act, get_id());
+    }
+};
+
+int main()
+{
+    // Test 1
+    //  test checkpoint a component using a shared_ptr
+    //[comp_test_2
+    std::vector<int> vec{1, 2, 3, 4, 5};
+    data_client A(hpx::find_here(), std::move(vec));
+
+    // Checkpoint Server
+    //]
+    hpx::id_type old_id = A.get_id();
+    //[comp_test_3
+    hpx::future<std::shared_ptr<data_server>> f_a_ptr =
+        hpx::get_ptr<data_server>(A.get_id());
+    std::shared_ptr<data_server> a_ptr = f_a_ptr.get();
+    hpx::future<checkpoint> f = save_checkpoint(a_ptr);
+
+    // Restore Server
+    // Create a new server instance
+    std::shared_ptr<data_server> b_server;
+    restore_checkpoint(f.get(), b_server);
+    //]
+
+    HPX_TEST(A.get_data().get() == b_server->get_data());
+
+    // Re-create Client
+    data_client B(std::move(old_id));
+
+    HPX_TEST(A.get_data().get() == B.get_data().get());
+
+    // Test 2
+    // try to checkpoint a component using a client
+    std::vector<int> vec2{5, 4, 3, 2, 1};
+    data_client C(hpx::find_here(), std::move(vec2));
+    hpx::future<checkpoint> f2 = save_checkpoint(C);
+
+    // Restore Server
+    std::shared_ptr<data_server> c_server_id;
+    restore_checkpoint(f2.get(), c_server_id);
+
+    HPX_TEST(C.get_data().get() == c_server_id->get_data());
+
+    // Test 3
+    // Try to checkpoint and restore a component with a client
+    //[comp_test_1
+    std::vector<int> vec3{10, 10, 10, 10, 10};
+    // Create a component instance through client constructor
+    data_client D(hpx::find_here(), std::move(vec3));
+    hpx::future<checkpoint> f3 = save_checkpoint(D);
+
+    // Create a new client
+    data_client E;
+    // Restore server inside client instance
+    restore_checkpoint(f3.get(), E);
+    //]
+
+    HPX_TEST(D.get_data().get() == E.get_data().get());
+
+    return 0;
+}

--- a/tests/unit/util/checkpoint_component.cpp
+++ b/tests/unit/util/checkpoint_component.cpp
@@ -15,6 +15,8 @@
 #include <hpx/util/lightweight_test.hpp>
 
 #include <fstream>
+#include <iostream>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -132,20 +134,8 @@ int main()
     data_client B(std::move(old_id));
 
     HPX_TEST(A.get_data().get() == B.get_data().get());
-
+    
     // Test 2
-    // try to checkpoint a component using a client
-    std::vector<int> vec2{5, 4, 3, 2, 1};
-    data_client C(hpx::find_here(), std::move(vec2));
-    hpx::future<checkpoint> f2 = save_checkpoint(C);
-
-    // Restore Server
-    std::shared_ptr<data_server> c_server_id;
-    restore_checkpoint(f2.get(), c_server_id);
-
-    HPX_TEST(C.get_data().get() == c_server_id->get_data());
-
-    // Test 3
     // Try to checkpoint and restore a component with a client
     //[comp_test_1
     std::vector<int> vec3{10, 10, 10, 10, 10};


### PR DESCRIPTION
Extended current implementation of `hpx::util::checkpoint` to properly handle components.

Summary:
 - Fixed `checkpoint.cpp` to make floats constant
   - Makes MSVC happy
 - Adding `checkpoint_component.cpp`
 - Raise abstraction level in checkpoint
   - Create new function arch_data that will be overloaded to properly
      handle components
 - Adding in components to test
 - Working component checkpointing!
   - Checkpoints a server
   - Still needs to create a new client
 - Create new client on restored server
 - Adding functionality to enable checkpointing of clients
   - Checkpoints the server the client points to
   - Still need to add functionality to restore which would
      create a new client with the resurrected server
 - Allowing components to be restored with provided client
   - Users can now use clients to  checkpoint and restore
      servers
 - Updating Documentation
 - Preparing unit test for checkpointing components
 - Fixing 1d_stencil_4_checkpoint example for Windows/Mac
 - Fixing compilation on gcc
 - Adding documentation for checkpointing components
 - Clean up code with Clang-Format
   - Update year on license
