### PR TITLE
This suppresses a deprecation warning that is being issued by MSVC 19.15.26726

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1320,6 +1320,7 @@ if(WIN32)
   hpx_add_config_cond_define(_CRT_NONSTDC_NO_WARNINGS)
   hpx_add_config_cond_define(_WINSOCK_DEPRECATED_NO_WARNINGS)
   hpx_add_config_cond_define(_CRT_NON_CONFORMING_SWPRINTFS)
+  hpx_add_config_cond_define(_SILENCE_FPOS_SEEKPOS_DEPRECATION_WARNING)
 
   ##############################################################################
   # Boost


### PR DESCRIPTION
This suppresses a warning that has no consequences for HPX