### PR TITLE
Fix format to

### DIFF
--- a/examples/quickstart/hello_world.cpp
+++ b/examples/quickstart/hello_world.cpp
@@ -42,10 +42,10 @@ std::size_t hello_world_worker(std::size_t desired)
     if (current == desired)
     {
         // The HPX-thread has been run on the desired OS-thread.
-        char const* msg = "hello world from OS-thread %1% on locality %2%";
+        char const* msg = "hello world from OS-thread %1% on locality %2%\n";
 
         hpx::util::format_to(hpx::cout, msg, desired, hpx::get_locality_id())
-                  << std::endl << hpx::flush;
+            << hpx::flush;
 
         return desired;
     }

--- a/hpx/util/format.hpp
+++ b/hpx/util/format.hpp
@@ -16,6 +16,11 @@
 #include <iosfwd>
 #include <string>
 
+namespace hpx { namespace iostreams {
+    template <typename Char, typename Sink>
+    struct ostream;
+}}
+
 namespace hpx { namespace util
 {
     template <typename ...Args>
@@ -27,6 +32,18 @@ namespace hpx { namespace util
         (void)_sequencer;
 
         return boost::str(fmt);
+    }
+
+    template <typename Char, typename Sink, typename ...Args>
+    hpx::iostreams::ostream<Char, Sink>& format_to(
+        hpx::iostreams::ostream<Char, Sink>& os,
+        std::string const& format_str, Args const&... args)
+    {
+        boost::format fmt(format_str);
+        int const _sequencer[] = { ((fmt % args), 0)... };
+        (void)_sequencer;
+
+        return os << fmt;
     }
 
     template <typename ...Args>


### PR DESCRIPTION
Fixes #3013.

## Proposed Changes

- Adds an overload to `hpx::util::format_to` taking a `hpx::iostreams::ostream` to make sure that the correct operators (`<<`) are called.

## Any background context you want to provide?

When a `hpx::iostreams::ostream` is used as a `std::stream` the correct virtual functions are not called, thus bypassing locks that are supposed to be taken in the `hpx::iostreams::ostream` implementation (base class functions are not virtual?). A proper fix would make sure the correct functions are called, but at the moment I have no fix for that.