### PR TITLE
Do not unwrap ready future

### DIFF
--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -514,6 +514,11 @@ namespace hpx { namespace lcos { namespace detail
     };
 
     ///////////////////////////////////////////////////////////////////////////
+    template <typename R>
+    typename hpx::traits::detail::shared_state_ptr<
+        typename future_unwrap_result<future<R>>::result_type>::type
+    unwrap(future<R> && future, error_code& ec = throws);
+
     template <typename Future>
     typename hpx::traits::detail::shared_state_ptr<
         typename future_unwrap_result<Future>::result_type>::type

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -794,9 +794,10 @@ namespace hpx { namespace lcos { namespace detail
     template <typename Future>
     inline typename traits::detail::shared_state_ptr<
         typename future_unwrap_result<Future>::result_type>::type
-    unwrap(Future && future, error_code& ec)
+    unwrap_impl(Future && future, error_code& ec)
     {
         typedef typename future_unwrap_result<Future>::result_type result_type;
+
         typedef detail::unwrap_continuation<result_type> shared_state;
         typedef typename shared_state::init_no_addref init_no_addref;
 
@@ -805,6 +806,37 @@ namespace hpx { namespace lcos { namespace detail
             new shared_state(init_no_addref()), false);
         static_cast<shared_state*>(p.get())->attach(std::forward<Future>(future));
         return p;
+    }
+
+    template <typename R>
+    inline typename traits::detail::shared_state_ptr<
+        typename future_unwrap_result<future<R>>::result_type>::type
+    unwrap(future<R> && fut, error_code& ec)
+    {
+        if (fut.is_ready() && !fut.has_exception())
+        {
+            typedef typename traits::future_traits<future<R>>::type inner_type;
+            inner_type f = fut.get();
+
+            // move the reference count into the returned intrusive_ptr
+            typedef
+                typename traits::detail::shared_state_ptr_for<inner_type>::type
+                    inner_shared_ptr_type;
+            return inner_shared_ptr_type(
+                traits::future_access<inner_type>::detach_shared_state(
+                    std::move(f)),
+                false);
+        }
+
+        return unwrap_impl(std::move(fut), ec);
+    }
+
+    template <typename Future>
+    inline typename traits::detail::shared_state_ptr<
+        typename future_unwrap_result<Future>::result_type>::type
+    unwrap(Future && future, error_code& ec)
+    {
+        return unwrap_impl(std::move(future), ec);
     }
 }}}
 


### PR DESCRIPTION
- if the outer future of a future<Future> is ready we don't need to allocate a new
  shared state while unwrapping
