### PR TITLE
Do not build guided pool examples with older GCC compilers

### DIFF
--- a/examples/resource_partitioner/CMakeLists.txt
+++ b/examples/resource_partitioner/CMakeLists.txt
@@ -9,11 +9,16 @@ set(example_programs
   simplest_resource_partitioner_1
   simplest_resource_partitioner_2
 )
-if (HPX_WITH_CXX14_RETURN_TYPE_DEDUCTION)
-  set(example_programs ${example_programs}
-    async_customization
-    guided_pool_test
-  )
+
+if(CMAKE_COMPILER_IS_GNUCXX AND HPX_WITH_GCC_VERSION_CHECK)
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 5.0)
+    if (HPX_WITH_CXX14_RETURN_TYPE_DEDUCTION)
+      set(example_programs ${example_programs}
+        async_customization
+        guided_pool_test
+      )
+    endif()
+  endif()
 endif()
 
 set(guided_pool_test_FLAGS DEPENDENCIES iostreams_component)


### PR DESCRIPTION
Buildbot confirms that this now passes on the gcc 4_9 builder. I do not know how to fix the problem correctly, so the safest thing is to simply disable the tests on gcc4.9 and lower