### PR TITLE
Check for forked repos in CircleCI docker push step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -872,7 +872,7 @@ jobs:
       - run:
           name: Push Docker Image
           command: |
-              if [ "$CIRCLE_BRANCH" == "master" ]; then
+              if [ -z "$CIRCLE_PR_NUMBER" ] && [ "$CIRCLE_BRANCH" == "master" ]; then
                   docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
                   docker push ${TARGET_IMAGE_NAME}
               else


### PR DESCRIPTION
Check `CIRCLE_PR_NUMBER` (in addition to checking for master branch) to see if a PR is from a forked repo in docker push step on CircleCI. With the old check PRs from master branches on forked repos would try to do `docker push` and fail.