### PR TITLE
Fix pu-step and pu-offset command line options

### DIFF
--- a/hpx/runtime/threads/policies/affinity_data.hpp
+++ b/hpx/runtime/threads/policies/affinity_data.hpp
@@ -54,8 +54,10 @@ namespace hpx { namespace threads { namespace policies { namespace detail
         mask_cref_type get_pu_mask(threads::topology const& topo,
             std::size_t num_thread) const;
 
-        mask_type get_used_pus_mask(std::size_t pu_num) const;
-        std::size_t get_thread_occupancy(std::size_t pid) const;
+        mask_type get_used_pus_mask(threads::topology const& topo,
+            std::size_t pu_num) const;
+        std::size_t get_thread_occupancy(threads::topology const& topo,
+            std::size_t pu_num) const;
 
         std::size_t get_pu_num(std::size_t num_thread) const
         {

--- a/src/runtime/resource/detail/detail_partitioner.cpp
+++ b/src/runtime/resource/detail/detail_partitioner.cpp
@@ -237,8 +237,9 @@ namespace hpx { namespace resource { namespace detail
     {
         threads::mask_type pu_mask = threads::mask_type();
         threads::set(pu_mask, pu_num);
+        threads::topology& topo = get_topology();
 
-        threads::mask_type comp = affinity_data_.get_used_pus_mask(pu_num);
+        threads::mask_type comp = affinity_data_.get_used_pus_mask(topo, pu_num);
         return threads::any(comp & pu_mask);
     }
 
@@ -280,7 +281,7 @@ namespace hpx { namespace resource { namespace detail
                     if (pu_exposed(pid))
                     {
                         c.pus_.emplace_back(pid, &c,
-                            affinity_data_.get_thread_occupancy(pid));
+                            affinity_data_.get_thread_occupancy(topo, pid));
                         pu &p = c.pus_.back();
 
                         if (p.thread_occupancy_ == 0)

--- a/src/runtime/threads/policies/affinity_data.cpp
+++ b/src/runtime/threads/policies/affinity_data.cpp
@@ -240,7 +240,8 @@ namespace hpx { namespace threads { namespace policies { namespace detail
         return topo.get_machine_affinity_mask();
     }
 
-    mask_type affinity_data::get_used_pus_mask(std::size_t pu_num) const
+    mask_type affinity_data::get_used_pus_mask(threads::topology const& topo,
+        std::size_t pu_num) const
     {
         mask_type ret = mask_type();
         threads::resize(ret, hardware_concurrency());
@@ -252,13 +253,16 @@ namespace hpx { namespace threads { namespace policies { namespace detail
             return ret;
         }
 
-        for(mask_cref_type pu_mask : affinity_masks_)
-            ret |= pu_mask;
+        for (std::size_t thread_num = 0; thread_num < num_threads_; ++thread_num)
+        {
+            ret |= get_pu_mask(topo, thread_num);
+        }
 
         return ret;
     }
 
-    std::size_t affinity_data::get_thread_occupancy(std::size_t pu_num) const
+    std::size_t affinity_data::get_thread_occupancy(
+        threads::topology const& topo, std::size_t pu_num) const
     {
         std::size_t count = 0;
         if (threads::test(no_affinity_, pu_num))
@@ -272,8 +276,9 @@ namespace hpx { namespace threads { namespace policies { namespace detail
             threads::resize(pu_mask, hardware_concurrency());
             threads::set(pu_mask, pu_num);
 
-            for (mask_cref_type affinity_mask : affinity_masks_)
+            for (std::size_t num_thread = 0; num_thread < num_threads_; ++num_thread)
             {
+                mask_cref_type affinity_mask = get_pu_mask(topo, num_thread);
                 if (threads::any(pu_mask & affinity_mask))
                     ++count;
             }


### PR DESCRIPTION
Fixes #3300.

## Proposed Changes

- Make sure pu masks and thread occupancy are used/computed correctly when using `pu-step` and `pu-offset` command line options.