### PR TITLE
Fix a missing apex thread data (wrapper) initialization

### DIFF
--- a/hpx/runtime/applier/apply.hpp
+++ b/hpx/runtime/applier/apply.hpp
@@ -435,6 +435,10 @@ namespace hpx
                 typename action_type::component_type>::call(addr));
 
             threads::thread_init_data data;
+#ifdef HPX_HAVE_APEX
+            data.apex_data = hpx::util::apex_new_task(
+                data.description, data.parent_id);
+#endif
             apply_helper<action_type>::call(std::move(data),
                 std::forward<Continuation>(cont), target,
                 addr.address_, addr.type_, priority, std::forward<Ts>(vs)...);


### PR DESCRIPTION
Fixes #3297 

I'm not sure if this is correct, but it fixes my problems and now the traces are written