### PR TITLE
Fix unused params warning

### DIFF
--- a/hpx/util/apex.hpp
+++ b/hpx/util/apex.hpp
@@ -121,7 +121,7 @@ namespace hpx { namespace util
 
     struct apex_wrapper_init
     {
-        apex_wrapper_init(int argc, char **argv)
+        apex_wrapper_init(int /*argc*/, char ** /*argv*/)
         {
             //apex::init(nullptr, hpx::get_locality_id(),
             //    hpx::get_initial_num_localities());


### PR DESCRIPTION
Only appears when APEX is enabled, so missed it in the last big warnings patch.