### PR TITLE
Add support for rpm packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1972,6 +1972,18 @@ if(HPX_WITH_VIM_YCM)
 endif()
 
 ################################################################################
+# Add rpm packaging
+
+hpx_option(HPX_WITH_RPM
+  BOOL
+  "Enable or disable the generation of rpm packages"
+OFF ADVANCED)
+
+if(HPX_WITH_RPM)
+add_subdirectory(cmake/packaging/rpm)
+endif()
+
+################################################################################
 # print overall configuration summary
 include(HPX_PrintSummary)
 

--- a/README.rst
+++ b/README.rst
@@ -106,6 +106,9 @@ for this project. Please refer to this document if you would like to know more
 about the expectations for members of our community, with regard to how they
 will behave toward each other.
 
+Please find the project's gpg key, which is used to sign HPX releases
+[here](http://hkps.pool.sks-keyservers.net/pks/lookup?search=Ste%7C%7Car+group&fingerprint=on&op=index).
+
 Citing
 ======
 

--- a/cmake/packaging/rpm/CMakeLists.txt
+++ b/cmake/packaging/rpm/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright (c) 2018 Patrick Diehl
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(CPACK_PACKAGE_VERSION ${HPX_VERSION})
+set(CPACK_GENERATOR "RPM")
+set(CPACK_PACKAGE_NAME "hpx")
+set(CPACK_PACKAGE_RELEASE 1)
+set(CPACK_PACKAGE_CONTACT "contact@stellar-group.org")
+set(CPACK_PACKAGE_VENDOR "Ste||ar group")
+set(CPACK_RPM_PACKAGE_LICENSE "BSL-1.0")
+set(CPACK_RPM_PACKAGE_URL "https://github.com/STEllAR-GROUP/hpx")
+set(CPACK_RPM_PACKAGE_SUMMARY "The C++ Standard Library for Parallelism and Concurrency (HPX)")
+set(CPACK_RPM_PACKAGE_DESCRIPTION "The C++ Standard Library for Parallelism and Concurrency compiled for educational usage")
+set(CPACK_RPM_PACKAGE_REQUIRES "boost, hwloc, gperftools")
+set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
+set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_PACKAGE_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}")
+set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION
+    /etc/ld.so.conf.d
+    /usr/local
+    /usr/local/bin
+    /usr/local/.build-id
+    /usr/local/include
+    /usr/local/share
+    /usr/local/lib
+  )
+set(CPACK_RPM_CHANGELOG_FILE "${CMAKE_HOME_DIRECTORY}/cmake/packaging/rpm/Changelog.txt")
+include(CPack)
+

--- a/cmake/packaging/rpm/Changelog.txt
+++ b/cmake/packaging/rpm/Changelog.txt
@@ -1,0 +1,2 @@
+* Wed Oct 24 2018 STE||AR Group <contact@stellar-group.org> 1.2.0-1
+- HPX Release 1.2 (https://stellar-group.github.io/hpx/docs/sphinx/tags/1.2.0/html/releases/whats_new_1_2_0.html)

--- a/docs/sphinx/contributing/release_procedure.rst
+++ b/docs/sphinx/contributing/release_procedure.rst
@@ -126,6 +126,9 @@ are completed to avoid confusion.
 #. Checkout the release branch, and replace the ``-rcN`` tag in
    ``hpx/config/version.hpp`` with an empty string.
 
+#. Add a new entry to the RPM changelog (``cmake/packaging/rpm/Changelog.txt``)
+   with the new version number and a link to the corresponding changelog.
+
 #. Add the release date to the caption of the current "What's New" section in
    the docs, and change the value of ``HPX_VERSION_DATE`` in
    ``hpx/config/version.hpp``.


### PR DESCRIPTION
Add support to generate rpm packages for HPX.

## Proposed Changes

  - Add HPX_WITH_RPM to generate a rpm packages using the cpack package
  - make package target generates the rpm packages containing the current HPX version
  -

## Any background context you want to provide?

make package generates hpx-1.2.0-1.x86_64.rpm in the build folder. The rpm packages contains boost, hwloc, and gperftools as its dependencies. 

sudo dnf install hpx-1.2.0-1.x86_64.rpm  install the headers, documentation, and all examples to /usr/local and installs the missing dependencies if they are not installed.

The package was generated on my desktop and installed within a VM using the same version of Fedora 28 and I was able to run the examples on the VM.

Once we have the debian package as well, the next step would be to integrate the packaging into our build process on circle-ci and store them as artifacts.


