### PR TITLE
Fixing Libfabric Parcelport

### DIFF
--- a/plugins/parcelport/libfabric/header.hpp
+++ b/plugins/parcelport/libfabric/header.hpp
@@ -8,6 +8,7 @@
 #ifndef HPX_PARCELSET_POLICIES_LIBFABRIC_HEADER_HPP
 #define HPX_PARCELSET_POLICIES_LIBFABRIC_HEADER_HPP
 
+#include <plugins/parcelport/parcelport_logging.hpp>
 #include <hpx/runtime/parcelset/parcel_buffer.hpp>
 #include <hpx/util/assert.hpp>
 //

--- a/plugins/parcelport/libfabric/libfabric_controller.hpp
+++ b/plugins/parcelport/libfabric/libfabric_controller.hpp
@@ -717,7 +717,7 @@ namespace libfabric
             }
             else if (ret == -FI_EAVAIL) {
                 struct fi_cq_err_entry e = {};
-                int err_sz = fi_cq_readerr(txcq_, &e ,0);
+                /*int err_sz =*/ fi_cq_readerr(txcq_, &e ,0);
                 // flags might not be set correctly
                 if (e.flags == (FI_MSG | FI_SEND)) {
                     LOG_ERROR_MSG("txcq Error for FI_SEND with len " << hexlength(e.len)
@@ -787,7 +787,7 @@ namespace libfabric
             }
             else if (ret == -FI_EAVAIL) {
                 struct fi_cq_err_entry e = {};
-                int err_sz = fi_cq_readerr(rxcq_, &e ,0);
+                /*int err_sz =*/ fi_cq_readerr(rxcq_, &e ,0);
                 LOG_ERROR_MSG("rxcq Error with flags " << hexlength(e.flags)
                     << "len " << hexlength(e.len));
             }

--- a/plugins/parcelport/libfabric/locality.hpp
+++ b/plugins/parcelport/libfabric/locality.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/runtime/parcelset/locality.hpp>
 #include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/runtime/serialization/array.hpp>
 //
 #include <utility>
 #include <cstring>

--- a/plugins/parcelport/libfabric/receiver.cpp
+++ b/plugins/parcelport/libfabric/receiver.cpp
@@ -129,7 +129,6 @@ namespace libfabric
             // potentially block all background threads.
             const long max_receivers =
                 HPX_PARCELPORT_LIBFABRIC_MAX_PREPOSTS;
-            std::size_t k = 0;
             if (threads::threadmanager_is_at_least(state_running)
                 && hpx::threads::get_self_ptr())
             {

--- a/plugins/parcelport/libfabric/rma_receiver.cpp
+++ b/plugins/parcelport/libfabric/rma_receiver.cpp
@@ -306,7 +306,7 @@ namespace libfabric
         // count reads
         ++rma_reads_;
 
-        hpx::util::yield_while([this, get_region]()
+        hpx::util::yield_while([this, get_region, remoteAddr, rkey]()
             {
                 LOG_EXCLUSIVE(
                     // write a pattern and dump out data for debugging purposes

--- a/plugins/parcelport/libfabric/sender.cpp
+++ b/plugins/parcelport/libfabric/sender.cpp
@@ -166,7 +166,7 @@ namespace libfabric
                     }
 
                     return false;
-                }, "sender::async_write")
+                }, "sender::async_write");
         }
         else
         {


### PR DESCRIPTION
This patch makes the libfabric parcelport compile and run again after the recent changes
