### PR TITLE
Make AGAS measurements optional

### DIFF
--- a/hpx/runtime/agas/server/component_namespace.hpp
+++ b/hpx/runtime/agas/server/component_namespace.hpp
@@ -79,16 +79,17 @@ struct HPX_EXPORT component_namespace
         struct api_counter_data
         {
             api_counter_data()
-                : count_(0)
-                , time_(0)
+              : count_(0)
+              , time_(0)
+              , enabled_(false)
             {}
 
             std::atomic<std::int64_t> count_;
             std::atomic<std::int64_t> time_;
+            bool enabled_;
         };
 
-        counter_data()
-        {}
+        counter_data() = default;
 
     public:
         // access current counter values
@@ -118,6 +119,8 @@ struct HPX_EXPORT component_namespace
         void increment_iterate_types_count();
         void increment_get_component_type_name_count();
         void increment_num_localities_count();
+
+        void enable_all();
 
     private:
         friend struct component_namespace;

--- a/hpx/runtime/agas/server/locality_namespace.hpp
+++ b/hpx/runtime/agas/server/locality_namespace.hpp
@@ -80,14 +80,15 @@ struct HPX_EXPORT locality_namespace
             api_counter_data()
               : count_(0)
               , time_(0)
+              , enabled_(false)
             {}
 
             std::atomic<std::int64_t> count_;
             std::atomic<std::int64_t> time_;
+            bool enabled_;
         };
 
-        counter_data()
-        {}
+        counter_data() = default;
 
     public:
         // access current counter values
@@ -116,6 +117,8 @@ struct HPX_EXPORT locality_namespace
         void increment_localities_count();
         void increment_num_localities_count();
         void increment_num_threads_count();
+
+        void enable_all();
 
     private:
         friend struct update_time_on_exit;

--- a/hpx/runtime/agas/server/primary_namespace.hpp
+++ b/hpx/runtime/agas/server/primary_namespace.hpp
@@ -157,14 +157,15 @@ struct HPX_EXPORT primary_namespace
             api_counter_data()
               : count_(0)
               , time_(0)
+              , enabled_(false)
             {}
 
             std::atomic<std::int64_t> count_;
             std::atomic<std::int64_t> time_;
+            bool enabled_;
         };
 
-        counter_data()
-        {}
+        counter_data() = default;
 
     public:
         // access current counter values
@@ -200,6 +201,8 @@ struct HPX_EXPORT primary_namespace
         void increment_allocate_count();
         void increment_begin_migration_count();
         void increment_end_migration_count();
+
+        void enable_all();
 
     private:
         friend struct primary_namespace;

--- a/hpx/runtime/agas/server/symbol_namespace.hpp
+++ b/hpx/runtime/agas/server/symbol_namespace.hpp
@@ -72,14 +72,15 @@ struct HPX_EXPORT symbol_namespace
             api_counter_data()
               : count_(0)
               , time_(0)
+              , enabled_(false)
             {}
 
             std::atomic<std::int64_t> count_;
             std::atomic<std::int64_t> time_;
+            bool enabled_;
         };
 
-        counter_data()
-        {}
+        counter_data() = default;
 
     public:
         // access current counter values
@@ -103,6 +104,8 @@ struct HPX_EXPORT symbol_namespace
         void increment_unbind_count();
         void increment_iterate_names_count();
         void increment_on_event_count();
+
+        void enable_all();
 
     private:
         friend struct update_time_on_exit;

--- a/hpx/util/scoped_timer.hpp
+++ b/hpx/util/scoped_timer.hpp
@@ -17,18 +17,44 @@ namespace hpx { namespace util
     template <typename T>
     struct scoped_timer
     {
-        scoped_timer(T& t)
-          : started_at_(hpx::util::high_resolution_clock::now())
-          , t_(t)
+        scoped_timer(T& t, bool enabled = true)
+          : started_at_(enabled ? hpx::util::high_resolution_clock::now() : 0)
+          , t_(enabled ? &t : nullptr)
         {}
+
+        scoped_timer(scoped_timer const&) = delete;
+        scoped_timer(scoped_timer && rhs) noexcept
+          : started_at_(rhs.started_at_)
+          , t_(rhs.t_)
+        {
+            rhs.t_ = nullptr;
+        }
 
         ~scoped_timer()
         {
-            t_ += (hpx::util::high_resolution_clock::now() - started_at_);
+            if (enabled())
+            {
+                *t_ += (hpx::util::high_resolution_clock::now() - started_at_);
+            }
         }
 
+        scoped_timer& operator=(scoped_timer const& rhs) = delete;
+        scoped_timer& operator=(scoped_timer && rhs) noexcept
+        {
+            started_at_ = rhs.started_at_;
+            t_ = rhs.t_;
+            rhs.t_ = nullptr;
+            return *this;
+        }
+
+        bool enabled() const noexcept
+        {
+            return t_ != nullptr;
+        }
+
+    private:
         std::uint64_t started_at_;
-        T& t_;
+        T* t_;
     };
 }}
 

--- a/src/runtime/agas/server/component_namespace_server.cpp
+++ b/src/runtime/agas/server/component_namespace_server.cpp
@@ -175,7 +175,8 @@ components::component_type component_namespace::bind_prefix(
     )
 { // {{{ bind_prefix implementation
     util::scoped_timer<std::atomic<std::int64_t> > update(
-        counter_data_.bind_prefix_.time_
+        counter_data_.bind_prefix_.time_,
+        counter_data_.bind_prefix_.enabled_
     );
     counter_data_.increment_bind_prefix_count();
 
@@ -270,7 +271,8 @@ components::component_type component_namespace::bind_name(
     )
 { // {{{ bind_name implementation
     util::scoped_timer<std::atomic<std::int64_t> > update(
-        counter_data_.bind_name_.time_
+        counter_data_.bind_name_.time_,
+        counter_data_.bind_name_.enabled_
     );
     counter_data_.increment_bind_name_count();
 
@@ -312,7 +314,8 @@ std::vector<std::uint32_t> component_namespace::resolve_id(
     )
 { // {{{ resolve_id implementation
     util::scoped_timer<std::atomic<std::int64_t> > update(
-        counter_data_.resolve_id_.time_
+        counter_data_.resolve_id_.time_,
+        counter_data_.resolve_id_.enabled_
     );
     counter_data_.increment_resolve_id_count();
 
@@ -361,7 +364,8 @@ bool component_namespace::unbind(
     )
 { // {{{ unbind implementation
     util::scoped_timer<std::atomic<std::int64_t> > update(
-        counter_data_.unbind_name_.time_
+        counter_data_.unbind_name_.time_,
+        counter_data_.unbind_name_.enabled_
     );
     counter_data_.increment_unbind_name_count();
 
@@ -397,7 +401,8 @@ void component_namespace::iterate_types(
     )
 { // {{{ iterate implementation
     util::scoped_timer<std::atomic<std::int64_t> > update(
-        counter_data_.iterate_types_.time_
+        counter_data_.iterate_types_.time_,
+        counter_data_.iterate_types_.enabled_
     );
     counter_data_.increment_iterate_types_count();
 
@@ -431,7 +436,8 @@ std::string component_namespace::get_component_type_name(
     )
 { // {{{ get_component_type_name implementation
     util::scoped_timer<std::atomic<std::int64_t> > update(
-        counter_data_.get_component_type_name_.time_
+        counter_data_.get_component_type_name_.time_,
+        counter_data_.get_component_type_name_.enabled_
     );
     counter_data_.increment_get_component_type_name_count();
 
@@ -478,7 +484,8 @@ std::uint32_t component_namespace::get_num_localities(
     )
 { // {{{ get_num_localities implementation
     util::scoped_timer<std::atomic<std::int64_t> > update(
-        counter_data_.num_localities_.time_
+        counter_data_.num_localities_.time_,
+        counter_data_.num_localities_.enabled_
     );
     counter_data_.increment_num_localities_count();
 
@@ -560,34 +567,42 @@ naming::gid_type component_namespace::statistics_counter(
         case component_ns_bind_prefix:
             get_data_func = util::bind_front(&cd::get_bind_prefix_count,
                 &counter_data_);
+            counter_data_.bind_prefix_.enabled_ = true;
             break;
         case component_ns_bind_name:
             get_data_func = util::bind_front(&cd::get_bind_name_count,
                 &counter_data_);
+            counter_data_.bind_name_.enabled_ = true;
             break;
         case component_ns_resolve_id:
             get_data_func = util::bind_front(&cd::get_resolve_id_count,
                 &counter_data_);
+            counter_data_.resolve_id_.enabled_ = true;
             break;
         case component_ns_unbind_name:
             get_data_func = util::bind_front(&cd::get_unbind_name_count,
                 &counter_data_);
+            counter_data_.unbind_name_.enabled_ = true;
             break;
         case component_ns_iterate_types:
             get_data_func = util::bind_front(&cd::get_iterate_types_count,
                 &counter_data_);
+            counter_data_.iterate_types_.enabled_ = true;
             break;
         case component_ns_get_component_type_name:
             get_data_func = util::bind_front(&cd::get_component_type_name_count,
                 &counter_data_);
+            counter_data_.get_component_type_name_.enabled_ = true;
             break;
         case component_ns_num_localities:
             get_data_func = util::bind_front(&cd::get_num_localities_count,
                 &counter_data_);
+            counter_data_.num_localities_.enabled_ = true;
             break;
         case component_ns_statistics_counter:
             get_data_func = util::bind_front(&cd::get_overall_count,
                 &counter_data_);
+            counter_data_.enable_all();
             break;
         default:
             HPX_THROW_EXCEPTION(bad_parameter
@@ -602,34 +617,42 @@ naming::gid_type component_namespace::statistics_counter(
         case component_ns_bind_prefix:
             get_data_func = util::bind_front(&cd::get_bind_prefix_time,
                 &counter_data_);
+            counter_data_.bind_prefix_.enabled_ = true;
             break;
         case component_ns_bind_name:
             get_data_func = util::bind_front(&cd::get_bind_name_time,
                 &counter_data_);
+            counter_data_.bind_name_.enabled_ = true;
             break;
         case component_ns_resolve_id:
             get_data_func = util::bind_front(&cd::get_resolve_id_time,
                 &counter_data_);
+            counter_data_.resolve_id_.enabled_ = true;
             break;
         case component_ns_unbind_name:
             get_data_func = util::bind_front(&cd::get_unbind_name_time,
                 &counter_data_);
+            counter_data_.unbind_name_.enabled_ = true;
             break;
         case component_ns_iterate_types:
             get_data_func = util::bind_front(&cd::get_iterate_types_time,
                 &counter_data_);
+            counter_data_.iterate_types_.enabled_ = true;
             break;
         case component_ns_get_component_type_name:
             get_data_func = util::bind_front(&cd::get_component_type_name_time,
                 &counter_data_);
+            counter_data_.get_component_type_name_.enabled_ = true;
             break;
         case component_ns_num_localities:
             get_data_func = util::bind_front(&cd::get_num_localities_time,
                 &counter_data_);
+            counter_data_.num_localities_.enabled_ = true;
             break;
         case component_ns_statistics_counter:
             get_data_func = util::bind_front(&cd::get_overall_time,
                 &counter_data_);
+            counter_data_.enable_all();
             break;
         default:
             HPX_THROW_EXCEPTION(bad_parameter
@@ -701,6 +724,17 @@ std::int64_t component_namespace::counter_data::get_overall_count(bool reset)
         util::get_and_reset_value(num_localities_.count_, reset);
 }
 
+void component_namespace::counter_data::enable_all()
+{
+    bind_prefix_.enabled_ = true;
+    bind_name_.enabled_ = true;
+    resolve_id_.enabled_ = true;
+    unbind_name_.enabled_ = true;
+    iterate_types_.enabled_ = true;
+    get_component_type_name_.enabled_ = true;
+    num_localities_.enabled_ = true;
+}
+
 // access execution time counters
 std::int64_t component_namespace::counter_data::get_bind_prefix_time(bool reset)
 {
@@ -752,37 +786,58 @@ std::int64_t component_namespace::counter_data::get_overall_time(bool reset)
 // increment counter values
 void component_namespace::counter_data::increment_bind_prefix_count()
 {
-    ++bind_prefix_.count_;
+    if (bind_prefix_.enabled_)
+    {
+        ++bind_prefix_.count_;
+    }
 }
 
 void component_namespace::counter_data::increment_bind_name_count()
 {
-    ++bind_name_.count_;
+    if (bind_name_.enabled_)
+    {
+        ++bind_name_.count_;
+    }
 }
 
 void component_namespace::counter_data::increment_resolve_id_count()
 {
-    ++resolve_id_.count_;
+    if (resolve_id_.enabled_)
+    {
+        ++resolve_id_.count_;
+    }
 }
 
 void component_namespace::counter_data::increment_unbind_name_count()
 {
-    ++unbind_name_.count_;
+    if (unbind_name_.enabled_)
+    {
+        ++unbind_name_.count_;
+    }
 }
 
 void component_namespace::counter_data::increment_iterate_types_count()
 {
-    ++iterate_types_.count_;
+    if (iterate_types_.enabled_)
+    {
+        ++iterate_types_.count_;
+    }
 }
 
 void component_namespace::counter_data::increment_get_component_type_name_count()
 {
-    ++get_component_type_name_.count_;
+    if (get_component_type_name_.enabled_)
+    {
+        ++get_component_type_name_.count_;
+    }
 }
 
 void component_namespace::counter_data::increment_num_localities_count()
 {
-    ++num_localities_.count_;
+    if (num_localities_.enabled_)
+    {
+        ++num_localities_.count_;
+    }
 }
 
 }}}

--- a/src/runtime/agas/server/primary_namespace_server.cpp
+++ b/src/runtime/agas/server/primary_namespace_server.cpp
@@ -222,7 +222,8 @@ std::pair<naming::id_type, naming::address>
 primary_namespace::begin_migration(naming::gid_type id)
 {
     util::scoped_timer<std::atomic<std::int64_t> > update(
-        counter_data_.begin_migration_.time_
+        counter_data_.begin_migration_.time_,
+        counter_data_.begin_migration_.enabled_
     );
     counter_data_.increment_begin_migration_count();
     using hpx::util::get;
@@ -269,7 +270,8 @@ primary_namespace::begin_migration(naming::gid_type id)
 bool primary_namespace::end_migration(naming::gid_type id)
 {
     util::scoped_timer<std::atomic<std::int64_t> > update(
-        counter_data_.end_migration_.time_
+        counter_data_.end_migration_.time_,
+        counter_data_.end_migration_.enabled_
     );
     counter_data_.increment_end_migration_count();
 
@@ -319,7 +321,8 @@ bool primary_namespace::bind_gid(
     )
 { // {{{ bind_gid implementation
     util::scoped_timer<std::atomic<std::int64_t> > update(
-        counter_data_.bind_gid_.time_
+        counter_data_.bind_gid_.time_,
+        counter_data_.bind_gid_.enabled_
     );
     counter_data_.increment_bind_gid_count();
     using hpx::util::get;
@@ -502,7 +505,8 @@ bool primary_namespace::bind_gid(
 primary_namespace::resolved_type primary_namespace::resolve_gid(naming::gid_type id)
 { // {{{ resolve_gid implementation
     util::scoped_timer<std::atomic<std::int64_t> > update(
-        counter_data_.resolve_gid_.time_
+        counter_data_.resolve_gid_.time_,
+        counter_data_.resolve_gid_.enabled_
     );
     counter_data_.increment_resolve_gid_count();
     using hpx::util::get;
@@ -551,7 +555,8 @@ naming::address primary_namespace::unbind_gid(
     )
 { // {{{ unbind_gid implementation
     util::scoped_timer<std::atomic<std::int64_t> > update(
-        counter_data_.unbind_gid_.time_
+        counter_data_.unbind_gid_.time_,
+        counter_data_.unbind_gid_.enabled_
     );
     counter_data_.increment_unbind_gid_count();
 
@@ -621,7 +626,8 @@ std::int64_t primary_namespace::increment_credit(
     )
 { // increment_credit implementation
     util::scoped_timer<std::atomic<std::int64_t> > update(
-        counter_data_.increment_credit_.time_
+        counter_data_.increment_credit_.time_,
+        counter_data_.increment_credit_.enabled_
     );
     counter_data_.increment_increment_credit_count();
 
@@ -655,7 +661,8 @@ std::vector<std::int64_t> primary_namespace::decrement_credit(
     )
 { // decrement_credit implementation
     util::scoped_timer<std::atomic<std::int64_t> > update(
-        counter_data_.decrement_credit_.time_
+        counter_data_.decrement_credit_.time_,
+        counter_data_.decrement_credit_.enabled_
     );
     counter_data_.increment_decrement_credit_count();
 
@@ -699,7 +706,8 @@ std::pair<naming::gid_type, naming::gid_type> primary_namespace::allocate(
     )
 { // {{{ allocate implementation
     util::scoped_timer<std::atomic<std::int64_t> > update(
-        counter_data_.allocate_.time_
+        counter_data_.allocate_.time_,
+        counter_data_.allocate_.enabled_
     );
     counter_data_.increment_allocate_count();
 
@@ -1300,42 +1308,52 @@ naming::gid_type primary_namespace::statistics_counter(std::string const& name)
         case primary_ns_route:
             get_data_func = util::bind_front(&cd::get_route_count,
                 &counter_data_);
+            counter_data_.route_.enabled_ = true;
             break;
         case primary_ns_bind_gid:
             get_data_func = util::bind_front(&cd::get_bind_gid_count,
                 &counter_data_);
+            counter_data_.bind_gid_.enabled_ = true;
             break;
         case primary_ns_resolve_gid:
             get_data_func = util::bind_front(&cd::get_resolve_gid_count,
                 &counter_data_);
+            counter_data_.resolve_gid_.enabled_ = true;
             break;
         case primary_ns_unbind_gid:
             get_data_func = util::bind_front(&cd::get_unbind_gid_count,
                 &counter_data_);
+            counter_data_.unbind_gid_.enabled_ = true;
             break;
         case primary_ns_increment_credit:
             get_data_func = util::bind_front(&cd::get_increment_credit_count,
                 &counter_data_);
+            counter_data_.increment_credit_.enabled_ = true;
             break;
         case primary_ns_decrement_credit:
             get_data_func = util::bind_front(&cd::get_decrement_credit_count,
                 &counter_data_);
+            counter_data_.decrement_credit_.enabled_ = true;
             break;
         case primary_ns_allocate:
             get_data_func = util::bind_front(&cd::get_allocate_count,
                 &counter_data_);
+            counter_data_.allocate_.enabled_ = true;
             break;
         case primary_ns_begin_migration:
             get_data_func = util::bind_front(&cd::get_begin_migration_count,
                 &counter_data_);
+            counter_data_.begin_migration_.enabled_ = true;
             break;
         case primary_ns_end_migration:
             get_data_func = util::bind_front(&cd::get_end_migration_count,
                 &counter_data_);
+            counter_data_.end_migration_.enabled_ = true;
             break;
         case primary_ns_statistics_counter:
             get_data_func = util::bind_front(&cd::get_overall_count,
                 &counter_data_);
+            counter_data_.enable_all();
             break;
         default:
             HPX_THROW_EXCEPTION(bad_parameter
@@ -1349,42 +1367,52 @@ naming::gid_type primary_namespace::statistics_counter(std::string const& name)
         case primary_ns_route:
             get_data_func = util::bind_front(&cd::get_route_time,
                 &counter_data_);
+            counter_data_.route_.enabled_ = true;
             break;
         case primary_ns_bind_gid:
             get_data_func = util::bind_front(&cd::get_bind_gid_time,
                 &counter_data_);
+            counter_data_.bind_gid_.enabled_ = true;
             break;
         case primary_ns_resolve_gid:
             get_data_func = util::bind_front(&cd::get_resolve_gid_time,
                 &counter_data_);
+            counter_data_.resolve_gid_.enabled_ = true;
             break;
         case primary_ns_unbind_gid:
             get_data_func = util::bind_front(&cd::get_unbind_gid_time,
                 &counter_data_);
+            counter_data_.unbind_gid_.enabled_ = true;
             break;
         case primary_ns_increment_credit:
             get_data_func = util::bind_front(&cd::get_increment_credit_time,
                 &counter_data_);
+            counter_data_.increment_credit_.enabled_ = true;
             break;
         case primary_ns_decrement_credit:
             get_data_func = util::bind_front(&cd::get_decrement_credit_time,
                 &counter_data_);
+            counter_data_.decrement_credit_.enabled_ = true;
             break;
         case primary_ns_allocate:
             get_data_func = util::bind_front(&cd::get_allocate_time,
                 &counter_data_);
+            counter_data_.allocate_.enabled_ = true;
             break;
         case primary_ns_begin_migration:
             get_data_func = util::bind_front(&cd::get_begin_migration_time,
                 &counter_data_);
+            counter_data_.begin_migration_.enabled_ = true;
             break;
         case primary_ns_end_migration:
             get_data_func = util::bind_front(&cd::get_end_migration_time,
                 &counter_data_);
             break;
+            counter_data_.end_migration_.enabled_ = true;
         case primary_ns_statistics_counter:
             get_data_func = util::bind_front(&cd::get_overall_time,
                 &counter_data_);
+            counter_data_.enable_all();
             break;
         default:
             HPX_THROW_EXCEPTION(bad_parameter
@@ -1525,50 +1553,90 @@ std::int64_t primary_namespace::counter_data::get_overall_time(bool reset)
         util::get_and_reset_value(end_migration_.time_, reset);
 }
 
+void primary_namespace::counter_data::enable_all()
+{
+    route_.enabled_ = true;
+    bind_gid_.enabled_ = true;
+    resolve_gid_.enabled_ = true;
+    unbind_gid_.enabled_ = true;
+    increment_credit_.enabled_ = true;
+    decrement_credit_.enabled_ = true;
+    allocate_.enabled_ = true;
+    begin_migration_.enabled_ = true;
+    end_migration_.enabled_ = true;
+}
+
 // increment counter values
 void primary_namespace::counter_data::increment_route_count()
 {
-    ++route_.count_;
+    if (route_.enabled_)
+    {
+        ++route_.count_;
+    }
 }
 
 void primary_namespace::counter_data::increment_bind_gid_count()
 {
-    ++bind_gid_.count_;
+    if (bind_gid_.enabled_)
+    {
+        ++bind_gid_.count_;
+    }
 }
 
 void primary_namespace::counter_data::increment_resolve_gid_count()
 {
-    ++resolve_gid_.count_;
+    if (resolve_gid_.enabled_)
+    {
+        ++resolve_gid_.count_;
+    }
 }
 
 void primary_namespace::counter_data::increment_unbind_gid_count()
 {
-    ++unbind_gid_.count_;
+    if (unbind_gid_.enabled_)
+    {
+        ++unbind_gid_.count_;
+    }
 }
 
 void primary_namespace::counter_data::increment_increment_credit_count()
 {
-    ++increment_credit_.count_;
+    if (increment_credit_.enabled_)
+    {
+        ++increment_credit_.count_;
+    }
 }
 
 void primary_namespace::counter_data::increment_decrement_credit_count()
 {
-    ++decrement_credit_.count_;
+    if (decrement_credit_.enabled_)
+    {
+        ++decrement_credit_.count_;
+    }
 }
 
 void primary_namespace::counter_data::increment_allocate_count()
 {
-    ++allocate_.count_;
+    if (allocate_.enabled_)
+    {
+        ++allocate_.count_;
+    }
 }
 
 void primary_namespace::counter_data::increment_begin_migration_count()
 {
-    ++begin_migration_.count_;
+    if (begin_migration_.enabled_)
+    {
+        ++begin_migration_.count_;
+    }
 }
 
 void primary_namespace::counter_data::increment_end_migration_count()
 {
-    ++end_migration_.count_;
+    if (end_migration_.enabled_)
+    {
+        ++end_migration_.count_;
+    }
 }
 
 }}}

--- a/src/runtime/agas/server/route.cpp
+++ b/src/runtime/agas/server/route.cpp
@@ -41,7 +41,8 @@ namespace hpx { namespace agas { namespace server
     void primary_namespace::route(parcelset::parcel && p)
     { // {{{ route implementation
         util::scoped_timer<std::atomic<std::int64_t> > update(
-            counter_data_.route_.time_
+            counter_data_.route_.time_,
+            counter_data_.route_.enabled_
         );
         counter_data_.increment_route_count();
 

--- a/src/runtime/agas/server/symbol_namespace_server.cpp
+++ b/src/runtime/agas/server/symbol_namespace_server.cpp
@@ -187,7 +187,8 @@ bool symbol_namespace::bind(
 { // {{{ bind implementation
     // parameters
     util::scoped_timer<std::atomic<std::int64_t> > update(
-        counter_data_.bind_.time_
+        counter_data_.bind_.time_,
+        counter_data_.bind_.enabled_
     );
     counter_data_.increment_bind_count();
 
@@ -304,7 +305,8 @@ naming::gid_type symbol_namespace::resolve(std::string const& key)
 { // {{{ resolve implementation
     // parameters
     util::scoped_timer<std::atomic<std::int64_t> > update(
-        counter_data_.resolve_.time_
+        counter_data_.resolve_.time_,
+        counter_data_.resolve_.enabled_
     );
     counter_data_.increment_resolve_count();
 
@@ -338,7 +340,8 @@ naming::gid_type symbol_namespace::resolve(std::string const& key)
 naming::gid_type symbol_namespace::unbind(std::string const& key)
 { // {{{ unbind implementation
     util::scoped_timer<std::atomic<std::int64_t> > update(
-        counter_data_.unbind_.time_
+        counter_data_.unbind_.time_,
+        counter_data_.unbind_.enabled_
     );
     counter_data_.increment_unbind_count();
 
@@ -372,7 +375,8 @@ symbol_namespace::iterate_names_return_type symbol_namespace::iterate(
     std::string const& pattern)
 { // {{{ iterate implementation
     util::scoped_timer<std::atomic<std::int64_t> > update(
-        counter_data_.iterate_names_.time_
+        counter_data_.iterate_names_.time_,
+        counter_data_.iterate_names_.enabled_
     );
     counter_data_.increment_iterate_names_count();
 
@@ -428,7 +432,8 @@ bool symbol_namespace::on_event(
     )
 { // {{{ on_event implementation
     util::scoped_timer<std::atomic<std::int64_t> > update(
-        counter_data_.on_event_.time_
+        counter_data_.on_event_.time_,
+        counter_data_.on_event_.enabled_
     );
     counter_data_.increment_on_event_count();
 
@@ -519,26 +524,32 @@ naming::gid_type symbol_namespace::statistics_counter(std::string const& name)
         case symbol_ns_bind:
             get_data_func = util::bind_front(&cd::get_bind_count,
                 &counter_data_);
+            counter_data_.bind_.enabled_ = true;
             break;
         case symbol_ns_resolve:
             get_data_func = util::bind_front(&cd::get_resolve_count,
                 &counter_data_);
+            counter_data_.resolve_.enabled_ = true;
             break;
         case symbol_ns_unbind:
             get_data_func = util::bind_front(&cd::get_unbind_count,
                 &counter_data_);
+            counter_data_.unbind_.enabled_ = true;
             break;
         case symbol_ns_iterate_names:
             get_data_func = util::bind_front(&cd::get_iterate_names_count,
                 &counter_data_);
+            counter_data_.iterate_names_.enabled_ = true;
             break;
         case symbol_ns_on_event:
             get_data_func = util::bind_front(&cd::get_on_event_count,
                 &counter_data_);
+            counter_data_.on_event_.enabled_ = true;
             break;
         case symbol_ns_statistics_counter:
             get_data_func = util::bind_front(&cd::get_overall_count,
                 &counter_data_);
+            counter_data_.enable_all();
             break;
         default:
             HPX_THROW_EXCEPTION(bad_parameter
@@ -552,26 +563,32 @@ naming::gid_type symbol_namespace::statistics_counter(std::string const& name)
         case symbol_ns_bind:
             get_data_func = util::bind_front(&cd::get_bind_time,
                 &counter_data_);
+            counter_data_.bind_.enabled_ = true;
             break;
         case symbol_ns_resolve:
             get_data_func = util::bind_front(&cd::get_resolve_time,
                 &counter_data_);
+            counter_data_.resolve_.enabled_ = true;
             break;
         case symbol_ns_unbind:
             get_data_func = util::bind_front(&cd::get_unbind_time,
                 &counter_data_);
+            counter_data_.unbind_.enabled_ = true;
             break;
         case symbol_ns_iterate_names:
             get_data_func = util::bind_front(&cd::get_iterate_names_time,
                 &counter_data_);
+            counter_data_.iterate_names_.enabled_ = true;
             break;
         case symbol_ns_on_event:
             get_data_func = util::bind_front(&cd::get_on_event_time,
                 &counter_data_);
+            counter_data_.on_event_.enabled_ = true;
             break;
         case symbol_ns_statistics_counter:
             get_data_func = util::bind_front(&cd::get_overall_time,
                 &counter_data_);
+            counter_data_.enable_all();
             break;
         default:
             HPX_THROW_EXCEPTION(bad_parameter
@@ -625,6 +642,15 @@ std::int64_t symbol_namespace::counter_data::get_overall_count(bool reset)
         util::get_and_reset_value(on_event_.count_, reset);
 }
 
+void symbol_namespace::counter_data::enable_all()
+{
+    bind_.enabled_ = true;
+    resolve_.enabled_ = true;
+    unbind_.enabled_ = true;
+    iterate_names_.enabled_ = true;
+    on_event_.enabled_ = true;
+}
+
 // access execution time counters
 std::int64_t symbol_namespace::counter_data::get_bind_time(bool reset)
 {
@@ -663,27 +689,42 @@ std::int64_t symbol_namespace::counter_data::get_overall_time(bool reset)
 // increment counter values
 void symbol_namespace::counter_data::increment_bind_count()
 {
-    ++bind_.count_;
+    if (bind_.enabled_)
+    {
+        ++bind_.count_;
+    }
 }
 
 void symbol_namespace::counter_data::increment_resolve_count()
 {
-    ++resolve_.count_;
+    if (resolve_.enabled_)
+    {
+        ++resolve_.count_;
+    }
 }
 
 void symbol_namespace::counter_data::increment_unbind_count()
 {
-    ++unbind_.count_;
+    if (unbind_.enabled_)
+    {
+        ++unbind_.count_;
+    }
 }
 
 void symbol_namespace::counter_data::increment_iterate_names_count()
 {
-    ++iterate_names_.count_;
+    if (iterate_names_.enabled_)
+    {
+        ++iterate_names_.count_;
+    }
 }
 
 void symbol_namespace::counter_data::increment_on_event_count()
 {
-    ++on_event_.count_;
+    if (on_event_.enabled_)
+    {
+        ++on_event_.count_;
+    }
 }
 
 }}}


### PR DESCRIPTION
- Make sure measurement of AGAS functionalities (count/time for the corresponding
  performance counters) is actually performed only if a performance counter has
  been instantiated.
