### PR TITLE
Apex refactoring with guids

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1539,7 +1539,7 @@ if(HPX_WITH_APEX)
   include(GitExternal)
   git_external(apex
     https://github.com/khuck/xpress-apex.git
-    generate_guids
+    v2.0
     ${_hpx_apex_no_update}
     VERBOSE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1539,7 +1539,7 @@ if(HPX_WITH_APEX)
   include(GitExternal)
   git_external(apex
     https://github.com/khuck/xpress-apex.git
-    master
+    generate_guids
     ${_hpx_apex_no_update}
     VERBOSE)
 

--- a/hpx/runtime/threads/coroutines/coroutine.hpp
+++ b/hpx/runtime/threads/coroutines/coroutine.hpp
@@ -97,9 +97,13 @@ namespace hpx { namespace threads { namespace coroutines
         }
 
 #if defined(HPX_HAVE_APEX)
-        void** get_apex_data() const
+        void* get_apex_data() const
         {
             return impl_.get_apex_data();
+        }
+        void set_apex_data(void * data)
+        {
+            return impl_.set_apex_data(data);
         }
 #endif
 

--- a/hpx/runtime/threads/coroutines/detail/context_base.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_base.hpp
@@ -48,6 +48,9 @@
 #include <hpx/runtime/threads/coroutines/exception.hpp>
 #include <hpx/runtime/threads/thread_id_type.hpp>
 #include <hpx/util/assert.hpp>
+#if defined(HPX_HAVE_APEX)
+#include <hpx/util/apex.hpp>
+#endif
 
 #include <atomic>
 #include <cstddef>
@@ -250,7 +253,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         }
 
 #if defined(HPX_HAVE_APEX)
-        void** get_apex_data() const
+        void* get_apex_data() const
         {
             // APEX wants the ADDRESS of a location to store
             // data.  This storage could be updated asynchronously,
@@ -258,7 +261,11 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
             // to remember state for the HPX thread in-betweeen
             // calls to apex::start/stop/yield/resume().
             // APEX will change the value pointed to by the address.
-            return const_cast<void**>(&m_apex_data);
+            return m_apex_data;
+        }
+        void set_apex_data(void * data)
+        {
+            m_apex_data = data;
         }
 #endif
 
@@ -338,7 +345,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 #endif
             HPX_ASSERT(m_thread_data == 0);
 #if defined(HPX_HAVE_APEX)
-            HPX_ASSERT(m_apex_data == 0ull);
+            m_apex_data = 0ull;
 #endif
             m_type_info = std::exception_ptr();
         }

--- a/hpx/runtime/threads/coroutines/detail/coroutine_self.hpp
+++ b/hpx/runtime/threads/coroutines/detail/coroutine_self.hpp
@@ -197,10 +197,15 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         static HPX_EXPORT void reset_self();
 
 #if defined(HPX_HAVE_APEX)
-        void** get_apex_data() const
+        void* get_apex_data(void) const
         {
             HPX_ASSERT(m_pimpl);
             return m_pimpl->get_apex_data();
+        }
+        void set_apex_data(void * data)
+        {
+            HPX_ASSERT(m_pimpl);
+            m_pimpl->set_apex_data(data);
         }
 #endif
 

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -354,7 +354,7 @@ namespace hpx { namespace threads { namespace detail
                     if (HPX_LIKELY(thrd_stat.is_valid() &&
                             thrd_stat.get_previous() == pending))
                     {
-#if defined(HPX_HAVE_APEX)
+#if defined(HPX_HAVE_APEX_disabled)
                         // get the APEX data pointer, in case we are resuming the
                         // thread and have to restore any leaf timers from
                         // direct actions, etc.
@@ -362,7 +362,6 @@ namespace hpx { namespace threads { namespace detail
                         // the address of tmp_data is getting stored
                         // by APEX during this call
                         util::apex_wrapper apex_profiler(
-                            background_thread->get_description(),
                             background_thread->get_apex_data());
 
                         thrd_stat = (*background_thread)();
@@ -526,7 +525,6 @@ namespace hpx { namespace threads { namespace detail
                                 // the address of tmp_data is getting stored
                                 // by APEX during this call
                                 util::apex_wrapper apex_profiler(
-                                    thrd->get_description(),
                                     thrd->get_apex_data());
 
                                 thrd_stat = (*thrd)();

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -510,6 +510,8 @@ namespace hpx { namespace threads { namespace detail
                                 if (thrd_stat.get_previous() == terminated)
                                 {
                                     apex_profiler.stop();
+                                    // just in case, clean up the now dead pointer.
+                                    thrd->set_apex_data(nullptr);
                                 }
                                 else
                                 {

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -354,29 +354,7 @@ namespace hpx { namespace threads { namespace detail
                     if (HPX_LIKELY(thrd_stat.is_valid() &&
                             thrd_stat.get_previous() == pending))
                     {
-#if defined(HPX_HAVE_APEX_disabled)
-                        // get the APEX data pointer, in case we are resuming the
-                        // thread and have to restore any leaf timers from
-                        // direct actions, etc.
-
-                        // the address of tmp_data is getting stored
-                        // by APEX during this call
-                        util::apex_wrapper apex_profiler(
-                            background_thread->get_apex_data());
-
                         thrd_stat = (*background_thread)();
-
-                        if (thrd_stat.get_previous() == terminated)
-                        {
-                            apex_profiler.stop();
-                        }
-                        else
-                        {
-                            apex_profiler.yield();
-                        }
-#else
-                        thrd_stat = (*background_thread)();
-#endif
                         thread_data* next = thrd_stat.get_next_thread();
                         if (next != nullptr && next != background_thread.get())
                         {

--- a/hpx/runtime/threads/thread_data.hpp
+++ b/hpx/runtime/threads/thread_data.hpp
@@ -526,9 +526,13 @@ namespace hpx { namespace threads
         }
 
 #if defined(HPX_HAVE_APEX)
-        void** get_apex_data() const
+        void* get_apex_data() const
         {
             return coroutine_.get_apex_data();
+        }
+        void set_apex_data(void * data)
+        {
+            return coroutine_.set_apex_data(data);
         }
 #endif
 
@@ -598,6 +602,9 @@ namespace hpx { namespace threads
             }
             if (0 == parent_locality_id_)
                 parent_locality_id_ = get_locality_id();
+#endif
+#if defined(HPX_HAVE_APEX)
+            set_apex_data(apex_new_task(get_description()));
 #endif
             HPX_ASSERT(init_data.stacksize != 0);
             HPX_ASSERT(coroutine_.is_ready());

--- a/hpx/runtime/threads/thread_data_fwd.hpp
+++ b/hpx/runtime/threads/thread_data_fwd.hpp
@@ -159,7 +159,8 @@ namespace hpx { namespace threads
         thread_state_enum state = unknown);
 
 #if defined(HPX_HAVE_APEX)
-    HPX_API_EXPORT void** get_self_apex_data();
+    HPX_API_EXPORT void* get_self_apex_data(void);
+    HPX_API_EXPORT void set_self_apex_data(void * data);
 #endif
 }}
 

--- a/hpx/util/annotated_function.hpp
+++ b/hpx/util/annotated_function.hpp
@@ -75,14 +75,14 @@ namespace hpx { namespace util
         explicit annotate_function(char const* name)
         {
             threads::set_self_apex_data(
-                apex_update_task(threads::get_self_apex_data(), 
+                apex_update_task(threads::get_self_apex_data(),
                 name));
         }
         template <typename F>
         explicit annotate_function(F && f)
         {
             threads::set_self_apex_data(
-                apex_update_task(threads::get_self_apex_data(), 
+                apex_update_task(threads::get_self_apex_data(),
                 hpx::util::thread_description(f)));
         }
     };

--- a/hpx/util/annotated_function.hpp
+++ b/hpx/util/annotated_function.hpp
@@ -73,16 +73,18 @@ namespace hpx { namespace util
         HPX_NON_COPYABLE(annotate_function);
 
         explicit annotate_function(char const* name)
-          : apex_profiler_(name, threads::get_self_apex_data())
-        {}
+        {
+            threads::set_self_apex_data(
+                apex_update_task(threads::get_self_apex_data(), 
+                name));
+        }
         template <typename F>
         explicit annotate_function(F && f)
-          : apex_profiler_(hpx::util::thread_description(f),
-                threads::get_self_apex_data())
-        {}
-
-    private:
-        hpx::util::apex_wrapper apex_profiler_;
+        {
+            threads::set_self_apex_data(
+                apex_update_task(threads::get_self_apex_data(), 
+                hpx::util::thread_description(f)));
+        }
     };
 #else
     struct annotate_function

--- a/hpx/util/apex.hpp
+++ b/hpx/util/apex.hpp
@@ -38,7 +38,7 @@ namespace hpx { namespace util
     inline void * apex_new_task(
                 thread_description const& description)
     {
-        if (description.kind() == 
+        if (description.kind() ==
                 thread_description::data_type_description) {
             return (void*)apex::new_task(description.get_description());
         } else {
@@ -51,14 +51,14 @@ namespace hpx { namespace util
         return (void*)apex::new_task(name);
     }
 
-    inline void * apex_update_task(void * wrapper, 
+    inline void * apex_update_task(void * wrapper,
                 thread_description const& description)
     {
         if (description.kind() == thread_description::data_type_description) {
-            return (void*)apex::update_task((apex::task_wrapper*)wrapper, 
+            return (void*)apex::update_task((apex::task_wrapper*)wrapper,
                 description.get_description());
         } else {
-            return (void*)apex::update_task((apex::task_wrapper*)wrapper, 
+            return (void*)apex::update_task((apex::task_wrapper*)wrapper,
                 description.get_address());
         }
     }

--- a/src/runtime/threads/thread_data.cpp
+++ b/src/runtime/threads/thread_data.cpp
@@ -214,12 +214,19 @@ namespace hpx { namespace threads
     }
 
 #if defined(HPX_HAVE_APEX)
-    void** get_self_apex_data()
+    void* get_self_apex_data()
     {
         thread_self* self = get_self_ptr();
         if (nullptr == self)
             return nullptr;
         return self->get_apex_data();
+    }
+    void set_self_apex_data(void* data)
+    {
+        thread_self* self = get_self_ptr();
+        if (nullptr == self)
+            return;
+        self->set_apex_data(data);
     }
 #endif
 }}


### PR DESCRIPTION
  - Adds apex_new_task() call when HPX threads are constructed.  The resulting object pointer (apex::task_wrapper* cast as a void*) is stored in the thread.
  - Updates the apex start/yield/stop calls to take the apex::task_wrapper object pointer.  The apex::stop call will destroy the object, so HPX doesn't have to manage that memory.
  - Removes the start/stop around the background thread - the measurement of that thread actually is handled when the work is scheduled in the regular scheduler.

This pull request updates the APEX/HPX integration to track task dependencies, generate GUIDs within APEX for tracking tasks, and adds those GUIDs to the OTF2 trace output.  The version of APEX that cmake will pull has been modified from "master" to "v2.0", a new tag in APEX representing these API changes.  v2.0 is currently a "beta" release, if all goes well it will become an official release soon.
