### PR TITLE
Updates doc with recent hpx_wrap implementation

### DIFF
--- a/docs/hpx.qbk
+++ b/docs/hpx.qbk
@@ -347,6 +347,7 @@ __boost_auto_index__ can be found in the collection of __boost_tools__.
 [include manual/system_components.qbk]
 
 [include manual/applications.qbk]
+[include manual/hpx_main_usage.qbk]
 [include manual/names.qbk]
 [include manual/applying_actions.qbk]
 [/ include manual/plain_actions.qbk]

--- a/docs/manual/applications.qbk
+++ b/docs/manual/applications.qbk
@@ -22,8 +22,8 @@ in 3 different ways:
 [heading:minimal Re-use the `main()` function as the main __hpx__ entry point]
 
 This method is the least intrusive to your code. It however provides you with
-the smallest flexibility in terms of initializing the __hpx__ runtime system
-only. The following code snippet shows what a minimal __hpx__ application using
+the smallest flexibility in terms of initializing the __hpx__ runtime system.
+ The following code snippet shows what a minimal __hpx__ application using
 this technique looks like:
 
     #include <``[headerref hpx/hpx_main.hpp `hpx/hpx_main.hpp`]``>
@@ -37,7 +37,7 @@ The only change to your code you have to make is to include the file
 [headerref hpx/hpx_main.hpp `hpx/hpx_main.hpp`].
 In this case the function `main()` will be invoked as the first __hpx__ thread
 of the application. The runtime system will be initialized behind the scenes
-before the function `main()` is executed and will automatically stopped after
+before the function `main()` is executed and will automatically stop after
 `main()` has returned. All __hpx__ API functions can be used from within this
 function now.
 
@@ -62,13 +62,22 @@ __commandline__ for more details on what options are recognized by __hpx__).
 The value returned from the function `main()` as shown above will be returned
 to the operating system as usual.
 
-[important To achieve this seamless integration, the header file
-           [headerref hpx/hpx_main.hpp `hpx/hpx_main.hpp`] defines a macro
-           ``
-              #define main hpx_startup::user_main
-           ``
-           which could result in unexpected behavior.]
+[important To achieve this seamless integration, we use different implementations
+            for different Operating Systems. In case of Linux or Mac OSX, the code
+            present in `hpx_wrap.cpp` is put into action. We hook into the system function
+            in case of Linux and provide alternate entry point in case of Mac OSX.
+            For other Operating Systems we rely on a macro
+            ``
+                #define main hpx_startup::user_main
+            ``
+            provided in the header file [headerref hpx/hpx_main.hpp `hpx/hpx_main.hpp`].
+            This implementation can result in unexpected behavior.]
 
+[caution We make use of an __override__ variable `include_libhpx_wrap` in the header file
+            [headerref hpx/hpx_main.hpp `hpx/hpx_main.hpp`] to swiftly choose the
+            function call stack at runtime. Therefore, the header file should __only__ be
+            included in the main executable. Including it in the components will result
+            in multiple definition of the variable.]
 
 [heading:medium Supply your own main __hpx__ entry point while blocking the main thread]
 

--- a/docs/manual/applications.qbk
+++ b/docs/manual/applications.qbk
@@ -1,5 +1,6 @@
 [/=============================================================================
     Copyright (C) 2007-2017 Hartmut Kaiser
+    Copyright (C) 2018      Nikunj Gupta
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/docs/manual/hpx_main_usage.qbk
+++ b/docs/manual/hpx_main_usage.qbk
@@ -1,0 +1,55 @@
+[/=============================================================================
+    Copyright (C) 2018 Nikunj Gupta
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================/]
+
+[section:hpx_main_usage Working of hpx_main.hpp]
+
+In order to initialize __hpx__ from main(), we make use of linker tricks.
+
+It is implemented differently for different Operating Systems. Method of
+implementation is as follows:
+
+* [link hpx.manual.hpx_main_usage.linux Linux]: Using linker `--wrap` option.
+* [link hpx.manual.hpx_main_usage.mac Mac OSX]: Using the linker `-e` option.
+* [link hpx.manual.hpx_main_usage.windows Windows]: Using
+`#define main hpx_startup::user_main`
+
+[heading:linux Linux Implementation]
+
+We make use of the Linux linker `ld`'s `--wrap` option to wrap the `main()`
+function. This way any call to `main()` are redirected to our own
+implementation of main. It is here that we check for the existence of
+`hpx_main.hpp` by making use of a shadow variable `include_libhpx_wrap`.
+The value of this variable determines the function stack at runtime.
+
+The implementation can be found in libhpx_wrap.a.
+
+[important It is necesaary that `hpx_main.hpp` be not included more than
+once. Multiple inclusions can result in multiple definition of
+`include_libhpx_wrap`.]
+
+[heading:mac Mac OSX Implementation]
+
+Here we make use of yet another linker option `-e` to change the entry
+point to our custom entry function `initialize_main`. We initialize the
+__hpx__ runtime system from this function and call main from the initialized
+system. We determine the function stack at runtime by making use of the
+shadow variable `include_libhpx_wrap`.
+
+The implementation can be found in libhpx_wrap.a.
+
+[important It is necesaary that `hpx_main.hpp` be not included more than
+once. Multiple inclusions can result in multiple definition of
+`include_libhpx_wrap`.]
+
+[heading:windows Windows Implementation]
+
+We make use of a macro `#define main hpx_startup::user_main` to take care of
+the initializations.
+
+This implementation could result in unexpected behaviors.
+
+[endsect]


### PR DESCRIPTION
This PR updates the docs to include the recent implementation for `hpx_main.hpp`. It now adds a `caution` for using `hpx_main.hpp` only once and in the executable. It also explains in brief how __HPX__ is able to seamlessly initiate things from main.

@hkaiser , I can add information specific to Linux and Apple implementations as well, if you want to include it in the docs.