### PR TITLE
Clean up suspension tests

### DIFF
--- a/hpx/runtime/resource/detail/partitioner.hpp
+++ b/hpx/runtime/resource/detail/partitioner.hpp
@@ -53,7 +53,9 @@ namespace hpx { namespace resource { namespace detail
 
     private:
         init_pool_data(const std::string &name,
-            scheduling_policy = scheduling_policy::unspecified);
+            scheduling_policy = scheduling_policy::unspecified,
+            hpx::threads::policies::scheduler_mode =
+                hpx::threads::policies::scheduler_mode::default_mode);
 
         init_pool_data(std::string const& name, scheduler_function create_func);
 
@@ -68,6 +70,7 @@ namespace hpx { namespace resource { namespace detail
 
         // counter for number of threads bound to this pool
         std::size_t num_threads_;
+        hpx::threads::policies::scheduler_mode mode_;
         scheduler_function create_function_;
     };
 
@@ -84,7 +87,9 @@ namespace hpx { namespace resource { namespace detail
 
         // create a thread_pool
         void create_thread_pool(std::string const& name,
-            scheduling_policy sched = scheduling_policy::unspecified);
+            scheduling_policy sched = scheduling_policy::unspecified,
+            hpx::threads::policies::scheduler_mode =
+                hpx::threads::policies::scheduler_mode::default_mode);
 
         // create a thread_pool with a callback function for creating a custom
         // scheduler
@@ -134,6 +139,9 @@ namespace hpx { namespace resource { namespace detail
         std::size_t get_num_threads() const;
         std::size_t get_num_threads(std::string const& pool_name) const;
         std::size_t get_num_threads(std::size_t pool_index) const;
+
+        hpx::threads::policies::scheduler_mode
+        get_scheduler_mode(std::size_t pool_index) const;
 
         std::string const& get_pool_name(std::size_t index) const;
         std::size_t get_pool_index(std::string const& pool_name) const;

--- a/hpx/runtime/resource/partitioner.hpp
+++ b/hpx/runtime/resource/partitioner.hpp
@@ -10,6 +10,7 @@
 #include <hpx/runtime/resource/partitioner_fwd.hpp>
 #include <hpx/runtime/resource/detail/create_partitioner.hpp>
 #include <hpx/runtime/runtime_mode.hpp>
+#include <hpx/runtime/threads/policies/scheduler_mode.hpp>
 #include <hpx/util/function.hpp>
 
 #include <boost/program_options.hpp>
@@ -194,7 +195,9 @@ namespace hpx { namespace resource
         ///////////////////////////////////////////////////////////////////////
         // Create one of the predefined thread pools
         HPX_EXPORT void create_thread_pool(std::string const& name,
-            scheduling_policy sched = scheduling_policy::unspecified);
+            scheduling_policy sched = scheduling_policy::unspecified,
+            hpx::threads::policies::scheduler_mode =
+                hpx::threads::policies::scheduler_mode::default_mode);
 
         // Create a custom thread pool with a callback function
         HPX_EXPORT void create_thread_pool(std::string const& name,

--- a/hpx/runtime/threads/policies/scheduler_mode.hpp
+++ b/hpx/runtime/threads/policies/scheduler_mode.hpp
@@ -30,6 +30,8 @@ namespace hpx { namespace threads { namespace policies
             ///< scheduler to dynamically increase and reduce the number of
             ///< processing units it runs on. Setting this value not succeed for
             ///< schedulers that do not support this functionality.
+        default_mode = do_background_work | reduce_thread_priority | delay_exit
+            ///< This option represents the default mode.
     };
 }}}
 

--- a/src/runtime/resource/detail/detail_partitioner.cpp
+++ b/src/runtime/resource/detail/detail_partitioner.cpp
@@ -8,6 +8,7 @@
 #include <hpx/runtime/resource/detail/partitioner.hpp>
 #include <hpx/runtime/resource/partitioner.hpp>
 #include <hpx/runtime/runtime_fwd.hpp>
+#include <hpx/runtime/threads/detail/scheduled_thread_pool.hpp>
 #include <hpx/runtime/threads/thread_pool_base.hpp>
 #include <hpx/runtime/threads/topology.hpp>
 #include <hpx/util/assert.hpp>
@@ -55,10 +56,12 @@ namespace hpx { namespace resource { namespace detail
     std::size_t init_pool_data::num_threads_overall = 0;
 
     init_pool_data::init_pool_data(
-            std::string const& name, scheduling_policy sched)
+            std::string const& name, scheduling_policy sched,
+            hpx::threads::policies::scheduler_mode mode)
         : pool_name_(name)
         , scheduling_policy_(sched)
         , num_threads_(0)
+        , mode_(mode)
     {
         if (name.empty())
         {
@@ -72,6 +75,7 @@ namespace hpx { namespace resource { namespace detail
         : pool_name_(name)
         , scheduling_policy_(user_defined)
         , num_threads_(0)
+        , mode_(hpx::threads::policies::scheduler_mode::default_mode)
         , create_function_(std::move(create_func))
     {
         if (name.empty())
@@ -519,8 +523,9 @@ namespace hpx { namespace resource { namespace detail
     }
 
     // create a new thread_pool
-    void partitioner::create_thread_pool(
-        std::string const& pool_name, scheduling_policy sched)
+    void partitioner::create_thread_pool(std::string const& pool_name,
+        scheduling_policy sched,
+        hpx::threads::policies::scheduler_mode mode)
     {
         if (get_runtime_ptr() != nullptr)
         {
@@ -543,7 +548,7 @@ namespace hpx { namespace resource { namespace detail
         if (pool_name==get_default_pool_name())
         {
             initial_thread_pools_[0] = detail::init_pool_data(
-                get_default_pool_name(), sched);
+                get_default_pool_name(), sched, mode);
             return;
         }
 
@@ -560,7 +565,7 @@ namespace hpx { namespace resource { namespace detail
             }
         }
 
-        initial_thread_pools_.push_back(detail::init_pool_data(pool_name, sched));
+        initial_thread_pools_.push_back(detail::init_pool_data(pool_name, sched, mode));
     }
 
     // create a new thread_pool
@@ -810,6 +815,13 @@ namespace hpx { namespace resource { namespace detail
     {
         std::unique_lock<mutex_type> l(mtx_);
         return get_pool_data(l, pool_name).num_threads_;
+    }
+
+    hpx::threads::policies::scheduler_mode
+    partitioner::get_scheduler_mode(std::size_t pool_index) const
+    {
+        std::unique_lock<mutex_type> l(mtx_);
+        return get_pool_data(l, pool_index).mode_;
     }
 
     detail::init_pool_data const& partitioner::get_pool_data(

--- a/src/runtime/resource/partitioner.cpp
+++ b/src/runtime/resource/partitioner.cpp
@@ -242,9 +242,10 @@ namespace hpx { namespace resource
 
     ///////////////////////////////////////////////////////////////////////////
     void partitioner::create_thread_pool(std::string const& name,
-        scheduling_policy sched /*= scheduling_policy::unspecified*/)
+        scheduling_policy sched /*= scheduling_policy::unspecified*/,
+        hpx::threads::policies::scheduler_mode mode)
     {
-        partitioner_.create_thread_pool(name, sched);
+        partitioner_.create_thread_pool(name, sched, mode);
     }
 
     void partitioner::create_thread_pool(

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -294,6 +294,7 @@ namespace hpx { namespace threads
             std::string name = rp.get_pool_name(i);
             resource::scheduling_policy sched_type = rp.which_scheduler(name);
             std::size_t num_threads_in_pool = rp.get_num_threads(i);
+            policies::scheduler_mode scheduler_mode = rp.get_scheduler_mode(i);
 
             // make sure the first thread-pool that gets instantiated is the default one
             if (i == 0)
@@ -347,10 +348,7 @@ namespace hpx { namespace threads
                     new hpx::threads::detail::scheduled_thread_pool<
                             local_sched_type
                         >(std::move(sched),
-                        notifier_, i, name.c_str(),
-                        policies::scheduler_mode(policies::do_background_work |
-                            policies::reduce_thread_priority |
-                            policies::delay_exit),
+                        notifier_, i, name.c_str(), scheduler_mode,
                         thread_offset));
                 pools_.push_back(std::move(pool));
 
@@ -389,10 +387,7 @@ namespace hpx { namespace threads
                     new hpx::threads::detail::scheduled_thread_pool<
                             local_sched_type
                         >(std::move(sched),
-                        notifier_, i, name.c_str(),
-                        policies::scheduler_mode(policies::do_background_work |
-                            policies::reduce_thread_priority |
-                            policies::delay_exit),
+                        notifier_, i, name.c_str(), scheduler_mode,
                         thread_offset));
                 pools_.push_back(std::move(pool));
 
@@ -425,10 +420,7 @@ namespace hpx { namespace threads
                     new hpx::threads::detail::scheduled_thread_pool<
                             local_sched_type
                         >(std::move(sched),
-                        notifier_, i, name.c_str(),
-                        policies::scheduler_mode(policies::do_background_work |
-                            policies::reduce_thread_priority |
-                            policies::delay_exit),
+                        notifier_, i, name.c_str(), scheduler_mode,
                         thread_offset));
                 pools_.push_back(std::move(pool));
 
@@ -460,10 +452,7 @@ namespace hpx { namespace threads
                     new hpx::threads::detail::scheduled_thread_pool<
                             local_sched_type
                         >(std::move(sched),
-                        notifier_, i, name.c_str(),
-                        policies::scheduler_mode(policies::do_background_work |
-                            policies::reduce_thread_priority |
-                            policies::delay_exit),
+                        notifier_, i, name.c_str(), scheduler_mode,
                         thread_offset));
                 pools_.push_back(std::move(pool));
 
@@ -505,10 +494,7 @@ namespace hpx { namespace threads
                     new hpx::threads::detail::scheduled_thread_pool<
                             local_sched_type
                         >(std::move(sched),
-                        notifier_, i, name.c_str(),
-                        policies::scheduler_mode(policies::do_background_work |
-                            policies::reduce_thread_priority |
-                            policies::delay_exit),
+                        notifier_, i, name.c_str(), scheduler_mode,
                         thread_offset));
                 pools_.push_back(std::move(pool));
 
@@ -545,10 +531,7 @@ namespace hpx { namespace threads
                     new hpx::threads::detail::scheduled_thread_pool<
                             local_sched_type
                         >(std::move(sched),
-                        notifier_, i, name.c_str(),
-                        policies::scheduler_mode(policies::do_background_work |
-                            policies::reduce_thread_priority |
-                            policies::delay_exit),
+                        notifier_, i, name.c_str(), scheduler_mode,
                         thread_offset));
                 pools_.push_back(std::move(pool));
 #else
@@ -584,10 +567,7 @@ namespace hpx { namespace threads
                     new hpx::threads::detail::scheduled_thread_pool<
                             local_sched_type
                         >(std::move(sched),
-                        notifier_, i, name.c_str(),
-                        policies::scheduler_mode(policies::do_background_work |
-                            policies::reduce_thread_priority |
-                            policies::delay_exit),
+                        notifier_, i, name.c_str(), scheduler_mode,
                         thread_offset));
                 pools_.push_back(std::move(pool));
 #else

--- a/tests/unit/resource/CMakeLists.txt
+++ b/tests/unit/resource/CMakeLists.txt
@@ -11,8 +11,9 @@ set(tests
     suspend_pool
     suspend_pool_external
     suspend_runtime
-    throttle
-    throttle_timed
+    suspend_thread
+    suspend_thread_external
+    suspend_thread_timed
     used_pus
 )
 
@@ -23,8 +24,9 @@ set(suspend_disabled_PARAMETERS THREADS_PER_LOCALITY 4)
 set(suspend_pool_PARAMETERS THREADS_PER_LOCALITY 4)
 set(suspend_pool_external_PARAMETERS THREADS_PER_LOCALITY 4)
 set(suspend_runtime_PARAMETERS THREADS_PER_LOCALITY 4)
-set(throttle_PARAMETERS THREADS_PER_LOCALITY 4)
-set(throttle_timed_PARAMETERS THREADS_PER_LOCALITY 4)
+set(suspend_thread_PARAMETERS THREADS_PER_LOCALITY 4)
+set(suspend_thread_external_PARAMETERS THREADS_PER_LOCALITY 4)
+set(suspend_thread_timed_PARAMETERS THREADS_PER_LOCALITY 4)
 set(used_pus_PARAMETERS THREADS_PER_LOCALITY 4)
 
 foreach(test ${tests})

--- a/tests/unit/resource/shutdown_suspended_pus.cpp
+++ b/tests/unit/resource/shutdown_suspended_pus.cpp
@@ -46,8 +46,8 @@ int hpx_main(int argc, char* argv[])
     return hpx::finalize();
 }
 
-template <typename Scheduler>
-void test_scheduler(int argc, char* argv[])
+void test_scheduler(int argc, char* argv[],
+    hpx::resource::scheduling_policy scheduler)
 {
     std::vector<std::string> cfg =
     {
@@ -56,28 +56,10 @@ void test_scheduler(int argc, char* argv[])
 
     hpx::resource::partitioner rp(argc, argv, std::move(cfg));
 
-    rp.create_thread_pool("default",
-        [](hpx::threads::policies::callback_notifier& notifier,
-            std::size_t num_threads, std::size_t thread_offset,
-            std::size_t pool_index, std::string const& pool_name)
-        -> std::unique_ptr<hpx::threads::thread_pool_base>
-        {
-            typename Scheduler::init_parameter_type init(num_threads);
-            std::unique_ptr<Scheduler> scheduler(new Scheduler(init));
-
-            auto mode = hpx::threads::policies::scheduler_mode(
-                hpx::threads::policies::do_background_work |
-                hpx::threads::policies::reduce_thread_priority |
-                hpx::threads::policies::delay_exit |
-                hpx::threads::policies::enable_elasticity);
-
-            std::unique_ptr<hpx::threads::thread_pool_base> pool(
-                new hpx::threads::detail::scheduled_thread_pool<Scheduler>(
-                    std::move(scheduler), notifier, pool_index, pool_name, mode,
-                    thread_offset));
-
-            return pool;
-        });
+    rp.create_thread_pool("default", scheduler,
+        hpx::threads::policies::scheduler_mode(
+            hpx::threads::policies::default_mode |
+            hpx::threads::policies::enable_elasticity));
 
     HPX_TEST_EQ(hpx::init(argc, argv), 0);
 }
@@ -87,39 +69,45 @@ int main(int argc, char* argv[])
     // NOTE: Periodic priority scheduler not tested because it does not take
     // into account scheduler states when scheduling work.
 
-    test_scheduler<hpx::threads::policies::local_queue_scheduler<>>(argc, argv);
-    test_scheduler<hpx::threads::policies::local_priority_queue_scheduler<>>(argc,
-        argv);
-
     {
-        bool exception_thrown = false;
-        try
-        {
-            test_scheduler<hpx::threads::policies::static_queue_scheduler<>>(argc,
-                argv);
-        }
-        catch (hpx::exception const&)
-        {
-            exception_thrown = true;
-        }
+        // These schedulers should succeed
+        std::vector<hpx::resource::scheduling_policy> schedulers =
+            {
+                hpx::resource::scheduling_policy::local,
+                hpx::resource::scheduling_policy::local_priority_fifo,
+                hpx::resource::scheduling_policy::local_priority_lifo,
+                hpx::resource::scheduling_policy::abp_priority_fifo,
+                hpx::resource::scheduling_policy::abp_priority_lifo
+            };
 
-        HPX_TEST(exception_thrown);
+        for (auto const scheduler : schedulers)
+        {
+            test_scheduler(argc, argv, scheduler);
+        }
     }
 
     {
-        bool exception_thrown = false;
-        try
+        // These schedulers should fail
+        std::vector<hpx::resource::scheduling_policy> schedulers =
         {
-            test_scheduler<
-                hpx::threads::policies::static_priority_queue_scheduler<>
-            >(argc, argv);
-        }
-        catch (hpx::exception const&)
-        {
-            exception_thrown = true;
-        }
+            hpx::resource::scheduling_policy::static_,
+            hpx::resource::scheduling_policy::static_priority,
+        };
 
-        HPX_TEST(exception_thrown);
+        for (auto const scheduler : schedulers)
+        {
+            bool exception_thrown = false;
+            try
+            {
+                test_scheduler(argc, argv, scheduler);
+            }
+            catch (hpx::exception const&)
+            {
+                exception_thrown = true;
+            }
+
+            HPX_TEST(exception_thrown);
+        }
     }
 
     return hpx::util::report_errors();

--- a/tests/unit/resource/suspend_disabled.cpp
+++ b/tests/unit/resource/suspend_disabled.cpp
@@ -49,5 +49,12 @@ int main(int argc, char* argv[])
     };
 
     hpx::resource::partitioner rp(argc, argv, std::move(cfg));
+
+    // Explicitly disable elasticity if it is in defaults
+    rp.create_thread_pool("default", hpx::resource::scheduling_policy::local,
+        hpx::threads::policies::scheduler_mode(
+            hpx::threads::policies::default_mode &
+            ~hpx::threads::policies::enable_elasticity));
+
     HPX_TEST_EQ(hpx::init(argc, argv), 0);
 }

--- a/tests/unit/resource/suspend_pool.cpp
+++ b/tests/unit/resource/suspend_pool.cpp
@@ -52,7 +52,7 @@ int hpx_main(int argc, char* argv[])
         // Suspend and resume pool with future
         hpx::util::high_resolution_timer t;
 
-        while (t.elapsed() < 5)
+        while (t.elapsed() < 2)
         {
             std::vector<hpx::future<void>> fs;
 
@@ -76,7 +76,7 @@ int hpx_main(int argc, char* argv[])
         hpx::lcos::local::counting_semaphore sem;
         hpx::util::high_resolution_timer t;
 
-        while (t.elapsed() < 5)
+        while (t.elapsed() < 2)
         {
             std::vector<hpx::future<void>> fs;
 
@@ -109,7 +109,7 @@ int hpx_main(int argc, char* argv[])
         // Suspend pool with some threads already suspended
         hpx::util::high_resolution_timer t;
 
-        while (t.elapsed() < 5)
+        while (t.elapsed() < 2)
         {
             for (std::size_t thread_num = 0;
                 thread_num < worker_pool_threads - 1; ++thread_num)
@@ -137,8 +137,8 @@ int hpx_main(int argc, char* argv[])
     return hpx::finalize();
 }
 
-template <typename Scheduler>
-void test_scheduler(int argc, char* argv[])
+void test_scheduler(int argc, char* argv[],
+    hpx::resource::scheduling_policy scheduler)
 {
     std::vector<std::string> cfg =
     {
@@ -147,27 +147,7 @@ void test_scheduler(int argc, char* argv[])
 
     hpx::resource::partitioner rp(argc, argv, std::move(cfg));
 
-    rp.create_thread_pool("worker",
-        [](hpx::threads::policies::callback_notifier& notifier,
-            std::size_t num_threads, std::size_t thread_offset,
-            std::size_t pool_index, std::string const& pool_name)
-        -> std::unique_ptr<hpx::threads::thread_pool_base>
-        {
-            typename Scheduler::init_parameter_type init(num_threads);
-            std::unique_ptr<Scheduler> scheduler(new Scheduler(init));
-
-            auto mode = hpx::threads::policies::scheduler_mode(
-                hpx::threads::policies::do_background_work |
-                hpx::threads::policies::reduce_thread_priority |
-                hpx::threads::policies::delay_exit);
-
-            std::unique_ptr<hpx::threads::thread_pool_base> pool(
-                new hpx::threads::detail::scheduled_thread_pool<Scheduler>(
-                    std::move(scheduler), notifier, pool_index, pool_name, mode,
-                    thread_offset));
-
-            return pool;
-        });
+    rp.create_thread_pool("worker", scheduler);
 
     int const worker_pool_threads = 3;
     int worker_pool_threads_added = 0;
@@ -192,12 +172,21 @@ void test_scheduler(int argc, char* argv[])
 
 int main(int argc, char* argv[])
 {
-    test_scheduler<hpx::threads::policies::local_queue_scheduler<>>(argc, argv);
-    test_scheduler<hpx::threads::policies::local_priority_queue_scheduler<>>(argc,
-        argv);
-    test_scheduler<hpx::threads::policies::static_queue_scheduler<>>(argc, argv);
-    test_scheduler<hpx::threads::policies::static_priority_queue_scheduler<>>(argc,
-        argv);
+    std::vector<hpx::resource::scheduling_policy> schedulers =
+        {
+            hpx::resource::scheduling_policy::local,
+            hpx::resource::scheduling_policy::local_priority_fifo,
+            hpx::resource::scheduling_policy::local_priority_lifo,
+            hpx::resource::scheduling_policy::abp_priority_fifo,
+            hpx::resource::scheduling_policy::abp_priority_lifo,
+            hpx::resource::scheduling_policy::static_,
+            hpx::resource::scheduling_policy::static_priority
+        };
+
+    for (auto const scheduler : schedulers)
+    {
+        test_scheduler(argc, argv, scheduler);
+    }
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/resource/suspend_thread.cpp
+++ b/tests/unit/resource/suspend_thread.cpp
@@ -191,8 +191,8 @@ int hpx_main(int argc, char* argv[])
     return hpx::finalize();
 }
 
-template <typename Scheduler>
-void test_scheduler(int argc, char* argv[])
+void test_scheduler(int argc, char* argv[],
+    hpx::resource::scheduling_policy scheduler)
 {
     std::vector<std::string> cfg =
     {
@@ -201,28 +201,10 @@ void test_scheduler(int argc, char* argv[])
 
     hpx::resource::partitioner rp(argc, argv, std::move(cfg));
 
-    rp.create_thread_pool("default",
-        [](hpx::threads::policies::callback_notifier& notifier,
-            std::size_t num_threads, std::size_t thread_offset,
-            std::size_t pool_index, std::string const& pool_name)
-        -> std::unique_ptr<hpx::threads::thread_pool_base>
-        {
-            typename Scheduler::init_parameter_type init(num_threads);
-            std::unique_ptr<Scheduler> scheduler(new Scheduler(init));
-
-            auto mode = hpx::threads::policies::scheduler_mode(
-                hpx::threads::policies::do_background_work |
-                hpx::threads::policies::reduce_thread_priority |
-                hpx::threads::policies::delay_exit |
-                hpx::threads::policies::enable_elasticity);
-
-            std::unique_ptr<hpx::threads::thread_pool_base> pool(
-                new hpx::threads::detail::scheduled_thread_pool<Scheduler>(
-                    std::move(scheduler), notifier, pool_index, pool_name, mode,
-                    thread_offset));
-
-            return pool;
-        });
+    rp.create_thread_pool("default", scheduler,
+         hpx::threads::policies::scheduler_mode(
+             hpx::threads::policies::default_mode |
+             hpx::threads::policies::enable_elasticity));
 
     HPX_TEST_EQ(hpx::init(argc, argv), 0);
 }
@@ -232,39 +214,45 @@ int main(int argc, char* argv[])
     // NOTE: Static schedulers do not support suspending the own worker thread
     // because they do not steal work.
 
-    test_scheduler<hpx::threads::policies::local_queue_scheduler<>>(argc, argv);
-    test_scheduler<hpx::threads::policies::local_priority_queue_scheduler<>>(argc,
-        argv);
-
     {
-        bool exception_thrown = false;
-        try
-        {
-            test_scheduler<hpx::threads::policies::static_queue_scheduler<>>(argc,
-                argv);
-        }
-        catch (hpx::exception const&)
-        {
-            exception_thrown = true;
-        }
+        // These schedulers should succeed
+        std::vector<hpx::resource::scheduling_policy> schedulers =
+            {
+                hpx::resource::scheduling_policy::local,
+                hpx::resource::scheduling_policy::local_priority_fifo,
+                hpx::resource::scheduling_policy::local_priority_lifo,
+                hpx::resource::scheduling_policy::abp_priority_fifo,
+                hpx::resource::scheduling_policy::abp_priority_lifo
+            };
 
-        HPX_TEST(exception_thrown);
+        for (auto const scheduler : schedulers)
+        {
+            test_scheduler(argc, argv, scheduler);
+        }
     }
 
     {
-        bool exception_thrown = false;
-        try
+        // These schedulers should fail
+        std::vector<hpx::resource::scheduling_policy> schedulers =
         {
-            test_scheduler<
-                hpx::threads::policies::static_priority_queue_scheduler<>
-            >(argc, argv);
-        }
-        catch (hpx::exception const&)
-        {
-            exception_thrown = true;
-        }
+            hpx::resource::scheduling_policy::static_,
+            hpx::resource::scheduling_policy::static_priority,
+        };
 
-        HPX_TEST(exception_thrown);
+        for (auto const scheduler : schedulers)
+        {
+            bool exception_thrown = false;
+            try
+            {
+                test_scheduler(argc, argv, scheduler);
+            }
+            catch (hpx::exception const&)
+            {
+                exception_thrown = true;
+            }
+
+            HPX_TEST(exception_thrown);
+        }
     }
 
     return hpx::util::report_errors();

--- a/tests/unit/resource/suspend_thread.cpp
+++ b/tests/unit/resource/suspend_thread.cpp
@@ -7,9 +7,9 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/async.hpp>
+#include <hpx/include/lcos.hpp>
 #include <hpx/include/resource_partitioner.hpp>
 #include <hpx/include/threads.hpp>
-#include <hpx/lcos/when_all.hpp>
 #include <hpx/runtime/threads/policies/scheduler_mode.hpp>
 #include <hpx/runtime/threads/policies/schedulers.hpp>
 #include <hpx/util/lightweight_test.hpp>

--- a/tests/unit/resource/suspend_thread_external.cpp
+++ b/tests/unit/resource/suspend_thread_external.cpp
@@ -1,0 +1,200 @@
+//  Copyright (c) 2017 Thomas Heller
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Simple test verifying basic resource_partitioner functionality.
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/async.hpp>
+#include <hpx/include/resource_partitioner.hpp>
+#include <hpx/include/threads.hpp>
+#include <hpx/runtime/threads/policies/scheduler_mode.hpp>
+#include <hpx/runtime/threads/policies/schedulers.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+int hpx_main(int argc, char* argv[])
+{
+    std::size_t const num_threads = hpx::resource::get_num_threads("worker");
+
+    HPX_TEST_EQ(std::size_t(3), num_threads);
+
+    hpx::threads::thread_pool_base& tp =
+        hpx::resource::get_thread_pool("worker");
+
+    {
+        // Check number of used resources
+        for (std::size_t thread_num = 0; thread_num < num_threads - 1; ++thread_num)
+        {
+            tp.suspend_processing_unit(thread_num).get();
+            HPX_TEST_EQ(std::size_t(num_threads - thread_num - 1),
+                tp.get_active_os_thread_count());
+        }
+
+        for (std::size_t thread_num = 0; thread_num < num_threads - 1; ++thread_num)
+        {
+            tp.resume_processing_unit(thread_num).get();
+            HPX_TEST_EQ(std::size_t(thread_num + 2),
+                tp.get_active_os_thread_count());
+        }
+    }
+
+    {
+        // Check suspending and resuming the same thread without waiting for
+        // each to finish.
+        for (std::size_t thread_num = 0;
+             thread_num < hpx::resource::get_num_threads("worker");
+             ++thread_num)
+        {
+            std::vector<hpx::future<void>> fs;
+
+            fs.push_back(tp.suspend_processing_unit(thread_num));
+            fs.push_back(tp.resume_processing_unit(thread_num));
+
+            hpx::wait_all(fs);
+
+            // Suspend is not guaranteed to run before resume, so make sure
+            // processing unit is running
+            tp.resume_processing_unit(thread_num).get();
+
+            fs.clear();
+
+            // Launching 4 (i.e. same as number of threads) tasks may deadlock
+            // as no thread is available to steal from the current thread.
+            fs.push_back(tp.suspend_processing_unit(thread_num));
+            fs.push_back(tp.suspend_processing_unit(thread_num));
+            fs.push_back(tp.suspend_processing_unit(thread_num));
+
+            hpx::wait_all(fs);
+
+            fs.clear();
+
+            // Launching 4 (i.e. same as number of threads) tasks may deadlock
+            // as no thread is available to steal from the current thread.
+            fs.push_back(tp.resume_processing_unit(thread_num));
+            fs.push_back(tp.resume_processing_unit(thread_num));
+            fs.push_back(tp.resume_processing_unit(thread_num));
+
+            hpx::wait_all(fs);
+        }
+    }
+
+    {
+        // Check random scheduling with reducing resources.
+        std::size_t thread_num = 0;
+        bool up = true;
+        std::vector<hpx::future<void>> fs;
+        hpx::util::high_resolution_timer t;
+        while (t.elapsed() < 2)
+        {
+            for (std::size_t i = 0;
+                i < hpx::resource::get_num_threads("worker") * 10;
+                ++i)
+            {
+                fs.push_back(hpx::async([](){}));
+            }
+
+            if (up)
+            {
+                if (thread_num < hpx::resource::get_num_threads("worker"))
+                {
+                    tp.suspend_processing_unit(thread_num).get();
+                }
+
+                ++thread_num;
+
+                if (thread_num == hpx::resource::get_num_threads("worker"))
+                {
+                    up = false;
+                    --thread_num;
+                }
+            }
+            else
+            {
+                tp.resume_processing_unit(thread_num - 1).get();
+
+                --thread_num;
+
+                if (thread_num == 0)
+                {
+                    up = true;
+                }
+            }
+        }
+
+        hpx::when_all(std::move(fs)).get();
+
+        // Don't exit with suspended pus
+        for (std::size_t thread_num_resume = 0; thread_num_resume < thread_num;
+            ++thread_num_resume)
+        {
+            tp.resume_processing_unit(thread_num_resume).get();
+        }
+    }
+
+    return hpx::finalize();
+}
+
+void test_scheduler(int argc, char* argv[],
+    hpx::resource::scheduling_policy scheduler)
+{
+    std::vector<std::string> cfg =
+    {
+        "hpx.os_threads=4"
+    };
+
+    hpx::resource::partitioner rp(argc, argv, std::move(cfg));
+
+    rp.create_thread_pool("worker", scheduler,
+        hpx::threads::policies::scheduler_mode(
+            hpx::threads::policies::default_mode |
+            hpx::threads::policies::enable_elasticity));
+
+    int const worker_pool_threads = 3;
+    int worker_pool_threads_added = 0;
+
+    for (const hpx::resource::numa_domain& d : rp.numa_domains())
+    {
+        for (const hpx::resource::core& c : d.cores())
+        {
+            for (const hpx::resource::pu& p : c.pus())
+            {
+                if (worker_pool_threads_added < worker_pool_threads)
+                {
+                    rp.add_resource(p, "worker");
+                    ++worker_pool_threads_added;
+                }
+            }
+        }
+    }
+
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<hpx::resource::scheduling_policy> schedulers =
+        {
+            hpx::resource::scheduling_policy::local,
+            hpx::resource::scheduling_policy::local_priority_fifo,
+            hpx::resource::scheduling_policy::local_priority_lifo,
+            hpx::resource::scheduling_policy::abp_priority_fifo,
+            hpx::resource::scheduling_policy::abp_priority_lifo,
+            hpx::resource::scheduling_policy::static_,
+            hpx::resource::scheduling_policy::static_priority,
+        };
+
+    for (auto const scheduler : schedulers)
+    {
+        test_scheduler(argc, argv, scheduler);
+    }
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/resource/suspend_thread_external.cpp
+++ b/tests/unit/resource/suspend_thread_external.cpp
@@ -7,6 +7,7 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/async.hpp>
+#include <hpx/include/lcos.hpp>
 #include <hpx/include/resource_partitioner.hpp>
 #include <hpx/include/threads.hpp>
 #include <hpx/runtime/threads/policies/scheduler_mode.hpp>

--- a/tests/unit/resource/suspend_thread_timed.cpp
+++ b/tests/unit/resource/suspend_thread_timed.cpp
@@ -96,8 +96,8 @@ int hpx_main(int argc, char* argv[])
     return hpx::finalize();
 }
 
-template <typename Scheduler>
-void test_scheduler(int argc, char* argv[])
+void test_scheduler(int argc, char* argv[],
+    hpx::resource::scheduling_policy scheduler)
 {
     std::vector<std::string> cfg =
     {
@@ -106,28 +106,10 @@ void test_scheduler(int argc, char* argv[])
 
     hpx::resource::partitioner rp(argc, argv, std::move(cfg));
 
-    rp.create_thread_pool("default",
-        [](hpx::threads::policies::callback_notifier& notifier,
-            std::size_t num_threads, std::size_t thread_offset,
-            std::size_t pool_index, std::string const& pool_name)
-        -> std::unique_ptr<hpx::threads::thread_pool_base>
-        {
-            typename Scheduler::init_parameter_type init(num_threads);
-            std::unique_ptr<Scheduler> scheduler(new Scheduler(init));
-
-            auto mode = hpx::threads::policies::scheduler_mode(
-                hpx::threads::policies::do_background_work |
-                hpx::threads::policies::reduce_thread_priority |
-                hpx::threads::policies::delay_exit |
-                hpx::threads::policies::enable_elasticity);
-
-            std::unique_ptr<hpx::threads::thread_pool_base> pool(
-                new hpx::threads::detail::scheduled_thread_pool<Scheduler>(
-                    std::move(scheduler), notifier, pool_index, pool_name, mode,
-                    thread_offset));
-
-            return pool;
-        });
+    rp.create_thread_pool("default", scheduler,
+         hpx::threads::policies::scheduler_mode(
+             hpx::threads::policies::default_mode |
+             hpx::threads::policies::enable_elasticity));
 
     HPX_TEST_EQ(hpx::init(argc, argv), 0);
 }
@@ -139,39 +121,45 @@ int main(int argc, char* argv[])
     // because it does not take into account scheduler states when scheduling
     // work.
 
-    test_scheduler<hpx::threads::policies::local_queue_scheduler<>>(argc, argv);
-    test_scheduler<hpx::threads::policies::local_priority_queue_scheduler<>>(argc,
-        argv);
-
     {
-        bool exception_thrown = false;
-        try
-        {
-            test_scheduler<hpx::threads::policies::static_queue_scheduler<>>(argc,
-                argv);
-        }
-        catch (hpx::exception const&)
-        {
-            exception_thrown = true;
-        }
+        // These schedulers should succeed
+        std::vector<hpx::resource::scheduling_policy> schedulers =
+            {
+                hpx::resource::scheduling_policy::local,
+                hpx::resource::scheduling_policy::local_priority_fifo,
+                hpx::resource::scheduling_policy::local_priority_lifo,
+                hpx::resource::scheduling_policy::abp_priority_fifo,
+                hpx::resource::scheduling_policy::abp_priority_lifo
+            };
 
-        HPX_TEST(exception_thrown);
+        for (auto const scheduler : schedulers)
+        {
+            test_scheduler(argc, argv, scheduler);
+        }
     }
 
     {
-        bool exception_thrown = false;
-        try
+        // These schedulers should fail
+        std::vector<hpx::resource::scheduling_policy> schedulers =
         {
-            test_scheduler<
-                hpx::threads::policies::static_priority_queue_scheduler<>
-            >(argc, argv);
-        }
-        catch (hpx::exception const&)
-        {
-            exception_thrown = true;
-        }
+            hpx::resource::scheduling_policy::static_,
+            hpx::resource::scheduling_policy::static_priority,
+        };
 
-        HPX_TEST(exception_thrown);
+        for (auto const scheduler : schedulers)
+        {
+            bool exception_thrown = false;
+            try
+            {
+                test_scheduler(argc, argv, scheduler);
+            }
+            catch (hpx::exception const&)
+            {
+                exception_thrown = true;
+            }
+
+            HPX_TEST(exception_thrown);
+        }
     }
 
     return hpx::util::report_errors();

--- a/tests/unit/resource/suspend_thread_timed.cpp
+++ b/tests/unit/resource/suspend_thread_timed.cpp
@@ -6,10 +6,10 @@
 // Simple test verifying basic resource_partitioner functionality.
 
 #include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/resource_partitioner.hpp>
 #include <hpx/include/threads.hpp>
-#include <hpx/lcos/when_all.hpp>
 #include <hpx/runtime/threads/executors/pool_executor.hpp>
 #include <hpx/runtime/threads/policies/scheduler_mode.hpp>
 #include <hpx/runtime/threads/policies/schedulers.hpp>


### PR DESCRIPTION
General cleanup of suspension tests.

## Proposed Changes

- Use new `create_thread_pool` function to set elasticity flag
- Rename throttle tests to suspend_thread_X
- Improve general consistency of tests
- Test all schedulers (whether they should succeed or not)

Depends on #3228 and #3230.