### PR TITLE
Remove thread specific ptr

### DIFF
--- a/examples/resource_partitioner/shared_priority_queue_scheduler.hpp
+++ b/examples/resource_partitioner/shared_priority_queue_scheduler.hpp
@@ -15,7 +15,6 @@
 #include <hpx/runtime/threads/thread_data.hpp>
 #include <hpx/runtime/threads/topology.hpp>
 #include <hpx/runtime/threads_fwd.hpp>
-#include <hpx/runtime/threads/detail/thread_num_tss.hpp>
 #include <hpx/throw_exception.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/logging.hpp>
@@ -726,8 +725,7 @@ namespace example {
             {
                 // Create thread on this worker thread if possible
                 LOG_CUSTOM_VAR(msg = msgs[0]);
-                std::size_t global_thread_num =
-                    threads::detail::thread_num_tss_.get_worker_thread_num();
+                std::size_t global_thread_num = hpx::get_worker_thread_num();
                 thread_num = this->global_to_local_thread_index(global_thread_num);
                 if (thread_num>=num_workers_) {
                     // This is a task being injected from a thread on another pool.
@@ -757,8 +755,7 @@ namespace example {
                 domain_num = data.schedulehint.hint % num_domains_;
                 // if the thread creating the new task is on the domain
                 // assigned to the new task - try to reuse the core as well
-                std::size_t global_thread_num =
-                    threads::detail::thread_num_tss_.get_worker_thread_num();
+                std::size_t global_thread_num = hpx::get_worker_thread_num();
                 thread_num = this->global_to_local_thread_index(global_thread_num);
                 if (d_lookup_[thread_num] == domain_num) {
                     q_index = q_lookup_[thread_num];
@@ -928,8 +925,7 @@ namespace example {
             {
                 // Create thread on this worker thread if possible
                 LOG_CUSTOM_VAR(msg = msgs[0]);
-                std::size_t global_thread_num =
-                    threads::detail::thread_num_tss_.get_worker_thread_num();
+                std::size_t global_thread_num = hpx::get_worker_thread_num();
                 thread_num = this->global_to_local_thread_index(global_thread_num);
                 if (thread_num>=num_workers_) {
                     // This is a task being injected from a thread on another pool.
@@ -960,8 +956,7 @@ namespace example {
                 domain_num = schedulehint.hint % num_domains_;
                 // if the thread creating the new task is on the domain
                 // assigned to the new task - try to reuse the core as well
-                std::size_t global_thread_num =
-                    threads::detail::thread_num_tss_.get_worker_thread_num();
+                std::size_t global_thread_num = hpx::get_worker_thread_num();
                 thread_num = this->global_to_local_thread_index(global_thread_num);
                 if (d_lookup_[thread_num] == domain_num) {
                     q_index = q_lookup_[thread_num];
@@ -1030,8 +1025,7 @@ namespace example {
             {
                 // Create thread on this worker thread if possible
                 LOG_CUSTOM_VAR(msg = msgs[0]);
-                std::size_t global_thread_num =
-                    threads::detail::thread_num_tss_.get_worker_thread_num();
+                std::size_t global_thread_num = hpx::get_worker_thread_num();
                 thread_num = this->global_to_local_thread_index(global_thread_num);
                 if (thread_num>=num_workers_) {
                     // This is a task being injected from a thread on another pool.
@@ -1062,8 +1056,7 @@ namespace example {
                 domain_num = schedulehint.hint % num_domains_;
                 // if the thread creating the new task is on the domain
                 // assigned to the new task - try to reuse the core as well
-                std::size_t global_thread_num =
-                    threads::detail::thread_num_tss_.get_worker_thread_num();
+                std::size_t global_thread_num = hpx::get_worker_thread_num();
                 thread_num = this->global_to_local_thread_index(global_thread_num);
                 if (d_lookup_[thread_num] == domain_num) {
                     q_index = q_lookup_[thread_num];

--- a/examples/resource_partitioner/system_characteristics.hpp
+++ b/examples/resource_partitioner/system_characteristics.hpp
@@ -24,7 +24,6 @@ void print_system_characteristics()
     hpx::runtime* rt = hpx::get_runtime_ptr();
     hpx::util::runtime_configuration cfg = rt->get_config();
     const hpx::threads::topology& topo = rt->get_topology();
-    hpx::threads::threadmanager& thrd_manager = rt->get_thread_manager();
 
     // -------------------------------------- //
     //      print runtime characteristics     //
@@ -34,13 +33,13 @@ void print_system_characteristics()
     //! -------------------------------------- runtime
     std::cout << "[Runtime], instance number " << rt->get_instance_number()
               << "\n"
-              << "called by thread named     " << rt->get_thread_name()
+              << "called by thread named     " << hpx::get_thread_name()
               << "\n\n";
 
     //! -------------------------------------- thread_manager
     std::cout << "[Thread manager]\n"
               << "worker thread number  : " << std::dec
-              << thrd_manager.get_worker_thread_num() << "\n\n";
+              << hpx::get_worker_thread_num() << "\n\n";
 
     //! -------------------------------------- runtime_configuration
     std::cout << "[Runtime configuration]\n"

--- a/hpx/runtime.hpp
+++ b/hpx/runtime.hpp
@@ -24,7 +24,6 @@
 #include <hpx/runtime_fwd.hpp>
 #include <hpx/state.hpp>
 #include <hpx/util/runtime_configuration.hpp>
-#include <hpx/util/thread_specific_ptr.hpp>
 
 #include <atomic>
 #include <cstddef>
@@ -121,13 +120,6 @@ namespace hpx
             return state_.load() == state_stopped;
         }
 
-        // the TSS holds a pointer to the runtime associated with a given
-        // OS thread
-        struct tls_tag {};
-        static util::thread_specific_ptr<runtime*, tls_tag> runtime_;
-        static util::thread_specific_ptr<std::string, tls_tag> thread_name_;
-        static util::thread_specific_ptr<std::uint64_t, tls_tag> uptime_;
-
         /// \brief access configuration information
         util::runtime_configuration& get_config()
         {
@@ -142,9 +134,6 @@ namespace hpx
         {
             return static_cast<std::size_t>(instance_number_);
         }
-
-        /// \brief Return the name of the calling thread.
-        static std::string get_thread_name();
 
         /// \brief Return the system uptime measure on the thread executing this call
         static std::uint64_t get_system_uptime();

--- a/hpx/runtime/applier/applier.hpp
+++ b/hpx/runtime/applier/applier.hpp
@@ -162,14 +162,6 @@ namespace hpx { namespace applier
             return memory_id_;
         }
 
-    public:
-        // the TSS holds a pointer to the applier associated with a given
-        // OS thread
-        struct tls_tag {};
-        static hpx::util::thread_specific_ptr<applier*, tls_tag> applier_;
-        void init_tss();
-        void deinit_tss();
-
     private:
         parcelset::parcelhandler& parcel_handler_;
         threads::threadmanager& thread_manager_;

--- a/hpx/runtime/runtime_fwd.hpp
+++ b/hpx/runtime/runtime_fwd.hpp
@@ -21,7 +21,7 @@ namespace hpx
     /// The function \a get_runtime returns a reference to the (thread
     /// specific) runtime instance.
     HPX_API_EXPORT runtime& get_runtime();
-    HPX_API_EXPORT runtime* get_runtime_ptr();
+    HPX_API_EXPORT runtime*& get_runtime_ptr();
 }
 
 #endif

--- a/hpx/runtime/threads/coroutines/detail/coroutine_self.hpp
+++ b/hpx/runtime/threads/coroutines/detail/coroutine_self.hpp
@@ -194,10 +194,16 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         }
 
     public:
-        static HPX_EXPORT void set_self(coroutine_self* self);
-        static HPX_EXPORT coroutine_self* get_self();
-        static HPX_EXPORT void init_self();
-        static HPX_EXPORT void reset_self();
+        static HPX_EXPORT coroutine_self*& local_self();
+
+        static void set_self(coroutine_self* self)
+        {
+            local_self() = self;
+        }
+        static coroutine_self* get_self()
+        {
+            return local_self();
+        }
 
 #if defined(HPX_HAVE_APEX)
         apex_task_wrapper get_apex_data(void) const

--- a/hpx/runtime/threads/detail/thread_num_tss.hpp
+++ b/hpx/runtime/threads/detail/thread_num_tss.hpp
@@ -7,7 +7,6 @@
 #define HPX_RUNTIME_THREADS_DETAIL_THREAD_NUM_TSS_JUL_17_2015_0811PM
 
 #include <hpx/config.hpp>
-#include <hpx/util/thread_specific_ptr.hpp>
 
 #include <cstddef>
 
@@ -15,35 +14,19 @@
 
 namespace hpx { namespace threads { namespace detail
 {
-    ///////////////////////////////////////////////////////////////////////////
-    class HPX_EXPORT thread_num_tss
-    {
-    public:
-        std::size_t set_tss_threadnum(std::size_t num);
-        void init_tss(std::size_t num);
-        void deinit_tss();
-
-        std::size_t get_worker_thread_num() const;
-
-    private:
-        // the TSS holds the number associated with a given OS thread
-        struct tls_tag {};
-        static hpx::util::thread_specific_ptr<std::size_t, tls_tag> thread_num_;
-    };
-
-    // the TSS holds the number associated with a given OS thread
-    extern HPX_EXPORT thread_num_tss thread_num_tss_;
+    HPX_EXPORT std::size_t set_thread_num_tss(std::size_t num);
+    HPX_EXPORT std::size_t get_thread_num_tss();
 
     ///////////////////////////////////////////////////////////////////////////
     struct reset_tss_helper
     {
         reset_tss_helper(std::size_t thread_num)
-          : thread_num_(thread_num_tss_.set_tss_threadnum(thread_num))
+          : thread_num_(set_thread_num_tss(thread_num))
         {}
 
         ~reset_tss_helper()
         {
-            thread_num_tss_.set_tss_threadnum(thread_num_);
+            set_thread_num_tss(thread_num_);
         }
 
         std::size_t previous_thread_num() const

--- a/hpx/runtime/threads/policies/shared_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/shared_priority_queue_scheduler.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/compat/mutex.hpp>
+#include <hpx/runtime/get_worker_thread_num.hpp>
 #include <hpx/runtime/threads/policies/lockfree_queue_backends.hpp>
 #include <hpx/runtime/threads/policies/queue_helpers.hpp>
 #include <hpx/runtime/threads/policies/scheduler_base.hpp>
@@ -15,7 +16,6 @@
 #include <hpx/runtime/threads/thread_data.hpp>
 #include <hpx/runtime/threads/topology.hpp>
 #include <hpx/runtime/threads_fwd.hpp>
-#include <hpx/runtime/threads/detail/thread_num_tss.hpp>
 #include <hpx/throw_exception.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/logging.hpp>
@@ -591,8 +591,7 @@ namespace policies {
             case thread_schedule_hint_mode::thread_schedule_hint_mode_none:
             {
                 // Create thread on this worker thread if possible
-                std::size_t global_thread_num =
-                    threads::detail::thread_num_tss_.get_worker_thread_num();
+                std::size_t global_thread_num = hpx::get_worker_thread_num();
                 thread_num = this->global_to_local_thread_index(global_thread_num);
                 if (thread_num>=num_workers_) {
                     // This is a task being injected from a thread on another pool.
@@ -620,8 +619,7 @@ namespace policies {
                 domain_num = data.schedulehint.hint % num_domains_;
                 // if the thread creating the new task is on the domain
                 // assigned to the new task - try to reuse the core as well
-                std::size_t global_thread_num =
-                    threads::detail::thread_num_tss_.get_worker_thread_num();
+                std::size_t global_thread_num = hpx::get_worker_thread_num();
                 thread_num = this->global_to_local_thread_index(global_thread_num);
                 if (d_lookup_[thread_num] == domain_num) {
                     q_index = q_lookup_[thread_num];
@@ -756,8 +754,7 @@ namespace policies {
             case thread_schedule_hint_mode::thread_schedule_hint_mode_none:
             {
                 // Create thread on this worker thread if possible
-                std::size_t global_thread_num =
-                    threads::detail::thread_num_tss_.get_worker_thread_num();
+                std::size_t global_thread_num = hpx::get_worker_thread_num();
                 thread_num = this->global_to_local_thread_index(global_thread_num);
                 if (thread_num>=num_workers_) {
                     // This is a task being injected from a thread on another pool.
@@ -786,8 +783,7 @@ namespace policies {
                 domain_num = schedulehint.hint % num_domains_;
                 // if the thread creating the new task is on the domain
                 // assigned to the new task - try to reuse the core as well
-                std::size_t global_thread_num =
-                    threads::detail::thread_num_tss_.get_worker_thread_num();
+                std::size_t global_thread_num = hpx::get_worker_thread_num();
                 thread_num = this->global_to_local_thread_index(global_thread_num);
                 if (d_lookup_[thread_num] == domain_num) {
                     q_index = q_lookup_[thread_num];
@@ -846,8 +842,7 @@ namespace policies {
             case thread_schedule_hint_mode::thread_schedule_hint_mode_none:
             {
                 // Create thread on this worker thread if possible
-                std::size_t global_thread_num =
-                    threads::detail::thread_num_tss_.get_worker_thread_num();
+                std::size_t global_thread_num = hpx::get_worker_thread_num();
                 thread_num = this->global_to_local_thread_index(global_thread_num);
                 if (thread_num>=num_workers_) {
                     // This is a task being injected from a thread on another pool.
@@ -876,8 +871,7 @@ namespace policies {
                 domain_num = schedulehint.hint % num_domains_;
                 // if the thread creating the new task is on the domain
                 // assigned to the new task - try to reuse the core as well
-                std::size_t global_thread_num =
-                    threads::detail::thread_num_tss_.get_worker_thread_num();
+                std::size_t global_thread_num = hpx::get_worker_thread_num();
                 thread_num = this->global_to_local_thread_index(global_thread_num);
                 if (d_lookup_[thread_num] == domain_num) {
                     q_index = q_lookup_[thread_num];

--- a/hpx/runtime/threads/thread_pool_base.hpp
+++ b/hpx/runtime/threads/thread_pool_base.hpp
@@ -165,7 +165,6 @@ namespace hpx { namespace threads
 
     public:
         /// \cond NOINTERNAL
-        std::size_t get_worker_thread_num() const;
         virtual std::size_t get_os_thread_count() const = 0;
 
         virtual compat::thread& get_os_thread_handle(

--- a/hpx/runtime/threads/threadmanager.hpp
+++ b/hpx/runtime/threads/threadmanager.hpp
@@ -245,14 +245,6 @@ namespace hpx { namespace threads
             }
         }
 
-        // Return the (global) sequence number of the current thread
-        std::size_t get_worker_thread_num(bool* /*numa_sensitive*/ = nullptr)
-        {
-            if (get_self_ptr() == nullptr)
-                return std::size_t(-1);
-            return detail::thread_num_tss_.get_worker_thread_num();
-        }
-
     public:
         /// The function register_counter_types() is called during startup to
         /// allow the registration of all performance counter types for this
@@ -300,12 +292,12 @@ namespace hpx { namespace threads
 
         void init_tss(std::size_t num)
         {
-            detail::thread_num_tss_.init_tss(num);
+            detail::set_thread_num_tss(num);
         }
 
         void deinit_tss()
         {
-            detail::thread_num_tss_.deinit_tss();
+            detail::set_thread_num_tss(std::size_t(-1));
         }
 
     public:

--- a/hpx/runtime_impl.hpp
+++ b/hpx/runtime_impl.hpp
@@ -23,7 +23,6 @@
 #include <hpx/runtime/threads/topology.hpp> //! FIXME remove
 #include <hpx/util/generate_unique_ids.hpp>
 #include <hpx/util/io_service_pool.hpp>
-#include <hpx/util/thread_specific_ptr.hpp>
 #include <hpx/util_fwd.hpp>
 
 #include <cstddef>

--- a/hpx/util/register_locks.hpp
+++ b/hpx/util/register_locks.hpp
@@ -37,7 +37,6 @@ namespace hpx { namespace util
     HPX_API_EXPORT void reset_ignored(void const* lock);
     HPX_API_EXPORT void ignore_all_locks();
     HPX_API_EXPORT void reset_ignored_all();
-    HPX_API_EXPORT void reset_held_lock_data();
 
     ///////////////////////////////////////////////////////////////////////////
     struct ignore_all_while_checking
@@ -119,9 +118,6 @@ namespace hpx { namespace util
     {
     }
     inline void reset_ignored_all()
-    {
-    }
-    inline void reset_held_lock_data()
     {
     }
 #endif

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -613,7 +613,7 @@ namespace hpx
             thread_info = true;
         }
 
-        std::string thread_name = runtime::get_thread_name();
+        std::string thread_name = hpx::get_thread_name();
         if (!thread_info)
             strm << thread_prefix;
         else

--- a/src/runtime/applier/applier.cpp
+++ b/src/runtime/applier/applier.cpp
@@ -7,6 +7,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/exception.hpp>
+#include <hpx/runtime.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/runtime/agas/interface.hpp>
 #include <hpx/runtime/applier/applier.hpp>
@@ -120,12 +121,9 @@ namespace hpx { namespace applier
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    hpx::util::thread_specific_ptr<applier*, applier::tls_tag> applier::applier_;
-
     applier::applier(parcelset::parcelhandler &ph, threads::threadmanager& tm)
       : parcel_handler_(ph), thread_manager_(tm)
     {
-        init_tss();
     }
 
     void applier::initialize(std::uint64_t rts, std::uint64_t mem)
@@ -217,35 +215,14 @@ namespace hpx { namespace applier
         return true;
     }
 
-    void applier::init_tss()
-    {
-        if (nullptr == applier::applier_.get())
-            applier::applier_.reset(new applier* (this));
-    }
-
-    void applier::deinit_tss()
-    {
-        applier::applier_.reset();
-    }
-
     applier& get_applier()
     {
-        // should have been initialized
-        HPX_ASSERT(nullptr != applier::applier_.get());
-        return **applier::applier_;
+        return hpx::get_runtime().get_applier();
     }
 
     applier* get_applier_ptr()
     {
-        applier** appl = applier::applier_.get();
-        return appl ? *appl : nullptr;
-    }
-
-    // The function \a get_locality_id returns the id of this locality
-    std::uint32_t get_locality_id(error_code& ec) //-V659
-    {
-        applier** appl = applier::applier_.get();
-        return appl ? (*appl)->get_locality_id(ec) : naming::invalid_locality_id;
+        return &hpx::get_runtime().get_applier();
     }
 }}
 

--- a/src/runtime/threads/coroutines/detail/coroutine_self.cpp
+++ b/src/runtime/threads/coroutines/detail/coroutine_self.cpp
@@ -7,35 +7,14 @@
 #include <hpx/config.hpp>
 #include <hpx/runtime/threads/coroutines/detail/coroutine_self.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/thread_specific_ptr.hpp>
 
 #include <cstddef>
 
 namespace hpx { namespace threads { namespace coroutines { namespace detail
 {
-    struct tls_tag {};
-
-    static util::thread_specific_ptr<coroutine_self*, tls_tag> self_;
-
-    void coroutine_self::set_self(coroutine_self* self)
+    coroutine_self*& coroutine_self::local_self()
     {
-        HPX_ASSERT(nullptr != self_.get());
-        *self_ = self;
-    }
-
-    coroutine_self* coroutine_self::get_self()
-    {
-        return (nullptr == self_.get()) ? nullptr : *self_;
-    }
-
-    void coroutine_self::init_self()
-    {
-        HPX_ASSERT(nullptr == self_.get());
-        self_.reset(new coroutine_self*(nullptr));
-    }
-
-    void coroutine_self::reset_self()
-    {
-        self_.reset(nullptr);
+        HPX_NATIVE_TLS coroutine_self* local_self_ = nullptr;
+        return local_self_;
     }
 }}}}

--- a/src/runtime/threads/detail/thread_num_tss.cpp
+++ b/src/runtime/threads/detail/thread_num_tss.cpp
@@ -3,53 +3,29 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config.hpp>
 #include <hpx/runtime/threads/detail/thread_num_tss.hpp>
-#include <hpx/util/assert.hpp>
 
 #include <cstddef>
 #include <utility>
 
 namespace hpx { namespace threads { namespace detail
 {
-    // the TSS holds the number associated with a given OS thread
-    thread_num_tss thread_num_tss_;
-
-    ///////////////////////////////////////////////////////////////////////////
-    hpx::util::thread_specific_ptr<
-            std::size_t, thread_num_tss::tls_tag
-        > thread_num_tss::thread_num_;
-
-    void thread_num_tss::init_tss(std::size_t num)
-    {
-        // shouldn't be initialized yet
-        if (nullptr == thread_num_tss::thread_num_.get())
+    namespace {
+        std::size_t& thread_num_tss()
         {
-            thread_num_tss::thread_num_.reset(new std::size_t);
-            *thread_num_tss::thread_num_.get() = num;
+            HPX_NATIVE_TLS std::size_t thread_num_tss_ = std::size_t(-1);
+            return thread_num_tss_;
         }
     }
 
-    void thread_num_tss::deinit_tss()
+    std::size_t set_thread_num_tss(std::size_t num)
     {
-        thread_num_tss::thread_num_.reset();
-    }
-
-    std::size_t thread_num_tss::set_tss_threadnum(std::size_t num)
-    {
-        // should have been initialized
-        HPX_ASSERT(nullptr != thread_num_tss::thread_num_.get());
-
-        std::swap(*thread_num_tss::thread_num_.get(), num);
+        std::swap(thread_num_tss(), num);
         return num;
     }
 
-    std::size_t thread_num_tss::get_worker_thread_num() const
+    std::size_t get_thread_num_tss()
     {
-        if (nullptr != thread_num_tss::thread_num_.get())
-            return *thread_num_tss::thread_num_;
-
-        // some OS threads are not managed by the thread-manager
-        return std::size_t(-1);
+        return thread_num_tss();
     }
 }}}

--- a/src/runtime/threads/executors/this_thread_executors.cpp
+++ b/src/runtime/threads/executors/this_thread_executors.cpp
@@ -14,10 +14,11 @@
 #  include <hpx/runtime/threads/policies/static_queue_scheduler.hpp>
 #endif
 
+#include <hpx/runtime/get_worker_thread_num.hpp>
 #include <hpx/runtime/threads/detail/scheduling_loop.hpp>
 #include <hpx/runtime/threads/detail/create_thread.hpp>
-#include <hpx/runtime/threads/detail/thread_num_tss.hpp>
 #include <hpx/runtime/threads/detail/set_thread_state.hpp>
+#include <hpx/runtime/threads/detail/thread_num_tss.hpp>
 #include <hpx/runtime/threads/executors/manage_thread_executor.hpp>
 #include <hpx/runtime/threads/resource_manager.hpp>
 #include <hpx/runtime/threads/thread_enums.hpp>
@@ -431,7 +432,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         HPX_ASSERT(std::size_t(-1) == orig_thread_num_);
 
         thread_num_ = thread_num;
-        orig_thread_num_ = threads::detail::thread_num_tss_.get_worker_thread_num();
+        orig_thread_num_ = hpx::get_worker_thread_num();
 
         std::atomic<hpx::state>& state = scheduler_.get_state(0);
         hpx::state expected = state_initialized;

--- a/src/runtime/threads/thread_helpers.cpp
+++ b/src/runtime/threads/thread_helpers.cpp
@@ -312,7 +312,7 @@ namespace hpx { namespace threads
         if (&ec != &throws)
             ec = make_success_code();
 
-        return id ? id->get_lco_description() : "<unknown>";
+        return id->get_lco_description();
     }
 
     util::thread_description set_thread_lco_description(
@@ -329,9 +329,7 @@ namespace hpx { namespace threads
         if (&ec != &throws)
             ec = make_success_code();
 
-        if (id)
-            return id->set_lco_description(desc);
-        return nullptr;
+        return id->set_lco_description(desc);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -352,7 +350,7 @@ namespace hpx { namespace threads
         if (&ec != &throws)
             ec = make_success_code();
 
-        return id ? id->get_backtrace() : nullptr;
+        return id->get_backtrace();
     }
 
 #ifdef HPX_HAVE_THREAD_FULLBACKTRACE_ON_SUSPENSION
@@ -373,7 +371,7 @@ namespace hpx { namespace threads
         if (&ec != &throws)
             ec = make_success_code();
 
-        return id ? id->set_backtrace(bt) : nullptr;
+        return id->set_backtrace(bt);
     }
 
     threads::executors::current_executor

--- a/src/runtime/threads/thread_pool_base.cpp
+++ b/src/runtime/threads/thread_pool_base.cpp
@@ -12,7 +12,6 @@
 #include <hpx/throw_exception.hpp>
 #include <hpx/runtime/get_worker_thread_num.hpp>
 #include <hpx/runtime/threads/detail/set_thread_state.hpp>
-#include <hpx/runtime/threads/detail/thread_num_tss.hpp>
 #include <hpx/runtime/threads/policies/callback_notifier.hpp>
 #include <hpx/runtime/threads/thread_pool_base.hpp>
 #include <hpx/runtime/threads/topology.hpp>
@@ -21,7 +20,6 @@
 #include <hpx/util/logging.hpp>
 #include <hpx/util/hardware/timestamp.hpp>
 #include <hpx/util/high_resolution_clock.hpp>
-#include <hpx/util/thread_specific_ptr.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -86,12 +84,6 @@ namespace hpx { namespace threads
         }
 
         return active_os_thread_count;
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    std::size_t thread_pool_base::get_worker_thread_num() const
-    {
-        return detail::thread_num_tss_.get_worker_thread_num();
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -61,6 +61,11 @@ namespace hpx
     std::list<shutdown_function_type> global_pre_shutdown_functions;
     std::list<shutdown_function_type> global_shutdown_functions;
 
+    namespace detail
+    {
+        extern std::string& runtime_thread_name();
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     void register_pre_startup_function(startup_function_type f)
     {
@@ -770,40 +775,36 @@ namespace hpx
         // initialize our TSS
         this->runtime::init_tss();
 
-        // initialize applier TSS
-        applier_.init_tss();
-
         // set the thread's name, if it's not already set
-        if (nullptr == runtime::thread_name_.get())
-        {
-            std::string* fullname = new std::string(locality);
-            if (!locality.empty())
-                *fullname += "/";
-            *fullname += context;
-            if (postfix && *postfix)
-                *fullname += postfix;
-            *fullname += "#" + std::to_string(num);
-            runtime::thread_name_.reset(fullname);
+        HPX_ASSERT(detail::runtime_thread_name().empty());
 
-            char const* name = runtime::thread_name_.get()->c_str();
+        std::string fullname = std::string(locality);
+        if (!locality.empty())
+            fullname += "/";
+        fullname += context;
+        if (postfix && *postfix)
+            fullname += postfix;
+        fullname += "#" + std::to_string(num);
+        detail::runtime_thread_name() = std::move(fullname);
 
-            // initialize thread mapping for external libraries (i.e. PAPI)
-            thread_support_->register_thread(name, ec);
+        char const* name = detail::runtime_thread_name().c_str();
 
-            // initialize coroutines context switcher
-            hpx::threads::coroutines::thread_startup(name);
+        // initialize thread mapping for external libraries (i.e. PAPI)
+        thread_support_->register_thread(name, ec);
 
-            // register this thread with any possibly active Intel tool
-            HPX_ITT_THREAD_SET_NAME(name);
+        // initialize coroutines context switcher
+        hpx::threads::coroutines::thread_startup(name);
 
-            // set thread name as shown in Visual Studio
-            util::set_thread_name(name);
+        // register this thread with any possibly active Intel tool
+        HPX_ITT_THREAD_SET_NAME(name);
+
+        // set thread name as shown in Visual Studio
+        util::set_thread_name(name);
 
 #if defined(HPX_HAVE_APEX)
-            if (std::strstr(name, "worker") != nullptr)
-                apex::register_thread(name);
+        if (std::strstr(name, "worker") != nullptr)
+            apex::register_thread(name);
 #endif
-        }
 
         // call thread-specific user-supplied on_error handler
         if (on_start_func_)
@@ -837,7 +838,7 @@ namespace hpx
 //                         , hpx::util::format(
 //                             "failed to set thread affinity mask ("
 //                             HPX_CPU_MASK_PREFIX "{:x}) for service thread: {}",
-//                             used_processing_units, runtime::thread_name_.get()));
+//                             used_processing_units, detail::runtime_thread_name()));
 //                 }
             }
 #endif
@@ -855,9 +856,6 @@ namespace hpx
         // initialize coroutines context switcher
         hpx::threads::coroutines::thread_shutdown();
 
-        // reset applier TSS
-        applier_.deinit_tss();
-
         // reset our TSS
         this->runtime::deinit_tss();
 
@@ -865,7 +863,7 @@ namespace hpx
         thread_support_->unregister_thread();
 
         // reset thread local storage
-        runtime::thread_name_.reset();
+        detail::runtime_thread_name().clear();
     }
 
     naming::gid_type
@@ -926,7 +924,7 @@ namespace hpx
     bool runtime_impl::register_thread(
         char const* name, std::size_t num, bool service_thread, error_code& ec)
     {
-        if (nullptr != runtime::thread_name_.get())
+        if (nullptr != get_runtime_ptr())
             return false;       // already registered
 
         // prefix thread name with locality number, if needed
@@ -944,10 +942,10 @@ namespace hpx
     /// Unregister an external OS-thread with HPX
     bool runtime_impl::unregister_thread()
     {
-        if (nullptr == runtime::thread_name_.get())
+        if (nullptr != get_runtime_ptr())
             return false;       // never registered
 
-        deinit_tss(get_thread_name().c_str(), hpx::get_worker_thread_num());
+        deinit_tss(detail::runtime_thread_name().c_str(), hpx::get_worker_thread_num());
         return true;
     }
 

--- a/src/util/register_locks.cpp
+++ b/src/util/register_locks.cpp
@@ -11,7 +11,6 @@
 #include <hpx/util/assert.hpp>
 #include <hpx/util/logging.hpp>
 #include <hpx/util/register_locks.hpp>
-#include <hpx/util/thread_specific_ptr.hpp>
 
 #include <map>
 #include <string>
@@ -72,83 +71,37 @@ namespace hpx { namespace util
                 bool ignore_all_locks_;
             };
 
-            struct tls_tag {};
-            static hpx::util::thread_specific_ptr<held_locks_data, tls_tag> held_locks_;
+            static HPX_NATIVE_TLS held_locks_data held_locks_;
 
             static bool lock_detection_enabled_;
 
             static held_locks_map& get_lock_map()
             {
-                if (nullptr == held_locks_.get())
-                {
-                    held_locks_.reset(new held_locks_data());
-                }
-
-                HPX_ASSERT(nullptr != held_locks_.get());
-                return held_locks_.get()->data_;
+                return held_locks_.data_;
             }
 
             static bool get_lock_enabled()
             {
-                if (nullptr == held_locks_.get())
-                {
-                    held_locks_.reset(new held_locks_data());
-                }
-
-                detail::register_locks::held_locks_data* m = held_locks_.get();
-                HPX_ASSERT(nullptr != m);
-
-                return m->enabled_;
+                return held_locks_.enabled_;
             }
 
             static void set_lock_enabled(bool enable)
             {
-                if (nullptr == held_locks_.get())
-                {
-                    held_locks_.reset(new held_locks_data());
-                }
-
-                detail::register_locks::held_locks_data* m = held_locks_.get();
-                HPX_ASSERT(nullptr != m);
-
-                m->enabled_ = enable;
+                held_locks_.enabled_ = enable;
             }
 
             static bool get_ignore_all_locks()
             {
-                if (nullptr == held_locks_.get())
-                {
-                    held_locks_.reset(new held_locks_data());
-                }
-
-                detail::register_locks::held_locks_data* m = held_locks_.get();
-                HPX_ASSERT(nullptr != m);
-
-                return !m->ignore_all_locks_;
+                return !held_locks_.ignore_all_locks_;
             }
 
             static void set_ignore_all_locks(bool enable)
             {
-                if (nullptr == held_locks_.get())
-                {
-                    held_locks_.reset(new held_locks_data());
-                }
-
-                detail::register_locks::held_locks_data* m = held_locks_.get();
-                HPX_ASSERT(nullptr != m);
-
-                m->ignore_all_locks_ = enable;
-            }
-
-            static void reset_held_lock_data()
-            {
-                held_locks_.reset();
+                held_locks_.ignore_all_locks_ = enable;
             }
         };
 
-        hpx::util::thread_specific_ptr<
-            register_locks::held_locks_data, register_locks::tls_tag
-        > register_locks::held_locks_;
+        HPX_NATIVE_TLS register_locks::held_locks_data register_locks::held_locks_;
         bool register_locks::lock_detection_enabled_ = false;
 
         struct reset_lock_enabled_on_exit
@@ -368,11 +321,6 @@ namespace hpx { namespace util
     {
         detail::register_locks::set_ignore_all_locks(false);
     }
-
-    void reset_held_lock_data()
-    {
-        detail::register_locks::reset_held_lock_data();
-    }
 #else
 
     bool register_lock(void const*, util::register_lock_data*)
@@ -406,10 +354,6 @@ namespace hpx { namespace util
     }
 
     void reset_ignored_all()
-    {
-    }
-
-    void reset_held_lock_data()
     {
     }
 #endif


### PR DESCRIPTION
`hpx::util::thread_specific_ptr` introduces an extra level of indirection and dynamic memory allocation where none should be needed. `thread_local` could be used instead, this patch is using `HPX_NATIVE_TLS` to allow for some backwards compatibility.