### PR TITLE
Propagating the MPI compile definitions to all relevant targets

### DIFF
--- a/plugins/parcelport/mpi/CMakeLists.txt
+++ b/plugins/parcelport/mpi/CMakeLists.txt
@@ -29,6 +29,10 @@ if(HPX_WITH_PARCELPORT_MPI)
     #    hpx_add_link_flag_if_available(${MPI_CXX_LINK_FLAGS})
   endif()
 
+  if(MPI_CXX_COMPILE_DEFINITIONS)
+    add_compile_definitions(${MPI_CXX_COMPILE_DEFINITIONS})
+  endif()
+
   # This list is to detect whether we run inside an mpi environment.
   # If one of those environment variables is set, the MPI parcelport
   # is enabled by default.


### PR DESCRIPTION
Without this change, the fix for issue #3475, introduced in PR #3496, does break under certain circumstances.