### PR TITLE
Use source cache and workspace between job steps on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,25 +36,42 @@ jobs:
       - image: stellargroup/build_env:debian_clang
     working_directory: /hpx
     steps:
+      # Try to restore source cache. Keys are tried in order. The checkout step
+      # correctly handles the case when there is a cache entry.
+      - restore_cache:
+          keys:
+            - source-v2-{{ .Branch }}-{{ .Revision }}
+            - source-v2-{{ .Branch }}-
+            - source-v2-
       - checkout:
-          path: /hpx/source
+          path: /hpx/source-cache
+      - save_cache:
+          key: source-v2-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - /hpx/source-cache
+      # Make a shallow clone of the current commit so that we don't have to copy
+      # the whole repository between work steps.
+      - run:
+          name: Creating shallow clone
+          command: |
+              git clone --depth=1 file:///hpx/source-cache source
       - run:
           name: Downloading CTest XML to Junit XML
           command: |
               curl \
                 https://raw.githubusercontent.com/Kitware/CDash/master/tests/circle/conv.xsl \
                 -o /hpx/conv.xsl
-      - save_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
+      - persist_to_workspace:
+          root: /hpx
           paths:
-            - /hpx/source
-            - /hpx/conv.xsl
+            - ./source
+            - ./conv.xsl
 
   configure:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
+      - attach_workspace:
+          at: /hpx
       - run:
           name: Running CMake
           command: |
@@ -72,17 +89,15 @@ jobs:
                 -DHPX_HAVE_THREAD_LOCAL_STORAGE=On \
                 -DCMAKE_EXPORT_COMPILE_COMMANDS=On
       - persist_to_workspace:
-          root: /hpx/build
+          root: /hpx
           paths:
-            - ./*
+            - ./build
 
   clang_tidy:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Running clang-tidy
           command: |
@@ -91,10 +106,8 @@ jobs:
   inspect:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Inspect Tool
           command: |
@@ -117,33 +130,29 @@ jobs:
       - store_test_results:
           path: /report
       - persist_to_workspace:
-          root: /hpx/build
+          root: /hpx
           paths:
-            - ./bin/inspect
+            - ./build/bin/inspect
 
   core:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Core
           command: |
               ninja -j2 core
       - persist_to_workspace:
-          root: /hpx/build
+          root: /hpx
           paths:
-            - ./*
+            - ./build
 
   tests.unit.actions:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Unit Tests
           command: |
@@ -163,10 +172,8 @@ jobs:
   tests.unit.agas:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Unit Tests
           command: |
@@ -186,10 +193,8 @@ jobs:
   tests.unit.build:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Unit Tests
           command: |
@@ -209,10 +214,8 @@ jobs:
   tests.unit.component:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Unit Tests
           command: |
@@ -232,10 +235,8 @@ jobs:
   tests.unit.computeapi:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Unit Tests
           command: |
@@ -255,10 +256,8 @@ jobs:
   tests.unit.diagnostics:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Unit Tests
           command: |
@@ -278,10 +277,8 @@ jobs:
   tests.unit.lcos:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Unit Tests
           command: |
@@ -301,10 +298,8 @@ jobs:
   tests.unit.parallel.algorithms:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Unit Tests
           command: |
@@ -324,10 +319,8 @@ jobs:
   tests.unit.parallel.block:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Unit Tests
           command: |
@@ -347,10 +340,8 @@ jobs:
   tests.unit.parallel.container_algorithms:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Unit Tests
           command: |
@@ -370,10 +361,8 @@ jobs:
   tests.unit.parallel.datapar_algorithms:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Unit Tests
           command: |
@@ -393,10 +382,8 @@ jobs:
   tests.unit.parallel.executors:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Unit Tests
           command: |
@@ -416,10 +403,8 @@ jobs:
   tests.unit.parallel.segmented_algorithms:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Unit Tests
           # We need to compile some tests serially because they eat too much
@@ -441,10 +426,8 @@ jobs:
   tests.unit.parcelset:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Unit Tests
           command: |
@@ -464,10 +447,8 @@ jobs:
   tests.unit.performance_counter:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Unit Tests
           command: |
@@ -487,10 +468,8 @@ jobs:
   tests.unit.resource:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Unit Tests
           command: |
@@ -510,10 +489,8 @@ jobs:
   tests.unit.serialization:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Unit Tests
           command: |
@@ -533,10 +510,8 @@ jobs:
   tests.unit.threads:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Unit Tests
           command: |
@@ -556,10 +531,8 @@ jobs:
   tests.unit.traits:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Unit Tests
           command: |
@@ -579,10 +552,8 @@ jobs:
   tests.unit.util:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Unit Tests
           command: |
@@ -602,10 +573,8 @@ jobs:
   tests.regressions:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Regressions Tests
           command: |
@@ -625,10 +594,8 @@ jobs:
   tests.headers.compat:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Header Tests
           command: |
@@ -643,10 +610,8 @@ jobs:
   tests.headers.components:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Header Tests
           command: |
@@ -661,10 +626,8 @@ jobs:
   tests.headers.compute:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Header Tests
           command: |
@@ -679,10 +642,8 @@ jobs:
   tests.headers.config:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Header Tests
           command: |
@@ -697,10 +658,8 @@ jobs:
   tests.headers.include:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Header Tests
           command: |
@@ -715,10 +674,8 @@ jobs:
   tests.headers.lcos:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Header Tests
           command: |
@@ -733,10 +690,8 @@ jobs:
   tests.headers.parallel:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Header Tests
           command: |
@@ -751,10 +706,8 @@ jobs:
   tests.headers.performance_counters:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Header Tests
           command: |
@@ -769,10 +722,8 @@ jobs:
   tests.headers.plugins:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Header Tests
           command: |
@@ -787,10 +738,8 @@ jobs:
   tests.headers.runtime:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Header Tests
           command: |
@@ -805,10 +754,8 @@ jobs:
   tests.headers.traits:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Header Tests
           command: |
@@ -823,10 +770,8 @@ jobs:
   tests.headers.util:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Header Tests
           command: |
@@ -841,10 +786,8 @@ jobs:
   tests.performance:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Performance Tests
           command: |
@@ -853,18 +796,16 @@ jobs:
   examples:
     <<: *defaults
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - run:
           name: Building Examples
           command: |
               ninja -j2 examples
       - persist_to_workspace:
-          root: /hpx/build
+          root: /hpx
           paths:
-            - ./*
+            - ./build
 
   install:
     docker:
@@ -872,10 +813,8 @@ jobs:
     environment:
       TARGET_IMAGE_NAME: stellargroup/hpx:dev
     steps:
-      - restore_cache:
-          key: v2-repo-{{ .Environment.CIRCLE_SHA1 }}
       - attach_workspace:
-          at: /hpx/build
+          at: /hpx
       - setup_remote_docker
       - run:
           name: Installing


### PR DESCRIPTION
Fixes #3424.

Note: this does a shallow local clone to avoid copying the whole 900 MB repository using the workspace between work steps. This is not strictly necessary and can be reverted if we ever want to query the git repo for more information than the current hash. I did this because copying the whole repo using the workspace was significantly slower than doing the same with the cache, but since there doesn't seem to be a way to save to the cache anymore on PRs from forked repos this is a small optimization to get it back to the same performance as before.