### PR TITLE
Allow suspension also on static schedulers

### DIFF
--- a/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
@@ -325,10 +325,7 @@ namespace hpx { namespace threads { namespace detail
         for (std::size_t virt_core = 0; virt_core != threads_.size();
              ++virt_core)
         {
-            if (mode_ & policies::enable_suspension)
-            {
-                this->sched_->Scheduler::resume(virt_core);
-            }
+            this->sched_->Scheduler::resume(virt_core);
         }
 
         if (blocking)
@@ -356,14 +353,6 @@ namespace hpx { namespace threads { namespace detail
             return hpx::make_ready_future();
         }
 
-        if (!(mode_ & policies::enable_suspension))
-        {
-            HPX_THROW_EXCEPTION(invalid_status,
-                "scheduled_thread_pool<Scheduler>::resume",
-                "this scheduler does not support suspension");
-            return hpx::make_ready_future();
-        }
-
         return hpx::async(
             hpx::util::bind(&scheduled_thread_pool::resume_internal, this, true,
                 std::move(throws)));
@@ -373,14 +362,6 @@ namespace hpx { namespace threads { namespace detail
     void scheduled_thread_pool<Scheduler>::resume_cb(
         std::function<void(void)> callback, error_code& ec)
     {
-        if (!(mode_ & policies::enable_suspension))
-        {
-            HPX_THROW_EXCEPTION(invalid_status,
-                "scheduled_thread_pool<Scheduler>::resume_cb",
-                "this scheduler does not support suspension");
-            return;
-        }
-
         std::function<void(void)> resume_internal_wrapper =
             [this, HPX_CAPTURE_MOVE(callback)]()
             {
@@ -406,14 +387,6 @@ namespace hpx { namespace threads { namespace detail
             HPX_THROWS_IF(ec, bad_parameter,
                 "scheduled_thread_pool<Scheduler>::resume_direct",
                 "cannot suspend a pool from itself");
-            return;
-        }
-
-        if (!(mode_ & policies::enable_suspension))
-        {
-            HPX_THROW_EXCEPTION(invalid_status,
-                "scheduled_thread_pool<Scheduler>::resume_direct",
-                "this scheduler does not support suspension");
             return;
         }
 
@@ -463,14 +436,6 @@ namespace hpx { namespace threads { namespace detail
                     "cannot suspend a pool from itself"));
         }
 
-        if (!(mode_ & policies::enable_suspension))
-        {
-            HPX_THROW_EXCEPTION(invalid_status,
-                "scheduled_thread_pool<Scheduler>::suspend",
-                "this scheduler does not support suspension");
-            return hpx::make_ready_future();
-        }
-
         return hpx::async(
             hpx::util::bind(&scheduled_thread_pool::suspend_internal, this,
                 std::move(throws)));
@@ -485,14 +450,6 @@ namespace hpx { namespace threads { namespace detail
             HPX_THROWS_IF(ec, bad_parameter,
                 "scheduled_thread_pool<Scheduler>::suspend_cb",
                 "cannot suspend a pool from itself");
-            return;
-        }
-
-        if (!(mode_ & policies::enable_suspension))
-        {
-            HPX_THROW_EXCEPTION(invalid_status,
-                "scheduled_thread_pool<Scheduler>::suspend_cb",
-                "this scheduler does not support suspension");
             return;
         }
 
@@ -521,14 +478,6 @@ namespace hpx { namespace threads { namespace detail
             HPX_THROWS_IF(ec, bad_parameter,
                 "scheduled_thread_pool<Scheduler>::suspend_direct",
                 "cannot suspend a pool from itself");
-            return;
-        }
-
-        if (!(mode_ & policies::enable_suspension))
-        {
-            HPX_THROW_EXCEPTION(invalid_status,
-                "scheduled_thread_pool<Scheduler>::suspend_direct",
-                "this scheduler does not support suspension");
             return;
         }
 
@@ -1752,6 +1701,15 @@ namespace hpx { namespace threads { namespace detail
                     "this thread pool does not support suspending "
                     "processing units"));
         }
+        else if (!sched_->Scheduler::has_thread_stealing() &&
+            hpx::this_thread::get_pool() == this)
+        {
+            return hpx::make_exceptional_future<void>(
+                HPX_GET_EXCEPTION(invalid_status,
+                    "scheduled_thread_pool<Scheduler>::suspend_processing_unit",
+                    "this thread pool does not support suspending "
+                    "processing units from itself (no thread stealing)"));
+        }
 
         return hpx::async(
             hpx::util::bind(
@@ -1781,6 +1739,15 @@ namespace hpx { namespace threads { namespace detail
 
         if (threads::get_self_ptr())
         {
+            if (!sched_->Scheduler::has_thread_stealing() &&
+                hpx::this_thread::get_pool() == this)
+            {
+                HPX_THROW_EXCEPTION(invalid_status,
+                    "scheduled_thread_pool<Scheduler>::suspend_processing_unit_cb",
+                    "this thread pool does not support suspending "
+                    "processing units from itself (no thread stealing)");
+            }
+
             hpx::apply(std::move(suspend_internal_wrapper));
         }
         else
@@ -1826,10 +1793,7 @@ namespace hpx { namespace threads { namespace detail
 
         util::yield_while([this, &state, virt_core]()
             {
-                if (mode_ & policies::enable_suspension)
-                {
-                    this->sched_->Scheduler::resume(virt_core);
-                }
+                this->sched_->Scheduler::resume(virt_core);
                 return state.load() == state_sleeping;
             }, "scheduled_thread_pool::resume_processing_unit_internal",
             hpx::threads::pending);

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -163,6 +163,7 @@ namespace hpx { namespace threads { namespace policies
         }
 
         bool numa_sensitive() const override { return numa_sensitive_ != 0; }
+        virtual bool has_thread_stealing() const override { return true; }
 
         static std::string get_scheduler_name()
         {

--- a/hpx/runtime/threads/policies/local_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_queue_scheduler.hpp
@@ -149,6 +149,7 @@ namespace hpx { namespace threads { namespace policies
         }
 
         bool numa_sensitive() const { return numa_sensitive_ != 0; }
+        virtual bool has_thread_stealing() const { return true; }
 
         static std::string get_scheduler_name()
         {

--- a/hpx/runtime/threads/policies/scheduler_base.hpp
+++ b/hpx/runtime/threads/policies/scheduler_base.hpp
@@ -265,6 +265,7 @@ namespace hpx { namespace threads { namespace policies
 
         ///////////////////////////////////////////////////////////////////////
         virtual bool numa_sensitive() const { return false; }
+        virtual bool has_thread_stealing() const { return false; }
 
         inline std::size_t domain_from_local_thread_index(std::size_t n)
         {

--- a/hpx/runtime/threads/policies/scheduler_mode.hpp
+++ b/hpx/runtime/threads/policies/scheduler_mode.hpp
@@ -28,11 +28,8 @@ namespace hpx { namespace threads { namespace policies
             ///< more frequently than normal. This option enables this behavior.
         enable_elasticity = 0x10,        ///< This options allows for the
             ///< scheduler to dynamically increase and reduce the number of
-            ///< processing units it runs on.
-        enable_suspension = 0x20        ///< This options allows for the
-            ///< scheduler to suspend/resume its operation. Setting this value
-            ///< may not succeed for schedulers that do not support this
-            ///< functionality.
+            ///< processing units it runs on. Setting this value not succeed for
+            ///< schedulers that do not support this functionality.
     };
 }}}
 

--- a/hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp
@@ -57,21 +57,11 @@ namespace hpx { namespace threads { namespace policies
           : base_type(init, deferred_initialization)
         {}
 
+        virtual bool has_thread_stealing() const { return false; }
+
         static std::string get_scheduler_name()
         {
             return "static_priority_queue_scheduler";
-        }
-
-        void suspend(std::size_t) override
-        {
-            HPX_ASSERT_MSG(false, "static_priority_queue_scheduler does not"
-                " support suspending");
-        }
-
-        void resume(std::size_t) override
-        {
-            HPX_ASSERT_MSG(false, "static_priority_queue_scheduler does not"
-                " support resuming");
         }
 
         /// Return the next thread to be executed, return false if non is

--- a/hpx/runtime/threads/policies/static_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/static_queue_scheduler.hpp
@@ -65,21 +65,11 @@ namespace hpx { namespace threads { namespace policies
           : base_type(init, deferred_initialization)
         {}
 
+        virtual bool has_thread_stealing() const { return false; }
+
         static std::string get_scheduler_name()
         {
             return "static_queue_scheduler";
-        }
-
-        void suspend(std::size_t) override
-        {
-            HPX_ASSERT_MSG(false, "static_queue_scheduler does not support"
-                " suspending");
-        }
-
-        void resume(std::size_t) override
-        {
-            HPX_ASSERT_MSG(false, "static_queue_scheduler does not support"
-                " resuming");
         }
 
         /// Return the next thread to be executed, return false if none is

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -410,8 +410,7 @@ namespace hpx { namespace threads
                         notifier_, i, name.c_str(),
                         policies::scheduler_mode(policies::do_background_work |
                             policies::reduce_thread_priority |
-                            policies::delay_exit |
-                            policies::enable_suspension),
+                            policies::delay_exit),
                         thread_offset));
                 pools_.push_back(std::move(pool));
 
@@ -454,8 +453,7 @@ namespace hpx { namespace threads
                         notifier_, i, name.c_str(),
                         policies::scheduler_mode(policies::do_background_work |
                             policies::reduce_thread_priority |
-                            policies::delay_exit |
-                            policies::enable_suspension),
+                            policies::delay_exit),
                         thread_offset));
                 pools_.push_back(std::move(pool));
 
@@ -492,8 +490,7 @@ namespace hpx { namespace threads
                         notifier_, i, name.c_str(),
                         policies::scheduler_mode(policies::do_background_work |
                             policies::reduce_thread_priority |
-                            policies::delay_exit |
-                            policies::enable_suspension),
+                            policies::delay_exit),
                         thread_offset));
                 pools_.push_back(std::move(pool));
 
@@ -617,8 +614,7 @@ namespace hpx { namespace threads
                         notifier_, i, name.c_str(),
                         policies::scheduler_mode(policies::do_background_work |
                             policies::reduce_thread_priority |
-                            policies::delay_exit |
-                            policies::enable_suspension),
+                            policies::delay_exit),
                         thread_offset));
                 pools_.push_back(std::move(pool));
 #else
@@ -1968,11 +1964,7 @@ namespace hpx { namespace threads
 
             for (auto& pool_iter : pools_)
             {
-                if (pool_iter->get_scheduler_mode() &
-                        policies::enable_suspension)
-                {
-                    fs.push_back(pool_iter->suspend());
-                }
+                fs.push_back(pool_iter->suspend());
             }
 
             hpx::wait_all(fs);
@@ -1981,11 +1973,7 @@ namespace hpx { namespace threads
         {
             for (auto& pool_iter : pools_)
             {
-                if (pool_iter->get_scheduler_mode() &
-                        policies::enable_suspension)
-                {
-                    pool_iter->suspend_direct();
-                }
+                pool_iter->suspend_direct();
             }
         }
     }
@@ -1998,11 +1986,7 @@ namespace hpx { namespace threads
 
             for (auto& pool_iter : pools_)
             {
-                if (pool_iter->get_scheduler_mode() &
-                        policies::enable_suspension)
-                {
-                    fs.push_back(pool_iter->resume());
-                }
+                fs.push_back(pool_iter->resume());
             }
             hpx::wait_all(fs);
         }
@@ -2010,11 +1994,7 @@ namespace hpx { namespace threads
         {
             for (auto& pool_iter : pools_)
             {
-                if (pool_iter->get_scheduler_mode() &
-                        policies::enable_suspension)
-                {
-                    pool_iter->resume_direct();
-                }
+                pool_iter->resume_direct();
             }
         }
     }

--- a/tests/unit/resource/shutdown_suspended_pus.cpp
+++ b/tests/unit/resource/shutdown_suspended_pus.cpp
@@ -69,8 +69,7 @@ void test_scheduler(int argc, char* argv[])
                 hpx::threads::policies::do_background_work |
                 hpx::threads::policies::reduce_thread_priority |
                 hpx::threads::policies::delay_exit |
-                hpx::threads::policies::enable_elasticity |
-                hpx::threads::policies::enable_suspension);
+                hpx::threads::policies::enable_elasticity);
 
             std::unique_ptr<hpx::threads::thread_pool_base> pool(
                 new hpx::threads::detail::scheduled_thread_pool<Scheduler>(
@@ -85,14 +84,43 @@ void test_scheduler(int argc, char* argv[])
 
 int main(int argc, char* argv[])
 {
-    // NOTE: Static schedulers do not support suspending the own worker thread
-    // because they do not steal work. Periodic priority scheduler not tested
-    // because it does not take into account scheduler states when scheduling
-    // work.
+    // NOTE: Periodic priority scheduler not tested because it does not take
+    // into account scheduler states when scheduling work.
 
     test_scheduler<hpx::threads::policies::local_queue_scheduler<>>(argc, argv);
     test_scheduler<hpx::threads::policies::local_priority_queue_scheduler<>>(argc,
         argv);
+
+    {
+        bool exception_thrown = false;
+        try
+        {
+            test_scheduler<hpx::threads::policies::static_queue_scheduler<>>(argc,
+                argv);
+        }
+        catch (hpx::exception const&)
+        {
+            exception_thrown = true;
+        }
+
+        HPX_TEST(exception_thrown);
+    }
+
+    {
+        bool exception_thrown = false;
+        try
+        {
+            test_scheduler<
+                hpx::threads::policies::static_priority_queue_scheduler<>
+            >(argc, argv);
+        }
+        catch (hpx::exception const&)
+        {
+            exception_thrown = true;
+        }
+
+        HPX_TEST(exception_thrown);
+    }
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/resource/suspend_pool.cpp
+++ b/tests/unit/resource/suspend_pool.cpp
@@ -159,9 +159,7 @@ void test_scheduler(int argc, char* argv[])
             auto mode = hpx::threads::policies::scheduler_mode(
                 hpx::threads::policies::do_background_work |
                 hpx::threads::policies::reduce_thread_priority |
-                hpx::threads::policies::delay_exit |
-                hpx::threads::policies::enable_elasticity |
-                hpx::threads::policies::enable_suspension);
+                hpx::threads::policies::delay_exit);
 
             std::unique_ptr<hpx::threads::thread_pool_base> pool(
                 new hpx::threads::detail::scheduled_thread_pool<Scheduler>(
@@ -196,6 +194,9 @@ int main(int argc, char* argv[])
 {
     test_scheduler<hpx::threads::policies::local_queue_scheduler<>>(argc, argv);
     test_scheduler<hpx::threads::policies::local_priority_queue_scheduler<>>(argc,
+        argv);
+    test_scheduler<hpx::threads::policies::static_queue_scheduler<>>(argc, argv);
+    test_scheduler<hpx::threads::policies::static_priority_queue_scheduler<>>(argc,
         argv);
 
     return hpx::util::report_errors();

--- a/tests/unit/resource/throttle.cpp
+++ b/tests/unit/resource/throttle.cpp
@@ -214,8 +214,7 @@ void test_scheduler(int argc, char* argv[])
                 hpx::threads::policies::do_background_work |
                 hpx::threads::policies::reduce_thread_priority |
                 hpx::threads::policies::delay_exit |
-                hpx::threads::policies::enable_elasticity |
-                hpx::threads::policies::enable_suspension);
+                hpx::threads::policies::enable_elasticity);
 
             std::unique_ptr<hpx::threads::thread_pool_base> pool(
                 new hpx::threads::detail::scheduled_thread_pool<Scheduler>(
@@ -238,6 +237,37 @@ int main(int argc, char* argv[])
     test_scheduler<hpx::threads::policies::local_queue_scheduler<>>(argc, argv);
     test_scheduler<hpx::threads::policies::local_priority_queue_scheduler<>>(argc,
         argv);
+
+    {
+        bool exception_thrown = false;
+        try
+        {
+            test_scheduler<hpx::threads::policies::static_queue_scheduler<>>(argc,
+                argv);
+        }
+        catch (hpx::exception const&)
+        {
+            exception_thrown = true;
+        }
+
+        HPX_TEST(exception_thrown);
+    }
+
+    {
+        bool exception_thrown = false;
+        try
+        {
+            test_scheduler<
+                hpx::threads::policies::static_priority_queue_scheduler<>
+            >(argc, argv);
+        }
+        catch (hpx::exception const&)
+        {
+            exception_thrown = true;
+        }
+
+        HPX_TEST(exception_thrown);
+    }
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/resource/throttle_timed.cpp
+++ b/tests/unit/resource/throttle_timed.cpp
@@ -119,8 +119,7 @@ void test_scheduler(int argc, char* argv[])
                 hpx::threads::policies::do_background_work |
                 hpx::threads::policies::reduce_thread_priority |
                 hpx::threads::policies::delay_exit |
-                hpx::threads::policies::enable_elasticity |
-                hpx::threads::policies::enable_suspension);
+                hpx::threads::policies::enable_elasticity);
 
             std::unique_ptr<hpx::threads::thread_pool_base> pool(
                 new hpx::threads::detail::scheduled_thread_pool<Scheduler>(
@@ -143,6 +142,37 @@ int main(int argc, char* argv[])
     test_scheduler<hpx::threads::policies::local_queue_scheduler<>>(argc, argv);
     test_scheduler<hpx::threads::policies::local_priority_queue_scheduler<>>(argc,
         argv);
+
+    {
+        bool exception_thrown = false;
+        try
+        {
+            test_scheduler<hpx::threads::policies::static_queue_scheduler<>>(argc,
+                argv);
+        }
+        catch (hpx::exception const&)
+        {
+            exception_thrown = true;
+        }
+
+        HPX_TEST(exception_thrown);
+    }
+
+    {
+        bool exception_thrown = false;
+        try
+        {
+            test_scheduler<
+                hpx::threads::policies::static_priority_queue_scheduler<>
+            >(argc, argv);
+        }
+        catch (hpx::exception const&)
+        {
+            exception_thrown = true;
+        }
+
+        HPX_TEST(exception_thrown);
+    }
 
     return hpx::util::report_errors();
 }


### PR DESCRIPTION
This is a follow-up on the fixes in #3180 to allow suspension on static schedulers (in most cases).

## Proposed Changes

- Add a `has_thread_stealing` function to schedulers
- Disallow thread suspension from the same pool if `has_thread_stealing` returns `false`
- Allow thread (except from same pool), pool and runtime suspension on static schedulers

## Any background context you want to provide?

#3179 and #3180.