### PR TITLE
Add new cuda kernel synchronization with hpx::future demo

### DIFF
--- a/examples/compute/cuda/CMakeLists.txt
+++ b/examples/compute/cuda/CMakeLists.txt
@@ -9,6 +9,7 @@ set(example_programs)
 if(HPX_WITH_CUDA)
   set(example_programs ${example_programs}
       cublas_matmul
+      cuda_future
       data_copy
       hello_compute
     )
@@ -25,9 +26,11 @@ if(HPX_WITH_CUDA)
   set(cublas_matmul_FLAGS
       DEPENDENCIES ${CUDA_LIBRARIES} ${CUDA_CUBLAS_LIBRARIES})
 
-  set(cublas_matmul_CUDA Off)
-  set(data_copy_CUDA On)
-  set(hello_compute_CUDA On)
+  set(cublas_matmul_CUDA OFF)
+  set(data_copy_CUDA ON)
+  set(hello_compute_CUDA ON)
+  set(cuda_future_CUDA OFF)
+  set(cuda_future_CUDA_SOURCE trivial_demo)
   set(partitioned_vector_CUDA ON)
   set(partitioned_vector_FLAGS COMPONENT_DEPENDENCIES partitioned_vector)
 endif()
@@ -39,6 +42,12 @@ foreach(example_program ${example_programs})
   else()
     set(sources
         ${example_program}.cpp)
+  endif()
+
+  if(${example_program}_CUDA_SOURCE)
+    message("got ${${example_program}_CUDA_SOURCE} " ${${example_program}_CUDA_SOURCE})
+    set(sources
+      ${sources} ${${example_program}_CUDA_SOURCE}.cu)
   endif()
 
   source_group("Source Files" FILES ${sources})
@@ -60,4 +69,3 @@ foreach(example_program ${example_programs})
   add_hpx_pseudo_dependencies(examples.compute.cuda.${example_program}
                               ${example_program}_exe)
 endforeach()
-

--- a/examples/compute/cuda/cuda_future.cpp
+++ b/examples/compute/cuda/cuda_future.cpp
@@ -1,0 +1,93 @@
+//  Copyright (c) 2018 John Biddiscombe
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_NO_CXX11_ALLOCATOR
+//
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/parallel_copy.hpp>
+#include <hpx/include/parallel_for_each.hpp>
+#include <hpx/include/parallel_for_loop.hpp>
+#include <hpx/include/parallel_executors.hpp>
+#include <hpx/include/parallel_executor_parameters.hpp>
+//
+#include <hpx/include/compute.hpp>
+#include <hpx/compute/cuda/target.hpp>
+// CUDA runtime
+#include <cuda_runtime.h>
+//
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <sstream>
+#include <utility>
+#include <vector>
+//
+#include "cuda_future_helper.h"
+
+// -------------------------------------------------------------------------
+// This example uses the normal C++ compiler to compile all the HPX stuff
+// but the cuda functions go in their own .cu file and are compiled with
+// nvcc, we don't mix them.
+// Declare functions we are importing - note that template instantiations
+// must be present in the .cu file and compiled so that we can link to them
+template <typename T>
+extern void cuda_trivial_kernel(T, cudaStream_t stream);
+
+// -------------------------------------------------------------------------
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    std::size_t device     = vm["device"].as<std::size_t>();
+    //
+    unsigned int seed = (unsigned int)std::time(nullptr);
+     if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    hpx::compute::cuda::target target(device);
+    //
+    hpx::compute::util::cuda_future_helper helper(device);
+    helper.print_local_targets();
+    //
+    float testf = 2.345;
+    cuda_trivial_kernel(testf, helper.get_stream());
+
+    double testd = 5.678;
+    cuda_trivial_kernel(testd, helper.get_stream());
+
+    auto fn = &cuda_trivial_kernel<double>;
+    double d = 3.1415;
+    auto f = helper.async(fn, d);
+    f.then([](hpx::future<void> &&f) {
+        std::cout << "trivial kernel completed \n";
+    });
+
+    return hpx::finalize();
+}
+
+// -------------------------------------------------------------------------
+int main(int argc, char **argv)
+{
+    printf("[HPX Cuda future] - Starting...\n");
+
+    using namespace boost::program_options;
+    options_description cmdline("usage: " HPX_APPLICATION_STRING " [options]");
+    cmdline.add_options()
+        (   "device",
+            boost::program_options::value<std::size_t>()->default_value(0),
+            "Device to use")
+        (   "iterations",
+            boost::program_options::value<std::size_t>()->default_value(30),
+            "iterations")
+        ("seed,s",
+            boost::program_options::value<unsigned int>(),
+            "the random number generator seed to use for this run")
+        ;
+
+    return hpx::init(cmdline, argc, argv);
+}

--- a/examples/compute/cuda/cuda_future_helper.h
+++ b/examples/compute/cuda/cuda_future_helper.h
@@ -1,0 +1,278 @@
+//  Copyright (c) 2018 John Biddiscombe
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef CUDA_HELPER_H
+#define CUDA_HELPER_H
+
+#define BOOST_NO_CXX11_ALLOCATOR
+#define CUDA_API_PER_THREAD_DEFAULT_STREAM
+//
+#include <hpx/compute/cuda/target.hpp>
+#include <hpx/include/compute.hpp>
+
+// CUDA runtime
+#include <cuda_runtime.h>
+// CuBLAS
+#include <cublas_v2.h>
+//
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <sstream>
+#include <utility>
+#include <vector>
+
+// -------------------------------------------------------------------------
+// A simple cuda wrapper helper object that can be used to synchronize
+// calls with an hpx future.
+//
+// NOTE: The implementation in this file is intended to be compiled with the
+// normal C++ compiler and so we cannot directly call a cuda kernel using the
+// <<<>>> operator. We therefore require the kernel to be compiled in another
+// file by nvcc/cuda-clang and a wrapper function provided that has c++ linkage
+//
+//        Here is a trivial kernel that can be invoked on the GPU
+//        __global__ int trivial_kernel(double val) {
+//          printf("hello from gpu with value %f\n", val);
+//          return 0;
+//        }
+//
+//        Here is a trivial wrapper that must be compiled into the *.cu
+//        int call_trivial_kernel(double val) {
+//            return trivial_kernel(val);
+//        }
+//
+// From the user C++ code we may now declare the wrapper and call it with our helper
+//        extern int call_trivial_kernel(double val);
+//        auto fut = helper.async(&call_trivial_kernel, 3.1415);
+//
+// -------------------------------------------------------------------------
+namespace hpx { namespace compute { namespace util
+{
+
+    // -------------------------------------------------------------------------
+    // Forward declare these error utility functions
+    void cuda_error(cudaError_t err);
+    void cublas_error(cublasStatus_t err);
+
+    namespace detail {
+
+        // -------------------------------------------------------------------------
+        // Error handling in cublas calls
+        // not all of these are supported by all cuda/cublas versions
+        // (comment them out if they cause compiler errors)
+        const char *_cublasGetErrorEnum(cublasStatus_t error)
+        {
+            switch (error) {
+                case CUBLAS_STATUS_SUCCESS:
+                    return "CUBLAS_STATUS_SUCCESS";
+                case CUBLAS_STATUS_NOT_INITIALIZED:
+                    return "CUBLAS_STATUS_NOT_INITIALIZED";
+                case CUBLAS_STATUS_ALLOC_FAILED:
+                    return "CUBLAS_STATUS_ALLOC_FAILED";
+                case CUBLAS_STATUS_INVALID_VALUE:
+                    return "CUBLAS_STATUS_INVALID_VALUE";
+                case CUBLAS_STATUS_ARCH_MISMATCH:
+                    return "CUBLAS_STATUS_ARCH_MISMATCH";
+                case CUBLAS_STATUS_MAPPING_ERROR:
+                    return "CUBLAS_STATUS_MAPPING_ERROR";
+                case CUBLAS_STATUS_EXECUTION_FAILED:
+                    return "CUBLAS_STATUS_EXECUTION_FAILED";
+                case CUBLAS_STATUS_INTERNAL_ERROR:
+                    return "CUBLAS_STATUS_INTERNAL_ERROR";
+                case CUBLAS_STATUS_NOT_SUPPORTED:
+                    return "CUBLAS_STATUS_NOT_SUPPORTED";
+                case CUBLAS_STATUS_LICENSE_ERROR:
+                    return "CUBLAS_STATUS_LICENSE_ERROR";
+            }
+            return "<unknown>";
+        }
+
+        // -------------------------------------------------------------------------
+        // To save writing nearly the same code N times, we will use a helper
+        // that we can specialize for cuda Error types
+        template <typename R, typename... Args>
+        struct async_helper;
+
+        // default implementation
+        template <typename R, typename... Args>
+        struct async_helper {
+            inline R operator()(R(*f)(Args...), Args... args) {
+                return f(args...);
+            }
+        };
+
+        // specialize invoker helper for return type void
+        template <typename... Args>
+        struct async_helper<void, Args...> {
+            inline void operator()(void(*f)(Args...), Args... args) {
+                f(args...);
+            }
+        };
+
+        // specialize invoker helper for return type of cudaError_t
+        template <typename... Args>
+        struct async_helper<cudaError_t, Args...> {
+            inline cudaError_t operator()(cudaError_t(*f)(Args...), Args... args) {
+                cudaError_t err = f(args...);
+                cuda_error(err);
+                return err;
+            }
+        };
+
+        // specialize invoker helper for return type of cublasStatus_t
+        template <typename... Args>
+        struct async_helper<cublasStatus_t, Args...> {
+            inline cublasStatus_t operator()(cublasStatus_t(*f)(Args...), Args... args) {
+                cublasStatus_t err = f(args...);
+                cublas_error(err);
+                return err;
+            }
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // Error message handling for cuda and cublas
+    // -------------------------------------------------------------------------
+    void cuda_error(cudaError_t err) {
+        if (err != cudaSuccess) {
+            std::stringstream temp;
+            temp << "cuda function returned error code "
+                 << cudaGetErrorString(err);
+            throw std::runtime_error(temp.str());
+        }
+    }
+
+    void cublas_error(cublasStatus_t err) {
+        if (err != CUBLAS_STATUS_SUCCESS) {
+            std::stringstream temp;
+            temp << "cublas function returned error code "
+                 << detail::_cublasGetErrorEnum(err);
+            throw std::runtime_error(temp.str());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Cuda future helper
+    // Allows you to launch kernels on a stream and get
+    // futures back when they are ready
+    // -------------------------------------------------------------------------
+    struct cuda_future_helper
+    {
+        using future_type = hpx::future<void>;
+
+        // construct - create a cuda stream that all tasks invoked by
+        // this helper will use
+        cuda_future_helper(std::size_t device = 0) : target_(device) {
+            stream_ = target_.native_handle().get_stream();
+        }
+
+        ~cuda_future_helper() {}
+
+        cuda_future_helper(cuda_future_helper& other) = delete;
+        cuda_future_helper(const cuda_future_helper& other) = delete;
+        cuda_future_helper operator=(const cuda_future_helper& other) = delete;
+
+        // -------------------------------------------------------------------------
+        // launch a kernel on our stream and return a future that will become ready
+        // when the task completes, this allows integregration of GPU kernels with
+        // hpx::futuresa and the tasking DAG.
+        template <typename R, typename... Params, typename... Args>
+        hpx::future<void> async(R(*cuda_kernel)(Params...), Args &&... args) {
+            // make sure we run on the correct device
+            cuda_error(cudaSetDevice(target_.native_handle().get_device()));
+            // insert the stream handle in the arg list and call the cuda function
+            detail::async_helper<R, Params...> helper;
+            helper(cuda_kernel, std::forward<Args>(args)..., stream_);
+            return get_future();
+        }
+
+        // -------------------------------------------------------------------------
+        // launch a kernel on our stream and return without a future
+        template <typename R, typename... Params, typename... Args>
+        R apply(R(*cuda_kernel)(Params...), Args &&... args) {
+            // make sure we run on the correct device
+            cuda_error(cudaSetDevice(target_.native_handle().get_device()));
+            // insert the stream handle in the arg list and call the cuda function
+            detail::async_helper<R, Params...> helper;
+            return helper(cuda_kernel, std::forward<Args>(args)..., stream_);
+        }
+
+        // -------------------------------------------------------------------------
+        // launch a task on our stream and pass the error code through from
+        // cuda back to te caller, otherwise this function mimics the
+        // behaviour of apply.
+        template <typename Func, typename... Args>
+        cudaError_t apply_pass_through(Func&& cuda_function, Args&&... args) {
+            // make sure we run on the correct device
+            cuda_error(cudaSetDevice(target_.native_handle().get_device()));
+            // insert the stream handle in the arg list and call the cuda function
+            return cuda_function(std::forward<Args>(args)..., stream_);
+        }
+
+        // -------------------------------------------------------------------------
+        // utility function for copying to/from the GPU, async and apply versions
+        template <typename... Args>
+        hpx::future<void> copy_async(Args&&... args) {
+            return async(cudaMemcpyAsync, std::forward<Args>(args)...);
+        }
+
+        template <typename... Args>
+        auto copy_apply(Args&&... args) {
+            return apply(cudaMemcpyAsync, std::forward<Args>(args)...);
+        }
+
+        // -------------------------------------------------------------------------
+        // utility function for setting memory on the GPU, async and apply versions
+        template <typename... Args>
+        hpx::future<void> memset_async(Args&&... args) {
+            return async(cudaMemsetAsync, std::forward<Args>(args)...);
+        }
+
+        template <typename... Args>
+        auto memset_apply(Args&&... args) {
+            return apply(cudaMemsetAsync, std::forward<Args>(args)...);
+        }
+
+        // -------------------------------------------------------------------------
+        // get the future to synchronize this cublas stream with
+        future_type get_future() {
+            return target_.get_future();
+        }
+
+        // -------------------------------------------------------------------------
+        // return a reference to the compute::cuda object owned by this class
+        hpx::compute::cuda::target& get_target() {
+            return target_;
+        }
+
+        // -------------------------------------------------------------------------
+        cudaStream_t get_stream() {
+            return stream_;
+        }
+
+        // -------------------------------------------------------------------------
+        // utility function to print target information for this helper object
+        static void print_local_targets(void) {
+            auto targets = hpx::compute::cuda::target::get_local_targets();
+            for (auto target : targets) {
+                std::cout << "GPU Device " << target.native_handle().get_device() << ": \""
+                          << target.native_handle().processor_name() << "\" "
+                          << "with compute capability " << target.native_handle().processor_family()
+                          << "\n";
+            }
+        }
+
+    protected:
+        cudaStream_t               stream_;
+        hpx::compute::cuda::target target_;
+    };
+
+}}} // namespace
+
+//#endif
+
+#endif

--- a/examples/compute/cuda/trivial_demo.cu
+++ b/examples/compute/cuda/trivial_demo.cu
@@ -1,0 +1,39 @@
+//  Copyright (c) 2018 John Biddiscombe
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include "cuda_runtime.h"
+#include <boost/preprocessor/seq/for_each.hpp>
+
+// Here is a trivial kernel that can be invoked on the GPU
+template <typename T>
+__global__ void trivial_kernel(T val) {
+  printf("hello from gpu with value %f\n", val);
+}
+
+// here is a wrapper that can call the kernel from C++ outsied of the .cu file
+template <typename T>
+void cuda_trivial_kernel(T t, cudaStream_t stream)
+{
+  trivial_kernel<<<1, 1, 0, stream>>>(t);
+}
+
+// -------------------------------------------------------------------------
+// To make the kernel visible for all template instantiations we might use
+// we must instantiate them here first in the cuda compiled code.
+// Use a simple boost preprocessor macro to allow any types to
+// be added.
+
+// list of types to generate code for
+#define TYPES (double)(float)                                             \
+  //
+
+#define GENERATE_SPECIALIZATIONS(_1, _2, elem)                            \
+  template                                                                \
+  __global__ void trivial_kernel<elem>(elem);                             \
+  template                                                                \
+  void cuda_trivial_kernel<elem>(elem, cudaStream_t);                     \
+  //
+
+BOOST_PP_SEQ_FOR_EACH(GENERATE_SPECIALIZATIONS, _, TYPES)


### PR DESCRIPTION
This example shows how to launch a kuda kernel and bind it to
an hpx::future so that continuations may be attached to it
in the same way as a CPU task.

A new helper class is introduced that can be used with the old
cuBlas +future example code. This commit unifies the two to make a
cleaner integration.

The cuda_future_helper might benefit from being moved into the main
hpx::compute tree rather than being in examples.
