### PR TITLE
Disable background thread when networking is off

### DIFF
--- a/cmake/HPX_AddTest.cmake
+++ b/cmake/HPX_AddTest.cmake
@@ -44,8 +44,13 @@ macro(add_hpx_test category name)
           "${CMAKE_BINARY_DIR}/bin/hpxrun.py"
           ${_exe}
           "-e" "${expected}"
-          "-l" "${${name}_LOCALITIES}"
           "-t" "${${name}_THREADS_PER_LOCALITY}")
+
+  if(HPX_WITH_NETWORKING)
+      list(APPEND cmd "-l" "${${name}_LOCALITIES}")
+  else()
+      set(${name}_LOCALITIES "1")
+  endif()
 
   if(${name}_LOCALITIES STREQUAL "1")
     add_test(

--- a/cmake/templates/hpxrun.py.in
+++ b/cmake/templates/hpxrun.py.in
@@ -54,11 +54,16 @@ def subproc(cmd):
 # Run with no run wrapper
 # This is just starting "localities" processes on the local node
 def run_none(cmd, localities, verbose):
-    for locality in range(localities):
-        exec_cmd = cmd + ['--hpx:node=' + str(locality)]
-        if verbose:
-            print('Executing command: ' + ' '.join(exec_cmd))
-        subproc(exec_cmd)
+    if localities > 1:
+        for locality in range(localities):
+            exec_cmd = cmd + ['--hpx:node=' + str(locality)]
+            if verbose:
+                print('Executing command: ' + ' '.join(exec_cmd))
+            subproc(exec_cmd)
+    else:
+         if verbose:
+             print('Executing command: ' + ' '.join(cmd))
+         subproc(cmd)
 
 # Run with mpiexec
 # This is executing mpiexec with the "-np" option set to the number of localities
@@ -113,7 +118,8 @@ def build_cmd(options, args):
         cmd += ['--hpx:threads=' + str(options.threads)]
 
     # set number of localities
-    cmd += ['--hpx:localities=' + str(options.localities)]
+    if options.localities > 1:
+        cmd += ['--hpx:localities=' + str(options.localities)]
 
     # Append the remaining args
     for arg in args:

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -500,6 +500,7 @@ namespace hpx { namespace threads { namespace detail
         // spin for some time after queues have become empty
         bool may_exit = false;
 
+#if defined(HPX_HAVE_NETWORKING)
         std::shared_ptr<bool> background_running = nullptr;
         thread_id_type background_thread;
 
@@ -510,6 +511,7 @@ namespace hpx { namespace threads { namespace detail
             background_thread = create_background_thread(scheduler, params,
                 background_running, num_thread, idle_loop_count);
         }
+#endif
 
         thread_data* next_thrd = nullptr;
         while (true) {
@@ -753,6 +755,7 @@ namespace hpx { namespace threads { namespace detail
                             if (!(scheduler.get_scheduler_mode() & policies::delay_exit))
                             {
                                 // If this is an inner scheduler, try to exit immediately
+#if defined(HPX_HAVE_NETWORKING)
                                 if (background_thread != nullptr)
                                 {
                                     HPX_ASSERT(background_running);
@@ -769,6 +772,9 @@ namespace hpx { namespace threads { namespace detail
                                     this_state.store(state_stopped);
                                     break;
                                 }
+#else
+                                this_state.store(state_stopped);
+#endif
                             }
                             else
                             {
@@ -781,6 +787,7 @@ namespace hpx { namespace threads { namespace detail
                     }
                 }
 
+#if defined(HPX_HAVE_NETWORKING)
                 // do background work in parcel layer and in agas
                 if (!call_background_thread(background_thread, next_thrd, scheduler,
                     num_thread, running))
@@ -799,6 +806,7 @@ namespace hpx { namespace threads { namespace detail
                     background_thread = create_background_thread(scheduler, params,
                         background_running, num_thread, idle_loop_count);
                 }
+#endif
 
                 // call back into invoking context
                 if (!params.inner_.empty())
@@ -813,6 +821,7 @@ namespace hpx { namespace threads { namespace detail
             {
                 busy_loop_count = 0;
 
+#if defined(HPX_HAVE_NETWORKING)
                 // do background work in parcel layer and in agas
                 if (!call_background_thread(background_thread, next_thrd, scheduler,
                     num_thread, running))
@@ -831,6 +840,7 @@ namespace hpx { namespace threads { namespace detail
                     background_thread = create_background_thread(scheduler, params,
                         background_running, num_thread, idle_loop_count);
                 }
+#endif
             }
             else if ((scheduler.get_scheduler_mode() & policies::fast_idle_mode) ||
                 idle_loop_count > params.max_idle_loop_count_ || may_exit)
@@ -847,6 +857,7 @@ namespace hpx { namespace threads { namespace detail
                 {
                     HPX_ASSERT(this_state.load() != state_pre_sleep);
 
+#if defined(HPX_HAVE_NETWORKING)
                     if (background_thread)
                     {
                         HPX_ASSERT(background_running);
@@ -859,6 +870,7 @@ namespace hpx { namespace threads { namespace detail
                         background_running.reset();
                     }
                     else
+#endif
                     {
                         bool can_exit =
                             !running &&

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -768,13 +768,11 @@ namespace hpx { namespace threads { namespace detail
                                     background_running.reset();
                                 }
                                 else
+#endif
                                 {
                                     this_state.store(state_stopped);
                                     break;
                                 }
-#else
-                                this_state.store(state_stopped);
-#endif
                             }
                             else
                             {

--- a/python/scripts/hpx_run_test.py
+++ b/python/scripts/hpx_run_test.py
@@ -173,9 +173,11 @@ if __name__ == '__main__':
         cmd = [options.launcher]
 
       cmd += [ name
-             , '-t' + str(threads_per_node)
-             , '-l' + str(nodes)
-             , '-' + str(node)]
+             , '-t' + str(threads_per_node)]
+
+      if nodes > 1:
+          cmd += [ '-l' + str(nodes)
+                 , '-' + str(node)]
 
       if options.args:
         cmd += [options.args]

--- a/tests/regressions/agas/CMakeLists.txt
+++ b/tests/regressions/agas/CMakeLists.txt
@@ -8,10 +8,15 @@ set(tests
     duplicate_id_registration_1596
     pass_by_value_id_type_action
     send_gid_keep_component_1624
-    register_with_basename_1804
    )
 
-set(register_with_basename_1804_PARAMETERS LOCALITIES 2)
+if(HPX_WITH_NETWORKING)
+    set(tests ${tests}
+        register_with_basename_1804
+       )
+
+  set(register_with_basename_1804_PARAMETERS LOCALITIES 2)
+endif()
 
 foreach(test ${tests})
   set(sources

--- a/tests/regressions/components/CMakeLists.txt
+++ b/tests/regressions/components/CMakeLists.txt
@@ -7,7 +7,6 @@ set(tests
     bulk_new_3054
     client_base_registration
     create_n_components_2323
-    create_remote_component_2334
     moveonly_constructor_arguments_1405
     new_2848
     partitioned_vector_2201
@@ -15,8 +14,15 @@ set(tests
    )
 
 set(bulk_new_3054_PARAMETERS LOCALITIES 2)
-set(create_remote_component_2334_PARAMETERS LOCALITIES 2)
 set(new_2848_PARAMETERS LOCALITIES 2)
+
+if(HPX_WITH_NETWORKING)
+    set(tests ${tests}
+        create_remote_component_2334
+       )
+
+  set(create_remote_component_2334_PARAMETERS LOCALITIES 2)
+endif()
 
 foreach(test ${tests})
   set(sources

--- a/tests/regressions/util/CMakeLists.txt
+++ b/tests/regressions/util/CMakeLists.txt
@@ -18,7 +18,6 @@ set(tests
     tuple_serialization_803
     unwrapped_1528
     use_all_cores_2262
-    zero_copy_parcels_1001
    )
 
 set(function_argument_FLAGS DEPENDENCIES iostreams_component)
@@ -38,7 +37,13 @@ if(WITH_PARCEL_COALESCING)
 endif()
 set(function_serialization_728_FLAGS DEPENDENCIES ${function_serialization_728_dependencies})
 
-set(zero_copy_parcels_1001_PARAMETERS LOCALITIES 2)
+if(HPX_WITH_NETWORKING)
+    set(tests ${tests}
+        zero_copy_parcels_1001
+       )
+
+  set(zero_copy_parcels_1001_PARAMETERS LOCALITIES 2)
+endif()
 
 foreach(test ${tests})
   set(sources
@@ -68,15 +73,17 @@ foreach(test ${tests})
                               ${test}_test_exe)
 endforeach()
 
-# run zero_copy_parcels_1001 with two additional configurations
-add_hpx_regression_test(
-    "util" zero_copy_parcels_1001_no_array_optimization
-    EXECUTABLE zero_copy_parcels_1001
-    ${zero_copy_parcels_1001_PARAMETERS}
-    ARGS --hpx:ini=hpx.parcel.array_optimization=0)
+if(HPX_WITH_NETWORKING)
+  # run zero_copy_parcels_1001 with two additional configurations
+  add_hpx_regression_test(
+      "util" zero_copy_parcels_1001_no_array_optimization
+      EXECUTABLE zero_copy_parcels_1001
+      ${zero_copy_parcels_1001_PARAMETERS}
+      ARGS --hpx:ini=hpx.parcel.array_optimization=0)
 
-add_hpx_regression_test(
-    "util" zero_copy_parcels_1001_no_zero_copy_optimization
-    EXECUTABLE zero_copy_parcels_1001
-    ${zero_copy_parcels_1001_PARAMETERS}
-    ARGS --hpx:ini=hpx.parcel.zero_copy_optimization=0)
+  add_hpx_regression_test(
+      "util" zero_copy_parcels_1001_no_zero_copy_optimization
+      EXECUTABLE zero_copy_parcels_1001
+      ${zero_copy_parcels_1001_PARAMETERS}
+      ARGS --hpx:ini=hpx.parcel.zero_copy_optimization=0)
+endif()

--- a/tests/regressions/util/command_line_arguments_706.cpp
+++ b/tests/regressions/util/command_line_arguments_706.cpp
@@ -12,8 +12,8 @@
 char const* argv[] =
 {
     "command_line_argument_test",
-    // We force one locality here
-    "--hpx:localities=1",
+    // We need only one thread, this argument should be gone in hpx_main
+    "--hpx:threads=1",
     "nx=1",
     "ny=1=5"
 };

--- a/tests/unit/agas/CMakeLists.txt
+++ b/tests/unit/agas/CMakeLists.txt
@@ -6,24 +6,78 @@
 add_subdirectory(components)
 
 set(tests
-    credit_exhaustion
     find_clients_from_prefix
     find_ids_from_prefix
     get_colocation_id
     gid_type
     local_address_rebind
     local_embedded_ref_to_local_object
-    local_embedded_ref_to_remote_object
-    remote_embedded_ref_to_local_object
-    remote_embedded_ref_to_remote_object
     refcnted_symbol_to_local_object
-    refcnted_symbol_to_remote_object
     scoped_ref_to_local_object
-    scoped_ref_to_remote_object
     split_credit
     uncounted_symbol_to_local_object
-    uncounted_symbol_to_remote_object
    )
+
+if(HPX_WITH_NETWORKING)
+    set(tests ${tests}
+        credit_exhaustion
+        local_embedded_ref_to_remote_object
+        remote_embedded_ref_to_local_object
+        remote_embedded_ref_to_remote_object
+        refcnted_symbol_to_remote_object
+        scoped_ref_to_remote_object
+        uncounted_symbol_to_remote_object
+       )
+
+  set(credit_exhaustion_FLAGS
+      DEPENDENCIES simple_refcnt_checker_component
+                   managed_refcnt_checker_component)
+  set(credit_exhaustion_PARAMETERS
+      LOCALITIES 2
+      THREADS_PER_LOCALITY 2)
+
+  set(local_embedded_ref_to_remote_object_FLAGS
+      DEPENDENCIES simple_refcnt_checker_component
+                   managed_refcnt_checker_component)
+  set(local_embedded_ref_to_remote_object_PARAMETERS
+      LOCALITIES 2
+      THREADS_PER_LOCALITY 2)
+
+  set(remote_embedded_ref_to_local_object_FLAGS
+      DEPENDENCIES simple_refcnt_checker_component
+                   managed_refcnt_checker_component)
+  set(remote_embedded_ref_to_local_object_PARAMETERS
+      LOCALITIES 2
+      THREADS_PER_LOCALITY 2)
+
+  set(remote_embedded_ref_to_remote_object_FLAGS
+      DEPENDENCIES simple_refcnt_checker_component
+                   managed_refcnt_checker_component)
+  set(remote_embedded_ref_to_remote_object_PARAMETERS
+      LOCALITIES 2
+      THREADS_PER_LOCALITY 2)
+
+  set(scoped_ref_to_remote_object_FLAGS
+      DEPENDENCIES simple_refcnt_checker_component
+                   managed_refcnt_checker_component)
+  set(scoped_ref_to_remote_object_PARAMETERS
+      LOCALITIES 2
+      THREADS_PER_LOCALITY 2)
+
+  set(refcnted_symbol_to_remote_object_FLAGS
+      DEPENDENCIES simple_refcnt_checker_component
+                   managed_refcnt_checker_component)
+  set(refcnted_symbol_to_remote_object_PARAMETERS
+      LOCALITIES 2
+      THREADS_PER_LOCALITY 2)
+
+  set(uncounted_symbol_to_remote_object_FLAGS
+      DEPENDENCIES simple_refcnt_checker_component
+                   managed_refcnt_checker_component)
+  set(uncounted_symbol_to_remote_object_PARAMETERS
+      LOCALITIES 2
+      THREADS_PER_LOCALITY 2)
+endif()
 
 set(find_ids_from_prefix_PARAMETERS LOCALITIES 2)
 set(find_clients_from_prefix_PARAMETERS LOCALITIES 2)
@@ -42,39 +96,11 @@ set(scoped_ref_to_local_object_FLAGS
 set(scoped_ref_to_local_object_PARAMETERS
     THREADS_PER_LOCALITY 4)
 
-set(scoped_ref_to_remote_object_FLAGS
-    DEPENDENCIES simple_refcnt_checker_component
-                 managed_refcnt_checker_component)
-set(scoped_ref_to_remote_object_PARAMETERS
-    LOCALITIES 2
-    THREADS_PER_LOCALITY 2)
-
 set(local_embedded_ref_to_local_object_FLAGS
     DEPENDENCIES simple_refcnt_checker_component
                  managed_refcnt_checker_component)
 set(local_embedded_ref_to_local_object_PARAMETERS
     THREADS_PER_LOCALITY 4)
-
-set(local_embedded_ref_to_remote_object_FLAGS
-    DEPENDENCIES simple_refcnt_checker_component
-                 managed_refcnt_checker_component)
-set(local_embedded_ref_to_remote_object_PARAMETERS
-    LOCALITIES 2
-    THREADS_PER_LOCALITY 2)
-
-set(remote_embedded_ref_to_local_object_FLAGS
-    DEPENDENCIES simple_refcnt_checker_component
-                 managed_refcnt_checker_component)
-set(remote_embedded_ref_to_local_object_PARAMETERS
-    LOCALITIES 2
-    THREADS_PER_LOCALITY 2)
-
-set(remote_embedded_ref_to_remote_object_FLAGS
-    DEPENDENCIES simple_refcnt_checker_component
-                 managed_refcnt_checker_component)
-set(remote_embedded_ref_to_remote_object_PARAMETERS
-    LOCALITIES 2
-    THREADS_PER_LOCALITY 2)
 
 set(refcnted_symbol_to_local_object_FLAGS
     DEPENDENCIES simple_refcnt_checker_component
@@ -82,32 +108,11 @@ set(refcnted_symbol_to_local_object_FLAGS
 set(refcnted_symbol_to_local_object_PARAMETERS
     THREADS_PER_LOCALITY 4)
 
-set(refcnted_symbol_to_remote_object_FLAGS
-    DEPENDENCIES simple_refcnt_checker_component
-                 managed_refcnt_checker_component)
-set(refcnted_symbol_to_remote_object_PARAMETERS
-    LOCALITIES 2
-    THREADS_PER_LOCALITY 2)
-
 set(uncounted_symbol_to_local_object_FLAGS
     DEPENDENCIES simple_refcnt_checker_component
                  managed_refcnt_checker_component)
 set(uncounted_symbol_to_local_object_PARAMETERS
     THREADS_PER_LOCALITY 4)
-
-set(uncounted_symbol_to_remote_object_FLAGS
-    DEPENDENCIES simple_refcnt_checker_component
-                 managed_refcnt_checker_component)
-set(uncounted_symbol_to_remote_object_PARAMETERS
-    LOCALITIES 2
-    THREADS_PER_LOCALITY 2)
-
-set(credit_exhaustion_FLAGS
-    DEPENDENCIES simple_refcnt_checker_component
-                 managed_refcnt_checker_component)
-set(credit_exhaustion_PARAMETERS
-    LOCALITIES 2
-    THREADS_PER_LOCALITY 2)
 
 set(split_credit_FLAGS
     DEPENDENCIES simple_refcnt_checker_component

--- a/tests/unit/component/CMakeLists.txt
+++ b/tests/unit/component/CMakeLists.txt
@@ -17,7 +17,6 @@ set(tests
     inheritance_3_classes_1_abstract
     inheritance_3_classes_2_abstract
     inheritance_3_classes_concrete
-    launch_process
     local_new
     migrate_component
     migrate_component_to_storage
@@ -32,19 +31,32 @@ set(tests
     coarray_all_reduce
    )
 
+if(HPX_WITH_NETWORKING)
+    set(tests ${tests}
+        launch_process
+       )
+
+    # add executable needed for launch_process_test
+    add_hpx_executable(launched_process_test
+      SOURCES launched_process.cpp
+      EXCLUDE_FROM_ALL
+      HPX_PREFIX ${HPX_BUILD_PREFIX}
+      FOLDER "Tests/Unit/Components"
+      COMPONENT_DEPENDENCIES launch_process_test_server)
+
+    set(launch_process_FLAGS
+        DEPENDENCIES iostreams_component process_component
+                     launch_process_test_server_component)
+    set(launch_process_PARAMETERS
+      --launch=$<TARGET_FILE:launched_process_test_exe>
+)
+endif()
+
 if(HPX_WITH_EXECUTOR_COMPATIBILITY)
   set(tests ${tests}
       distribution_policy_executor_v1
      )
 endif()
-
-# add executable needed for launch_process_test
-add_hpx_executable(launched_process_test
-  SOURCES launched_process.cpp
-  EXCLUDE_FROM_ALL
-  HPX_PREFIX ${HPX_BUILD_PREFIX}
-  FOLDER "Tests/Unit/Components"
-  COMPONENT_DEPENDENCIES launch_process_test_server)
 
 set(action_invoke_no_more_than_PARAMETERS
     THREADS_PER_LOCALITY 4)
@@ -62,13 +74,6 @@ set(copy_component_PARAMETERS
 set(get_ptr_PARAMETERS
     LOCALITIES 2
     THREADS_PER_LOCALITY 2)
-
-set(launch_process_FLAGS
-    DEPENDENCIES iostreams_component process_component
-                 launch_process_test_server_component)
-set(launch_process_PARAMETERS
-  --launch=$<TARGET_FILE:launched_process_test_exe>
-)
 
 set(migrate_component_PARAMETERS
     LOCALITIES 2
@@ -155,4 +160,6 @@ foreach(test ${tests})
 
 endforeach()
 
-add_hpx_pseudo_dependencies(tests.unit.component.launch_process launched_process_test_exe)
+if(HPX_WITH_NETWORKING)
+    add_hpx_pseudo_dependencies(tests.unit.component.launch_process launched_process_test_exe)
+endif()

--- a/tests/unit/parallel/executors/service_executors.cpp
+++ b/tests/unit/parallel/executors/service_executors.cpp
@@ -155,20 +155,26 @@ int hpx_main(int argc, char* argv[])
     using namespace hpx::parallel;
     using hpx::threads::executors::service_executor_type;
 
+#if defined(HPX_HAVE_IO_POOL)
     {
         execution::service_executor exec(service_executor_type::io_thread_pool);
         test_service_executor(exec);
     }
+#endif
 
+#if defined(HPX_HAVE_NETWORKING)
     {
         execution::service_executor exec(service_executor_type::parcel_thread_pool);
         test_service_executor(exec);
     }
+#endif
 
+#if defined(HPX_HAVE_TIMER_POOL)
     {
         execution::service_executor exec(service_executor_type::timer_thread_pool);
         test_service_executor(exec);
     }
+#endif
 
     {
         execution::service_executor exec(service_executor_type::main_thread);

--- a/tests/unit/parcelset/put_parcels.cpp
+++ b/tests/unit/parcelset/put_parcels.cpp
@@ -218,9 +218,11 @@ int hpx_main(boost::program_options::variables_map& vm)
         test_mixed_arguments(id);
     }
 
+#if defined(HPX_HAVE_NETWORKING)
     // compare number of parcels with number of messages generated
     print_counters("/parcels/count/*/sent");
     print_counters("/messages/count/*/sent");
+#endif
 
     return hpx::finalize();
 }
@@ -240,7 +242,9 @@ int main(int argc, char* argv[])
 
     // explicitly disable message handlers (parcel coalescing)
     std::vector<std::string> const cfg = {
+#if defined(HPX_HAVE_NETWORKING)
         "hpx.parcel.message_handlers=0"
+#endif
     };
 
     // Initialize and run HPX


### PR DESCRIPTION
## Proposed Changes

- Disable the background thread completely in `scheduling_loop` if `HPX_HAVE_NETWORKING=OFF`
- The flag can still be set but has no effect
- This is unlikely to give a big speedup in any application, but it's nice to disable as the background thread doesn't do anything useful with networking off

@biddisco Might give you a *tiny* speedup for Cholesky, unless you've already disabled the background thread.

WIP as I will still run the tests with pycicle and networking off.