### PR TITLE
Fixes #3426

### DIFF
--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -290,7 +290,7 @@ namespace hpx_start
 {
     // Importing weak symbol from libhpx_wrap.a which may be shadowed by one present in
     // hpx_main.hpp.
-    HPX_SYMBOL_EXPORT __attribute__((weak)) extern bool include_libhpx_wrap;
+    HPX_SYMBOL_EXPORT __attribute__((weak)) bool include_libhpx_wrap = false;
 }
 
 #endif
@@ -611,7 +611,7 @@ namespace hpx
                             "using hpx::init. Exiting...\n";
                         return -1;
                     }
-                    #endif
+                #endif
 
                     std::cerr << "hpx::init: can't initialize runtime system "
                         "more than once! Exiting...\n";


### PR DESCRIPTION
Fixes #3426 

Changes the `extern bool` to actual bool variable in `hpx_init.cpp`. Turns out Mac OSX works differently for `weak` variables as compared to Linux. In Linux, if a variable is declared `extern weak` then it allows to compile and link without producing any errors. For Mac OSX, however, it produces errors while linking (it does compile without errors though).

I do not understand as to why we didn't get such an error before while merging the Mac OSX implementation. As of now, this PR should fix things.

**PS.** Tested with Mac OSX Sierra and Ubuntu Budgie 18.04.