### PR TITLE
Don't create tasks immediately with hpx::apply

### DIFF
--- a/hpx/parallel/executors/post_policy_dispatch.hpp
+++ b/hpx/parallel/executors/post_policy_dispatch.hpp
@@ -29,7 +29,7 @@ namespace hpx { namespace parallel { namespace execution { namespace detail
             threads::register_thread_nullary(
                 hpx::util::deferred_call(
                     std::forward<F>(f), std::forward<Ts>(ts)...),
-                desc, threads::pending, true, policy.priority());
+                desc, threads::pending, false, policy.priority());
         }
     };
 

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -12,6 +12,7 @@
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/util/format.hpp>
 #include <hpx/util/high_resolution_timer.hpp>
+#include <hpx/include/apply.hpp>
 #include <hpx/include/async.hpp>
 #include <hpx/include/iostreams.hpp>
 #include <hpx/include/threads.hpp>
@@ -35,6 +36,7 @@ using hpx::naming::id_type;
 
 using hpx::future;
 using hpx::async;
+using hpx::apply;
 using hpx::lcos::wait_each;
 
 using hpx::util::high_resolution_timer;
@@ -170,7 +172,7 @@ void measure_function_futures_thread_count(std::uint64_t count, bool csv)
     high_resolution_timer walltime;
 
     for (std::uint64_t i = 0; i < count; ++i)
-        async(&null_function);
+        apply(&null_function);
 
     // Yield until there is only this and background threads left.
     auto this_pool = hpx::this_thread::get_pool();

--- a/tests/performance/local/resume_suspend.cpp
+++ b/tests/performance/local/resume_suspend.cpp
@@ -47,7 +47,7 @@ int main(int argc, char ** argv)
     std::uint64_t threads = hpx::resource::get_num_threads("default");
 
     std::cout
-        << "threads, resume [s], async [s], suspend [s]"
+        << "threads, resume [s], apply [s], suspend [s]"
         << std::endl;
 
     double suspend_time = 0;
@@ -64,10 +64,10 @@ int main(int argc, char ** argv)
 
         for (std::size_t thread = 0; thread < threads; ++thread)
         {
-            hpx::async([](){});
+            hpx::apply([](){});
         }
 
-        auto t_async = timer.elapsed();
+        auto t_apply = timer.elapsed();
 
         hpx::suspend();
         auto t_suspend = timer.elapsed();
@@ -76,7 +76,7 @@ int main(int argc, char ** argv)
         std::cout
             << threads << ", "
             << t_resume << ", "
-            << t_async << ", "
+            << t_apply << ", "
             << t_suspend
             << std::endl;
     }
@@ -85,7 +85,7 @@ int main(int argc, char ** argv)
     hpx::util::print_cdash_timing("SuspendTime", suspend_time);
 
     hpx::resume();
-    hpx::async([]() { hpx::finalize(); });
+    hpx::apply([]() { hpx::finalize(); });
     hpx::stop();
 }
 

--- a/tests/performance/local/start_stop.cpp
+++ b/tests/performance/local/start_stop.cpp
@@ -45,7 +45,7 @@ int main(int argc, char ** argv)
     hpx::stop();
 
     std::cout
-        << "threads, resume [s], async [s], suspend [s]"
+        << "threads, resume [s], apply [s], suspend [s]"
         << std::endl;
 
     double start_time = 0;
@@ -62,10 +62,10 @@ int main(int argc, char ** argv)
 
         for (std::size_t thread = 0; thread < threads; ++thread)
         {
-            hpx::async([](){});
+            hpx::apply([](){});
         }
 
-        auto t_async = timer.elapsed();
+        auto t_apply = timer.elapsed();
 
         hpx::stop();
         auto t_stop = timer.elapsed();
@@ -74,7 +74,7 @@ int main(int argc, char ** argv)
         std::cout
             << threads << ", "
             << t_start << ", "
-            << t_async << ", "
+            << t_apply << ", "
             << t_stop
             << std::endl;
     }

--- a/tests/unit/resource/shutdown_suspended_pus.cpp
+++ b/tests/unit/resource/shutdown_suspended_pus.cpp
@@ -6,7 +6,7 @@
 // Simple test verifying basic resource_partitioner functionality.
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/async.hpp>
+#include <hpx/include/apply.hpp>
 #include <hpx/include/resource_partitioner.hpp>
 #include <hpx/include/threads.hpp>
 #include <hpx/runtime/threads/policies/scheduler_mode.hpp>
@@ -39,7 +39,7 @@ int hpx_main(int argc, char* argv[])
     // Schedule some dummy work
     for (std::size_t i = 0; i < 100000; ++i)
     {
-        hpx::async([](){});
+        hpx::apply([](){});
     }
 
     // Start shutdown

--- a/tests/unit/resource/suspend_runtime.cpp
+++ b/tests/unit/resource/suspend_runtime.cpp
@@ -8,7 +8,6 @@
 #include <hpx/hpx_start.hpp>
 #include <hpx/hpx_suspend.hpp>
 #include <hpx/include/apply.hpp>
-#include <hpx/include/async.hpp>
 #include <hpx/include/threadmanager.hpp>
 #include <hpx/include/threads.hpp>
 #include <hpx/util/lightweight_test.hpp>
@@ -44,11 +43,11 @@ void test_scheduler(int argc, char* argv[],
     {
         hpx::resume();
 
-        hpx::async([]()
+        hpx::apply([]()
             {
                 for (std::size_t i = 0; i < 10000; ++i)
                 {
-                    hpx::async([](){});
+                    hpx::apply([](){});
                 }
             });
 

--- a/tests/unit/resource/suspend_thread.cpp
+++ b/tests/unit/resource/suspend_thread.cpp
@@ -81,7 +81,7 @@ int hpx_main(int argc, char* argv[])
                 }
             }
 
-            hpx::async(test_function).get();
+            hpx::async(test_function).wait();
 
             for (std::size_t thread_num_resume = 0;
                 thread_num_resume < num_threads;


### PR DESCRIPTION
Changes the `run_now` parameter to `false` in `post_policy_dispatch`, meaning the task is not immediately created. This can sometimes have a big impact in the `future_overhead` test when using `apply` (I changed one of the variations to use `apply`). Not creating the task immediately is also the same behaviour as with `async`.

It should also get rid of errors like [this](http://cdash.cscs.ch/testDetails.php?test=3504221&build=21298).

With the lazy thread init and friends PRs this won't be needed anymore.

I also changed `async` to `apply` in some places in the suspension tests where the futures were not used.