### PR TITLE
Disabling MPI's (deprecated) C++ interface

### DIFF
--- a/plugins/parcelport/mpi/CMakeLists.txt
+++ b/plugins/parcelport/mpi/CMakeLists.txt
@@ -10,7 +10,9 @@ include(HPX_AddLibrary)
 # Decide whether to use the MPI based parcelport
 ################################################################################
 if(HPX_WITH_PARCELPORT_MPI)
+  set(MPI_CXX_SKIP_MPICXX TRUE)
   find_package(MPI)
+
   if(NOT MPI_CXX_FOUND)
     hpx_error("MPI could not be found and HPX_WITH_PARCELPORT_MPI=On, please specify MPI_CXX_COMPILER to point to a working MPI C++ compiler for your platform")
   endif()

--- a/tests/headers/CMakeLists.txt
+++ b/tests/headers/CMakeLists.txt
@@ -35,7 +35,9 @@ endif()
 # add the MPI include path here, because for the main library, it's only
 # added for the plugin.
 if(HPX_WITH_PARCELPORT_MPI)
+  set(MPI_CXX_SKIP_MPICXX TRUE)
   find_package(MPI)
+
   if(MPI_CXX_INCLUDE_PATH)
     include_directories(${MPI_CXX_INCLUDE_PATH})
   endif()


### PR DESCRIPTION
Fixes #3475

## Proposed Changes

Disable MPI's (deprecated) C++ interface.

## Any background context you want to provide?

Including mpi.h might result in undefined references since it contains both the C and C++ interfaces but HPX only links against the C runtime. As HPX only uses the C interface, the C++ interface can be safely disabled to resolve the linker errors.

#3477 can be closed after merging this PR since it only provides an alternative fix.
