### PR TITLE
Fix some thread suspension timeouts

### DIFF
--- a/hpx/runtime/threads/detail/scheduled_thread_pool.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool.hpp
@@ -156,7 +156,7 @@ namespace hpx { namespace threads { namespace detail
 
         std::size_t get_os_thread_count() const
         {
-            return threads_.size();
+            return thread_count_;
         }
 
         std::size_t get_active_os_thread_count() const

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -569,6 +569,11 @@ namespace hpx { namespace threads { namespace policies
                     return false;
             }
 
+            if (!running)
+            {
+                return false;
+            }
+
             for (std::size_t idx: victim_threads_[num_thread])
             {
                 HPX_ASSERT(idx != num_thread);

--- a/hpx/runtime/threads/policies/local_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_queue_scheduler.hpp
@@ -358,6 +358,11 @@ namespace hpx { namespace threads { namespace policies
                     return false;
             }
 
+            if (!running)
+            {
+                return false;
+            }
+
             if (numa_sensitive_ != 0)
             {
                 auto const& rp = resource::get_partitioner();

--- a/hpx/runtime/threads/policies/scheduler_base.hpp
+++ b/hpx/runtime/threads/policies/scheduler_base.hpp
@@ -216,35 +216,64 @@ namespace hpx { namespace threads { namespace policies
 
                 if (!allow_fallback)
                 {
-                    // Try indefinitely if fallback is not allowed
-                    hpx::util::yield_while([this, states_size, &l, &num_thread]()
+                    // Try indefinitely as long as at least one thread is
+                    // available for scheduling. Increase allowed state if no
+                    // threads are available for scheduling.
+                    auto max_allowed_state = state_suspended;
+
+                    hpx::util::yield_while([this, states_size, &l, &num_thread,
+                                               &max_allowed_state]() {
+                        int num_allowed_threads = 0;
+
+                        for (std::size_t offset = 0; offset < states_size;
+                             ++offset)
                         {
-                            for (std::size_t offset = 0; offset < states_size;
-                                ++offset)
+                            std::size_t num_thread_local =
+                                (num_thread + offset) % states_size;
+
+                            l = std::unique_lock<pu_mutex_type>(
+                                pu_mtxs_[num_thread_local], std::try_to_lock);
+
+                            if (l.owns_lock())
                             {
-                                std::size_t num_thread_local =
-                                    (num_thread + offset) % states_size;
-
-                                l = std::unique_lock<pu_mutex_type>(
-                                    pu_mtxs_[num_thread_local],
-                                    std::try_to_lock);
-
-                                if (l.owns_lock())
+                                if (states_[num_thread_local] <=
+                                    max_allowed_state)
                                 {
-                                    if (states_[num_thread_local] <=
-                                        state_suspended)
-                                    {
-                                        num_thread = num_thread_local;
-                                        return false;
-                                    }
-
-                                    l.unlock();
+                                    num_thread = num_thread_local;
+                                    return false;
                                 }
+
+                                l.unlock();
                             }
 
-                            // Yield after trying all pus, then try again
-                            return true;
-                        });
+                            if (states_[num_thread_local] <= max_allowed_state)
+                            {
+                                ++num_allowed_threads;
+                            }
+                        }
+
+                        if (0 == num_allowed_threads)
+                        {
+                            if (max_allowed_state <= state_suspended)
+                            {
+                                max_allowed_state = state_sleeping;
+                            }
+                            else if (max_allowed_state <= state_sleeping)
+                            {
+                                max_allowed_state = state_stopping;
+                            }
+                            else
+                            {
+                                // All threads are terminating or stopped.
+                                // Just return num_thread to avoid infinite
+                                // loop.
+                                return false;
+                            }
+                        }
+
+                        // Yield after trying all pus, then try again
+                        return true;
+                    });
 
                     return num_thread;
                 }

--- a/hpx/runtime/threads/policies/scheduler_base.hpp
+++ b/hpx/runtime/threads/policies/scheduler_base.hpp
@@ -286,7 +286,21 @@ namespace hpx { namespace threads { namespace policies
         {
             typedef std::atomic<hpx::state> state_type;
             for (state_type& state : states_)
+            {
                 state.store(s);
+            }
+        }
+
+        void set_all_states_at_least(hpx::state s)
+        {
+            typedef std::atomic<hpx::state> state_type;
+            for (state_type& state : states_)
+            {
+                if (state < s)
+                {
+                    state.store(s);
+                }
+            }
         }
 
         // return whether all states are at least at the given one


### PR DESCRIPTION
Adds an early return to `get_next_thread` in `local_(priority_)queue_scheduler` when
suspending worker thread (i.e. when not running).

The old behavior was to still try to steal pending threads from other worker threads. The current behavior is similar to `wait_or_add_new`, which already had an early return to not steal staged threads
when suspending. This should fix worker thread suspension cases where the HPX thread trying to suspend a worker thread would get scheduled on another thread (correctly) but then be stolen back immediately by the worker thread being suspended before another worker thread has the chance to run it. This should probably have been there all along.

Quick testing showed an immediate improvement but I'll keep this WIP until I've soak tested it a bit longer (and I'm sure it doesn't break other tests again).

Found a few more problems, most of them related to termination on an error:

- `scheduler_base::select_active_pu` could get stuck in an infinite loop if all threads have stopped (e.g. because of an error), now it falls back to less strict checks for the thread state if no thread has a suitable state.
- `scheduled_thread_pool::stop_locked/remove_processing_unit_internal` used to set the thread state to `state_stopping` even if an error occurred. The worker thread would then not stop from `state_stopping` if there are suspended threads left and nothing to schedule the suspended threads.

- (unrelated) `scheduled_thread_pool::get_os_thread_count` calls `threads_.size()` without a lock which can happen at the same time as a `threads_.resize()` (with a lock). I can't confirm that this actually is a problem, but it smells like the problem of very rare hangs during startup. I changed this to return the atomic `thread_count_` instead, which is in any case more appropriate (since `threads_.size()` doesn't have to reflect how many threads exist at the moment, although right now they are the same modulo race conditions since we don't fully remove worker threads dynamically). 