### PR TITLE
Fixing return type calculation for bulk_then_execute.

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -143,7 +143,7 @@ set(doxygen_dependencies
     "${PROJECT_SOURCE_DIR}/hpx/performance_counters/manage_counter_type.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/runtime_fwd.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/runtime/applier_fwd.hpp"
-    "${PROJECT_SOURCE_DIR}/hpx/runtime/basename_registration.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/runtime/basename_registration_fwd.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/runtime/find_here.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/runtime/find_localities.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/runtime/get_colocation_id.hpp"

--- a/hpx/apply.hpp
+++ b/hpx/apply.hpp
@@ -7,11 +7,11 @@
 #define HPX_APPLY_APR_16_20012_0943AM
 
 #include <hpx/config.hpp>
-#include <hpx/lcos/future.hpp>
 #include <hpx/runtime/applier/apply.hpp>
 #include <hpx/runtime/applier/apply_continue.hpp>
 #include <hpx/runtime/threads/thread_executor.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
+#include <hpx/runtime_fwd.hpp>
 #include <hpx/traits/is_executor.hpp>
 #include <hpx/traits/is_launch_policy.hpp>
 #include <hpx/util/bind_action.hpp>

--- a/hpx/compute/cuda/target_distribution_policy.hpp
+++ b/hpx/compute/cuda/target_distribution_policy.hpp
@@ -12,7 +12,7 @@
 
 #if defined(HPX_HAVE_CUDA)
 
-#include <hpx/dataflow.hpp>
+#include <hpx/lcos/dataflow.hpp>
 #include <hpx/lcos/future.hpp>
 #include <hpx/runtime/components/stubs/stub_base.hpp>
 #include <hpx/runtime/serialization/base_object.hpp>

--- a/hpx/compute/host/target_distribution_policy.hpp
+++ b/hpx/compute/host/target_distribution_policy.hpp
@@ -10,7 +10,7 @@
 
 #include <hpx/config.hpp>
 
-#include <hpx/dataflow.hpp>
+#include <hpx/lcos/dataflow.hpp>
 #include <hpx/lcos/future.hpp>
 #include <hpx/runtime/components/stubs/stub_base.hpp>
 #include <hpx/runtime/serialization/base_object.hpp>

--- a/hpx/dataflow.hpp
+++ b/hpx/dataflow.hpp
@@ -6,6 +6,7 @@
 #ifndef HPX_DATAFLOW_HPP
 #define HPX_DATAFLOW_HPP
 
+#include <hpx/lcos/future.hpp>
 #include <hpx/lcos/dataflow.hpp>
 #include <hpx/lcos/local/dataflow.hpp>
 

--- a/hpx/hpx.hpp
+++ b/hpx/hpx.hpp
@@ -6,6 +6,9 @@
 #if !defined(HPX_MAR_24_2008_1118AM)
 #define HPX_MAR_24_2008_1118AM
 
+#include <hpx/apply.hpp>
+#include <hpx/async.hpp>
+#include <hpx/dataflow.hpp>
 #include <hpx/exception.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/performance_counters.hpp>

--- a/hpx/lcos/broadcast.hpp
+++ b/hpx/lcos/broadcast.hpp
@@ -135,6 +135,7 @@ namespace hpx { namespace lcos
 #define HPX_LCOS_BROADCAST_HPP
 
 #include <hpx/config.hpp>
+#include <hpx/apply.hpp>
 #include <hpx/lcos/detail/async_colocated.hpp>
 #include <hpx/lcos/future.hpp>
 #include <hpx/lcos/when_all.hpp>

--- a/hpx/lcos/dataflow.hpp
+++ b/hpx/lcos/dataflow.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,13 +6,16 @@
 // hpxinspect:nodeprecatedinclude:boost/ref.hpp
 // hpxinspect:nodeprecatedname:boost::reference_wrapper
 
+#include <hpx/config.hpp>
+
+// Intentionally #include future.hpp outside of the guards as it may #include
+// dataflow.hpp itself
+#include <hpx/lcos/future.hpp>
+
 #ifndef HPX_LCOS_DATAFLOW_HPP
 #define HPX_LCOS_DATAFLOW_HPP
 
-#include <hpx/config.hpp>
-#include <hpx/apply.hpp>
 #include <hpx/lcos/detail/future_transforms.hpp>
-#include <hpx/lcos/future.hpp>
 #include <hpx/runtime/get_worker_thread_num.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/traits/acquire_future.hpp>
@@ -36,6 +39,7 @@
 #include <hpx/parallel/executors/v1/executor_traits.hpp>
 #endif
 #include <hpx/parallel/executors/execution.hpp>
+#include <hpx/parallel/executors/parallel_executor.hpp>
 
 #include <boost/intrusive_ptr.hpp>
 #include <boost/ref.hpp>

--- a/hpx/lcos/detail/future_transforms.hpp
+++ b/hpx/lcos/detail/future_transforms.hpp
@@ -6,6 +6,7 @@
 #ifndef HPX_LCOS_DETAIL_FUTURE_TRANSFORMS_HPP
 #define HPX_LCOS_DETAIL_FUTURE_TRANSFORMS_HPP
 
+#include <hpx/lcos/detail/future_traits.hpp>
 #include <hpx/lcos_fwd.hpp>
 #include <hpx/traits/acquire_future.hpp>
 #include <hpx/traits/acquire_shared_state.hpp>

--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -37,6 +37,7 @@
 #include <hpx/util/invoke.hpp>
 #include <hpx/util/lazy_enable_if.hpp>
 #include <hpx/util/result_of.hpp>
+#include <hpx/util/serialize_exception.hpp>
 #include <hpx/util/steady_clock.hpp>
 #include <hpx/util/void_guard.hpp>
 

--- a/hpx/lcos/when_all_fwd.hpp
+++ b/hpx/lcos/when_all_fwd.hpp
@@ -1,0 +1,26 @@
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_LCOS_WHEN_ALL_FWD_HPP)
+#define HPX_LCOS_WHEN_ALL_FWD_HPP
+
+#include <hpx/config.hpp>
+#include <hpx/lcos_fwd.hpp>
+
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace lcos
+{
+    // special forwarding function to break #include dependencies
+    HPX_API_EXPORT hpx::future<void> when_all_fwd(
+        std::vector<hpx::future<void>>&);
+
+    HPX_API_EXPORT hpx::future<void> when_all_fwd(
+        std::vector<hpx::future<void>>&&);
+}}
+
+#endif
+

--- a/hpx/parallel/executors/default_executor.hpp
+++ b/hpx/parallel/executors/default_executor.hpp
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_EXECUTORS_DEFAULT_EXECUTOR_AUG_24_2015_0624PM
 
 #include <hpx/config.hpp>
+#include <hpx/lcos/future.hpp>
 #include <hpx/parallel/executors/execution_parameters.hpp>
 #include <hpx/parallel/executors/thread_execution.hpp>
 #include <hpx/parallel/executors/thread_execution_information.hpp>

--- a/hpx/parallel/executors/execution.hpp
+++ b/hpx/parallel/executors/execution.hpp
@@ -13,9 +13,11 @@
 #include <hpx/parallel/executors/execution_fwd.hpp>
 
 #include <hpx/exception_list.hpp>
+#include <hpx/lcos/dataflow.hpp>
 #include <hpx/lcos/future.hpp>
 #include <hpx/lcos/wait_all.hpp>
 #include <hpx/traits/detail/wrap_int.hpp>
+#include <hpx/traits/executor_traits.hpp>
 #include <hpx/traits/future_access.hpp>
 #include <hpx/traits/future_then_result.hpp>
 #include <hpx/traits/future_traits.hpp>
@@ -1133,6 +1135,7 @@ namespace hpx { namespace parallel { namespace execution
                 typedef typename bulk_then_execute_result<
                         F, Shape, Future, Ts...
                     >::type result_type;
+
                 typedef typename hpx::traits::detail::shared_state_ptr<
                         result_type
                     >::type shared_state_type;
@@ -1304,15 +1307,17 @@ namespace hpx { namespace parallel { namespace execution
                     Future&& predecessor, Ts &&... ts)
             ->  typename hpx::traits::executor_future<
                     Executor,
-                    typename then_bulk_function_result<
+                    typename bulk_then_execute_result<
                         F, Shape, Future, Ts...
                     >::type
                 >::type
             {
+                // result_of_t<F(Shape::value_type, Future)>
                 typedef typename then_bulk_function_result<
                         F, Shape, Future, Ts...
                     >::type func_result_type;
 
+                // std::vector<future<func_result_type>>
                 typedef std::vector<typename hpx::traits::executor_future<
                         Executor, func_result_type, Ts...
                     >::type> result_type;
@@ -1321,18 +1326,33 @@ namespace hpx { namespace parallel { namespace execution
                     exec, std::forward<F>(f), shape,
                     hpx::util::make_tuple(std::forward<Ts>(ts)...));
 
+                // void or std::vector<func_result_type>
+                typedef typename bulk_then_execute_result<
+                        F, Shape, Future, Ts...
+                    >::type vector_result_type;
+
+                // future<vector_result_type>
+                typedef typename hpx::traits::executor_future<
+                        Executor, vector_result_type
+                    >::type result_future_type;
+
                 typedef typename hpx::traits::detail::shared_state_ptr<
-                        result_type
+                        result_future_type
                     >::type shared_state_type;
 
-                shared_state_type p =
-                    lcos::detail::make_continuation_exec<result_type>(
-                        std::forward<Future>(predecessor),
-                        std::forward<BulkExecutor>(exec), std::move(func));
+                typedef typename std::decay<Future>::type future_type;
 
-                typedef typename hpx::traits::executor_future<
-                        Executor, result_type
-                    >::type result_future_type;
+                shared_state_type p =
+                    lcos::detail::make_continuation_exec<result_future_type>(
+                        std::forward<Future>(predecessor),
+                        std::forward<BulkExecutor>(exec),
+                        [HPX_CAPTURE_MOVE(func)](future_type&& predecessor) mutable
+                        ->  result_future_type
+                        {
+                            return hpx::dataflow(
+                                hpx::util::functional::unwrap{},
+                                func(std::move(predecessor)));
+                        });
 
                 return hpx::traits::future_access<result_future_type>::create(
                     std::move(p));
@@ -1375,8 +1395,6 @@ namespace hpx { namespace parallel { namespace execution
     }
     /// \endcond
 }}}
-
-
 
 #endif
 

--- a/hpx/parallel/executors/parallel_executor.hpp
+++ b/hpx/parallel/executors/parallel_executor.hpp
@@ -11,7 +11,7 @@
 #include <hpx/config.hpp>
 #include <hpx/async_launch_policy_dispatch.hpp>
 #include <hpx/lcos/future.hpp>
-#include <hpx/lcos/when_all.hpp>
+#include <hpx/lcos/when_all_fwd.hpp>
 #include <hpx/parallel/algorithms/detail/predicates.hpp>
 #include <hpx/parallel/executors/post_policy_dispatch.hpp>
 #include <hpx/parallel/executors/static_chunk_size.hpp>
@@ -197,7 +197,7 @@ namespace hpx { namespace parallel { namespace execution
 
                 HPX_ASSERT(size == 0);
 
-                return hpx::when_all(tasks);
+                return hpx::lcos::when_all_fwd(std::move(tasks));
             }
 
             // spawn all tasks sequentially

--- a/hpx/parallel/executors/pool_executor.hpp
+++ b/hpx/parallel/executors/pool_executor.hpp
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_EXECUTORS_POOL_EXECUTOR_FEB_17_2018_0327PM
 
 #include <hpx/config.hpp>
+#include <hpx/lcos/future.hpp>
 #include <hpx/parallel/executors/execution_parameters.hpp>
 #include <hpx/parallel/executors/thread_execution.hpp>
 #include <hpx/parallel/executors/thread_execution_information.hpp>

--- a/hpx/parallel/executors/service_executors.hpp
+++ b/hpx/parallel/executors/service_executors.hpp
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_EXECUTORS_SERVICE_EXECUTORS_MAY_15_2015_0548PM
 
 #include <hpx/config.hpp>
+#include <hpx/lcos/future.hpp>
 #include <hpx/parallel/executors/static_chunk_size.hpp>
 #include <hpx/parallel/executors/thread_execution.hpp>
 #include <hpx/runtime/threads/executors/service_executors.hpp>

--- a/hpx/parallel/executors/static_chunk_size.hpp
+++ b/hpx/parallel/executors/static_chunk_size.hpp
@@ -12,7 +12,7 @@
 #include <hpx/runtime/serialization/serialize.hpp>
 #include <hpx/traits/is_executor_parameters.hpp>
 
-#include <hpx/parallel/executors/execution_parameters.hpp>
+#include <hpx/parallel/executors/execution_parameters_fwd.hpp>
 
 #include <cstddef>
 #include <type_traits>

--- a/hpx/parallel/executors/this_thread_executors.hpp
+++ b/hpx/parallel/executors/this_thread_executors.hpp
@@ -7,6 +7,7 @@
 #define HPX_PARALLEL_EXECUTORS_THIS_THREAD_EXECUTORS_JUL_16_2015_0809PM
 
 #include <hpx/config.hpp>
+#include <hpx/lcos/future.hpp>
 #include <hpx/parallel/executors/execution_parameters.hpp>
 #include <hpx/parallel/executors/thread_execution.hpp>
 #include <hpx/parallel/executors/thread_execution_information.hpp>

--- a/hpx/parallel/executors/thread_pool_executors.hpp
+++ b/hpx/parallel/executors/thread_pool_executors.hpp
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_EXECUTORS_THREAD_POOL_EXECUTORS_MAY_15_2015_0548PM
 
 #include <hpx/config.hpp>
+#include <hpx/lcos/future.hpp>
 #include <hpx/parallel/executors/execution_parameters.hpp>
 #include <hpx/parallel/executors/thread_execution.hpp>
 #include <hpx/parallel/executors/thread_execution_information.hpp>

--- a/hpx/parallel/executors/thread_pool_os_executors.hpp
+++ b/hpx/parallel/executors/thread_pool_os_executors.hpp
@@ -9,6 +9,7 @@
 #define HPX_PARALLEL_EXECUTORS_THREAD_POOL_OS_EXECUTORS_AUG_22_2015_0739PM
 
 #include <hpx/config.hpp>
+#include <hpx/lcos/future.hpp>
 #include <hpx/parallel/executors/execution_parameters.hpp>
 #include <hpx/parallel/executors/thread_execution.hpp>
 #include <hpx/parallel/executors/thread_execution_information.hpp>

--- a/hpx/parallel/task_block.hpp
+++ b/hpx/parallel/task_block.hpp
@@ -10,8 +10,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/async.hpp>
-#include <hpx/dataflow.hpp>
 #include <hpx/exception.hpp>
+#include <hpx/lcos/dataflow.hpp>
 #include <hpx/lcos/future.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 #include <hpx/lcos/when_all.hpp>

--- a/hpx/performance_counters/performance_counter_set.hpp
+++ b/hpx/performance_counters/performance_counter_set.hpp
@@ -11,7 +11,7 @@
 #include <hpx/lcos/dataflow.hpp>
 #include <hpx/lcos/future.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
-#include <hpx/performance_counters/counters_fwd.hpp>
+#include <hpx/performance_counters/counters.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/util/unwrap.hpp>
 

--- a/hpx/runtime/applier/apply.hpp
+++ b/hpx/runtime/applier/apply.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,7 +8,6 @@
 #define HPX_APPLIER_APPLY_NOV_27_2008_0957AM
 
 #include <hpx/config.hpp>
-#include <hpx/runtime.hpp>
 #include <hpx/runtime/actions/action_priority.hpp>
 #include <hpx/runtime/agas/interface.hpp>
 #include <hpx/runtime/applier/apply_helper.hpp>
@@ -17,8 +16,9 @@
 #include <hpx/runtime/naming/address.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime/naming/name.hpp>
-#include <hpx/runtime/parcelset/put_parcel.hpp>
 #include <hpx/runtime/parcelset/detail/parcel_await.hpp>
+#include <hpx/runtime/parcelset/put_parcel.hpp>
+#include <hpx/runtime/parcelset_fwd.hpp>
 #include <hpx/traits/component_type_is_compatible.hpp>
 #include <hpx/traits/extract_action.hpp>
 #include <hpx/traits/is_action.hpp>
@@ -407,8 +407,7 @@ namespace hpx
                 parcelset::write_handler_type(), 0,
                 [](parcelset::parcel&& p, parcelset::write_handler_type&&)
                 {
-                    hpx::get_runtime().get_parcel_handler()
-                        .sync_put_parcel(std::move(p));
+                    hpx::parcelset::sync_put_parcel(std::move(p));
                 });
             return false;     // destination is remote
         }

--- a/hpx/runtime/basename_registration.hpp
+++ b/hpx/runtime/basename_registration.hpp
@@ -3,8 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-/// \file hpx/runtime/basename_registration.hpp
-
 #if !defined(HPX_RUNTIME_BASENAME_REGISTRATION_AUG_17_2015_0432PM)
 #define HPX_RUNTIME_BASENAME_REGISTRATION_AUG_17_2015_0432PM
 
@@ -12,6 +10,7 @@
 #include <hpx/components_fwd.hpp>
 
 #include <hpx/lcos/future.hpp>
+#include <hpx/runtime/basename_registration_fwd.hpp>
 #include <hpx/runtime/components/make_client.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 
@@ -22,36 +21,6 @@
 
 namespace hpx
 {
-    /// \cond NOINTERNAL
-    namespace detail
-    {
-        HPX_API_EXPORT std::string name_from_basename(
-            std::string const& basename, std::size_t idx);
-    }
-    /// \endcond
-
-    ///////////////////////////////////////////////////////////////////////////
-    /// Return all registered ids from all localities from the given base
-    /// name.
-    ///
-    /// This function locates all ids which were registered with the given
-    /// base name. It returns a list of futures representing those ids.
-    ///
-    /// \param base_name    [in] The base name for which to retrieve the
-    ///                     registered ids.
-    /// \param num_ids      [in] The number of registered ids to expect.
-    ///
-    /// \returns A list of futures representing the ids which were registered
-    ///          using the given base name.
-    ///
-    /// \note   The futures will become ready even if the event (for instance,
-    ///         binding the name to an id) has already happened in the past.
-    ///         This is important in order to reliably retrieve ids from a
-    ///         name, even if the name was already registered.
-    ///
-    HPX_API_EXPORT std::vector<hpx::future<hpx::id_type>>
-    find_all_from_basename(std::string base_name, std::size_t num_ids);
-
     ///////////////////////////////////////////////////////////////////////////
     /// Return all registered clients from all localities from the given base
     /// name.
@@ -81,27 +50,6 @@ namespace hpx
         return components::make_clients<Client>(
             find_all_from_basename(std::move(base_name), num_ids));
     }
-
-    /// Return registered ids from the given base name and sequence numbers.
-    ///
-    /// This function locates the ids which were registered with the given
-    /// base name and the given sequence numbers. It returns a list of futures
-    /// representing those ids.
-    ///
-    /// \param base_name    [in] The base name for which to retrieve the
-    ///                     registered ids.
-    /// \param ids          [in] The sequence numbers of the registered ids.
-    ///
-    /// \returns A list of futures representing the ids which were registered
-    ///          using the given base name and sequence numbers.
-    ///
-    /// \note   The futures will become ready even if the event (for instance,
-    ///         binding the name to an id) has already happened in the past.
-    ///         This is important in order to reliably retrieve ids from a
-    ///         name, even if the name was already registered.
-    ///
-    HPX_API_EXPORT std::vector<hpx::future<hpx::id_type>> find_from_basename(
-        std::string base_name, std::vector<std::size_t> const& ids);
 
     /// Return registered clients from the given base name and sequence numbers.
     ///
@@ -138,27 +86,6 @@ namespace hpx
     /// base name and the given sequence number. It returns a future
     /// representing those id.
     ///
-    /// \param base_name    [in] The base name for which to retrieve the
-    ///                     registered ids.
-    /// \param sequence_nr  [in] The sequence number of the registered id.
-    ///
-    /// \returns A representing the id which was registered using the given
-    ///          base name and sequence numbers.
-    ///
-    /// \note   The future will become ready even if the event (for instance,
-    ///         binding the name to an id) has already happened in the past.
-    ///         This is important in order to reliably retrieve ids from a
-    ///         name, even if the name was already registered.
-    ///
-    HPX_API_EXPORT hpx::future<hpx::id_type> find_from_basename(
-        std::string base_name, std::size_t sequence_nr = ~0U);
-
-    /// \brief Return registered id from the given base name and sequence number.
-    ///
-    /// This function locates the id which was registered with the given
-    /// base name and the given sequence number. It returns a future
-    /// representing those id.
-    ///
     /// \tparam Client     The client type to return
     ///
     /// \param base_name    [in] The base name for which to retrieve the
@@ -175,70 +102,10 @@ namespace hpx
     ///         name, even if the name was already registered.
     ///
     template <typename Client>
-    Client find_from_basename(std::string base_name,
-        std::size_t sequence_nr = ~0U)
+    Client find_from_basename(std::string base_name, std::size_t sequence_nr)
     {
         return components::make_client<Client>(
             find_from_basename(std::move(base_name), sequence_nr));
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    /// \brief Register the given id using the given base name.
-    ///
-    /// The function registers the given ids using the provided base name.
-    ///
-    /// \param base_name    [in] The base name for which to retrieve the
-    ///                     registered ids.
-    /// \param id           [in] The id to register using the given base name.
-    /// \param sequence_nr  [in, optional] The sequential number to use for the
-    ///                     registration of the id. This number has to be
-    ///                     unique system wide for each registration using the
-    ///                     same base name. The default is the current locality
-    ///                     identifier. Also, the sequence numbers have to be
-    ///                     consecutive starting from zero.
-    ///
-    /// \returns A future representing the result of the registration operation
-    ///          itself.
-    ///
-    /// \note    The operation will fail if the given sequence number is not
-    ///          unique.
-    ///
-    HPX_API_EXPORT hpx::future<bool> register_with_basename(
-        std::string base_name, hpx::id_type id, std::size_t sequence_nr = ~0U);
-
-    /// Register the id wrapped in the given future using the given base name.
-    ///
-    /// The function registers the object the given future refers to using the
-    /// provided base name.
-    ///
-    /// \param base_name    [in] The base name for which to retrieve the
-    ///                     registered ids.
-    /// \param f            [in] The future which should be registered using
-    ///                     the given base name.
-    /// \param sequence_nr  [in, optional] The sequential number to use for the
-    ///                     registration of the id. This number has to be
-    ///                     unique system wide for each registration using the
-    ///                     same base name. The default is the current locality
-    ///                     identifier. Also, the sequence numbers have to be
-    ///                     consecutive starting from zero.
-    ///
-    /// \returns A future representing the result of the registration operation
-    ///          itself.
-    ///
-    /// \note    The operation will fail if the given sequence number is not
-    ///          unique.
-    ///
-    inline hpx::future<bool> register_with_basename(std::string base_name,
-        hpx::future<hpx::id_type> f, std::size_t sequence_nr = ~0U)
-    {
-        return f.then(
-            [sequence_nr, HPX_CAPTURE_MOVE(base_name)](
-                hpx::future<hpx::id_type> && f
-            ) mutable -> hpx::future<bool>
-            {
-                return register_with_basename(
-                    std::move(base_name), f.get(), sequence_nr);
-            });
     }
 
     /// Register the id wrapped in the given client using the given base name.
@@ -268,7 +135,7 @@ namespace hpx
     template <typename Client, typename Stub>
     hpx::future<bool> register_with_basename(std::string base_name,
         components::client_base<Client, Stub>& client,
-        std::size_t sequence_nr = ~0U)
+        std::size_t sequence_nr)
     {
         return client.then(
             [sequence_nr, HPX_CAPTURE_MOVE(base_name)](
@@ -279,23 +146,6 @@ namespace hpx
                     std::move(base_name), c.get_id(), sequence_nr);
             });
     }
-
-    /// \brief Unregister the given id using the given base name.
-    ///
-    /// The function unregisters the given ids using the provided base name.
-    ///
-    /// \param base_name    [in] The base name for which to retrieve the
-    ///                     registered ids.
-    /// \param sequence_nr  [in, optional] The sequential number to use for the
-    ///                     un-registration. This number has to be the same
-    ///                     as has been used with \a register_with_basename
-    ///                     before.
-    ///
-    /// \returns A future representing the result of the un-registration
-    ///          operation itself.
-    ///
-    HPX_API_EXPORT hpx::future<hpx::id_type> unregister_with_basename(
-        std::string base_name, std::size_t sequence_nr = ~0U);
 
     /// Unregister the given base name.
     ///
@@ -315,7 +165,7 @@ namespace hpx
     ///
     template <typename Client>
     Client unregister_with_basename(
-        std::string base_name, std::size_t sequence_nr = ~0U)
+        std::string base_name, std::size_t sequence_nr)
     {
         return components::make_client<Client>(
             unregister_with_basename(std::move(base_name), sequence_nr));

--- a/hpx/runtime/basename_registration_fwd.hpp
+++ b/hpx/runtime/basename_registration_fwd.hpp
@@ -1,0 +1,289 @@
+//  Copyright (c) 2007-2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file hpx/runtime/basename_registration.hpp
+
+#if !defined(HPX_RUNTIME_BASENAME_REGISTRATION_FWD_AUG_17_2015_0432PM)
+#define HPX_RUNTIME_BASENAME_REGISTRATION_FWD_AUG_17_2015_0432PM
+
+#include <hpx/config.hpp>
+#include <hpx/components_fwd.hpp>
+
+#include <hpx/lcos_fwd.hpp>
+#include <hpx/runtime/components/make_client.hpp>
+#include <hpx/runtime/naming/id_type.hpp>
+
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace hpx
+{
+    /// \cond NOINTERNAL
+    namespace detail
+    {
+        HPX_API_EXPORT std::string name_from_basename(
+            std::string const& basename, std::size_t idx);
+    }
+    /// \endcond
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Return all registered ids from all localities from the given base
+    /// name.
+    ///
+    /// This function locates all ids which were registered with the given
+    /// base name. It returns a list of futures representing those ids.
+    ///
+    /// \param base_name    [in] The base name for which to retrieve the
+    ///                     registered ids.
+    /// \param num_ids      [in] The number of registered ids to expect.
+    ///
+    /// \returns A list of futures representing the ids which were registered
+    ///          using the given base name.
+    ///
+    /// \note   The futures will become ready even if the event (for instance,
+    ///         binding the name to an id) has already happened in the past.
+    ///         This is important in order to reliably retrieve ids from a
+    ///         name, even if the name was already registered.
+    ///
+    HPX_API_EXPORT std::vector<hpx::future<hpx::id_type>>
+    find_all_from_basename(std::string base_name, std::size_t num_ids);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Return all registered clients from all localities from the given base
+    /// name.
+    ///
+    /// This function locates all ids which were registered with the given
+    /// base name. It returns a list of futures representing those ids.
+    ///
+    /// \tparam Client     The client type to return
+    ///
+    /// \param base_name    [in] The base name for which to retrieve the
+    ///                     registered ids.
+    /// \param num_ids      [in] The number of registered ids to expect.
+    ///
+    /// \returns A list of futures representing the ids which were registered
+    ///          using the given base name.
+    ///
+    /// \note   The futures embedded in the returned client objects will become
+    ///         ready even if the event (for instance,
+    ///         binding the name to an id) has already happened in the past.
+    ///         This is important in order to reliably retrieve ids from a
+    ///         name, even if the name was already registered.
+    ///
+    template <typename Client>
+    std::vector<Client>
+    find_all_from_basename(std::string base_name, std::size_t num_ids);
+
+    /// Return registered ids from the given base name and sequence numbers.
+    ///
+    /// This function locates the ids which were registered with the given
+    /// base name and the given sequence numbers. It returns a list of futures
+    /// representing those ids.
+    ///
+    /// \param base_name    [in] The base name for which to retrieve the
+    ///                     registered ids.
+    /// \param ids          [in] The sequence numbers of the registered ids.
+    ///
+    /// \returns A list of futures representing the ids which were registered
+    ///          using the given base name and sequence numbers.
+    ///
+    /// \note   The futures will become ready even if the event (for instance,
+    ///         binding the name to an id) has already happened in the past.
+    ///         This is important in order to reliably retrieve ids from a
+    ///         name, even if the name was already registered.
+    ///
+    HPX_API_EXPORT std::vector<hpx::future<hpx::id_type>> find_from_basename(
+        std::string base_name, std::vector<std::size_t> const& ids);
+
+    /// Return registered clients from the given base name and sequence numbers.
+    ///
+    /// This function locates the ids which were registered with the given
+    /// base name and the given sequence numbers. It returns a list of futures
+    /// representing those ids.
+    ///
+    /// \tparam Client     The client type to return
+    ///
+    /// \param base_name    [in] The base name for which to retrieve the
+    ///                     registered ids.
+    /// \param ids          [in] The sequence numbers of the registered ids.
+    ///
+    /// \returns A list of futures representing the ids which were registered
+    ///          using the given base name and sequence numbers.
+    ///
+    /// \note   The futures embedded in the returned client objects will become
+    ///         ready even if the event (for instance,
+    ///         binding the name to an id) has already happened in the past.
+    ///         This is important in order to reliably retrieve ids from a
+    ///         name, even if the name was already registered.
+    ///
+    template <typename Client>
+    std::vector<Client> find_from_basename(std::string base_name,
+        std::vector<std::size_t> const& ids);
+
+    /// \brief Return registered id from the given base name and sequence number.
+    ///
+    /// This function locates the id which was registered with the given
+    /// base name and the given sequence number. It returns a future
+    /// representing those id.
+    ///
+    /// \param base_name    [in] The base name for which to retrieve the
+    ///                     registered ids.
+    /// \param sequence_nr  [in] The sequence number of the registered id.
+    ///
+    /// \returns A representing the id which was registered using the given
+    ///          base name and sequence numbers.
+    ///
+    /// \note   The future will become ready even if the event (for instance,
+    ///         binding the name to an id) has already happened in the past.
+    ///         This is important in order to reliably retrieve ids from a
+    ///         name, even if the name was already registered.
+    ///
+    HPX_API_EXPORT hpx::future<hpx::id_type> find_from_basename(
+        std::string base_name, std::size_t sequence_nr = ~0U);
+
+    /// \brief Return registered id from the given base name and sequence number.
+    ///
+    /// This function locates the id which was registered with the given
+    /// base name and the given sequence number. It returns a future
+    /// representing those id.
+    ///
+    /// \tparam Client     The client type to return
+    ///
+    /// \param base_name    [in] The base name for which to retrieve the
+    ///                     registered ids.
+    /// \param sequence_nr  [in] The sequence number of the registered id.
+    ///
+    /// \returns A representing the id which was registered using the given
+    ///          base name and sequence numbers.
+    ///
+    /// \note   The future embedded in the returned client object will become
+    ///         ready even if the event (for instance,
+    ///         binding the name to an id) has already happened in the past.
+    ///         This is important in order to reliably retrieve ids from a
+    ///         name, even if the name was already registered.
+    ///
+    template <typename Client>
+    Client find_from_basename(std::string base_name,
+        std::size_t sequence_nr = ~0U);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// \brief Register the given id using the given base name.
+    ///
+    /// The function registers the given ids using the provided base name.
+    ///
+    /// \param base_name    [in] The base name for which to retrieve the
+    ///                     registered ids.
+    /// \param id           [in] The id to register using the given base name.
+    /// \param sequence_nr  [in, optional] The sequential number to use for the
+    ///                     registration of the id. This number has to be
+    ///                     unique system wide for each registration using the
+    ///                     same base name. The default is the current locality
+    ///                     identifier. Also, the sequence numbers have to be
+    ///                     consecutive starting from zero.
+    ///
+    /// \returns A future representing the result of the registration operation
+    ///          itself.
+    ///
+    /// \note    The operation will fail if the given sequence number is not
+    ///          unique.
+    ///
+    HPX_API_EXPORT hpx::future<bool> register_with_basename(
+        std::string base_name, hpx::id_type id, std::size_t sequence_nr = ~0U);
+
+    /// Register the id wrapped in the given future using the given base name.
+    ///
+    /// The function registers the object the given future refers to using the
+    /// provided base name.
+    ///
+    /// \param base_name    [in] The base name for which to retrieve the
+    ///                     registered ids.
+    /// \param f            [in] The future which should be registered using
+    ///                     the given base name.
+    /// \param sequence_nr  [in, optional] The sequential number to use for the
+    ///                     registration of the id. This number has to be
+    ///                     unique system wide for each registration using the
+    ///                     same base name. The default is the current locality
+    ///                     identifier. Also, the sequence numbers have to be
+    ///                     consecutive starting from zero.
+    ///
+    /// \returns A future representing the result of the registration operation
+    ///          itself.
+    ///
+    /// \note    The operation will fail if the given sequence number is not
+    ///          unique.
+    ///
+    HPX_API_EXPORT hpx::future<bool> register_with_basename(std::string base_name,
+        hpx::future<hpx::id_type> f, std::size_t sequence_nr = ~0U);
+
+    /// Register the id wrapped in the given client using the given base name.
+    ///
+    /// The function registers the object the given client refers to using the
+    /// provided base name.
+    ///
+    /// \tparam Client      The client type to register
+    ///
+    /// \param base_name    [in] The base name for which to retrieve the
+    ///                     registered ids.
+    /// \param client       [in] The client which should be registered using
+    ///                     the given base name.
+    /// \param sequence_nr  [in, optional] The sequential number to use for the
+    ///                     registration of the id. This number has to be
+    ///                     unique system wide for each registration using the
+    ///                     same base name. The default is the current locality
+    ///                     identifier. Also, the sequence numbers have to be
+    ///                     consecutive starting from zero.
+    ///
+    /// \returns A future representing the result of the registration operation
+    ///          itself.
+    ///
+    /// \note    The operation will fail if the given sequence number is not
+    ///          unique.
+    ///
+    template <typename Client, typename Stub>
+    hpx::future<bool> register_with_basename(std::string base_name,
+        components::client_base<Client, Stub>& client,
+        std::size_t sequence_nr = ~0U);
+
+    /// \brief Unregister the given id using the given base name.
+    ///
+    /// The function unregisters the given ids using the provided base name.
+    ///
+    /// \param base_name    [in] The base name for which to retrieve the
+    ///                     registered ids.
+    /// \param sequence_nr  [in, optional] The sequential number to use for the
+    ///                     un-registration. This number has to be the same
+    ///                     as has been used with \a register_with_basename
+    ///                     before.
+    ///
+    /// \returns A future representing the result of the un-registration
+    ///          operation itself.
+    ///
+    HPX_API_EXPORT hpx::future<hpx::id_type> unregister_with_basename(
+        std::string base_name, std::size_t sequence_nr = ~0U);
+
+    /// Unregister the given base name.
+    ///
+    /// The function unregisters the given ids using the provided base name.
+    ///
+    /// \tparam Client      The client type to return
+    ///
+    /// \param base_name    [in] The base name for which to retrieve the
+    ///                     registered ids.
+    /// \param sequence_nr  [in, optional] The sequential number to use for the
+    ///                     un-registration. This number has to be the same
+    ///                     as has been used with \a register_with_basename
+    ///                     before.
+    ///
+    /// \returns A future representing the result of the un-registration
+    ///          operation itself.
+    ///
+    template <typename Client>
+    Client unregister_with_basename(
+        std::string base_name, std::size_t sequence_nr = ~0U);
+}
+
+#endif

--- a/hpx/runtime/components/binpacking_distribution_policy.hpp
+++ b/hpx/runtime/components/binpacking_distribution_policy.hpp
@@ -14,6 +14,7 @@
 #include <hpx/performance_counters/performance_counter.hpp>
 #include <hpx/runtime/components/component_type.hpp>
 #include <hpx/runtime/components/stubs/stub_base.hpp>
+#include <hpx/runtime/find_here.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime/naming/name.hpp>
 #include <hpx/runtime/serialization/serialization_fwd.hpp>

--- a/hpx/runtime/components/default_distribution_policy.hpp
+++ b/hpx/runtime/components/default_distribution_policy.hpp
@@ -9,13 +9,14 @@
 #define HPX_COMPONENTS_DISTRIBUTION_POLICY_APR_07_2015_1246PM
 
 #include <hpx/config.hpp>
-#include <hpx/dataflow.hpp>
+#include <hpx/lcos/dataflow.hpp>
 #include <hpx/lcos/future.hpp>
 #include <hpx/lcos/packaged_action.hpp>
 #include <hpx/runtime/actions/action_support.hpp>
 #include <hpx/runtime/applier/apply.hpp>
 #include <hpx/runtime/components/stubs/stub_base.hpp>
 #include <hpx/runtime/launch_policy.hpp>
+#include <hpx/runtime/find_here.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime/naming/name.hpp>
 #include <hpx/runtime/serialization/serialization_fwd.hpp>

--- a/hpx/runtime/components/target_distribution_policy.hpp
+++ b/hpx/runtime/components/target_distribution_policy.hpp
@@ -9,14 +9,15 @@
 #define HPX_COMPONENTS_TARGET_DISTRIBUTION_POLICY_APR_12_2015_1245PM
 
 #include <hpx/config.hpp>
+#include <hpx/lcos/dataflow.hpp>
 #include <hpx/lcos/detail/async_implementations_fwd.hpp>
-#include <hpx/dataflow.hpp>
 #include <hpx/lcos/future.hpp>
 #include <hpx/lcos/packaged_action.hpp>
 #include <hpx/runtime/actions/action_support.hpp>
 #include <hpx/runtime/agas/interface.hpp>
 #include <hpx/runtime/applier/detail/apply_implementations_fwd.hpp>
 #include <hpx/runtime/components/stubs/stub_base.hpp>
+#include <hpx/runtime/find_here.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime/naming/name.hpp>

--- a/hpx/runtime/get_colocation_id.hpp
+++ b/hpx/runtime/get_colocation_id.hpp
@@ -10,7 +10,7 @@
 #define HPX_RUNTIME_GET_COLOCATION_ID_HPP
 
 #include <hpx/exception_fwd.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/lcos_fwd.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 

--- a/hpx/runtime/get_locality_name.hpp
+++ b/hpx/runtime/get_locality_name.hpp
@@ -9,7 +9,7 @@
 #define HPX_RUNTIME_GET_LOCALITY_NAME_SEP_26_2013_0533PM
 
 #include <hpx/config.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/lcos_fwd.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 
 #include <string>

--- a/hpx/runtime/parcelset/put_parcel.hpp
+++ b/hpx/runtime/parcelset/put_parcel.hpp
@@ -170,9 +170,7 @@ namespace hpx { namespace parcelset {
 
             void operator()(parcel&& p)
             {
-                parcelset::parcelhandler& ph =
-                    hpx::get_runtime().get_parcel_handler();
-                ph.put_parcel(std::move(p), std::move(cb_));
+                hpx::parcelset::put_parcel(std::move(p), std::move(cb_));
             }
 
             typename hpx::util::decay<Callback>::type cb_;

--- a/hpx/runtime/parcelset_fwd.hpp
+++ b/hpx/runtime/parcelset_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -46,6 +46,14 @@ namespace hpx {
         typedef util::function_nonser<
             void(boost::system::error_code const&, parcel const&)
         > write_handler_type;
+
+        ///////////////////////////////////////////////////////////////////////
+        /// Hand a parcel to the underlying parcel layer for delivery.
+        HPX_API_EXPORT void put_parcel(parcel&& p, write_handler_type&& f);
+
+        /// Hand a parcel to the underlying parcel layer for delivery.
+        /// Wait for the operation to finish before returning to the user.
+        HPX_API_EXPORT void sync_put_parcel(parcelset::parcel&& p);
     }
 }
 

--- a/hpx/runtime/threads/policies/hierarchy_scheduler.hpp
+++ b/hpx/runtime/threads/policies/hierarchy_scheduler.hpp
@@ -200,7 +200,7 @@ namespace hpx { namespace threads { namespace policies
             }
         }
 
-        bool numa_sensitive() const { return numa_sensitive_; }
+        bool numa_sensitive() const override { return numa_sensitive_; }
 
         static std::string get_scheduler_name()
         {
@@ -221,7 +221,8 @@ namespace hpx { namespace threads { namespace policies
 
         ///////////////////////////////////////////////////////////////////////
         // Queries the current length of the queues (work items and new items).
-        std::int64_t get_queue_length(std::size_t num_thread = std::size_t(-1)) const
+        std::int64_t get_queue_length(
+            std::size_t num_thread = std::size_t(-1)) const override
         {
             HPX_ASSERT(tree.size());
             // Return queue length of one specific queue.
@@ -255,7 +256,8 @@ namespace hpx { namespace threads { namespace policies
         // Queries the current thread count of the queues.
         std::int64_t get_thread_count(thread_state_enum state = unknown,
             thread_priority priority = thread_priority_default,
-            std::size_t num_thread = std::size_t(-1), bool reset = false) const
+            std::size_t num_thread = std::size_t(-1),
+            bool reset = false) const override
         {
             HPX_ASSERT(tree.size());
             // Return thread count of one specific queue.
@@ -289,7 +291,7 @@ namespace hpx { namespace threads { namespace policies
         // Enumerate matching threads from all queues
         bool enumerate_threads(
             util::function_nonser<bool(thread_id_type)> const& f,
-            thread_state_enum state = unknown) const
+            thread_state_enum state = unknown) const override
         {
             bool result = true;
             for(size_type i = 0; i < tree.size(); ++i)
@@ -406,7 +408,8 @@ namespace hpx { namespace threads { namespace policies
 #endif
 
 #ifdef HPX_HAVE_THREAD_STEALING_COUNTS
-        std::int64_t get_num_pending_misses(std::size_t num_thread, bool reset)
+        std::int64_t get_num_pending_misses(
+            std::size_t num_thread, bool reset) override
         {
             std::int64_t num_pending_misses = 0;
             if (num_thread == std::size_t(-1))
@@ -433,7 +436,8 @@ namespace hpx { namespace threads { namespace policies
             return num_pending_misses;
         }
 
-        std::int64_t get_num_pending_accesses(std::size_t num_thread, bool reset)
+        std::int64_t get_num_pending_accesses(
+            std::size_t num_thread, bool reset) override
         {
             std::int64_t num_pending_accesses = 0;
             if (num_thread == std::size_t(-1))
@@ -460,7 +464,8 @@ namespace hpx { namespace threads { namespace policies
             return num_pending_accesses;
         }
 
-        std::int64_t get_num_stolen_from_pending(std::size_t num_thread, bool reset)
+        std::int64_t get_num_stolen_from_pending(
+            std::size_t num_thread, bool reset) override
         {
             std::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
@@ -487,7 +492,8 @@ namespace hpx { namespace threads { namespace policies
             return num_stolen_threads;
         }
 
-        std::int64_t get_num_stolen_to_pending(std::size_t num_thread, bool reset)
+        std::int64_t get_num_stolen_to_pending(
+            std::size_t num_thread, bool reset) override
         {
             std::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
@@ -514,7 +520,8 @@ namespace hpx { namespace threads { namespace policies
             return num_stolen_threads;
         }
 
-        std::int64_t get_num_stolen_from_staged(std::size_t num_thread, bool reset)
+        std::int64_t get_num_stolen_from_staged(
+            std::size_t num_thread, bool reset) override
         {
             std::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
@@ -541,7 +548,8 @@ namespace hpx { namespace threads { namespace policies
             return num_stolen_threads;
         }
 
-        std::int64_t get_num_stolen_to_staged(std::size_t num_thread, bool reset)
+        std::int64_t get_num_stolen_to_staged(
+            std::size_t num_thread, bool reset) override
         {
             std::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
@@ -570,7 +578,7 @@ namespace hpx { namespace threads { namespace policies
 #endif
 
         ///////////////////////////////////////////////////////////////////////
-        void abort_all_suspended_threads()
+        void abort_all_suspended_threads() override
         {
             HPX_ASSERT(tree.size());
             for(size_type i = 0; i != tree.size(); ++i)
@@ -584,7 +592,7 @@ namespace hpx { namespace threads { namespace policies
         }
 
         ///////////////////////////////////////////////////////////////////////
-        bool cleanup_terminated(bool delete_all)
+        bool cleanup_terminated(bool delete_all) override
         {
             HPX_ASSERT(tree.size());
             bool empty = true;
@@ -599,7 +607,7 @@ namespace hpx { namespace threads { namespace policies
             return empty;
         }
 
-        bool cleanup_terminated(std::size_t num_thread, bool delete_all)
+        bool cleanup_terminated(std::size_t num_thread, bool delete_all) override
         {
             return cleanup_terminated(delete_all);
         }
@@ -610,7 +618,7 @@ namespace hpx { namespace threads { namespace policies
         // TODO: add recycling
         void create_thread(thread_init_data& data, thread_id_type* id,
             thread_state_enum initial_state, bool run_now, error_code& ec,
-            std::size_t num_thread)
+            std::size_t num_thread) override
         {
             HPX_ASSERT(tree.size());
             HPX_ASSERT(tree.back().size());
@@ -668,7 +676,7 @@ namespace hpx { namespace threads { namespace policies
         /// Return the next thread to be executed, return false if none is
         /// available
         bool get_next_thread(std::size_t num_thread, bool running,
-            std::int64_t& idle_loop_count, threads::thread_data*& thrd)
+            std::int64_t& idle_loop_count, threads::thread_data*& thrd) override
         {
             HPX_ASSERT(tree.size());
             HPX_ASSERT(num_thread < tree[0].size());
@@ -693,7 +701,7 @@ namespace hpx { namespace threads { namespace policies
 
         /// Schedule the passed thread
         void schedule_thread(threads::thread_data* thrd, std::size_t num_thread,
-            thread_priority /*priority*/ = thread_priority_normal)
+            thread_priority /*priority*/ = thread_priority_normal) override
         {
             HPX_ASSERT(tree.size());
             HPX_ASSERT(tree.back().size());
@@ -702,7 +710,7 @@ namespace hpx { namespace threads { namespace policies
 
         void schedule_thread_last(threads::thread_data* thrd,
             std::size_t num_thread,
-            thread_priority priority = thread_priority_normal)
+            thread_priority priority = thread_priority_normal) override
         {
             HPX_ASSERT(tree.size());
             HPX_ASSERT(tree.back().size());
@@ -710,7 +718,8 @@ namespace hpx { namespace threads { namespace policies
         }
 
         /// Destroy the passed thread as it has been terminated
-        void destroy_thread(threads::thread_data* thrd, std::int64_t& busy_count)
+        void destroy_thread(
+            threads::thread_data* thrd, std::int64_t& busy_count) override
         {
             HPX_ASSERT(thrd->get_scheduler_base() == this);
             thrd->get_queue<thread_queue_type>().destroy_thread(thrd, busy_count);
@@ -768,7 +777,7 @@ namespace hpx { namespace threads { namespace policies
         /// scheduler. Returns true if the OS thread calling this function
         /// has to be terminated (i.e. no more work has to be done).
         bool wait_or_add_new(std::size_t num_thread, bool running,
-            std::int64_t& idle_loop_count)
+            std::int64_t& idle_loop_count) override
         {
             HPX_ASSERT(tree.size());
             HPX_ASSERT(num_thread < tree.at(0).size());
@@ -785,19 +794,19 @@ namespace hpx { namespace threads { namespace policies
         }
 
         ///////////////////////////////////////////////////////////////////////
-        void on_start_thread(std::size_t num_thread)
+        void on_start_thread(std::size_t num_thread) override
         {
             HPX_ASSERT(tree.size());
             HPX_ASSERT(num_thread < tree.at(0).size());
             tree.at(0).at(num_thread)->on_start_thread(num_thread);
         }
-        void on_stop_thread(std::size_t num_thread)
+        void on_stop_thread(std::size_t num_thread) override
         {
             HPX_ASSERT(tree.size());
             HPX_ASSERT(num_thread < tree.at(0).size());
             tree.at(0).at(num_thread)->on_stop_thread(num_thread);
         }
-        void on_error(std::size_t num_thread, std::exception_ptr const& e)
+        void on_error(std::size_t num_thread, std::exception_ptr const& e) override
         {
             HPX_ASSERT(tree.size());
             HPX_ASSERT(num_thread < tree.at(0).size());

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -162,7 +162,7 @@ namespace hpx { namespace threads { namespace policies
                 delete high_priority_queues_[i];
         }
 
-        bool numa_sensitive() const { return numa_sensitive_ != 0; }
+        bool numa_sensitive() const override { return numa_sensitive_ != 0; }
 
         static std::string get_scheduler_name()
         {
@@ -203,7 +203,8 @@ namespace hpx { namespace threads { namespace policies
 #endif
 
 #ifdef HPX_HAVE_THREAD_STEALING_COUNTS
-        std::int64_t get_num_pending_misses(std::size_t num_thread, bool reset)
+        std::int64_t get_num_pending_misses(
+            std::size_t num_thread, bool reset) override
         {
             std::int64_t num_pending_misses = 0;
             if (num_thread == std::size_t(-1))
@@ -238,7 +239,8 @@ namespace hpx { namespace threads { namespace policies
             return num_pending_misses;
         }
 
-        std::int64_t get_num_pending_accesses(std::size_t num_thread, bool reset)
+        std::int64_t get_num_pending_accesses(
+            std::size_t num_thread, bool reset) override
         {
             std::int64_t num_pending_accesses = 0;
             if (num_thread == std::size_t(-1))
@@ -273,7 +275,8 @@ namespace hpx { namespace threads { namespace policies
             return num_pending_accesses;
         }
 
-        std::int64_t get_num_stolen_from_pending(std::size_t num_thread, bool reset)
+        std::int64_t get_num_stolen_from_pending(
+            std::size_t num_thread, bool reset) override
         {
             std::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
@@ -308,7 +311,8 @@ namespace hpx { namespace threads { namespace policies
             return num_stolen_threads;
         }
 
-        std::int64_t get_num_stolen_to_pending(std::size_t num_thread, bool reset)
+        std::int64_t get_num_stolen_to_pending(
+            std::size_t num_thread, bool reset) override
         {
             std::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
@@ -343,7 +347,8 @@ namespace hpx { namespace threads { namespace policies
             return num_stolen_threads;
         }
 
-        std::int64_t get_num_stolen_from_staged(std::size_t num_thread, bool reset)
+        std::int64_t get_num_stolen_from_staged(
+            std::size_t num_thread, bool reset) override
         {
             std::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
@@ -378,7 +383,8 @@ namespace hpx { namespace threads { namespace policies
             return num_stolen_threads;
         }
 
-        std::int64_t get_num_stolen_to_staged(std::size_t num_thread, bool reset)
+        std::int64_t get_num_stolen_to_staged(
+            std::size_t num_thread, bool reset) override
         {
             std::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
@@ -415,7 +421,7 @@ namespace hpx { namespace threads { namespace policies
 #endif
 
         ///////////////////////////////////////////////////////////////////////
-        void abort_all_suspended_threads()
+        void abort_all_suspended_threads() override
         {
             for (std::size_t i = 0; i != queues_.size(); ++i)
                 queues_[i]->abort_all_suspended_threads();
@@ -427,7 +433,7 @@ namespace hpx { namespace threads { namespace policies
         }
 
         ///////////////////////////////////////////////////////////////////////
-        bool cleanup_terminated(bool delete_all)
+        bool cleanup_terminated(bool delete_all) override
         {
             bool empty = true;
 
@@ -445,7 +451,7 @@ namespace hpx { namespace threads { namespace policies
             return empty;
         }
 
-        bool cleanup_terminated(std::size_t num_thread, bool delete_all)
+        bool cleanup_terminated(std::size_t num_thread, bool delete_all) override
         {
             bool empty = true;
 
@@ -465,7 +471,7 @@ namespace hpx { namespace threads { namespace policies
         // pending
         void create_thread(thread_init_data& data, thread_id_type* id,
             thread_state_enum initial_state, bool run_now, error_code& ec,
-            std::size_t num_thread)
+            std::size_t num_thread) override
         {
 #ifdef HPX_HAVE_THREAD_TARGET_ADDRESS
 //             // try to figure out the NUMA node where the data lives
@@ -529,8 +535,8 @@ namespace hpx { namespace threads { namespace policies
 
         /// Return the next thread to be executed, return false if none is
         /// available
-        virtual bool get_next_thread(std::size_t num_thread, bool running,
-            std::int64_t& idle_loop_count, threads::thread_data*& thrd)
+        bool get_next_thread(std::size_t num_thread, bool running,
+            std::int64_t& idle_loop_count, threads::thread_data*& thrd) override
         {
             std::size_t queues_size = queues_.size();
             std::size_t high_priority_queues = high_priority_queues_.size();
@@ -598,7 +604,7 @@ namespace hpx { namespace threads { namespace policies
         /// Schedule the passed thread
         void schedule_thread(threads::thread_data* thrd,
             std::size_t num_thread,
-            thread_priority priority = thread_priority_normal)
+            thread_priority priority = thread_priority_normal) override
         {
             std::size_t queue_size = queues_.size();
             if (std::size_t(-1) == num_thread)
@@ -624,7 +630,7 @@ namespace hpx { namespace threads { namespace policies
 
         void schedule_thread_last(threads::thread_data* thrd,
             std::size_t num_thread,
-            thread_priority priority = thread_priority_normal)
+            thread_priority priority = thread_priority_normal) override
         {
             std::size_t queue_size = queues_.size();
             if (std::size_t(-1) == num_thread)
@@ -649,7 +655,8 @@ namespace hpx { namespace threads { namespace policies
         }
 
         /// Destroy the passed thread as it has been terminated
-        void destroy_thread(threads::thread_data* thrd, std::int64_t& busy_count)
+        void destroy_thread(
+            threads::thread_data* thrd, std::int64_t& busy_count) override
         {
             HPX_ASSERT(thrd->get_scheduler_base() == this);
             thrd->get_queue<thread_queue_type>().destroy_thread(thrd, busy_count);
@@ -657,7 +664,8 @@ namespace hpx { namespace threads { namespace policies
 
         ///////////////////////////////////////////////////////////////////////
         // This returns the current length of the queues (work items and new items)
-        std::int64_t get_queue_length(std::size_t num_thread = std::size_t(-1)) const
+        std::int64_t get_queue_length(
+            std::size_t num_thread = std::size_t(-1)) const override
         {
             // Return queue length of one specific queue.
             std::int64_t count = 0;
@@ -689,7 +697,8 @@ namespace hpx { namespace threads { namespace policies
         // Queries the current thread count of the queues.
         std::int64_t get_thread_count(thread_state_enum state = unknown,
             thread_priority priority = thread_priority_default,
-            std::size_t num_thread = std::size_t(-1), bool reset = false) const
+            std::size_t num_thread = std::size_t(-1),
+            bool reset = false) const override
         {
             // Return thread count of one specific queue.
             std::int64_t count = 0;
@@ -792,7 +801,7 @@ namespace hpx { namespace threads { namespace policies
         // Enumerate matching threads from all queues
         bool enumerate_threads(
             util::function_nonser<bool(thread_id_type)> const& f,
-            thread_state_enum state = unknown) const
+            thread_state_enum state = unknown) const override
         {
             bool result = true;
             for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
@@ -814,7 +823,7 @@ namespace hpx { namespace threads { namespace policies
         ///////////////////////////////////////////////////////////////////////
         // Queries the current average thread wait time of the queues.
         std::int64_t get_average_thread_wait_time(
-            std::size_t num_thread = std::size_t(-1)) const
+            std::size_t num_thread = std::size_t(-1)) const override
         {
             // Return average thread wait time of one specific queue.
             std::uint64_t wait_time = 0;
@@ -862,7 +871,7 @@ namespace hpx { namespace threads { namespace policies
         ///////////////////////////////////////////////////////////////////////
         // Queries the current average task wait time of the queues.
         std::int64_t get_average_task_wait_time(
-            std::size_t num_thread = std::size_t(-1)) const
+            std::size_t num_thread = std::size_t(-1)) const override
         {
             // Return average task wait time of one specific queue.
             std::uint64_t wait_time = 0;
@@ -913,8 +922,8 @@ namespace hpx { namespace threads { namespace policies
         /// manager to allow for maintenance tasks to be executed in the
         /// scheduler. Returns true if the OS thread calling this function
         /// has to be terminated (i.e. no more work has to be done).
-        virtual bool wait_or_add_new(std::size_t num_thread, bool running,
-            std::int64_t& idle_loop_count)
+        bool wait_or_add_new(std::size_t num_thread, bool running,
+            std::int64_t& idle_loop_count) override
         {
             std::size_t added = 0;
             bool result = true;
@@ -1008,7 +1017,7 @@ namespace hpx { namespace threads { namespace policies
         }
 
         ///////////////////////////////////////////////////////////////////////
-        void on_start_thread(std::size_t num_thread)
+        void on_start_thread(std::size_t num_thread) override
         {
             if (nullptr == queues_[num_thread])
             {
@@ -1136,7 +1145,7 @@ namespace hpx { namespace threads { namespace policies
             }
         }
 
-        void on_stop_thread(std::size_t num_thread)
+        void on_stop_thread(std::size_t num_thread) override
         {
             if (num_thread < high_priority_queues_.size())
                 high_priority_queues_[num_thread]->on_stop_thread(num_thread);
@@ -1146,7 +1155,7 @@ namespace hpx { namespace threads { namespace policies
             queues_[num_thread]->on_stop_thread(num_thread);
         }
 
-        void on_error(std::size_t num_thread, std::exception_ptr const& e)
+        void on_error(std::size_t num_thread, std::exception_ptr const& e) override
         {
             if (num_thread < high_priority_queues_.size())
                 high_priority_queues_[num_thread]->on_error(num_thread, e);
@@ -1156,7 +1165,7 @@ namespace hpx { namespace threads { namespace policies
             queues_[num_thread]->on_error(num_thread, e);
         }
 
-        void reset_thread_distribution()
+        void reset_thread_distribution() override
         {
             curr_queue_.store(0);
         }

--- a/hpx/runtime/threads/policies/periodic_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/periodic_priority_queue_scheduler.hpp
@@ -50,7 +50,7 @@ namespace hpx { namespace threads { namespace policies
         typedef std::true_type has_periodic_maintenance;
 
         void start_periodic_maintenance(
-            std::atomic<hpx::state>& global_state)
+            std::atomic<hpx::state>& global_state) override
         {
             threads::detail::start_periodic_maintenance(*this, global_state,
                 has_periodic_maintenance());

--- a/hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp
@@ -77,7 +77,7 @@ namespace hpx { namespace threads { namespace policies
         /// Return the next thread to be executed, return false if non is
         /// available
         bool get_next_thread(std::size_t num_thread, bool running,
-            std::int64_t& idle_loop_count, threads::thread_data*& thrd)
+            std::int64_t& idle_loop_count, threads::thread_data*& thrd) override
         {
             std::size_t queues_size = this->queues_.size();
 
@@ -119,7 +119,7 @@ namespace hpx { namespace threads { namespace policies
         /// scheduler. Returns true if the OS thread calling this function
         /// has to be terminated (i.e. no more work has to be done).
         bool wait_or_add_new(std::size_t num_thread, bool running,
-            std::int64_t& idle_loop_count)
+            std::int64_t& idle_loop_count) override
         {
             HPX_ASSERT(num_thread < this->queues_.size());
 

--- a/hpx/runtime/threads/policies/static_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/static_queue_scheduler.hpp
@@ -84,8 +84,8 @@ namespace hpx { namespace threads { namespace policies
 
         /// Return the next thread to be executed, return false if none is
         /// available
-        virtual bool get_next_thread(std::size_t num_thread, bool,
-            std::int64_t& idle_loop_count, threads::thread_data*& thrd)
+        bool get_next_thread(std::size_t num_thread, bool,
+            std::int64_t& idle_loop_count, threads::thread_data*& thrd) override
         {
             typedef typename base_type::thread_queue_type thread_queue_type;
 
@@ -110,8 +110,8 @@ namespace hpx { namespace threads { namespace policies
         /// manager to allow for maintenance tasks to be executed in the
         /// scheduler. Returns true if the OS thread calling this function
         /// has to be terminated (i.e. no more work has to be done).
-        virtual bool wait_or_add_new(std::size_t num_thread, bool running,
-            std::int64_t& idle_loop_count)
+        bool wait_or_add_new(std::size_t num_thread, bool running,
+            std::int64_t& idle_loop_count) override
         {
             std::size_t queues_size = this->queues_.size();
             HPX_ASSERT(num_thread < queues_size);

--- a/hpx/runtime/threads/thread.hpp
+++ b/hpx/runtime/threads/thread.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/exception_fwd.hpp>
+#include <hpx/lcos/local/spinlock.hpp>
 #include <hpx/lcos_fwd.hpp>
 #include <hpx/runtime/threads/thread_data_fwd.hpp>
 #include <hpx/runtime_fwd.hpp>

--- a/hpx/runtime_fwd.hpp
+++ b/hpx/runtime_fwd.hpp
@@ -11,7 +11,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/exception_fwd.hpp>
-#include <hpx/runtime/basename_registration.hpp>
+#include <hpx/runtime/basename_registration_fwd.hpp>
 #include <hpx/runtime/config_entry.hpp>
 #include <hpx/runtime/find_localities.hpp>
 #include <hpx/runtime/get_colocation_id.hpp>

--- a/hpx/traits/future_access.hpp
+++ b/hpx/traits/future_access.hpp
@@ -127,11 +127,26 @@ namespace hpx { namespace traits
             return lcos::future<R>(shared_state);
         }
 
-        template <typename SharedState>
+        template <typename T = void>
         static lcos::future<R>
-        create(boost::intrusive_ptr<SharedState> && shared_state)
+        create(typename detail::shared_state_ptr_for<
+            lcos::future<lcos::future<R>>>::type const& shared_state)
+        {
+            return lcos::future<lcos::future<R>>(shared_state);
+        }
+
+        template <typename SharedState>
+        static lcos::future<R> create(
+            boost::intrusive_ptr<SharedState>&& shared_state)
         {
             return lcos::future<R>(std::move(shared_state));
+        }
+
+        template <typename T = void>
+        static lcos::future<R> create(typename detail::shared_state_ptr_for<
+            lcos::future<lcos::future<R>>>::type&& shared_state)
+        {
+            return lcos::future<lcos::future<R>>(std::move(shared_state));
         }
 
         template <typename SharedState>
@@ -169,11 +184,28 @@ namespace hpx { namespace traits
             return lcos::shared_future<R>(shared_state);
         }
 
+        template <typename T = void>
+        static lcos::shared_future<R> create(
+            typename detail::shared_state_ptr_for<
+                lcos::shared_future<lcos::future<R>>>::type const& shared_state)
+        {
+            return lcos::shared_future<lcos::future<R>>(shared_state);
+        }
+
         template <typename SharedState>
         static lcos::shared_future<R>
         create(boost::intrusive_ptr<SharedState> && shared_state)
         {
             return lcos::shared_future<R>(std::move(shared_state));
+        }
+
+        template <typename T = void>
+        static lcos::shared_future<R> create(
+            typename detail::shared_state_ptr_for<
+                lcos::shared_future<lcos::future<R>>>::type&& shared_state)
+        {
+            return lcos::shared_future<lcos::future<R>>(
+                std::move(shared_state));
         }
 
         template <typename SharedState>

--- a/hpx/util/unwrap.hpp
+++ b/hpx/util/unwrap.hpp
@@ -68,6 +68,24 @@ namespace util {
         return detail::unwrap_depth_impl<1U>(std::forward<Args>(args)...);
     }
 
+    namespace functional
+    {
+        /// A helper function object for functionally invoking
+        /// `hpx::util::unwrap`. For more information please refer to its
+        /// documentation.
+        struct unwrap
+        {
+            /// \cond NOINTERNAL
+            template <typename... Args>
+            auto operator()(Args&&... args)
+                -> decltype(util::unwrap(std::forward<Args>(args)...))
+            {
+                return util::unwrap(std::forward<Args>(args)...);
+            }
+            /// \endcond
+        };
+    }
+
     /// An alterntive version of hpx::util::unwrap(), which unwraps the given
     /// arguments to a certain depth of hpx::lcos::future like objects.
     ///
@@ -84,6 +102,25 @@ namespace util {
         return detail::unwrap_depth_impl<Depth>(std::forward<Args>(args)...);
     }
 
+    namespace functional
+    {
+        /// A helper function object for functionally invoking
+        /// `hpx::util::unwrap_n`. For more information please refer to its
+        /// documentation.
+        template <std::size_t Depth>
+        struct unwrap_n
+        {
+            /// \cond NOINTERNAL
+            template <typename... Args>
+            auto operator()(Args&&... args)
+                -> decltype(util::unwrap_n<Depth>(std::forward<Args>(args)...))
+            {
+                return util::unwrap_n<Depth>(std::forward<Args>(args)...);
+            }
+            /// \endcond
+        };
+    }
+
     /// An alterntive version of hpx::util::unwrap(), which unwraps the given
     /// arguments recursively so that all contained hpx::lcos::future like
     /// objects are replaced by their actual value.
@@ -95,6 +132,24 @@ namespace util {
         -> decltype(detail::unwrap_depth_impl<0U>(std::forward<Args>(args)...))
     {
         return detail::unwrap_depth_impl<0U>(std::forward<Args>(args)...);
+    }
+
+    namespace functional
+    {
+        /// A helper function object for functionally invoking
+        /// `hpx::util::unwrap_all`. For more information please refer to its
+        /// documentation.
+        struct unwrap_all
+        {
+            /// \cond NOINTERNAL
+            template <typename... Args>
+            auto operator()(Args&&... args)
+                -> decltype(util::unwrap_all(std::forward<Args>(args)...))
+            {
+                return util::unwrap_all(std::forward<Args>(args)...);
+            }
+            /// \endcond
+        };
     }
 
     /// Returns a callable object which unwraps its arguments upon

--- a/src/lcos/when_all_fwd.cpp
+++ b/src/lcos/when_all_fwd.cpp
@@ -1,0 +1,27 @@
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/lcos/future.hpp>
+#include <hpx/lcos/when_all.hpp>
+#include <hpx/lcos/when_all_fwd.hpp>
+
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace lcos
+{
+    // special forwarding function to break #include dependencies
+    hpx::future<void> when_all_fwd(std::vector<hpx::future<void>>& tasks)
+    {
+        return hpx::when_all(tasks);
+    }
+
+    hpx::future<void> when_all_fwd(std::vector<hpx::future<void>>&& tasks)
+    {
+        return hpx::when_all(std::move(tasks));
+    }
+}}

--- a/src/performance_counters/counters.cpp
+++ b/src/performance_counters/counters.cpp
@@ -16,6 +16,9 @@
 #include <hpx/runtime/components/stubs/runtime_support.hpp>
 #include <hpx/runtime/thread_pool_helpers.hpp>
 #include <hpx/runtime/get_num_localities.hpp>
+#include <hpx/runtime/serialization/base_object.hpp>
+#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/runtime/serialization/vector.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/format.hpp>
 #include <hpx/util/function.hpp>
@@ -1247,6 +1250,84 @@ namespace hpx { namespace performance_counters
 
         counter_info info(name);          // set full counter name
         return get_counter_async(info, ec);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    void counter_value::serialize(
+        serialization::output_archive& ar, const unsigned int)
+    {
+        ar & status_ & time_ & count_ & value_ & scaling_ & scale_inverse_;
+    }
+
+    void counter_value::serialize(
+        serialization::input_archive& ar, const unsigned int)
+    {
+        ar & status_ & time_ & count_ & value_ & scaling_ & scale_inverse_;
+    }
+
+    void counter_values_array::serialize(
+        serialization::output_archive& ar, const unsigned int)
+    {
+        ar & status_ & time_ & count_ & values_ & scaling_ & scale_inverse_;
+    }
+
+    void counter_values_array::serialize(
+        serialization::input_archive& ar, const unsigned int)
+    {
+        ar & status_ & time_ & count_ & values_ & scaling_ & scale_inverse_;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    void counter_type_path_elements::serialize(
+        serialization::output_archive& ar, const unsigned int)
+    {
+        ar & objectname_ & countername_ & parameters_;
+    }
+
+    void counter_type_path_elements::serialize(
+        serialization::input_archive& ar, const unsigned int)
+    {
+        ar & objectname_ & countername_ & parameters_;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    void counter_path_elements::serialize(
+        serialization::output_archive& ar, const unsigned int)
+    {
+        typedef counter_type_path_elements base_type;
+        hpx::serialization::base_object_type<counter_path_elements, base_type>
+            base = hpx::serialization::base_object<base_type>(*this);
+
+        ar & base &
+            parentinstancename_ & instancename_ & subinstancename_ &
+            parentinstanceindex_ & instanceindex_ & subinstanceindex_ &
+            parentinstance_is_basename_;
+    }
+
+    void counter_path_elements::serialize(
+        serialization::input_archive& ar, const unsigned int)
+    {
+        typedef counter_type_path_elements base_type;
+        hpx::serialization::base_object_type<counter_path_elements, base_type>
+            base = hpx::serialization::base_object<base_type>(*this);
+
+        ar & base &
+            parentinstancename_ & instancename_ & subinstancename_ &
+            parentinstanceindex_ & instanceindex_ & subinstanceindex_ &
+            parentinstance_is_basename_;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    void counter_info::serialize(
+        serialization::output_archive& ar, const unsigned int)
+    {
+        ar & type_ & version_ & status_ & fullname_ & helptext_ & unit_of_measure_;
+    }
+
+    void counter_info::serialize(
+        serialization::input_archive& ar, const unsigned int)
+    {
+        ar & type_ & version_ & status_ & fullname_ & helptext_ & unit_of_measure_;
     }
 }}
 

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -13,16 +13,18 @@
 #include <hpx/performance_counters/registry.hpp>
 #include <hpx/runtime.hpp>
 #include <hpx/runtime/agas/addressing_service.hpp>
+#include <hpx/runtime/applier/applier.hpp>
 #include <hpx/runtime/components/server/memory.hpp>
 #include <hpx/runtime/components/server/memory_block.hpp>
 #include <hpx/runtime/components/server/runtime_support.hpp>
 #include <hpx/runtime/components/server/simple_component_base.hpp>    // EXPORTS get_next_id
 #include <hpx/runtime/config_entry.hpp>
 #include <hpx/runtime/launch_policy.hpp>
+#include <hpx/runtime/parcelset/parcelhandler.hpp>
 #include <hpx/runtime/threads/coroutines/coroutine.hpp>
 #include <hpx/runtime/threads/policies/scheduler_mode.hpp>
-#include <hpx/runtime/threads/topology.hpp>
 #include <hpx/runtime/threads/threadmanager.hpp>
+#include <hpx/runtime/threads/topology.hpp>
 #include <hpx/state.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/backtrace.hpp>

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -31,6 +31,8 @@
 #include <hpx/runtime/agas/detail/bootstrap_locality_namespace.hpp>
 #include <hpx/runtime/find_localities.hpp>
 #include <hpx/runtime/naming/split_gid.hpp>
+#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/runtime/serialization/vector.hpp>
 #include <hpx/util/bind.hpp>
 #include <hpx/util/bind_back.hpp>
 #include <hpx/util/format.hpp>
@@ -45,6 +47,7 @@
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/manage_counter_type.hpp>
 #include <hpx/lcos/wait_all.hpp>
+#include <hpx/lcos/when_all.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -2850,6 +2853,19 @@ namespace hpx
 
         std::string name = detail::name_from_basename(basename, sequence_nr);
         return agas::register_name(std::move(name), id);
+    }
+
+    hpx::future<bool> register_with_basename(std::string base_name,
+        hpx::future<hpx::id_type> f, std::size_t sequence_nr)
+    {
+        return f.then(
+            [sequence_nr, HPX_CAPTURE_MOVE(base_name)](
+                hpx::future<hpx::id_type> && f
+            ) mutable -> hpx::future<bool>
+            {
+                return register_with_basename(
+                    std::move(base_name), f.get(), sequence_nr);
+            });
     }
 
     hpx::future<hpx::id_type> unregister_with_basename(

--- a/src/runtime/agas/detail/hosted_locality_namespace.cpp
+++ b/src/runtime/agas/detail/hosted_locality_namespace.cpp
@@ -22,11 +22,6 @@
 #include <string>
 #include <vector>
 
-HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(
-    hpx::parcelset::endpoints_type, parcelset_endpoints_type,
-    hpx::actions::base_lco_with_value_parcelset_endpoints_get,
-    hpx::actions::base_lco_with_value_parcelset_endpoints_set)
-
 namespace hpx { namespace agas { namespace detail
 {
     hosted_locality_namespace::hosted_locality_namespace(naming::address addr)

--- a/src/runtime/agas/locality_namespace.cpp
+++ b/src/runtime/agas/locality_namespace.cpp
@@ -24,6 +24,11 @@ HPX_DEFINE_COMPONENT_NAME(locality_namespace,
 HPX_DEFINE_GET_COMPONENT_TYPE_STATIC(
     locality_namespace, component_agas_locality_namespace)
 
+HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(
+    hpx::parcelset::endpoints_type, parcelset_endpoints_type,
+    hpx::actions::base_lco_with_value_parcelset_endpoints_get,
+    hpx::actions::base_lco_with_value_parcelset_endpoints_set)
+
 HPX_REGISTER_ACTION_ID(
     locality_namespace::allocate_action,
     locality_namespace_allocate_action,

--- a/src/runtime/parcelset/put_parcel.cpp
+++ b/src/runtime/parcelset/put_parcel.cpp
@@ -9,13 +9,29 @@
 
 #include <utility>
 
-namespace hpx { namespace parcelset { namespace detail
+namespace hpx { namespace parcelset
 {
-    void put_parcel_handler::operator()(parcel&& p) const
+    namespace detail
+    {
+        void put_parcel_handler::operator()(parcel&& p) const
+        {
+            parcelset::parcelhandler& ph =
+                hpx::get_runtime().get_parcel_handler();
+            ph.put_parcel(std::move(p));
+        }
+    }
+
+    void put_parcel(parcel&& p, write_handler_type&& f)
     {
         parcelset::parcelhandler& ph =
             hpx::get_runtime().get_parcel_handler();
-        ph.put_parcel(std::move(p));
+        ph.put_parcel(std::move(p), std::move(f));
     }
-}}}
 
+    void sync_put_parcel(parcel&& p)
+    {
+        parcelset::parcelhandler& ph =
+            hpx::get_runtime().get_parcel_handler();
+        ph.sync_put_parcel(std::move(p));
+    }
+}}

--- a/src/runtime/threads/executors/service_executor.cpp
+++ b/src/runtime/threads/executors/service_executor.cpp
@@ -10,6 +10,7 @@
 #include <hpx/throw_exception.hpp>
 #include <hpx/runtime_fwd.hpp>
 #include <hpx/runtime/threads/thread_enums.hpp>
+#include <hpx/runtime/threads/thread_helpers.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/bind.hpp>
 #include <hpx/util/io_service_pool.hpp>

--- a/tests/headers/CMakeLists.txt
+++ b/tests/headers/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2017 Hartmut Kaiser
+# Copyright (c) 2015-2018 Hartmut Kaiser
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -16,10 +16,14 @@ set(exclude_from_all_headers
   "util/hardware/timestamp/bgq.hpp"
 )
 
+# These files are either known to expose incomplete types or are known to
+# require special handling to avoid circular #include dependencies.
 set(exclude_from_headers
   "parallel/executors/execution_fwd.hpp"
   "parallel/executors/execution_information_fwd.hpp"
   "parallel/executors/timed_execution_fwd.hpp"
+  "parallel/executors/parallel_executor.hpp"
+  "lcos/local/futures_factory.hpp"
 )
 
 # If we compile with the MPI parcelport enabled, we need to additionally

--- a/tests/regressions/parallel/executors/CMakeLists.txt
+++ b/tests/regressions/parallel/executors/CMakeLists.txt
@@ -1,9 +1,10 @@
-# Copyright (c) 2014-2015 Hartmut Kaiser
+# Copyright (c) 2014-2018 Hartmut Kaiser
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    bulk_then_execute_3182
     handled_exception_2959
     is_executor_1691
    )

--- a/tests/regressions/parallel/executors/bulk_then_execute_3182.cpp
+++ b/tests/regressions/parallel/executors/bulk_then_execute_3182.cpp
@@ -1,0 +1,89 @@
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// #3182: bulk_then_execute has unexpected return type/does not compile
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <hpx/include/parallel_executors.hpp>
+#include <hpx/include/parallel_algorithm.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+std::atomic<int> void_count(0);
+void fun1(int, hpx::shared_future<int> f)
+{
+    HPX_TEST(f.is_ready());
+    HPX_TEST_EQ(f.get(), 42);
+
+    ++void_count;
+}
+
+std::atomic<int> int_count(0);
+int fun2(int i, hpx::shared_future<int> f)
+{
+    HPX_TEST(f.is_ready());
+    HPX_TEST_EQ(f.get(), 42);
+
+    ++int_count;
+    return i;
+}
+
+template <typename Executor>
+void test_bulk_then_execute(Executor && exec)
+{
+    hpx::shared_future<int> f = hpx::make_ready_future(42);
+    std::vector<int> v(100);
+    std::iota(v.begin(), v.end(), 0);
+
+    {
+        hpx::future<void> fut =
+            hpx::parallel::execution::bulk_then_execute(exec, &fun1, v, f);
+        fut.get();
+
+        HPX_TEST_EQ(void_count.load(), 100);
+    }
+
+    {
+        hpx::future<std::vector<int>> fut =
+            hpx::parallel::execution::bulk_then_execute(exec, &fun2, v, f);
+        auto result = fut.get();
+
+        HPX_TEST_EQ(int_count.load(), 100);
+        HPX_TEST(result == v);
+    }
+}
+
+int hpx_main(int argc, char* argv[])
+{
+    {
+        void_count.store(0);
+        int_count.store(0);
+
+        hpx::parallel::execution::parallel_executor exec;
+        test_bulk_then_execute(exec);
+    }
+
+    {
+        void_count.store(0);
+        int_count.store(0);
+
+        hpx::parallel::execution::pool_executor exec{"default"};
+        test_bulk_then_execute(exec);
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    return hpx::init(argc, argv);
+}
+

--- a/tests/unit/resource/named_pool_executor.cpp
+++ b/tests/unit/resource/named_pool_executor.cpp
@@ -12,6 +12,7 @@
 #include <hpx/include/parallel_execution.hpp>
 #include <hpx/include/resource_partitioner.hpp>
 #include <hpx/include/threads.hpp>
+#include <hpx/lcos/when_all.hpp>
 #include <hpx/runtime/threads/executors/pool_executor.hpp>
 #include <hpx/util/lightweight_test.hpp>
 

--- a/tests/unit/resource/throttle.cpp
+++ b/tests/unit/resource/throttle.cpp
@@ -9,6 +9,7 @@
 #include <hpx/include/async.hpp>
 #include <hpx/include/resource_partitioner.hpp>
 #include <hpx/include/threads.hpp>
+#include <hpx/lcos/when_all.hpp>
 #include <hpx/runtime/threads/policies/scheduler_mode.hpp>
 #include <hpx/runtime/threads/policies/schedulers.hpp>
 #include <hpx/util/lightweight_test.hpp>

--- a/tests/unit/resource/throttle_timed.cpp
+++ b/tests/unit/resource/throttle_timed.cpp
@@ -9,6 +9,7 @@
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/resource_partitioner.hpp>
 #include <hpx/include/threads.hpp>
+#include <hpx/lcos/when_all.hpp>
 #include <hpx/runtime/threads/executors/pool_executor.hpp>
 #include <hpx/runtime/threads/policies/scheduler_mode.hpp>
 #include <hpx/runtime/threads/policies/schedulers.hpp>

--- a/tests/unit/threads/thread_suspension_executor.cpp
+++ b/tests/unit/threads/thread_suspension_executor.cpp
@@ -4,6 +4,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
+#include <hpx/include/apply.hpp>
 #include <hpx/include/async.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/parallel_execution.hpp>


### PR DESCRIPTION
- flyby: added util::functional::unwrap[_n|_all]
- some restructuring required by circular #include dependencies

Fixes #3182

Unfortunately this PR contains a lot of unrelated changes that were necessary in order to disentangle a couple of circular #include dependencies that were introduced by the initial fix to the original problem.