### PR TITLE
Fix bogus `throws` bindings in scheduled_thread_pool_impl

### DIFF
--- a/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
@@ -355,7 +355,7 @@ namespace hpx { namespace threads { namespace detail
 
         return hpx::async(
             hpx::util::bind(&scheduled_thread_pool::resume_internal, this, true,
-                std::move(throws)));
+                std::ref(throws)));
     }
 
     template <typename Scheduler>
@@ -438,7 +438,7 @@ namespace hpx { namespace threads { namespace detail
 
         return hpx::async(
             hpx::util::bind(&scheduled_thread_pool::suspend_internal, this,
-                std::move(throws)));
+                std::ref(throws)));
     }
 
     template <typename Scheduler>
@@ -1836,7 +1836,7 @@ namespace hpx { namespace threads { namespace detail
         return hpx::async(
             hpx::util::bind(
                 &scheduled_thread_pool::suspend_processing_unit_internal, this,
-                virt_core, std::move(throws)));
+                virt_core, std::ref(throws)));
     }
 
     template <typename Scheduler>
@@ -1938,7 +1938,7 @@ namespace hpx { namespace threads { namespace detail
         return hpx::async(
             hpx::util::bind(
                 &scheduled_thread_pool::resume_processing_unit_internal, this,
-                virt_core, std::move(throws)));
+                virt_core, std::ref(throws)));
     }
 
     template <typename Scheduler>


### PR DESCRIPTION
Cherry-picked from @K-ballo's ref-qual-bind branch.

The `std::move`s were supposed to be `std::ref`s all along.