### PR TITLE
Adds new feature: changing interval used in interval_timer (issue 3244)

### DIFF
--- a/hpx/util/interval_timer.hpp
+++ b/hpx/util/interval_timer.hpp
@@ -62,8 +62,6 @@ namespace hpx { namespace util { namespace detail
 
         std::int64_t get_interval() const;
 
-        void slow_down(std::int64_t max_interval);
-        void speed_up(std::int64_t min_interval);
         void change_interval(std::int64_t new_interval);
 
     protected:
@@ -145,12 +143,8 @@ namespace hpx { namespace util
 
         std::int64_t get_interval() const;
 
-        void slow_down(std::int64_t max_interval);
-        void speed_up(std::int64_t min_interval);
         void change_interval(std::int64_t new_interval);
 
-        void slow_down(util::steady_duration const& max_interval);
-        void speed_up(util::steady_duration const& min_interval);
         void change_interval(util::steady_duration const& new_interval);
 
     private:

--- a/hpx/util/interval_timer.hpp
+++ b/hpx/util/interval_timer.hpp
@@ -64,6 +64,7 @@ namespace hpx { namespace util { namespace detail
 
         void slow_down(std::int64_t max_interval);
         void speed_up(std::int64_t min_interval);
+        void change_interval(std::int64_t new_interval);
 
     protected:
         // schedule a high priority task after a given time interval
@@ -146,9 +147,11 @@ namespace hpx { namespace util
 
         void slow_down(std::int64_t max_interval);
         void speed_up(std::int64_t min_interval);
+        void change_interval(std::int64_t new_interval);
 
         void slow_down(util::steady_duration const& max_interval);
         void speed_up(util::steady_duration const& min_interval);
+        void change_interval(util::steady_duration const& new_interval);
 
     private:
         std::shared_ptr<detail::interval_timer> timer_;

--- a/src/util/interval_timer.cpp
+++ b/src/util/interval_timer.cpp
@@ -166,17 +166,6 @@ namespace hpx { namespace util { namespace detail
         return microsecs_;
     }
 
-    void interval_timer::slow_down(std::int64_t max_interval)
-    {
-        std::lock_guard<mutex_type> l(mtx_);
-        microsecs_ = (std::min)((110 * microsecs_) / 100, max_interval);
-    }
-    void interval_timer::speed_up(std::int64_t min_interval)
-    {
-        std::lock_guard<mutex_type> l(mtx_);
-        microsecs_ = (std::max)((90 * microsecs_) / 100, min_interval);
-    }
-
     void interval_timer::change_interval(std::int64_t new_interval)
     {
         HPX_ASSERT(new_interval > 0);
@@ -334,29 +323,9 @@ namespace hpx { namespace util
         return timer_->get_interval();
     }
 
-    void interval_timer::slow_down(std::int64_t max_interval)
-    {
-        return timer_->slow_down(max_interval);
-    }
-
-    void interval_timer::speed_up(std::int64_t min_interval)
-    {
-        return timer_->speed_up(min_interval);
-    }
-
     void interval_timer::change_interval(std::int64_t new_interval)
     {
         return timer_->change_interval(new_interval);
-    }
-
-    void interval_timer::slow_down(util::steady_duration const& max_interval)
-    {
-        return timer_->slow_down(max_interval.value().count() / 1000);
-    }
-
-    void interval_timer::speed_up(util::steady_duration const& min_interval)
-    {
-        return timer_->speed_up(min_interval.value().count() / 1000);
     }
 
     void interval_timer::change_interval(util::steady_duration const& new_interval)

--- a/src/util/interval_timer.cpp
+++ b/src/util/interval_timer.cpp
@@ -177,6 +177,14 @@ namespace hpx { namespace util { namespace detail
         microsecs_ = (std::max)((90 * microsecs_) / 100, min_interval);
     }
 
+    void interval_timer::change_interval(std::int64_t new_interval)
+    {
+        HPX_ASSERT(new_interval > 0);
+
+        std::lock_guard<mutex_type> l(mtx_);
+        microsecs_ = new_interval;
+    }
+
     threads::thread_result_type interval_timer::evaluate(
         threads::thread_state_ex_enum statex)
     {
@@ -336,6 +344,11 @@ namespace hpx { namespace util
         return timer_->speed_up(min_interval);
     }
 
+    void interval_timer::change_interval(std::int64_t new_interval)
+    {
+        return timer_->change_interval(new_interval);
+    }
+
     void interval_timer::slow_down(util::steady_duration const& max_interval)
     {
         return timer_->slow_down(max_interval.value().count() / 1000);
@@ -344,5 +357,10 @@ namespace hpx { namespace util
     void interval_timer::speed_up(util::steady_duration const& min_interval)
     {
         return timer_->speed_up(min_interval.value().count() / 1000);
+    }
+
+    void interval_timer::change_interval(util::steady_duration const& new_interval)
+    {
+        return timer_->change_interval(new_interval.value().count() / 1000);
     }
 }}


### PR DESCRIPTION
Adds the function change_interval in hpx::util::interval_timer. This function allows the user to change the interval (attribute microsecs_) used by an interval_timer, thereby, slowing it down or speeding it up.
