### PR TITLE
Fix comparison for expect_connecting_localities config entry

### DIFF
--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -272,7 +272,7 @@ namespace hpx { namespace components { namespace server
 {
     ///////////////////////////////////////////////////////////////////////////
     runtime_support::runtime_support(hpx::util::runtime_configuration & cfg)
-      : stop_called_(false), stop_done_(false), terminated_(false),
+      : stop_called_(true), stop_done_(true), terminated_(false),
         dijkstra_color_(false), shutdown_all_invoked_(false),
         modules_(cfg.modules())
     {}

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -648,7 +648,8 @@ namespace hpx { namespace util
         ini_config += std::string("hpx.expect_connecting_localities=") +
             (expect_connections ? "1" : "0");
 
-        if (num_localities_ != 1 || expect_connections)
+        if (num_localities_ != 1 || expect_connections ||
+            env.found_batch_environment())
         {
             initial_hpx_port =
                 boost::lexical_cast<std::uint16_t>(

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -640,7 +640,7 @@ namespace hpx { namespace util
         //  - num_localities > 1
         expect_connections =
             cfgmap.get_value<int>("hpx.expect_connecting_localities",
-                num_localities_ > 1 ? 0 : 1) ? true : false;
+                num_localities_ > 1 ? 1 : 0) ? true : false;
 
         if (vm.count("hpx:expect-connecting-localities"))
             expect_connections = true;

--- a/tests/unit/component/launch_process.cpp
+++ b/tests/unit/component/launch_process.cpp
@@ -162,7 +162,8 @@ int main(int argc, char* argv[])
     // This explicitly enables the component we depend on (it is disabled by
     // default to avoid being loaded outside of this test).
     std::vector<std::string> const cfg = {
-        "hpx.components.launch_process_test_server.enabled!=1"
+        "hpx.components.launch_process_test_server.enabled!=1",
+        "hpx.expect_connecting_localities!=1",
     };
 
     HPX_TEST_EQ_MSG(


### PR DESCRIPTION
I think this fixes #3453, although I'm not quite sure if there are side effects with multiple localities. This at least works for me with a single locality.

The `expect_connections` variable was set opposite to what the comment above it says, and the comment sounds like the correct thing to do, so I've changed it to expect connections only if the number of localities is greater than one (or if it's set explicitly of course).

@khuck could you check if this works for phylanx?