### PR TITLE
Fixed Documentation for "using_hpx_pkgconfig"

### DIFF
--- a/docs/manual/build_system/using_hpx_pkgconfig.qbk
+++ b/docs/manual/build_system/using_hpx_pkgconfig.qbk
@@ -109,7 +109,7 @@ this example, we'll choose a directory named ''my_hpx_libs''.
 
 ``
     mkdir ~/my_hpx_libs
-    mv libhello_world.so ~/my_hpx_libs
+    mv libhpx_hello_world.so ~/my_hpx_libs
 ``
 
 [note __hpx__ libraries have different names in debug and release mode. If you


### PR DESCRIPTION
## Proposed Changes

  - The ``mv`` command was trying to move libhello_world.so when there was no file by the name of libhello_world.

