### PR TITLE
- cmake : create the parent directory before symlinking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1839,6 +1839,12 @@ endif()
 add_plugin_modules()
 
 ################################################################################
+# Prepare the Build Directory
+################################################################################
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/share)
+
+
+################################################################################
 # Configure the header to include all compile definitions
 ################################################################################
 generate_config_defines_header(${CMAKE_BINARY_DIR})


### PR DESCRIPTION
    The share directory is not created when the cmake tries to symlink
    HPX installation to share directory. This creates a minor and
    eventually inconsequential error in the configuration as shown
    below:

	failed to create symbolic link '/home/jayesh/build/hpx/share/hpx': No such file or directory

    This commit fixes it by creating a directory beforehand.


Fixes #3462 
