### PR TITLE
Relax locks for thread suspension to avoid holding locks when yielding

### DIFF
--- a/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
@@ -1696,8 +1696,7 @@ namespace hpx { namespace threads { namespace detail
             l(sched_->Scheduler::get_pu_mutex(virt_core), std::defer_lock);
         util::yield_while([&l]()
             {
-                l.try_lock();
-                return !l.owns_lock();
+                return !l.try_lock();
             }, "scheduled_thread_pool::suspend_processing_unit_internal",
             hpx::threads::pending);
 
@@ -1796,8 +1795,7 @@ namespace hpx { namespace threads { namespace detail
             l(sched_->Scheduler::get_pu_mutex(virt_core), std::defer_lock);
         util::yield_while([&l]()
             {
-                l.try_lock();
-                return !l.owns_lock();
+                return !l.try_lock();
             }, "scheduled_thread_pool::resume_processing_unit_internal",
             hpx::threads::pending);
 


### PR DESCRIPTION
Fixes locks held during suspension.

## Proposed Changes

- Unlock locks earlier so that they are not held while suspending (HPX threads)
- This still keeps the guarantee the new threads are not created on suspended threads (when elasticity is enabled)

## Any background context you want to provide?

This fixes a problem uncovered by #3203 and #3209.