### PR TITLE
Always convert inspect results to JUnit XML

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,7 @@ jobs:
               /hpx/source/tools/inspect/inspect_to_junit.py \
                   ./hpx_inspect_report.html \
                   /report/hpx_inspect.xml
+          when: always
       - store_artifacts:
           path: hpx_inspect_report.html
           destination: hpx_inspect_report.html


### PR DESCRIPTION
Currently the inspect tool results are not converted to JUnit XML when it does actually fail. This PR ensures that it does.