### PR TITLE
Performance improvements

### DIFF
--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -448,7 +448,7 @@ namespace hpx { namespace lcos { namespace detail
                 if (!this->started_)
                     HPX_THROW_THREAD_INTERRUPTED_EXCEPTION();
 
-                if (this->is_ready_locked(l))
+                if (this->is_ready())
                     return;   // nothing we can do
 
                 if (id_ != threads::invalid_thread_id) {

--- a/hpx/runtime/applier/apply_helper.hpp
+++ b/hpx/runtime/applier/apply_helper.hpp
@@ -12,6 +12,7 @@
 #include <hpx/runtime/actions/action_support.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/runtime/naming/address.hpp>
+#include <hpx/runtime/threads/thread_data_fwd.hpp>
 #include <hpx/runtime/threads/thread_enums.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
 #include <hpx/runtime_fwd.hpp>
@@ -229,7 +230,8 @@ namespace hpx { namespace applier { namespace detail
         {
             // Direct actions should be able to be executed from a
             // non-HPX thread as well
-            if (this_thread::has_sufficient_stack_space() ||
+            if ((nullptr == hpx::threads::get_self_ptr()) ||
+                this_thread::has_sufficient_stack_space() ||
                 !threads::threadmanager_is_at_least(state_running))
             {
                 call_sync<Action>(lva, comptype, std::forward<Ts>(vs)...);
@@ -250,7 +252,8 @@ namespace hpx { namespace applier { namespace detail
         {
             // Direct actions should be able to be executed from a
             // non-HPX thread as well
-            if (this_thread::has_sufficient_stack_space() ||
+            if ((nullptr == hpx::threads::get_self_ptr()) ||
+                this_thread::has_sufficient_stack_space() ||
                 !threads::threadmanager_is_at_least(state_running))
             {
                 call_sync<Action>(std::forward<Continuation>(cont), lva,

--- a/hpx/runtime/components/component_type.hpp
+++ b/hpx/runtime/components/component_type.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //  Copyright (c)      2017 Thomas Heller
 //  Copyright (c)      2011 Bryce Lelbach
 //
@@ -56,12 +56,12 @@ namespace hpx { namespace components
         component_base_lco_with_value = 6,
 
         // Synchronization latch, barrier, and flex_barrier LCOs.
-        component_latch = ((7 << 16) | component_base_lco_with_value),
-        component_barrier = ((8 << 16) | component_base_lco),
-        component_flex_barrier = ((9 << 16) | component_base_lco),
+        component_latch = ((7 << 10) | component_base_lco_with_value),
+        component_barrier = ((8 << 10) | component_base_lco),
+        component_flex_barrier = ((9 << 10) | component_base_lco),
 
         // An LCO representing a value which may not have been computed yet.
-        component_promise = ((10 << 16) | component_base_lco_with_value),
+        component_promise = ((10 << 10) | component_base_lco_with_value),
 
         // AGAS locality services.
         component_agas_locality_namespace = 11,
@@ -78,8 +78,8 @@ namespace hpx { namespace components
         component_last,
         component_first_dynamic = component_last,
 
-        // Force this enum type to be at least 32 bits.
-        component_upper_bound = 0x7fffffffL    //-V112
+        // Force this enum type to be at least 20 bits.
+        component_upper_bound = 0xfffffL    //-V112
     };
 
     enum factory_state_enum
@@ -102,13 +102,13 @@ namespace hpx { namespace components
     /// exposing the actions.
     inline component_type get_base_type(component_type t)
     {
-        return component_type(t & 0xFFFF);
+        return component_type(t & 0x3FF);
     }
 
     /// The upper short word of the component is the actual component type
     inline component_type get_derived_type(component_type t)
     {
-        return component_type((t >> 16) & 0xFFFF);
+        return component_type((t >> 10) & 0x3FF);
     }
 
     /// A component derived from a base component exposing the actions needs to
@@ -116,7 +116,7 @@ namespace hpx { namespace components
     inline component_type
     derived_component_type(component_type derived, component_type base)
     {
-        return component_type(derived << 16 | base);
+        return component_type(derived << 10 | base);
     }
 
     /// \brief Verify the two given component types are matching (compatible)

--- a/hpx/runtime/components/server/component_base.hpp
+++ b/hpx/runtime/components/server/component_base.hpp
@@ -119,8 +119,11 @@ namespace hpx { namespace components
             // with the AGAS service
             //
             // Returns he global id (GID) assigned to this instance of a component
-            HPX_EXPORT naming::gid_type get_base_gid(
+            HPX_EXPORT naming::gid_type get_base_gid_dynamic(
                 naming::gid_type const& assign_gid,
+                naming::address const& addr) const;
+
+            HPX_EXPORT naming::gid_type get_base_gid(
                 naming::address const& addr) const;
 
         protected:
@@ -200,7 +203,8 @@ namespace hpx { namespace components
         naming::gid_type get_base_gid(
             naming::gid_type const& assign_gid = naming::invalid_gid) const
         {
-            return this->detail::base_component::get_base_gid(assign_gid,
+            HPX_ASSERT(!assign_gid);        // migration is not supported here
+            return this->detail::base_component::get_base_gid(
                 static_cast<Component const&>(*this).get_current_address());
         }
     };

--- a/hpx/runtime/components/server/component_base.hpp
+++ b/hpx/runtime/components/server/component_base.hpp
@@ -120,11 +120,12 @@ namespace hpx { namespace components
             //
             // Returns he global id (GID) assigned to this instance of a component
             HPX_EXPORT naming::gid_type get_base_gid_dynamic(
-                naming::gid_type const& assign_gid,
-                naming::address const& addr) const;
+                naming::gid_type const& assign_gid, naming::address const& addr,
+                naming::gid_type (*f)(naming::gid_type) = nullptr) const;
 
             HPX_EXPORT naming::gid_type get_base_gid(
-                naming::address const& addr) const;
+                naming::address const& addr,
+                naming::gid_type (*f)(naming::gid_type) = nullptr) const;
 
         protected:
             mutable naming::gid_type gid_;

--- a/hpx/runtime/components/server/fixed_component_base.hpp
+++ b/hpx/runtime/components/server/fixed_component_base.hpp
@@ -63,8 +63,7 @@ public:
       , lsb_(lsb)
     {}
 
-    ~fixed_component_base()
-    {}
+    ~fixed_component_base() = default;
 
     /// \brief finalize() will be called just before the instance gets
     ///        destructed
@@ -165,10 +164,18 @@ public:
     }
 
     // Pinning functionality
-    void pin() {}
-    void unpin() {}
-    std::uint32_t pin_count() const { return 0; }
+    HPX_CXX14_CONSTEXPR static void pin() {}
+    HPX_CXX14_CONSTEXPR static void unpin() {}
+    HPX_CONSTEXPR static std::uint32_t pin_count() { return 0; }
 
+#if defined(HPX_DISABLE_ASSERTS) || defined(BOOST_DISABLE_ASSERTS) || defined(NDEBUG)
+    HPX_CXX14_CONSTEXPR static void mark_as_migrated()
+    {
+    }
+    HPX_CXX14_CONSTEXPR static void on_migrated()
+    {
+    }
+#else
     void mark_as_migrated()
     {
         // If this assertion is triggered then this component instance is being
@@ -184,6 +191,7 @@ public:
         // migration.
         HPX_ASSERT(false);
     }
+#endif
 
 private:
     mutable naming::gid_type gid_;
@@ -196,6 +204,15 @@ namespace detail
     ///////////////////////////////////////////////////////////////////////
     struct fixed_heap
     {
+#if defined(HPX_DISABLE_ASSERTS) || defined(BOOST_DISABLE_ASSERTS) || defined(NDEBUG)
+        HPX_CONSTEXPR static void* alloc(std::size_t count)
+        {
+            return nullptr;
+        }
+        HPX_CXX14_CONSTEXPR static void free(void* p, std::size_t count)
+        {
+        }
+#else
         static void* alloc(std::size_t count)
         {
             HPX_ASSERT(false);        // this shouldn't ever be called
@@ -205,6 +222,7 @@ namespace detail
         {
             HPX_ASSERT(false);        // this shouldn't ever be called
         }
+#endif
     };
 }
 
@@ -218,6 +236,16 @@ class fixed_component : public Component
     typedef component_type derived_type;
     typedef detail::fixed_heap heap_type;
 
+#if defined(HPX_DISABLE_ASSERTS) || defined(BOOST_DISABLE_ASSERTS) || defined(NDEBUG)
+    HPX_CONSTEXPR static Component* create(std::size_t count)
+    {
+        return nullptr;
+    }
+
+    HPX_CXX14_CONSTEXPR static void destroy(Component* p, std::size_t count = 1)
+    {
+    }
+#else
     /// \brief  The function \a create is used for allocation and
     ///         initialization of instances of the derived components.
     static Component* create(std::size_t count)
@@ -232,6 +260,7 @@ class fixed_component : public Component
     {
         HPX_ASSERT(false);        // this shouldn't ever be called
     }
+#endif
 };
 
 }}

--- a/hpx/runtime/components/server/migration_support.hpp
+++ b/hpx/runtime/components/server/migration_support.hpp
@@ -54,16 +54,23 @@ namespace hpx { namespace components
         naming::gid_type get_base_gid(
             naming::gid_type const& assign_gid = naming::invalid_gid) const
         {
-            // we don't store migrating objects in the AGAS cache
             naming::gid_type result =
-                this->detail::base_component::get_base_gid_dynamic(assign_gid,
-                    static_cast<Component const&>(*this).get_current_address());
-            naming::detail::set_dont_store_in_cache(result);
+                this->BaseComponent::get_base_gid_dynamic(assign_gid,
+                    static_cast<this_component_type const&>(*this)
+                        .get_current_address(),
+                    [](naming::gid_type gid) -> naming::gid_type
+                    {
+                        // we don't store migrating objects in the AGAS cache
+                        naming::detail::set_dont_store_in_cache(gid);
+                        // also mark gid as migratable
+                        naming::detail::set_is_migratable(gid);
+                        return gid;
+                    });
             return result;
         }
 
         // This component type supports migration.
-        static HPX_CONSTEXPR bool supports_migration() { return true; }
+        HPX_CONSTEXPR static bool supports_migration() { return true; }
 
         // Pinning functionality
         void pin()
@@ -160,7 +167,7 @@ namespace hpx { namespace components
 
         /// This hook is invoked on the newly created object after the migration
         /// has been finished
-        void on_migrated() {}
+        HPX_CXX14_CONSTEXPR void on_migrated() {}
 
         typedef void decorates_action;
 

--- a/hpx/runtime/components/server/migration_support.hpp
+++ b/hpx/runtime/components/server/migration_support.hpp
@@ -55,7 +55,9 @@ namespace hpx { namespace components
             naming::gid_type const& assign_gid = naming::invalid_gid) const
         {
             // we don't store migrating objects in the AGAS cache
-            naming::gid_type result = this->base_type::get_base_gid(assign_gid);
+            naming::gid_type result =
+                this->detail::base_component::get_base_gid_dynamic(assign_gid,
+                    static_cast<Component const&>(*this).get_current_address());
             naming::detail::set_dont_store_in_cache(result);
             return result;
         }

--- a/hpx/runtime/naming/name.hpp
+++ b/hpx/runtime/naming/name.hpp
@@ -81,10 +81,13 @@ namespace hpx { namespace naming
         static std::uint64_t const locality_id_mask = 0xffffffff00000000ull;
         static std::uint16_t const locality_id_shift = 32; //-V112
 
-        static std::uint64_t const virtual_memory_mask = 0x7fffffull;
+        static std::uint64_t const virtual_memory_mask = 0x3fffffull;
 
         // don't cache this id in the AGAS caches
         static std::uint64_t const dont_cache_mask = 0x800000ull; //-V112
+
+        // the object is migratable
+        static std::uint64_t const is_migratable = 0x400000ull; //-V112
 
         // Bit 64 is set for all dynamically assigned ids (if this is not set
         // then the lsb corresponds to the lva of the referenced object).
@@ -100,7 +103,8 @@ namespace hpx { namespace naming
         static std::uint64_t const credit_bits_mask =
             credit_mask | was_split_mask | has_credits_mask;
         static std::uint64_t const internal_bits_mask = credit_bits_mask |
-            is_locked_mask | dont_cache_mask | component_type_mask;
+            is_locked_mask | dont_cache_mask | is_migratable |
+            component_type_mask;
         static std::uint64_t const special_bits_mask =
             locality_id_mask | internal_bits_mask;
 
@@ -536,6 +540,17 @@ namespace hpx { namespace naming
         inline void set_dont_store_in_cache(id_type& id)
         {
             id.set_msb(id.get_msb() | gid_type::dont_cache_mask);
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        inline bool is_migratable(gid_type const& id)
+        {
+            return (id.get_msb() & gid_type::is_migratable) ? true : false;
+        }
+
+        inline void set_is_migratable(gid_type& gid)
+        {
+            gid.set_msb(gid.get_msb() | gid_type::is_migratable);
         }
 
         ///////////////////////////////////////////////////////////////////////

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -869,6 +869,7 @@ bool addressing_service::is_local_address_cached(
     // Assume non-local operation if the gid is known to have been migrated
     naming::gid_type id(naming::detail::get_stripped_gid_except_dont_cache(gid));
 
+    if (naming::detail::is_migratable(gid))
     {
         std::lock_guard<mutex_type> lock(migrated_objects_mtx_);
         if (was_object_migrated_locked(id))
@@ -1126,6 +1127,7 @@ bool addressing_service::resolve_cached(
     }
 
     // force routing if target object was migrated
+    if (naming::detail::is_migratable(id))
     {
         std::lock_guard<mutex_type> lock(migrated_objects_mtx_);
         if (was_object_migrated_locked(id))
@@ -2615,6 +2617,8 @@ hpx::future<void> addressing_service::mark_as_migrated(
                 "invalid reference gid"));
     }
 
+    HPX_ASSERT(naming::detail::is_migratable(gid_));
+
     naming::gid_type gid(naming::detail::get_stripped_gid(gid_));
 
     // Always first grab the AGAS lock before invoking the user supplied
@@ -2668,6 +2672,8 @@ void addressing_service::unmark_as_migrated(
         return;
     }
 
+    HPX_ASSERT(naming::detail::is_migratable(gid_));
+
     naming::gid_type gid(naming::detail::get_stripped_gid(gid_));
 
     std::unique_lock<mutex_type> lock(migrated_objects_mtx_);
@@ -2704,6 +2710,8 @@ addressing_service::begin_migration(naming::id_type const& id)
             "invalid reference id");
     }
 
+    HPX_ASSERT(naming::detail::is_migratable(id.get_gid()));
+
     naming::gid_type gid(naming::detail::get_stripped_gid(id.get_gid()));
 
     return primary_ns_.begin_migration(gid);
@@ -2719,6 +2727,8 @@ bool addressing_service::end_migration(
             "addressing_service::end_migration_async",
             "invalid reference id");
     }
+
+    HPX_ASSERT(naming::detail::is_migratable(id.get_gid()));
 
     naming::gid_type gid(naming::detail::get_stripped_gid(id.get_gid()));
 
@@ -2748,6 +2758,11 @@ std::pair<bool, components::pinned_ptr>
             "addressing_service::was_object_migrated",
             "invalid reference gid");
         return std::make_pair(false, components::pinned_ptr());
+    }
+
+    if (!naming::detail::is_migratable(gid))
+    {
+        return std::make_pair(false, f());
     }
 
     // Always first grab the AGAS lock before invoking the user supplied

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -937,31 +937,41 @@ bool addressing_service::resolve_locally_known_addresses(
 {
     // LVA-encoded GIDs (located on this machine)
     std::uint64_t lsb = id.get_lsb();
-    std::uint64_t msb =
-        naming::detail::strip_internal_bits_from_gid(id.get_msb());
+    std::uint64_t msb = id.get_msb();
 
     if (is_local_lva_encoded_address(msb))
     {
         addr.locality_ = get_local_locality();
 
         // An LSB of 0 references the runtime support component
-        HPX_ASSERT(rts_lva_);
-
         if (0 == lsb || lsb == rts_lva_)
         {
+            HPX_ASSERT(rts_lva_);
+
             addr.type_ = components::component_runtime_support;
             addr.address_ = rts_lva_;
+            return true;
         }
-        else
+
+        if (naming::refers_to_virtual_memory(msb))
         {
             HPX_ASSERT(mem_lva_);
 
             addr.type_ = components::component_memory;
             addr.address_ = mem_lva_;
+            return true;
         }
 
-        return true;
+        if (naming::refers_to_local_lva(id))
+        {
+            // handle (non-migratable) components located on this locality first
+            addr.type_ = naming::detail::get_component_type_from_gid(msb);
+            addr.address_ = lsb;
+            return true;
+        }
     }
+
+    msb = naming::detail::strip_internal_bits_from_gid(msb);
 
     // explicitly resolve localities
     if (naming::is_locality(id))

--- a/src/runtime/agas/server/primary_namespace_server.cpp
+++ b/src/runtime/agas/server/primary_namespace_server.cpp
@@ -500,7 +500,10 @@ primary_namespace::resolved_type primary_namespace::resolve_gid(naming::gid_type
         std::unique_lock<mutex_type> l(mutex_);
 
         // wait for any migration to be completed
-        wait_for_migration_locked(l, id, hpx::throws);
+        if (naming::detail::is_migratable(id))
+        {
+            wait_for_migration_locked(l, id, hpx::throws);
+        }
 
         // now, resolve the id
         r = resolve_gid_locked(l, id, hpx::throws);
@@ -882,8 +885,11 @@ void primary_namespace::resolve_free_list(
         // The mapping's key space.
         key_type gid = it->first;
 
-        // wait for any migration to be completed
-        wait_for_migration_locked(l, gid, ec);
+        if (naming::detail::is_migratable(gid))
+        {
+            // wait for any migration to be completed
+            wait_for_migration_locked(l, gid, ec);
+        }
 
         // Resolve the query GID.
         resolved_type r = resolve_gid_locked(l, gid, ec);

--- a/src/runtime/agas/server/route.cpp
+++ b/src/runtime/agas/server/route.cpp
@@ -59,7 +59,10 @@ namespace hpx { namespace agas { namespace server
             std::unique_lock<mutex_type> l(mutex_);
 
             // wait for any migration to be completed
-            wait_for_migration_locked(l, gid, ec);
+            if (naming::detail::is_migratable(gid))
+            {
+                wait_for_migration_locked(l, gid, ec);
+            }
 
             cache_address = resolve_gid_locked(l, gid, ec);
 

--- a/src/runtime/components/server/component_base.cpp
+++ b/src/runtime/components/server/component_base.cpp
@@ -18,6 +18,7 @@
 #include <hpx/throw_exception.hpp>
 #include <hpx/util/assert.hpp>
 
+#include <cstdint>
 #include <mutex>
 #include <sstream>
 

--- a/src/runtime/components/server/component_base.cpp
+++ b/src/runtime/components/server/component_base.cpp
@@ -33,13 +33,22 @@ namespace hpx { namespace components { namespace detail
     }
 
     naming::gid_type base_component::get_base_gid_dynamic(
-        naming::gid_type const& assign_gid, naming::address const& addr) const
+        naming::gid_type const& assign_gid, naming::address const& addr,
+        naming::gid_type (*f)(naming::gid_type)) const
     {
         if (!gid_)
         {
             if (!assign_gid)
             {
-                gid_ = hpx::detail::get_next_id();
+                if (f != nullptr)
+                {
+                    gid_ = f(hpx::detail::get_next_id());
+                }
+                else
+                {
+                    gid_ = hpx::detail::get_next_id();
+                }
+
                 if (!applier::bind_gid_local(gid_, addr))
                 {
                     std::ostringstream strm;
@@ -98,13 +107,20 @@ namespace hpx { namespace components { namespace detail
         return gid;
     }
 
-    naming::gid_type base_component::get_base_gid(
-        naming::address const& addr) const
+    naming::gid_type base_component::get_base_gid(naming::address const& addr,
+        naming::gid_type (*f)(naming::gid_type)) const
     {
         if (!gid_)
         {
             // generate purely local gid
-            gid_ = naming::gid_type(addr.address_);
+            if (f != nullptr)
+            {
+                gid_ = f(naming::gid_type(addr.address_));
+            }
+            else
+            {
+                gid_ = naming::gid_type(addr.address_);
+            }
 
             naming::detail::set_credit_for_gid(
                 gid_, std::int64_t(HPX_GLOBALCREDIT_INITIAL));

--- a/tools/VS/gid_type.natvis
+++ b/tools/VS/gid_type.natvis
@@ -12,15 +12,16 @@
   <Type Name="hpx::naming::gid_type">
     <DisplayString>{{ msb={id_msb_,x} lsb={id_lsb_,x} }}</DisplayString>
     <Expand>
-      <Item Name="[msb]">id_msb_ &amp; 0x7fffffull,x</Item>
+      <Item Name="[msb]">id_msb_ &amp; 0x1ull,x</Item>
       <Item Name="[lsb]">id_lsb_,x</Item>
       <Item Name="[has_credit]">(id_msb_ &amp; 0x40000000ull) ? true : false</Item>
-      <Item Condition="(id_msb_ &amp; 0x40000000ull) != 0" Name="[log2credits]">(id_msb_ &gt;&gt; 24) &amp; 0x1full</Item>
-      <Item Condition="(id_msb_ &amp; 0x40000000ull) != 0" Name="[credits]">1ull &lt;&lt; ((id_msb_ &gt;&gt; 24) &amp; 0x1full),x</Item>
+      <Item Condition="(id_msb_ &amp; 0x40000000ull) != 0" Name="[log2credits]">(int)(id_msb_ &gt;&gt; 24) &amp; 0x1full</Item>
+      <Item Condition="(id_msb_ &amp; 0x40000000ull) != 0" Name="[credits]">1ull &lt;&lt; ((id_msb_ &gt;&gt; 24) &amp; 0x1f),x</Item>
       <Item Condition="(id_msb_ &amp; 0x40000000ull) != 0" Name="[was_split]">(id_msb_ &amp; 0x80000000ull) ? true : false</Item>
       <Item Name="[is_locked]">(id_msb_ &amp; 0x20000000ull) ? true : false</Item>
       <Item Name="[dont_cache]">(id_msb_ &amp; 0x00800000ull) ? true : false</Item>
-      <Item Condition="((id_msb_ &gt;&gt; 32) &amp; 0xffffffffull) != 0" Name="[locality_id]">((id_msb_ &gt;&gt; 32) &amp; 0xffffffffull) - 1</Item>
+      <Item Condition="((id_msb_ &gt;&gt; 32) &amp; 0xffffffffull) != 0" Name="[locality_id]">(unsigned int)((id_msb_ &gt;&gt; 32) &amp; 0xffffffffull) - 1</Item>
+      <Item Condition="(id_msb_ &amp; 1ull) == 0" Name="[comptype]">(hpx::components::component_enum_type)((id_msb_ &gt;&gt; 1ull) &amp; 0xfffffull)</Item>
     </Expand>
   </Type>
 
@@ -28,16 +29,17 @@
     <DisplayString  Condition="gid_.px == 0">empty</DisplayString>
     <DisplayString  Condition="gid_.px != 0">{{ msb={gid_.px->id_msb_,x} lsb={gid_.px->id_lsb_,x} }}</DisplayString>
     <Expand>
-      <Item Condition="gid_.px != 0" Name="[msb]">gid_.px->id_msb_ &amp; 0x7fffffull,x</Item>
+      <Item Condition="gid_.px != 0" Name="[msb]">gid_.px->id_msb_ &amp; 0x1ull,x</Item>
       <Item Condition="gid_.px != 0" Name="[lsb]">gid_.px->id_lsb_,x</Item>
       <Item Condition="gid_.px != 0" Name="[type]">gid_.px->type_</Item>
-      <Item Condition="gid_.px != 0 &lt;&lt; (gid_.px->type_ != unmanaged) != 0" Name="[has_credit]">(gid_.px->id_msb_ &amp; 0x40000000ull) ? true : false</Item>
-      <Item Condition="gid_.px != 0 &lt;&lt; (gid_.px->type_ != unmanaged) != 0" Name="[log2credits]">(gid_.px->id_msb_ &gt;&gt; 24) &amp; 0x1full</Item>
-      <Item Condition="gid_.px != 0 &lt;&lt; (gid_.px->type_ != unmanaged) != 0" Name="[credits]">1ull &lt;&lt; ((gid_.px->id_msb_ &gt;&gt; 24) &amp; 0x1full),x</Item>
-      <Item Condition="gid_.px != 0 &lt;&lt; (gid_.px->type_ != unmanaged) != 0" Name="[was_split]">(gid_.px->id_msb_ &amp; 0x80000000ull) ? true : false</Item>
+      <Item Condition="gid_.px != 0 &amp;&amp; (gid_.px->type_ != unmanaged) != 0" Name="[has_credit]">(gid_.px->id_msb_ &amp; 0x40000000ull) ? true : false</Item>
+      <Item Condition="gid_.px != 0 &amp;&amp; (gid_.px->type_ != unmanaged) != 0" Name="[log2credits]">(int)(gid_.px->id_msb_ &gt;&gt; 24) &amp; 0x1f</Item>
+      <Item Condition="gid_.px != 0 &amp;&amp; (gid_.px->type_ != unmanaged) != 0" Name="[credits]">1ull &lt;&lt; ((gid_.px->id_msb_ &gt;&gt; 24) &amp; 0x1full),x</Item>
+      <Item Condition="gid_.px != 0 &amp;&amp; (gid_.px->type_ != unmanaged) != 0" Name="[was_split]">(gid_.px->id_msb_ &amp; 0x80000000ull) ? true : false</Item>
       <Item Condition="gid_.px != 0" Name="[is_locked]">(gid_.px->id_msb_ &amp; 0x20000000ull) ? true : false</Item>
       <Item Condition="gid_.px != 0" Name="[dont_cache]">(gid_.px->id_msb_ &amp; 0x00800000ull) ? true : false</Item>
-      <Item Condition="gid_.px != 0 &lt;&lt; ((gid_.px->id_msb_ &gt;&gt; 32) &amp; 0xffffffffull) != 0" Name="[locality_id]">((gid_.px->id_msb_ &gt;&gt; 32) &amp; 0xffffffffull) - 1</Item>
+      <Item Condition="gid_.px != 0 &amp;&amp; ((gid_.px->id_msb_ &gt;&gt; 32) &amp; 0xffffffffull) != 0" Name="[locality_id]">(unsigned int)((gid_.px->id_msb_ &gt;&gt; 32) &amp; 0xffffffffull) - 1</Item>
+      <Item Condition="gid_.px != 0 &amp;&amp; (gid_.px->id_msb_ &amp; 1ull) == 0" Name="[comptype]">(hpx::components::component_enum_type)((gid_.px->id_msb_ &gt;&gt; 1ull) &amp; 0xfffffull)</Item>
       <Item Condition="gid_.px != 0" Name="[count]">gid_.px->count_.value_</Item>
     </Expand>
   </Type>

--- a/tools/VS/gid_type.natvis
+++ b/tools/VS/gid_type.natvis
@@ -20,6 +20,7 @@
       <Item Condition="(id_msb_ &amp; 0x40000000ull) != 0" Name="[was_split]">(id_msb_ &amp; 0x80000000ull) ? true : false</Item>
       <Item Name="[is_locked]">(id_msb_ &amp; 0x20000000ull) ? true : false</Item>
       <Item Name="[dont_cache]">(id_msb_ &amp; 0x00800000ull) ? true : false</Item>
+      <Item Name="[migratable]">(id_msb_ &amp; 0x00400000ull) ? true : false</Item>
       <Item Condition="((id_msb_ &gt;&gt; 32) &amp; 0xffffffffull) != 0" Name="[locality_id]">(unsigned int)((id_msb_ &gt;&gt; 32) &amp; 0xffffffffull) - 1</Item>
       <Item Condition="(id_msb_ &amp; 1ull) == 0" Name="[comptype]">(hpx::components::component_enum_type)((id_msb_ &gt;&gt; 1ull) &amp; 0xfffffull)</Item>
     </Expand>
@@ -38,6 +39,7 @@
       <Item Condition="gid_.px != 0 &amp;&amp; (gid_.px->type_ != unmanaged) != 0" Name="[was_split]">(gid_.px->id_msb_ &amp; 0x80000000ull) ? true : false</Item>
       <Item Condition="gid_.px != 0" Name="[is_locked]">(gid_.px->id_msb_ &amp; 0x20000000ull) ? true : false</Item>
       <Item Condition="gid_.px != 0" Name="[dont_cache]">(gid_.px->id_msb_ &amp; 0x00800000ull) ? true : false</Item>
+      <Item Condition="gid_.px != 0" Name="[migratable]">(gid_.px->id_msb_ &amp; 0x00400000ull) ? true : false</Item>
       <Item Condition="gid_.px != 0 &amp;&amp; ((gid_.px->id_msb_ &gt;&gt; 32) &amp; 0xffffffffull) != 0" Name="[locality_id]">(unsigned int)((gid_.px->id_msb_ &gt;&gt; 32) &amp; 0xffffffffull) - 1</Item>
       <Item Condition="gid_.px != 0 &amp;&amp; (gid_.px->id_msb_ &amp; 1ull) == 0" Name="[comptype]">(hpx::components::component_enum_type)((gid_.px->id_msb_ &gt;&gt; 1ull) &amp; 0xfffffull)</Item>
       <Item Condition="gid_.px != 0" Name="[count]">gid_.px->count_.value_</Item>


### PR DESCRIPTION
This PR is a collection of performance improvements:

- AGAS: all non-migratable (non-managed) components now store their lva and component type directly in the gid
- AGAS: all migratable component now have a special bit set in their gid
- LCOS: future state is now stored as a `std::atomic<state>`