### PR TITLE
Make sure HPX is usable with latest released version of Vc (V1.4.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -643,7 +643,7 @@ hpx_option(HPX_WITH_HPXMP BOOL
   "Enable hpxMP OpenMP emulation." OFF CATEGORY "OpenMP")
 if(HPX_WITH_HPXMP)
   if(NOT MSVC AND (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-	OR ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")))
+    OR ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")))
     hpx_option(HPX_WITH_HPXMP_NO_UPDATE BOOL
       "Do not update code from remote hpxMP repository." OFF CATEGORY "OpenMP")
   else()
@@ -1344,6 +1344,17 @@ if(HPX_WITH_COMPILER_WARNINGS)
       # The file contains a character starting at offset ... that is illegal in
       # the current source character set
       hpx_add_compile_flag(-wd4828)
+    endif()
+
+    if(HPX_WITH_DATAPAR_VC)
+      # unary minus operator applied to unsigned type, result still unsigned
+      hpx_add_compile_flag(-wd4146)
+
+      # '<=': signed/unsigned mismatch
+      hpx_add_compile_flag(-wd4018)
+
+      # 'return': conversion from 'short' to 'Vc_1::schar', possible loss of data
+      hpx_add_compile_flag(-wd4244)
     endif()
 
   else() # Trial and error approach for any other compiler ...

--- a/cmake/HPX_SetupVc.cmake
+++ b/cmake/HPX_SetupVc.cmake
@@ -33,19 +33,22 @@
 # Vc_SSE_INTRINSICS_BROKEN
 # Vc_AVX_INTRINSICS_BROKEN
 
-find_package(Vc ${Vc_FIND_VERSION} QUIET NO_MODULE PATHS ${Vc_ROOT})
+find_package(Vc ${Vc_FIND_VERSION} QUIET)
 
 if(NOT Vc_FOUND)
-  if(NOT Vc_VERSION_STRING OR (${Vc_VERSION_STRING} VERSION_LESS "1.70.0"))
+  if(NOT Vc_VERSION_STRING)
     # didn't find any version of Vc
-    hpx_error("Vc was not found while datapar support was requested. Set Vc_ROOT to the installation path of Vc")
+    hpx_error("Vc was not found while datapar support was requested. Set Vc_DIR to the installation path of Vc")
+  elseif(${Vc_VERSION_STRING} VERSION_LESS "1.70.0")
+    # didn't find current version of Vc
+    hpx_error("The Vc was found for requested datapar support was too old. Set Vc_DIR to the installation path of Vc (V1.70.0 is required)")
   endif()
 endif()
 
 if(Vc_VERSION_STRING AND (NOT ${Vc_VERSION_STRING} VERSION_LESS "1.70.0"))
   # found Vc V2
   if(NOT Vc_INCLUDE_DIR)
-    hpx_error("Vc was not found while datapar support was requested. Set Vc_ROOT to the installation path of Vc")
+    hpx_error("Vc was not found while datapar support was requested. Set Vc_DIR to the installation path of Vc")
   endif()
   set(HPX_WITH_DATAPAR_VC_NO_LIBRARY On)
 endif()

--- a/tests/unit/parallel/datapar_algorithms/count_datapar.cpp
+++ b/tests/unit/parallel/datapar_algorithms/count_datapar.cpp
@@ -29,7 +29,9 @@ void count_test()
 {
     test_count<std::random_access_iterator_tag>();
     test_count<std::forward_iterator_tag>();
+#if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
     test_count<std::input_iterator_tag>();
+#endif
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -49,7 +51,9 @@ void count_exception_test()
 {
     test_count_exception<std::random_access_iterator_tag>();
     test_count_exception<std::forward_iterator_tag>();
+#if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
     test_count_exception<std::input_iterator_tag>();
+#endif
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -69,7 +73,9 @@ void count_bad_alloc_test()
 {
     test_count_bad_alloc<std::random_access_iterator_tag>();
     test_count_bad_alloc<std::forward_iterator_tag>();
+#if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
     test_count_bad_alloc<std::input_iterator_tag>();
+#endif
 }
 
 int hpx_main(boost::program_options::variables_map& vm)

--- a/tests/unit/parallel/datapar_algorithms/countif_datapar.cpp
+++ b/tests/unit/parallel/datapar_algorithms/countif_datapar.cpp
@@ -30,7 +30,9 @@ void count_if_test()
 {
     test_count_if<std::random_access_iterator_tag>();
     test_count_if<std::forward_iterator_tag>();
+#if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
     test_count_if<std::input_iterator_tag>();
+#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -69,7 +71,9 @@ void count_if_bad_alloc_test()
 {
     test_count_if_bad_alloc<std::random_access_iterator_tag>();
     test_count_if_bad_alloc<std::forward_iterator_tag>();
+#if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
     test_count_if_bad_alloc<std::input_iterator_tag>();
+#endif
 }
 
 int hpx_main(boost::program_options::variables_map& vm)

--- a/tests/unit/parallel/datapar_algorithms/foreach_datapar.cpp
+++ b/tests/unit/parallel/datapar_algorithms/foreach_datapar.cpp
@@ -30,7 +30,9 @@ void for_each_test()
 {
     test_for_each<std::random_access_iterator_tag>();
     test_for_each<std::forward_iterator_tag>();
+#if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
     test_for_each<std::input_iterator_tag>();
+#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -50,7 +52,9 @@ void for_each_exception_test()
 {
     test_for_each_exception<std::random_access_iterator_tag>();
     test_for_each_exception<std::forward_iterator_tag>();
+#if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
     test_for_each_exception<std::input_iterator_tag>();
+#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -70,7 +74,9 @@ void for_each_bad_alloc_test()
 {
     test_for_each_bad_alloc<std::random_access_iterator_tag>();
     test_for_each_bad_alloc<std::forward_iterator_tag>();
+#if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
     test_for_each_bad_alloc<std::input_iterator_tag>();
+#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/parallel/datapar_algorithms/foreachn_datapar.cpp
+++ b/tests/unit/parallel/datapar_algorithms/foreachn_datapar.cpp
@@ -31,7 +31,9 @@ void for_each_n_test()
 {
     test_for_each_n<std::random_access_iterator_tag>();
     test_for_each_n<std::forward_iterator_tag>();
+#if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
     test_for_each_n<std::input_iterator_tag>();
+#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/parallel/datapar_algorithms/transform_binary2_datapar.cpp
+++ b/tests/unit/parallel/datapar_algorithms/transform_binary2_datapar.cpp
@@ -32,7 +32,9 @@ void transform_binary2_test()
 {
     test_transform_binary2<std::random_access_iterator_tag>();
     test_transform_binary2<std::forward_iterator_tag>();
+#if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
     test_transform_binary2<std::input_iterator_tag>();
+#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -54,7 +56,9 @@ void transform_binary2_exception_test()
 {
     test_transform_binary2_exception<std::random_access_iterator_tag>();
     test_transform_binary2_exception<std::forward_iterator_tag>();
+#if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
     test_transform_binary2_exception<std::input_iterator_tag>();
+#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -76,7 +80,9 @@ void transform_binary2_bad_alloc_test()
 {
     test_transform_binary2_bad_alloc<std::random_access_iterator_tag>();
     test_transform_binary2_bad_alloc<std::forward_iterator_tag>();
+#if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
     test_transform_binary2_bad_alloc<std::input_iterator_tag>();
+#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/parallel/datapar_algorithms/transform_binary_datapar.cpp
+++ b/tests/unit/parallel/datapar_algorithms/transform_binary_datapar.cpp
@@ -32,7 +32,9 @@ void transform_binary_test()
 {
     test_transform_binary<std::random_access_iterator_tag>();
     test_transform_binary<std::forward_iterator_tag>();
+#if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
     test_transform_binary<std::input_iterator_tag>();
+#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -54,7 +56,9 @@ void transform_binary_exception_test()
 {
     test_transform_binary_exception<std::random_access_iterator_tag>();
     test_transform_binary_exception<std::forward_iterator_tag>();
+#if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
     test_transform_binary_exception<std::input_iterator_tag>();
+#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -76,7 +80,9 @@ void transform_binary_bad_alloc_test()
 {
     test_transform_binary_bad_alloc<std::random_access_iterator_tag>();
     test_transform_binary_bad_alloc<std::forward_iterator_tag>();
+#if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
     test_transform_binary_bad_alloc<std::input_iterator_tag>();
+#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/parallel/datapar_algorithms/transform_datapar.cpp
+++ b/tests/unit/parallel/datapar_algorithms/transform_datapar.cpp
@@ -30,7 +30,9 @@ void transform_test()
 {
     test_transform<std::random_access_iterator_tag>();
     test_transform<std::forward_iterator_tag>();
+#if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
     test_transform<std::input_iterator_tag>();
+#endif
 }
 
 template <typename IteratorTag>
@@ -49,7 +51,9 @@ void transform_exception_test()
 {
     test_transform_exception<std::random_access_iterator_tag>();
     test_transform_exception<std::forward_iterator_tag>();
+#if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
     test_transform_exception<std::input_iterator_tag>();
+#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -69,7 +73,9 @@ void transform_bad_alloc_test()
 {
     test_transform_bad_alloc<std::random_access_iterator_tag>();
     test_transform_bad_alloc<std::forward_iterator_tag>();
+#if defined(HPX_HAVE_ALGORITHM_INPUT_ITERATOR_SUPPORT)
     test_transform_bad_alloc<std::input_iterator_tag>();
+#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #3570

@diehlpk This ensures that all tests are compiling properly with the latest released version of Vc (V1.4.1)
