### PR TITLE
Fix typo/mistake in thread queue cleanup_terminated

### DIFF
--- a/hpx/runtime/threads/policies/thread_queue.hpp
+++ b/hpx/runtime/threads/policies/thread_queue.hpp
@@ -509,7 +509,7 @@ namespace hpx { namespace threads { namespace policies
                 while (true)
                 {
                     std::lock_guard<mutex_type> lk(mtx_);
-                    if (cleanup_terminated_locked(false))
+                    if (cleanup_terminated_locked(true))
                     {
                         return true;
                     }


### PR DESCRIPTION
I noticed performance issues due to excessive memory use and believe that this error has crept into the master branch and needs to be fixed.