### PR TITLE
Fix FLAGS - Use correct version of target_compile_options

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -243,12 +243,14 @@ endif()
 
 # Default unnamed config (not Debug/Release/etc) are in this var
 get_property(_temp_flags GLOBAL PROPERTY HPX_CMAKE_FLAGS_CXX_)
-add_compile_options(${_temp_flags})
+target_compile_options(hpx PUBLIC ${_temp_flags})
+# message("Adding ${_temp_flags}")
 
 # Could potentially use CMAKE_CONFIGURATION_TYPES in case a user defined config exists
 foreach(_config "DEBUG" "RELEASE" "RELWITHDEBINFO" "MINSIZEREL")
   get_property(_temp_flags GLOBAL PROPERTY HPX_CMAKE_FLAGS_CXX_${_config})
-  add_compile_options($<$<CONFIG:${_config}>:${_temp_flags}>)
+  target_compile_options(hpx PUBLIC $<$<CONFIG:${_config}>:${_temp_flags}>)
+  # message("Adding $<$<CONFIG:${_config}>:${_temp_flags}>")
 endforeach()
 
 #if(HPX_WITH_STATIC_LINKING)


### PR DESCRIPTION
The previous PR #3458 somehow got pushed by me with the wrong flag setting CMake call.
This one uses `target_compile_options` for the main hpx target and adds the PUBLIC setting so that all targets that depend on hpx also pick up the same flags.

@khuck noted on IRC that warnings had increased and he was correct.
