### PR TITLE
Replacing hpx_main's #define main with overriding __libc_start_main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -505,6 +505,29 @@ jobs:
       - store_artifacts:
           path: tests.unit.resource
 
+  tests.unit.runtime:
+    <<: *defaults
+    steps:
+      - restore_cache:
+          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
+      - attach_workspace:
+          at: /hpx/build
+      - run:
+          name: Building Unit Tests
+          command: |
+              ninja -j2 -k 0 tests.unit.runtime
+      - run:
+          name: Running Unit Tests
+          when: always
+          command: |
+              ctest -T test --no-compress-output --output-on-failure -R tests.unit.runtime
+      - run:
+          <<: *convert_xml
+      - store_test_results:
+          path: tests.unit.runtime
+      - store_artifacts:
+          path: tests.unit.runtime
+
   tests.unit.serialization:
     <<: *defaults
     steps:

--- a/hpx/hpx_main.hpp
+++ b/hpx/hpx_main.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2018 Nikunj Gupta
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -31,31 +32,31 @@ char** __envp = nullptr;
 ///////////////////////////////////////////////////////////////////////////////
 // Default implementation of __hpx_entry() for initializing the HPX runtime
 // system
-// 
+//
 int __hpx_entry(int argc, char* argv[])
 {
-	// Call to the Compiler's main with HPX runt time
-	// initiated.
-	actual_main(__argc, __argv, __envp);
+    // Call to the Compiler's main with HPX runt time
+    // initiated.
+    actual_main(__argc, __argv, __envp);
 
-	return hpx::finalize();
+    return hpx::finalize();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 // Default entry point for the runtime system.
-// 
+//
 // Note: This function is now the equivalent of Comipler's main i.e the entry
 // point has been shifted from "main" to "initializing_main"
-// 
+//
 int __initializing_main (int argc, char** argv, char** envp)
 {
-	__argc = argc;
-	__argv = argv;
-	__envp = envp;
+    __argc = argc;
+    __argv = argv;
+    __envp = envp;
 
-	std::vector<std::string> const cfg = {
-		// allow for unknown command line options
-		"hpx.commandline.allow_unknown!=1",
+    std::vector<std::string> const cfg = {
+        // allow for unknown command line options
+        "hpx.commandline.allow_unknown!=1",
 	};
 
     using hpx::util::placeholders::_1;
@@ -63,29 +64,29 @@ int __initializing_main (int argc, char** argv, char** envp)
     hpx::util::function_nonser<int(int, char**)> start_function =
         hpx::util::bind(&__hpx_entry, _1, _2);
 
-	// Initializing HPX runtime using hpx::init
-	return hpx::init(start_function, argc, argv, cfg, hpx::runtime_mode_console);
+    // Initializing HPX runtime using hpx::init
+    return hpx::init(start_function, argc, argv, cfg, hpx::runtime_mode_console);
 }
 
-// Wrapper for the Compiler's __libc_start_main function. 
-extern "C" int __libc_start_main ( 
-				int (*main)(int, char**, char**), int argc, char * * ubp_av, 
-				void (*init) (void), void (*fini) (void), 
-				void (*rtld_fini) (void), void (* stack_end)) 
+// Wrapper for the Compiler's __libc_start_main function.
+extern "C" int __libc_start_main (
+                int (*main)(int, char**, char**), int argc, char * * ubp_av,
+                void (*init) (void), void (*fini) (void),
+                void (*rtld_fini) (void), void (* stack_end))
 {
-	// Storing pointer to the __libc_start_main
-	int (*real_start_main)(int (*main) (int, char**, char**), int argc, 
-		char** ubp_av, void (*init) (void), 
-		void (*fini) (void), void (*rtld_fini) (void), void (* stack_end)) 
-		= 
-		(int (*)(int (*)(int, char**, char**), int, char**, void (*)(), 
-		void (*)(), void (*)(), void*))dlsym(RTLD_NEXT, "__libc_start_main");
-	
-	actual_main = main;
+    // Storing pointer to the __libc_start_main
+    int (*real_start_main)(int (*main) (int, char**, char**), int argc,
+        char** ubp_av, void (*init) (void),
+        void (*fini) (void), void (*rtld_fini) (void), void (* stack_end))
+        =
+        (int (*)(int (*)(int, char**, char**), int, char**, void (*)(),
+        void (*)(), void (*)(), void*))dlsym(RTLD_NEXT, "__libc_start_main");
 
-	// call original __libc_start_main, but replace "main" with our custom implementation
-	return real_start_main(__initializing_main, argc, ubp_av,
-			init, fini, rtld_fini, stack_end);
+    actual_main = main;
+
+    // call original __libc_start_main, but replace "main" with our custom implementation
+    return real_start_main(__initializing_main, argc, ubp_av,
+            init, fini, rtld_fini, stack_end);
 }
 
 #elif defined(HPX_HAVE_STATIC_LINKING)

--- a/hpx/hpx_main.hpp
+++ b/hpx/hpx_main.hpp
@@ -9,13 +9,92 @@
 #include <hpx/config.hpp>
 #include <hpx/hpx_init.hpp>
 
-#if defined(HPX_HAVE_STATIC_LINKING)
+#if defined(__GNUC__) || (__clang__)
+
+#define _GNU_SOURCE
+
+#include <hpx/hpx.hpp>
+#include <hpx/include/run_as.hpp>
+#include <hpx/hpx_start.hpp>
+
+#include <dlfcn.h>
+#include <iostream>
+#include <vector>
+
+// To store the pointer to the compiler's main
+int (*actual_main)(int, char**, char**);
+int __argc = 0;
+char** __argv = nullptr;
+char** __envp = nullptr;
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Default implementation of __hpx_entry() for initializing the HPX runtime
+// system
+// 
+int __hpx_entry(int argc, char* argv[])
+{
+	// Call to the Compiler's main with HPX runt time
+	// initiated.
+	actual_main(__argc, __argv, __envp);
+
+	return hpx::finalize();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Default entry point for the runtime system.
+// 
+// Note: This function is now the equivalent of Comipler's main i.e the entry
+// point has been shifted from "main" to "initializing_main"
+// 
+int __initializing_main (int argc, char** argv, char** envp)
+{
+	__argc = argc;
+	__argv = argv;
+	__envp = envp;
+
+	std::vector<std::string> const cfg = {
+		// allow for unknown command line options
+		"hpx.commandline.allow_unknown!=1",
+	};
+
+    using hpx::util::placeholders::_1;
+    using hpx::util::placeholders::_2;
+    hpx::util::function_nonser<int(int, char**)> start_function =
+        hpx::util::bind(&__hpx_entry, _1, _2);
+
+	// Initializing HPX runtime using hpx::init
+	return hpx::init(start_function, argc, argv, cfg, hpx::runtime_mode_console);
+}
+
+// Wrapper for the Compiler's __libc_start_main function. 
+extern "C" int __libc_start_main ( 
+				int (*main)(int, char**, char**), int argc, char * * ubp_av, 
+				void (*init) (void), void (*fini) (void), 
+				void (*rtld_fini) (void), void (* stack_end)) 
+{
+	// Storing pointer to the __libc_start_main
+	int (*real_start_main)(int (*main) (int, char**, char**), int argc, 
+		char** ubp_av, void (*init) (void), 
+		void (*fini) (void), void (*rtld_fini) (void), void (* stack_end)) 
+		= 
+		(int (*)(int (*)(int, char**, char**), int, char**, void (*)(), 
+		void (*)(), void (*)(), void*))dlsym(RTLD_NEXT, "__libc_start_main");
+	
+	actual_main = main;
+
+	// call original __libc_start_main, but replace "main" with our custom implementation
+	return real_start_main(__initializing_main, argc, ubp_av,
+			init, fini, rtld_fini, stack_end);
+}
+
+#elif defined(HPX_HAVE_STATIC_LINKING)
 #include <hpx/hpx_main_impl.hpp>
-#endif
 
 // We support redefining the plain C-main provided by the user to be executed
 // as the first HPX-thread (equivalent to hpx_main()). This is implemented by
 // a macro redefining main, so we disable it by default.
 #define main hpx_startup::user_main
+#endif
 
 #endif /*HPX_HPX_MAIN_HPP*/

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -15,6 +15,7 @@ set(subdirs
     parcelset
     performance_counter
     resource
+    runtime
     serialization
     threads
     traits

--- a/tests/unit/runtime/CMakeLists.txt
+++ b/tests/unit/runtime/CMakeLists.txt
@@ -36,7 +36,4 @@ if(NOT MSVC)
                                 ${test}_test_exe)
   endforeach()
 
-else()
-  message(FATAL_ERROR "This test is meant only for gcc and clang compilers.")
-
 endif()

--- a/tests/unit/runtime/CMakeLists.txt
+++ b/tests/unit/runtime/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Copyright (c) 2018 Nikunj Gupta
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if(NOT MSVC)
+
+  set(tests
+      runtime_initialization)
+
+  foreach(test ${tests})
+    set(sources
+        ${test}.cpp)
+
+    source_group("Source Files" FILES ${sources})
+
+    # add example executable
+    add_hpx_executable(${test}_test
+                       SOURCES ${sources}
+                       ${${test}_FLAGS}
+                       EXCLUDE_FROM_ALL
+                       HPX_PREFIX ${HPX_BUILD_PREFIX}
+                       FOLDER "Tests/Unit/Runtime/")
+
+    add_hpx_unit_test("runtime" ${test} ${${test}_PARAMETERS})
+
+    # add a custom target for this example
+    add_hpx_pseudo_target(tests.unit.runtime.${test})
+
+    # make pseudo-targets depend on master pseudo-target
+    add_hpx_pseudo_dependencies(tests.unit.runtime
+                                tests.unit.runtime.${test})
+
+    # add dependencies to pseudo-target
+    add_hpx_pseudo_dependencies(tests.unit.runtime.${test}
+                                ${test}_test_exe)
+  endforeach()
+
+else()
+  message(FATAL_ERROR "This test is meant only for gcc and clang compilers.")
+
+endif()

--- a/tests/unit/runtime/runtime_initialization.cpp
+++ b/tests/unit/runtime/runtime_initialization.cpp
@@ -1,0 +1,32 @@
+//  Copyright (c) 2018 Nikunj Gupta
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Simple test verifying runtime initialization sequence
+
+#define _GNU_SOURCE
+
+#include <dlfcn.h>
+#include <iostream>
+#include <vector>
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_main.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+// For testing hpx::future and hpx::async
+int test_future()
+{
+    return 42;
+}
+
+
+// This will try to use HPX functionality directly from main
+int main(int argc, char** argv)
+{
+    hpx::future<int> f = hpx::async(&test_future);
+    HPX_TEST(f.get() == 42);
+
+    return 0;
+}

--- a/tests/unit/runtime/runtime_initialization.cpp
+++ b/tests/unit/runtime/runtime_initialization.cpp
@@ -4,13 +4,6 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 // Simple test verifying runtime initialization sequence
-
-#define _GNU_SOURCE
-
-#include <dlfcn.h>
-#include <iostream>
-#include <vector>
-
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_main.hpp>
 #include <hpx/util/lightweight_test.hpp>


### PR DESCRIPTION
This is my first GSoC'18 commit. Currently, this commit provides code for refining **hpx_main.hpp** for **gcc** and **clang** based compilers. I am working on **msvc** based compilers and will provide code for the same soon.

## Proposed Changes

  - Refining **hpx_main.hpp** by using wrapper for ``__libc_start_main``


## Any background context you want to provide?

I have created a wrapper for ``__libc_start_main`` and created a hook for the function. I changed the signature of ``__libc_Start_main`` by providing my own entry point (``__initializing_main``) instead of ``main``. From here I call the ``hpx::init`` to start the HPX runtime system. From the initialized system, I call the ``main`` function.

For a user, including this header will enable him to use HPX functionality directly from ``int main``.


## Current challenges and refinement required

This implementation has a few drawbacks which I'm currently working on. These are as follows:
 - It will NOT work for any global object using HPX functionality.
 - It has used global scope variables, which in my opinion is not a good practice

Any suggestions and reviews are welcomed.