### PR TITLE
Move type info into hpx::debug namespace and add print helper functions

### DIFF
--- a/hpx/runtime/actions/action_support.hpp
+++ b/hpx/runtime/actions/action_support.hpp
@@ -72,7 +72,7 @@ namespace hpx { namespace actions
             static_assert(
                 traits::needs_automatic_registration<Action>::value,
                 "HPX_REGISTER_ACTION_DECLARATION missing");
-            return util::type_id<Action>::typeid_.type_id();
+            return debug::type_id<Action>::typeid_.type_id();
         }
 #endif
 

--- a/hpx/runtime/actions/action_support.hpp
+++ b/hpx/runtime/actions/action_support.hpp
@@ -23,6 +23,7 @@
 #include <hpx/util/detail/pp/cat.hpp>
 #include <hpx/util/detail/pp/nargs.hpp>
 #include <hpx/util/tuple.hpp>
+#include <hpx/util/debug/demangle_helper.hpp>
 #if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
 #include <hpx/util/itt_notify.hpp>
 #endif
@@ -72,7 +73,7 @@ namespace hpx { namespace actions
             static_assert(
                 traits::needs_automatic_registration<Action>::value,
                 "HPX_REGISTER_ACTION_DECLARATION missing");
-            return debug::type_id<Action>::typeid_.type_id();
+            return util::debug::type_id<Action>::typeid_.type_id();
         }
 #endif
 

--- a/hpx/runtime/actions/continuation.hpp
+++ b/hpx/runtime/actions/continuation.hpp
@@ -23,7 +23,6 @@
 #include <hpx/traits/future_traits.hpp>
 #include <hpx/traits/is_continuation.hpp>
 #include <hpx/util/decay.hpp>
-#include <hpx/util/demangle_helper.hpp>
 #include <hpx/util/detail/pp/stringize.hpp>
 #include <hpx/util/logging.hpp>
 #include <hpx/util/unique_function.hpp>

--- a/hpx/runtime/serialization/detail/polymorphic_intrusive_factory.hpp
+++ b/hpx/runtime/serialization/detail/polymorphic_intrusive_factory.hpp
@@ -157,12 +157,12 @@ namespace hpx { namespace serialization { namespace detail
 
 #define HPX_SERIALIZATION_POLYMORPHIC_TEMPLATE(Class)                         \
   HPX_SERIALIZATION_POLYMORPHIC_WITH_NAME(                                    \
-      Class, hpx::util::type_id<Class>::typeid_.type_id();)                   \
+      Class, hpx::debug::type_id<Class>::typeid_.type_id();)                   \
 /**/
 
 #define HPX_SERIALIZATION_POLYMORPHIC_TEMPLATE_SPLITTED(Class)                \
   HPX_SERIALIZATION_POLYMORPHIC_WITH_NAME_SPLITTED(                           \
-      Class, hpx::util::type_id<T>::typeid_.type_id();)                       \
+      Class, hpx::debug::type_id<T>::typeid_.type_id();)                       \
 /**/
 
 #endif

--- a/hpx/runtime/serialization/detail/polymorphic_intrusive_factory.hpp
+++ b/hpx/runtime/serialization/detail/polymorphic_intrusive_factory.hpp
@@ -10,7 +10,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/runtime/serialization/serialization_fwd.hpp>
-#include <hpx/util/demangle_helper.hpp>
+#include <hpx/util/debug/demangle_helper.hpp>
 #include <hpx/util/detail/pp/stringize.hpp>
 #include <hpx/util/jenkins_hash.hpp>
 
@@ -157,12 +157,12 @@ namespace hpx { namespace serialization { namespace detail
 
 #define HPX_SERIALIZATION_POLYMORPHIC_TEMPLATE(Class)                         \
   HPX_SERIALIZATION_POLYMORPHIC_WITH_NAME(                                    \
-      Class, hpx::debug::type_id<Class>::typeid_.type_id();)                   \
+      Class, hpx::util::debug::type_id<Class>::typeid_.type_id();)            \
 /**/
 
 #define HPX_SERIALIZATION_POLYMORPHIC_TEMPLATE_SPLITTED(Class)                \
   HPX_SERIALIZATION_POLYMORPHIC_WITH_NAME_SPLITTED(                           \
-      Class, hpx::debug::type_id<T>::typeid_.type_id();)                       \
+      Class, hpx::util::debug::type_id<T>::typeid_.type_id();)                \
 /**/
 
 #endif

--- a/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
+++ b/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
@@ -48,7 +48,7 @@ namespace hpx { namespace serialization { namespace detail
             static_assert(
                 traits::needs_automatic_registration<T>::value,
                 "HPX_REGISTER_ACTION_DECLARATION missing");
-            return util::type_id<T>::typeid_.type_id();
+            return debug::type_id<T>::typeid_.type_id();
         }
     };
 #endif
@@ -281,7 +281,7 @@ namespace hpx { namespace serialization { namespace detail
 #define HPX_SERIALIZATION_REGISTER_CLASS_TEMPLATE(Parameters, Template)       \
     HPX_SERIALIZATION_REGISTER_CLASS_NAME_TEMPLATE(                           \
         Parameters, Template,                                                 \
-        hpx::util::type_id<HPX_PP_STRIP_PARENS(Template) >::typeid_.type_id())\
+        hpx::debug::type_id<HPX_PP_STRIP_PARENS(Template) >::typeid_.type_id())\
     HPX_PP_STRIP_PARENS(Parameters) hpx::serialization::detail::register_class< \
         HPX_PP_STRIP_PARENS(Template)>                                        \
         HPX_PP_STRIP_PARENS(Template)::hpx_register_class_instance;           \

--- a/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
+++ b/hpx/runtime/serialization/detail/polymorphic_nonintrusive_factory.hpp
@@ -16,7 +16,7 @@
 #include <hpx/traits/needs_automatic_registration.hpp>
 #include <hpx/traits/polymorphic_traits.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/demangle_helper.hpp>
+#include <hpx/util/debug/demangle_helper.hpp>
 #include <hpx/util/detail/pp/stringize.hpp>
 #include <hpx/util/detail/pp/strip_parens.hpp>
 #include <hpx/util/jenkins_hash.hpp>
@@ -48,7 +48,7 @@ namespace hpx { namespace serialization { namespace detail
             static_assert(
                 traits::needs_automatic_registration<T>::value,
                 "HPX_REGISTER_ACTION_DECLARATION missing");
-            return debug::type_id<T>::typeid_.type_id();
+            return util::debug::type_id<T>::typeid_.type_id();
         }
     };
 #endif
@@ -281,7 +281,7 @@ namespace hpx { namespace serialization { namespace detail
 #define HPX_SERIALIZATION_REGISTER_CLASS_TEMPLATE(Parameters, Template)       \
     HPX_SERIALIZATION_REGISTER_CLASS_NAME_TEMPLATE(                           \
         Parameters, Template,                                                 \
-        hpx::debug::type_id<HPX_PP_STRIP_PARENS(Template) >::typeid_.type_id())\
+        hpx::util::debug::type_id<HPX_PP_STRIP_PARENS(Template) >::typeid_.type_id())\
     HPX_PP_STRIP_PARENS(Parameters) hpx::serialization::detail::register_class< \
         HPX_PP_STRIP_PARENS(Template)>                                        \
         HPX_PP_STRIP_PARENS(Template)::hpx_register_class_instance;           \

--- a/hpx/util/debug/demangle_helper.hpp
+++ b/hpx/util/debug/demangle_helper.hpp
@@ -4,8 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(HPX_UTIL_DEMANGLE_HELPER_OCT_28_2011_0410PM)
-#define HPX_UTIL_DEMANGLE_HELPER_OCT_28_2011_0410PM
+#if !defined(HPX_UTIL_DEBUG_DEMANGLE_HELPER_OCT_28_2011_0410PM)
+#define HPX_UTIL_DEBUG_DEMANGLE_HELPER_OCT_28_2011_0410PM
 
 #include <hpx/config.hpp>
 #include <string>
@@ -15,7 +15,7 @@
 #include <cxxabi.h>
 #include <stdlib.h>
 
-namespace hpx { namespace debug
+namespace hpx { namespace util { namespace debug
 {
     // --------------------------------------------------------------------
     // demangle an arbitrary c++ type using gnu utility
@@ -41,13 +41,14 @@ namespace hpx { namespace debug
     private:
         char* demangled_;
     };
-}}
+
+}}}
 
 #else
 
 #include <typeinfo>
 
-namespace hpx { namespace debug
+namespace hpx { namespace util { namespace debug
 {
     template <typename T>
     struct demangle_helper
@@ -57,12 +58,12 @@ namespace hpx { namespace debug
             return typeid(T).name();
         }
     };
-}}
+}}}
 
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace debug
+namespace hpx { namespace util { namespace debug
 {
     template <typename T>
     struct type_id
@@ -81,7 +82,7 @@ namespace hpx { namespace debug
     template <typename T=void>
     inline std::string print_type(const char *delim="")
     {
-        return std::string(debug::type_id<T>::typeid_.type_id());
+        return std::string(hpx::util::debug::type_id<T>::typeid_.type_id());
     }
 
     template <>
@@ -94,10 +95,9 @@ namespace hpx { namespace debug
     inline typename std::enable_if<sizeof...(Args)!=0, std::string>::type
     print_type(const char *delim="")
     {
-        std::string temp(debug::type_id<T>::typeid_.type_id());
+        std::string temp(hpx::util::debug::type_id<T>::typeid_.type_id());
         return temp + delim + print_type<Args...>(delim);
     }
-}}
+}}}
 
 #endif
-

--- a/hpx/util/demangle_helper.hpp
+++ b/hpx/util/demangle_helper.hpp
@@ -47,7 +47,7 @@ namespace hpx { namespace debug
 
 #include <typeinfo>
 
-namespace hpx { namespace util
+namespace hpx { namespace debug
 {
     template <typename T>
     struct demangle_helper
@@ -81,7 +81,7 @@ namespace hpx { namespace debug
     template <typename T=void>
     inline std::string print_type(const char *delim="")
     {
-        return std::string(debug::type_id<T>::typeid_.type_id());;
+        return std::string(debug::type_id<T>::typeid_.type_id());
     }
 
     template <>

--- a/hpx/util/demangle_helper.hpp
+++ b/hpx/util/demangle_helper.hpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2017 John Biddiscombe
 //  Copyright (c) 2007-2012 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,14 +8,18 @@
 #define HPX_UTIL_DEMANGLE_HELPER_OCT_28_2011_0410PM
 
 #include <hpx/config.hpp>
+#include <string>
+#include <type_traits>
 
-// disable the code specific to gcc for now as this causes problems
-// (see #811: simple_central_tuplespace_client run error)
-#if 0 // defined(__GNUC__)
+#if defined(__GNUC__)
 #include <cxxabi.h>
+#include <stdlib.h>
 
-namespace hpx { namespace util
+namespace hpx { namespace debug
 {
+    // --------------------------------------------------------------------
+    // demangle an arbitrary c++ type using gnu utility
+    // --------------------------------------------------------------------
     template <typename T>
     class demangle_helper
     {
@@ -57,7 +62,7 @@ namespace hpx { namespace util
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace util
+namespace hpx { namespace debug
 {
     template <typename T>
     struct type_id
@@ -67,6 +72,31 @@ namespace hpx { namespace util
 
     template <typename T>
     demangle_helper<T> type_id<T>::typeid_ = demangle_helper<T>();
+
+    // --------------------------------------------------------------------
+    // print type information
+    // usage : std::cout << print_type<args...>("separator")
+    // separator is appended if the number of types > 1
+    // --------------------------------------------------------------------
+    template <typename T=void>
+    inline std::string print_type(const char *delim="")
+    {
+        return std::string(debug::type_id<T>::typeid_.type_id());;
+    }
+
+    template <>
+    inline std::string print_type<>(const char *)
+    {
+        return "void";
+    }
+
+    template <typename T, typename ...Args>
+    inline typename std::enable_if<sizeof...(Args)!=0, std::string>::type
+    print_type(const char *delim="")
+    {
+        std::string temp(debug::type_id<T>::typeid_.type_id());
+        return temp + delim + print_type<Args...>(delim);
+    }
 }}
 
 #endif

--- a/hpx/util/detail/function_registration.hpp
+++ b/hpx/util/detail/function_registration.hpp
@@ -30,7 +30,7 @@ namespace hpx { namespace util { namespace detail
         static char const* call()
 #ifdef HPX_HAVE_AUTOMATIC_SERIALIZATION_REGISTRATION
         {
-            return util::type_id<F>::typeid_.type_id();
+            return debug::type_id<F>::typeid_.type_id();
         }
 #else
         = delete;

--- a/hpx/util/detail/function_registration.hpp
+++ b/hpx/util/detail/function_registration.hpp
@@ -9,7 +9,7 @@
 #define HPX_UTIL_DETAIL_FUNCTION_REGISTRATION_HPP
 
 #include <hpx/config.hpp>
-#include <hpx/util/demangle_helper.hpp>
+#include <hpx/util/debug/demangle_helper.hpp>
 #include <hpx/util/detail/pp/stringize.hpp>
 #include <hpx/util/detail/pp/strip_parens.hpp>
 


### PR DESCRIPTION
## Proposed Changes
Adds an extra couple of type info print helpers and moves the demangler into the debug namespace.
Might not compile on all platforms because we had some problems with it in the past, so wanting to see what pycicle gives after a build/test of this PR.