### PR TITLE
Fixing 1205

### DIFF
--- a/hpx/runtime/threads/coroutines/detail/tss.hpp
+++ b/hpx/runtime/threads/coroutines/detail/tss.hpp
@@ -51,6 +51,25 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
             value_(val)
         {}
 
+        tss_data_node(tss_data_node const&) = delete;
+        tss_data_node& operator=(tss_data_node const&) = delete;
+
+        tss_data_node(tss_data_node&& other)
+          : func_(std::move(other.func_)),
+            value_(other.value_)
+        {
+            other.value_ = nullptr;
+        }
+
+        tss_data_node& operator=(tss_data_node&& other)
+        {
+            cleanup();
+            func_ = std::move(other.func_);
+            value_ = other.value_;
+            other.value_ = nullptr;
+            return *this;
+        }
+
         ~tss_data_node()
         {
             cleanup();

--- a/src/runtime/threads/coroutines/detail/coroutine_impl.cpp
+++ b/src/runtime/threads/coroutines/detail/coroutine_impl.cpp
@@ -91,8 +91,6 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 
                     result_last = m_fun(*this->args());
                     HPX_ASSERT(result_last.first == thread_state_enum::terminated);
-
-                    this->reset();
                 }
 
                 // return value to other side of the fence
@@ -101,9 +99,9 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
             catch (...) {
                 status = super_type::ctx_exited_abnormally;
                 tinfo = std::current_exception();
-                this->reset();
             }
 
+            this->reset();
             this->do_return(status, std::move(tinfo));
         } while (this->m_state == super_type::ctx_running);
 


### PR DESCRIPTION
Fixes #1205

## Proposed Changes

  - Fixing double delete problem:
    - This adds a move ctor and move assignment for tss_node to avoid double deletes
    in case of temporary objects.
  - Unbreaking unit test:
    - The test had a timing issues. The TSS dtors are called after the task making
    the future ready returns.
  - Properly reseting the coroutine context to avoid an assertion being triggered.
