### PR TITLE
Replace boost::regex with C++11 <regex>

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -487,6 +487,13 @@ macro(hpx_check_for_cxx11_std_reference_wrapper)
 endmacro()
 
 ###############################################################################
+macro(hpx_check_for_cxx11_std_regex)
+  add_hpx_config_test(HPX_WITH_CXX11_REGEX
+    SOURCE cmake/tests/cxx11_std_regex.cpp
+    FILE ${ARGN})
+endmacro()
+
+###############################################################################
 macro(hpx_check_for_cxx11_std_shared_ptr)
   add_hpx_config_test(HPX_WITH_CXX11_SHARED_PTR
     SOURCE cmake/tests/cxx11_std_shared_ptr.cpp

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -122,6 +122,9 @@ macro(hpx_perform_cxx_feature_tests)
   hpx_check_for_cxx11_std_reference_wrapper(
     REQUIRED "HPX needs support for C++11 std::ref and std::reference_wrapper")
 
+  hpx_check_for_cxx11_std_regex(
+    REQUIRED "HPX needs support for C++11 std::regex")
+
   hpx_check_for_cxx11_std_shared_ptr(
     REQUIRED "HPX needs support for C++11 std::shared_ptr")
 

--- a/cmake/HPX_SetupBoost.cmake
+++ b/cmake/HPX_SetupBoost.cmake
@@ -66,7 +66,6 @@ set(__boost_libraries
   atomic
   filesystem
   program_options
-  regex
   system)
 
 find_package(Boost 1.55 REQUIRED COMPONENTS ${__boost_libraries})
@@ -93,6 +92,13 @@ if(HPX_WITH_COMPRESSION_BZIP2 OR HPX_WITH_COMPRESSION_ZLIB)
   else()
     hpx_error("Could not find Boost.Iostreams but HPX_WITH_COMPRESSION_BZIP2=On or HPX_WITH_COMPRESSION_LIB=On. Either set it to off or provide a boost installation including the iostreams library")
   endif()
+  set(Boost_TMP_LIBRARIES ${Boost_TMP_LIBRARIES} ${Boost_LIBRARIES})
+endif()
+
+# attempt to load Boost.Regex (if available), it's needed for inspect
+find_package(Boost 1.55 QUIET COMPONENTS regex)
+if(Boost_REGEX_FOUND)
+  hpx_info("  regex")
   set(Boost_TMP_LIBRARIES ${Boost_TMP_LIBRARIES} ${Boost_LIBRARIES})
 endif()
 

--- a/cmake/tests/cxx11_std_regex.cpp
+++ b/cmake/tests/cxx11_std_regex.cpp
@@ -1,0 +1,21 @@
+////////////////////////////////////////////////////////////////////////////////
+//  Copyright (c) 2017 Agustin Berge
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+////////////////////////////////////////////////////////////////////////////////
+
+#include <regex>
+#include <string>
+
+int main()
+{
+    std::string text = "Lorem ipsum dolor sit amet";
+
+    std::regex re("[a-z]+");
+    std::smatch match;
+    if (std::regex_match(text, match, re))
+    {
+        std::ssub_match smatch = match[0];
+    }
+}

--- a/examples/quickstart/pipeline1.cpp
+++ b/examples/quickstart/pipeline1.cpp
@@ -8,12 +8,12 @@
 
 #include <iostream>
 #include <iterator>
+#include <regex>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include <boost/algorithm/string/trim.hpp>
-#include <boost/regex.hpp>
 
 struct pipeline
 {
@@ -22,8 +22,8 @@ struct pipeline
         // job for first stage
         auto grep = [](std::string const& re, std::string const& item)
         {
-            boost::regex regex(re);
-            if (boost::regex_match(item, regex))
+            std::regex regex(re);
+            if (std::regex_match(item, regex))
             {
                 auto trim = [](std::string const& s)
                 {

--- a/plugins/parcel/coalescing/coalescing_counter_registry.cpp
+++ b/plugins/parcel/coalescing/coalescing_counter_registry.cpp
@@ -12,10 +12,10 @@
 
 #include <hpx/plugins/parcel/coalescing_counter_registry.hpp>
 
-#include <boost/regex.hpp>
 
 #include <cstdint>
 #include <mutex>
+#include <regex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -261,7 +261,7 @@ namespace hpx { namespace plugins { namespace parcel
             if (ec) return false;
 
             bool found_one = false;
-            boost::regex rx(str_rx, boost::regex::perl);
+            std::regex rx(str_rx);
 
             std::unique_lock<mutex_type> l(mtx_);
 
@@ -269,7 +269,7 @@ namespace hpx { namespace plugins { namespace parcel
                 map_type::const_iterator end = map_.end();
                 for (map_type::const_iterator it = map_.begin(); it != end; ++it)
                 {
-                    if (!boost::regex_match((*it).first, rx))
+                    if (!std::regex_match((*it).first, rx))
                         continue;
                     found_one = true;
 

--- a/src/performance_counters/registry.cpp
+++ b/src/performance_counters/registry.cpp
@@ -23,13 +23,13 @@
 #include <hpx/util/rolling_max.hpp>
 #include <hpx/util/rolling_min.hpp>
 
-#include <boost/regex.hpp>
 #include <boost/accumulators/statistics_fwd.hpp>
 #include <boost/accumulators/statistics/rolling_variance.hpp>
 
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <regex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -175,13 +175,13 @@ namespace hpx { namespace performance_counters
             if (ec) return status_invalid_data;
 
             bool found_one = false;
-            boost::regex rx(str_rx, boost::regex::perl);
+            std::regex rx(str_rx);
 
             counter_type_map_type::const_iterator end = countertypes_.end();
             for (counter_type_map_type::const_iterator it = countertypes_.begin();
                  it != end; ++it)
             {
-                if (!boost::regex_match((*it).first, rx))
+                if (!std::regex_match((*it).first, rx))
                     continue;
                 found_one = true;
 

--- a/src/runtime/actions/detail/invocation_count_registry.cpp
+++ b/src/runtime/actions/detail/invocation_count_registry.cpp
@@ -11,9 +11,9 @@
 #include <hpx/util/format.hpp>
 #include <hpx/util/regex_from_pattern.hpp>
 
+#include <regex>
 #include <string>
 
-#include <boost/regex.hpp>
 
 namespace hpx { namespace actions { namespace detail
 {
@@ -105,12 +105,12 @@ namespace hpx { namespace actions { namespace detail
             if (ec) return false;
 
             bool found_one = false;
-            boost::regex rx(str_rx, boost::regex::perl);
+            std::regex rx(str_rx);
 
             map_type::const_iterator end = map_.end();
             for (map_type::const_iterator it = map_.begin(); it != end; ++it)
             {
-                if (!boost::regex_match((*it).first, rx))
+                if (!std::regex_match((*it).first, rx))
                     continue;
                 found_one = true;
 

--- a/src/runtime/agas/server/symbol_namespace_server.cpp
+++ b/src/runtime/agas/server/symbol_namespace_server.cpp
@@ -33,11 +33,10 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <regex>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <boost/regex.hpp>
 
 namespace hpx { namespace agas
 {
@@ -385,13 +384,13 @@ symbol_namespace::iterate_names_return_type symbol_namespace::iterate(
     if (pattern.find_first_of("*?[]") != std::string::npos)
     {
         std::string str_rx(util::regex_from_pattern(pattern, throws));
-        boost::regex rx(str_rx, boost::regex::perl);
+        std::regex rx(str_rx);
 
         std::unique_lock<mutex_type> l(mutex_);
         for (gid_table_type::iterator it = gids_.begin(); it != gids_.end();
              ++it)
         {
-            if (!boost::regex_match(it->first, rx))
+            if (!std::regex_match(it->first, rx))
                 continue;
 
             // hold on to entry while map is unlocked

--- a/src/runtime/parcelset/detail/per_action_data_counter_registry.cpp
+++ b/src/runtime/parcelset/detail/per_action_data_counter_registry.cpp
@@ -15,11 +15,11 @@
 #include <hpx/util/regex_from_pattern.hpp>
 
 #include <cstdint>
+#include <regex>
 #include <string>
 #include <unordered_set>
 #include <utility>
 
-#include <boost/regex.hpp>
 
 namespace hpx { namespace parcelset { namespace detail
 {
@@ -99,12 +99,12 @@ namespace hpx { namespace parcelset { namespace detail
             if (ec) return false;
 
             bool found_one = false;
-            boost::regex rx(str_rx, boost::regex::perl);
+            std::regex rx(str_rx);
 
             map_type::const_iterator end = map_.end();
             for (map_type::const_iterator it = map_.begin(); it != end; ++it)
             {
-                if (!boost::regex_match(*it, rx))
+                if (!std::regex_match(*it, rx))
                     continue;
                 found_one = true;
 

--- a/src/util/ini.cpp
+++ b/src/util/ini.cpp
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <list>
 #include <mutex>
+#include <regex>
 #include <string>
 #include <vector>
 #include <utility>
@@ -34,7 +35,6 @@
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/replace.hpp>
-#include <boost/regex.hpp>
 
 #ifdef __APPLE__
 #include <crt_externs.h>
@@ -204,13 +204,11 @@ void section::parse (std::string const& sourcename,
     int linenum = 0;
     section* current = this;
 
-    boost::regex regex_comment (pattern_comment, boost::regex::perl
-        | boost::regex::icase);
-    boost::regex regex_section (pattern_section, boost::regex::perl
-        | boost::regex::icase);
-    boost::regex regex_qualified_entry
-        (pattern_qualified_entry, boost::regex::perl | boost::regex::icase);
-    boost::regex regex_entry (pattern_entry,   boost::regex::perl | boost::regex::icase);
+    std::regex regex_comment (pattern_comment, std::regex_constants::icase);
+    std::regex regex_section (pattern_section, std::regex_constants::icase);
+    std::regex regex_qualified_entry (pattern_qualified_entry,
+        std::regex_constants::icase);
+    std::regex regex_entry (pattern_entry, std::regex_constants::icase);
 
     std::vector<std::string>::const_iterator end = lines.end();
     for (std::vector<std::string>::const_iterator it = lines.begin();
@@ -228,8 +226,8 @@ void section::parse (std::string const& sourcename,
         // weed out comments
         if (weed_out_comments)
         {
-            boost::smatch what_comment;
-            if (boost::regex_match (line, what_comment, regex_comment))
+            std::smatch what_comment;
+            if (std::regex_match (line, what_comment, regex_comment))
             {
                 HPX_ASSERT(3 == what_comment.size());
 
@@ -241,8 +239,8 @@ void section::parse (std::string const& sourcename,
 
         // no comments anymore: line is either section, key=val,
         // or garbage/empty
-        boost::smatch what;
-        if (boost::regex_match(line, what, regex_qualified_entry))
+        std::smatch what;
+        if (std::regex_match(line, what, regex_qualified_entry))
         {
             // found a entry line
             if (4 != what.size()) //-V112
@@ -286,7 +284,7 @@ void section::parse (std::string const& sourcename,
             current = s;
         }
 
-        else if (boost::regex_match(line, what, regex_section))
+        else if (std::regex_match(line, what, regex_section))
         {
             // found a section line
             if (2 != what.size())
@@ -312,7 +310,7 @@ void section::parse (std::string const& sourcename,
         }
 
         // did not match section, so might be key/val entry
-        else if ( boost::regex_match (line, what, regex_entry) )
+        else if ( std::regex_match (line, what, regex_entry) )
         {
             // found a entry line
             if (3 != what.size())

--- a/src/util/regex_from_pattern.cpp
+++ b/src/util/regex_from_pattern.cpp
@@ -9,8 +9,6 @@
 
 #include <string>
 
-#include <boost/regex.hpp>
-
 namespace hpx { namespace util
 {
     namespace detail

--- a/src/util/sed_transform.cpp
+++ b/src/util/sed_transform.cpp
@@ -7,9 +7,9 @@
 
 #include <hpx/exception.hpp>
 #include <hpx/util/sed_transform.hpp>
-#include <boost/regex.hpp>
 
 #include <memory>
+#include <regex>
 #include <string>
 
 namespace hpx { namespace util
@@ -84,7 +84,7 @@ struct sed_transform::command
       , replace_(replace)
     {}
 
-    boost::regex search_;
+    std::regex search_;
     std::string replace_;
 };
 
@@ -112,10 +112,11 @@ std::string sed_transform::operator()(
     if (!command_)
         return input;
 
-    return boost::regex_replace(input
+    return std::regex_replace(input
                               , command_->search_
                               , command_->replace_
-                              , boost::match_default | boost::format_sed);
+                              , std::regex_constants::match_default
+                              | std::regex_constants::format_sed);
 }
 
 }}

--- a/tools/inspect/CMakeLists.txt
+++ b/tools/inspect/CMakeLists.txt
@@ -10,6 +10,10 @@ add_hpx_executable(inspect
   NOLIBS
   FOLDER "Tools/Inspect")
 
+if(NOT Boost_REGEX_FOUND)
+  hpx_error("HPX inspect tool requires Boost.Regex")
+endif()
+
 if((NOT MSVC) OR HPX_WITH_VCPKG)
   target_link_libraries(inspect_exe ${HPX_TLL_PUBLIC} ${Boost_LIBRARIES})
 endif()

--- a/tools/inspect/deprecated_include_check.cpp
+++ b/tools/inspect/deprecated_include_check.cpp
@@ -49,6 +49,7 @@ namespace boost
       { "boost/nondet_random.hpp", "random" },
       { "boost/random/([^\\s]*)\\.hpp", "random" },
       { "boost/format\\.hpp", "hpx/util/format.hpp" },
+      { "boost/regex.hpp", "regex" },
       { nullptr, nullptr }
     };
 

--- a/tools/inspect/deprecated_name_check.cpp
+++ b/tools/inspect/deprecated_name_check.cpp
@@ -89,6 +89,7 @@ namespace boost
         "(acq_rel)|(seq_cst))\\b)", "std::memory_order_\\2" },
       { "(\\bboost\\s*::\\s*random\\s*::\\s*([^\\s]*)\\b)", "std::\\2" },
       { "(\\bboost\\s*::\\s*format\\b)", "hpx::util::format[_to]" },
+      { "(\\bboost\\s*::\\s*(regex[^\\s]*)\\b)", "std::\\2" },
       /////////////////////////////////////////////////////////////////////////
       { "((\\bhpx::\\b)?\\btraits\\s*::\\bis_callable\\b)", "\\2traits::is_invocable[_r]" },
       { "((\\bhpx::\\b)?\\butil\\s*::\\bresult_of\\b)", "\\2util::invoke_result" },


### PR DESCRIPTION
Replace Boost.Regex in HPX core. It remains an optional dependency, required when building the inspect tool.