### PR TITLE
Only run docker push on master on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -914,10 +914,12 @@ jobs:
       - run:
           name: Push Docker Image
           command: |
-              docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
-              docker push ${TARGET_IMAGE_NAME}
-          filters:
-              branches: master
+              if [ "$CIRCLE_BRANCH" == "master" ]; then
+                  docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
+                  docker push ${TARGET_IMAGE_NAME}
+              else
+                  echo "Skipping docker push on non-master branch"
+              fi
 
 workflows:
   version: 2


### PR DESCRIPTION
This is a dumb solution to filtering not working on individual commands in the CircleCI config, i.e. it does the filtering with a bash if statement by checking the `CIRCLE_BRANCH` environment variable.

As far as I could tell, doing this the official way would involve copying files using the cache/workspace and or duplicating workflow steps, so I thought this is more manageable even though the docker push step will still show up on PRs.