### PR TITLE
Fix lifo queue backend

### DIFF
--- a/docs/manual/commandline.qbk
+++ b/docs/manual/commandline.qbk
@@ -85,9 +85,9 @@ described in the table below:
     [[`--hpx:print-bind`]       [print to the console the bit masks calculated from the
                                  arguments specified to all `--hpx:bind` options.]]
     [[`--hpx:queuing arg`]      [the queue scheduling policy to use, options are
-                                 'local/l', 'local-priority-fifo/lo', 'local-priority-lifo', 'abp/a',
-                                 'abp-priority', 'hierarchy/h', and 'periodic/pe'
-                                 (default: local-priority-fifo/lo)]]
+                                 'local/l', 'local-priority-fifo/lo', 'local-priority-lifo',
+                                 'abp-priority-fifo/a', 'abp-priority-lifo', 'hierarchy/h', and
+                                 'periodic/pe' (default: local-priority-fifo/lo)]]
     [[`--hpx:hierarchy-arity`]  [the arity of the of the thread queue tree, valid for
                                  `--hpx:queuing=hierarchy` only (default: 2)]]
     [[`--hpx:high-priority-threads arg`] [the number of operating system threads

--- a/docs/manual/parallel_algorithms.qbk
+++ b/docs/manual/parallel_algorithms.qbk
@@ -630,7 +630,7 @@ by __cpp11_n4406__ (Parallel Algorithms Need Executors).
 Executors are modular components for requisitioning execution agents. During
 parallel algorithm execution, execution policies generate execution agents by
 requesting their creation from an associated executor. Rather than focusing on
-asynchronous task queueing, our complementary treatment of executors casts
+asynchronous task queuing, our complementary treatment of executors casts
 them as modular components for invoking functions over the points of an index
 space. We believe that executors may be conceived of as allocators for
 execution agents and our interface's design reflects this analogy. The process

--- a/docs/manual/scheduling_policies.qbk
+++ b/docs/manual/scheduling_policies.qbk
@@ -74,7 +74,7 @@ robin fashion. There is no thread stealing in this policy.
 
 [heading Priority ABP Scheduling Policy]
 
-* invoke using: [hpx_cmdline `--hpx:queuing=abp-priority`]
+* invoke using: [hpx_cmdline `--hpx:queuing=abp-priority-fifo`]
 * flag to turn on for build: `HPX_THREAD_SCHEDULERS=all` or
   `HPX_THREAD_SCHEDULERS=abp-priority`
 
@@ -90,6 +90,11 @@ sensitivity using the command line option [hpx_cmdline `--hpx:numa-sensitive`].
 When NUMA sensitivity is turned on work stealing is done from queues associated
 with the same NUMA domain first, only after that work is stolen from other NUMA
 domains.
+
+This scheduler can be used with two underlying queuing policies (FIFO:
+first-in-first-out, and LIFO: last-in-first-out). In order to use the LIFO
+policy use the command line option [hpx_cmdline
+`--hpx:queuing=abp-priority-lifo`].
 
 [heading Hierarchy Scheduling Policy]
 

--- a/docs/manual/scheduling_policies.qbk
+++ b/docs/manual/scheduling_policies.qbk
@@ -38,9 +38,9 @@ same NUMA domain first, only after that work is stolen from other NUMA domains.
 
 This scheduler is enabled at build time by default and will be available always.
 
-This scheduler can be used with two underlying queueing policies (FIFO:
+This scheduler can be used with two underlying queuing policies (FIFO:
 first-in-first-out, and LIFO: last-in-first-out). The default is FIFO. In order
-to use the LIFO policiy use the command line option
+to use the LIFO policy use the command line option
 [hpx_cmdline `--hpx:queuing=local-priority-lifo`].
 
 [heading Static Priority Scheduling Policy]

--- a/docs/whats_new_previous.qbk
+++ b/docs/whats_new_previous.qbk
@@ -3350,8 +3350,8 @@ approximately 70 tickets (bugs, feature requests, etc.).
   thread.
 * Added two new experimental thread schedulers: hierarchy_scheduler and
   periodic_priority_scheduler. These can be activated by using the command line
-  options [hpx_cmdline [^--hpx:queueing=hierarchy]] or
-  [hpx_cmdline [^--hpx:queueing=periodic]].
+  options [hpx_cmdline [^--hpx:queuing=hierarchy]] or
+  [hpx_cmdline [^--hpx:queuing=periodic]].
 
 [heading Example Applications]
 

--- a/hpx/runtime/resource/partitioner_fwd.hpp
+++ b/hpx/runtime/resource/partitioner_fwd.hpp
@@ -61,10 +61,11 @@ namespace hpx
             local_priority_lifo = 2,
             static_ = 3,
             static_priority = 4,
-            abp_priority = 5,
-            hierarchy = 6,
-            periodic_priority = 7,
-            throttle = 8
+            abp_priority_fifo = 5,
+            abp_priority_lifo = 6,
+            hierarchy = 7,
+            periodic_priority = 8,
+            throttle = 9
         };
     }
 }

--- a/src/runtime/resource/detail/detail_partitioner.cpp
+++ b/src/runtime/resource/detail/detail_partitioner.cpp
@@ -144,8 +144,11 @@ namespace hpx { namespace resource { namespace detail
         case resource::static_priority:
             sched = "static_priority";
             break;
-        case resource::abp_priority:
-            sched = "abp_priority";
+        case resource::abp_priority_fifo:
+            sched = "abp_priority_fifo";
+            break;
+        case resource::abp_priority_lifo:
+            sched = "abp_priority_lifo";
             break;
         case resource::hierarchy:
             sched = "hierarchy";
@@ -428,9 +431,13 @@ namespace hpx { namespace resource { namespace detail
         {
             default_scheduler = scheduling_policy::static_priority;
         }
-        else if (0 == std::string("abp-priority").find(cfg_.queuing_))
+        else if (0 == std::string("abp-priority-fifo").find(cfg_.queuing_))
         {
-            default_scheduler = scheduling_policy::abp_priority;
+            default_scheduler = scheduling_policy::abp_priority_fifo;
+        }
+        else if (0 == std::string("abp-priority-lifo").find(cfg_.queuing_))
+        {
+            default_scheduler = scheduling_policy::abp_priority_lifo;
         }
         else if (0 == std::string("hierarchy").find(cfg_.queuing_))
         {

--- a/src/runtime/threads/detail/scheduled_thread_pool.cpp
+++ b/src/runtime/threads/detail/scheduled_thread_pool.cpp
@@ -38,6 +38,9 @@ template class HPX_EXPORT hpx::threads::detail::scheduled_thread_pool<
 template class HPX_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::local_priority_queue_scheduler<hpx::compat::mutex,
         hpx::threads::policies::lockfree_abp_fifo>>;
+template class HPX_EXPORT hpx::threads::detail::scheduled_thread_pool<
+    hpx::threads::policies::local_priority_queue_scheduler<hpx::compat::mutex,
+        hpx::threads::policies::lockfree_abp_lifo>>;
 #endif
 
 #if defined(HPX_HAVE_HIERARCHY_SCHEDULER)

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -198,7 +198,7 @@ namespace hpx { namespace util
             return num_localities;
         }
 
-        std::string handle_queueing(util::manage_config& cfgmap,
+        std::string handle_queuing(util::manage_config& cfgmap,
             boost::program_options::variables_map& vm, std::string default_)
         {
             // command line options is used preferred
@@ -748,7 +748,7 @@ namespace hpx { namespace util
 #endif
 
         // handle setting related to schedulers
-        queuing_ = detail::handle_queueing(cfgmap, vm, "local-priority-fifo");
+        queuing_ = detail::handle_queuing(cfgmap, vm, "local-priority-fifo");
         ini_config += "hpx.scheduler=" + queuing_;
 
         affinity_domain_ = detail::handle_affinity(cfgmap, vm, "pu");

--- a/src/util/parse_command_line.cpp
+++ b/src/util/parse_command_line.cpp
@@ -446,7 +446,7 @@ namespace hpx { namespace util
                 ("hpx:queuing", value<std::string>(),
                   "the queue scheduling policy to use, options are "
                   "'local', 'local-priority-fifo','local-priority-lifo', "
-                  "'abp-priority', "
+                  "'abp-priority-fifo', 'abp-priority-lifo', "
                   "'hierarchy', 'static', 'static-priority', and "
                   "'periodic-priority' (default: 'local-priority'; "
                   "all option values can be abbreviated)")

--- a/tests/unit/threads/CMakeLists.txt
+++ b/tests/unit/threads/CMakeLists.txt
@@ -6,6 +6,7 @@
 set(tests
     lockfree_fifo
     resource_manager
+    schedule_last
     set_thread_state
     stack_check
     thread

--- a/tests/unit/threads/schedule_last.cpp
+++ b/tests/unit/threads/schedule_last.cpp
@@ -13,7 +13,9 @@
 #include <hpx/util/lightweight_test.hpp>
 
 #include <cstddef>
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 int hpx_main(int argc, char* argv[])

--- a/tests/unit/threads/schedule_last.cpp
+++ b/tests/unit/threads/schedule_last.cpp
@@ -1,0 +1,109 @@
+//  Copyright (c) 2018 Mikael Simberg
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/compat/mutex.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/async.hpp>
+#include <hpx/include/resource_partitioner.hpp>
+#include <hpx/include/threads.hpp>
+#include <hpx/runtime/threads/policies/scheduler_mode.hpp>
+#include <hpx/runtime/threads/policies/schedulers.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+int hpx_main(int argc, char* argv[])
+{
+    bool run = false;
+    hpx::future<void> f1 = hpx::async([&run]()
+        {
+            run = true;
+        });
+
+    if (!run)
+    {
+        // This thread should get scheduled last (because of
+        // hpx::threads::pending) and let the function spawned above run.
+        hpx::this_thread::suspend(hpx::threads::pending);
+    }
+
+    HPX_TEST(run);
+
+    return hpx::finalize();
+}
+
+template <typename Scheduler>
+void test_scheduler(int argc, char* argv[])
+{
+    std::vector<std::string> cfg =
+    {
+        "hpx.os_threads=1"
+    };
+
+    hpx::resource::partitioner rp(argc, argv, std::move(cfg));
+
+    rp.create_thread_pool("default",
+        [](hpx::threads::policies::callback_notifier& notifier,
+            std::size_t num_threads, std::size_t thread_offset,
+            std::size_t pool_index, std::string const& pool_name)
+        -> std::unique_ptr<hpx::threads::thread_pool_base>
+        {
+            typename Scheduler::init_parameter_type init(num_threads);
+            std::unique_ptr<Scheduler> scheduler(new Scheduler(init));
+
+            auto mode = hpx::threads::policies::scheduler_mode(
+                hpx::threads::policies::do_background_work |
+                hpx::threads::policies::reduce_thread_priority |
+                hpx::threads::policies::delay_exit);
+
+            std::unique_ptr<hpx::threads::thread_pool_base> pool(
+                new hpx::threads::detail::scheduled_thread_pool<Scheduler>(
+                    std::move(scheduler), notifier, pool_index, pool_name, mode,
+                    thread_offset));
+
+            return pool;
+        });
+
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+}
+
+int main(int argc, char* argv[])
+{
+    {
+        using scheduler_type =
+            hpx::threads::policies::local_priority_queue_scheduler<
+                hpx::compat::mutex, hpx::threads::policies::lockfree_lifo
+            >;
+        test_scheduler<scheduler_type>(argc, argv);
+    }
+
+    {
+        using scheduler_type =
+            hpx::threads::policies::local_priority_queue_scheduler<
+                hpx::compat::mutex, hpx::threads::policies::lockfree_fifo
+            >;
+        test_scheduler<scheduler_type>(argc, argv);
+    }
+
+    {
+        using scheduler_type =
+            hpx::threads::policies::local_priority_queue_scheduler<
+                hpx::compat::mutex, hpx::threads::policies::lockfree_abp_lifo
+            >;
+        test_scheduler<scheduler_type>(argc, argv);
+    }
+
+    {
+        using scheduler_type =
+            hpx::threads::policies::local_priority_queue_scheduler<
+                hpx::compat::mutex, hpx::threads::policies::lockfree_abp_fifo
+            >;
+        test_scheduler<scheduler_type>(argc, argv);
+    }
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
This addresses the issue in #3166.

The issue in this case was that when `shutdown_all` waits for all threads to finish it calls `suspend(pending)` which eventually calls `schedule_last` for the `shutdown_all` thread. For the lifo queue backend `schedule_last` is the same as `schedule` and `shutdown_all` will be scheduled as the next thread again, leaving no chance for the remaining threads to run. I suspect we haven't seen this with more than 1 thread because then other OS threads will be able to steal the threads and/or most tests and examples wait for all futures before calling `hpx::finalize`.

## Proposed Changes

- Use deque for the non-abp lifo and fifo queue backends so that `schedule_last` can actually schedule a thread last in the queue.
- Add a test which reproduces the issue.
- Fix some naming in the documentation related to schedulers.

Note: from my preliminary tests deque is neither slower nor faster than stack or queue, but I need to check with more examples to see that this holds more generally.
