### PR TITLE
 Make bind propagate value category

### DIFF
--- a/hpx/lcos/async.hpp
+++ b/hpx/lcos/async.hpp
@@ -108,10 +108,10 @@ namespace hpx { namespace detail
             }
 
             // defer invocation otherwise
-            return c.then(util::bind(
-                util::one_shot(async_action_client_dispatch<Action>()),
+            return c.then(util::one_shot(util::bind(
+                async_action_client_dispatch<Action>(),
                 std::forward<Policy_>(launch_policy), c, std::forward<Ts>(ts)...
-            ));
+            )));
         }
 
         // distribution policy

--- a/hpx/lcos/sync.hpp
+++ b/hpx/lcos/sync.hpp
@@ -102,10 +102,10 @@ namespace hpx { namespace detail
             }
 
             // defer invocation otherwise
-            return c.then(util::bind(
-                util::one_shot(sync_action_client_dispatch<Action>()),
+            return c.then(util::one_shot(util::bind(
+                sync_action_client_dispatch<Action>(),
                 std::forward<Policy_>(launch_policy), c, std::forward<Ts>(ts)...
-            )).get();
+            ))).get();
         }
     };
 

--- a/hpx/parallel/executors/execution.hpp
+++ b/hpx/parallel/executors/execution.hpp
@@ -190,9 +190,8 @@ namespace hpx { namespace parallel { namespace execution
                         F, Future, Ts...
                     >::type result_type;
 
-                auto func = hpx::util::bind_back(
-                    hpx::util::one_shot(std::forward<F>(f)),
-                    std::forward<Ts>(ts)...);
+                auto func = hpx::util::one_shot(hpx::util::bind_back(
+                    std::forward<F>(f), std::forward<Ts>(ts)...));
 
                 typename hpx::traits::detail::shared_state_ptr<result_type>::type
                     p = lcos::detail::make_continuation_exec<result_type>(
@@ -469,9 +468,8 @@ namespace hpx { namespace parallel { namespace execution
                         F, Future, Ts...
                     >::type result_type;
 
-                auto func = hpx::util::bind_back(
-                    hpx::util::one_shot(std::forward<F>(f)),
-                    std::forward<Ts>(ts)...);
+                auto func = hpx::util::one_shot(hpx::util::bind_back(
+                    std::forward<F>(f), std::forward<Ts>(ts)...));
 
                 typename hpx::traits::detail::shared_state_ptr<result_type>::type
                     p = lcos::detail::make_continuation_exec<result_type>(

--- a/hpx/parallel/executors/thread_execution.hpp
+++ b/hpx/parallel/executors/thread_execution.hpp
@@ -89,9 +89,8 @@ namespace hpx { namespace threads
                 F, Future, Ts...
             >::type result_type;
 
-        auto func = hpx::util::bind_back(
-            hpx::util::one_shot(std::forward<F>(f)),
-            std::forward<Ts>(ts)...);
+        auto func = hpx::util::one_shot(hpx::util::bind_back(
+            std::forward<F>(f), std::forward<Ts>(ts)...));
 
         typename hpx::traits::detail::shared_state_ptr<result_type>::type p =
             hpx::lcos::detail::make_continuation_exec<result_type>(

--- a/hpx/parallel/executors/timed_executors.hpp
+++ b/hpx/parallel/executors/timed_executors.hpp
@@ -63,11 +63,11 @@ namespace hpx { namespace parallel { namespace execution
             {
                 auto predecessor = make_ready_future_at(abs_time);
                 return execution::then_execute(sequenced_executor(),
-                    hpx::util::bind(
-                        hpx::util::one_shot(sync_execute_at_helper()),
+                    hpx::util::one_shot(hpx::util::bind(
+                        sync_execute_at_helper(),
                         hpx::util::placeholders::_1, std::ref(exec),
                         hpx::util::deferred_call(
-                            std::forward<F>(f), std::forward<Ts>(ts)...)),
+                            std::forward<F>(f), std::forward<Ts>(ts)...))),
                     predecessor).get();
             }
 
@@ -171,11 +171,11 @@ namespace hpx { namespace parallel { namespace execution
             {
                 auto predecessor = make_ready_future_at(abs_time);
                 return execution::then_execute(sequenced_executor(),
-                    hpx::util::bind(
-                        hpx::util::one_shot(async_execute_at_helper()),
+                    hpx::util::one_shot(hpx::util::bind(
+                        async_execute_at_helper(),
                         hpx::util::placeholders::_1, std::forward<Executor>(exec),
                         hpx::util::deferred_call(
-                            std::forward<F>(f), std::forward<Ts>(ts)...)),
+                            std::forward<F>(f), std::forward<Ts>(ts)...))),
                     predecessor);
             }
 
@@ -270,11 +270,11 @@ namespace hpx { namespace parallel { namespace execution
             {
                 auto predecessor = make_ready_future_at(abs_time);
                 execution::then_execute(sequenced_executor(),
-                    hpx::util::bind(
-                        hpx::util::one_shot(post_at_helper()),
+                    hpx::util::one_shot(hpx::util::bind(
+                        post_at_helper(),
                         hpx::util::placeholders::_1, std::forward<Executor>(exec),
                         hpx::util::deferred_call(std::forward<F>(f),
-                            std::forward<Ts>(ts)...)),
+                            std::forward<Ts>(ts)...))),
                     predecessor);
             }
 

--- a/hpx/parallel/task_block.hpp
+++ b/hpx/parallel/task_block.hpp
@@ -194,9 +194,8 @@ namespace hpx { namespace parallel { inline namespace v2
             return
                 result::get(
                     hpx::dataflow(
-                        hpx::util::bind_back(
-                            hpx::util::one_shot(&task_block::on_ready),
-                            std::move(errors)),
+                        hpx::util::one_shot(hpx::util::bind_back(
+                            &task_block::on_ready, std::move(errors))),
                         std::move(tasks)
                     ));
         }

--- a/hpx/runtime/actions/basic_action.hpp
+++ b/hpx/runtime/actions/basic_action.hpp
@@ -298,15 +298,15 @@ namespace hpx { namespace actions
                 target.get_management_type() == naming::id_type::unmanaged)
             {
                 return traits::action_decorate_function<Derived>::call(lva,
-                    util::bind(util::one_shot(
-                        typename Derived::thread_function()),
-                        lva, comptype, std::forward<Ts>(vs)...));
+                    util::one_shot(util::bind(
+                        typename Derived::thread_function(),
+                        lva, comptype, std::forward<Ts>(vs)...)));
             }
 
             return traits::action_decorate_function<Derived>::call(lva,
-                util::bind(util::one_shot(
-                    typename Derived::thread_function(target)),
-                    lva, comptype, std::forward<Ts>(vs)...));
+                util::one_shot(util::bind(
+                    typename Derived::thread_function(target),
+                    lva, comptype, std::forward<Ts>(vs)...)));
         }
 
         // This static construct_thread_function allows to construct

--- a/hpx/runtime/components/server/locking_hook.hpp
+++ b/hpx/runtime/components/server/locking_hook.hpp
@@ -55,12 +55,12 @@ namespace hpx { namespace components
         static threads::thread_function_type
         decorate_action(naming::address::address_type lva, F && f)
         {
-            return util::bind(
-                util::one_shot(&locking_hook::thread_function),
+            return util::one_shot(util::bind(
+                &locking_hook::thread_function,
                 get_lva<this_component_type>::call(lva),
                 util::placeholders::_1,
                 traits::component_decorate_function<base_type>::call(
-                    lva, std::forward<F>(f)));
+                    lva, std::forward<F>(f))));
         }
 
     protected:

--- a/hpx/runtime/components/server/migration_support.hpp
+++ b/hpx/runtime/components/server/migration_support.hpp
@@ -192,13 +192,13 @@ namespace hpx { namespace components
             // Make sure we pin the component at construction of the bound object
             // which will also unpin it once the thread runs to completion (the
             // bound object goes out of scope).
-            return util::bind(
-                util::one_shot(&migration_support::thread_function),
+            return util::one_shot(util::bind(
+                &migration_support::thread_function,
                 get_lva<this_component_type>::call(lva),
                 util::placeholders::_1,
                 traits::component_decorate_function<base_type>::call(
                     lva, std::forward<F>(f)),
-                components::pinned_ptr::create<this_component_type>(lva));
+                components::pinned_ptr::create<this_component_type>(lva)));
         }
 
         // Return whether the given object was migrated, if it was not

--- a/hpx/runtime/parcelset/decode_parcels.hpp
+++ b/hpx/runtime/parcelset/decode_parcels.hpp
@@ -211,13 +211,11 @@ namespace hpx { namespace parcelset
                         {
                             // schedule all but the first parcel on a new thread.
                             hpx::applier::register_thread_nullary(
-                                util::bind(
-                                    util::one_shot(
-                                        [num_thread](parcel&& p)
-                                        {
-                                            p.schedule_action(num_thread);
-                                        }
-                                    ), std::move(deferred_parcels[i])),
+                                util::one_shot(util::bind(
+                                    [num_thread](parcel&& p)
+                                    {
+                                        p.schedule_action(num_thread);
+                                    }, std::move(deferred_parcels[i]))),
                                 "schedule_parcel",
                                 threads::pending, true,
                                 threads::thread_priority_boost,
@@ -290,9 +288,9 @@ namespace hpx { namespace parcelset
 //         if(hpx::is_running() && parcelport.async_serialization())
 //         {
 //             hpx::applier::register_thread_nullary(
-//                 util::bind(
-//                     util::one_shot(&decode_message<Parcelport, Buffer>),
-//                     std::ref(parcelport), std::move(buffer), 1, num_thread),
+//                 util::one_shot(util::bind(
+//                     &decode_message<Parcelport, Buffer>,
+//                     std::ref(parcelport), std::move(buffer), 1, num_thread)),
 //                 "decode_parcels",
 //                 threads::pending, true, threads::thread_priority_boost,
 //                 parcelport.get_next_num_thread());
@@ -309,9 +307,9 @@ namespace hpx { namespace parcelset
 //         if(hpx::is_running() && parcelport.async_serialization())
 //         {
 //             hpx::applier::register_thread_nullary(
-//                 util::bind(
-//                     util::one_shot(&decode_message<Parcelport, Buffer>),
-//                     std::ref(parcelport), std::move(buffer), 0, num_thread),
+//                 util::one_shot(util::bind(
+//                     &decode_message<Parcelport, Buffer>,
+//                     std::ref(parcelport), std::move(buffer), 0, num_thread)),
 //                 "decode_parcels",
 //                 threads::pending, true, threads::thread_priority_boost,
 //                 parcelport.get_next_num_thread());

--- a/hpx/runtime/parcelset/put_parcel.hpp
+++ b/hpx/runtime/parcelset/put_parcel.hpp
@@ -130,26 +130,24 @@ namespace hpx { namespace parcelset {
                 {
                     split_gid.then(
                         hpx::launch::sync,
-                        hpx::util::bind(
-                            hpx::util::one_shot(
-                                [is_continuation, dest]
-                                (hpx::future<naming::gid_type> f,
-                                 typename util::decay<PutParcel>::type&& pp_,
-                                 naming::address&& addr_,
-                                 typename util::decay<Args>::type&&... args_)
-                                {
-                                    HPX_UNUSED(dest);
-                                    pp_(detail::create_parcel::call(
-                                        is_continuation,
-                                        f.get(), std::move(addr_),
-                                        std::move(args_)...
-                                    ));
-                                }
-                            ),
+                        hpx::util::one_shot(hpx::util::bind(
+                            [is_continuation, dest]
+                            (hpx::future<naming::gid_type> f,
+                             typename util::decay<PutParcel>::type&& pp_,
+                             naming::address&& addr_,
+                             typename util::decay<Args>::type&&... args_)
+                            {
+                                HPX_UNUSED(dest);
+                                pp_(detail::create_parcel::call(
+                                    is_continuation,
+                                    f.get(), std::move(addr_),
+                                    std::move(args_)...
+                                ));
+                            },
                             hpx::util::placeholders::_1,
                             std::forward<PutParcel>(pp), std::move(addr),
                             std::forward<Args>(args)...
-                        )
+                        ))
                     );
                 }
             }

--- a/hpx/util/bind_action.hpp
+++ b/hpx/util/bind_action.hpp
@@ -19,7 +19,6 @@
 #include <hpx/traits/is_placeholder.hpp>
 #include <hpx/traits/promise_local_result.hpp>
 #include <hpx/util/bind.hpp>
-#include <hpx/util/decay.hpp>
 #include <hpx/util/tuple.hpp>
 
 #include <cstddef>
@@ -272,17 +271,17 @@ namespace hpx { namespace util
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename ...Ts>
     typename std::enable_if<
-        traits::is_action<typename util::decay<Action>::type>::value
+        traits::is_action<typename std::decay<Action>::type>::value
       , detail::bound_action<
-            typename util::decay<Action>::type
-          , util::tuple<typename util::decay<Ts>::type...>
+            typename std::decay<Action>::type
+          , util::tuple<typename std::decay<Ts>::type...>
         >
     >::type
     bind(Ts&&... vs)
     {
         typedef detail::bound_action<
-            typename util::decay<Action>::type,
-            util::tuple<typename util::decay<Ts>::type...>
+            typename std::decay<Action>::type,
+            util::tuple<typename std::decay<Ts>::type...>
         > result_type;
 
         return result_type(Action(),
@@ -294,7 +293,7 @@ namespace hpx { namespace util
       , typename ...Ts>
     detail::bound_action<
         Derived
-      , util::tuple<typename util::decay<Ts>::type...>
+      , util::tuple<typename std::decay<Ts>::type...>
     >
     bind(
         hpx::actions::basic_action<Component, Signature, Derived> action,
@@ -302,7 +301,7 @@ namespace hpx { namespace util
     {
         typedef detail::bound_action<
             Derived,
-            util::tuple<typename util::decay<Ts>::type...>
+            util::tuple<typename std::decay<Ts>::type...>
         > result_type;
 
         return result_type(static_cast<Derived const&>(action),

--- a/hpx/util/bind_action.hpp
+++ b/hpx/util/bind_action.hpp
@@ -41,12 +41,12 @@ namespace hpx { namespace util
             static HPX_FORCEINLINE
             type call(
                 detail::pack_c<std::size_t, Is...>
-              , Ts& bound, Us&& unbound
+              , Ts&& bound, Us&& unbound
             )
             {
                 return hpx::apply<Action>(
-                    bind_eval<Action, typename util::tuple_element<Is, Ts>::type>(
-                        util::get<Is>(bound),
+                    bind_eval(
+                        util::get<Is>(std::forward<Ts>(bound)),
                         std::forward<Us>(unbound))...);
             }
         };
@@ -54,11 +54,11 @@ namespace hpx { namespace util
         template <typename Action, typename Ts, typename Us>
         HPX_FORCEINLINE
         bool
-        bind_action_apply(Ts& bound, Us&& unbound)
+        bind_action_apply(Ts&& bound, Us&& unbound)
         {
             return bind_action_apply_impl<Action, Ts, Us>::call(
                 typename detail::make_index_pack<
-                    util::tuple_size<Ts>::value
+                    util::tuple_size<typename std::decay<Ts>::type>::value
                 >::type(),
                 bound, std::forward<Us>(unbound));
         }
@@ -74,12 +74,12 @@ namespace hpx { namespace util
             type call(
                 detail::pack_c<std::size_t, Is...>
               , naming::id_type const& cont
-              , Ts& bound, Us&& unbound
+              , Ts&& bound, Us&& unbound
             )
             {
                 return hpx::apply_c<Action>(cont,
-                    bind_eval<Action, typename util::tuple_element<Is, Ts>::type>(
-                        util::get<Is>(bound),
+                    bind_eval(
+                        util::get<Is>(std::forward<Ts>(bound)),
                         std::forward<Us>(unbound))...);
             }
         };
@@ -88,14 +88,14 @@ namespace hpx { namespace util
         HPX_FORCEINLINE
         bool
         bind_action_apply_cont(naming::id_type const& cont,
-            Ts& bound, Us&& unbound
+            Ts&& bound, Us&& unbound
         )
         {
             return bind_action_apply_cont_impl<
                     Action, Ts, Us
                 >::call(
                     typename detail::make_index_pack<
-                        util::tuple_size<Ts>::value
+                        util::tuple_size<typename std::decay<Ts>::type>::value
                     >::type(), cont,
                     bound, std::forward<Us>(unbound));
         }
@@ -111,12 +111,12 @@ namespace hpx { namespace util
             type call(
                 detail::pack_c<std::size_t, Is...>
               , Continuation && cont
-              , Ts& bound, Us&& unbound
+              , Ts&& bound, Us&& unbound
             )
             {
                 return hpx::apply<Action>(std::forward<Continuation>(cont),
-                    bind_eval<Action, typename util::tuple_element<Is, Ts>::type>(
-                        util::get<Is>(bound),
+                    bind_eval(
+                        util::get<Is>(std::forward<Ts>(bound)),
                         std::forward<Us>(unbound))...);
             }
         };
@@ -128,13 +128,13 @@ namespace hpx { namespace util
             traits::is_continuation<Continuation>::value, bool
         >::type
         bind_action_apply_cont2(Continuation && cont,
-            Ts& bound, Us&& unbound)
+            Ts&& bound, Us&& unbound)
         {
             return bind_action_apply_cont_impl2<
                     Action, Ts, Us
                 >::call(
                     typename detail::make_index_pack<
-                        util::tuple_size<Ts>::value
+                        util::tuple_size<typename std::decay<Ts>::type>::value
                     >::type(), std::forward<Continuation>(cont),
                     bound, std::forward<Us>(unbound));
         }
@@ -151,12 +151,12 @@ namespace hpx { namespace util
             static HPX_FORCEINLINE
             type call(
                 detail::pack_c<std::size_t, Is...>
-              , Ts& bound, Us&& unbound
+              , Ts&& bound, Us&& unbound
             )
             {
                 return hpx::async<Action>(
-                    bind_eval<Action, typename util::tuple_element<Is, Ts>::type>(
-                        util::get<Is>(bound),
+                    bind_eval(
+                        util::get<Is>(std::forward<Ts>(bound)),
                         std::forward<Us>(unbound))...);
             }
         };
@@ -166,11 +166,11 @@ namespace hpx { namespace util
         lcos::future<typename traits::promise_local_result<
             typename hpx::traits::extract_action<Action>::remote_result_type
         >::type>
-        bind_action_async(Ts& bound, Us&& unbound)
+        bind_action_async(Ts&& bound, Us&& unbound)
         {
             return bind_action_async_impl<Action, Ts, Us>::call(
                 typename detail::make_index_pack<
-                    util::tuple_size<Ts>::value
+                    util::tuple_size<typename std::decay<Ts>::type>::value
                 >::type(),
                 bound, std::forward<Us>(unbound));
         }
@@ -181,11 +181,11 @@ namespace hpx { namespace util
         typename traits::promise_local_result<
             typename hpx::traits::extract_action<Action>::remote_result_type
         >::type
-        bind_action_invoke(Ts& bound, Us&& unbound)
+        bind_action_invoke(Ts&& bound, Us&& unbound)
         {
             return bind_action_async_impl<Action, Ts, Us>::call(
                 typename detail::make_index_pack<
-                    util::tuple_size<Ts>::value
+                    util::tuple_size<typename std::decay<Ts>::type>::value
                 >::type(),
                 bound, std::forward<Us>(unbound)).get();
         }

--- a/hpx/util/bind_back.hpp
+++ b/hpx/util/bind_back.hpp
@@ -24,10 +24,6 @@ namespace hpx { namespace util
 {
     namespace detail
     {
-        template <typename F>
-        class one_shot_wrapper;
-
-        ///////////////////////////////////////////////////////////////////////
         template <typename F, typename Ts, typename ...Us>
         struct invoke_bound_back_result;
 
@@ -49,17 +45,6 @@ namespace hpx { namespace util
         template <typename F, typename ...Ts, typename ...Us>
         struct invoke_bound_back_result<F const&&, util::tuple<Ts...> const&&, Us...>
           : util::invoke_result<F const, Us..., Ts const...>
-        {};
-
-        // one-shot wrapper is not const callable
-        template <typename F, typename ...Ts, typename ...Us>
-        struct invoke_bound_back_result<
-            one_shot_wrapper<F> const&, util::tuple<Ts...> const&, Us...>
-        {};
-
-        template <typename F, typename ...Ts, typename ...Us>
-        struct invoke_bound_back_result<
-            one_shot_wrapper<F> const&&, util::tuple<Ts...> const&&, Us...>
         {};
 
         template <typename F, std::size_t ...Is, typename Ts, typename ...Us>
@@ -199,6 +184,99 @@ namespace hpx { namespace util
 
         private:
             typename std::decay<F>::type _f;
+            util::tuple<typename util::decay_unwrap<Ts>::type...> _args;
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename F>
+        class one_shot_wrapper;
+
+        template <typename F, typename ...Ts>
+        struct bound_back<one_shot_wrapper<F>, Ts...>
+        {
+        public:
+            bound_back() {} // needed for serialization
+
+            template <typename F_, typename ...Ts_, typename =
+                typename std::enable_if<
+                    !std::is_same<typename std::decay<F_>::type, bound_back>::value
+                >::type>
+            HPX_CONSTEXPR explicit bound_back(F_&& f, Ts_&&... vs)
+              : _f(std::forward<F_>(f))
+              , _args(std::forward<Ts_>(vs)...)
+            {}
+
+#if !defined(__NVCC__) && !defined(__CUDACC__)
+            bound_back(bound_back const&) = default;
+            bound_back(bound_back&&) = default;
+#else
+            HPX_CONSTEXPR HPX_HOST_DEVICE bound_back(bound_back const& other)
+              : _f(other._f)
+              , _args(other._args)
+            {}
+
+            HPX_CONSTEXPR HPX_HOST_DEVICE bound_back(bound_back&& other)
+              : _f(std::move(other._f))
+              , _args(std::move(other._args))
+            {}
+#endif
+
+            bound_back& operator=(bound_back const&) = delete;
+
+            template <typename ...Us>
+            HPX_CXX14_CONSTEXPR HPX_HOST_DEVICE
+            typename invoke_bound_back_result<
+                one_shot_wrapper<F>&&,
+                util::tuple<typename util::decay_unwrap<Ts>::type...>&&,
+                Us...
+            >::type operator()(Us&&... vs)
+            {
+                return detail::bound_back_impl(std::move(_f),
+                    typename detail::make_index_pack<sizeof...(Ts)>::type(),
+                    std::move(_args), std::forward<Us>(vs)...);
+            }
+
+            template <typename Archive>
+            void serialize(Archive& ar, unsigned int const /*version*/)
+            {
+                ar & _f;
+                ar & _args;
+            }
+
+            std::size_t get_function_address() const
+            {
+                return traits::get_function_address<
+                        one_shot_wrapper<F>
+                    >::call(_f);
+            }
+
+            char const* get_function_annotation() const
+            {
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+                return traits::get_function_annotation<
+                        one_shot_wrapper<F>
+                    >::call(_f);
+#else
+                return nullptr;
+#endif
+            }
+
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+            util::itt::string_handle get_function_annotation_itt() const
+            {
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+                return traits::get_function_annotation_itt<
+                        one_shot_wrapper<F>
+                    >::call(_f);
+#else
+                static util::itt::string_handle sh("bound_back");
+                return sh;
+#endif
+            }
+#endif
+
+        private:
+            one_shot_wrapper<F> _f;
             util::tuple<typename util::decay_unwrap<Ts>::type...> _args;
         };
     }

--- a/hpx/util/bind_back.hpp
+++ b/hpx/util/bind_back.hpp
@@ -13,6 +13,7 @@
 #include <hpx/util/decay.hpp>
 #include <hpx/util/detail/pack.hpp>
 #include <hpx/util/invoke.hpp>
+#include <hpx/util/one_shot.hpp>
 #include <hpx/util/result_of.hpp>
 #include <hpx/util/tuple.hpp>
 
@@ -184,99 +185,6 @@ namespace hpx { namespace util
 
         private:
             typename std::decay<F>::type _f;
-            util::tuple<typename util::decay_unwrap<Ts>::type...> _args;
-        };
-
-        ///////////////////////////////////////////////////////////////////////
-        template <typename F>
-        class one_shot_wrapper;
-
-        template <typename F, typename ...Ts>
-        struct bound_back<one_shot_wrapper<F>, Ts...>
-        {
-        public:
-            bound_back() {} // needed for serialization
-
-            template <typename F_, typename ...Ts_, typename =
-                typename std::enable_if<
-                    !std::is_same<typename std::decay<F_>::type, bound_back>::value
-                >::type>
-            HPX_CONSTEXPR explicit bound_back(F_&& f, Ts_&&... vs)
-              : _f(std::forward<F_>(f))
-              , _args(std::forward<Ts_>(vs)...)
-            {}
-
-#if !defined(__NVCC__) && !defined(__CUDACC__)
-            bound_back(bound_back const&) = default;
-            bound_back(bound_back&&) = default;
-#else
-            HPX_CONSTEXPR HPX_HOST_DEVICE bound_back(bound_back const& other)
-              : _f(other._f)
-              , _args(other._args)
-            {}
-
-            HPX_CONSTEXPR HPX_HOST_DEVICE bound_back(bound_back&& other)
-              : _f(std::move(other._f))
-              , _args(std::move(other._args))
-            {}
-#endif
-
-            bound_back& operator=(bound_back const&) = delete;
-
-            template <typename ...Us>
-            HPX_CXX14_CONSTEXPR HPX_HOST_DEVICE
-            typename invoke_bound_back_result<
-                one_shot_wrapper<F>&&,
-                util::tuple<typename util::decay_unwrap<Ts>::type...>&&,
-                Us...
-            >::type operator()(Us&&... vs)
-            {
-                return detail::bound_back_impl(std::move(_f),
-                    typename detail::make_index_pack<sizeof...(Ts)>::type(),
-                    std::move(_args), std::forward<Us>(vs)...);
-            }
-
-            template <typename Archive>
-            void serialize(Archive& ar, unsigned int const /*version*/)
-            {
-                ar & _f;
-                ar & _args;
-            }
-
-            std::size_t get_function_address() const
-            {
-                return traits::get_function_address<
-                        one_shot_wrapper<F>
-                    >::call(_f);
-            }
-
-            char const* get_function_annotation() const
-            {
-#if defined(HPX_HAVE_THREAD_DESCRIPTION)
-                return traits::get_function_annotation<
-                        one_shot_wrapper<F>
-                    >::call(_f);
-#else
-                return nullptr;
-#endif
-            }
-
-#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
-            util::itt::string_handle get_function_annotation_itt() const
-            {
-#if defined(HPX_HAVE_THREAD_DESCRIPTION)
-                return traits::get_function_annotation_itt<
-                        one_shot_wrapper<F>
-                    >::call(_f);
-#else
-                static util::itt::string_handle sh("bound_back");
-                return sh;
-#endif
-            }
-#endif
-
-        private:
-            one_shot_wrapper<F> _f;
             util::tuple<typename util::decay_unwrap<Ts>::type...> _args;
         };
     }

--- a/hpx/util/bind_front.hpp
+++ b/hpx/util/bind_front.hpp
@@ -13,6 +13,7 @@
 #include <hpx/util/decay.hpp>
 #include <hpx/util/detail/pack.hpp>
 #include <hpx/util/invoke.hpp>
+#include <hpx/util/one_shot.hpp>
 #include <hpx/util/result_of.hpp>
 #include <hpx/util/tuple.hpp>
 
@@ -184,99 +185,6 @@ namespace hpx { namespace util
 
         private:
             typename std::decay<F>::type _f;
-            util::tuple<typename util::decay_unwrap<Ts>::type...> _args;
-        };
-
-        ///////////////////////////////////////////////////////////////////////
-        template <typename F>
-        class one_shot_wrapper;
-
-        template <typename F, typename ...Ts>
-        struct bound_front<one_shot_wrapper<F>, Ts...>
-        {
-        public:
-            bound_front() {} // needed for serialization
-
-            template <typename F_, typename ...Ts_, typename =
-                typename std::enable_if<
-                    !std::is_same<typename std::decay<F_>::type, bound_front>::value
-                >::type>
-            HPX_CONSTEXPR explicit bound_front(F_&& f, Ts_&&... vs)
-              : _f(std::forward<F_>(f))
-              , _args(std::forward<Ts_>(vs)...)
-            {}
-
-#if !defined(__NVCC__) && !defined(__CUDACC__)
-            bound_front(bound_front const&) = default;
-            bound_front(bound_front&&) = default;
-#else
-            HPX_CONSTEXPR HPX_HOST_DEVICE bound_front(bound_front const& other)
-              : _f(other._f)
-              , _args(other._args)
-            {}
-
-            HPX_CONSTEXPR HPX_HOST_DEVICE bound_front(bound_front&& other)
-              : _f(std::move(other._f))
-              , _args(std::move(other._args))
-            {}
-#endif
-
-            bound_front& operator=(bound_front const&) = delete;
-
-            template <typename ...Us>
-            HPX_CXX14_CONSTEXPR HPX_HOST_DEVICE
-            typename invoke_bound_front_result<
-                one_shot_wrapper<F>&&,
-                util::tuple<typename util::decay_unwrap<Ts>::type...>&&,
-                Us...
-            >::type operator()(Us&&... vs)
-            {
-                return detail::bound_front_impl(std::move(_f),
-                    typename detail::make_index_pack<sizeof...(Ts)>::type(),
-                    std::move(_args), std::forward<Us>(vs)...);
-            }
-
-            template <typename Archive>
-            void serialize(Archive& ar, unsigned int const /*version*/)
-            {
-                ar & _f;
-                ar & _args;
-            }
-
-            std::size_t get_function_address() const
-            {
-                return traits::get_function_address<
-                        one_shot_wrapper<F>
-                    >::call(_f);
-            }
-
-            char const* get_function_annotation() const
-            {
-#if defined(HPX_HAVE_THREAD_DESCRIPTION)
-                return traits::get_function_annotation<
-                        one_shot_wrapper<F>
-                    >::call(_f);
-#else
-                return nullptr;
-#endif
-            }
-
-#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
-            util::itt::string_handle get_function_annotation_itt() const
-            {
-#if defined(HPX_HAVE_THREAD_DESCRIPTION)
-                return traits::get_function_annotation_itt<
-                        one_shot_wrapper<F>
-                    >::call(_f);
-#else
-                static util::itt::string_handle sh("bound_front");
-                return sh;
-#endif
-            }
-#endif
-
-        private:
-            one_shot_wrapper<F> _f;
             util::tuple<typename util::decay_unwrap<Ts>::type...> _args;
         };
     }

--- a/hpx/util/one_shot.hpp
+++ b/hpx/util/one_shot.hpp
@@ -1,0 +1,200 @@
+//  Copyright (c) 2011-2012 Thomas Heller
+//  Copyright (c) 2013-2016 Agustin Berge
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_UTIL_ONE_SHOT_HPP
+#define HPX_UTIL_ONE_SHOT_HPP
+
+#include <hpx/config.hpp>
+#include <hpx/traits/get_function_address.hpp>
+#include <hpx/traits/get_function_annotation.hpp>
+#include <hpx/traits/is_action.hpp>
+#include <hpx/traits/is_bind_expression.hpp>
+#include <hpx/traits/is_placeholder.hpp>
+#include <hpx/util/assert.hpp>
+#include <hpx/util/decay.hpp>
+#include <hpx/util/detail/pack.hpp>
+#include <hpx/util/invoke.hpp>
+#include <hpx/util/invoke_fused.hpp>
+#include <hpx/util/one_shot.hpp>
+#include <hpx/util/result_of.hpp>
+#include <hpx/util/tuple.hpp>
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace util
+{
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        template <typename F>
+        class one_shot_wrapper //-V690
+        {
+        public:
+#           if !defined(HPX_DISABLE_ASSERTS)
+            // default constructor is needed for serialization
+            HPX_CONSTEXPR one_shot_wrapper()
+              : _called(false)
+            {}
+
+            HPX_CONSTEXPR explicit one_shot_wrapper(F const& f)
+              : _f(f)
+              , _called(false)
+            {}
+            HPX_CONSTEXPR explicit one_shot_wrapper(F&& f)
+              : _f(std::move(f))
+              , _called(false)
+            {}
+
+            HPX_CXX14_CONSTEXPR one_shot_wrapper(one_shot_wrapper&& other)
+              : _f(std::move(other._f))
+              , _called(other._called)
+            {
+                other._called = true;
+            }
+
+            void check_call()
+            {
+                HPX_ASSERT(!_called);
+
+                _called = true;
+            }
+#           else
+            // default constructor is needed for serialization
+            HPX_CONSTEXPR one_shot_wrapper()
+            {}
+
+            HPX_CONSTEXPR explicit one_shot_wrapper(F const& f)
+              : _f(f)
+            {}
+            HPX_CONSTEXPR explicit one_shot_wrapper(F&& f)
+              : _f(std::move(f))
+            {}
+
+            HPX_CONSTEXPR one_shot_wrapper(one_shot_wrapper&& other)
+              : _f(std::move(other._f))
+            {}
+
+            void check_call()
+            {}
+#           endif
+
+            template <typename ...Ts>
+            HPX_CXX14_CONSTEXPR HPX_HOST_DEVICE
+            typename util::invoke_result<F, Ts...>::type
+            operator()(Ts&&... vs)
+            {
+                check_call();
+                return util::invoke(std::move(_f), std::forward<Ts>(vs)...);
+            }
+
+            template <typename Archive>
+            void serialize(Archive& ar, unsigned int const /*version*/)
+            {
+                ar & _f;
+            }
+
+            std::size_t get_function_address() const
+            {
+                return traits::get_function_address<F>::call(_f);
+            }
+
+            char const* get_function_annotation() const
+            {
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+                return traits::get_function_annotation<F>::call(_f);
+#else
+                return nullptr;
+#endif
+            }
+
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+            util::itt::string_handle get_function_annotation_itt() const
+            {
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+                return traits::get_function_annotation_itt<F>::call(_f);
+#else
+                static util::itt::string_handle sh("one_shot_wrapper");
+                return sh;
+#endif
+            }
+#endif
+
+        public: // exposition-only
+            F _f;
+#           if !defined(HPX_DISABLE_ASSERTS)
+            bool _called;
+#           endif
+        };
+    }
+
+    template <typename F>
+    HPX_CONSTEXPR detail::one_shot_wrapper<typename std::decay<F>::type>
+    one_shot(F&& f)
+    {
+        typedef
+            detail::one_shot_wrapper<typename std::decay<F>::type>
+            result_type;
+
+        return result_type(std::forward<F>(f));
+    }
+}}
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace traits
+{
+    ///////////////////////////////////////////////////////////////////////////
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+    template <typename F>
+    struct get_function_address<util::detail::one_shot_wrapper<F> >
+    {
+        static std::size_t
+            call(util::detail::one_shot_wrapper<F> const& f) noexcept
+        {
+            return f.get_function_address();
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename F>
+    struct get_function_annotation<util::detail::one_shot_wrapper<F> >
+    {
+        static char const*
+            call(util::detail::one_shot_wrapper<F> const& f) noexcept
+        {
+            return f.get_function_annotation();
+        }
+    };
+
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+    template <typename F>
+    struct get_function_annotation_itt<util::detail::one_shot_wrapper<F> >
+    {
+        static util::itt::string_handle
+            call(util::detail::one_shot_wrapper<F> const& f) noexcept
+        {
+            return f.get_function_annotation_itt();
+        }
+    };
+#endif
+#endif
+}}
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace serialization
+{
+    template <typename Archive, typename F>
+    void serialize(
+        Archive& ar
+      , ::hpx::util::detail::one_shot_wrapper<F>& one_shot_wrapper
+      , unsigned int const version = 0)
+    {
+        one_shot_wrapper.serialize(ar, version);
+    }
+}}
+
+#endif

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -804,10 +804,10 @@ hpx::future<bool> addressing_service::bind_range_async(
 
     return f.then(
         hpx::launch::sync,
-        util::bind(
-            util::one_shot(&addressing_service::bind_postproc),
+        util::one_shot(util::bind(
+            &addressing_service::bind_postproc,
             this, _1, id, g
-        ));
+        )));
 }
 
 hpx::future<naming::address> addressing_service::unbind_range_async(
@@ -1289,10 +1289,10 @@ hpx::future<naming::address> addressing_service::resolve_full_async(
     using util::placeholders::_1;
     return f.then(
         hpx::launch::sync,
-        util::bind(
-            util::one_shot(&addressing_service::resolve_full_postproc),
+        util::one_shot(util::bind(
+            &addressing_service::resolve_full_postproc,
             this, _1, gid
-        ));
+        )));
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1553,10 +1553,10 @@ lcos::future<std::int64_t> addressing_service::incref_async(
     using util::placeholders::_1;
     return f.then(
         hpx::launch::sync,
-        util::bind(
-            util::one_shot(&addressing_service::synchronize_with_async_incref),
+        util::one_shot(util::bind(
+            &addressing_service::synchronize_with_async_incref,
             this, _1, keep_alive, pending_decrefs
-        ));
+        )));
 } // }}}
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1675,10 +1675,10 @@ lcos::future<bool> addressing_service::register_name_async(
     {
         return f.then(
             hpx::launch::sync,
-            util::bind_back(
-                util::one_shot(&correct_credit_on_failure),
+            util::one_shot(util::bind_back(
+                &correct_credit_on_failure,
                 id, std::int64_t(HPX_GLOBALCREDIT_INITIAL), new_credit
-            ));
+            )));
     }
 
     return f;
@@ -1757,9 +1757,9 @@ future<hpx::id_type> addressing_service::on_symbol_namespace_event(
     using util::placeholders::_1;
     return f.then(
         hpx::launch::sync,
-        util::bind(
-            util::one_shot(&detail::on_register_event), _1, std::move(result_f)
-        ));
+        util::one_shot(util::bind(
+            &detail::on_register_event, _1, std::move(result_f)
+        )));
 }
 
 // Return all matching entries in the symbol namespace

--- a/src/runtime/agas/big_boot_barrier.cpp
+++ b/src/runtime/agas/big_boot_barrier.cpp
@@ -560,13 +560,13 @@ void register_worker(registration_header const& header)
         // delay the final response until the runtime system is up and running
         util::unique_function_nonser<void()>* thunk =
             new util::unique_function_nonser<void()>(
-                util::bind(
-                    util::one_shot(&big_boot_barrier::apply_notification)
+                util::one_shot(util::bind(
+                    &big_boot_barrier::apply_notification
                   , std::ref(get_big_boot_barrier())
                   , 0
                   , naming::get_locality_id_from_gid(prefix)
                   , dest
-                  , std::move(hdr)));
+                  , std::move(hdr))));
         get_big_boot_barrier().add_thunk(thunk);
     }
 }

--- a/src/runtime/threads/executors/current_executor.cpp
+++ b/src/runtime/threads/executors/current_executor.cpp
@@ -60,9 +60,9 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         error_code& ec)
     {
         // create a new thread
-        thread_init_data data(util::bind(
-            util::one_shot(&current_executor::thread_function_nullary),
-            std::move(f)), desc);
+        thread_init_data data(util::one_shot(util::bind(
+            &current_executor::thread_function_nullary,
+            std::move(f))), desc);
         data.stacksize = threads::get_stack_size(stacksize);
 
         threads::thread_id_type id = threads::invalid_thread_id;
@@ -80,9 +80,9 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         threads::thread_stacksize stacksize, error_code& ec)
     {
         // create a new suspended thread
-        thread_init_data data(util::bind(
-            util::one_shot(&current_executor::thread_function_nullary),
-            std::move(f)), desc);
+        thread_init_data data(util::one_shot(util::bind(
+            &current_executor::thread_function_nullary,
+            std::move(f))), desc);
         data.stacksize = threads::get_stack_size(stacksize);
 
         threads::thread_id_type id = threads::invalid_thread_id;

--- a/src/runtime/threads/executors/pool_executor.cpp
+++ b/src/runtime/threads/executors/pool_executor.cpp
@@ -74,10 +74,9 @@ namespace hpx { namespace threads { namespace executors
         {
             // create a new thread
             thread_init_data data(
-                util::bind(
-                    util::one_shot(
-                        &pool_executor::thread_function_nullary),
-                    std::move(f)),
+                util::one_shot(util::bind(
+                    &pool_executor::thread_function_nullary,
+                    std::move(f))),
                 desc);
 
             if (stacksize == threads::thread_stacksize_default)
@@ -108,10 +107,9 @@ namespace hpx { namespace threads { namespace executors
         {
             // create a new suspended thread
             thread_init_data data(
-                util::bind(
-                    util::one_shot(
-                        &pool_executor::thread_function_nullary),
-                    std::move(f)),
+                util::one_shot(util::bind(
+                    &pool_executor::thread_function_nullary,
+                    std::move(f))),
                 desc);
 
             if (stacksize == threads::thread_stacksize_default)

--- a/src/runtime/threads/executors/this_thread_executors.cpp
+++ b/src/runtime/threads/executors/this_thread_executors.cpp
@@ -144,9 +144,9 @@ namespace hpx { namespace threads { namespace executors { namespace detail
 
 
         // create a new thread
-        thread_init_data data(util::bind(
-            util::one_shot(&this_thread_executor::thread_function_nullary),
-            this, std::move(f)), desc);
+        thread_init_data data(util::one_shot(util::bind(
+            &this_thread_executor::thread_function_nullary,
+            this, std::move(f))), desc);
         data.stacksize = threads::get_stack_size(stacksize);
 
         // update statistics
@@ -183,9 +183,9 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         scheduler_.get_state(0).compare_exchange_strong(expected, state_starting);
 
         // create a new suspended thread
-        thread_init_data data(util::bind(
-            util::one_shot(&this_thread_executor::thread_function_nullary),
-            this, std::move(f)), desc);
+        thread_init_data data(util::one_shot(util::bind(
+            &this_thread_executor::thread_function_nullary,
+            this, std::move(f))), desc);
         data.stacksize = threads::get_stack_size(stacksize);
 
         threads::thread_id_type id = threads::invalid_thread_id;

--- a/src/runtime/threads/executors/thread_pool_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_executors.cpp
@@ -162,9 +162,9 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         error_code& ec)
     {
         // create a new thread
-        thread_init_data data(util::bind(
-            util::one_shot(&thread_pool_executor::thread_function_nullary),
-            this, std::move(f)), desc);
+        thread_init_data data(util::one_shot(util::bind(
+            &thread_pool_executor::thread_function_nullary,
+            this, std::move(f))), desc);
         data.stacksize = threads::get_stack_size(stacksize);
 
         // update statistics
@@ -192,9 +192,9 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         threads::thread_stacksize stacksize, error_code& ec)
     {
         // create a new suspended thread
-        thread_init_data data(util::bind(
-            util::one_shot(&thread_pool_executor::thread_function_nullary),
-            this, std::move(f)), desc);
+        thread_init_data data(util::one_shot(util::bind(
+            &thread_pool_executor::thread_function_nullary,
+            this, std::move(f))), desc);
         data.stacksize = threads::get_stack_size(stacksize);
 
         threads::thread_id_type id = threads::invalid_thread_id;
@@ -433,8 +433,8 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         {
             ++curr_punits_;
             register_thread_nullary(
-                util::bind(util::one_shot(&thread_pool_executor::run), this,
-                    virt_core, thread_num),
+                util::one_shot(util::bind(&thread_pool_executor::run, this,
+                    virt_core, thread_num)),
                 "thread_pool_executor thread", threads::pending, true,
                 threads::thread_priority_normal,
                 threads::thread_schedule_hint(

--- a/src/runtime/threads/executors/thread_pool_os_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_os_executors.cpp
@@ -168,9 +168,9 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         error_code& ec)
     {
         // create a new thread
-        thread_init_data data(util::bind(
-            util::one_shot(&thread_pool_os_executor::thread_function_nullary),
-            std::move(f)), desc);
+        thread_init_data data(util::one_shot(util::bind(
+            &thread_pool_os_executor::thread_function_nullary,
+            std::move(f))), desc);
         data.stacksize = threads::get_stack_size(stacksize);
 
         threads::thread_id_type id = threads::invalid_thread_id;
@@ -193,9 +193,9 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         threads::thread_stacksize stacksize, error_code& ec)
     {
         // create a new suspended thread
-        thread_init_data data(util::bind(
-            util::one_shot(&thread_pool_os_executor::thread_function_nullary),
-            std::move(f)), desc);
+        thread_init_data data(util::one_shot(util::bind(
+            &thread_pool_os_executor::thread_function_nullary,
+            std::move(f))), desc);
         data.stacksize = threads::get_stack_size(stacksize);
 
         threads::thread_id_type id = threads::invalid_thread_id;

--- a/src/runtime/threads/thread.cpp
+++ b/src/runtime/threads/thread.cpp
@@ -153,8 +153,8 @@ namespace hpx
     void thread::start_thread(util::unique_function_nonser<void()>&& func)
     {
         threads::thread_init_data data(
-            util::bind(util::one_shot(&thread::thread_function_nullary),
-                std::move(func)),
+            util::one_shot(util::bind(&thread::thread_function_nullary,
+                std::move(func))),
             "thread::thread_function_nullary");
 
         // create the new thread, note that id_ is guaranteed to be valid

--- a/tests/unit/component/action_invoke_no_more_than.hpp
+++ b/tests/unit/component/action_invoke_no_more_than.hpp
@@ -98,12 +98,12 @@ namespace hpx { namespace actions { namespace detail
         static threads::thread_function_type
         call(naming::address::address_type lva, F && f, std::false_type)
         {
-            return util::bind(
-                util::one_shot(&action_decorate_function::thread_function),
+            return util::one_shot(util::bind(
+                &action_decorate_function::thread_function,
                 util::placeholders::_1,
                 traits::action_decorate_function<action_wrapper>::call(
                     lva, std::forward<F>(f))
-            );
+            ));
         }
 
         // If the action returns a future we wait on the semaphore as well,
@@ -120,12 +120,12 @@ namespace hpx { namespace actions { namespace detail
         static threads::thread_function_type
         call(naming::address::address_type lva, F && f, std::true_type)
         {
-            return util::bind(
-                util::one_shot(&action_decorate_function::thread_function_future),
+            return util::one_shot(util::bind(
+                &action_decorate_function::thread_function_future,
                 util::placeholders::_1,
                 traits::action_decorate_function<action_wrapper>::call(
                     lva, std::forward<F>(f))
-            );
+            ));
         }
 
         ///////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Make bind propagate value category to the target callable. Make one_shot into a generic wrapper that forces rvalue-qualified invocation.