### PR TITLE
Drop util::[unique_]function target_type

### DIFF
--- a/hpx/util/detail/basic_function.hpp
+++ b/hpx/util/detail/basic_function.hpp
@@ -23,7 +23,6 @@
 #include <cstring>
 #include <string>
 #include <type_traits>
-#include <typeinfo>
 #include <utility>
 
 namespace hpx { namespace util { namespace detail
@@ -152,11 +151,6 @@ namespace hpx { namespace util { namespace detail
         explicit operator bool() const noexcept
         {
             return !empty();
-        }
-
-        std::type_info const& target_type() const noexcept
-        {
-            return empty() ? typeid(void) : vptr->get_type();
         }
 
         template <typename T>

--- a/hpx/util/detail/vtable/vtable.hpp
+++ b/hpx/util/detail/vtable/vtable.hpp
@@ -13,7 +13,6 @@
 #include <cstddef>
 #include <memory>
 #include <type_traits>
-#include <typeinfo>
 #include <utility>
 
 namespace hpx { namespace util { namespace detail
@@ -98,13 +97,6 @@ namespace hpx { namespace util { namespace detail
         }
 
         template <typename T>
-        HPX_FORCEINLINE static std::type_info const& _get_type()
-        {
-            return typeid(T);
-        }
-        std::type_info const& (*get_type)();
-
-        template <typename T>
         HPX_FORCEINLINE static void _destruct(void** v)
         {
             get<T>(v).~T();
@@ -125,8 +117,7 @@ namespace hpx { namespace util { namespace detail
 
         template <typename T>
         HPX_CONSTEXPR vtable(construct_vtable<T>) noexcept
-          : get_type(&vtable::template _get_type<T>)
-          , destruct(&vtable::template _destruct<T>)
+          : destruct(&vtable::template _destruct<T>)
           , delete_(&vtable::template _delete<T>)
         {}
     };

--- a/hpx/util/function.hpp
+++ b/hpx/util/function.hpp
@@ -124,7 +124,6 @@ namespace hpx { namespace util
         using base_type::assign;
         using base_type::reset;
         using base_type::empty;
-        using base_type::target_type;
         using base_type::target;
     };
 

--- a/hpx/util/unique_function.hpp
+++ b/hpx/util/unique_function.hpp
@@ -86,7 +86,6 @@ namespace hpx { namespace util
         using base_type::assign;
         using base_type::reset;
         using base_type::empty;
-        using base_type::target_type;
         using base_type::target;
     };
 

--- a/tests/unit/util/function/function_target.cpp
+++ b/tests/unit/util/function/function_target.cpp
@@ -20,14 +20,12 @@ int main()
     {
         hpx::util::function<int()> fun = foo();
 
-        HPX_TEST(fun.target_type() == typeid(foo));
         HPX_TEST(fun.target<foo>() != nullptr);
     }
 
     {
         hpx::util::function<int()> fun = foo();
 
-        HPX_TEST(fun.target_type() == typeid(foo const));
         HPX_TEST(fun.target<foo const>() != nullptr);
     }
 


### PR DESCRIPTION
The functionality is not particularly useful, and has a high cost in binary bloat.