### PR TITLE
Adding DHPX_HAVE_THREAD_LOCAL_STORAGE=ON to builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,7 @@ jobs:
                 -DCMAKE_CXX_FLAGS="-fcolor-diagnostics" \
                 -DHPX_WITH_TESTS_HEADERS=On \
                 -DHPX_WITH_DEPRECATION_WARNINGS=Off \
+                -DHPX_HAVE_THREAD_LOCAL_STORAGE=On \
                 -DCMAKE_EXPORT_COMPILE_COMMANDS=On
       - persist_to_workspace:
           root: /hpx/build


### PR DESCRIPTION
This PR adds `-DHPX_HAVE_THREAD_LOCAL_STORAGE=ON` to HPX builds. This is done since the HPX image created by CircleCI is used by the [HPX project](https://github.com/STEllAR-GROUP/hpxmp).