### PR TITLE
Adding emplace support to promise and make_ready_future

### DIFF
--- a/hpx/lcos/local/futures_factory.hpp
+++ b/hpx/lcos/local/futures_factory.hpp
@@ -54,12 +54,12 @@ namespace hpx { namespace lcos { namespace local
               : f_(std::move(f))
             {}
 
-            task_object(F const& f, init_no_addref no_addref)
+            task_object(init_no_addref no_addref, F const& f)
               : base_type(no_addref)
               , f_(f)
             {}
 
-            task_object(F&& f, init_no_addref no_addref)
+            task_object(init_no_addref no_addref, F&& f)
               : base_type(no_addref)
               , f_(std::move(f))
             {}
@@ -152,23 +152,23 @@ namespace hpx { namespace lcos { namespace local
               , exec_(&exec)
             {}
 
-            task_object(F const& f, init_no_addref no_addref)
+            task_object(init_no_addref no_addref, F const& f)
               : base_type(f, no_addref)
               , exec_(nullptr)
             {}
 
-            task_object(F&& f, init_no_addref no_addref)
+            task_object(init_no_addref no_addref, F&& f)
               : base_type(std::move(f), no_addref)
               , exec_(nullptr)
             {}
 
-            task_object(Executor& exec, F const& f, init_no_addref no_addref)
-              : base_type(f, no_addref)
+            task_object(Executor& exec, init_no_addref no_addref, F const& f)
+              : base_type(no_addref, f)
               , exec_(&exec)
             {}
 
-            task_object(Executor& exec, F&& f, init_no_addref no_addref)
-              : base_type(std::move(f), no_addref)
+            task_object(Executor& exec, init_no_addref no_addref, F&& f)
+              : base_type(no_addref, std::move(f))
               , exec_(&exec)
             {}
 
@@ -234,12 +234,12 @@ namespace hpx { namespace lcos { namespace local
               : base_type(std::move(f))
             {}
 
-            cancelable_task_object(F const& f, init_no_addref no_addref)
-              : base_type(f, no_addref)
+            cancelable_task_object(init_no_addref no_addref, F const& f)
+              : base_type(no_addref, f)
             {}
 
-            cancelable_task_object(F && f, init_no_addref no_addref)
-              : base_type(std::move(f), no_addref)
+            cancelable_task_object(init_no_addref no_addref, F && f)
+              : base_type(no_addref, std::move(f))
             {}
         };
 
@@ -271,22 +271,22 @@ namespace hpx { namespace lcos { namespace local
               : base_type(exec, std::move(f))
             {}
 
-            cancelable_task_object(F const& f, init_no_addref no_addref)
-              : base_type(f, no_addref)
+            cancelable_task_object(init_no_addref no_addref, F const& f)
+              : base_type(no_addref, f)
             {}
 
-            cancelable_task_object(F && f, init_no_addref no_addref)
-              : base_type(std::move(f), no_addref)
+            cancelable_task_object(init_no_addref no_addref, F && f)
+              : base_type(no_addref, std::move(f))
             {}
 
-            cancelable_task_object(Executor& exec, F const& f,
-                    init_no_addref no_addref)
-              : base_type(exec, f, no_addref)
+            cancelable_task_object(
+                    Executor& exec, init_no_addref no_addref, F const& f)
+              : base_type(exec, no_addref, f)
             {}
 
-            cancelable_task_object(Executor& exec, F && f,
-                    init_no_addref no_addref)
-              : base_type(exec, std::move(f), no_addref)
+            cancelable_task_object(
+                    Executor& exec, init_no_addref no_addref, F&& f)
+              : base_type(exec, no_addref, std::move(f))
             {}
         };
     }
@@ -320,8 +320,8 @@ namespace hpx { namespace lcos { namespace local
             static return_type call(F&& f)
             {
                 return return_type(
-                    new task_object<Result, F, void>(
-                        std::forward<F>(f), init_no_addref()),
+                    new task_object<Result, F, void>(init_no_addref{},
+                        std::forward<F>(f)),
                     false);
             }
 
@@ -330,7 +330,7 @@ namespace hpx { namespace lcos { namespace local
             {
                 return return_type(
                     new task_object<Result, Result (*)(), void>(
-                        f, init_no_addref()),
+                        init_no_addref{}, f),
                     false);
             }
         };
@@ -351,7 +351,7 @@ namespace hpx { namespace lcos { namespace local
             {
                 return return_type(
                     new task_object<Result, F, Executor>(exec,
-                        std::forward<F>(f), init_no_addref()),
+                        init_no_addref{}, std::forward<F>(f)),
                     false);
             }
 
@@ -360,7 +360,7 @@ namespace hpx { namespace lcos { namespace local
             {
                 return return_type(
                     new task_object<Result, Result (*)(), Executor>(
-                        exec, f, init_no_addref()),
+                        exec, init_no_addref{}, f),
                     false);
             }
         };
@@ -381,7 +381,7 @@ namespace hpx { namespace lcos { namespace local
             {
                 return return_type(
                     new cancelable_task_object<Result, F, void>(
-                        std::forward<F>(f), init_no_addref()),
+                        init_no_addref{}, std::forward<F>(f)),
                     false);
             }
 
@@ -390,7 +390,7 @@ namespace hpx { namespace lcos { namespace local
             {
                 return return_type(
                     new cancelable_task_object<Result, Result (*)(), void>(
-                        f, init_no_addref()),
+                        init_no_addref{}, f),
                     false);
             }
         };
@@ -411,7 +411,7 @@ namespace hpx { namespace lcos { namespace local
             {
                 return return_type(
                     new cancelable_task_object<Result, F, Executor>(
-                        exec, std::forward<F>(f), init_no_addref()),
+                        exec, init_no_addref{}, std::forward<F>(f)),
                     false);
             }
 
@@ -420,7 +420,7 @@ namespace hpx { namespace lcos { namespace local
             {
                 return return_type(
                     new cancelable_task_object<Result, Result (*)(), Executor>(
-                        exec, f, init_no_addref()),
+                        exec, init_no_addref{}, f),
                     false);
             }
         };

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -223,7 +223,7 @@ namespace hpx { namespace lcos { namespace detail
         {}
 
         template <typename Func>
-        continuation(Func && f, init_no_addref no_addref)
+        continuation(init_no_addref no_addref, Func && f)
           : base_type(no_addref),
             started_(false), id_(threads::invalid_thread_id),
             f_(std::forward<Func>(f))
@@ -628,7 +628,7 @@ namespace hpx { namespace lcos { namespace detail
 
         // create a continuation
         typename traits::detail::shared_state_ptr<result_type>::type p(
-            new shared_state(std::forward<F>(f), init_no_addref()), false);
+            new shared_state(init_no_addref{}, std::forward<F>(f)), false);
         static_cast<shared_state*>(p.get())->attach(
             future, std::forward<Policy>(policy));
         return p;
@@ -649,7 +649,7 @@ namespace hpx { namespace lcos { namespace detail
 
         // create a continuation
         typename traits::detail::shared_state_ptr<result_type>::type p(
-            new shared_state(std::forward<F>(f), init_no_addref()), false);
+            new shared_state(init_no_addref{}, std::forward<F>(f)), false);
         static_cast<shared_state*>(p.get())->attach_exec_v1(future, exec);
         return p;
     }
@@ -665,7 +665,7 @@ namespace hpx { namespace lcos { namespace detail
 
         // create a continuation
         typename traits::detail::shared_state_ptr<ContResult>::type p(
-            new shared_state(std::forward<F>(f), init_no_addref()), false);
+            new shared_state(init_no_addref{}, std::forward<F>(f)), false);
         static_cast<shared_state*>(p.get())->template attach_exec<Executor>(
             future, exec);
         return p;
@@ -803,7 +803,7 @@ namespace hpx { namespace lcos { namespace detail
 
         // create a continuation
         typename traits::detail::shared_state_ptr<result_type>::type p(
-            new shared_state(init_no_addref()), false);
+            new shared_state(init_no_addref{}), false);
         static_cast<shared_state*>(p.get())->attach(std::forward<Future>(future));
         return p;
     }

--- a/hpx/lcos/promise.hpp
+++ b/hpx/lcos/promise.hpp
@@ -221,9 +221,9 @@ namespace lcos {
         //   - promise_already_satisfied if its shared state already has a
         //     stored value or exception.
         //   - no_state if *this has no shared state.
-        void set_value(error_code& ec = throws)
+        void set_value()
         {
-            base_type::set_value(hpx::util::unused, ec);
+            base_type::set_value(hpx::util::unused);
         }
 
         // Effects: atomically stores the exception pointer p in the shared

--- a/hpx/lcos/wait_all.hpp
+++ b/hpx/lcos/wait_all.hpp
@@ -217,7 +217,7 @@ namespace hpx { namespace lcos
               : t_(t)
             {}
 
-            wait_all_frame(Tuple const& t, init_no_addref no_addref)
+            wait_all_frame(init_no_addref no_addref, Tuple const& t)
               : base_type(no_addref), t_(t)
             {}
 
@@ -367,7 +367,7 @@ namespace hpx { namespace lcos
         typedef typename frame_type::init_no_addref init_no_addref;
 
         result_type data(values);
-        frame_type frame{data, init_no_addref()};
+        frame_type frame{init_no_addref{}, data};
         frame.wait_all();
     }
 
@@ -392,7 +392,7 @@ namespace hpx { namespace lcos
         typedef typename frame_type::init_no_addref init_no_addref;
 
         result_type data(values);
-        frame_type frame (data, init_no_addref());
+        frame_type frame (init_no_addref{}, data);
         frame.wait_all();
     }
 
@@ -467,7 +467,7 @@ namespace hpx { namespace lcos
         result_type values =
             result_type(traits::detail::get_shared_state(ts)...);
 
-        frame_type frame(values, init_no_addref());
+        frame_type frame(init_no_addref{}, values);
         frame.wait_all();
     }
 }}

--- a/hpx/runtime/components/client_base.hpp
+++ b/hpx/runtime/components/client_base.hpp
@@ -172,16 +172,16 @@ namespace hpx { namespace lcos { namespace detail
           : future_data_base<id_type>(no_addref)
         {}
 
-        template <typename Target>
-        future_data(Target && data, init_no_addref no_addref)
-          : future_data_base<id_type>(std::forward<Target>(data), no_addref)
+        template <typename ... T>
+        future_data(init_no_addref no_addref, T&& ... ts)
+          : future_data_base<id_type>(no_addref, std::forward<T>(ts)...)
         {}
 
-        future_data(std::exception_ptr const& e, init_no_addref no_addref)
-          : future_data_base<id_type>(e, no_addref)
+        future_data(init_no_addref no_addref, std::exception_ptr const& e)
+          : future_data_base<id_type>(no_addref, e)
         {}
-        future_data(std::exception_ptr && e, init_no_addref no_addref)
-          : future_data_base<id_type>(std::move(e), no_addref)
+        future_data(init_no_addref no_addref, std::exception_ptr && e)
+          : future_data_base<id_type>(no_addref, std::move(e))
         {}
 
         ~future_data() noexcept override

--- a/tests/unit/lcos/CMakeLists.txt
+++ b/tests/unit/lcos/CMakeLists.txt
@@ -35,6 +35,7 @@ set(tests
     future_then_executor
     future_wait
     global_spmd_block
+    make_ready_future
     local_latch
     local_barrier
     local_dataflow
@@ -47,6 +48,7 @@ set(tests
     packaged_action
     promise
     promise_allocator
+    promise_emplace
     reduce
     remote_dataflow
     remote_latch

--- a/tests/unit/lcos/make_ready_future.cpp
+++ b/tests/unit/lcos/make_ready_future.cpp
@@ -1,0 +1,115 @@
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <string>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+void test_nullary_void()
+{
+    hpx::future<void> f1 = hpx::make_ready_future();
+    HPX_TEST(f1.is_ready());
+
+    hpx::future<void> f2 = hpx::make_ready_future<void>();
+    HPX_TEST(f2.is_ready());
+}
+
+struct A
+{
+    A() = default;
+};
+
+void test_nullary()
+{
+    hpx::future<A> f1 = hpx::make_ready_future<A>();
+    HPX_TEST(f1.is_ready());
+}
+
+struct B
+{
+    B(int i) : i_(i) {}
+
+    int i_;
+};
+
+void test_unary()
+{
+    hpx::future<B> f1 = hpx::make_ready_future(B(42));
+    HPX_TEST(f1.is_ready());
+    HPX_TEST_EQ(f1.get().i_, 42);
+
+    hpx::future<B> f2 = hpx::make_ready_future<B>(42);
+    HPX_TEST(f2.is_ready());
+    HPX_TEST_EQ(f2.get().i_, 42);
+}
+
+struct C
+{
+    C(int i) : i_(i), j_(0) {}
+    C(int i, int j) : i_(i), j_(j) {}
+
+    C(C const&) = delete;
+    C(C&& rhs) : i_(rhs.i_), j_(rhs.j_) {}
+
+    int i_;
+    int j_;
+};
+
+void test_variadic()
+{
+    hpx::future<C> f1 = hpx::make_ready_future(C(42));
+    HPX_TEST(f1.is_ready());
+    C r1 = f1.get();
+    HPX_TEST_EQ(r1.i_, 42);
+    HPX_TEST_EQ(r1.j_, 0);
+
+    hpx::future<C> f2 = hpx::make_ready_future<C>(42);
+    HPX_TEST(f2.is_ready());
+    C r2 = f2.get();
+    HPX_TEST_EQ(r2.i_, 42);
+    HPX_TEST_EQ(r2.j_, 0);
+
+    hpx::future<C> f3 = hpx::make_ready_future(C(42, 43));
+    HPX_TEST(f3.is_ready());
+    C r3 = f3.get();
+    HPX_TEST_EQ(r3.i_, 42);
+    HPX_TEST_EQ(r3.j_, 43);
+
+    hpx::future<C> f4 = hpx::make_ready_future<C>(42, 43);
+    HPX_TEST(f4.is_ready());
+    C r4 = f4.get();
+    HPX_TEST_EQ(r4.i_, 42);
+    HPX_TEST_EQ(r4.j_, 43);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    test_nullary_void();
+    test_nullary();
+
+    test_unary();
+    test_variadic();
+
+    return hpx::finalize();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char* argv[])
+{
+    // We force this test to use several threads by default.
+    std::vector<std::string> const cfg = {
+        "hpx.os_threads=all"
+    };
+
+    // Initialize and run HPX
+    HPX_TEST_EQ(hpx::init(argc, argv, cfg), 0);
+    return hpx::util::report_errors();
+}
+

--- a/tests/unit/lcos/promise_emplace.cpp
+++ b/tests/unit/lcos/promise_emplace.cpp
@@ -1,0 +1,196 @@
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <string>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+void test_nullary_void()
+{
+    {
+        hpx::lcos::promise<void> p;
+        hpx::future<void> f = p.get_future();
+        p.set_value();
+        HPX_TEST(f.is_ready());
+    }
+
+    {
+        hpx::lcos::local::promise<void> p;
+        hpx::future<void> f = p.get_future();
+        p.set_value();
+        HPX_TEST(f.is_ready());
+    }
+}
+
+struct A
+{
+    A() : i_(42) {}
+    A(int i) : i_(i) {}
+
+    int i_;
+};
+
+void test_nullary()
+{
+    {
+        hpx::lcos::promise<A> p;
+        hpx::future<A> f = p.get_future();
+        p.set_value();
+        HPX_TEST(f.is_ready());
+        HPX_TEST_EQ(f.get().i_, 42);
+    }
+
+    {
+        hpx::lcos::local::promise<A> p;
+        hpx::future<A> f = p.get_future();
+        p.set_value();
+        HPX_TEST(f.is_ready());
+        HPX_TEST_EQ(f.get().i_, 42);
+    }
+}
+
+void test_unary()
+{
+    {
+        hpx::lcos::promise<A> p1;
+        hpx::future<A> f1 = p1.get_future();
+        p1.set_value(A(42));
+        HPX_TEST(f1.is_ready());
+        HPX_TEST_EQ(f1.get().i_, 42);
+
+        hpx::lcos::promise<A> p2;
+        hpx::future<A> f2 = p2.get_future();
+        p2.set_value(42);
+        HPX_TEST(f2.is_ready());
+        HPX_TEST_EQ(f2.get().i_, 42);
+    }
+
+    {
+        hpx::lcos::local::promise<A> p1;
+        hpx::future<A> f1 = p1.get_future();
+        p1.set_value(A(42));
+        HPX_TEST(f1.is_ready());
+        HPX_TEST_EQ(f1.get().i_, 42);
+
+        hpx::lcos::local::promise<A> p2;
+        hpx::future<A> f2 = p2.get_future();
+        p2.set_value(42);
+        HPX_TEST(f2.is_ready());
+        HPX_TEST_EQ(f2.get().i_, 42);
+    }
+}
+
+struct B
+{
+    B(int i) : i_(i), j_(0) {}
+    B(int i, int j) : i_(i), j_(j) {}
+
+    B(B const&) = delete;
+    B(B&& rhs) : i_(rhs.i_), j_(rhs.j_) {}
+
+    int i_;
+    int j_;
+};
+
+void test_variadic()
+{
+    {
+        hpx::lcos::promise<B> p1;
+        hpx::future<B> f1 = p1.get_future();
+        p1.set_value(B(42));
+        HPX_TEST(f1.is_ready());
+        B r1 = f1.get();
+        HPX_TEST_EQ(r1.i_, 42);
+        HPX_TEST_EQ(r1.j_, 0);
+
+        hpx::lcos::promise<B> p2;
+        hpx::future<B> f2 = p2.get_future();
+        p2.set_value(42);
+        HPX_TEST(f2.is_ready());
+        B r2 = f2.get();
+        HPX_TEST_EQ(r2.i_, 42);
+        HPX_TEST_EQ(r2.j_, 0);
+
+        hpx::lcos::promise<B> p3;
+        hpx::future<B> f3 = p3.get_future();
+        p3.set_value(B(42, 43));
+        HPX_TEST(f3.is_ready());
+        B r3 = f3.get();
+        HPX_TEST_EQ(r3.i_, 42);
+        HPX_TEST_EQ(r3.j_, 43);
+
+        hpx::lcos::promise<B> p4;
+        hpx::future<B> f4 = p4.get_future();
+        p4.set_value(42, 43);
+        HPX_TEST(f4.is_ready());
+        B r4 = f4.get();
+        HPX_TEST_EQ(r4.i_, 42);
+        HPX_TEST_EQ(r4.j_, 43);
+    }
+
+    {
+        hpx::lcos::local::promise<B> p1;
+        hpx::future<B> f1 = p1.get_future();
+        p1.set_value(B(42));
+        HPX_TEST(f1.is_ready());
+        B r1 = f1.get();
+        HPX_TEST_EQ(r1.i_, 42);
+        HPX_TEST_EQ(r1.j_, 0);
+
+        hpx::lcos::local::promise<B> p2;
+        hpx::future<B> f2 = p2.get_future();
+        p2.set_value(42);
+        HPX_TEST(f2.is_ready());
+        B r2 = f2.get();
+        HPX_TEST_EQ(r2.i_, 42);
+        HPX_TEST_EQ(r2.j_, 0);
+
+        hpx::lcos::local::promise<B> p3;
+        hpx::future<B> f3 = p3.get_future();
+        p3.set_value(B(42, 43));
+        HPX_TEST(f3.is_ready());
+        B r3 = f3.get();
+        HPX_TEST_EQ(r3.i_, 42);
+        HPX_TEST_EQ(r3.j_, 43);
+
+        hpx::lcos::local::promise<B> p4;
+        hpx::future<B> f4 = p4.get_future();
+        p4.set_value(42, 43);
+        HPX_TEST(f4.is_ready());
+        B r4 = f4.get();
+        HPX_TEST_EQ(r4.i_, 42);
+        HPX_TEST_EQ(r4.j_, 43);
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    test_nullary_void();
+    test_nullary();
+
+    test_unary();
+    test_variadic();
+
+    return hpx::finalize();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char* argv[])
+{
+    // We force this test to use several threads by default.
+    std::vector<std::string> const cfg = {
+        "hpx.os_threads=all"
+    };
+
+    // Initialize and run HPX
+    HPX_TEST_EQ(hpx::init(argc, argv, cfg), 0);
+    return hpx::util::report_errors();
+}
+


### PR DESCRIPTION
This adds support for [P0319](http://wg21.link/p0319) to `hpx::lcos::promise`, `hpx::lcos::local::promise`, and hpx::make_ready_future`