### PR TITLE
Only enable service pool config options if pools are enabled

### DIFF
--- a/src/util/runtime_configuration.cpp
+++ b/src/util/runtime_configuration.cpp
@@ -237,12 +237,18 @@ namespace hpx { namespace util
 #endif
 
             "[hpx.threadpools]",
+#if defined(HPX_HAVE_IO_POOL)
             "io_pool_size = ${HPX_NUM_IO_POOL_SIZE:"
                 HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_NUM_IO_POOL_SIZE)) "}",
+#endif
+#if defined(HPX_HAVE_NETWORKING)
             "parcel_pool_size = ${HPX_NUM_PARCEL_POOL_SIZE:"
                 HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_NUM_PARCEL_POOL_SIZE)) "}",
+#endif
+#if defined(HPX_HAVE_TIMER_POOL)
             "timer_pool_size = ${HPX_NUM_TIMER_POOL_SIZE:"
                 HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_NUM_TIMER_POOL_SIZE)) "}",
+#endif
 
             "[hpx.thread_queue]",
             "min_tasks_to_steal_pending = "


### PR DESCRIPTION
Fixes `start_stop_callbacks` test when service pools are disabled (e.g. `HPX_HAVE_NETWORKING=OFF`).