### PR TITLE
Add examples as unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,23 @@ jobs:
           paths:
             - ./build
 
+  tests.examples:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /hpx
+      - run:
+          name: Running Unit Tests
+          when: always
+          command: |
+              ctest -T test --no-compress-output --output-on-failure -R tests.examples
+      - run:
+          <<: *convert_xml
+      - store_test_results:
+          path: tests.examples
+      - store_artifacts:
+          path: tests.examples
+
   tests.unit.actions:
     <<: *defaults
     steps:
@@ -883,6 +900,9 @@ workflows:
           requires:
             - configure
           <<: *gh_pages_filter
+      - tests.examples:
+          requires:
+            - examples
       - tests.unit.actions:
           <<: *core_dependency
       - tests.unit.agas:
@@ -958,6 +978,7 @@ workflows:
             - inspect
             - clang_tidy
             - core
+            - tests.examples
             - tests.unit.actions
             - tests.unit.agas
             - tests.unit.build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,6 +266,7 @@ hpx_option(HPX_WITH_TESTS_REGRESSIONS BOOL "Build HPX regression tests (default:
 hpx_option(HPX_WITH_TESTS_UNIT BOOL "Build HPX unit tests (default: ON)" ON ADVANCED CATEGORY "Build Targets")
 hpx_option(HPX_WITH_TESTS_HEADERS BOOL "Build HPX header tests (default: OFF)" OFF ADVANCED CATEGORY "Build Targets")
 hpx_option(HPX_WITH_TESTS_EXTERNAL_BUILD BOOL "Build external cmake build tests (default: ON)" ON ADVANCED CATEGORY "Build Targets")
+hpx_option(HPX_WITH_TESTS_EXAMPLES BOOL "Add HPX examples as tests (default: ON)" ON ADVANCED CATEGORY "Build Targets")
 hpx_option(HPX_WITH_TOOLS BOOL "Build HPX tools (default: OFF)" OFF ADVANCED CATEGORY "Build Targets")
 hpx_option(HPX_WITH_RUNTIME BOOL "Build HPX runtime (default: ON)" ON ADVANCED CATEGORY "Build Targets")
 
@@ -1798,12 +1799,6 @@ endif()
 add_hpx_pseudo_target(core)
 add_subdirectory(src)
 
-if(HPX_WITH_EXAMPLES)
-  add_hpx_pseudo_target(examples)
-  include_directories(examples)
-  add_subdirectory(examples)
-endif()
-
 ###############################################################################
 # Tests
 ###############################################################################
@@ -1821,6 +1816,12 @@ if(HPX_WITH_TESTS)
 
   include_directories(tests)
   add_subdirectory(tests)
+endif()
+
+if(HPX_WITH_EXAMPLES)
+  add_hpx_pseudo_target(examples)
+  include_directories(examples)
+  add_subdirectory(examples)
 endif()
 
 if(HPX_WITH_RUNTIME)

--- a/cmake/HPX_AddTest.cmake
+++ b/cmake/HPX_AddTest.cmake
@@ -23,6 +23,8 @@ macro(add_hpx_test category name)
 
   if(TARGET ${${name}_EXECUTABLE}_test_exe)
     set(_exe "$<TARGET_FILE:${${name}_EXECUTABLE}_test_exe>")
+  elseif(TARGET ${${name}_EXECUTABLE}_exe)
+    set(_exe "$<TARGET_FILE:${${name}_EXECUTABLE}_exe>")
   else()
     set(_exe "${${name}_EXECUTABLE}")
   endif()
@@ -135,4 +137,9 @@ endmacro()
 macro(add_hpx_regression_test category name)
   add_hpx_test("tests.regressions.${category}" ${name} ${ARGN})
 endmacro()
+
+macro(add_hpx_example_test category name)
+  add_hpx_test("tests.examples.${category}" ${name} ${ARGN})
+endmacro()
+
 

--- a/cmake/toolchains/BGION-gcc.cmake
+++ b/cmake/toolchains/BGION-gcc.cmake
@@ -75,6 +75,7 @@ set(HPX_WITH_TESTS                ON  CACHE BOOL "Testing enabled by default")
 set(HPX_WITH_TESTS_BENCHMARKS     ON  CACHE BOOL "Testing enabled by default")
 set(HPX_WITH_TESTS_REGRESSIONS    ON  CACHE BOOL "Testing enabled by default")
 set(HPX_WITH_TESTS_UNIT           ON  CACHE BOOL "Testing enabled by default")
+set(HPX_WITH_TESTS_EXAMPLES       ON  CACHE BOOL "Testing enabled by default")
 set(HPX_WITH_TESTS_EXTERNAL_BUILD OFF CACHE BOOL "Turn off build of cmake build tests")
 set(DART_TESTING_TIMEOUT           45  CACHE STRING "Life is too short")
 

--- a/examples/1d_stencil/CMakeLists.txt
+++ b/examples/1d_stencil/CMakeLists.txt
@@ -21,13 +21,32 @@ if(HPX_WITH_APEX)
       1d_stencil_4_repart
       1d_stencil_4_throttle
      )
+
+  set(1d_stencil_4_repart_PARAMETERS THREADS_PER_LOCALITY 4)
+  set(1d_stencil_4_throttle_PARAMETERS THREADS_PER_LOCALITY 4)
 endif()
 
 if(HPX_WITH_EXAMPLES_OPENMP)
   set(example_programs ${example_programs}
       1d_stencil_1_omp
       1d_stencil_3_omp)
+
+  set(disabled_tests
+      1d_stencil_1_omp
+      1d_stencil_3_omp
+     )
 endif()
+
+set(1d_stencil_1_PARAMETERS THREADS_PER_LOCALITY 4)
+set(1d_stencil_2_PARAMETERS THREADS_PER_LOCALITY 4)
+set(1d_stencil_3_PARAMETERS THREADS_PER_LOCALITY 4)
+set(1d_stencil_4_PARAMETERS THREADS_PER_LOCALITY 4)
+set(1d_stencil_4_checkpoint_PARAMETERS THREADS_PER_LOCALITY 4)
+set(1d_stencil_4_parallel_PARAMETERS THREADS_PER_LOCALITY 4)
+set(1d_stencil_5_PARAMETERS THREADS_PER_LOCALITY 4)
+set(1d_stencil_6_PARAMETERS THREADS_PER_LOCALITY 4)
+set(1d_stencil_7_PARAMETERS THREADS_PER_LOCALITY 4)
+set(1d_stencil_8_PARAMETERS THREADS_PER_LOCALITY 4)
 
 foreach(example_program ${example_programs})
 
@@ -53,6 +72,16 @@ foreach(example_program ${example_programs})
   # add dependencies to pseudo-target
   add_hpx_pseudo_dependencies(examples.1d_stencil.${example_program}
                               ${example_program}_exe)
+
+    if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES AND
+      NOT ("${example_program}" IN_LIST disabled_tests))
+    add_hpx_example_test("1d_stencil" ${example_program} ${${example_program}_PARAMETERS})
+    add_hpx_pseudo_target(tests.examples.1d_stencil.${example_program})
+    add_hpx_pseudo_dependencies(tests.examples.1d_stencil
+                                tests.examples.1d_stencil.${example_program})
+    add_hpx_pseudo_dependencies(tests.examples.1d_stencil.${example_program}
+                                ${example_program}_exe)
+  endif()
 endforeach()
 
 if(HPX_WITH_EXAMPLES_OPENMP)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -55,7 +55,17 @@ if(HPX_WITH_COMPUTE)
      )
 endif()
 
+if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
+  add_hpx_pseudo_target(tests.examples)
+  add_hpx_pseudo_dependencies(tests tests.examples)
+endif()
+
 foreach(subdir ${subdirs})
+  if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
+    add_hpx_pseudo_target(tests.examples.${subdir})
+    add_hpx_pseudo_dependencies(tests.examples tests.examples.${subdir})
+  endif()
+
   add_hpx_pseudo_target(examples.${subdir})
   add_subdirectory(${subdir})
   add_hpx_pseudo_dependencies(examples examples.${subdir})

--- a/examples/accumulators/CMakeLists.txt
+++ b/examples/accumulators/CMakeLists.txt
@@ -10,6 +10,8 @@ set(examples
     template_function_accumulator
    )
 
+# TODO: Add non-interactive version that can be tested.
+
 # for all targets specified above
 foreach(example ${examples})
   set(client_sources ${example}_client.cpp)
@@ -41,4 +43,3 @@ foreach(example ${examples})
   add_hpx_pseudo_dependencies(examples.accumulators.${example}
                               ${example}_client_exe)
 endforeach()
-

--- a/examples/apex/CMakeLists.txt
+++ b/examples/apex/CMakeLists.txt
@@ -12,6 +12,12 @@ set(example_programs
     apex_fibonacci
    )
 
+set(apex_policy_engine_periodic_PARAMETERS THREADS_PER_LOCALITY 4)
+set(apex_policy_engine_events_PARAMETERS THREADS_PER_LOCALITY 4)
+set(apex_policy_engine_active_thread_coutn_PARAMETERS THREADS_PER_LOCALITY 4)
+set(apex_balance_PARAMETERS THREADS_PER_LOCALITY 4)
+set(apex_fibonacci_PARAMETERS THREADS_PER_LOCALITY 4)
+
 foreach(example_program ${example_programs})
   set(sources
       ${example_program}.cpp)
@@ -34,5 +40,13 @@ foreach(example_program ${example_programs})
   # add dependencies to pseudo-target
   add_hpx_pseudo_dependencies(examples.apex.${example_program}
                               ${example_program}_exe)
-endforeach()
 
+  if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
+    add_hpx_example_test("apex" ${example_program} ${${example_program}_PARAMETERS})
+    add_hpx_pseudo_target(tests.examples.apex.${example_program})
+    add_hpx_pseudo_dependencies(tests.examples.apex
+                                tests.examples.apex.${example_program})
+    add_hpx_pseudo_dependencies(tests.examples.apex.${example_program}
+                                ${example_program}_exe)
+  endif()
+endforeach()

--- a/examples/async_io/CMakeLists.txt
+++ b/examples/async_io/CMakeLists.txt
@@ -9,6 +9,11 @@ set(example_programs
     async_io_external
     async_io_low_level)
 
+set(async_io_simple_PARAMETERS THREADS_PER_LOCALITY 4)
+set(async_io_action_PARAMETERS THREADS_PER_LOCALITY 4)
+set(async_io_external_PARAMETERS THREADS_PER_LOCALITY 4)
+set(async_io_low_level_PARAMETERS THREADS_PER_LOCALITY 4)
+
 foreach(example_program ${example_programs})
 
   set(${example_program}_FLAGS DEPENDENCIES iostreams_component)
@@ -33,5 +38,13 @@ foreach(example_program ${example_programs})
   # add dependencies to pseudo-target
   add_hpx_pseudo_dependencies(examples.async_io.${example_program}
                               ${example_program}_exe)
-endforeach()
 
+  if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
+    add_hpx_example_test("async_io" ${example_program} ${${example_program}_PARAMETERS})
+    add_hpx_pseudo_target(tests.examples.async_io.${example_program})
+    add_hpx_pseudo_dependencies(tests.examples.async_io
+                                tests.examples.async_io.${example_program})
+    add_hpx_pseudo_dependencies(tests.examples.async_io.${example_program}
+                                ${example_program}_exe)
+  endif()
+endforeach()

--- a/examples/balancing/CMakeLists.txt
+++ b/examples/balancing/CMakeLists.txt
@@ -9,6 +9,9 @@ set(example_programs
 
 set(os_thread_num_FLAGS DEPENDENCIES iostreams_component)
 
+set(os_thread_num_PARAMETERS THREADS_PER_LOCALITY 4)
+set(hpx_thread_phase_PARAMETERS THREADS_PER_LOCALITY 4)
+
 foreach(example_program ${example_programs})
   set(sources ${example_program}.cpp)
 
@@ -30,5 +33,13 @@ foreach(example_program ${example_programs})
   # add dependencies to pseudo-target
   add_hpx_pseudo_dependencies(examples.balancing.${example_program}
                               ${example_program}_exe)
-endforeach()
 
+  if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
+    add_hpx_example_test("balancing" ${example_program} ${${example_program}_PARAMETERS})
+    add_hpx_pseudo_target(tests.examples.balancing.${example_program})
+    add_hpx_pseudo_dependencies(tests.examples.balancing
+                                tests.examples.balancing.${example_program})
+    add_hpx_pseudo_dependencies(tests.examples.balancing.${example_program}
+                                ${example_program}_exe)
+  endif()
+endforeach()

--- a/examples/cancelable_action/CMakeLists.txt
+++ b/examples/cancelable_action/CMakeLists.txt
@@ -27,3 +27,11 @@ add_hpx_pseudo_dependencies(examples examples.cancelable_action)
 add_hpx_pseudo_dependencies(examples.cancelable_action
     cancelable_action_client_exe)
 
+if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
+  add_hpx_example_test("cancelable_action" cancelable_action_client THREADS_PER_LOCALITY 4)
+  add_hpx_pseudo_target(tests.examples.cancelable_action.cancelable_action)
+  add_hpx_pseudo_dependencies(tests.examples.cancelable_action
+                              tests.examples.cancelable_action.cancelable_action)
+  add_hpx_pseudo_dependencies(tests.examples.cancelable_action.cancelable_action
+                              cancelable_action_client_exe)
+endif()

--- a/examples/compute/CMakeLists.txt
+++ b/examples/compute/CMakeLists.txt
@@ -13,8 +13,12 @@ if(HPX_WITH_CUDA)
 endif()
 
 foreach(subdir ${subdirs})
+  if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
+    add_hpx_pseudo_target(tests.examples.compute.${subdir})
+    add_hpx_pseudo_dependencies(tests.examples.compute tests.examples.compute.${subdir})
+  endif()
+
   add_hpx_pseudo_target(examples.compute.${subdir})
   add_subdirectory(${subdir})
   add_hpx_pseudo_dependencies(examples examples.compute.${subdir})
 endforeach()
-

--- a/examples/compute/cuda/CMakeLists.txt
+++ b/examples/compute/cuda/CMakeLists.txt
@@ -14,11 +14,17 @@ if(HPX_WITH_CUDA)
       hello_compute
     )
 
+  set(cublas_matmul_PARAMETERS THREADS_PER_LOCALITY 4)
+  set(cuda_future_PARAMETERS THREADS_PER_LOCALITY 4)
+  set(data_copy_PARAMETERS THREADS_PER_LOCALITY 4)
+  set(hello_compute_PARAMETERS THREADS_PER_LOCALITY 4)
+
 # Append example programs that only compiles with Cuda Clang
   if(HPX_WITH_CUDA_CLANG)
     list(APPEND example_programs
          partitioned_vector
         )
+    set(partitioned_vector_PARAMETERS THREADS_PER_LOCALITY 4)
   endif()
 
   include_directories(${CUDA_INCLUDE_DIRS})
@@ -67,4 +73,13 @@ foreach(example_program ${example_programs})
   # add dependencies to pseudo-target
   add_hpx_pseudo_dependencies(examples.compute.cuda.${example_program}
                               ${example_program}_exe)
+
+  if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
+    add_hpx_example_test("cuda" ${example_program} ${${example_program}_PARAMETERS})
+    add_hpx_pseudo_target(tests.examples.compute.cuda.${example_program})
+    add_hpx_pseudo_dependencies(tests.examples.compute.cuda
+                                tests.examples.compute.cuda.${example_program})
+    add_hpx_pseudo_dependencies(tests.examples.compute.cuda.${example_program}
+                                ${example_program}_exe)
+  endif()
 endforeach()

--- a/examples/future_reduce/CMakeLists.txt
+++ b/examples/future_reduce/CMakeLists.txt
@@ -11,6 +11,7 @@ if(HPX_HAVE_CXX11_STD_RANDOM)
       ${example_programs}
       rnd_future_reduce)
   set(rnd_future_reduce_FLAGS DEPENDENCIES iostreams_component)
+  set(rnd_future_reduce_PARAMETERS THREADS_PER_LOCALITY 4)
 endif()
 
 foreach(example_program ${example_programs})
@@ -35,5 +36,13 @@ foreach(example_program ${example_programs})
   # add dependencies to pseudo-target
   add_hpx_pseudo_dependencies(examples.future_reduce.${example_program}
                               ${example_program}_exe)
-endforeach()
 
+  if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
+    add_hpx_example_test("future_reduce" ${example_program} ${${example_program}_PARAMETERS})
+    add_hpx_pseudo_target(tests.examples.future_reduce.${example_program})
+    add_hpx_pseudo_dependencies(tests.examples.future_reduce
+                                tests.examples.future_reduce.${example_program})
+    add_hpx_pseudo_dependencies(tests.examples.future_reduce.${example_program}
+                                ${example_program}_exe)
+  endif()
+endforeach()

--- a/examples/heartbeat/CMakeLists.txt
+++ b/examples/heartbeat/CMakeLists.txt
@@ -40,3 +40,4 @@ add_hpx_executable(heartbeat_console
 # add pseudo-target dependencies
 add_hpx_pseudo_dependencies(examples.heartbeat heartbeat_console_exe)
 
+# TODO: Add non-interactive version that can be tested.

--- a/examples/interpolate1d/CMakeLists.txt
+++ b/examples/interpolate1d/CMakeLists.txt
@@ -15,6 +15,8 @@ if(HPX_WITH_EXAMPLES_HDF5)
   set(subdirs
       interpolate1d)
 
+  set(interpolate1d_PARAMETERS THREADS_PER_LOCALITY 4)
+
   # for all targets specified above
   foreach(subdir ${subdirs})
     add_subdirectory(${subdir})
@@ -40,6 +42,15 @@ if(HPX_WITH_EXAMPLES_HDF5)
     # add dependencies to pseudo-target
     add_hpx_pseudo_dependencies(examples.interpolate1d.${subdir}_
                                 ${subdir}_client_exe)
+
+    if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
+      add_hpx_example_test("interpolate1d" ${subdir} ${${subdir}_PARAMETERS})
+      add_hpx_pseudo_target(tests.examples.interpolate1d.${subdir})
+      add_hpx_pseudo_dependencies(tests.examples.interpolate1d
+                                  tests.examples.interpolate1d.${subdir})
+      add_hpx_pseudo_dependencies(tests.examples.interpolate1d.${subdir}
+                                  ${subdir}_client_exe)
+    endif()
   endforeach()
 
   add_hpx_executable(create_1d_testdata

--- a/examples/jacobi/CMakeLists.txt
+++ b/examples/jacobi/CMakeLists.txt
@@ -29,3 +29,5 @@ add_hpx_pseudo_dependencies(examples.jacobi
 # add dependencies to pseudo-target
 add_hpx_pseudo_dependencies(examples.jacobi.jacobi_simple
                             jacobi_exe)
+
+# TODO: Fix example. Not added to unit tests until fixed.

--- a/examples/jacobi_smp/CMakeLists.txt
+++ b/examples/jacobi_smp/CMakeLists.txt
@@ -7,6 +7,15 @@ set(jacobi_smp_applications
     jacobi_hpx
     jacobi_nonuniform_hpx)
 
+set(jacobi_hpx_PARAMETERS THREADS_PER_LOCALITY 4)
+set(jacobi_nonuniform_hpx_PARAMETERS THREADS_PER_LOCALITY 4)
+
+set(disabled_tests
+    # Disabled because requires external input data. TODO: Download data when
+    # running test.
+    jacobi_nonuniform_hpx
+   )
+
 if(HPX_WITH_EXAMPLES_OPENMP)
   set(jacobi_smp_applications ${jacobi_smp_applications}
       jacobi_omp_static
@@ -17,6 +26,12 @@ if(HPX_WITH_EXAMPLES_OPENMP)
   set(jacobi_omp_dynamic_sources jacobi.cpp)
   set(jacobi_nonuniform_omp_static_sources jacobi_nonuniform.cpp)
   set(jacobi_nonuniform_omp_dynamic_sources jacobi_nonuniform.cpp)
+
+  set(disabled_tests ${disabled_tests}
+      jacobi_omp_static
+      jacobi_omp_dynamic
+      jacobi_nonuniform_omp_static
+      jacobi_nonuniform_omp_dynamic)
 endif()
 
 set(jacobi_hpx_sources jacobi.cpp)
@@ -45,6 +60,16 @@ foreach(jacobi_smp_application ${jacobi_smp_applications})
     # add dependencies to pseudo-target
     add_hpx_pseudo_dependencies(examples.jacobi_smp.${jacobi_smp_application}
         ${jacobi_smp_application}_exe)
+
+    if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES AND
+        NOT ("${jacobi_smp_application}" IN_LIST disabled_tests))
+        add_hpx_example_test("jacobi_smp" ${jacobi_smp_application} ${${jacobi_smp_application}_PARAMETERS})
+        add_hpx_pseudo_target(tests.examples.jacobi_smp.${jacobi_smp_application})
+        add_hpx_pseudo_dependencies(tests.examples.jacobi_smp
+                                    tests.examples.jacobi_smp.${jacobi_smp_application})
+        add_hpx_pseudo_dependencies(tests.examples.jacobi_smp.${jacobi_smp_application}
+                                    ${jacobi_smp_application}_exe)
+    endif()
 endforeach()
 
 if(HPX_WITH_EXAMPLES_OPENMP)

--- a/examples/nqueen/CMakeLists.txt
+++ b/examples/nqueen/CMakeLists.txt
@@ -19,3 +19,4 @@ add_hpx_executable(nqueen_client
 # add dependencies to pseudo-target
 add_hpx_pseudo_dependencies(examples.nqueen nqueen_client_exe)
 
+# TODO: Add non-interactive version that can be tested.

--- a/examples/performance_counters/CMakeLists.txt
+++ b/examples/performance_counters/CMakeLists.txt
@@ -10,6 +10,9 @@ set(example_programs
     simplest_performance_counter
    )
 
+set(access_counter_set_PARAMETERS THREADS_PER_LOCALITY 4)
+set(simplest_performance_counter_PARAMETERS THREADS_PER_LOCALITY 4)
+
 set(access_counter_set_FLAGS COMPONENT_DEPENDENCIES iostreams)
 
 foreach(example_program ${example_programs})
@@ -36,6 +39,13 @@ foreach(example_program ${example_programs})
   # add dependencies to pseudo-target
   add_hpx_pseudo_dependencies(examples.performance_counters.${example_program}
                               ${example_program}_exe)
+
+  if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
+    add_hpx_example_test("performance_counters" ${example_program} ${${example_program}_PARAMETERS})
+    add_hpx_pseudo_target(tests.examples.performance_counters.${example_program})
+    add_hpx_pseudo_dependencies(tests.examples.performance_counters
+                                tests.examples.performance_counters.${example_program})
+    add_hpx_pseudo_dependencies(tests.examples.performance_counters.${example_program}
+                                ${example_program}_exe)
+  endif()
 endforeach()
-
-

--- a/examples/queue/CMakeLists.txt
+++ b/examples/queue/CMakeLists.txt
@@ -11,4 +11,12 @@ add_hpx_pseudo_target(examples.queue.queue_client)
 add_hpx_pseudo_dependencies(examples.queue examples.queue.queue_client)
 add_hpx_pseudo_dependencies(examples.queue.queue_client queue_client_exe)
 
+if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
+  add_hpx_example_test("queue" queue_client THREADS_PER_LOCALITY 4)
+  add_hpx_pseudo_target(tests.examples.queue.queue_client)
+  add_hpx_pseudo_dependencies(tests.examples.queue
+                              tests.examples.queue.queue_client)
+  add_hpx_pseudo_dependencies(tests.examples.queue.queue_client
+                              queue_client_exe)
+endif()
 

--- a/examples/quickstart/CMakeLists.txt
+++ b/examples/quickstart/CMakeLists.txt
@@ -58,6 +58,15 @@ set(example_programs
     zerocopy_rdma
    )
 
+# TODO: These examples currently fail. Disabled until they are fixed.
+set(disabled_tests
+    error_handling
+    fibonacci_await
+    non_atomic_rma
+    shared_mutex
+    zerocopy_rdma
+   )
+
 set(1d_wave_equation_FLAGS COMPONENT_DEPENDENCIES iostreams)
 set(allow_unknown_options_FLAGS COMPONENT_DEPENDENCIES iostreams)
 set(command_line_handling_FLAGS COMPONENT_DEPENDENCIES iostreams)
@@ -90,11 +99,36 @@ set(timed_futures_FLAGS COMPONENT_DEPENDENCIES iostreams)
 set(vector_counting_dotproduct_FLAGS COMPONENT_DEPENDENCIES iostreams)
 set(vector_zip_dotproduct_FLAGS COMPONENT_DEPENDENCIES iostreams)
 
+set(1d_wave_equation_PARAMETERS THREADS_PER_LOCALITY 4 "-Ihpx.stacks.use_guard_pages=0")
+set(allow_unknown_options_PARAMETERS THREADS_PER_LOCALITY 4)
+set(command_line_handling_PARAMETERS THREADS_PER_LOCALITY 4)
+set(component_in_executable_PARAMETERS THREADS_PER_LOCALITY 4)
+set(component_ctors_PARAMETERS THREADS_PER_LOCALITY 4)
+set(component_inheritance_PARAMETERS THREADS_PER_LOCALITY 4)
+set(component_with_executor_PARAMETERS THREADS_PER_LOCALITY 4)
+set(customize_async_PARAMETERS THREADS_PER_LOCALITY 4)
+set(enumerate_threads_PARAMETERS THREADS_PER_LOCALITY 4)
+set(event_synchronization_PARAMETERS THREADS_PER_LOCALITY 4)
+set(error_handling_PARAMETERS THREADS_PER_LOCALITY 4)
+set(fractals_PARAMETERS THREADS_PER_LOCALITY 4)
+set(hello_world_PARAMETERS THREADS_PER_LOCALITY 4)
+set(interval_timer_PARAMETERS THREADS_PER_LOCALITY 4)
+set(local_channel_PARAMETERS THREADS_PER_LOCALITY 4)
+set(sierpinski_PARAMETERS THREADS_PER_LOCALITY 4)
+set(partitioned_vector_spmd_foreach_PARAMETERS THREADS_PER_LOCALITY 4)
+set(pingpong_PARAMETERS THREADS_PER_LOCALITY 4)
+set(simplest_hello_world_PARAMETERS THREADS_PER_LOCALITY 4)
+set(simple_future_continuation_PARAMETERS THREADS_PER_LOCALITY 4)
+set(timed_futures_PARAMETERS THREADS_PER_LOCALITY 4)
+set(vector_counting_dotproduct_PARAMETERS THREADS_PER_LOCALITY 4)
+set(vector_zip_dotproduct_PARAMETERS THREADS_PER_LOCALITY 4)
+
 if(HPX_WITH_LOCAL_SCHEDULER OR HPX_WITH_ALL_SCHEDULERS)
   set(example_programs ${example_programs}
       fractals_executor
      )
   set(fractals_executor_FLAGS COMPONENT_DEPENDENCIES iostreams)
+set(fractals_executor_PARAMETERS THREADS_PER_LOCALITY 4)
 endif()
 
 if(HPX_WITH_TUPLE_RVALUE_SWAP)
@@ -126,5 +160,14 @@ foreach(example_program ${example_programs})
   # add dependencies to pseudo-target
   add_hpx_pseudo_dependencies(examples.quickstart.${example_program}
                               ${example_program}_exe)
-endforeach()
 
+  if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES AND
+      NOT ("${example_program}" IN_LIST disabled_tests))
+    add_hpx_example_test("quickstart" ${example_program} ${${example_program}_PARAMETERS})
+    add_hpx_pseudo_target(tests.examples.quickstart.${example_program})
+    add_hpx_pseudo_dependencies(tests.examples.quickstart
+                                tests.examples.quickstart.${example_program})
+    add_hpx_pseudo_dependencies(tests.examples.quickstart.${example_program}
+                                ${example_program}_exe)
+  endif()
+endforeach()

--- a/examples/random_mem_access/CMakeLists.txt
+++ b/examples/random_mem_access/CMakeLists.txt
@@ -7,6 +7,8 @@
 set(subdirs
     random_mem_access)
 
+set(random_mem_access_PARAMETERS THREADS_PER_LOCALITY 4)
+
 # for all targets specified above
 foreach(subdir ${subdirs})
   add_subdirectory(${subdir})
@@ -33,5 +35,13 @@ foreach(subdir ${subdirs})
   # add dependencies to pseudo-target
   add_hpx_pseudo_dependencies(examples.random_mem_access.${subdir}_dir
                               ${subdir}_client_exe)
-endforeach()
 
+  if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
+    add_hpx_example_test("random_mem_access" ${subdir}_client ${${subdir}_PARAMETERS})
+    add_hpx_pseudo_target(tests.examples.random_mem_access.${subdir})
+    add_hpx_pseudo_dependencies(tests.examples.random_mem_access
+                                tests.examples.random_mem_access.${subdir})
+    add_hpx_pseudo_dependencies(tests.examples.random_mem_access.${subdir}
+                                ${subdir}_client_exe)
+  endif()
+endforeach()

--- a/examples/resource_partitioner/CMakeLists.txt
+++ b/examples/resource_partitioner/CMakeLists.txt
@@ -11,6 +11,11 @@ set(example_programs
 set(oversubscribing_resource_partitioner_FLAGS DEPENDENCIES iostreams_component)
 set(simple_resource_partitioner_FLAGS DEPENDENCIES iostreams_component)
 
+set(oversubscribing_resource_partitioner_PARAMETERS
+    THREADS_PER_LOCALITY 4 "--use-pools" "--use-scheduler")
+set(simple_resource_partitioner_PARAMETERS
+    THREADS_PER_LOCALITY 4 "--use-pools" "--use-scheduler")
+
 foreach(example_program ${example_programs})
   set(sources
       ${example_program}.cpp)
@@ -37,5 +42,13 @@ foreach(example_program ${example_programs})
   # add dependencies to pseudo-target
   add_hpx_pseudo_dependencies(examples.resource_partitioner.${example_program}
                               ${example_program}_exe)
-endforeach()
 
+  if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
+    add_hpx_example_test("resource_partitioner" ${example_program} ${${example_program}_PARAMETERS})
+    add_hpx_pseudo_target(tests.examples.resource_partitioner.${example_program})
+    add_hpx_pseudo_dependencies(tests.examples.resource_partitioner
+                                tests.examples.resource_partitioner.${example_program})
+    add_hpx_pseudo_dependencies(tests.examples.resource_partitioner.${example_program}
+                                ${example_program}_exe)
+  endif()
+endforeach()

--- a/examples/resource_partitioner/oversubscribing_resource_partitioner.cpp
+++ b/examples/resource_partitioner/oversubscribing_resource_partitioner.cpp
@@ -79,6 +79,14 @@ int hpx_main(boost::program_options::variables_map& vm)
     std::size_t num_threads = hpx::get_num_worker_threads();
     hpx::cout << "HPX using threads = " << num_threads << std::endl;
 
+    if (num_threads == 1)
+    {
+        HPX_THROW_EXCEPTION(hpx::commandline_option_error,
+            "hpx_main",
+            "the oversubscribing_resource_partitioner example requires at "
+            "least 2 worker threads (1 given)");
+    }
+
     std::size_t loop_count = num_threads * 1;
     std::size_t async_count = num_threads * 1;
 

--- a/examples/sheneos/CMakeLists.txt
+++ b/examples/sheneos/CMakeLists.txt
@@ -37,6 +37,8 @@ if(HPX_WITH_EXAMPLES_HDF5)
   # add dependencies to pseudo-target
   add_hpx_pseudo_dependencies(examples.sheneos sheneos_test_exe)
 
+  # TODO: Fix example. Not added to unit tests until fixed.
+
   if(HPX_WITH_FORTRAN)
     if(CMAKE_Fortran_COMPILER AND HDF5_FORTRAN_FOUND)
       add_hpx_executable(sheneos_compare

--- a/examples/spell_check/CMakeLists.txt
+++ b/examples/spell_check/CMakeLists.txt
@@ -9,6 +9,9 @@ set(example_programs
     spell_check_file
    )
 
+set(spell_check_simple_PARAMETERS THREADS_PER_LOCALITY 4)
+set(spell_check_file_PARAMETERS THREADS_PER_LOCALITY 4)
+
 foreach(example_program ${example_programs})
   set(sources
       ${example_program}.cpp)
@@ -31,5 +34,13 @@ foreach(example_program ${example_programs})
   # add dependencies to pseudo-target
   add_hpx_pseudo_dependencies(examples.spell_check.${example_program}
                               ${example_program}_exe)
-endforeach()
 
+  if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
+    add_hpx_example_test("spell_check" ${example_program} ${${example_program}_PARAMETERS})
+    add_hpx_pseudo_target(tests.examples.spell_check.${example_program})
+    add_hpx_pseudo_dependencies(tests.examples.spell_check
+                                tests.examples.spell_check.${example_program})
+    add_hpx_pseudo_dependencies(tests.examples.spell_check.${example_program}
+                                ${example_program}_exe)
+  endif()
+endforeach()

--- a/examples/thread_aware_timer/CMakeLists.txt
+++ b/examples/thread_aware_timer/CMakeLists.txt
@@ -11,3 +11,11 @@ add_hpx_executable(thread_aware_timer
 # add pseudo-target dependencies
 add_hpx_pseudo_dependencies(examples.thread_aware_timer thread_aware_timer_exe)
 
+if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
+  add_hpx_example_test("thread_aware_timer" thread_aware_timer THREADS_PER_LOCALITY 4)
+  add_hpx_pseudo_target(tests.examples.thread_aware_timer.thread_aware_timer)
+  add_hpx_pseudo_dependencies(tests.examples.thread_aware_timer
+                              tests.examples.thread_aware_timer.thread_aware_timer)
+  add_hpx_pseudo_dependencies(tests.examples.thread_aware_timer.thread_aware_timer
+                              thread_aware_timer_exe)
+endif()

--- a/examples/throttle/CMakeLists.txt
+++ b/examples/throttle/CMakeLists.txt
@@ -8,6 +8,8 @@
 set(subdirs
     throttle)
 
+# TODO: Add non-interactive version that can be tested.
+
 # for all targets specified above
 foreach(subdir ${subdirs})
   add_subdirectory(${subdir})
@@ -47,4 +49,3 @@ add_hpx_pseudo_dependencies(examples.throttle examples.throttle.spin)
 
 # add dependencies to pseudo-target
 add_hpx_pseudo_dependencies(examples.throttle.spin spin_exe)
-

--- a/examples/transpose/CMakeLists.txt
+++ b/examples/transpose/CMakeLists.txt
@@ -22,6 +22,12 @@ endif()
 
 set(transpose_serial_vector_FLAGS DEPENDENCIES partitioned_vector_component)
 
+set(transpose_smp_PARAMETERS THREADS_PER_LOCALITY 4)
+set(transpose_smp_block_PARAMETERS THREADS_PER_LOCALITY 4)
+set(transpose_block_PARAMETERS THREADS_PER_LOCALITY 4)
+set(transpose_block_numa_PARAMETERS THREADS_PER_LOCALITY 4
+    "--transpose-threads=4" "--transpose-numa-domains=1")
+
 foreach(example_program ${example_programs})
 
   set(sources ${example_program}.cpp)
@@ -44,4 +50,13 @@ foreach(example_program ${example_programs})
   # add dependencies to pseudo-target
   add_hpx_pseudo_dependencies(examples.transpose.${example_program}
                               ${example_program}_exe)
+
+  if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
+    add_hpx_example_test("transpose" ${example_program} ${${example_program}_PARAMETERS})
+    add_hpx_pseudo_target(tests.examples.transpose.${example_program})
+    add_hpx_pseudo_dependencies(tests.examples.transpose
+                                tests.examples.transpose.${example_program})
+    add_hpx_pseudo_dependencies(tests.examples.transpose.${example_program}
+                                ${example_program}_exe)
+  endif()
 endforeach()

--- a/examples/tuplespace/CMakeLists.txt
+++ b/examples/tuplespace/CMakeLists.txt
@@ -10,6 +10,8 @@ set(examples
     simple_central_tuplespace
    )
 
+set(simple_central_tuplespace_PARAMETERS THREADS_PER_LOCALITY 4)
+
 # for all targets specified above
 foreach(example ${examples})
   set(sources ${example}_client.cpp)
@@ -32,5 +34,13 @@ foreach(example ${examples})
   # add dependencies to pseudo-target
   add_hpx_pseudo_dependencies(examples.tuplespace.${example}
                               ${example}_client_exe)
-endforeach()
 
+  if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
+    add_hpx_example_test("tuplespace" ${example}_client ${${example}_PARAMETERS})
+    add_hpx_pseudo_target(tests.examples.tuplespace.${example})
+    add_hpx_pseudo_dependencies(tests.examples.tuplespace
+                                tests.examples.tuplespace.${example})
+    add_hpx_pseudo_dependencies(tests.examples.tuplespace.${example}
+                                ${example}_client_exe)
+  endif()
+endforeach()

--- a/tests/performance/local/CMakeLists.txt
+++ b/tests/performance/local/CMakeLists.txt
@@ -187,13 +187,13 @@ foreach(benchmark ${benchmarks})
 endforeach()
 
 if(HPX_WITH_EXAMPLES_OPENMP)
-  set_target_properties(openmp_homogeneous_timed_task_spawn_exe
+  set_target_properties(openmp_homogeneous_timed_task_spawn_test_exe
     PROPERTIES COMPILE_FLAGS ${OpenMP_CXX_FLAGS})
-  set_target_properties(openmp_homogeneous_timed_task_spawn_exe
+  set_target_properties(openmp_homogeneous_timed_task_spawn_test_exe
     PROPERTIES LINK_FLAGS ${OpenMP_CXX_FLAGS})
-  set_target_properties(openmp_parallel_region_exe
+  set_target_properties(openmp_parallel_region_test_exe
     PROPERTIES COMPILE_FLAGS ${OpenMP_CXX_FLAGS})
-  set_target_properties(openmp_parallel_region_exe
+  set_target_properties(openmp_parallel_region_test_exe
     PROPERTIES LINK_FLAGS ${OpenMP_CXX_FLAGS})
 endif()
 


### PR DESCRIPTION
This adds (most) examples as unit tests under `tests.examples`. Some of them are excluded because they are broken or they are interactive (any ideas for testing the interactive ones?).

The tests are enabled by default, but I can change this if someone thinks they shouldn't be.