### PR TITLE
libfabric parcelport w/o HPX_PARCELPORT_LIBFABRIC_ENDPOINT_RDM

### DIFF
--- a/cmake/HPX_SetupBoost.cmake
+++ b/cmake/HPX_SetupBoost.cmake
@@ -26,7 +26,7 @@ set(Boost_ADDITIONAL_VERSIONS
 set(__boost_libraries)
 if(HPX_PARCELPORT_VERBS_WITH_LOGGING OR HPX_PARCELPORT_VERBS_WITH_DEV_MODE OR
    HPX_PARCELPORT_LIBFABRIC_WITH_LOGGING OR HPX_PARCELPORT_LIBFABRIC_WITH_DEV_MODE)
-  set(__boost_libraries ${__boost_libraries} log log_setup)
+  set(__boost_libraries ${__boost_libraries} log log_setup date_time chrono thread)
 endif()
 
 if(HPX_WITH_THREAD_COMPATIBILITY OR NOT(HPX_WITH_CXX11_THREAD))

--- a/plugins/parcelport/libfabric/CMakeLists.txt
+++ b/plugins/parcelport/libfabric/CMakeLists.txt
@@ -239,18 +239,6 @@ hpx_add_config_define_namespace(
     NAMESPACE parcelport)
 
 #------------------------------------------------------------------------------
-# Hardware checks
-#------------------------------------------------------------------------------
-if (HPX_PARCELPORT_LIBFABRIC_INTERFACE MATCHES "roq")
-  message(WARNING
-    "The roq interface on BGQ IO nodes does not support immediate data, disabling it")
-  hpx_add_config_define_namespace(
-      DEFINE HPX_PARCELPORT_LIBFABRIC_IMM_UNSUPPORTED
-      VALUE  1
-      NAMESPACE parcelport)
-endif()
-
-#------------------------------------------------------------------------------
 # Define the ParcelPort registration macro
 #------------------------------------------------------------------------------
 include(HPX_AddLibrary)

--- a/plugins/parcelport/libfabric/libfabric_controller.hpp
+++ b/plugins/parcelport/libfabric/libfabric_controller.hpp
@@ -727,7 +727,7 @@ namespace libfabric
                 struct fi_cq_err_entry e = {};
                 int err_sz = fi_cq_readerr(txcq_, &e ,0);
                 // from the manpage 'man 3 fi_cq_readerr'
-                // 
+                //
                 // On error, a negative value corresponding to
                 // 'fabric errno' is returned
                 //
@@ -806,7 +806,7 @@ namespace libfabric
                 struct fi_cq_err_entry e = {};
                 int err_sz = fi_cq_readerr(rxcq_, &e ,0);
                 // from the manpage 'man 3 fi_cq_readerr'
-                // 
+                //
                 // On error, a negative value corresponding to
                 // 'fabric errno' is returned
                 //

--- a/plugins/parcelport/libfabric/libfabric_controller.hpp
+++ b/plugins/parcelport/libfabric/libfabric_controller.hpp
@@ -411,6 +411,13 @@ namespace libfabric
             bind_endpoint_to_queues(ep_active_);
 #else
             bind_endpoint_to_queues(ep_passive_);
+            fabric_info_->handle = &(ep_passive->fid);
+
+            LOG_DEBUG_MSG("Creating active endpoint");
+            new_endpoint_active(fabric_info_, &ep_active_);
+            LOG_DEBUG_MSG("active endpoint " << hexpointer(ep_active_);
+
+            bind_endpoint_to_queues(ep_active_);
 #endif
 
             // filling our vector of receivers...
@@ -487,6 +494,7 @@ namespace libfabric
         locality create_local_endpoint()
         {
             struct fid *id;
+            int ret;
 #ifdef HPX_PARCELPORT_LIBFABRIC_ENDPOINT_RDM
             LOG_DEBUG_MSG("Creating active endpoint");
             new_endpoint_active(fabric_info_, &ep_active_);
@@ -504,7 +512,7 @@ namespace libfabric
             locality::locality_data local_addr;
             std::size_t addrlen = locality::array_size;
             LOG_DEBUG_MSG("Fetching local address using size " << decnumber(addrlen));
-            int ret = fi_getname(id, local_addr.data(), &addrlen);
+            ret = fi_getname(id, local_addr.data(), &addrlen);
             if (ret || (addrlen>locality::array_size)) {
                 fabric_error(ret, "fi_getname - size error or other problem");
             }
@@ -717,7 +725,16 @@ namespace libfabric
             }
             else if (ret == -FI_EAVAIL) {
                 struct fi_cq_err_entry e = {};
-                /*int err_sz =*/ fi_cq_readerr(txcq_, &e ,0);
+                int err_sz = fi_cq_readerr(txcq_, &e ,0);
+                // from the manpage 'man 3 fi_cq_readerr'
+                // 
+                // On error, a negative value corresponding to
+                // 'fabric errno' is returned
+                //
+                if(e.err == err_sz) {
+                    LOG_ERROR_MSG("txcq_ Error with len " << hexlength(e.len)
+                        << "context " << hexpointer(e.op_context));
+                }
                 // flags might not be set correctly
                 if (e.flags == (FI_MSG | FI_SEND)) {
                     LOG_ERROR_MSG("txcq Error for FI_SEND with len " << hexlength(e.len)
@@ -787,7 +804,16 @@ namespace libfabric
             }
             else if (ret == -FI_EAVAIL) {
                 struct fi_cq_err_entry e = {};
-                /*int err_sz =*/ fi_cq_readerr(rxcq_, &e ,0);
+                int err_sz = fi_cq_readerr(rxcq_, &e ,0);
+                // from the manpage 'man 3 fi_cq_readerr'
+                // 
+                // On error, a negative value corresponding to
+                // 'fabric errno' is returned
+                //
+                if(e.err == err_sz) {
+                    LOG_ERROR_MSG("txcq_ Error with len " << hexlength(e.len)
+                        << "context " << hexpointer(e.op_context));
+                }
                 LOG_ERROR_MSG("rxcq Error with flags " << hexlength(e.flags)
                     << "len " << hexlength(e.len));
             }

--- a/plugins/parcelport/libfabric/parcelport_libfabric.cpp
+++ b/plugins/parcelport/libfabric/parcelport_libfabric.cpp
@@ -267,8 +267,8 @@ namespace libfabric
             delete snd;
         }
         LOG_DEBUG_MSG(
-            << "sends_posted "  << decnumber(sends_posted)
-            << "sends_deleted " << decnumber(sends_posted)
+               "sends_posted "  << decnumber(sends_posted)
+            << "sends_deleted " << decnumber(sends_deleted)
             << "acks_received " << decnumber(acks_received)
             << "non_rma-send "  << decnumber(sends_posted-acks_received));
         //

--- a/plugins/parcelport/libfabric/parcelport_libfabric.cpp
+++ b/plugins/parcelport/libfabric/parcelport_libfabric.cpp
@@ -40,16 +40,10 @@
 // when we have maxed out the number of sends we can handle
 #define HPX_PARCELPORT_LIBFABRIC_SUSPEND_WAKE  (HPX_PARCELPORT_LIBFABRIC_THROTTLE_SENDS/2)
 
-
 // --------------------------------------------------------------------
 // Enable the use of boost small_vector for certain short lived storage
 // elements within the parcelport. This can reduce some memory allocations
 #define HPX_PARCELPORT_LIBFABRIC_USE_SMALL_VECTOR    true
-
-// until we implement immediate data, or counted rdma send completions
-// we will use a small message returned to the sender to signal ok
-// to release buffers.
-#define HPX_PARCELPORT_LIBFABRIC_IMM_UNSUPPORTED 1
 
 // --------------------------------------------------------------------
 #include <plugins/parcelport/unordered_map.hpp>

--- a/plugins/parcelport/libfabric/rma_receiver.cpp
+++ b/plugins/parcelport/libfabric/rma_receiver.cpp
@@ -315,7 +315,7 @@ namespace libfabric
                     std::fill(buffer, buffer + get_region->get_size()/4,
                        0xDEADC0DE);
                     LOG_TRACE_MSG(
-                        CRC32_MEM(get_region->get_address(), c.size_,
+                        CRC32_MEM(get_region->get_address(), get_region->get_size(),
                                   "(RDMA GET region (pre-fi_read))"));
                     );
 


### PR DESCRIPTION
HPX_PARCELPORT_LIBFABRIC_ENDPOINT_RDM fixes.

Fixes #2650 

## Any background context you want to provide?

platforms without LIBFABRIC_ENDPOINT_RDM turned on have compile time errors. this patch resolves compile issues. this patch also fixes an issue where the passive endpoint is not turned into an active endpoint for IPC. without this fix active endpoints are never created; active endpoints are created only in blocks of code with the HPX_PARCELPORT_LIBFABRIC_ENDPOINT_RDM #define guard. active endpoints are necessary for IPC.