### PR TITLE
Fixing warnings related to silent conversion of size_t --> int16_t

### DIFF
--- a/hpx/lcos/local/futures_factory.hpp
+++ b/hpx/lcos/local/futures_factory.hpp
@@ -24,6 +24,7 @@
 #include <boost/intrusive_ptr.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <exception>
 #include <type_traits>
 #include <utility>
@@ -104,14 +105,16 @@ namespace hpx { namespace lcos { namespace local
                 typedef typename Base::future_base_type future_base_type;
                 future_base_type this_(this);
 
-                if (policy == launch::fork) {
+                if (policy == launch::fork)
+                {
                     return threads::register_thread_nullary(
                         util::deferred_call(
                             &base_type::run_impl, std::move(this_)),
                         util::thread_description(f_, "task_object::apply"),
                         threads::pending_do_not_schedule, true,
                         threads::thread_priority_boost,
-                        threads::thread_schedule_hint(get_worker_thread_num()),
+                        threads::thread_schedule_hint(
+                            static_cast<std::int16_t>(get_worker_thread_num())),
                         stacksize, ec);
                 }
 

--- a/hpx/runtime/parcelset/decode_parcels.hpp
+++ b/hpx/runtime/parcelset/decode_parcels.hpp
@@ -221,7 +221,8 @@ namespace hpx { namespace parcelset
                                 "schedule_parcel",
                                 threads::pending, true,
                                 threads::thread_priority_boost,
-                                threads::thread_schedule_hint(num_thread),
+                                threads::thread_schedule_hint(
+                                    static_cast<std::int16_t>(num_thread)),
                                 threads::thread_stacksize_default);
                         }
                         // If we are the first deferred parcel, we don't need to spin

--- a/hpx/runtime/threads/thread_enums.hpp
+++ b/hpx/runtime/threads/thread_enums.hpp
@@ -156,15 +156,22 @@ namespace hpx { namespace threads
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    struct thread_schedule_hint {
-        thread_schedule_hint() : mode(thread_schedule_hint_mode_none),
-            hint(-1) {}
+    struct thread_schedule_hint
+    {
+        thread_schedule_hint()
+          : mode(thread_schedule_hint_mode_none)
+          , hint(-1)
+        {}
 
         thread_schedule_hint(std::int16_t thread_hint)
-            : mode(thread_schedule_hint_mode_thread), hint(thread_hint) {}
+          : mode(thread_schedule_hint_mode_thread)
+          , hint(thread_hint)
+        {}
 
         thread_schedule_hint(thread_schedule_hint_mode mode, std::int16_t hint)
-            : mode(mode), hint(hint) {}
+          : mode(mode)
+          , hint(hint)
+        {}
 
         thread_schedule_hint_mode mode;
         std::int16_t hint;


### PR DESCRIPTION
- flyby: adding some override keywords
