### PR TITLE
Fix partitioned vector include in partitioned_vector_find tests

### DIFF
--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -836,7 +836,7 @@ namespace hpx { namespace lcos { namespace detail
         typename future_unwrap_result<Future>::result_type>::type
     unwrap(Future && future, error_code& ec)
     {
-        return unwrap_impl(std::move(future), ec);
+        return unwrap_impl(std::forward<Future>(future), ec);
     }
 }}}
 

--- a/tests/unit/parallel/segmented_algorithms/partitioned_vector_find.cpp
+++ b/tests/unit/parallel/segmented_algorithms/partitioned_vector_find.cpp
@@ -4,7 +4,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/partitioned_vector.hpp>
+#include <hpx/include/partitioned_vector_predef.hpp>
 #include <hpx/include/parallel_find.hpp>
 #include <hpx/include/parallel_scan.hpp>
 

--- a/tests/unit/parallel/segmented_algorithms/partitioned_vector_find2.cpp
+++ b/tests/unit/parallel/segmented_algorithms/partitioned_vector_find2.cpp
@@ -4,7 +4,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/partitioned_vector.hpp>
+#include <hpx/include/partitioned_vector_predef.hpp>
 #include <hpx/include/parallel_find.hpp>
 #include <hpx/include/parallel_scan.hpp>
 


### PR DESCRIPTION
Fixes failures like [these](http://rostam.cct.lsu.edu/builders/hpx_clang_3_9_boost_1_62_centos_x86_64_release/builds/10/steps/run_unit_tests/logs/tests.unit.parallel.segmented_algorithms.distributed.tcp.partitioned_vector_find%20%280.78%20sec%29).
