### PR TITLE
Allowing for all command line options to be used as configuration settings

### DIFF
--- a/hpx/util/command_line_handling.hpp
+++ b/hpx/util/command_line_handling.hpp
@@ -84,6 +84,9 @@ namespace hpx { namespace util
             boost::program_options::options_description const& help);
 
         void handle_attach_debugger();
+
+        std::vector<std::string> preprocess_config_settings(
+            int argc, char** argv);
     };
 
     void handle_print_bind(boost::program_options::variables_map const& vm,

--- a/hpx/util/parse_command_line.hpp
+++ b/hpx/util/parse_command_line.hpp
@@ -29,8 +29,7 @@ namespace hpx { namespace util
 
     ///////////////////////////////////////////////////////////////////////////
     // parse the command line
-    HPX_API_EXPORT bool parse_commandline(
-        hpx::util::section const& rtcfg,
+    HPX_API_EXPORT bool parse_commandline(hpx::util::section const& rtcfg,
         boost::program_options::options_description const& app_options,
         std::string const& cmdline, boost::program_options::variables_map& vm,
         std::size_t node, int error_mode = return_on_error,
@@ -38,11 +37,11 @@ namespace hpx { namespace util
         boost::program_options::options_description* visible = nullptr,
         std::vector<std::string>* unregistered_options = nullptr);
 
-    HPX_API_EXPORT bool parse_commandline(
-        hpx::util::section const& rtcfg,
+    HPX_API_EXPORT bool parse_commandline(hpx::util::section const& rtcfg,
         boost::program_options::options_description const& app_options,
-        int argc, char** argv, boost::program_options::variables_map& vm,
-        std::size_t node, int error_mode = return_on_error,
+        std::string const& arg0, std::vector<std::string> const& args,
+        boost::program_options::variables_map& vm, std::size_t node,
+        int error_mode = return_on_error,
         hpx::runtime_mode mode = runtime_mode_default,
         boost::program_options::options_description* visible = nullptr,
         std::vector<std::string>* unregistered_options = nullptr);

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -13,6 +13,7 @@
 #include <hpx/runtime/threads/thread.hpp>
 #include <hpx/runtime/threads/threadmanager.hpp>
 #include <hpx/runtime/threads/topology.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/util/asio_util.hpp>
 #include <hpx/util/batch_environment.hpp>
 #include <hpx/util/debugging.hpp>
@@ -1201,12 +1202,44 @@ namespace hpx { namespace util
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    // separate command line arguments from configuration settings
+    std::vector<std::string> command_line_handling::preprocess_config_settings(
+        int argc, char** argv)
+    {
+        std::vector<std::string> options;
+        options.reserve(argc + ini_config_.size());
+
+        // extract all command line arguments from configuration settings and
+        // remove them from this list
+        auto it = std::stable_partition(
+            ini_config_.begin(), ini_config_.end(),
+            [](std::string const& e)
+            {
+                return e.find("--hpx:") != 0;
+            });
+
+        std::move(it, ini_config_.end(), std::back_inserter(options));
+        ini_config_.erase(it, ini_config_.end());
+
+        // now append all original command line options
+        for (int i = 1; i != argc; ++i)
+        {
+            options.emplace_back(argv[i]);
+        }
+
+        return options;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     int command_line_handling::call(
         boost::program_options::options_description const& desc_cmdline,
         int argc, char** argv)
     {
         // set the flag signaling that command line parsing has been done
         cmd_line_parsed_ = true;
+
+        // separate command line arguments from configuration settings
+        std::vector<std::string> args = preprocess_config_settings(argc, argv);
 
         util::manage_config cfgmap(ini_config_);
 
@@ -1230,8 +1263,8 @@ namespace hpx { namespace util
             // creating a separate instance just for the preliminary
             // command line handling.
             boost::program_options::variables_map prevm;
-            if (!util::parse_commandline(rtcfg_, desc_cmdline, argc,
-                    argv, prevm, std::size_t(-1), error_mode,
+            if (!util::parse_commandline(rtcfg_, desc_cmdline, argv[0], args,
+                    prevm, std::size_t(-1), error_mode,
                     rtcfg_.mode_))
             {
                 return -1;
@@ -1298,7 +1331,7 @@ namespace hpx { namespace util
         std::vector<std::string> unregistered_options;
 
         if (!util::parse_commandline(rtcfg_, desc_cmdline,
-                argc, argv, vm_, node_, error_mode, rtcfg_.mode_,
+                argv[0], args, vm_, node_, error_mode, rtcfg_.mode_,
                 &help, &unregistered_options))
         {
             return -1;

--- a/src/util/parse_command_line.cpp
+++ b/src/util/parse_command_line.cpp
@@ -304,11 +304,11 @@ namespace hpx { namespace util
 
     ///////////////////////////////////////////////////////////////////////////
     // parse the command line
-    bool parse_commandline(
-        util::section const& rtcfg,
+    bool parse_commandline(util::section const& rtcfg,
         boost::program_options::options_description const& app_options,
-        int argc, char** argv, boost::program_options::variables_map& vm,
-        std::size_t node, int error_mode, hpx::runtime_mode mode,
+        std::string const& arg0, std::vector<std::string> const& args,
+        boost::program_options::variables_map& vm, std::size_t node,
+        int error_mode, hpx::runtime_mode mode,
         boost::program_options::options_description* visible,
         std::vector<std::string>* unregistered_options)
     {
@@ -602,7 +602,7 @@ namespace hpx { namespace util
 
                 // parse command line, allow for unregistered options this point
                 parsed_options opts(detail::get_commandline_parser(
-                        command_line_parser(argc, argv)
+                        command_line_parser(args)
                             .options(desc_cmdline)
                             .positional(pd)
                             .style(unix_style)
@@ -625,7 +625,7 @@ namespace hpx { namespace util
             {
                 // parse command line, allow for unregistered options this point
                 parsed_options opts(detail::get_commandline_parser(
-                        command_line_parser(argc, argv)
+                        command_line_parser(args)
                             .options(desc_cmdline)
                             .style(unix_style)
                             .extra_parser(detail::option_parser(rtcfg, node)),
@@ -660,7 +660,7 @@ namespace hpx { namespace util
             notify(vm);
 
             detail::handle_generic_config_options(
-                argv[0], vm, desc_cfgfile, rtcfg, node, error_mode);
+                arg0, vm, desc_cfgfile, rtcfg, node, error_mode);
             detail::handle_config_options(
                 vm, desc_cfgfile, rtcfg, node, error_mode);
         }
@@ -676,6 +676,19 @@ namespace hpx { namespace util
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        std::string extract_arg0(std::string const& cmdline)
+        {
+            std::string::size_type p = cmdline.find_first_of(" \t");
+            if (p != std::string::npos)
+            {
+                return cmdline.substr(0, p);
+            }
+            return cmdline;
+        }
+    }
+
     bool parse_commandline(
         util::section const& rtcfg,
         boost::program_options::options_description const& app_options,
@@ -690,15 +703,9 @@ namespace hpx { namespace util
 #else
         std::vector<std::string> args = split_unix(cmdline);
 #endif
-
-        boost::scoped_array<char*> argv(new char* [args.size()+1]);
-        for (std::size_t i = 0; i < args.size(); ++i)
-            argv[i] = const_cast<char*>(args[i].c_str());
-        argv[args.size()] = nullptr;
-
-        return parse_commandline(
-            rtcfg, app_options, static_cast<int>(args.size()), argv.get(), vm,
-            node, error_mode, mode, visible, unregistered_options);
+        return parse_commandline(rtcfg, app_options,
+            detail::extract_arg0(cmdline), args, vm, node, error_mode, mode,
+            visible, unregistered_options);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/tests/regressions/CMakeLists.txt
+++ b/tests/regressions/CMakeLists.txt
@@ -37,6 +37,7 @@ set(tests
     id_type_ref_counting_1032
     multiple_init
     multiple_init_2918
+    options_as_config_3339
     unhandled_exception_582
    )
 

--- a/tests/regressions/options_as_config_3339.cpp
+++ b/tests/regressions/options_as_config_3339.cpp
@@ -1,0 +1,26 @@
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+int hpx_main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(hpx::get_config_entry("hpx.cores", "1"), std::string("3"));
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> const cfg =
+    {
+        "--hpx:cores=3"
+    };
+
+    HPX_TEST_EQ(hpx::init(argc, argv, cfg), 0);
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Fixes #3339

This patch allows for command line options to be used instead of the configuration setting as explained in #3339.

@bcumming, @biddisco please check whether this solves your problem