### PR TITLE
Addition of new arithmetic performance counter "Count"

### DIFF
--- a/docs/manual/existing_performance_counters.qbk
+++ b/docs/manual/existing_performance_counters.qbk
@@ -1659,6 +1659,15 @@ system and application performance.
          this counter is accessed. Any wildcards in the counter names will
          be expanded.]
     ]
+    [   [`/arithmetics/count`]
+        [None]
+        [Returns the count value of all values queried from the
+         underlying counters (the ones specified as the parameters).]
+        [The parameter will be interpreted as a comma separated list of
+         full performance counter names which are queried whenever
+         this counter is accessed. Any wildcards in the counter names will
+         be expanded.]
+    ]
 ]
 
 [note The /arithmetics counters can consume an arbitrary number of other counters.

--- a/src/performance_counters/registry.cpp
+++ b/src/performance_counters/registry.cpp
@@ -987,7 +987,7 @@ namespace hpx { namespace performance_counters
                 gid = components::server::construct<counter_t>(
                     complemented_info, base_counter_names);
             }
-             else if (p.countername_ == "count") {
+            else if (p.countername_ == "count") {
                 typedef hpx::components::component<
                     performance_counters::server::arithmetics_counter_extended<
                         boost::accumulators::tag::count>

--- a/src/performance_counters/registry.cpp
+++ b/src/performance_counters/registry.cpp
@@ -987,6 +987,14 @@ namespace hpx { namespace performance_counters
                 gid = components::server::construct<counter_t>(
                     complemented_info, base_counter_names);
             }
+             else if (p.countername_ == "count") {
+                typedef hpx::components::component<
+                    performance_counters::server::arithmetics_counter_extended<
+                        boost::accumulators::tag::count>
+                > counter_t;
+                gid = components::server::construct<counter_t>(
+                    complemented_info, base_counter_names);
+            }
             else {
                 HPX_THROWS_IF(ec, bad_parameter,
                     "registry::create_arithmetics_counter",

--- a/src/performance_counters/server/arithmetics_counter_extended.cpp
+++ b/src/performance_counters/server/arithmetics_counter_extended.cpp
@@ -22,6 +22,7 @@
 #include <boost/accumulators/statistics/variance.hpp>
 #include <boost/accumulators/statistics/max.hpp>
 #include <boost/accumulators/statistics/min.hpp>
+#include <boost/accumulators/statistics/count.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -103,6 +104,16 @@ namespace hpx { namespace performance_counters { namespace server
                 return (boost::accumulators::max)(accum);
             }
         };
+        
+        template <>
+        struct statistic_get_value<boost::accumulators::tag::count>
+        {
+            template <typename Accumulator>
+            static double call(Accumulator const& accum)
+            {
+                return boost::accumulators::count(accum);
+            }
+        };
     }
 
     template <typename Statistic>
@@ -175,6 +186,9 @@ hpx::performance_counters::server::arithmetics_counter_extended<
 template class HPX_EXPORT
 hpx::performance_counters::server::arithmetics_counter_extended<
     boost::accumulators::tag::max>;
+template class HPX_EXPORT
+hpx::performance_counters::server::arithmetics_counter_extended<
+    boost::accumulators::tag::count>;
 
 ///////////////////////////////////////////////////////////////////////////////
 // /arithmetic/mean
@@ -235,6 +249,18 @@ HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
     max_arithmetics_counter_type, max_arithmetics_counter,
     "base_performance_counter", hpx::components::factory_enabled)
 HPX_DEFINE_GET_COMPONENT_TYPE(max_arithmetics_counter_type::wrapped_type)
+    
+///////////////////////////////////////////////////////////////////////////////
+// /arithmetic/count
+typedef hpx::components::component<
+    hpx::performance_counters::server::arithmetics_counter_extended<
+        boost::accumulators::tag::count>
+> count_arithmetics_counter_type;
+
+HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
+    count_arithmetics_counter_type, count_arithmetics_counter,
+    "base_performance_counter", hpx::components::factory_enabled)
+HPX_DEFINE_GET_COMPONENT_TYPE(count_arithmetics_counter_type::wrapped_type)    
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace performance_counters { namespace detail

--- a/src/performance_counters/server/arithmetics_counter_extended.cpp
+++ b/src/performance_counters/server/arithmetics_counter_extended.cpp
@@ -104,7 +104,7 @@ namespace hpx { namespace performance_counters { namespace server
                 return (boost::accumulators::max)(accum);
             }
         };
-        
+
         template <>
         struct statistic_get_value<boost::accumulators::tag::count>
         {
@@ -249,7 +249,7 @@ HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
     max_arithmetics_counter_type, max_arithmetics_counter,
     "base_performance_counter", hpx::components::factory_enabled)
 HPX_DEFINE_GET_COMPONENT_TYPE(max_arithmetics_counter_type::wrapped_type)
-    
+
 ///////////////////////////////////////////////////////////////////////////////
 // /arithmetic/count
 typedef hpx::components::component<
@@ -260,7 +260,7 @@ typedef hpx::components::component<
 HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
     count_arithmetics_counter_type, count_arithmetics_counter,
     "base_performance_counter", hpx::components::factory_enabled)
-HPX_DEFINE_GET_COMPONENT_TYPE(count_arithmetics_counter_type::wrapped_type)    
+HPX_DEFINE_GET_COMPONENT_TYPE(count_arithmetics_counter_type::wrapped_type)
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace performance_counters { namespace detail

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -645,6 +645,16 @@ namespace hpx
               &performance_counters::default_counter_discoverer,
               ""
             },
+            // arithmetics count counter
+            { "/arithmetics/count", performance_counters::counter_aggregating,
+              "returns the count value of all values of the specified "
+              "base counters; pass the required base counters as the parameters: "
+              "/arithmetics/count@<base_counter_name1>,<base_counter_name2>",
+              HPX_PERFORMANCE_COUNTER_V1,
+              &performance_counters::detail::arithmetics_counter_extended_creator,
+              &performance_counters::default_counter_discoverer,
+              ""
+            },
         };
         performance_counters::install_counter_types(
             arithmetic_counter_types,


### PR DESCRIPTION
References #2455 

## Proposed Changes
This PR has added one new arithmetic performance counter which is ```count``` . This mainly returns the count of values present in the accumulator containing values of the underlying counters.