### PR TITLE
Use correct MPI CXX libraries for MPI parcelport

### DIFF
--- a/plugins/parcelport/CMakeLists.txt
+++ b/plugins/parcelport/CMakeLists.txt
@@ -64,6 +64,10 @@ macro(add_parcelport name)
       ${HPX_STATIC_PARCELPORT_PLUGINS_SOURCES}
       CACHE INTERNAL "" FORCE)
 
+    set_source_files_properties(${${name}_SOURCES}
+      PROPERTIES COMPILE_FLAGS
+      "${${name}_COMPILE_FLAGS}")
+
     hpx_libraries(${${name}_DEPENDENCIES})
 
   else()

--- a/plugins/parcelport/mpi/CMakeLists.txt
+++ b/plugins/parcelport/mpi/CMakeLists.txt
@@ -41,6 +41,8 @@ if(HPX_WITH_PARCELPORT_MPI)
   endif()
 
   macro(add_parcelport_mpi_module)
+    # find MPI again to re-populate variables in this context
+    find_package(MPI)
     hpx_debug("add_parcelport_mpi_module")
     if(MPI_CXX_INCLUDE_PATH)
       include_directories(${MPI_CXX_INCLUDE_PATH})
@@ -78,6 +80,8 @@ if(HPX_WITH_PARCELPORT_MPI)
         "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/mpi/sender.hpp"
         "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/mpi/sender_connection.hpp"
         "${PROJECT_SOURCE_DIR}/hpx/plugins/parcelport/mpi/tag_provider.hpp"
+      COMPILE_FLAGS
+        ${MPI_CXX_COMPILE_FLAGS}
       DEPENDENCIES
         ${_mpi_libraries}
       FOLDER "Core/Plugins/Parcelport/MPI")


### PR DESCRIPTION
## Proposed Changes

  - Use MPI_CXX_LIB_NAMES instead of MPI_C_LIB_NAMES to identify MPI parcelport link libraries

## Any background context you want to provide?

- This fixes compilation with HPX_WITH_PARCELPORT_MPI=ON on stock Ubuntu 18.04 (OpenMPI 2.1.1 and CMake 3.10.2).