### PR TITLE
Fix uint64_t causing compilation fail on i686

### DIFF
--- a/examples/resource_partitioner/async_customization.cpp
+++ b/examples/resource_partitioner/async_customization.cpp
@@ -29,7 +29,7 @@
 #include "shared_priority_queue_scheduler.hpp"
 //
 #include <cstddef>
-#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -382,11 +382,11 @@ int test(Executor &exec)
     // test 3b
     std::cout << "============================" << std::endl;
     std::cout << "Test 3b : when_all(shared)" << std::endl;
-    future<uint64_t>     fws1 = make_ready_future(uint64_t(42));
+    future<std::uint64_t>     fws1 = make_ready_future(std::uint64_t(42));
     shared_future<float> fws2 = make_ready_future(3.1415f).share();
     //
     auto fws = when_all(fws1, fws2).then(exec,
-        [](future<util::tuple<future<uint64_t>, shared_future<float>>> && f)
+        [](future<util::tuple<future<std::uint64_t>, shared_future<float>>> && f)
         {
             auto tup = f.get();
             auto cmplx = std::complex<double>(
@@ -401,13 +401,13 @@ int test(Executor &exec)
     // test 4a
     std::cout << "============================" << std::endl;
     std::cout << "Test 4a : dataflow()" << std::endl;
-    future<uint16_t> f1 = make_ready_future(uint16_t(255));
+    future<std::uint16_t> f1 = make_ready_future(std::uint16_t(255));
     future<double>   f2 = make_ready_future(127.890);
     //
     auto fd = dataflow(exec,
-        [](future<uint16_t> && f1, future<double> && f2)
+        [](future<std::uint16_t> && f1, future<double> && f2)
         {
-            auto cmplx = std::complex<uint64_t>(f1.get(), f2.get());
+            auto cmplx = std::complex<std::uint64_t>(f1.get(), f2.get());
             std::cout << "Inside dataflow : " << cmplx << std::endl;
             return cmplx;
         }
@@ -419,13 +419,13 @@ int test(Executor &exec)
     // test 4b
     std::cout << "============================" << std::endl;
     std::cout << "Test 4b : dataflow(shared)" << std::endl;
-    future<uint16_t>      fs1 = make_ready_future(uint16_t(255));
+    future<std::uint16_t>      fs1 = make_ready_future(std::uint16_t(255));
     shared_future<double> fs2 = make_ready_future(127.890).share();
     //
     auto fds = dataflow(exec,
-        [](future<uint16_t> && f1, shared_future<double> && f2)
+        [](future<std::uint16_t> && f1, shared_future<double> && f2)
         {
-            auto cmplx = std::complex<uint64_t>(f1.get(), f2.get());
+            auto cmplx = std::complex<std::uint64_t>(f1.get(), f2.get());
             std::cout << "Inside dataflow(shared) : " << cmplx << std::endl;
             return cmplx;
         }
@@ -453,14 +453,14 @@ namespace hpx { namespace threads { namespace executors
           std::cout << "Hint 2 \n";
           return 0;
       }
-      int operator()(const uint16_t, const double) const {
+      int operator()(const std::uint16_t, const double) const {
           std::cout << "Hint 3 \n";
           return 0;
       }
       int operator()(const util::tuple<future<int>, future<double>> &) const {
           return 0;
       }
-      int operator()(const util::tuple<future<long unsigned int>,
+      int operator()(const util::tuple<future<std::uint64_t>,
                      shared_future<float>> &) const
       {
           return 0;


### PR DESCRIPTION
Fixes #3549 

Simple mistake in type of int that would cause a problem on a 64bit int machine.