### PR TITLE
Deleting one include of median from BOOST library to arithmetics_counter file

### DIFF
--- a/src/performance_counters/server/statistics_counter.cpp
+++ b/src/performance_counters/server/statistics_counter.cpp
@@ -20,7 +20,6 @@
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/mean.hpp>
-#include <boost/accumulators/statistics/median.hpp>
 #include <boost/accumulators/statistics/variance.hpp>
 #include <boost/accumulators/statistics/max.hpp>
 #include <boost/accumulators/statistics/min.hpp>
@@ -36,6 +35,7 @@
 #  pragma warning(push)
 #  pragma warning(disable: 4244)
 #endif
+#include <boost/accumulators/statistics/median.hpp>
 #if defined(HPX_MSVC)
 #  pragma warning(pop)
 #endif

--- a/src/performance_counters/server/statistics_counter.cpp
+++ b/src/performance_counters/server/statistics_counter.cpp
@@ -36,7 +36,6 @@
 #  pragma warning(push)
 #  pragma warning(disable: 4244)
 #endif
-#include <boost/accumulators/statistics/median.hpp>
 #if defined(HPX_MSVC)
 #  pragma warning(pop)
 #endif


### PR DESCRIPTION
Two times **"#include <boost/accumulators/statistics/median.hpp>"** is included. So, one should be removed .
@hkaiser Would you mind to review !!