### PR TITLE
Fixing the handling of quoted command line arguments.

### DIFF
--- a/hpx/util/parse_command_line.hpp
+++ b/hpx/util/parse_command_line.hpp
@@ -67,7 +67,7 @@ namespace hpx { namespace util
     {
         inline std::string enquote(std::string const& arg)
         {
-            if (arg.find_first_of(" \t") != std::string::npos)
+            if (arg.find_first_of(" \t\"") != std::string::npos)
                 return std::string("\"") + arg + "\"";
             return arg;
         }


### PR DESCRIPTION
Previously quoted command line arguments were stripped of the outermost pair of quotes. The proposed change fixes this issue.