### PR TITLE
Fix brackets and indentation in existing_performance_counters.qbk

### DIFF
--- a/docs/manual/existing_performance_counters.qbk
+++ b/docs/manual/existing_performance_counters.qbk
@@ -1211,69 +1211,68 @@ system and application performance.
          __hpx__- worker thread or the accumulated value for all worker threads.]
         [None]
     ]
-        [///////////////////////////////////////////////////////////////////////////////]
-        [///////////// Background Thread Related Counters ////////////////////////////]
-        [   [`/threads/time/background-work-duration`]
-                [`locality#*/total` or[br]
-                 `locality#*/worker-thread#*`
+    [/////////////////////////////////////////////////////////////////////////]
+    [///////////// Background Thread Related Counters ////////////////////////]
+    [   [`/threads/time/background-work-duration`]
+        [`locality#*/total` or[br]
+         `locality#*/worker-thread#*`
 
-                  where:[br]
-                  `locality#*` is defining the locality for which the overall time spent
-                  performing background work should be queried
-                  for. The locality id (given by `*`) is a (zero based) number
-                  identifying the locality.
+          where:[br]
+          `locality#*` is defining the locality for which the overall time spent
+          performing background work should be queried
+          for. The locality id (given by `*`) is a (zero based) number
+          identifying the locality.
 
-                  `worker-thread#*` is defining the worker thread for which the
-                  overall time spent performing background work should
-                  be queried for. The worker thread number (given by the `*`) is a
-                  (zero based) number identifying the worker thread. The number of
-                  available worker threads is usually specified on the command line
-                  for the application using the option [hpx_cmdline `--hpx:threads`].
-                ]
-                [Returns the overall time spent performing background work on the
-                 given locality since application start. If the
-                 instance name is `total` the counter returns the overall time spent
-                 performing background work for all worker threads
-                 (cores) on that locality. If the instance name is `worker-thread#*`
-                 the counter will return the overall time spent performing backgound work
-                 for all worker threads separately.
-                 This counter is available only if the configuration time constants
-                 `HPX_WITH_BACKGROUND_THREAD_COUNTERS` (default: OFF) and
-                 `HPX_WITH_THREAD_IDLE_RATES` are set to `ON` (default: OFF).
-                  The unit of  measure for this counter is nanosecond [ns].]
-                [None]
+          `worker-thread#*` is defining the worker thread for which the
+          overall time spent performing background work should
+          be queried for. The worker thread number (given by the `*`) is a
+          (zero based) number identifying the worker thread. The number of
+          available worker threads is usually specified on the command line
+          for the application using the option [hpx_cmdline `--hpx:threads`].
         ]
-        [   [`/threads/background-overhead`]
-                [`locality#*/total` or[br]
-                 `locality#*/worker-thread#*`
-
-                  where:[br]
-                  `locality#*` is defining the locality for which the
-                   background overhead should be queried
-                  for. The locality id (given by `*`) is a (zero based) number
-                  identifying the locality.
-
-                  `worker-thread#*` is defining the worker thread for which the
-                  background overhead should
-                  be queried for. The worker thread number (given by the `*`) is a
-                  (zero based) number identifying the worker thread. The number of
-                  available worker threads is usually specified on the command line
-                  for the application using the option [hpx_cmdline `--hpx:threads`].
-                ]
-                [Returns the background overhead on the
-                 given locality since application start. If the
-                 instance name is `total` the counter returns the background overhead
-                  for all worker threads (cores) on that locality. If the instance name
-                  is `worker-thread#*` the counter will return background overhead
-                 for all worker threads separately.
-                 This counter is available only if the configuration time constants
-                 `HPX_WITH_BACKGROUND_THREAD_COUNTERS` (default: OFF) and
-                 `HPX_WITH_THREAD_IDLE_RATES` are set to `ON` (default: OFF).
-                  The unit of  measure displayed for this counter is 0.1%.]
-                [None]
-        ]
-        [///////////////////////////////////////////////////////////////////////////]
+        [Returns the overall time spent performing background work on the
+         given locality since application start. If the
+         instance name is `total` the counter returns the overall time spent
+         performing background work for all worker threads
+         (cores) on that locality. If the instance name is `worker-thread#*`
+         the counter will return the overall time spent performing backgound work
+         for all worker threads separately.
+         This counter is available only if the configuration time constants
+         `HPX_WITH_BACKGROUND_THREAD_COUNTERS` (default: OFF) and
+         `HPX_WITH_THREAD_IDLE_RATES` are set to `ON` (default: OFF).
+          The unit of  measure for this counter is nanosecond [ns].]
+        [None]
     ]
+    [   [`/threads/background-overhead`]
+        [`locality#*/total` or[br]
+         `locality#*/worker-thread#*`
+
+          where:[br]
+          `locality#*` is defining the locality for which the
+           background overhead should be queried
+          for. The locality id (given by `*`) is a (zero based) number
+          identifying the locality.
+
+          `worker-thread#*` is defining the worker thread for which the
+          background overhead should
+          be queried for. The worker thread number (given by the `*`) is a
+          (zero based) number identifying the worker thread. The number of
+          available worker threads is usually specified on the command line
+          for the application using the option [hpx_cmdline `--hpx:threads`].
+        ]
+        [Returns the background overhead on the
+         given locality since application start. If the
+         instance name is `total` the counter returns the background overhead
+          for all worker threads (cores) on that locality. If the instance name
+          is `worker-thread#*` the counter will return background overhead
+         for all worker threads separately.
+         This counter is available only if the configuration time constants
+         `HPX_WITH_BACKGROUND_THREAD_COUNTERS` (default: OFF) and
+         `HPX_WITH_THREAD_IDLE_RATES` are set to `ON` (default: OFF).
+          The unit of  measure displayed for this counter is 0.1%.]
+        [None]
+    ]
+    [/////////////////////////////////////////////////////////////////////////]
 ]
 
 [/////////////////////////////////////////////////////////////////////////////]


### PR DESCRIPTION
Mismatched brackets were causing docs build failures. I've also changed the indentation to match the style that was there.