### PR TITLE
Atomic future state

### DIFF
--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -37,6 +37,7 @@
 #include <boost/container/small_vector.hpp>
 #endif
 
+#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <exception>
@@ -226,29 +227,19 @@ namespace detail
 
         /// Return whether or not the data is available for this
         /// \a future.
-        bool is_ready() const
+        bool is_ready(std::memory_order order = std::memory_order_acquire) const
         {
-            std::unique_lock<mutex_type> l(mtx_);
-            return is_ready_locked(l);
-        }
-
-        template <typename Lock>
-        bool is_ready_locked(Lock& l) const
-        {
-            HPX_ASSERT_OWNS_LOCK(l);
-            return (state_ & ready) != 0;
+            return (state_.load(order) & ready) != 0;
         }
 
         bool has_value() const
         {
-            std::unique_lock<mutex_type> l(mtx_);
-            return state_ == value;
+            return state_.load(std::memory_order_acquire) == value;
         }
 
         bool has_exception() const
         {
-            std::unique_lock<mutex_type> l(mtx_);
-            return state_ == exception;
+            return state_.load(std::memory_order_acquire) == exception;
         }
 
         virtual void execute_deferred(error_code& /*ec*/ = throws) {}
@@ -310,7 +301,7 @@ namespace detail
 
     protected:
         mutable mutex_type mtx_;
-        state state_;                               // current state
+        std::atomic<state> state_;                  // current state
         completed_callback_vector_type on_completed_;
         local::detail::condition_variable cond_;    // threads waiting in read
     };
@@ -357,7 +348,7 @@ namespace detail
         {
             result_type* value_ptr = reinterpret_cast<result_type*>(&storage_);
             construct(value_ptr);
-            state_ = value;
+            state_.store(value, std::memory_order_release);
         }
 
         template <typename ... Ts>
@@ -375,7 +366,7 @@ namespace detail
             std::exception_ptr* exception_ptr =
                 reinterpret_cast<std::exception_ptr*>(&storage_);
             ::new ((void*)exception_ptr) std::exception_ptr(e);
-            state_ = exception;
+            state_.store(exception, std::memory_order_release);
         }
         future_data_base(init_no_addref no_addref, std::exception_ptr && e)
           : base_type(no_addref)
@@ -383,7 +374,7 @@ namespace detail
             std::exception_ptr* exception_ptr =
                 reinterpret_cast<std::exception_ptr*>(&storage_);
             ::new ((void*)exception_ptr) std::exception_ptr(std::move(e));
-            state_ = exception;
+            state_.store(exception, std::memory_order_release);
         }
 
         virtual ~future_data_base() noexcept
@@ -423,26 +414,37 @@ namespace detail
         template <typename ... Ts>
         void set_value(Ts&& ... ts)
         {
-            std::unique_lock<mutex_type> l(mtx_);
+            // Note: it is safe to access the data store as no other thread
+            //       should access it concurrently. There shouldn't be any
+            //       threads attempting to read the value as the state is still
+            //       empty. Also, there can be only one thread (this thread)
+            //       attempting to set the value by definition.
 
-            // check whether the data has already been set
-            if (is_ready_locked(l)) {
-                l.unlock();
+            // set the data
+            result_type* value_ptr = reinterpret_cast<result_type*>(&storage_);
+            construct(value_ptr, std::forward<Ts>(ts)...);
+
+            // The value has been set, changing the state to 'value' at this
+            // point signals to all other threads that this future is ready.
+            state expected = empty;
+            if (!state_.compare_exchange_strong(
+                    expected, value, std::memory_order_release))
+            {
+                // this future should be 'empty' still (it can't be made ready
+                // more than once).
                 HPX_THROW_EXCEPTION(promise_already_satisfied,
                     "future_data_base::set_value",
                     "data has already been set for this future");
                 return;
             }
 
-            auto on_completed = std::move(on_completed_);
-            on_completed_.clear();
-
-            // set the data
-            result_type* value_ptr = reinterpret_cast<result_type*>(&storage_);
-            construct(value_ptr, std::forward<Ts>(ts)...);
-            state_ = value;
+            // At this point the lock needs to be acquired to safely access the
+            // registered continuations
+            std::unique_lock<mutex_type> l(mtx_);
 
             // handle all threads waiting for the future to become ready
+            auto on_completed = std::move(on_completed_);
+            on_completed_.clear();
 
             // Note: we use notify_one repeatedly instead of notify_all as we
             //       know: a) that most of the time we have at most one thread
@@ -466,27 +468,38 @@ namespace detail
 
         void set_exception(std::exception_ptr data) override
         {
-            std::unique_lock<mutex_type> l(mtx_);
+            // Note: it is safe to access the data store as no other thread
+            //       should access it concurrently. There shouldn't be any
+            //       threads attempting to read the value as the state is still
+            //       empty. Also, there can be only one thread (this thread)
+            //       attempting to set the value by definition.
 
-            // check whether the data has already been set
-            if (is_ready_locked(l)) {
-                l.unlock();
+            // set the data
+            std::exception_ptr* exception_ptr =
+                reinterpret_cast<std::exception_ptr*>(&storage_);
+            ::new ((void*)exception_ptr) std::exception_ptr(std::move(data));
+
+            // The value has been set, changing the state to 'exception' at this
+            // point signals to all other threads that this future is ready.
+            state expected = empty;
+            if (!state_.compare_exchange_strong(
+                    expected, exception, std::memory_order_release))
+            {
+                // this future should be 'empty' still (it can't be made ready
+                // more than once).
                 HPX_THROW_EXCEPTION(promise_already_satisfied,
                     "future_data_base::set_exception",
                     "data has already been set for this future");
                 return;
             }
 
-            auto on_completed = std::move(on_completed_);
-            on_completed_.clear();
-
-            // set the data
-            std::exception_ptr* exception_ptr =
-                reinterpret_cast<std::exception_ptr*>(&storage_);
-            ::new ((void*)exception_ptr) std::exception_ptr(std::move(data));
-            state_ = exception;
+            // At this point the lock needs to be acquired to safely access the
+            // registered continuations
+            std::unique_lock<mutex_type> l(mtx_);
 
             // handle all threads waiting for the future to become ready
+            auto on_completed = std::move(on_completed_);
+            on_completed_.clear();
 
             // Note: we use notify_one repeatedly instead of notify_all as we
             //       know: a) that most of the time we have at most one thread
@@ -551,7 +564,7 @@ namespace detail
             // and no reader
 
             // release any stored data and callback functions
-            switch (state_) {
+            switch (state_.exchange(empty)) {
             case value:
             {
                 result_type* value_ptr =
@@ -569,13 +582,12 @@ namespace detail
             default: break;
             }
 
-            state_ = empty;
             on_completed_.clear();
         }
 
         std::exception_ptr get_exception_ptr() const override
         {
-            HPX_ASSERT(state_ == exception);
+            HPX_ASSERT(state_.load(std::memory_order_acquire) == exception);
             return *reinterpret_cast<std::exception_ptr const*>(&storage_);
         }
 
@@ -921,7 +933,7 @@ namespace detail
                 if (!this->started_)
                     HPX_THROW_THREAD_INTERRUPTED_EXCEPTION();
 
-                if (this->is_ready_locked(l))
+                if (this->is_ready(std::memory_order_relaxed))
                     return;   // nothing we can do
 
                 if (id_ != threads::invalid_thread_id) {

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -348,7 +348,7 @@ namespace detail
         {
             result_type* value_ptr = reinterpret_cast<result_type*>(&storage_);
             construct(value_ptr);
-            state_.store(value, std::memory_order_release);
+            state_.store(value, std::memory_order_relaxed);
         }
 
         template <typename ... Ts>
@@ -366,7 +366,7 @@ namespace detail
             std::exception_ptr* exception_ptr =
                 reinterpret_cast<std::exception_ptr*>(&storage_);
             ::new ((void*)exception_ptr) std::exception_ptr(e);
-            state_.store(exception, std::memory_order_release);
+            state_.store(exception, std::memory_order_relaxed);
         }
         future_data_base(init_no_addref no_addref, std::exception_ptr && e)
           : base_type(no_addref)
@@ -374,7 +374,7 @@ namespace detail
             std::exception_ptr* exception_ptr =
                 reinterpret_cast<std::exception_ptr*>(&storage_);
             ::new ((void*)exception_ptr) std::exception_ptr(std::move(e));
-            state_.store(exception, std::memory_order_release);
+            state_.store(exception, std::memory_order_relaxed);
         }
 
         virtual ~future_data_base() noexcept
@@ -933,7 +933,7 @@ namespace detail
                 if (!this->started_)
                     HPX_THROW_THREAD_INTERRUPTED_EXCEPTION();
 
-                if (this->is_ready(std::memory_order_relaxed))
+                if (this->is_ready())
                     return;   // nothing we can do
 
                 if (id_ != threads::invalid_thread_id) {

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -448,7 +448,7 @@ namespace hpx { namespace lcos { namespace detail
                 if (!this->started_)
                     HPX_THROW_THREAD_INTERRUPTED_EXCEPTION();
 
-                if (this->is_ready_locked(l))
+                if (this->is_ready())
                     return;   // nothing we can do
 
                 if (id_ != threads::invalid_thread_id) {

--- a/src/lcos/detail/future_data.cpp
+++ b/src/lcos/detail/future_data.cpp
@@ -99,7 +99,9 @@ namespace hpx { namespace lcos { namespace detail
         // - there are multiple readers only (shared_future, lock hurts
         //   concurrency)
 
-        if (state_ == empty) {
+        state s = state_.load(std::memory_order_acquire);
+        if (s == empty)
+        {
             // the value has already been moved out of this future
             HPX_THROWS_IF(ec, no_state,
                 "future_data_base::get_result",
@@ -110,7 +112,7 @@ namespace hpx { namespace lcos { namespace detail
         // the thread has been re-activated by one of the actions
         // supported by this promise (see promise::set_event
         // and promise::set_exception).
-        if (state_ == exception)
+        if (s == exception)
         {
             std::exception_ptr const* exception_ptr =
                 static_cast<std::exception_ptr const*>(storage);
@@ -237,31 +239,48 @@ namespace hpx { namespace lcos { namespace detail
     {
         if (!data_sink) return;
 
-        std::unique_lock<mutex_type> l(mtx_);
-
-        if (is_ready_locked(l)) {
-
-            HPX_ASSERT(on_completed_.empty());
-
+        if (is_ready())
+        {
             // invoke the callback (continuation) function right away
-            l.unlock();
-
             handle_on_completed(std::move(data_sink));
         }
-        else {
-            on_completed_.push_back(std::move(data_sink));
+        else
+        {
+            std::unique_lock<mutex_type> l(mtx_);
+            if (is_ready(std::memory_order_relaxed))
+            {
+#if !(defined(HPX_DISABLE_ASSERTS) || defined(BOOST_DISABLE_ASSERTS) ||        \
+    defined(NDEBUG))
+                // HPX_ASSERT might suspend
+                auto t = std::move(on_completed_);
+                l.unlock();
+                HPX_ASSERT(t.empty());
+#else
+                l.unlock();
+#endif
+
+                // invoke the callback (continuation) function
+                handle_on_completed(std::move(data_sink));
+            }
+            else
+            {
+                on_completed_.push_back(std::move(data_sink));
+            }
         }
     }
 
     void future_data_base<traits::detail::future_data_void>::
         wait(error_code& ec)
     {
-        std::unique_lock<mutex_type> l(mtx_);
-
         // block if this entry is empty
-        if (state_ == empty) {
-            cond_.wait(l, "future_data_base::wait", ec);
-            if (ec) return;
+        if (state_.load(std::memory_order_acquire) == empty)
+        {
+            std::unique_lock<mutex_type> l(mtx_);
+            if (state_.load(std::memory_order_relaxed) == empty)
+            {
+                cond_.wait(l, "future_data_base::wait", ec);
+                if (ec) return;
+            }
         }
 
         if (&ec != &throws)
@@ -271,19 +290,20 @@ namespace hpx { namespace lcos { namespace detail
     future_status future_data_base<traits::detail::future_data_void>::
         wait_until(util::steady_clock::time_point const& abs_time, error_code& ec)
     {
-        std::unique_lock<mutex_type> l(mtx_);
-
         // block if this entry is empty
-        if (state_ == empty) {
-            threads::thread_state_ex_enum const reason =
-                cond_.wait_until(l, abs_time,
-                    "future_data_base::wait_until", ec);
-            if (ec) return future_status::uninitialized;
+        if (state_.load(std::memory_order_acquire) == empty)
+        {
+            std::unique_lock<mutex_type> l(mtx_);
+            if (state_.load(std::memory_order_relaxed) == empty)
+            {
+                threads::thread_state_ex_enum const reason =
+                    cond_.wait_until(l, abs_time,
+                        "future_data_base::wait_until", ec);
+                if (ec) return future_status::uninitialized;
 
-            if (reason == threads::wait_timeout)
-                return future_status::timeout;
-
-            return future_status::ready;
+                if (reason == threads::wait_timeout)
+                    return future_status::timeout;
+            }
         }
 
         if (&ec != &throws)

--- a/src/lcos/detail/future_data.cpp
+++ b/src/lcos/detail/future_data.cpp
@@ -99,7 +99,7 @@ namespace hpx { namespace lcos { namespace detail
         // - there are multiple readers only (shared_future, lock hurts
         //   concurrency)
 
-        state s = state_.load(std::memory_order_acquire);
+        state s = state_.load(std::memory_order_relaxed);
         if (s == empty)
         {
             // the value has already been moved out of this future
@@ -247,7 +247,7 @@ namespace hpx { namespace lcos { namespace detail
         else
         {
             std::unique_lock<mutex_type> l(mtx_);
-            if (is_ready(std::memory_order_relaxed))
+            if (is_ready())
             {
 #if !(defined(HPX_DISABLE_ASSERTS) || defined(BOOST_DISABLE_ASSERTS) ||        \
     defined(NDEBUG))


### PR DESCRIPTION
This converts the state of a future into an atomic variable which greatly reduces the need for a lock in the future's shared state. Measurements in Phylanx showed a performance gain of 8-10% just from this change.