### PR TITLE
Fix threads cores

### DIFF
--- a/cmake/templates/hpxrun.py.in
+++ b/cmake/templates/hpxrun.py.in
@@ -112,7 +112,11 @@ def build_cmd(options, args):
         cmd += select_parcelport(options.parcelport)
 
     # set number of threads
-    if options.threads >= -1:
+    if options.threads == -1:
+        cmd += ['--hpx:threads=all']
+    if options.threads == -2:
+        cmd += ['--hpx:threads=cores']
+    if options.threads >= 1:
         cmd += ['--hpx:threads=' + str(options.threads)]
 
     # set number of localities
@@ -139,7 +143,7 @@ def check_options(parser, options, args):
         print('Can not start less than one locality', sys.stderr)
         sys.exit(1)
 
-    if options.threads < 1 and options.threads != -1:
+    if options.threads < 1 and options.threads != -1 and options.threads != -2:
         print('Can not start less than one thread per locality', sys.stderr)
         sys.exit(1)
 

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -355,6 +355,8 @@ namespace hpx { namespace util
                 threads_str = vm["hpx:threads"].as<std::string>();
                 if ("all" == threads_str)
                 {
+                    default_threads = thread::hardware_concurrency();
+                    batch_threads = env.retrieve_number_of_threads();
                     if (batch_threads == std::size_t(-1))
                     {
                         batch_threads = thread::hardware_concurrency();


### PR DESCRIPTION
Fixes a mistake introduced in #3429, hpx:threads=all was not working as expected and one test was failing due to a problem with hpxrun.py
