### PR TITLE
Allow debug option to be enabled only for Linux systems with dynamic main on

### DIFF
--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -284,7 +284,8 @@ namespace hpx { namespace detail
 }}
 
 #if (HPX_HAVE_DYNAMIC_HPX_MAIN != 0) && \
-    (defined(__linux) || defined(__linux__) || defined(linux))
+    (defined(__linux) || defined(__linux__) || defined(linux) || \
+    defined(__APPLE__))
 namespace hpx_start
 {
     // Importing weak symbol from libhpx_wrap.a which may be shadowed by one present in
@@ -598,6 +599,9 @@ namespace hpx
                 // make sure the runtime system is not active yet
                 if (get_runtime_ptr() != nullptr)
                 {
+                #if (HPX_HAVE_DYNAMIC_HPX_MAIN != 0) && \
+                (defined(__linux) || defined(__linux__) || defined(linux) || \
+                defined(__APPLE__))
                     // make sure the runtime system is not initialized
                     // after its activation from int main()
                     if(hpx_start::include_libhpx_wrap)
@@ -607,6 +611,8 @@ namespace hpx
                             "using hpx::init. Exiting...\n";
                         return -1;
                     }
+                    #endif
+
                     std::cerr << "hpx::init: can't initialize runtime system "
                         "more than once! Exiting...\n";
                     return -1;


### PR DESCRIPTION
This PR fixes the breaking of master on non Linux systems for not finding out about `hpx_start` and `include_libhpx_wrap`.