### PR TITLE
Fixing the scope of the imported MPI CMake variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1695,6 +1695,14 @@ if(HPX_WITH_VIM_YCM)
   SET(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 endif()
 
+if(HPX_WITH_PARCELPORT_MPI)
+  if(CMAKE_VERSION VERSION_LESS 3.10)
+    find_package(MPI)
+  else()
+    find_package(MPI COMPONENTS CXX)
+  endif()
+endif()
+
 ################################################################################
 # Check Build Options based on the found dependencies. We also check for errors
 # with incompatible options with the currently selected platform.

--- a/plugins/parcelport/mpi/CMakeLists.txt
+++ b/plugins/parcelport/mpi/CMakeLists.txt
@@ -10,7 +10,6 @@ include(HPX_AddLibrary)
 # Decide whether to use the MPI based parcelport
 ################################################################################
 if(HPX_WITH_PARCELPORT_MPI)
-  find_package(MPI)
   if(NOT MPI_CXX_FOUND)
     hpx_error("MPI could not be found and HPX_WITH_PARCELPORT_MPI=On, please specify MPI_CXX_COMPILER to point to a working MPI C++ compiler for your platform")
   endif()


### PR DESCRIPTION
As these variables are used as part of a macro they must be visible at the point of expansion.

This fixes #3475.

While this PR fixes the issue, it might be better to get rid of the macro in the long run.