### PR TITLE
Fix unused param and extra ; warnings emitted by gcc 8.x

### DIFF
--- a/hpx/lcos/base_lco_with_value.hpp
+++ b/hpx/lcos/base_lco_with_value.hpp
@@ -101,7 +101,7 @@ namespace hpx { namespace lcos
         virtual void set_value (RemoteResult && result) = 0;
 
         virtual result_type get_value() = 0;
-        virtual result_type get_value(error_code& ec)
+        virtual result_type get_value(error_code& /*ec*/)
         {
             return get_value();
         }

--- a/hpx/lcos/detail/async_implementations.hpp
+++ b/hpx/lcos/detail/async_implementations.hpp
@@ -136,7 +136,7 @@ namespace hpx { namespace detail
     {
         template <typename ...Ts>
         static lcos::future<Result>
-        call(naming::id_type const& id, naming::address && addr, Ts &&... vs)
+        call(naming::id_type const& /*id*/, naming::address && addr, Ts &&... vs)
         {
             try
             {
@@ -174,7 +174,7 @@ namespace hpx { namespace detail
     {
         template <typename ...Ts>
         static lcos::future<void>
-        call(naming::id_type const& id, naming::address && addr, Ts &&... vs)
+        call(naming::id_type const& /*id*/, naming::address && addr, Ts &&... vs)
         {
             try
             {
@@ -360,7 +360,7 @@ namespace hpx { namespace detail
         hpx::future<Result>& f, Ts&&... vs)
     {
         typedef typename hpx::traits::extract_action<Action>::type action_type;
-        typedef typename action_type::local_result_type result_type;
+        //typedef typename action_type::local_result_type result_type;
         typedef typename action_type::component_type component_type;
 
         // route launch policy through component

--- a/hpx/lcos/detail/async_unwrap_result_implementations.hpp
+++ b/hpx/lcos/detail/async_unwrap_result_implementations.hpp
@@ -72,7 +72,7 @@ namespace hpx { namespace detail
         Result& result, Ts&&... vs)
     {
         typedef typename hpx::traits::extract_action<Action>::type action_type;
-        typedef typename action_type::local_result_type result_type;
+        //typedef typename action_type::local_result_type result_type;
         typedef typename action_type::component_type component_type;
 
         // route launch policy through component
@@ -109,7 +109,7 @@ namespace hpx { namespace detail
     {
         typedef typename hpx::traits::extract_action<Action>::type action_type;
         typedef typename action_type::local_result_type result_type;
-        typedef typename action_type::component_type component_type;
+        //typedef typename action_type::component_type component_type;
 
         std::pair<bool, components::pinned_ptr> r;
 

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -301,7 +301,7 @@ namespace detail
                 "future_data_base::get_registered_name",
                 "this future does not support name registration");
         }
-        virtual void register_as(std::string const& name, bool manage_lifetime)
+        virtual void register_as(std::string const& /*name*/, bool /*manage_lifetime*/)
         {
             HPX_THROW_EXCEPTION(invalid_status,
                 "future_data_base::set_registered_name",
@@ -737,7 +737,7 @@ namespace detail
           : base_type(no_addref), started_(false)
         {}
 
-        virtual void execute_deferred(error_code& ec = throws)
+        virtual void execute_deferred(error_code& /*ec*/ = throws)
         {
             if (!started_test_and_set())
                 this->do_run();
@@ -815,9 +815,9 @@ namespace detail
         }
 
         // run in a separate thread
-        virtual threads::thread_id_type apply(launch policy,
-            threads::thread_priority priority,
-            threads::thread_stacksize stacksize, error_code& ec)
+        virtual threads::thread_id_type apply(launch /*policy*/,
+            threads::thread_priority /*priority*/,
+            threads::thread_stacksize /*stacksize*/, error_code& /*ec*/)
         {
             HPX_ASSERT(false);      // shouldn't ever be called
             return threads::invalid_thread_id;

--- a/hpx/lcos/detail/promise_base.hpp
+++ b/hpx/lcos/detail/promise_base.hpp
@@ -110,8 +110,8 @@ namespace lcos {
         {
             template <typename SharedState>
             HPX_FORCEINLINE static void call(hpx::traits::detail::wrap_int,
-                SharedState const& shared_state, id_type const& id,
-                bool& id_retrieved)
+                SharedState const& /*shared_state*/, id_type const& /*id*/,
+                bool& /*id_retrieved*/)
             {
                 // by default, do nothing
             }

--- a/hpx/lcos/detail/promise_lco.hpp
+++ b/hpx/lcos/detail/promise_lco.hpp
@@ -96,13 +96,13 @@ namespace lcos {
         private:
             // intrusive reference counting, noop since we don't require
             // reference counting here.
-            friend void intrusive_ptr_add_ref(promise_lco_base* p)
+            friend void intrusive_ptr_add_ref(promise_lco_base* /*p*/)
             {
             }
 
             // intrusive reference counting, noop since we don't require
             // reference counting here.
-            friend void intrusive_ptr_release(promise_lco_base* p)
+            friend void intrusive_ptr_release(promise_lco_base* /*p*/)
             {
             }
         };

--- a/hpx/lcos/local/channel.hpp
+++ b/hpx/lcos/local/channel.hpp
@@ -456,7 +456,7 @@ namespace hpx { namespace lcos { namespace local
                 return buffer_.push(std::move(t), l);
             }
 
-            std::size_t close(bool force_delete_entries = false)
+            std::size_t close(bool /*force_delete_entries*/ = false)
             {
                 std::unique_lock<mutex_type> l(mtx_);
 

--- a/hpx/lcos/local/condition_variable.hpp
+++ b/hpx/lcos/local/condition_variable.hpp
@@ -69,7 +69,7 @@ namespace hpx { namespace lcos { namespace local
 
         template <class Predicate>
         void wait(std::unique_lock<mutex>& lock, Predicate pred,
-            error_code& ec = throws)
+            error_code& /*ec*/ = throws)
         {
             HPX_ASSERT_OWNS_LOCK(lock);
 

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -308,7 +308,7 @@ namespace hpx { namespace lcos { namespace detail
             typename traits::detail::shared_state_ptr_for<
                 Future
             >::type && f,
-            threads::thread_priority priority,
+            threads::thread_priority /*priority*/,
             error_code& ec)
         {
             {
@@ -794,7 +794,7 @@ namespace hpx { namespace lcos { namespace detail
     template <typename Future>
     inline typename traits::detail::shared_state_ptr<
         typename future_unwrap_result<Future>::result_type>::type
-    unwrap_impl(Future && future, error_code& ec)
+    unwrap_impl(Future && future, error_code& /*ec*/)
     {
         typedef typename future_unwrap_result<Future>::result_type result_type;
 

--- a/hpx/lcos/server/latch.hpp
+++ b/hpx/lcos/server/latch.hpp
@@ -135,7 +135,7 @@ HPX_REGISTER_ACTION_DECLARATION(
     hpx_lcos_server_latch_wait_action)
 
 HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(
-    bool, std::ptrdiff_t, bool_std_ptrdiff);
+    bool, std::ptrdiff_t, bool_std_ptrdiff)
 
 #endif
 

--- a/hpx/parallel/execution_policy.hpp
+++ b/hpx/parallel/execution_policy.hpp
@@ -86,7 +86,7 @@ namespace hpx { namespace parallel { namespace execution
         /// \returns The new sequenced_task_policy
         ///
         HPX_CONSTEXPR sequenced_task_policy operator()(
-            task_policy_tag tag) const
+            task_policy_tag /*tag*/) const
         {
             return *this;
         }
@@ -395,7 +395,7 @@ namespace hpx { namespace parallel { namespace execution
         /// \returns The new sequenced_task_policy
         ///
         HPX_CONSTEXPR sequenced_task_policy operator()(
-            task_policy_tag tag) const
+            task_policy_tag /*tag*/) const
         {
             return sequenced_task_policy();
         }
@@ -702,7 +702,7 @@ namespace hpx { namespace parallel { namespace execution
         /// \returns The new parallel_task_policy
         ///
         HPX_CONSTEXPR parallel_task_policy operator()(
-            task_policy_tag tag) const
+            task_policy_tag /*tag*/) const
         {
             return *this;
         }
@@ -1002,7 +1002,7 @@ namespace hpx { namespace parallel { namespace execution
         /// \returns The new parallel_policy
         ///
         HPX_CONSTEXPR parallel_task_policy operator()(
-            task_policy_tag tag) const
+            task_policy_tag /*tag*/) const
         {
             return parallel_task_policy();
         }
@@ -1285,7 +1285,7 @@ namespace hpx { namespace parallel { namespace execution
         /// \returns The new parallel_unsequenced_policy
         ///
         parallel_unsequenced_policy operator()(
-            task_policy_tag tag) const
+            task_policy_tag /*tag*/) const
         {
             return *this;
         }

--- a/hpx/parallel/executors/execution_parameters.hpp
+++ b/hpx/parallel/executors/execution_parameters.hpp
@@ -92,7 +92,7 @@ namespace hpx { namespace parallel { namespace execution
             }
         };
 
-        HPX_HAS_MEMBER_XXX_TRAIT_DEF(get_chunk_size);
+        HPX_HAS_MEMBER_XXX_TRAIT_DEF(get_chunk_size)
 
         ///////////////////////////////////////////////////////////////////////
         // customization point for interface maximal_number_of_chunks()
@@ -139,7 +139,7 @@ namespace hpx { namespace parallel { namespace execution
             }
         };
 
-        HPX_HAS_MEMBER_XXX_TRAIT_DEF(maximal_number_of_chunks);
+        HPX_HAS_MEMBER_XXX_TRAIT_DEF(maximal_number_of_chunks)
 
         ///////////////////////////////////////////////////////////////////////
         // customization point for interface reset_thread_distribution()
@@ -201,7 +201,7 @@ namespace hpx { namespace parallel { namespace execution
             }
         };
 
-        HPX_HAS_MEMBER_XXX_TRAIT_DEF(reset_thread_distribution);
+        HPX_HAS_MEMBER_XXX_TRAIT_DEF(reset_thread_distribution)
 
         ///////////////////////////////////////////////////////////////////////
         // customization point for interface count_processing_units()
@@ -246,7 +246,7 @@ namespace hpx { namespace parallel { namespace execution
             }
         };
 
-        HPX_HAS_MEMBER_XXX_TRAIT_DEF(count_processing_units);
+        HPX_HAS_MEMBER_XXX_TRAIT_DEF(count_processing_units)
 
         ///////////////////////////////////////////////////////////////////////
         // customization point for interface mark_begin_execution()
@@ -288,7 +288,7 @@ namespace hpx { namespace parallel { namespace execution
             }
         };
 
-        HPX_HAS_MEMBER_XXX_TRAIT_DEF(mark_begin_execution);
+        HPX_HAS_MEMBER_XXX_TRAIT_DEF(mark_begin_execution)
 
         ///////////////////////////////////////////////////////////////////////
         // customization point for interface mark_end_execution()
@@ -329,7 +329,7 @@ namespace hpx { namespace parallel { namespace execution
             }
         };
 
-        HPX_HAS_MEMBER_XXX_TRAIT_DEF(mark_end_execution);
+        HPX_HAS_MEMBER_XXX_TRAIT_DEF(mark_end_execution)
 
         /// \endcond
     }

--- a/hpx/parallel/executors/sequenced_executor.hpp
+++ b/hpx/parallel/executors/sequenced_executor.hpp
@@ -35,12 +35,12 @@ namespace hpx { namespace parallel { namespace execution
     struct sequenced_executor
     {
         /// \cond NOINTERNAL
-        bool operator==(sequenced_executor const& rhs) const noexcept
+        bool operator==(sequenced_executor const& /*rhs*/) const noexcept
         {
             return true;
         }
 
-        bool operator!=(sequenced_executor const& rhs) const noexcept
+        bool operator!=(sequenced_executor const& /*rhs*/) const noexcept
         {
             return false;
         }

--- a/hpx/performance_counters/server/base_performance_counter.hpp
+++ b/hpx/performance_counters/server/base_performance_counter.hpp
@@ -38,7 +38,7 @@ namespace hpx { namespace performance_counters { namespace server
                 "set_counter_value is not implemented for this counter");
         }
 
-        virtual counter_value get_counter_value(bool reset) override
+        virtual counter_value get_counter_value(bool /*reset*/) override
         {
             HPX_THROW_EXCEPTION(invalid_status, "get_counter_value",
                 "get_counter_value is not implemented for this counter");
@@ -46,7 +46,7 @@ namespace hpx { namespace performance_counters { namespace server
         }
 
         virtual counter_values_array get_counter_values_array(
-            bool reset) override
+            bool /*reset*/) override
         {
             HPX_THROW_EXCEPTION(invalid_status, "get_counter_values_array",
                 "get_counter_values_array is not implemented for this "
@@ -64,7 +64,7 @@ namespace hpx { namespace performance_counters { namespace server
             return false;    // nothing to do
         }
 
-        virtual void reinit(bool reset) override
+        virtual void reinit(bool /*reset*/) override
         {
         }
 
@@ -195,7 +195,7 @@ namespace hpx { namespace performance_counters { namespace server
 
 HPX_ACTION_HAS_CRITICAL_PRIORITY(
     hpx::performance_counters::server::base_performance_counter
-    ::get_counter_info_action);
+    ::get_counter_info_action)
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::performance_counters::server::base_performance_counter
     ::get_counter_info_action,
@@ -203,7 +203,7 @@ HPX_REGISTER_ACTION_DECLARATION(
 
 HPX_ACTION_HAS_CRITICAL_PRIORITY(
     hpx::performance_counters::server::base_performance_counter
-    ::get_counter_value_action);
+    ::get_counter_value_action)
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::performance_counters::server::base_performance_counter
     ::get_counter_value_action,
@@ -211,7 +211,7 @@ HPX_REGISTER_ACTION_DECLARATION(
 
 HPX_ACTION_HAS_CRITICAL_PRIORITY(
     hpx::performance_counters::server::base_performance_counter
-    ::get_counter_values_array_action);
+    ::get_counter_values_array_action)
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::performance_counters::server::base_performance_counter
     ::get_counter_values_array_action,
@@ -219,7 +219,7 @@ HPX_REGISTER_ACTION_DECLARATION(
 
 HPX_ACTION_HAS_CRITICAL_PRIORITY(
     hpx::performance_counters::server::base_performance_counter
-    ::set_counter_value_action);
+    ::set_counter_value_action)
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::performance_counters::server::base_performance_counter
     ::set_counter_value_action,
@@ -227,20 +227,20 @@ HPX_REGISTER_ACTION_DECLARATION(
 
 HPX_ACTION_HAS_CRITICAL_PRIORITY(
     hpx::performance_counters::server::base_performance_counter
-    ::reset_counter_value_action);
+    ::reset_counter_value_action)
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::performance_counters::server::base_performance_counter
     ::reset_counter_value_action,
     performance_counter_reset_counter_value_action)
 
 HPX_ACTION_HAS_CRITICAL_PRIORITY(
-    hpx::performance_counters::server::base_performance_counter::start_action);
+    hpx::performance_counters::server::base_performance_counter::start_action)
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::performance_counters::server::base_performance_counter::start_action,
     performance_counter_start_action)
 
 HPX_ACTION_HAS_CRITICAL_PRIORITY(
-    hpx::performance_counters::server::base_performance_counter::stop_action);
+    hpx::performance_counters::server::base_performance_counter::stop_action)
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::performance_counters::server::base_performance_counter::stop_action,
     performance_counter_stop_action)

--- a/hpx/plugins/plugin_registry_base.hpp
+++ b/hpx/plugins/plugin_registry_base.hpp
@@ -38,7 +38,7 @@ namespace hpx { namespace plugins
         ///         implemented in this module.
         virtual bool get_plugin_info(std::vector<std::string>& fillini) = 0;
 
-        virtual void init(int *argc, char ***argv, util::command_line_handling&)
+        virtual void init(int * /*argc*/, char *** /*argv*/, util::command_line_handling&)
         {
         }
     };

--- a/hpx/runtime/actions/component_action.hpp
+++ b/hpx/runtime/actions/component_action.hpp
@@ -72,7 +72,7 @@ namespace hpx { namespace actions
         template <typename R_, typename ...Ts>
         static typename std::enable_if<!traits::is_future<R_>::value, R_>::type
         invoke_helper(detail::tag<R_>, naming::address::address_type lva,
-            naming::address::component_type comptype, Ts&&... vs)
+            naming::address::component_type /*comptype*/, Ts&&... vs)
         {
             basic_action<Component, R_(Ps...), Derived>::
                 increment_invocation_count();
@@ -136,7 +136,7 @@ namespace hpx { namespace actions
         template <typename R_, typename ...Ts>
         static typename std::enable_if<!traits::is_future<R_>::value, R_>::type
         invoke_helper(detail::tag<R_>, naming::address::address_type lva,
-            naming::address::component_type comptype, Ts&&... vs)
+            naming::address::component_type /*comptype*/, Ts&&... vs)
         {
             basic_action<Component const, R_(Ps...), Derived>::
                 increment_invocation_count();

--- a/hpx/runtime/actions/transfer_action.hpp
+++ b/hpx/runtime/actions/transfer_action.hpp
@@ -156,7 +156,7 @@ namespace hpx { namespace actions
         naming::gid_type const& target_gid,
         naming::address::address_type lva,
         naming::address::component_type comptype,
-        std::size_t num_thread)
+        std::size_t /*num_thread*/)
     {
         naming::id_type target;
         if (naming::detail::has_credits(target_gid))

--- a/hpx/runtime/actions/transfer_continuation_action.hpp
+++ b/hpx/runtime/actions/transfer_continuation_action.hpp
@@ -164,7 +164,7 @@ namespace hpx { namespace actions
         util::detail::pack_c<std::size_t, Is...>,
         naming::gid_type const& target_gid,
         naming::address::address_type lva,
-        naming::address::component_type comptype, std::size_t num_thread)
+        naming::address::component_type comptype, std::size_t /*num_thread*/)
     {
         naming::id_type target;
         if (naming::detail::has_credits(target_gid))

--- a/hpx/runtime/agas/addressing_service.hpp
+++ b/hpx/runtime/agas/addressing_service.hpp
@@ -153,7 +153,7 @@ public:
         state_.store(new_state);
     }
 
-    naming::gid_type const& get_local_locality(error_code& ec = throws) const
+    naming::gid_type const& get_local_locality(error_code& /*ec*/ = throws) const
     {
         return locality_;
     }

--- a/hpx/runtime/agas/component_namespace.hpp
+++ b/hpx/runtime/agas/component_namespace.hpp
@@ -51,10 +51,10 @@ namespace hpx { namespace agas
         virtual void register_counter_types()
         {}
 
-        virtual void register_server_instance(std::uint32_t locality_id)
+        virtual void register_server_instance(std::uint32_t /*locality_id*/)
         {}
 
-        virtual void unregister_server_instance(error_code& ec)
+        virtual void unregister_server_instance(error_code& /*ec*/)
         {}
     };
 

--- a/hpx/runtime/agas/gva.hpp
+++ b/hpx/runtime/agas/gva.hpp
@@ -139,7 +139,7 @@ struct gva
     friend class hpx::serialization::access;
 
     template<class Archive>
-    void save(Archive& ar, const unsigned int version) const
+    void save(Archive& ar, const unsigned int /*version*/) const
     { ar << prefix << type << count << lva_ << offset; } //-V128
 
     template<class Archive>

--- a/hpx/runtime/agas/locality_namespace.hpp
+++ b/hpx/runtime/agas/locality_namespace.hpp
@@ -61,9 +61,9 @@ namespace hpx { namespace agas
 
         virtual void register_counter_types() {}
 
-        virtual void register_server_instance(std::uint32_t locality_id) {}
+        virtual void register_server_instance(std::uint32_t /*locality_id*/) {}
 
-        virtual void unregister_server_instance(error_code& ec) {}
+        virtual void unregister_server_instance(error_code& /*ec*/) {}
     };
 }}
 

--- a/hpx/runtime/components/server/component_base.hpp
+++ b/hpx/runtime/components/server/component_base.hpp
@@ -42,11 +42,11 @@ namespace hpx { namespace components
             HPX_EXPORT ~base_component();
 
             // Copy construction and copy assignment should not copy the gid_.
-            base_component(base_component const& rhs)
+            base_component(base_component const& /*rhs*/)
             {
             }
 
-            base_component& operator=(base_component const& rhs)
+            base_component& operator=(base_component const& /*rhs*/)
             {
                 return *this;
             }

--- a/hpx/runtime/components/server/fixed_component_base.hpp
+++ b/hpx/runtime/components/server/fixed_component_base.hpp
@@ -208,12 +208,12 @@ namespace detail
         {
         }
 #else
-        static void* alloc(std::size_t count)
+        static void* alloc(std::size_t /*count*/)
         {
             HPX_ASSERT(false);        // this shouldn't ever be called
             return nullptr;
         }
-        static void free(void* p, std::size_t count)
+        static void free(void* /*p*/, std::size_t /*count*/)
         {
             HPX_ASSERT(false);        // this shouldn't ever be called
         }

--- a/hpx/runtime/components/server/memory_block.hpp
+++ b/hpx/runtime/components/server/memory_block.hpp
@@ -438,7 +438,7 @@ namespace hpx { namespace components { namespace server { namespace detail
         HPX_DEFINE_COMPONENT_ACTION(memory_block, clone);
 
         // This component type requires valid id for its actions to be invoked
-        HPX_CONSTEXPR static bool is_target_valid(naming::id_type const& id)
+        HPX_CONSTEXPR static bool is_target_valid(naming::id_type const& /*id*/)
         {
             return true;
         }

--- a/hpx/runtime/parcelset/parcel.hpp
+++ b/hpx/runtime/parcelset/parcel.hpp
@@ -187,7 +187,7 @@ namespace hpx { namespace parcelset
     HPX_EXPORT std::string dump_parcel(parcel const& p);
 }}
 
-HPX_IS_BITWISE_SERIALIZABLE(hpx::parcelset::detail::parcel_data);
+HPX_IS_BITWISE_SERIALIZABLE(hpx::parcelset::detail::parcel_data)
 
 #include <hpx/config/warnings_suffix.hpp>
 

--- a/hpx/runtime/resource/detail/create_partitioner.hpp
+++ b/hpx/runtime/resource/detail/create_partitioner.hpp
@@ -138,7 +138,7 @@ namespace hpx { namespace resource { namespace detail
     }
 
     inline partitioner& create_partitioner(
-        std::nullptr_t f, int argc, char** argv,
+        std::nullptr_t /*f*/, int argc, char** argv,
         resource::partitioner_mode rpmode = resource::mode_default,
         hpx::runtime_mode mode = hpx::runtime_mode_default, bool check = true)
     {
@@ -156,7 +156,7 @@ namespace hpx { namespace resource { namespace detail
     }
 
     inline partitioner& create_partitioner(
-        std::nullptr_t f, int argc, char** argv,
+        std::nullptr_t /*f*/, int argc, char** argv,
         std::vector<std::string> const& cfg,
         resource::partitioner_mode rpmode = resource::mode_default,
         hpx::runtime_mode mode = hpx::runtime_mode_default, bool check = true)
@@ -174,7 +174,7 @@ namespace hpx { namespace resource { namespace detail
     }
 
     inline partitioner& create_partitioner(
-        std::nullptr_t f,
+        std::nullptr_t /*f*/,
         boost::program_options::options_description const& desc_cmdline,
         int argc, char** argv, std::vector<std::string> const& cfg,
         resource::partitioner_mode rpmode = resource::mode_default,

--- a/hpx/runtime/serialization/array.hpp
+++ b/hpx/runtime/serialization/array.hpp
@@ -42,7 +42,7 @@ namespace hpx { namespace serialization
         }
 
         template <class Archive>
-        void serialize_optimized(Archive& ar, unsigned int v, std::false_type)
+        void serialize_optimized(Archive& ar, unsigned int /*v*/, std::false_type)
         {
             for (std::size_t i = 0; i != m_element_count; ++i)
                 ar & m_t[i];

--- a/hpx/runtime/serialization/binary_filter.hpp
+++ b/hpx/runtime/serialization/binary_filter.hpp
@@ -30,7 +30,7 @@ namespace hpx { namespace serialization
             std::size_t size, std::size_t buffer_size) = 0;
         virtual void load(void* dst, std::size_t dst_count) = 0;
 
-        template <class T> void serialize(T& ar, unsigned){}
+        template <class T> void serialize(T& /*ar*/, unsigned){}
         HPX_SERIALIZATION_POLYMORPHIC_ABSTRACT(binary_filter);
 
         virtual ~binary_filter() {}

--- a/hpx/runtime/serialization/output_container.hpp
+++ b/hpx/runtime/serialization/output_container.hpp
@@ -57,7 +57,7 @@ namespace hpx { namespace serialization
                 return 1;
             }
 
-            static void push_back(serialization_chunk && chunk) {}
+            static void push_back(serialization_chunk && /*chunk*/) {}
 
             static void reset() {}
         };

--- a/hpx/runtime/serialization/shared_ptr.hpp
+++ b/hpx/runtime/serialization/shared_ptr.hpp
@@ -32,7 +32,7 @@ namespace hpx { namespace serialization
     }
 
     HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE((template <typename T>),
-            (boost::shared_ptr<T>));
+            (boost::shared_ptr<T>))
 
     template <typename T>
     void load(input_archive& ar, std::shared_ptr<T>& ptr, unsigned)
@@ -47,7 +47,7 @@ namespace hpx { namespace serialization
     }
 
     HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE((template <typename T>),
-            (std::shared_ptr<T>));
+            (std::shared_ptr<T>))
 }}
 
 #endif

--- a/hpx/runtime/serialization/unique_ptr.hpp
+++ b/hpx/runtime/serialization/unique_ptr.hpp
@@ -26,7 +26,7 @@ namespace hpx { namespace serialization
         detail::serialize_pointer_untracked(ar, ptr);
     }
 
-    HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE((template <typename T>), (std::unique_ptr<T>));
+    HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE((template <typename T>), (std::unique_ptr<T>))
 }}
 
 #endif

--- a/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
@@ -253,7 +253,7 @@ namespace hpx { namespace threads { namespace coroutines
 //
 #define COROUTINE_STACKOVERFLOW_ADDR_EPSILON 1000UL
 
-            static void sigsegv_handler(int signum, siginfo_t *infoptr,
+            static void sigsegv_handler(int /*signum*/, siginfo_t *infoptr,
                 void *ctxptr)
             {
                 ucontext_t * uc_ctx = static_cast< ucontext_t* >(ctxptr);

--- a/hpx/runtime/threads/coroutines/detail/tss.hpp
+++ b/hpx/runtime/threads/coroutines/detail/tss.hpp
@@ -122,7 +122,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         {
             return 0;
         }
-        std::size_t set_thread_data(std::size_t val)
+        std::size_t set_thread_data(std::size_t /*val*/)
         {
             return 0;
         }

--- a/hpx/runtime/threads/cpu_mask.hpp
+++ b/hpx/runtime/threads/cpu_mask.hpp
@@ -69,12 +69,12 @@ namespace hpx { namespace threads
         mask &= not_(bits(idx));
     }
 
-    inline std::size_t mask_size(mask_cref_type mask)
+    inline std::size_t mask_size(mask_cref_type /*mask*/)
     {
         return CHAR_BIT * sizeof(mask_type);
     }
 
-    inline void resize(mask_type& mask, std::size_t s)
+    inline void resize(mask_type& /*mask*/, std::size_t s)
     {
         HPX_ASSERT(s <= CHAR_BIT * sizeof(mask_type));
     }

--- a/hpx/runtime/threads/policies/scheduler_base.hpp
+++ b/hpx/runtime/threads/policies/scheduler_base.hpp
@@ -491,7 +491,7 @@ namespace hpx { namespace threads { namespace policies
 #endif
 
         virtual void start_periodic_maintenance(
-            std::atomic<hpx::state>& global_state)
+            std::atomic<hpx::state>& /*global_state*/)
         {}
 
         virtual void reset_thread_distribution() {}

--- a/hpx/runtime/threads/thread_executor.hpp
+++ b/hpx/runtime/threads/thread_executor.hpp
@@ -188,7 +188,7 @@ namespace hpx { namespace threads
 
             // Set the new scheduler mode
             virtual void set_scheduler_mode(
-                threads::policies::scheduler_mode mode) {}
+                threads::policies::scheduler_mode /*mode*/) {}
 
             // retrieve executor id
             virtual executor_id get_id() const

--- a/hpx/runtime/threads/thread_helpers.hpp
+++ b/hpx/runtime/threads/thread_helpers.hpp
@@ -118,7 +118,7 @@ namespace hpx { namespace threads
         thread_state_enum state = pending,
         thread_state_ex_enum stateex = wait_timeout,
         thread_priority priority = thread_priority_normal,
-        error_code& ec = throws)
+        error_code& /*ec*/ = throws)
     {
         return set_thread_state(id, abs_time, nullptr, state, stateex,
             priority, throws);

--- a/hpx/runtime/threads/thread_pool_base.hpp
+++ b/hpx/runtime/threads/thread_pool_base.hpp
@@ -211,44 +211,44 @@ namespace hpx { namespace threads
         // performance counters
 #if defined(HPX_HAVE_THREAD_CUMULATIVE_COUNTS)
         virtual std::int64_t get_executed_threads(
-            std::size_t thread_num, bool reset) { return 0; }
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
         virtual std::int64_t get_executed_thread_phases(
-            std::size_t thread_num, bool reset) { return 0; }
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
 #if defined(HPX_HAVE_THREAD_IDLE_RATES)
         virtual std::int64_t get_thread_phase_duration(
-            std::size_t thread_num, bool reset) { return 0; }
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
         virtual std::int64_t get_thread_duration(
-            std::size_t thread_num, bool reset) { return 0; }
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
         virtual std::int64_t get_thread_phase_overhead(
-            std::size_t thread_num, bool reset) { return 0; }
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
         virtual std::int64_t get_thread_overhead(
-            std::size_t thread_num, bool reset) { return 0; }
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
         virtual std::int64_t get_cumulative_thread_duration(
-            std::size_t thread_num, bool reset) { return 0; }
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
         virtual std::int64_t get_cumulative_thread_overhead(
-            std::size_t thread_num, bool reset) { return 0; }
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
 #endif
 #endif
 
         virtual std::int64_t get_cumulative_duration(
-            std::size_t thread_num, bool reset) { return 0; }
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
 
 #if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
         virtual std::int64_t get_background_work_duration(
-            std::size_t thread_num, bool reset) { return 0; }
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
         virtual std::int64_t get_background_overhead(
-            std::size_t thread_num, bool reset) { return 0; }
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
 #endif    // HPX_HAVE_BACKGROUND_THREAD_COUNTERS
 
 #if defined(HPX_HAVE_THREAD_IDLE_RATES)
-        virtual std::int64_t avg_idle_rate_all(bool reset) { return 0; }
+        virtual std::int64_t avg_idle_rate_all(bool /*reset*/) { return 0; }
         virtual std::int64_t avg_idle_rate(std::size_t, bool) { return 0; }
 
 #if defined(HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES)
         virtual std::int64_t avg_creation_idle_rate(
-            std::size_t thread_num, bool reset) { return 0; }
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
         virtual std::int64_t avg_cleanup_idle_rate(
-            std::size_t thread_num, bool reset) { return 0; }
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
 #endif
 #endif
 
@@ -256,30 +256,30 @@ namespace hpx { namespace threads
 
 #if defined(HPX_HAVE_THREAD_QUEUE_WAITTIME)
         virtual std::int64_t get_average_thread_wait_time(
-            std::size_t thread_num, bool reset) { return 0; }
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
         virtual std::int64_t get_average_task_wait_time(
-            std::size_t thread_num, bool reset) { return 0; }
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
 #endif
 
 #if defined(HPX_HAVE_THREAD_STEALING_COUNTS)
         virtual std::int64_t get_num_pending_misses(
-            std::size_t thread_num, bool reset) { return 0; }
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
         virtual std::int64_t get_num_pending_accesses(
-            std::size_t thread_num, bool reset) { return 0; }
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
 
         virtual std::int64_t get_num_stolen_from_pending(
-            std::size_t thread_num, bool reset) { return 0; }
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
         virtual std::int64_t get_num_stolen_to_pending(
-            std::size_t thread_num, bool reset) { return 0; }
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
         virtual std::int64_t get_num_stolen_from_staged(
-            std::size_t thread_num, bool reset) { return 0; }
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
         virtual std::int64_t get_num_stolen_to_staged(
-            std::size_t thread_num, bool reset) { return 0; }
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
 #endif
 
-        virtual std::int64_t get_thread_count(thread_state_enum state,
-            thread_priority priority, std::size_t num_thread,
-            bool reset) { return 0; }
+        virtual std::int64_t get_thread_count(thread_state_enum /*state*/,
+            thread_priority /*priority*/, std::size_t /*num_thread*/,
+            bool /*reset*/) { return 0; }
 
         virtual std::int64_t get_background_thread_count() { return 0; }
 
@@ -327,8 +327,8 @@ namespace hpx { namespace threads
 
         ///////////////////////////////////////////////////////////////////////
         virtual bool enumerate_threads(
-            util::function_nonser<bool(thread_id_type)> const& f,
-            thread_state_enum state = unknown) const
+            util::function_nonser<bool(thread_id_type)> const& /*f*/,
+            thread_state_enum /*state*/ = unknown) const
         {
             return false;
         }
@@ -339,14 +339,14 @@ namespace hpx { namespace threads
 
         //
         virtual void abort_all_suspended_threads() {}
-        virtual bool cleanup_terminated(bool delete_all) { return false; }
+        virtual bool cleanup_terminated(bool /*delete_all*/) { return false; }
 
         virtual hpx::state get_state() const = 0;
         virtual hpx::state get_state(std::size_t num_thread) const = 0;
 
         virtual bool has_reached_state(hpx::state s) const = 0;
 
-        virtual void do_some_work(std::size_t num_thread) {}
+        virtual void do_some_work(std::size_t /*num_thread*/) {}
 
         virtual void report_error(std::size_t num, std::exception_ptr const& e)
         {

--- a/hpx/runtime/threads/threadmanager.hpp
+++ b/hpx/runtime/threads/threadmanager.hpp
@@ -246,7 +246,7 @@ namespace hpx { namespace threads
         }
 
         // Return the (global) sequence number of the current thread
-        std::size_t get_worker_thread_num(bool* numa_sensitive = nullptr)
+        std::size_t get_worker_thread_num(bool* /*numa_sensitive*/ = nullptr)
         {
             if (get_self_ptr() == nullptr)
                 return std::size_t(-1);

--- a/hpx/runtime/threads/topology.hpp
+++ b/hpx/runtime/threads/topology.hpp
@@ -92,7 +92,7 @@ namespace hpx { namespace threads
         ///                   if this is pre-initialized to \a hpx#throws
         ///                   the function will throw on error instead.
         std::size_t get_socket_number(std::size_t num_thread,
-            error_code& ec = throws) const
+            error_code& /*ec*/ = throws) const
         {
             return socket_numbers_[num_thread % num_of_pus_];
         }
@@ -104,7 +104,7 @@ namespace hpx { namespace threads
         ///                   if this is pre-initialized to \a hpx#throws
         ///                   the function will throw on error instead.
         std::size_t get_numa_node_number(std::size_t num_thread,
-            error_code& ec = throws) const
+            error_code& /*ec*/ = throws) const
         {
             return numa_node_numbers_[num_thread % num_of_pus_];
         }
@@ -239,7 +239,7 @@ namespace hpx { namespace threads
         std::size_t get_number_of_socket_cores(std::size_t socket) const;
 
         std::size_t get_core_number(std::size_t num_thread,
-            error_code& ec = throws) const
+            error_code& /*ec*/ = throws) const
         {
             return core_numbers_[num_thread % num_of_pus_];
         }

--- a/hpx/traits/acquire_future.hpp
+++ b/hpx/traits/acquire_future.hpp
@@ -102,7 +102,7 @@ namespace hpx { namespace traits
         };
 
         ///////////////////////////////////////////////////////////////////////
-        HPX_HAS_MEMBER_XXX_TRAIT_DEF(push_back);
+        HPX_HAS_MEMBER_XXX_TRAIT_DEF(push_back)
 
         ///////////////////////////////////////////////////////////////////////
         template <typename Range>

--- a/hpx/traits/action_decorate_continuation.hpp
+++ b/hpx/traits/action_decorate_continuation.hpp
@@ -21,7 +21,7 @@ namespace hpx { namespace traits
         typedef typename traits::action_continuation<Action>::type
             continuation_type;
 
-        static bool call(continuation_type& cont)
+        static bool call(continuation_type& /*cont*/)
         {
             // by default we do nothing
             return false; // continuation has not been modified

--- a/hpx/traits/action_decorate_function.hpp
+++ b/hpx/traits/action_decorate_function.hpp
@@ -26,7 +26,7 @@ namespace hpx { namespace traits
             // by default we return the unchanged function
             template <typename Component, typename F>
             static threads::thread_function_type
-            call(wrap_int, naming::address_type lva, F && f)
+            call(wrap_int, naming::address_type /*lva*/, F && f)
             {
                 return std::forward<F>(f);
             }

--- a/hpx/traits/detail/reserve.hpp
+++ b/hpx/traits/detail/reserve.hpp
@@ -23,7 +23,7 @@ namespace hpx { namespace traits { namespace detail
     ///////////////////////////////////////////////////////////////////////
     // not every random access sequence is reservable
     // so we need an explicit trait to determine this
-    HPX_HAS_MEMBER_XXX_TRAIT_DEF(reserve);
+    HPX_HAS_MEMBER_XXX_TRAIT_DEF(reserve)
 
     template <typename Range>
     using is_reservable = std::integral_constant<bool,

--- a/hpx/traits/executor_traits.hpp
+++ b/hpx/traits/executor_traits.hpp
@@ -27,13 +27,13 @@ namespace hpx { namespace parallel { namespace execution
     ///////////////////////////////////////////////////////////////////////////
     namespace detail
     {
-        HPX_HAS_MEMBER_XXX_TRAIT_DEF(post);
-        HPX_HAS_MEMBER_XXX_TRAIT_DEF(sync_execute);
-        HPX_HAS_MEMBER_XXX_TRAIT_DEF(async_execute);
-        HPX_HAS_MEMBER_XXX_TRAIT_DEF(then_execute);
-        HPX_HAS_MEMBER_XXX_TRAIT_DEF(bulk_sync_execute);
-        HPX_HAS_MEMBER_XXX_TRAIT_DEF(bulk_async_execute);
-        HPX_HAS_MEMBER_XXX_TRAIT_DEF(bulk_then_execute);
+        HPX_HAS_MEMBER_XXX_TRAIT_DEF(post)
+        HPX_HAS_MEMBER_XXX_TRAIT_DEF(sync_execute)
+        HPX_HAS_MEMBER_XXX_TRAIT_DEF(async_execute)
+        HPX_HAS_MEMBER_XXX_TRAIT_DEF(then_execute)
+        HPX_HAS_MEMBER_XXX_TRAIT_DEF(bulk_sync_execute)
+        HPX_HAS_MEMBER_XXX_TRAIT_DEF(bulk_async_execute)
+        HPX_HAS_MEMBER_XXX_TRAIT_DEF(bulk_then_execute)
     }
 
     template <typename T, typename Enable = void>

--- a/hpx/traits/get_function_annotation.hpp
+++ b/hpx/traits/get_function_annotation.hpp
@@ -18,7 +18,7 @@ namespace hpx { namespace traits
     template <typename F, typename Enable = void>
     struct get_function_annotation
     {
-        static char const* call(F const& f) noexcept
+        static char const* call(F const& /*f*/) noexcept
         {
             return nullptr;
         }

--- a/hpx/traits/polymorphic_traits.hpp
+++ b/hpx/traits/polymorphic_traits.hpp
@@ -18,7 +18,7 @@ namespace hpx { namespace traits
     namespace detail
     {
         HPX_HAS_XXX_TRAIT_DEF(serialized_with_id);
-        HPX_HAS_MEMBER_XXX_TRAIT_DEF(hpx_serialization_get_name);
+        HPX_HAS_MEMBER_XXX_TRAIT_DEF(hpx_serialization_get_name)
     } // namespace detail
 
     template <typename T>

--- a/hpx/util/annotated_function.hpp
+++ b/hpx/util/annotated_function.hpp
@@ -182,9 +182,9 @@ namespace hpx { namespace util
     {
         HPX_NON_COPYABLE(annotate_function);
 
-        explicit annotate_function(char const* name) {}
+        explicit annotate_function(char const* /*name*/) {}
         template <typename F>
-        explicit HPX_HOST_DEVICE annotate_function(F && f) {}
+        explicit HPX_HOST_DEVICE annotate_function(F && /*f*/) {}
 
         // add empty (but non-trivial) destructor to silence warnings
         HPX_HOST_DEVICE ~annotate_function() {}

--- a/hpx/util/assert_owns_lock.hpp
+++ b/hpx/util/assert_owns_lock.hpp
@@ -15,7 +15,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace util { namespace detail
 {
-    HPX_HAS_MEMBER_XXX_TRAIT_DEF(owns_lock);
+    HPX_HAS_MEMBER_XXX_TRAIT_DEF(owns_lock)
 
     template <typename Lock>
     void assert_owns_lock(Lock const&, int)

--- a/hpx/util/detail/vtable/serializable_vtable.hpp
+++ b/hpx/util/detail/vtable/serializable_vtable.hpp
@@ -18,7 +18,7 @@ namespace hpx { namespace util { namespace detail
     {
         template <typename T>
         static void _save_object(void* const* v,
-            serialization::output_archive& ar, unsigned version)
+            serialization::output_archive& ar, unsigned /*version*/)
         {
             ar << vtable::get<T>(v);
         }
@@ -26,7 +26,7 @@ namespace hpx { namespace util { namespace detail
 
         template <typename T>
         static void _load_object(void** v,
-            serialization::input_archive& ar, unsigned version)
+            serialization::input_archive& ar, unsigned /*version*/)
         {
             vtable::default_construct<T>(v);
             ar >> vtable::get<T>(v);

--- a/hpx/util/format.hpp
+++ b/hpx/util/format.hpp
@@ -109,7 +109,7 @@ namespace hpx { namespace util
         struct formatter<void const*, /*IsFundamental=*/false>
         {
             static void call(
-                std::ostream& os, boost::string_ref spec, void const* ptr)
+                std::ostream& os, boost::string_ref /*spec*/, void const* ptr)
             {
                 os << ptr;
             }
@@ -325,7 +325,7 @@ namespace hpx { namespace util { namespace detail
     inline void format_to(
         std::ostream& os,
         boost::string_ref format_str,
-        format_arg const* args, std::size_t count)
+        format_arg const* args, std::size_t /*count*/)
     {
         std::size_t index = 0;
         while (!format_str.empty())

--- a/hpx/util/integer/uint128.hpp
+++ b/hpx/util/integer/uint128.hpp
@@ -138,36 +138,36 @@ namespace hpx { namespace util { namespace integer
     // GLOBAL OPERATOR INLINES
 
     inline uint128 operator + (const uint128 & a, const uint128 & b) throw () {
-        return uint128 (a) += b; };
+        return uint128 (a) += b; }
     inline uint128 operator - (const uint128 & a, const uint128 & b) throw () {
-        return uint128 (a) -= b; };
+        return uint128 (a) -= b; }
     inline uint128 operator * (const uint128 & a, const uint128 & b) throw () {
-        return uint128 (a) *= b; };
+        return uint128 (a) *= b; }
     inline uint128 operator / (const uint128 & a, const uint128 & b) throw () {
-        return uint128 (a) /= b; };
+        return uint128 (a) /= b; }
     inline uint128 operator % (const uint128 & a, const uint128 & b) throw () {
-        return uint128 (a) %= b; };
+        return uint128 (a) %= b; }
 
     inline uint128 operator >> (const uint128 & a, unsigned int n) throw () {
-        return uint128 (a) >>= n; };
+        return uint128 (a) >>= n; }
     inline uint128 operator << (const uint128 & a, unsigned int n) throw () {
-        return uint128 (a) <<= n; };
+        return uint128 (a) <<= n; }
 
     inline uint128 operator & (const uint128 & a, const uint128 & b) throw () {
-        return uint128 (a) &= b; };
+        return uint128 (a) &= b; }
     inline uint128 operator | (const uint128 & a, const uint128 & b) throw () {
-        return uint128 (a) |= b; };
+        return uint128 (a) |= b; }
     inline uint128 operator ^ (const uint128 & a, const uint128 & b) throw () {
-        return uint128 (a) ^= b; };
+        return uint128 (a) ^= b; }
 
     inline bool operator >  (const uint128 & a, const uint128 & b) throw () {
-        return   b < a; };
+        return   b < a; }
     inline bool operator <= (const uint128 & a, const uint128 & b) throw () {
-        return !(b < a); };
+        return !(b < a); }
     inline bool operator >= (const uint128 & a, const uint128 & b) throw () {
-        return !(a < b); };
+        return !(a < b); }
     inline bool operator != (const uint128 & a, const uint128 & b) throw () {
-        return !(a == b); };
+        return !(a == b); }
 }}}
 
 // MISC

--- a/hpx/util/one_size_heap_list.hpp
+++ b/hpx/util/one_size_heap_list.hpp
@@ -44,6 +44,7 @@ namespace hpx { namespace util
 #if defined(HPX_DEBUG)
             return std::make_shared<Heap>(name, counter, parameters);
 #else
+            (void)counter;
             return std::make_shared<Heap>(name, 0, parameters);
 #endif
         }

--- a/hpx/util/plugin/plugin_factory.hpp
+++ b/hpx/util/plugin/plugin_factory.hpp
@@ -123,7 +123,7 @@ namespace hpx { namespace util { namespace plugin {
         ///////////////////////////////////////////////////////////////////////
         inline void
         get_abstract_factory_names_static(get_plugins_list_type f,
-            std::vector<std::string>& names, error_code& ec = throws)
+            std::vector<std::string>& names, error_code& /*ec*/ = throws)
         {
             exported_plugins_type& e = *f();
 

--- a/hpx/util/register_locks.hpp
+++ b/hpx/util/register_locks.hpp
@@ -55,7 +55,7 @@ namespace hpx { namespace util
 
     namespace detail
     {
-        HPX_HAS_MEMBER_XXX_TRAIT_DEF(mutex);
+        HPX_HAS_MEMBER_XXX_TRAIT_DEF(mutex)
     }
 
     template <typename Lock>
@@ -83,7 +83,7 @@ namespace hpx { namespace util
     template <typename Lock, typename Enable>
     struct ignore_while_checking
     {
-        ignore_while_checking(void const* lock) {}
+        ignore_while_checking(void const* /*lock*/) {}
     };
 
     struct ignore_all_while_checking

--- a/hpx/util/serialize_exception.hpp
+++ b/hpx/util/serialize_exception.hpp
@@ -53,7 +53,7 @@ namespace hpx { namespace serialization
     template <typename Archive>
     void load(Archive& ar, std::exception_ptr& e, unsigned int);
 
-    HPX_SERIALIZATION_SPLIT_FREE(std::exception_ptr);
+    HPX_SERIALIZATION_SPLIT_FREE(std::exception_ptr)
 }}
 
 #endif

--- a/hpx/util/thread_description.hpp
+++ b/hpx/util/thread_description.hpp
@@ -188,7 +188,7 @@ namespace hpx { namespace util
         {
         }
 
-        thread_description(char const* desc) noexcept
+        thread_description(char const* /*desc*/) noexcept
         {
         }
 
@@ -197,8 +197,8 @@ namespace hpx { namespace util
                 !std::is_same<F, thread_description>::value &&
                 !traits::is_action<F>::value
             >::type>
-        explicit thread_description(F const& f,
-            char const* altname = nullptr) noexcept
+        explicit thread_description(F const& /*f*/,
+            char const* /*altname*/ = nullptr) noexcept
         {
         }
 
@@ -207,7 +207,7 @@ namespace hpx { namespace util
                 traits::is_action<Action>::value
             >::type>
         explicit thread_description(Action,
-            char const* altname = nullptr) noexcept
+            char const* /*altname*/ = nullptr) noexcept
         {
         }
 

--- a/hpx/util/tuple.hpp
+++ b/hpx/util/tuple.hpp
@@ -1079,7 +1079,7 @@ namespace hpx { namespace serialization
     void serialize(
         Archive& ar
       , ::hpx::util::tuple<Ts...>& t
-      , unsigned int const version = 0
+      , unsigned int const /*version*/ = 0
     )
     {
         ar & t._impl;


### PR DESCRIPTION
GCC 8 seems to have much more aggressive warnings about unused parameters and this patch reduces warnings from tens of thousands to just a few when compiling a full project.
