### PR TITLE
fixing minor doc typo --hpx:print-counter-at arg

### DIFF
--- a/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
+++ b/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
@@ -1631,7 +1631,7 @@ The predefined command line options for any application using
    and ``csv`` or ``csv-short`` format specified with
    :option:`--hpx:print-counter-format` without header
 
-.. option:: --hpx:printer-counter-at arg
+.. option:: --hpx:print-counter-at arg
 
    print the performance counter(s) specified with :option:`--hpx:print-counter`
    (or :option:`--hpx:print-counter-reset` at the given point in time, possible

--- a/docs/sphinx/manual/optimizing_hpx_applications.rst
+++ b/docs/sphinx/manual/optimizing_hpx_applications.rst
@@ -275,7 +275,7 @@ The following table summarizes the available command line options:
      * print the performance counter(s) specified with ``--hpx:print-counter``
        and ``csv`` or ``csv-short`` format specified with
        ``--hpx:print-counter-format`` without header.
-   * * ``--hpx:printer-counter-at arg``
+   * * ``--hpx:print-counter-at arg``
      * print the performance counter(s) specified with ``--hpx:print-counter``
        (or ``--hpx:print-counter-reset``) at the given point in time, possible
        argument values: ``startup``, ``shutdown`` (default), ``noshutdown``.


### PR DESCRIPTION
fixing minor doc typo --hpx:print-counter-at arg