### PR TITLE
Fix bulk_construct with count = 0

### DIFF
--- a/hpx/compute/host/block_allocator.hpp
+++ b/hpx/compute/host/block_allocator.hpp
@@ -162,6 +162,11 @@ namespace hpx { namespace compute { namespace host
         template <typename U, typename ... Args>
         void bulk_construct(U* p, std::size_t count, Args &&... args)
         {
+            if (count == std::size_t(0))
+            {
+                return;
+            }
+
             auto irange = boost::irange(std::size_t(0), count);
             auto policy =
                 hpx::parallel::execution::parallel_policy()
@@ -236,6 +241,11 @@ namespace hpx { namespace compute { namespace host
         template <typename U>
         void bulk_destroy(U* p, std::size_t count)
         {
+            if (count == std::size_t(0))
+            {
+                return;
+            }
+
             // keep memory locality, use executor...
             auto irange = boost::irange(std::size_t(0), count);
             hpx::parallel::for_each(

--- a/tests/unit/computeapi/host/block_allocator.cpp
+++ b/tests/unit/computeapi/host/block_allocator.cpp
@@ -78,7 +78,7 @@ int hpx_main(boost::program_options::variables_map& vm)
 
     std::cout << "using seed: " << seed << std::endl;
     std::mt19937 gen(seed);
-    std::uniform_int_distribution<> dis(0, 511);
+    std::uniform_int_distribution<> dis(1, 512);
 
     {
         std::size_t count = dis(gen);
@@ -91,6 +91,8 @@ int hpx_main(boost::program_options::variables_map& vm)
         HPX_TEST_EQ(construction_count.load(), count);
         HPX_TEST_EQ(destruction_count.load(), count);
     }
+
+    test_bulk_allocator<int>(0);
 
     return hpx::finalize();
 }


### PR DESCRIPTION
Fixes #3267.

## Proposed Changes

- Make `bulk_construct` and `bulk_destroy` no-ops if `count` is `0`.