### PR TITLE
Adding test ensuring ticket 3565 is fixed

### DIFF
--- a/tests/unit/component/CMakeLists.txt
+++ b/tests/unit/component/CMakeLists.txt
@@ -16,6 +16,7 @@ set(tests
     inheritance_2_classes_concrete
     inheritance_3_classes_1_abstract
     inheritance_3_classes_2_abstract
+    inheritance_2_classes_concrete_simple
     inheritance_3_classes_concrete
     local_new
     migrate_component

--- a/tests/unit/component/inheritance_2_classes_concrete_simple.cpp
+++ b/tests/unit/component/inheritance_2_classes_concrete_simple.cpp
@@ -1,9 +1,7 @@
-////////////////////////////////////////////////////////////////////////////////
-//  Copyright (c) 2012 Bryce Adelstein-Lelbach
+//  Copyright (c) 2018 Maximilian Bremer
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-///////////////////////////////////////////////////////////////////////////////
 
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/components.hpp>
@@ -20,7 +18,7 @@ bool b_dtor = false;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Concrete
-struct A : hpx::components::managed_component_base<A>
+struct A : hpx::components::component_base<A>
 {
     A() { a_ctor = true; }
     virtual ~A() { a_dtor = true; }
@@ -30,7 +28,7 @@ struct A : hpx::components::managed_component_base<A>
     HPX_DEFINE_COMPONENT_ACTION(A, test0_nonvirt, test0_action);
 };
 
-typedef hpx::components::managed_component<A> serverA_type;
+typedef hpx::components::simple_component<A> serverA_type;
 HPX_REGISTER_COMPONENT(serverA_type, A);
 
 typedef A::test0_action test0_action;
@@ -39,14 +37,16 @@ HPX_REGISTER_ACTION(test0_action);
 
 ///////////////////////////////////////////////////////////////////////////////
 // Concrete
-struct B : A, hpx::components::managed_component_base<B>
+struct B : A, hpx::components::component_base<B>
 {
-    typedef hpx::components::managed_component_base<B>::wrapping_type
+    typedef hpx::components::component_base<B>::wrapping_type
         wrapping_type;
-    typedef hpx::components::managed_component_base<B>::wrapped_type
+    typedef hpx::components::component_base<B>::wrapped_type
         wrapped_type;
-    using hpx::components::managed_component_base<B>::set_back_ptr;
-    using hpx::components::managed_component_base<B>::finalize;
+
+    using hpx::components::component_base<B>::finalize;
+    using hpx::components::component_base<B>::get_base_gid;
+    using hpx::components::component_base<B>::get_current_address;
 
     typedef B type_holder;
     typedef A base_type_holder;
@@ -60,7 +60,7 @@ struct B : A, hpx::components::managed_component_base<B>
     HPX_DEFINE_COMPONENT_ACTION(B, test1, test1_action);
 };
 
-typedef hpx::components::managed_component<B> serverB_type;
+typedef hpx::components::simple_component<B> serverB_type;
 HPX_REGISTER_DERIVED_COMPONENT_FACTORY(serverB_type, B, "A");
 
 typedef B::test1_action test1_action;
@@ -164,4 +164,3 @@ int main()
 
     return 0;
 }
-


### PR DESCRIPTION
- flyby: make sure inheritance_2_classes_concrete test actually passes if run on  one core

@bremerm31 Everything is ok, the test you created (and the similar one that was already in HPX) was flawed. Because of the non-immediate nature of deleting components by AGAS the destructor of the objects was not called before you checked. I added an explicit call to `garbage_collect` (enforcing deletion of all pending objects) and now everything looks fine.

This fixes #3565 

