### PR TITLE
Replace `simple_component*` with `component*` in the Documentation

### DIFF
--- a/docs/manual/applying_actions.qbk
+++ b/docs/manual/applying_actions.qbk
@@ -85,7 +85,7 @@ demonstrating this. The first snippet has to go into the header file:
     namespace app
     {
         struct some_component
-          : hpx::components::simple_component_base<some_component>
+          : hpx::components::component_base<some_component>
         {
             int some_member_function(std::string s)
             {
@@ -108,7 +108,7 @@ demonstrating this. The first snippet has to go into the header file:
 The next snippet belongs into a source file (e.g. the main application source
 file) in the simplest case:
 
-    typedef hpx::components::simple_component<app::some_component> component_type;
+    typedef hpx::components::component<app::some_component> component_type;
     typedef app::some_component some_component;
 
     HPX_REGISTER_COMPONENT(component_type, some_component);

--- a/docs/manual/components.qbk
+++ b/docs/manual/components.qbk
@@ -15,7 +15,7 @@ highlight how components can be defined, created, and used.
 [section:components_server Defining Components]
 
 In order for a C++ class type to be managed remotely in __hpx__, the type must
-be derived from the `hpx::components::simple_component_base` template type. We
+be derived from the `hpx::components::component_base` template type. We
 call such C++ class types 'components'.
 
 Note that the component type itself is passed as a template argument to the
@@ -29,7 +29,7 @@ base class.
     {
         // Define a new component type 'some_component'
         struct some_component
-          : hpx::components::simple_component_base<some_component>
+          : hpx::components::component_base<some_component>
         {
             // This member function is has to be invoked remotely
             int some_member_function(std::string const& s)
@@ -68,7 +68,7 @@ For instance:
     // remote creation of 'app::some_component' instances with 'hpx::new_<>()'
     //
     using some_component = app::some_component;
-    using some_component_type = hpx::components::simple_component<some_component>;
+    using some_component_type = hpx::components::component<some_component>;
 
     // Please note that the second argument to this macro must be a
     // (system-wide) unique C++-style identifier (without any namespaces)

--- a/docs/manual/loading_components.qbk
+++ b/docs/manual/loading_components.qbk
@@ -75,7 +75,7 @@ referenced by [teletype]`$APP_ROOT`[c++]:
     {
         // Define a simple component exposing one action 'print_greeting'
         class HPX_COMPONENT_EXPORT server
-          : public hpx::components::simple_component_base<server>
+          : public hpx::components::component_base<server>
         {
             void print_greeting ()
             {

--- a/docs/tutorial/futurization_example.qbk
+++ b/docs/tutorial/futurization_example.qbk
@@ -146,7 +146,7 @@ to global objects. Example 5 renames example 4's
 [^struct partition] to [^partition_data] and
 adds serialization support. Next we add the server side
 representation of the data in the structure [^partition_server].
-[^Partition_server] inherits from [^hpx::components::simple_component_base]
+[^Partition_server] inherits from [^hpx::components::component_base]
 which contains a server side component boilerplate.
 The boilerplate code allows a component's public members
 to be accessible anywhere on the


### PR DESCRIPTION
The futurization examples use `hpx::components::component` opposed to what is stated in the description. According to H. Kaiser the usage of the template class aliases `simple_component` and `simple_component_base` is deprecated.
