### PR TITLE
Adapted parallel::{search | search_n} for Ranges TS (see #1668)

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -126,6 +126,7 @@ set(doxygen_dependencies
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/replace.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/reverse.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/rotate.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/search.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/sort.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/transform.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/unique.hpp"

--- a/hpx/include/parallel_search.hpp
+++ b/hpx/include/parallel_search.hpp
@@ -8,6 +8,7 @@
 #define HPX_PARALLEL_SEARCH_OCT_25_130PM
 
 #include <hpx/parallel/algorithms/search.hpp>
+#include <hpx/parallel/container_algorithms/search.hpp>
 
 #endif
 

--- a/hpx/parallel/algorithms/search.hpp
+++ b/hpx/parallel/algorithms/search.hpp
@@ -209,7 +209,13 @@ namespace hpx {namespace parallel { inline namespace v1
         hpx::traits::is_iterator<FwdIter>::value &&
         traits::is_projected<Proj1, FwdIter>::value &&
         hpx::traits::is_iterator<FwdIter2>::value &&
-        traits::is_projected<Proj2, FwdIter2>::value
+        traits::is_projected<Proj2, FwdIter2>::value &&
+        std::is_convertible<
+            decltype(hpx::util::invoke(std::declval<Proj2>(),
+                std::declval<typename std::iterator_traits<FwdIter2>::value_type>())),
+            decltype(hpx::util::invoke(std::declval<Proj1>(),
+                std::declval<typename std::iterator_traits<FwdIter>::value_type>()))
+        >::value
     )>
     typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
     search(ExPolicy && policy, FwdIter first, FwdIter last,

--- a/hpx/parallel/algorithms/search.hpp
+++ b/hpx/parallel/algorithms/search.hpp
@@ -118,8 +118,9 @@ namespace hpx {namespace parallel { inline namespace v1
                                         local_count != diff && len != count;
                                         ++local_count, ++len, ++mid)
                                     {
-                                        if(hpx::util::invoke(proj1, *mid) !=
-                                           hpx::util::invoke(proj2, *++needle))
+                                        if(!hpx::util::invoke(op,
+                                           hpx::util::invoke(proj1, *mid),
+                                           hpx::util::invoke(proj2, *++needle)))
                                             break;
                                     }
 
@@ -352,8 +353,9 @@ namespace hpx {namespace parallel { inline namespace v1
                                         len != difference_type(count);
                                         ++local_count, ++len, ++mid)
                                     {
-                                        if(hpx::util::invoke(proj1, *mid) !=
-                                           hpx::util::invoke(proj2, *++needle))
+                                        if(!hpx::util::invoke(op,
+                                           hpx::util::invoke(proj1, *mid),
+                                           hpx::util::invoke(proj2, *++needle)))
                                            break;
                                     }
 

--- a/hpx/parallel/algorithms/search.hpp
+++ b/hpx/parallel/algorithms/search.hpp
@@ -236,12 +236,6 @@ namespace hpx {namespace parallel { inline namespace v1
         traits::is_projected<Proj1, FwdIter>::value &&
         hpx::traits::is_iterator<FwdIter2>::value &&
         traits::is_projected<Proj2, FwdIter2>::value &&
-        std::is_convertible<
-            decltype(hpx::util::invoke(std::declval<Proj2>(),
-                std::declval<typename std::iterator_traits<FwdIter2>::value_type>())),
-            decltype(hpx::util::invoke(std::declval<Proj1>(),
-                std::declval<typename std::iterator_traits<FwdIter>::value_type>()))
-        >::value &&
         traits::is_indirect_callable<
             ExPolicy, Pred,
             traits::projected<Proj1, FwdIter>,
@@ -457,12 +451,6 @@ namespace hpx {namespace parallel { inline namespace v1
         traits::is_projected<Proj1, FwdIter>::value &&
         hpx::traits::is_iterator<FwdIter2>::value &&
         traits::is_projected<Proj2, FwdIter2>::value &&
-        std::is_convertible<
-            decltype(hpx::util::invoke(std::declval<Proj2>(),
-                std::declval<typename std::iterator_traits<FwdIter2>::value_type>())),
-            decltype(hpx::util::invoke(std::declval<Proj1>(),
-                std::declval<typename std::iterator_traits<FwdIter>::value_type>()))
-        >::value &&
         traits::is_indirect_callable<
             ExPolicy, Pred,
             traits::projected<Proj1, FwdIter>,

--- a/hpx/parallel/container_algorithms.hpp
+++ b/hpx/parallel/container_algorithms.hpp
@@ -22,6 +22,7 @@
 #include <hpx/parallel/container_algorithms/replace.hpp>
 #include <hpx/parallel/container_algorithms/reverse.hpp>
 #include <hpx/parallel/container_algorithms/rotate.hpp>
+#include <hpx/parallel/container_algorithms/search.hpp>
 #include <hpx/parallel/container_algorithms/sort.hpp>
 #include <hpx/parallel/container_algorithms/transform.hpp>
 #include <hpx/parallel/container_algorithms/unique.hpp>

--- a/hpx/parallel/container_algorithms/search.hpp
+++ b/hpx/parallel/container_algorithms/search.hpp
@@ -122,7 +122,8 @@ namespace hpx { namespace parallel { inline namespace v1
         ExPolicy,
         typename hpx::traits::range_iterator<Rng1>::type
     >::type
-    search(ExPolicy && policy, Rng1 rng1, Rng2 rng2, Pred && op = Pred(),
+    search(ExPolicy && policy, Rng1 && rng1,
+        Rng2 && rng2, Pred && op = Pred(),
         Proj1 && proj1 = Proj1(), Proj2 && proj2 = Proj2())
     {
         return search(std::forward<ExPolicy>(policy),

--- a/hpx/parallel/container_algorithms/search.hpp
+++ b/hpx/parallel/container_algorithms/search.hpp
@@ -17,6 +17,7 @@
 #include <hpx/parallel/traits/projected.hpp>
 #include <hpx/parallel/traits/projected_range.hpp>
 
+#include <cstddef>
 #include <type_traits>
 #include <utility>
 
@@ -234,19 +235,18 @@ namespace hpx { namespace parallel { inline namespace v1
         ExPolicy,
         typename hpx::traits::range_iterator<Rng1>::type
     >::type
-    search_n(ExPolicy && policy, Rng1 rng1, std::size_t count, Rng2 rng2,
+    search_n(ExPolicy && policy, Rng1 && rng1,
+        std::size_t count, Rng2 && rng2,
         Pred && op = Pred(), Proj1 && proj1 = Proj1(),
         Proj2 && proj2 = Proj2())
     {
-        return search(std::forward<ExPolicy>(policy),
-            hpx::util::begin(rng1), hpx::util::end(rng1),
+        return search_n(std::forward<ExPolicy>(policy),
+            hpx::util::begin(rng1), count,
             hpx::util::begin(rng2), hpx::util::end(rng2),
             std::forward<Pred>(op),
             std::forward<Proj1>(proj1),
             std::forward<Proj2>(proj2));
     }
-
-
 }}}
 
 #endif

--- a/hpx/parallel/container_algorithms/search.hpp
+++ b/hpx/parallel/container_algorithms/search.hpp
@@ -1,0 +1,137 @@
+//  Copyright (c) 2018 Christopher Ogle
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/container_algorithms/search.hpp
+
+#if !defined(HPX_PARALLEL_CONTAINER_ALGORITHM_SEARCH_FEB_28_2018_0007AM)
+#define HPX_PARALLEL_CONTAINER_ALGORITHM_SEARCH_FEB_28_2018_0007AM
+
+#include <hpx/config.hpp>
+#include <hpx/traits/is_execution_policy.hpp>
+#include <hpx/traits/is_range.hpp>
+#include <hpx/util/range.hpp>
+
+#include <hpx/parallel/algorithms/search.hpp>
+#include <hpx/parallel/traits/projected.hpp>
+#include <hpx/parallel/traits/projected_range.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { inline namespace v1
+{
+    /// Searches the range [first, last) for any elements in the range [s_first, s_last).
+    /// Uses a provided predicate to compare elements.
+    ///
+    /// \note   Complexity: at most (S*N) comparisons where
+    ///         \a S = distance(s_first, s_last) and
+    ///         \a N = distance(first, last).
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng1        The type of the examine range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Rng2        The type of the search range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a adjacent_find requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj1       The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity and is applied
+    ///                     to the elements of \a Rng1.
+    /// \tparam Proj2       The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity and is applied
+    ///                     to the elements of \a Rng2.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     of the first range the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements of
+    ///                     the first range the algorithm will be applied to.
+    /// \param rng1         Refers to the sequence of elements the algorithm
+    ///                     will be examining.
+    /// \param rng2         Refers to the sequence of elements the algorithm
+    ///                     will be searching for.
+    /// \param op           Refers to the binary predicate which returns true if the
+    ///                     elements should be treated as equal. the signature of
+    ///                     the function should be equivalent to
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type2 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const &, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The types \a Type1 and \a Type2 must be such
+    ///                     that objects of types \a FwdIter1 and \a FwdIter2 can
+    ///                     be dereferenced and then implicitly converted to
+    ///                     \a Type1 and \a Type2 respectively
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of \a rng1
+    ///                     as a projection operation before the actual
+    ///                     predicate \a is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of \a rng2
+    ///                     as a projection operation before the actual
+    ///                     predicate \a is invoked.
+    ///
+    /// The comparison operations in the parallel \a search algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The comparison operations in the parallel \a search algorithm invoked
+    /// with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a search algorithm returns a \a hpx::future<FwdIter> if the
+    ///           execution policy is of type \a task_execution_policy and
+    ///           returns \a FwdIter otherwise.
+    ///           The \a search algorithm returns an iterator to the beginning of
+    ///           the first subsequence [s_first, s_last) in range [first, last).
+    ///           If the length of the subsequence [s_first, s_last) is greater
+    ///           than the length of the range [first, last), \a last is returned.
+    ///           Additionally if the size of the subsequence is empty \a first is
+    ///           returned. If no subsequence is found, \a last is returned.
+    ///
+    template <typename ExPolicy, typename Rng1, typename Rng2,
+        typename Pred = detail::equal_to,
+        typename Proj1 = util::projection_identity,
+        typename Proj2 = util::projection_identity,
+    HPX_CONCEPT_REQUIRES_(
+        execution::is_execution_policy<ExPolicy>::value &&
+        hpx::traits::is_range<Rng1>::value &&
+        traits::is_projected_range<Proj1, Rng1>::value &&
+        hpx::traits::is_range<Rng2>::value &&
+        traits::is_projected_range<Proj2, Rng2>::value &&
+        traits::is_indirect_callable<
+            ExPolicy, Pred,
+            traits::projected_range<Proj1, Rng1>,
+            traits::projected_range<Proj2, Rng2>
+        >::value
+    )>
+    typename util::detail::algorithm_result<
+        ExPolicy,
+        typename hpx::traits::range_iterator<Rng1>::type
+    >::type
+    search(ExPolicy && policy, Rng rng1, Rng2 rng2, Pred && op = Pred(),
+        Proj1 && proj1 = Proj1(), Proj2 && proj2 = Proj2())
+    {
+        return search(std::forward<ExPolicy>(policy),
+            hpx::util::begin(rng1), hpx::util::end(rng1),
+            hpx::util::begin(rng2), hpx::util::end(rng2),
+            std::forward<Pred>(op),
+            std::forward<Proj1>(proj1),
+            std::forward<Proj2>(proj2));
+    }
+}}}
+
+#endif

--- a/hpx/parallel/container_algorithms/search.hpp
+++ b/hpx/parallel/container_algorithms/search.hpp
@@ -122,7 +122,7 @@ namespace hpx { namespace parallel { inline namespace v1
         ExPolicy,
         typename hpx::traits::range_iterator<Rng1>::type
     >::type
-    search(ExPolicy && policy, Rng rng1, Rng2 rng2, Pred && op = Pred(),
+    search(ExPolicy && policy, Rng1 rng1, Rng2 rng2, Pred && op = Pred(),
         Proj1 && proj1 = Proj1(), Proj2 && proj2 = Proj2())
     {
         return search(std::forward<ExPolicy>(policy),
@@ -132,6 +132,120 @@ namespace hpx { namespace parallel { inline namespace v1
             std::forward<Proj1>(proj1),
             std::forward<Proj2>(proj2));
     }
+
+    /// Searches the range [first, last) for any elements in the range [s_first, s_last).
+    /// Uses a provided predicate to compare elements.
+    ///
+    /// \note   Complexity: at most (S*N) comparisons where
+    ///         \a S = distance(s_first, s_last) and
+    ///         \a N = distance(first, last).
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng1        The type of the examine range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Rng2        The type of the search range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a adjacent_find requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj1       The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity and is applied
+    ///                     to the elements of \a Rng1.
+    /// \tparam Proj2       The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity and is applied
+    ///                     to the elements of \a Rng2.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     of the first range the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements of
+    ///                     the first range the algorithm will be applied to.
+    /// \param rng1         Refers to the sequence of elements the algorithm
+    ///                     will be examining.
+    /// \param rng2         Refers to the sequence of elements the algorithm
+    ///                     will be searching for.
+    /// \param op           Refers to the binary predicate which returns true if the
+    ///                     elements should be treated as equal. the signature of
+    ///                     the function should be equivalent to
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type2 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const &, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The types \a Type1 and \a Type2 must be such
+    ///                     that objects of types \a FwdIter1 and \a FwdIter2 can
+    ///                     be dereferenced and then implicitly converted to
+    ///                     \a Type1 and \a Type2 respectively
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of \a rng1
+    ///                     as a projection operation before the actual
+    ///                     predicate \a is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of \a rng2
+    ///                     as a projection operation before the actual
+    ///                     predicate \a is invoked.
+    ///
+    /// The comparison operations in the parallel \a search algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The comparison operations in the parallel \a search algorithm invoked
+    /// with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a search algorithm returns a \a hpx::future<FwdIter> if the
+    ///           execution policy is of type \a task_execution_policy and
+    ///           returns \a FwdIter otherwise.
+    ///           The \a search algorithm returns an iterator to the beginning of
+    ///           the first subsequence [s_first, s_last) in range [first, last).
+    ///           If the length of the subsequence [s_first, s_last) is greater
+    ///           than the length of the range [first, last), \a last is returned.
+    ///           Additionally if the size of the subsequence is empty \a first is
+    ///           returned. If no subsequence is found, \a last is returned.
+    ///
+    template <typename ExPolicy, typename Rng1, typename Rng2,
+        typename Pred = detail::equal_to,
+        typename Proj1 = util::projection_identity,
+        typename Proj2 = util::projection_identity,
+    HPX_CONCEPT_REQUIRES_(
+        execution::is_execution_policy<ExPolicy>::value &&
+        hpx::traits::is_range<Rng1>::value &&
+        traits::is_projected_range<Proj1, Rng1>::value &&
+        hpx::traits::is_range<Rng2>::value &&
+        traits::is_projected_range<Proj2, Rng2>::value &&
+        traits::is_indirect_callable<
+            ExPolicy, Pred,
+            traits::projected_range<Proj1, Rng1>,
+            traits::projected_range<Proj2, Rng2>
+        >::value
+    )>
+    typename util::detail::algorithm_result<
+        ExPolicy,
+        typename hpx::traits::range_iterator<Rng1>::type
+    >::type
+    search_n(ExPolicy && policy, Rng1 rng1, std::size_t count, Rng2 rng2,
+        Pred && op = Pred(), Proj1 && proj1 = Proj1(),
+        Proj2 && proj2 = Proj2())
+    {
+        return search(std::forward<ExPolicy>(policy),
+            hpx::util::begin(rng1), hpx::util::end(rng1),
+            hpx::util::begin(rng2), hpx::util::end(rng2),
+            std::forward<Pred>(op),
+            std::forward<Proj1>(proj1),
+            std::forward<Proj2>(proj2));
+    }
+
+
 }}}
 
 #endif

--- a/hpx/parallel/util/compare_projected.hpp
+++ b/hpx/parallel/util/compare_projected.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2016-2017 Hartmut Kaiser
+//  Copyright (c) 2018 Christopher Ogle
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -14,8 +15,11 @@
 namespace hpx { namespace parallel { namespace util
 {
     ///////////////////////////////////////////////////////////////////////////
+    template <typename Compare, typename ... Proj>
+    struct compare_projected;
+
     template <typename Compare, typename Proj>
-    struct compare_projected
+    struct compare_projected<Compare, Proj>
     {
         template <typename Compare_, typename Proj_>
         compare_projected(Compare_ && comp, Proj_ && proj)
@@ -33,6 +37,29 @@ namespace hpx { namespace parallel { namespace util
 
         Compare comp_;
         Proj proj_;
+    };
+
+    template <typename Compare, typename Proj1, typename Proj2>
+    struct compare_projected<Compare, Proj1, Proj2>
+    {
+        template <typename Compare_, typename Proj1_, typename Proj2_>
+        compare_projected(Compare_ && comp, Proj1_ && proj1, Proj2_ && proj2)
+            : comp_(std::forward<Compare_>(comp)),
+            proj1_(std::forward<Proj1_>(proj1)),
+            proj2_(std::forward<Proj2_>(proj2))
+        {}
+
+        template <typename T1, typename T2>
+        inline bool operator()(T1 && t1, T2 && t2) const
+        {
+            return hpx::util::invoke(comp_,
+                hpx::util::invoke(proj1_, std::forward<T1>(t1)),
+                hpx::util::invoke(proj1_, std::forward<T2>(t2)));
+        }
+
+        Compare comp_;
+        Proj1 proj1_;
+        Proj2 proj2_;
     };
 }}}
 

--- a/hpx/parallel/util/compare_projected.hpp
+++ b/hpx/parallel/util/compare_projected.hpp
@@ -54,7 +54,7 @@ namespace hpx { namespace parallel { namespace util
         {
             return hpx::util::invoke(comp_,
                 hpx::util::invoke(proj1_, std::forward<T1>(t1)),
-                hpx::util::invoke(proj1_, std::forward<T2>(t2)));
+                hpx::util::invoke(proj2_, std::forward<T2>(t2)));
         }
 
         Compare comp_;

--- a/tests/unit/parallel/container_algorithms/CMakeLists.txt
+++ b/tests/unit/parallel/container_algorithms/CMakeLists.txt
@@ -37,6 +37,7 @@ set(tests
     rotate_range
     rotate_copy_range
     search_range
+    searchn_range
     sort_range
     transform_range
     transform_range_binary

--- a/tests/unit/parallel/container_algorithms/CMakeLists.txt
+++ b/tests/unit/parallel/container_algorithms/CMakeLists.txt
@@ -36,6 +36,7 @@ set(tests
     reverse_copy_range
     rotate_range
     rotate_copy_range
+    search_range
     sort_range
     transform_range
     transform_range_binary

--- a/tests/unit/parallel/container_algorithms/search_range.cpp
+++ b/tests/unit/parallel/container_algorithms/search_range.cpp
@@ -1,0 +1,412 @@
+//  Copyright (c) 2018 Christopher Ogle
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/include/parallel_search.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_search1(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    // fill vector with random values above 2
+    std::fill(std::begin(c), std::end(c), (std::rand() % 100) + 3);
+    // create subsequence in middle of vector
+    c[c.size()/2] = 1;
+    c[c.size()/2 + 1] = 2;
+
+    std::size_t h[] = { 1, 2 };
+
+    iterator index = hpx::parallel::search(policy,
+        iterator(std::begin(c)), iterator(std::end(c)),
+        std::begin(h), std::end(h));
+
+    base_iterator test_index = std::begin(c) + c.size()/2;
+
+    HPX_TEST(index == iterator(test_index));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_search1_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    // fill vector with random values above 2
+    std::fill(std::begin(c), std::end(c), (std::rand() % 100) + 3);
+    // create subsequence in middle of vector
+    c[c.size()/2] = 1;
+    c[c.size()/2 + 1] = 2;
+
+    std::size_t h[] = { 1, 2 };
+
+    hpx::future<iterator> f =
+        hpx::parallel::search(p,
+            iterator(std::begin(c)), iterator(std::end(c)),
+            std::begin(h), std::end(h));
+    f.wait();
+
+    // create iterator at position of value to be found
+    base_iterator test_index = std::begin(c) + c.size()/2;
+
+    HPX_TEST(f.get() == iterator(test_index));
+}
+
+template <typename IteratorTag>
+void test_search1()
+{
+    using namespace hpx::parallel;
+    test_search1(execution::seq, IteratorTag());
+    test_search1(execution::par, IteratorTag());
+    test_search1(execution::par_unseq, IteratorTag());
+
+    test_search1_async(execution::seq(execution::task), IteratorTag());
+    test_search1_async(execution::par(execution::task), IteratorTag());
+
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
+    test_search1(execution_policy(execution::seq), IteratorTag());
+    test_search1(execution_policy(execution::par), IteratorTag());
+    test_search1(execution_policy(execution::par_unseq), IteratorTag());
+    test_search1(execution_policy(execution::seq(execution::task)),
+        IteratorTag());
+    test_search1(execution_policy(execution::par(execution::task)),
+        IteratorTag());
+#endif
+}
+
+void search_test1()
+{
+    test_search1<std::random_access_iterator_tag>();
+    test_search1<std::forward_iterator_tag>();
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_search2(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    // fill vector with random values about 2
+    std::fill(std::begin(c), std::end(c), (std::rand() % 100) + 3);
+    // create subsequence at start and end
+    c[0] = 1;
+    c[1] = 2;
+    c[c.size()-1] = 2;
+    c[c.size()-2] = 1;
+
+    std::size_t h[] = { 1, 2 };
+
+    iterator index = hpx::parallel::search(policy,
+        iterator(std::begin(c)), iterator(std::end(c)),
+        std::begin(h), std::end(h));
+
+    base_iterator test_index = std::begin(c);
+
+    HPX_TEST(index == iterator(test_index));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_search2_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    // fill vector with random values above 2
+    std::fill(std::begin(c), std::end(c), (std::rand() % 100) + 3);
+    // create subsequence at start and end
+    c[0] = 1;
+    c[1] = 2;
+    c[c.size()-1] = 2;
+    c[c.size()-2] = 1;
+
+    std::size_t h[] = { 1, 2 };
+
+    hpx::future<iterator> f =
+        hpx::parallel::search(p,
+            iterator(std::begin(c)), iterator(std::end(c)),
+            std::begin(h), std::end(h));
+    f.wait();
+
+    // create iterator at position of value to be found
+    base_iterator test_index = std::begin(c);
+
+    HPX_TEST(f.get() == iterator(test_index));
+}
+
+template <typename IteratorTag>
+void test_search2()
+{
+    using namespace hpx::parallel;
+    test_search2(execution::seq, IteratorTag());
+    test_search2(execution::par, IteratorTag());
+    test_search2(execution::par_unseq, IteratorTag());
+
+    test_search2_async(execution::seq(execution::task), IteratorTag());
+    test_search2_async(execution::par(execution::task), IteratorTag());
+
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
+    test_search2(execution_policy(execution::seq), IteratorTag());
+    test_search2(execution_policy(execution::par), IteratorTag());
+    test_search2(execution_policy(execution::par_unseq), IteratorTag());
+
+    test_search2(execution_policy(execution::seq(execution::task)),
+        IteratorTag());
+    test_search2(execution_policy(execution::par(execution::task)),
+        IteratorTag());
+#endif
+}
+
+void search_test2()
+{
+    test_search2<std::random_access_iterator_tag>();
+    test_search2<std::forward_iterator_tag>();
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_search3(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    // fill vector with random values above 2
+    std::fill(std::begin(c), std::end(c), (std::rand() % 100) + 3);
+    // create subsequence large enough to always be split into multiple partitions
+    std::iota(std::begin(c), std::begin(c) + c.size()/16+1, 1);
+    std::size_t sub_size = c.size()/16 + 1;
+    std::vector<std::size_t> h(sub_size);
+    std::iota(std::begin(h), std::end(h), 1);
+
+    iterator index = hpx::parallel::search(policy,
+        iterator(std::begin(c)), iterator(std::end(c)),
+        std::begin(h), std::end(h));
+
+    base_iterator test_index = std::begin(c);
+
+    HPX_TEST(index == iterator(test_index));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_search3_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    // fill vector with random values above 6
+    std::fill(std::begin(c), std::end(c), (std::rand() % 100) + 7);
+    // create subsequence large enough to always be split into multiple partitions
+    std::iota(std::begin(c), std::begin(c) + c.size()/16+1, 1);
+    std::size_t sub_size = c.size()/16 + 1;
+    std::vector<std::size_t> h(sub_size);
+    std::iota(std::begin(h), std::end(h), 1);
+
+    // create only two partitions, splitting the desired sub sequence into
+    // separate partitions.
+    hpx::future<iterator> f =
+        hpx::parallel::search(p,
+            iterator(std::begin(c)), iterator(std::end(c)),
+            std::begin(h), std::end(h));
+    f.wait();
+
+    //create iterator at position of value to be found
+    base_iterator test_index = std::begin(c);
+
+    HPX_TEST(f.get() == iterator(test_index));
+}
+
+template <typename IteratorTag>
+void test_search3()
+{
+    using namespace hpx::parallel;
+    test_search3(execution::seq, IteratorTag());
+    test_search3(execution::par, IteratorTag());
+    test_search3(execution::par_unseq, IteratorTag());
+
+    test_search3_async(execution::seq(execution::task), IteratorTag());
+    test_search3_async(execution::par(execution::task), IteratorTag());
+
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
+    test_search3(execution_policy(execution::seq), IteratorTag());
+    test_search3(execution_policy(execution::par), IteratorTag());
+    test_search3(execution_policy(execution::par_unseq), IteratorTag());
+
+    test_search3(execution_policy(execution::seq(execution::task)),
+        IteratorTag());
+    test_search3(execution_policy(execution::par(execution::task)),
+        IteratorTag());
+#endif
+}
+
+void search_test3()
+{
+    test_search3<std::random_access_iterator_tag>();
+    test_search3<std::forward_iterator_tag>();
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_search4(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    // fill vector with random values above 2
+    std::fill(std::begin(c), std::end(c), (std::rand() % 100) + 3);
+    // create subsequence in middle of vector
+    c[c.size()/2] = 1;
+    c[c.size()/2 + 1] = 2;
+
+    std::size_t h[] = { 1, 2 };
+
+    auto op =
+        [](std::size_t a, std::size_t b)
+        {
+            return !(a != b);
+        };
+
+    iterator index = hpx::parallel::search(policy,
+        iterator(std::begin(c)), iterator(std::end(c)),
+        std::begin(h), std::end(h), op);
+
+    base_iterator test_index = std::begin(c) + c.size()/2;
+
+    HPX_TEST(index == iterator(test_index));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_search4_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    // fill vector with random values above 2
+    std::fill(std::begin(c), std::end(c), (std::rand() % 100) + 3);
+    // create subsequence in middle of vector, provide custom predicate
+    // for search
+    c[c.size()/2] = 1;
+    c[c.size()/2 + 1] = 2;
+
+    std::size_t h[] = { 1, 2 };
+
+    auto op =
+        [](std::size_t a, std::size_t b)
+        {
+            return !(a != b);
+        };
+
+    hpx::future<iterator> f =
+        hpx::parallel::search(p,
+            iterator(std::begin(c)), iterator(std::end(c)),
+            std::begin(h), std::end(h), op);
+    f.wait();
+
+    // create iterator at position of value to be found
+    base_iterator test_index = std::begin(c) + c.size()/2;
+
+    HPX_TEST(f.get() == iterator(test_index));
+}
+
+template <typename IteratorTag>
+void test_search4()
+{
+    using namespace hpx::parallel;
+    test_search4(execution::seq, IteratorTag());
+    test_search4(execution::par, IteratorTag());
+    test_search4(execution::par_unseq, IteratorTag());
+
+    test_search4_async(execution::seq(execution::task), IteratorTag());
+    test_search4_async(execution::par(execution::task), IteratorTag());
+
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
+    test_search4(execution_policy(execution::seq), IteratorTag());
+    test_search4(execution_policy(execution::par), IteratorTag());
+    test_search4(execution_policy(execution::par_unseq), IteratorTag());
+    test_search4(execution_policy(execution::seq(execution::task)),
+        IteratorTag());
+    test_search4(execution_policy(execution::par(execution::task)),
+        IteratorTag());
+#endif
+}
+
+void search_test4()
+{
+    test_search4<std::random_access_iterator_tag>();
+    test_search4<std::forward_iterator_tag>();
+}
+
+////////////////////////////////////////////////////////////////////////////
+int hpx_main(boost::program_options::variables_map& vm)
+{
+
+    unsigned int seed = (unsigned int)std::time(nullptr);
+    if(vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    search_test1();
+    search_test2();
+    search_test3();
+    search_test4();
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    using namespace boost::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()
+        ("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run")
+        ;
+
+    std::vector<std::string> const cfg = {
+        "hpx.os_threads=all"
+    };
+
+    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}
+

--- a/tests/unit/parallel/container_algorithms/search_range.cpp
+++ b/tests/unit/parallel/container_algorithms/search_range.cpp
@@ -17,6 +17,21 @@
 
 #include "test_utils.hpp"
 
+
+struct user_defined_type_1
+{
+    user_defined_type_1() = default;
+    user_defined_type_1(int v) : val(v){}
+    unsigned int val;
+};
+
+struct user_defined_type_2
+{
+    user_defined_type_2() = default;
+    user_defined_type_2(int v) : val(v){}
+    std::size_t val;
+};
+
 ////////////////////////////////////////////////////////////////////////////
 template <typename ExPolicy, typename IteratorTag>
 void test_search1(ExPolicy policy, IteratorTag)
@@ -25,9 +40,6 @@ void test_search1(ExPolicy policy, IteratorTag)
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::vector<std::size_t> c(10007);
     // fill vector with random values above 2
     std::fill(std::begin(c), std::end(c), (std::rand() % 100) + 3);
@@ -37,21 +49,15 @@ void test_search1(ExPolicy policy, IteratorTag)
 
     std::size_t h[] = { 1, 2 };
 
-    iterator index = hpx::parallel::search(policy,
-        iterator(std::begin(c)), iterator(std::end(c)),
-        std::begin(h), std::end(h));
+    auto index = hpx::parallel::search(policy, c, h);
+    auto test_index = std::begin(c) + c.size()/2;
 
-    base_iterator test_index = std::begin(c) + c.size()/2;
-
-    HPX_TEST(index == iterator(test_index));
+    HPX_TEST(index == test_index);
 }
 
 template <typename ExPolicy, typename IteratorTag>
 void test_search1_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::vector<std::size_t> c(10007);
     // fill vector with random values above 2
     std::fill(std::begin(c), std::end(c), (std::rand() % 100) + 3);
@@ -61,16 +67,13 @@ void test_search1_async(ExPolicy p, IteratorTag)
 
     std::size_t h[] = { 1, 2 };
 
-    hpx::future<iterator> f =
-        hpx::parallel::search(p,
-            iterator(std::begin(c)), iterator(std::end(c)),
-            std::begin(h), std::end(h));
+    auto f = hpx::parallel::search(p, c, h);
     f.wait();
 
     // create iterator at position of value to be found
-    base_iterator test_index = std::begin(c) + c.size()/2;
+    auto test_index = std::begin(c) + c.size()/2;
 
-    HPX_TEST(f.get() == iterator(test_index));
+    HPX_TEST(f.get() == test_index);
 }
 
 template <typename IteratorTag>
@@ -108,9 +111,6 @@ void test_search2(ExPolicy policy, IteratorTag)
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::vector<std::size_t> c(10007);
     // fill vector with random values about 2
     std::fill(std::begin(c), std::end(c), (std::rand() % 100) + 3);
@@ -122,13 +122,11 @@ void test_search2(ExPolicy policy, IteratorTag)
 
     std::size_t h[] = { 1, 2 };
 
-    iterator index = hpx::parallel::search(policy,
-        iterator(std::begin(c)), iterator(std::end(c)),
-        std::begin(h), std::end(h));
+    auto index = hpx::parallel::search(policy, c, h);
 
-    base_iterator test_index = std::begin(c);
+    auto test_index = std::begin(c);
 
-    HPX_TEST(index == iterator(test_index));
+    HPX_TEST(index == test_index);
 }
 
 template <typename ExPolicy, typename IteratorTag>
@@ -148,16 +146,13 @@ void test_search2_async(ExPolicy p, IteratorTag)
 
     std::size_t h[] = { 1, 2 };
 
-    hpx::future<iterator> f =
-        hpx::parallel::search(p,
-            iterator(std::begin(c)), iterator(std::end(c)),
-            std::begin(h), std::end(h));
+    auto f = hpx::parallel::search(p, c, h);
     f.wait();
 
     // create iterator at position of value to be found
-    base_iterator test_index = std::begin(c);
+    auto test_index = std::begin(c);
 
-    HPX_TEST(f.get() == iterator(test_index));
+    HPX_TEST(f.get() == test_index);
 }
 
 template <typename IteratorTag>
@@ -196,9 +191,6 @@ void test_search3(ExPolicy policy, IteratorTag)
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::vector<std::size_t> c(10007);
     // fill vector with random values above 2
     std::fill(std::begin(c), std::end(c), (std::rand() % 100) + 3);
@@ -208,21 +200,16 @@ void test_search3(ExPolicy policy, IteratorTag)
     std::vector<std::size_t> h(sub_size);
     std::iota(std::begin(h), std::end(h), 1);
 
-    iterator index = hpx::parallel::search(policy,
-        iterator(std::begin(c)), iterator(std::end(c)),
-        std::begin(h), std::end(h));
+    auto index = hpx::parallel::search(policy, c, h);
 
-    base_iterator test_index = std::begin(c);
+    auto test_index = std::begin(c);
 
-    HPX_TEST(index == iterator(test_index));
+    HPX_TEST(index == test_index);
 }
 
 template <typename ExPolicy, typename IteratorTag>
 void test_search3_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::vector<std::size_t> c(10007);
     // fill vector with random values above 6
     std::fill(std::begin(c), std::end(c), (std::rand() % 100) + 7);
@@ -234,16 +221,13 @@ void test_search3_async(ExPolicy p, IteratorTag)
 
     // create only two partitions, splitting the desired sub sequence into
     // separate partitions.
-    hpx::future<iterator> f =
-        hpx::parallel::search(p,
-            iterator(std::begin(c)), iterator(std::end(c)),
-            std::begin(h), std::end(h));
+    auto f = hpx::parallel::search(p, c, h);
     f.wait();
 
     //create iterator at position of value to be found
-    base_iterator test_index = std::begin(c);
+    auto test_index = std::begin(c);
 
-    HPX_TEST(f.get() == iterator(test_index));
+    HPX_TEST(f.get() == test_index);
 }
 
 template <typename IteratorTag>
@@ -282,9 +266,6 @@ void test_search4(ExPolicy policy, IteratorTag)
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::vector<std::size_t> c(10007);
     // fill vector with random values above 2
     std::fill(std::begin(c), std::end(c), (std::rand() % 100) + 3);
@@ -300,21 +281,16 @@ void test_search4(ExPolicy policy, IteratorTag)
             return !(a != b);
         };
 
-    iterator index = hpx::parallel::search(policy,
-        iterator(std::begin(c)), iterator(std::end(c)),
-        std::begin(h), std::end(h), op);
+    auto index = hpx::parallel::search(policy, c, h, op);
 
-    base_iterator test_index = std::begin(c) + c.size()/2;
+    auto test_index = std::begin(c) + c.size()/2;
 
-    HPX_TEST(index == iterator(test_index));
+    HPX_TEST(index == test_index);
 }
 
 template <typename ExPolicy, typename IteratorTag>
 void test_search4_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::vector<std::size_t> c(10007);
     // fill vector with random values above 2
     std::fill(std::begin(c), std::end(c), (std::rand() % 100) + 3);
@@ -331,16 +307,13 @@ void test_search4_async(ExPolicy p, IteratorTag)
             return !(a != b);
         };
 
-    hpx::future<iterator> f =
-        hpx::parallel::search(p,
-            iterator(std::begin(c)), iterator(std::end(c)),
-            std::begin(h), std::end(h), op);
+    auto f = hpx::parallel::search(p, c, h, op);
     f.wait();
 
     // create iterator at position of value to be found
-    base_iterator test_index = std::begin(c) + c.size()/2;
+    auto test_index = std::begin(c) + c.size()/2;
 
-    HPX_TEST(f.get() == iterator(test_index));
+    HPX_TEST(f.get() == test_index);
 }
 
 template <typename IteratorTag>
@@ -371,10 +344,103 @@ void search_test4()
     test_search4<std::forward_iterator_tag>();
 }
 
+template <typename ExPolicy, typename IteratorTag>
+void test_search5(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    std::vector<std::size_t> c(10007);
+    // fill vector with random values above 2
+    std::fill(std::begin(c), std::end(c), (std::rand() % 100) + 3);
+    // create subsequence in middle of vector
+    c[c.size()/2] = 1;
+    c[c.size()/2 + 1] = 2;
+
+    std::size_t h[] = { 1, 2 };
+
+    auto index = hpx::parallel::search(policy, c, h);
+    auto test_index = std::begin(c) + c.size()/2;
+
+    HPX_TEST(index == test_index);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_search5_async(ExPolicy p, IteratorTag)
+{
+    std::vector<user_defined_type_1> c(10007);
+    // fill vector with random values above 2
+    std::for_each(std::begin(c), std::end(c), [](user_defined_type_1 & ut1){
+        ut1.val = (std::rand() % 100) + 3;
+    });
+    // create subsequence in middle of vector, provide custom predicate
+    // for search
+    c[c.size()/2].val = 1;
+    c[c.size()/2 + 1].val = 2;
+
+    user_defined_type_2 h[] = { user_defined_type_2(1), user_defined_type_2(2) };
+
+    auto op =
+        [](std::size_t a, std::size_t b)
+        {
+            return !(a != b);
+        };
+
+    auto proj1 =
+        [](const user_defined_type_1 & ut1)
+        {
+            return ut1.val;
+        };
+
+    auto proj2 =
+        [](const user_defined_type_2 & ut2)
+        {
+            return ut2.val;
+        };
+
+
+    auto f = hpx::parallel::search(p, c, h, op, proj1, proj2);
+    f.wait();
+
+    // create iterator at position of value to be found
+    auto test_index = std::begin(c) + c.size()/2;
+
+    HPX_TEST(f.get() == test_index);
+}
+
+template <typename IteratorTag>
+void test_search5()
+{
+    using namespace hpx::parallel;
+    test_search5(execution::seq, IteratorTag());
+    test_search5(execution::par, IteratorTag());
+    test_search5(execution::par_unseq, IteratorTag());
+
+    test_search5_async(execution::seq(execution::task), IteratorTag());
+    test_search5_async(execution::par(execution::task), IteratorTag());
+
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
+    test_search5(execution_policy(execution::seq), IteratorTag());
+    test_search5(execution_policy(execution::par), IteratorTag());
+    test_search5(execution_policy(execution::par_unseq), IteratorTag());
+    test_search5(execution_policy(execution::seq(execution::task)),
+        IteratorTag());
+    test_search5(execution_policy(execution::par(execution::task)),
+        IteratorTag());
+#endif
+}
+
+void search_test5()
+{
+    test_search5<std::random_access_iterator_tag>();
+    test_search5<std::forward_iterator_tag>();
+}
+
+
 ////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
-
     unsigned int seed = (unsigned int)std::time(nullptr);
     if(vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
@@ -386,6 +452,7 @@ int hpx_main(boost::program_options::variables_map& vm)
     search_test2();
     search_test3();
     search_test4();
+    search_test5();
     return hpx::finalize();
 }
 
@@ -409,4 +476,3 @@ int main(int argc, char* argv[])
 
     return hpx::util::report_errors();
 }
-

--- a/tests/unit/parallel/container_algorithms/searchn_range.cpp
+++ b/tests/unit/parallel/container_algorithms/searchn_range.cpp
@@ -34,7 +34,7 @@ struct user_defined_type_2
 
 ////////////////////////////////////////////////////////////////////////////
 template <typename ExPolicy, typename IteratorTag>
-void test_search1(ExPolicy policy, IteratorTag)
+void test_search_n1(ExPolicy policy, IteratorTag)
 {
     static_assert(
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
@@ -49,14 +49,14 @@ void test_search1(ExPolicy policy, IteratorTag)
 
     std::size_t h[] = { 1, 2 };
 
-    auto index = hpx::parallel::search(policy, c, h);
+    auto index = hpx::parallel::search_n(policy, c, c.size(), h);
     auto test_index = std::begin(c) + c.size()/2;
 
     HPX_TEST(index == test_index);
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_search1_async(ExPolicy p, IteratorTag)
+void test_search_n1_async(ExPolicy p, IteratorTag)
 {
     std::vector<std::size_t> c(10007);
     // fill vector with random values above 2
@@ -67,7 +67,7 @@ void test_search1_async(ExPolicy p, IteratorTag)
 
     std::size_t h[] = { 1, 2 };
 
-    auto f = hpx::parallel::search(p, c, h);
+    auto f = hpx::parallel::search_n(p, c, c.size(), h);
     f.wait();
 
     // create iterator at position of value to be found
@@ -77,35 +77,35 @@ void test_search1_async(ExPolicy p, IteratorTag)
 }
 
 template <typename IteratorTag>
-void test_search1()
+void test_search_n1()
 {
     using namespace hpx::parallel;
-    test_search1(execution::seq, IteratorTag());
-    test_search1(execution::par, IteratorTag());
-    test_search1(execution::par_unseq, IteratorTag());
+    test_search_n1(execution::seq, IteratorTag());
+    test_search_n1(execution::par, IteratorTag());
+    test_search_n1(execution::par_unseq, IteratorTag());
 
-    test_search1_async(execution::seq(execution::task), IteratorTag());
-    test_search1_async(execution::par(execution::task), IteratorTag());
+    test_search_n1_async(execution::seq(execution::task), IteratorTag());
+    test_search_n1_async(execution::par(execution::task), IteratorTag());
 
 #if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_search1(execution_policy(execution::seq), IteratorTag());
-    test_search1(execution_policy(execution::par), IteratorTag());
-    test_search1(execution_policy(execution::par_unseq), IteratorTag());
-    test_search1(execution_policy(execution::seq(execution::task)),
+    test_search_n1(execution_policy(execution::seq), IteratorTag());
+    test_search_n1(execution_policy(execution::par), IteratorTag());
+    test_search_n1(execution_policy(execution::par_unseq), IteratorTag());
+    test_search_n1(execution_policy(execution::seq(execution::task)),
         IteratorTag());
-    test_search1(execution_policy(execution::par(execution::task)),
+    test_search_n1(execution_policy(execution::par(execution::task)),
         IteratorTag());
 #endif
 }
 
-void search_test1()
+void search_test_n1()
 {
-    test_search1<std::random_access_iterator_tag>();
-    test_search1<std::forward_iterator_tag>();
+    test_search_n1<std::random_access_iterator_tag>();
+    test_search_n1<std::forward_iterator_tag>();
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_search2(ExPolicy policy, IteratorTag)
+void test_search_n2(ExPolicy policy, IteratorTag)
 {
     static_assert(
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
@@ -115,6 +115,7 @@ void test_search2(ExPolicy policy, IteratorTag)
     // fill vector with random values about 2
     std::fill(std::begin(c), std::end(c), (std::rand() % 100) + 3);
     // create subsequence at start and end
+
     c[0] = 1;
     c[1] = 2;
     c[c.size()-1] = 2;
@@ -122,7 +123,7 @@ void test_search2(ExPolicy policy, IteratorTag)
 
     std::size_t h[] = { 1, 2 };
 
-    auto index = hpx::parallel::search(policy, c, h);
+    auto index = hpx::parallel::search_n(policy, c, c.size(), h);
 
     auto test_index = std::begin(c);
 
@@ -130,7 +131,7 @@ void test_search2(ExPolicy policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_search2_async(ExPolicy p, IteratorTag)
+void test_search_n2_async(ExPolicy p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -146,7 +147,7 @@ void test_search2_async(ExPolicy p, IteratorTag)
 
     std::size_t h[] = { 1, 2 };
 
-    auto f = hpx::parallel::search(p, c, h);
+    auto f = hpx::parallel::search_n(p, c, c.size(), h);
     f.wait();
 
     // create iterator at position of value to be found
@@ -156,36 +157,36 @@ void test_search2_async(ExPolicy p, IteratorTag)
 }
 
 template <typename IteratorTag>
-void test_search2()
+void test_search_n2()
 {
     using namespace hpx::parallel;
-    test_search2(execution::seq, IteratorTag());
-    test_search2(execution::par, IteratorTag());
-    test_search2(execution::par_unseq, IteratorTag());
+    test_search_n2(execution::seq, IteratorTag());
+    test_search_n2(execution::par, IteratorTag());
+    test_search_n2(execution::par_unseq, IteratorTag());
 
-    test_search2_async(execution::seq(execution::task), IteratorTag());
-    test_search2_async(execution::par(execution::task), IteratorTag());
+    test_search_n2_async(execution::seq(execution::task), IteratorTag());
+    test_search_n2_async(execution::par(execution::task), IteratorTag());
 
 #if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_search2(execution_policy(execution::seq), IteratorTag());
-    test_search2(execution_policy(execution::par), IteratorTag());
-    test_search2(execution_policy(execution::par_unseq), IteratorTag());
+    test_search_n2(execution_policy(execution::seq), IteratorTag());
+    test_search_n2(execution_policy(execution::par), IteratorTag());
+    test_search_n2(execution_policy(execution::par_unseq), IteratorTag());
 
-    test_search2(execution_policy(execution::seq(execution::task)),
+    test_search_n2(execution_policy(execution::seq(execution::task)),
         IteratorTag());
-    test_search2(execution_policy(execution::par(execution::task)),
+    test_search_n2(execution_policy(execution::par(execution::task)),
         IteratorTag());
 #endif
 }
 
-void search_test2()
+void search_test_n2()
 {
-    test_search2<std::random_access_iterator_tag>();
-    test_search2<std::forward_iterator_tag>();
+    test_search_n2<std::random_access_iterator_tag>();
+    test_search_n2<std::forward_iterator_tag>();
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_search3(ExPolicy policy, IteratorTag)
+void test_search_n3(ExPolicy policy, IteratorTag)
 {
     static_assert(
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
@@ -200,7 +201,7 @@ void test_search3(ExPolicy policy, IteratorTag)
     std::vector<std::size_t> h(sub_size);
     std::iota(std::begin(h), std::end(h), 1);
 
-    auto index = hpx::parallel::search(policy, c, h);
+    auto index = hpx::parallel::search_n(policy, c, c.size(), h);
 
     auto test_index = std::begin(c);
 
@@ -208,7 +209,7 @@ void test_search3(ExPolicy policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_search3_async(ExPolicy p, IteratorTag)
+void test_search_n3_async(ExPolicy p, IteratorTag)
 {
     std::vector<std::size_t> c(10007);
     // fill vector with random values above 6
@@ -221,7 +222,7 @@ void test_search3_async(ExPolicy p, IteratorTag)
 
     // create only two partitions, splitting the desired sub sequence into
     // separate partitions.
-    auto f = hpx::parallel::search(p, c, h);
+    auto f = hpx::parallel::search_n(p, c, c.size(), h);
     f.wait();
 
     //create iterator at position of value to be found
@@ -231,36 +232,36 @@ void test_search3_async(ExPolicy p, IteratorTag)
 }
 
 template <typename IteratorTag>
-void test_search3()
+void test_search_n3()
 {
     using namespace hpx::parallel;
-    test_search3(execution::seq, IteratorTag());
-    test_search3(execution::par, IteratorTag());
-    test_search3(execution::par_unseq, IteratorTag());
+    test_search_n3(execution::seq, IteratorTag());
+    test_search_n3(execution::par, IteratorTag());
+    test_search_n3(execution::par_unseq, IteratorTag());
 
-    test_search3_async(execution::seq(execution::task), IteratorTag());
-    test_search3_async(execution::par(execution::task), IteratorTag());
+    test_search_n3_async(execution::seq(execution::task), IteratorTag());
+    test_search_n3_async(execution::par(execution::task), IteratorTag());
 
 #if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_search3(execution_policy(execution::seq), IteratorTag());
-    test_search3(execution_policy(execution::par), IteratorTag());
-    test_search3(execution_policy(execution::par_unseq), IteratorTag());
+    test_search_n3(execution_policy(execution::seq), IteratorTag());
+    test_search_n3(execution_policy(execution::par), IteratorTag());
+    test_search_n3(execution_policy(execution::par_unseq), IteratorTag());
 
-    test_search3(execution_policy(execution::seq(execution::task)),
+    test_search_n3(execution_policy(execution::seq(execution::task)),
         IteratorTag());
-    test_search3(execution_policy(execution::par(execution::task)),
+    test_search_n3(execution_policy(execution::par(execution::task)),
         IteratorTag());
 #endif
 }
 
-void search_test3()
+void search_test_n3()
 {
-    test_search3<std::random_access_iterator_tag>();
-    test_search3<std::forward_iterator_tag>();
+    test_search_n3<std::random_access_iterator_tag>();
+    test_search_n3<std::forward_iterator_tag>();
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_search4(ExPolicy policy, IteratorTag)
+void test_search_n4(ExPolicy policy, IteratorTag)
 {
     static_assert(
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
@@ -281,7 +282,7 @@ void test_search4(ExPolicy policy, IteratorTag)
             return !(a != b);
         };
 
-    auto index = hpx::parallel::search(policy, c, h, op);
+    auto index = hpx::parallel::search_n(policy, c, c.size(), h, op);
 
     auto test_index = std::begin(c) + c.size()/2;
 
@@ -289,7 +290,7 @@ void test_search4(ExPolicy policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_search4_async(ExPolicy p, IteratorTag)
+void test_search_n4_async(ExPolicy p, IteratorTag)
 {
     std::vector<std::size_t> c(10007);
     // fill vector with random values above 2
@@ -307,7 +308,7 @@ void test_search4_async(ExPolicy p, IteratorTag)
             return !(a != b);
         };
 
-    auto f = hpx::parallel::search(p, c, h, op);
+    auto f = hpx::parallel::search_n(p, c, c.size(), h, op);
     f.wait();
 
     // create iterator at position of value to be found
@@ -317,35 +318,35 @@ void test_search4_async(ExPolicy p, IteratorTag)
 }
 
 template <typename IteratorTag>
-void test_search4()
+void test_search_n4()
 {
     using namespace hpx::parallel;
-    test_search4(execution::seq, IteratorTag());
-    test_search4(execution::par, IteratorTag());
-    test_search4(execution::par_unseq, IteratorTag());
+    test_search_n4(execution::seq, IteratorTag());
+    test_search_n4(execution::par, IteratorTag());
+    test_search_n4(execution::par_unseq, IteratorTag());
 
-    test_search4_async(execution::seq(execution::task), IteratorTag());
-    test_search4_async(execution::par(execution::task), IteratorTag());
+    test_search_n4_async(execution::seq(execution::task), IteratorTag());
+    test_search_n4_async(execution::par(execution::task), IteratorTag());
 
 #if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_search4(execution_policy(execution::seq), IteratorTag());
-    test_search4(execution_policy(execution::par), IteratorTag());
-    test_search4(execution_policy(execution::par_unseq), IteratorTag());
-    test_search4(execution_policy(execution::seq(execution::task)),
+    test_search_n4(execution_policy(execution::seq), IteratorTag());
+    test_search_n4(execution_policy(execution::par), IteratorTag());
+    test_search_n4(execution_policy(execution::par_unseq), IteratorTag());
+    test_search_n4(execution_policy(execution::seq(execution::task)),
         IteratorTag());
-    test_search4(execution_policy(execution::par(execution::task)),
+    test_search_n4(execution_policy(execution::par(execution::task)),
         IteratorTag());
 #endif
 }
 
-void search_test4()
+void search_test_n4()
 {
-    test_search4<std::random_access_iterator_tag>();
-    test_search4<std::forward_iterator_tag>();
+    test_search_n4<std::random_access_iterator_tag>();
+    test_search_n4<std::forward_iterator_tag>();
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_search5(ExPolicy policy, IteratorTag)
+void test_search_n5(ExPolicy policy, IteratorTag)
 {
     static_assert(
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
@@ -382,14 +383,16 @@ void test_search5(ExPolicy policy, IteratorTag)
             return ut2.val;
         };
 
-    auto index = hpx::parallel::search(policy, c, h, op, proj1, proj2);
+    auto index = hpx::parallel::search_n(policy, c, c.size(), h,
+        op, proj1, proj2);
+
     auto test_index = std::begin(c) + c.size()/2;
 
     HPX_TEST(index == test_index);
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_search5_async(ExPolicy p, IteratorTag)
+void test_search_n5_async(ExPolicy p, IteratorTag)
 {
     std::vector<user_defined_type_1> c(10007);
     // fill vector with random values above 2
@@ -422,7 +425,9 @@ void test_search5_async(ExPolicy p, IteratorTag)
         };
 
 
-    auto f = hpx::parallel::search(p, c, h, op, proj1, proj2);
+    auto f = hpx::parallel::search_n(p, c, c.size(), h,
+        op, proj1, proj2);
+
     f.wait();
 
     // create iterator at position of value to be found
@@ -432,31 +437,31 @@ void test_search5_async(ExPolicy p, IteratorTag)
 }
 
 template <typename IteratorTag>
-void test_search5()
+void test_search_n5()
 {
     using namespace hpx::parallel;
-    test_search5(execution::seq, IteratorTag());
-    test_search5(execution::par, IteratorTag());
-    test_search5(execution::par_unseq, IteratorTag());
+    test_search_n5(execution::seq, IteratorTag());
+    test_search_n5(execution::par, IteratorTag());
+    test_search_n5(execution::par_unseq, IteratorTag());
 
-    test_search5_async(execution::seq(execution::task), IteratorTag());
-    test_search5_async(execution::par(execution::task), IteratorTag());
+    test_search_n5_async(execution::seq(execution::task), IteratorTag());
+    test_search_n5_async(execution::par(execution::task), IteratorTag());
 
 #if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
-    test_search5(execution_policy(execution::seq), IteratorTag());
-    test_search5(execution_policy(execution::par), IteratorTag());
-    test_search5(execution_policy(execution::par_unseq), IteratorTag());
-    test_search5(execution_policy(execution::seq(execution::task)),
+    test_search_n5(execution_policy(execution::seq), IteratorTag());
+    test_search_n5(execution_policy(execution::par), IteratorTag());
+    test_search_n5(execution_policy(execution::par_unseq), IteratorTag());
+    test_search_n5(execution_policy(execution::seq(execution::task)),
         IteratorTag());
-    test_search5(execution_policy(execution::par(execution::task)),
+    test_search_n5(execution_policy(execution::par(execution::task)),
         IteratorTag());
 #endif
 }
 
-void search_test5()
+void search_test_n5()
 {
-    test_search5<std::random_access_iterator_tag>();
-    test_search5<std::forward_iterator_tag>();
+    test_search_n5<std::random_access_iterator_tag>();
+    test_search_n5<std::forward_iterator_tag>();
 }
 
 
@@ -470,11 +475,11 @@ int hpx_main(boost::program_options::variables_map& vm)
     std::cout << "using seed: " << seed << std::endl;
     std::srand(seed);
 
-    search_test1();
-    search_test2();
-    search_test3();
-    search_test4();
-    search_test5();
+    search_test_n1();
+    search_test_n2();
+    search_test_n3();
+    search_test_n4();
+    search_test_n5();
     return hpx::finalize();
 }
 


### PR DESCRIPTION
This is further continuation of my work with regards to issue #1668. For this particular pull request please take your time with the review process as this is my largest contribution to the library thus far, and I did make some changes to the existing library most notably, to `hpx/parallel/util/compare_projected.hpp` in order to extend it such that it can take two distinct projections. In addition I added an extra constraint to the search(_n) algorithm's template parameter list, enforcing that the two respective iterators are implicitly convertible which is a constraint stated [here](http://en.cppreference.com/w/cpp/algorithm/search). 

Edit: I have since removed the implicit convertible check as it appears after consulting with stack overflow that this an error in the website's template.