### PR TITLE
Fix libfabric tcp

### DIFF
--- a/plugins/parcelport/libfabric/libfabric_controller.hpp
+++ b/plugins/parcelport/libfabric/libfabric_controller.hpp
@@ -509,6 +509,14 @@ namespace libfabric
             LOG_DEBUG_MSG("passive endpoint " << hexpointer(ep_passive_));
             id = &ep_passive_->fid;
 #endif
+
+#ifdef HPX_HAVE_PARCELPORT_TCP
+            // with tcp we do not use PMI boot, so enable the endpoint now
+            LOG_DEBUG_MSG("Enabling endpoint (TCP) " << hexpointer(ep_active_));
+            ret = fi_enable(ep_active_);
+            if (ret) throw fabric_error(ret, "fi_enable");
+#endif
+
             locality::locality_data local_addr;
             std::size_t addrlen = locality::array_size;
             LOG_DEBUG_MSG("Fetching local address using size " << decnumber(addrlen));

--- a/plugins/parcelport/libfabric/libfabric_controller.hpp
+++ b/plugins/parcelport/libfabric/libfabric_controller.hpp
@@ -116,7 +116,7 @@ namespace libfabric
 
         // Map of connections started, needed until connection is completed
         hpx::concurrent::unordered_map<uint32_t, promise_tuple_type> endpoint_tmp_;
-        std::unordered_map<uint32_t, fi_addr_t> endpoint_av_;
+        std::unordered_map<uint64_t, fi_addr_t> endpoint_av_;
 
         locality here_;
         locality agas_;
@@ -621,7 +621,8 @@ namespace libfabric
         // --------------------------------------------------------------------
         fi_addr_t get_fabric_address(const locality &dest_fabric)
         {
-            return endpoint_av_.find(dest_fabric.ip_address())->second;
+            uint64_t key = (uint64_t)dest_fabric.ip_address() << 32 | dest_fabric.port();
+            return endpoint_av_.find(key)->second;
         }
 
         // --------------------------------------------------------------------
@@ -1063,9 +1064,11 @@ namespace libfabric
             else if (ret != 1) {
                 fabric_error(ret, "fi_av_insert did not return 1");
             }
-            endpoint_av_.insert(std::make_pair(remote.ip_address(), result));
+            uint64_t key = (uint64_t)remote.ip_address() << 32 | remote.port();
+            endpoint_av_.insert(std::make_pair(key, result));
             LOG_DEBUG_MSG("Address inserted in vector "
-                << ipaddress(remote.ip_address()) << hexuint64(result));
+                << ipaddress(remote.ip_address()) << ":"
+                << remote.port() << hexuint64(result));
             FUNC_END_DEBUG_MSG;
             return result;
         }


### PR DESCRIPTION
Fixes #3352 

Allows nodes to send messages using libfabric over TCP
Does not yet fix the boot/initialization, this still uses the default TCP boost:asio parcelport