### PR TITLE
Update description of hpx.os_threads config parameter.

### DIFF
--- a/docs/manual/config_defaults.qbk
+++ b/docs/manual/config_defaults.qbk
@@ -95,7 +95,7 @@ by section basis below.
       separated by `':'` (Linux, Android, and MacOS) or using `';'` (Windows).]]
     [[`hpx.os_threads`]
      [This setting reflects the number of OS-threads used for running __hpx__-threads.
-      Defaults to `1`.]]
+      Defaults to number of detected PUs.]]
     [[`hpx.localities`]
      [This setting reflects the number of localities the application is running on.
       Defaults to `1`.]]


### PR DESCRIPTION
## Proposed Changes

  - description of parameter hpx.os_threads was deprecated in the documentation (saying that the value defaults to 1). I updated the the description (the value defaults to number of detected PUs).