### PR TITLE
Making sure the application's exit code is properly propagated back to the OS

### DIFF
--- a/src/hpx_wrap.cpp
+++ b/src/hpx_wrap.cpp
@@ -61,16 +61,17 @@ namespace hpx_start
     // main entry point of the HPX runtime system
     int hpx_entry(int argc, char* argv[])
     {
-        #if defined(__linux) || defined(__linux__) || defined(linux)
+#if defined(__linux) || defined(__linux__) || defined(linux)
         // Call to the main() function
         int return_value = __real_main(argc, argv);
-        #else /* APPLE */
+#else /* APPLE */
         // call to the main() function
         int return_value = main(argc, argv);
-        #endif
+#endif
 
-        //Finalizing the HPX runtime
-        return hpx::finalize(return_value);
+        // Finalizing the HPX runtime
+        hpx::finalize();
+        return return_value;
     }
 }
 
@@ -81,10 +82,10 @@ namespace hpx_start
 // the hpx_main() as the entry point.
 extern "C" int initialize_main(int argc, char** argv)
 {
-    #if defined(__APPLE__)
+#if defined(__APPLE__)
     if(hpx_start::include_libhpx_wrap)
     {
-    #endif
+#endif
         // Configuring HPX system before runtime
         std::vector<std::string> const cfg = {
             "hpx.commandline.allow_unknown!=1",
@@ -99,10 +100,10 @@ extern "C" int initialize_main(int argc, char** argv)
         // Initialize the HPX runtime system
         return hpx::init(start_function, argc, argv,
             cfg, hpx::runtime_mode_console);
-    #if defined(__APPLE__)
+#if defined(__APPLE__)
     }
     return main(argc, argv);
-    #endif
+#endif
 }
 
 #if defined(__linux) || defined(__linux__) || defined(linux)

--- a/tests/regressions/lcos/call_promise_get_gid_more_than_once.cpp
+++ b/tests/regressions/lcos/call_promise_get_gid_more_than_once.cpp
@@ -4,7 +4,7 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx.hpp>
-#include <hpx/hpx_main.hpp>
+#include <hpx/hpx_init.hpp>
 
 #include <hpx/util/lightweight_test.hpp>
 

--- a/tests/unit/threads/tss.cpp
+++ b/tests/unit/threads/tss.cpp
@@ -10,6 +10,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <chrono>
 #include <mutex>
 #include <vector>
 #include <utility>
@@ -100,6 +101,12 @@ void test_tss_with_custom_cleanup()
 {
     hpx::thread t(&tss_thread_with_custom_cleanup);
     t.join();
+
+    // make sure the custom cleanup can run first (this is necessary as the TSS
+    // cleanup runs after the exit callbacks of a thread, which in this case
+    // might cause the t.join() above to return before the TSS was actually
+    // cleaned up.
+    hpx::this_thread::sleep_for(std::chrono::microseconds(100));
 
     HPX_TEST(tss_cleanup_called);
 }


### PR DESCRIPTION
This fixes the issue that some tests don't report their errors back to CircleCI.