### PR TITLE
Fix check in sequenced_executor test

### DIFF
--- a/tests/unit/parallel/executors/sequenced_executor.cpp
+++ b/tests/unit/parallel/executors/sequenced_executor.cpp
@@ -65,7 +65,7 @@ void test_then()
 ///////////////////////////////////////////////////////////////////////////////
 void bulk_test(int value, hpx::thread::id tid, int passed_through) //-V813
 {
-    HPX_TEST(tid == hpx::this_thread::get_id());
+    HPX_TEST_EQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 
@@ -94,7 +94,7 @@ void bulk_test_f(int value, hpx::shared_future<void> f, hpx::thread::id tid,
 
     f.get();                    // propagate exceptions
 
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_EQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 


### PR DESCRIPTION
Fixes the `sequenced_executor` test, assuming I've read the docs correctly and that they are correct.

## Proposed Changes

Check in the test that the launched thread(s) is(are) executed in the calling thread (not in a different thread). This only applies for the `bulk_then_execute` test. The others already do the correct check.

## Any background context you want to provide?

See my comment in #3205 for background.