### PR TITLE
Add projection function to find_* (and fix very bad bug)

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -118,6 +118,7 @@ set(doxygen_dependencies
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/copy.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/count.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/fill.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/find.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/for_each.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/generate.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/parallel/container_algorithms/is_heap.hpp"

--- a/hpx/include/parallel_find.hpp
+++ b/hpx/include/parallel_find.hpp
@@ -8,6 +8,7 @@
 #define HPX_PARALLEL_FIND_JUL_21_2014_0248PM
 
 #include <hpx/parallel/algorithms/find.hpp>
+#include <hpx/parallel/container_algorithms/find.hpp>
 #include <hpx/parallel/segmented_algorithms/find.hpp>
 
 #endif

--- a/hpx/parallel/algorithms/find.hpp
+++ b/hpx/parallel/algorithms/find.hpp
@@ -916,9 +916,13 @@ namespace hpx { namespace parallel { inline namespace v1
     ///                     that objects of types \a FwdIter1 and \a FwdIter2
     ///                     can be dereferenced and then implicitly converted
     ///                     to \a Type1 and \a Type2 respectively.
-    /// \param proj         Specifies the function (or function object) which
+    /// \param proj1        Specifies the function (or function object) which
     ///                     will be invoked for each of the elements of type
     ///                     dereferenced \a FwdIter1 as a projection operation
+    ///                     before the function \a op is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of type
+    ///                     dereferenced \a FwdIter2 as a projection operation
     ///                     before the function \a op is invoked.
     ///
     /// The comparison operations in the parallel \a find_first_of algorithm invoked

--- a/hpx/parallel/container_algorithms.hpp
+++ b/hpx/parallel/container_algorithms.hpp
@@ -13,6 +13,7 @@
 #include <hpx/parallel/container_algorithms/copy.hpp>
 #include <hpx/parallel/container_algorithms/count.hpp>
 #include <hpx/parallel/container_algorithms/fill.hpp>
+#include <hpx/parallel/container_algorithms/find.hpp>
 #include <hpx/parallel/container_algorithms/for_each.hpp>
 #include <hpx/parallel/container_algorithms/generate.hpp>
 #include <hpx/parallel/container_algorithms/is_heap.hpp>

--- a/hpx/parallel/container_algorithms.hpp
+++ b/hpx/parallel/container_algorithms.hpp
@@ -9,13 +9,16 @@
 
 #include <hpx/parallel/algorithm.hpp>
 
+#include <hpx/parallel/container_algorithms/all_any_none.hpp>
 #include <hpx/parallel/container_algorithms/copy.hpp>
+#include <hpx/parallel/container_algorithms/count.hpp>
 #include <hpx/parallel/container_algorithms/fill.hpp>
 #include <hpx/parallel/container_algorithms/for_each.hpp>
 #include <hpx/parallel/container_algorithms/generate.hpp>
 #include <hpx/parallel/container_algorithms/is_heap.hpp>
 #include <hpx/parallel/container_algorithms/merge.hpp>
 #include <hpx/parallel/container_algorithms/minmax.hpp>
+#include <hpx/parallel/container_algorithms/move.hpp>
 #include <hpx/parallel/container_algorithms/partition.hpp>
 #include <hpx/parallel/container_algorithms/remove.hpp>
 #include <hpx/parallel/container_algorithms/remove_copy.hpp>

--- a/hpx/parallel/container_algorithms/find.hpp
+++ b/hpx/parallel/container_algorithms/find.hpp
@@ -1,0 +1,250 @@
+//  Copyright (c) 2018 Bruno Pitrus
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/container_algorithms/find.hpp
+
+#if !defined(HPX_PARALLEL_CONTAINER_ALGORITHMS_FIND)
+#define HPX_PARALLEL_CONTAINER_ALGORITHMS_FIND
+
+#include <hpx/config.hpp>
+#include <hpx/traits/concepts.hpp>
+#include <hpx/traits/is_execution_policy.hpp>
+#include <hpx/traits/is_range.hpp>
+#include <hpx/util/range.hpp>
+
+#include <hpx/parallel/algorithms/find.hpp>
+#include <hpx/parallel/traits/projected.hpp>
+#include <hpx/parallel/traits/projected_range.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { inline namespace v1
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // find_end
+
+    /// Returns the last subsequence of elements \a rng2 found in the range
+    /// \a rng using the given predicate \a f to compare elements.
+    ///
+    /// \note   Complexity: at most S*(N-S+1) comparisons where
+    ///         \a S = distance(begin(rng2), end(rng2)) and
+    ///         \a N = distance(begin(rng), end(rng)).
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng         The type of the first source range (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of a forward iterator.
+    /// \tparam Rng2        The type of the second source range (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of a forward iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a replace requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the first sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param rng2         Refers to the second sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param op           The binary predicate which returns \a true
+    ///                     if the elements should be treated as equal. The signature
+    ///                     should be equivalent to the following:
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type2 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const &, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The types \a Type1 and \a Type2 must be such
+    ///                     that objects of types \a iterator_t<Rng> and \a iterator_t<Rng2>
+    ///                     can be dereferenced and then implicitly converted
+    ///                     to \a Type1 and \a Type2 respectively.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of type
+    ///                     dereferenced \a iterator_t<Rng> and
+    ///                     dereferenced \a iterator_t<Rng2>
+    ///                     as a projection operation before the function \a op
+    ///                     is invoked.
+    ///
+    /// The comparison operations in the parallel \a find_end algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The comparison operations in the parallel \a find_end algorithm invoked
+    /// with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a find_end algorithm returns a \a hpx::future<iterator_t<Rng> >
+    ///           if the execution policy is of type \a sequenced_task_policy
+    ///           or \a parallel_task_policy and returns \a iterator_t<Rng> otherwise.
+    ///           The \a find_end algorithm returns an iterator to the beginning of
+    ///           the last subsequence \a rng2 in range \a rng.
+    ///           If the length of the subsequence \a rng2 is greater
+    ///           than the length of the range \a rng, \a end(rng) is returned.
+    ///           Additionally if the size of the subsequence is empty or no subsequence
+    ///           is found, \a end(rng) is also returned.
+    ///
+    /// This overload of \a find_end is available if the user decides to provide the
+    /// algorithm their own predicate \a op.
+    ///
+    template <typename ExPolicy, typename Rng, typename Rng2,
+        typename Pred = detail::equal_to,
+        typename Proj = util::projection_identity,
+    HPX_CONCEPT_REQUIRES_(
+        execution::is_execution_policy<ExPolicy>::value &&
+        hpx::traits::is_range<Rng>::value &&
+        traits::is_projected_range<Proj, Rng>::value &&
+        hpx::traits::is_range<Rng2>::value &&
+        traits::is_projected_range<Proj, Rng2>::value &&
+        traits::is_indirect_callable<
+            ExPolicy, Pred,
+            traits::projected_range<Proj, Rng>,
+            traits::projected_range<Proj, Rng2>
+        >::value
+    )>
+    typename util::detail::algorithm_result<
+        ExPolicy,
+        typename hpx::traits::range_iterator<Rng>::type
+    >::type
+    find_end(ExPolicy && policy, Rng && rng,
+        Rng2 && rng2, Pred && op = Pred(), Proj && proj = Proj())
+    {
+        return find_end(std::forward<ExPolicy>(policy),
+            hpx::util::begin(rng), hpx::util::end(rng),
+            hpx::util::begin(rng2), hpx::util::end(rng2),
+            std::forward<Pred>(op),
+            std::forward<Proj>(proj));
+    }
+    ///////////////////////////////////////////////////////////////////////////
+    // find_first_of
+
+    /// Searches the range \a rng1 for any elements in the range \a rng2.
+    /// Uses binary predicate \a p to compare elements
+    ///
+    /// \note   Complexity: at most (S*N) comparisons where
+    ///         \a S = distance(begin(rng2), end(rng2)) and
+    ///         \a N = distance(begin(rng1), end(rng1)).
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng1        The type of the first source range (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of a forward iterator.
+    /// \tparam Rng2        The type of the second source range (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of a forward iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a replace requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj1       The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity and is
+    ///                     applied to the elements in \a rng1.
+    /// \tparam Proj2       The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity and is
+    ///                     applied to the elements in \a rng2.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng1         Refers to the first sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param rng2         Refers to the second sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param op           The binary predicate which returns \a true
+    ///                     if the elements should be treated as equal. The signature
+    ///                     should be equivalent to the following:
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type2 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const &, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The types \a Type1 and \a Type2 must be such
+    ///                     that objects of types \a iterator_t<Rng1>
+    ///                     and \a iterator_t<Rng2>
+    ///                     can be dereferenced and then implicitly converted
+    ///                     to \a Type1 and \a Type2 respectively.
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of type
+    ///                     dereferenced \a iterator_t<Rng1> before the function
+    ///                     \a op is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of type
+    ///                     dereferenced \a iterator_t<Rng2> before the function
+    ///                     \a op is invoked.
+    ///
+    /// The comparison operations in the parallel \a find_first_of algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The comparison operations in the parallel \a find_first_of algorithm invoked
+    /// with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a find_end algorithm returns a \a hpx::future<iterator_t<Rng1> >
+    ///           if the execution policy is of type \a sequenced_task_policy
+    ///           or \a parallel_task_policy and returns \a iterator_t<Rng1> otherwise.
+    ///           The \a find_first_of algorithm returns an iterator to the first element
+    ///           in the range \a rng1 that is equal to an element from the range
+    ///           \a rng2.
+    ///           If the length of the subsequence \a rng2 is
+    ///           greater than the length of the range \a rng1,
+    ///           \a end(rng1) is returned.
+    ///           Additionally if the size of the subsequence is empty or no subsequence
+    ///           is found, \a end(rng1) is also returned.
+    ///
+    /// This overload of \a find_first_of is available if the user decides to provide the
+    /// algorithm their own predicate \a op.
+    ///
+    template <typename ExPolicy, typename Rng1, typename Rng2,
+        typename Pred = detail::equal_to,
+        typename Proj1 = util::projection_identity,
+        typename Proj2 = util::projection_identity,
+    HPX_CONCEPT_REQUIRES_(
+        execution::is_execution_policy<ExPolicy>::value &&
+        hpx::traits::is_range<Rng1>::value &&
+        traits::is_projected_range<Proj1, Rng1>::value &&
+        hpx::traits::is_range<Rng2>::value &&
+        traits::is_projected_range<Proj2, Rng2>::value &&
+        traits::is_indirect_callable<
+            ExPolicy, Pred,
+            traits::projected_range<Proj1, Rng1>,
+            traits::projected_range<Proj2, Rng2>
+        >::value
+    )>
+    typename util::detail::algorithm_result<
+        ExPolicy,
+        typename hpx::traits::range_iterator<Rng1>::type
+    >::type
+    find_first_of(ExPolicy && policy, Rng1 && rng1,
+        Rng2 && rng2, Pred && op = Pred(),
+        Proj1 && proj1 = Proj1(), Proj2 && proj2 = Proj2())
+    {
+        return find_first_of(std::forward<ExPolicy>(policy),
+            hpx::util::begin(rng1), hpx::util::end(rng1),
+            hpx::util::begin(rng2), hpx::util::end(rng2),
+            std::forward<Pred>(op),
+            std::forward<Proj1>(proj1),
+            std::forward<Proj2>(proj2));
+    }
+
+}}}
+
+#endif

--- a/tests/unit/parallel/algorithms/findend.cpp
+++ b/tests/unit/parallel/algorithms/findend.cpp
@@ -3,12 +3,13 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
 #include <hpx/include/parallel_find.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <cstddef>
+#include <functional>
 #include <iostream>
 #include <iterator>
 #include <numeric>
@@ -21,8 +22,8 @@
 ////////////////////////////////////////////////////////////////////////////
 unsigned int seed = std::random_device{}();
 std::mt19937 gen(seed);
-std::uniform_int_distribution<> dis(3,102);
-std::uniform_int_distribution<> dist(7,106);
+std::uniform_int_distribution<> dis(3, 102);
+std::uniform_int_distribution<> dist(7, 106);
 
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end1(ExPolicy policy, IteratorTag)
@@ -38,20 +39,46 @@ void test_find_end1(ExPolicy policy, IteratorTag)
     // fill vector with random values above 2
     std::fill(std::begin(c), std::end(c), dis(gen));
     // create subsequence in middle of vector
-    c[c.size()/2] = 1;
-    c[c.size()/2 + 1] = 2;
+    c[c.size() / 2] = 1;
+    c[c.size() / 2 + 1] = 2;
 
-    std::size_t h[] = { 1, 2 };
+    std::size_t h[] = {1, 2};
 
-    iterator index = hpx::parallel::find_end(policy,
-        iterator(std::begin(c)), iterator(std::end(c)),
-        std::begin(h), std::end(h));
+    iterator index = hpx::parallel::find_end(policy, iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(h), std::end(h));
 
-    base_iterator test_index = std::begin(c) + c.size()/2;
+    base_iterator test_index = std::begin(c) + c.size() / 2;
 
     HPX_TEST(index == iterator(test_index));
 }
 
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end1_proj(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    // fill vector with random values above 2
+    std::fill(std::begin(c), std::end(c), dis(gen));
+    // create subsequence in middle of vector
+    c[c.size() / 2] = 1 + 65536;
+    c[c.size() / 2 + 1] = 2 + 65536;
+
+    std::size_t h[] = {1, 2};
+
+    iterator index = hpx::parallel::find_end(policy, iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(h), std::end(h),
+        std::equal_to<std::size_t>(), [](std::size_t x){return x % 65536;});
+
+    base_iterator test_index = std::begin(c) + c.size() / 2;
+
+    HPX_TEST(index == iterator(test_index));
+}
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end1_async(ExPolicy p, IteratorTag)
 {
@@ -62,23 +89,48 @@ void test_find_end1_async(ExPolicy p, IteratorTag)
     // fill vector with random values above 2
     std::fill(std::begin(c), std::end(c), dis(gen));
     // create subsequence in middle of vector
-    c[c.size()/2] = 1;
-    c[c.size()/2 + 1] = 2;
+    c[c.size() / 2] = 1;
+    c[c.size() / 2 + 1] = 2;
 
-    std::size_t h[] = { 1, 2 };
+    std::size_t h[] = {1, 2};
 
     hpx::future<iterator> f =
-        hpx::parallel::find_end(p,
-            iterator(std::begin(c)), iterator(std::end(c)),
-            std::begin(h), std::end(h));
+        hpx::parallel::find_end(p, iterator(std::begin(c)),
+            iterator(std::end(c)), std::begin(h), std::end(h));
     f.wait();
 
     // create iterator at position of value to be found
-    base_iterator test_index = std::begin(c) + c.size()/2;
+    base_iterator test_index = std::begin(c) + c.size() / 2;
 
     HPX_TEST(f.get() == iterator(test_index));
 }
 
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end1_async_proj(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    // fill vector with random values above 2
+    std::fill(std::begin(c), std::end(c), dis(gen));
+    // create subsequence in middle of vector
+    c[c.size() / 2] = 1+65536;
+    c[c.size() / 2 + 1] = 2+65536;
+
+    std::size_t h[] = {1, 2};
+
+    hpx::future<iterator> f =
+        hpx::parallel::find_end(p, iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(h), std::end(h),
+        std::equal_to<std::size_t>(), [](std::size_t x){return x % 65536;});
+    f.wait();
+
+    // create iterator at position of value to be found
+    base_iterator test_index = std::begin(c) + c.size() / 2;
+
+    HPX_TEST(f.get() == iterator(test_index));
+}
 template <typename IteratorTag>
 void test_find_end1()
 {
@@ -86,17 +138,31 @@ void test_find_end1()
     test_find_end1(execution::seq, IteratorTag());
     test_find_end1(execution::par, IteratorTag());
     test_find_end1(execution::par_unseq, IteratorTag());
+    test_find_end1_proj(execution::seq, IteratorTag());
+    test_find_end1_proj(execution::par, IteratorTag());
+    test_find_end1_proj(execution::par_unseq, IteratorTag());
 
     test_find_end1_async(execution::seq(execution::task), IteratorTag());
     test_find_end1_async(execution::par(execution::task), IteratorTag());
+    test_find_end1_async_proj(execution::seq(execution::task), IteratorTag());
+    test_find_end1_async_proj(execution::par(execution::task), IteratorTag());
 
 #if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_end1(execution_policy(execution::seq), IteratorTag());
     test_find_end1(execution_policy(execution::par), IteratorTag());
     test_find_end1(execution_policy(execution::par_unseq), IteratorTag());
+    test_find_end1_proj(execution_policy(execution::seq), IteratorTag());
+    test_find_end1_proj(execution_policy(execution::par), IteratorTag());
+    test_find_end1_proj(execution_policy(execution::par_unseq), IteratorTag());
 
-    test_find_end1(execution_policy(execution::seq(execution::task)), IteratorTag());
-    test_find_end1(execution_policy(execution::par(execution::task)), IteratorTag());
+    test_find_end1(
+        execution_policy(execution::seq(execution::task)), IteratorTag());
+    test_find_end1(
+        execution_policy(execution::par(execution::task)), IteratorTag());
+    test_find_end1_proj(
+        execution_policy(execution::seq(execution::task)), IteratorTag());
+    test_find_end1_proj(
+        execution_policy(execution::par(execution::task)), IteratorTag());
 #endif
 }
 
@@ -122,16 +188,46 @@ void test_find_end2(ExPolicy policy, IteratorTag)
     // create subsequence at start and end
     c[0] = 1;
     c[1] = 2;
-    c[c.size()-1] = 2;
-    c[c.size()-2] = 1;
+    c[c.size() - 1] = 2;
+    c[c.size() - 2] = 1;
 
-    std::size_t h[] = { 1, 2 };
+    std::size_t h[] = {1, 2};
 
-    iterator index = hpx::parallel::find_end(policy,
-        iterator(std::begin(c)), iterator(std::end(c)),
-        std::begin(h), std::end(h));
+    iterator index = hpx::parallel::find_end(policy, iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(h), std::end(h));
 
-    base_iterator test_index = std::begin(c) + c.size()-2;
+    base_iterator test_index = std::begin(c) + c.size() - 2;
+
+    HPX_TEST(index == iterator(test_index));
+}
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end2_proj(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    // fill vector with random values about 2
+    std::fill(std::begin(c), std::end(c), dis(gen));
+    // create subsequence at start and end
+    c[0] = 1;
+    c[1] = 2;
+    c[c.size() - 1] = 2;
+    c[c.size() - 2] = 1;
+
+    std::size_t h[] = {1+65536, 2+65536};
+
+    iterator index = hpx::parallel::find_end(policy, iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(h), std::end(h),
+        std::equal_to<std::size_t>(),
+        [](std::size_t x) { return x % 65536; });
+
+
+    base_iterator test_index = std::begin(c) + c.size() - 2;
 
     HPX_TEST(index == iterator(test_index));
 }
@@ -149,19 +245,50 @@ void test_find_end2_async(ExPolicy p, IteratorTag)
     // create subsequence at start and end
     c[0] = 1;
     c[1] = 2;
-    c[c.size()-1] = 2;
-    c[c.size()-2] = 1;
+    c[c.size() - 1] = 2;
+    c[c.size() - 2] = 1;
 
-    std::size_t h[] = { 1, 2 };
+    std::size_t h[] = {1, 2};
 
     hpx::future<iterator> f =
-        hpx::parallel::find_end(p,
-            iterator(std::begin(c)), iterator(std::end(c)),
-            std::begin(h), std::end(h));
+        hpx::parallel::find_end(p, iterator(std::begin(c)),
+            iterator(std::end(c)), std::begin(h), std::end(h));
     f.wait();
 
     // create iterator at position of value to be found
-    base_iterator test_index = std::begin(c) + c.size()-2;
+    base_iterator test_index = std::begin(c) + c.size() - 2;
+
+    HPX_TEST(f.get() == iterator(test_index));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end2_async_proj(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    // fill vector with random values above 2
+    std::vector<std::size_t> c(10007);
+    std::fill(std::begin(c), std::end(c), dis(gen));
+
+    // create subsequence at start and end
+    c[0] = 1;
+    c[1] = 2;
+    c[c.size() - 1] = 2;
+    c[c.size() - 2] = 1;
+
+    std::size_t h[] = {1+65536, 2+65536};
+
+    hpx::future<iterator> f =
+        hpx::parallel::find_end(p, iterator(std::begin(c)),
+            iterator(std::end(c)), std::begin(h), std::end(h),
+            std::equal_to<std::size_t>(),
+            [](std::size_t x) { return x % 65536; });
+
+    f.wait();
+
+    // create iterator at position of value to be found
+    base_iterator test_index = std::begin(c) + c.size() - 2;
 
     HPX_TEST(f.get() == iterator(test_index));
 }
@@ -173,17 +300,31 @@ void test_find_end2()
     test_find_end2(execution::seq, IteratorTag());
     test_find_end2(execution::par, IteratorTag());
     test_find_end2(execution::par_unseq, IteratorTag());
+    test_find_end2_proj(execution::seq, IteratorTag());
+    test_find_end2_proj(execution::par, IteratorTag());
+    test_find_end2_proj(execution::par_unseq, IteratorTag());
 
     test_find_end2_async(execution::seq(execution::task), IteratorTag());
     test_find_end2_async(execution::par(execution::task), IteratorTag());
+    test_find_end2_async_proj(execution::seq(execution::task), IteratorTag());
+    test_find_end2_async_proj(execution::par(execution::task), IteratorTag());
 
 #if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_end2(execution_policy(execution::seq), IteratorTag());
     test_find_end2(execution_policy(execution::par), IteratorTag());
     test_find_end2(execution_policy(execution::par_unseq), IteratorTag());
+    test_find_end2_proj(execution_policy(execution::seq), IteratorTag());
+    test_find_end2_proj(execution_policy(execution::par), IteratorTag());
+    test_find_end2_proj(execution_policy(execution::par_unseq), IteratorTag());
 
-    test_find_end2(execution_policy(execution::seq(execution::task)), IteratorTag());
-    test_find_end2(execution_policy(execution::par(execution::task)), IteratorTag());
+    test_find_end2(
+        execution_policy(execution::seq(execution::task)), IteratorTag());
+    test_find_end2(
+        execution_policy(execution::par(execution::task)), IteratorTag());
+    test_find_end2_proj(
+        execution_policy(execution::seq(execution::task)), IteratorTag());
+    test_find_end2_proj(
+        execution_policy(execution::par(execution::task)), IteratorTag());
 #endif
 }
 
@@ -208,21 +349,50 @@ void test_find_end3(ExPolicy policy, IteratorTag)
     std::fill(std::begin(c), std::end(c), dis(gen));
 
     // create subsequence large enough to always be split into multiple partitions
-    std::iota(std::begin(c), std::begin(c) + c.size()/16+1, 1);
-    std::size_t sub_size = c.size()/16 + 1;
+    std::iota(std::begin(c), std::begin(c) + c.size() / 16 + 1, 1);
+    std::size_t sub_size = c.size() / 16 + 1;
 
     std::vector<std::size_t> h(sub_size);
     std::iota(std::begin(h), std::end(h), 1);
 
-    iterator index = hpx::parallel::find_end(policy,
-        iterator(std::begin(c)), iterator(std::end(c)),
-        std::begin(h), std::end(h));
+    iterator index = hpx::parallel::find_end(policy, iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(h), std::end(h));
 
     base_iterator test_index = std::begin(c);
 
     HPX_TEST(index == iterator(test_index));
 }
 
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end3_proj(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    // fill vector with random values above 2
+    std::vector<std::size_t> c(10007);
+    std::fill(std::begin(c), std::end(c), dis(gen));
+
+    // create subsequence large enough to always be split into multiple partitions
+    std::iota(std::begin(c), std::begin(c) + c.size() / 16 + 1, 1);
+    std::size_t sub_size = c.size() / 16 + 1;
+
+    std::vector<std::size_t> h(sub_size);
+    std::iota(std::begin(h), std::end(h), 1+65536);
+
+    iterator index = hpx::parallel::find_end(policy, iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(h), std::end(h),
+        std::equal_to<std::size_t>(),
+        [](std::size_t x) { return x % 65536; });
+
+    base_iterator test_index = std::begin(c);
+
+    HPX_TEST(index == iterator(test_index));
+}
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end3_async(ExPolicy p, IteratorTag)
 {
@@ -234,8 +404,8 @@ void test_find_end3_async(ExPolicy p, IteratorTag)
     std::fill(std::begin(c), std::end(c), dist(gen));
 
     // create subsequence large enough to always be split into multiple partitions
-    std::iota(std::begin(c), std::begin(c) + c.size()/16+1, 1);
-    std::size_t sub_size = c.size()/16 + 1;
+    std::iota(std::begin(c), std::begin(c) + c.size() / 16 + 1, 1);
+    std::size_t sub_size = c.size() / 16 + 1;
 
     std::vector<std::size_t> h(sub_size);
     std::iota(std::begin(h), std::end(h), 1);
@@ -243,9 +413,8 @@ void test_find_end3_async(ExPolicy p, IteratorTag)
     // create only two partitions, splitting the desired sub sequence into
     // separate partitions.
     hpx::future<iterator> f =
-        hpx::parallel::find_end(p,
-            iterator(std::begin(c)), iterator(std::end(c)),
-            std::begin(h), std::end(h));
+        hpx::parallel::find_end(p, iterator(std::begin(c)),
+            iterator(std::end(c)), std::begin(h), std::end(h));
     f.wait();
 
     //create iterator at position of value to be found
@@ -254,6 +423,38 @@ void test_find_end3_async(ExPolicy p, IteratorTag)
     HPX_TEST(f.get() == iterator(test_index));
 }
 
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end3_async_proj(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    // fill vector with random values above 6
+    std::vector<std::size_t> c(10007);
+    std::fill(std::begin(c), std::end(c), dist(gen));
+
+    // create subsequence large enough to always be split into multiple partitions
+    std::iota(std::begin(c), std::begin(c) + c.size() / 16 + 1, 1);
+    std::size_t sub_size = c.size() / 16 + 1;
+
+    std::vector<std::size_t> h(sub_size);
+    std::iota(std::begin(h), std::end(h), 1+65536);
+
+    // create only two partitions, splitting the desired sub sequence into
+    // separate partitions.
+    hpx::future<iterator> f =
+        hpx::parallel::find_end(p, iterator(std::begin(c)),
+            iterator(std::end(c)), std::begin(h), std::end(h),
+            std::equal_to<std::size_t>(),
+            [](std::size_t x) { return x % 65536; });
+
+    f.wait();
+
+    //create iterator at position of value to be found
+    base_iterator test_index = std::begin(c);
+
+    HPX_TEST(f.get() == iterator(test_index));
+}
 template <typename IteratorTag>
 void test_find_end3()
 {
@@ -261,17 +462,31 @@ void test_find_end3()
     test_find_end3(execution::seq, IteratorTag());
     test_find_end3(execution::par, IteratorTag());
     test_find_end3(execution::par_unseq, IteratorTag());
+    test_find_end3_proj(execution::seq, IteratorTag());
+    test_find_end3_proj(execution::par, IteratorTag());
+    test_find_end3_proj(execution::par_unseq, IteratorTag());
 
     test_find_end3_async(execution::seq(execution::task), IteratorTag());
     test_find_end3_async(execution::par(execution::task), IteratorTag());
+    test_find_end3_async_proj(execution::seq(execution::task), IteratorTag());
+    test_find_end3_async_proj(execution::par(execution::task), IteratorTag());
 
 #if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_end3(execution_policy(execution::seq), IteratorTag());
     test_find_end3(execution_policy(execution::par), IteratorTag());
     test_find_end3(execution_policy(execution::par_unseq), IteratorTag());
+    test_find_end3_proj(execution_policy(execution::seq), IteratorTag());
+    test_find_end3_proj(execution_policy(execution::par), IteratorTag());
+    test_find_end3_proj(execution_policy(execution::par_unseq), IteratorTag());
 
-    test_find_end3(execution_policy(execution::seq(execution::task)), IteratorTag());
-    test_find_end3(execution_policy(execution::par(execution::task)), IteratorTag());
+    test_find_end3(
+        execution_policy(execution::seq(execution::task)), IteratorTag());
+    test_find_end3(
+        execution_policy(execution::par(execution::task)), IteratorTag());
+    test_find_end3_proj(
+        execution_policy(execution::seq(execution::task)), IteratorTag());
+    test_find_end3_proj(
+        execution_policy(execution::par(execution::task)), IteratorTag());
 #endif
 }
 
@@ -295,19 +510,45 @@ void test_find_end4(ExPolicy policy, IteratorTag)
     // fill vector with random values above 2
     std::fill(std::begin(c), std::end(c), dis(gen));
     // create subsequence in middle of vector
-    c[c.size()/2] = 1;
-    c[c.size()/2 + 1] = 2;
+    c[c.size() / 2] = 1;
+    c[c.size() / 2 + 1] = 2;
 
-    std::size_t h[] = { 1, 2 };
+    std::size_t h[] = {1, 2};
 
-    iterator index = hpx::parallel::find_end(policy,
-        iterator(std::begin(c)), iterator(std::end(c)),
-        std::begin(h), std::end(h),
-        [](std::size_t v1, std::size_t v2) {
-            return !(v1 != v2);
-        });
+    iterator index = hpx::parallel::find_end(policy, iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(h), std::end(h),
+        [](std::size_t v1, std::size_t v2) { return !(v1 != v2); });
 
-    base_iterator test_index = std::begin(c) + c.size()/2;
+    base_iterator test_index = std::begin(c) + c.size() / 2;
+
+    HPX_TEST(index == iterator(test_index));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end4_proj(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    // fill vector with random values above 2
+    std::fill(std::begin(c), std::end(c), dis(gen));
+    // create subsequence in middle of vector
+    c[c.size() / 2] = 1;
+    c[c.size() / 2 + 1] = 2;
+
+    std::size_t h[] = {1+65536, 2+65536};
+
+    iterator index = hpx::parallel::find_end(policy, iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(h), std::end(h),
+        [](std::size_t v1, std::size_t v2) { return !(v1 != v2); },
+        [](std::size_t x) { return x % 65536; });
+
+    base_iterator test_index = std::begin(c) + c.size() / 2;
 
     HPX_TEST(index == iterator(test_index));
 }
@@ -323,22 +564,49 @@ void test_find_end4_async(ExPolicy p, IteratorTag)
     std::fill(std::begin(c), std::end(c), dis(gen));
 
     // create subsequence in middle of vector
-    c[c.size()/2] = 1;
-    c[c.size()/2 + 1] = 2;
+    c[c.size() / 2] = 1;
+    c[c.size() / 2 + 1] = 2;
 
-    std::size_t h[] = { 1, 2 };
+    std::size_t h[] = {1, 2};
 
     hpx::future<iterator> f =
-        hpx::parallel::find_end(p,
-            iterator(std::begin(c)), iterator(std::end(c)),
-            std::begin(h), std::end(h),
-            [](std::size_t v1, std::size_t v2) {
-                return !(v1 != v2);
-        });
+        hpx::parallel::find_end(p, iterator(std::begin(c)),
+            iterator(std::end(c)), std::begin(h), std::end(h),
+            [](std::size_t v1, std::size_t v2) { return !(v1 != v2); });
     f.wait();
 
     //create iterator at position of value to be found
-    base_iterator test_index = std::begin(c) + c.size()/2;
+    base_iterator test_index = std::begin(c) + c.size() / 2;
+
+    HPX_TEST(f.get() == iterator(test_index));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end4_async_proj(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    // fill vector with random values above 2
+    std::vector<std::size_t> c(10007);
+    std::fill(std::begin(c), std::end(c), dis(gen));
+
+    // create subsequence in middle of vector
+    c[c.size() / 2] = 1;
+    c[c.size() / 2 + 1] = 2;
+
+    std::size_t h[] = {1+65536, 2+65536};
+
+    hpx::future<iterator> f =
+        hpx::parallel::find_end(p, iterator(std::begin(c)),
+            iterator(std::end(c)), std::begin(h), std::end(h),
+            [](std::size_t v1, std::size_t v2) { return !(v1 != v2); },
+        [](std::size_t v) { return v % 65536; });
+
+    f.wait();
+
+    //create iterator at position of value to be found
+    base_iterator test_index = std::begin(c) + c.size() / 2;
 
     HPX_TEST(f.get() == iterator(test_index));
 }
@@ -350,17 +618,31 @@ void test_find_end4()
     test_find_end4(execution::seq, IteratorTag());
     test_find_end4(execution::par, IteratorTag());
     test_find_end4(execution::par_unseq, IteratorTag());
+    test_find_end4_proj(execution::seq, IteratorTag());
+    test_find_end4_proj(execution::par, IteratorTag());
+    test_find_end4_proj(execution::par_unseq, IteratorTag());
 
     test_find_end4_async(execution::seq(execution::task), IteratorTag());
     test_find_end4_async(execution::par(execution::task), IteratorTag());
+    test_find_end4_async_proj(execution::seq(execution::task), IteratorTag());
+    test_find_end4_async_proj(execution::par(execution::task), IteratorTag());
 
 #if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_end4(execution_policy(execution::seq), IteratorTag());
     test_find_end4(execution_policy(execution::par), IteratorTag());
     test_find_end4(execution_policy(execution::par_unseq), IteratorTag());
+    test_find_end4_proj(execution_policy(execution::seq), IteratorTag());
+    test_find_end4_proj(execution_policy(execution::par), IteratorTag());
+    test_find_end4_proj(execution_policy(execution::par_unseq), IteratorTag());
 
-    test_find_end4(execution_policy(execution::seq(execution::task)), IteratorTag());
-    test_find_end4(execution_policy(execution::par(execution::task)), IteratorTag());
+    test_find_end4(
+        execution_policy(execution::seq(execution::task)), IteratorTag());
+    test_find_end4(
+        execution_policy(execution::par(execution::task)), IteratorTag());
+    test_find_end4_proj(
+        execution_policy(execution::seq(execution::task)), IteratorTag());
+    test_find_end4_proj(
+        execution_policy(execution::par(execution::task)), IteratorTag());
 #endif
 }
 
@@ -383,30 +665,31 @@ void test_find_end_exception(ExPolicy policy, IteratorTag)
         decorated_iterator;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
-    c[c.size()/2] = 1;
-    c[c.size()/2+1] = 2;
+    c[c.size() / 2] = 1;
+    c[c.size() / 2 + 1] = 2;
 
     std::vector<std::size_t> h;
     h.push_back(1);
     h.push_back(2);
 
     bool caught_exception = false;
-    try {
+    try
+    {
         hpx::parallel::find_end(policy,
             decorated_iterator(
-                std::begin(c),
-                [](){ throw std::runtime_error("test"); }),
+                std::begin(c), []() { throw std::runtime_error("test"); }),
             decorated_iterator(
-                std::end(c),
-                [](){ throw std::runtime_error("test"); }),
+                std::end(c), []() { throw std::runtime_error("test"); }),
             std::begin(h), std::end(h));
         HPX_TEST(false);
     }
-    catch(hpx::exception_list const& e) {
+    catch (hpx::exception_list const& e)
+    {
         caught_exception = true;
         test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
     }
-    catch(...) {
+    catch (...)
+    {
         HPX_TEST(false);
     }
 
@@ -422,33 +705,33 @@ void test_find_end_exception_async(ExPolicy p, IteratorTag)
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
-    c[c.size()/2] = 1;
-    c[c.size()/2+1] = 2;
+    c[c.size() / 2] = 1;
+    c[c.size() / 2 + 1] = 2;
 
-    std::size_t h[] = { 1, 2 };
+    std::size_t h[] = {1, 2};
 
     bool caught_exception = false;
     bool returned_from_algorithm = false;
-    try {
-        hpx::future<decorated_iterator> f =
-            hpx::parallel::find_end(p,
-                decorated_iterator(
-                    std::begin(c),
-                    [](){ throw std::runtime_error("test"); }),
-                decorated_iterator(
-                    std::end(c),
-                    [](){ throw std::runtime_error("test"); }),
+    try
+    {
+        hpx::future<decorated_iterator> f = hpx::parallel::find_end(p,
+            decorated_iterator(
+                std::begin(c), []() { throw std::runtime_error("test"); }),
+            decorated_iterator(
+                std::end(c), []() { throw std::runtime_error("test"); }),
             std::begin(h), std::end(h));
         returned_from_algorithm = true;
         f.get();
 
         HPX_TEST(false);
     }
-    catch(hpx::exception_list const& e) {
+    catch (hpx::exception_list const& e)
+    {
         caught_exception = true;
         test::test_num_exceptions<ExPolicy, IteratorTag>::call(p, e);
     }
-    catch(...) {
+    catch (...)
+    {
         HPX_TEST(false);
     }
 
@@ -467,16 +750,18 @@ void test_find_end_exception()
     test_find_end_exception(execution::seq, IteratorTag());
     test_find_end_exception(execution::par, IteratorTag());
 
-    test_find_end_exception_async(execution::seq(execution::task), IteratorTag());
-    test_find_end_exception_async(execution::par(execution::task), IteratorTag());
+    test_find_end_exception_async(
+        execution::seq(execution::task), IteratorTag());
+    test_find_end_exception_async(
+        execution::par(execution::task), IteratorTag());
 
 #if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_end_exception(execution_policy(execution::seq), IteratorTag());
 
-    test_find_end_exception(execution_policy(execution::seq(execution::task)),
-        IteratorTag());
-    test_find_end_exception(execution_policy(execution::par(execution::task)),
-        IteratorTag());
+    test_find_end_exception(
+        execution_policy(execution::seq(execution::task)), IteratorTag());
+    test_find_end_exception(
+        execution_policy(execution::par(execution::task)), IteratorTag());
 #endif
 }
 
@@ -500,26 +785,25 @@ void test_find_end_bad_alloc(ExPolicy policy, IteratorTag)
 
     std::vector<std::size_t> c(100007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
-    c[c.size()/2] = 0;
+    c[c.size() / 2] = 0;
 
-    std::size_t h[] = { 1, 2 };
+    std::size_t h[] = {1, 2};
 
     bool caught_bad_alloc = false;
-    try {
+    try
+    {
         hpx::parallel::find_end(policy,
-            decorated_iterator(
-                std::begin(c),
-                [](){ throw std::bad_alloc(); }),
-            decorated_iterator(
-                std::end(c),
-                [](){ throw std::bad_alloc(); }),
+            decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
+            decorated_iterator(std::end(c), []() { throw std::bad_alloc(); }),
             std::begin(h), std::end(h));
         HPX_TEST(false);
     }
-    catch(std::bad_alloc const&) {
+    catch (std::bad_alloc const&)
+    {
         caught_bad_alloc = true;
     }
-    catch(...) {
+    catch (...)
+    {
         HPX_TEST(false);
     }
 
@@ -535,31 +819,29 @@ void test_find_end_bad_alloc_async(ExPolicy p, IteratorTag)
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
-    c[c.size()/2] = 0;
+    c[c.size() / 2] = 0;
 
-    std::size_t h[] = { 1, 2 };
+    std::size_t h[] = {1, 2};
 
     bool caught_bad_alloc = false;
     bool returned_from_algorithm = false;
-    try {
-        hpx::future<decorated_iterator> f =
-            hpx::parallel::find_end(p,
-                decorated_iterator(
-                    std::begin(c),
-                    [](){ throw std::bad_alloc(); }),
-                decorated_iterator(
-                    std::end(c),
-                    [](){ throw std::bad_alloc(); }),
-                std::begin(h), std::end(h));
+    try
+    {
+        hpx::future<decorated_iterator> f = hpx::parallel::find_end(p,
+            decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
+            decorated_iterator(std::end(c), []() { throw std::bad_alloc(); }),
+            std::begin(h), std::end(h));
         returned_from_algorithm = true;
         f.get();
 
         HPX_TEST(false);
     }
-    catch(std::bad_alloc const&) {
+    catch (std::bad_alloc const&)
+    {
         caught_bad_alloc = true;
     }
-    catch(...) {
+    catch (...)
+    {
         HPX_TEST(false);
     }
 
@@ -578,17 +860,19 @@ void test_find_end_bad_alloc()
     test_find_end_bad_alloc(execution::seq, IteratorTag());
     test_find_end_bad_alloc(execution::par, IteratorTag());
 
-    test_find_end_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_find_end_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_find_end_bad_alloc_async(
+        execution::seq(execution::task), IteratorTag());
+    test_find_end_bad_alloc_async(
+        execution::par(execution::task), IteratorTag());
 
 #if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
     test_find_end_bad_alloc(execution_policy(execution::seq), IteratorTag());
     test_find_end_bad_alloc(execution_policy(execution::par), IteratorTag());
 
-    test_find_end_bad_alloc(execution_policy(execution::seq(execution::task)),
-        IteratorTag());
-    test_find_end_bad_alloc(execution_policy(execution::par(execution::task)),
-        IteratorTag());
+    test_find_end_bad_alloc(
+        execution_policy(execution::seq(execution::task)), IteratorTag());
+    test_find_end_bad_alloc(
+        execution_policy(execution::par(execution::task)), IteratorTag());
 #endif
 }
 
@@ -622,15 +906,11 @@ int main(int argc, char* argv[])
     options_description desc_commandline(
         "Usage: " HPX_APPLICATION_STRING " [options]");
 
-    desc_commandline.add_options()
-        ("seed,s", value<unsigned int>(),
-        "the random number generator seed to use for this run")
-        ;
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
 
     // By default this test should run on all available cores
-    std::vector<std::string> const cfg = {
-        "hpx.os_threads=all"
-    };
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
     HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,

--- a/tests/unit/parallel/algorithms/findfirstof.cpp
+++ b/tests/unit/parallel/algorithms/findfirstof.cpp
@@ -72,7 +72,8 @@ void test_find_first_of_proj(ExPolicy policy, IteratorTag)
         hpx::parallel::find_first_of(policy, iterator(std::begin(c)),
             iterator(std::end(c)), std::begin(h), std::end(h),
             std::equal_to<std::size_t>(),
-        [](std::size_t x){ return x % 65536;});
+        [](std::size_t x){ return x % 65536;},
+        [](std::size_t x) { return x % 65536; });
 
     base_iterator test_index = std::begin(c) + find_first_of_pos;
 
@@ -122,7 +123,8 @@ void test_find_first_of_async_proj(ExPolicy p, IteratorTag)
         hpx::parallel::find_first_of(p, iterator(std::begin(c)),
             iterator(std::end(c)), std::begin(h), std::end(h),
             std::equal_to<std::size_t>(),
-        [](std::size_t x){ return x % 65536;});
+        [](std::size_t x){ return x % 65536;},
+        [](std::size_t x) { return x % 65536; });
     f.wait();
 
     // create iterator at position of value to be found

--- a/tests/unit/parallel/container_algorithms/CMakeLists.txt
+++ b/tests/unit/parallel/container_algorithms/CMakeLists.txt
@@ -10,6 +10,8 @@ set(tests
     copyif_range
     count_range
     countif_range
+    find_end_range
+    find_first_of_range
     foreach_range
     foreach_range_projection
     generate_range

--- a/tests/unit/parallel/container_algorithms/find_end_range.cpp
+++ b/tests/unit/parallel/container_algorithms/find_end_range.cpp
@@ -1,0 +1,653 @@
+//  Copyright (c) 2014 Grant Mercer
+//                2018 Bruno Pitrus
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/parallel_find.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstddef>
+#include <functional>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+unsigned int seed = std::random_device{}();
+std::mt19937 gen(seed);
+std::uniform_int_distribution<> dis(3, 102);
+std::uniform_int_distribution<> dist(7, 106);
+
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end1(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+
+    std::vector<std::size_t> c(10007);
+    // fill vector with random values above 2
+    std::fill(std::begin(c), std::end(c), dis(gen));
+    // create subsequence in middle of vector
+    c[c.size() / 2] = 1;
+    c[c.size() / 2 + 1] = 2;
+
+    std::size_t h[] = {1, 2};
+
+    base_iterator index = hpx::parallel::find_end(policy, c, h);
+
+    base_iterator test_index = std::begin(c) + c.size() / 2;
+
+    HPX_TEST(index == test_index);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end1_proj(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+
+    std::vector<std::size_t> c(10007);
+    // fill vector with random values above 2
+    std::fill(std::begin(c), std::end(c), dis(gen));
+    // create subsequence in middle of vector
+    c[c.size() / 2] = 1 + 65536;
+    c[c.size() / 2 + 1] = 2 + 65536;
+
+    std::size_t h[] = {1, 2};
+
+    base_iterator index = hpx::parallel::find_end(policy, c, h,
+        std::equal_to<std::size_t>(), [](std::size_t x) { return x % 65536; });
+
+    base_iterator test_index = std::begin(c) + c.size() / 2;
+
+    HPX_TEST(index == test_index);
+}
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end1_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+
+    std::vector<std::size_t> c(10007);
+    // fill vector with random values above 2
+    std::fill(std::begin(c), std::end(c), dis(gen));
+    // create subsequence in middle of vector
+    c[c.size() / 2] = 1;
+    c[c.size() / 2 + 1] = 2;
+
+    std::size_t h[] = {1, 2};
+
+    hpx::future<base_iterator> f =
+        hpx::parallel::find_end(p, c, h);
+    f.wait();
+
+    // create iterator at position of value to be found
+    base_iterator test_index = std::begin(c) + c.size() / 2;
+
+    HPX_TEST(f.get() == test_index);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end1_async_proj(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+
+    std::vector<std::size_t> c(10007);
+    // fill vector with random values above 2
+    std::fill(std::begin(c), std::end(c), dis(gen));
+    // create subsequence in middle of vector
+    c[c.size() / 2] = 1 + 65536;
+    c[c.size() / 2 + 1] = 2 + 65536;
+
+    std::size_t h[] = {1, 2};
+
+    hpx::future<base_iterator> f = hpx::parallel::find_end(p,
+       c, h, std::equal_to<std::size_t>(),
+        [](std::size_t x) { return x % 65536; });
+    f.wait();
+
+    // create iterator at position of value to be found
+    base_iterator test_index = std::begin(c) + c.size() / 2;
+
+    HPX_TEST(f.get() == test_index);
+}
+template <typename IteratorTag>
+void test_find_end1()
+{
+    using namespace hpx::parallel;
+    test_find_end1(execution::seq, IteratorTag());
+    test_find_end1(execution::par, IteratorTag());
+    test_find_end1(execution::par_unseq, IteratorTag());
+    test_find_end1_proj(execution::seq, IteratorTag());
+    test_find_end1_proj(execution::par, IteratorTag());
+    test_find_end1_proj(execution::par_unseq, IteratorTag());
+
+    test_find_end1_async(execution::seq(execution::task), IteratorTag());
+    test_find_end1_async(execution::par(execution::task), IteratorTag());
+    test_find_end1_async_proj(execution::seq(execution::task), IteratorTag());
+    test_find_end1_async_proj(execution::par(execution::task), IteratorTag());
+
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
+    test_find_end1(execution_policy(execution::seq), IteratorTag());
+    test_find_end1(execution_policy(execution::par), IteratorTag());
+    test_find_end1(execution_policy(execution::par_unseq), IteratorTag());
+    test_find_end1_proj(execution_policy(execution::seq), IteratorTag());
+    test_find_end1_proj(execution_policy(execution::par), IteratorTag());
+    test_find_end1_proj(execution_policy(execution::par_unseq), IteratorTag());
+
+    test_find_end1(
+        execution_policy(execution::seq(execution::task)), IteratorTag());
+    test_find_end1(
+        execution_policy(execution::par(execution::task)), IteratorTag());
+    test_find_end1_proj(
+        execution_policy(execution::seq(execution::task)), IteratorTag());
+    test_find_end1_proj(
+        execution_policy(execution::par(execution::task)), IteratorTag());
+#endif
+}
+
+void find_end_test1()
+{
+    test_find_end1<std::random_access_iterator_tag>();
+    test_find_end1<std::forward_iterator_tag>();
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end2(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+
+    std::vector<std::size_t> c(10007);
+    // fill vector with random values about 2
+    std::fill(std::begin(c), std::end(c), dis(gen));
+    // create subsequence at start and end
+    c[0] = 1;
+    c[1] = 2;
+    c[c.size() - 1] = 2;
+    c[c.size() - 2] = 1;
+
+    std::size_t h[] = {1, 2};
+
+    base_iterator index = hpx::parallel::find_end(policy, c, h);
+
+    base_iterator test_index = std::begin(c) + c.size() - 2;
+
+    HPX_TEST(index == test_index);
+}
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end2_proj(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+
+    std::vector<std::size_t> c(10007);
+    // fill vector with random values about 2
+    std::fill(std::begin(c), std::end(c), dis(gen));
+    // create subsequence at start and end
+    c[0] = 1;
+    c[1] = 2;
+    c[c.size() - 1] = 2;
+    c[c.size() - 2] = 1;
+
+    std::size_t h[] = {1 + 65536, 2 + 65536};
+
+    base_iterator index = hpx::parallel::find_end(policy,c, h,
+        std::equal_to<std::size_t>(), [](std::size_t x) { return x % 65536; });
+
+    base_iterator test_index = std::begin(c) + c.size() - 2;
+
+    HPX_TEST(index == test_index);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end2_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+
+    // fill vector with random values above 2
+    std::vector<std::size_t> c(10007);
+    std::fill(std::begin(c), std::end(c), dis(gen));
+
+    // create subsequence at start and end
+    c[0] = 1;
+    c[1] = 2;
+    c[c.size() - 1] = 2;
+    c[c.size() - 2] = 1;
+
+    std::size_t h[] = {1, 2};
+
+    hpx::future<base_iterator> f =
+        hpx::parallel::find_end(p,c, h);
+    f.wait();
+
+    // create iterator at position of value to be found
+    base_iterator test_index = std::begin(c) + c.size() - 2;
+
+    HPX_TEST(f.get() == test_index);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end2_async_proj(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+
+    // fill vector with random values above 2
+    std::vector<std::size_t> c(10007);
+    std::fill(std::begin(c), std::end(c), dis(gen));
+
+    // create subsequence at start and end
+    c[0] = 1;
+    c[1] = 2;
+    c[c.size() - 1] = 2;
+    c[c.size() - 2] = 1;
+
+    std::size_t h[] = {1 + 65536, 2 + 65536};
+
+    hpx::future<base_iterator> f = hpx::parallel::find_end(p,
+       c, h, std::equal_to<std::size_t>(),
+        [](std::size_t x) { return x % 65536; });
+
+    f.wait();
+
+    // create iterator at position of value to be found
+    base_iterator test_index = std::begin(c) + c.size() - 2;
+
+    HPX_TEST(f.get() == test_index);
+}
+
+template <typename IteratorTag>
+void test_find_end2()
+{
+    using namespace hpx::parallel;
+    test_find_end2(execution::seq, IteratorTag());
+    test_find_end2(execution::par, IteratorTag());
+    test_find_end2(execution::par_unseq, IteratorTag());
+    test_find_end2_proj(execution::seq, IteratorTag());
+    test_find_end2_proj(execution::par, IteratorTag());
+    test_find_end2_proj(execution::par_unseq, IteratorTag());
+
+    test_find_end2_async(execution::seq(execution::task), IteratorTag());
+    test_find_end2_async(execution::par(execution::task), IteratorTag());
+    test_find_end2_async_proj(execution::seq(execution::task), IteratorTag());
+    test_find_end2_async_proj(execution::par(execution::task), IteratorTag());
+
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
+    test_find_end2(execution_policy(execution::seq), IteratorTag());
+    test_find_end2(execution_policy(execution::par), IteratorTag());
+    test_find_end2(execution_policy(execution::par_unseq), IteratorTag());
+    test_find_end2_proj(execution_policy(execution::seq), IteratorTag());
+    test_find_end2_proj(execution_policy(execution::par), IteratorTag());
+    test_find_end2_proj(execution_policy(execution::par_unseq), IteratorTag());
+
+    test_find_end2(
+        execution_policy(execution::seq(execution::task)), IteratorTag());
+    test_find_end2(
+        execution_policy(execution::par(execution::task)), IteratorTag());
+    test_find_end2_proj(
+        execution_policy(execution::seq(execution::task)), IteratorTag());
+    test_find_end2_proj(
+        execution_policy(execution::par(execution::task)), IteratorTag());
+#endif
+}
+
+void find_end_test2()
+{
+    test_find_end2<std::random_access_iterator_tag>();
+    test_find_end2<std::forward_iterator_tag>();
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end3(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+
+    // fill vector with random values above 2
+    std::vector<std::size_t> c(10007);
+    std::fill(std::begin(c), std::end(c), dis(gen));
+
+    // create subsequence large enough to always be split into multiple partitions
+    std::iota(std::begin(c), std::begin(c) + c.size() / 16 + 1, 1);
+    std::size_t sub_size = c.size() / 16 + 1;
+
+    std::vector<std::size_t> h(sub_size);
+    std::iota(std::begin(h), std::end(h), 1);
+
+    base_iterator index = hpx::parallel::find_end(policy, c, h);
+
+    base_iterator test_index = std::begin(c);
+
+    HPX_TEST(index == test_index);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end3_proj(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+
+    // fill vector with random values above 2
+    std::vector<std::size_t> c(10007);
+    std::fill(std::begin(c), std::end(c), dis(gen));
+
+    // create subsequence large enough to always be split into multiple partitions
+    std::iota(std::begin(c), std::begin(c) + c.size() / 16 + 1, 1);
+    std::size_t sub_size = c.size() / 16 + 1;
+
+    std::vector<std::size_t> h(sub_size);
+    std::iota(std::begin(h), std::end(h), 1 + 65536);
+
+    base_iterator index = hpx::parallel::find_end(policy,c, h,
+        std::equal_to<std::size_t>(), [](std::size_t x) { return x % 65536; });
+
+    base_iterator test_index = std::begin(c);
+
+    HPX_TEST(index == test_index);
+}
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end3_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+
+    // fill vector with random values above 6
+    std::vector<std::size_t> c(10007);
+    std::fill(std::begin(c), std::end(c), dist(gen));
+
+    // create subsequence large enough to always be split into multiple partitions
+    std::iota(std::begin(c), std::begin(c) + c.size() / 16 + 1, 1);
+    std::size_t sub_size = c.size() / 16 + 1;
+
+    std::vector<std::size_t> h(sub_size);
+    std::iota(std::begin(h), std::end(h), 1);
+
+    // create only two partitions, splitting the desired sub sequence into
+    // separate partitions.
+    hpx::future<base_iterator> f =
+        hpx::parallel::find_end(p, c,h);
+    f.wait();
+
+    //create iterator at position of value to be found
+    base_iterator test_index = std::begin(c);
+
+    HPX_TEST(f.get() == test_index);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end3_async_proj(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+
+    // fill vector with random values above 6
+    std::vector<std::size_t> c(10007);
+    std::fill(std::begin(c), std::end(c), dist(gen));
+
+    // create subsequence large enough to always be split into multiple partitions
+    std::iota(std::begin(c), std::begin(c) + c.size() / 16 + 1, 1);
+    std::size_t sub_size = c.size() / 16 + 1;
+
+    std::vector<std::size_t> h(sub_size);
+    std::iota(std::begin(h), std::end(h), 1 + 65536);
+
+    // create only two partitions, splitting the desired sub sequence into
+    // separate partitions.
+    hpx::future<base_iterator> f = hpx::parallel::find_end(p,
+       c ,h, std::equal_to<std::size_t>(),
+        [](std::size_t x) { return x % 65536; });
+
+    f.wait();
+
+    //create iterator at position of value to be found
+    base_iterator test_index = std::begin(c);
+
+    HPX_TEST(f.get() == test_index);
+}
+template <typename IteratorTag>
+void test_find_end3()
+{
+    using namespace hpx::parallel;
+    test_find_end3(execution::seq, IteratorTag());
+    test_find_end3(execution::par, IteratorTag());
+    test_find_end3(execution::par_unseq, IteratorTag());
+    test_find_end3_proj(execution::seq, IteratorTag());
+    test_find_end3_proj(execution::par, IteratorTag());
+    test_find_end3_proj(execution::par_unseq, IteratorTag());
+
+    test_find_end3_async(execution::seq(execution::task), IteratorTag());
+    test_find_end3_async(execution::par(execution::task), IteratorTag());
+    test_find_end3_async_proj(execution::seq(execution::task), IteratorTag());
+    test_find_end3_async_proj(execution::par(execution::task), IteratorTag());
+
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
+    test_find_end3(execution_policy(execution::seq), IteratorTag());
+    test_find_end3(execution_policy(execution::par), IteratorTag());
+    test_find_end3(execution_policy(execution::par_unseq), IteratorTag());
+    test_find_end3_proj(execution_policy(execution::seq), IteratorTag());
+    test_find_end3_proj(execution_policy(execution::par), IteratorTag());
+    test_find_end3_proj(execution_policy(execution::par_unseq), IteratorTag());
+
+    test_find_end3(
+        execution_policy(execution::seq(execution::task)), IteratorTag());
+    test_find_end3(
+        execution_policy(execution::par(execution::task)), IteratorTag());
+    test_find_end3_proj(
+        execution_policy(execution::seq(execution::task)), IteratorTag());
+    test_find_end3_proj(
+        execution_policy(execution::par(execution::task)), IteratorTag());
+#endif
+}
+
+void find_end_test3()
+{
+    test_find_end3<std::random_access_iterator_tag>();
+    test_find_end3<std::forward_iterator_tag>();
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end4(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+
+    std::vector<std::size_t> c(10007);
+    // fill vector with random values above 2
+    std::fill(std::begin(c), std::end(c), dis(gen));
+    // create subsequence in middle of vector
+    c[c.size() / 2] = 1;
+    c[c.size() / 2 + 1] = 2;
+
+    std::size_t h[] = {1, 2};
+
+    base_iterator index = hpx::parallel::find_end(policy, c, h,
+        [](std::size_t v1, std::size_t v2) { return !(v1 != v2); });
+
+    base_iterator test_index = std::begin(c) + c.size() / 2;
+
+    HPX_TEST(index == test_index);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end4_proj(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+
+    std::vector<std::size_t> c(10007);
+    // fill vector with random values above 2
+    std::fill(std::begin(c), std::end(c), dis(gen));
+    // create subsequence in middle of vector
+    c[c.size() / 2] = 1;
+    c[c.size() / 2 + 1] = 2;
+
+    std::size_t h[] = {1 + 65536, 2 + 65536};
+
+    base_iterator index = hpx::parallel::find_end(policy, c, h,
+        [](std::size_t v1, std::size_t v2) { return !(v1 != v2); },
+        [](std::size_t x) { return x % 65536; });
+
+    base_iterator test_index = std::begin(c) + c.size() / 2;
+
+    HPX_TEST(index == test_index);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end4_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+
+    // fill vector with random values above 2
+    std::vector<std::size_t> c(10007);
+    std::fill(std::begin(c), std::end(c), dis(gen));
+
+    // create subsequence in middle of vector
+    c[c.size() / 2] = 1;
+    c[c.size() / 2 + 1] = 2;
+
+    std::size_t h[] = {1, 2};
+
+    hpx::future<base_iterator> f =
+        hpx::parallel::find_end(p, c, h,
+            [](std::size_t v1, std::size_t v2) { return !(v1 != v2); });
+    f.wait();
+
+    //create iterator at position of value to be found
+    base_iterator test_index = std::begin(c) + c.size() / 2;
+
+    HPX_TEST(f.get() == test_index);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_find_end4_async_proj(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+
+    // fill vector with random values above 2
+    std::vector<std::size_t> c(10007);
+    std::fill(std::begin(c), std::end(c), dis(gen));
+
+    // create subsequence in middle of vector
+    c[c.size() / 2] = 1;
+    c[c.size() / 2 + 1] = 2;
+
+    std::size_t h[] = {1 + 65536, 2 + 65536};
+
+    hpx::future<base_iterator> f = hpx::parallel::find_end(p,
+       c, h, [](std::size_t v1, std::size_t v2) { return !(v1 != v2); },
+        [](std::size_t v) { return v % 65536; });
+
+    f.wait();
+
+    //create iterator at position of value to be found
+    base_iterator test_index = std::begin(c) + c.size() / 2;
+
+    HPX_TEST(f.get() == test_index);
+}
+
+template <typename IteratorTag>
+void test_find_end4()
+{
+    using namespace hpx::parallel;
+    test_find_end4(execution::seq, IteratorTag());
+    test_find_end4(execution::par, IteratorTag());
+    test_find_end4(execution::par_unseq, IteratorTag());
+    test_find_end4_proj(execution::seq, IteratorTag());
+    test_find_end4_proj(execution::par, IteratorTag());
+    test_find_end4_proj(execution::par_unseq, IteratorTag());
+
+    test_find_end4_async(execution::seq(execution::task), IteratorTag());
+    test_find_end4_async(execution::par(execution::task), IteratorTag());
+    test_find_end4_async_proj(execution::seq(execution::task), IteratorTag());
+    test_find_end4_async_proj(execution::par(execution::task), IteratorTag());
+
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
+    test_find_end4(execution_policy(execution::seq), IteratorTag());
+    test_find_end4(execution_policy(execution::par), IteratorTag());
+    test_find_end4(execution_policy(execution::par_unseq), IteratorTag());
+    test_find_end4_proj(execution_policy(execution::seq), IteratorTag());
+    test_find_end4_proj(execution_policy(execution::par), IteratorTag());
+    test_find_end4_proj(execution_policy(execution::par_unseq), IteratorTag());
+
+    test_find_end4(
+        execution_policy(execution::seq(execution::task)), IteratorTag());
+    test_find_end4(
+        execution_policy(execution::par(execution::task)), IteratorTag());
+    test_find_end4_proj(
+        execution_policy(execution::seq(execution::task)), IteratorTag());
+    test_find_end4_proj(
+        execution_policy(execution::par(execution::task)), IteratorTag());
+#endif
+}
+
+void find_end_test4()
+{
+    test_find_end4<std::random_access_iterator_tag>();
+    test_find_end4<std::forward_iterator_tag>();
+}
+
+
+//////////////////////////////////////////////////////////////////////////////
+
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    gen.seed(seed);
+
+    find_end_test1();
+    find_end_test2();
+    find_end_test3();
+    find_end_test4();
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace boost::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/parallel/container_algorithms/find_first_of_range.cpp
+++ b/tests/unit/parallel/container_algorithms/find_first_of_range.cpp
@@ -1,0 +1,203 @@
+//  copyright (c) 2014 Grant Mercer
+//                2018 Bruno Pitrus
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/hpx.hpp>
+#include <hpx/include/parallel_find.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+unsigned int seed = std::random_device{}();
+std::mt19937 gen(seed);
+std::uniform_int_distribution<> dis(0,10006);
+std::uniform_int_distribution<> dist(0,2);
+
+template <typename ExPolicy, typename IteratorTag>
+void test_find_first_of(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+
+    int find_first_of_pos = dis(gen);
+    int random_sub_seq_pos = dist(gen);
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen() + 19);
+    std::size_t h[] = {1, 7, 18, 3};
+    c[find_first_of_pos] = h[random_sub_seq_pos]; //-V108
+
+    base_iterator index = hpx::parallel::find_first_of(policy, c, h);
+
+    base_iterator test_index = std::begin(c) + find_first_of_pos;
+
+    HPX_TEST(index == test_index);
+}
+template <typename ExPolicy, typename IteratorTag>
+void test_find_first_of_proj(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+
+    int find_first_of_pos = dis(gen);
+    int random_sub_seq_pos = dist(gen);
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), (gen() % 32768) + 19);
+    std::size_t h[] = {1+65536, 7+65536, 18+65536, 3+65536};
+    c[find_first_of_pos] = h[random_sub_seq_pos];    //-V108
+
+    base_iterator index =
+        hpx::parallel::find_first_of(policy, c, h,
+            std::equal_to<std::size_t>(),
+        [](std::size_t x){ return x % 65536;},
+        [](std::size_t x) { return x % 65536; });
+
+    base_iterator test_index = std::begin(c) + find_first_of_pos;
+
+    HPX_TEST(index == test_index);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_find_first_of_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+
+    int find_first_of_pos = dis(gen);
+    int random_sub_seq_pos = dist(gen);
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen() + 19);
+    std::size_t h[] = {1, 7, 18, 3};
+    c[find_first_of_pos] = h[random_sub_seq_pos]; //-V108
+
+    hpx::future<base_iterator> f = hpx::parallel::find_first_of(p, c, h);
+    f.wait();
+
+    // create iterator at position of value to be found
+    base_iterator test_index = std::begin(c) + find_first_of_pos;
+
+    HPX_TEST(f.get() == test_index);
+}
+template <typename ExPolicy, typename IteratorTag>
+void test_find_first_of_async_proj(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+
+    int find_first_of_pos = dis(gen);
+    int random_sub_seq_pos = dist(gen);
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c),( gen() % 32768)  + 19);
+    std::size_t h[] = {1+65536, 7+65536, 18+65536, 3+65536};
+    c[find_first_of_pos] = h[random_sub_seq_pos];    //-V108
+
+    hpx::future<base_iterator> f =
+        hpx::parallel::find_first_of(p, c,h,
+            std::equal_to<std::size_t>(),
+        [](std::size_t x){ return x % 65536;},
+        [](std::size_t x) { return x % 65536; });
+    f.wait();
+
+    // create iterator at position of value to be found
+    base_iterator test_index = std::begin(c) + find_first_of_pos;
+
+    HPX_TEST(f.get() == test_index);
+}
+
+template <typename IteratorTag>
+void test_find_first_of()
+{
+    using namespace hpx::parallel;
+    test_find_first_of(execution::seq, IteratorTag());
+    test_find_first_of(execution::par, IteratorTag());
+    test_find_first_of(execution::par_unseq, IteratorTag());
+    test_find_first_of_proj(execution::seq, IteratorTag());
+    test_find_first_of_proj(execution::par, IteratorTag());
+    test_find_first_of_proj(execution::par_unseq, IteratorTag());
+
+    test_find_first_of_async(execution::seq(execution::task), IteratorTag());
+    test_find_first_of_async(execution::par(execution::task), IteratorTag());
+    test_find_first_of_async_proj(execution::seq(execution::task), IteratorTag());
+    test_find_first_of_async_proj(execution::par(execution::task), IteratorTag());
+
+#if defined(HPX_HAVE_GENERIC_EXECUTION_POLICY)
+    test_find_first_of(execution_policy(execution::seq), IteratorTag());
+    test_find_first_of(execution_policy(execution::par), IteratorTag());
+    test_find_first_of(execution_policy(execution::par_unseq), IteratorTag());
+    test_find_first_of_proj(execution_policy(execution::seq), IteratorTag());
+    test_find_first_of_proj(execution_policy(execution::par), IteratorTag());
+    test_find_first_of_proj(execution_policy(execution::par_unseq), IteratorTag());
+
+    test_find_first_of(execution_policy(execution::seq(execution::task)), IteratorTag());
+    test_find_first_of(execution_policy(execution::par(execution::task)), IteratorTag());
+    test_find_first_of_proj(
+        execution_policy(execution::seq(execution::task)), IteratorTag());
+    test_find_first_of_proj(
+        execution_policy(execution::par(execution::task)), IteratorTag());
+#endif
+}
+
+void find_first_of_test()
+{
+    test_find_first_of<std::random_access_iterator_tag>();
+    test_find_first_of<std::forward_iterator_tag>();
+#if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
+    test_find_first_of<std::input_iterator_tag>();
+#endif
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    gen.seed(seed);
+
+    find_first_of_test();
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace boost::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()
+        ("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run")
+        ;
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {
+        "hpx.os_threads=all"
+    };
+
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
This started as an attempt to make find_* Ranges TS compliant (see #1668). But during testing, i discovered and fixed a bad bug in find_end making it unusable with custom comparison operator.
Because of this bug, i am making this pull request now, before writing a container version of the above algorithms. The regular versions are already usable as given in this pull request.