### PR TITLE
Reorder a variadic array to satisfy VS 2017 15.6

### DIFF
--- a/hpx/util/detail/pack_traversal_async_impl.hpp
+++ b/hpx/util/detail/pack_traversal_async_impl.hpp
@@ -447,10 +447,10 @@ namespace util {
                 pack_c<std::size_t, Sequence...>,
                 Current&& current)
             {
-                int dummy[] = {0,
-                    ((void) async_traverse_one_checked(
-                         current.template relocate<Sequence>()),
-                        0)...};
+                int dummy[] = {((void) async_traverse_one_checked(
+                                    current.template relocate<Sequence>()),
+                                   0)...,
+                    0};
                 (void) dummy;
             }
 


### PR DESCRIPTION
Previous form caused compiler errors, new form is fine.