### PR TITLE
Updating Runtime.cpp by adding correct description of Performance counters during register

### DIFF
--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -428,7 +428,7 @@ namespace hpx
 
             // rolling_averaging counter
             { "/statistics/rolling_average", performance_counters::counter_aggregating,
-              "returns the averaged value of its base counter over "
+              "returns the rolling average value of its base counter over "
               "an arbitrary time line; pass required base counter as the instance "
               "name: /statistics{<base_counter_name>}/rolling_averaging",
               HPX_PERFORMANCE_COUNTER_V1,
@@ -452,7 +452,7 @@ namespace hpx
 
             // median counter
             { "/statistics/median", performance_counters::counter_aggregating,
-              "returns the averaged value of its base counter over "
+              "returns the median value of its base counter over "
               "an arbitrary time line; pass required base counter as the instance "
               "name: /statistics{<base_counter_name>}/median",
               HPX_PERFORMANCE_COUNTER_V1,
@@ -463,7 +463,7 @@ namespace hpx
 
             // max counter
             { "/statistics/max", performance_counters::counter_aggregating,
-              "returns the averaged value of its base counter over "
+              "returns the maximum value of its base counter over "
               "an arbitrary time line; pass required base counter as the instance "
               "name: /statistics{<base_counter_name>}/max",
               HPX_PERFORMANCE_COUNTER_V1,
@@ -474,7 +474,7 @@ namespace hpx
 
             // min counter
             { "/statistics/min", performance_counters::counter_aggregating,
-              "returns the averaged value of its base counter over "
+              "returns the minimum value of its base counter over "
               "an arbitrary time line; pass required base counter as the instance "
               "name: /statistics{<base_counter_name>}/min",
               HPX_PERFORMANCE_COUNTER_V1,


### PR DESCRIPTION
Updating file as during registering performance counter in function ```void runtime::register_counter_types()``` the description of some performance counter is not aptly correct , which should be updated .
@hkaiser Would you mind to have a review. 