### PR TITLE
Remove leftover code from context_generic_context.hpp

### DIFF
--- a/hpx/runtime/threads/coroutines/detail/context_generic_context.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_generic_context.hpp
@@ -243,8 +243,6 @@ namespace hpx { namespace threads { namespace coroutines
                 if (ctx_ && stack_pointer_)
                 {
                     alloc_.deallocate(stack_pointer_, stack_size_);
-                    ctx_.fc_stack.size = 0;
-                    ctx_.fc_stack.sp = 0;
                 }
             }
 


### PR DESCRIPTION
The two removed lines were wrapped in `#if BOOST_VERSION < 105600`, and should not be there now that the minimum required Boost version is higher.

Should fix [these build failures](http://rostam.cct.lsu.edu/builders/hpx_gcc_6_boost_1_63_centos_x86_64_debug/builds/260/steps/build_core/logs/stdio), although I could not reproduce it with gcc 6.3 (rostam has 6.4).