### PR TITLE
Replace boost::format with custom sprintf-based implementation

### DIFF
--- a/examples/1d_stencil/1d_stencil_4_throttle.cpp
+++ b/examples/1d_stencil/1d_stencil_4_throttle.cpp
@@ -42,7 +42,7 @@ using hpx::performance_counters::stubs::performance_counter;
 using hpx::performance_counters::counter_value;
 using hpx::performance_counters::status_is_valid;
 static bool counters_initialized = false;
-static const char * counter_name = "/threadqueue{locality#%d/total}/length";
+static const char * counter_name = "/threadqueue{{locality#{}/total}/length";
 hpx::naming::id_type counter_id;
 
 id_type get_counter_id() {

--- a/examples/1d_stencil/print_time_results.hpp
+++ b/examples/1d_stencil/print_time_results.hpp
@@ -30,13 +30,13 @@ void print_time_results(
                 "Points_per_Partition,Partitions,Time_Steps\n"
              << std::flush;
 
-    std::string const locs_str = hpx::util::format("%u,", num_localities);
-    std::string const threads_str = hpx::util::format("%lu,", num_os_threads);
-    std::string const nx_str = hpx::util::format("%lu,", nx);
-    std::string const np_str = hpx::util::format("%lu,", np);
-    std::string const nt_str = hpx::util::format("%lu ", nt);
+    std::string const locs_str = hpx::util::format("{},", num_localities);
+    std::string const threads_str = hpx::util::format("{},", num_os_threads);
+    std::string const nx_str = hpx::util::format("{},", nx);
+    std::string const np_str = hpx::util::format("{},", np);
+    std::string const nt_str = hpx::util::format("{} ", nt);
 
-    hpx::util::format_to(std::cout, "%-6s %-6s %.14g, %-21s %-21s %-21s\n",
+    hpx::util::format_to(std::cout, "{:-6} {:-6} {:.14g}, {:-21} {:-21} {:-21}\n",
         locs_str, threads_str, elapsed / 1e9, nx_str, np_str,
         nt_str) << std::flush;
 }
@@ -56,12 +56,12 @@ void print_time_results(
                 "Points_per_Partition,Partitions,Time_Steps\n"
              << std::flush;
 
-    std::string const threads_str = hpx::util::format("%lu,", num_os_threads);
-    std::string const nx_str = hpx::util::format("%lu,", nx);
-    std::string const np_str = hpx::util::format("%lu,", np);
-    std::string const nt_str = hpx::util::format("%lu ", nt);
+    std::string const threads_str = hpx::util::format("{},", num_os_threads);
+    std::string const nx_str = hpx::util::format("{},", nx);
+    std::string const np_str = hpx::util::format("{},", np);
+    std::string const nt_str = hpx::util::format("{} ", nt);
 
-    hpx::util::format_to(std::cout, "%-21s %.14g, %-21s %-21s %-21s\n",
+    hpx::util::format_to(std::cout, "{:-21} {:.14g}, {:-21} {:-21} {:-21}\n",
         threads_str, elapsed / 1e9, nx_str, np_str,
         nt_str) << std::flush;
 }
@@ -79,11 +79,11 @@ void print_time_results(
                 "Grid_Points,Time_Steps\n"
              << std::flush;
 
-    std::string const threads_str = hpx::util::format("%lu,", num_os_threads);
-    std::string const nx_str = hpx::util::format("%lu,", nx);
-    std::string const nt_str = hpx::util::format("%lu ", nt);
+    std::string const threads_str = hpx::util::format("{},", num_os_threads);
+    std::string const nx_str = hpx::util::format("{},", nx);
+    std::string const nt_str = hpx::util::format("{} ", nt);
 
-    hpx::util::format_to(std::cout, "%-21s %10.12s, %-21s %-21s\n",
+    hpx::util::format_to(std::cout, "{:-21} {:10.12}, {:-21} {:-21}\n",
         threads_str, elapsed / 1e9, nx_str, nt_str) << std::flush;
 }
 

--- a/examples/apex/apex_balance.cpp
+++ b/examples/apex/apex_balance.cpp
@@ -84,7 +84,7 @@ int hpx_main(boost::program_options::variables_map& vm)
     }
 
 
-    char const* fmt = "elapsed time: %1% [s]\n";
+    char const* fmt = "elapsed time: {1} [s]\n";
     hpx::util::format_to(std::cout, fmt, t.elapsed());
 
     return hpx::finalize(); // Handles HPX shutdown

--- a/examples/apex/apex_fibonacci.cpp
+++ b/examples/apex/apex_fibonacci.cpp
@@ -66,7 +66,7 @@ int hpx_main(boost::program_options::variables_map& vm)
         fibonacci_action fib;
         std::uint64_t r = fib(hpx::find_here(), n);
 
-        char const* fmt = "fibonacci(%1%) == %2%\nelapsed time: %3% [s]\n";
+        char const* fmt = "fibonacci({1}) == {2}\nelapsed time: {3} [s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, t.elapsed());
     }
 

--- a/examples/apex/apex_policy_engine_active_thread_count.cpp
+++ b/examples/apex/apex_policy_engine_active_thread_count.cpp
@@ -57,14 +57,14 @@ using hpx::performance_counters::stubs::performance_counter;
 using hpx::performance_counters::counter_value;
 using hpx::performance_counters::status_is_valid;
 static bool counters_initialized = false;
-static const char * counter_name = "/threadqueue{locality#%d/total}/length";
+static const char * counter_name = "/threadqueue{{locality#{}/total}/length";
 
 id_type get_counter_id() {
     // Resolve the GID of the performances counter using it's symbolic name.
     std::uint32_t const prefix = hpx::get_locality_id();
     /*
     id_type id = get_counter(hpx::util::format(
-        "/threads{locality#%d/total}/count/instantaneous/active",
+        "/threads{{locality#{}/total}/count/instantaneous/active",
         prefix));
     */
     id_type id = get_counter(hpx::util::format(counter_name, prefix));
@@ -104,7 +104,7 @@ int hpx_main(boost::program_options::variables_map& vm)
         fibonacci_action fib;
         std::uint64_t r = fib(hpx::find_here(), n);
 
-        char const* fmt = "fibonacci(%1%) == %2%\nelapsed time: %3% [s]\n";
+        char const* fmt = "fibonacci({1}) == {2}\nelapsed time: {3} [s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, t.elapsed());
     }
 

--- a/examples/apex/apex_policy_engine_events.cpp
+++ b/examples/apex/apex_policy_engine_events.cpp
@@ -62,7 +62,7 @@ int hpx_main(boost::program_options::variables_map& vm)
         fibonacci_action fib;
         std::uint64_t r = fib(hpx::find_here(), n);
 
-        char const* fmt = "fibonacci(%1%) == %2%\nelapsed time: %3% [s]\n";
+        char const* fmt = "fibonacci({1}) == {2}\nelapsed time: {3} [s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, t.elapsed());
     }
 

--- a/examples/apex/apex_policy_engine_periodic.cpp
+++ b/examples/apex/apex_policy_engine_periodic.cpp
@@ -62,7 +62,7 @@ int hpx_main(boost::program_options::variables_map& vm)
         fibonacci_action fib;
         std::uint64_t r = fib(hpx::find_here(), n);
 
-        char const* fmt = "fibonacci(%1%) == %2%\nelapsed time: %3% [s]\n";
+        char const* fmt = "fibonacci({1}) == {2}\nelapsed time: {3} [s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, t.elapsed());
     }
 

--- a/examples/balancing/os_thread_num.cpp
+++ b/examples/balancing/os_thread_num.cpp
@@ -113,12 +113,12 @@ int hpx_main(variables_map& vm)
         {
             if (csv)
                 hpx::util::format_to(cout,
-                    "%1%,%2%\n",
+                    "{1},{2}\n",
                     result.second,
                     result.first) << flush;
             else
                 hpx::util::format_to(cout,
-                    "OS-thread %1% ran %2% PX-threads\n",
+                    "OS-thread {1} ran {2} PX-threads\n",
                     result.second,
                     result.first) << flush;
         }

--- a/examples/heartbeat/heartbeat.cpp
+++ b/examples/heartbeat/heartbeat.cpp
@@ -45,7 +45,7 @@ int monitor(double runfor, std::string const& name, std::uint64_t pause)
     if (!id)
     {
         hpx::util::format_to(std::cout,
-            "error: performance counter not found (%s)",
+            "error: performance counter not found ({})",
             name) << std::endl;
         return 1;
     }
@@ -54,7 +54,7 @@ int monitor(double runfor, std::string const& name, std::uint64_t pause)
     if (locality_id == hpx::naming::get_locality_id_from_gid(id.get_gid()))
     {
         hpx::util::format_to(std::cout,
-            "error: cannot query performance counters on its own locality (%s)",
+            "error: cannot query performance counters on its own locality ({})",
             name) << std::endl;
         return 1;
     }
@@ -86,7 +86,7 @@ int monitor(double runfor, std::string const& name, std::uint64_t pause)
                 zero_time = value.time_;
 
             hpx::util::format_to(std::cout,
-                "  %s,%d,%d[s],%d\n",
+                "  {},{},{}[s],{}\n",
                 name,
                 value.count_,
                 double((value.time_ - zero_time) * 1e-9),

--- a/examples/performance_counters/sine/sine_client.cpp
+++ b/examples/performance_counters/sine/sine_client.cpp
@@ -58,13 +58,13 @@ int monitor(std::uint64_t pause, std::uint64_t values)
 
     using hpx::performance_counters::performance_counter;
     performance_counter sine_explicit(hpx::util::format(
-        "/sine{locality#%d/instance#%d}/immediate/explicit",
+        "/sine{{locality#{}/instance#{}}/immediate/explicit",
         prefix, 0));
     performance_counter sine_implicit(hpx::util::format(
-        "/sine{locality#%d/total}/immediate/implicit",
+        "/sine{{locality#{}/total}/immediate/implicit",
         prefix));
     performance_counter sine_average(hpx::util::format(
-        "/statistics{/sine{locality#%d/instance#%d}/immediate/explicit}/average@100",
+        "/statistics{{/sine{{locality#{}/instance#{}}/immediate/explicit}/average@100",
         prefix, 1));
 
     // We need to explicitly start all counters before we can use them. For
@@ -92,7 +92,7 @@ int monitor(std::uint64_t pause, std::uint64_t values)
             if (!start_time)
                 start_time = value2.time_;
 
-            hpx::util::format_to(std::cout, "%.3f: %.4f, %.4f, %.4f\n",
+            hpx::util::format_to(std::cout, "{:.3}: {:.4}, {:.4}, {:.4}\n",
                 (value2.time_ - start_time) * 1e-9,
                 value1.get_value<double>(),
                 value2.get_value<double>() / 100000.,

--- a/examples/quickstart/1d_wave_equation.cpp
+++ b/examples/quickstart/1d_wave_equation.cpp
@@ -137,7 +137,7 @@ double calculate_u_tplus_x_1st(double u_t_xplus, double u_t_x,
 double wave(std::uint64_t t, std::uint64_t x)
 {
   std::lock_guard<hpx::lcos::local::mutex> l(u[t][x].mtx);
-  //  hpx::util::format_to(cout, "calling wave... t=%1% x=%2%\n", t, x) << flush;
+  //  hpx::util::format_to(cout, "calling wave... t={1} x={2}\n", t, x) << flush;
   if (u[t][x].computed)
     {
       //cout << ("already computed!\n") << flush;
@@ -216,9 +216,9 @@ int hpx_main(variables_map& vm)
 
   u = std::vector<std::vector<data> >(nt, std::vector<data>(nx));
 
-  hpx::util::format_to(cout, "dt = %1%\n", dt) << flush;
-  hpx::util::format_to(cout, "dx = %1%\n", dx) << flush;
-  hpx::util::format_to(cout, "alpha^2 = %1%\n", alpha_squared) << flush;
+  hpx::util::format_to(cout, "dt = {1}\n", dt) << flush;
+  hpx::util::format_to(cout, "dx = {1}\n", dx) << flush;
+  hpx::util::format_to(cout, "alpha^2 = {1}\n", alpha_squared) << flush;
 
   {
     // Keep track of the time required to execute.
@@ -234,11 +234,11 @@ int hpx_main(variables_map& vm)
 
     wait(futures, [&](std::size_t i, double n)
          { double x_here = i*dx;
-           hpx::util::format_to(outfile, "%1% %2%\n", x_here, n) << flush; });
+           hpx::util::format_to(outfile, "{1} {2}\n", x_here, n) << flush; });
 
     outfile.close();
 
-    char const* fmt = "elapsed time: %1% [s]\n";
+    char const* fmt = "elapsed time: {1} [s]\n";
     hpx::util::format_to(std::cout, fmt, t.elapsed());
   }
 

--- a/examples/quickstart/factorial.cpp
+++ b/examples/quickstart/factorial.cpp
@@ -46,8 +46,8 @@ int hpx_main(boost::program_options::variables_map& vm)
 
         double elapsed = t.elapsed();
         hpx::util::format_to(std::cout,
-            "factorial(%1%) == %2%\n"
-            "elapsed time == %3% [s]\n",
+            "factorial({1}) == {2}\n"
+            "elapsed time == {3} [s]\n",
             n, r, elapsed);
     }
 

--- a/examples/quickstart/fibonacci.cpp
+++ b/examples/quickstart/fibonacci.cpp
@@ -64,7 +64,7 @@ int hpx_main(boost::program_options::variables_map& vm)
         fibonacci_action fib;
         std::uint64_t r = fib(hpx::find_here(), n);
 
-        char const* fmt = "fibonacci(%1%) == %2%\nelapsed time: %3% [s]\n";
+        char const* fmt = "fibonacci({1}) == {2}\nelapsed time: {3} [s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, t.elapsed());
     }
 

--- a/examples/quickstart/fibonacci_await.cpp
+++ b/examples/quickstart/fibonacci_await.cpp
@@ -187,8 +187,8 @@ int hpx_main(boost::program_options::variables_map& vm)
 
 //      double d = double(hpx::util::high_resolution_clock::now() - start) / 1.e9;
         std::uint64_t d = hpx::util::high_resolution_clock::now() - start;
-        char const* fmt = "fibonacci_serial(%1%) == %2%,"
-            "elapsed time:,%3%,[s]\n";
+        char const* fmt = "fibonacci_serial({1}) == {2},"
+            "elapsed time:,{3},[s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, d / max_runs);
 
         executed_one = true;
@@ -208,8 +208,8 @@ int hpx_main(boost::program_options::variables_map& vm)
 
 //      double d = double(hpx::util::high_resolution_clock::now() - start) / 1.e9;
         std::uint64_t d = hpx::util::high_resolution_clock::now() - start;
-        char const* fmt = "fibonacci_await(%1%) == %2%,"
-            "elapsed time:,%3%,[s]\n";
+        char const* fmt = "fibonacci_await({1}) == {2},"
+            "elapsed time:,{3},[s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, d / max_runs);
 
         executed_one = true;

--- a/examples/quickstart/fibonacci_dataflow.cpp
+++ b/examples/quickstart/fibonacci_dataflow.cpp
@@ -90,8 +90,8 @@ int hpx_main(boost::program_options::variables_map& vm)
 
 //      double d = double(hpx::util::high_resolution_clock::now() - start) / 1.e9;
         std::uint64_t d = hpx::util::high_resolution_clock::now() - start;
-        char const* fmt = "fibonacci_serial(%1%) == %2%,"
-            "elapsed time:,%3%,[s]\n";
+        char const* fmt = "fibonacci_serial({1}) == {2},"
+            "elapsed time:,{3},[s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, d / max_runs);
 
         executed_one = true;
@@ -111,8 +111,8 @@ int hpx_main(boost::program_options::variables_map& vm)
 
 //      double d = double(hpx::util::high_resolution_clock::now() - start) / 1.e9;
         std::uint64_t d = hpx::util::high_resolution_clock::now() - start;
-        char const* fmt = "fibonacci_await(%1%) == %2%,"
-            "elapsed time:,%3%,[s]\n";
+        char const* fmt = "fibonacci_await({1}) == {2},"
+            "elapsed time:,{3},[s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, d / max_runs);
 
         executed_one = true;

--- a/examples/quickstart/fibonacci_futures.cpp
+++ b/examples/quickstart/fibonacci_futures.cpp
@@ -268,8 +268,8 @@ int hpx_main(boost::program_options::variables_map& vm)
         }
 
         std::uint64_t d = hpx::util::high_resolution_clock::now() - start;
-        char const* fmt = "fibonacci_serial(%1%) == %2%,"
-            "elapsed time:,%3%,[s]\n";
+        char const* fmt = "fibonacci_serial({1}) == {2},"
+            "elapsed time:,{3},[s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, d / max_runs);
 
         executed_one = true;
@@ -288,8 +288,8 @@ int hpx_main(boost::program_options::variables_map& vm)
         }
 
         std::uint64_t d = hpx::util::high_resolution_clock::now() - start;
-        char const* fmt = "fibonacci_future_one(%1%) == %2%,"
-            "elapsed time:,%3%,[s]\n";
+        char const* fmt = "fibonacci_future_one({1}) == {2},"
+            "elapsed time:,{3},[s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, d / max_runs);
 
         executed_one = true;
@@ -309,7 +309,7 @@ int hpx_main(boost::program_options::variables_map& vm)
 
 //        double d = double(hpx::util::high_resolution_clock::now() - start) / 1.e9;
         std::uint64_t d = hpx::util::high_resolution_clock::now() - start;
-        char const* fmt = "fibonacci(%1%) == %2%,elapsed time:,%3%,[s]\n";
+        char const* fmt = "fibonacci({1}) == {2},elapsed time:,{3},[s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, d / max_runs);
 
         executed_one = true;
@@ -328,7 +328,7 @@ int hpx_main(boost::program_options::variables_map& vm)
         }
 
         std::uint64_t d = hpx::util::high_resolution_clock::now() - start;
-        char const* fmt = "fibonacci_fork(%1%) == %2%,elapsed time:,%3%,[s]\n";
+        char const* fmt = "fibonacci_fork({1}) == {2},elapsed time:,{3},[s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, d / max_runs);
 
         executed_one = true;
@@ -347,7 +347,7 @@ int hpx_main(boost::program_options::variables_map& vm)
         }
 
         std::uint64_t d = hpx::util::high_resolution_clock::now() - start;
-        char const* fmt = "fibonacci_future(%1%) == %2%,elapsed time:,%3%,[s]\n";
+        char const* fmt = "fibonacci_future({1}) == {2},elapsed time:,{3},[s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, d / max_runs);
 
         executed_one = true;
@@ -366,7 +366,7 @@ int hpx_main(boost::program_options::variables_map& vm)
         }
 
         std::uint64_t d = hpx::util::high_resolution_clock::now() - start;
-        char const* fmt = "fibonacci_future_fork(%1%) == %2%,elapsed time:,%3%,[s]\n";
+        char const* fmt = "fibonacci_future_fork({1}) == {2},elapsed time:,{3},[s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, d / max_runs);
 
         executed_one = true;
@@ -386,7 +386,7 @@ int hpx_main(boost::program_options::variables_map& vm)
 
         std::uint64_t d = hpx::util::high_resolution_clock::now() - start;
         char const* fmt =
-            "fibonacci_future_when_all(%1%) == %2%,elapsed time:,%3%,[s]\n";
+            "fibonacci_future_when_all({1}) == {2},elapsed time:,{3},[s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, d / max_runs);
 
         executed_one = true;
@@ -406,7 +406,7 @@ int hpx_main(boost::program_options::variables_map& vm)
 
         std::uint64_t d = hpx::util::high_resolution_clock::now() - start;
         char const* fmt =
-            "fibonacci_future_unwrapped_when_all(%1%) == %2%,elapsed time:,%3%,[s]\n";
+            "fibonacci_future_unwrapped_when_all({1}) == {2},elapsed time:,{3},[s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, d / max_runs);
 
         executed_one = true;
@@ -426,7 +426,7 @@ int hpx_main(boost::program_options::variables_map& vm)
 
         std::uint64_t d = hpx::util::high_resolution_clock::now() - start;
         char const* fmt =
-            "fibonacci_future_all(%1%) == %2%,elapsed time:,%3%,[s]\n";
+            "fibonacci_future_all({1}) == {2},elapsed time:,{3},[s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, d / max_runs);
 
         executed_one = true;
@@ -446,7 +446,7 @@ int hpx_main(boost::program_options::variables_map& vm)
 
         std::uint64_t d = hpx::util::high_resolution_clock::now() - start;
         char const* fmt =
-            "fibonacci_future_all_when_all(%1%) == %2%,elapsed time:,%3%,[s]\n";
+            "fibonacci_future_all_when_all({1}) == {2},elapsed time:,{3},[s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, d / max_runs);
 
         executed_one = true;

--- a/examples/quickstart/fibonacci_futures_distributed.cpp
+++ b/examples/quickstart/fibonacci_futures_distributed.cpp
@@ -129,8 +129,8 @@ int hpx_main(boost::program_options::variables_map& vm)
 
 //        double d = double(hpx::util::high_resolution_clock::now() - start) / 1.e9;
         std::uint64_t d = hpx::util::high_resolution_clock::now() - start;
-        char const* fmt = "fibonacci_serial(%1%) == %2%,"
-            "elapsed time:,%3%,[s]\n";
+        char const* fmt = "fibonacci_serial({1}) == {2},"
+            "elapsed time:,{3},[s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, d);
 
         executed_one = true;
@@ -150,7 +150,7 @@ int hpx_main(boost::program_options::variables_map& vm)
 
 //        double d = double(hpx::util::high_resolution_clock::now() - start) / 1.e9;
         std::uint64_t d = hpx::util::high_resolution_clock::now() - start;
-        char const* fmt = "fibonacci_future(%1%) == %2%,elapsed time:,%3%,[s],%4%\n";
+        char const* fmt = "fibonacci_future({1}) == {2},elapsed time:,{3},[s],{4}\n";
         hpx::util::format_to(std::cout, fmt, n, r, d / max_runs,
             next_locality.load());
 
@@ -158,7 +158,7 @@ int hpx_main(boost::program_options::variables_map& vm)
         for (hpx::id_type const& loc : hpx::find_all_localities())
         {
             std::size_t count = serial_count(loc);
-            hpx::util::format_to(std::cout, "  serial-count,%1%,%2%\n",
+            hpx::util::format_to(std::cout, "  serial-count,{1},{2}\n",
                 loc, count / max_runs);
         }
 

--- a/examples/quickstart/fibonacci_one.cpp
+++ b/examples/quickstart/fibonacci_one.cpp
@@ -80,7 +80,7 @@ int hpx_main(boost::program_options::variables_map& vm)
         // wait for future f to return value
         std::uint64_t r = f.get();
 
-        char const* fmt = "fibonacci(%1%) == %2%, elapsed time: %3% [s]\n";
+        char const* fmt = "fibonacci({1}) == {2}, elapsed time: {3} [s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, t.elapsed());
     }
 
@@ -90,7 +90,7 @@ int hpx_main(boost::program_options::variables_map& vm)
 
         std::uint64_t r = fibonacci_direct(n);;
 
-        char const* fmt = "fibonacci_direct(%1%) == %2%, elapsed time: %3% [s]\n";
+        char const* fmt = "fibonacci_direct({1}) == {2}, elapsed time: {3} [s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, t.elapsed());
     }
 

--- a/examples/quickstart/hello_world.cpp
+++ b/examples/quickstart/hello_world.cpp
@@ -42,7 +42,7 @@ std::size_t hello_world_worker(std::size_t desired)
     if (current == desired)
     {
         // The HPX-thread has been run on the desired OS-thread.
-        char const* msg = "hello world from OS-thread %1% on locality %2%\n";
+        char const* msg = "hello world from OS-thread {1} on locality {2}\n";
 
         hpx::util::format_to(hpx::cout, msg, desired, hpx::get_locality_id())
             << hpx::flush;

--- a/examples/throttle/spin.cpp
+++ b/examples/throttle/spin.cpp
@@ -48,7 +48,7 @@ int hpx_main(variables_map& vm)
                 {
                     address addr = hpx::agas::resolve(locality_).get();
 
-                    hpx::util::format_to(std::cout, "  [%1%] %2%\n",
+                    hpx::util::format_to(std::cout, "  [{1}] {2}\n",
                         get_locality_id_from_gid(locality_.get_gid()),
                         addr.locality_);
                 }
@@ -57,7 +57,7 @@ int hpx_main(variables_map& vm)
             }
 
             else if (0 != std::string("help").find(arg))
-                hpx::util::format_to(std::cout, "error: unknown command '%1%'\n",
+                hpx::util::format_to(std::cout, "error: unknown command '{1}'\n",
                     arg);
 
             std::cout << "commands: localities, help, quit\n";

--- a/examples/throttle/throttle_client.cpp
+++ b/examples/throttle/throttle_client.cpp
@@ -30,7 +30,7 @@ using hpx::naming::get_agas_client;
 int hpx_main(variables_map& vm)
 {
     try {
-        hpx::util::format_to(std::cout, "prefix: %d",
+        hpx::util::format_to(std::cout, "prefix: {}",
             hpx::naming::get_locality_id_from_id(hpx::find_here())) << std::endl;
 
         // Try to connect to existing throttle instance, create a new one if

--- a/examples/transpose/transpose_block_numa.cpp
+++ b/examples/transpose/transpose_block_numa.cpp
@@ -573,8 +573,8 @@ int main(int argc, char* argv[])
         "hpx.run_hpx_main!=1",
         "hpx.numa_sensitive=2",  // no-cross NUMA stealing
         // block all cores of requested number of NUMA-domains
-        hpx::util::format("hpx.cores=%d", numa_nodes * num_cores),
-        hpx::util::format("hpx.os_threads=%d", numa_nodes * pus.second)
+        hpx::util::format("hpx.cores={}", numa_nodes * num_cores),
+        hpx::util::format("hpx.os_threads={}", numa_nodes * pus.second)
     };
 
     std::string node_name("numanode");
@@ -589,7 +589,7 @@ int main(int argc, char* argv[])
 
         std::size_t base_thread = i * pus.second;
         bind_desc += hpx::util::format(
-            "thread:%d-%d=%s:%d.core:0-%d.pu:0",
+            "thread:{}-{}={}:{}.core:0-{}.pu:0",
             base_thread, (base_thread+pus.second-1), // thread:%d-%d
             node_name, i,                            // %s:%d
             pus.second-1                             // core:0-%d

--- a/hpx/components/performance_counters/papi/util/papi.hpp
+++ b/hpx/components/performance_counters/papi/util/papi.hpp
@@ -42,7 +42,7 @@ namespace hpx { namespace performance_counters { namespace papi { namespace util
         if (rc != ok)
         {
             HPX_THROW_EXCEPTION(hpx::no_success, fname,
-                hpx::util::format("%s (%s)", info, PAPI_strerror(rc)));
+                hpx::util::format("{} ({})", info, PAPI_strerror(rc)));
         }
     }
     inline void papi_call(int rc, std::string const& info, char const *fname,

--- a/hpx/components/process/util/windows/initializers/throw_on_error.hpp
+++ b/hpx/components/process/util/windows/initializers/throw_on_error.hpp
@@ -41,8 +41,8 @@ public:
         {
             HPX_THROW_EXCEPTION(kernel_error,
                 "process::on_CreateProcess_error",
-                hpx::util::format("format message failed with %x (while "
-                    "retrieving message for %x)", GetLastError(), hr));
+                hpx::util::format("format message failed with {:x} (while "
+                    "retrieving message for {:x})", GetLastError(), hr));
             return;
         }
 

--- a/hpx/runtime/applier/apply_callback.hpp
+++ b/hpx/runtime/applier/apply_callback.hpp
@@ -156,7 +156,7 @@ namespace hpx
         if (!traits::action_is_target_valid<Action>::call(gid)) {
             HPX_THROW_EXCEPTION(bad_parameter, "apply_p_cb",
                 hpx::util::format(
-                    "the target (destination) does not match the action type (%s)",
+                    "the target (destination) does not match the action type ({})",
                     hpx::actions::detail::get_action_name<Action>()));
             return false;
         }

--- a/hpx/runtime/applier/detail/apply_implementations.hpp
+++ b/hpx/runtime/applier/detail/apply_implementations.hpp
@@ -35,7 +35,7 @@ namespace hpx { namespace detail
         if (!traits::action_is_target_valid<Action>::call(id)) {
             HPX_THROW_EXCEPTION(bad_parameter, "hpx::detail::apply_impl",
                 hpx::util::format(
-                    "the target (destination) does not match the action type (%s)",
+                    "the target (destination) does not match the action type ({})",
                     hpx::actions::detail::get_action_name<Action>()));
             return false;
         }
@@ -83,7 +83,7 @@ namespace hpx { namespace detail
             if (!traits::action_is_target_valid<Action>::call(id)) {
                 HPX_THROW_EXCEPTION(bad_parameter, "hpx::detail::apply_impl",
                     hpx::util::format(
-                        "the target (destination) does not match the action type (%s)",
+                        "the target (destination) does not match the action type ({})",
                         hpx::actions::detail::get_action_name<Action>()));
                 return false;
             }
@@ -131,7 +131,7 @@ namespace hpx { namespace detail
         if (!traits::action_is_target_valid<Action>::call(id)) {
             HPX_THROW_EXCEPTION(bad_parameter, "hpx::detail::apply_impl",
                 hpx::util::format(
-                    "the target (destination) does not match the action type (%s)",
+                    "the target (destination) does not match the action type ({})",
                     hpx::actions::detail::get_action_name<Action>()));
             return false;
         }
@@ -175,7 +175,7 @@ namespace hpx { namespace detail
             if (!traits::action_is_target_valid<Action>::call(id)) {
                 HPX_THROW_EXCEPTION(bad_parameter, "hpx::detail::apply_impl",
                     hpx::util::format(
-                        "the target (destination) does not match the action type (%s)",
+                        "the target (destination) does not match the action type ({})",
                         hpx::actions::detail::get_action_name<Action>()));
                 return false;
             }
@@ -221,7 +221,7 @@ namespace hpx { namespace detail
         if (!traits::action_is_target_valid<Action>::call(id)) {
             HPX_THROW_EXCEPTION(bad_parameter, "hpx::detail::apply_cb_impl",
                 hpx::util::format(
-                    "the target (destination) does not match the action type (%s)",
+                    "the target (destination) does not match the action type ({})",
                     hpx::actions::detail::get_action_name<Action>()));
             return false;
         }
@@ -273,7 +273,7 @@ namespace hpx { namespace detail
         if (!traits::action_is_target_valid<Action>::call(id)) {
             HPX_THROW_EXCEPTION(bad_parameter, "hpx::detail::apply_cb_impl",
                 hpx::util::format(
-                    "the target (destination) does not match the action type (%s)",
+                    "the target (destination) does not match the action type ({})",
                     hpx::actions::detail::get_action_name<Action>()));
             return false;
         }

--- a/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
@@ -193,14 +193,14 @@ namespace hpx { namespace threads { namespace coroutines
                 {
                     throw std::runtime_error(
                         hpx::util::format(
-                            "stack size of %1% is not page aligned, page size is %2%",
+                            "stack size of {1} is not page aligned, page size is {2}",
                             m_stack_size, EXEC_PAGESIZE));
                 }
 
                 if (0 >= m_stack_size)
                 {
                     throw std::runtime_error(
-                        hpx::util::format("stack size of %1% is invalid",
+                        hpx::util::format("stack size of {1} is invalid",
                             m_stack_size));
                 }
 

--- a/hpx/util/format.hpp
+++ b/hpx/util/format.hpp
@@ -1,20 +1,24 @@
-//  Copyright (c) 2017 Agustin Berge
+//  Copyright (c) 2017-2018 Agustin Berge
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-
-// hpxinspect:nodeprecatedinclude:boost/format.hpp
-// hpxinspect:nodeprecatedname:boost::format
 
 #ifndef HPX_UTIL_FORMAT_HPP
 #define HPX_UTIL_FORMAT_HPP
 
 #include <hpx/config.hpp>
 
-#include <boost/format.hpp>
+#include <boost/utility/string_ref.hpp>
 
-#include <iosfwd>
+#include <cctype>
+#include <cstddef>
+#include <cstdio>
+#include <ostream>
+#include <stdexcept>
 #include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 namespace hpx { namespace iostreams {
     template <typename Char, typename Sink>
@@ -23,15 +27,212 @@ namespace hpx { namespace iostreams {
 
 namespace hpx { namespace util
 {
+    namespace detail
+    {
+        ///////////////////////////////////////////////////////////////////////
+        template <typename T>
+        struct type_specifier
+        {
+            static char const* value() noexcept;
+        };
+
+#       define DECL_TYPE_SPECIFIER(Type, Spec)                                \
+        template <> struct type_specifier<Type>                               \
+        { static char const* value() noexcept { return #Spec; } }             \
+        /**/
+
+        DECL_TYPE_SPECIFIER(char, c);
+        DECL_TYPE_SPECIFIER(wchar_t, lc);
+
+        DECL_TYPE_SPECIFIER(signed char, hhd);
+        DECL_TYPE_SPECIFIER(short, hd);
+        DECL_TYPE_SPECIFIER(int, d);
+        DECL_TYPE_SPECIFIER(long, ld);
+        DECL_TYPE_SPECIFIER(long long, lld);
+
+        DECL_TYPE_SPECIFIER(unsigned char, hhu);
+        DECL_TYPE_SPECIFIER(unsigned short, hu);
+        DECL_TYPE_SPECIFIER(unsigned int, u);
+        DECL_TYPE_SPECIFIER(unsigned long, lu);
+        DECL_TYPE_SPECIFIER(unsigned long long, llu);
+
+        DECL_TYPE_SPECIFIER(float, f);
+        DECL_TYPE_SPECIFIER(double, lf);
+        DECL_TYPE_SPECIFIER(long double, Lf);
+
+#       undef DECL_TYPE_SPECIFIER
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename T, bool IsFundamental = std::is_fundamental<T>::value>
+        struct formatter
+        {
+            static void call(
+                std::ostream& os, boost::string_ref spec, void const* ptr)
+            {
+                // conversion specifier
+                char const* conv_spec = "";
+                if (spec.empty() || !std::isalpha(spec.back()))
+                    conv_spec = type_specifier<T>::value();
+
+                // copy spec to a null terminated buffer
+                char format[16];
+                std::sprintf(format, "%%%.*s%s",
+                    (int)spec.size(), spec.data(), conv_spec);
+
+                T const& value = *static_cast<T const*>(ptr);
+                std::size_t length = std::snprintf(nullptr, 0, format, value);
+                std::vector<char> buffer(length + 1);
+                length = std::snprintf(buffer.data(), length + 1, format, value);
+
+                os.write(buffer.data(), length);
+            }
+        };
+
+        template <>
+        struct formatter<bool>
+          : formatter<int>
+        {
+            static void call(
+                std::ostream& os, boost::string_ref spec, void const* ptr)
+            {
+                int const value = *static_cast<bool const*>(ptr) ? 1 : 0;
+                return formatter<int>::call(os, spec, &value);
+            }
+        };
+
+        template <>
+        struct formatter<void const*, /*IsFundamental=*/false>
+        {
+            static void call(
+                std::ostream& os, boost::string_ref spec, void const* ptr)
+            {
+                os << ptr;
+            }
+        };
+
+        template <typename T>
+        struct formatter<T const*, /*IsFundamental=*/false>
+          : formatter<void const*>
+        {};
+
+        template <>
+        struct formatter<char const*, /*IsFundamental=*/false>
+        {
+            static void call(
+                std::ostream& os, boost::string_ref spec, void const* ptr)
+            {
+                char const* value = static_cast<char const*>(ptr);
+
+                // conversion specifier
+                if (spec.empty() || spec == "s")
+                {
+                    os << value;
+                } else {
+                    // copy spec to a null terminated buffer
+                    char format[16];
+                    std::sprintf(format, "%%%.*ss",
+                        (int)spec.size(), spec.data());
+
+                    std::size_t length = std::snprintf(nullptr, 0, format, value);
+                    std::vector<char> buffer(length + 1);
+                    length = std::snprintf(buffer.data(), length + 1, format, value);
+
+                    os.write(buffer.data(), length);
+                }
+            }
+        };
+
+        template <>
+        struct formatter<std::string, /*IsFundamental=*/false>
+          : formatter<char const*>
+        {
+            static void call(
+                std::ostream& os, boost::string_ref spec, void const* ptr)
+            {
+                std::string const& value = *static_cast<std::string const*>(ptr);
+
+                if (spec.empty() || spec == "s")
+                    os.write(value.data(), value.size());
+                else
+                    formatter<char const*>::call(os, spec, value.c_str());
+            }
+        };
+
+        template <typename T>
+        void format_value(std::ostream& os, boost::string_ref spec, T const& value)
+        {
+            if (!spec.empty())
+                throw std::runtime_error("Not a valid format specifier");
+
+            os << value;
+        }
+
+        template <typename T>
+        struct formatter<T, /*IsFundamental=*/false>
+        {
+            static void call(
+                std::ostream& os, boost::string_ref spec, void const* value)
+            {
+                // ADL customization point
+                format_value(os, spec, *static_cast<T const*>(value));
+            }
+        };
+
+        struct format_arg
+        {
+            template <typename T>
+            format_arg(T const& arg)
+              : _data(&arg)
+              , _formatter(&detail::formatter<T>::call)
+            {}
+
+            template <typename T>
+            format_arg(T* arg)
+              : _data(arg)
+              , _formatter(&detail::formatter<T const*>::call)
+            {}
+            template <typename T>
+            format_arg(T const* arg)
+              : _data(arg)
+              , _formatter(&detail::formatter<T const*>::call)
+            {}
+
+            void operator()(std::ostream& os, boost::string_ref spec) const
+            {
+                _formatter(os, spec, _data);
+            }
+
+            void const* _data;
+            void (*_formatter)(std::ostream&, boost::string_ref spec, void const*);
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        /*HPX_EXPORT*/ void format_to(
+            std::ostream& os,
+            boost::string_ref format_str,
+            format_arg const* args, std::size_t count);
+
+        /*HPX_EXPORT*/ std::string format(
+            boost::string_ref format_str,
+            format_arg const* args, std::size_t count);
+    }
+
     template <typename ...Args>
     std::string format(
-        std::string const& format_str, Args const&... args)
+        boost::string_ref format_str, Args const&... args)
     {
-        boost::format fmt(format_str);
-        int const _sequencer[] = { ((fmt % args), 0)... };
-        (void)_sequencer;
+        detail::format_arg const format_args[] = { args..., 0 };
+        return detail::format(format_str, format_args, sizeof...(Args));
+    }
 
-        return boost::str(fmt);
+    template <typename ...Args>
+    std::ostream& format_to(
+        std::ostream& os,
+        boost::string_ref format_str, Args const&... args)
+    {
+        detail::format_arg const format_args[] = { args..., 0 };
+        detail::format_to(os, format_str, format_args, sizeof...(Args));
+        return os;
     }
 
     template <typename Char, typename Sink, typename ...Args>
@@ -39,24 +240,128 @@ namespace hpx { namespace util
         hpx::iostreams::ostream<Char, Sink>& os,
         std::string const& format_str, Args const&... args)
     {
-        boost::format fmt(format_str);
-        int const _sequencer[] = { ((fmt % args), 0)... };
-        (void)_sequencer;
-
-        return os << fmt;
-    }
-
-    template <typename ...Args>
-    std::ostream& format_to(
-        std::ostream& os,
-        std::string const& format_str, Args const&... args)
-    {
-        boost::format fmt(format_str);
-        int const _sequencer[] = { ((fmt % args), 0)... };
-        (void)_sequencer;
-
-        return os << fmt;
+        return os << format(format_str, args...);
     }
 }}
+
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright (c) 2017-2018 Agustin Berge
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/util/format.hpp>
+
+#include <hpx/util/assert.hpp>
+
+#include <boost/utility/string_ref.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <ostream>
+#include <sstream>
+#include <string>
+
+namespace hpx { namespace util { namespace detail
+{
+    ///////////////////////////////////////////////////////////////////////////
+    inline std::size_t format_atoi(
+        boost::string_ref str, std::size_t* pos = nullptr) noexcept
+    {
+        // copy input to a null terminated buffer
+        static constexpr std::size_t digits10 =
+            std::numeric_limits<std::size_t>::digits10 + 1;
+        char buffer[digits10 + 1] = {};
+        std::memcpy(buffer, str.data(), (std::min)(str.size(), digits10));
+
+        char const* first = buffer;
+        char* last = buffer;
+        std::size_t r = std::strtoull(first, &last, 10);
+        if (pos != nullptr)
+            *pos = last - first;
+        return r;
+    }
+
+    inline boost::string_ref format_substr(
+        boost::string_ref str,
+        std::size_t start, std::size_t end = boost::string_ref::npos) noexcept
+    {
+        return start < str.size()
+            ? str.substr(start, end - start) : boost::string_ref{};
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // replacement-field ::= '{' [arg-id] [':' format-spec] '}'
+    struct format_field
+    {
+        std::size_t arg_id;
+        boost::string_ref spec;
+    };
+
+    inline format_field parse_field(boost::string_ref field) noexcept
+    {
+        std::size_t const sep = field.find(':');
+        if (sep != field.npos)
+        {
+            boost::string_ref const arg_id = format_substr(field, 0, sep);
+            boost::string_ref const spec = format_substr(field, sep + 1);
+
+            std::size_t const id = format_atoi(arg_id);
+            return format_field{id, spec};
+        } else {
+            std::size_t const id = format_atoi(field);
+            return format_field{id, ""};
+        }
+    }
+
+    inline void format_to(
+        std::ostream& os,
+        boost::string_ref format_str,
+        format_arg const* args, std::size_t count)
+    {
+        std::size_t index = 0;
+        while (!format_str.empty())
+        {
+            if (format_str[0] == '{')
+            {
+                HPX_ASSERT(!format_str.empty());
+                if (format_str[1] == '{')
+                {
+                    os.write(format_str.data(), 1); // '{'
+                } else {
+                    std::size_t const end = format_str.find('}');
+                    boost::string_ref field_str = format_substr(format_str, 1, end);
+                    format_field const field = parse_field(field_str);
+                    format_str.remove_prefix(end - 1);
+
+                    std::size_t const id =
+                        field.arg_id ? field.arg_id - 1 : index;
+                    args[id](os, field.spec);
+                    ++index;
+                }
+                format_str.remove_prefix(2);
+            } else {
+                std::size_t const next = format_str.find('{');
+                std::size_t const count =
+                    next != format_str.npos ? next : format_str.size();
+
+                os.write(format_str.data(), count);
+                format_str.remove_prefix(count);
+            }
+        }
+    }
+
+    inline std::string format(
+        boost::string_ref format_str,
+        format_arg const* args, std::size_t count)
+    {
+        std::ostringstream os;
+        detail::format_to(os, format_str, args, count);
+        return os.str();
+    }
+}}}
 
 #endif /*HPX_UTIL_FORMAT_HPP*/

--- a/hpx/util/functional/colocated_helpers.hpp
+++ b/hpx/util/functional/colocated_helpers.hpp
@@ -39,7 +39,7 @@ namespace hpx { namespace util { namespace functional
                 HPX_THROW_EXCEPTION(hpx::no_success,
                     "extract_locality::operator()",
                     hpx::util::format(
-                        "could not resolve colocated locality for id(%1%)",
+                        "could not resolve colocated locality for id({1})",
                         id));
                 return naming::invalid_id;
             }

--- a/plugins/binary_filter/bzip2/bzip2_serialization_filter.cpp
+++ b/plugins/binary_filter/bzip2/bzip2_serialization_filter.cpp
@@ -125,7 +125,7 @@ namespace hpx { namespace plugins { namespace compression
             HPX_THROW_EXCEPTION(serialization_error,
                 "bzip2_serialization_filter::load",
                 hpx::util::format("decompression failure, number of "
-                    "bytes expected: %d, number of bytes decoded: %d",
+                    "bytes expected: {}, number of bytes decoded: {}",
                     size, s));
             return 0;
         }

--- a/plugins/binary_filter/zlib/zlib_serialization_filter.cpp
+++ b/plugins/binary_filter/zlib/zlib_serialization_filter.cpp
@@ -96,7 +96,7 @@ namespace hpx { namespace plugins { namespace compression
             HPX_THROW_EXCEPTION(serialization_error,
                 "zlib_serialization_filter::load",
                 hpx::util::format("decompression failure, number of "
-                    "bytes expected: %d, number of bytes decoded: %d",
+                    "bytes expected: {}, number of bytes decoded: {}",
                     size, s));
             return 0;
         }

--- a/plugins/parcel/coalescing/coalescing_counter_registry.cpp
+++ b/plugins/parcel/coalescing/coalescing_counter_registry.cpp
@@ -309,8 +309,8 @@ namespace hpx { namespace plugins { namespace parcel
                 HPX_THROWS_IF(ec, bad_parameter,
                     "coalescing_counter_registry::counter_discoverer",
                     hpx::util::format(
-                        "action type %s does not match any known type, "
-                        "known action types: \n%s", p.parameters_, types));
+                        "action type {} does not match any known type, "
+                        "known action types: \n{}", p.parameters_, types));
                 return false;
             }
 
@@ -339,8 +339,8 @@ namespace hpx { namespace plugins { namespace parcel
                 HPX_THROWS_IF(ec, bad_parameter,
                     "coalescing_counter_registry::counter_discoverer",
                     hpx::util::format(
-                        "action type %s does not match any known type, "
-                        "known action types: \n%s", p.parameters_, types));
+                        "action type {} does not match any known type, "
+                        "known action types: \n{}", p.parameters_, types));
                 return false;
             }
         }

--- a/plugins/parcelport/libfabric/parcelport_libfabric.hpp
+++ b/plugins/parcelport/libfabric/parcelport_libfabric.hpp
@@ -237,7 +237,7 @@ struct plugin_config_data<hpx::parcelset::policies::libfabric::parcelport> {
             boost::log::keywords::format =
                 (
                     boost::log::expressions::stream
-                    // << hpx::util::format("%05d", expr::attr< unsigned int >("LineID"))
+                    // << hpx::util::format("{:05}", expr::attr< unsigned int >("LineID"))
                     << boost::log::expressions::attr< unsigned int >("LineID")
                     << ": <" << boost::log::trivial::severity
                     << "> " << boost::log::expressions::smessage

--- a/plugins/parcelport/verbs/parcelport_verbs.cpp
+++ b/plugins/parcelport/verbs/parcelport_verbs.cpp
@@ -1668,7 +1668,7 @@ struct plugin_config_data<hpx::parcelset::policies::verbs::parcelport> {
             boost::log::keywords::format =
                 (
                     boost::log::expressions::stream
-                    // << hpx::util::format("%05d", expr::attr< unsigned int >("LineID"))
+                    // << hpx::util::format("{:05}", expr::attr< unsigned int >("LineID"))
                     << boost::log::expressions::attr< unsigned int >("LineID")
                     << ": <" << boost::log::trivial::severity
                     << "> " << boost::log::expressions::smessage

--- a/src/components/performance_counters/io/io_counters.cpp
+++ b/src/components/performance_counters/io/io_counters.cpp
@@ -79,13 +79,13 @@ namespace hpx { namespace performance_counters { namespace io
     void parse_proc_io(proc_io& pio)
     {
         pid_t pid = getpid();
-        std::string fn = hpx::util::format("/proc/%1%/io", pid);
+        std::string fn = hpx::util::format("/proc/{1}/io", pid);
         std::ifstream ins(fn);
 
         if (!ins.is_open())
             HPX_THROW_EXCEPTION(hpx::no_success,
                 "hpx::performance_counters::io::parse_proc_io",
-                hpx::util::format("failed to open /proc/%1%/io", pid));
+                hpx::util::format("failed to open /proc/{1}/io", pid));
 
         typedef boost::spirit::basic_istream_iterator<char> iterator;
         iterator it(ins), end;
@@ -94,7 +94,7 @@ namespace hpx { namespace performance_counters { namespace io
         if (!qi::phrase_parse(it, end, p, ascii::space, pio))
             HPX_THROW_EXCEPTION(hpx::no_success,
                 "hpx::performance_counters::io::parse_proc_io",
-                hpx::util::format("failed to parse /proc/%1%/io", pid));
+                hpx::util::format("failed to parse /proc/{1}/io", pid));
     }
 
     std::uint64_t get_pio_riss(bool)

--- a/src/components/performance_counters/memory/mem_counter_linux.cpp
+++ b/src/components/performance_counters/memory/mem_counter_linux.cpp
@@ -94,7 +94,7 @@ namespace hpx { namespace performance_counters { namespace memory
     bool read_proc_statm(proc_statm& ps, std::int32_t pid)
     {
         std::string filename
-            = hpx::util::format("/proc/%1%/statm", pid);
+            = hpx::util::format("/proc/{1}/statm", pid);
 
         ifstream_raii in(filename.c_str(), std::ios_base::in);
 
@@ -126,7 +126,7 @@ namespace hpx { namespace performance_counters { namespace memory
             HPX_THROW_EXCEPTION(
                 hpx::invalid_data,
                 "hpx::performance_counters::memory::read_psm_virtual",
-                hpx::util::format("failed to parse '/proc/%1%/statm'",
+                hpx::util::format("failed to parse '/proc/{1}/statm'",
                     getpid()));
             return std::uint64_t(-1);
         }
@@ -145,7 +145,7 @@ namespace hpx { namespace performance_counters { namespace memory
             HPX_THROW_EXCEPTION(
                 hpx::invalid_data,
                 "hpx::performance_counters::memory::read_psm_resident",
-                hpx::util::format("failed to parse '/proc/%1%/statm'",
+                hpx::util::format("failed to parse '/proc/{1}/statm'",
                     getpid()));
             return std::uint64_t(-1);
         }

--- a/src/components/performance_counters/memory/mem_counter_windows.cpp
+++ b/src/components/performance_counters/memory/mem_counter_windows.cpp
@@ -14,6 +14,7 @@
 #include <cstring>
 #include <string>
 
+#include <windows.h> // this must go before psapi.h
 #include <psapi.h>
 
 namespace hpx { namespace performance_counters { namespace memory
@@ -41,8 +42,8 @@ namespace hpx { namespace performance_counters { namespace memory
             {
                 HPX_THROW_EXCEPTION(kernel_error,
                     "hpx::performance_counters::memory::read_psm_virtual",
-                    hpx::util::format("format message failed with %x (while "
-                        "retrieving message for %x)", GetLastError(), hr));
+                    hpx::util::format("format message failed with {:x} (while "
+                        "retrieving message for {:x})", GetLastError(), hr));
                 return std::uint64_t(-1);
             }
 
@@ -79,8 +80,8 @@ namespace hpx { namespace performance_counters { namespace memory
             {
                 HPX_THROW_EXCEPTION(kernel_error,
                     "hpx::performance_counters::memory::read_psm_resident",
-                    hpx::util::format("format message failed with %x (while "
-                        "retrieving message for %x)", GetLastError(), hr));
+                    hpx::util::format("format message failed with {:x} (while "
+                        "retrieving message for {:x})", GetLastError(), hr));
                 return std::uint64_t(-1);
             }
 
@@ -114,8 +115,8 @@ namespace hpx { namespace performance_counters { namespace memory
             {
                 HPX_THROW_EXCEPTION(kernel_error,
                     "hpx::performance_counters::memory::read_total_mem_avail",
-                    hpx::util::format("format message failed with %x (while "
-                        "retrieving message for %x)", GetLastError(), hr));
+                    hpx::util::format("format message failed with {:x} (while "
+                        "retrieving message for {:x})", GetLastError(), hr));
                 return std::uint64_t(-1);
             }
 

--- a/src/components/performance_counters/papi/util/papi.cpp
+++ b/src/components/performance_counters/papi/util/papi.cpp
@@ -205,11 +205,11 @@ namespace hpx { namespace performance_counters { namespace papi { namespace util
         for (it = boost::make_generator_iterator(gen); *it != nullptr; ++it)
         {
             hpx::util::format_to(std::cout,
-                "Event        : %s\n"
-                "Type         : %s\n"
-                "Code         : 0x%x\n"
-                "Derived from : %s\n"
-                "Description  : %s\n",
+                "Event        : {}\n"
+                "Type         : {}\n"
+                "Code         : {:x}\n"
+                "Derived from : {}\n"
+                "Description  : {}\n",
                 (*it)->symbol,
                 decode_preset_type((*it)->event_type),
                 (*it)->event_code,
@@ -235,7 +235,7 @@ namespace hpx { namespace performance_counters { namespace papi { namespace util
             {
                 if (!regs.empty()) regs += std::string(15, ' ');
                 regs += hpx::util::format(
-                    "reg[%d] name: %-20s value: 0x%16x\n",
+                    "reg[{}] name: {:-20} value: {:#16x}\n",
                     i, info.name[i], info.code[i]);
             }
         }
@@ -245,11 +245,11 @@ namespace hpx { namespace performance_counters { namespace papi { namespace util
     void print_native_info(PAPI_event_info_t const& info)
     {
         hpx::util::format_to(std::cout,
-            "Event        : %s\n"
+            "Event        : {}\n"
             "Type         : native\n"
-            "Code         : 0x%x\n"
-            "Derived from : %s\n"
-            "Description  : %s\n",
+            "Code         : {:#x}\n"
+            "Derived from : {}\n"
+            "Description  : {}\n",
             info.symbol,
             info.event_code,
             registers(info),
@@ -286,11 +286,11 @@ namespace hpx { namespace performance_counters { namespace papi { namespace util
         std::string hdr("PAPI events available on ");
         if (!host.empty())
         {
-            hdr += hpx::util::format("%s (locality %d):", host, hpx::get_locality_id());
+            hdr += hpx::util::format("{} (locality {}):", host, hpx::get_locality_id());
         }
         else
         {
-            hdr += hpx::util::format("locality %d:", hpx::get_locality_id());
+            hdr += hpx::util::format("locality {}:", hpx::get_locality_id());
         }
         std::cout << hdr << std::endl
                   << std::string(hdr.length(), '=') << std::endl;
@@ -308,7 +308,7 @@ namespace hpx { namespace performance_counters { namespace papi { namespace util
         }
         else
         {
-            label = hpx::util::format("%s#%d", cpe.instancename_, cpe.instanceindex_);
+            label = hpx::util::format("{}#{}", cpe.instancename_, cpe.instanceindex_);
         }
         return tm.get_thread_index(label);
     }

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -209,7 +209,7 @@ namespace hpx { namespace detail
 
         std::sort(env.begin(), env.end());
 
-        std::string retval = hpx::util::format("%d entries:\n", env.size());
+        std::string retval = hpx::util::format("{} entries:\n", env.size());
         for (std::string const& s : env)
         {
             retval += "  " + s + "\n";
@@ -603,7 +603,7 @@ namespace hpx
         std::size_t const* thread_id =
             xi.get<hpx::detail::throw_thread_id>();
         if (thread_id && *thread_id)
-            hpx::util::format_to(strm, "{thread-id}: %016x\n", *thread_id);
+            hpx::util::format_to(strm, "{thread-id}: {:016x}\n", *thread_id);
 
         std::string const* thread_description =
             xi.get<hpx::detail::throw_thread_name>();

--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -183,7 +183,7 @@ namespace hpx { namespace detail
               << '\n';
 
         strm << "version:  ";        // 0xMMmmrrrr
-        hpx::util::format_to(strm, "%d.%d.%d\n",
+        hpx::util::format_to(strm, "{}.{}.{}\n",
             info.version_ / 0x1000000,
             info.version_ / 0x10000 % 0x100,
             info.version_ % 0x10000);
@@ -252,7 +252,7 @@ namespace hpx { namespace detail
     void list_component_type(std::string const& name,
         components::component_type ctype)
     {
-        print(hpx::util::format("%1%, %|40t|%2%",
+        print(hpx::util::format("{1:-40}, {2}",
             name, components::get_component_type_name(ctype)));
     }
 

--- a/src/performance_counters/counters.cpp
+++ b/src/performance_counters/counters.cpp
@@ -294,7 +294,7 @@ namespace hpx { namespace performance_counters
         if (!parse_counter_name(name, elements))
         {
             HPX_THROWS_IF(ec, bad_parameter, "get_counter_path_elements",
-                hpx::util::format("invalid counter name format: %s", name));
+                hpx::util::format("invalid counter name format: {}", name));
             return status_invalid_data;
         }
 
@@ -350,7 +350,7 @@ namespace hpx { namespace performance_counters
                         HPX_THROWS_IF(ec, bad_parameter,
                             "get_counter_path_elements",
                             hpx::util::format(
-                                "invalid counter name format: %s", name));
+                                "invalid counter name format: {}", name));
                         return status_invalid_data;
                     }
                 }
@@ -388,7 +388,7 @@ namespace hpx { namespace performance_counters
         if (!parse_counter_name(name, elements))
         {
             HPX_THROWS_IF(ec, bad_parameter, "get_counter_type_path_elements",
-                hpx::util::format("invalid counter name format: %s", name));
+                hpx::util::format("invalid counter name format: {}", name));
             return status_invalid_data;
         }
 
@@ -1113,7 +1113,7 @@ namespace hpx { namespace performance_counters
                     throw;
                 ec = make_error_code(e.get_error(), e.what());
                 LPCS_(warning) << hpx::util::format(
-                    "failed to create counter %s (%s)",
+                    "failed to create counter {} ({})",
                     remove_counter_prefix(complemented_info.fullname_), e.what());
                 return lcos::future<naming::id_type>();
             }

--- a/src/performance_counters/performance_counter_set.cpp
+++ b/src/performance_counters/performance_counter_set.cpp
@@ -89,7 +89,7 @@ namespace hpx { namespace performance_counters
             HPX_THROWS_IF(ec, bad_parameter,
                 "performance_counter_set::find_counter",
                 hpx::util::format(
-                    "unknown performance counter: '%1%' (%2%)",
+                    "unknown performance counter: '{1}' ({2})",
                     info.fullname_, ec.get_message()));
             return false;
         }

--- a/src/performance_counters/registry.cpp
+++ b/src/performance_counters/registry.cpp
@@ -85,7 +85,7 @@ namespace hpx { namespace performance_counters
         if (it != countertypes_.end()) {
             HPX_THROWS_IF(ec, bad_parameter, "registry::add_counter_type",
                 hpx::util::format(
-                    "counter type already defined: %s", type_name));
+                    "counter type already defined: {}", type_name));
             return status_already_defined;
         }
 
@@ -95,13 +95,13 @@ namespace hpx { namespace performance_counters
 
         if (!p.second) {
             LPCS_(warning) << hpx::util::format(
-                "failed to register counter type %s",
+                "failed to register counter type {}",
                 type_name);
             return status_invalid_data;
         }
 
         LPCS_(info) << hpx::util::format(
-            "counter type %s registered",
+            "counter type {} registered",
             type_name);
 
         if (&ec != &throws)
@@ -136,8 +136,8 @@ namespace hpx { namespace performance_counters
                 HPX_THROWS_IF(ec, bad_parameter,
                     "registry::discover_counter_type",
                     hpx::util::format(
-                        "unknown counter type: %s, known counter "
-                        "types: \n%s", type_name, types));
+                        "unknown counter type: {}, known counter "
+                        "types: \n{}", type_name, types));
                 return status_counter_type_unknown;
             }
 
@@ -210,8 +210,8 @@ namespace hpx { namespace performance_counters
 
                 HPX_THROWS_IF(ec, bad_parameter, "registry::discover_counter_type",
                     hpx::util::format(
-                        "counter type %s does not match any known type, "
-                        "known counter types: \n%s", type_name, types));
+                        "counter type {} does not match any known type, "
+                        "known counter types: \n{}", type_name, types));
                 return status_counter_type_unknown;
             }
         }
@@ -281,8 +281,8 @@ namespace hpx { namespace performance_counters
             HPX_THROWS_IF(ec, bad_parameter,
                 "registry::get_counter_create_function",
                 hpx::util::format(
-                    "counter type %s is not defined, known counter "
-                    "types: \n%s", type_name, types));
+                    "counter type {} is not defined, known counter "
+                    "types: \n{}", type_name, types));
             return status_counter_type_unknown;
         }
 
@@ -290,7 +290,7 @@ namespace hpx { namespace performance_counters
             HPX_THROWS_IF(ec, bad_parameter,
                 "registry::get_counter_create_function",
                 hpx::util::format(
-                    "counter type %s has no associated create "
+                    "counter type {} has no associated create "
                     "function", type_name));
             return status_invalid_data;
         }
@@ -317,7 +317,7 @@ namespace hpx { namespace performance_counters
             HPX_THROWS_IF(ec, bad_parameter,
                 "registry::get_counter_discovery_function",
                 hpx::util::format(
-                    "counter type %s is not defined", type_name));
+                    "counter type {} is not defined", type_name));
             return status_counter_type_unknown;
         }
 
@@ -325,7 +325,7 @@ namespace hpx { namespace performance_counters
             HPX_THROWS_IF(ec, bad_parameter,
                 "registry::get_counter_discovery_function",
                 hpx::util::format(
-                    "counter type %s has no associated discovery "
+                    "counter type {} has no associated discovery "
                     "function", type_name));
             return status_invalid_data;
         }
@@ -354,7 +354,7 @@ namespace hpx { namespace performance_counters
         }
 
         LPCS_(info) << hpx::util::format(
-            "counter type %s unregistered",
+            "counter type {} unregistered",
             type_name);
 
         countertypes_.erase(it);
@@ -417,7 +417,7 @@ namespace hpx { namespace performance_counters
         counter_type_map_type::iterator it = locate_counter_type(type_name);
         if (it == countertypes_.end()) {
             HPX_THROWS_IF(ec, bad_parameter, "registry::create_raw_counter",
-                hpx::util::format("unknown counter type %s", type_name));
+                hpx::util::format("unknown counter type {}", type_name));
             return status_counter_type_unknown;
         }
 
@@ -445,13 +445,13 @@ namespace hpx { namespace performance_counters
                 throw;
             ec = make_error_code(e.get_error(), e.what());
             LPCS_(warning) << hpx::util::format(
-                "failed to create raw counter %s (%s)",
+                "failed to create raw counter {} ({})",
                 complemented_info.fullname_, e.what());
             return status_invalid_data;
         }
 
         LPCS_(info) << hpx::util::format(
-            "raw counter %s created at %s",
+            "raw counter {} created at {}",
             complemented_info.fullname_, id);
 
         if (&ec != &throws)
@@ -481,7 +481,7 @@ namespace hpx { namespace performance_counters
         counter_type_map_type::iterator it = locate_counter_type(type_name);
         if (it == countertypes_.end()) {
             HPX_THROWS_IF(ec, bad_parameter, "registry::create_raw_counter",
-                hpx::util::format("unknown counter type %s", type_name));
+                hpx::util::format("unknown counter type {}", type_name));
             return status_counter_type_unknown;
         }
 
@@ -513,13 +513,13 @@ namespace hpx { namespace performance_counters
                 throw;
             ec = make_error_code(e.get_error(), e.what());
             LPCS_(warning) << hpx::util::format(
-                "failed to create raw counter %s (%s)",
+                "failed to create raw counter {} ({})",
                 complemented_info.fullname_, e.what());
             return status_invalid_data;
         }
 
         LPCS_(info) << hpx::util::format(
-            "raw counter %s created at %s",
+            "raw counter {} created at {}",
             complemented_info.fullname_, id);
 
         if (&ec != &throws)
@@ -539,7 +539,7 @@ namespace hpx { namespace performance_counters
         counter_type_map_type::iterator it = locate_counter_type(type_name);
         if (it == countertypes_.end()) {
             HPX_THROWS_IF(ec, bad_parameter, "registry::create_counter",
-                hpx::util::format("unknown counter type %s", type_name));
+                hpx::util::format("unknown counter type {}", type_name));
             return status_counter_type_unknown;
         }
 
@@ -576,13 +576,13 @@ namespace hpx { namespace performance_counters
                 throw;
             ec = make_error_code(e.get_error(), e.what());
             LPCS_(warning) << hpx::util::format(
-                "failed to create counter %s (%s)",
+                "failed to create counter {} ({})",
                 complemented_info.fullname_, e.what());
             return status_invalid_data;
         }
 
         LPCS_(info) << hpx::util::format(
-            "counter %s created at %s",
+            "counter {} created at {}",
             complemented_info.fullname_, id);
 
         if (&ec != &throws)
@@ -606,7 +606,7 @@ namespace hpx { namespace performance_counters
         counter_type_map_type::iterator it = locate_counter_type(type_name);
         if (it == countertypes_.end()) {
             HPX_THROWS_IF(ec, bad_parameter, "registry::create_statistics_counter",
-                hpx::util::format("unknown counter type %s", type_name));
+                hpx::util::format("unknown counter type {}", type_name));
             return status_counter_type_unknown;
         }
 
@@ -787,13 +787,13 @@ namespace hpx { namespace performance_counters
 
             ec = make_error_code(e.get_error(), e.what());
             LPCS_(warning) << hpx::util::format(
-                "failed to create statistics counter %s (%s)",
+                "failed to create statistics counter {} ({})",
                 complemented_info.fullname_, e.what());
             return status_invalid_data;
         }
 
         LPCS_(info) << hpx::util::format(
-            "statistics counter %s created at %s",
+            "statistics counter {} created at {}",
             complemented_info.fullname_, gid);
 
         if (&ec != &throws)
@@ -816,7 +816,7 @@ namespace hpx { namespace performance_counters
         if (it == countertypes_.end()) {
             HPX_THROWS_IF(ec, bad_parameter,
                 "registry::create_arithmetics_counter",
-                hpx::util::format("unknown counter type %s", type_name));
+                hpx::util::format("unknown counter type {}", type_name));
             return status_counter_type_unknown;
         }
 
@@ -886,13 +886,13 @@ namespace hpx { namespace performance_counters
 
             ec = make_error_code(e.get_error(), e.what());
             LPCS_(warning) << hpx::util::format(
-                "failed to create aggregating counter %s (%s)",
+                "failed to create aggregating counter {} ({})",
                 complemented_info.fullname_, e.what());
             return status_invalid_data;
         }
 
         LPCS_(info) << hpx::util::format(
-            "aggregating counter %s created at %s",
+            "aggregating counter {} created at {}",
             complemented_info.fullname_, gid);
 
         if (&ec != &throws)
@@ -915,7 +915,7 @@ namespace hpx { namespace performance_counters
         if (it == countertypes_.end()) {
             HPX_THROWS_IF(ec, bad_parameter,
                 "registry::create_arithmetics_counter_extended",
-                hpx::util::format("unknown counter type %s", type_name));
+                hpx::util::format("unknown counter type {}", type_name));
             return status_counter_type_unknown;
         }
 
@@ -1005,13 +1005,13 @@ namespace hpx { namespace performance_counters
 
             ec = make_error_code(e.get_error(), e.what());
             LPCS_(warning) << hpx::util::format(
-                "failed to create aggregating counter %s (%s)",
+                "failed to create aggregating counter {} ({})",
                 complemented_info.fullname_, e.what());
             return status_invalid_data;
         }
 
         LPCS_(info) << hpx::util::format(
-            "aggregating counter %s created at %s",
+            "aggregating counter {} created at {}",
             complemented_info.fullname_, gid);
 
         if (&ec != &throws)
@@ -1039,7 +1039,7 @@ namespace hpx { namespace performance_counters
         counter_type_map_type::iterator it = locate_counter_type(type_name);
         if (it == countertypes_.end()) {
             HPX_THROWS_IF(ec, bad_parameter, "registry::add_counter",
-                hpx::util::format("unknown counter type %s", type_name));
+                hpx::util::format("unknown counter type {}", type_name));
             return status_counter_type_unknown;
         }
 
@@ -1074,7 +1074,7 @@ namespace hpx { namespace performance_counters
         agas::unregister_name(launch::sync, name, ec);
         if (ec) {
             LPCS_(warning) << hpx::util::format(
-                "failed to remove counter %s",
+                "failed to remove counter {}",
                 complemented_info.fullname_);
             return status_invalid_data;
         }
@@ -1114,7 +1114,7 @@ namespace hpx { namespace performance_counters
         counter_type_map_type::iterator it = locate_counter_type(type_name);
         if (it == countertypes_.end()) {
             HPX_THROWS_IF(ec, bad_parameter, "registry::get_counter_type",
-                hpx::util::format("unknown counter type %s", type_name));
+                hpx::util::format("unknown counter type {}", type_name));
             return status_counter_type_unknown;
         }
 

--- a/src/performance_counters/server/statistics_counter.cpp
+++ b/src/performance_counters/server/statistics_counter.cpp
@@ -500,7 +500,7 @@ namespace hpx { namespace performance_counters { namespace server
                 HPX_THROW_EXCEPTION(bad_parameter,
                     "statistics_counter<Statistic>::evaluate_base_counter",
                     hpx::util::format(
-                        "could not get or create performance counter: '%s'",
+                        "could not get or create performance counter: '{}'",
                         base_counter_name_));
                 return false;
             }

--- a/src/runtime/actions/detail/invocation_count_registry.cpp
+++ b/src/runtime/actions/detail/invocation_count_registry.cpp
@@ -142,8 +142,8 @@ namespace hpx { namespace actions { namespace detail
                 HPX_THROWS_IF(ec, bad_parameter,
                     "invocation_count_registry::counter_discoverer",
                     hpx::util::format(
-                        "action type %s does not match any known type, "
-                        "known action types: \n%s", p.parameters_, types));
+                        "action type {} does not match any known type, "
+                        "known action types: \n{}", p.parameters_, types));
                 return false;
             }
 
@@ -168,8 +168,8 @@ namespace hpx { namespace actions { namespace detail
             HPX_THROWS_IF(ec, bad_parameter,
                 "invocation_count_registry::counter_discoverer",
                 hpx::util::format(
-                    "action type %s does not match any known type, "
-                    "known action types: \n%s", p.parameters_, types));
+                    "action type {} does not match any known type, "
+                    "known action types: \n{}", p.parameters_, types));
             return false;
         }
 

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -250,7 +250,7 @@ void addressing_service::launch_bootstrap(
             symbol_ns_.ptr());
 
     rt.get_config().parse("assigned locality",
-        hpx::util::format("hpx.locality!=%1%",
+        hpx::util::format("hpx.locality!={1}",
             naming::get_locality_id_from_gid(here)));
 
     std::uint32_t num_threads = hpx::util::get_entry_as<std::uint32_t>(
@@ -289,8 +289,8 @@ void addressing_service::adjust_local_cache_size(std::size_t cache_size)
             gva_cache_->reserve(cache_size);
 
         LAGAS_(info) << hpx::util::format(
-            "addressing_service::adjust_local_cache_size, previous size: %1%, "
-            "new size: %2%",
+            "addressing_service::adjust_local_cache_size, previous size: {1}, "
+            "new size: {2}",
             previous, cache_size);
     }
 } // }}}
@@ -511,7 +511,7 @@ bool addressing_service::get_console_locality(
 
             LAGAS_(debug) << hpx::util::format(
                 "addressing_server::get_console_locality, "
-                "caching console locality, prefix(%1%)",
+                "caching console locality, prefix({1})",
                 console);
 
             return true;
@@ -1138,7 +1138,7 @@ bool addressing_service::resolve_cached(
 /*
         LAGAS_(debug) << hpx::util::format(
             "addressing_service::resolve_cached, "
-            "cache hit for address %1%, lva %2% (base %3%, lva %4%)",
+            "cache hit for address {1}, lva {2} (base {3}, lva {4})",
             id,
             reinterpret_cast<void*>(addr.address_),
             idbase.get_gid(),
@@ -1153,7 +1153,7 @@ bool addressing_service::resolve_cached(
 
     LAGAS_(debug) << hpx::util::format(
         "addressing_service::resolve_cached, "
-        "cache miss for address %1%",
+        "cache miss for address {1}",
         id);
 
     return false;
@@ -1450,7 +1450,7 @@ lcos::future<std::int64_t> addressing_service::incref_async(
     {
         HPX_THROW_EXCEPTION(bad_parameter
           , "addressing_service::incref_async"
-          , hpx::util::format("invalid credit count of %1%", credit));
+          , hpx::util::format("invalid credit count of {1}", credit));
         return lcos::future<std::int64_t>();
     }
 
@@ -1566,7 +1566,7 @@ void addressing_service::decref(
     {
         HPX_THROWS_IF(ec, bad_parameter
           , "addressing_service::decref"
-          , hpx::util::format("invalid credit count of %1%", credit));
+          , hpx::util::format("invalid credit count of {1}", credit));
         return;
     }
 
@@ -1594,7 +1594,7 @@ void addressing_service::decref(
                 HPX_THROWS_IF(ec, bad_parameter
                   , "addressing_service::decref"
                   , hpx::util::format("couldn't insert decref request "
-                        "for %1% (%2%)", raw, credit));
+                        "for {1} ({2})", raw, credit));
                 return;
             }
         }
@@ -1809,7 +1809,7 @@ void addressing_service::update_cache_entry(
         const std::uint64_t count = (g.count ? g.count : 1);
 
         LAGAS_(debug) << hpx::util::format(
-            "addressing_service::update_cache_entry, gid(%1%), count(%2%)",
+            "addressing_service::update_cache_entry, gid({1}), count({2})",
             gid, count);
 
         const gva_cache_key key(gid, count);
@@ -1837,7 +1837,7 @@ void addressing_service::update_cache_entry(
                     LAGAS_(warning) << hpx::util::format(
                         "addressing_service::update_cache_entry, "
                         "aborting update due to key collision in cache, "
-                        "new_gid(%1%), new_count(%2%), old_gid(%3%), old_count(%4%)",
+                        "new_gid({1}), new_count({2}), old_gid({3}), old_count({4})",
                         gid, count, idbase.get_gid(), idbase.get_count());
                 }
             }
@@ -2403,7 +2403,7 @@ void addressing_service::send_refcnt_requests(
 
         std::stringstream ss;
         hpx::util::format_to(ss,
-            "%1%, dumping client-side refcnt table, requests(%2%):",
+            "{1}, dumping client-side refcnt table, requests({2}):",
             func_name, requests.size());
 
         typedef addressing_service::refcnt_requests_type::const_reference
@@ -2414,7 +2414,7 @@ void addressing_service::send_refcnt_requests(
             // The [client] tag is in there to make it easier to filter
             // through the logs.
             hpx::util::format_to(ss,
-                "\n  [client] gid(%1%), credits(%2%)",
+                "\n  [client] gid({1}), credits({2})",
                 e.first,
                 e.second);
         }
@@ -2446,7 +2446,7 @@ void addressing_service::send_refcnt_requests_non_blocking(
 
         LAGAS_(info) << hpx::util::format(
             "addressing_service::send_refcnt_requests_non_blocking, "
-            "requests(%1%)",
+            "requests({1})",
             p->size());
 
 #if defined(HPX_HAVE_AGAS_DUMP_REFCNT_ENTRIES)
@@ -2519,7 +2519,7 @@ addressing_service::send_refcnt_requests_async(
 
     LAGAS_(info) << hpx::util::format(
         "addressing_service::send_refcnt_requests_async, "
-        "requests(%1%)",
+        "requests({1})",
         p->size());
 
 #if defined(HPX_HAVE_AGAS_DUMP_REFCNT_ENTRIES)

--- a/src/runtime/agas/big_boot_barrier.cpp
+++ b/src/runtime/agas/big_boot_barrier.cpp
@@ -467,7 +467,7 @@ void register_worker(registration_header const& header)
         HPX_THROW_EXCEPTION(internal_server_error
             , "agas::register_worker"
             , hpx::util::format(
-                "worker node (%s) can't suggest locality_id zero, "
+                "worker node ({}) can't suggest locality_id zero, "
                 "this is reserved for the console",
                 header.endpoints));
         return;
@@ -478,7 +478,7 @@ void register_worker(registration_header const& header)
         HPX_THROW_EXCEPTION(internal_server_error
             , "agas::register_worker"
             , hpx::util::format(
-                "attempt to register locality %s more than once",
+                "attempt to register locality {} more than once",
                 header.endpoints));
         return;
     }
@@ -599,7 +599,7 @@ void notify_worker(notification_header const& header)
     agas_client.set_local_locality(header.prefix);
     agas_client.register_console(header.agas_endpoints);
     cfg.parse("assigned locality",
-        hpx::util::format("hpx.locality!=%1%",
+        hpx::util::format("hpx.locality!={1}",
             naming::get_locality_id_from_gid(header.prefix)));
 
     // store the full addresses of the agas servers in our local service

--- a/src/runtime/agas/primary_namespace.cpp
+++ b/src/runtime/agas/primary_namespace.cpp
@@ -122,7 +122,7 @@ namespace hpx { namespace agas {
             HPX_THROWS_IF(ec, bad_parameter,
                 "primary_namespace::get_service_instance",
                 hpx::util::format(
-                    "can't retrieve a valid locality id from global address (%1%): ",
+                    "can't retrieve a valid locality id from global address ({1}): ",
                     dest));
             return naming::gid_type();
         }

--- a/src/runtime/agas/server/component_namespace_server.cpp
+++ b/src/runtime/agas/server/component_namespace_server.cpp
@@ -75,11 +75,11 @@ void component_namespace::register_counter_types(
         if (detail::component_namespace_services[i].target_ ==
              detail::counter_target_count)
             help = hpx::util::format(
-                "returns the number of invocations of the AGAS service '%s'",
+                "returns the number of invocations of the AGAS service '{}'",
                 name.substr(p+1));
         else
             help = hpx::util::format(
-                "returns the overall execution time of the AGAS service '%s'",
+                "returns the overall execution time of the AGAS service '{}'",
                 name.substr(p+1));
 
         performance_counters::install_counter_type(
@@ -222,7 +222,7 @@ components::component_type component_namespace::bind_prefix(
               , "component_namespace::bind_prefix"
               , hpx::util::format(
                     "component id is already registered for the given "
-                    "locality, key(%1%), prefix(%2%), ctype(%3%)",
+                    "locality, key({1}), prefix({2}), ctype({3})",
                     key, prefix, cit->second));
             return components::component_invalid;
         }
@@ -233,8 +233,8 @@ components::component_type component_namespace::bind_prefix(
         // convey the fact that another locality already registered this
         // component type.
         LAGAS_(info) << hpx::util::format(
-            "component_namespace::bind_prefix, key(%1%), prefix(%2%), "
-            "ctype(%3%), response(no_success)",
+            "component_namespace::bind_prefix, key({1}), prefix({2}), "
+            "ctype({3}), response(no_success)",
             key, prefix, cit->second);
 
         return cit->second;
@@ -259,7 +259,7 @@ components::component_type component_namespace::bind_prefix(
     fit->second.insert(prefix);
 
     LAGAS_(info) << hpx::util::format(
-        "component_namespace::bind_prefix, key(%1%), prefix(%2%), ctype(%3%)",
+        "component_namespace::bind_prefix, key({1}), prefix({2}), ctype({3})",
         key, prefix, cit->second);
 
     return cit->second;
@@ -301,7 +301,7 @@ components::component_type component_namespace::bind_name(
     }
 
     LAGAS_(info) << hpx::util::format(
-        "component_namespace::bind_name, key(%1%), ctype(%2%)",
+        "component_namespace::bind_name, key({1}), ctype({2})",
         key, it->second);
 
     return it->second;
@@ -331,7 +331,7 @@ std::vector<std::uint32_t> component_namespace::resolve_id(
     if (it == end || it->second.empty())
     {
         LAGAS_(info) << hpx::util::format(
-            "component_namespace::resolve_id, key(%1%), localities(0)",
+            "component_namespace::resolve_id, key({1}), localities(0)",
             key);
 
         return std::vector<std::uint32_t>();
@@ -349,7 +349,7 @@ std::vector<std::uint32_t> component_namespace::resolve_id(
             p.push_back(*pit);
 
         LAGAS_(info) << hpx::util::format(
-            "component_namespace::resolve_id, key(%1%), localities(%2%)",
+            "component_namespace::resolve_id, key({1}), localities({2})",
             key, prefixes.size());
 
         return p;
@@ -373,7 +373,7 @@ bool component_namespace::unbind(
     if (it == component_ids_.left.end())
     {
         LAGAS_(info) <<hpx::util::format(
-            "component_namespace::unbind, key(%1%), response(no_success)",
+            "component_namespace::unbind, key({1}), response(no_success)",
             key);
 
        return false;
@@ -385,7 +385,7 @@ bool component_namespace::unbind(
     component_ids_.left.erase(it);
 
     LAGAS_(info) << hpx::util::format(
-        "component_namespace::unbind, key(%1%)",
+        "component_namespace::unbind, key({1})",
         key);
 
     return true;
@@ -457,7 +457,7 @@ std::string component_namespace::get_component_type_name(
     {
         LAGAS_(info) << hpx::util::format(
             "component_namespace::get_component_typename, "
-            "key(%1%/%2%), response(no_success)",
+            "key({1}/{2}), response(no_success)",
             int(components::get_derived_type(t)),
             int(components::get_base_type(t)));
 
@@ -465,7 +465,7 @@ std::string component_namespace::get_component_type_name(
     }
 
     LAGAS_(info) << hpx::util::format(
-        "component_namespace::get_component_typename, key(%1%/%2%), response(%3%)",
+        "component_namespace::get_component_typename, key({1}/{2}), response({3})",
         int(components::get_derived_type(t)),
         int(components::get_base_type(t)),
         result);
@@ -494,7 +494,7 @@ std::uint32_t component_namespace::get_num_localities(
     if (it == end)
     {
         LAGAS_(info) << hpx::util::format(
-            "component_namespace::get_num_localities, key(%1%), localities(0)",
+            "component_namespace::get_num_localities, key({1}), localities(0)",
             key);
 
         return std::uint32_t(0);
@@ -503,7 +503,7 @@ std::uint32_t component_namespace::get_num_localities(
     std::uint32_t num_localities = static_cast<std::uint32_t>(it->second.size());
 
     LAGAS_(info) << hpx::util::format(
-        "component_namespace::get_num_localities, key(%1%), localities(%2%)",
+        "component_namespace::get_num_localities, key({1}), localities({2})",
         key, num_localities);
 
     return num_localities;

--- a/src/runtime/agas/server/locality_namespace_server.cpp
+++ b/src/runtime/agas/server/locality_namespace_server.cpp
@@ -65,11 +65,11 @@ void locality_namespace::register_counter_types(
         if (detail::locality_namespace_services[i].target_ ==
             detail::counter_target_count)
             help = hpx::util::format(
-                "returns the number of invocations of the AGAS service '%s'",
+                "returns the number of invocations of the AGAS service '{}'",
                 name.substr(p+1));
         else
             help = hpx::util::format(
-                "returns the overall execution time of the AGAS service '%s'",
+                "returns the overall execution time of the AGAS service '{}'",
                 name.substr(p+1));
 
         performance_counters::install_counter_type(
@@ -235,8 +235,8 @@ std::uint32_t locality_namespace::allocate(
           , "locality_namespace::allocate"
           , hpx::util::format(
                 "partition table insertion failed due to a locking "
-                "error or memory corruption, endpoint(%1%), "
-                "prefix(%2%)", endpoints, prefix));
+                "error or memory corruption, endpoint({1}), "
+                "prefix({2})", endpoints, prefix));
     }
 
 
@@ -253,14 +253,14 @@ std::uint32_t locality_namespace::allocate(
             HPX_THROW_EXCEPTION(bad_request
               , "locality_namespace::allocate"
               , hpx::util::format(
-                    "unable to bind prefix(%1%) to a gid", prefix));
+                    "unable to bind prefix({1}) to a gid", prefix));
         }
         return prefix;
     }
 
     LAGAS_(info) << hpx::util::format(
-        "locality_namespace::allocate, ep(%1%), count(%2%), "
-        "prefix(%3%)",
+        "locality_namespace::allocate, ep({1}), count({2}), "
+        "prefix({3})",
         endpoints, count, prefix);
 
     return prefix;
@@ -347,14 +347,14 @@ void locality_namespace::free(naming::gid_type locality)
 
         /*
         LAGAS_(info) << hpx::util::format(
-            "locality_namespace::free, ep(%1%)",
+            "locality_namespace::free, ep({1})",
             ep);
         */
     }
 
     /*
     LAGAS_(info) << hpx::util::format(
-        "locality_namespace::free, ep(%1%), "
+        "locality_namespace::free, ep({1}), "
         "response(no_success)",
         ep);
     */
@@ -378,7 +378,7 @@ std::vector<std::uint32_t> locality_namespace::localities()
         p.push_back(it->first);
 
     LAGAS_(info) << hpx::util::format(
-        "locality_namespace::localities, localities(%1%)",
+        "locality_namespace::localities, localities({1})",
         p.size());
 
     return p;
@@ -396,7 +396,7 @@ std::uint32_t locality_namespace::get_num_localities()
         static_cast<std::uint32_t>(partitions_.size());
 
     LAGAS_(info) << hpx::util::format(
-        "locality_namespace::get_num_localities, localities(%1%)",
+        "locality_namespace::get_num_localities, localities({1})",
         num_localities);
 
     return num_localities;
@@ -417,7 +417,7 @@ std::vector<std::uint32_t> locality_namespace::get_num_threads()
     }
 
     LAGAS_(info) << hpx::util::format(
-        "locality_namespace::get_num_threads, localities(%1%)",
+        "locality_namespace::get_num_threads, localities({1})",
         num_threads.size());
 
     return num_threads;
@@ -438,7 +438,7 @@ std::uint32_t locality_namespace::get_num_overall_threads()
     }
 
     LAGAS_(info) << hpx::util::format(
-        "locality_namespace::get_num_overall_threads, localities(%1%)",
+        "locality_namespace::get_num_overall_threads, localities({1})",
         num_threads);
 
     return num_threads;

--- a/src/runtime/agas/server/primary_namespace_server.cpp
+++ b/src/runtime/agas/server/primary_namespace_server.cpp
@@ -85,11 +85,11 @@ void primary_namespace::register_counter_types(
         if (detail::primary_namespace_services[i].target_
             == detail::counter_target_count)
             help = hpx::util::format(
-                "returns the number of invocations of the AGAS service '%s'",
+                "returns the number of invocations of the AGAS service '{}'",
                 name.substr(p+1));
         else
             help = hpx::util::format(
-                "returns the overall execution time of the AGAS service '%s'",
+                "returns the overall execution time of the AGAS service '{}'",
                 name.substr(p+1));
 
         performance_counters::install_counter_type(
@@ -236,7 +236,7 @@ primary_namespace::begin_migration(naming::gid_type id)
         l.unlock();
 
         LAGAS_(info) << hpx::util::format(
-            "primary_namespace::begin_migration, gid(%1%), response(no_success)",
+            "primary_namespace::begin_migration, gid({1}), response(no_success)",
             id);
 
         return std::make_pair(naming::invalid_id, naming::address());
@@ -361,7 +361,7 @@ bool primary_namespace::bind_gid(
                   , "primary_namespace::bind_gid"
                   , hpx::util::format(
                         "attempt to update a GVA with an invalid type, "
-                        "gid(%1%), gva(%2%), locality(%3%)",
+                        "gid({1}), gva({2}), locality({3})",
                         id, g, locality));
             }
 
@@ -373,7 +373,7 @@ bool primary_namespace::bind_gid(
                   , "primary_namespace::bind_gid"
                   , hpx::util::format(
                         "attempt to update a GVA with an invalid locality id, "
-                        "gid(%1%), gva(%2%), locality(%3%)",
+                        "gid({1}), gva({2}), locality({3})",
                         id, g, locality));
             }
 
@@ -387,8 +387,8 @@ bool primary_namespace::bind_gid(
             l.unlock();
 
             LAGAS_(info) << hpx::util::format(
-                "primary_namespace::bind_gid, gid(%1%), gva(%2%), "
-                "locality(%3%), response(repeated_request)",
+                "primary_namespace::bind_gid, gid({1}), gva({2}), "
+                "locality({3}), response(repeated_request)",
                 id, g, locality);
 
             return false;
@@ -448,7 +448,7 @@ bool primary_namespace::bind_gid(
           , "primary_namespace::bind_gid"
           , hpx::util::format(
                 "attempt to insert a GVA with an invalid type, "
-                "gid(%1%), gva(%2%), locality(%3%)",
+                "gid({1}), gva({2}), locality({3})",
                 id, g, locality));
     }
 
@@ -462,14 +462,14 @@ bool primary_namespace::bind_gid(
           , "primary_namespace::bind_gid"
           , hpx::util::format(
                 "GVA table insertion failed due to a locking error or "
-                "memory corruption, gid(%1%), gva(%2%), locality(%3%)",
+                "memory corruption, gid({1}), gva({2}), locality({3})",
                 id, g, locality));
     }
 
     l.unlock();
 
     LAGAS_(info) << hpx::util::format(
-        "primary_namespace::bind_gid, gid(%1%), gva(%2%), locality(%3%)",
+        "primary_namespace::bind_gid, gid({1}), gva({2}), locality({3})",
         id, g, locality);
 
     return true;
@@ -498,15 +498,15 @@ primary_namespace::resolved_type primary_namespace::resolve_gid(naming::gid_type
     if (get<0>(r) == naming::invalid_gid)
     {
         LAGAS_(info) << hpx::util::format(
-            "primary_namespace::resolve_gid, gid(%1%), response(no_success)",
+            "primary_namespace::resolve_gid, gid({1}), response(no_success)",
             id);
 
         return resolved_type(naming::invalid_gid, gva(), naming::invalid_gid);
     }
 
     LAGAS_(info) << hpx::util::format(
-        "primary_namespace::resolve_gid, gid(%1%), base(%2%), "
-        "gva(%3%), locality_id(%4%)",
+        "primary_namespace::resolve_gid, gid({1}), base({2}), "
+        "gva({3}), locality_id({4})",
         id, get<0>(r), get<1>(r), get<2>(r));
 
     return r;
@@ -552,8 +552,8 @@ naming::address primary_namespace::unbind_gid(
 
         l.unlock();
         LAGAS_(info) << hpx::util::format(
-            "primary_namespace::unbind_gid, gid(%1%), count(%2%), gva(%3%), "
-            "locality_id(%4%)",
+            "primary_namespace::unbind_gid, gid({1}), count({2}), gva({3}), "
+            "locality_id({4})",
             id, count, data.first, data.second);
 
         gva g = data.first;
@@ -563,7 +563,7 @@ naming::address primary_namespace::unbind_gid(
     l.unlock();
 
     LAGAS_(info) << hpx::util::format(
-        "primary_namespace::unbind_gid, gid(%1%), count(%2%), "
+        "primary_namespace::unbind_gid, gid({1}), count({2}), "
         "response(no_success)",
         id, count);
 
@@ -597,7 +597,7 @@ std::int64_t primary_namespace::increment_credit(
     {
         HPX_THROW_EXCEPTION(bad_parameter
           , "primary_namespace::increment_credit"
-          , hpx::util::format("invalid credit count of %1%", credits));
+          , hpx::util::format("invalid credit count of {1}", credits));
         return 0;
     }
 
@@ -642,7 +642,7 @@ std::vector<std::int64_t> primary_namespace::decrement_credit(
         {
             HPX_THROW_EXCEPTION(bad_parameter
               , "primary_namespace::decrement_credit"
-              , hpx::util::format("invalid credit count of %1%", credits));
+              , hpx::util::format("invalid credit count of {1}", credits));
         }
         res_credits.push_back(credits);
     }
@@ -666,8 +666,8 @@ std::pair<naming::gid_type, naming::gid_type> primary_namespace::allocate(
     if (0 == count)
     {
         LAGAS_(info) << hpx::util::format(
-            "primary_namespace::allocate, count(%1%), "
-            "lower(%1%), upper(%3%), prefix(%4%), response(repeated_request)",
+            "primary_namespace::allocate, count({1}), "
+            "lower({1}), upper({3}), prefix({4}), response(repeated_request)",
             count, next_id_, next_id_,
             naming::get_locality_id_from_gid(next_id_));
 
@@ -706,8 +706,8 @@ std::pair<naming::gid_type, naming::gid_type> primary_namespace::allocate(
     naming::detail::set_credit_for_gid(upper, std::int64_t(HPX_GLOBALCREDIT_INITIAL));
 
     LAGAS_(info) << hpx::util::format(
-        "primary_namespace::allocate, count(%1%), "
-        "lower(%2%), upper(%3%), response(success)",
+        "primary_namespace::allocate, count({1}), "
+        "lower({2}), upper({3}), response(success)",
         count, lower, upper);
 
     return std::make_pair(lower, upper);
@@ -731,8 +731,8 @@ std::pair<naming::gid_type, naming::gid_type> primary_namespace::allocate(
 
         std::stringstream ss;
         hpx::util::format_to(ss,
-            "%1%, dumping server-side refcnt table matches, lower(%2%), "
-            "upper(%3%):",
+            "{1}, dumping server-side refcnt table matches, lower({2}), "
+            "upper({3}):",
             func_name, lower, upper);
 
         for (/**/; lower_it != upper_it; ++lower_it)
@@ -740,7 +740,7 @@ std::pair<naming::gid_type, naming::gid_type> primary_namespace::allocate(
             // The [server] tag is in there to make it easier to filter
             // through the logs.
             hpx::util::format_to(ss,
-                "\n  [server] lower(%1%), credits(%2%)",
+                "\n  [server] lower({1}), credits({2})",
                 lower_it->first,
                 lower_it->second);
         }
@@ -810,7 +810,7 @@ void primary_namespace::increment(
                     , "primary_namespace::increment"
                     , hpx::util::format(
                         "couldn't create entry in reference count table, "
-                        "raw(%1%), ref-count(%2%)",
+                        "raw({1}), ref-count({2})",
                         raw, count));
                 return;
             }
@@ -823,7 +823,7 @@ void primary_namespace::increment(
         }
 
         LAGAS_(info) << hpx::util::format(
-            "primary_namespace::increment, raw(%1%), refcnt(%2%)",
+            "primary_namespace::increment, raw({1}), refcnt({2})",
             lower, it->second);
     }
 
@@ -870,7 +870,7 @@ void primary_namespace::resolve_free_list(
                 , "primary_namespace::resolve_free_list"
                 , hpx::util::format(
                     "primary_namespace::resolve_free_list, failed to resolve "
-                    "gid, gid(%1%)",
+                    "gid, gid({1})",
                     gid));
             return;       // couldn't resolve this one
         }
@@ -887,7 +887,7 @@ void primary_namespace::resolve_free_list(
                 , "primary_namespace::resolve_free_list"
                 , hpx::util::format(
                     "encountered a GVA with an invalid type while "
-                    "performing a decrement, gid(%1%), gva(%2%)",
+                    "performing a decrement, gid({1}), gva({2})",
                     gid, g));
             return;
         }
@@ -899,14 +899,14 @@ void primary_namespace::resolve_free_list(
                 , "primary_namespace::resolve_free_list"
                 , hpx::util::format(
                     "encountered a GVA with a count of zero while "
-                    "performing a decrement, gid(%1%), gva(%2%)",
+                    "performing a decrement, gid({1}), gva({2})",
                     gid, g));
             return;
         }
 
         LAGAS_(info) << hpx::util::format(
             "primary_namespace::resolve_free_list, resolved match, "
-            "gid(%1%), gva(%2%)",
+            "gid({1}), gva({2})",
             gid, g);
 
         // Fully resolve the range.
@@ -931,8 +931,8 @@ void primary_namespace::decrement_sweep(
     )
 { // {{{ decrement_sweep implementation
     LAGAS_(info) << hpx::util::format(
-        "primary_namespace::decrement_sweep, lower(%1%), upper(%2%), "
-        "credits(%3%)",
+        "primary_namespace::decrement_sweep, lower({1}), upper({2}), "
+        "credits({3})",
         lower, upper, credits);
 
     free_entry_list.clear();
@@ -985,8 +985,8 @@ void primary_namespace::decrement_sweep(
                     HPX_THROWS_IF(ec, invalid_data
                       , "primary_namespace::decrement_sweep"
                       , hpx::util::format(
-                            "negative entry in reference count table, raw(%1%), "
-                            "refcount(%2%)",
+                            "negative entry in reference count table, raw({1}), "
+                            "refcount({2})",
                             raw,
                             std::int64_t(HPX_GLOBALCREDIT_INITIAL) - credits));
                     return;
@@ -1005,7 +1005,7 @@ void primary_namespace::decrement_sweep(
                       , "primary_namespace::decrement_sweep"
                       , hpx::util::format(
                             "couldn't create entry in reference count table, "
-                            "raw(%1%), ref-count(%2%)",
+                            "raw({1}), ref-count({2})",
                             raw, count));
                     return;
                 }
@@ -1025,8 +1025,8 @@ void primary_namespace::decrement_sweep(
                 HPX_THROWS_IF(ec, invalid_data
                   , "primary_namespace::decrement_sweep"
                   , hpx::util::format(
-                        "negative entry in reference count table, raw(%1%), "
-                        "refcount(%2%)",
+                        "negative entry in reference count table, raw({1}), "
+                        "refcount({2})",
                         raw, it->second));
                 return;
             }
@@ -1065,8 +1065,8 @@ void primary_namespace::free_components_sync(
         {
             LAGAS_(info) << hpx::util::format(
                 "primary_namespace::free_components_sync, cancelling free "
-                "operation because the threadmanager is down, lower(%1%), "
-                "upper(%2%), base(%3%), gva(%4%), locality(%5%)",
+                "operation because the threadmanager is down, lower({1}), "
+                "upper({2}), base({3}), gva({4}), locality({5})",
                 lower,
                 upper,
                 e.gid_, e.gva_, e.locality_);
@@ -1075,7 +1075,7 @@ void primary_namespace::free_components_sync(
 
         LAGAS_(info) << hpx::util::format(
             "primary_namespace::free_components_sync, freeing component, "
-            "lower(%1%), upper(%2%), base(%3%), gva(%4%), locality(%5%)",
+            "lower({1}), upper({2}), base({3}), gva({4}), locality({5})",
             lower,
             upper,
             e.gid_, e.gva_, e.locality_);

--- a/src/runtime/agas/server/route.cpp
+++ b/src/runtime/agas/server/route.cpp
@@ -70,7 +70,7 @@ namespace hpx { namespace agas { namespace server
                 HPX_THROWS_IF(ec, no_success,
                     "primary_namespace::route",
                     hpx::util::format(
-                        "can't route parcel to unknown gid: %s",
+                        "can't route parcel to unknown gid: {}",
                         gid));
 
                 return;

--- a/src/runtime/agas/server/symbol_namespace_server.cpp
+++ b/src/runtime/agas/server/symbol_namespace_server.cpp
@@ -81,11 +81,11 @@ void symbol_namespace::register_counter_types(
         if (detail::symbol_namespace_services[i].target_
             == detail::counter_target_count)
             help = hpx::util::format(
-                "returns the number of invocations of the AGAS service '%s'",
+                "returns the number of invocations of the AGAS service '{}'",
                 name.substr(p+1));
         else
             help = hpx::util::format(
-                "returns the overall execution time of the AGAS service '%s'",
+                "returns the overall execution time of the AGAS service '{}'",
                 name.substr(p+1));
 
         performance_counters::install_counter_type(
@@ -208,8 +208,8 @@ bool symbol_namespace::bind(
         if (raw_gid == gid)
         {
             LAGAS_(info) << hpx::util::format(
-                "symbol_namespace::bind, key(%1%), gid(%2%), old_credit(%3%), "
-                "new_credit(%4%)",
+                "symbol_namespace::bind, key({1}), gid({2}), old_credit({3}), "
+                "new_credit({4})",
                 key, gid,
                 naming::detail::get_credit_from_gid(*(it->second)),
                 naming::detail::get_credit_from_gid(*(it->second)) + credits);
@@ -224,7 +224,7 @@ bool symbol_namespace::bind(
         {
             naming::detail::add_credit_to_gid(gid, credits);
             LAGAS_(info) << hpx::util::format(
-                "symbol_namespace::bind, key(%1%), gid(%2%), response(no_success)",
+                "symbol_namespace::bind, key({1}), gid({2}), response(no_success)",
                 key, gid);
         }
 
@@ -294,7 +294,7 @@ bool symbol_namespace::bind(
     l.unlock();
 
     LAGAS_(info) << hpx::util::format(
-        "symbol_namespace::bind, key(%1%), gid(%2%)",
+        "symbol_namespace::bind, key({1}), gid({2})",
         key, gid);
 
     return true;
@@ -316,7 +316,7 @@ naming::gid_type symbol_namespace::resolve(std::string const& key)
     if (it == end)
     {
         LAGAS_(info) << hpx::util::format(
-            "symbol_namespace::resolve, key(%1%), response(no_success)",
+            "symbol_namespace::resolve, key({1}), response(no_success)",
             key);
 
         return naming::invalid_gid;
@@ -329,7 +329,7 @@ naming::gid_type symbol_namespace::resolve(std::string const& key)
     naming::gid_type gid = naming::detail::split_gid_if_needed(*current_gid).get();
 
     LAGAS_(info) << hpx::util::format(
-        "symbol_namespace::resolve, key(%1%), gid(%2%)",
+        "symbol_namespace::resolve, key({1}), gid({2})",
         key, gid);
 
     return gid;
@@ -350,7 +350,7 @@ naming::gid_type symbol_namespace::unbind(std::string const& key)
     if (it == end)
     {
         LAGAS_(info) << hpx::util::format(
-            "symbol_namespace::unbind, key(%1%), response(no_success)",
+            "symbol_namespace::unbind, key({1}), response(no_success)",
             key);
 
         return naming::invalid_gid;
@@ -361,7 +361,7 @@ naming::gid_type symbol_namespace::unbind(std::string const& key)
     gids_.erase(it);
 
     LAGAS_(info) << hpx::util::format(
-        "symbol_namespace::unbind, key(%1%), gid(%2%)",
+        "symbol_namespace::unbind, key({1}), gid({2})",
         key, gid);
 
     return gid;

--- a/src/runtime/agas/symbol_namespace.cpp
+++ b/src/runtime/agas/symbol_namespace.cpp
@@ -80,7 +80,7 @@ namespace hpx { namespace agas
             HPX_THROWS_IF(ec, bad_parameter,
                 "symbol_namespace::get_service_instance",
                 hpx::util::format(
-                    "can't retrieve a valid locality id from global address (%1%): ",
+                    "can't retrieve a valid locality id from global address ({1}): ",
                     dest));
             return naming::gid_type();
         }

--- a/src/runtime/parcelset/detail/per_action_data_counter_registry.cpp
+++ b/src/runtime/parcelset/detail/per_action_data_counter_registry.cpp
@@ -136,8 +136,8 @@ namespace hpx { namespace parcelset { namespace detail
                 HPX_THROWS_IF(ec, bad_parameter,
                     "per_action_data_counter_registry::counter_discoverer",
                     hpx::util::format(
-                        "action type %s does not match any known type, "
-                        "known action types: \n%s", p.parameters_, types));
+                        "action type {} does not match any known type, "
+                        "known action types: \n{}", p.parameters_, types));
                 return false;
             }
 
@@ -162,8 +162,8 @@ namespace hpx { namespace parcelset { namespace detail
             HPX_THROWS_IF(ec, bad_parameter,
                 "per_action_data_counter_registry::counter_discoverer",
                 hpx::util::format(
-                    "action type %s does not match any known type, "
-                    "known action types: \n%s", p.parameters_, types));
+                    "action type {} does not match any known type, "
+                    "known action types: \n{}", p.parameters_, types));
             return false;
         }
 

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -1190,10 +1190,10 @@ namespace hpx { namespace parcelset
 
         performance_counters::generic_counter_type_data const counter_types[] =
         {
-            { hpx::util::format("/parcels/count/%s/sent", pp_type),
+            { hpx::util::format("/parcels/count/{}/sent", pp_type),
               performance_counters::counter_raw,
               hpx::util::format(
-                  "returns the number of parcels sent using the %s "
+                  "returns the number of parcels sent using the {} "
                   "connection type for the referenced locality", pp_type),
               HPX_PERFORMANCE_COUNTER_V1,
 #if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
@@ -1209,10 +1209,10 @@ namespace hpx { namespace parcelset
 #endif
               ""
             },
-            { hpx::util::format("/parcels/count/%s/received", pp_type),
+            { hpx::util::format("/parcels/count/{}/received", pp_type),
                performance_counters::counter_raw,
               hpx::util::format(
-                  "returns the number of parcels received using the %s "
+                  "returns the number of parcels received using the {} "
                   "connection type for the referenced locality", pp_type),
               HPX_PERFORMANCE_COUNTER_V1,
 #if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
@@ -1228,10 +1228,10 @@ namespace hpx { namespace parcelset
 #endif
               ""
             },
-            { hpx::util::format("/messages/count/%s/sent", pp_type),
+            { hpx::util::format("/messages/count/{}/sent", pp_type),
               performance_counters::counter_raw,
               hpx::util::format(
-                  "returns the number of messages sent using the %s "
+                  "returns the number of messages sent using the {} "
                   "connection type for the referenced locality", pp_type),
               HPX_PERFORMANCE_COUNTER_V1,
               util::bind(&performance_counters::locality_raw_counter_creator,
@@ -1239,10 +1239,10 @@ namespace hpx { namespace parcelset
               &performance_counters::locality_counter_discoverer,
               ""
             },
-            { hpx::util::format("/messages/count/%s/received", pp_type),
+            { hpx::util::format("/messages/count/{}/received", pp_type),
               performance_counters::counter_raw,
               hpx::util::format(
-                  "returns the number of messages received using the %s "
+                  "returns the number of messages received using the {} "
                   "connection type for the referenced locality", pp_type),
               HPX_PERFORMANCE_COUNTER_V1,
               util::bind(&performance_counters::locality_raw_counter_creator,
@@ -1251,12 +1251,12 @@ namespace hpx { namespace parcelset
               ""
             },
 
-            { hpx::util::format("/data/time/%s/sent", pp_type),
+            { hpx::util::format("/data/time/{}/sent", pp_type),
               performance_counters::counter_raw,
               hpx::util::format(
                   "returns the total time between the start of each "
                   "asynchronous write and the invocation of the write callback "
-                  "using the %s connection type for the referenced locality",
+                  "using the {} connection type for the referenced locality",
                       pp_type),
               HPX_PERFORMANCE_COUNTER_V1,
               util::bind(&performance_counters::locality_raw_counter_creator,
@@ -1264,12 +1264,12 @@ namespace hpx { namespace parcelset
               &performance_counters::locality_counter_discoverer,
               "ns"
             },
-            { hpx::util::format("/data/time/%s/received", pp_type),
+            { hpx::util::format("/data/time/{}/received", pp_type),
               performance_counters::counter_raw,
               hpx::util::format(
                   "returns the total time between the start of each "
                   "asynchronous read and the invocation of the read callback "
-                  "using the %s connection type for the referenced locality",
+                  "using the {} connection type for the referenced locality",
                       pp_type),
               HPX_PERFORMANCE_COUNTER_V1,
               util::bind(&performance_counters::locality_raw_counter_creator,
@@ -1277,11 +1277,11 @@ namespace hpx { namespace parcelset
               &performance_counters::locality_counter_discoverer,
               "ns"
             },
-            { hpx::util::format("/serialize/time/%s/sent", pp_type),
+            { hpx::util::format("/serialize/time/{}/sent", pp_type),
               performance_counters::counter_raw,
               hpx::util::format(
                   "returns the total time required to serialize all sent "
-                  "parcels using the %s connection type for the referenced "
+                  "parcels using the {} connection type for the referenced "
                   "locality", pp_type),
               HPX_PERFORMANCE_COUNTER_V1,
 #if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
@@ -1297,11 +1297,11 @@ namespace hpx { namespace parcelset
 #endif
               "ns"
             },
-            { hpx::util::format("/serialize/time/%s/received", pp_type),
+            { hpx::util::format("/serialize/time/{}/received", pp_type),
               performance_counters::counter_raw,
               hpx::util::format(
                   "returns the total time required to de-serialize all "
-                  "received parcels using the %s connection type for the "
+                  "received parcels using the {} connection type for the "
                   "referenced locality", pp_type),
               HPX_PERFORMANCE_COUNTER_V1,
 #if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
@@ -1318,11 +1318,11 @@ namespace hpx { namespace parcelset
               "ns"
             },
 
-            { hpx::util::format("/data/count/%s/sent", pp_type),
+            { hpx::util::format("/data/count/{}/sent", pp_type),
               performance_counters::counter_raw,
               hpx::util::format(
                   "returns the amount of (uncompressed) parcel argument data "
-                  "sent using the %s connection type by the referenced "
+                  "sent using the {} connection type by the referenced "
                   "locality", pp_type),
               HPX_PERFORMANCE_COUNTER_V1,
               util::bind(&performance_counters::locality_raw_counter_creator,
@@ -1330,11 +1330,11 @@ namespace hpx { namespace parcelset
               &performance_counters::locality_counter_discoverer,
               "bytes"
             },
-            { hpx::util::format("/data/count/%s/received", pp_type),
+            { hpx::util::format("/data/count/{}/received", pp_type),
               performance_counters::counter_raw,
               hpx::util::format(
                   "returns the amount of (uncompressed) parcel argument data "
-                  "received using the %s connection type by the referenced "
+                  "received using the {} connection type by the referenced "
                   "locality", pp_type),
               HPX_PERFORMANCE_COUNTER_V1,
               util::bind(&performance_counters::locality_raw_counter_creator,
@@ -1343,11 +1343,11 @@ namespace hpx { namespace parcelset
               "bytes"
             },
             { hpx::util::format(
-                  "/serialize/count/%s/sent", pp_type),
+                  "/serialize/count/{}/sent", pp_type),
               performance_counters::counter_raw,
               hpx::util::format(
                   "returns the amount of parcel data (including headers, "
-                  "possibly compressed) sent using the %s connection type "
+                  "possibly compressed) sent using the {} connection type "
                   "by the referenced locality", pp_type),
               HPX_PERFORMANCE_COUNTER_V1,
 #if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
@@ -1364,11 +1364,11 @@ namespace hpx { namespace parcelset
               "bytes"
             },
             { hpx::util::format(
-                  "/serialize/count/%s/received", pp_type),
+                  "/serialize/count/{}/received", pp_type),
               performance_counters::counter_raw,
               hpx::util::format(
                   "returns the amount of parcel data (including headers, "
-                  "possibly compressed) received using the %s connection type "
+                  "possibly compressed) received using the {} connection type "
                   "by the referenced locality", pp_type),
               HPX_PERFORMANCE_COUNTER_V1,
 #if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
@@ -1385,11 +1385,11 @@ namespace hpx { namespace parcelset
               "bytes"
             },
             { hpx::util::format(
-                "/parcels/time/%s/buffer_allocate/received", pp_type),
+                "/parcels/time/{}/buffer_allocate/received", pp_type),
               performance_counters::counter_raw,
               hpx::util::format(
                   "returns the time needed to allocate the buffers for "
-                  "serializing using the %s connection type", pp_type),
+                  "serializing using the {} connection type", pp_type),
               HPX_PERFORMANCE_COUNTER_V1,
               util::bind(&performance_counters::locality_raw_counter_creator,
                   _1, std::move(buffer_allocate_time_received), _2),
@@ -1397,11 +1397,11 @@ namespace hpx { namespace parcelset
               "ns"
             },
             { hpx::util::format(
-                "/parcels/time/%s/buffer_allocate/sent", pp_type),
+                "/parcels/time/{}/buffer_allocate/sent", pp_type),
               performance_counters::counter_raw,
               hpx::util::format(
                   "returns the time needed to allocate the buffers for "
-                  "serializing using the %s connection type", pp_type),
+                  "serializing using the {} connection type", pp_type),
               HPX_PERFORMANCE_COUNTER_V1,
               util::bind(&performance_counters::locality_raw_counter_creator,
                   _1, std::move(buffer_allocate_time_sent), _2),
@@ -1443,11 +1443,11 @@ namespace hpx { namespace parcelset
             connection_cache_types[] =
         {
             { hpx::util::format(
-                  "/parcelport/count/%s/cache-insertions", pp_type),
+                  "/parcelport/count/{}/cache-insertions", pp_type),
               performance_counters::counter_raw,
               hpx::util::format(
                   "returns the number of cache insertions while accessing the "
-                  "connection cache for the %s connection type on the "
+                  "connection cache for the {} connection type on the "
                   "referenced locality", pp_type),
               HPX_PERFORMANCE_COUNTER_V1,
               util::bind(&performance_counters::locality_raw_counter_creator,
@@ -1456,11 +1456,11 @@ namespace hpx { namespace parcelset
               ""
             },
             { hpx::util::format(
-                  "/parcelport/count/%s/cache-evictions", pp_type),
+                  "/parcelport/count/{}/cache-evictions", pp_type),
               performance_counters::counter_raw,
               hpx::util::format(
                   "returns the number of cache evictions while accessing the "
-                  "connection cache for the %s connection type on the "
+                  "connection cache for the {} connection type on the "
                   "referenced locality", pp_type),
               HPX_PERFORMANCE_COUNTER_V1,
               util::bind(&performance_counters::locality_raw_counter_creator,
@@ -1469,11 +1469,11 @@ namespace hpx { namespace parcelset
               ""
             },
             { hpx::util::format(
-                  "/parcelport/count/%s/cache-hits", pp_type),
+                  "/parcelport/count/{}/cache-hits", pp_type),
               performance_counters::counter_raw,
               hpx::util::format(
                   "returns the number of cache hits while accessing the "
-                  "connection cache for the %s connection type on the "
+                  "connection cache for the {} connection type on the "
                   "referenced locality", pp_type),
               HPX_PERFORMANCE_COUNTER_V1,
               util::bind(&performance_counters::locality_raw_counter_creator,
@@ -1482,11 +1482,11 @@ namespace hpx { namespace parcelset
               ""
             },
             { hpx::util::format(
-                  "/parcelport/count/%s/cache-misses", pp_type),
+                  "/parcelport/count/{}/cache-misses", pp_type),
               performance_counters::counter_raw,
               hpx::util::format(
                   "returns the number of cache misses while accessing the "
-                  "connection cache for the %s connection type on the "
+                  "connection cache for the {} connection type on the "
                   "referenced locality", pp_type),
               HPX_PERFORMANCE_COUNTER_V1,
               util::bind(&performance_counters::locality_raw_counter_creator,
@@ -1495,11 +1495,11 @@ namespace hpx { namespace parcelset
               ""
             },
             { hpx::util::format(
-                  "/parcelport/count/%s/cache-reclaims", pp_type),
+                  "/parcelport/count/{}/cache-reclaims", pp_type),
               performance_counters::counter_raw,
               hpx::util::format(
                   "returns the number of cache reclaims while accessing the "
-                  "connection cache for the %s connection type on the "
+                  "connection cache for the {} connection type on the "
                   "referenced locality", pp_type),
               HPX_PERFORMANCE_COUNTER_V1,
               util::bind(&performance_counters::locality_raw_counter_creator,

--- a/src/runtime/threads/policies/affinity_data.cpp
+++ b/src/runtime/threads/policies/affinity_data.cpp
@@ -158,8 +158,8 @@ namespace hpx { namespace threads { namespace policies { namespace detail
                     "affinity_data::affinity_data",
                     hpx::util::format(
                         "The number of OS threads requested "
-                        "(%1%) does not match the number of threads to "
-                        "bind (%2%)", num_threads_, num_initialized));
+                        "({1}) does not match the number of threads to "
+                        "bind ({2})", num_threads_, num_initialized));
             }
         }
         else if (pu_offset == std::size_t(-1))

--- a/src/runtime/threads/policies/parse_affinity_options.cpp
+++ b/src/runtime/threads/policies/parse_affinity_options.cpp
@@ -371,7 +371,7 @@ namespace hpx { namespace threads { namespace detail
         default:
             HPX_THROWS_IF(ec, bad_parameter, "extract_socket_or_numanode_mask",
                 hpx::util::format(
-                    "unexpected specification type %s",
+                    "unexpected specification type {}",
                     spec_type::type_name(s.type_)));
             break;
         }
@@ -443,7 +443,7 @@ namespace hpx { namespace threads { namespace detail
         default:
             HPX_THROWS_IF(ec, bad_parameter, "extract_core_mask",
                 hpx::util::format(
-                    "unexpected specification type %s",
+                    "unexpected specification type {}",
                     spec_type::type_name(s.type_)));
             break;
         }
@@ -529,7 +529,7 @@ namespace hpx { namespace threads { namespace detail
         default:
             HPX_THROWS_IF(ec, bad_parameter, "extract_pu_mask",
                 hpx::util::format(
-                    "unexpected specification type %s",
+                    "unexpected specification type {}",
                     spec_type::type_name(s.type_)));
             break;
         }
@@ -554,7 +554,7 @@ namespace hpx { namespace threads { namespace detail
         {
             HPX_THROWS_IF(ec, bad_parameter, "decode_mapping",
                 hpx::util::format(
-                    "no %1% mapping bounds are specified",
+                    "no {1} mapping bounds are specified",
                     spec_type::type_name(fmt.first.type_)));
             return;
         }
@@ -737,7 +737,7 @@ namespace hpx { namespace threads { namespace detail
                         HPX_THROWS_IF(ec, bad_parameter,
                             "decode_compact_distribution",
                             hpx::util::format(
-                                "affinity mask for thread %1% has "
+                                "affinity mask for thread {1} has "
                                 "already been set",
                                 num_thread));
                         return;
@@ -773,7 +773,7 @@ namespace hpx { namespace threads { namespace detail
                     HPX_THROWS_IF(ec, bad_parameter,
                         "decode_scatter_distribution",
                         hpx::util::format(
-                            "affinity mask for thread %1% has "
+                            "affinity mask for thread {1} has "
                             "already been set",
                             num_thread));
                     return;
@@ -827,7 +827,7 @@ namespace hpx { namespace threads { namespace detail
                     HPX_THROWS_IF(ec, bad_parameter,
                         "decode_balanced_distribution",
                         hpx::util::format(
-                            "affinity mask for thread %1% has "
+                            "affinity mask for thread {1} has "
                             "already been set",
                             num_thread));
                     return;
@@ -907,7 +907,7 @@ namespace hpx { namespace threads { namespace detail
                         HPX_THROWS_IF(ec, bad_parameter,
                             "decode_numabalanced_distribution",
                             hpx::util::format(
-                                "affinity mask for thread %1% has "
+                                "affinity mask for thread {1} has "
                                 "already been set",
                                 num_thread));
                         return;
@@ -997,7 +997,7 @@ namespace hpx { namespace threads
                         HPX_THROWS_IF(ec, bad_parameter,
                             "parse_affinity_options",
                             hpx::util::format(
-                                "bind specification (%1%) is ill formatted",
+                                "bind specification ({1}) is ill formatted",
                                 spec));
                         return;
                     }
@@ -1007,7 +1007,7 @@ namespace hpx { namespace threads
                         HPX_THROWS_IF(ec, bad_parameter,
                             "parse_affinity_options",
                             hpx::util::format(
-                                "bind specification (%1%) is ill formatted",
+                                "bind specification ({1}) is ill formatted",
                                 spec));
                         return;
                     }
@@ -1019,7 +1019,7 @@ namespace hpx { namespace threads
                         HPX_THROWS_IF(ec, bad_parameter,
                             "parse_affinity_options",
                             hpx::util::format(
-                                "bind specification (%1%) is ill formatted",
+                                "bind specification ({1}) is ill formatted",
                                 spec));
                         return;
                     }

--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -814,7 +814,7 @@ namespace hpx {
 //                         , "runtime_impl::init_tss_ex"
 //                         , hpx::util::format(
 //                             "failed to set thread affinity mask ("
-//                             HPX_CPU_MASK_PREFIX "%x) for service thread: %s",
+//                             HPX_CPU_MASK_PREFIX "{:x}) for service thread: {}",
 //                             used_processing_units, runtime::thread_name_.get()));
 //                 }
             }

--- a/src/util/activate_counters.cpp
+++ b/src/util/activate_counters.cpp
@@ -50,7 +50,7 @@ namespace hpx { namespace util
             HPX_THROWS_IF(ec, bad_parameter,
                 "activate_counters::find_counter",
                 hpx::util::format(
-                    "unknown performance counter: '%1%' (%2%)",
+                    "unknown performance counter: '{1}' ({2})",
                     info.fullname_, ec.get_message()));
             return false;
         }

--- a/src/util/batch_environments/pbs_environment.cpp
+++ b/src/util/batch_environments/pbs_environment.cpp
@@ -112,7 +112,7 @@ namespace hpx { namespace util { namespace batch_environments
 
             // raise hard error if nodefile could not be opened
             throw hpx::detail::command_line_error(hpx::util::format(
-                "Could not open nodefile: '%s'", node_file));
+                "Could not open nodefile: '{}'", node_file));
         }
     }
 

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -522,7 +522,7 @@ namespace hpx { namespace util
             // Check for parsing failures
             if (!iftransform) {
                 throw hpx::detail::command_line_error(hpx::util::format(
-                    "Could not parse --hpx:iftransform argument '%1%'",
+                    "Could not parse --hpx:iftransform argument '{1}'",
                     vm["hpx:iftransform"].as<std::string>()));
             }
 
@@ -565,7 +565,7 @@ namespace hpx { namespace util
 
                 // raise hard error if node file could not be opened
                 throw hpx::detail::command_line_error(hpx::util::format(
-                    "Could not open nodefile: '%s'", node_file));
+                    "Could not open nodefile: '{}'", node_file));
             }
         }
         else if (vm.count("hpx:nodes")) {
@@ -981,7 +981,7 @@ namespace hpx { namespace util
 
                 throw hpx::detail::command_line_error(hpx::util::format(
                     "Invalid argument for option --hpx:print-counter-at: "
-                    "'%1%', allowed values: 'startup', 'shutdown' (default), "
+                    "'{1}', allowed values: 'startup', 'shutdown' (default), "
                     "'noshutdown'", s));
             }
         }
@@ -1081,7 +1081,7 @@ namespace hpx { namespace util
             }
             else {
                 throw hpx::detail::command_line_error(hpx::util::format(
-                    "Invalid argument for option --hpx:help: '%1%', allowed values: "
+                    "Invalid argument for option --hpx:help: '{1}', allowed values: "
                     "'minimal' (default) and 'full'", help_option));
             }
         }
@@ -1162,10 +1162,10 @@ namespace hpx { namespace util
                     HPX_THROW_EXCEPTION(invalid_status,
                         "handle_print_bind",
                         hpx::util::format(
-                            "unexpected mismatch between locality %1%: "
+                            "unexpected mismatch between locality {1}: "
                             "binding "
-                            "reported from HWLOC(%2%) and HPX(%3%) on "
-                            "thread %4%",
+                            "reported from HWLOC({2}) and HPX({3}) on "
+                            "thread {4}",
                             hpx::get_locality_id(), boundcpu_str,
                             pu_mask_str, i));
                 }

--- a/src/util/one_size_heap_list.cpp
+++ b/src/util/one_size_heap_list.cpp
@@ -29,8 +29,8 @@ namespace hpx { namespace util
     {
 #if defined(HPX_DEBUG)
         LOSH_(info) << hpx::util::format(
-            "%1%::~%1%: size(%2%), max_count(%3%), alloc_count(%4%), "
-            "free_count(%5%)",
+            "{1}::~{1}: size({2}), max_count({3}), alloc_count({4}), "
+            "free_count({5})",
             name(),
             heap_count_,
             max_alloc_count_,
@@ -40,7 +40,7 @@ namespace hpx { namespace util
         if (alloc_count_ > free_count_)
         {
             LOSH_(warning) << hpx::util::format(
-                "%1%::~%1%: releasing with %2% allocated objects",
+                "{1}::~{1}: releasing with {2} allocated objects",
                 name(),
                 alloc_count_ - free_count_);
         }
@@ -87,9 +87,9 @@ namespace hpx { namespace util
 
 #if defined(HPX_DEBUG)
                     LOSH_(info) << hpx::util::format(
-                        "%1%::alloc: failed to allocate from heap[%2%] "
-                        "(heap[%2%] has allocated %3% objects and has "
-                        "space for %4% more objects)",
+                        "{1}::alloc: failed to allocate from heap[{2}] "
+                        "(heap[{2}] has allocated {3} objects and has "
+                        "space for {4} more objects)",
                         name(),
                         heap->heap_count(),
                         heap->size(),
@@ -126,7 +126,7 @@ namespace hpx { namespace util
                 HPX_THROW_EXCEPTION(out_of_memory,
                     name() + "::alloc",
                     hpx::util::format(
-                        "new heap failed to allocate %1% objects",
+                        "new heap failed to allocate {1} objects",
                         count));
             }
 
@@ -135,7 +135,7 @@ namespace hpx { namespace util
             ++heap_count_;
 
             LOSH_(info) << hpx::util::format(
-                "%1%::alloc: creating new heap[%2%], size is now %3%",
+                "{1}::alloc: creating new heap[{2}], size is now {3}",
                 name(),
                 heap_count_,
                 heap_list_.size());
@@ -202,7 +202,7 @@ namespace hpx { namespace util
         HPX_THROW_EXCEPTION(bad_parameter,
             name() + "::free",
             hpx::util::format(
-                "pointer %1% was not allocated by this %2%",
+                "pointer {1} was not allocated by this {2}",
                 p, name()));
     }
 

--- a/src/util/query_counters.cpp
+++ b/src/util/query_counters.cpp
@@ -149,7 +149,7 @@ namespace hpx { namespace util
             *out  << "," << value.count_ << ",";
 
             double elapsed = static_cast<double>(value.time_) * 1e-9;
-            *out << hpx::util::format("%.6f", elapsed)
+            *out << hpx::util::format("{:.6}", elapsed)
                 << ",[s]," << val;
             if (!uom.empty())
                 *out << ",[" << uom << "]";
@@ -175,7 +175,7 @@ namespace hpx { namespace util
         *out << "," << value.count_ << ",";
 
         double elapsed = static_cast<double>(value.time_) * 1e-9;
-        *out << hpx::util::format("%.6f", elapsed) << ",[s],";
+        *out << hpx::util::format("{:.6}", elapsed) << ",[s],";
 
         bool first = true;
         for (std::int64_t val : value.values_)

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -57,7 +57,7 @@ namespace hpx
 
     std::string full_version_as_string()
     {
-        return hpx::util::format("%d.%d.%d", //-V609
+        return hpx::util::format("{}.{}.{}", //-V609
             HPX_VERSION_MAJOR,
             HPX_VERSION_MINOR,
             HPX_VERSION_SUBMINOR);
@@ -184,7 +184,7 @@ namespace hpx
 
     std::string build_string()
     {
-        return hpx::util::format("V%s%s (AGAS: V%d.%d), Git: %.10s", //-V609
+        return hpx::util::format("V{}{} (AGAS: V{}.{}), Git: {:.10}", //-V609
             full_version_as_string(), HPX_VERSION_TAG,
             HPX_AGAS_VERSION / 0x10, HPX_AGAS_VERSION % 0x10,
             HPX_HAVE_GIT_COMMIT);
@@ -193,7 +193,7 @@ namespace hpx
     std::string boost_version()
     {
         // BOOST_VERSION: 105800
-        return hpx::util::format("V%d.%d.%d",
+        return hpx::util::format("V{}.{}.{}",
             BOOST_VERSION / 100000,
             BOOST_VERSION / 100 % 1000,
             BOOST_VERSION % 100);
@@ -202,7 +202,7 @@ namespace hpx
     std::string hwloc_version()
     {
         // HWLOC_API_VERSION: 0x00010700
-        return hpx::util::format("V%d.%d.%d",
+        return hpx::util::format("V{}.{}.{}",
             HWLOC_API_VERSION / 0x10000,
             HWLOC_API_VERSION / 0x100 % 0x100,
             HWLOC_API_VERSION % 0x100);
@@ -234,19 +234,19 @@ namespace hpx
     {
         std::string version = hpx::util::format(
             "Versions:\n"
-            "  HPX: %s\n"
-            "  Boost: %s\n"
-            "  Hwloc: %s\n"
+            "  HPX: {}\n"
+            "  Boost: {}\n"
+            "  Hwloc: {}\n"
 #if defined(HPX_HAVE_PARCELPORT_MPI)
-            "  MPI: %s\n"
+            "  MPI: {}\n"
 #endif
             "\n"
             "Build:\n"
-            "  Type: %s\n"
-            "  Date: %s\n"
-            "  Platform: %s\n"
-            "  Compiler: %s\n"
-            "  Standard Library: %s\n",
+            "  Type: {}\n"
+            "  Date: {}\n"
+            "  Platform: {}\n"
+            "  Compiler: {}\n"
+            "  Standard Library: {}\n",
             build_string(),
             boost_version(),
             hwloc_version(),

--- a/tests/performance/local/boost_tls_overhead.cpp
+++ b/tests/performance/local/boost_tls_overhead.cpp
@@ -118,14 +118,14 @@ int main(
     // output results
     if (vm.count("csv"))
         hpx::util::format_to(std::cout,
-            "%1%,%2%,%3%\n",
+            "{1},{2},{3}\n",
             updates,
             threads,
             duration);
     else
         hpx::util::format_to(std::cout,
-            "ran %1% updates per OS-thread on %2% "
-            "OS-threads in %3% seconds\n",
+            "ran {1} updates per OS-thread on {2} "
+            "OS-threads in {3} seconds\n",
             updates,
             threads,
             duration);

--- a/tests/performance/local/coroutines_call_overhead.cpp
+++ b/tests/performance/local/coroutines_call_overhead.cpp
@@ -114,7 +114,7 @@ void print_results(
         ;
 */
 
-    hpx::util::format_to(cout, "%lu %lu %lu %lu %lu %.14g",
+    hpx::util::format_to(cout, "{} {} {} {} {} {:.14g}",
         payload,
         os_thread_count,
         contexts,
@@ -128,7 +128,7 @@ void print_results(
     if (ac)
     {
         for (std::uint64_t i = 0; i < counter_shortnames.size(); ++i)
-            hpx::util::format_to(cout, " %.14g",
+            hpx::util::format_to(cout, " {:.14g}",
                 counter_values[i].get_value<double>());
     }
 */

--- a/tests/performance/local/delay_baseline.cpp
+++ b/tests/performance/local/delay_baseline.cpp
@@ -77,10 +77,10 @@ void print_results(
                 ;
     }
 
-    std::string const tasks_str = hpx::util::format("%lu,", tasks);
-    std::string const delay_str = hpx::util::format("%lu,", delay);
+    std::string const tasks_str = hpx::util::format("{},", tasks);
+    std::string const delay_str = hpx::util::format("{},", delay);
 
-    hpx::util::format_to(cout, "%lu %lu %.14g\n",
+    hpx::util::format_to(cout, "{} {} {:.14g}\n",
         delay, tasks, mean_);
 }
 

--- a/tests/performance/local/delay_baseline_threaded.cpp
+++ b/tests/performance/local/delay_baseline_threaded.cpp
@@ -81,10 +81,10 @@ void print_results(
                 ;
     }
 
-    std::string const tasks_str = hpx::util::format("%lu,", tasks);
-    std::string const delay_str = hpx::util::format("%lu,", delay);
+    std::string const tasks_str = hpx::util::format("{},", tasks);
+    std::string const delay_str = hpx::util::format("{},", delay);
 
-    hpx::util::format_to(cout, "%lu %lu %lu %.14g\n",
+    hpx::util::format_to(cout, "{} {} {} {:.14g}\n",
         delay, tasks, threads, mean_);
 }
 

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -81,12 +81,12 @@ void measure_action_futures(std::uint64_t count, bool csv)
 
     if (csv)
         hpx::util::format_to(cout,
-            "%1%,%2%\n",
+            "{1},{2}\n",
             count,
             duration) << flush;
     else
         hpx::util::format_to(cout,
-            "invoked %1% futures (actions) in %2% seconds\n",
+            "invoked {1} futures (actions) in {2} seconds\n",
             count,
             duration) << flush;
 }
@@ -110,12 +110,12 @@ void measure_function_futures(std::uint64_t count, bool csv)
 
     if (csv)
         hpx::util::format_to(cout,
-            "%1%,%2%\n",
+            "{1},{2}\n",
             count,
             duration) << flush;
     else
         hpx::util::format_to(cout,
-            "invoked %1% futures (functions) in %2% seconds\n",
+            "invoked {1} futures (functions) in {2} seconds\n",
             count,
             duration) << flush;
 }

--- a/tests/performance/local/hpx_heterogeneous_timed_task_spawn.cpp
+++ b/tests/performance/local/hpx_heterogeneous_timed_task_spawn.cpp
@@ -61,19 +61,19 @@ void print_results(
                 "Total Walltime (seconds),Walltime per Task (seconds)\n"
              << flush;
 
-    std::string const cores_str = hpx::util::format("%lu,", cores);
-    std::string const seed_str  = hpx::util::format("%lu,", seed);
-    std::string const tasks_str = hpx::util::format("%lu,", tasks);
+    std::string const cores_str = hpx::util::format("{},", cores);
+    std::string const seed_str  = hpx::util::format("{},", seed);
+    std::string const tasks_str = hpx::util::format("{},", tasks);
 
     std::string const min_delay_str
-        = hpx::util::format("%lu,", min_delay);
+        = hpx::util::format("{},", min_delay);
     std::string const max_delay_str
-        = hpx::util::format("%lu,", max_delay);
+        = hpx::util::format("{},", max_delay);
     std::string const total_delay_str
-        = hpx::util::format("%lu,", total_delay);
+        = hpx::util::format("{},", total_delay);
 
     hpx::util::format_to(cout,
-        "%-21s %-21s %-21s %-21s %-21s %-21s %10.12s, %10.12s\n",
+        "{:-21} {:-21} {:-21} {:-21} {:-21} {:-21} {:10.12}, {:10.12}\n",
         cores_str, seed_str, tasks_str,
         min_delay_str, max_delay_str, total_delay_str,
         walltime, walltime / tasks) << flush;

--- a/tests/performance/local/hpx_homogeneous_timed_task_spawn_executors.cpp
+++ b/tests/performance/local/hpx_homogeneous_timed_task_spawn_executors.cpp
@@ -52,12 +52,12 @@ void print_results(
                 "Total Walltime (seconds),Walltime per Task (seconds)\n"
              << flush;
 
-    std::string const cores_str = hpx::util::format("%lu,", cores);
-    std::string const tasks_str = hpx::util::format("%lu,", tasks);
-    std::string const delay_str = hpx::util::format("%lu,", delay);
+    std::string const cores_str = hpx::util::format("{},", cores);
+    std::string const tasks_str = hpx::util::format("{},", tasks);
+    std::string const delay_str = hpx::util::format("{},", delay);
 
     hpx::util::format_to(cout,
-        "%-21s %-21s %-21s %10.12s, %10.12s\n",
+        "{:-21} {:-21} {:-21} {:10.12}, {:10.12}\n",
         cores_str, tasks_str, delay_str,
         walltime, walltime / tasks) << flush;
 }

--- a/tests/performance/local/hpx_tls_overhead.cpp
+++ b/tests/performance/local/hpx_tls_overhead.cpp
@@ -110,14 +110,14 @@ int main(
     // output results
     if (vm.count("csv"))
         hpx::util::format_to(std::cout,
-            "%1%,%2%,%3%\n",
+            "{1},{2},{3}\n",
             updates,
             threads,
             duration);
     else
         hpx::util::format_to(std::cout,
-            "ran %1% updates per OS-thread on %2% "
-            "OS-threads in %3% seconds\n",
+            "ran {1} updates per OS-thread on {2} "
+            "OS-threads in {3} seconds\n",
             updates,
             threads,
             duration);

--- a/tests/performance/local/htts_v2/htts2_hpx.cpp
+++ b/tests/performance/local/htts_v2/htts2_hpx.cpp
@@ -206,7 +206,7 @@ struct hpx_driver : htts2::driver
                 << "Total Walltime [nanoseconds]"
                 << "\n";
 
-        hpx::util::format_to(std::cout, "%lu,%lu,%lu,%.14g\n",
+        hpx::util::format_to(std::cout, "{},{},{},{:.14g}\n",
             this->osthreads_,
             this->tasks_,
             this->payload_duration_,

--- a/tests/performance/local/htts_v2/htts2_omp.cpp
+++ b/tests/performance/local/htts_v2/htts2_omp.cpp
@@ -83,7 +83,7 @@ struct omp_driver : htts2::driver
                 << "Total Walltime [nanoseconds]"
                 << "\n";
 
-        hpx::util::format_to(std::cout, "%lu,%lu,%lu,%.14g\n",
+        hpx::util::format_to(std::cout, "{},{},{},{:.14g}\n",
             this->osthreads_,
             this->tasks_,
             this->payload_duration_,

--- a/tests/performance/local/htts_v2/htts2_payload_precision.cpp
+++ b/tests/performance/local/htts_v2/htts2_payload_precision.cpp
@@ -182,7 +182,7 @@ struct payload_precision_driver : htts2::driver
                 << "\n";
 
         hpx::util::format_to(std::cout,
-            "%lu,%lu,%lu,%.14g,%.14g,%.14g,%.14g\n",
+            "{},{},{},{:.14g},{:.14g},{:.14g},{:.14g}\n",
             this->osthreads_,
             this->tasks_,
             this->payload_duration_,

--- a/tests/performance/local/htts_v2/htts2_qthreads.cpp
+++ b/tests/performance/local/htts_v2/htts2_qthreads.cpp
@@ -82,7 +82,7 @@ struct qthreads_driver : htts2::driver
                 << "Total Walltime [nanoseconds]"
                 << "\n";
 
-        hpx::util::format_to(std::cout, "%lu,%lu,%lu,%.14g\n",
+        hpx::util::format_to(std::cout, "{},{},{},{:.14g}\n",
             this->osthreads_,
             this->tasks_,
             this->payload_duration_,

--- a/tests/performance/local/htts_v2/htts2_tbb.cpp
+++ b/tests/performance/local/htts_v2/htts2_tbb.cpp
@@ -155,7 +155,7 @@ struct tbb_driver : htts2::driver
                 << "Total Walltime [nanoseconds]"
                 << "\n";
 
-        hpx::util::format_to(std::cout, "%lu,%lu,%lu,%.14g\n",
+        hpx::util::format_to(std::cout, "{},{},{},{:.14g}\n",
             this->osthreads_,
             this->tasks_,
             this->payload_duration_,

--- a/tests/performance/local/native_tls_overhead.cpp
+++ b/tests/performance/local/native_tls_overhead.cpp
@@ -137,14 +137,14 @@ int main(
     // output results
     if (vm.count("csv"))
         hpx::util::format_to(std::cout,
-            "%1%,%2%,%3%\n",
+            "{1},{2},{3}\n",
             updates,
             threads,
             duration);
     else
         hpx::util::format_to(std::cout,
-            "ran %1% updates per OS-thread on %2% "
-            "OS-threads in %3% seconds\n",
+            "ran {1} updates per OS-thread on {2} "
+            "OS-threads in {3} seconds\n",
             updates,
             threads,
             duration);

--- a/tests/performance/local/nonconcurrent_fifo_overhead.cpp
+++ b/tests/performance/local/nonconcurrent_fifo_overhead.cpp
@@ -96,7 +96,7 @@ void print_results(
 
     if (iterations != 0)
         hpx::util::format_to(std::cout,
-            "%lu %lu %lu %.14g %.14g %.14g %.14g\n",
+            "{} {} {} {:.14g} {:.14g} {:.14g} {:.14g}\n",
             iterations,
             blocksize,
             threads,
@@ -107,7 +107,7 @@ void print_results(
         );
     else
         hpx::util::format_to(std::cout,
-            "%lu %lu %lu %.14g %.14g %.14g %.14g\n",
+            "{} {} {} {:.14g} {:.14g} {:.14g} {:.14g}\n",
             iterations,
             blocksize,
             threads,

--- a/tests/performance/local/nonconcurrent_lifo_overhead.cpp
+++ b/tests/performance/local/nonconcurrent_lifo_overhead.cpp
@@ -94,7 +94,7 @@ void print_results(
 
     if (iterations != 0)
         hpx::util::format_to(std::cout,
-            "%lu %lu %lu %.14g %.14g %.14g %.14g\n",
+            "{} {} {} {:.14g} {:.14g} {:.14g} {:.14g}\n",
             iterations,
             blocksize,
             threads,
@@ -105,7 +105,7 @@ void print_results(
         );
     else
         hpx::util::format_to(std::cout,
-            "%lu %lu %lu %.14g %.14g %.14g %.14g\n",
+            "{} {} {} {:.14g} {:.14g} {:.14g} {:.14g}\n",
             iterations,
             blocksize,
             threads,

--- a/tests/performance/local/openmp_homogeneous_timed_task_spawn.cpp
+++ b/tests/performance/local/openmp_homogeneous_timed_task_spawn.cpp
@@ -73,12 +73,12 @@ void print_results(
         std::cout << "OS-threads,Tasks,Delay (iterations),"
                      "Total Walltime (seconds),Walltime per Task (seconds)\n";
 
-    std::string const cores_str = hpx::util::format("%lu,", cores);
-    std::string const tasks_str = hpx::util::format("%lu,", tasks);
-    std::string const delay_str = hpx::util::format("%lu,", delay);
+    std::string const cores_str = hpx::util::format("{},", cores);
+    std::string const tasks_str = hpx::util::format("{},", tasks);
+    std::string const delay_str = hpx::util::format("{},", delay);
 
     hpx::util::format_to(std::cout,
-        "%-21s %-21s %-21s %10.12s, %10.12s\n",
+        "{:-21} {:-21} {:-21} {:10.12}, {:10.12}\n",
         cores_str, tasks_str, delay_str,
         walltime, walltime / tasks);
 }

--- a/tests/performance/local/parent_vs_child_stealing.cpp
+++ b/tests/performance/local/parent_vs_child_stealing.cpp
@@ -90,7 +90,7 @@ int hpx_main(boost::program_options::variables_map& vm)
     }
 
     hpx::util::format_to(hpx::cout,
-        "%d,%d,%f,%f",
+        "{},{},{},{}",
         num_cores,
         iterations,
         child_stealing_time,

--- a/tests/performance/local/qthreads_heterogeneous_timed_task_spawn.cpp
+++ b/tests/performance/local/qthreads_heterogeneous_timed_task_spawn.cpp
@@ -83,19 +83,19 @@ void print_results(
                      "Maximum Delay (iterations),Total Delay (iterations),"
                      "Total Walltime (seconds),Walltime per Task (seconds)\n";
 
-    std::string const cores_str = hpx::util::format("%lu,", cores);
-    std::string const seed_str  = hpx::util::format("%lu,", seed);
-    std::string const tasks_str = hpx::util::format("%lu,", tasks);
+    std::string const cores_str = hpx::util::format("{},", cores);
+    std::string const seed_str  = hpx::util::format("{},", seed);
+    std::string const tasks_str = hpx::util::format("{},", tasks);
 
     std::string const min_delay_str
-        = hpx::util::format("%lu,", min_delay);
+        = hpx::util::format("{},", min_delay);
     std::string const max_delay_str
-        = hpx::util::format("%lu,", max_delay);
+        = hpx::util::format("{},", max_delay);
     std::string const total_delay_str
-        = hpx::util::format("%lu,", total_delay);
+        = hpx::util::format("{},", total_delay);
 
     hpx::util::format_to(std::cout,
-        "%-21s %-21s %-21s %-21s %-21s %-21s %10.12s\n",
+        "{:-21} {:-21} {:-21} {:-21} {:-21} {:-21} {:10.12}\n",
         cores_str, seed_str, tasks_str,
         min_delay_str, max_delay_str, total_delay_str,
         walltime, walltime / tasks);

--- a/tests/performance/local/qthreads_homogeneous_timed_task_spawn.cpp
+++ b/tests/performance/local/qthreads_homogeneous_timed_task_spawn.cpp
@@ -75,12 +75,12 @@ void print_results(
         std::cout << "OS-threads,Tasks,Delay (micro-seconds),"
                      "Total Walltime (seconds),Walltime per Task (seconds)\n";
 
-    std::string const cores_str = hpx::util::format("%lu,", cores);
-    std::string const tasks_str = hpx::util::format("%lu,", tasks);
-    std::string const delay_str = hpx::util::format("%lu,", delay);
+    std::string const cores_str = hpx::util::format("{},", cores);
+    std::string const tasks_str = hpx::util::format("{},", tasks);
+    std::string const delay_str = hpx::util::format("{},", delay);
 
     hpx::util::format_to(std::cout,
-        "%-21s %-21s %-21s %10.12s, %10.12s\n",
+        "{:-21} {:-21} {:-21} {:10.12}, {:10.12}\n",
         cores_str, tasks_str, delay_str,
         walltime, walltime / tasks);
 }

--- a/tests/performance/local/serialization_overhead.cpp
+++ b/tests/performance/local/serialization_overhead.cpp
@@ -177,7 +177,7 @@ int hpx_main(boost::program_options::variables_map& vm)
     if (print_header)
         hpx::cout << "datasize,testcount,average_time[s]\n" << hpx::flush;
 
-    hpx::util::format_to(hpx::cout, "%d,%d,%f\n",
+    hpx::util::format_to(hpx::cout, "{},{},{}\n",
         data_size, iterations, overall_time / concurrency) << hpx::flush;
 
     return hpx::finalize();

--- a/tests/performance/local/sizeof.cpp
+++ b/tests/performance/local/sizeof.cpp
@@ -29,7 +29,7 @@ int hpx_main(
 {
     {
 #       define HPX_SIZEOF(type)                                               \
-            hpx::util::format("%1% %|40t|%2%\n",                              \
+            hpx::util::format("{1:-40} {2}\n",                                \
                 HPX_PP_STRINGIZE(type), sizeof(type))                         \
             /**/
 

--- a/tests/performance/local/spinlock_overhead1.cpp
+++ b/tests/performance/local/spinlock_overhead1.cpp
@@ -228,7 +228,7 @@ int hpx_main(
 
                 if (vm.count("csv"))
                     hpx::util::format_to(cout,
-                        "%3%,%4%,%2%\n",
+                        "{3},{4},{2}\n",
                         count,
                         duration,
                         k1,
@@ -236,8 +236,8 @@ int hpx_main(
                     ) << flush;
                 else
                     hpx::util::format_to(cout,
-                        "invoked %1% futures in %2% seconds "
-                        "(k1 = %3%, k2 = %4%)\n",
+                        "invoked {1} futures in {2} seconds "
+                        "(k1 = {3}, k2 = {4})\n",
                         count,
                         duration,
                         k1,

--- a/tests/performance/local/spinlock_overhead2.cpp
+++ b/tests/performance/local/spinlock_overhead2.cpp
@@ -254,7 +254,7 @@ int hpx_main(
 
                 if (vm.count("csv"))
                     hpx::util::format_to(cout,
-                        "%3%,%4%,%5%,%2%\n",
+                        "{3},{4},{5},{2}\n",
                         count,
                         duration,
                         k1,
@@ -263,8 +263,8 @@ int hpx_main(
                     ) << flush;
                 else
                     hpx::util::format_to(cout,
-                        "invoked %1% futures in %2% seconds "
-                        "(k1 = %3%, k2 = %4%, k3 = %5%)\n",
+                        "invoked {1} futures in {2} seconds "
+                        "(k1 = {3}, k2 = {4}, k3 = {5})\n",
                         count,
                         duration,
                         k1,

--- a/tests/performance/local/tbb_homogeneous_timed_task_spawn.cpp
+++ b/tests/performance/local/tbb_homogeneous_timed_task_spawn.cpp
@@ -74,12 +74,12 @@ void print_results(
         std::cout << "OS-threads,Tasks,Delay (iterations),"
                      "Total Walltime (seconds),Walltime per Task (seconds)\n";
 
-    std::string const cores_str = hpx::util::format("%lu,", cores);
-    std::string const tasks_str = hpx::util::format("%lu,", tasks);
-    std::string const delay_str = hpx::util::format("%lu,", delay);
+    std::string const cores_str = hpx::util::format("{},", cores);
+    std::string const tasks_str = hpx::util::format("{},", tasks);
+    std::string const delay_str = hpx::util::format("{},", delay);
 
     hpx::util::format_to(std::cout,
-        "%-21s %-21s %-21s %10.12s, %10.12s\n",
+        "{:-21} {:-21} {:-21} {:10.12}, {:10.12}\n",
         cores_str, tasks_str, delay_str,
         walltime, walltime / tasks);
 }

--- a/tests/performance/local/timed_task_spawn.cpp
+++ b/tests/performance/local/timed_task_spawn.cpp
@@ -148,7 +148,7 @@ void print_results(
     }
 
     hpx::util::format_to(cout,
-        "%lu, %lu, %lu, %lu, %.14g, %.14g",
+        "{}, {}, {}, {}, {:.14g}, {:.14g}",
         delay,
         tasks,
         suspended_tasks,
@@ -160,7 +160,7 @@ void print_results(
     if (ac)
     {
         for (std::uint64_t i = 0; i < counter_shortnames.size(); ++i)
-            hpx::util::format_to(cout, ", %.14g",
+            hpx::util::format_to(cout, ", {:.14g}",
                 counter_values[i].get_value<double>());
     }
 

--- a/tests/performance/local/wait_all_timings.cpp
+++ b/tests/performance/local/wait_all_timings.cpp
@@ -118,18 +118,18 @@ int hpx_main(boost::program_options::variables_map& vm)
              << hpx::endl;
     }
 
-    std::string const tasks_str = hpx::util::format("%lu", num_tasks);
-    std::string const chunks_str = hpx::util::format("%lu", num_chunks);
-    std::string const delay_str = hpx::util::format("%lu", delay);
+    std::string const tasks_str = hpx::util::format("{}", num_tasks);
+    std::string const chunks_str = hpx::util::format("{}", num_chunks);
+    std::string const delay_str = hpx::util::format("{}", delay);
 
     hpx::util::format_to(hpx::cout,
-        "%10s,%10s,%10s,%10.12s,%10.12s",
+        "{:10},{:10},{:10},{:10},{:10.12},{:10.12}\n",
         tasks_str, std::string("1"), delay_str,
         elapsed_seq, elapsed_seq / num_tasks) << hpx::endl;
     if (num_chunks != 1)
     {
         hpx::util::format_to(hpx::cout,
-            "%10s,%10s,%10s,%10.12s,%10.12s",
+            "{:10},{:10},{:10},{:10},{:10.12},{:10.12}\n",
             tasks_str, chunks_str, delay_str,
             elapsed_chunks, elapsed_chunks / num_tasks) << hpx::endl;
     }

--- a/tests/performance/network/network_storage/network_storage.cpp
+++ b/tests/performance/network/network_storage/network_storage.cpp
@@ -674,8 +674,8 @@ void test_write(
         std::cout << "Aggregate BW Write   : " << writeBW   << " MB/s" << std::endl;
         // a complete set of results that our python matplotlib script will ingest
         char const* msg = "CSVData, write, network, "
-            "%1%, ranks, %2%, threads, %3%, Memory, %4%, IOPsize, %5%, "
-            "IOPS/s, %6%, BW(MB/s), %7%, ";
+            "{1}, ranks, {2}, threads, {3}, Memory, {4}, IOPsize, {5}, "
+            "IOPS/s, {6}, BW(MB/s), {7}, ";
         if (!options.warmup) {
             hpx::util::format_to(std::cout, msg,
                 options.network,
@@ -891,9 +891,9 @@ void test_read(
         std::cout << "IOPs/s (local)       : " << IOPs_s    << "\n";
         std::cout << "Aggregate BW Read    : " << readBW << " MB/s" << std::endl;
         // a complete set of results that our python matplotlib script will ingest
-        char const* msg = "CSVData, read, network, %1%, ranks, "
-            "%2%, threads, %3%, Memory, %4%, IOPsize, %5%, IOPS/s, %6%, "
-            "BW(MB/s), %7%, ";
+        char const* msg = "CSVData, read, network, {1}, ranks, "
+            "{2}, threads, {3}, Memory, {4}, IOPsize, {5}, IOPS/s, {6}, "
+            "BW(MB/s), {7}, ";
         hpx::util::format_to(std::cout, msg, options.network, nranks,
             options.threads, readMB, options.transfer_size_B,
             IOPs_s, readBW) << std::endl;
@@ -923,8 +923,8 @@ int hpx_main(boost::program_options::variables_map& vm)
       return 1;
     }
 
-    char const* msg = "hello world from OS-thread %1% on locality "
-        "%2% rank %3% hostname %4%";
+    char const* msg = "hello world from OS-thread {1} on locality "
+        "{2} rank {3} hostname {4}";
     hpx::util::format_to(std::cout, msg, current, hpx::get_locality_id(),
         rank, name.c_str()) << std::endl;
     //

--- a/tests/performance/network/network_storage/simple_profiler.hpp
+++ b/tests/performance/network/network_storage/simple_profiler.hpp
@@ -66,8 +66,8 @@ class simple_profiler {
             }
           );
           // prepare format string for output
-          char const* fmt1 = "Profile %20s : %2i %5i %9.3f %s %7.3f";
-          std::string fmt2 = "Total   " + std::string(41,' ') + " %s %7.3f";
+          char const* fmt1 = "Profile {:20} : {:2} {:5} {:9.3} {} {:7.3}";
+          std::string fmt2 = "Total   " + std::string(41,' ') + " {} {:7.3}";
           // add this level to top of list
           this->_profiles[this->_title] = std::make_tuple(elapsed,0,1);
           // print each of the sub nodes

--- a/tests/performance/parallel_algorithms/local/benchmark_inplace_merge.cpp
+++ b/tests/performance/parallel_algorithms/local/benchmark_inplace_merge.cpp
@@ -143,7 +143,7 @@ void run_benchmark(std::size_t vector_left_size, std::size_t vector_right_size,
             org_first, org_last, first, middle, last);
 
     std::cout << "\n-------------- Benchmark Result --------------" << std::endl;
-    auto fmt = "inplace_merge (%1%) : %2%(sec)";
+    auto fmt = "inplace_merge ({1}) : {2}(sec)";
     hpx::util::format_to(std::cout, fmt, "std", time_std) << std::endl;
     hpx::util::format_to(std::cout, fmt, "seq", time_seq) << std::endl;
     hpx::util::format_to(std::cout, fmt, "par", time_par) << std::endl;

--- a/tests/performance/parallel_algorithms/local/benchmark_is_heap.cpp
+++ b/tests/performance/parallel_algorithms/local/benchmark_is_heap.cpp
@@ -179,7 +179,7 @@ int hpx_main(boost::program_options::variables_map& vm)
         run_is_heap_benchmark_par_unseq(test_count, v);
 
     std::cout << "\n-------------- Benchmark Result --------------" << std::endl;
-    auto fmt = "is_heap (%1%) : %2%(sec)";
+    auto fmt = "is_heap ({1}) : {2}(sec)";
     hpx::util::format_to(std::cout, fmt, "std", time_std) << std::endl;
     hpx::util::format_to(std::cout, fmt, "seq", time_seq) << std::endl;
     hpx::util::format_to(std::cout, fmt, "par", time_par) << std::endl;

--- a/tests/performance/parallel_algorithms/local/benchmark_is_heap_until.cpp
+++ b/tests/performance/parallel_algorithms/local/benchmark_is_heap_until.cpp
@@ -183,7 +183,7 @@ int hpx_main(boost::program_options::variables_map& vm)
         run_is_heap_until_benchmark_par_unseq(test_count, v);
 
     std::cout << "\n-------------- Benchmark Result --------------" << std::endl;
-    auto fmt = "is_heap_until (%1%) : %2%(sec)";
+    auto fmt = "is_heap_until ({1}) : {2}(sec)";
     hpx::util::format_to(std::cout, fmt, "std", time_std) << std::endl;
     hpx::util::format_to(std::cout, fmt, "seq", time_seq) << std::endl;
     hpx::util::format_to(std::cout, fmt, "par", time_par) << std::endl;

--- a/tests/performance/parallel_algorithms/local/benchmark_merge.cpp
+++ b/tests/performance/parallel_algorithms/local/benchmark_merge.cpp
@@ -131,7 +131,7 @@ void run_benchmark(std::size_t vector_size1, std::size_t vector_size2,
             first1, last1, first2, last2, dest);
 
     std::cout << "\n-------------- Benchmark Result --------------" << std::endl;
-    auto fmt = "merge (%1%) : %2%(sec)";
+    auto fmt = "merge ({1}) : {2}(sec)";
     hpx::util::format_to(std::cout, fmt, "std", time_std) << std::endl;
     hpx::util::format_to(std::cout, fmt, "seq", time_seq) << std::endl;
     hpx::util::format_to(std::cout, fmt, "par", time_par) << std::endl;

--- a/tests/performance/parallel_algorithms/local/benchmark_partition.cpp
+++ b/tests/performance/parallel_algorithms/local/benchmark_partition.cpp
@@ -144,7 +144,7 @@ void run_benchmark(std::size_t vector_size, int test_count, int base_num,
             first, last, pred);
 
     std::cout << "\n-------------- Benchmark Result --------------" << std::endl;
-    auto fmt = "partition (%1%) : %2%(sec)";
+    auto fmt = "partition ({1}) : {2}(sec)";
     hpx::util::format_to(std::cout, fmt, "std", time_std) << std::endl;
     hpx::util::format_to(std::cout, fmt, "seq", time_seq) << std::endl;
     hpx::util::format_to(std::cout, fmt, "par", time_par) << std::endl;
@@ -238,8 +238,8 @@ int main(int argc, char* argv[])
             boost::program_options::value<int>(),
             hpx::util::format(
                 "the base number for partitioning."
-                " The range of random_fill is [0, %1%]"
-                " (default: random number in the range [0, %2%]",
+                " The range of random_fill is [0, {1}]"
+                " (default: random number in the range [0, {2}]",
                 random_fill_range, random_fill_range).c_str())
         ("test_count",
             boost::program_options::value<int>()->default_value(10),

--- a/tests/performance/parallel_algorithms/local/benchmark_partition_copy.cpp
+++ b/tests/performance/parallel_algorithms/local/benchmark_partition_copy.cpp
@@ -141,7 +141,7 @@ void run_benchmark(std::size_t vector_size, int test_count, IteratorTag)
             first, last, dest_true, dest_false, pred);
 
     std::cout << "\n-------------- Benchmark Result --------------" << std::endl;
-    auto fmt = "partition_copy (%1%) : %2%(sec)";
+    auto fmt = "partition_copy ({1}) : {2}(sec)";
     hpx::util::format_to(std::cout, fmt, "std", time_std) << std::endl;
     hpx::util::format_to(std::cout, fmt, "seq", time_seq) << std::endl;
     hpx::util::format_to(std::cout, fmt, "par", time_par) << std::endl;

--- a/tests/performance/parallel_algorithms/local/benchmark_remove.cpp
+++ b/tests/performance/parallel_algorithms/local/benchmark_remove.cpp
@@ -185,7 +185,7 @@ void run_benchmark(std::size_t vector_size, int test_count,
             org_first, org_last, first, last, value);
 
     std::cout << "\n-------------- Benchmark Result --------------" << std::endl;
-    auto fmt = "remove (%1%) : %2%(sec)";
+    auto fmt = "remove ({1}) : {2}(sec)";
     hpx::util::format_to(std::cout, fmt, "std", time_std) << std::endl;
     hpx::util::format_to(std::cout, fmt, "seq", time_seq) << std::endl;
     hpx::util::format_to(std::cout, fmt, "par", time_par) << std::endl;

--- a/tests/performance/parallel_algorithms/local/benchmark_remove_if.cpp
+++ b/tests/performance/parallel_algorithms/local/benchmark_remove_if.cpp
@@ -185,7 +185,7 @@ void run_benchmark(std::size_t vector_size, int test_count,
             org_first, org_last, first, last, pred);
 
     std::cout << "\n-------------- Benchmark Result --------------" << std::endl;
-    auto fmt = "remove_if (%1%) : %2%(sec)";
+    auto fmt = "remove_if ({1}) : {2}(sec)";
     hpx::util::format_to(std::cout, fmt, "std", time_std) << std::endl;
     hpx::util::format_to(std::cout, fmt, "seq", time_seq) << std::endl;
     hpx::util::format_to(std::cout, fmt, "par", time_par) << std::endl;

--- a/tests/performance/parallel_algorithms/local/benchmark_unique.cpp
+++ b/tests/performance/parallel_algorithms/local/benchmark_unique.cpp
@@ -180,7 +180,7 @@ void run_benchmark(std::size_t vector_size, int test_count,
             org_first, org_last, first, last);
 
     std::cout << "\n-------------- Benchmark Result --------------" << std::endl;
-    auto fmt = "unique (%1%) : %2%(sec)";
+    auto fmt = "unique ({1}) : {2}(sec)";
     hpx::util::format_to(std::cout, fmt, "std", time_std) << std::endl;
     hpx::util::format_to(std::cout, fmt, "seq", time_seq) << std::endl;
     hpx::util::format_to(std::cout, fmt, "par", time_par) << std::endl;

--- a/tests/performance/parallel_algorithms/local/benchmark_unique_copy.cpp
+++ b/tests/performance/parallel_algorithms/local/benchmark_unique_copy.cpp
@@ -127,7 +127,7 @@ void run_benchmark(std::size_t vector_size, int test_count,
             first, last, dest);
 
     std::cout << "\n-------------- Benchmark Result --------------" << std::endl;
-    auto fmt = "unique_copy (%1%) : %2%(sec)";
+    auto fmt = "unique_copy ({1}) : {2}(sec)";
     hpx::util::format_to(std::cout, fmt, "std", time_std) << std::endl;
     hpx::util::format_to(std::cout, fmt, "seq", time_seq) << std::endl;
     hpx::util::format_to(std::cout, fmt, "par", time_par) << std::endl;

--- a/tests/regressions/agas/duplicate_id_registration_1596.cpp
+++ b/tests/regressions/agas/duplicate_id_registration_1596.cpp
@@ -31,13 +31,13 @@ struct ViewRegistrationListener
     ViewRegistrationListener(const string &name) :
         name(name)
     {
-        hpx::util::format_to(cout, "constructed server listener %1% (%2%)",
+        hpx::util::format_to(cout, "constructed server listener {1} ({2})",
             name, this) << endl;
     }
 
     void register_view()
     {
-        hpx::util::format_to(cout, "register view at listener %1% (%2%)",
+        hpx::util::format_to(cout, "register view at listener {1} ({2})",
             name, this) << endl;
     }
     HPX_DEFINE_COMPONENT_ACTION(ViewRegistrationListener, register_view);

--- a/tests/regressions/agas/send_gid_keep_component_1624.cpp
+++ b/tests/regressions/agas/send_gid_keep_component_1624.cpp
@@ -23,7 +23,7 @@ namespace server
         int register_view(const hpx::naming::id_type &gid)
         {
             hpx::util::format_to(std::cout,
-                "register view at %1% by %2%",
+                "register view at {1} by {2}",
                 this->get_unmanaged_id(), gid) << std::endl;
             registered_regions_.push_back(gid);
             return 0;
@@ -98,7 +98,7 @@ namespace server
             for (const auto &id : writers)
             {
                 hpx::util::format_to(std::cout,
-                    "%1% registering region at %2%",
+                    "{1} registering region at {2}",
                     this->get_unmanaged_id(), id) << std::endl;
 
                 client::view_registry listener(id);

--- a/tests/regressions/lcos/dataflow_future_swap.cpp
+++ b/tests/regressions/lcos/dataflow_future_swap.cpp
@@ -26,7 +26,7 @@ struct mul
     double operator()( double x1 , double x2 ) const
     {
         hpx::this_thread::sleep_for( std::chrono::milliseconds(10000) );
-        hpx::util::format_to(hpx::cout, "func: %f , %f\n", x1, x2) << hpx::flush;
+        hpx::util::format_to(hpx::cout, "func: {}, {}\n", x1, x2) << hpx::flush;
         return x1*x2;
     }
 };
@@ -49,8 +49,8 @@ int main()
 
     future_swap( f1 , f2 );
 
-    hpx::util::format_to(hpx::cout, "f1: %d\n", f1.get()) << hpx::flush;
-    hpx::util::format_to(hpx::cout, "f2: %d\n", f2.get()) << hpx::flush;
+    hpx::util::format_to(hpx::cout, "f1: {}\n", f1.get()) << hpx::flush;
+    hpx::util::format_to(hpx::cout, "f2: {}\n", f2.get()) << hpx::flush;
 
     return 0;
 }

--- a/tests/regressions/lcos/dataflow_future_swap2.cpp
+++ b/tests/regressions/lcos/dataflow_future_swap2.cpp
@@ -26,7 +26,7 @@ struct mul
     double operator()( double x1 , double x2 ) const
     {
         //compat::this_thread::sleep_for( std::chrono::milliseconds(1000) );
-        hpx::util::format_to(hpx::cout, "func: %f , %f\n", x1, x2) << hpx::flush;
+        hpx::util::format_to(hpx::cout, "func: {}, {}\n", x1, x2) << hpx::flush;
         return x1*x2;
     }
 };
@@ -36,7 +36,7 @@ struct divide
     double operator()( double x1 , double x2 ) const
     {
         //compat::this_thread::sleep_for( std::chrono::milliseconds(1000) );
-        hpx::util::format_to(hpx::cout, "func: %f , %f\n", x1, x2) << hpx::flush;
+        hpx::util::format_to(hpx::cout, "func: {}, {}\n", x1, x2) << hpx::flush;
         return x1/x2;
     }
 };
@@ -68,8 +68,8 @@ int main()
 
     hpx::cout << "futures ready\n" << hpx::flush;
 
-    hpx::util::format_to(hpx::cout,"f1: %d\n", f1.get()) << hpx::flush;
-    hpx::util::format_to(hpx::cout, "f2: %d\n", f2.get()) << hpx::flush;
+    hpx::util::format_to(hpx::cout,"f1: {}\n", f1.get()) << hpx::flush;
+    hpx::util::format_to(hpx::cout, "f2: {}\n", f2.get()) << hpx::flush;
 
     return 0;
 }

--- a/tests/regressions/lcos/future_hang_on_get_629.cpp
+++ b/tests/regressions/lcos/future_hang_on_get_629.cpp
@@ -174,7 +174,7 @@ int hpx_main(
                 double step_speed = (1 / local_clock.elapsed());
 
                 char const* fmt =
-                    "%016u, %.7g,%|31t| %.7g%|41t| [steps/second]\n";
+                    "{:016u}, {:.7g|31t} {:.7g|41t} [steps/second]\n";
 
                 hpx::util::format_to(std::cout, fmt, i, d, step_speed)
                     << std::flush;

--- a/tests/regressions/lcos/future_hang_on_then_629.cpp
+++ b/tests/regressions/lcos/future_hang_on_then_629.cpp
@@ -195,7 +195,7 @@ int hpx_main(
                 double step_speed = (1 / local_clock.elapsed());
 
                 char const* fmt =
-                    "%016u, %.7g,%|31t| %.7g%|41t| [steps/second]\n";
+                    "{:016u}, {:.7g|31t} {:.7g|41t} [steps/second]\n";
 
                 hpx::util::format_to(std::cout, fmt, i, d, step_speed)
                     << std::flush;

--- a/tests/regressions/lcos/future_hang_on_wait_with_callback_629.cpp
+++ b/tests/regressions/lcos/future_hang_on_wait_with_callback_629.cpp
@@ -156,7 +156,7 @@ int hpx_main(
             d += null_act(here, 0, children, 1, max_depth, delay_iterations);
 
             if (verbose)
-                hpx::util::format_to(std::cout, "%016u : %f\n", i, d)
+                hpx::util::format_to(std::cout, "{:016u} : {}\n", i, d)
                     << std::flush;
         }
     }

--- a/tests/regressions/performance_counters/papi_counters_basic_functions.cpp
+++ b/tests/regressions/performance_counters/papi_counters_basic_functions.cpp
@@ -31,7 +31,7 @@ int hpx_main(boost::program_options::variables_map&)
     using hpx::performance_counters::counter_value;
 
     id_type id = get_counter(hpx::util::format(
-        "/papi{locality#%d/worker-thread#0}/PAPI_FP_INS", prefix));
+        "/papi{{locality#{}/worker-thread#0}/PAPI_FP_INS", prefix));
 
     performance_counter::start(hpx::launch::sync, id);
 

--- a/tests/unit/agas/components/server/managed_refcnt_checker.cpp
+++ b/tests/unit/agas/components/server/managed_refcnt_checker.cpp
@@ -27,7 +27,7 @@ managed_refcnt_checker::~managed_refcnt_checker()
 
     if (!references_.empty())
     {
-        hpx::util::format_to(strm, "[%1%/%2%]: held references\n",
+        hpx::util::format_to(strm, "[{1}/{2}]: held references\n",
             prefix_, this_);
 
         for (naming::id_type const& ref : references_)
@@ -44,10 +44,10 @@ managed_refcnt_checker::~managed_refcnt_checker()
 
     if (naming::invalid_id != target_)
     {
-        hpx::util::format_to(strm, "[%1%/%2%]: destroying object\n",
+        hpx::util::format_to(strm, "[{1}/{2}]: destroying object\n",
             prefix_, this_);
 
-        hpx::util::format_to(strm, "[%1%/%2%]: triggering flag %3%\n",
+        hpx::util::format_to(strm, "[{1}/{2}]: triggering flag {3}\n",
             prefix_, this_, target_);
 
         hpx::trigger_lco_event(target_);

--- a/tests/unit/agas/components/server/simple_refcnt_checker.cpp
+++ b/tests/unit/agas/components/server/simple_refcnt_checker.cpp
@@ -27,7 +27,7 @@ simple_refcnt_checker::~simple_refcnt_checker()
 
     if (!references_.empty())
     {
-        hpx::util::format_to(strm, "[%1%/%2%]: held references\n",
+        hpx::util::format_to(strm, "[{1}/{2}]: held references\n",
             prefix_, this_);
 
         for (naming::id_type const& ref : references_)
@@ -44,10 +44,10 @@ simple_refcnt_checker::~simple_refcnt_checker()
 
     if (naming::invalid_id != target_)
     {
-        hpx::util::format_to(strm, "[%1%/%2%]: destroying object\n",
+        hpx::util::format_to(strm, "[{1}/{2}]: destroying object\n",
             prefix_, this_);
 
-        hpx::util::format_to(strm, "[%1%/%2%]: triggering flag %3%\n",
+        hpx::util::format_to(strm, "[{1}/{2}]: triggering flag {3}\n",
             prefix_, this_, target_);
 
         hpx::trigger_lco_event(target_);

--- a/tests/unit/apex/apex_action_count.cpp
+++ b/tests/unit/apex/apex_action_count.cpp
@@ -70,7 +70,7 @@ int hpx_main(boost::program_options::variables_map& vm)
         fibonacci_action fib;
         std::uint64_t r = fib(hpx::find_here(), n);
 
-        char const* fmt = "fibonacci(%1%) == %2%\nelapsed time: %3% [s]\n";
+        char const* fmt = "fibonacci({1}) == {2}\nelapsed time: {3} [s]\n";
         hpx::util::format_to(std::cout, fmt, n, r, t.elapsed());
     }
 

--- a/tests/unit/parallel/algorithms/sort_tests.hpp
+++ b/tests/unit/parallel/algorithms/sort_tests.hpp
@@ -98,7 +98,7 @@ int verify_(const std::vector <IA> &A, Compare comp, std::uint64_t elapsed,
         {
             if (comp((*it), temp)) {
                 if (print)
-                    hpx::util::format_to(std::cout, "fail %8.6f", elapsed / 1e9)
+                    hpx::util::format_to(std::cout, "fail {:8.6}", elapsed / 1e9)
                       << A.size() << std::endl;
                 return 0;
             }
@@ -106,7 +106,7 @@ int verify_(const std::vector <IA> &A, Compare comp, std::uint64_t elapsed,
         }
     }
     if (print)
-        hpx::util::format_to(std::cout, "OK %8.6f", elapsed / 1e9)
+        hpx::util::format_to(std::cout, "OK {:8.6}", elapsed / 1e9)
           << A.size() << std::endl;
     return 1;
 }

--- a/tests/unit/parallel/container_algorithms/sort_range_tests.hpp
+++ b/tests/unit/parallel/container_algorithms/sort_range_tests.hpp
@@ -98,7 +98,7 @@ int verify_(const std::vector <IA> &A, Compare comp, std::uint64_t elapsed,
         {
             if (comp((*it), temp)) {
                 if (print)
-                    hpx::util::format_to(std::cout, "fail %8.6f", elapsed / 1e9)
+                    hpx::util::format_to(std::cout, "fail {:8.6}", elapsed / 1e9)
                       << A.size() << std::endl;
                 return 0;
             }
@@ -106,7 +106,7 @@ int verify_(const std::vector <IA> &A, Compare comp, std::uint64_t elapsed,
         }
     }
     if (print)
-        hpx::util::format_to(std::cout, "OK %8.6f", elapsed / 1e9)
+        hpx::util::format_to(std::cout, "OK {:8.6}", elapsed / 1e9)
           << A.size() << std::endl;
     return 1;
 }

--- a/tests/unit/util/CMakeLists.txt
+++ b/tests/unit/util/CMakeLists.txt
@@ -10,6 +10,7 @@ set(tests
     bind_action
     checkpoint
     config_entry
+    format
     function
     pack_traversal
     pack_traversal_async

--- a/tests/unit/util/format.cpp
+++ b/tests/unit/util/format.cpp
@@ -1,0 +1,45 @@
+//  Copyright (c) 2018 Agustin Berge
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/util/format.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <string>
+
+int main(int argc, char* argv[])
+{
+    using hpx::util::format;
+    {
+        HPX_TEST_EQ((format("Hello")), "Hello");
+        HPX_TEST_EQ((format("Hello, {}!", "world")), "Hello, world!");
+        HPX_TEST_EQ((format("The number is {}", 1)), "The number is 1");
+    }
+
+    {
+        HPX_TEST_EQ((format("{} {}", 1, 2)), "1 2");
+        HPX_TEST_EQ((format("{} {1}", 1, 2)), "1 1");
+        HPX_TEST_EQ((format("{2} {}", 1, 2)), "2 2");
+        HPX_TEST_EQ((format("{2} {1}", 1, 2)), "2 1");
+
+        HPX_TEST_EQ((format("{:}", 42)), "42");
+        HPX_TEST_EQ((format("{:04}", 42)), "0042");
+        HPX_TEST_EQ((format("{2:04}", 42, 43)), "0043");
+
+        HPX_TEST_EQ((format("{:x}", 42)), "2a");
+        HPX_TEST_EQ((format("{:04x}", 42)), "002a");
+        HPX_TEST_EQ((format("{2:04x}", 42, 43)), "002b");
+
+        HPX_TEST_EQ((format("{:#x}", 42)), "0x2a");
+        HPX_TEST_EQ((format("{:#06x}", 42)), "0x002a");
+        HPX_TEST_EQ((format("{2:#06x}", 42, 43)), "0x002b");
+    }
+
+    {
+        HPX_TEST_EQ((format("{} {}", true, false)), "1 0");
+    }
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
The format replacement specification grammar takes the form: `'{' [arg] [':' spec] '}'`.
- The first field, `arg`, is a numeric value and it specifies the 1-based index of the argument to use in the replacement (the 0-th argument is the format string itself). If not present it is derived from the index of the replacement within the format string.
- The second field, `spec`, is an arbitrary value and it specifies the format to use in the replacement. The meaning depends on the type of the value under replacement:
  - For fundamental types, pointers, and strings, the format specifier follows the format of the `printf` family, except that the type conversion specifier is optional and is derived from the type of the value under replacement if not present.
  - For types that opt into custom formatting via the ADL customization point, the meaning and interpretation of the format specifier is entirely up to user defined overload.
  - For every other type the format specification must be empty.

The ADL customization point signature is:
```
template <typename T>
void format_value(std::ostream& os, boost::string_ref spec, T const& value);
```
