### PR TITLE
Fixing type attribute warning for transfer_action

### DIFF
--- a/hpx/components/containers/partitioned_vector/export_definitions.hpp
+++ b/hpx/components/containers/partitioned_vector/export_definitions.hpp
@@ -9,7 +9,11 @@
 #include <hpx/config/export_definitions.hpp>
 
 #if defined(HPX_PARTITIONED_VECTOR_MODULE_EXPORTS)
-# define HPX_PARTITIONED_VECTOR_EXPORT HPX_SYMBOL_EXPORT
+# if defined(HPX_MSVC) || defined(HPX_MINGW)
+#  define HPX_PARTITIONED_VECTOR_EXPORT HPX_SYMBOL_EXPORT
+# else
+#  define HPX_PARTITIONED_VECTOR_EXPORT
+# endif
 #else
 # define HPX_PARTITIONED_VECTOR_EXPORT HPX_SYMBOL_IMPORT
 #endif

--- a/hpx/runtime/actions/basic_action.hpp
+++ b/hpx/runtime/actions/basic_action.hpp
@@ -855,6 +855,7 @@ namespace hpx { namespace serialization
 #define HPX_REGISTER_ACTION_1(action)                                         \
     HPX_REGISTER_ACTION_2(action, action)                                     \
 /**/
+#if defined(HPX_MSVC) || defined(HPX_MINGW)
 #define HPX_REGISTER_ACTION_2(action, actionname)                             \
     HPX_DEFINE_GET_ACTION_NAME_(action, actionname)                           \
     HPX_REGISTER_ACTION_INVOCATION_COUNT(action)                              \
@@ -865,6 +866,17 @@ namespace hpx { namespace serialization
             transfer_continuation_action< action>;                            \
     }}                                                                        \
 /**/
+#else
+#define HPX_REGISTER_ACTION_2(action, actionname)                             \
+    HPX_DEFINE_GET_ACTION_NAME_(action, actionname)                           \
+    HPX_REGISTER_ACTION_INVOCATION_COUNT(action)                              \
+    HPX_REGISTER_PER_ACTION_DATA_COUNTER_TYPES(action)                        \
+    namespace hpx { namespace actions {                                       \
+        template struct transfer_action< action>;                             \
+        template struct transfer_continuation_action< action>;                \
+    }}                                                                        \
+/**/
+#endif
 
 #if defined(HPX_MSVC) || defined(HPX_MINGW)
 #define HPX_REGISTER_ACTION_EXTERN_DECLARATION(action)                        \


### PR DESCRIPTION
Retry of #3483. I didn't change anything from @sithhell's original, so I'm expecting pycicle gcc builds to fail.