### PR TITLE
Support NONAMEPREFIX in add_hpx_library()

### DIFF
--- a/cmake/HPX_AddLibrary.cmake
+++ b/cmake/HPX_AddLibrary.cmake
@@ -6,7 +6,7 @@
 
 macro(add_hpx_library name)
   # retrieve arguments
-  set(options EXCLUDE_FROM_ALL NOLIBS AUTOGLOB STATIC PLUGIN)
+  set(options EXCLUDE_FROM_ALL NOLIBS AUTOGLOB STATIC PLUGIN NONAMEPREFIX)
   set(one_value_args FOLDER SOURCE_ROOT HEADER_ROOT SOURCE_GLOB HEADER_GLOB OUTPUT_SUFFIX INSTALL_SUFFIX)
   set(multi_value_args SOURCES HEADERS AUXILIARY DEPENDENCIES COMPONENT_DEPENDENCIES COMPILER_FLAGS LINK_FLAGS)
   cmake_parse_arguments(${name} "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
@@ -113,6 +113,9 @@ macro(add_hpx_library name)
 
   if(${name}_PLUGIN)
     set(_target_flags ${_target_flags} PLUGIN)
+  endif()
+  if(${name}_NONAMEPREFIX)
+    set(_target_flags ${_target_flags} NONAMEPREFIX)
   endif()
 
   if(${name}_STATIC)


### PR DESCRIPTION
This just exposes `NONAMEPREFIX` to users of `add_hpx_library()` (not only `setup_target()`)