### PR TITLE
Making sure object is pinned while executing actions, even if action returns a future

### DIFF
--- a/hpx/components/component_storage/server/migrate_from_storage.hpp
+++ b/hpx/components/component_storage/server/migrate_from_storage.hpp
@@ -12,6 +12,7 @@
 #include <hpx/runtime/naming/address.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/throw_exception.hpp>
+#include <hpx/traits/component_pin_support.hpp>
 #include <hpx/traits/component_supports_migration.hpp>
 #include <hpx/util/bind_back.hpp>
 
@@ -103,7 +104,7 @@ namespace hpx { namespace components { namespace server
             }
 
             // make sure the migration code works properly
-            ptr->pin();
+            traits::component_pin_support<Component>::pin(ptr.get());
 
             // if target locality is not specified, use the address of the last
             // locality where the object was living before

--- a/hpx/include/traits.hpp
+++ b/hpx/include/traits.hpp
@@ -21,6 +21,7 @@
 #include <hpx/traits/action_stacksize.hpp>
 #include <hpx/traits/action_was_object_migrated.hpp>
 #include <hpx/traits/component_config_data.hpp>
+#include <hpx/traits/component_pin_support.hpp>
 #include <hpx/traits/component_supports_migration.hpp>
 #include <hpx/traits/component_type_database.hpp>
 #include <hpx/traits/component_type_is_compatible.hpp>

--- a/hpx/lcos/detail/async_implementations.hpp
+++ b/hpx/lcos/detail/async_implementations.hpp
@@ -16,6 +16,7 @@
 #include <hpx/runtime/threads/thread.hpp>
 #include <hpx/runtime/threads/thread_init_data.hpp>
 #include <hpx/throw_exception.hpp>
+#include <hpx/traits/action_decorate_function.hpp>
 #include <hpx/traits/action_was_object_migrated.hpp>
 #include <hpx/traits/action_select_direct_execution.hpp>
 #include <hpx/traits/component_supports_migration.hpp>

--- a/hpx/runtime.hpp
+++ b/hpx/runtime.hpp
@@ -58,7 +58,7 @@ namespace hpx
         namespace server
         {
             class runtime_support;
-            class memory;
+            class HPX_EXPORT memory;
         }
     }
 

--- a/hpx/runtime/components/pinned_ptr.hpp
+++ b/hpx/runtime/components/pinned_ptr.hpp
@@ -9,6 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/runtime/get_lva.hpp>
 #include <hpx/runtime/naming_fwd.hpp>
+#include <hpx/traits/component_pin_support.hpp>
 #include <hpx/util/assert.hpp>
 
 #include <memory>
@@ -64,13 +65,19 @@ namespace hpx { namespace components
             void pin()
             {
                 if (0 != this->lva_)
-                    get_lva<Component>::call(this->lva_)->pin();
+                {
+                    traits::component_pin_support<Component>::pin(
+                        get_lva<Component>::call(this->lva_));
+                }
             }
 
             void unpin()
             {
                 if (0 != this->lva_)
-                    get_lva<Component>::call(this->lva_)->unpin();
+                {
+                    traits::component_pin_support<Component>::unpin(
+                        get_lva<Component>::call(this->lva_));
+                }
                 this->lva_ = 0;
             }
         };

--- a/hpx/runtime/components/server/component_base.hpp
+++ b/hpx/runtime/components/server/component_base.hpp
@@ -76,18 +76,6 @@ namespace hpx { namespace components
             HPX_EXPORT naming::id_type get_unmanaged_id(
                 naming::gid_type const& gid) const;
 
-            // Pinning functionality
-            HPX_CXX14_CONSTEXPR static void pin()
-            {
-            }
-            HPX_CXX14_CONSTEXPR static void unpin()
-            {
-            }
-            HPX_CONSTEXPR static std::uint32_t pin_count()
-            {
-                return 0;
-            }
-
 #if defined(HPX_DISABLE_ASSERTS) || defined(BOOST_DISABLE_ASSERTS) || defined(NDEBUG)
             HPX_CXX14_CONSTEXPR static void mark_as_migrated()
             {

--- a/hpx/runtime/components/server/fixed_component_base.hpp
+++ b/hpx/runtime/components/server/fixed_component_base.hpp
@@ -163,11 +163,6 @@ public:
         }
     }
 
-    // Pinning functionality
-    HPX_CXX14_CONSTEXPR static void pin() {}
-    HPX_CXX14_CONSTEXPR static void unpin() {}
-    HPX_CONSTEXPR static std::uint32_t pin_count() { return 0; }
-
 #if defined(HPX_DISABLE_ASSERTS) || defined(BOOST_DISABLE_ASSERTS) || defined(NDEBUG)
     HPX_CXX14_CONSTEXPR static void mark_as_migrated()
     {

--- a/hpx/runtime/components/server/locking_hook.hpp
+++ b/hpx/runtime/components/server/locking_hook.hpp
@@ -59,7 +59,7 @@ namespace hpx { namespace components
                 util::one_shot(&locking_hook::thread_function),
                 get_lva<this_component_type>::call(lva),
                 util::placeholders::_1,
-                traits::action_decorate_function<base_type>::call(
+                traits::component_decorate_function<base_type>::call(
                     lva, std::forward<F>(f)));
         }
 

--- a/hpx/runtime/components/server/managed_component_base.hpp
+++ b/hpx/runtime/components/server/managed_component_base.hpp
@@ -170,11 +170,6 @@ namespace hpx { namespace components
             ///        destructed
             HPX_CXX14_CONSTEXPR static void finalize() {}
 
-            // Pinning functionality
-            HPX_CXX14_CONSTEXPR static void pin() {}
-            HPX_CXX14_CONSTEXPR static void unpin() {}
-            HPX_CONSTEXPR static std::uint32_t pin_count() { return 0; }
-
 #if defined(HPX_DISABLE_ASSERTS) || defined(BOOST_DISABLE_ASSERTS) || defined(NDEBUG)
             HPX_CXX14_CONSTEXPR static void mark_as_migrated()
             {

--- a/hpx/runtime/components/server/memory.hpp
+++ b/hpx/runtime/components/server/memory.hpp
@@ -22,7 +22,7 @@
 namespace hpx { namespace components { namespace server
 {
     ///////////////////////////////////////////////////////////////////////////
-    class HPX_EXPORT memory
+    class memory
     {
     public:
         typedef memory type_holder;
@@ -39,12 +39,11 @@ namespace hpx { namespace components { namespace server
         typedef util::integer::uint128 uint128_t;
 
         // constructor
-        memory()
-        {}
+        memory() = default;
 
         /// \brief finalize() will be called just before the instance gets
         ///        destructed
-        void finalize() {}
+        HPX_CXX14_CONSTEXPR static void finalize() {}
 
         ///////////////////////////////////////////////////////////////////////
         // exposed functionality of this component
@@ -123,7 +122,10 @@ namespace hpx { namespace components { namespace server
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(memory, load128);
 
         // This component type requires valid id for its actions to be invoked
-        static bool is_target_valid(naming::id_type const& id) { return true; }
+        HPX_CONSTEXPR static bool is_target_valid(naming::id_type const&)
+        {
+            return true;
+        }
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/components/server/memory_block.hpp
+++ b/hpx/runtime/components/server/memory_block.hpp
@@ -438,7 +438,10 @@ namespace hpx { namespace components { namespace server { namespace detail
         HPX_DEFINE_COMPONENT_ACTION(memory_block, clone);
 
         // This component type requires valid id for its actions to be invoked
-        static bool is_target_valid(naming::id_type const& id) { return true; }
+        HPX_CONSTEXPR static bool is_target_valid(naming::id_type const& id)
+        {
+            return true;
+        }
     };
 }}}}
 
@@ -508,7 +511,7 @@ namespace hpx { namespace components { namespace server
         /// \param self [in] The HPX \a thread used to execute this function.
         /// \param appl [in] The applier to be used for finalization of the
         ///             component instance.
-        void finalize() {}
+        HPX_CXX14_CONSTEXPR static void finalize() {}
 
     public:
         /// \brief The destructor releases any wrapped instances

--- a/hpx/runtime/components/server/migrate_component.hpp
+++ b/hpx/runtime/components/server/migrate_component.hpp
@@ -230,11 +230,9 @@ namespace hpx { namespace components { namespace server
         auto r = agas::begin_migration(to_migrate);
 
         // perform actual object migration
-        typedef migrate_component_action<
-                Component, DistPolicy
-            > action_type;
-        return async<action_type>(r.first, to_migrate, r.second,
-            policy).then(
+        typedef migrate_component_action<Component, DistPolicy> action_type;
+        return async<action_type>(r.first, to_migrate, r.second, policy)
+            .then(
                 [to_migrate](future<id_type> && f) -> id_type
                 {
                     agas::end_migration(to_migrate);

--- a/hpx/runtime/components/server/migration_support.hpp
+++ b/hpx/runtime/components/server/migration_support.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -106,7 +106,7 @@ namespace hpx { namespace components { namespace server
         /// \param self [in] The HPX \a thread used to execute this function.
         /// \param appl [in] The applier to be used for finalization of the
         ///             component instance.
-        void finalize() {}
+        HPX_CXX14_CONSTEXPR static void finalize() {}
 
         void delete_function_lists();
         void tidy();

--- a/hpx/runtime/get_ptr.hpp
+++ b/hpx/runtime/get_ptr.hpp
@@ -19,6 +19,7 @@
 #include <hpx/runtime/naming/name.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/throw_exception.hpp>
+#include <hpx/traits/component_pin_support.hpp>
 #include <hpx/traits/component_type_is_compatible.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/bind_back.hpp>
@@ -40,7 +41,7 @@ namespace hpx
             void operator()(Component* p)
             {
                 id_ = naming::invalid_id;       // release component
-                p->unpin();
+                traits::component_pin_support<Component>::unpin(p);
             }
 
             naming::id_type id_;                // holds component alive
@@ -55,7 +56,8 @@ namespace hpx
             template <typename Component>
             void operator()(Component* p)
             {
-                bool was_migrated = p->unpin();
+                bool was_migrated =
+                    traits::component_pin_support<Component>::unpin(p);
 
                 if (was_migrated)
                 {
@@ -94,7 +96,8 @@ namespace hpx
             Component* p = get_lva<Component>::call(addr.address_);
             std::shared_ptr<Component> ptr(p, Deleter(id));
 
-            ptr->pin();     // the shared_ptr pins the component
+            // the shared_ptr pins the component
+            traits::component_pin_support<Component>::pin(ptr.get());
             return ptr;
         }
 

--- a/hpx/traits/action_decorate_function.hpp
+++ b/hpx/traits/action_decorate_function.hpp
@@ -74,6 +74,11 @@ namespace hpx { namespace traits
         }
     };
 
+    template <typename Action, typename Enable = void>
+    struct component_decorates_action
+      : detail::has_decorates_action<typename std::decay<Action>::type>
+    {};
+
     template <typename Component, typename Enable = void>
     struct component_decorate_function
     {

--- a/hpx/traits/component_pin_support.hpp
+++ b/hpx/traits/component_pin_support.hpp
@@ -1,0 +1,92 @@
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_TRAITS_COMPONENT_PIN_SUPPORT_MAY_21_2018_1246PM)
+#define HPX_TRAITS_COMPONENT_PIN_SUPPORT_MAY_21_2018_1246PM
+
+#include <hpx/config.hpp>
+#include <hpx/traits/detail/wrap_int.hpp>
+
+#include <cstdint>
+
+namespace hpx { namespace traits
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // Customization point for component pinning
+    namespace detail
+    {
+        struct pin_helper
+        {
+            template <typename Component>
+            HPX_CXX14_CONSTEXPR static void call(wrap_int, Component* p)
+            {
+            }
+
+            // forward the call if the component implements the function
+            template <typename Component>
+            HPX_CXX14_CONSTEXPR static auto call(int, Component* p)
+            ->  decltype(p->pin())
+            {
+                p->pin();
+            }
+        };
+
+        struct unpin_helper
+        {
+            template <typename Component>
+            HPX_CONSTEXPR static bool call(wrap_int, Component* p)
+            {
+                return false;
+            }
+
+            // forward the call if the component implements the function
+            template <typename Component>
+            HPX_CONSTEXPR static auto call(int, Component* p)
+            ->  decltype(p->unpin())
+            {
+                return p->unpin();
+            }
+        };
+
+        struct pin_count_helper
+        {
+            template <typename Component>
+            HPX_CONSTEXPR static std::uint32_t call(wrap_int, Component* p)
+            {
+                return 0;
+            }
+
+            // forward the call if the component implements the function
+            template <typename Component>
+            HPX_CONSTEXPR static auto call(int, Component* p)
+            ->  decltype(p->pin_count())
+            {
+                return p->pin_count();
+            }
+        };
+    }
+
+    template <typename Component, typename Enable = void>
+    struct component_pin_support
+    {
+        HPX_CXX14_CONSTEXPR static void pin(Component* p)
+        {
+            detail::pin_helper::call(0, p);
+        }
+
+        HPX_CONSTEXPR static bool unpin(Component* p)
+        {
+            return detail::unpin_helper::call(0, p);
+        }
+
+        HPX_CONSTEXPR static std::uint32_t pin_count(Component* p)
+        {
+            return detail::pin_count_helper::call(0, p);
+        }
+    };
+}}
+
+#endif
+

--- a/tests/unit/component/migrate_component.cpp
+++ b/tests/unit/component/migrate_component.cpp
@@ -32,17 +32,50 @@ struct test_server
 
     hpx::id_type call() const
     {
+        HPX_TEST(pin_count() != 0);
         return hpx::find_here();
     }
 
     void busy_work() const
     {
+        HPX_TEST(pin_count() != 0);
         hpx::this_thread::sleep_for(std::chrono::seconds(1));
+        HPX_TEST(pin_count() != 0);
+    }
+
+    hpx::future<void> lazy_busy_work() const
+    {
+        HPX_TEST(pin_count() != 0);
+
+        auto f = hpx::make_ready_future_after(std::chrono::seconds(1));
+
+        return f.then(
+            [this](hpx::future<void> && f)
+            {
+                f.get();
+                HPX_TEST(pin_count() != 0);
+            });
     }
 
     int get_data() const
     {
+        HPX_TEST(pin_count() != 0);
         return data_;
+    }
+
+    hpx::future<int> lazy_get_data() const
+    {
+        HPX_TEST(pin_count() != 0);
+
+        auto f =
+            hpx::make_ready_future(/*_after(std::chrono::seconds(1), */data_);
+
+        return f.then(
+            [this](hpx::future<int> && f)
+            {
+                HPX_TEST(pin_count() != 0);
+                return f.get();
+            });
     }
 
     // Components which should be migrated using hpx::migrate<> need to
@@ -70,7 +103,9 @@ struct test_server
 
     HPX_DEFINE_COMPONENT_ACTION(test_server, call, call_action);
     HPX_DEFINE_COMPONENT_ACTION(test_server, busy_work, busy_work_action);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, lazy_busy_work, lazy_busy_work_action);
     HPX_DEFINE_COMPONENT_ACTION(test_server, get_data, get_data_action);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, lazy_get_data, lazy_get_data_action);
 
     template <typename Archive>
     void serialize(Archive& ar, unsigned version)
@@ -93,9 +128,17 @@ typedef test_server::busy_work_action busy_work_action;
 HPX_REGISTER_ACTION_DECLARATION(busy_work_action);
 HPX_REGISTER_ACTION(busy_work_action);
 
+typedef test_server::lazy_busy_work_action lazy_busy_work_action;
+HPX_REGISTER_ACTION_DECLARATION(lazy_busy_work_action);
+HPX_REGISTER_ACTION(lazy_busy_work_action);
+
 typedef test_server::get_data_action get_data_action;
 HPX_REGISTER_ACTION_DECLARATION(get_data_action);
 HPX_REGISTER_ACTION(get_data_action);
+
+typedef test_server::lazy_get_data_action lazy_get_data_action;
+HPX_REGISTER_ACTION_DECLARATION(lazy_get_data_action);
+HPX_REGISTER_ACTION(lazy_get_data_action);
 
 struct test_client
   : hpx::components::client_base<test_client, test_server>
@@ -117,9 +160,19 @@ struct test_client
         return hpx::async<busy_work_action>(this->get_id());
     }
 
+    hpx::future<void> lazy_busy_work() const
+    {
+        return hpx::async<lazy_busy_work_action>(this->get_id());
+    }
+
     int get_data() const
     {
         return get_data_action()(this->get_id());
+    }
+
+    int lazy_get_data() const
+    {
+        return lazy_get_data_action()(this->get_id()).get();
     }
 };
 
@@ -147,6 +200,38 @@ bool test_migrate_component(hpx::id_type source, hpx::id_type target)
         // the migrated object should live on the target now
         HPX_TEST_EQ(t2.call(), target);
         HPX_TEST_EQ(t2.get_data(), 42);
+    }
+    catch (hpx::exception const& e) {
+        hpx::cout << hpx::get_error_what(e) << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+bool test_migrate_lazy_component(hpx::id_type source, hpx::id_type target)
+{
+    // create component on given locality
+    test_client t1 = hpx::new_<test_client>(source, 42);
+    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+
+    // the new object should live on the source locality
+    HPX_TEST_EQ(t1.call(), source);
+    HPX_TEST_EQ(t1.lazy_get_data(), 42);
+
+    try {
+        // migrate t1 to the target
+        test_client t2(hpx::components::migrate(t1, target));
+
+        // wait for migration to be done
+        HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+
+        // the migrated object should have the same id as before
+        HPX_TEST_EQ(t1.get_id(), t2.get_id());
+
+        // the migrated object should live on the target now
+        HPX_TEST_EQ(t2.call(), target);
+        HPX_TEST_EQ(t2.lazy_get_data(), 42);
     }
     catch (hpx::exception const& e) {
         hpx::cout << hpx::get_error_what(e) << std::endl;
@@ -197,6 +282,47 @@ bool test_migrate_busy_component(hpx::id_type source, hpx::id_type target)
     return true;
 }
 
+///////////////////////////////////////////////////////////////////////////////
+bool test_migrate_lazy_busy_component(hpx::id_type source, hpx::id_type target)
+{
+    // create component on given locality
+    test_client t1 = hpx::new_<test_client>(source, 42);
+    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+
+    // the new object should live on the source locality
+    HPX_TEST_EQ(t1.call(), source);
+    HPX_TEST_EQ(t1.lazy_get_data(), 42);
+
+    // add some concurrent busy work
+    hpx::future<void> lazy_busy_work = t1.lazy_busy_work();
+
+    try {
+        // migrate t1 to the target
+        test_client t2(hpx::components::migrate(t1, target));
+
+        HPX_TEST_EQ(t1.lazy_get_data(), 42);
+
+        // wait for migration to be done
+        HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+
+        // the migrated object should have the same id as before
+        HPX_TEST_EQ(t1.get_id(), t2.get_id());
+
+        // the migrated object should live on the target now
+        HPX_TEST_EQ(t2.call(), target);
+        HPX_TEST_EQ(t2.lazy_get_data(), 42);
+    }
+    catch (hpx::exception const& e) {
+        hpx::cout << hpx::get_error_what(e) << std::endl;
+        return false;
+    }
+
+    // the busy work should be finished by now, wait anyways
+    lazy_busy_work.wait();
+
+    return true;
+}
+
 bool test_migrate_component2(hpx::id_type source, hpx::id_type target)
 {
     test_client t1 = hpx::new_<test_client>(source, 42);
@@ -227,6 +353,52 @@ bool test_migrate_component2(hpx::id_type source, hpx::id_type target)
             // the migrated object should live on the target now
             HPX_TEST_EQ(t2.call(), target);
             HPX_TEST_EQ(t2.get_data(), 42);
+
+            hpx::cout << "." << std::flush;
+
+            std::swap(source, target);
+        }
+
+        hpx::cout << std::endl;
+    }
+    catch (hpx::exception const& e) {
+        hpx::cout << hpx::get_error_what(e) << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+bool test_migrate_lazy_component2(hpx::id_type source, hpx::id_type target)
+{
+    test_client t1 = hpx::new_<test_client>(source, 42);
+    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+
+    // the new object should live on the source locality
+    HPX_TEST_EQ(t1.call(), source);
+    HPX_TEST_EQ(t1.lazy_get_data(), 42);
+
+    std::size_t N = 100;
+
+    try {
+        // migrate an object back and forth between 2 localities a couple of
+        // times
+        for(std::size_t i = 0; i < N; ++i)
+        {
+            // migrate t1 to the target (loc2)
+            test_client t2(hpx::components::migrate(t1, target));
+
+            HPX_TEST_EQ(t1.lazy_get_data(), 42);
+
+            // wait for migration to be done
+            HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+
+            // the migrated object should have the same id as before
+            HPX_TEST_EQ(t1.get_id(), t2.get_id());
+
+            // the migrated object should live on the target now
+            HPX_TEST_EQ(t2.call(), target);
+            HPX_TEST_EQ(t2.lazy_get_data(), 42);
 
             hpx::cout << "." << std::flush;
 
@@ -315,6 +487,78 @@ bool test_migrate_busy_component2(hpx::id_type source, hpx::id_type target)
     return true;
 }
 
+bool test_migrate_lazy_busy_component2(hpx::id_type source, hpx::id_type target)
+{
+    test_client t1 = hpx::new_<test_client>(source, 42);
+    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+
+    // the new object should live on the source locality
+    HPX_TEST_EQ(t1.call(), source);
+    HPX_TEST_EQ(t1.get_data(), 42);
+
+    std::size_t N = 100;
+
+    // First, spawn a thread (locally) that will migrate the object between
+    // source and target a few times
+    hpx::future<void> migrate_future = hpx::async(
+        [source, target, t1, N]() mutable
+        {
+            for(std::size_t i = 0; i < N; ++i)
+            {
+                // migrate t1 to the target (loc2)
+                test_client t2(hpx::components::migrate(t1, target));
+
+                HPX_TEST_EQ(t1.lazy_get_data(), 42);
+
+                // wait for migration to be done
+                HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+
+                // the migrated object should have the same id as before
+                HPX_TEST_EQ(t1.get_id(), t2.get_id());
+
+                // the migrated object should live on the target now
+                HPX_TEST_EQ(t2.call(), target);
+                HPX_TEST_EQ(t2.lazy_get_data(), 42);
+
+                hpx::cout << "." << std::flush;
+
+                std::swap(source, target);
+            }
+
+            hpx::cout << std::endl;
+        }
+    );
+
+    // Second, we generate tons of work which should automatically follow
+    // the migration.
+    hpx::future<void> create_work = hpx::async(
+        [t1, N]()
+        {
+            for(std::size_t i = 0; i < 2*N; ++i)
+            {
+                hpx::cout
+                    << hpx::naming::get_locality_id_from_id(t1.call())
+                    << std::flush;
+                HPX_TEST_EQ(t1.lazy_get_data(), 42);
+            }
+        }
+    );
+
+    hpx::wait_all(migrate_future, create_work);
+
+    // rethrow exceptions
+    try {
+        migrate_future.get();
+        create_work.get();
+    }
+    catch (hpx::exception const& e) {
+        hpx::cout << hpx::get_error_what(e) << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 int main()
 {
@@ -326,6 +570,11 @@ int main()
         HPX_TEST(test_migrate_component(hpx::find_here(), id));
         hpx::cout << "test_migrate_component: <-" << id << std::endl;
         HPX_TEST(test_migrate_component(id, hpx::find_here()));
+
+        hpx::cout << "test_migrate_lazy_component: ->" << id << std::endl;
+        HPX_TEST(test_migrate_lazy_component(hpx::find_here(), id));
+        hpx::cout << "test_migrate_lazy_component: <-" << id << std::endl;
+        HPX_TEST(test_migrate_lazy_component(id, hpx::find_here()));
     }
 
     for (hpx::id_type const& id : localities)
@@ -334,6 +583,11 @@ int main()
         HPX_TEST(test_migrate_busy_component(hpx::find_here(), id));
         hpx::cout << "test_migrate_busy_component: <-" << id << std::endl;
         HPX_TEST(test_migrate_busy_component(id, hpx::find_here()));
+
+        hpx::cout << "test_migrate_lazy_busy_component: ->" << id << std::endl;
+        HPX_TEST(test_migrate_lazy_busy_component(hpx::find_here(), id));
+        hpx::cout << "test_migrate_lazy_busy_component: <-" << id << std::endl;
+        HPX_TEST(test_migrate_lazy_busy_component(id, hpx::find_here()));
     }
 
     for (hpx::id_type const& id : localities)
@@ -342,6 +596,11 @@ int main()
         HPX_TEST(test_migrate_component2(hpx::find_here(), id));
         hpx::cout << "test_migrate_component2: <-" << id << std::endl;
         HPX_TEST(test_migrate_component2(id, hpx::find_here()));
+
+        hpx::cout << "test_migrate_lazy_component2: ->" << id << std::endl;
+        HPX_TEST(test_migrate_lazy_component2(hpx::find_here(), id));
+        hpx::cout << "test_migrate_lazy_component2: <-" << id << std::endl;
+        HPX_TEST(test_migrate_lazy_component2(id, hpx::find_here()));
     }
 
     for (hpx::id_type const& id : localities)
@@ -350,6 +609,11 @@ int main()
         HPX_TEST(test_migrate_busy_component2(hpx::find_here(), id));
         hpx::cout << "test_migrate_busy_component2: <-" << id << std::endl;
         HPX_TEST(test_migrate_busy_component2(id, hpx::find_here()));
+
+        hpx::cout << "test_migrate_lazy_busy_component2: ->" << id << std::endl;
+        HPX_TEST(test_migrate_lazy_busy_component2(hpx::find_here(), id));
+        hpx::cout << "test_migrate_lazy_busy_component2: <-" << id << std::endl;
+        HPX_TEST(test_migrate_lazy_busy_component2(id, hpx::find_here()));
     }
 
     return hpx::util::report_errors();


### PR DESCRIPTION

- fix problem in traits::action_decorate_function when used with component type
- adding more test cases for migrating components that expose actions returning futures
- flyby: factor out pinning/unpinning into separate trait

This fixes #3325


