### PR TITLE
Fix includes for 1d_stencil_*_omp examples

### DIFF
--- a/examples/1d_stencil/1d_stencil_1_omp.cpp
+++ b/examples/1d_stencil/1d_stencil_1_omp.cpp
@@ -12,7 +12,9 @@
 // The only difference to 1d_stencil_1 is that this example uses OpenMP for
 // parallelizing the inner loop.
 
-#include <hpx/config/defines.hpp>   // avoid issues with Intel14/libstdc++4.4 nullptr
+// Include before any Boost header and avoid issues with Intel14/libstdc++4.4
+// nullptr
+#include <hpx/config.hpp>
 
 #include <boost/program_options.hpp>
 

--- a/examples/1d_stencil/1d_stencil_3_omp.cpp
+++ b/examples/1d_stencil/1d_stencil_3_omp.cpp
@@ -14,7 +14,9 @@
 // The only difference to 1d_stencil_3 is that this example uses OpenMP for
 // parallelizing the inner loop.
 
-#include <hpx/config/defines.hpp>   // avoid issues with Intel14/libstdc++4.4 nullptr
+// Include before any Boost header and avoid issues with Intel14/libstdc++4.4
+// nullptr
+#include <hpx/config.hpp>
 
 #include <boost/program_options.hpp>
 


### PR DESCRIPTION
Makes sure the `1d_stencil` examples with OpenMP build.

Includes `hpx/config.hpp` before including `boost/program_options.hpp` to avoid this:
```
In file included from /home/simbergm/src/hpx/hpx/util/format.hpp:9:0,
                 from /home/simbergm/src/hpx/examples/1d_stencil/print_time_results.hpp:10,
                 from /home/simbergm/src/hpx/examples/1d_stencil/1d_stencil_1_omp.cpp:28:
/home/simbergm/src/hpx/hpx/config.hpp:14:2: error: #error Boost.Config was included before the hpx config header. This might lead to subtile failures and compile errors. Please include <hpx/config.hpp> before any other boost header
 #error Boost.Config was included before the hpx config header. This might lead to subtile failures and compile errors. Please include <hpx/config.hpp> before any other boost header
```
