### PR TITLE
Fixing the build system of the MPI parcelport

### DIFF
--- a/plugins/parcelport/mpi/CMakeLists.txt
+++ b/plugins/parcelport/mpi/CMakeLists.txt
@@ -10,7 +10,6 @@ include(HPX_AddLibrary)
 # Decide whether to use the MPI based parcelport
 ################################################################################
 if(HPX_WITH_PARCELPORT_MPI)
-  set(MPI_CXX_SKIP_MPICXX TRUE)
   find_package(MPI)
 
   if(NOT MPI_CXX_FOUND)
@@ -58,11 +57,11 @@ if(HPX_WITH_PARCELPORT_MPI)
     endif()
 
     set(_mpi_libraries)
-    if(MPI_C_LIBRARIES)
-      set(_mpi_libraries ${_mpi_libraries} ${MPI_C_LIBRARIES})
-    elseif(MPI_C_LIB_NAMES)
+    if(MPI_CXX_LIBRARIES)
+      set(_mpi_libraries ${_mpi_libraries} ${MPI_CXX_LIBRARIES})
+    elseif(MPI_CXX_LIB_NAMES)
       # cmake V3.10.2 has changed the way MPI libraries are being discovered
-      foreach(lib ${MPI_C_LIB_NAMES})
+      foreach(lib ${MPI_CXX_LIB_NAMES})
         set(_mpi_libraries ${_mpi_libraries} ${MPI_${lib}_LIBRARY})
       endforeach()
     endif()

--- a/plugins/parcelport/mpi/CMakeLists.txt
+++ b/plugins/parcelport/mpi/CMakeLists.txt
@@ -30,7 +30,9 @@ if(HPX_WITH_PARCELPORT_MPI)
   endif()
 
   if(MPI_CXX_COMPILE_DEFINITIONS)
-    add_compile_definitions(${MPI_CXX_COMPILE_DEFINITIONS})
+    # Emulate add_compile_definitions.
+    # This command was only introduced as part of CMake 3.11, but we already require it for versions >= 3.10.
+    set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS ${MPI_CXX_COMPILE_DEFINITIONS})
   endif()
 
   # This list is to detect whether we run inside an mpi environment.

--- a/tests/headers/CMakeLists.txt
+++ b/tests/headers/CMakeLists.txt
@@ -35,7 +35,6 @@ endif()
 # add the MPI include path here, because for the main library, it's only
 # added for the plugin.
 if(HPX_WITH_PARCELPORT_MPI)
-  set(MPI_CXX_SKIP_MPICXX TRUE)
   find_package(MPI)
 
   if(MPI_CXX_INCLUDE_PATH)


### PR DESCRIPTION
Fixes #3475.

## Proposed Changes

  - Emulate add_compile_definitions. It was only introduced as part of CMake 3.11.
  - Link against the C++-enabled MPI libraries

## Any background context you want to provide?

Unfortunately, our previous fix of disabling MPI's C++ interface via `MPI_CXX_SKIP_MPICXX` is broken. Newer versions of CMake introduce it as a cache variable. Therefore, we can not reliable
disable the C++ interface programmatically and have to link against the proper set of libraries.

If the C++ interfaces causes problems, `MPI_CXX_SKIP_MPICXX` can still be enabled manually.
