### PR TITLE
Make sure logging is up and running while modules are being discovered.

### DIFF
--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -76,7 +76,10 @@ namespace hpx
       : boost::system::system_error(make_error_code(e, plain))
     {
         HPX_ASSERT((e >= success && e < last_error) || (e & system_error_flag));
-        LERR_(error) << "created exception: " << this->what();
+        if (e != success)
+        {
+            LERR_(error) << "created exception: " << this->what();
+        }
     }
 
     /// Construct a hpx::exception from a boost#system_error.
@@ -101,7 +104,10 @@ namespace hpx
       : boost::system::system_error(make_system_error_code(e, mode), msg)
     {
         HPX_ASSERT((e >= success && e < last_error) || (e & system_error_flag));
-        LERR_(error) << "created exception: " << this->what();
+        if (e != success)
+        {
+            LERR_(error) << "created exception: " << this->what();
+        }
     }
 
     /// Construct a hpx::exception from a \a hpx::error and an error message.
@@ -119,7 +125,10 @@ namespace hpx
       : boost::system::system_error(make_system_error_code(e, mode), msg)
     {
         HPX_ASSERT((e >= success && e < last_error) || (e & system_error_flag));
-        LERR_(error) << "created exception: " << this->what();
+        if (e != success)
+        {
+            LERR_(error) << "created exception: " << this->what();
+        }
     }
 
     /// Destruct a hpx::exception

--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -30,7 +30,6 @@
 #include <hpx/util/command_line_handling.hpp>
 #include <hpx/util/format.hpp>
 #include <hpx/util/function.hpp>
-#include <hpx/util/init_logging.hpp>
 #include <hpx/util/logging.hpp>
 #include <hpx/util/query_counters.hpp>
 
@@ -603,11 +602,6 @@ namespace hpx
                 // Setup all internal parameters of the resource_partitioner
                 rp.configure_pools();
 
-                // initialize logging
-                util::command_line_handling& cms = rp.get_command_line_switches();
-                util::detail::init_logging(
-                    cms.rtcfg_, cms.rtcfg_.mode_ == runtime_mode_console);
-
                 util::apex_wrapper_init apex(argc, argv);
 
                 // Initialize and start the HPX runtime.
@@ -615,6 +609,8 @@ namespace hpx
 
                 // Build and configure this runtime instance.
                 typedef hpx::runtime_impl runtime_type;
+
+                util::command_line_handling& cms = rp.get_command_line_switches();
                 std::unique_ptr<hpx::runtime> rt(new runtime_type(cms.rtcfg_));
 
                 result = rp.parse_result();


### PR DESCRIPTION
- add more logging to module discovery
- flyby: don't log hpx::success as error
