### PR TITLE
Adds Debug option for hpx initializing from main

### DIFF
--- a/hpx/hpx_main.hpp
+++ b/hpx/hpx_main.hpp
@@ -20,8 +20,8 @@ namespace hpx_start
     // include_libhpx_wrap here is an override for the one present in
     // src/hpx_wrap.cpp. The value of this variable defines if we need
     // to change the program's entry point or not.
-    extern bool include_libhpx_wrap;
-    bool include_libhpx_wrap = true;
+    HPX_SYMBOL_EXPORT extern bool include_libhpx_wrap;
+    HPX_SYMBOL_EXPORT bool include_libhpx_wrap = true;
 }
 
 #else

--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -595,22 +595,18 @@ namespace hpx
 
             int result = 0;
             try {
-                #if (HPX_HAVE_DYNAMIC_HPX_MAIN != 0) && \
-                    (defined(__linux) || defined(__linux__) || defined(linux))
-                // make sure the runtime system is not initialized
-                // after its activation from int main()
-                if(get_runtime_ptr() != nullptr &&
-                    hpx_start::include_libhpx_wrap)
-                {
-                    std::cerr << "hpx is already initialized from main.\n"
-                        "Note: Delete hpx_main.hpp to initialize hpx system "
-                        "using hpx::init. Exiting...\n";
-                    return -1;
-                }
-                #endif
                 // make sure the runtime system is not active yet
                 if (get_runtime_ptr() != nullptr)
                 {
+                    // make sure the runtime system is not initialized
+                    // after its activation from int main()
+                    if(hpx_start::include_libhpx_wrap)
+                    {
+                        std::cerr << "hpx is already initialized from main.\n"
+                            "Note: Delete hpx_main.hpp to initialize hpx system "
+                            "using hpx::init. Exiting...\n";
+                        return -1;
+                    }
                     std::cerr << "hpx::init: can't initialize runtime system "
                         "more than once! Exiting...\n";
                     return -1;

--- a/src/hpx_wrap.cpp
+++ b/src/hpx_wrap.cpp
@@ -18,8 +18,8 @@ namespace hpx_start
     // will change the program's entry point to HPX's own custom entry point
     // initialize_main. Subsequent calls before entering main() are handled
     // by this code.
-    extern bool include_libhpx_wrap;
-    bool include_libhpx_wrap __attribute__((weak)) = false;
+    HPX_SYMBOL_EXPORT extern bool include_libhpx_wrap;
+    HPX_SYMBOL_EXPORT bool include_libhpx_wrap __attribute__((weak)) = false;
 }
 
 #include <hpx/hpx_init.hpp>


### PR DESCRIPTION
## Proposed Changes

This PR adds Debug option for `hpx` initialization after using `hpx_main.hpp`. Consider the following example:

```cpp
#include <hpx/hpx_init.hpp>
#include <hpx/hpx_main.hpp>

int hpx_main()
{
  return hpx::finalize();
}

int main()
{
  return hpx::init();
}
```

Since `hpx` runtime is already initialized from main, this would result in the following error message:

```
hpx is already initialized from main.
Note: Delete hpx_main.hpp to initialize hpx system using hpx::init. Exiting...
```

This is more verbose as compared to previous error message which would explain that `hpx::init can't initialize the runtime system.`