### PR TITLE
Replacing C++14 feature with equivalent C++11 code

### DIFF
--- a/tests/performance/parallel_algorithms/local/benchmark_remove.cpp
+++ b/tests/performance/parallel_algorithms/local/benchmark_remove.cpp
@@ -33,8 +33,8 @@ unsigned int seed = std::random_device{}();
 struct random_fill
 {
     random_fill(std::size_t random_range)
-        : gen(seed),
-          dist(0, random_range - 1)
+      : gen(seed),
+        dist(0, static_cast<int>(random_range - 1))
     {}
 
     int operator()()
@@ -59,8 +59,7 @@ struct vector_type
 
     bool operator==(vector_type const & t) const
     {
-        return std::equal(std::begin(vec_), std::end(vec_),
-            std::begin(t.vec_), std::end(t.vec_));
+        return vec_ == t.vec_;
     }
 
     std::vector<int> vec_;
@@ -78,8 +77,7 @@ struct array_type
 
     bool operator==(array_type const & t) const
     {
-        return std::equal(std::begin(arr_), std::end(arr_),
-            std::begin(t.arr_), std::end(t.arr_));
+        return arr_ == t.arr_;
     }
 
     static const std::size_t arr_size_{ 30 };
@@ -101,7 +99,7 @@ double run_remove_benchmark_std(int test_count,
             org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
-        std::remove(first, last, value);
+        (void)std::remove(first, last, value);
         time += hpx::util::high_resolution_clock::now() - elapsed;
     }
 
@@ -153,7 +151,7 @@ void run_benchmark(std::size_t vector_size, int test_count,
         random_fill(random_range));
     org_v = v;
 
-    auto value = DataType(random_range / 2);
+    auto value = DataType(static_cast<int>(random_range / 2));
 
     auto dest_dist = std::distance(first, std::remove(first, last, value));
 

--- a/tests/performance/parallel_algorithms/local/benchmark_remove_if.cpp
+++ b/tests/performance/parallel_algorithms/local/benchmark_remove_if.cpp
@@ -33,8 +33,8 @@ unsigned int seed = std::random_device{}();
 struct random_fill
 {
     random_fill(std::size_t random_range)
-        : gen(seed),
-          dist(0, random_range - 1)
+      : gen(seed),
+        dist(0, static_cast<int>(random_range - 1))
     {}
 
     int operator()()
@@ -59,8 +59,7 @@ struct vector_type
 
     bool operator==(vector_type const & t) const
     {
-        return std::equal(std::begin(vec_), std::end(vec_),
-            std::begin(t.vec_), std::end(t.vec_));
+        return vec_ == t.vec_;
     }
 
     std::vector<int> vec_;
@@ -78,8 +77,7 @@ struct array_type
 
     bool operator==(array_type const & t) const
     {
-        return std::equal(std::begin(arr_), std::end(arr_),
-            std::begin(t.arr_), std::end(t.arr_));
+        return arr_ == t.arr_;
     }
 
     static const std::size_t arr_size_{ 30 };
@@ -152,7 +150,7 @@ void run_benchmark(std::size_t vector_size, int test_count,
         random_fill(random_range));
     org_v = v;
 
-    auto value = DataType(random_range /2);
+    auto value = DataType(static_cast<int>(random_range / 2));
     auto pred = [value](DataType const& a) -> bool { return a == value; };
 
     auto dest_dist = std::distance(first, std::remove_if(first, last, pred));

--- a/tests/performance/parallel_algorithms/local/benchmark_unique.cpp
+++ b/tests/performance/parallel_algorithms/local/benchmark_unique.cpp
@@ -34,7 +34,7 @@ struct random_fill
 {
     random_fill(std::size_t random_range)
         : gen(seed),
-        dist(0, random_range - 1)
+        dist(0, static_cast<int>(random_range - 1))
     {}
 
     int operator()()
@@ -59,8 +59,7 @@ struct vector_type
 
     bool operator==(vector_type const & t) const
     {
-        return std::equal(std::begin(vec_), std::end(vec_),
-            std::begin(t.vec_), std::end(t.vec_));
+        return vec_ == t.vec_;
     }
 
     std::vector<int> vec_;
@@ -78,8 +77,7 @@ struct array_type
 
     bool operator==(array_type const & t) const
     {
-        return std::equal(std::begin(arr_), std::end(arr_),
-            std::begin(t.arr_), std::end(t.arr_));
+        return arr_ == t.arr_;
     }
 
     static const std::size_t arr_size_{ 30 };
@@ -100,7 +98,7 @@ double run_unique_benchmark_std(int test_count,
             org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
-        std::unique(first, last);
+        (void)std::unique(first, last);
         time += hpx::util::high_resolution_clock::now() - elapsed;
     }
 


### PR DESCRIPTION
Fixes #3318

## Any background context you want to provide?

The 4-argument version of `std::equal` that was used in the failing benchmarks is a C++14 feature which shouldn't have been used.