### PR TITLE
Adding step to synchronize the APEX release

### DIFF
--- a/docs/release_procedure.rst
+++ b/docs/release_procedure.rst
@@ -47,6 +47,11 @@ the lines as they are completed to avoid confusion.
          *   Update collaborators
          *   Update grant information
 
+#.  Change the APEX release branch to be the most current release tag available
+    in the "git_external" APEX section of the main CMakeLists.txt.
+    Please contact the maintainers at http://github.com/khuck/xpress-apex to generate
+    a new release to synchronize with the HPX relelase.
+
 #.  If there have been any commits to the release branch since the last release
     create a tag from the old release branch before deleting the old release
     branch in the next step.


### PR DESCRIPTION
Adding a release step to synchronize the APEX release with the most recent stable release of APEX, rather than the "develop" branch.

this goes along with pull request #3413.