### PR TITLE
Add compiler specific fallthrough attributes if C++17 attribute is not available

### DIFF
--- a/hpx/config/attributes.hpp
+++ b/hpx/config/attributes.hpp
@@ -59,6 +59,12 @@
 // handle [[fallthrough]]
 #if defined(HPX_HAVE_CXX17_FALLTHROUGH_ATTRIBUTE)
 #   define HPX_FALLTHROUGH [[fallthrough]]
+#elif defined(HPX_GCC_VERSION) && (HPX_GCC_VERSION >= 70000)
+#   define HPX_FALLTHROUGH __attribute__((fallthrough))
+// All versions of clang supported by HPX have the [[clang::fallthrough]]
+// attribute.
+#elif defined(HPX_CLANG_VERSION)
+#   define HPX_FALLTHROUGH [[clang::fallthrough]]
 #else
 #   define HPX_FALLTHROUGH
 #endif


### PR DESCRIPTION
These warnings come up when building HPX with C++11 or 14 and a new compiler such as gcc 7.