### PR TITLE
Modify task counting in thread_queue.hpp

### DIFF
--- a/hpx/runtime/threads/policies/thread_queue.hpp
+++ b/hpx/runtime/threads/policies/thread_queue.hpp
@@ -319,9 +319,9 @@ namespace hpx { namespace threads { namespace policies
                         "Couldn't add new thread to the thread map");
                     return 0;
                 }
-                
+
                 ++thread_map_count_;
-                
+
                 // Decrement only after thread_map_count_ has been incremented
                 --addfrom->new_tasks_count_;
 
@@ -821,7 +821,7 @@ namespace hpx { namespace threads { namespace policies
 #endif
 
                 bool finish = count == ++new_tasks_count_;
-                
+
                 // Decrement only after the local new_tasks_count_ has
                 // been incremented
                 --src->new_tasks_count_;

--- a/hpx/runtime/threads/policies/thread_queue.hpp
+++ b/hpx/runtime/threads/policies/thread_queue.hpp
@@ -293,7 +293,7 @@ namespace hpx { namespace threads { namespace policies
                     ++addfrom->new_tasks_wait_count_;
                 }
 #endif
-                --addfrom->new_tasks_count_;
+
 
                 // measure thread creation time
                 util::block_profiler_wrapper<add_new_tag> bp(add_new_logger_);
@@ -312,13 +312,18 @@ namespace hpx { namespace threads { namespace policies
                     thread_map_.insert(thrd);
 
                 if (HPX_UNLIKELY(!p.second)) {
+                    --addfrom->new_tasks_count_;
                     lk.unlock();
                     HPX_THROW_EXCEPTION(hpx::out_of_memory,
                         "threadmanager::add_new",
                         "Couldn't add new thread to the thread map");
                     return 0;
                 }
+                
                 ++thread_map_count_;
+                
+                // Decrement only after thread_map_count_ has been incremented
+                --addfrom->new_tasks_count_;
 
                 // only insert the thread into the work-items queue if it is in
                 // pending state
@@ -804,7 +809,7 @@ namespace hpx { namespace threads { namespace policies
             task_description* task;
             while (src->new_tasks_.pop(task))
             {
-                --src->new_tasks_count_;
+
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
                 if (maintain_queue_wait_times) {
@@ -816,6 +821,11 @@ namespace hpx { namespace threads { namespace policies
 #endif
 
                 bool finish = count == ++new_tasks_count_;
+                
+                // Decrement only after the local new_tasks_count_ has
+                // been incremented
+                --src->new_tasks_count_;
+
                 if (new_tasks_.push(task))
                 {
                     if (finish)


### PR DESCRIPTION
## Proposed Changes

- Make sure that `new_tasks_count_` is decremented only after a corresponding count has been incremented (when moving tasks from one queue to another)
- This is to make sure `new_tasks_count_ + thread_map_count_` never goes to 0 while there are tasks available (see below for example)

## Any background context you want to provide?

This is relevant for suspending the runtime after launching a task
```
// in main thread

// no tasks in queues at this point
hpx::async(...); // task added to new_tasks
// scheduler on worker thread removes task from new_tasks (decrements count)
hpx::suspend(); // get_thread_count returns 0, runtime suspends even though
                // it should wait for the async task to run
// scheduler on worker thread adds task to thread_map (increments count)
```

I find this a bit ugly, but I expect it to be temporary. Once #3146 and a follow up PR to remove the `new_tasks_` queue, this will not be needed anymore.

A bit last minute, but this I would still like to have in the release assuming tests pass.