### PR TITLE
Fix deadlock during shutdown

### DIFF
--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -243,7 +243,7 @@ namespace hpx { namespace components { namespace server
         void stopped();
         void notify_waiting_main();
 
-        bool was_stopped() const { return stopped_; }
+        bool was_stopped() const { return stop_called_; }
 
         void add_pre_startup_function(startup_function_type f)
         {
@@ -365,7 +365,8 @@ namespace hpx { namespace components { namespace server
         compat::mutex mtx_;
         compat::condition_variable wait_condition_;
         compat::condition_variable stop_condition_;
-        bool stopped_;
+        bool stop_called_;
+        bool stop_done_;
         bool terminated_;
         bool dijkstra_color_;   // false: white, true: black
         std::atomic<bool> shutdown_all_invoked_;


### PR DESCRIPTION
Fixes #3358.

The problem was likely introduced by me in #3209. The added `unlock_guard` in `runtime_support_server.cpp` allowed the `wait` function to proceed occasionally. This PR splits the `stopped_` variable to `stop_called_` (which prevents `stop` from being called multiple times) and `stop_done_` (which prevents `wait` from proceeding too early).