### PR TITLE
Don't print docker credentials as part of the environment.

### DIFF
--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -221,7 +221,10 @@ namespace hpx { namespace detail
         std::string retval = hpx::util::format("{} entries:\n", env.size());
         for (std::string const& s : env)
         {
-            retval += "  " + s + "\n";
+            if (retval.find("DOCKER") == std::string::npos)
+            {
+                retval += "  " + s + "\n";
+            }
         }
         return retval;
     }


### PR DESCRIPTION
On CircleCI the docker credentials of the current user are printed as part of the execution environment. This PR removes those from the output.