### PR TITLE
Add several functionalities allowing to optimize synchronous action invocation

### DIFF
--- a/hpx/include/components.hpp
+++ b/hpx/include/components.hpp
@@ -52,7 +52,7 @@
 #include <hpx/runtime/components/binpacking_distribution_policy.hpp>
 #include <hpx/runtime/components/colocating_distribution_policy.hpp>
 #include <hpx/runtime/components/default_distribution_policy.hpp>
-#include <hpx/runtime/components/unwrapping_distribution_policy.hpp>
+#include <hpx/runtime/components/unwrapping_result_policy.hpp>
 
 #include <hpx/runtime/get_ptr.hpp>
 

--- a/hpx/include/components.hpp
+++ b/hpx/include/components.hpp
@@ -52,6 +52,7 @@
 #include <hpx/runtime/components/binpacking_distribution_policy.hpp>
 #include <hpx/runtime/components/colocating_distribution_policy.hpp>
 #include <hpx/runtime/components/default_distribution_policy.hpp>
+#include <hpx/runtime/components/unwrapping_distribution_policy.hpp>
 
 #include <hpx/runtime/get_ptr.hpp>
 

--- a/hpx/include/sync.hpp
+++ b/hpx/include/sync.hpp
@@ -1,0 +1,12 @@
+//  Copyright (c) 2007-2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_SYNC_JUL_21_2018_0945PM)
+#define HPX_SYNC_JUL_21_2018_0945PM
+
+#include <hpx/sync.hpp>
+
+#endif
+

--- a/hpx/lcos/dataflow.hpp
+++ b/hpx/lcos/dataflow.hpp
@@ -329,7 +329,8 @@ namespace hpx { namespace lcos { namespace detail
         }
 
         /// Finish the dataflow when the traversal has finished
-        void operator()(util::async_traverse_complete_tag, Futures futures)
+        HPX_FORCEINLINE void operator()(
+            util::async_traverse_complete_tag, Futures futures)
         {
             finalize(policy_, std::move(futures));
         }

--- a/hpx/lcos/detail/async_implementations.hpp
+++ b/hpx/lcos/detail/async_implementations.hpp
@@ -214,118 +214,19 @@ namespace hpx { namespace detail
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Action, typename ...Ts>
+    template <typename Action, typename... Ts>
     hpx::future<
-        typename hpx::traits::extract_action<Action>::type::local_result_type
-    >
-    async_impl(launch policy, hpx::id_type const& id, Ts&&... vs)
+        typename hpx::traits::extract_action<Action>::type::local_result_type>
+    async_remote_impl(launch::sync_policy, hpx::id_type const& id,
+        naming::address&& addr, Ts&&... vs)
     {
         typedef typename hpx::traits::extract_action<Action>::type action_type;
         typedef typename action_type::local_result_type result_type;
-        typedef typename action_type::component_type component_type;
-
-        std::pair<bool, components::pinned_ptr> r;
-
-        naming::address addr;
-        if (agas::is_local_address_cached(id, addr) &&
-            can_invoke_locally<action_type>())
-        {
-            // route launch policy through component
-            policy = traits::action_select_direct_execution<Action>::call(
-                policy, addr.address_);
-
-            if (traits::component_supports_migration<component_type>::call())
-            {
-                r = traits::action_was_object_migrated<Action>::call(
-                        id, addr.address_);
-                if (!r.first)
-                {
-                    if (policy == launch::sync ||
-                        action_type::direct_execution::value)
-                    {
-                        return hpx::detail::sync_local_invoke<action_type, result_type>::
-                            call(id, std::move(addr), std::forward<Ts>(vs)...);
-                    }
-                }
-            }
-            else if (policy == launch::sync ||
-                action_type::direct_execution::value)
-            {
-                return hpx::detail::sync_local_invoke<action_type, result_type>::
-                    call(id, std::move(addr), std::forward<Ts>(vs)...);
-            }
-        }
-
-        future<result_type> f;
-        {
-            handle_managed_target<result_type> hmt(id, f);
-
-            if (policy == launch::sync ||
-                hpx::detail::has_async_policy(policy))
-            {
-                lcos::packaged_action<action_type, result_type> p;
-
-                f = p.get_future();
-                p.apply(std::move(addr), hmt.get_id(), std::forward<Ts>(vs)...);
-                if (policy == launch::sync)
-                    f.wait();
-            }
-            else if (policy == launch::deferred)
-            {
-                lcos::packaged_action<action_type, result_type> p;
-
-                f = p.get_future();
-                p.apply_deferred(std::move(addr), hmt.get_id(),
-                    std::forward<Ts>(vs)...);
-            }
-            else
-            {
-                HPX_THROW_EXCEPTION(bad_parameter,
-                    "async_impl", "unknown launch policy");
-                return f;
-            }
-        }
-        return f;
-    }
-
-    template <typename Action, typename ...Ts>
-    hpx::future<
-        typename hpx::traits::extract_action<Action>::type::local_result_type
-    >
-    async_impl(hpx::detail::sync_policy, hpx::id_type const& id, Ts&&... vs)
-    {
-        typedef typename hpx::traits::extract_action<Action>::type action_type;
-        typedef typename action_type::local_result_type result_type;
-        typedef typename action_type::component_type component_type;
-
-        std::pair<bool, components::pinned_ptr> r;
-
-        naming::address addr;
-        if (agas::is_local_address_cached(id, addr) &&
-            can_invoke_locally<action_type>())
-        {
-            if (traits::component_supports_migration<component_type>::call())
-            {
-                r = traits::action_was_object_migrated<Action>::call(
-                        id, addr.address_);
-                if (!r.first)
-                {
-                    return hpx::detail::sync_local_invoke<action_type, result_type>::
-                        call(id, std::move(addr), std::forward<Ts>(vs)...);
-                }
-            }
-            else
-            {
-                return hpx::detail::sync_local_invoke<action_type, result_type>::
-                    call(id, std::move(addr), std::forward<Ts>(vs)...);
-            }
-        }
 
         future<result_type> f;
         {
             handle_managed_target<result_type> hmt(id, f);
             lcos::packaged_action<action_type, result_type> p;
-
             f = p.get_future();
             p.apply(std::move(addr), hmt.get_id(), std::forward<Ts>(vs)...);
             f.wait();
@@ -333,6 +234,74 @@ namespace hpx { namespace detail
         return f;
     }
 
+    template <typename Action, typename... Ts>
+    hpx::future<
+        typename hpx::traits::extract_action<Action>::type::local_result_type>
+    async_remote_impl(launch::async_policy, hpx::id_type const& id,
+        naming::address&& addr, Ts&&... vs)
+    {
+        typedef typename hpx::traits::extract_action<Action>::type action_type;
+        typedef typename action_type::local_result_type result_type;
+
+        hpx::future<result_type> f;
+        {
+            handle_managed_target<result_type> hmt(id, f);
+            lcos::packaged_action<action_type, result_type> p;
+            f = p.get_future();
+            p.apply(std::move(addr), hmt.get_id(), std::forward<Ts>(vs)...);
+        }
+        return f;
+    }
+
+    template <typename Action, typename... Ts>
+    hpx::future<
+        typename hpx::traits::extract_action<Action>::type::local_result_type>
+    async_remote_impl(launch::deferred_policy, hpx::id_type const& id,
+        naming::address&& addr, Ts&&... vs)
+    {
+        typedef typename hpx::traits::extract_action<Action>::type action_type;
+        typedef typename action_type::local_result_type result_type;
+
+        hpx::future<result_type> f;
+        {
+            handle_managed_target<result_type> hmt(id, f);
+            lcos::packaged_action<action_type, result_type> p;
+            f = p.get_future();
+            p.apply_deferred(std::move(addr), hmt.get_id(),
+                std::forward<Ts>(vs)...);
+        }
+        return f;
+    }
+
+    // generic function for dynamic launch policy
+    template <typename Action, typename... Ts>
+    hpx::future<
+        typename hpx::traits::extract_action<Action>::type::local_result_type>
+    async_remote_impl(launch policy, hpx::id_type const& id,
+            naming::address&& addr, Ts&&... vs)
+    {
+        if (policy == launch::sync)
+        {
+            return async_remote_impl<Action>(launch::sync, id,
+                std::move(addr), std::forward<Ts>(vs)...);
+        }
+        else if (hpx::detail::has_async_policy(policy))
+        {
+            return async_remote_impl<Action>(launch::async, id,
+                std::move(addr), std::forward<Ts>(vs)...);
+        }
+        else if (policy == launch::deferred)
+        {
+            return async_remote_impl<Action>(launch::deferred, id,
+                std::move(addr), std::forward<Ts>(vs)...);
+        }
+
+        HPX_THROW_EXCEPTION(
+            bad_parameter, "async_remote_impl", "unknown launch policy");
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // do local invocation, if possible
     template <typename Action>
     struct action_invoker
     {
@@ -351,131 +320,106 @@ namespace hpx { namespace detail
         }
     };
 
+    ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename... Ts>
     hpx::future<
-        typename hpx::traits::extract_action<Action>::type::local_result_type
-    >
-    async_impl(hpx::detail::async_policy async_policy, hpx::id_type const& id,
+        typename hpx::traits::extract_action<Action>::type::local_result_type>
+    async_local_impl(launch policy, hpx::id_type const& id,
+        naming::address& addr, std::pair<bool, components::pinned_ptr>& r,
         Ts&&... vs)
+    {
+        typedef typename hpx::traits::extract_action<Action>::type action_type;
+        typedef typename action_type::local_result_type result_type;
+
+        if (policy == launch::sync || action_type::direct_execution::value)
+        {
+            return hpx::detail::sync_local_invoke<
+                        action_type, result_type
+                    >::call(id, std::move(addr), std::forward<Ts>(vs)...);
+        }
+        else if (hpx::detail::has_async_policy(policy))
+        {
+            return keep_alive(
+                hpx::async(action_invoker<action_type>(), addr.address_,
+                    addr.type_, std::forward<Ts>(vs)...),
+                id, std::move(r.second));
+        }
+
+        HPX_ASSERT(policy == launch::deferred);
+
+        return keep_alive(
+            hpx::async(launch::deferred, action_invoker<action_type>(),
+                addr.address_, addr.type_, std::forward<Ts>(vs)...),
+            id, std::move(r.second));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Action, typename Result, typename... Ts>
+    bool async_local_impl_all(launch policy, hpx::id_type const& id,
+        naming::address& addr, std::pair<bool, components::pinned_ptr>& r,
+        hpx::future<Result>& f, Ts&&... vs)
     {
         typedef typename hpx::traits::extract_action<Action>::type action_type;
         typedef typename action_type::local_result_type result_type;
         typedef typename action_type::component_type component_type;
 
-        future<result_type> f;
+        // route launch policy through component
+        policy = traits::action_select_direct_execution<Action>::call(
+            policy, addr.address_);
+
+        if (traits::component_supports_migration<component_type>::call())
+        {
+            r = traits::action_was_object_migrated<Action>::call(
+                    id, addr.address_);
+
+            if (!r.first)
+            {
+                f = async_local_impl<Action>(policy, id, addr, r,
+                        std::forward<Ts>(vs)...);
+                return true;
+            }
+
+            // can't locally handle object if it is currently being migrated
+            return false;
+        }
+
+        f = async_local_impl<Action>(
+                policy, id, addr, r, std::forward<Ts>(vs)...);
+
+        return true;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Action, typename Launch, typename ...Ts>
+    hpx::future<
+        typename hpx::traits::extract_action<Action>::type::local_result_type
+    >
+    async_impl(Launch && policy, hpx::id_type const& id, Ts&&... vs)
+    {
+        typedef typename hpx::traits::extract_action<Action>::type action_type;
+        typedef typename action_type::local_result_type result_type;
+
         std::pair<bool, components::pinned_ptr> r;
 
         naming::address addr;
         if (agas::is_local_address_cached(id, addr) &&
             can_invoke_locally<action_type>())
         {
-            // route launch policy through component
-            launch policy = traits::action_select_direct_execution<Action>::call(
-                async_policy, addr.address_);
-
-            if (traits::component_supports_migration<component_type>::call())
+            hpx::future<result_type> f;
+            if (async_local_impl_all<Action>(
+                    policy, id, addr, r, f, std::forward<Ts>(vs)...))
             {
-                r = traits::action_was_object_migrated<Action>::call(
-                        id, addr.address_);
-                if (!r.first)
-                {
-                    if (policy == launch::sync ||
-                        action_type::direct_execution::value)
-                    {
-                        return sync_local_invoke<action_type, result_type>::call(
-                            id, std::move(addr), std::forward<Ts>(vs)...);
-                    }
-                    else
-                    {
-                        f = hpx::async(action_invoker<action_type>(),
-                                addr.address_, addr.type_, std::forward<Ts>(vs)...);
-
-                        return keep_alive(std::move(f), id, std::move(r.second));
-                    }
-                }
-            }
-            else
-            {
-                if (policy == launch::sync ||
-                    action_type::direct_execution::value)
-                {
-                    return sync_local_invoke<action_type, result_type>::call(
-                        id, std::move(addr), std::forward<Ts>(vs)...);
-                }
-                else
-                {
-                    f = hpx::async(action_invoker<action_type>(), addr.address_,
-                            addr.type_, std::forward<Ts>(vs)...);
-                    return keep_alive(std::move(f), id);
-                }
+                return f;
             }
         }
 
-        {
-            handle_managed_target<result_type> hmt(id, f);
-            lcos::packaged_action<action_type, result_type> p;
-
-            f = p.get_future();
-            p.apply(std::move(addr), hmt.get_id(), std::forward<Ts>(vs)...);
-        }
-
-        return f;
-    }
-
-    template <typename Action, typename ...Ts>
-    hpx::future<
-        typename hpx::traits::extract_action<Action>::type::local_result_type
-    >
-    async_impl(hpx::detail::deferred_policy, hpx::id_type const& id, Ts&&... vs)
-    {
-        typedef typename hpx::traits::extract_action<Action>::type action_type;
-        typedef typename action_type::local_result_type result_type;
-        typedef typename action_type::component_type component_type;
-
-        future<result_type> f;
-        std::pair<bool, components::pinned_ptr> r;
-
-        naming::address addr;
-        if (agas::is_local_address_cached(id, addr))
-        {
-            if (traits::component_supports_migration<component_type>::call())
-            {
-                r = traits::action_was_object_migrated<Action>::call(
-                        id, addr.address_);
-                if (!r.first)
-                {
-                    f = hpx::async(launch::deferred,
-                            action_invoker<action_type>(), addr.address_,
-                            addr.type_, std::forward<Ts>(vs)...);
-
-                    return keep_alive(std::move(f), id, std::move(r.second));
-                }
-            }
-            else
-            {
-                f = hpx::async(launch::deferred, action_invoker<action_type>(),
-                        addr.address_, addr.type_, std::forward<Ts>(vs)...);
-
-                return keep_alive(std::move(f), id);
-            }
-        }
-
-        {
-            handle_managed_target<result_type> hmt(id, f);
-            lcos::packaged_action<action_type, result_type> p;
-
-            f = p.get_future();
-            p.apply_deferred(std::move(addr), hmt.get_id(),
-                std::forward<Ts>(vs)...);
-        }
-
-        return f;
+        return async_remote_impl<Action>(std::forward<Launch>(policy), id,
+            std::move(addr), std::forward<Ts>(vs)...);
     }
 
     ///////////////////////////////////////////////////////////////////////////
     /// \note This function is part of the invocation policy implemented by
     ///       this class
-    ///
     template <typename Action, typename Callback, typename ...Ts>
     hpx::future<
         typename hpx::traits::extract_action<Action>::type::local_result_type

--- a/hpx/lcos/detail/async_implementations_fwd.hpp
+++ b/hpx/lcos/detail/async_implementations_fwd.hpp
@@ -16,33 +16,11 @@
 namespace hpx { namespace detail
 {
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Action, typename ...Ts>
+    template <typename Action, typename Launch, typename ...Ts>
     hpx::future<
         typename hpx::traits::extract_action<Action>::type::local_result_type
     >
-    async_impl(launch policy, hpx::id_type const& id,
-        Ts&&... vs);
-
-    template <typename Action, typename ...Ts>
-    hpx::future<
-        typename hpx::traits::extract_action<Action>::type::local_result_type
-    >
-    async_impl(hpx::detail::sync_policy, hpx::id_type const& id,
-        Ts&&... vs);
-
-    template <typename Action, typename ...Ts>
-    hpx::future<
-        typename hpx::traits::extract_action<Action>::type::local_result_type
-    >
-    async_impl(hpx::detail::async_policy, hpx::id_type const& id,
-        Ts&&... vs);
-
-    template <typename Action, typename ...Ts>
-    hpx::future<
-        typename hpx::traits::extract_action<Action>::type::local_result_type
-    >
-    async_impl(hpx::detail::deferred_policy, hpx::id_type const& id,
-        Ts&&... vs);
+    async_impl(Launch && policy, hpx::id_type const& id, Ts&&... vs);
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Callback, typename ...Ts>

--- a/hpx/lcos/detail/async_unwrap_result_implementations.hpp
+++ b/hpx/lcos/detail/async_unwrap_result_implementations.hpp
@@ -10,6 +10,7 @@
 #include <hpx/lcos/future.hpp>
 #include <hpx/lcos/detail/async_implementations.hpp>
 #include <hpx/lcos/detail/async_unwrap_result_implementations_fwd.hpp>
+#include <hpx/lcos/detail/sync_implementations.hpp>
 #include <hpx/lcos/packaged_action.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/runtime/naming/address.hpp>
@@ -33,205 +34,100 @@ namespace hpx { namespace detail
 {
     /// \cond NOINTERNAL
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Action, typename ...Ts>
+    template <typename Action, typename... Ts>
     typename hpx::traits::extract_action<Action>::type::local_result_type
-    async_unwrap_result_impl(launch policy, hpx::id_type const& id, Ts&&... vs)
-    {
-        typedef typename hpx::traits::extract_action<Action>::type action_type;
-        typedef typename action_type::local_result_type result_type;
-        typedef typename action_type::component_type component_type;
-
-        std::pair<bool, components::pinned_ptr> r;
-
-        naming::address addr;
-        if (agas::is_local_address_cached(id, addr) &&
-            can_invoke_locally<action_type>())
-        {
-            // route launch policy through component
-            policy = traits::action_select_direct_execution<Action>::call(
-                policy, addr.address_);
-
-            if (traits::component_supports_migration<component_type>::call())
-            {
-                r = traits::action_was_object_migrated<Action>::call(
-                        id, addr.address_);
-                if (!r.first)
-                {
-                    if (policy == launch::sync ||
-                        action_type::direct_execution::value)
-                    {
-                        return hpx::detail::sync_local_invoke_direct<
-                                action_type, result_type
-                        >::call(id, std::move(addr), std::forward<Ts>(vs)...);
-                    }
-                }
-            }
-            else if (policy == launch::sync ||
-                action_type::direct_execution::value)
-            {
-                return hpx::detail::sync_local_invoke_direct<
-                        action_type, result_type
-                    >::call(id, std::move(addr), std::forward<Ts>(vs)...);
-            }
-        }
-
-        // the asynchronous result is auto-unwrapped by the return type
-        future<result_type> f;
-        {
-            handle_managed_target<result_type> hmt(id, f);
-
-            if (policy == launch::sync ||
-                hpx::detail::has_async_policy(policy))
-            {
-                lcos::packaged_action<action_type, result_type> p;
-
-                f = p.get_future();
-                p.apply(std::move(addr), hmt.get_id(), std::forward<Ts>(vs)...);
-                if (policy == launch::sync)
-                    f.wait();
-            }
-            else if (policy == launch::deferred)
-            {
-                lcos::packaged_action<action_type, result_type> p;
-
-                f = p.get_future();
-                p.apply_deferred(std::move(addr), hmt.get_id(),
-                    std::forward<Ts>(vs)...);
-            }
-            else
-            {
-                HPX_THROW_EXCEPTION(bad_parameter,
-                    "async_impl", "unknown launch policy");
-                return f;
-            }
-        }
-        return f;
-    }
-
-    template <typename Action, typename ...Ts>
-    typename hpx::traits::extract_action<Action>::type::local_result_type
-    async_unwrap_result_impl(hpx::detail::sync_policy, hpx::id_type const& id,
+    async_local_unwrap_impl(launch policy, hpx::id_type const& id,
+        naming::address& addr, std::pair<bool, components::pinned_ptr>& r,
         Ts&&... vs)
     {
         typedef typename hpx::traits::extract_action<Action>::type action_type;
         typedef typename action_type::local_result_type result_type;
-        typedef typename action_type::component_type component_type;
 
-        std::pair<bool, components::pinned_ptr> r;
-
-        naming::address addr;
-        if (agas::is_local_address_cached(id, addr) &&
-            can_invoke_locally<action_type>())
+        if (policy == launch::sync || action_type::direct_execution::value)
         {
-            if (traits::component_supports_migration<component_type>::call())
-            {
-                r = traits::action_was_object_migrated<Action>::call(
-                        id, addr.address_);
-                if (!r.first)
-                {
-                    return hpx::detail::sync_local_invoke_direct<
-                            action_type, result_type
-                        >::call(id, std::move(addr), std::forward<Ts>(vs)...);
-                }
-            }
-            else
-            {
-                return hpx::detail::sync_local_invoke_direct<
+            return hpx::detail::sync_local_invoke_direct<
                         action_type, result_type
                     >::call(id, std::move(addr), std::forward<Ts>(vs)...);
-            }
         }
-
-        // the asynchronous result is auto-unwrapped by the return type
-        future<result_type> f;
+        else if (hpx::detail::has_async_policy(policy))
         {
-            handle_managed_target<result_type> hmt(id, f);
-            lcos::packaged_action<action_type, result_type> p;
-
-            f = p.get_future();
-            p.apply(std::move(addr), hmt.get_id(), std::forward<Ts>(vs)...);
-            f.wait();
+            return keep_alive(
+                hpx::async(action_invoker<action_type>(), addr.address_,
+                    addr.type_, std::forward<Ts>(vs)...),
+                id, std::move(r.second));
         }
-        return f;
+
+        HPX_ASSERT(policy == launch::deferred);
+
+        return keep_alive(
+            hpx::async(launch::deferred, action_invoker<action_type>(),
+                addr.address_, addr.type_, std::forward<Ts>(vs)...),
+            id, std::move(r.second));
     }
 
-    template <typename Action, typename... Ts>
-    typename hpx::traits::extract_action<Action>::type::local_result_type
-    async_unwrap_result_impl(hpx::detail::async_policy async_policy,
-        hpx::id_type const& id, Ts&&... vs)
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Action, typename Result, typename... Ts>
+    bool async_local_unwrap_impl_all(launch policy, hpx::id_type const& id,
+        naming::address& addr, std::pair<bool, components::pinned_ptr>& r,
+        Result& result, Ts&&... vs)
     {
         typedef typename hpx::traits::extract_action<Action>::type action_type;
         typedef typename action_type::local_result_type result_type;
         typedef typename action_type::component_type component_type;
 
-        future<result_type> f;
+        // route launch policy through component
+        policy = traits::action_select_direct_execution<Action>::call(
+            policy, addr.address_);
+
+        if (traits::component_supports_migration<component_type>::call())
+        {
+            r = traits::action_was_object_migrated<Action>::call(
+                    id, addr.address_);
+
+            if (!r.first)
+            {
+                result = async_local_unwrap_impl<Action>(
+                    policy, id, addr, r, std::forward<Ts>(vs)...);
+
+                return true;
+            }
+
+            // can't locally handle object if it is currently being migrated
+            return false;
+        }
+
+        result = async_local_unwrap_impl<Action>(
+            policy, id, addr, r, std::forward<Ts>(vs)...);
+
+        return true;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Action, typename Launch, typename ...Ts>
+    typename hpx::traits::extract_action<Action>::type::local_result_type
+    async_unwrap_result_impl(Launch && policy, hpx::id_type const& id, Ts&&... vs)
+    {
+        typedef typename hpx::traits::extract_action<Action>::type action_type;
+        typedef typename action_type::local_result_type result_type;
+        typedef typename action_type::component_type component_type;
+
         std::pair<bool, components::pinned_ptr> r;
 
         naming::address addr;
         if (agas::is_local_address_cached(id, addr) &&
             can_invoke_locally<action_type>())
         {
-            // route launch policy through component
-            launch policy = traits::action_select_direct_execution<Action>::call(
-                async_policy, addr.address_);
-
-            if (traits::component_supports_migration<component_type>::call())
+            result_type result;
+            if (async_local_unwrap_impl_all<Action>(
+                    policy, id, addr, r, result, std::forward<Ts>(vs)...))
             {
-                r = traits::action_was_object_migrated<Action>::call(
-                        id, addr.address_);
-                if (!r.first)
-                {
-                    if (policy == launch::sync ||
-                        action_type::direct_execution::value)
-                    {
-                        return sync_local_invoke_direct<
-                                action_type, result_type
-                            >::call(id, std::move(addr), std::forward<Ts>(vs)...);
-                    }
-                    else
-                    {
-                        f = hpx::async(action_invoker<action_type>(),
-                                addr.address_, addr.type_, std::forward<Ts>(vs)...);
-
-                        return keep_alive(std::move(f), id, std::move(r.second));
-                    }
-                }
-            }
-            else
-            {
-                if (policy == launch::sync ||
-                    action_type::direct_execution::value)
-                {
-                    return sync_local_invoke_direct<
-                            action_type, result_type
-                        >::call(id, std::move(addr), std::forward<Ts>(vs)...);
-                }
-                else
-                {
-                    f = hpx::async(action_invoker<action_type>(), addr.address_,
-                            addr.type_, std::forward<Ts>(vs)...);
-                    return keep_alive(std::move(f), id);
-                }
+                return result;
             }
         }
 
-        {
-            handle_managed_target<result_type> hmt(id, f);
-            lcos::packaged_action<action_type, result_type> p;
-
-            f = p.get_future();
-            p.apply(std::move(addr), hmt.get_id(), std::forward<Ts>(vs)...);
-        }
-
-        return f;
-    }
-
-    template <typename Action, typename ...Ts>
-    typename hpx::traits::extract_action<Action>::type::local_result_type
-    async_unwrap_result_impl(hpx::launch::deferred_policy,
-        hpx::id_type const& id, Ts&&... vs)
-    {
-        return async_impl(hpx::launch::deferred, id, std::forward<Ts>(vs)...);
+        // the asynchronous result is auto-unwrapped by the return type
+        return async_remote_impl<Action>(std::forward<Launch>(policy), id,
+            std::move(addr), std::forward<Ts>(vs)...);
     }
     /// \endcond
 }}

--- a/hpx/lcos/detail/async_unwrap_result_implementations.hpp
+++ b/hpx/lcos/detail/async_unwrap_result_implementations.hpp
@@ -1,0 +1,239 @@
+//  Copyright (c) 2007-2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_LCOS_ASYNC_UNWRAP_IMPLEMENTATIONS_JUL_22_2018_0137PM)
+#define HPX_LCOS_ASYNC_UNWRAP_IMPLEMENTATIONS_JUL_22_2018_0137PM
+
+#include <hpx/config.hpp>
+#include <hpx/lcos/future.hpp>
+#include <hpx/lcos/detail/async_implementations.hpp>
+#include <hpx/lcos/detail/async_unwrap_result_implementations_fwd.hpp>
+#include <hpx/lcos/packaged_action.hpp>
+#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/runtime/naming/address.hpp>
+#include <hpx/runtime/naming/id_type.hpp>
+#include <hpx/runtime/threads/thread.hpp>
+#include <hpx/runtime/threads/thread_init_data.hpp>
+#include <hpx/throw_exception.hpp>
+#include <hpx/traits/action_decorate_function.hpp>
+#include <hpx/traits/action_was_object_migrated.hpp>
+#include <hpx/traits/action_select_direct_execution.hpp>
+#include <hpx/traits/component_supports_migration.hpp>
+#include <hpx/traits/component_type_is_compatible.hpp>
+#include <hpx/traits/extract_action.hpp>
+#include <hpx/traits/future_access.hpp>
+#include <hpx/util/assert.hpp>
+
+#include <cstddef>
+#include <utility>
+
+namespace hpx { namespace detail
+{
+    /// \cond NOINTERNAL
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Action, typename ...Ts>
+    typename hpx::traits::extract_action<Action>::type::local_result_type
+    async_unwrap_result_impl(launch policy, hpx::id_type const& id, Ts&&... vs)
+    {
+        typedef typename hpx::traits::extract_action<Action>::type action_type;
+        typedef typename action_type::local_result_type result_type;
+        typedef typename action_type::component_type component_type;
+
+        std::pair<bool, components::pinned_ptr> r;
+
+        naming::address addr;
+        if (agas::is_local_address_cached(id, addr) &&
+            can_invoke_locally<action_type>())
+        {
+            // route launch policy through component
+            policy = traits::action_select_direct_execution<Action>::call(
+                policy, addr.address_);
+
+            if (traits::component_supports_migration<component_type>::call())
+            {
+                r = traits::action_was_object_migrated<Action>::call(
+                        id, addr.address_);
+                if (!r.first)
+                {
+                    if (policy == launch::sync ||
+                        action_type::direct_execution::value)
+                    {
+                        return hpx::detail::sync_local_invoke_direct<
+                                action_type, result_type
+                        >::call(id, std::move(addr), std::forward<Ts>(vs)...);
+                    }
+                }
+            }
+            else if (policy == launch::sync ||
+                action_type::direct_execution::value)
+            {
+                return hpx::detail::sync_local_invoke_direct<
+                        action_type, result_type
+                    >::call(id, std::move(addr), std::forward<Ts>(vs)...);
+            }
+        }
+
+        // the asynchronous result is auto-unwrapped by the return type
+        future<result_type> f;
+        {
+            handle_managed_target<result_type> hmt(id, f);
+
+            if (policy == launch::sync ||
+                hpx::detail::has_async_policy(policy))
+            {
+                lcos::packaged_action<action_type, result_type> p;
+
+                f = p.get_future();
+                p.apply(std::move(addr), hmt.get_id(), std::forward<Ts>(vs)...);
+                if (policy == launch::sync)
+                    f.wait();
+            }
+            else if (policy == launch::deferred)
+            {
+                lcos::packaged_action<action_type, result_type> p;
+
+                f = p.get_future();
+                p.apply_deferred(std::move(addr), hmt.get_id(),
+                    std::forward<Ts>(vs)...);
+            }
+            else
+            {
+                HPX_THROW_EXCEPTION(bad_parameter,
+                    "async_impl", "unknown launch policy");
+                return f;
+            }
+        }
+        return f;
+    }
+
+    template <typename Action, typename ...Ts>
+    typename hpx::traits::extract_action<Action>::type::local_result_type
+    async_unwrap_result_impl(hpx::detail::sync_policy, hpx::id_type const& id,
+        Ts&&... vs)
+    {
+        typedef typename hpx::traits::extract_action<Action>::type action_type;
+        typedef typename action_type::local_result_type result_type;
+        typedef typename action_type::component_type component_type;
+
+        std::pair<bool, components::pinned_ptr> r;
+
+        naming::address addr;
+        if (agas::is_local_address_cached(id, addr) &&
+            can_invoke_locally<action_type>())
+        {
+            if (traits::component_supports_migration<component_type>::call())
+            {
+                r = traits::action_was_object_migrated<Action>::call(
+                        id, addr.address_);
+                if (!r.first)
+                {
+                    return hpx::detail::sync_local_invoke_direct<
+                            action_type, result_type
+                        >::call(id, std::move(addr), std::forward<Ts>(vs)...);
+                }
+            }
+            else
+            {
+                return hpx::detail::sync_local_invoke_direct<
+                        action_type, result_type
+                    >::call(id, std::move(addr), std::forward<Ts>(vs)...);
+            }
+        }
+
+        // the asynchronous result is auto-unwrapped by the return type
+        future<result_type> f;
+        {
+            handle_managed_target<result_type> hmt(id, f);
+            lcos::packaged_action<action_type, result_type> p;
+
+            f = p.get_future();
+            p.apply(std::move(addr), hmt.get_id(), std::forward<Ts>(vs)...);
+            f.wait();
+        }
+        return f;
+    }
+
+    template <typename Action, typename... Ts>
+    typename hpx::traits::extract_action<Action>::type::local_result_type
+    async_unwrap_result_impl(hpx::detail::async_policy async_policy,
+        hpx::id_type const& id, Ts&&... vs)
+    {
+        typedef typename hpx::traits::extract_action<Action>::type action_type;
+        typedef typename action_type::local_result_type result_type;
+        typedef typename action_type::component_type component_type;
+
+        future<result_type> f;
+        std::pair<bool, components::pinned_ptr> r;
+
+        naming::address addr;
+        if (agas::is_local_address_cached(id, addr) &&
+            can_invoke_locally<action_type>())
+        {
+            // route launch policy through component
+            launch policy = traits::action_select_direct_execution<Action>::call(
+                async_policy, addr.address_);
+
+            if (traits::component_supports_migration<component_type>::call())
+            {
+                r = traits::action_was_object_migrated<Action>::call(
+                        id, addr.address_);
+                if (!r.first)
+                {
+                    if (policy == launch::sync ||
+                        action_type::direct_execution::value)
+                    {
+                        return sync_local_invoke_direct<
+                                action_type, result_type
+                            >::call(id, std::move(addr), std::forward<Ts>(vs)...);
+                    }
+                    else
+                    {
+                        f = hpx::async(action_invoker<action_type>(),
+                                addr.address_, addr.type_, std::forward<Ts>(vs)...);
+
+                        return keep_alive(std::move(f), id, std::move(r.second));
+                    }
+                }
+            }
+            else
+            {
+                if (policy == launch::sync ||
+                    action_type::direct_execution::value)
+                {
+                    return sync_local_invoke_direct<
+                            action_type, result_type
+                        >::call(id, std::move(addr), std::forward<Ts>(vs)...);
+                }
+                else
+                {
+                    f = hpx::async(action_invoker<action_type>(), addr.address_,
+                            addr.type_, std::forward<Ts>(vs)...);
+                    return keep_alive(std::move(f), id);
+                }
+            }
+        }
+
+        {
+            handle_managed_target<result_type> hmt(id, f);
+            lcos::packaged_action<action_type, result_type> p;
+
+            f = p.get_future();
+            p.apply(std::move(addr), hmt.get_id(), std::forward<Ts>(vs)...);
+        }
+
+        return f;
+    }
+
+    template <typename Action, typename ...Ts>
+    typename hpx::traits::extract_action<Action>::type::local_result_type
+    async_unwrap_result_impl(hpx::launch::deferred_policy,
+        hpx::id_type const& id, Ts&&... vs)
+    {
+        return async_impl(hpx::launch::deferred, id, std::forward<Ts>(vs)...);
+    }
+    /// \endcond
+}}
+
+#endif

--- a/hpx/lcos/detail/async_unwrap_result_implementations_fwd.hpp
+++ b/hpx/lcos/detail/async_unwrap_result_implementations_fwd.hpp
@@ -16,25 +16,9 @@
 namespace hpx { namespace detail
 {
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Action, typename ...Ts>
+    template <typename Action, typename Launch, typename ...Ts>
     typename hpx::traits::extract_action<Action>::type::local_result_type
-    async_unwrap_result_impl(launch policy, hpx::id_type const& id,
-        Ts&&... vs);
-
-    template <typename Action, typename ...Ts>
-    typename hpx::traits::extract_action<Action>::type::local_result_type
-    async_unwrap_result_impl(hpx::launch::sync_policy, hpx::id_type const& id,
-        Ts&&... vs);
-
-    template <typename Action, typename ...Ts>
-    typename hpx::traits::extract_action<Action>::type::local_result_type
-    async_unwrap_result_impl(hpx::launch::async_policy, hpx::id_type const& id,
-        Ts&&... vs);
-
-    template <typename Action, typename... Ts>
-    typename hpx::traits::extract_action<Action>::type::local_result_type
-    async_unwrap_result_impl(
-        hpx::launch::deferred_policy, hpx::id_type const& id, Ts&&... vs);
+    async_unwrap_result_impl(Launch && policy, hpx::id_type const& id, Ts&&... vs);
 }}
 
 #endif

--- a/hpx/lcos/detail/async_unwrap_result_implementations_fwd.hpp
+++ b/hpx/lcos/detail/async_unwrap_result_implementations_fwd.hpp
@@ -1,0 +1,40 @@
+//  Copyright (c) 2007-2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_LCOS_ASYNC_UNWRAP_IMPLEMENTATIONS_FWD_JUL_22_2018_0145PM)
+#define HPX_LCOS_ASYNC_UNWRAP_IMPLEMENTATIONS_FWD_JUL_22_2018_0145PM
+
+#include <hpx/config.hpp>
+#include <hpx/lcos/async_fwd.hpp>
+#include <hpx/lcos/future.hpp>
+#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/runtime/naming_fwd.hpp>
+#include <hpx/traits/extract_action.hpp>
+
+namespace hpx { namespace detail
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Action, typename ...Ts>
+    typename hpx::traits::extract_action<Action>::type::local_result_type
+    async_unwrap_result_impl(launch policy, hpx::id_type const& id,
+        Ts&&... vs);
+
+    template <typename Action, typename ...Ts>
+    typename hpx::traits::extract_action<Action>::type::local_result_type
+    async_unwrap_result_impl(hpx::launch::sync_policy, hpx::id_type const& id,
+        Ts&&... vs);
+
+    template <typename Action, typename ...Ts>
+    typename hpx::traits::extract_action<Action>::type::local_result_type
+    async_unwrap_result_impl(hpx::launch::async_policy, hpx::id_type const& id,
+        Ts&&... vs);
+
+    template <typename Action, typename... Ts>
+    typename hpx::traits::extract_action<Action>::type::local_result_type
+    async_unwrap_result_impl(
+        hpx::launch::deferred_policy, hpx::id_type const& id, Ts&&... vs);
+}}
+
+#endif

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -273,12 +273,15 @@ namespace detail
         // continuation support
 
         // deferred execution of a given continuation
-        bool run_on_completed(completed_callback_vector_type && on_completed,
+        bool run_on_completed(completed_callback_type&& on_completed,
+            std::exception_ptr& ptr);
+        bool run_on_completed(completed_callback_vector_type&& on_completed,
             std::exception_ptr& ptr);
 
         // make sure continuation invocation does not recurse deeper than
         // allowed
-        void handle_on_completed(completed_callback_vector_type && on_completed);
+        template <typename Callback>
+        void handle_on_completed(Callback&& on_completed);
 
         /// Set the callback which needs to be invoked when the future becomes
         /// ready. If the future is ready the function will be invoked
@@ -432,7 +435,7 @@ namespace detail
             }
 
             auto on_completed = std::move(on_completed_);
-            on_completed_ = completed_callback_vector_type();
+            on_completed_.clear();
 
             // set the data
             result_type* value_ptr = reinterpret_cast<result_type*>(&storage_);
@@ -475,7 +478,7 @@ namespace detail
             }
 
             auto on_completed = std::move(on_completed_);
-            on_completed_ = completed_callback_vector_type();
+            on_completed_.clear();
 
             // set the data
             std::exception_ptr* exception_ptr =
@@ -567,7 +570,7 @@ namespace detail
             }
 
             state_ = empty;
-            on_completed_ = completed_callback_vector_type();
+            on_completed_.clear();
         }
 
         std::exception_ptr get_exception_ptr() const override

--- a/hpx/lcos/detail/future_transforms.hpp
+++ b/hpx/lcos/detail/future_transforms.hpp
@@ -31,10 +31,17 @@ namespace lcos {
                 typename std::decay<T>::type>::value>::type* = nullptr>
         bool async_visit_future(T&& current)
         {
+            // Check for state right away as the element might not be able to
+            // produce a shared state (even if it's ready).
+            if (current.is_ready())
+            {
+                return true;
+            }
+
             auto const& state =
                 traits::detail::get_shared_state(std::forward<T>(current));
 
-            if ((state.get() == nullptr) || state->is_ready())
+            if (state.get() == nullptr)
             {
                 return true;
             }

--- a/hpx/lcos/detail/sync_implementations.hpp
+++ b/hpx/lcos/detail/sync_implementations.hpp
@@ -1,0 +1,141 @@
+//  Copyright (c) 2007-2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_LCOS_SYNC_IMPLEMENTATIONS_JUL_21_2018_0921PM)
+#define HPX_LCOS_SYNC_IMPLEMENTATIONS_JUL_21_2018_0921PM
+
+#include <hpx/config.hpp>
+#include <hpx/lcos/detail/async_implementations.hpp>
+#include <hpx/lcos/detail/sync_implementations_fwd.hpp>
+#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/runtime/naming/address.hpp>
+#include <hpx/runtime/naming/id_type.hpp>
+#include <hpx/traits/action_was_object_migrated.hpp>
+#include <hpx/traits/action_select_direct_execution.hpp>
+#include <hpx/traits/component_supports_migration.hpp>
+#include <hpx/traits/extract_action.hpp>
+
+#include <cstddef>
+#include <utility>
+
+namespace hpx { namespace detail
+{
+    /// \cond NOINTERNAL
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Action, typename Result>
+    struct sync_local_invoke_direct
+    {
+        template <typename ...Ts>
+        static Result
+        call(naming::id_type const& id, naming::address && addr, Ts &&... vs)
+        {
+            typedef typename Action::remote_result_type remote_result_type;
+
+            typedef traits::get_remote_result<Result, remote_result_type>
+                get_remote_result_type;
+
+            return get_remote_result_type::call(Action::execute_function(
+                addr.address_, addr.type_, std::forward<Ts>(vs)...));
+        }
+    };
+
+    template <typename Action>
+    struct sync_local_invoke_direct<Action, void>
+    {
+        template <typename ...Ts>
+        static void
+        call(naming::id_type const& id, naming::address && addr, Ts &&... vs)
+        {
+            Action::execute_function(
+                addr.address_, addr.type_, std::forward<Ts>(vs)...);
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Action, typename ...Ts>
+    typename hpx::traits::extract_action<Action>::type::local_result_type
+    sync_impl(launch policy, hpx::id_type const& id, Ts&&... vs)
+    {
+        typedef typename hpx::traits::extract_action<Action>::type action_type;
+        typedef typename action_type::local_result_type result_type;
+        typedef typename action_type::component_type component_type;
+
+        std::pair<bool, components::pinned_ptr> r;
+
+        naming::address addr;
+        if (agas::is_local_address_cached(id, addr) &&
+            can_invoke_locally<action_type>())
+        {
+            // route launch policy through component
+            policy = traits::action_select_direct_execution<Action>::call(
+                policy, addr.address_);
+
+            if (traits::component_supports_migration<component_type>::call())
+            {
+                r = traits::action_was_object_migrated<Action>::call(
+                        id, addr.address_);
+                if (!r.first)
+                {
+                    if (policy == launch::sync ||
+                        action_type::direct_execution::value)
+                    {
+                        return hpx::detail::sync_local_invoke_direct<
+                            action_type, result_type
+                        >::call(id, std::move(addr), std::forward<Ts>(vs)...);
+                    }
+                }
+            }
+            else if (policy == launch::sync ||
+                action_type::direct_execution::value)
+            {
+                return hpx::detail::sync_local_invoke_direct<
+                        action_type, result_type
+                    >::call(id, std::move(addr), std::forward<Ts>(vs)...);
+            }
+        }
+
+        return async_impl<Action>(policy, id, std::forward<Ts>(vs)...).get();
+    }
+
+    template <typename Action, typename ...Ts>
+    typename hpx::traits::extract_action<Action>::type::local_result_type
+    sync_impl(hpx::detail::sync_policy, hpx::id_type const& id, Ts&&... vs)
+    {
+        typedef typename hpx::traits::extract_action<Action>::type action_type;
+        typedef typename action_type::local_result_type result_type;
+        typedef typename action_type::component_type component_type;
+
+        std::pair<bool, components::pinned_ptr> r;
+
+        naming::address addr;
+        if (agas::is_local_address_cached(id, addr) &&
+            can_invoke_locally<action_type>())
+        {
+            if (traits::component_supports_migration<component_type>::call())
+            {
+                r = traits::action_was_object_migrated<Action>::call(
+                        id, addr.address_);
+                if (!r.first)
+                {
+                    return hpx::detail::sync_local_invoke_direct<
+                            action_type, result_type
+                    >::call(id, std::move(addr), std::forward<Ts>(vs)...);
+                }
+            }
+            else
+            {
+                return hpx::detail::sync_local_invoke_direct<
+                        action_type, result_type
+                    >::call(id, std::move(addr), std::forward<Ts>(vs)...);
+            }
+        }
+
+        return async_impl<Action>(launch::sync, id, std::forward<Ts>(vs)...).get();
+    }
+    /// \endcond
+}}
+
+#endif

--- a/hpx/lcos/detail/sync_implementations_fwd.hpp
+++ b/hpx/lcos/detail/sync_implementations_fwd.hpp
@@ -1,0 +1,27 @@
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_LCOS_SYNC_IMPLEMENTATIONS_FWD_JUL_21_2018_0917PM)
+#define HPX_LCOS_SYNC_IMPLEMENTATIONS_FWD_JUL_21_2018_0917PM
+
+#include <hpx/config.hpp>
+#include <hpx/lcos/sync_fwd.hpp>
+#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/runtime/naming_fwd.hpp>
+#include <hpx/traits/extract_action.hpp>
+
+namespace hpx { namespace detail
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Action, typename ...Ts>
+    typename hpx::traits::extract_action<Action>::type::local_result_type
+    sync_impl(launch policy, hpx::id_type const& id, Ts&&... vs);
+
+    template <typename Action, typename... Ts>
+    typename hpx::traits::extract_action<Action>::type::local_result_type
+    sync_impl(hpx::detail::sync_policy, hpx::id_type const& id, Ts&&... vs);
+}}
+
+#endif

--- a/hpx/lcos/detail/sync_implementations_fwd.hpp
+++ b/hpx/lcos/detail/sync_implementations_fwd.hpp
@@ -15,13 +15,9 @@
 namespace hpx { namespace detail
 {
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Action, typename ...Ts>
+    template <typename Action, typename Launch, typename ...Ts>
     typename hpx::traits::extract_action<Action>::type::local_result_type
-    sync_impl(launch policy, hpx::id_type const& id, Ts&&... vs);
-
-    template <typename Action, typename... Ts>
-    typename hpx::traits::extract_action<Action>::type::local_result_type
-    sync_impl(hpx::detail::sync_policy, hpx::id_type const& id, Ts&&... vs);
+    sync_impl(Launch && policy, hpx::id_type const& id, Ts&&... vs);
 }}
 
 #endif

--- a/hpx/lcos/sync.hpp
+++ b/hpx/lcos/sync.hpp
@@ -1,15 +1,14 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(HPX_LCOS_ASYNC_SEP_28_2011_0840AM)
-#define HPX_LCOS_ASYNC_SEP_28_2011_0840AM
+#if !defined(HPX_LCOS_SYNC_JUL_21_2018_0933PM)
+#define HPX_LCOS_SYNC_JUL_21_2018_0933PM
 
 #include <hpx/config.hpp>
-#include <hpx/lcos/async_fwd.hpp>
-#include <hpx/lcos/detail/async_implementations.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/lcos/sync_fwd.hpp>
+#include <hpx/lcos/detail/sync_implementations.hpp>
 #include <hpx/runtime/components/client_base.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
@@ -22,7 +21,6 @@
 #include <hpx/traits/promise_local_result.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/bind.hpp>
-#include <hpx/util/lazy_enable_if.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -32,25 +30,23 @@ namespace hpx { namespace detail
 {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action>
-    struct async_action_client_dispatch
+    struct sync_action_client_dispatch
     {
         template <typename Policy, typename Client, typename Stub, typename ...Ts>
         HPX_FORCEINLINE
         typename std::enable_if<
             traits::is_launch_policy<Policy>::value,
-            lcos::future<
-                typename traits::promise_local_result<
-                    typename traits::extract_action<
-                        Action
-                    >::remote_result_type
-                >::type
-            >
+            typename traits::promise_local_result<
+                typename traits::extract_action<
+                    Action
+                >::remote_result_type
+            >::type
         >::type
         operator()(Policy const& launch_policy,
             components::client_base<Client, Stub> const& c, Ts &&... ts) const
         {
             HPX_ASSERT(c.is_ready());
-            return hpx::detail::async_impl<Action>(launch_policy, c.get_id(),
+            return hpx::detail::sync_impl<Action>(launch_policy, c.get_id(),
                 std::forward<Ts>(ts)...);
         }
     };
@@ -58,7 +54,7 @@ namespace hpx { namespace detail
     ///////////////////////////////////////////////////////////////////////////
     // launch
     template <typename Action, typename Policy>
-    struct async_action_dispatch<Action, Policy,
+    struct sync_action_dispatch<Action, Policy,
         typename std::enable_if<
             traits::is_launch_policy<Policy>::value
         >::type>
@@ -66,27 +62,25 @@ namespace hpx { namespace detail
         // id_type
         template <typename Policy_, typename ...Ts>
         HPX_FORCEINLINE static
-        lcos::future<
-            typename traits::promise_local_result<
-                typename hpx::traits::extract_action<
-                    Action
-                >::remote_result_type
-            >::type>
+        typename traits::promise_local_result<
+            typename hpx::traits::extract_action<
+                Action
+            >::remote_result_type
+        >::type
         call(Policy_ && launch_policy, naming::id_type const& id, Ts&&... ts)
         {
-            return hpx::detail::async_impl<Action>(
+            return hpx::detail::sync_impl<Action>(
                 std::forward<Policy_>(launch_policy), id,
                 std::forward<Ts>(ts)...);
         }
 
         template <typename Policy_, typename Client, typename Stub, typename ...Ts>
         HPX_FORCEINLINE static
-        lcos::future<
-            typename traits::promise_local_result<
-                typename traits::extract_action<
-                    Action
-                >::remote_result_type
-            >::type>
+        typename traits::promise_local_result<
+            typename traits::extract_action<
+                Action
+            >::remote_result_type
+        >::type
         call(Policy_ && launch_policy,
             components::client_base<Client, Stub> c, Ts&&... ts)
         {
@@ -102,97 +96,63 @@ namespace hpx { namespace detail
             // invoke directly if client is ready
             if (c.is_ready())
             {
-                return hpx::detail::async_impl<Action>(
+                return hpx::detail::sync_impl<Action>(
                     std::forward<Policy_>(launch_policy), c.get_id(),
                     std::forward<Ts>(ts)...);
             }
 
             // defer invocation otherwise
             return c.then(util::bind(
-                util::one_shot(async_action_client_dispatch<Action>()),
+                util::one_shot(sync_action_client_dispatch<Action>()),
                 std::forward<Policy_>(launch_policy), c, std::forward<Ts>(ts)...
-            ));
-        }
-
-        // distribution policy
-        template <typename Policy_, typename DistPolicy, typename ...Ts>
-        HPX_FORCEINLINE static
-        typename util::lazy_enable_if<
-            traits::is_distribution_policy<DistPolicy>::value,
-            typename DistPolicy::template async_result<Action>
-        >::type
-        call(Policy_ && launch_policy, DistPolicy const& policy, Ts&&... ts)
-        {
-            return policy.template async<Action>(
-                std::forward<Policy_>(launch_policy),
-                std::forward<Ts>(ts)...);
+            )).get();
         }
     };
 
     // naming::id_type
     template <typename Action>
-    struct async_action_dispatch<Action, naming::id_type>
+    struct sync_action_dispatch<Action, naming::id_type>
     {
         template <typename ...Ts>
         HPX_FORCEINLINE static
-        lcos::future<
-            typename traits::promise_local_result<
-                typename hpx::traits::extract_action<
-                    Action
-                >::remote_result_type
-            >::type>
+        typename traits::promise_local_result<
+            typename hpx::traits::extract_action<
+                Action
+            >::remote_result_type
+        >::type
         call(naming::id_type const& id, Ts&&... ts)
         {
-            return async_action_dispatch<
-                    Action, hpx::detail::async_policy
-                >::call(launch::async, id, std::forward<Ts>(ts)...);
+            return sync_action_dispatch<
+                    Action, hpx::detail::sync_policy
+                >::call(launch::sync, id, std::forward<Ts>(ts)...);
         }
     };
 
     // component::client
     template <typename Action, typename Client>
-    struct async_action_dispatch<Action, Client,
+    struct sync_action_dispatch<Action, Client,
         typename std::enable_if<
             traits::is_client<Client>::value
         >::type>
     {
         template <typename Client_, typename Stub, typename ...Ts>
         HPX_FORCEINLINE static
-        lcos::future<
-            typename traits::promise_local_result<
-                typename traits::extract_action<
-                    Action
-                >::remote_result_type
-            >::type>
+        typename traits::promise_local_result<
+            typename traits::extract_action<
+                Action
+            >::remote_result_type
+        >::type
         call(components::client_base<Client_, Stub> const& c, Ts&&... ts)
         {
-            return async_action_dispatch<
-                    Action, hpx::detail::async_policy
-                >::call(launch::async, c, std::forward<Ts>(ts)...);
-        }
-    };
-
-    // distribution policy
-    template <typename Action, typename Policy>
-    struct async_action_dispatch<Action, Policy,
-        typename std::enable_if<
-            traits::is_distribution_policy<Policy>::value
-        >::type>
-    {
-        template <typename DistPolicy, typename ...Ts>
-        HPX_FORCEINLINE static
-        typename DistPolicy::template async_result<Action>::type
-        call(DistPolicy const& policy, Ts&&... ts)
-        {
-            return async_action_dispatch<
-                    Action, hpx::detail::async_policy
-                >::call(launch::async, policy, std::forward<Ts>(ts)...);
+            return sync_action_dispatch<
+                    Action, hpx::detail::sync_policy
+                >::call(launch::sync, c, std::forward<Ts>(ts)...);
         }
     };
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action>
-    struct async_launch_policy_dispatch<Action,
+    struct sync_launch_policy_dispatch<Action,
         typename std::enable_if<
             traits::is_action<Action>::value
         >::type>
@@ -203,18 +163,17 @@ namespace hpx { namespace detail
                 >::remote_result_type
             >::type result_type;
 
-        template <typename Policy, typename... Ts>
-        HPX_FORCEINLINE static auto call(
-            Policy&& launch_policy, Action const&, Ts&&... ts)
-        ->  decltype(async<Action>(
-                std::forward<Policy>(launch_policy), std::forward<Ts>(ts)...))
+        template <typename Policy, typename ...Ts>
+        HPX_FORCEINLINE static
+        result_type
+        call(Policy && launch_policy, Action const&, Ts &&... ts)
         {
             static_assert(
                 traits::is_launch_policy<
                     typename std::decay<Policy>::type
                 >::value,
                 "Policy must be a valid launch policy");
-            return async<Action>(
+            return sync<Action>(
                 std::forward<Policy>(launch_policy), std::forward<Ts>(ts)...);
         }
     };
@@ -224,12 +183,12 @@ namespace hpx
 {
     template <typename Action, typename F, typename ...Ts>
     HPX_FORCEINLINE
-    auto async(F && f, Ts &&... ts)
-    ->  decltype(detail::async_action_dispatch<
+    auto sync(F && f, Ts &&... ts)
+    ->  decltype(detail::sync_action_dispatch<
                     Action, typename util::decay<F>::type
             >::call(std::forward<F>(f), std::forward<Ts>(ts)...))
     {
-        return detail::async_action_dispatch<
+        return detail::sync_action_dispatch<
                 Action, typename util::decay<F>::type
             >::call(std::forward<F>(f), std::forward<Ts>(ts)...);
     }
@@ -241,7 +200,7 @@ namespace hpx { namespace detail
     ///////////////////////////////////////////////////////////////////////////
     // any action
     template <typename Action>
-    struct async_dispatch<Action,
+    struct sync_dispatch<Action,
         typename std::enable_if<
             traits::is_action<Action>::value
         >::type>
@@ -249,27 +208,27 @@ namespace hpx { namespace detail
         template <
             typename Component, typename Signature, typename Derived,
             typename ...Ts>
-        HPX_FORCEINLINE static lcos::future<
-            typename traits::promise_local_result<
-                typename hpx::traits::extract_action<
-                    Derived
-                >::remote_result_type
-            >::type>
+        HPX_FORCEINLINE static
+        typename traits::promise_local_result<
+            typename hpx::traits::extract_action<
+                Derived
+            >::remote_result_type
+        >::type
         call(hpx::actions::basic_action<Component, Signature, Derived> const&,
             naming::id_type const& id, Ts&&... vs)
         {
-            return async<Derived>(launch::async, id, std::forward<Ts>(vs)...);
+            return sync<Derived>(launch::sync, id, std::forward<Ts>(vs)...);
         }
 
         template <
             typename Component, typename Signature, typename Derived,
             typename Client, typename Stub, typename ...Ts>
-        HPX_FORCEINLINE static lcos::future<
-            typename traits::promise_local_result<
-                typename traits::extract_action<
-                    Derived
-                >::remote_result_type
-            >::type>
+        HPX_FORCEINLINE static
+        typename traits::promise_local_result<
+            typename traits::extract_action<
+                Derived
+            >::remote_result_type
+        >::type
         call(hpx::actions::basic_action<Component, Signature, Derived> const&,
             components::client_base<Client, Stub> const& c, Ts&&... vs)
         {
@@ -281,25 +240,14 @@ namespace hpx { namespace detail
             static_assert(is_valid::value,
                 "The action to invoke is not supported by the target");
 
-            return async<Derived>(launch::async, c.get_id(),
+            return sync<Derived>(launch::sync, c.get_id(),
                 std::forward<Ts>(vs)...);
-        }
-
-        template <
-            typename Component, typename Signature, typename Derived,
-            typename DistPolicy, typename ...Ts>
-        HPX_FORCEINLINE static
-            typename DistPolicy::template async_result<Derived>::type
-        call(hpx::actions::basic_action<Component, Signature, Derived> const&,
-            DistPolicy const& policy, Ts&&... vs)
-        {
-            return async<Derived>(policy, std::forward<Ts>(vs)...);
         }
     };
 
     // launch with any action
     template <typename Policy>
-    struct async_dispatch<Policy,
+    struct sync_dispatch<Policy,
         typename std::enable_if<
             traits::is_launch_policy<Policy>::value
         >::type>
@@ -307,12 +255,12 @@ namespace hpx { namespace detail
         template <typename Policy_, typename F, typename ...Ts>
         HPX_FORCEINLINE static auto
         call(Policy_ && launch_policy, F && f, Ts &&... ts)
-        ->  decltype(detail::async_launch_policy_dispatch<
+        ->  decltype(detail::sync_launch_policy_dispatch<
                 typename util::decay<F>::type
             >::call(std::forward<Policy_>(launch_policy), std::forward<F>(f),
                 std::forward<Ts>(ts)...))
         {
-            return detail::async_launch_policy_dispatch<
+            return detail::sync_launch_policy_dispatch<
                 typename util::decay<F>::type
             >::call(std::forward<Policy_>(launch_policy), std::forward<F>(f),
                 std::forward<Ts>(ts)...);
@@ -321,12 +269,11 @@ namespace hpx { namespace detail
         template <typename Policy_, typename Component, typename Signature,
             typename Derived, typename Client, typename Stub, typename ...Ts>
         HPX_FORCEINLINE static
-        lcos::future<
-            typename traits::promise_local_result<
-                typename traits::extract_action<
-                    Derived
-                >::remote_result_type
-            >::type>
+        typename traits::promise_local_result<
+            typename traits::extract_action<
+                Derived
+            >::remote_result_type
+        >::type
         call(Policy_ && launch_policy,
             hpx::actions::basic_action<Component, Signature, Derived> const&,
             components::client_base<Client, Stub> const& c, Ts&&... ts)
@@ -339,28 +286,11 @@ namespace hpx { namespace detail
             static_assert(is_valid::value,
                 "The action to invoke is not supported by the target");
 
-            return async<Derived>(std::forward<Policy_>(launch_policy),
+            return sync<Derived>(std::forward<Policy_>(launch_policy),
                 c.get_id(), std::forward<Ts>(ts)...);
-        }
-
-        template <typename Policy_, typename Component, typename Signature,
-            typename Derived, typename DistPolicy, typename ...Ts>
-        HPX_FORCEINLINE static
-        typename util::lazy_enable_if<
-            traits::is_distribution_policy<DistPolicy>::value,
-            typename DistPolicy::template async_result<Derived>
-        >::type
-        call(Policy_ && launch_policy,
-            hpx::actions::basic_action<Component, Signature, Derived> const&,
-            DistPolicy const& policy, Ts&&... ts)
-        {
-            return async<Derived>(std::forward<Policy_>(launch_policy), policy,
-                std::forward<Ts>(ts)...);
         }
     };
 }}
-
-#include <hpx/lcos/sync.hpp>
 
 #endif
 

--- a/hpx/lcos/sync_fwd.hpp
+++ b/hpx/lcos/sync_fwd.hpp
@@ -1,0 +1,53 @@
+//  Copyright (c) 2007-2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+///////////////////////////////////////////////////////////////////////////////
+
+#if !defined(HPX_LCOS_SYNC_FWD_JUL_21_2018_0919PM)
+#define HPX_LCOS_SYNC_FWD_JUL_21_2018_0919PM
+
+#include <hpx/config.hpp>
+#include <hpx/util/decay.hpp>
+
+#include <utility>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx
+{
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        // dispatch point used for async implementations
+        template <typename Func, typename Enable = void>
+        struct sync_dispatch;
+
+        // dispatch point used for async<Action> implementations
+        template <typename Action, typename Func, typename Enable = void>
+        struct sync_action_dispatch;
+
+        // dispatch point used for launch_policy implementations
+        template <typename Action, typename Enable = void>
+        struct sync_launch_policy_dispatch;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Action, typename F, typename ...Ts>
+    HPX_FORCEINLINE
+    auto sync(F && f, Ts &&... ts)
+    ->  decltype(detail::sync_action_dispatch<
+                Action, typename util::decay<F>::type
+            >::call(std::forward<F>(f), std::forward<Ts>(ts)...)
+        );
+
+    template <typename F, typename ...Ts>
+    HPX_FORCEINLINE
+    auto sync(F && f, Ts&&... ts)
+    ->  decltype(detail::sync_dispatch<
+                typename util::decay<F>::type
+            >::call(std::forward<F>(f), std::forward<Ts>(ts)...)
+        );
+}
+
+#endif

--- a/hpx/runtime/actions/basic_action.hpp
+++ b/hpx/runtime/actions/basic_action.hpp
@@ -12,17 +12,18 @@
 
 #include <hpx/config.hpp>
 #include <hpx/exception.hpp>
+#include <hpx/lcos/sync_fwd.hpp>
 #include <hpx/runtime/actions/action_support.hpp>
-#include <hpx/runtime/actions/transfer_action.hpp>
-#include <hpx/runtime/actions/transfer_continuation_action.hpp>
 #include <hpx/runtime/actions/basic_action_fwd.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/runtime/actions/detail/action_factory.hpp>
 #include <hpx/runtime/actions/detail/invocation_count_registry.hpp>
-#include <hpx/runtime/parcelset/detail/per_action_data_counter_registry.hpp>
+#include <hpx/runtime/actions/transfer_action.hpp>
+#include <hpx/runtime/actions/transfer_continuation_action.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/runtime/naming/address.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
+#include <hpx/runtime/parcelset/detail/per_action_data_counter_registry.hpp>
 #include <hpx/runtime/threads/thread_data_fwd.hpp>
 #include <hpx/runtime/threads/thread_enums.hpp>
 #include <hpx/runtime_fwd.hpp>
@@ -35,11 +36,11 @@
 #include <hpx/traits/is_future.hpp>
 #include <hpx/traits/promise_local_result.hpp>
 #include <hpx/util/bind.hpp>
+#include <hpx/util/detail/pack.hpp>
 #include <hpx/util/detail/pp/cat.hpp>
 #include <hpx/util/detail/pp/expand.hpp>
 #include <hpx/util/detail/pp/nargs.hpp>
 #include <hpx/util/detail/pp/stringize.hpp>
-#include <hpx/util/detail/pack.hpp>
 #include <hpx/util/get_and_reset_value.hpp>
 #include <hpx/util/logging.hpp>
 #include <hpx/util/tuple.hpp>
@@ -359,8 +360,8 @@ namespace hpx { namespace actions
                 Policy const& policy, IdOrPolicy const& id_or_policy,
                 error_code& ec, Ts&&... vs)
             {
-                return hpx::async<basic_action>(policy, id_or_policy,
-                    std::forward<Ts>(vs)...).get(ec);
+                return hpx::sync<basic_action>(policy, id_or_policy,
+                    std::forward<Ts>(vs)...);
             }
         };
 

--- a/hpx/runtime/components/colocating_distribution_policy.hpp
+++ b/hpx/runtime/components/colocating_distribution_policy.hpp
@@ -147,11 +147,16 @@ namespace hpx { namespace components
         /// \note This function is part of the invocation policy implemented by
         ///       this class
         ///
-        template <typename Action, typename ...Ts>
-        hpx::future<
-            typename traits::promise_local_result<
+        template <typename Action>
+        struct async_result
+        {
+            using type = hpx::future<typename traits::promise_local_result<
                 typename hpx::traits::extract_action<Action>::remote_result_type
-            >::type>
+            >::type>;
+        };
+
+        template <typename Action, typename ...Ts>
+        typename async_result<Action>::type
         async(launch policy, Ts&&... vs) const
         {
             if (!id_)
@@ -167,10 +172,7 @@ namespace hpx { namespace components
         ///       this class
         ///
         template <typename Action, typename Callback, typename ...Ts>
-        hpx::future<
-            typename traits::promise_local_result<
-                typename hpx::traits::extract_action<Action>::remote_result_type
-            >::type>
+        typename async_result<Action>::type
         async_cb(launch policy, Callback&& cb, Ts&&... vs) const
         {
             if (!id_)

--- a/hpx/runtime/components/default_distribution_policy.hpp
+++ b/hpx/runtime/components/default_distribution_policy.hpp
@@ -202,11 +202,16 @@ namespace hpx { namespace components
         /// \note This function is part of the invocation policy implemented by
         ///       this class
         ///
-        template <typename Action, typename ...Ts>
-        hpx::future<
-            typename traits::promise_local_result<
+        template <typename Action>
+        struct async_result
+        {
+            using type = hpx::future<typename traits::promise_local_result<
                 typename hpx::traits::extract_action<Action>::remote_result_type
-            >::type>
+            >::type>;
+        };
+
+        template <typename Action, typename ...Ts>
+        typename async_result<Action>::type
         async(launch policy, Ts&&... vs) const
         {
             return hpx::detail::async_impl<Action>(policy,
@@ -217,10 +222,7 @@ namespace hpx { namespace components
         ///       this class
         ///
         template <typename Action, typename Callback, typename ...Ts>
-        hpx::future<
-            typename traits::promise_local_result<
-                typename hpx::traits::extract_action<Action>::remote_result_type
-            >::type>
+        typename async_result<Action>::type
         async_cb(launch policy, Callback&& cb, Ts&&... vs) const
         {
             return hpx::detail::async_cb_impl<Action>(policy,

--- a/hpx/runtime/components/target_distribution_policy.hpp
+++ b/hpx/runtime/components/target_distribution_policy.hpp
@@ -119,11 +119,16 @@ namespace hpx { namespace components
         /// \note This function is part of the invocation policy implemented by
         ///       this class
         ///
-        template <typename Action, typename ...Ts>
-        HPX_FORCEINLINE hpx::future<
-            typename traits::promise_local_result<
+        template <typename Action>
+        struct async_result
+        {
+            using type = hpx::future<typename traits::promise_local_result<
                 typename hpx::traits::extract_action<Action>::remote_result_type
-            >::type>
+            >::type>;
+        };
+
+        template <typename Action, typename ...Ts>
+        HPX_FORCEINLINE typename async_result<Action>::type
         async(launch policy, Ts&&... vs) const
         {
             return hpx::detail::async_impl<Action>(policy,
@@ -134,10 +139,7 @@ namespace hpx { namespace components
         ///       this class
         ///
         template <typename Action, typename Callback, typename ...Ts>
-        HPX_FORCEINLINE hpx::future<
-            typename traits::promise_local_result<
-                typename hpx::traits::extract_action<Action>::remote_result_type
-            >::type>
+        HPX_FORCEINLINE typename async_result<Action>::type
         async_cb(launch policy, Callback&& cb, Ts&&... vs) const
         {
             return hpx::detail::async_cb_impl<Action>(policy,

--- a/hpx/runtime/components/unwrapping_distribution_policy.hpp
+++ b/hpx/runtime/components/unwrapping_distribution_policy.hpp
@@ -68,7 +68,7 @@ namespace hpx { namespace components
         };
 
         template <typename Action, typename ...Ts>
-        typename async_result<Action>::type
+        HPX_FORCEINLINE typename async_result<Action>::type
         async(launch policy, Ts&&... vs) const
         {
             return hpx::detail::async_unwrap_result_impl<Action>(
@@ -76,7 +76,7 @@ namespace hpx { namespace components
         }
 
         template <typename Action, typename ...Ts>
-        typename async_result<Action>::type
+        HPX_FORCEINLINE typename async_result<Action>::type
         async(launch::sync_policy, Ts&&... vs) const
         {
             return hpx::detail::sync_impl<Action>(

--- a/hpx/runtime/components/unwrapping_distribution_policy.hpp
+++ b/hpx/runtime/components/unwrapping_distribution_policy.hpp
@@ -1,0 +1,124 @@
+//  Copyright (c) 2014-2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file colocating_distribution_policy.hpp
+
+#if !defined(HPX_COMPONENTS_UNWRAPPING_DISTRIBUTION_POLICY_JUL_22_2018_1240PM)
+#define HPX_COMPONENTS_UNWRAPPING_DISTRIBUTION_POLICY_JUL_22_2018_1240PM
+
+#include <hpx/config.hpp>
+#include <hpx/lcos/detail/async_implementations.hpp>
+#include <hpx/lcos/detail/sync_implementations.hpp>
+#include <hpx/lcos/detail/async_unwrap_result_implementations.hpp>
+#include <hpx/runtime/components/client_base.hpp>
+#include <hpx/runtime/components/target_distribution_policy.hpp>
+#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/runtime/naming/id_type.hpp>
+#include <hpx/runtime/naming/name.hpp>
+#include <hpx/traits/extract_action.hpp>
+#include <hpx/traits/is_distribution_policy.hpp>
+#include <hpx/traits/promise_local_result.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace components
+{
+    /// This class is a distribution policy that can be using with actions that
+    /// return futures. For those actions it is possible to apply certain
+    /// optimizations if the action is invoked synchronously.
+    struct unwrapping_distribution_policy : target_distribution_policy
+    {
+    public:
+        /// Default-construct a new instance of a \a unwrapping_distribution_policy.
+        /// This policy will represent the local locality.
+        unwrapping_distribution_policy() = default;
+
+        /// Create a new \a unwrapping_distribution_policy representing the
+        /// target locality
+        ///
+        /// \param id     [in] The global address of the target object
+        ///
+        unwrapping_distribution_policy operator()(id_type const& id) const
+        {
+            return unwrapping_distribution_policy(id);
+        }
+
+        /// Create a new \a unwrapping_distribution_policy representing the
+        /// target locality
+        ///
+        /// \param client  [in] The client side representation of the target
+        ///                object
+        ///
+        template <typename Client, typename Stub>
+        unwrapping_distribution_policy operator()(
+            client_base<Client, Stub> const& client) const
+        {
+            return unwrapping_distribution_policy(client.get_id());
+        }
+
+        template <typename Action>
+        struct async_result
+        {
+            using type = typename traits::promise_local_result<
+                typename hpx::traits::extract_action<Action>::remote_result_type
+            >::type;
+        };
+
+        template <typename Action, typename ...Ts>
+        typename async_result<Action>::type
+        async(launch policy, Ts&&... vs) const
+        {
+            return hpx::detail::async_unwrap_result_impl<Action>(
+                policy, this->get_next_target(), std::forward<Ts>(vs)...);
+        }
+
+        template <typename Action, typename ...Ts>
+        typename async_result<Action>::type
+        async(launch::sync_policy, Ts&&... vs) const
+        {
+            return hpx::detail::sync_impl<Action>(
+                launch::sync, this->get_next_target(), std::forward<Ts>(vs)...);
+        }
+
+        template <typename Action, typename Callback, typename ...Ts>
+        typename async_result<Action>::type
+        async_cb(launch policy, Callback&& cb, Ts&&... vs) const
+        {
+            return this->target_distribution_policy::async_cb(policy,
+                std::forward<Callback>(cb), std::forward<Ts>(vs)...);
+        }
+
+    protected:
+        /// \cond NOINTERNAL
+        unwrapping_distribution_policy(id_type const& id)
+          : target_distribution_policy(id)
+        {}
+        /// \endcond
+    };
+
+    /// A predefined instance of the unwrap_result \a distribution_policy. It
+    /// will represent the local locality and will place all items to create
+    /// here.
+    static unwrapping_distribution_policy const unwrap_result;
+}}
+
+/// \cond NOINTERNAL
+namespace hpx
+{
+    using hpx::components::unwrapping_distribution_policy;
+    using hpx::components::unwrap_result;
+
+    namespace traits
+    {
+        template <>
+        struct is_distribution_policy<components::unwrapping_distribution_policy>
+          : std::true_type
+        {};
+    }
+}
+/// \endcond
+
+#endif

--- a/hpx/runtime/components/unwrapping_result_policy.hpp
+++ b/hpx/runtime/components/unwrapping_result_policy.hpp
@@ -5,8 +5,8 @@
 
 /// \file colocating_distribution_policy.hpp
 
-#if !defined(HPX_COMPONENTS_UNWRAPPING_DISTRIBUTION_POLICY_JUL_22_2018_1240PM)
-#define HPX_COMPONENTS_UNWRAPPING_DISTRIBUTION_POLICY_JUL_22_2018_1240PM
+#if !defined(HPX_COMPONENTS_UNWRAPPING_RESULT_POLICY_JUL_22_2018_1240PM)
+#define HPX_COMPONENTS_UNWRAPPING_RESULT_POLICY_JUL_22_2018_1240PM
 
 #include <hpx/config.hpp>
 #include <hpx/lcos/detail/async_implementations.hpp>
@@ -29,34 +29,34 @@ namespace hpx { namespace components
     /// This class is a distribution policy that can be using with actions that
     /// return futures. For those actions it is possible to apply certain
     /// optimizations if the action is invoked synchronously.
-    struct unwrapping_distribution_policy : target_distribution_policy
+    struct unwrapping_result_policy : target_distribution_policy
     {
     public:
-        /// Default-construct a new instance of a \a unwrapping_distribution_policy.
+        /// Default-construct a new instance of a \a unwrapping_result_policy.
         /// This policy will represent the local locality.
-        unwrapping_distribution_policy() = default;
+        unwrapping_result_policy() = default;
 
-        /// Create a new \a unwrapping_distribution_policy representing the
+        /// Create a new \a unwrapping_result_policy representing the
         /// target locality
         ///
         /// \param id     [in] The global address of the target object
         ///
-        unwrapping_distribution_policy operator()(id_type const& id) const
+        unwrapping_result_policy operator()(id_type const& id) const
         {
-            return unwrapping_distribution_policy(id);
+            return unwrapping_result_policy(id);
         }
 
-        /// Create a new \a unwrapping_distribution_policy representing the
+        /// Create a new \a unwrapping_result_policy representing the
         /// target locality
         ///
         /// \param client  [in] The client side representation of the target
         ///                object
         ///
         template <typename Client, typename Stub>
-        unwrapping_distribution_policy operator()(
+        unwrapping_result_policy operator()(
             client_base<Client, Stub> const& client) const
         {
-            return unwrapping_distribution_policy(client.get_id());
+            return unwrapping_result_policy(client.get_id());
         }
 
         template <typename Action>
@@ -93,7 +93,7 @@ namespace hpx { namespace components
 
     protected:
         /// \cond NOINTERNAL
-        unwrapping_distribution_policy(id_type const& id)
+        unwrapping_result_policy(id_type const& id)
           : target_distribution_policy(id)
         {}
         /// \endcond
@@ -102,19 +102,19 @@ namespace hpx { namespace components
     /// A predefined instance of the unwrap_result \a distribution_policy. It
     /// will represent the local locality and will place all items to create
     /// here.
-    static unwrapping_distribution_policy const unwrap_result;
+    static unwrapping_result_policy const unwrap_result;
 }}
 
 /// \cond NOINTERNAL
 namespace hpx
 {
-    using hpx::components::unwrapping_distribution_policy;
+    using hpx::components::unwrapping_result_policy;
     using hpx::components::unwrap_result;
 
     namespace traits
     {
         template <>
-        struct is_distribution_policy<components::unwrapping_distribution_policy>
+        struct is_distribution_policy<components::unwrapping_result_policy>
           : std::true_type
         {};
     }

--- a/hpx/sync.hpp
+++ b/hpx/sync.hpp
@@ -1,0 +1,109 @@
+//  Copyright (c) 2007-2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_SYNC_JUL_21_2018_0937PM)
+#define HPX_SYNC_JUL_21_2018_0937PM
+
+#include <hpx/config.hpp>
+#include <hpx/lcos/sync.hpp>
+#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/runtime_fwd.hpp>
+#include <hpx/traits/is_action.hpp>
+#include <hpx/traits/is_executor.hpp>
+#include <hpx/traits/is_launch_policy.hpp>
+#include <hpx/util/bind_action.hpp>
+#include <hpx/util/deferred_call.hpp>
+
+#include <hpx/parallel/executors/execution.hpp>
+#include <hpx/parallel/executors/parallel_executor.hpp>
+
+#include <exception>
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace detail
+{
+    // Launch the given function or function object synchronously. This exists
+    // mostly for symmetry with hpx::async.
+    template <typename Func, typename Enable>
+    struct sync_dispatch
+    {
+        template <typename F, typename ...Ts>
+        HPX_FORCEINLINE static
+        typename std::enable_if<
+            traits::detail::is_deferred_invocable<F, Ts...>::value,
+            typename util::detail::invoke_deferred_result<F, Ts...>::type
+        >::type
+        call(F && f, Ts &&... ts)
+        {
+            parallel::execution::parallel_executor exec;
+            return parallel::execution::sync_execute(
+                exec, std::forward<F>(f), std::forward<Ts>(ts)...);
+        }
+    };
+
+    // The overload for hpx::sync taking an executor simply forwards to the
+    // corresponding executor customization point.
+    //
+    // parallel::execution::executor
+    // threads::executor
+    template <typename Executor>
+    struct sync_dispatch<Executor,
+        typename std::enable_if<
+            traits::is_one_way_executor<Executor>::value ||
+            traits::is_two_way_executor<Executor>::value ||
+            traits::is_threads_executor<Executor>::value
+        >::type>
+    {
+        template <typename Executor_, typename F, typename ...Ts>
+        HPX_FORCEINLINE static
+        typename std::enable_if<
+            traits::detail::is_deferred_invocable<F, Ts...>::value,
+            typename util::detail::invoke_deferred_result<F, Ts...>::type
+        >::type
+        call(Executor_ && exec, F && f, Ts &&... ts)
+        {
+            return parallel::execution::sync_execute(
+                std::forward<Executor_>(exec), std::forward<F>(f),
+                std::forward<Ts>(ts)...);
+        }
+    };
+
+    // bound action
+    template <typename Bound>
+    struct sync_dispatch<Bound,
+        typename std::enable_if<
+            traits::is_bound_action<Bound>::value
+        >::type>
+    {
+        template <typename Action, typename BoundArgs, typename ...Ts>
+        HPX_FORCEINLINE
+        static typename hpx::util::detail::bound_action<
+            Action, BoundArgs
+        >::result_type
+        call(hpx::util::detail::bound_action<Action, BoundArgs> const& bound,
+            Ts&&... ts)
+        {
+            return bound(std::forward<Ts>(ts)...);
+        }
+    };
+}}
+
+namespace hpx
+{
+    template <typename F, typename ...Ts>
+    HPX_FORCEINLINE auto sync(F&& f, Ts&&... ts)
+    ->  decltype(detail::sync_dispatch<typename util::decay<F>::type>::call(
+            std::forward<F>(f), std::forward<Ts>(ts)...
+        ))
+    {
+        return detail::sync_dispatch<
+                typename util::decay<F>::type
+            >::call(std::forward<F>(f), std::forward<Ts>(ts)...);
+    }
+}
+
+#endif

--- a/hpx/util/detail/pack_traversal_async_impl.hpp
+++ b/hpx/util/detail/pack_traversal_async_impl.hpp
@@ -596,16 +596,15 @@ namespace util {
             typename types::visitor_pointer_type
         {
             // Create the frame on the heap which stores the arguments
-            // to traverse asynchronous.
-            auto frame = [&] {
-                auto ptr = new
-                    typename types::frame_type(std::forward<Visitor>(visitor),
-                        std::forward<Args>(args)...);
-
-                // Create an intrusive_ptr from the heap object, don't increase
-                // reference count (it's already 'one').
-                return typename types::frame_pointer_type(ptr, false);
-            }();
+            // to traverse asynchronously.
+            //
+            // Create an intrusive_ptr without increasing its reference count
+            // (it's already 'one').
+            auto frame = typename types::frame_pointer_type(
+                new typename types::frame_type(
+                    std::forward<Visitor>(visitor),
+                    std::forward<Args>(args)...),
+                false);
 
             // Create a static range for the top level tuple
             auto range = make_static_range(frame->head());

--- a/tests/unit/lcos/CMakeLists.txt
+++ b/tests/unit/lcos/CMakeLists.txt
@@ -20,6 +20,7 @@ set(tests
     async_local_executor
     async_remote
     async_remote_client
+    async_unwrap_result
     barrier
     broadcast
     broadcast_apply
@@ -58,6 +59,7 @@ set(tests
     sliding_semaphore
     split_future
     split_shared_future
+    sync_remote
     use_allocator
     wait_all_std_array
     wait_any_std_array

--- a/tests/unit/lcos/async_unwrap_result.cpp
+++ b/tests/unit/lcos/async_unwrap_result.cpp
@@ -1,0 +1,151 @@
+//  Copyright (c) 2007-2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/traits.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/components.hpp>
+#include <hpx/include/async.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+struct decrement_server
+  : hpx::components::managed_component_base<decrement_server>
+{
+    hpx::future<std::int32_t> call(std::int32_t i) const
+    {
+        return hpx::make_ready_future(i - 1);
+    }
+
+    HPX_DEFINE_COMPONENT_ACTION(decrement_server, call);
+};
+
+typedef hpx::components::managed_component<decrement_server> server_type;
+HPX_REGISTER_COMPONENT(server_type, decrement_server);
+
+typedef decrement_server::call_action call_action;
+HPX_REGISTER_ACTION_DECLARATION(call_action);
+HPX_REGISTER_ACTION(call_action);
+
+///////////////////////////////////////////////////////////////////////////////
+struct test_server : hpx::components::simple_component_base<test_server>
+{
+    hpx::future<std::int32_t> increment(std::int32_t i)
+    {
+        return hpx::make_ready_future(i + 1);
+    }
+    HPX_DEFINE_COMPONENT_ACTION(test_server, increment);
+
+    hpx::future<std::int32_t> increment_with_future(
+        hpx::shared_future<std::int32_t> fi)
+    {
+        return hpx::make_ready_future(fi.get() + 1);
+    }
+    HPX_DEFINE_COMPONENT_ACTION(test_server, increment_with_future);
+};
+
+typedef hpx::components::simple_component<test_server> test_server_type;
+HPX_REGISTER_COMPONENT(test_server_type, test_server);
+
+typedef test_server::increment_action increment_action;
+HPX_REGISTER_ACTION_DECLARATION(increment_action);
+HPX_REGISTER_ACTION(increment_action);
+
+typedef test_server::increment_with_future_action increment_with_future_action;
+HPX_REGISTER_ACTION_DECLARATION(increment_with_future_action);
+HPX_REGISTER_ACTION(increment_with_future_action);
+
+struct test_client : hpx::components::client_base<test_client, test_server>
+{
+    typedef hpx::components::client_base<test_client, test_server> base_type;
+
+    test_client(hpx::id_type const& id)
+      : base_type(id)
+    {}
+    test_client(hpx::future<hpx::id_type> && id)
+      : base_type(std::move(id))
+    {}
+};
+
+///////////////////////////////////////////////////////////////////////////////
+void test_remote_async_unwrap_result(test_client const& target)
+{
+    {
+        increment_action inc;
+
+        hpx::future<std::int32_t> f1 =
+            hpx::async(inc, hpx::unwrap_result(target), 42);
+        HPX_TEST_EQ(f1.get(), 43);
+
+        hpx::future<std::int32_t> f2 = hpx::async(
+            hpx::launch::all, inc, hpx::unwrap_result(target), 42);
+        HPX_TEST_EQ(f2.get(), 43);
+
+        hpx::future<std::int32_t> f3 = hpx::async(
+            hpx::launch::sync, inc, hpx::unwrap_result(target), 42);
+        HPX_TEST_EQ(f3.get(), 43);
+    }
+
+    {
+        increment_with_future_action inc;
+
+        hpx::promise<std::int32_t> p;
+        hpx::shared_future<std::int32_t> f = p.get_future();
+
+        hpx::future<std::int32_t> f1 =
+            hpx::async(inc, hpx::unwrap_result(target), f);
+        hpx::future<std::int32_t> f2 = hpx::async(
+            hpx::launch::all, inc, hpx::unwrap_result(target), f);
+
+        p.set_value(42);
+        HPX_TEST_EQ(f1.get(), 43);
+        HPX_TEST_EQ(f2.get(), 43);
+
+        hpx::future<std::int32_t> f3 = hpx::async(
+            hpx::launch::sync, inc, hpx::unwrap_result(target), f);
+
+        HPX_TEST_EQ(f3.get(), 43);
+    }
+
+    {
+        hpx::future<std::int32_t> f1 =
+            hpx::async<increment_action>(hpx::unwrap_result(target), 42);
+        HPX_TEST_EQ(f1.get(), 43);
+
+        hpx::future<std::int32_t> f2 = hpx::async<increment_action>(
+            hpx::launch::all, hpx::unwrap_result(target), 42);
+        HPX_TEST_EQ(f2.get(), 43);
+
+        hpx::future<std::int32_t> f3 = hpx::async<increment_action>(
+            hpx::launch::sync, hpx::unwrap_result(target), 42);
+        HPX_TEST_EQ(f3.get(), 43);
+    }
+}
+
+int hpx_main()
+{
+    std::vector<hpx::id_type> localities = hpx::find_all_localities();
+    for (hpx::id_type const& id : localities)
+    {
+        test_client client(hpx::new_<test_client>(id));
+        test_remote_async_unwrap_result(client);
+    }
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}
+

--- a/tests/unit/lcos/sync_remote.cpp
+++ b/tests/unit/lcos/sync_remote.cpp
@@ -1,0 +1,213 @@
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/components.hpp>
+#include <hpx/include/sync.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+std::int32_t increment(std::int32_t i)
+{
+    return i + 1;
+}
+HPX_PLAIN_ACTION(increment);
+
+std::int32_t increment_with_future(hpx::shared_future<std::int32_t> fi)
+{
+    return fi.get() + 1;
+}
+HPX_PLAIN_ACTION(increment_with_future);
+
+///////////////////////////////////////////////////////////////////////////////
+struct decrement_server
+  : hpx::components::managed_component_base<decrement_server>
+{
+    std::int32_t call(std::int32_t i) const
+    {
+        return i - 1;
+    }
+
+    HPX_DEFINE_COMPONENT_ACTION(decrement_server, call);
+};
+
+typedef hpx::components::managed_component<decrement_server> server_type;
+HPX_REGISTER_COMPONENT(server_type, decrement_server);
+
+typedef decrement_server::call_action call_action;
+HPX_REGISTER_ACTION_DECLARATION(call_action);
+HPX_REGISTER_ACTION(call_action);
+
+///////////////////////////////////////////////////////////////////////////////
+void test_remote_sync(hpx::id_type const& target)
+{
+    {
+        increment_action inc;
+
+        std::int32_t r1 = hpx::sync(inc, target, 42);
+        HPX_TEST_EQ(r1, 43);
+
+        std::int32_t r2 = hpx::sync(hpx::launch::all, inc, target, 42);
+        HPX_TEST_EQ(r2, 43);
+
+        std::int32_t r3 = hpx::sync(hpx::launch::sync, inc, target, 42);
+        HPX_TEST_EQ(r3, 43);
+    }
+
+    {
+        increment_with_future_action inc;
+        hpx::promise<std::int32_t> p;
+        hpx::shared_future<std::int32_t> f = p.get_future();
+
+        p.set_value(42);
+
+        std::int32_t r1 = hpx::sync(inc, target, f);
+        std::int32_t r2 = hpx::sync(hpx::launch::all, inc, target, f);
+
+        HPX_TEST_EQ(r1, 43);
+        HPX_TEST_EQ(r2, 43);
+
+        std::int32_t r3 = hpx::sync(hpx::launch::sync, inc, target, f);
+        HPX_TEST_EQ(r3, 43);
+    }
+
+    {
+        increment_action inc;
+
+        std::int32_t r1 = hpx::sync(hpx::util::bind(inc, target, 42));
+        HPX_TEST_EQ(r1, 43);
+    }
+
+    {
+        std::int32_t r1 = hpx::sync<increment_action>(target, 42);
+        HPX_TEST_EQ(r1, 43);
+
+        std::int32_t r2 =
+            hpx::sync<increment_action>(hpx::launch::all, target, 42);
+        HPX_TEST_EQ(r2, 43);
+
+        std::int32_t r3 =
+            hpx::sync<increment_action>(hpx::launch::sync, target, 42);
+        HPX_TEST_EQ(r3, 43);
+    }
+
+    {
+        hpx::future<hpx::id_type> dec_f =
+            hpx::components::new_<decrement_server>(target);
+        hpx::id_type dec = dec_f.get();
+
+        call_action call;
+
+        std::int32_t r1 = hpx::sync(call, dec, 42);
+        HPX_TEST_EQ(r1, 41);
+
+        std::int32_t r2 = hpx::sync(hpx::launch::all, call, dec, 42);
+        HPX_TEST_EQ(r2, 41);
+
+        std::int32_t r3 = hpx::sync(hpx::launch::sync, call, dec, 42);
+        HPX_TEST_EQ(r3, 41);
+    }
+
+    {
+        hpx::future<hpx::id_type> dec_f =
+            hpx::components::new_<decrement_server>(target);
+        hpx::id_type dec = dec_f.get();
+
+        call_action call;
+
+        std::int32_t r1 = hpx::sync(hpx::util::bind(call, dec, 42));
+        HPX_TEST_EQ(r1, 41);
+
+        using hpx::util::placeholders::_1;
+        using hpx::util::placeholders::_2;
+
+        std::int32_t r2 = hpx::sync(hpx::util::bind(call, _1, 42), dec);
+        HPX_TEST_EQ(r2, 41);
+
+        std::int32_t r3 = hpx::sync(hpx::util::bind(call, _1, _2), dec, 42);
+        HPX_TEST_EQ(r3, 41);
+    }
+
+    {
+        hpx::future<hpx::id_type> dec_f =
+            hpx::components::new_<decrement_server>(target);
+        hpx::id_type dec = dec_f.get();
+
+        std::int32_t r1 = hpx::sync<call_action>(dec, 42);
+        HPX_TEST_EQ(r1, 41);
+
+        std::int32_t r2 = hpx::sync<call_action>(hpx::launch::all, dec, 42);
+        HPX_TEST_EQ(r2, 41);
+
+        std::int32_t r3 = hpx::sync<call_action>(hpx::launch::sync, dec, 42);
+        HPX_TEST_EQ(r3, 41);
+    }
+
+    {
+        increment_with_future_action inc;
+        hpx::shared_future<std::int32_t> f =
+            hpx::async(hpx::launch::deferred, hpx::util::bind(&increment, 42));
+
+        std::int32_t r1 = hpx::sync(inc, target, f);
+        std::int32_t r2 = hpx::sync(hpx::launch::all, inc, target, f);
+        std::int32_t r3 = hpx::sync(hpx::launch::sync, inc, target, f);
+
+        HPX_TEST_EQ(r1, 44);
+        HPX_TEST_EQ(r2, 44);
+        HPX_TEST_EQ(r3, 44);
+    }
+
+    {
+        auto policy1 =
+            hpx::launch::select([]()
+            {
+                return hpx::launch::deferred;
+            });
+
+        increment_with_future_action inc;
+        hpx::shared_future<std::int32_t> f =
+            hpx::async(policy1, hpx::util::bind(&increment, 42));
+
+        std::atomic<int> count(0);
+        auto policy2 =
+            hpx::launch::select([&count]() -> hpx::launch
+            {
+                if (count++ == 0)
+                    return hpx::launch::sync;
+                return hpx::launch::sync;
+            });
+
+        std::int32_t r1 = hpx::sync(policy2, inc, target, f);
+        std::int32_t r2 = hpx::sync(policy2, inc, target, f);
+
+        HPX_TEST_EQ(r1, 44);
+        HPX_TEST_EQ(r2, 44);
+    }
+}
+
+int hpx_main()
+{
+    std::vector<hpx::id_type> localities = hpx::find_all_localities();
+    for (hpx::id_type const& id : localities)
+    {
+        test_remote_sync(id);
+    }
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}
+


### PR DESCRIPTION
- add hpx::sync, semantically equivalent to hpx::async().get(), except that in the
  case of local execution of a direct action no future needs to be created
- add hpx::unwrap_result 'distribution policy' that can be used with hpx::async and
  direct actions that return a future on the server side. That allows to avoid
  creating the outer future in case of local synchronous execution.
- several minor optimizations for hpx::future and hpx::unwrapping

