### PR TITLE
Improving spinlock pools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -599,6 +599,12 @@ if(HPX_WITH_SCHEDULER_LOCAL_STORAGE)
   hpx_add_config_define(HPX_HAVE_SCHEDULER_LOCAL_STORAGE)
 endif()
 
+hpx_option(HPX_WITH_SPINLOCK_POOL_NUM STRING
+  "Number of elements a spinlock pool manages (default: 128)"
+  128 CATEGORY "Thread Manager" ADVANCED)
+
+hpx_add_config_define(HPX_HAVE_SPINLOCK_POOL_NUM ${HPX_WITH_SPINLOCK_POOL_NUM})
+
 # Count number of terminated threads before forcefully cleaning up all of
 # them. Note: terminated threads are cleaned up either when this number is
 # reached for a particular thread queue or if the HPX_BUSY_LOOP_COUNT_MAX is

--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -214,6 +214,14 @@ function(hpx_check_for_cxx11_alias_templates)
 endfunction()
 
 ###############################################################################
+function(hpx_check_for_cxx11_alignas)
+  add_hpx_config_test(HPX_WITH_CXX11_ALIGNAS
+    SOURCE cmake/tests/cxx11_alignas.cpp
+    FILE ${ARGN}
+    CMAKECXXFEATURE cxx_alignas)
+endfunction()
+
+###############################################################################
 function(hpx_check_for_cxx11_auto)
   add_hpx_config_test(HPX_WITH_CXX11_AUTO
     SOURCE cmake/tests/cxx11_auto.cpp
@@ -656,6 +664,13 @@ endfunction()
 function(hpx_check_for_cxx17_fallthrough_attribute)
   add_hpx_config_test(HPX_WITH_CXX17_FALLTHROUGH_ATTRIBUTE
     SOURCE cmake/tests/cxx17_fallthrough_attribute.cpp
+    FILE ${ARGN})
+endfunction()
+
+###############################################################################
+function(hpx_check_for_cxx17_hardware_destructive_interference_size)
+  add_hpx_config_test(HPX_WITH_CXX17_HARDWARE_DESTRUCTIVE_INTERFERENCE_SIZE
+    SOURCE cmake/tests/cxx17_hardware_destructive_interference_size.cpp
     FILE ${ARGN})
 endfunction()
 

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -15,6 +15,9 @@ function(hpx_perform_cxx_feature_tests)
   hpx_check_for_cxx11_alias_templates(
     REQUIRED "HPX needs support for C++11 alias templates")
 
+  hpx_check_for_cxx11_alignas(
+    DEFINITIONS HPX_HAVE_CXX11_ALIGNAS)
+
   hpx_check_for_cxx11_auto(
     REQUIRED "HPX needs support for C++11 auto")
 
@@ -195,5 +198,8 @@ function(hpx_perform_cxx_feature_tests)
 
     hpx_check_for_cxx17_fallthrough_attribute(
       DEFINITIONS HPX_HAVE_CXX17_FALLTHROUGH_ATTRIBUTE)
+
+    hpx_check_for_cxx17_hardware_destructive_interference_size(
+      DEFINITIONS HPX_HAVE_CXX17_HARDWARE_DESTRUCTIVE_INTERFERENCE_SIZE)
   endif()
 endfunction()

--- a/cmake/tests/cxx11_alignas.cpp
+++ b/cmake/tests/cxx11_alignas.cpp
@@ -1,0 +1,12 @@
+//  Copyright (c) 2019 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+struct alignas(64) spinlock {};
+
+int main()
+{
+    static spinlock pool[32];
+    return 0;
+}

--- a/cmake/tests/cxx17_hardware_destructive_interference_size.cpp
+++ b/cmake/tests/cxx17_hardware_destructive_interference_size.cpp
@@ -1,0 +1,12 @@
+//  Copyright (c) 2019 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <new>
+
+int main()
+{
+    auto cache_size = std::hardware_destructive_interference_size;
+    return 0;
+}

--- a/hpx/lcos/local/spinlock.hpp
+++ b/hpx/lcos/local/spinlock.hpp
@@ -15,7 +15,6 @@
 #include <hpx/config.hpp>
 
 #include <hpx/runtime/threads/thread_helpers.hpp>
-#include <hpx/runtime/threads/topology.hpp>
 #include <hpx/util/detail/yield_k.hpp>
 #include <hpx/util/itt_notify.hpp>
 #include <hpx/util/register_locks.hpp>

--- a/hpx/lcos/local/spinlock.hpp
+++ b/hpx/lcos/local/spinlock.hpp
@@ -15,6 +15,7 @@
 #include <hpx/config.hpp>
 
 #include <hpx/runtime/threads/thread_helpers.hpp>
+#include <hpx/runtime/threads/topology.hpp>
 #include <hpx/util/detail/yield_k.hpp>
 #include <hpx/util/itt_notify.hpp>
 #include <hpx/util/register_locks.hpp>
@@ -127,7 +128,6 @@ namespace hpx { namespace lcos { namespace local
 #endif
         }
     };
-
 }}}
 
 #endif // HPX_B3A83B49_92E0_4150_A551_488F9F5E1113

--- a/hpx/lcos/local/spinlock_pool.hpp
+++ b/hpx/lcos/local/spinlock_pool.hpp
@@ -14,6 +14,7 @@
 #define HPX_LCOS_LOCAL_SPINLOCK_POOL_HPP
 
 #include <hpx/config.hpp>
+#include <hpx/util/fibhash.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 
 #include <cstddef>
@@ -24,7 +25,7 @@ namespace hpx { namespace lcos { namespace local
 #if HPX_HAVE_ITTNOTIFY != 0
     namespace detail
     {
-        template <typename Tag>
+        template <typename Tag, std::size_t N>
         struct itt_spinlock_init
         {
             itt_spinlock_init();
@@ -33,11 +34,10 @@ namespace hpx { namespace lcos { namespace local
     }
 #endif
 
-    template <typename Tag>
+    template <typename Tag, std::size_t N = 128>
     class spinlock_pool
     {
     private:
-        static const std::size_t N = 41;
         static lcos::local::spinlock pool_[N];
 #if HPX_HAVE_ITTNOTIFY != 0
         static detail::itt_spinlock_init<Tag> init_;
@@ -45,7 +45,7 @@ namespace hpx { namespace lcos { namespace local
     public:
         static lcos::local::spinlock & spinlock_for(void const * pv)
         {
-            std::size_t i = reinterpret_cast< std::size_t >( pv ) % N;
+            std::size_t i = util::fibhash<N>(reinterpret_cast< std::size_t >(pv));
             return pool_[ i ];
         }
 
@@ -85,38 +85,36 @@ namespace hpx { namespace lcos { namespace local
         };
     };
 
-    template <typename Tag>
-    lcos::local::spinlock spinlock_pool<Tag>::pool_[spinlock_pool<Tag>::N];
+    template <typename Tag, std::size_t N>
+    lcos::local::spinlock spinlock_pool<Tag, N>::pool_[N];
 
 #if HPX_HAVE_ITTNOTIFY != 0
     namespace detail
     {
-        template <typename Tag>
-        itt_spinlock_init<Tag>::itt_spinlock_init()
+        template <typename Tag, std::size_t N>
+        itt_spinlock_init<Tag, N>::itt_spinlock_init()
         {
             for (int i = 0; i < 41; ++i)
             {
-                HPX_ITT_SYNC_CREATE(&lcos::local::spinlock_pool<Tag>::pool_[i],
+                HPX_ITT_SYNC_CREATE(&lcos::local::spinlock_pool<Tag, N>::pool_[i],
                     "hpx::lcos::spinlock", 0);
-                HPX_ITT_SYNC_RENAME(&lcos::local::spinlock_pool<Tag>::pool_[i],
+                HPX_ITT_SYNC_RENAME(&lcos::local::spinlock_pool<Tag, N>::pool_[i],
                     "hpx::lcos::spinlock");
             }
         }
 
-        template <typename Tag>
-        itt_spinlock_init<Tag>::~itt_spinlock_init()
+        template <typename Tag, std::size_t N>
+        itt_spinlock_init<Tag, N>::~itt_spinlock_init()
         {
-            for (int i = 0; i < 41; ++i)
+            for (int i = 0; i < N; ++i)
             {
-                HPX_ITT_SYNC_DESTROY(&lcos::local::spinlock_pool<Tag>::pool_[i]);
+                HPX_ITT_SYNC_DESTROY(&spinlock_pool<Tag, N>::pool_[i]);
             }
         }
     }
 
-    template <typename Tag>
-    lcos::local::detail::itt_spinlock_init<Tag>
-        lcos::local::spinlock_pool<Tag>::init_ =
-            lcos::local::detail::itt_spinlock_init<Tag>();
+    template <typename Tag, std::size_t N>
+    util::detail::itt_spinlock_init<Tag, N> spinlock_pool<Tag, N>::init_;
 #endif
 }}}
 

--- a/hpx/lcos/local/spinlock_pool.hpp
+++ b/hpx/lcos/local/spinlock_pool.hpp
@@ -16,6 +16,7 @@
 #include <hpx/config.hpp>
 #include <hpx/util/fibhash.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
+#include <hpx/runtime/threads/topology.hpp>
 
 #include <cstddef>
 
@@ -32,13 +33,21 @@ namespace hpx { namespace lcos { namespace local
             ~itt_spinlock_init();
         };
 #endif
-        // special struct to ensure cache line alignemnt
-        struct spinlock_holder
+#if defined(HPX_HAVE_CXX11_ALIGNAS)
+        struct alignas(threads::get_cache_line_size()) spinlock_holder
         {
-            // pad to 64 bytes
-            char cacheline_pad[64 - sizeof(lcos::local::spinlock)];
             lcos::local::spinlock lock;
         };
+#else
+        // special struct to ensure cache line alignment
+        struct spinlock_holder
+        {
+            // pad to cache line size bytes
+            char cacheline_pad[threads::get_cache_line_size() -
+                sizeof(lcos::local::spinlock)];
+            lcos::local::spinlock lock;
+        };
+#endif
     }
 
     template <typename Tag, std::size_t N = HPX_HAVE_SPINLOCK_POOL_NUM>

--- a/hpx/runtime/naming/name.hpp
+++ b/hpx/runtime/naming/name.hpp
@@ -9,8 +9,7 @@
 #define HPX_RUNTIME_NAMING_NAME_HPP
 
 #include <hpx/config.hpp>
-#include <hpx/lcos/local/spinlock.hpp>
-#include <hpx/lcos/local/spinlock_pool.hpp>
+#include <hpx/util/spinlock_pool.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/runtime/serialization/serialization_fwd.hpp>
@@ -371,7 +370,7 @@ namespace hpx { namespace naming
         HPX_SERIALIZATION_SPLIT_MEMBER()
 
         // lock implementation
-        typedef lcos::local::spinlock_pool<tag> internal_mutex_type;
+        typedef util::spinlock_pool<tag> internal_mutex_type;
 
         // returns whether lock has been acquired
         bool acquire_lock()

--- a/hpx/runtime/threads/topology.hpp
+++ b/hpx/runtime/threads/topology.hpp
@@ -425,6 +425,17 @@ namespace hpx { namespace threads
         parse_affinity_options(spec, affinities, 1, 1, affinities.size(),
             num_pus, ec);
     }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // abstract away cache-line size
+    HPX_STATIC_CONSTEXPR std::size_t get_cache_line_size()
+    {
+#if defined(HPX_HAVE_CXX17_HARDWARE_DESTRUCTIVE_INTERFERENCE_SIZE)
+        return std::hardware_destructive_interference_size;
+#else
+        return 64;      // assume 64 byte cache-line size
+#endif
+    }
 }}
 
 #endif /*HPX_RUNTIME_THREADS_TOPOLOGY_HPP*/

--- a/hpx/util/fibhash.hpp
+++ b/hpx/util/fibhash.hpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2018 Thomas Heller
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// This code is based on the article found here:
+// https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/
+
+#ifndef HPX_UTIL_FIBHASH_HPP
+#define HPX_UTIL_FIBHASH_HPP
+
+#include <cstdlib>
+#include <cstddef>
+
+namespace hpx { namespace util {
+    namespace detail
+    {
+        template <std::size_t N>
+        struct hash_helper;
+
+        template <>
+        struct hash_helper<0>
+        {
+            static constexpr int log2 = -1;
+        };
+
+        template <std::size_t N>
+        struct hash_helper
+        {
+            static constexpr std::size_t log2 = hash_helper<(N >> 1)>::log2 + 1;
+            static constexpr std::size_t shift_amount = 64 - log2;
+        };
+
+        constexpr std::size_t golden_ratio = 11400714819323198485llu;
+    }
+
+    // This function calculates the hash based on a multiplicative fibonacci
+    // scheme
+    template <std::size_t N>
+    constexpr std::size_t fibhash(std::size_t i)
+    {
+        using helper = detail::hash_helper<N>;
+        static_assert(N != 0, "This algorithm only works with N != 0");
+        static_assert((1 << helper::log2) == N, "N must be a power of two");
+        return
+            (detail::golden_ratio * (i ^ (i >> helper::shift_amount)))
+            >> helper::shift_amount;
+    }
+}}
+
+#endif

--- a/hpx/util/fibhash.hpp
+++ b/hpx/util/fibhash.hpp
@@ -9,10 +9,13 @@
 #ifndef HPX_UTIL_FIBHASH_HPP
 #define HPX_UTIL_FIBHASH_HPP
 
+#include <hpx/config.hpp>
+
 #include <cstdlib>
 #include <cstddef>
 
-namespace hpx { namespace util {
+namespace hpx { namespace util
+{
     namespace detail
     {
         template <std::size_t N>
@@ -21,23 +24,23 @@ namespace hpx { namespace util {
         template <>
         struct hash_helper<0>
         {
-            static constexpr int log2 = -1;
+            HPX_STATIC_CONSTEXPR int log2 = -1;
         };
 
         template <std::size_t N>
         struct hash_helper
         {
-            static constexpr std::size_t log2 = hash_helper<(N >> 1)>::log2 + 1;
-            static constexpr std::size_t shift_amount = 64 - log2;
+            HPX_STATIC_CONSTEXPR std::size_t log2 = hash_helper<(N >> 1)>::log2 + 1;
+            HPX_STATIC_CONSTEXPR std::size_t shift_amount = 64 - log2;
         };
 
-        constexpr std::size_t golden_ratio = 11400714819323198485llu;
+        HPX_STATIC_CONSTEXPR std::size_t golden_ratio = 11400714819323198485llu;
     }
 
-    // This function calculates the hash based on a multiplicative fibonacci
+    // This function calculates the hash based on a multiplicative Fibonacci
     // scheme
     template <std::size_t N>
-    constexpr std::size_t fibhash(std::size_t i)
+    HPX_CONSTEXPR std::size_t fibhash(std::size_t i)
     {
         using helper = detail::hash_helper<N>;
         static_assert(N != 0, "This algorithm only works with N != 0");

--- a/hpx/util/spinlock_pool.hpp
+++ b/hpx/util/spinlock_pool.hpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <hpx/config.hpp>
+#include <hpx/util/fibhash.hpp>
 #include <hpx/util/itt_notify.hpp>
 #include <hpx/util/register_locks.hpp>
 
@@ -32,7 +33,7 @@ namespace hpx { namespace util
 #if HPX_HAVE_ITTNOTIFY != 0
     namespace detail
     {
-        template <typename Tag>
+        template <typename Tag, std::size_t N>
         struct itt_spinlock_init
         {
             itt_spinlock_init();
@@ -41,20 +42,20 @@ namespace hpx { namespace util
     }
 #endif
 
-    template <typename Tag>
+    template <typename Tag, std::size_t N = 128>
     class spinlock_pool
     {
     private:
-        static boost::detail::spinlock pool_[ 41 ];
+        static boost::detail::spinlock pool_[N];
 #if HPX_HAVE_ITTNOTIFY != 0
-        static detail::itt_spinlock_init<Tag> init_;
+        static detail::itt_spinlock_init<Tag, N> init_;
 #endif
 
     public:
 
         static boost::detail::spinlock & spinlock_for( void const * pv )
         {
-            std::size_t i = reinterpret_cast< std::size_t >( pv ) % 41;
+            std::size_t i = fibhash<N>(reinterpret_cast< std::size_t >(pv));
             return pool_[ i ];
         }
 
@@ -95,60 +96,36 @@ namespace hpx { namespace util
         };
     };
 
-    template <typename Tag>
-    boost::detail::spinlock spinlock_pool<Tag>::pool_[ 41 ] =
-    {
-        BOOST_DETAIL_SPINLOCK_INIT, BOOST_DETAIL_SPINLOCK_INIT,
-        BOOST_DETAIL_SPINLOCK_INIT, BOOST_DETAIL_SPINLOCK_INIT,
-        BOOST_DETAIL_SPINLOCK_INIT, BOOST_DETAIL_SPINLOCK_INIT,
-        BOOST_DETAIL_SPINLOCK_INIT, BOOST_DETAIL_SPINLOCK_INIT,
-        BOOST_DETAIL_SPINLOCK_INIT, BOOST_DETAIL_SPINLOCK_INIT,
-        BOOST_DETAIL_SPINLOCK_INIT, BOOST_DETAIL_SPINLOCK_INIT,
-        BOOST_DETAIL_SPINLOCK_INIT, BOOST_DETAIL_SPINLOCK_INIT,
-        BOOST_DETAIL_SPINLOCK_INIT, BOOST_DETAIL_SPINLOCK_INIT,
-        BOOST_DETAIL_SPINLOCK_INIT, BOOST_DETAIL_SPINLOCK_INIT,
-        BOOST_DETAIL_SPINLOCK_INIT, BOOST_DETAIL_SPINLOCK_INIT,
-        BOOST_DETAIL_SPINLOCK_INIT, BOOST_DETAIL_SPINLOCK_INIT,
-        BOOST_DETAIL_SPINLOCK_INIT, BOOST_DETAIL_SPINLOCK_INIT,
-        BOOST_DETAIL_SPINLOCK_INIT, BOOST_DETAIL_SPINLOCK_INIT,
-        BOOST_DETAIL_SPINLOCK_INIT, BOOST_DETAIL_SPINLOCK_INIT,
-        BOOST_DETAIL_SPINLOCK_INIT, BOOST_DETAIL_SPINLOCK_INIT,
-        BOOST_DETAIL_SPINLOCK_INIT, BOOST_DETAIL_SPINLOCK_INIT,
-        BOOST_DETAIL_SPINLOCK_INIT, BOOST_DETAIL_SPINLOCK_INIT,
-        BOOST_DETAIL_SPINLOCK_INIT, BOOST_DETAIL_SPINLOCK_INIT,
-        BOOST_DETAIL_SPINLOCK_INIT, BOOST_DETAIL_SPINLOCK_INIT,
-        BOOST_DETAIL_SPINLOCK_INIT, BOOST_DETAIL_SPINLOCK_INIT,
-        BOOST_DETAIL_SPINLOCK_INIT
-    };
+    template <typename Tag, std::size_t N>
+    boost::detail::spinlock spinlock_pool<Tag, N>::pool_[ N ];
 
 #if HPX_HAVE_ITTNOTIFY != 0
     namespace detail
     {
-        template <typename Tag>
-        itt_spinlock_init<Tag>::itt_spinlock_init()
+        template <typename Tag, std::size_t N>
+        itt_spinlock_init<Tag, N>::itt_spinlock_init()
         {
-            for (int i = 0; i < 41; ++i)
+            for (int i = 0; i < N; ++i)
             {
-                HPX_ITT_SYNC_CREATE(&spinlock_pool<Tag>::pool_[i],
+                HPX_ITT_SYNC_CREATE(&spinlock_pool<Tag, N>::pool_[i],
                     "boost::detail::spinlock", 0);
-                HPX_ITT_SYNC_RENAME(&spinlock_pool<Tag>::pool_[i],
+                HPX_ITT_SYNC_RENAME(&spinlock_pool<Tag, N>::pool_[i],
                     "boost::detail::spinlock");
             }
         }
 
-        template <typename Tag>
-        itt_spinlock_init<Tag>::~itt_spinlock_init()
+        template <typename Tag, std::size_t N>
+        itt_spinlock_init<Tag, N>::~itt_spinlock_init()
         {
-            for (int i = 0; i < 41; ++i)
+            for (int i = 0; i < N; ++i)
             {
-                HPX_ITT_SYNC_DESTROY(&spinlock_pool<Tag>::pool_[i]);
+                HPX_ITT_SYNC_DESTROY(&spinlock_pool<Tag, N>::pool_[i]);
             }
         }
     }
 
-    template <typename Tag>
-    util::detail::itt_spinlock_init<Tag>
-        spinlock_pool<Tag>::init_ = util::detail::itt_spinlock_init<Tag>();
+    template <typename Tag, std::size_t N>
+    util::detail::itt_spinlock_init<Tag, N> spinlock_pool<Tag, N>::init_;
 #endif
 
 }} // namespace hpx::util

--- a/hpx/util/yield_while.hpp
+++ b/hpx/util/yield_while.hpp
@@ -33,7 +33,7 @@ namespace hpx { namespace util {
         {
             for (std::size_t k = 0; predicate(); ++k)
             {
-                detail::yield_k(k % 32, thread_name, p);
+                detail::yield_k(k & 31/*k % 32*/, thread_name, p);
             }
         }
     }


### PR DESCRIPTION
This patch introduces a multiplicative hashing algorithm for the spinlock pools to avoid modulo operations in the critical paths.
This, together with #3498 shows up to 10% performance increase on the Phylanx simple loop benchmark: https://docs.google.com/spreadsheets/d/15aNdbbyrWg3L56kY5Ud56sflX3Iy3tqbOC5dBaDijsc/edit#gid=0