### PR TITLE
Make idle backoff exponential with maximum sleep time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -451,7 +451,7 @@ hpx_option(HPX_WITH_THREAD_STACK_MMAP BOOL
   CATEGORY "Thread Manager" ADVANCED)
 
 hpx_option(HPX_WITH_THREAD_MANAGER_IDLE_BACKOFF BOOL
-  "HPX scheduler threads are backing off on idle queues (default: ON)"
+  "HPX scheduler threads do exponential backoff on idle queues (default: ON)"
   ON
   CATEGORY "Thread Manager" ADVANCED)
 

--- a/docs/manual/config_defaults.qbk
+++ b/docs/manual/config_defaults.qbk
@@ -65,6 +65,7 @@ by section basis below.
     max_background_threads = ${HPX_MAX_BACKGROUND_THREADS:$[hpx.os_threads]}
     max_idle_loop_count = ${HPX_MAX_IDLE_LOOP_COUNT:<hpx_idle_loop_count_max>}
     max_busy_loop_count = ${HPX_MAX_BUSY_LOOP_COUNT:<hpx_busy_loop_count_max>}
+    max_idle_backoff_time = ${HPX_MAX_IDLE_BACKOFF_TIME:<hpx_idle_backoff_time_max>}
 
     [hpx.stacks]
     small_size = ${HPX_SMALL_STACK_SIZE:<hpx_small_stack_size>}
@@ -145,6 +146,14 @@ by section basis below.
       scheduler. By default this is defined by the preprocessor constant
       `HPX_BUSY_LOOP_COUNT_MAX`. This is an internal setting which you should
       change only if you know exactly what you are doing.]]
+    [[`hpx.max_idle_backoff_time`]
+     [This setting defines the maximum time (in milliseconds) for the scheduler
+      to sleep after being idle for `hpx.max_idle_loop_count` iterations. This
+      setting is applicable only if `HPX_WITH_THREAD_MANAGER_IDLE_BACKOFF` is set
+      during configuration in CMake. By default this is defined by the
+      preprocessor constant `HPX_IDLE_BACKOFF_TIME_MAX`. This is an internal
+      setting which you should change only if you know exactly what you are
+      doing.]]
 
     [[`hpx.stacks.small_size`]
      [This is initialized to the small stack size to be used by __hpx__-threads.

--- a/hpx/config.hpp
+++ b/hpx/config.hpp
@@ -370,6 +370,14 @@
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
+// Maximum sleep time for idle backoff in milliseconds.
+#if defined(HPX_HAVE_THREAD_MANAGER_IDLE_BACKOFF)
+#  if !defined(HPX_IDLE_BACKOFF_TIME_MAX)
+#    define HPX_IDLE_BACKOFF_TIME_MAX 1000
+#  endif
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
 #if !defined(HPX_WRAPPER_HEAP_STEP)
 #  define HPX_WRAPPER_HEAP_STEP 0xFFFFU
 #endif

--- a/hpx/runtime/threads/policies/scheduler_base.hpp
+++ b/hpx/runtime/threads/policies/scheduler_base.hpp
@@ -10,6 +10,7 @@
 #include <hpx/compat/condition_variable.hpp>
 #include <hpx/compat/mutex.hpp>
 #include <hpx/runtime/agas/interface.hpp>
+#include <hpx/runtime/config_entry.hpp>
 #include <hpx/runtime/parcelset_fwd.hpp>
 #include <hpx/runtime/resource/detail/partitioner.hpp>
 #include <hpx/runtime/threads/policies/scheduler_mode.hpp>
@@ -17,6 +18,7 @@
 #include <hpx/runtime/threads/thread_pool_base.hpp>
 #include <hpx/state.hpp>
 #include <hpx/util/assert.hpp>
+#include <hpx/util/safe_lexical_cast.hpp>
 #include <hpx/util/yield_while.hpp>
 #include <hpx/util_fwd.hpp>
 #if defined(HPX_HAVE_SCHEDULER_LOCAL_STORAGE)
@@ -78,6 +80,10 @@ namespace hpx { namespace threads { namespace policies
           : mode_(mode)
 #if defined(HPX_HAVE_THREAD_MANAGER_IDLE_BACKOFF)
           , wait_count_(0)
+          , max_idle_backoff_time_(
+                hpx::util::safe_lexical_cast<double>(
+                    hpx::get_config_entry("hpx.max_idle_backoff_time",
+                        HPX_IDLE_BACKOFF_TIME_MAX)))
 #endif
           , suspend_mtxs_(num_threads)
           , suspend_conds_(num_threads)
@@ -124,7 +130,13 @@ namespace hpx { namespace threads { namespace policies
 #if defined(HPX_HAVE_THREAD_MANAGER_IDLE_BACKOFF)
             // Put this thread to sleep for some time, additionally it gets
             // woken up on new work.
-            std::chrono::milliseconds period(++wait_count_);
+
+            // Exponential backoff with a maximum sleep time.
+            std::chrono::milliseconds period(
+                std::lround(std::min(max_idle_backoff_time_,
+                    std::pow(2.0, wait_count_))));
+
+            ++wait_count_;
 
             std::unique_lock<pu_mutex_type> l(mtx_);
             cond_.wait_for(l, period);
@@ -491,6 +503,7 @@ namespace hpx { namespace threads { namespace policies
         pu_mutex_type mtx_;
         compat::condition_variable cond_;
         std::atomic<std::uint32_t> wait_count_;
+        double max_idle_backoff_time_;
 #endif
 
         // support for suspension of pus

--- a/hpx/runtime/threads/policies/scheduler_base.hpp
+++ b/hpx/runtime/threads/policies/scheduler_base.hpp
@@ -133,7 +133,7 @@ namespace hpx { namespace threads { namespace policies
 
             // Exponential backoff with a maximum sleep time.
             std::chrono::milliseconds period(
-                std::lround(std::min(max_idle_backoff_time_,
+                std::lround((std::min)(max_idle_backoff_time_,
                     std::pow(2.0, wait_count_))));
 
             ++wait_count_;

--- a/src/util/runtime_configuration.cpp
+++ b/src/util/runtime_configuration.cpp
@@ -195,6 +195,10 @@ namespace hpx { namespace util
                 HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_IDLE_LOOP_COUNT_MAX)) "}",
             "max_busy_loop_count = ${HPX_MAX_BUSY_LOOP_COUNT:"
                 HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_BUSY_LOOP_COUNT_MAX)) "}",
+#if defined(HPX_HAVE_THREAD_MANAGER_IDLE_BACKOFF)
+            "max_idle_backoff_time = ${HPX_MAX_IDLE_BACKOFF_TIME:"
+            HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_IDLE_BACKOFF_TIME_MAX)) "}",
+#endif
 
             /// If HPX_HAVE_ATTACH_DEBUGGER_ON_TEST_FAILURE is set,
             /// then apply the test-failure value as default.


### PR DESCRIPTION
## Proposed Changes

- Make scheduling loop idle backoff exponential
- Add maximum sleep time (can be configured through `hpx.max_idle_backoff_time`)

This makes HPX idle quicker than with the linear backoff. Combined with decreasing `hpx.max_idle_loop_count` this makes HPX idle CPU usage close to 0. This is useful for interactive HPX usage where HPX might not have work all the time (`HPX_HAVE_THREADMANAGER_IDLE_BACKOFF=Off` is still there for those who don't want this behaviour).