### PR TITLE
Make sure empty startup/shutdown functions are not being used

### DIFF
--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //  Copyright (c) 2011 Bryce Lelbach
 //  Copyright (c) 2011-2017 Thomas Heller
 //
@@ -28,7 +28,6 @@
 #include <hpx/traits/is_component.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/plugin.hpp>
-#include <hpx/util/unlock_guard.hpp>
 #include <hpx/util_fwd.hpp>
 
 #include <boost/program_options/options_description.hpp>
@@ -39,7 +38,6 @@
 #include <list>
 #include <map>
 #include <memory>
-#include <mutex>
 #include <set>
 #include <sstream>
 #include <string>
@@ -240,29 +238,10 @@ namespace hpx { namespace components { namespace server
 
         bool was_stopped() const { return stop_called_; }
 
-        void add_pre_startup_function(startup_function_type f)
-        {
-            std::lock_guard<lcos::local::spinlock> l(globals_mtx_);
-            pre_startup_functions_.push_back(std::move(f));
-        }
-
-        void add_startup_function(startup_function_type f)
-        {
-            std::lock_guard<lcos::local::spinlock> l(globals_mtx_);
-            startup_functions_.push_back(std::move(f));
-        }
-
-        void add_pre_shutdown_function(shutdown_function_type f)
-        {
-            std::lock_guard<lcos::local::spinlock> l(globals_mtx_);
-            pre_shutdown_functions_.push_back(std::move(f));
-        }
-
-        void add_shutdown_function(shutdown_function_type f)
-        {
-            std::lock_guard<lcos::local::spinlock> l(globals_mtx_);
-            shutdown_functions_.push_back(std::move(f));
-        }
+        void add_pre_startup_function(startup_function_type f);
+        void add_startup_function(startup_function_type f);
+        void add_pre_shutdown_function(shutdown_function_type f);
+        void add_shutdown_function(shutdown_function_type f);
 
         void remove_here_from_connection_cache();
         void remove_here_from_console_connection_cache();

--- a/src/runtime/components/runtime_support.cpp
+++ b/src/runtime/components/runtime_support.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -7,5 +7,49 @@
 #include <hpx/runtime/components/runtime_support.hpp>
 #include <hpx/runtime/components/component_registry.hpp>
 
+#include <mutex>
+#include <utility>
+
 HPX_PLUGIN_EXPORT_LIST(HPX_PLUGIN_COMPONENT_PREFIX, factory)
 HPX_REGISTER_REGISTRY_MODULE()
+
+namespace hpx { namespace components { namespace server
+{
+    void runtime_support::add_pre_startup_function(startup_function_type f)
+    {
+        if (!f.empty())
+        {
+            std::lock_guard<lcos::local::spinlock> l(globals_mtx_);
+            pre_startup_functions_.push_back(std::move(f));
+        }
+    }
+
+    void runtime_support::add_startup_function(startup_function_type f)
+    {
+        if (!f.empty())
+        {
+            std::lock_guard<lcos::local::spinlock> l(globals_mtx_);
+            startup_functions_.push_back(std::move(f));
+        }
+    }
+
+    void runtime_support::add_pre_shutdown_function(shutdown_function_type f)
+    {
+        if (!f.empty())
+        {
+            std::lock_guard<lcos::local::spinlock> l(globals_mtx_);
+            pre_shutdown_functions_.push_back(std::move(f));
+        }
+    }
+
+    void runtime_support::add_shutdown_function(shutdown_function_type f)
+    {
+        if (!f.empty())
+        {
+            std::lock_guard<lcos::local::spinlock> l(globals_mtx_);
+            shutdown_functions_.push_back(std::move(f));
+        }
+    }
+}}}
+
+

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -1566,20 +1566,34 @@ namespace hpx { namespace components { namespace server
             bool pre_startup = true;
             if (startup_shutdown->get_startup_function(startup, pre_startup))
             {
-                if (pre_startup)
-                    pre_startup_functions_.push_back(std::move(startup));
-                else
-                    startup_functions_.push_back(std::move(startup));
+                if (!startup.empty())
+                {
+                    if (pre_startup)
+                    {
+                        pre_startup_functions_.push_back(std::move(startup));
+                    }
+                    else
+                    {
+                        startup_functions_.push_back(std::move(startup));
+                    }
+                }
             }
 
             shutdown_function_type shutdown;
             bool pre_shutdown = false;
             if (startup_shutdown->get_shutdown_function(shutdown, pre_shutdown))
             {
-                if (pre_shutdown)
-                    pre_shutdown_functions_.push_back(std::move(shutdown));
-                else
-                    shutdown_functions_.push_back(std::move(shutdown));
+                if (!shutdown.empty())
+                {
+                    if (pre_shutdown)
+                    {
+                        pre_shutdown_functions_.push_back(std::move(shutdown));
+                    }
+                    else
+                    {
+                        shutdown_functions_.push_back(std::move(shutdown));
+                    }
+                }
             }
         }
         catch (hpx::exception const&) {


### PR DESCRIPTION
Fixes the possible use of empty startup/shutdown functions in the main HPX module.
