### PR TITLE
Changing used namespace for seq execution policy

### DIFF
--- a/cmake/HPX_SetupVc.cmake
+++ b/cmake/HPX_SetupVc.cmake
@@ -78,6 +78,8 @@ if(NOT MSVC)
   foreach(_flag ${Vc_ARCHITECTURE_FLAGS})
     hpx_add_compile_flag(${_flag})
   endforeach()
+else()
+  hpx_add_config_cond_define(_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS)
 endif()
 
 hpx_add_config_define(HPX_HAVE_DATAPAR)

--- a/hpx/parallel/datapar/transform_loop.hpp
+++ b/hpx/parallel/datapar/transform_loop.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -127,7 +127,7 @@ namespace hpx { namespace parallel { namespace util
             >::type
             call(InIter first, InIter last, OutIter dest, F && f)
             {
-                return util::transform_loop(parallel::v1::seq,
+                return util::transform_loop(parallel::execution::seq,
                     first, last, dest, std::forward<F>(f));
             }
         };


### PR DESCRIPTION
- flyby: disable C++17 compatibility warnings for MSVC when compiling using Vc

Fixes #3165
