### PR TITLE
 Add runtime start/stop, resume/suspend and OpenMP benchmarks 

### DIFF
--- a/tests/performance/local/CMakeLists.txt
+++ b/tests/performance/local/CMakeLists.txt
@@ -17,7 +17,9 @@ set(benchmarks
     hpx_heterogeneous_timed_task_spawn
     parent_vs_child_stealing
     print_heterogeneous_payloads
+    resume_suspend
     skynet
+    start_stop
     timed_task_spawn
     wait_all_timings
 )
@@ -34,8 +36,11 @@ if(HPX_WITH_EXAMPLES_OPENMP)
   set(benchmarks
       ${benchmarks}
       openmp_homogeneous_timed_task_spawn
+      openmp_parallel_region
      )
 
+  set(openmp_homogeneous_timed_task_spawn_FLAGS NOLIBS
+      DEPENDENCIES ${boost_library_dependencies})
   set(openmp_homogeneous_timed_task_spawn_FLAGS NOLIBS
       DEPENDENCIES ${boost_library_dependencies})
 endif()
@@ -160,6 +165,10 @@ if(HPX_WITH_EXAMPLES_OPENMP)
   set_target_properties(openmp_homogeneous_timed_task_spawn_exe
     PROPERTIES COMPILE_FLAGS ${OpenMP_CXX_FLAGS})
   set_target_properties(openmp_homogeneous_timed_task_spawn_exe
+    PROPERTIES LINK_FLAGS ${OpenMP_CXX_FLAGS})
+  set_target_properties(openmp_parallel_region_exe
+    PROPERTIES COMPILE_FLAGS ${OpenMP_CXX_FLAGS})
+  set_target_properties(openmp_parallel_region_exe
     PROPERTIES LINK_FLAGS ${OpenMP_CXX_FLAGS})
 endif()
 

--- a/tests/performance/local/openmp_homogeneous_timed_task_spawn.cpp
+++ b/tests/performance/local/openmp_homogeneous_timed_task_spawn.cpp
@@ -79,7 +79,7 @@ void print_results(
 
     hpx::util::format_to(std::cout,
         "%-21s %-21s %-21s %10.12s, %10.12s\n",
-        cores_str, tasks_str, delay_str
+        cores_str, tasks_str, delay_str,
         walltime, walltime / tasks);
 }
 

--- a/tests/performance/local/openmp_parallel_region.cpp
+++ b/tests/performance/local/openmp_parallel_region.cpp
@@ -1,0 +1,71 @@
+//  Copyright (c) 2018 Mikael Simberg
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This example benchmarks the time it takes to enter and exit an OpenMP
+// parallel region. This is meant to be compared to resume_suspend and
+// start_stop.
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_start.hpp>
+#include <hpx/util/high_resolution_clock.hpp>
+#include <hpx/util/yield_while.hpp>
+
+#include <boost/program_options.hpp>
+#include <omp.h>
+
+#include <cstddef>
+#include <iostream>
+
+int main(int argc, char ** argv)
+{
+    boost::program_options::options_description desc_commandline;
+    desc_commandline.add_options()
+        ("repetitions",
+         boost::program_options::value<std::uint64_t>()->default_value(100),
+         "Number of repetitions");
+
+    boost::program_options::variables_map vm;
+    boost::program_options::store(
+        boost::program_options::command_line_parser(argc, argv)
+        .allow_unregistered()
+        .options(desc_commandline)
+        .run(),
+        vm);
+
+    std::uint64_t repetitions = vm["repetitions"].as<std::uint64_t>();
+
+    // Do one warmup iteration and get the number of threads
+    int x = 0;
+#   pragma omp parallel
+    {
+        x += 1;
+    }
+
+    std::size_t threads = omp_get_max_threads();
+
+    std::cout
+        << "threads, parallel region [s]"
+        << std::endl;
+
+    hpx::util::high_resolution_timer timer;
+
+    for (std::size_t i = 0; i < repetitions; ++i)
+    {
+        timer.restart();
+
+        // TODO: Is there a more minimal way of starting all OpenMP threads?
+#       pragma omp parallel
+        {
+            x += 1;
+        }
+
+        auto t_parallel = timer.elapsed();
+
+        std::cout
+            << threads << ", "
+            << t_parallel
+            << std::endl;
+    }
+}

--- a/tests/performance/local/resume_suspend.cpp
+++ b/tests/performance/local/resume_suspend.cpp
@@ -1,0 +1,84 @@
+//  Copyright (c) 2018 Mikael Simberg
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This example benchmarks the time it takes to resume and suspend the HPX
+// runtime. This is meant to be compared to start_stop and
+// openmp_parallel_region.
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_start.hpp>
+#include <hpx/util/high_resolution_clock.hpp>
+#include <hpx/util/yield_while.hpp>
+
+#include <boost/program_options.hpp>
+
+#include <cstddef>
+#include <iostream>
+
+int main(int argc, char ** argv)
+{
+    boost::program_options::options_description desc_commandline;
+    desc_commandline.add_options()
+        ("repetitions",
+         boost::program_options::value<std::uint64_t>()->default_value(100),
+         "Number of repetitions");
+
+    boost::program_options::variables_map vm;
+    boost::program_options::store(
+        boost::program_options::command_line_parser(argc, argv)
+        .allow_unregistered()
+        .options(desc_commandline)
+        .run(),
+        vm);
+
+    std::uint64_t repetitions = vm["repetitions"].as<std::uint64_t>();
+
+    hpx::start(nullptr, desc_commandline, argc, argv);
+    hpx::runtime* rt = hpx::get_runtime_ptr();
+    hpx::util::yield_while([rt]()
+        {
+            return rt->get_state() < hpx::state_running;
+        });
+    hpx::suspend();
+
+    std::uint64_t threads = hpx::resource::get_num_threads("default");
+
+    std::cout
+        << "threads, resume [s], async [s], suspend [s]"
+        << std::endl;
+
+    hpx::util::high_resolution_timer timer;
+
+    for (std::size_t i = 0; i < repetitions; ++i)
+    {
+        timer.restart();
+
+        hpx::resume();
+        auto t_resume = timer.elapsed();
+
+        for (std::size_t thread = 0; thread < threads; ++thread)
+        {
+            hpx::async([](){});
+        }
+
+        auto t_async = timer.elapsed();
+
+        hpx::suspend();
+        auto t_suspend = timer.elapsed();
+
+        std::cout
+            << threads << ", "
+            << t_resume << ", "
+            << t_async << ", "
+            << t_suspend
+            << std::endl;
+    }
+
+    hpx::resume();
+    hpx::async([]() { hpx::finalize(); });
+    hpx::stop();
+}
+
+

--- a/tests/performance/local/start_stop.cpp
+++ b/tests/performance/local/start_stop.cpp
@@ -1,0 +1,77 @@
+//  Copyright (c) 2018 Mikael Simberg
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This example benchmarks the time it takes to start and stop the HPX runtime.
+// This is meant to be compared to resume_suspend and openmp_parallel_region.
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_start.hpp>
+#include <hpx/util/high_resolution_clock.hpp>
+#include <hpx/util/yield_while.hpp>
+
+#include <boost/program_options.hpp>
+
+#include <cstddef>
+#include <iostream>
+
+int hpx_main()
+{
+    return hpx::finalize();
+}
+
+int main(int argc, char ** argv)
+{
+    boost::program_options::options_description desc_commandline;
+    desc_commandline.add_options()
+        ("repetitions",
+         boost::program_options::value<std::uint64_t>()->default_value(100),
+         "Number of repetitions");
+
+    boost::program_options::variables_map vm;
+    boost::program_options::store(
+        boost::program_options::command_line_parser(argc, argv)
+        .allow_unregistered()
+        .options(desc_commandline)
+        .run(),
+        vm);
+
+    std::uint64_t repetitions = vm["repetitions"].as<std::uint64_t>();
+
+    hpx::start(desc_commandline, argc, argv);
+    std::uint64_t threads = hpx::resource::get_num_threads("default");
+    hpx::stop();
+
+    std::cout
+        << "threads, resume [s], async [s], suspend [s]"
+        << std::endl;
+
+    hpx::util::high_resolution_timer timer;
+
+    for (std::size_t i = 0; i < repetitions; ++i)
+    {
+        timer.restart();
+
+        hpx::start(desc_commandline, argc, argv);
+        auto t_start = timer.elapsed();
+
+        for (std::size_t thread = 0; thread < threads; ++thread)
+        {
+            hpx::async([](){});
+        }
+
+        auto t_async = timer.elapsed();
+
+        hpx::stop();
+        auto t_stop = timer.elapsed();
+
+        std::cout
+            << threads << ", "
+            << t_start << ", "
+            << t_async << ", "
+            << t_stop
+            << std::endl;
+    }
+}
+


### PR DESCRIPTION
## Proposed Changes

- Add resume/suspend benchmark
- Add start/stop benchmark
- Add OpenMP parallel region benchmark
- Flyby: fix a missing comma in an existing OpenMP performance test

## Any background context you want to provide?

#3137 