### PR TITLE
Apex task wrapper memory bug

### DIFF
--- a/hpx/runtime/threads/coroutines/detail/context_posix.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_posix.hpp
@@ -406,10 +406,11 @@ namespace hpx { namespace threads { namespace coroutines
             void * cb_;
             void(*funp_)(void*);
 
+#if defined(HPX_HAVE_STACKOVERFLOW_DETECTION)
             struct sigaction action;
             stack_t segv_stack;
+#endif
         };
-
         typedef ucontext_context_impl context_impl;
     }}
 }}}

--- a/hpx/runtime/threads/thread_data.hpp
+++ b/hpx/runtime/threads/thread_data.hpp
@@ -608,21 +608,13 @@ namespace hpx { namespace threads
                 {
                     parent_thread_id_ = threads::get_self_id();
                     parent_thread_phase_ = self->get_thread_phase();
-#if defined(HPX_HAVE_APEX)
-                    // We have a valid parent pointer.
-                    set_apex_data(apex_new_task(get_description(),
-                        parent_thread_id_.get()->get_apex_data()));
-#endif
-                } else {
-#if defined(HPX_HAVE_APEX)
-                    // We do not have a valid parent pointer.
-                    set_apex_data(apex_new_task(get_description(),
-                        nullptr));
-#endif
                 }
             }
             if (0 == parent_locality_id_)
                 parent_locality_id_ = get_locality_id();
+#endif
+#if defined(HPX_HAVE_APEX)
+            set_apex_data(init_data.apex_data);
 #endif
             HPX_ASSERT(init_data.stacksize != 0);
             HPX_ASSERT(coroutine_.is_ready());
@@ -674,21 +666,13 @@ namespace hpx { namespace threads
                 {
                     parent_thread_id_ = threads::get_self_id();
                     parent_thread_phase_ = self->get_thread_phase();
-#if defined(HPX_HAVE_APEX)
-                    // We have a valid parent pointer.
-                    set_apex_data(apex_new_task(get_description(),
-                        parent_thread_id_.get()->get_apex_data()));
-#endif
-                } else {
-#if defined(HPX_HAVE_APEX)
-                    // We do not have a valid parent pointer.
-                    set_apex_data(apex_new_task(get_description(),
-                        nullptr));
-#endif
                 }
             }
             if (0 == parent_locality_id_)
                 parent_locality_id_ = get_locality_id();
+#endif
+#if defined(HPX_HAVE_APEX)
+            set_apex_data(init_data.apex_data);
 #endif
         }
 

--- a/hpx/runtime/threads/thread_data.hpp
+++ b/hpx/runtime/threads/thread_data.hpp
@@ -608,19 +608,21 @@ namespace hpx { namespace threads
                 {
                     parent_thread_id_ = threads::get_self_id();
                     parent_thread_phase_ = self->get_thread_phase();
+#if defined(HPX_HAVE_APEX)
+                    // We have a valid parent pointer.
+                    set_apex_data(apex_new_task(get_description(),
+                        parent_thread_id_.get()->get_apex_data()));
+#endif
+                } else {
+#if defined(HPX_HAVE_APEX)
+                    // We do not have a valid parent pointer.
+                    set_apex_data(apex_new_task(get_description(),
+                        nullptr));
+#endif
                 }
             }
             if (0 == parent_locality_id_)
                 parent_locality_id_ = get_locality_id();
-#endif
-#if defined(HPX_HAVE_APEX)
-            if (parent_thread_id_ != nullptr) {
-                set_apex_data(apex_new_task(get_description(),
-                    parent_thread_id_.get()->get_apex_data()));
-            } else {
-                set_apex_data(apex_new_task(get_description(),
-                    nullptr));
-            }
 #endif
             HPX_ASSERT(init_data.stacksize != 0);
             HPX_ASSERT(coroutine_.is_ready());
@@ -672,19 +674,21 @@ namespace hpx { namespace threads
                 {
                     parent_thread_id_ = threads::get_self_id();
                     parent_thread_phase_ = self->get_thread_phase();
+#if defined(HPX_HAVE_APEX)
+                    // We have a valid parent pointer.
+                    set_apex_data(apex_new_task(get_description(),
+                        parent_thread_id_.get()->get_apex_data()));
+#endif
+                } else {
+#if defined(HPX_HAVE_APEX)
+                    // We do not have a valid parent pointer.
+                    set_apex_data(apex_new_task(get_description(),
+                        nullptr));
+#endif
                 }
             }
             if (0 == parent_locality_id_)
                 parent_locality_id_ = get_locality_id();
-#endif
-#if defined(HPX_HAVE_APEX)
-            if (parent_thread_id_ != nullptr) {
-                set_apex_data(apex_new_task(get_description(),
-                    parent_thread_id_.get()->get_apex_data()));
-            } else {
-                set_apex_data(apex_new_task(get_description(),
-                    nullptr));
-            }
 #endif
         }
 

--- a/hpx/runtime/threads/thread_init_data.hpp
+++ b/hpx/runtime/threads/thread_init_data.hpp
@@ -13,6 +13,7 @@
 #include <hpx/runtime/threads/thread_enums.hpp>
 #include <hpx/runtime/threads_fwd.hpp>
 #include <hpx/util/thread_description.hpp>
+#include <hpx/util/apex.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -38,6 +39,11 @@ namespace hpx { namespace threads
 #if defined(HPX_HAVE_THREAD_PARENT_REFERENCE)
             parent_locality_id(0), parent_id(nullptr), parent_phase(0),
 #endif
+#ifdef HPX_HAVE_APEX
+        /* HPX_HAVE_APEX forces the HPX_HAVE_THREAD_DESCRIPTION
+         * and HPX_HAVE_THREAD_PARENT_REFERENCE settings to be on */
+            apex_data(apex_new_task(description,parent_id)),
+#endif
             priority(thread_priority_normal),
             num_os_thread(std::size_t(-1)),
             stacksize(get_default_stack_size()),
@@ -55,6 +61,11 @@ namespace hpx { namespace threads
 #if defined(HPX_HAVE_THREAD_PARENT_REFERENCE)
             parent_locality_id(rhs.parent_locality_id), parent_id(rhs.parent_id),
             parent_phase(rhs.parent_phase),
+#endif
+#ifdef HPX_HAVE_APEX
+        /* HPX_HAVE_APEX forces the HPX_HAVE_THREAD_DESCRIPTION
+         * and HPX_HAVE_THREAD_PARENT_REFERENCE settings to be on */
+            apex_data(apex_new_task(description,parent_id)),
 #endif
             priority(rhs.priority),
             num_os_thread(rhs.num_os_thread),
@@ -82,6 +93,11 @@ namespace hpx { namespace threads
 #if defined(HPX_HAVE_THREAD_PARENT_REFERENCE)
             parent_locality_id(0), parent_id(nullptr), parent_phase(0),
 #endif
+#ifdef HPX_HAVE_APEX
+        /* HPX_HAVE_APEX forces the HPX_HAVE_THREAD_DESCRIPTION
+         * and HPX_HAVE_THREAD_PARENT_REFERENCE settings to be on */
+            apex_data(apex_new_task(description,parent_id)),
+#endif
             priority(priority_), num_os_thread(os_thread),
             stacksize(stacksize_ == std::ptrdiff_t(-1) ?
                 get_default_stack_size() : stacksize_),
@@ -103,6 +119,11 @@ namespace hpx { namespace threads
         std::uint32_t parent_locality_id;
         threads::thread_id_type parent_id;
         std::size_t parent_phase;
+#endif
+#ifdef HPX_HAVE_APEX
+        /* HPX_HAVE_APEX forces the HPX_HAVE_THREAD_DESCRIPTION
+         * and HPX_HAVE_THREAD_PARENT_REFERENCE settings to be on */
+        void * apex_data;
 #endif
 
         thread_priority priority;

--- a/hpx/util/annotated_function.hpp
+++ b/hpx/util/annotated_function.hpp
@@ -67,25 +67,6 @@ namespace hpx { namespace util
         hpx::util::itt::thread_domain thread_domain_;
         hpx::util::itt::task task_;
     };
-#elif defined(HPX_HAVE_APEX)
-    struct annotate_function
-    {
-        HPX_NON_COPYABLE(annotate_function);
-
-        explicit annotate_function(char const* name)
-        {
-            threads::set_self_apex_data(
-                apex_update_task(threads::get_self_apex_data(),
-                name));
-        }
-        template <typename F>
-        explicit annotate_function(F && f)
-        {
-            threads::set_self_apex_data(
-                apex_update_task(threads::get_self_apex_data(),
-                hpx::util::thread_description(f)));
-        }
-    };
 #else
     struct annotate_function
     {
@@ -96,7 +77,13 @@ namespace hpx { namespace util
                 hpx::threads::set_thread_description(
                     hpx::threads::get_self_id(), name) :
                 nullptr)
-        {}
+        {
+#if defined(HPX_HAVE_APEX)
+            threads::set_self_apex_data(
+                apex_update_task(threads::get_self_apex_data(),
+                desc_));
+#endif
+        }
 
         template <typename F>
         explicit annotate_function(F && f)
@@ -105,7 +92,13 @@ namespace hpx { namespace util
                     hpx::threads::get_self_id(),
                     hpx::util::thread_description(f)) :
                 nullptr)
-        {}
+        {
+#if defined(HPX_HAVE_APEX)
+            threads::set_self_apex_data(
+                apex_update_task(threads::get_self_apex_data(),
+                desc_));
+#endif
+        }
 
         ~annotate_function()
         {

--- a/hpx/util/apex.hpp
+++ b/hpx/util/apex.hpp
@@ -35,19 +35,9 @@ namespace hpx { namespace util
         apex::finalize();
     }
 
-    inline void * apex_new_task(
+    void * apex_new_task(
                 thread_description const& description,
-                void * parent_task)
-    {
-        if (description.kind() ==
-                thread_description::data_type_description) {
-            return (void*)apex::new_task(description.get_description(),
-                UINTMAX_MAX, (apex::task_wrapper*)parent_task);
-        } else {
-            return (void*)apex::new_task(description.get_address(),
-                UINTMAX_MAX, (apex::task_wrapper*)parent_task);
-        }
-    }
+                threads::thread_id_type const& parent_task);
 
     inline void * apex_update_task(void * wrapper,
                 thread_description const& description)

--- a/src/util/apex.cpp
+++ b/src/util/apex.cpp
@@ -1,0 +1,31 @@
+//  Copyright (c) 2007-2013 Kevin Huck
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <hpx/config.hpp>
+#include <hpx/util/apex.hpp>
+#include <hpx/runtime/threads/thread_helpers.hpp>
+#include <hpx/runtime/threads/thread_data.hpp>
+
+namespace hpx { namespace util
+{
+    void * apex_new_task(thread_description const& description,
+           threads::thread_id_type const& parent_task)
+    {
+        apex::task_wrapper* parent_wrapper = nullptr;
+        if (parent_task != nullptr) {
+            parent_wrapper = (apex::task_wrapper*)(parent_task.get()->get_apex_data());
+        }
+        if (description.kind() ==
+                thread_description::data_type_description) {
+            return (void*)apex::new_task(description.get_description(),
+                UINTMAX_MAX, parent_wrapper);
+        } else {
+            return (void*)apex::new_task(description.get_address(),
+                UINTMAX_MAX, parent_wrapper);
+        }
+    }
+}}
+


### PR DESCRIPTION
Fixes #3296 and #3297

## Proposed Changes

  - parent/child dependency is captured when the thread_init_data object is constructed (and the parent is still alive)
  - the apex_data pointer is transferred to the hpx_thread object when the thread is constructed or rebound
  - all dependencies are now correct, and HPX doesn't crash.

## Any background context you want to provide?

This is to support task dependency tracking in HPX and Phylanx.  Currently, this will fix dependencies in OTF2 files completely.  Unfortunately, annotated functions are double-counted when capturing a task graph in APEX, but that is an APEX problem and will soon be fixed.  I also fixed a few compiler warnings.