### PR TITLE
This patch adds various optimizations extracted from the thread_local_allocator work

### DIFF
--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -279,7 +279,7 @@ namespace detail
         /// immediately.
         void set_on_completed(completed_callback_type data_sink) override;
 
-        virtual void wait(error_code& ec = throws);
+        virtual state wait(error_code& ec = throws);
 
         virtual future_status wait_until(
             util::steady_clock::time_point const& abs_time, error_code& ec = throws);
@@ -400,9 +400,9 @@ namespace detail
         ///               error description if <code>&ec == &throws</code>.
         virtual result_type* get_result(error_code& ec = throws)
         {
-            if (!get_result_void(ec))
-                return nullptr;
-            return reinterpret_cast<result_type*>(&storage_);
+            if (get_result_void(ec) != nullptr)
+                return reinterpret_cast<result_type*>(&storage_);
+            return nullptr;
         }
 
         util::unused_type* get_result_void(error_code& ec = throws) override
@@ -648,26 +648,35 @@ namespace detail
                     rebind_alloc<future_data_allocator>
             other_allocator;
 
+        typedef typename future_data_base<Result>::default_construct
+            default_construct;
+
         future_data_allocator(other_allocator const& alloc)
           : future_data<Result>()
           , alloc_(alloc)
         {}
-        future_data_allocator(init_no_addref no_addref,
-                other_allocator const& alloc)
-          : future_data<Result>(no_addref)
-          , alloc_(alloc)
-        {}
+
         template <typename... T>
-        future_data_allocator(init_no_addref no_addref, T&&... ts,
-                other_allocator const& alloc)
+        future_data_allocator(init_no_addref no_addref,
+                other_allocator const& alloc, T&&... ts)
           : future_data<Result>(no_addref, std::forward<T>(ts)...)
           , alloc_(alloc)
         {}
+
+        template <typename... T>
+        future_data_allocator(init_no_addref no_addref,
+                default_construct defctr,
+                other_allocator const& alloc, T&&... ts)
+          : future_data<Result>(no_addref, defctr, std::forward<T>(ts)...)
+          , alloc_(alloc)
+        {}
+
         future_data_allocator(init_no_addref no_addref,
                 std::exception_ptr const& e, other_allocator const& alloc)
           : future_data<Result>(no_addref, e)
           , alloc_(alloc)
         {}
+
         future_data_allocator(init_no_addref no_addref,
                 std::exception_ptr && e, other_allocator const& alloc)
           : future_data<Result>(no_addref, std::move(e))
@@ -767,11 +776,11 @@ namespace detail
         }
 
         // wait support
-        virtual void wait(error_code& ec = throws)
+        virtual typename base_type::state wait(error_code& ec = throws)
         {
             if (!started_test_and_set())
                 this->do_run();
-            this->future_data<Result>::wait(ec);
+            return this->future_data<Result>::wait(ec);
         }
 
         virtual future_status

--- a/hpx/lcos/detail/sync_implementations.hpp
+++ b/hpx/lcos/detail/sync_implementations.hpp
@@ -29,7 +29,7 @@ namespace hpx { namespace detail
     struct sync_local_invoke_direct
     {
         template <typename ...Ts>
-        static Result
+        HPX_FORCEINLINE static Result
         call(naming::id_type const& id, naming::address && addr, Ts &&... vs)
         {
             typedef typename Action::remote_result_type remote_result_type;
@@ -46,7 +46,7 @@ namespace hpx { namespace detail
     struct sync_local_invoke_direct<Action, void>
     {
         template <typename ...Ts>
-        static void
+        HPX_FORCEINLINE static void
         call(naming::id_type const& id, naming::address && addr, Ts &&... vs)
         {
             Action::execute_function(

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -31,6 +31,7 @@
 
 #include <exception>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <type_traits>
 #include <utility>
@@ -42,7 +43,8 @@ namespace hpx { namespace lcos { namespace detail
     struct transfer_result
     {
         template <typename Source, typename Destination>
-        void apply(Source && src, Destination& dest, std::false_type) const
+        HPX_FORCEINLINE void apply(
+            Source&& src, Destination& dest, std::false_type) const
         {
             try {
                 dest.set_value(src.get());
@@ -53,7 +55,8 @@ namespace hpx { namespace lcos { namespace detail
         }
 
         template <typename Source, typename Destination>
-        void apply(Source && src, Destination& dest, std::true_type) const
+        HPX_FORCEINLINE void apply(
+            Source&& src, Destination& dest, std::true_type) const
         {
             try {
                 src.get();
@@ -65,7 +68,8 @@ namespace hpx { namespace lcos { namespace detail
         }
 
         template <typename SourceState, typename DestinationState>
-        void operator()(SourceState && src, DestinationState const& dest) const
+        HPX_FORCEINLINE void operator()(
+            SourceState&& src, DestinationState const& dest) const
         {
             typedef std::is_void<
                 typename traits::future_traits<Future>::type
@@ -174,8 +178,7 @@ namespace hpx { namespace lcos { namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Future, typename F, typename ContResult>
-    class continuation
-      : public future_data<ContResult>
+    class continuation : public detail::future_data<ContResult>
     {
     private:
         typedef future_data<ContResult> base_type;
@@ -615,6 +618,61 @@ namespace hpx { namespace lcos { namespace detail
         typename util::decay<F>::type f_;
     };
 
+    template <typename Allocator, typename Future, typename F,
+        typename ContResult>
+    class continuation_allocator : public continuation<Future, F, ContResult>
+    {
+        typedef continuation<Future, F, ContResult> base_type;
+
+        typedef typename
+                std::allocator_traits<Allocator>::template
+                    rebind_alloc<continuation_allocator>
+            other_allocator;
+
+    public:
+        typedef typename base_type::init_no_addref init_no_addref;
+
+        template <typename Func>
+        continuation_allocator(other_allocator const& alloc, Func && f)
+          : base_type(std::forward<Func>(f))
+          , alloc_(alloc)
+        {}
+
+        template <typename Func>
+        continuation_allocator(init_no_addref no_addref,
+                other_allocator const& alloc, Func && f)
+          : base_type(no_addref, std::forward<Func>(f))
+          , alloc_(alloc)
+        {}
+
+    private:
+        void destroy() override
+        {
+            typedef std::allocator_traits<other_allocator> traits;
+
+            other_allocator alloc(alloc_);
+            traits::destroy(alloc, this);
+            traits::deallocate(alloc, this, 1);
+        }
+
+        other_allocator alloc_;
+    };
+}}}
+
+namespace hpx { namespace traits { namespace detail
+{
+    template <typename Future, typename F, typename ContResult,
+        typename Allocator>
+    struct shared_state_allocator<
+        lcos::detail::continuation<Future, F, ContResult>, Allocator>
+    {
+        typedef lcos::detail::continuation_allocator<
+            Allocator, Future, F, ContResult> type;
+    };
+}}}
+
+namespace hpx { namespace lcos { namespace detail
+{
     ///////////////////////////////////////////////////////////////////////////
     template <typename ContResult, typename Future, typename Policy, typename F>
     inline typename traits::detail::shared_state_ptr<
@@ -632,6 +690,47 @@ namespace hpx { namespace lcos { namespace detail
         static_cast<shared_state*>(p.get())->attach(
             future, std::forward<Policy>(policy));
         return p;
+    }
+
+    // same as above, except with allocator
+    template <typename ContResult, typename Allocator, typename Future,
+        typename Policy, typename F>
+    inline typename traits::detail::shared_state_ptr<
+        typename continuation_result<ContResult>::type
+    >::type
+    make_continuation_alloc(Allocator const& a,
+        Future const& future, Policy&& policy, F&& f)
+    {
+        using result_type = typename continuation_result<ContResult>::type;
+
+        using base_allocator = Allocator;
+        using shared_state = typename traits::detail::shared_state_allocator<
+                detail::continuation<Future, F, result_type>, base_allocator
+            >::type;
+
+        using other_allocator = typename std::allocator_traits<base_allocator>::
+            template rebind_alloc<shared_state>;
+        using traits = std::allocator_traits<other_allocator>;
+
+        using init_no_addref = typename shared_state::init_no_addref;
+
+        using unique_ptr = std::unique_ptr<shared_state,
+            util::allocator_deleter<other_allocator>>;
+
+        other_allocator alloc(a);
+        unique_ptr p(traits::allocate(alloc, 1),
+            util::allocator_deleter<other_allocator>{alloc});
+        traits::construct(
+            alloc, p.get(), init_no_addref{}, alloc, std::forward<F>(f));
+
+        // create a continuation
+        typename hpx::traits::detail::shared_state_ptr<result_type>::type r(
+            p.release(), false);
+
+        static_cast<shared_state*>(r.get())->attach(
+            future, std::forward<Policy>(policy));
+
+        return r;
     }
 
 #if defined(HPX_HAVE_EXECUTOR_COMPATIBILITY)

--- a/hpx/lcos/local/promise.hpp
+++ b/hpx/lcos/local/promise.hpp
@@ -12,6 +12,7 @@
 #include <hpx/lcos/future.hpp>
 #include <hpx/throw_exception.hpp>
 #include <hpx/traits/future_access.hpp>
+#include <hpx/util/allocator_deleter.hpp>
 #include <hpx/util/unused.hpp>
 
 #include <boost/intrusive_ptr.hpp>
@@ -31,19 +32,6 @@ namespace hpx { namespace lcos { namespace local
         {
             typedef SharedState shared_state_type;
             typedef typename shared_state_type::init_no_addref init_no_addref;
-
-            template <typename Allocator>
-            struct deleter
-            {
-                template <typename SharedState_>
-                void operator()(SharedState_* state)
-                {
-                    typedef std::allocator_traits<Allocator> traits;
-                    traits::deallocate(alloc_, state, 1);
-                }
-
-                Allocator& alloc_;
-            };
 
         public:
             promise_base()
@@ -66,12 +54,13 @@ namespace hpx { namespace lcos { namespace local
                     other_allocator;
                 typedef std::allocator_traits<other_allocator> traits;
                 typedef std::unique_ptr<
-                        allocator_shared_state_type, deleter<other_allocator>
+                        allocator_shared_state_type,
+                        util::allocator_deleter<other_allocator>
                     > unique_pointer;
 
                 other_allocator alloc(a);
                 unique_pointer p (traits::allocate(alloc, 1),
-                    deleter<other_allocator>{alloc});
+                    util::allocator_deleter<other_allocator>{alloc});
 
                 traits::construct(alloc, p.get(), init_no_addref{}, alloc);
                 shared_state_.reset(p.release(), false);

--- a/hpx/lcos/packaged_action.hpp
+++ b/hpx/lcos/packaged_action.hpp
@@ -25,6 +25,7 @@
 #include <boost/asio/error.hpp>
 
 #include <exception>
+#include <memory>
 #include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -237,7 +238,12 @@ namespace lcos {
         {
         }
 
-        ///////////////////////////////////////////////////////////////////////
+        template <typename Allocator>
+        packaged_action(std::allocator_arg_t, Allocator const& alloc)
+          : base_type(std::allocator_arg, alloc)
+        {
+        }
+
         template <typename... Ts>
         void apply(naming::id_type const& id, Ts&&... vs)
         {

--- a/hpx/runtime/components/client_base.hpp
+++ b/hpx/runtime/components/client_base.hpp
@@ -90,10 +90,10 @@ namespace hpx { namespace traits
 
             template <typename SharedState>
             HPX_FORCEINLINE static Derived
-            create(SharedState* shared_state)
+            create(SharedState* shared_state, bool addref = true)
             {
                 return Derived(future<id_type>(
-                    boost::intrusive_ptr<SharedState>(shared_state)));
+                    boost::intrusive_ptr<SharedState>(shared_state, addref)));
             }
 
             HPX_FORCEINLINE static

--- a/hpx/runtime/components/unwrapping_result_policy.hpp
+++ b/hpx/runtime/components/unwrapping_result_policy.hpp
@@ -10,10 +10,10 @@
 
 #include <hpx/config.hpp>
 #include <hpx/lcos/detail/async_implementations.hpp>
-#include <hpx/lcos/detail/sync_implementations.hpp>
 #include <hpx/lcos/detail/async_unwrap_result_implementations.hpp>
+#include <hpx/lcos/detail/sync_implementations.hpp>
+#include <hpx/runtime/applier/detail/apply_implementations_fwd.hpp>
 #include <hpx/runtime/components/client_base.hpp>
-#include <hpx/runtime/components/target_distribution_policy.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime/naming/name.hpp>
@@ -29,35 +29,17 @@ namespace hpx { namespace components
     /// This class is a distribution policy that can be using with actions that
     /// return futures. For those actions it is possible to apply certain
     /// optimizations if the action is invoked synchronously.
-    struct unwrapping_result_policy : target_distribution_policy
+    struct unwrapping_result_policy
     {
     public:
-        /// Default-construct a new instance of a \a unwrapping_result_policy.
-        /// This policy will represent the local locality.
-        unwrapping_result_policy() = default;
+        unwrapping_result_policy(id_type const& id)
+          : id_(id)
+        {}
 
-        /// Create a new \a unwrapping_result_policy representing the
-        /// target locality
-        ///
-        /// \param id     [in] The global address of the target object
-        ///
-        unwrapping_result_policy operator()(id_type const& id) const
-        {
-            return unwrapping_result_policy(id);
-        }
-
-        /// Create a new \a unwrapping_result_policy representing the
-        /// target locality
-        ///
-        /// \param client  [in] The client side representation of the target
-        ///                object
-        ///
         template <typename Client, typename Stub>
-        unwrapping_result_policy operator()(
-            client_base<Client, Stub> const& client) const
-        {
-            return unwrapping_result_policy(client.get_id());
-        }
+        unwrapping_result_policy(client_base<Client, Stub> const& client)
+          : id_(client.get_id())
+        {}
 
         template <typename Action>
         struct async_result
@@ -72,7 +54,7 @@ namespace hpx { namespace components
         async(launch policy, Ts&&... vs) const
         {
             return hpx::detail::async_unwrap_result_impl<Action>(
-                policy, this->get_next_target(), std::forward<Ts>(vs)...);
+                policy, get_next_target(), std::forward<Ts>(vs)...);
         }
 
         template <typename Action, typename ...Ts>
@@ -80,36 +62,74 @@ namespace hpx { namespace components
         async(launch::sync_policy, Ts&&... vs) const
         {
             return hpx::detail::sync_impl<Action>(
-                launch::sync, this->get_next_target(), std::forward<Ts>(vs)...);
+                launch::sync, get_next_target(), std::forward<Ts>(vs)...);
         }
 
         template <typename Action, typename Callback, typename ...Ts>
         typename async_result<Action>::type
         async_cb(launch policy, Callback&& cb, Ts&&... vs) const
         {
-            return this->target_distribution_policy::async_cb(policy,
+            return hpx::detail::async_cb_impl<Action>(policy,
+                get_next_target(), std::forward<Callback>(cb),
+                std::forward<Ts>(vs)...);
+        }
+
+        /// \note This function is part of the invocation policy implemented by
+        ///       this class
+        ///
+        template <typename Action, typename Continuation, typename... Ts>
+        bool apply(Continuation&& c, threads::thread_priority priority,
+            Ts&&... vs) const
+        {
+            return hpx::detail::apply_impl<Action>(std::forward<Continuation>(c),
+                get_next_target(), priority, std::forward<Ts>(vs)...);
+        }
+
+        template <typename Action, typename... Ts>
+        bool apply(threads::thread_priority priority, Ts&&... vs) const
+        {
+            return hpx::detail::apply_impl<Action>(
+                get_next_target(), priority, std::forward<Ts>(vs)...);
+        }
+
+        /// \note This function is part of the invocation policy implemented by
+        ///       this class
+        ///
+        template <typename Action, typename Continuation, typename Callback,
+            typename... Ts>
+        bool apply_cb(Continuation&& c, threads::thread_priority priority,
+            Callback&& cb, Ts&&... vs) const
+        {
+            return hpx::detail::apply_cb_impl<Action>(
+                std::forward<Continuation>(c), get_next_target(), priority,
                 std::forward<Callback>(cb), std::forward<Ts>(vs)...);
+        }
+
+        template <typename Action, typename Callback, typename... Ts>
+        bool apply_cb(
+            threads::thread_priority priority, Callback&& cb, Ts&&... vs) const
+        {
+            return hpx::detail::apply_cb_impl<Action>(
+                get_next_target(), priority,
+                std::forward<Callback>(cb), std::forward<Ts>(vs)...);
+        }
+
+        hpx::id_type const& get_next_target() const
+        {
+            return id_;
         }
 
     protected:
         /// \cond NOINTERNAL
-        unwrapping_result_policy(id_type const& id)
-          : target_distribution_policy(id)
-        {}
+        hpx::id_type const& id_;   // locality to encapsulate
         /// \endcond
     };
-
-    /// A predefined instance of the unwrap_result \a distribution_policy. It
-    /// will represent the local locality and will place all items to create
-    /// here.
-    static unwrapping_result_policy const unwrap_result{};
 }}
 
 /// \cond NOINTERNAL
 namespace hpx
 {
-    using hpx::components::unwrapping_result_policy;
-    using hpx::components::unwrap_result;
+    using unwrap_result = hpx::components::unwrapping_result_policy;
 
     namespace traits
     {

--- a/hpx/traits/future_access.hpp
+++ b/hpx/traits/future_access.hpp
@@ -151,10 +151,10 @@ namespace hpx { namespace traits
 
         template <typename SharedState>
         static lcos::future<R>
-        create(SharedState* shared_state)
+        create(SharedState* shared_state, bool addref = true)
         {
             return lcos::future<R>(
-                boost::intrusive_ptr<SharedState>(shared_state));
+                boost::intrusive_ptr<SharedState>(shared_state, addref));
         }
 
         HPX_FORCEINLINE static
@@ -208,10 +208,10 @@ namespace hpx { namespace traits
 
         template <typename SharedState>
         static lcos::shared_future<R>
-        create(SharedState* shared_state)
+        create(SharedState* shared_state, bool addref = true)
         {
             return lcos::shared_future<R>(
-                boost::intrusive_ptr<SharedState>(shared_state));
+                boost::intrusive_ptr<SharedState>(shared_state, addref));
         }
 
         HPX_FORCEINLINE static

--- a/hpx/util/allocator_deleter.hpp
+++ b/hpx/util/allocator_deleter.hpp
@@ -1,0 +1,33 @@
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// This is partially taken from: http://www.garret.ru/threadalloc/readme.html
+
+#if !defined(HPX_UTIL_ALLOCATOR_DELETER_AUG_08_2018_1047AM)
+#define HPX_UTIL_ALLOCATOR_DELETER_AUG_08_2018_1047AM
+
+#include <hpx/config.hpp>
+
+#include <memory>
+
+namespace hpx { namespace util
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Allocator>
+    struct allocator_deleter
+    {
+        template <typename SharedState>
+        void operator()(SharedState* state)
+        {
+            using traits = std::allocator_traits<Allocator>;
+            traits::deallocate(alloc_, state, 1);
+        }
+
+        Allocator alloc_;
+    };
+}}
+
+#endif
+

--- a/hpx/util/detail/pack_traversal_async_impl.hpp
+++ b/hpx/util/detail/pack_traversal_async_impl.hpp
@@ -7,6 +7,8 @@
 #define HPX_UTIL_DETAIL_PACK_TRAVERSAL_ASYNC_IMPL_HPP
 
 #include <hpx/config.hpp>
+#include <hpx/traits/future_access.hpp>
+#include <hpx/util/allocator_deleter.hpp>
 #include <hpx/util/always_void.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/detail/container_category.hpp>
@@ -102,6 +104,7 @@ namespace util {
         template <typename Visitor, typename... Args>
         class async_traversal_frame : public Visitor
         {
+        protected:
             tuple<Args...> args_;
             std::atomic<bool> finished_;
 
@@ -187,6 +190,61 @@ namespace util {
             }
         };
 
+        /// Stores the visitor and the arguments to traverse
+        template <typename Allocator, typename Visitor, typename... Args>
+        class async_traversal_frame_allocator
+          : public async_traversal_frame<Visitor, Args...>
+        {
+            typedef async_traversal_frame<Visitor, Args...> base_type;
+            typedef typename
+                    std::allocator_traits<Allocator>::template
+                        rebind_alloc<async_traversal_frame_allocator>
+                other_allocator;
+
+        public:
+            explicit async_traversal_frame_allocator(
+                    other_allocator const& alloc, Visitor visitor, Args... args)
+              : base_type(std::move(visitor), std::move(args)...)
+              , alloc_(alloc)
+            {}
+
+            template <typename MapperArg>
+            explicit async_traversal_frame_allocator(
+                    other_allocator const& alloc,
+                    async_traverse_in_place_tag<Visitor> tag,
+                    MapperArg&& mapper_arg, Args... args)
+              : base_type(tag, std::forward<MapperArg>(mapper_arg),
+                  std::move(args)...)
+              , alloc_(alloc)
+            {}
+
+        private:
+            void destroy() override
+            {
+                typedef std::allocator_traits<other_allocator> traits;
+
+                other_allocator alloc(alloc_);
+                traits::destroy(alloc, this);
+                traits::deallocate(alloc, this, 1);
+            }
+
+            other_allocator alloc_;
+        };
+    }}
+
+    namespace traits { namespace detail
+    {
+        template <typename Visitor, typename... Args, typename Allocator>
+        struct shared_state_allocator<
+            util::detail::async_traversal_frame<Visitor, Args...>, Allocator>
+        {
+            typedef util::detail::async_traversal_frame_allocator<
+                Allocator, Visitor, Args...> type;
+        };
+    }}
+
+    namespace util { namespace detail
+    {
         template <typename Target, std::size_t Begin, std::size_t End>
         struct static_async_range
         {
@@ -605,6 +663,50 @@ namespace util {
                     std::forward<Visitor>(visitor),
                     std::forward<Args>(args)...),
                 false);
+
+            // Create a static range for the top level tuple
+            auto range = make_static_range(frame->head());
+
+            auto resumer = make_resume_traversal_callable(
+                frame, util::make_tuple(std::move(range)));
+
+            // Start the asynchronous traversal
+            resumer();
+            return frame;
+        }
+
+        /// Traverses the given pack with the given mapper, uses given allocator
+        /// to allocate the traversal frame
+        template <typename Allocator, typename Visitor, typename... Args,
+            typename types = async_traversal_types<Visitor, Args...>>
+        auto apply_pack_transform_async_allocator(
+                Allocator const& a, Visitor&& visitor, Args&&... args)
+        -> typename types::visitor_pointer_type
+        {
+            // Create the frame on the heap which stores the arguments
+            // to traverse asynchronously.
+            //
+            // Create an intrusive_ptr without increasing its reference count
+            // (it's already 'one').
+            using shared_state = typename traits::detail::shared_state_allocator<
+                    typename types::frame_type, Allocator
+                >::type;
+
+            using other_allocator = typename std::allocator_traits<Allocator>::
+                template rebind_alloc<shared_state>;
+            using traits = std::allocator_traits<other_allocator>;
+
+            using unique_ptr = std::unique_ptr<shared_state,
+                util::allocator_deleter<other_allocator>>;
+
+            other_allocator frame_alloc(a);
+            unique_ptr p(traits::allocate(frame_alloc, 1),
+                util::allocator_deleter<other_allocator>{frame_alloc});
+            traits::construct(
+                frame_alloc, p.get(), frame_alloc,
+                std::forward<Visitor>(visitor), std::forward<Args>(args)...);
+
+            auto frame = typename types::frame_pointer_type(p.release(), false);
 
             // Create a static range for the top level tuple
             auto range = make_static_range(frame->head());

--- a/src/runtime/threads/thread_data.cpp
+++ b/src/runtime/threads/thread_data.cpp
@@ -105,7 +105,8 @@ namespace hpx { namespace threads
     thread_self& get_self()
     {
         thread_self* p = get_self_ptr();
-        if (HPX_UNLIKELY(!p)) {
+        if (HPX_UNLIKELY(p == nullptr))
+        {
             HPX_THROW_EXCEPTION(null_thread_id, "threads::get_self",
                 "null thread id encountered (is this executed on a HPX-thread?)");
         }
@@ -135,7 +136,7 @@ namespace hpx { namespace threads
     {
         thread_self* p = thread_self::get_self();
 
-        if (HPX_UNLIKELY(!p))
+        if (HPX_UNLIKELY(p == nullptr))
         {
             HPX_THROWS_IF(ec, null_thread_id, "threads::get_self_ptr_checked",
                 "null thread id encountered (is this executed on a HPX-thread?)");
@@ -151,10 +152,10 @@ namespace hpx { namespace threads
     thread_id_type get_self_id()
     {
         thread_self* self = get_self_ptr();
-        if (nullptr == self)
-            return threads::invalid_thread_id;
+        if (HPX_LIKELY(nullptr != self))
+            return self->get_thread_id();
 
-        return self->get_thread_id();
+        return threads::invalid_thread_id;
     }
 
     std::size_t get_self_stacksize()
@@ -182,25 +183,25 @@ namespace hpx { namespace threads
     thread_id_type get_parent_id()
     {
         thread_self* self = get_self_ptr();
-        if (nullptr == self)
-            return threads::invalid_thread_id;
-        return self->get_thread_id()->get_parent_thread_id();
+        if (HPX_LIKELY(nullptr != self))
+            return self->get_thread_id()->get_parent_thread_id();
+        return threads::invalid_thread_id;
     }
 
     std::size_t get_parent_phase()
     {
         thread_self* self = get_self_ptr();
-        if (nullptr == self)
-            return 0;
-        return self->get_thread_id()->get_parent_thread_phase();
+        if (HPX_LIKELY(nullptr != self))
+            return self->get_thread_id()->get_parent_thread_phase();
+        return 0;
     }
 
     std::uint32_t get_parent_locality_id()
     {
         thread_self* self = get_self_ptr();
-        if (nullptr == self)
-            return naming::invalid_locality_id;
-        return self->get_thread_id()->get_parent_locality_id();
+        if (HPX_LIKELY(nullptr != self))
+            return self->get_thread_id()->get_parent_locality_id();
+        return naming::invalid_locality_id;
     }
 #endif
 
@@ -210,9 +211,9 @@ namespace hpx { namespace threads
         return 0;
 #else
         thread_self* self = get_self_ptr();
-        if (nullptr == self)
-            return 0;
-        return self->get_thread_id()->get_component_id();
+        if (HPX_LIKELY(nullptr != self))
+            return self->get_thread_id()->get_component_id();
+        return 0;
 #endif
     }
 
@@ -220,16 +221,16 @@ namespace hpx { namespace threads
     apex_task_wrapper get_self_apex_data()
     {
         thread_self* self = get_self_ptr();
-        if (nullptr == self)
-            return nullptr;
-        return self->get_apex_data();
+        if (HPX_LIKELY(nullptr != self))
+            return self->get_apex_data();
+        return nullptr;
     }
     void set_self_apex_data(apex_task_wrapper data)
     {
         thread_self* self = get_self_ptr();
-        if (nullptr == self)
-            return;
-        self->set_apex_data(data);
+        if (HPX_LIKELY(nullptr != self))
+            self->set_apex_data(data);
+        return;
     }
 #endif
 }}

--- a/tests/unit/lcos/when_each.cpp
+++ b/tests/unit/lcos/when_each.cpp
@@ -150,7 +150,7 @@ template <class Container>
 void test_when_each_n_from_list_iterators()
 {
     unsigned count = 10;
-    unsigned const n = 5;
+    unsigned n = 5;
 
     unsigned call_count = 0;
     unsigned call_with_index_count = 0;

--- a/tests/unit/parallel/segmented_algorithms/CMakeLists.txt
+++ b/tests/unit/parallel/segmented_algorithms/CMakeLists.txt
@@ -22,6 +22,7 @@ set(tests
     partitioned_vector_inclusive_scan
     partitioned_vector_inclusive_scan2
     partitioned_vector_exclusive_scan
+    partitioned_vector_exclusive_scan2
     partitioned_vector_transform_scan
     partitioned_vector_transform_scan2
     partitioned_vector_reduce

--- a/tests/unit/parallel/segmented_algorithms/partitioned_vector_exclusive_scan2.cpp
+++ b/tests/unit/parallel/segmented_algorithms/partitioned_vector_exclusive_scan2.cpp
@@ -350,7 +350,7 @@ void exclusive_scan_tests(std::vector<hpx::id_type>& localities)
 int main()
 {
     std::vector<hpx::id_type> localities = hpx::find_all_localities();
-    exclusive_scan_tests<long long>(localities);
+    exclusive_scan_tests<double>(localities);
 
     return hpx::util::report_errors();
 }


### PR DESCRIPTION

- make AGAS properly (fast-)resolve local-only ids
- avoid reading atomic in future state  more than necessary
- marking certain hot-spot functions as force-inline
- extend `future_access_customization_point` to support addref-control while creating a future from a shared state
- `unwrapping_result_policy` now holds id by reference
- flyby: fix warnings in `when_each` test
- flyby: split `partitioned_vector_exclusive_scan` test

This also adds overloads for APIs that produce futures taking an allocator (dataflow, make_ready_future, etc.)

This may supersede #3406 if we decide not to add the `thread_local_allocator` proposed there.