### PR TITLE
Fix returns when setting config entries

### DIFF
--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -817,11 +817,13 @@ namespace hpx
         if (get_runtime_ptr() != nullptr)
         {
             get_runtime_ptr()->get_config().add_entry(key, value);
+            return;
         }
         if (resource::is_partitioner_valid())
         {
             resource::get_partitioner()
                 .get_command_line_switches().rtcfg_.add_entry(key, value);
+            return;
         }
     }
 
@@ -831,12 +833,14 @@ namespace hpx
         {
             get_runtime_ptr()->get_config().add_entry(
                 key, std::to_string(value));
+            return;
         }
         if (resource::is_partitioner_valid())
         {
             resource::get_partitioner()
                 .get_command_line_switches().rtcfg_.
                     add_entry(key, std::to_string(value));
+            return;
         }
     }
 
@@ -848,12 +852,14 @@ namespace hpx
         {
             get_runtime_ptr()->get_config().add_notification_callback(
                 key, callback);
+            return;
         }
         if (resource::is_partitioner_valid())
         {
-            return resource::get_partitioner()
+            resource::get_partitioner()
                 .get_command_line_switches()
                 .rtcfg_.add_notification_callback(key, callback);
+            return;
         }
     }
 


### PR DESCRIPTION
Fixes [this](http://rostam.cct.lsu.edu/builders/hpx_clang_3_9_boost_1_62_centos_x86_64_release/builds/231/steps/run_regression_tests/logs/tests.regressions.util.set_config_entry_deadlock%20%280.29%20sec%29).

## Proposed Changes

- Don't set config entries twice if both resource partitioner and runtime are valid.