### PR TITLE
WIP Improve CMake Testing  

### DIFF
--- a/cmake/HPX_AddTest.cmake
+++ b/cmake/HPX_AddTest.cmake
@@ -29,105 +29,53 @@ macro(add_hpx_test category name)
     set(_exe "${${name}_EXECUTABLE}")
   endif()
 
-  set(expected "0")
-
-  if(${name}_FAILURE_EXPECTED)
-    set(expected "1")
-  endif()
-
   set(args)
 
   foreach(arg ${${name}_UNPARSED_ARGUMENTS})
     set(args ${args} "${arg}")
   endforeach()
-  set(args "-v" "--" ${args})
 
-  set(cmd "${PYTHON_EXECUTABLE}"
+  if(${name}_LOCALITIES EQUAL "1")
+    set(_cmd ${_exe} --hpx:threads ${${name}_THREADS_PER_LOCALITY})
+    add_test(
+      NAME "${category}.${name}"
+      COMMAND ${_cmd} ${args})
+    set_tests_properties("${category}.${name}" PROPERTIES WILL_FAIL ${name}_FAILURE_EXPECTED)
+  else()
+    message("Test ${name} is a multi-locality test " ${${name}_LOCALITIES})
+    if(NOT HPX_WITH_NETWORKING)
+      message(FATAL_ERROR "Adding a multi-locality test with networking disabled")
+    endif()
+    # add distributed versions of each multi-locality test
+    foreach(_pp ${HPX_STATIC_PARCELPORT_PLUGINS}) # ${${name}_PARCELPORTS})
+      message("Adding test for parcelport ${_pp}")
+      if (${_pp} STREQUAL "mpi")
+        set(_cmd
+          "${MPIEXEC_EXECUTABLE}" "${MPIEXEC_PREFLAGS}" "${MPIEXEC_NUMPROC_FLAG}" "${${name}_LOCALITIES}"
+          "${_exe}"
+          --hpx:threads ${${name}_THREADS_PER_LOCALITY}
+        )
+      else()
+        set(expected "0")
+        if(${name}_FAILURE_EXPECTED)
+          set(expected "1")
+        endif()
+        set(_cmd "${PYTHON_EXECUTABLE}"
           "${CMAKE_BINARY_DIR}/bin/hpxrun.py"
           ${_exe}
           "-e" "${expected}"
-          "-t" "${${name}_THREADS_PER_LOCALITY}")
-
-  if(HPX_WITH_NETWORKING)
-      list(APPEND cmd "-l" "${${name}_LOCALITIES}")
-  else()
-      set(${name}_LOCALITIES "1")
+          "-t" "${${name}_THREADS_PER_LOCALITY}"
+          "-l" "${${name}_LOCALITIES}"
+          "-p" "${_pp}"
+          "-v" -- ${args})
+      endif()
+      add_test(
+        NAME "${category}.distributed.${_pp}.${name}"
+        COMMAND ${_cmd}
+      )
+      set_tests_properties("${category}.distributed.${_pp}.${name}" PROPERTIES WILL_FAIL ${name}_FAILURE_EXPECTED)
+    endforeach()
   endif()
-
-  if(${name}_LOCALITIES STREQUAL "1")
-    add_test(
-      NAME "${category}.${name}"
-      COMMAND ${cmd} ${args})
-    else()
-      if(HPX_WITH_PARCELPORT_VERBS)
-        set(_add_test FALSE)
-        if(DEFINED ${name}_PARCELPORTS)
-          set(PP_FOUND -1)
-          list(FIND ${name}_PARCELPORTS "verbs" PP_FOUND)
-          if(NOT PP_FOUND EQUAL -1)
-            set(_add_test TRUE)
-          endif()
-        else()
-          set(_add_test TRUE)
-        endif()
-        if(_add_test)
-          add_test(
-            NAME "${category}.distributed.verbs.${name}"
-            COMMAND ${cmd} "-p" "verbs" ${args})
-        endif()
-      endif()
-      if(HPX_WITH_PARCELPORT_IPC)
-        set(_add_test FALSE)
-        if(DEFINED ${name}_PARCELPORTS)
-          set(PP_FOUND -1)
-          list(FIND ${name}_PARCELPORTS "ipc" PP_FOUND)
-          if(NOT PP_FOUND EQUAL -1)
-            set(_add_test TRUE)
-          endif()
-        else()
-          set(_add_test TRUE)
-        endif()
-        if(_add_test)
-          add_test(
-            NAME "${category}.distributed.ipc.${name}"
-            COMMAND ${cmd} "-p" "ipc" ${args})
-        endif()
-      endif()
-      if(HPX_WITH_PARCELPORT_MPI)
-        set(_add_test FALSE)
-        if(DEFINED ${name}_PARCELPORTS)
-          set(PP_FOUND -1)
-          list(FIND ${name}_PARCELPORTS "mpi" PP_FOUND)
-          if(NOT PP_FOUND EQUAL -1)
-            set(_add_test TRUE)
-          endif()
-        else()
-          set(_add_test TRUE)
-        endif()
-        if(_add_test)
-          add_test(
-            NAME "${category}.distributed.mpi.${name}"
-            COMMAND ${cmd} "-p" "mpi" "-r" "mpi" ${args})
-        endif()
-      endif()
-      if(HPX_WITH_PARCELPORT_TCP)
-        set(_add_test FALSE)
-        if(DEFINED ${name}_PARCELPORTS)
-          set(PP_FOUND -1)
-          list(FIND ${name}_PARCELPORTS "tcp" PP_FOUND)
-          if(NOT PP_FOUND EQUAL -1)
-            set(_add_test TRUE)
-          endif()
-        else()
-          set(_add_test TRUE)
-        endif()
-        if(_add_test)
-          add_test(
-            NAME "${category}.distributed.tcp.${name}"
-            COMMAND ${cmd} "-p" "tcp" ${args})
-        endif()
-      endif()
-    endif()
 endmacro()
 
 macro(add_hpx_unit_test category name)

--- a/cmake/templates/hpxrun.py.in
+++ b/cmake/templates/hpxrun.py.in
@@ -70,11 +70,13 @@ def run_none(cmd, localities, verbose):
 def run_mpi(cmd, localities, verbose):
     mpiexec = '@MPIEXEC@'
     if mpiexec == '':
+        mpiexec = '@MPIEXEC_EXECUTABLE@'
+    if mpiexec == '':
         msg = 'mpiexec not available on this platform. '
         msg += 'Please rerun CMake with HPX_PARCELPORT_MPI=True.'
         print(msg, sys.stderr)
         sys.exit(1)
-    exec_cmd = ['@MPIEXEC@', '@MPIEXEC_NUMPROC_FLAG@', str(localities)] + cmd
+    exec_cmd = [mpiexec, '@MPIEXEC_NUMPROC_FLAG@', str(localities)] + cmd
     if verbose:
         print('Executing command: ' + ' '.join(exec_cmd))
     subproc(exec_cmd)

--- a/cmake/templates/hpxrun.py.in
+++ b/cmake/templates/hpxrun.py.in
@@ -110,6 +110,7 @@ def build_cmd(options, args):
             else ['--hpx:ini=hpx.parcel.ipc.enable=1'] if pp == 'ipc'
             else ['--hpx:ini=hpx.parcel.mpi.enable=1', '--hpx:ini=hpx.parcel.bootstrap=mpi'] if pp == 'mpi'
             else ['--hpx:ini=hpx.parcel.tcp.enable=1'] if pp == 'tcp'
+            else ['--hpx:ini=hpx.parcel.libfabric.enable=1'] if pp == 'libfabric'
             else [])
         cmd += select_parcelport(options.parcelport)
 
@@ -150,7 +151,7 @@ def check_options(parser, options, args):
         sys.exit(1)
 
     check_valid_parcelport = (lambda x:
-            x == 'verbs' or x == 'ipc' or x == 'mpi' or x == 'tcp');
+            x == 'verbs' or x == 'ipc' or x == 'mpi' or x == 'tcp' or x == 'libfabric');
     if not check_valid_parcelport(options.parcelport):
         print('Error: Parcelport option not valid\n', sys.stderr)
         parser.print_help()
@@ -213,7 +214,7 @@ if __name__ == '__main__':
     parser.add_option('-p', '--parcelport'
       , action='store', type='string'
       , dest='parcelport', default=default_env('HPXRUN_PARCELPORT', 'tcp')
-      , help='Which parcelport to use (Options are: verbs, ipc, mpi, tcp) '
+      , help='Which parcelport to use (Options are: verbs, ipc, mpi, tcp, libfabric) '
              '(environment variable HPXRUN_PARCELPORT')
 
     parser.add_option('-r', '--runwrapper'


### PR DESCRIPTION
Currently, the CMake driven tests are run on machines like daint at CSCS by calling srun from the hpx-runwrapper.py script. Unfortunately, calling srun 600+ times during testing places a large burden on slurm and causes false positive test fails due to slurm timeouts etc.

This branch removes the runwrapper invocation for tests that only use a single locality, so they are run directly rather than via runwrapper/srun/mpiexec

This PR  is an experimental branch to try to solve issues with pycicle/daint and not intended to be merged yet.