### PR TITLE
Split parallel::remove_if tests to avoid OOM on CircleCI

### DIFF
--- a/tests/unit/parallel/algorithms/CMakeLists.txt
+++ b/tests/unit/parallel/algorithms/CMakeLists.txt
@@ -87,6 +87,7 @@ set(tests
     remove1
     remove2
     remove_if
+    remove_if1
     remove_copy
     remove_copy_if
     replace

--- a/tests/unit/parallel/algorithms/remove_if1.cpp
+++ b/tests/unit/parallel/algorithms/remove_if1.cpp
@@ -19,22 +19,19 @@
 void remove_test()
 {
     std::cout << "--- remove_test ---" << std::endl;
-    test_remove<std::random_access_iterator_tag>(true);
-    test_remove<std::bidirectional_iterator_tag>(true);
+    test_remove<std::forward_iterator_tag>(true);
 }
 
 void remove_exception_test()
 {
     std::cout << "--- remove_exception_test ---" << std::endl;
-    test_remove_exception<std::random_access_iterator_tag>(true);
-    test_remove_exception<std::bidirectional_iterator_tag>(true);
+    test_remove_exception<std::forward_iterator_tag>(true);
 }
 
 void remove_bad_alloc_test()
 {
     std::cout << "--- remove_bad_alloc_test ---" << std::endl;
-    test_remove_bad_alloc<std::random_access_iterator_tag>(true);
-    test_remove_bad_alloc<std::bidirectional_iterator_tag>(true);
+    test_remove_bad_alloc<std::forward_iterator_tag>(true);
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes random test failures on CircleCI
