### PR TITLE
Fixing dataflow

### DIFF
--- a/hpx/util/detail/pack_traversal_async_impl.hpp
+++ b/hpx/util/detail/pack_traversal_async_impl.hpp
@@ -22,6 +22,7 @@
 #include <atomic>
 #include <cstddef>
 #include <exception>
+#include <functional>
 #include <iterator>
 #include <memory>
 #include <type_traits>
@@ -362,6 +363,12 @@ namespace util {
             return Range{std::begin(element), std::end(element)};
         }
 
+        template <typename T, typename Range = dynamic_async_range_of_t<T>>
+        Range make_dynamic_async_range(std::reference_wrapper<T> ref_element)
+        {
+            return Range{std::begin(ref_element.get()), std::end(ref_element.get())};
+        }
+
         /// Represents a particular point in a asynchronous traversal hierarchy
         template <typename Frame, typename... Hierarchy>
         class async_traversal_point
@@ -483,7 +490,7 @@ namespace util {
             void async_traverse_one(Current&& current)
             {
                 using ElementType =
-                    typename std::decay<decltype(*current)>::type;
+                    typename hpx::util::decay_unwrap<decltype(*current)>::type;
                 return async_traverse_one_impl(
                     container_category_of_t<ElementType>{},
                     std::forward<Current>(current));

--- a/hpx/util/detail/pack_traversal_impl.hpp
+++ b/hpx/util/detail/pack_traversal_impl.hpp
@@ -902,7 +902,7 @@ namespace util {
             auto traverse(Strategy, T&& element)
                 -> decltype(std::declval<mapping_helper>().match(
                     std::declval<container_category_of_t<
-                        typename std::decay<T>::type>>(),
+                        typename hpx::util::decay_unwrap<T>::type>>(),
                     std::declval<T>()));
 
             /// \copybrief traverse
@@ -910,14 +910,14 @@ namespace util {
             auto try_traverse(Strategy, T&& element)
                 -> decltype(std::declval<mapping_helper>().try_match(
                     std::declval<container_category_of_t<
-                        typename std::decay<T>::type>>(),
+                        typename hpx::util::decay_unwrap<T>::type>>(),
                     std::declval<T>()))
             {
                 // We use tag dispatching here, to categorize the type T whether
                 // it satisfies the container or tuple like requirements.
                 // Then we can choose the underlying implementation accordingly.
                 return try_match(
-                    container_category_of_t<typename std::decay<T>::type>{},
+                    container_category_of_t<typename hpx::util::decay_unwrap<T>::type>{},
                     std::forward<T>(element));
             }
 


### PR DESCRIPTION
This patch correctly handles vectors of futures that are passed in via `std::ref`.

Fixes #3248.