### PR TITLE
- bugfix : fix compilation with llvm-7.0

### DIFF
--- a/hpx/runtime/agas/interface.hpp
+++ b/hpx/runtime/agas/interface.hpp
@@ -12,7 +12,7 @@
 #include <hpx/config.hpp>
 
 #include <hpx/exception_fwd.hpp>
-#include <hpx/lcos_fwd.hpp>
+#include <hpx/lcos/future.hpp>
 #include <hpx/runtime/components/component_type.hpp>
 #include <hpx/runtime/components_fwd.hpp>
 #include <hpx/runtime/launch_policy.hpp>

--- a/hpx/runtime/components/make_client.hpp
+++ b/hpx/runtime/components/make_client.hpp
@@ -7,7 +7,7 @@
 #define HPX_COMPONENTS_MAKE_CLIENT_JAN_02_2017_0220PM
 
 #include <hpx/config.hpp>
-#include <hpx/lcos_fwd.hpp>
+#include <hpx/lcos/future.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/traits/is_client.hpp>
 


### PR DESCRIPTION
    -    this bugfix allows hpx to compile with llvm-7.0. In the
    following places, full headers were needed but only fwd headers were
    used. Leading to compilation errors.


Fixes #3461 

## Proposed Changes

  - include full headers instead of fwd headers in `hpx/runtime/agas/interface.hpp` and `hpx/runtime/components/make_client.hpp`.

