### PR TITLE
Add CDash timing output to future overhead test (for graphs)

### DIFF
--- a/hpx/util/lightweight_test.hpp
+++ b/hpx/util/lightweight_test.hpp
@@ -20,6 +20,7 @@
 #include <boost/smart_ptr/detail/spinlock.hpp>
 
 #include <cstddef>
+#include <sstream>
 #include <iostream>
 #include <mutex>
 
@@ -204,6 +205,15 @@ inline int report_errors(std::ostream& stream = std::cerr)
                << std::endl;
         return 1;
     }
+}
+
+inline void print_cdash_timing(const char *name, double time)
+{
+    // use stringstream followed by single cout for better multithreaded output
+    std::stringstream temp;
+    temp << "<DartMeasurement name=\"" << name << "\" "
+         << "type=\"numeric/double\">" << time << "</DartMeasurement>";
+    std::cout << temp.str() << std::endl;
 }
 
 }} // hpx::util

--- a/tests/performance/local/CMakeLists.txt
+++ b/tests/performance/local/CMakeLists.txt
@@ -142,12 +142,14 @@ foreach(benchmark ${benchmarks})
   source_group("Source Files" FILES ${sources})
 
   # add example executable
-  add_hpx_executable(${benchmark}
+  add_hpx_executable(${benchmark}_test
                      SOURCES ${sources}
                      ${${benchmark}_FLAGS}
                      EXCLUDE_FROM_ALL
                      HPX_PREFIX ${HPX_BUILD_PREFIX}
                      FOLDER "Benchmarks/Local")
+
+  add_hpx_test("tests.performance.local" ${benchmark} ${${benchmark}_PARAMETERS})
 
   # add a custom target for this example
   add_hpx_pseudo_target(tests.performance.local.${benchmark})
@@ -158,7 +160,8 @@ foreach(benchmark ${benchmarks})
 
   # add dependencies to pseudo-target
   add_hpx_pseudo_dependencies(tests.performance.local.${benchmark}
-                              ${benchmark}_exe)
+                              ${benchmark}_test_exe)
+
 endforeach()
 
 if(HPX_WITH_EXAMPLES_OPENMP)

--- a/tests/performance/local/CMakeLists.txt
+++ b/tests/performance/local/CMakeLists.txt
@@ -128,6 +128,26 @@ set(transform_reduce_scaling_FLAGS DEPENDENCIES iostreams_component)
 set(partitioned_vector_foreach_FLAGS
   DEPENDENCIES iostreams_component partitioned_vector_component)
 
+set(future_overhead_PARAMETERS THREADS_PER_LOCALITY 4)
+
+# These tests do not run on hpx threads, so we don't want to pass hpx params into them
+set(delay_baseline_PARAMETERS NO_HPX_MAIN)
+set(delay_baseline_threaded_PARAMETERS NO_HPX_MAIN)
+set(function_object_wrapper_overhead_PARAMETERS NO_HPX_MAIN)
+set(nonconcurrent_fifo_overhead_PARAMETERS NO_HPX_MAIN)
+set(nonconcurrent_lifo_overhead_PARAMETERS NO_HPX_MAIN)
+set(print_heterogeneous_payloads_PARAMETERS NO_HPX_MAIN)
+
+# These tests fail, so I am marking them as non HPX tests until they are fixed
+set(print_heterogeneous_payloads_PARAMETERS NO_HPX_MAIN)
+set(hpx_homogeneous_timed_task_spawn_executors_PARAMETERS NO_HPX_MAIN)
+set(skynet_PARAMETERS NO_HPX_MAIN)
+set(timed_task_spawn_PARAMETERS NO_HPX_MAIN)
+set(hpx_tls_overhead_PARAMETERS NO_HPX_MAIN)
+set(native_tls_overhead_PARAMETERS NO_HPX_MAIN)
+set(coroutines_call_overhead_PARAMETERS NO_HPX_MAIN)
+set(serialization_performance_PARAMETERS NO_HPX_MAIN)
+
 if(HPX_WITH_CUDA)
   set_source_files_properties(stream.cpp PROPERTIES CUDA_SOURCE_PROPERTY_FORMAT OBJ)
 endif()
@@ -149,7 +169,9 @@ foreach(benchmark ${benchmarks})
                      HPX_PREFIX ${HPX_BUILD_PREFIX}
                      FOLDER "Benchmarks/Local")
 
-  add_hpx_test("tests.performance.local" ${benchmark} ${${benchmark}_PARAMETERS})
+  if(NOT "${${benchmark}_PARAMETERS}" MATCHES NO_HPX_MAIN)
+    add_hpx_test("tests.performance.local" ${benchmark} ${${benchmark}_PARAMETERS})
+  endif()
 
   # add a custom target for this example
   add_hpx_pseudo_target(tests.performance.local.${benchmark})

--- a/tests/performance/local/agas_cache_timings.cpp
+++ b/tests/performance/local/agas_cache_timings.cpp
@@ -16,6 +16,7 @@
 #include <hpx/util/cache/statistics/local_full_statistics.hpp>
 #include <hpx/util/detail/pp/stringize.hpp>
 #include <hpx/util/histogram.hpp>
+#include <hpx/util/lightweight_test.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/accumulators/accumulators.hpp>
@@ -242,9 +243,14 @@ int hpx_main(boost::program_options::variables_map& vm)
 
     hpx::naming::gid_type first_key = hpx::detail::get_next_id();
 
+    hpx::util::high_resolution_timer t1;
+
     test_insert(cache, num_entries);
     test_get(cache, first_key);
     test_update(cache, first_key);
+
+    double elapsed = t1.elapsed();
+    hpx::util::print_cdash_timing("AGASCache", elapsed);
 
     return hpx::finalize();
 }

--- a/tests/performance/local/async_overheads.cpp
+++ b/tests/performance/local/async_overheads.cpp
@@ -5,6 +5,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
+#include <hpx/util/lightweight_test.hpp>
 
 #include "worker_timed.hpp"
 
@@ -87,6 +88,7 @@ int hpx_main(boost::program_options::variables_map& vm)
                   << (end - start) / 1e9 << " [s], ("
                   << seqential_time_per_task << " [s])"
                   << std::endl;
+        hpx::util::print_cdash_timing("AsyncSequential", seqential_time_per_task);
     }
 
     double hierarchical_time_per_task = 0;
@@ -104,12 +106,16 @@ int hpx_main(boost::program_options::variables_map& vm)
                   << (end - start) / 1e9 << " [s], ("
                   << hierarchical_time_per_task << " [s])"
                   << std::endl;
+        hpx::util::print_cdash_timing("AsyncHierarchical", hierarchical_time_per_task);
     }
 
     std::cout
         << "Ratio (speedup): "
         << seqential_time_per_task / hierarchical_time_per_task
         << std::endl;
+
+    hpx::util::print_cdash_timing("AsyncSpeedup",
+        seqential_time_per_task/hierarchical_time_per_task);
 
     return hpx::finalize();
 }

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -41,6 +41,10 @@ using hpx::util::high_resolution_timer;
 using hpx::cout;
 using hpx::flush;
 
+#define CDASH_TIMING(name,time) \
+    cout << "<DartMeasurement name=\"" << name << "\" " \
+    << "type=\"numeric/double\"> " << time << " </DartMeasurement> \n";
+
 ///////////////////////////////////////////////////////////////////////////////
 // we use globals here to prevent the delay from being optimized away
 double global_scratch = 0;
@@ -93,6 +97,7 @@ void measure_action_futures(std::uint64_t count, bool csv)
             "invoked {1} futures (actions) in {2} seconds\n",
             count,
             duration) << flush;
+    CDASH_TIMING("FutureOverhead_Actions", duration)
 }
 
 void measure_function_futures_wait_each(std::uint64_t count, bool csv)
@@ -122,6 +127,7 @@ void measure_function_futures_wait_each(std::uint64_t count, bool csv)
             "invoked {1} futures (functions, wait_each) in {2} seconds\n",
             count,
             duration) << flush;
+    CDASH_TIMING("FutureOverhead_WaitEach", duration)
 }
 
 void measure_function_futures_wait_all(std::uint64_t count, bool csv)
@@ -151,6 +157,7 @@ void measure_function_futures_wait_all(std::uint64_t count, bool csv)
             "invoked {1} futures (functions, wait_all) in {2} seconds\n",
             count,
             duration) << flush;
+    CDASH_TIMING("FutureOverhead_FuturesWait", duration)
 }
 
 void measure_function_futures_thread_count(std::uint64_t count, bool csv)
@@ -186,6 +193,7 @@ void measure_function_futures_thread_count(std::uint64_t count, bool csv)
             "invoked {1} futures (functions, thread count) in {2} seconds\n",
             count,
             duration) << flush;
+    CDASH_TIMING("FutureOverhead_ThreadCount", duration)
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -16,6 +16,7 @@
 #include <hpx/include/iostreams.hpp>
 #include <hpx/include/threads.hpp>
 #include <hpx/util/yield_while.hpp>
+#include <hpx/util/lightweight_test.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -40,10 +41,6 @@ using hpx::util::high_resolution_timer;
 
 using hpx::cout;
 using hpx::flush;
-
-#define CDASH_TIMING(name,time) \
-    cout << "<DartMeasurement name=\"" << name << "\" " \
-    << "type=\"numeric/double\"> " << time << " </DartMeasurement> \n";
 
 ///////////////////////////////////////////////////////////////////////////////
 // we use globals here to prevent the delay from being optimized away
@@ -97,7 +94,8 @@ void measure_action_futures(std::uint64_t count, bool csv)
             "invoked {1} futures (actions) in {2} seconds\n",
             count,
             duration) << flush;
-    CDASH_TIMING("FutureOverhead_Actions", duration)
+    // CDash graph plotting
+    hpx::util::print_cdash_timing("FutureOverheadActions", duration);
 }
 
 void measure_function_futures_wait_each(std::uint64_t count, bool csv)
@@ -127,7 +125,8 @@ void measure_function_futures_wait_each(std::uint64_t count, bool csv)
             "invoked {1} futures (functions, wait_each) in {2} seconds\n",
             count,
             duration) << flush;
-    CDASH_TIMING("FutureOverhead_WaitEach", duration)
+    // CDash graph plotting
+    hpx::util::print_cdash_timing("FutureOverheadWaitEach", duration);
 }
 
 void measure_function_futures_wait_all(std::uint64_t count, bool csv)
@@ -157,7 +156,8 @@ void measure_function_futures_wait_all(std::uint64_t count, bool csv)
             "invoked {1} futures (functions, wait_all) in {2} seconds\n",
             count,
             duration) << flush;
-    CDASH_TIMING("FutureOverhead_FuturesWait", duration)
+    // CDash graph plotting
+    hpx::util::print_cdash_timing("FutureOverheadFuturesWait", duration);
 }
 
 void measure_function_futures_thread_count(std::uint64_t count, bool csv)
@@ -193,7 +193,8 @@ void measure_function_futures_thread_count(std::uint64_t count, bool csv)
             "invoked {1} futures (functions, thread count) in {2} seconds\n",
             count,
             duration) << flush;
-    CDASH_TIMING("FutureOverhead_ThreadCount", duration)
+    // CDash graph plotting
+    hpx::util::print_cdash_timing("FutureOverheadThreadCount", duration);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/performance/local/resume_suspend.cpp
+++ b/tests/performance/local/resume_suspend.cpp
@@ -11,6 +11,7 @@
 #include <hpx/hpx_start.hpp>
 #include <hpx/util/high_resolution_clock.hpp>
 #include <hpx/util/yield_while.hpp>
+#include <hpx/util/lightweight_test.hpp>
 
 #include <boost/program_options.hpp>
 
@@ -49,6 +50,8 @@ int main(int argc, char ** argv)
         << "threads, resume [s], async [s], suspend [s]"
         << std::endl;
 
+    double suspend_time = 0;
+    double resume_time  = 0;
     hpx::util::high_resolution_timer timer;
 
     for (std::size_t i = 0; i < repetitions; ++i)
@@ -57,6 +60,7 @@ int main(int argc, char ** argv)
 
         hpx::resume();
         auto t_resume = timer.elapsed();
+        resume_time += t_resume;
 
         for (std::size_t thread = 0; thread < threads; ++thread)
         {
@@ -67,6 +71,7 @@ int main(int argc, char ** argv)
 
         hpx::suspend();
         auto t_suspend = timer.elapsed();
+        suspend_time += t_suspend;
 
         std::cout
             << threads << ", "
@@ -75,6 +80,9 @@ int main(int argc, char ** argv)
             << t_suspend
             << std::endl;
     }
+
+    hpx::util::print_cdash_timing("ResumeTime",  resume_time);
+    hpx::util::print_cdash_timing("SuspendTime", suspend_time);
 
     hpx::resume();
     hpx::async([]() { hpx::finalize(); });

--- a/tests/performance/local/serialization_overhead.cpp
+++ b/tests/performance/local/serialization_overhead.cpp
@@ -8,6 +8,7 @@
 #include <hpx/include/iostreams.hpp>
 #include <hpx/util/format.hpp>
 #include <hpx/runtime/serialization/detail/preprocess.hpp>
+#include <hpx/util/lightweight_test.hpp>
 
 #include <boost/lexical_cast.hpp>
 
@@ -179,6 +180,7 @@ int hpx_main(boost::program_options::variables_map& vm)
 
     hpx::util::format_to(hpx::cout, "{},{},{}\n",
         data_size, iterations, overall_time / concurrency) << hpx::flush;
+    hpx::util::print_cdash_timing("Serialization", overall_time / concurrency);
 
     return hpx::finalize();
 }

--- a/tests/performance/local/spinlock_overhead1.cpp
+++ b/tests/performance/local/spinlock_overhead1.cpp
@@ -15,6 +15,7 @@
 #include <hpx/util/register_locks.hpp>
 #include <hpx/include/async.hpp>
 #include <hpx/include/iostreams.hpp>
+#include <hpx/util/lightweight_test.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -243,6 +244,7 @@ int hpx_main(
                         k1,
                         k2
                     ) << flush;
+                hpx::util::print_cdash_timing("Spinlock1", duration);
             }
         }
     }

--- a/tests/performance/local/spinlock_overhead2.cpp
+++ b/tests/performance/local/spinlock_overhead2.cpp
@@ -15,6 +15,7 @@
 #include <hpx/util/register_locks.hpp>
 #include <hpx/include/async.hpp>
 #include <hpx/include/iostreams.hpp>
+#include <hpx/util/lightweight_test.hpp>
 
 #include <chrono>
 #include <cstddef>
@@ -271,6 +272,7 @@ int hpx_main(
                         k2,
                         k3
                     ) << flush;
+                hpx::util::print_cdash_timing("Spinlock2", duration);
             }
         }
     }

--- a/tests/performance/local/start_stop.cpp
+++ b/tests/performance/local/start_stop.cpp
@@ -10,6 +10,7 @@
 #include <hpx/hpx_start.hpp>
 #include <hpx/util/high_resolution_clock.hpp>
 #include <hpx/util/yield_while.hpp>
+#include <hpx/util/lightweight_test.hpp>
 
 #include <boost/program_options.hpp>
 
@@ -47,6 +48,8 @@ int main(int argc, char ** argv)
         << "threads, resume [s], async [s], suspend [s]"
         << std::endl;
 
+    double start_time = 0;
+    double stop_time  = 0;
     hpx::util::high_resolution_timer timer;
 
     for (std::size_t i = 0; i < repetitions; ++i)
@@ -55,6 +58,7 @@ int main(int argc, char ** argv)
 
         hpx::start(desc_commandline, argc, argv);
         auto t_start = timer.elapsed();
+        start_time += t_start;
 
         for (std::size_t thread = 0; thread < threads; ++thread)
         {
@@ -65,6 +69,7 @@ int main(int argc, char ** argv)
 
         hpx::stop();
         auto t_stop = timer.elapsed();
+        stop_time += t_stop;
 
         std::cout
             << threads << ", "
@@ -73,5 +78,7 @@ int main(int argc, char ** argv)
             << t_stop
             << std::endl;
     }
+    hpx::util::print_cdash_timing("StartTime", start_time);
+    hpx::util::print_cdash_timing("StopTime",  stop_time);
 }
 

--- a/tests/performance/local/stencil3_iterators.cpp
+++ b/tests/performance/local/stencil3_iterators.cpp
@@ -9,6 +9,7 @@
 #include <hpx/util/high_resolution_clock.hpp>
 #include <hpx/util/transform_iterator.hpp>
 #include <hpx/include/iostreams.hpp>
+#include <hpx/util/lightweight_test.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -533,6 +534,7 @@ int hpx_main(boost::program_options::variables_map& vm)
             for (int i = 0; i != test_count; ++i)
                 t += bench_stencil3_iterator_full();
             hpx::cout << "full: " << (t * 1e-9) / test_count << std::endl;
+            hpx::util::print_cdash_timing("Stencil3Full", (t * 1e-9) / test_count);
         }
 
         // now run explicit (no-check) stencil3 tests
@@ -541,6 +543,8 @@ int hpx_main(boost::program_options::variables_map& vm)
             for (int i = 0; i != test_count; ++i)
                 t += bench_stencil3_iterator_v1();
             hpx::cout << "nocheck(v1): " << (t * 1e-9) / test_count << std::endl;
+            hpx::util::print_cdash_timing("Stencil3NocheckV1",
+                (t * 1e-9) / test_count);
         }
 
         {
@@ -548,6 +552,8 @@ int hpx_main(boost::program_options::variables_map& vm)
             for (int i = 0; i != test_count; ++i)
                 t += bench_stencil3_iterator_v2();
             hpx::cout << "nocheck(v2): " << (t * 1e-9) / test_count << std::endl;
+            hpx::util::print_cdash_timing("Stencil3NocheckV2",
+                (t * 1e-9) / test_count);
         }
 
         // now run explicit tests
@@ -556,6 +562,8 @@ int hpx_main(boost::program_options::variables_map& vm)
             for (int i = 0; i != test_count; ++i)
                 t += bench_stencil3_iterator_explicit();
             hpx::cout << "explicit: " << (t * 1e-9) / test_count << std::endl;
+            hpx::util::print_cdash_timing("Stencil3Explicit",
+                (t * 1e-9) / test_count);
         }
     }
 

--- a/tests/performance/local/wait_all_timings.cpp
+++ b/tests/performance/local/wait_all_timings.cpp
@@ -8,6 +8,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/util/format.hpp>
 #include <hpx/util/high_resolution_timer.hpp>
+#include <hpx/util/lightweight_test.hpp>
 
 #include <boost/program_options.hpp>
 
@@ -126,12 +127,15 @@ int hpx_main(boost::program_options::variables_map& vm)
         "{:10},{:10},{:10},{:10},{:10.12},{:10.12}\n",
         tasks_str, std::string("1"), delay_str,
         elapsed_seq, elapsed_seq / num_tasks) << hpx::endl;
+    hpx::util::print_cdash_timing("WaitAll", elapsed_seq / num_tasks);
+
     if (num_chunks != 1)
     {
         hpx::util::format_to(hpx::cout,
             "{:10},{:10},{:10},{:10},{:10.12},{:10.12}\n",
             tasks_str, chunks_str, delay_str,
             elapsed_chunks, elapsed_chunks / num_tasks) << hpx::endl;
+        hpx::util::print_cdash_timing("WaitAllChunks", elapsed_chunks / num_tasks);
     }
     return hpx::finalize();
 }

--- a/tests/unit/parallel/algorithms/exclusive_scan.cpp
+++ b/tests/unit/parallel/algorithms/exclusive_scan.cpp
@@ -46,8 +46,8 @@ void exclusive_scan_benchmark()
       bool ok = std::equal(std::begin(d), std::end(d), std::begin(e));
       HPX_TEST(ok);
       if (ok) {
-          std::cout << "<DartMeasurement name=\"ExclusiveScanTime\" \n"
-              << "type=\"numeric/double\">" << elapsed << "</DartMeasurement> \n";
+          // CDash graph plotting
+          hpx::util::print_cdash_timing("ExclusiveScanTime", elapsed);
       }
     }
     catch (...) {
@@ -161,16 +161,8 @@ int hpx_main(boost::program_options::variables_map& vm)
     std::cout << "using seed: " << seed << std::endl;
     std::srand(seed);
 
-    // if benchmark is requested we run it even in debug mode
-    if (vm.count("benchmark")) {
-        exclusive_scan_benchmark();
-    }
-    else {
-        exclusive_scan_test1();
-#ifndef HPX_DEBUG
-        exclusive_scan_benchmark();
-#endif
-    }
+    exclusive_scan_test1();
+    exclusive_scan_benchmark();
 
   return hpx::finalize();
 }
@@ -184,8 +176,8 @@ int main(int argc, char* argv[])
 
     desc_commandline.add_options()
         ("seed,s", value<unsigned int>(),
-        "the random number generator seed to use for this run")
-        ;
+        "the random number generator seed to use for this run");
+
     // By default this test should run on all available cores
     std::vector<std::string> const cfg = {
         "hpx.os_threads=all"

--- a/tests/unit/parallel/algorithms/inclusive_scan.cpp
+++ b/tests/unit/parallel/algorithms/inclusive_scan.cpp
@@ -212,23 +212,15 @@ int hpx_main(boost::program_options::variables_map& vm)
     std::cout << "using seed: " << seed << std::endl;
     std::srand(seed);
 
-    // if benchmark is requested we run it even in debug mode
-    if (vm.count("benchmark")) {
-        inclusive_scan_benchmark();
-    }
-    else {
-        inclusive_scan_test1();
-        inclusive_scan_test2();
-        inclusive_scan_test3();
+    inclusive_scan_test1();
+    inclusive_scan_test2();
+    inclusive_scan_test3();
 
-        inclusive_scan_exception_test();
-        inclusive_scan_bad_alloc_test();
+    inclusive_scan_exception_test();
+    inclusive_scan_bad_alloc_test();
 
-        inclusive_scan_validate();
-#ifndef HPX_DEBUG
-        inclusive_scan_benchmark();
-#endif
-    }
+    inclusive_scan_validate();
+    inclusive_scan_benchmark();
 
     return hpx::finalize();
 }
@@ -242,8 +234,7 @@ int main(int argc, char* argv[])
 
     desc_commandline.add_options()
         ("seed,s", value<unsigned int>(),
-        "the random number generator seed to use for this run")
-        ("benchmark", "run a timing benchmark only");
+        "the random number generator seed to use for this run");
 
     // By default this test should run on all available cores
     std::vector<std::string> const cfg = {

--- a/tests/unit/parallel/algorithms/inclusive_scan_tests.hpp
+++ b/tests/unit/parallel/algorithms/inclusive_scan_tests.hpp
@@ -50,8 +50,8 @@ void inclusive_scan_benchmark()
         bool ok = std::equal(std::begin(d), std::end(d), std::begin(e));
         HPX_TEST(ok);
         if (ok) {
-            std::cout << "<DartMeasurement name=\"InclusiveScanTime\" \n"
-                << "type=\"numeric/double\">" << elapsed << "</DartMeasurement> \n";
+            // CDash graph plotting
+            hpx::util::print_cdash_timing("InclusiveScanTime", elapsed);
         }
     }
     catch (...)

--- a/tests/unit/parallel/algorithms/reduce_by_key.cpp
+++ b/tests/unit/parallel/algorithms/reduce_by_key.cpp
@@ -8,6 +8,7 @@
 #include <hpx/parallel/algorithm.hpp>
 #include <hpx/parallel/algorithms/generate.hpp>
 #include <hpx/parallel/algorithms/reduce_by_key.hpp>
+#include <hpx/util/lightweight_test.hpp>
 //
 #include <random>
 #include <utility>
@@ -172,8 +173,8 @@ void test_reduce_by_key1(ExPolicy && policy, Tkey, Tval, bool benchmark, const O
     HPX_TEST(is_equal);
     if (is_equal) {
         if (benchmark) {
-            std::cout << "<DartMeasurement name=\"ReduceByKeyTime\" \n"
-                << "type=\"numeric/double\">" << elapsed << "</DartMeasurement> \n";
+            // CDash graph plotting
+            hpx::util::print_cdash_timing("ReduceByKeyTime", elapsed);
         }
     }
     else {
@@ -273,8 +274,8 @@ void test_reduce_by_key_const(ExPolicy && policy, Tkey, Tval, bool benchmark,
     HPX_TEST(is_equal);
     if (is_equal) {
         if (benchmark) {
-            std::cout << "<DartMeasurement name=\"ReduceByKeyTime\" \n"
-                << "type=\"numeric/double\">" << elapsed << "</DartMeasurement> \n";
+            // CDash graph plotting
+            hpx::util::print_cdash_timing("ReduceByKeyTime", elapsed);
         }
     }
     else {

--- a/tests/unit/parallel/algorithms/sort.cpp
+++ b/tests/unit/parallel/algorithms/sort.cpp
@@ -5,6 +5,7 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
+#include <hpx/util/lightweight_test.hpp>
 
 #include <cstddef>
 #include <iostream>
@@ -20,7 +21,7 @@
 #include "sort_tests.hpp"
 
 ////////////////////////////////////////////////////////////////////////////////
-// this function times a sort and outputs the time for cDash to plot it
+// this function times a sort and outputs the time for CDash to plot it
 void sort_benchmark()
 {
     try {
@@ -38,8 +39,8 @@ void sort_benchmark()
         bool is_sorted = (verify_(c, std::less<double>(), elapsed, true)!=0);
         HPX_TEST(is_sorted);
         if (is_sorted) {
-            std::cout << "<DartMeasurement name=\"SortDoublesTime\" \n"
-                << "type=\"numeric/double\">" << elapsed << "</DartMeasurement> \n";
+            // CDash graph plotting
+            hpx::util::print_cdash_timing("SortDoublesTime", elapsed);
         }
     }
     catch (...) {
@@ -179,17 +180,10 @@ int hpx_main(boost::program_options::variables_map& vm)
     std::cout << "using seed: " << seed << std::endl;
     std::srand(seed);
 
-    // if benchmark is requested we run it even in debug mode
-    if (vm.count("benchmark")) {
-        sort_benchmark();
-    }
-    else {
-        test_sort1();
-        test_sort2();
-#ifndef HPX_DEBUG
-        sort_benchmark();
-#endif
-    }
+    test_sort1();
+    test_sort2();
+    sort_benchmark();
+
     return hpx::finalize();
 }
 
@@ -202,8 +196,7 @@ int main(int argc, char* argv[])
 
     desc_commandline.add_options()
         ("seed,s", value<unsigned int>(),
-        "the random number generator seed to use for this run")
-        ("benchmark", "run a timing benchmark only");
+        "the random number generator seed to use for this run");
 
     // By default this test should run on all available cores
     std::vector<std::string> const cfg = {

--- a/tests/unit/parallel/algorithms/sort_by_key.cpp
+++ b/tests/unit/parallel/algorithms/sort_by_key.cpp
@@ -8,6 +8,7 @@
 #include <hpx/parallel/algorithm.hpp>
 #include <hpx/parallel/algorithms/generate.hpp>
 #include <hpx/parallel/algorithms/sort_by_key.hpp>
+#include <hpx/util/lightweight_test.hpp>
 //
 #include <iostream>
 #include <numeric>
@@ -98,8 +99,8 @@ void sort_by_key_benchmark()
         bool is_equal = std::equal(keys.begin(), keys.end(), o_values.begin());
         HPX_TEST(is_equal);
         if (is_equal) {
-            std::cout << "<DartMeasurement name=\"SortByKeyTime\" \n"
-            << "type=\"numeric/double\">" << elapsed << "</DartMeasurement> \n";
+            // CDash graph plotting
+            hpx::util::print_cdash_timing("SortByKeyTime", elapsed);
         }
     }
     catch (...) {
@@ -275,16 +276,9 @@ int hpx_main(boost::program_options::variables_map &vm)
     std::cout << "using seed: " << seed << std::endl;
     std::srand(seed);
 
-    // if benchmark is requested we run it even in debug mode
-    if (vm.count("benchmark")) {
-        sort_by_key_benchmark();
-    }
-    else {
-#ifndef HPX_DEBUG
-        test_sort_by_key1();
-#endif
-        sort_by_key_benchmark();
-    }
+    test_sort_by_key1();
+    sort_by_key_benchmark();
+
     return hpx::finalize();
 }
 
@@ -296,8 +290,7 @@ int main(int argc, char *argv[])
 
     desc_commandline.add_options()
         ("seed,s", value<unsigned int>(),
-        "the random number generator seed to use for this run")
-        ("benchmark", "run a timing benchmark only");
+        "the random number generator seed to use for this run");
 
     // By default this test should run on all available cores
     std::vector<std::string> const cfg = {


### PR DESCRIPTION
This adds `DartMeasurement` tags to the output so that timing can be plotted in CDash.

The idea behind this is that if we take some simple test that provides a useful benchmark, we ought to be able to see if atomic futures and scheduling fixes make a noticable difference over time.