### PR TITLE
Support external plugins

### DIFF
--- a/hpx/config.hpp
+++ b/hpx/config.hpp
@@ -347,14 +347,6 @@
 #  define HPX_PLUGIN_PLUGIN_PREFIX HPX_MANGLE_NAME(HPX_PLUGIN_NAME)
 #endif
 
-#if !defined(HPX_PLUGIN_PATH_SUFFIX)
-#  define HPX_PLUGIN_PATH_SUFFIX "hpx"
-#endif
-
-#if !defined(HPX_PLUGIN_CONFIG_SECTION)
-#  define HPX_PLUGIN_CONFIG_SECTION "hpx"
-#endif
-
 ///////////////////////////////////////////////////////////////////////////////
 #if !defined(HPX_APPLICATION_STRING)
 #  if defined(HPX_APPLICATION_NAME)

--- a/hpx/config.hpp
+++ b/hpx/config.hpp
@@ -347,6 +347,14 @@
 #  define HPX_PLUGIN_PLUGIN_PREFIX HPX_MANGLE_NAME(HPX_PLUGIN_NAME)
 #endif
 
+#if !defined(HPX_PLUGIN_PATH_SUFFIX)
+#  define HPX_PLUGIN_PATH_SUFFIX "hpx"
+#endif
+
+#if !defined(HPX_PLUGIN_CONFIG_SECTION)
+#  define HPX_PLUGIN_CONFIG_SECTION "hpx"
+#endif
+
 ///////////////////////////////////////////////////////////////////////////////
 #if !defined(HPX_APPLICATION_STRING)
 #  if defined(HPX_APPLICATION_NAME)

--- a/hpx/plugins/plugin_registry.hpp
+++ b/hpx/plugins/plugin_registry.hpp
@@ -38,12 +38,10 @@ namespace hpx { namespace plugins
     /// functions to be exposed by a plugin's registry instance.
     ///
     /// \tparam Plugin   The plugin type this registry should be responsible for.
-    template <typename Plugin>
+    template <typename Plugin, char const* const Name,
+        char const* const Section, char const* const Suffix>
     struct plugin_registry : public plugin_registry_base
     {
-        ///
-        ~plugin_registry() {}
-
         /// \brief Return the ini-information for all contained components
         ///
         /// \param fillini  [in] The module is expected to fill this vector
@@ -54,14 +52,14 @@ namespace hpx { namespace plugins
         /// \return Returns \a true if the parameter \a fillini has been
         ///         successfully initialized with the registry data of all
         ///         implemented in this module.
-        bool get_plugin_info(std::vector<std::string>& fillini)
+        bool get_plugin_info(std::vector<std::string>& fillini) override
         {
             using namespace boost::assign;
-            fillini += std::string("[" HPX_PLUGIN_CONFIG_SECTION ".plugins.") +
+            fillini += std::string("[") + Section + ".plugins." +
                 unique_plugin_name<plugin_registry>::call() + "]";
-            fillini += "name = " HPX_PLUGIN_STRING;
-            fillini += std::string("path = ") + util::find_prefixes(
-                    "/" HPX_PLUGIN_PATH_SUFFIX, HPX_PLUGIN_STRING);
+            fillini += std::string("name = ") + Name;
+            fillini += std::string("path = ") +
+                util::find_prefixes(std::string("/") + Suffix, Name);
             fillini += "enabled = 1";
 
             char const* more = traits::plugin_config_data<Plugin>::call();
@@ -89,15 +87,32 @@ namespace hpx { namespace plugins
     )(__VA_ARGS__))                                                           \
 /**/
 
-#define HPX_REGISTER_PLUGIN_REGISTRY_2(PluginType, pluginname)                \
-    typedef hpx::plugins::plugin_registry<PluginType>                         \
-        pluginname ## _plugin_registry_type;                                  \
-    HPX_REGISTER_PLUGIN_BASE_REGISTRY(                                        \
-        pluginname ## _plugin_registry_type, pluginname)                      \
-    HPX_DEF_UNIQUE_PLUGIN_NAME(                                               \
-        pluginname ## _plugin_registry_type, pluginname)                      \
-    template struct hpx::plugins::plugin_registry<PluginType >;               \
-/**/
+#define HPX_REGISTER_PLUGIN_REGISTRY_2(PluginType, pluginname)                 \
+    HPX_REGISTER_PLUGIN_REGISTRY_5(                                            \
+        PluginType, pluginname, HPX_PLUGIN_NAME, "hpx", "hpx")                 \
+    /**/
+#define HPX_REGISTER_PLUGIN_REGISTRY_4(                                        \
+    PluginType, pluginname, pluginsection, pluginsuffix)                       \
+    HPX_REGISTER_PLUGIN_REGISTRY_5(PluginType, pluginname, HPX_PLUGIN_NAME,    \
+        pluginsection, pluginsuffix)                                           \
+    /**/
+#define HPX_REGISTER_PLUGIN_REGISTRY_5(                                        \
+        PluginType, pluginname, pluginstring, pluginsection, pluginsuffix)     \
+    HPX_CXX14_CONSTEXPR char __##pluginname##_string[] =                       \
+        HPX_PP_STRINGIZE(pluginstring);                                        \
+    HPX_CXX14_CONSTEXPR char __##pluginname##_section[] = pluginsection;       \
+    HPX_CXX14_CONSTEXPR char __##pluginname##_suffix[] = pluginsuffix;         \
+    typedef hpx::plugins::plugin_registry<PluginType, __##pluginname##_string, \
+        __##pluginname##_section, __##pluginname##_suffix>                     \
+        __##pluginname##_plugin_registry_type;                                 \
+    HPX_REGISTER_PLUGIN_BASE_REGISTRY(                                         \
+        __##pluginname##_plugin_registry_type, pluginname)                     \
+    HPX_DEF_UNIQUE_PLUGIN_NAME(                                                \
+        __##pluginname##_plugin_registry_type, pluginname)                     \
+    template struct hpx::plugins::plugin_registry<PluginType,                  \
+        __##pluginname##_string, __##pluginname##_section,                     \
+        __##pluginname##_suffix>;                                              \
+    /**/
 
 #endif
 

--- a/hpx/plugins/plugin_registry.hpp
+++ b/hpx/plugins/plugin_registry.hpp
@@ -57,11 +57,11 @@ namespace hpx { namespace plugins
         bool get_plugin_info(std::vector<std::string>& fillini)
         {
             using namespace boost::assign;
-            fillini += std::string("[hpx.plugins.") +
+            fillini += std::string("[" HPX_PLUGIN_CONFIG_SECTION ".plugins.") +
                 unique_plugin_name<plugin_registry>::call() + "]";
             fillini += "name = " HPX_PLUGIN_STRING;
-            fillini += std::string("path = ") +
-                util::find_prefixes("/hpx", HPX_PLUGIN_STRING);
+            fillini += std::string("path = ") + util::find_prefixes(
+                    "/" HPX_PLUGIN_PATH_SUFFIX, HPX_PLUGIN_STRING);
             fillini += "enabled = 1";
 
             char const* more = traits::plugin_config_data<Plugin>::call();

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -1967,7 +1967,7 @@ namespace hpx { namespace components { namespace server
                               << ": " << e.what();
                 if (e.get_error_code().value() == hpx::commandline_option_error)
                 {
-                    std::cerr << "runtime_support::load_pluginss: "
+                    std::cerr << "runtime_support::load_plugins: "
                               << "invalid command line option(s) to "
                               << instance << " component: " << e.what()
                               << std::endl;

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -1199,12 +1199,12 @@ namespace hpx { namespace util
 
         util::manage_config cfgmap(ini_config_);
 
-        std::vector<std::shared_ptr<plugins::plugin_registry_base> >
-            plugin_registries = rtcfg_.load_modules();
-
-        // insert the pre-configured ini settings after loading modules
+        // insert the pre-configured ini settings before loading modules
         for (std::string const& e : ini_config_)
             rtcfg_.parse("<user supplied config>", e, true, false);
+
+        std::vector<std::shared_ptr<plugins::plugin_registry_base> >
+            plugin_registries = rtcfg_.load_modules();
 
         // support re-throwing command line exceptions for testing purposes
         int error_mode = util::allow_unregistered;


### PR DESCRIPTION
A couple of minor changes allowing for external libraries to load their own plugins through HPX's plugin infrastructure. 

These are changes required by Phylanx.