### PR TITLE
Replace C++14 overload of std::equal with C++11 code.

### DIFF
--- a/tests/unit/parallel/algorithms/inplace_merge_tests.hpp
+++ b/tests/unit/parallel/algorithms/inplace_merge_tests.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Taeguk Kwon
+//  Copyright (c) 2017-2018 Taeguk Kwon
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -147,9 +147,7 @@ void test_inplace_merge(ExPolicy policy, IteratorTag, DataType, Comp comp,
         sol_first, sol_middle, sol_last,
         comp);
 
-    bool equality = std::equal(
-        res_first, res_last,
-        sol_first, sol_last);
+    bool equality = test::equal(res_first, res_last, sol_first, sol_last);
 
     HPX_TEST(equality);
 }
@@ -192,9 +190,7 @@ void test_inplace_merge_async(ExPolicy policy, IteratorTag, DataType, Comp comp,
         sol_first, sol_middle, sol_last,
         comp);
 
-    bool equality = std::equal(
-        res_first, res_last,
-        sol_first, sol_last);
+    bool equality = test::equal(res_first, res_last, sol_first, sol_last);
 
     HPX_TEST(equality);
 }
@@ -406,9 +402,7 @@ void test_inplace_merge_etc(ExPolicy policy, IteratorTag,
         std::inplace_merge(
             sol_first, sol_middle, sol_last);
 
-        bool equality = std::equal(
-            res_first, res_last,
-            sol_first, sol_last);
+        bool equality = test::equal(res_first, res_last, sol_first, sol_last);
 
         HPX_TEST(equality);
     }
@@ -432,9 +426,7 @@ void test_inplace_merge_etc(ExPolicy policy, IteratorTag,
             });
 
         // The container must not be changed.
-        bool equality = std::equal(
-            res_first, res_last,
-            sol_first, sol_last);
+        bool equality = test::equal(res_first, res_last, sol_first, sol_last);
 
         HPX_TEST(equality);
 #endif

--- a/tests/unit/parallel/algorithms/merge_tests.hpp
+++ b/tests/unit/parallel/algorithms/merge_tests.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Taeguk Kwon
+//  Copyright (c) 2017-2018 Taeguk Kwon
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -142,7 +142,7 @@ void test_merge(ExPolicy policy, IteratorTag, DataType, Comp comp,
         std::begin(dest_sol),
         comp);
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(dest_res), get<2>(result).base(),
         std::begin(dest_sol), solution);
 
@@ -183,7 +183,7 @@ void test_merge_async(ExPolicy policy, IteratorTag, DataType, Comp comp,
         std::begin(dest_sol),
         comp);
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(dest_res), get<2>(result).base(),
         std::begin(dest_sol), solution);
 
@@ -383,7 +383,7 @@ void test_merge_etc(ExPolicy policy, IteratorTag,
             std::begin(src2), std::end(src2),
             std::begin(dest_sol));
 
-        bool equality = std::equal(
+        bool equality = test::equal(
             std::begin(dest_res), get<2>(result).base(),
             std::begin(dest_sol), solution);
 
@@ -445,7 +445,7 @@ void test_merge_etc(ExPolicy policy, IteratorTag,
             std::begin(src2), std::end(src2),
             std::begin(dest_sol));
 
-        bool equality = std::equal(
+        bool equality = test::equal(
             std::begin(dest_res), get<2>(result).base(),
             std::begin(dest_sol), solution);
 

--- a/tests/unit/parallel/algorithms/partition_copy_tests.hpp
+++ b/tests/unit/parallel/algorithms/partition_copy_tests.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Taeguk Kwon
+//  Copyright (c) 2017-2018 Taeguk Kwon
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -120,10 +120,10 @@ void test_partition_copy(ExPolicy policy, IteratorTag, DataType, Pred pred,
 
     HPX_TEST(get<0>(result).base() == std::end(c));
 
-    bool equality_true = std::equal(
+    bool equality_true = test::equal(
         std::begin(d_true_res), get<1>(result).base(),
         std::begin(d_true_sol), get<0>(solution));
-    bool equality_false = std::equal(
+    bool equality_false = test::equal(
         std::begin(d_false_res), get<2>(result).base(),
         std::begin(d_false_sol), get<1>(solution));
 
@@ -161,10 +161,10 @@ void test_partition_copy_async(ExPolicy policy, IteratorTag, DataType, Pred pred
 
     HPX_TEST(get<0>(result).base() == std::end(c));
 
-    bool equality_true = std::equal(
+    bool equality_true = test::equal(
         std::begin(d_true_res), get<1>(result).base(),
         std::begin(d_true_sol), get<0>(solution));
-    bool equality_false = std::equal(
+    bool equality_false = test::equal(
         std::begin(d_false_res), get<2>(result).base(),
         std::begin(d_false_sol), get<1>(solution));
 

--- a/tests/unit/parallel/algorithms/partition_tests.hpp
+++ b/tests/unit/parallel/algorithms/partition_tests.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Taeguk Kwon
+//  Copyright (c) 2017-2018 Taeguk Kwon
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -129,7 +129,7 @@ void test_partition(ExPolicy policy, IteratorTag, DataType, Pred pred,
     std::sort(std::begin(c), std::end(c));
     std::sort(std::begin(c_org), std::end(c_org));
 
-    bool unchanged = std::equal(
+    bool unchanged = test::equal(
         std::begin(c), std::end(c),
         std::begin(c_org), std::end(c_org));
 
@@ -169,7 +169,7 @@ void test_partition_async(ExPolicy policy, IteratorTag, DataType, Pred pred,
     std::sort(std::begin(c), std::end(c));
     std::sort(std::begin(c_org), std::end(c_org));
 
-    bool unchanged = std::equal(
+    bool unchanged = test::equal(
         std::begin(c), std::end(c),
         std::begin(c_org), std::end(c_org));
 

--- a/tests/unit/parallel/algorithms/remove_tests.hpp
+++ b/tests/unit/parallel/algorithms/remove_tests.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Taeguk Kwon
+//  Copyright (c) 2017-2018 Taeguk Kwon
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -127,7 +127,7 @@ void test_remove(ExPolicy policy, IteratorTag, DataType, ValueType value,
         iterator(std::begin(c)), iterator(std::end(c)), value);
     auto solution = std::remove(std::begin(d), std::end(d), value);
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(c), result.base(),
         std::begin(d), solution);
 
@@ -156,7 +156,7 @@ void test_remove_async(ExPolicy policy, IteratorTag, DataType, ValueType value,
     auto result = f.get();
     auto solution = std::remove(std::begin(d), std::end(d), value);
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(c), result.base(),
         std::begin(d), solution);
 
@@ -184,7 +184,7 @@ void test_remove_if(ExPolicy policy, IteratorTag, DataType, Pred pred,
         iterator(std::begin(c)), iterator(std::end(c)), pred);
     auto solution = std::remove_if(std::begin(d), std::end(d), pred);
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(c), result.base(),
         std::begin(d), solution);
 
@@ -212,7 +212,7 @@ void test_remove_if_async(ExPolicy policy, IteratorTag, DataType, Pred pred,
     auto result = f.get();
     auto solution = std::remove_if(std::begin(d), std::end(d), pred);
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(c), result.base(),
         std::begin(d), solution);
 

--- a/tests/unit/parallel/algorithms/test_utils.hpp
+++ b/tests/unit/parallel/algorithms/test_utils.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014-2015 Hartmut Kaiser
+//  Copyright (c)      2018 Taeguk Kwon
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -290,6 +291,17 @@ namespace test
             ++i;
         }
         return c;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename InputIter1, typename InputIter2>
+    bool equal(InputIter1 first1, InputIter1 last1,
+        InputIter2 first2, InputIter2 last2)
+    {
+        if (std::distance(first1, last1) != std::distance(first2, last2))
+            return false;
+
+        return std::equal(first1, last1, first2);
     }
 }
 

--- a/tests/unit/parallel/algorithms/unique_copy_tests.hpp
+++ b/tests/unit/parallel/algorithms/unique_copy_tests.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Taeguk Kwon
+//  Copyright (c) 2017-2018 Taeguk Kwon
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -132,7 +132,7 @@ void test_unique_copy(ExPolicy policy, IteratorTag, DataType, Pred pred,
         std::begin(dest_sol),
         pred);
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(dest_res), get<1>(result).base(),
         std::begin(dest_sol), solution);
 
@@ -165,7 +165,7 @@ void test_unique_copy_async(ExPolicy policy, IteratorTag, DataType, Pred pred,
         std::begin(dest_sol),
         pred);
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(dest_res), get<1>(result).base(),
         std::begin(dest_sol), solution);
 
@@ -337,7 +337,7 @@ void test_unique_copy_etc(ExPolicy policy, IteratorTag,
         auto solution = std::unique_copy(std::begin(c), std::end(c),
             std::begin(dest_sol));
 
-        bool equality = std::equal(
+        bool equality = test::equal(
             std::begin(dest_res), get<1>(result).base(),
             std::begin(dest_sol), solution);
 
@@ -384,7 +384,7 @@ void test_unique_copy_etc(ExPolicy policy, IteratorTag,
         auto solution = std::unique_copy(std::begin(c), std::end(c),
             std::begin(dest_sol));
 
-        bool equality = std::equal(
+        bool equality = test::equal(
             std::begin(dest_res), get<1>(result).base(),
             std::begin(dest_sol), solution);
 

--- a/tests/unit/parallel/algorithms/unique_tests.hpp
+++ b/tests/unit/parallel/algorithms/unique_tests.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Taeguk Kwon
+//  Copyright (c) 2017-2018 Taeguk Kwon
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -127,7 +127,7 @@ void test_unique(ExPolicy policy, IteratorTag, DataType, Pred pred,
         iterator(std::begin(c)), iterator(std::end(c)), pred);
     auto solution = std::unique(std::begin(d), std::end(d), pred);
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(c), result.base(),
         std::begin(d), solution);
 
@@ -155,7 +155,7 @@ void test_unique_async(ExPolicy policy, IteratorTag, DataType, Pred pred,
     auto result = f.get();
     auto solution = std::unique(std::begin(d), std::end(d), pred);
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(c), result.base(),
         std::begin(d), solution);
 
@@ -320,7 +320,7 @@ void test_unique_etc(ExPolicy policy, IteratorTag,
             iterator(std::begin(c)), iterator(std::end(c)));
         auto solution = std::unique(std::begin(d), std::end(d));
 
-        bool equality = std::equal(
+        bool equality = test::equal(
             std::begin(c), result.base(),
             std::begin(d), solution);
 
@@ -365,7 +365,7 @@ void test_unique_etc(ExPolicy policy, IteratorTag,
             });
         auto solution = std::unique(std::begin(d), std::end(d));
 
-        bool equality = std::equal(
+        bool equality = test::equal(
             std::begin(c), result.base(),
             std::begin(d), solution);
 

--- a/tests/unit/parallel/container_algorithms/inplace_merge_range.cpp
+++ b/tests/unit/parallel/container_algorithms/inplace_merge_range.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Taeguk Kwon
+//  Copyright (c) 2017-2018 Taeguk Kwon
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -116,7 +116,7 @@ void test_inplace_merge(ExPolicy policy, DataType)
 
     HPX_TEST(result == res_last);
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         res_first, res_last,
         sol_first, sol_last);
 
@@ -153,7 +153,7 @@ void test_inplace_merge_async(ExPolicy policy, DataType)
 
     HPX_TEST(result == res_last);
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         res_first, res_last,
         std::begin(sol), std::end(sol));
 

--- a/tests/unit/parallel/container_algorithms/merge_range.cpp
+++ b/tests/unit/parallel/container_algorithms/merge_range.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Taeguk Kwon
+//  Copyright (c) 2017-2018 Taeguk Kwon
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -115,7 +115,7 @@ void test_merge(ExPolicy policy, DataType)
     HPX_TEST(get<0>(result) == std::end(src1));
     HPX_TEST(get<1>(result) == std::end(src2));
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(dest_res), get<2>(result),
         std::begin(dest_sol), solution);
 
@@ -151,7 +151,7 @@ void test_merge_async(ExPolicy policy, DataType)
     HPX_TEST(get<0>(result) == std::end(src1));
     HPX_TEST(get<1>(result) == std::end(src2));
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(dest_res), get<2>(result),
         std::begin(dest_sol), solution);
 
@@ -187,7 +187,7 @@ void test_merge_outiter(ExPolicy policy, DataType)
     HPX_TEST(get<0>(result) == std::end(src1));
     HPX_TEST(get<1>(result) == std::end(src2));
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(dest_res), std::end(dest_res),
         std::begin(dest_sol), std::end(dest_sol));
 
@@ -223,7 +223,7 @@ void test_merge_outiter_async(ExPolicy policy, DataType)
     HPX_TEST(get<0>(result) == std::end(src1));
     HPX_TEST(get<1>(result) == std::end(src2));
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(dest_res), std::end(dest_res),
         std::begin(dest_sol), std::end(dest_sol));
 

--- a/tests/unit/parallel/container_algorithms/partition_copy_range.cpp
+++ b/tests/unit/parallel/container_algorithms/partition_copy_range.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Taeguk Kwon
+//  Copyright (c) 2017-2018 Taeguk Kwon
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -107,10 +107,10 @@ void test_partition_copy(ExPolicy policy, DataType)
     HPX_UNUSED(solution);
     HPX_TEST(get<0>(result) == std::end(c));
 
-    bool equality_true = std::equal(
+    bool equality_true = test::equal(
         std::begin(d_true_res), std::end(d_true_res),
         std::begin(d_true_sol), std::end(d_true_sol));
-    bool equality_false = std::equal(
+    bool equality_false = test::equal(
         std::begin(d_false_res), std::end(d_false_res),
         std::begin(d_false_sol), std::end(d_false_sol));
 
@@ -151,10 +151,10 @@ void test_partition_copy_async(ExPolicy policy, DataType)
     HPX_UNUSED(solution);
     HPX_TEST(get<0>(result) == std::end(c));
 
-    bool equality_true = std::equal(
+    bool equality_true = test::equal(
         std::begin(d_true_res), std::end(d_true_res),
         std::begin(d_true_sol), std::end(d_true_sol));
-    bool equality_false = std::equal(
+    bool equality_false = test::equal(
         std::begin(d_false_res), std::end(d_false_res),
         std::begin(d_false_sol), std::end(d_false_sol));
 
@@ -194,10 +194,10 @@ void test_partition_copy_outiter(ExPolicy policy, DataType)
 
     HPX_TEST(get<0>(result) == std::end(c));
 
-    bool equality_true = std::equal(
+    bool equality_true = test::equal(
         std::begin(d_true_res), std::end(d_true_res),
         std::begin(d_true_sol), std::end(d_true_sol));
-    bool equality_false = std::equal(
+    bool equality_false = test::equal(
         std::begin(d_false_res), std::end(d_false_res),
         std::begin(d_false_sol), std::end(d_false_sol));
 
@@ -237,10 +237,10 @@ void test_partition_copy_outiter_async(ExPolicy policy, DataType)
 
     HPX_TEST(get<0>(result) == std::end(c));
 
-    bool equality_true = std::equal(
+    bool equality_true = test::equal(
         std::begin(d_true_res), std::end(d_true_res),
         std::begin(d_true_sol), std::end(d_true_sol));
-    bool equality_false = std::equal(
+    bool equality_false = test::equal(
         std::begin(d_false_res), std::end(d_false_res),
         std::begin(d_false_sol), std::end(d_false_sol));
 

--- a/tests/unit/parallel/container_algorithms/partition_range.cpp
+++ b/tests/unit/parallel/container_algorithms/partition_range.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Taeguk Kwon
+//  Copyright (c) 2017-2018 Taeguk Kwon
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -117,7 +117,7 @@ void test_partition(ExPolicy policy, DataType)
     std::sort(std::begin(c), std::end(c));
     std::sort(std::begin(c_org), std::end(c_org));
 
-    bool unchanged = std::equal(
+    bool unchanged = test::equal(
         std::begin(c), std::end(c),
         std::begin(c_org), std::end(c_org));
 
@@ -161,7 +161,7 @@ void test_partition_async(ExPolicy policy, DataType)
     std::sort(std::begin(c), std::end(c));
     std::sort(std::begin(c_org), std::end(c_org));
 
-    bool unchanged = std::equal(
+    bool unchanged = test::equal(
         std::begin(c), std::end(c),
         std::begin(c_org), std::end(c_org));
 

--- a/tests/unit/parallel/container_algorithms/remove_if_range.cpp
+++ b/tests/unit/parallel/container_algorithms/remove_if_range.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Taeguk Kwon
+//  Copyright (c) 2017-2018 Taeguk Kwon
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -84,7 +84,7 @@ void test_remove_if(ExPolicy policy, DataType)
     auto result = hpx::parallel::remove_if(policy, c, pred);
     auto solution = std::remove_if(std::begin(d), std::end(d), pred);
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(c), result,
         std::begin(d), solution);
 
@@ -111,7 +111,7 @@ void test_remove_if_async(ExPolicy policy, DataType)
     auto result = f.get();
     auto solution = std::remove_if(std::begin(d), std::end(d), pred);
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(c), result,
         std::begin(d), solution);
 

--- a/tests/unit/parallel/container_algorithms/remove_range.cpp
+++ b/tests/unit/parallel/container_algorithms/remove_range.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Taeguk Kwon
+//  Copyright (c) 2017-2018 Taeguk Kwon
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -84,7 +84,7 @@ void test_remove(ExPolicy policy, DataType)
     auto result = hpx::parallel::remove(policy, c, value);
     auto solution = std::remove(std::begin(d), std::end(d), value);
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(c), result,
         std::begin(d), solution);
 
@@ -111,7 +111,7 @@ void test_remove_async(ExPolicy policy, DataType)
     auto result = f.get();
     auto solution = std::remove(std::begin(d), std::end(d), value);
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(c), result,
         std::begin(d), solution);
 

--- a/tests/unit/parallel/container_algorithms/test_utils.hpp
+++ b/tests/unit/parallel/container_algorithms/test_utils.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014-2015 Hartmut Kaiser
+//  Copyright (c)      2018 Taeguk Kwon
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -316,6 +317,17 @@ namespace test
             ++i;
         }
         return c;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename InputIter1, typename InputIter2>
+    bool equal(InputIter1 first1, InputIter1 last1,
+        InputIter2 first2, InputIter2 last2)
+    {
+        if (std::distance(first1, last1) != std::distance(first2, last2))
+            return false;
+
+        return std::equal(first1, last1, first2);
     }
 }
 

--- a/tests/unit/parallel/container_algorithms/unique_copy_range.cpp
+++ b/tests/unit/parallel/container_algorithms/unique_copy_range.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Taeguk Kwon
+//  Copyright (c) 2017-2018 Taeguk Kwon
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -80,7 +80,7 @@ void test_unique_copy(ExPolicy policy, DataType)
 
     HPX_TEST(get<0>(result) == std::end(c));
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(dest_res), get<1>(result),
         std::begin(dest_sol), solution);
 
@@ -108,7 +108,7 @@ void test_unique_copy_async(ExPolicy policy, DataType)
 
     HPX_TEST(get<0>(result) == std::end(c));
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(dest_res), get<1>(result),
         std::begin(dest_sol), solution);
 
@@ -136,7 +136,7 @@ void test_unique_copy_outiter(ExPolicy policy, DataType)
 
     HPX_TEST(get<0>(result) == std::end(c));
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(dest_res), std::end(dest_res),
         std::begin(dest_sol), std::end(dest_sol));
 
@@ -164,7 +164,7 @@ void test_unique_copy_outiter_async(ExPolicy policy, DataType)
 
     HPX_TEST(get<0>(result) == std::end(c));
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(dest_res), std::end(dest_res),
         std::begin(dest_sol), std::end(dest_sol));
 

--- a/tests/unit/parallel/container_algorithms/unique_range.cpp
+++ b/tests/unit/parallel/container_algorithms/unique_range.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Taeguk Kwon
+//  Copyright (c) 2017-2018 Taeguk Kwon
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -77,7 +77,7 @@ void test_unique(ExPolicy policy, DataType)
     auto result = hpx::parallel::unique(policy, c);
     auto solution = std::unique(std::begin(d), std::end(d));
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(c), result,
         std::begin(d), solution);
 
@@ -102,7 +102,7 @@ void test_unique_async(ExPolicy policy, DataType)
     auto result = f.get();
     auto solution = std::unique(std::begin(d), std::end(d));
 
-    bool equality = std::equal(
+    bool equality = test::equal(
         std::begin(c), result,
         std::begin(d), solution);
 


### PR DESCRIPTION
This is related to #3318 and #3319.

I fixed my mistakes in the codes written by me. (Sorry to my mistake)