### PR TITLE
parallel::{fill|fill_n}  updated for Ranges TS.

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -114,6 +114,7 @@ set(doxygen_dependencies
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/all_any_none.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/copy.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/count.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/fill.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/for_each.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/generate.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/is_heap.hpp"

--- a/hpx/include/parallel_fill.hpp
+++ b/hpx/include/parallel_fill.hpp
@@ -8,6 +8,7 @@
 #define HPX_PARALLEL_FILL_JUL_07_2014_1222PM
 
 #include <hpx/parallel/algorithms/fill.hpp>
+#include <hpx/parallel/container_algorithms/fill.hpp>
 #include <hpx/parallel/segmented_algorithms/fill.hpp>
 
 #endif

--- a/hpx/parallel/algorithms/count.hpp
+++ b/hpx/parallel/algorithms/count.hpp
@@ -228,6 +228,10 @@ namespace hpx { namespace parallel { inline namespace v1
     /// \param last         Refers to the end of the sequence of elements the
     ///                     algorithm will be applied to.
     /// \param value        The value to search for.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
     ///
     /// The comparisons in the parallel \a count algorithm invoked with
     /// an execution policy object of type \a sequenced_policy
@@ -426,6 +430,10 @@ namespace hpx { namespace parallel { inline namespace v1
     ///                     it. The type \a Type must be such that an object of
     ///                     type \a FwdIter can be dereferenced and then
     ///                     implicitly converted to Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
     ///
     /// \note The assignments in the parallel \a count_if algorithm invoked with
     ///       an execution policy object of type \a sequenced_policy

--- a/hpx/parallel/algorithms/fill.hpp
+++ b/hpx/parallel/algorithms/fill.hpp
@@ -160,11 +160,11 @@ namespace hpx { namespace parallel { inline namespace v1
     ///           returns \a difference_type otherwise (where \a difference_type
     ///           is defined by \a void.
     ///
-    template <typename ExPolicy, typename FwdIter, typename T>
-    inline typename std::enable_if<
-        execution::is_execution_policy<ExPolicy>::value,
-        typename util::detail::algorithm_result<ExPolicy>::type
-    >::type
+    template <typename ExPolicy, typename FwdIter, typename T,
+    HPX_CONCEPT_REQUIRES_(
+        execution::is_execution_policy<ExPolicy>::value &&
+        hpx::traits::is_forward_iterator<FwdIter>::value)>
+    typename util::detail::algorithm_result<ExPolicy>::type
     fill(ExPolicy && policy, FwdIter first, FwdIter last, T value)
     {
 #if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
@@ -268,11 +268,12 @@ namespace hpx { namespace parallel { inline namespace v1
     ///           returns \a difference_type otherwise (where \a difference_type
     ///           is defined by \a void.
     ///
-    template <typename ExPolicy, typename FwdIter, typename Size, typename T>
-    inline typename std::enable_if<
-        execution::is_execution_policy<ExPolicy>::value,
-        typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
-    >::type
+    template <typename ExPolicy, typename FwdIter,
+        typename Size, typename T,
+    HPX_CONCEPT_REQUIRES_(
+        execution::is_execution_policy<ExPolicy>::value &&
+        hpx::traits::is_forward_iterator<FwdIter>::value)>
+    typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
     fill_n(ExPolicy && policy, FwdIter first, Size count, T value)
     {
 #if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)

--- a/hpx/parallel/container_algorithms.hpp
+++ b/hpx/parallel/container_algorithms.hpp
@@ -10,6 +10,7 @@
 #include <hpx/parallel/algorithm.hpp>
 
 #include <hpx/parallel/container_algorithms/copy.hpp>
+#include <hpx/parallel/container_algorithms/fill.hpp>
 #include <hpx/parallel/container_algorithms/for_each.hpp>
 #include <hpx/parallel/container_algorithms/generate.hpp>
 #include <hpx/parallel/container_algorithms/is_heap.hpp>

--- a/hpx/parallel/container_algorithms/fill.hpp
+++ b/hpx/parallel/container_algorithms/fill.hpp
@@ -1,0 +1,133 @@
+//  Copyright (c) 2018 Christopher Ogle
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/container_algorithms/fill.hpp
+
+#if !defined(HPX_PARALLEL_CONTAINER_ALGORITHM_FILL_FEB_23_2018_0057AM)
+#define HPX_PARALLEL_CONTAINER_ALGORITHM_FILL_FEB_23_2018_0057AM
+
+#include <hpx/config.hpp>
+#include <hpx/traits/is_execution_policy.hpp>
+#include <hpx/traits/is_range.hpp>
+#include <hpx/util/range.hpp>
+
+#include <hpx/parallel/algorithms/fill.hpp>
+
+#include <iterator>
+#include <type_traits>
+
+namespace hpx { namespace parallel { inline namespace v1
+{
+    /// Assigns the given value to the elements in the range [first, last).
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam T           The type of the value to be assigned (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param value        The value to be assigned.
+    ///
+    /// The comparisons in the parallel \a fill algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The comparisons in the parallel \a fill algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a fill algorithm returns a \a hpx::future<void> if the
+    ///           execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a difference_type otherwise (where \a difference_type
+    ///           is defined by \a void.
+    ///
+    template <typename ExPolicy, typename Rng, typename T>
+    inline typename std::enable_if<
+        execution::is_execution_policy<ExPolicy>::value,
+        typename util::detail::algorithm_result<
+            ExPolicy, typename std::iterator_traits<
+            typename hpx::traits::range_traits<Rng>::iterator_type
+            >::difference_type
+        >::type
+    >::type
+    fill(ExPolicy && policy, Rng && rng, T value)
+    {
+        return fill(std::forward<ExPolicy>(policy),
+            hpx::util::begin(rng), hpx::util::end(rng), value);
+    }
+
+    /// Assigns the given value value to the first count elements in the range
+    /// beginning at first if count > 0. Does nothing otherwise.
+    ///
+    /// \note   Complexity: Performs exactly \a count assignments, for
+    ///         count > 0.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Size        The type of the argument specifying the number of
+    ///                     elements to apply \a f to.
+    /// \tparam T           The type of the value to be assigned (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param count        Refers to the number of elements starting at
+    ///                     \a first the algorithm will be applied to.
+    /// \param value        The value to be assigned.
+    ///
+    /// The comparisons in the parallel \a fill_n algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The comparisons in the parallel \a fill_n algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a fill_n algorithm returns a \a hpx::future<void> if the
+    ///           execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a difference_type otherwise (where \a difference_type
+    ///           is defined by \a void.
+    ///
+    template <typename ExPolicy, typename Rng, typename Size, typename T>
+    inline typename std::enable_if<
+        execution::is_execution_policy<ExPolicy>::value,
+        typename util::detail::algorithm_result<
+            ExPolicy, typename std::iterator_traits<
+            typename hpx::traits::range_traits<Rng>::iterator_type
+            >::difference_type
+        >::type
+    >::type
+    fill_n(ExPolicy && policy, Rng & rng, Size count, T value)
+    {
+        return fill_n(std::forward<ExPolicy>(policy),
+            hpx::util::begin(rng), count, value);
+    }
+
+}}}
+
+#endif

--- a/hpx/parallel/container_algorithms/fill.hpp
+++ b/hpx/parallel/container_algorithms/fill.hpp
@@ -56,15 +56,11 @@ namespace hpx { namespace parallel { inline namespace v1
     ///           returns \a difference_type otherwise (where \a difference_type
     ///           is defined by \a void.
     ///
-    template <typename ExPolicy, typename Rng, typename T>
-    inline typename std::enable_if<
-        execution::is_execution_policy<ExPolicy>::value,
-        typename util::detail::algorithm_result<
-            ExPolicy, typename std::iterator_traits<
-            typename hpx::traits::range_traits<Rng>::iterator_type
-            >::difference_type
-        >::type
-    >::type
+    template <typename ExPolicy, typename Rng, typename T,
+    HPX_CONCEPT_REQUIRES_(
+        execution::is_execution_policy<ExPolicy>::value &&
+        hpx::traits::is_range<Rng>::value)>
+    typename util::detail::algorithm_result<ExPolicy>::type
     fill(ExPolicy && policy, Rng && rng, T value)
     {
         return fill(std::forward<ExPolicy>(policy),
@@ -113,14 +109,14 @@ namespace hpx { namespace parallel { inline namespace v1
     ///           returns \a difference_type otherwise (where \a difference_type
     ///           is defined by \a void.
     ///
-    template <typename ExPolicy, typename Rng, typename Size, typename T>
-    inline typename std::enable_if<
-        execution::is_execution_policy<ExPolicy>::value,
-        typename util::detail::algorithm_result<
-            ExPolicy, typename std::iterator_traits<
-            typename hpx::traits::range_traits<Rng>::iterator_type
-            >::difference_type
-        >::type
+    template <typename ExPolicy, typename Rng,
+        typename Size, typename T,
+    HPX_CONCEPT_REQUIRES_(
+        execution::is_execution_policy<ExPolicy>::value &&
+        hpx::traits::is_range<Rng>::value)>
+    typename util::detail::algorithm_result<
+        ExPolicy,
+        typename hpx::traits::range_traits<Rng>::iterator_type
     >::type
     fill_n(ExPolicy && policy, Rng & rng, Size count, T value)
     {

--- a/hpx/parallel/container_algorithms/fill.hpp
+++ b/hpx/parallel/container_algorithms/fill.hpp
@@ -15,8 +15,8 @@
 
 #include <hpx/parallel/algorithms/fill.hpp>
 
-#include <iterator>
 #include <type_traits>
+#include <utility>
 
 namespace hpx { namespace parallel { inline namespace v1
 {

--- a/tests/unit/parallel/container_algorithms/fill_range.cpp
+++ b/tests/unit/parallel/container_algorithms/fill_range.cpp
@@ -1,0 +1,126 @@
+//  copyright (c) 2018 Christopher Ogle
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/parallel_fill.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_fill(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    hpx::parallel::fill(policy, c, 10);
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c),
+        [&count](std::size_t v) -> void {
+            HPX_TEST_EQ(v, std::size_t(10));
+            ++count;
+    });
+
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_fill_async(ExPolicy p, IteratorTag)
+{
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    hpx::future<void> f = hpx::parallel::fill(p, c, 10);
+    f.wait();
+
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c),
+        [&count](std::size_t v) -> void {
+            HPX_TEST_EQ(v, std::size_t(10));
+            ++count;
+    });
+
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename IteratorTag>
+void test_fill()
+{
+    using namespace hpx::parallel;
+    test_fill(execution::seq, IteratorTag());
+    test_fill(execution::par, IteratorTag());
+    test_fill(execution::par_unseq, IteratorTag());
+
+    test_fill_async(execution::seq(execution::task), IteratorTag());
+    test_fill_async(execution::par(execution::task), IteratorTag());
+
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
+    test_fill(execution_policy(execution::seq), IteratorTag());
+    test_fill(execution_policy(execution::par), IteratorTag());
+    test_fill(execution_policy(execution::par_unseq), IteratorTag());
+
+    test_fill(execution_policy(execution::seq(execution::task)), IteratorTag());
+    test_fill(execution_policy(execution::par(execution::task)), IteratorTag());
+#endif
+}
+
+void fill_test()
+{
+    test_fill<std::random_access_iterator_tag>();
+    test_fill<std::forward_iterator_tag>();
+}
+
+////////////////////////////////////////////////////////////////////////////
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int)std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    fill_test();
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace boost::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()
+        ("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run")
+        ;
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {
+        "hpx.os_threads=all"
+    };
+
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/parallel/container_algorithms/filln_range.cpp
+++ b/tests/unit/parallel/container_algorithms/filln_range.cpp
@@ -1,0 +1,126 @@
+//  copyright (c) 2018 Christopher Ogle
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/parallel_fill.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_fill_n(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    hpx::parallel::fill_n(policy, c, c.size(), 10);
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c),
+        [&count](std::size_t v) -> void {
+            HPX_TEST_EQ(v, std::size_t(10));
+            ++count;
+    });
+
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_fill_async(ExPolicy p, IteratorTag)
+{
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    hpx::future<void> f = hpx::parallel::fill_n(p, c, c.size(), 10);
+    f.wait();
+
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c),
+        [&count](std::size_t v) -> void {
+            HPX_TEST_EQ(v, std::size_t(10));
+            ++count;
+    });
+
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename IteratorTag>
+void test_fill_n()
+{
+    using namespace hpx::parallel;
+    test_fill_n(execution::seq, IteratorTag());
+    test_fill_n(execution::par, IteratorTag());
+    test_fill_n(execution::par_unseq, IteratorTag());
+
+    test_fill_n_async(execution::seq(execution::task), IteratorTag());
+    test_fill_n_async(execution::par(execution::task), IteratorTag());
+
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
+    test_fill_n(execution_policy(execution::seq), IteratorTag());
+    test_fill_n(execution_policy(execution::par), IteratorTag());
+    test_fill_n(execution_policy(execution::par_unseq), IteratorTag());
+
+    test_fill_n(execution_policy(execution::seq(execution::task)), IteratorTag());
+    test_fill_n(execution_policy(execution::par(execution::task)), IteratorTag());
+#endif
+}
+
+void fill_test()
+{
+    test_fill_n<std::random_access_iterator_tag>();
+    test_fill_n<std::forward_iterator_tag>();
+}
+
+////////////////////////////////////////////////////////////////////////////
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int)std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    fill_test();
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace boost::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()
+        ("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run")
+        ;
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {
+        "hpx.os_threads=all"
+    };
+
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
This is a continuation of my work on #1668. This brings `parallel::fill` and `parallel::fill_n` into accordance with the Ranges TS. 