### PR TITLE
Add optional scheduler mode parameter to create_thread_pool function

### DIFF
--- a/hpx/runtime/resource/detail/partitioner.hpp
+++ b/hpx/runtime/resource/detail/partitioner.hpp
@@ -53,7 +53,9 @@ namespace hpx { namespace resource { namespace detail
 
     private:
         init_pool_data(const std::string &name,
-            scheduling_policy = scheduling_policy::unspecified);
+            scheduling_policy = scheduling_policy::unspecified,
+            hpx::threads::policies::scheduler_mode =
+                hpx::threads::policies::scheduler_mode::default_mode);
 
         init_pool_data(std::string const& name, scheduler_function create_func);
 
@@ -68,6 +70,7 @@ namespace hpx { namespace resource { namespace detail
 
         // counter for number of threads bound to this pool
         std::size_t num_threads_;
+        hpx::threads::policies::scheduler_mode mode_;
         scheduler_function create_function_;
     };
 
@@ -84,7 +87,9 @@ namespace hpx { namespace resource { namespace detail
 
         // create a thread_pool
         void create_thread_pool(std::string const& name,
-            scheduling_policy sched = scheduling_policy::unspecified);
+            scheduling_policy sched = scheduling_policy::unspecified,
+            hpx::threads::policies::scheduler_mode =
+                hpx::threads::policies::scheduler_mode::default_mode);
 
         // create a thread_pool with a callback function for creating a custom
         // scheduler
@@ -134,6 +139,9 @@ namespace hpx { namespace resource { namespace detail
         std::size_t get_num_threads() const;
         std::size_t get_num_threads(std::string const& pool_name) const;
         std::size_t get_num_threads(std::size_t pool_index) const;
+
+        hpx::threads::policies::scheduler_mode
+        get_scheduler_mode(std::size_t pool_index) const;
 
         std::string const& get_pool_name(std::size_t index) const;
         std::size_t get_pool_index(std::string const& pool_name) const;

--- a/hpx/runtime/resource/partitioner.hpp
+++ b/hpx/runtime/resource/partitioner.hpp
@@ -10,6 +10,7 @@
 #include <hpx/runtime/resource/partitioner_fwd.hpp>
 #include <hpx/runtime/resource/detail/create_partitioner.hpp>
 #include <hpx/runtime/runtime_mode.hpp>
+#include <hpx/runtime/threads/policies/scheduler_mode.hpp>
 #include <hpx/util/function.hpp>
 
 #include <boost/program_options.hpp>
@@ -194,7 +195,9 @@ namespace hpx { namespace resource
         ///////////////////////////////////////////////////////////////////////
         // Create one of the predefined thread pools
         HPX_EXPORT void create_thread_pool(std::string const& name,
-            scheduling_policy sched = scheduling_policy::unspecified);
+            scheduling_policy sched = scheduling_policy::unspecified,
+            hpx::threads::policies::scheduler_mode =
+                hpx::threads::policies::scheduler_mode::default_mode);
 
         // Create a custom thread pool with a callback function
         HPX_EXPORT void create_thread_pool(std::string const& name,

--- a/hpx/runtime/threads/policies/scheduler_mode.hpp
+++ b/hpx/runtime/threads/policies/scheduler_mode.hpp
@@ -30,6 +30,8 @@ namespace hpx { namespace threads { namespace policies
             ///< scheduler to dynamically increase and reduce the number of
             ///< processing units it runs on. Setting this value not succeed for
             ///< schedulers that do not support this functionality.
+        default_mode = do_background_work | reduce_thread_priority | delay_exit
+            ///< This option represents the default mode.
     };
 }}}
 

--- a/src/runtime/resource/detail/detail_partitioner.cpp
+++ b/src/runtime/resource/detail/detail_partitioner.cpp
@@ -8,6 +8,7 @@
 #include <hpx/runtime/resource/detail/partitioner.hpp>
 #include <hpx/runtime/resource/partitioner.hpp>
 #include <hpx/runtime/runtime_fwd.hpp>
+#include <hpx/runtime/threads/detail/scheduled_thread_pool.hpp>
 #include <hpx/runtime/threads/thread_pool_base.hpp>
 #include <hpx/runtime/threads/topology.hpp>
 #include <hpx/util/assert.hpp>
@@ -55,10 +56,12 @@ namespace hpx { namespace resource { namespace detail
     std::size_t init_pool_data::num_threads_overall = 0;
 
     init_pool_data::init_pool_data(
-            std::string const& name, scheduling_policy sched)
+            std::string const& name, scheduling_policy sched,
+            hpx::threads::policies::scheduler_mode mode)
         : pool_name_(name)
         , scheduling_policy_(sched)
         , num_threads_(0)
+        , mode_(mode)
     {
         if (name.empty())
         {
@@ -72,6 +75,7 @@ namespace hpx { namespace resource { namespace detail
         : pool_name_(name)
         , scheduling_policy_(user_defined)
         , num_threads_(0)
+        , mode_(hpx::threads::policies::scheduler_mode::default_mode)
         , create_function_(std::move(create_func))
     {
         if (name.empty())
@@ -519,8 +523,9 @@ namespace hpx { namespace resource { namespace detail
     }
 
     // create a new thread_pool
-    void partitioner::create_thread_pool(
-        std::string const& pool_name, scheduling_policy sched)
+    void partitioner::create_thread_pool(std::string const& pool_name,
+        scheduling_policy sched,
+        hpx::threads::policies::scheduler_mode mode)
     {
         if (get_runtime_ptr() != nullptr)
         {
@@ -543,7 +548,7 @@ namespace hpx { namespace resource { namespace detail
         if (pool_name==get_default_pool_name())
         {
             initial_thread_pools_[0] = detail::init_pool_data(
-                get_default_pool_name(), sched);
+                get_default_pool_name(), sched, mode);
             return;
         }
 
@@ -560,7 +565,7 @@ namespace hpx { namespace resource { namespace detail
             }
         }
 
-        initial_thread_pools_.push_back(detail::init_pool_data(pool_name, sched));
+        initial_thread_pools_.push_back(detail::init_pool_data(pool_name, sched, mode));
     }
 
     // create a new thread_pool
@@ -810,6 +815,13 @@ namespace hpx { namespace resource { namespace detail
     {
         std::unique_lock<mutex_type> l(mtx_);
         return get_pool_data(l, pool_name).num_threads_;
+    }
+
+    hpx::threads::policies::scheduler_mode
+    partitioner::get_scheduler_mode(std::size_t pool_index) const
+    {
+        std::unique_lock<mutex_type> l(mtx_);
+        return get_pool_data(l, pool_index).mode_;
     }
 
     detail::init_pool_data const& partitioner::get_pool_data(

--- a/src/runtime/resource/partitioner.cpp
+++ b/src/runtime/resource/partitioner.cpp
@@ -242,9 +242,10 @@ namespace hpx { namespace resource
 
     ///////////////////////////////////////////////////////////////////////////
     void partitioner::create_thread_pool(std::string const& name,
-        scheduling_policy sched /*= scheduling_policy::unspecified*/)
+        scheduling_policy sched /*= scheduling_policy::unspecified*/,
+        hpx::threads::policies::scheduler_mode mode)
     {
-        partitioner_.create_thread_pool(name, sched);
+        partitioner_.create_thread_pool(name, sched, mode);
     }
 
     void partitioner::create_thread_pool(

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -294,6 +294,7 @@ namespace hpx { namespace threads
             std::string name = rp.get_pool_name(i);
             resource::scheduling_policy sched_type = rp.which_scheduler(name);
             std::size_t num_threads_in_pool = rp.get_num_threads(i);
+            policies::scheduler_mode scheduler_mode = rp.get_scheduler_mode(i);
 
             // make sure the first thread-pool that gets instantiated is the default one
             if (i == 0)
@@ -347,10 +348,7 @@ namespace hpx { namespace threads
                     new hpx::threads::detail::scheduled_thread_pool<
                             local_sched_type
                         >(std::move(sched),
-                        notifier_, i, name.c_str(),
-                        policies::scheduler_mode(policies::do_background_work |
-                            policies::reduce_thread_priority |
-                            policies::delay_exit),
+                        notifier_, i, name.c_str(), scheduler_mode,
                         thread_offset));
                 pools_.push_back(std::move(pool));
 
@@ -389,10 +387,7 @@ namespace hpx { namespace threads
                     new hpx::threads::detail::scheduled_thread_pool<
                             local_sched_type
                         >(std::move(sched),
-                        notifier_, i, name.c_str(),
-                        policies::scheduler_mode(policies::do_background_work |
-                            policies::reduce_thread_priority |
-                            policies::delay_exit),
+                        notifier_, i, name.c_str(), scheduler_mode,
                         thread_offset));
                 pools_.push_back(std::move(pool));
 
@@ -425,10 +420,7 @@ namespace hpx { namespace threads
                     new hpx::threads::detail::scheduled_thread_pool<
                             local_sched_type
                         >(std::move(sched),
-                        notifier_, i, name.c_str(),
-                        policies::scheduler_mode(policies::do_background_work |
-                            policies::reduce_thread_priority |
-                            policies::delay_exit),
+                        notifier_, i, name.c_str(), scheduler_mode,
                         thread_offset));
                 pools_.push_back(std::move(pool));
 
@@ -460,10 +452,7 @@ namespace hpx { namespace threads
                     new hpx::threads::detail::scheduled_thread_pool<
                             local_sched_type
                         >(std::move(sched),
-                        notifier_, i, name.c_str(),
-                        policies::scheduler_mode(policies::do_background_work |
-                            policies::reduce_thread_priority |
-                            policies::delay_exit),
+                        notifier_, i, name.c_str(), scheduler_mode,
                         thread_offset));
                 pools_.push_back(std::move(pool));
 
@@ -505,10 +494,7 @@ namespace hpx { namespace threads
                     new hpx::threads::detail::scheduled_thread_pool<
                             local_sched_type
                         >(std::move(sched),
-                        notifier_, i, name.c_str(),
-                        policies::scheduler_mode(policies::do_background_work |
-                            policies::reduce_thread_priority |
-                            policies::delay_exit),
+                        notifier_, i, name.c_str(), scheduler_mode,
                         thread_offset));
                 pools_.push_back(std::move(pool));
 
@@ -545,10 +531,7 @@ namespace hpx { namespace threads
                     new hpx::threads::detail::scheduled_thread_pool<
                             local_sched_type
                         >(std::move(sched),
-                        notifier_, i, name.c_str(),
-                        policies::scheduler_mode(policies::do_background_work |
-                            policies::reduce_thread_priority |
-                            policies::delay_exit),
+                        notifier_, i, name.c_str(), scheduler_mode,
                         thread_offset));
                 pools_.push_back(std::move(pool));
 #else
@@ -584,10 +567,7 @@ namespace hpx { namespace threads
                     new hpx::threads::detail::scheduled_thread_pool<
                             local_sched_type
                         >(std::move(sched),
-                        notifier_, i, name.c_str(),
-                        policies::scheduler_mode(policies::do_background_work |
-                            policies::reduce_thread_priority |
-                            policies::delay_exit),
+                        notifier_, i, name.c_str(), scheduler_mode,
                         thread_offset));
                 pools_.push_back(std::move(pool));
 #else


### PR DESCRIPTION
## Proposed Changes

- Add a `default_mode` value to the scheduler mode enum
- Add a an optional scheduler mode parameter to `create_thread_pool` with a default value of `default_mode`

## Any background context you want to provide?

Addresses #3082, but I'm not sure what more we might want. This at least simplifies the use cases in the suspension tests (one does not need to use the callback version of `create_thread_pool` anymore to change scheduler modes).