### PR TITLE
Make schedule_thread take suspended threads into account

### DIFF
--- a/examples/resource_partitioner/shared_priority_scheduler.hpp
+++ b/examples/resource_partitioner/shared_priority_scheduler.hpp
@@ -603,7 +603,8 @@ namespace threads {
             // to pending
             void create_thread(thread_init_data& data, thread_id_type* thrd,
                 thread_state_enum initial_state, bool run_now, error_code& ec,
-                std::size_t pool_queue_num)
+                std::size_t pool_queue_num,
+                std::size_t /*pool_queue_num_fallback*/)
             {
                 HPX_ASSERT(data.scheduler_base == this);
 
@@ -787,6 +788,7 @@ namespace threads {
             /// Schedule the passed thread
             void schedule_thread(threads::thread_data* thrd,
                 std::size_t pool_queue_num,
+                std::size_t /*pool_queue_num_fallback*/,
                 thread_priority priority = thread_priority_normal)
             {
                 HPX_ASSERT(thrd->get_scheduler_base() == this);
@@ -826,6 +828,7 @@ namespace threads {
             /// Put task on the back of the queue
             void schedule_thread_last(threads::thread_data* thrd,
                 std::size_t num_queue,
+                std::size_t /*num_queue_fallback*/,
                 thread_priority priority = thread_priority_normal)
             {
                 HPX_ASSERT(thrd->get_scheduler_base() == this);

--- a/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
@@ -1573,7 +1573,7 @@ namespace hpx { namespace threads { namespace detail
         std::size_t virt_core, std::size_t thread_num,
         std::shared_ptr<compat::barrier> startup, error_code& ec)
     {
-        std::unique_lock<compat::mutex>
+        std::unique_lock<typename Scheduler::pu_mutex_type>
             l(sched_->Scheduler::get_pu_mutex(virt_core));
 
         if (threads_.size() <= virt_core)
@@ -1643,7 +1643,7 @@ namespace hpx { namespace threads { namespace detail
     void scheduled_thread_pool<Scheduler>::remove_processing_unit_internal(
         std::size_t virt_core, error_code& ec)
     {
-        std::unique_lock<compat::mutex>
+        std::unique_lock<typename Scheduler::pu_mutex_type>
             l(sched_->Scheduler::get_pu_mutex(virt_core));
 
         if (threads_.size() <= virt_core || !threads_[virt_core].joinable())
@@ -1692,7 +1692,7 @@ namespace hpx { namespace threads { namespace detail
     {
         // Yield to other HPX threads if lock is not available to avoid
         // deadlocks when multiple HPX threads try to resume or suspend pus.
-        std::unique_lock<compat::mutex>
+        std::unique_lock<typename Scheduler::pu_mutex_type>
             l(sched_->Scheduler::get_pu_mutex(virt_core), std::defer_lock);
         util::yield_while([&l]()
             {
@@ -1791,7 +1791,7 @@ namespace hpx { namespace threads { namespace detail
     {
         // Yield to other HPX threads if lock is not available to avoid
         // deadlocks when multiple HPX threads try to resume or suspend pus.
-        std::unique_lock<compat::mutex>
+        std::unique_lock<typename Scheduler::pu_mutex_type>
             l(sched_->Scheduler::get_pu_mutex(virt_core), std::defer_lock);
         util::yield_while([&l]()
             {

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -323,7 +323,8 @@ namespace hpx { namespace threads { namespace detail
         // Create in suspended to prevent the thread from being scheduled
         // directly...
         scheduler.SchedulingPolicy::create_thread(background_init,
-            &background_thread, suspended, true, hpx::throws, num_thread);
+            &background_thread, suspended, true, hpx::throws, num_thread,
+            num_thread);
         HPX_ASSERT(background_thread);
         scheduler.SchedulingPolicy::increment_background_thread_count();
         // We can now set the state to pending
@@ -388,7 +389,7 @@ namespace hpx { namespace threads { namespace detail
                             else
                             {
                                 next->get_scheduler_base()->schedule_thread(
-                                    next, num_thread);
+                                    next, num_thread, num_thread);
                             }
                         }
                     }
@@ -596,7 +597,7 @@ namespace hpx { namespace threads { namespace detail
                         // schedule this thread again, make sure it ends up at
                         // the end of the queue
                         scheduler.SchedulingPolicy::schedule_thread_last(thrd,
-                            num_thread);
+                            num_thread, num_thread);
                         scheduler.SchedulingPolicy::do_some_work(num_thread);
                     }
                     else if (HPX_UNLIKELY(state_val == pending_boost))
@@ -621,7 +622,8 @@ namespace hpx { namespace threads { namespace detail
                                 // schedule this thread again immediately with
                                 // boosted priority
                                 scheduler.SchedulingPolicy::schedule_thread(
-                                    thrd, num_thread, thread_priority_boost);
+                                    thrd, num_thread, num_thread,
+                                    thread_priority_boost);
                                 scheduler.SchedulingPolicy::do_some_work(
                                     num_thread);
                             }
@@ -631,7 +633,8 @@ namespace hpx { namespace threads { namespace detail
                             // schedule this thread again immediately with
                             // boosted priority
                             scheduler.SchedulingPolicy::schedule_thread(
-                                thrd, num_thread, thread_priority_boost);
+                                thrd, num_thread, num_thread,
+                                thread_priority_boost);
                             scheduler.SchedulingPolicy::do_some_work(
                                 num_thread);
                         }
@@ -647,7 +650,8 @@ namespace hpx { namespace threads { namespace detail
                     // this might happen, if some thread has been added to the
                     // scheduler queue already but the state has not been reset
                     // yet
-                    scheduler.SchedulingPolicy::schedule_thread(thrd, num_thread);
+                    scheduler.SchedulingPolicy::schedule_thread(thrd,
+                        num_thread, num_thread);
                 }
 
                 // Remove the mapping from thread_map_ if HPX thread is depleted
@@ -705,7 +709,7 @@ namespace hpx { namespace threads { namespace detail
                                     scheduler.SchedulingPolicy::
                                         decrement_background_thread_count();
                                     scheduler.SchedulingPolicy::schedule_thread(
-                                        background_thread.get(), num_thread);
+                                        background_thread.get(), num_thread, num_thread);
                                     background_thread.reset();
                                     background_running.reset();
                                 }
@@ -799,7 +803,7 @@ namespace hpx { namespace threads { namespace detail
                         scheduler.SchedulingPolicy::
                             decrement_background_thread_count();
                         scheduler.SchedulingPolicy::schedule_thread(
-                            background_thread.get(), num_thread);
+                            background_thread.get(), num_thread, num_thread);
                         background_thread.reset();
                         background_running.reset();
                     }

--- a/hpx/runtime/threads/policies/hierarchy_scheduler.hpp
+++ b/hpx/runtime/threads/policies/hierarchy_scheduler.hpp
@@ -618,7 +618,8 @@ namespace hpx { namespace threads { namespace policies
         // TODO: add recycling
         void create_thread(thread_init_data& data, thread_id_type* id,
             thread_state_enum initial_state, bool run_now, error_code& ec,
-            std::size_t num_thread) override
+            std::size_t num_thread,
+            std::size_t /*num_thread_fallback*/ = std::size_t(-1)) override
         {
             HPX_ASSERT(tree.size());
             HPX_ASSERT(tree.back().size());
@@ -701,6 +702,7 @@ namespace hpx { namespace threads { namespace policies
 
         /// Schedule the passed thread
         void schedule_thread(threads::thread_data* thrd, std::size_t num_thread,
+            std::size_t /*num_thread_fallback*/ = std::size_t(-1),
             thread_priority /*priority*/ = thread_priority_normal) override
         {
             HPX_ASSERT(tree.size());
@@ -710,6 +712,7 @@ namespace hpx { namespace threads { namespace policies
 
         void schedule_thread_last(threads::thread_data* thrd,
             std::size_t num_thread,
+            std::size_t /*num_thread_fallback*/ = std::size_t(-1),
             thread_priority priority = thread_priority_normal) override
         {
             HPX_ASSERT(tree.size());

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -501,7 +501,7 @@ namespace hpx { namespace threads { namespace policies
             }
 
             std::unique_lock<pu_mutex_type> l;
-            select_active_pu(l, num_thread, num_thread_fallback);
+            num_thread = select_active_pu(l, num_thread, num_thread_fallback);
 
             // now create the thread
             if (data.priority == thread_priority_high_recursive ||
@@ -622,7 +622,7 @@ namespace hpx { namespace threads { namespace policies
             }
 
             std::unique_lock<pu_mutex_type> l;
-            select_active_pu(l, num_thread, num_thread_fallback);
+            num_thread = select_active_pu(l, num_thread, num_thread_fallback);
 
             if (priority == thread_priority_high_recursive ||
                 priority == thread_priority_high ||
@@ -664,7 +664,7 @@ namespace hpx { namespace threads { namespace policies
             }
 
             std::unique_lock<pu_mutex_type> l;
-            select_active_pu(l, num_thread, num_thread_fallback);
+            num_thread = select_active_pu(l, num_thread, num_thread_fallback);
 
             if (priority == thread_priority_high_recursive ||
                 priority == thread_priority_high ||

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -471,7 +471,8 @@ namespace hpx { namespace threads { namespace policies
         // pending
         void create_thread(thread_init_data& data, thread_id_type* id,
             thread_state_enum initial_state, bool run_now, error_code& ec,
-            std::size_t num_thread) override
+            std::size_t num_thread,
+            std::size_t num_thread_fallback = std::size_t(-1)) override
         {
 #ifdef HPX_HAVE_THREAD_TARGET_ADDRESS
 //             // try to figure out the NUMA node where the data lives
@@ -486,24 +487,21 @@ namespace hpx { namespace threads { namespace policies
             std::size_t queue_size = queues_.size();
 
             if (std::size_t(-1) == num_thread)
-                num_thread = curr_queue_++ % queue_size;
-
-            if (num_thread >= queue_size)
-                num_thread %= queue_size;
-
-            // Select an OS thread which hasn't been disabled
-            std::unique_lock<compat::mutex> l;
-            if (mode_ & threads::policies::enable_elasticity)
             {
-                l = std::unique_lock<compat::mutex>(pu_mtxs_[num_thread],
-                    std::try_to_lock);
-                while (!l.owns_lock() || states_[num_thread] > state_suspended)
-                {
-                    num_thread = (num_thread + 1) % queue_size;
-                    l = std::unique_lock<compat::mutex>(pu_mtxs_[num_thread],
-                        std::try_to_lock);
-                }
+                num_thread = curr_queue_++ % queue_size;
             }
+            else if (num_thread >= queue_size)
+            {
+                num_thread %= queue_size;
+            }
+
+            if (num_thread_fallback != std::size_t(-1))
+            {
+                num_thread_fallback %= queue_size;
+            }
+
+            std::unique_lock<pu_mutex_type> l;
+            select_active_pu(l, num_thread, num_thread_fallback);
 
             // now create the thread
             if (data.priority == thread_priority_high_recursive ||
@@ -604,11 +602,27 @@ namespace hpx { namespace threads { namespace policies
         /// Schedule the passed thread
         void schedule_thread(threads::thread_data* thrd,
             std::size_t num_thread,
+            std::size_t num_thread_fallback = std::size_t(-1),
             thread_priority priority = thread_priority_normal) override
         {
             std::size_t queue_size = queues_.size();
+
             if (std::size_t(-1) == num_thread)
+            {
                 num_thread = curr_queue_++ % queue_size;
+            }
+            else if (num_thread >= queue_size)
+            {
+                num_thread %= queue_size;
+            }
+
+            if (num_thread_fallback != std::size_t(-1))
+            {
+                num_thread_fallback %= queue_size;
+            }
+
+            std::unique_lock<pu_mutex_type> l;
+            select_active_pu(l, num_thread, num_thread_fallback);
 
             if (priority == thread_priority_high_recursive ||
                 priority == thread_priority_high ||
@@ -630,11 +644,27 @@ namespace hpx { namespace threads { namespace policies
 
         void schedule_thread_last(threads::thread_data* thrd,
             std::size_t num_thread,
+            std::size_t num_thread_fallback = std::size_t(-1),
             thread_priority priority = thread_priority_normal) override
         {
             std::size_t queue_size = queues_.size();
+
             if (std::size_t(-1) == num_thread)
+            {
                 num_thread = curr_queue_++ % queue_size;
+            }
+            else if (num_thread >= queue_size)
+            {
+                num_thread %= queue_size;
+            }
+
+            if (num_thread_fallback != std::size_t(-1))
+            {
+                num_thread_fallback %= queue_size;
+            }
+
+            std::unique_lock<pu_mutex_type> l;
+            select_active_pu(l, num_thread, num_thread_fallback);
 
             if (priority == thread_priority_high_recursive ||
                 priority == thread_priority_high ||

--- a/hpx/runtime/threads/policies/local_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_queue_scheduler.hpp
@@ -328,7 +328,7 @@ namespace hpx { namespace threads { namespace policies
             }
 
             std::unique_lock<pu_mutex_type> l;
-            select_active_pu(l, num_thread, num_thread_fallback);
+            num_thread = select_active_pu(l, num_thread, num_thread_fallback);
 
             HPX_ASSERT(num_thread < queue_size);
             queues_[num_thread]->create_thread(data, id, initial_state,
@@ -474,7 +474,7 @@ namespace hpx { namespace threads { namespace policies
             }
 
             std::unique_lock<pu_mutex_type> l;
-            select_active_pu(l, num_thread, num_thread_fallback);
+            num_thread = select_active_pu(l, num_thread, num_thread_fallback);
 
             HPX_ASSERT(thrd->get_scheduler_base() == this);
 
@@ -504,7 +504,7 @@ namespace hpx { namespace threads { namespace policies
             }
 
             std::unique_lock<pu_mutex_type> l;
-            select_active_pu(l, num_thread, num_thread_fallback);
+            num_thread = select_active_pu(l, num_thread, num_thread_fallback);
 
             HPX_ASSERT(thrd->get_scheduler_base() == this);
 

--- a/hpx/runtime/threads/policies/local_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_queue_scheduler.hpp
@@ -297,7 +297,8 @@ namespace hpx { namespace threads { namespace policies
         // pending
         void create_thread(thread_init_data& data, thread_id_type* id,
             thread_state_enum initial_state, bool run_now, error_code& ec,
-            std::size_t num_thread)
+            std::size_t num_thread,
+            std::size_t num_thread_fallback = std::size_t(-1))
         {
 #ifdef HPX_HAVE_THREAD_TARGET_ADDRESS
 //             // try to figure out the NUMA node where the data lives
@@ -309,27 +310,25 @@ namespace hpx { namespace threads { namespace policies
 //                 }
 //             }
 #endif
+
             std::size_t queue_size = queues_.size();
 
             if (std::size_t(-1) == num_thread)
-                num_thread = curr_queue_++ % queue_size;
-
-            if (num_thread >= queue_size)
-                num_thread %= queue_size;
-
-            // Select an OS thread which hasn't been disabled
-            std::unique_lock<compat::mutex> l;
-            if (mode_ & threads::policies::enable_elasticity)
             {
-                l = std::unique_lock<compat::mutex>(pu_mtxs_[num_thread],
-                    std::try_to_lock);
-                while (!l.owns_lock() || states_[num_thread] > state_suspended)
-                {
-                    num_thread = (num_thread + 1) % queue_size;
-                    l = std::unique_lock<compat::mutex>(pu_mtxs_[num_thread],
-                        std::try_to_lock);
-                }
+                num_thread = curr_queue_++ % queue_size;
             }
+            else if (num_thread >= queue_size)
+            {
+                num_thread %= queue_size;
+            }
+
+            if (num_thread_fallback != std::size_t(-1))
+            {
+                num_thread_fallback %= queue_size;
+            }
+
+            std::unique_lock<pu_mutex_type> l;
+            select_active_pu(l, num_thread, num_thread_fallback);
 
             HPX_ASSERT(num_thread < queue_size);
             queues_[num_thread]->create_thread(data, id, initial_state,
@@ -455,10 +454,27 @@ namespace hpx { namespace threads { namespace policies
 
         /// Schedule the passed thread
         void schedule_thread(threads::thread_data* thrd, std::size_t num_thread,
+            std::size_t num_thread_fallback = std::size_t(-1),
             thread_priority priority = thread_priority_normal)
         {
+            std::size_t queue_size = queues_.size();
+
             if (std::size_t(-1) == num_thread)
-                num_thread = curr_queue_++ % queues_.size();
+            {
+                num_thread = curr_queue_++ % queue_size;
+            }
+            else if (num_thread >= queue_size)
+            {
+                num_thread %= queue_size;
+            }
+
+            if (num_thread_fallback != std::size_t(-1))
+            {
+                num_thread_fallback %= queue_size;
+            }
+
+            std::unique_lock<pu_mutex_type> l;
+            select_active_pu(l, num_thread, num_thread_fallback);
 
             HPX_ASSERT(thrd->get_scheduler_base() == this);
 
@@ -468,10 +484,27 @@ namespace hpx { namespace threads { namespace policies
 
         void schedule_thread_last(threads::thread_data* thrd,
             std::size_t num_thread,
+            std::size_t num_thread_fallback = std::size_t(-1),
             thread_priority priority = thread_priority_normal)
         {
+            std::size_t queue_size = queues_.size();
+
             if (std::size_t(-1) == num_thread)
-                num_thread = curr_queue_++ % queues_.size();
+            {
+                num_thread = curr_queue_++ % queue_size;
+            }
+            else if (num_thread >= queue_size)
+            {
+                num_thread %= queue_size;
+            }
+
+            if (num_thread_fallback != std::size_t(-1))
+            {
+                num_thread_fallback %= queue_size;
+            }
+
+            std::unique_lock<pu_mutex_type> l;
+            select_active_pu(l, num_thread, num_thread_fallback);
 
             HPX_ASSERT(thrd->get_scheduler_base() == this);
 

--- a/hpx/runtime/threads/policies/throttling_scheduler.hpp
+++ b/hpx/runtime/threads/policies/throttling_scheduler.hpp
@@ -110,7 +110,8 @@ namespace hpx { namespace threads { namespace policies
                 thread_queue_type* q = queues_[num_thread];
                 while (q->get_next_thread(thrd)) {
                     this->wait_or_add_new(num_thread, running, idle_loop_count) ;
-                    this->schedule_thread(thrd, num_thread, thread_priority_normal);
+                    this->schedule_thread(thrd, num_thread, num_thread,
+                        thread_priority_normal);
                 }
 
                 std::unique_lock<compat::mutex> l(mtx_);
@@ -125,6 +126,7 @@ namespace hpx { namespace threads { namespace policies
 
         /// Schedule the passed thread
         void schedule_thread(threads::thread_data* thrd, std::size_t num_thread,
+            std::size_t /*num_thread_fallback*/ = std::size_t(-1),
             thread_priority priority = thread_priority_normal)
         {
             // Loop and find a thread that is not disabled


### PR DESCRIPTION
This was an oversight when doing thread suspension, and makes sure `create_thread` and `schedule_thread` behave the same way in terms of not scheduling on suspended threads.

## Proposed Changes

- Add a `select_active_pu` function to `scheduler_base` which accepts an initial thread number (this one is tried first, others are tried sequentially, wrapping around when needed), and an optional fallback thread number (used in case locks can't be taken immediately to avoid looping forever; the fallback is used in `scheduling_loop` to avoid looping for too long when the current pu could do work)
  - None of the above is done if elasticity is disabled