### PR TITLE
Add nullptr_t overloads to resource partitioner

### DIFF
--- a/hpx/runtime/resource/detail/create_partitioner.hpp
+++ b/hpx/runtime/resource/detail/create_partitioner.hpp
@@ -136,6 +136,58 @@ namespace hpx { namespace resource { namespace detail
             desc_cmdline, argc, argv, std::move(ini_config), rpmode, mode,
             check);
     }
+
+    inline partitioner& create_partitioner(
+        std::nullptr_t f, int argc, char** argv,
+        resource::partitioner_mode rpmode = resource::mode_default,
+        hpx::runtime_mode mode = hpx::runtime_mode_default, bool check = true)
+    {
+        boost::program_options::options_description desc_cmdline(
+            std::string("Usage: ") + HPX_APPLICATION_STRING + " [options]");
+
+        util::set_hpx_prefix(HPX_PREFIX);
+
+        return create_partitioner(
+            util::function_nonser<
+                int(boost::program_options::variables_map& vm)
+            >(),
+            desc_cmdline, argc, argv, std::vector<std::string>(), rpmode, mode,
+            check);
+    }
+
+    inline partitioner& create_partitioner(
+        std::nullptr_t f, int argc, char** argv,
+        std::vector<std::string> const& cfg,
+        resource::partitioner_mode rpmode = resource::mode_default,
+        hpx::runtime_mode mode = hpx::runtime_mode_default, bool check = true)
+    {
+        boost::program_options::options_description desc_cmdline(
+            std::string("Usage: ") + HPX_APPLICATION_STRING + " [options]");
+
+        util::set_hpx_prefix(HPX_PREFIX);
+
+        return create_partitioner(
+            util::function_nonser<
+                int(boost::program_options::variables_map& vm)
+            >(),
+            desc_cmdline, argc, argv, cfg, rpmode, mode, check);
+    }
+
+    inline partitioner& create_partitioner(
+        std::nullptr_t f,
+        boost::program_options::options_description const& desc_cmdline,
+        int argc, char** argv, std::vector<std::string> const& cfg,
+        resource::partitioner_mode rpmode = resource::mode_default,
+        hpx::runtime_mode mode = hpx::runtime_mode_default, bool check = true)
+    {
+        util::set_hpx_prefix(HPX_PREFIX);
+
+        return create_partitioner(
+            util::function_nonser<
+                int(boost::program_options::variables_map& vm)
+            >(),
+            desc_cmdline, argc, argv, cfg, rpmode, mode, check);
+    }
 #endif
 }}}
 

--- a/hpx/runtime/resource/partitioner.hpp
+++ b/hpx/runtime/resource/partitioner.hpp
@@ -190,6 +190,31 @@ namespace hpx { namespace resource
           : partitioner_(detail::create_partitioner(
                 desc_cmdline, argc, argv, std::move(ini_config), rpmode, mode))
         {}
+
+        partitioner(std::nullptr_t f, int argc, char** argv,
+            resource::partitioner_mode rpmode = resource::mode_default,
+            hpx::runtime_mode mode = hpx::runtime_mode_default)
+          : partitioner_(
+                detail::create_partitioner(f, argc, argv, rpmode, mode))
+        {}
+
+        partitioner(std::nullptr_t f, int argc, char** argv,
+            std::vector<std::string> const& cfg,
+            resource::partitioner_mode rpmode = resource::mode_default,
+            hpx::runtime_mode mode = hpx::runtime_mode_default)
+          : partitioner_(
+                detail::create_partitioner(f, argc, argv, cfg, rpmode, mode))
+        {}
+
+        partitioner(std::nullptr_t f,
+            boost::program_options::options_description const& desc_cmdline,
+            int argc, char** argv, std::vector<std::string> ini_config,
+            resource::partitioner_mode rpmode = resource::mode_default,
+            runtime_mode mode = runtime_mode_default)
+            : partitioner_(detail::create_partitioner(
+                  f, desc_cmdline, argc, argv, std::move(ini_config), rpmode,
+                  mode))
+        {}
 #endif
 
         ///////////////////////////////////////////////////////////////////////

--- a/tests/unit/resource/suspend_pool_external.cpp
+++ b/tests/unit/resource/suspend_pool_external.cpp
@@ -23,12 +23,6 @@
 #include <utility>
 #include <vector>
 
-// NOTE: Needed for now when initializing resource partitioner separately.
-int hpx_main()
-{
-    return 0;
-}
-
 void test_scheduler(int argc, char* argv[],
     hpx::resource::scheduling_policy scheduler)
 {
@@ -37,7 +31,7 @@ void test_scheduler(int argc, char* argv[],
         "hpx.os_threads=4"
     };
 
-    hpx::resource::partitioner rp(argc, argv, std::move(cfg));
+    hpx::resource::partitioner rp(nullptr, argc, argv, std::move(cfg));
 
     rp.create_thread_pool("default", scheduler);
 

--- a/tests/unit/resource/suspend_runtime.cpp
+++ b/tests/unit/resource/suspend_runtime.cpp
@@ -7,6 +7,7 @@
 
 #include <hpx/hpx_start.hpp>
 #include <hpx/hpx_suspend.hpp>
+#include <hpx/include/apply.hpp>
 #include <hpx/include/async.hpp>
 #include <hpx/include/threadmanager.hpp>
 #include <hpx/include/threads.hpp>
@@ -18,12 +19,6 @@
 #include <utility>
 #include <vector>
 
-// NOTE: Needed for now when initializing resource partitioner separately.
-int hpx_main()
-{
-    return 0;
-}
-
 void test_scheduler(int argc, char* argv[],
     hpx::resource::scheduling_policy scheduler)
 {
@@ -32,11 +27,11 @@ void test_scheduler(int argc, char* argv[],
         "hpx.os_threads=4"
     };
 
-    hpx::resource::partitioner rp(argc, argv, std::move(cfg));
+    hpx::resource::partitioner rp(nullptr, argc, argv, std::move(cfg));
 
     rp.create_thread_pool("default", scheduler);
 
-    hpx::start(argc, argv, cfg);
+    hpx::start(nullptr, argc, argv);
 
     // Wait for runtime to start
     hpx::runtime* rt = hpx::get_runtime_ptr();
@@ -61,7 +56,7 @@ void test_scheduler(int argc, char* argv[],
     }
 
     hpx::resume();
-    hpx::async([]() { hpx::finalize(); });
+    hpx::apply([]() { hpx::finalize(); });
     HPX_TEST_EQ(hpx::stop(), 0);
 }
 


### PR DESCRIPTION
Adds `nullptr_t` overloads to the resource partitioner (as previously for `hpx::init` and `start`). This is needed if one wants to use the resource partitioner and not set an entrypoint (since `hpx::init` and `start` have no effect after the resource partitioner has been created).

Also cleans up some suspension tests where `hpx_main` was not used.