### PR TITLE
Set pre_main status before launching run_helper

### DIFF
--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -356,9 +356,9 @@ namespace hpx {
             "run_helper", 0, threads::thread_priority_normal, std::size_t(-1),
             threads::get_stack_size(threads::thread_stacksize_large));
 
+        this->runtime::starting();
         threads::thread_id_type id = threads:: invalid_thread_id;
         thread_manager_->register_thread(data, id);
-        this->runtime::starting();
 
         // }}}
 


### PR DESCRIPTION
This fixes a race where `runtime_impl::run_helper` could set the runtime status to `running` before `runtime_impl::start` sets the status to `pre_main` (the status would then be stuck at `pre_main` instead of `running` after actually starting the runtime).