### PR TITLE
Readding accidently removed std::abort

### DIFF
--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -59,7 +59,7 @@
 namespace hpx
 {
     ///////////////////////////////////////////////////////////////////////////
-    HPX_NORETURN void handle_termination(char const* reason)
+    void handle_termination(char const* reason)
     {
         if (get_config_entry("hpx.attach_debugger", "") == "exception")
         {
@@ -134,6 +134,7 @@ namespace hpx
                 << "{what}: " << (reason ? reason : "Unknown signal") << "\n"
                 << full_build_string();           // add full build information
         }
+        std::abort();
     }
 }
 


### PR DESCRIPTION
This abort was removed with #3188.

## Any background context you want to provide?

Without this change, applications can not be stopped by for example hitting ctrl+c or when an exception occurs.