### PR TITLE
Use preinit_array to set argc/argv in init_globally example

### DIFF
--- a/examples/quickstart/init_globally.cpp
+++ b/examples/quickstart/init_globally.cpp
@@ -33,14 +33,14 @@
 int __argc = 0;
 char** __argv = nullptr;
 
-void set_argv_argv(int argc, char* argv[], char* env[])
+void set_argc_argv(int argc, char* argv[], char* env[])
 {
     __argc = argc;
     __argv = argv;
 }
 
-__attribute__((section(".init_array")))
-    void (*set_global_argc_argv)(int, char*[], char*[]) = &set_argv_argv;
+__attribute__((section(".preinit_array")))
+    void (*set_global_argc_argv)(int, char*[], char*[]) = &set_argc_argv;
 
 #elif defined(__APPLE__)
 


### PR DESCRIPTION
Fixes #3208.

## Proposed Changes

- Use `.preinit_array` section instead of `.init_array` to get `argc` and `argv` in the `init_globally` example.

## Any background context you want to provide?

The problem in #3204 was that `argc`  and `argv` were not initialized before the global `manage_global_runtime` object was constructed, leading `hpx::start` to fail (assumes that `argc >= 1`).

From my brief googling it seems that functions in `.preinit_array` are supposed to run before constructors of global objects, but I could not find a definitive source ([this](https://www.cs.stevens.edu/~jschauma/810/elf.html) was the best I could find), and it's not clear to me why release and debug behave differently. This should, however, not be worse than using `.init_array`.

@NK-nikunj Could you try this out to see that this doesn't just work on my system?