### PR TITLE
Reinit counters synchronously in reinit_counters test

### DIFF
--- a/tests/unit/performance_counter/reinit_counters.cpp
+++ b/tests/unit/performance_counter/reinit_counters.cpp
@@ -143,7 +143,7 @@ int hpx_main(boost::program_options::variables_map& vm)
     {
         hpx::performance_counters::performance_counter c("/test/reinit-values");
 
-        c.reinit();
+        c.reinit(hpx::launch::sync);
 
         auto values = c.get_counter_values_array(hpx::launch::sync, false);
 


### PR DESCRIPTION
The reinit must happen before `get_counter_values_array` is called.

## Any background context you want to provide?

This is required by #3243, where the `reinit` always gets called after `get_counter_values_array`.