### PR TITLE
Adapt integration of HPXMP to latest build system changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1614,7 +1614,7 @@ if(HPX_WITH_HPXMP)
     ${_hpxmp_no_update}
     VERBOSE)
 
-  add_subdirectory(hpxmp/src)
+  add_subdirectory(hpxmp)
 
   # make sure thread-local storage is supported
   hpx_add_config_define(HPX_HAVE_THREAD_LOCAL_STORAGE)


### PR DESCRIPTION
This is to adapt the integration of HPXMP to its latest changes (see https://github.com/STEllAR-GROUP/hpxMP/pull/6)