### PR TITLE
Fix virtual method override warnings in static schedulers

### DIFF
--- a/hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp
@@ -57,7 +57,7 @@ namespace hpx { namespace threads { namespace policies
           : base_type(init, deferred_initialization)
         {}
 
-        virtual bool has_thread_stealing() const { return false; }
+        virtual bool has_thread_stealing() const override { return false; }
 
         static std::string get_scheduler_name()
         {

--- a/hpx/runtime/threads/policies/static_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/static_queue_scheduler.hpp
@@ -65,7 +65,7 @@ namespace hpx { namespace threads { namespace policies
           : base_type(init, deferred_initialization)
         {}
 
-        virtual bool has_thread_stealing() const { return false; }
+        virtual bool has_thread_stealing() const override { return false; }
 
         static std::string get_scheduler_name()
         {


### PR DESCRIPTION
Fixes warnings in the static schedulers about virtual methods not being marked override.