### PR TITLE
Fix guided exec

### DIFF
--- a/hpx/lcos/local/futures_factory.hpp
+++ b/hpx/lcos/local/futures_factory.hpp
@@ -245,7 +245,8 @@ namespace hpx { namespace lcos { namespace local
                 if (exec_) {
                     parallel::execution::post(*exec_,
                         util::deferred_call(
-                            &base_type::run_impl, std::move(this_)));
+                            &base_type::run_impl, std::move(this_)),
+                            schedulehint);
                     return threads::invalid_thread_id;
                 }
                 else if (policy == launch::fork) {

--- a/hpx/parallel/executors/thread_execution.hpp
+++ b/hpx/parallel/executors/thread_execution.hpp
@@ -129,7 +129,7 @@ namespace hpx { namespace threads
         std::is_same<typename hpx::util::decay<Hint>::type,
             hpx::threads::thread_schedule_hint>::value
     >::type
-    post(Executor && exec, F && f, Ts &&... ts, Hint && hint)
+    post(Executor && exec, F && f, Hint && hint, Ts &&... ts)
     {
         exec.add(
             util::deferred_call(std::forward<F>(f), std::forward<Ts>(ts)...),

--- a/hpx/parallel/executors/thread_execution.hpp
+++ b/hpx/parallel/executors/thread_execution.hpp
@@ -126,7 +126,8 @@ namespace hpx { namespace threads
     HPX_FORCEINLINE
     typename std::enable_if<
         hpx::traits::is_threads_executor<Executor>::value &&
-        std::is_same<Hint, hpx::threads::thread_schedule_hint>::value
+        std::is_same<typename hpx::util::decay<Hint>::type,
+            hpx::threads::thread_schedule_hint>::value
     >::type
     post(Executor && exec, F && f, Ts &&... ts, Hint && hint)
     {

--- a/hpx/runtime/threads/executors/guided_pool_executor.hpp
+++ b/hpx/runtime/threads/executors/guided_pool_executor.hpp
@@ -251,9 +251,7 @@ namespace hpx { namespace threads { namespace executors
                       << "async_execute : Result      : "
                       << util::debug::print_type<result_type>() << "\n"
                       << "async_execute : Numa Hint   : "
-                      << util::debug::print_type<pool_numa_hint<Tag>>() << "\n"
-/*                      << "async_execute : Hint   : "
-                      << util::debug::print_type<H>() << "\n"*/;
+                      << util::debug::print_type<pool_numa_hint<Tag>>() << "\n";
 #endif
 
             // hold onto the function until all futures have become ready

--- a/hpx/runtime/threads/executors/guided_pool_executor.hpp
+++ b/hpx/runtime/threads/executors/guided_pool_executor.hpp
@@ -121,14 +121,16 @@ namespace hpx { namespace threads { namespace executors
                     hpx::launch::sync,
                     executor_.get_priority(),
                     executor_.get_stacksize(),
-                    threads::thread_schedule_hint(domain));
+                    threads::thread_schedule_hint(
+                                thread_schedule_hint_mode_numa, domain));
             }
             else {
                 p.apply(
                     hpx::launch::async,
                     executor_.get_priority(),
                     executor_.get_stacksize(),
-                    threads::thread_schedule_hint(domain));
+                    threads::thread_schedule_hint(
+                                thread_schedule_hint_mode_numa, domain));
             }
 
             return p.get_future();
@@ -181,14 +183,16 @@ namespace hpx { namespace threads { namespace executors
                     hpx::launch::sync,
                     executor_.get_priority(),
                     executor_.get_stacksize(),
-                    threads::thread_schedule_hint(domain));
+                    threads::thread_schedule_hint(
+                                thread_schedule_hint_mode_numa, domain));
             }
             else {
                 p.apply(
                     hpx::launch::async,
                     executor_.get_priority(),
                     executor_.get_stacksize(),
-                    threads::thread_schedule_hint(domain));
+                    threads::thread_schedule_hint(
+                                thread_schedule_hint_mode_numa, domain));
             }
 
             return p.get_future();
@@ -248,8 +252,8 @@ namespace hpx { namespace threads { namespace executors
                       << util::debug::print_type<result_type>() << "\n"
                       << "async_execute : Numa Hint   : "
                       << util::debug::print_type<pool_numa_hint<Tag>>() << "\n"
-                      << "async_execute : Hint   : "
-                      << util::debug::print_type<H>() << "\n";
+/*                      << "async_execute : Hint   : "
+                      << util::debug::print_type<H>() << "\n"*/;
 #endif
 
             // hold onto the function until all futures have become ready
@@ -457,14 +461,16 @@ namespace hpx { namespace threads { namespace executors
                     hpx::launch::sync,
                     pool_executor_.get_priority(),
                     pool_executor_.get_stacksize(),
-                    threads::thread_schedule_hint(domain));
+                    threads::thread_schedule_hint(
+                                thread_schedule_hint_mode_numa, domain));
             }
             else {
                 p.apply(
                     hpx::launch::async,
                     pool_executor_.get_priority(),
                     pool_executor_.get_stacksize(),
-                    threads::thread_schedule_hint(domain));
+                    threads::thread_schedule_hint(
+                                thread_schedule_hint_mode_numa, domain));
             }
             return p.get_future();
         }

--- a/hpx/runtime/threads/policies/shared_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/shared_priority_queue_scheduler.hpp
@@ -712,6 +712,7 @@ namespace policies {
 
             // low priority task
             if (!result) {
+#ifdef JB_LP_STEALING
                 for (std::size_t d=domain_num; d<domain_num+num_domains_; ++d) {
                     std::size_t dom = d % num_domains_;
                     // set the preferred queue for this domain, if applicable
@@ -723,6 +724,10 @@ namespace policies {
                     result = lp_queues_[dom].get_next_thread(q_index, thrd);
                     if (result) break;
                 }
+#else
+                // no cross domain stealing for LP queues
+                result = lp_queues_[domain_num].get_next_thread(0, thrd);
+#endif
             }
             if (result)
             {
@@ -1109,6 +1114,7 @@ namespace policies {
 
             // low priority task
             if (!result) {
+#ifdef JB_LP_STEALING
                 for (std::size_t d=domain_num; d<domain_num+num_domains_; ++d) {
                     std::size_t dom = d % num_domains_;
                     // set the preferred queue for this domain, if applicable
@@ -1121,6 +1127,12 @@ namespace policies {
                         idle_loop_count, added);
                     if (0 != added) return result;
                 }
+#else
+                // no cross domain stealing for LP queues
+                result = lp_queues_[domain_num].wait_or_add_new(0, running,
+                    idle_loop_count, added);
+                if (0 != added) return result;
+#endif
             }
 
             return result;


### PR DESCRIPTION
These patches appear to fix a couple of problems that sneaked through the guided executor merge.

Committing this to see if all tests pass with the slight tweak to the executor interface.
