### PR TITLE
Marking migratable objects in their gid to allow not handling migration in AGAS

### DIFF
--- a/hpx/runtime/components/server/migration_support.hpp
+++ b/hpx/runtime/components/server/migration_support.hpp
@@ -62,6 +62,8 @@ namespace hpx { namespace components
                     {
                         // we don't store migrating objects in the AGAS cache
                         naming::detail::set_dont_store_in_cache(gid);
+                        // also mark gid as migratable
+                        naming::detail::set_is_migratable(gid);
                         return gid;
                     });
             return result;

--- a/hpx/runtime/naming/name.hpp
+++ b/hpx/runtime/naming/name.hpp
@@ -84,10 +84,13 @@ namespace hpx { namespace naming
         static std::uint64_t const locality_id_mask = 0xffffffff00000000ull;
         static std::uint16_t const locality_id_shift = 32; //-V112
 
-        static std::uint64_t const virtual_memory_mask = 0x7fffffull;
+        static std::uint64_t const virtual_memory_mask = 0x3fffffull;
 
         // don't cache this id in the AGAS caches
         static std::uint64_t const dont_cache_mask = 0x800000ull; //-V112
+
+        // the object is migratable
+        static std::uint64_t const is_migratable = 0x400000ull; //-V112
 
         // Bit 64 is set for all dynamically assigned ids (if this is not set
         // then the lsb corresponds to the lva of the referenced object).
@@ -103,7 +106,7 @@ namespace hpx { namespace naming
         static std::uint64_t const credit_bits_mask =
             credit_mask | was_split_mask | has_credits_mask;
         static std::uint64_t const internal_bits_mask = credit_bits_mask |
-            is_locked_mask | dont_cache_mask;
+            is_locked_mask | dont_cache_mask | is_migratable;
         static std::uint64_t const special_bits_mask =
             locality_id_mask | internal_bits_mask | component_type_mask;
 
@@ -548,6 +551,17 @@ namespace hpx { namespace naming
         inline void set_dont_store_in_cache(id_type& id)
         {
             id.set_msb(id.get_msb() | gid_type::dont_cache_mask);
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        inline bool is_migratable(gid_type const& id)
+        {
+            return (id.get_msb() & gid_type::is_migratable) ? true : false;
+        }
+
+        inline void set_is_migratable(gid_type& gid)
+        {
+            gid.set_msb(gid.get_msb() | gid_type::is_migratable);
         }
 
         ///////////////////////////////////////////////////////////////////////

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -869,6 +869,7 @@ bool addressing_service::is_local_address_cached(
     // Assume non-local operation if the gid is known to have been migrated
     naming::gid_type id(naming::detail::get_stripped_gid_except_dont_cache(gid));
 
+    if (naming::detail::is_migratable(gid))
     {
         std::lock_guard<mutex_type> lock(migrated_objects_mtx_);
         if (was_object_migrated_locked(id))
@@ -1126,6 +1127,7 @@ bool addressing_service::resolve_cached(
     }
 
     // force routing if target object was migrated
+    if (naming::detail::is_migratable(id))
     {
         std::lock_guard<mutex_type> lock(migrated_objects_mtx_);
         if (was_object_migrated_locked(id))
@@ -2615,6 +2617,8 @@ hpx::future<void> addressing_service::mark_as_migrated(
                 "invalid reference gid"));
     }
 
+    HPX_ASSERT(naming::detail::is_migratable(gid_));
+
     naming::gid_type gid(naming::detail::get_stripped_gid(gid_));
 
     // Always first grab the AGAS lock before invoking the user supplied
@@ -2668,6 +2672,8 @@ void addressing_service::unmark_as_migrated(
         return;
     }
 
+    HPX_ASSERT(naming::detail::is_migratable(gid_));
+
     naming::gid_type gid(naming::detail::get_stripped_gid(gid_));
 
     std::unique_lock<mutex_type> lock(migrated_objects_mtx_);
@@ -2704,6 +2710,8 @@ addressing_service::begin_migration(naming::id_type const& id)
             "invalid reference id");
     }
 
+    HPX_ASSERT(naming::detail::is_migratable(id.get_gid()));
+
     naming::gid_type gid(naming::detail::get_stripped_gid(id.get_gid()));
 
     return primary_ns_.begin_migration(gid);
@@ -2719,6 +2727,8 @@ bool addressing_service::end_migration(
             "addressing_service::end_migration_async",
             "invalid reference id");
     }
+
+    HPX_ASSERT(naming::detail::is_migratable(id.get_gid()));
 
     naming::gid_type gid(naming::detail::get_stripped_gid(id.get_gid()));
 
@@ -2748,6 +2758,11 @@ std::pair<bool, components::pinned_ptr>
             "addressing_service::was_object_migrated",
             "invalid reference gid");
         return std::make_pair(false, components::pinned_ptr());
+    }
+
+    if (!naming::detail::is_migratable(gid))
+    {
+        return std::make_pair(false, f());
     }
 
     // Always first grab the AGAS lock before invoking the user supplied

--- a/src/runtime/agas/server/primary_namespace_server.cpp
+++ b/src/runtime/agas/server/primary_namespace_server.cpp
@@ -513,7 +513,10 @@ primary_namespace::resolved_type primary_namespace::resolve_gid(naming::gid_type
         std::unique_lock<mutex_type> l(mutex_);
 
         // wait for any migration to be completed
-        wait_for_migration_locked(l, id, hpx::throws);
+        if (naming::detail::is_migratable(id))
+        {
+            wait_for_migration_locked(l, id, hpx::throws);
+        }
 
         // now, resolve the id
         r = resolve_gid_locked(l, id, hpx::throws);
@@ -895,8 +898,11 @@ void primary_namespace::resolve_free_list(
         // The mapping's key space.
         key_type gid = it->first;
 
-        // wait for any migration to be completed
-        wait_for_migration_locked(l, gid, ec);
+        if (naming::detail::is_migratable(gid))
+        {
+            // wait for any migration to be completed
+            wait_for_migration_locked(l, gid, ec);
+        }
 
         // Resolve the query GID.
         resolved_type r = resolve_gid_locked(l, gid, ec);

--- a/src/runtime/agas/server/route.cpp
+++ b/src/runtime/agas/server/route.cpp
@@ -59,7 +59,10 @@ namespace hpx { namespace agas { namespace server
             std::unique_lock<mutex_type> l(mutex_);
 
             // wait for any migration to be completed
-            wait_for_migration_locked(l, gid, ec);
+            if (naming::detail::is_migratable(gid))
+            {
+                wait_for_migration_locked(l, gid, ec);
+            }
 
             cache_address = resolve_gid_locked(l, gid, ec);
 

--- a/tools/VS/gid_type.natvis
+++ b/tools/VS/gid_type.natvis
@@ -20,6 +20,7 @@
       <Item Condition="(id_msb_ &amp; 0x40000000ull) != 0" Name="[was_split]">(id_msb_ &amp; 0x80000000ull) ? true : false</Item>
       <Item Name="[is_locked]">(id_msb_ &amp; 0x20000000ull) ? true : false</Item>
       <Item Name="[dont_cache]">(id_msb_ &amp; 0x00800000ull) ? true : false</Item>
+      <Item Name="[migratable]">(id_msb_ &amp; 0x00400000ull) ? true : false</Item>
       <Item Condition="((id_msb_ &gt;&gt; 32) &amp; 0xffffffffull) != 0" Name="[locality_id]">(unsigned int)((id_msb_ &gt;&gt; 32) &amp; 0xffffffffull) - 1</Item>
       <Item Condition="(id_msb_ &amp; 1ull) == 0" Name="[comptype]">(hpx::components::component_enum_type)((id_msb_ &gt;&gt; 1ull) &amp; 0xfffffull)</Item>
     </Expand>
@@ -38,6 +39,7 @@
       <Item Condition="gid_.px != 0 &amp;&amp; (gid_.px->type_ != unmanaged) != 0" Name="[was_split]">(gid_.px->id_msb_ &amp; 0x80000000ull) ? true : false</Item>
       <Item Condition="gid_.px != 0" Name="[is_locked]">(gid_.px->id_msb_ &amp; 0x20000000ull) ? true : false</Item>
       <Item Condition="gid_.px != 0" Name="[dont_cache]">(gid_.px->id_msb_ &amp; 0x00800000ull) ? true : false</Item>
+      <Item Condition="gid_.px != 0" Name="[migratable]">(gid_.px->id_msb_ &amp; 0x00400000ull) ? true : false</Item>
       <Item Condition="gid_.px != 0 &amp;&amp; ((gid_.px->id_msb_ &gt;&gt; 32) &amp; 0xffffffffull) != 0" Name="[locality_id]">(unsigned int)((gid_.px->id_msb_ &gt;&gt; 32) &amp; 0xffffffffull) - 1</Item>
       <Item Condition="gid_.px != 0 &amp;&amp; (gid_.px->id_msb_ &amp; 1ull) == 0" Name="[comptype]">(hpx::components::component_enum_type)((gid_.px->id_msb_ &gt;&gt; 1ull) &amp; 0xfffffull)</Item>
       <Item Condition="gid_.px != 0" Name="[count]">gid_.px->count_.value_</Item>


### PR DESCRIPTION
- this removes acquiring a lock from various AGAS operation for all
  non-migratable object
