### PR TITLE
Various minor changes to support FLeCSI

### DIFF
--- a/hpx/include/thread_executors.hpp
+++ b/hpx/include/thread_executors.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -8,6 +8,7 @@
 
 #include <hpx/runtime/threads/executors/current_executor.hpp>
 #include <hpx/runtime/threads/executors/default_executor.hpp>
+#include <hpx/runtime/threads/executors/pool_executor.hpp>
 #include <hpx/runtime/threads/executors/service_executors.hpp>
 #include <hpx/runtime/threads/executors/thread_pool_executors.hpp>
 #include <hpx/runtime/threads/executors/thread_pool_os_executors.hpp>

--- a/hpx/parallel/executors.hpp
+++ b/hpx/parallel/executors.hpp
@@ -22,6 +22,7 @@
 #include <hpx/parallel/executors/default_executor.hpp>
 #include <hpx/parallel/executors/distribution_policy_executor.hpp>
 #include <hpx/parallel/executors/parallel_executor.hpp>
+#include <hpx/parallel/executors/pool_executor.hpp>
 #include <hpx/parallel/executors/sequenced_executor.hpp>
 #include <hpx/parallel/executors/service_executors.hpp>
 #include <hpx/parallel/executors/this_thread_executors.hpp>

--- a/hpx/parallel/executors/pool_executor.hpp
+++ b/hpx/parallel/executors/pool_executor.hpp
@@ -1,0 +1,24 @@
+//  Copyright (c) 2007-2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/executors/pool_executor.hpp
+
+#if !defined(HPX_PARALLEL_EXECUTORS_POOL_EXECUTOR_FEB_17_2018_0327PM)
+#define HPX_PARALLEL_EXECUTORS_POOL_EXECUTOR_FEB_17_2018_0327PM
+
+#include <hpx/config.hpp>
+#include <hpx/parallel/executors/execution_parameters.hpp>
+#include <hpx/parallel/executors/thread_execution.hpp>
+#include <hpx/parallel/executors/thread_execution_information.hpp>
+#include <hpx/parallel/executors/thread_timed_execution.hpp>
+#include <hpx/runtime/threads/executors/pool_executor.hpp>
+
+namespace hpx { namespace parallel { namespace execution
+{
+    ///////////////////////////////////////////////////////////////////////////
+    using pool_executor = threads::executors::pool_executor;
+}}}
+
+#endif

--- a/hpx/runtime/resource/detail/create_partitioner.hpp
+++ b/hpx/runtime/resource/detail/create_partitioner.hpp
@@ -9,6 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/runtime/resource/partitioner_fwd.hpp>
 #include <hpx/runtime/runtime_mode.hpp>
+#include <hpx/util/bind_back.hpp>
 #include <hpx/util/find_prefix.hpp>
 #include <hpx/util/function.hpp>
 

--- a/hpx/runtime/resource/detail/create_partitioner.hpp
+++ b/hpx/runtime/resource/detail/create_partitioner.hpp
@@ -10,6 +10,7 @@
 #include <hpx/runtime/resource/partitioner_fwd.hpp>
 #include <hpx/runtime/runtime_mode.hpp>
 #include <hpx/util/find_prefix.hpp>
+#include <hpx/util/function.hpp>
 
 #include <boost/program_options.hpp>
 
@@ -23,6 +24,13 @@
 int hpx_main(boost::program_options::variables_map& vm);
 typedef int (*hpx_main_type)(boost::program_options::variables_map&);
 #endif
+
+namespace hpx { namespace detail
+{
+    HPX_EXPORT int init_helper(
+        boost::program_options::variables_map&,
+        util::function_nonser<int(int, char**)> const&);
+}}
 
 namespace hpx { namespace resource { namespace detail
 {
@@ -54,6 +62,36 @@ namespace hpx { namespace resource { namespace detail
         return create_partitioner(static_cast<hpx_main_type>(::hpx_main),
             desc_cmdline, argc, argv, std::vector<std::string>(),
             rpmode, mode, check);
+    }
+
+    inline partitioner& create_partitioner(
+        util::function_nonser<int(int, char**)> const& f, int argc, char** argv,
+        resource::partitioner_mode rpmode = resource::mode_default,
+        hpx::runtime_mode mode = hpx::runtime_mode_default, bool check = true)
+    {
+        boost::program_options::options_description desc_cmdline(
+            std::string("Usage: ") + HPX_APPLICATION_STRING + " [options]");
+
+        util::set_hpx_prefix(HPX_PREFIX);
+
+        return create_partitioner(util::bind_back(hpx::detail::init_helper, f),
+            desc_cmdline, argc, argv, std::vector<std::string>(), rpmode, mode,
+            check);
+    }
+
+    inline partitioner& create_partitioner(
+        util::function_nonser<int(int, char**)> const& f, int argc, char** argv,
+        std::vector<std::string> const& cfg,
+        resource::partitioner_mode rpmode = resource::mode_default,
+        hpx::runtime_mode mode = hpx::runtime_mode_default, bool check = true)
+    {
+        boost::program_options::options_description desc_cmdline(
+            std::string("Usage: ") + HPX_APPLICATION_STRING + " [options]");
+
+        util::set_hpx_prefix(HPX_PREFIX);
+
+        return create_partitioner(util::bind_back(hpx::detail::init_helper, f),
+            desc_cmdline, argc, argv, cfg, rpmode, mode, check);
     }
 
     inline partitioner &create_partitioner(

--- a/hpx/runtime/resource/partitioner.hpp
+++ b/hpx/runtime/resource/partitioner.hpp
@@ -141,6 +141,22 @@ namespace hpx { namespace resource
         {}
 
 #if !defined(HPX_EXPORTS)
+        partitioner(util::function_nonser<int(int, char**)> const& f,
+            int argc, char** argv,
+            resource::partitioner_mode rpmode = resource::mode_default,
+            hpx::runtime_mode mode = hpx::runtime_mode_default)
+          : partitioner_(
+                detail::create_partitioner(f, argc, argv, rpmode, mode))
+        {}
+
+        partitioner(util::function_nonser<int(int, char**)> const& f,
+            int argc, char** argv, std::vector<std::string> const& cfg,
+            resource::partitioner_mode rpmode = resource::mode_default,
+            hpx::runtime_mode mode = hpx::runtime_mode_default)
+          : partitioner_(
+                detail::create_partitioner(f, argc, argv, cfg, rpmode, mode))
+        {}
+
         partitioner(int argc, char** argv,
             resource::partitioner_mode rpmode = resource::mode_default,
             runtime_mode mode = runtime_mode_default)

--- a/hpx/runtime/threads/executors/pool_executor.hpp
+++ b/hpx/runtime/threads/executors/pool_executor.hpp
@@ -95,12 +95,14 @@ namespace hpx { namespace threads { namespace executors
     ///////////////////////////////////////////////////////////////////////
     struct HPX_EXPORT pool_executor : public scheduled_executor
     {
-        pool_executor(const std::string& pool_name);
+        pool_executor() = default;
 
-        pool_executor(const std::string& pool_name,
+        pool_executor(std::string const& pool_name);
+
+        pool_executor(std::string const& pool_name,
                 thread_stacksize stacksize);
 
-        pool_executor(const std::string& pool_name,
+        pool_executor(std::string const& pool_name,
                 thread_priority priority,
                 thread_stacksize stacksize = thread_stacksize_default);
     };

--- a/hpx/runtime/threads/policies/hierarchy_scheduler.hpp
+++ b/hpx/runtime/threads/policies/hierarchy_scheduler.hpp
@@ -207,13 +207,13 @@ namespace hpx { namespace threads { namespace policies
             return "hierarchy_scheduler";
         }
 
-        void suspend(std::size_t)
+        void suspend(std::size_t) override
         {
             HPX_ASSERT_MSG(false, "hierarchy_scheduler does not support"
                 " suspending");
         }
 
-        void resume(std::size_t)
+        void resume(std::size_t) override
         {
             HPX_ASSERT_MSG(false, "hierarchy_scheduler does not support"
                 " resuming");

--- a/hpx/runtime/threads/policies/periodic_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/periodic_priority_queue_scheduler.hpp
@@ -75,13 +75,13 @@ namespace hpx { namespace threads { namespace policies
             return "periodic_priority_queue_scheduler";
         }
 
-        void suspend(std::size_t)
+        void suspend(std::size_t) override
         {
             HPX_ASSERT_MSG(false, "periodic_priority_queue_scheduler does not"
                 " support suspending");
         }
 
-        void resume(std::size_t)
+        void resume(std::size_t) override
         {
             HPX_ASSERT_MSG(false, "periodic_priority_queue_scheduler does not"
                 " support resuming");

--- a/hpx/runtime/threads/policies/scheduler_base.hpp
+++ b/hpx/runtime/threads/policies/scheduler_base.hpp
@@ -154,7 +154,7 @@ namespace hpx { namespace threads { namespace policies
 #endif
         }
 
-        void suspend(std::size_t num_thread)
+        virtual void suspend(std::size_t num_thread)
         {
             HPX_ASSERT(num_thread < suspend_conds_.size());
 
@@ -172,7 +172,7 @@ namespace hpx { namespace threads { namespace policies
                 expected == state_stopping || expected == state_terminating);
         }
 
-        void resume(std::size_t num_thread)
+        virtual void resume(std::size_t num_thread)
         {
             if (num_thread == std::size_t(-1))
             {

--- a/hpx/runtime/threads/policies/scheduler_mode.hpp
+++ b/hpx/runtime/threads/policies/scheduler_mode.hpp
@@ -26,9 +26,13 @@ namespace hpx { namespace threads { namespace policies
             ///< to act as 'embedded' schedulers. In this case it needs to
             ///< periodically invoke a provided callback into the outer scheduler
             ///< more frequently than normal. This option enables this behavior.
-        enable_elasticity = 0x10        ///< This options allows for the
+        enable_elasticity = 0x10,        ///< This options allows for the
             ///< scheduler to dynamically increase and reduce the number of
             ///< processing units it runs on.
+        enable_suspension = 0x20        ///< This options allows for the
+            ///< scheduler to suspend/resume its operation. Setting this value
+            ///< may not succeed for schedulers that do not support this
+            ///< functionality.
     };
 }}}
 

--- a/hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp
@@ -62,13 +62,13 @@ namespace hpx { namespace threads { namespace policies
             return "static_priority_queue_scheduler";
         }
 
-        void suspend(std::size_t)
+        void suspend(std::size_t) override
         {
             HPX_ASSERT_MSG(false, "static_priority_queue_scheduler does not"
                 " support suspending");
         }
 
-        void resume(std::size_t)
+        void resume(std::size_t) override
         {
             HPX_ASSERT_MSG(false, "static_priority_queue_scheduler does not"
                 " support resuming");

--- a/hpx/runtime/threads/policies/static_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/static_queue_scheduler.hpp
@@ -70,13 +70,13 @@ namespace hpx { namespace threads { namespace policies
             return "static_queue_scheduler";
         }
 
-        void suspend(std::size_t)
+        void suspend(std::size_t) override
         {
             HPX_ASSERT_MSG(false, "static_queue_scheduler does not support"
                 " suspending");
         }
 
-        void resume(std::size_t)
+        void resume(std::size_t) override
         {
             HPX_ASSERT_MSG(false, "static_queue_scheduler does not support"
                 " resuming");

--- a/hpx/runtime/threads/thread_pool_base.hpp
+++ b/hpx/runtime/threads/thread_pool_base.hpp
@@ -436,6 +436,13 @@ namespace hpx { namespace threads
             std::function<void(void)> callback, std::size_t virt_core,
                 error_code& ec = throws) = 0;
 
+        /// \cond NOINTERNAL
+        policies::scheduler_mode get_scheduler_mode() const
+        {
+            return mode_;
+        }
+        /// \endcond
+
     protected:
         /// \cond NOINTERNAL
         void init_pool_time_scale();

--- a/src/runtime/threads/executors/pool_executor.cpp
+++ b/src/runtime/threads/executors/pool_executor.cpp
@@ -18,26 +18,25 @@ namespace hpx { namespace threads { namespace executors
 {
     namespace detail
     {
-        pool_executor::pool_executor(
-                std::string const& pool_name)
-            : pool_(hpx::threads::get_thread_manager().get_pool(pool_name))
-            , stacksize_(thread_stacksize_default)
-            , priority_(thread_priority_default)
+        pool_executor::pool_executor(std::string const& pool_name)
+          : pool_(hpx::threads::get_thread_manager().get_pool(pool_name))
+          , stacksize_(thread_stacksize_default)
+          , priority_(thread_priority_default)
         {}
 
-        pool_executor::pool_executor(const std::string& pool_name,
-                thread_stacksize stacksize)
-            : pool_(hpx::threads::get_thread_manager().get_pool(pool_name))
-            , stacksize_(stacksize)
-            , priority_(thread_priority_default)
+        pool_executor::pool_executor(std::string const& pool_name,
+            thread_stacksize stacksize)
+          : pool_(hpx::threads::get_thread_manager().get_pool(pool_name))
+          , stacksize_(stacksize)
+          , priority_(thread_priority_default)
         {}
 
-        pool_executor::pool_executor(const std::string& pool_name,
-                thread_priority priority, thread_stacksize stacksize)
-            : pool_(hpx::threads::get_thread_manager().get_pool(pool_name))
-            , stacksize_(stacksize)
-            , priority_(priority)
-            {}
+        pool_executor::pool_executor(std::string const& pool_name,
+            thread_priority priority, thread_stacksize stacksize)
+          : pool_(hpx::threads::get_thread_manager().get_pool(pool_name))
+          , stacksize_(stacksize)
+          , priority_(priority)
+        {}
 
         threads::thread_result_type
         pool_executor::thread_function_nullary(closure_type func)
@@ -164,21 +163,21 @@ namespace hpx { namespace threads { namespace executors
 
 namespace hpx { namespace threads { namespace executors
 {
-    pool_executor::pool_executor(
-        const std::string& pool_name)
-      : scheduled_executor(new detail::pool_executor(pool_name))
-    {}
+    pool_executor::pool_executor(std::string const& pool_name)
+        : scheduled_executor(new detail::pool_executor(pool_name))
+    {
+    }
 
-    pool_executor::pool_executor(const std::string& pool_name,
+    pool_executor::pool_executor(std::string const& pool_name,
             thread_stacksize stacksize)
-        : scheduled_executor(new detail::pool_executor(pool_name, stacksize))
-    {}
+      : scheduled_executor(new detail::pool_executor(pool_name, stacksize))
+    {
+    }
 
-    pool_executor::pool_executor(const std::string& pool_name,
+    pool_executor::pool_executor(std::string const& pool_name,
             thread_priority priority, thread_stacksize stacksize)
-        : scheduled_executor(
-              new detail::pool_executor(pool_name, priority, stacksize))
-    {}
-
-
+      : scheduled_executor(
+            new detail::pool_executor(pool_name, priority, stacksize))
+    {
+    }
 }}}

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -410,7 +410,8 @@ namespace hpx { namespace threads
                         notifier_, i, name.c_str(),
                         policies::scheduler_mode(policies::do_background_work |
                             policies::reduce_thread_priority |
-                            policies::delay_exit),
+                            policies::delay_exit |
+                            policies::enable_suspension),
                         thread_offset));
                 pools_.push_back(std::move(pool));
 
@@ -453,7 +454,8 @@ namespace hpx { namespace threads
                         notifier_, i, name.c_str(),
                         policies::scheduler_mode(policies::do_background_work |
                             policies::reduce_thread_priority |
-                            policies::delay_exit),
+                            policies::delay_exit |
+                            policies::enable_suspension),
                         thread_offset));
                 pools_.push_back(std::move(pool));
 
@@ -490,7 +492,8 @@ namespace hpx { namespace threads
                         notifier_, i, name.c_str(),
                         policies::scheduler_mode(policies::do_background_work |
                             policies::reduce_thread_priority |
-                            policies::delay_exit),
+                            policies::delay_exit |
+                            policies::enable_suspension),
                         thread_offset));
                 pools_.push_back(std::move(pool));
 
@@ -614,7 +617,8 @@ namespace hpx { namespace threads
                         notifier_, i, name.c_str(),
                         policies::scheduler_mode(policies::do_background_work |
                             policies::reduce_thread_priority |
-                            policies::delay_exit),
+                            policies::delay_exit |
+                            policies::enable_suspension),
                         thread_offset));
                 pools_.push_back(std::move(pool));
 #else
@@ -1923,7 +1927,11 @@ namespace hpx { namespace threads
 
             for (auto& pool_iter : pools_)
             {
-                fs.push_back(pool_iter->suspend());
+                if (pool_iter->get_scheduler_mode() &
+                        policies::enable_suspension)
+                {
+                    fs.push_back(pool_iter->suspend());
+                }
             }
 
             hpx::wait_all(fs);
@@ -1932,7 +1940,11 @@ namespace hpx { namespace threads
         {
             for (auto& pool_iter : pools_)
             {
-                pool_iter->suspend_direct();
+                if (pool_iter->get_scheduler_mode() &
+                        policies::enable_suspension)
+                {
+                    pool_iter->suspend_direct();
+                }
             }
         }
     }
@@ -1945,16 +1957,23 @@ namespace hpx { namespace threads
 
             for (auto& pool_iter : pools_)
             {
-                fs.push_back(pool_iter->resume());
+                if (pool_iter->get_scheduler_mode() &
+                        policies::enable_suspension)
+                {
+                    fs.push_back(pool_iter->resume());
+                }
             }
-
             hpx::wait_all(fs);
         }
         else
         {
             for (auto& pool_iter : pools_)
             {
-                pool_iter->resume_direct();
+                if (pool_iter->get_scheduler_mode() &
+                        policies::enable_suspension)
+                {
+                    pool_iter->resume_direct();
+                }
             }
         }
     }

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -352,6 +352,30 @@ namespace hpx { namespace util
 #endif
             }
 
+            // make sure minimal requested number of threads is observed
+            std::size_t min_os_threads = cfgmap.get_value<std::size_t>(
+                "hpx.force_min_os_threads", threads);
+
+            if (min_os_threads == 0)
+            {
+                throw hpx::detail::command_line_error(
+                    "Number of hpx.force_min_os_threads must be greater than "
+                    "0");
+            }
+
+#if defined(HPX_HAVE_MAX_CPU_COUNT)
+            if (min_os_threads > HPX_HAVE_MAX_CPU_COUNT)
+            {
+                throw hpx::detail::command_line_error("Requested more than "
+                    HPX_PP_STRINGIZE(HPX_HAVE_MAX_CPU_COUNT)
+                    " hpx.force_min_os_threads "
+                    "to use for this application, use the option "
+                    "-DHPX_WITH_MAX_CPU_COUNT=<N> when configuring HPX.");
+            }
+#endif
+
+            threads = (std::max)(threads, min_os_threads);
+
             if (!initial && env.found_batch_environment() &&
                 using_nodelist && (threads > batch_threads))
             {

--- a/tests/unit/resource/shutdown_suspended_pus.cpp
+++ b/tests/unit/resource/shutdown_suspended_pus.cpp
@@ -69,7 +69,8 @@ void test_scheduler(int argc, char* argv[])
                 hpx::threads::policies::do_background_work |
                 hpx::threads::policies::reduce_thread_priority |
                 hpx::threads::policies::delay_exit |
-                hpx::threads::policies::enable_elasticity);
+                hpx::threads::policies::enable_elasticity |
+                hpx::threads::policies::enable_suspension);
 
             std::unique_ptr<hpx::threads::thread_pool_base> pool(
                 new hpx::threads::detail::scheduled_thread_pool<Scheduler>(

--- a/tests/unit/resource/suspend_pool.cpp
+++ b/tests/unit/resource/suspend_pool.cpp
@@ -160,7 +160,8 @@ void test_scheduler(int argc, char* argv[])
                 hpx::threads::policies::do_background_work |
                 hpx::threads::policies::reduce_thread_priority |
                 hpx::threads::policies::delay_exit |
-                hpx::threads::policies::enable_elasticity);
+                hpx::threads::policies::enable_elasticity |
+                hpx::threads::policies::enable_suspension);
 
             std::unique_ptr<hpx::threads::thread_pool_base> pool(
                 new hpx::threads::detail::scheduled_thread_pool<Scheduler>(

--- a/tests/unit/resource/throttle.cpp
+++ b/tests/unit/resource/throttle.cpp
@@ -213,7 +213,8 @@ void test_scheduler(int argc, char* argv[])
                 hpx::threads::policies::do_background_work |
                 hpx::threads::policies::reduce_thread_priority |
                 hpx::threads::policies::delay_exit |
-                hpx::threads::policies::enable_elasticity);
+                hpx::threads::policies::enable_elasticity |
+                hpx::threads::policies::enable_suspension);
 
             std::unique_ptr<hpx::threads::thread_pool_base> pool(
                 new hpx::threads::detail::scheduled_thread_pool<Scheduler>(

--- a/tests/unit/resource/throttle_timed.cpp
+++ b/tests/unit/resource/throttle_timed.cpp
@@ -118,7 +118,8 @@ void test_scheduler(int argc, char* argv[])
                 hpx::threads::policies::do_background_work |
                 hpx::threads::policies::reduce_thread_priority |
                 hpx::threads::policies::delay_exit |
-                hpx::threads::policies::enable_elasticity);
+                hpx::threads::policies::enable_elasticity |
+                hpx::threads::policies::enable_suspension);
 
             std::unique_ptr<hpx::threads::thread_pool_base> pool(
                 new hpx::threads::detail::scheduled_thread_pool<Scheduler>(


### PR DESCRIPTION
- adding more constructors to resource::partitioner (aligned with hpx::init)
- adding hpx::parallel::execution::pool_executor alias (for consistency)
- adding default constructor for pool-executor
- adding support to request minimal number of cores (threads) (hpx.force_min_os_threads)
- Making sure resume/suspend is not called for schedulers that don't support it
