### PR TITLE
Add performance counters background overhead and background work duration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -878,6 +878,14 @@ if(HPX_WITH_NETWORKING)
     "Enable the parcel coalescing plugin (default: ON)." ON ADVANCED)
   if(HPX_WITH_PARCEL_COALESCING)
     hpx_add_config_define(HPX_HAVE_PARCEL_COALESCING)
+
+    #Adaptive parcel coalescing related metrics counters
+    hpx_option(HPX_WITH_ADAPTIVE_COALESCING_COUNTERS BOOL
+       "Enable performance counters related to adaptive parcel coalescing (default: OFF)." OFF ADVANCED)
+    if(HPX_WITH_ADAPTIVE_COALESCING_COUNTERS)
+      hpx_add_config_define(HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS)
+    endif()
+
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -878,14 +878,15 @@ if(HPX_WITH_NETWORKING)
     "Enable the parcel coalescing plugin (default: ON)." ON ADVANCED)
   if(HPX_WITH_PARCEL_COALESCING)
     hpx_add_config_define(HPX_HAVE_PARCEL_COALESCING)
-
-    #Adaptive parcel coalescing related metrics counters
-    hpx_option(HPX_WITH_ADAPTIVE_COALESCING_COUNTERS BOOL
-       "Enable performance counters related to adaptive parcel coalescing (default: OFF)." OFF ADVANCED)
-    if(HPX_WITH_ADAPTIVE_COALESCING_COUNTERS)
-      hpx_add_config_define(HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS)
-    endif()
-
+    #Adaptive parcel coalescing related metrics counters are enabled only if both
+    #parcel coalescing plugin and thread idle rate counters are enabled.
+      if(HPX_WITH_THREAD_IDLE_RATES)
+        hpx_option(HPX_WITH_ADAPTIVE_COALESCING_COUNTERS BOOL
+           "Enable performance counters related to adaptive parcel coalescing (default: OFF)." OFF ADVANCED)
+        if(HPX_WITH_ADAPTIVE_COALESCING_COUNTERS)
+          hpx_add_config_define(HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS)
+        endif()
+       endif()
   endif()
 endif()
 

--- a/docs/manual/existing_performance_counters.qbk
+++ b/docs/manual/existing_performance_counters.qbk
@@ -1213,7 +1213,7 @@ system and application performance.
     ]
         [///////////////////////////////////////////////////////////////////////////////]
         [///////////// Adaptive Coalescing Related Counters ////////////////////////////]
-        [   [`/threads/time/experimental-bg-work`]
+        [   [`/threads/time/background-work-duration`]
                 [`locality#*/total` or[br]
                  `locality#*/worker-thread#*`
 
@@ -1236,10 +1236,14 @@ system and application performance.
                  performing background work for all worker threads
                  (cores) on that locality. If the instance name is `worker-thread#*`
                  the counter will return the overall time spent performing backgound work
-                 for all worker threads separately. ]
+                 for all worker threads separately.
+                 This counter is available only if the configuration time constants
+                 `HPX_WITH_ADAPTIVE_COALESCING_COUNTERS` (default: OFF) and
+                 `HPX_WITH_THREAD_IDLE_RATES` are set to `ON` (default: OFF).
+                  The unit of  measure for this counter is nanosecond [ns].]
                 [None]
         ]
-        [   [`/threads/time/experimental-bg-overhead`]
+        [   [`/threads/background-overhead`]
                 [`locality#*/total` or[br]
                  `locality#*/worker-thread#*`
 
@@ -1261,7 +1265,11 @@ system and application performance.
                  instance name is `total` the counter returns the background overhead
                   for all worker threads (cores) on that locality. If the instance name
                   is `worker-thread#*` the counter will return background overhead
-                 for all worker threads separately. ]
+                 for all worker threads separately.
+                 This counter is available only if the configuration time constants
+                 `HPX_WITH_ADAPTIVE_COALESCING_COUNTERS` (default: OFF) and
+                 `HPX_WITH_THREAD_IDLE_RATES` are set to `ON` (default: OFF).
+                  The unit of  measure displayed for this counter is 0.1%.]
                 [None]
         ]
         [///////////////////////////////////////////////////////////////////////////]

--- a/docs/manual/existing_performance_counters.qbk
+++ b/docs/manual/existing_performance_counters.qbk
@@ -1211,6 +1211,61 @@ system and application performance.
          __hpx__- worker thread or the accumulated value for all worker threads.]
         [None]
     ]
+        [///////////////////////////////////////////////////////////////////////////////]
+        [///////////// Adaptive Coalescing Related Counters ////////////////////////////]
+        [   [`/threads/time/experimental-bg-work`]
+                [`locality#*/total` or[br]
+                 `locality#*/worker-thread#*`
+
+                  where:[br]
+                  `locality#*` is defining the locality for which the overall time spent
+                  performing background work should be queried
+                  for. The locality id (given by `*`) is a (zero based) number
+                  identifying the locality.
+
+                  `worker-thread#*` is defining the worker thread for which the
+                  overall time spent performing background work should
+                  be queried for. The worker thread number (given by the `*`) is a
+                  (zero based) number identifying the worker thread. The number of
+                  available worker threads is usually specified on the command line
+                  for the application using the option [hpx_cmdline `--hpx:threads`].
+                ]
+                [Returns the overall time spent performing background work on the
+                 given locality since application start. If the
+                 instance name is `total` the counter returns the overall time spent
+                 performing background work for all worker threads
+                 (cores) on that locality. If the instance name is `worker-thread#*`
+                 the counter will return the overall time spent performing backgound work
+                 for all worker threads separately. ]
+                [None]
+        ]
+        [   [`/threads/time/experimental-bg-overhead`]
+                [`locality#*/total` or[br]
+                 `locality#*/worker-thread#*`
+
+                  where:[br]
+                  `locality#*` is defining the locality for which the
+                   background overhead should be queried
+                  for. The locality id (given by `*`) is a (zero based) number
+                  identifying the locality.
+
+                  `worker-thread#*` is defining the worker thread for which the
+                  background overhead should
+                  be queried for. The worker thread number (given by the `*`) is a
+                  (zero based) number identifying the worker thread. The number of
+                  available worker threads is usually specified on the command line
+                  for the application using the option [hpx_cmdline `--hpx:threads`].
+                ]
+                [Returns the background overhead on the
+                 given locality since application start. If the
+                 instance name is `total` the counter returns the background overhead
+                  for all worker threads (cores) on that locality. If the instance name
+                  is `worker-thread#*` the counter will return background overhead
+                 for all worker threads separately. ]
+                [None]
+        ]
+        [///////////////////////////////////////////////////////////////////////////]
+    ]
 ]
 
 [/////////////////////////////////////////////////////////////////////////////]

--- a/hpx/runtime/threads/detail/scheduled_thread_pool.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool.hpp
@@ -242,6 +242,11 @@ namespace hpx { namespace threads { namespace detail
 
         std::int64_t get_cumulative_duration(std::size_t, bool);
 
+#ifdef HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
+        std::int64_t get_background_work_duration(std::size_t, bool);
+        std::int64_t get_background_overhead(std::size_t, bool);
+#endif    //HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
+
 #if defined(HPX_HAVE_THREAD_IDLE_RATES)
         std::int64_t avg_idle_rate_all(bool reset);
         std::int64_t avg_idle_rate(std::size_t, bool);
@@ -361,6 +366,13 @@ namespace hpx { namespace threads { namespace detail
         // tfunc_impl timers
         std::vector<std::uint64_t> exec_times_, tfunc_times_;
         std::vector<std::uint64_t> reset_tfunc_times_;
+
+#ifdef HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
+        std::vector<std::uint64_t> background_duration_,
+            reset_background_duration_;
+        std::vector<std::uint64_t> reset_background_tfunc_times_;
+        std::vector<std::uint64_t> reset_background_overhead_;
+#endif    //HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
 
         std::vector<std::int64_t> idle_loop_counts_, busy_loop_counts_;
 

--- a/hpx/runtime/threads/detail/scheduled_thread_pool.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool.hpp
@@ -242,7 +242,7 @@ namespace hpx { namespace threads { namespace detail
 
         std::int64_t get_cumulative_duration(std::size_t, bool);
 
-#ifdef HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
+#if defined(HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
         std::int64_t get_background_work_duration(std::size_t, bool);
         std::int64_t get_background_overhead(std::size_t, bool);
 #endif    //HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
@@ -367,9 +367,11 @@ namespace hpx { namespace threads { namespace detail
         std::vector<std::uint64_t> exec_times_, tfunc_times_;
         std::vector<std::uint64_t> reset_tfunc_times_;
 
-#ifdef HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
-        std::vector<std::uint64_t> background_duration_,
-            reset_background_duration_;
+        //background duration for adaptive coalescing counters
+        std::vector<std::uint64_t> background_duration_;
+
+#if defined(HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
+        std::vector<std::uint64_t> reset_background_duration_;
         std::vector<std::uint64_t> reset_background_tfunc_times_;
         std::vector<std::uint64_t> reset_background_overhead_;
 #endif    //HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS

--- a/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
@@ -1182,7 +1182,7 @@ namespace hpx { namespace threads { namespace detail
 #endif
 #endif
 
-#ifdef HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
+#if defined(HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
     ////////////////////////////////////////////////////////////
     template <typename Scheduler>
     std::int64_t scheduled_thread_pool<Scheduler>::get_background_overhead(
@@ -1532,8 +1532,9 @@ namespace hpx { namespace threads { namespace detail
 
         tasks_active_.resize(pool_threads);
 
-#ifdef HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
         background_duration_.resize(pool_threads);
+
+#if defined(HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
         reset_background_duration_.resize(pool_threads);
         reset_background_tfunc_times_.resize(pool_threads);
         reset_background_overhead_.resize(pool_threads);

--- a/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
@@ -572,7 +572,8 @@ namespace hpx { namespace threads { namespace detail
                     exec_times_[thread_num],
                     idle_loop_counts_[thread_num],
                     busy_loop_counts_[thread_num],
-                    tasks_active_[thread_num]);
+                    tasks_active_[thread_num],
+                    background_duration_[thread_num]);
 
                 detail::scheduling_callbacks callbacks(
                     util::bind(    //-V107
@@ -1181,6 +1182,107 @@ namespace hpx { namespace threads { namespace detail
 #endif
 #endif
 
+#ifdef HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
+    ////////////////////////////////////////////////////////////
+    template <typename Scheduler>
+    std::int64_t scheduled_thread_pool<Scheduler>::get_background_overhead(
+        std::size_t num, bool reset)
+    {
+        std::uint64_t bg_total = 0ul;
+        std::uint64_t reset_bg_total = 0ul;
+        std::uint64_t tfunc_total = 0ul;
+        std::uint64_t reset_tfunc_total = 0ul;
+
+        if (num != std::size_t(-1))
+        {
+            tfunc_total = tfunc_times_[num];
+            reset_tfunc_total = reset_background_tfunc_times_[num];
+
+            bg_total = background_duration_[num];
+            reset_bg_total = reset_background_overhead_[num];
+
+            if (reset)
+            {
+                reset_background_overhead_[num] = bg_total;
+                reset_background_tfunc_times_[num] = tfunc_total;
+            }
+        }
+        else
+        {
+            tfunc_total = std::accumulate(
+                tfunc_times_.begin(), tfunc_times_.end(), std::uint64_t(0));
+            reset_tfunc_total =
+                std::accumulate(reset_background_tfunc_times_.begin(),
+                    reset_background_tfunc_times_.end(), std::uint64_t(0));
+
+            bg_total = std::accumulate(background_duration_.begin(),
+                background_duration_.end(), std::uint64_t(0));
+            reset_bg_total = std::accumulate(reset_background_overhead_.begin(),
+                reset_background_overhead_.end(), std::uint64_t(0));
+
+            if (reset)
+            {
+                std::copy(tfunc_times_.begin(), tfunc_times_.end(),
+                    reset_background_tfunc_times_.begin());
+
+                std::copy(background_duration_.begin(),
+                    background_duration_.end(),
+                    reset_background_overhead_.begin());
+            }
+        }
+
+        HPX_ASSERT(bg_total >= reset_bg_total);
+        HPX_ASSERT(tfunc_total >= reset_tfunc_total);
+
+        if (tfunc_total == 0)    // avoid division by zero
+            return 1000LL;
+
+        tfunc_total -= reset_tfunc_total;
+        bg_total -= reset_bg_total;
+        //this is now a 0.1 %
+        return std::uint64_t((double(bg_total) / tfunc_total) * 1000);
+    }
+
+    template <typename Scheduler>
+    std::int64_t scheduled_thread_pool<Scheduler>::get_background_work_duration(
+        std::size_t num, bool reset)
+    {
+        std::uint64_t bg_total = 0ul;
+        std::uint64_t reset_bg_total = 0ul;
+
+        if (num != std::size_t(-1))
+        {
+            bg_total = background_duration_[num];
+            reset_bg_total = reset_background_duration_[num];
+
+            if (reset)
+            {
+                reset_background_duration_[num] = bg_total;
+            }
+        }
+        else
+        {
+            bg_total = std::accumulate(background_duration_.begin(),
+                background_duration_.end(), std::uint64_t(0));
+            reset_bg_total = std::accumulate(reset_background_duration_.begin(),
+                reset_background_duration_.end(), std::uint64_t(0));
+
+            if (reset)
+            {
+                std::copy(background_duration_.begin(),
+                    background_duration_.end(),
+                    reset_background_duration_.begin());
+            }
+        }
+
+        HPX_ASSERT(bg_total >= reset_bg_total);
+        bg_total -= reset_bg_total;
+        return std::uint64_t(double(bg_total) * timestamp_scale_);
+    }
+
+#endif    //HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
+          //////////////////////////////////////////////////////////////////////
+
     template <typename Scheduler>
     std::int64_t scheduled_thread_pool<Scheduler>::get_cumulative_duration(
         std::size_t num, bool reset)
@@ -1429,6 +1531,13 @@ namespace hpx { namespace threads { namespace detail
         reset_tfunc_times_.resize(pool_threads);
 
         tasks_active_.resize(pool_threads);
+
+#ifdef HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
+        background_duration_.resize(pool_threads);
+        reset_background_duration_.resize(pool_threads);
+        reset_background_tfunc_times_.resize(pool_threads);
+        reset_background_overhead_.resize(pool_threads);
+#endif    //HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
 
 #if defined(HPX_HAVE_THREAD_CUMULATIVE_COUNTS)
         // timestamps/values of last reset operation for various

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -279,7 +279,7 @@ namespace hpx { namespace threads { namespace detail
 #endif
 
     ///////////////////////////////////////////////////////////////////////////
-#ifdef HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
+#if defined(HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
 
     struct background_work_duration_counter
     {
@@ -467,7 +467,7 @@ namespace hpx { namespace threads { namespace detail
                     if (HPX_LIKELY(thrd_stat.is_valid() &&
                             thrd_stat.get_previous() == pending))
                     {
-#ifdef HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
+#if defined(HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
                         //count background work duration
                         background_work_duration_counter bg_work_duration(
                             background_work_exec_time_init);

--- a/hpx/runtime/threads/thread_pool_base.hpp
+++ b/hpx/runtime/threads/thread_pool_base.hpp
@@ -233,7 +233,7 @@ namespace hpx { namespace threads
         virtual std::int64_t get_cumulative_duration(
             std::size_t thread_num, bool reset) { return 0; }
 
-#ifdef HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
+#if defined(HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
         virtual std::int64_t get_background_work_duration(
             std::size_t thread_num, bool reset) { return 0; }
         virtual std::int64_t get_background_overhead(

--- a/hpx/runtime/threads/thread_pool_base.hpp
+++ b/hpx/runtime/threads/thread_pool_base.hpp
@@ -233,6 +233,13 @@ namespace hpx { namespace threads
         virtual std::int64_t get_cumulative_duration(
             std::size_t thread_num, bool reset) { return 0; }
 
+#ifdef HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
+        virtual std::int64_t get_background_work_duration(
+            std::size_t thread_num, bool reset) { return 0; }
+        virtual std::int64_t get_background_overhead(
+            std::size_t thread_num, bool reset) { return 0; }
+#endif    //HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
+
 #if defined(HPX_HAVE_THREAD_IDLE_RATES)
         virtual std::int64_t avg_idle_rate_all(bool reset) { return 0; }
         virtual std::int64_t avg_idle_rate(std::size_t, bool) { return 0; }

--- a/hpx/runtime/threads/threadmanager.hpp
+++ b/hpx/runtime/threads/threadmanager.hpp
@@ -346,7 +346,7 @@ namespace hpx { namespace threads
         std::int64_t get_average_thread_wait_time(bool reset);
         std::int64_t get_average_task_wait_time(bool reset);
 #endif
-#ifdef HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
+#if defined(HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
         std::int64_t get_background_work_duration(bool reset);
         std::int64_t get_background_overhead(bool reset);
 #endif    //HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS

--- a/hpx/runtime/threads/threadmanager.hpp
+++ b/hpx/runtime/threads/threadmanager.hpp
@@ -346,6 +346,11 @@ namespace hpx { namespace threads
         std::int64_t get_average_thread_wait_time(bool reset);
         std::int64_t get_average_task_wait_time(bool reset);
 #endif
+#ifdef HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
+        std::int64_t get_background_work_duration(bool reset);
+        std::int64_t get_background_overhead(bool reset);
+#endif    //HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
+
         std::int64_t get_cumulative_duration(bool reset);
 
         std::int64_t get_thread_count_unknown(bool reset)

--- a/src/runtime/threads/executors/this_thread_executors.cpp
+++ b/src/runtime/threads/executors/this_thread_executors.cpp
@@ -343,14 +343,14 @@ namespace hpx { namespace threads { namespace executors { namespace detail
 
             // FIXME: turn these values into performance counters
             std::int64_t executed_threads = 0, executed_thread_phases = 0;
-            std::uint64_t overall_times = 0, thread_times = 0;
+            std::uint64_t overall_times = 0, thread_times = 0, bg_work=0;
             std::int64_t idle_loop_count = 0, busy_loop_count = 0;
             std::uint8_t task_active = 0;
 
             threads::detail::scheduling_counters counters(
                 executed_threads, executed_thread_phases,
                 overall_times, thread_times, idle_loop_count, busy_loop_count,
-                task_active);
+                task_active, bg_work);
 
             threads::detail::scheduling_callbacks callbacks(
                 threads::detail::scheduling_callbacks::callback_type(),

--- a/src/runtime/threads/executors/thread_pool_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_executors.cpp
@@ -339,14 +339,14 @@ namespace hpx { namespace threads { namespace executors { namespace detail
 
             // FIXME: turn these values into performance counters
             std::int64_t executed_threads = 0, executed_thread_phases = 0;
-            std::uint64_t overall_times = 0, thread_times = 0;
+            std::uint64_t overall_times = 0, thread_times = 0, bg_work=0;
             std::int64_t idle_loop_count = 0, busy_loop_count = 0;
             std::uint8_t task_active = 0;
 
             threads::detail::scheduling_counters counters(
                 executed_threads, executed_thread_phases,
                 overall_times, thread_times, idle_loop_count, busy_loop_count,
-                task_active);
+                task_active, bg_work);
 
             threads::detail::scheduling_callbacks callbacks(
                 threads::detail::scheduling_callbacks::callback_type(),

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -824,7 +824,7 @@ namespace hpx { namespace threads
         return result;
     }
 
-#ifdef HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
+#if defined(HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
     std::int64_t threadmanager::get_background_work_duration(bool reset)
     {
         std::int64_t result = 0;
@@ -1513,8 +1513,8 @@ namespace hpx { namespace threads
 #endif
 #endif
 
-#ifdef HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
-            {"/threads/time/experimental-bg-work",
+#if defined(HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
+            {"/threads/time/background-work-duration",
                 performance_counters::counter_raw,
                 "returns the overall time spent running background work",
                 HPX_PERFORMANCE_COUNTER_V1,
@@ -1524,7 +1524,7 @@ namespace hpx { namespace threads
                     &thread_pool_base::get_background_work_duration),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 "ns"},
-            {"/threads/time/experimental-bg-overhead",
+            {"/threads/background-overhead",
                 performance_counters::counter_raw,
                 "returns the overall background overhead",
                 HPX_PERFORMANCE_COUNTER_V1,

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -824,6 +824,25 @@ namespace hpx { namespace threads
         return result;
     }
 
+#ifdef HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
+    std::int64_t threadmanager::get_background_work_duration(bool reset)
+    {
+        std::int64_t result = 0;
+        for (auto const& pool_iter : pools_)
+            result +=
+                pool_iter->get_background_work_duration(all_threads, reset);
+        return result;
+    }
+
+    std::int64_t threadmanager::get_background_overhead(bool reset)
+    {
+        std::int64_t result = 0;
+        for (auto const& pool_iter : pools_)
+            result += pool_iter->get_background_overhead(all_threads, reset);
+        return result;
+    }
+#endif    //HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
+
 #ifdef HPX_HAVE_THREAD_IDLE_RATES
     std::int64_t threadmanager::avg_idle_rate(bool reset)
     {
@@ -1493,6 +1512,30 @@ namespace hpx { namespace threads
                 "ns"},
 #endif
 #endif
+
+#ifdef HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
+            {"/threads/time/experimental-bg-work",
+                performance_counters::counter_raw,
+                "returns the overall time spent running background work",
+                HPX_PERFORMANCE_COUNTER_V1,
+                util::bind_front(
+                    &threadmanager::locality_pool_thread_counter_creator, this,
+                    &threadmanager::get_background_work_duration,
+                    &thread_pool_base::get_background_work_duration),
+                &performance_counters::locality_pool_thread_counter_discoverer,
+                "ns"},
+            {"/threads/time/experimental-bg-overhead",
+                performance_counters::counter_raw,
+                "returns the overall background overhead",
+                HPX_PERFORMANCE_COUNTER_V1,
+                util::bind_front(
+                    &threadmanager::locality_pool_thread_counter_creator, this,
+                    &threadmanager::get_background_overhead,
+                    &thread_pool_base::get_background_overhead),
+                &performance_counters::locality_pool_thread_counter_discoverer,
+                "0.1%"},
+#endif    //HPX_HAVE_ADAPTIVE_COALESCING_COUNTERS
+
             {"/threads/time/overall", performance_counters::counter_raw,
                 "returns the overall time spent running the scheduler on a "
                 "core",


### PR DESCRIPTION
## Proposed Changes

  - This pull request adds 2 new counters:
     - threads/time/background-work-duration 
     - threads/background-overhead

## Any background context you want to provide?
These counters measure the total time spent doing background work and the fraction of time spent doing background work with respect to the overall time spent running the scheduler. 
These counters need to be explicitly enabled (off by default) and hence should not add any overheads when not enabled. 