### PR TITLE
Fix locking problems during shutdown

### DIFF
--- a/src/runtime/resource/partitioner.cpp
+++ b/src/runtime/resource/partitioner.cpp
@@ -140,7 +140,8 @@ namespace hpx { namespace resource
 
         void delete_partitioner()
         {
-            std::lock_guard<compat::mutex> l(partitioner_mtx());
+            // don't lock the mutex as otherwise will be still locked while
+            // being destroyed (leading to problems on some platforms)
             std::unique_ptr<detail::partitioner>& part = partitioner_ref();
             if (part)
                 part.reset();


### PR DESCRIPTION
This is to test if this helps for the Windows shutdown problems, but I will still see if we can get by with the `stopped_` and `terminated_` flags being `atomic<bool>`s instead (the mutex has to be locked in any case for the condition variables).

## Proposed Changes

- Unlock mutex while yielding/suspending HPX thread during shutdown
- Includes #3203 

## Any background context you want to provide?

HPX threads can migrate between OS threads. Holding an OS mutex in an HPX thread which gets migrated to another OS thread is undefined behaviour (this is checked on Windows). For #3203 a mutex was being held while being destructed.