### PR TITLE
Fix nqueen example

### DIFF
--- a/examples/nqueen/nqueen.hpp
+++ b/examples/nqueen/nqueen.hpp
@@ -34,7 +34,12 @@ namespace nqueen
 
         void init_board(std::size_t size)
         {
-            hpx::apply<server::board::init_action>(this->get_id(), size);
+            return init_board_async(size).get();
+        }
+
+        hpx::lcos::future<void> init_board_async(std::size_t size)
+        {
+            return hpx::async<server::board::init_action>(this->get_id(), size);
         }
 
         //-------------------------------------------------------


### PR DESCRIPTION
Fixes #3048.

## Proposed changes
- Initialize board synchronously to make sure it is initialized before being
accessed.
