### PR TITLE
Store thread exit functions in forward_list instead of deque to avoid allocations

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -423,6 +423,13 @@ function(hpx_check_for_cxx11_std_exception_ptr)
 endfunction()
 
 ###############################################################################
+function(hpx_check_for_cxx11_std_forward_list)
+  add_hpx_config_test(HPX_WITH_CXX11_FORWARD_LIST
+    SOURCE cmake/tests/cxx11_std_forward_list.cpp
+    FILE ${ARGN})
+endfunction()
+
+###############################################################################
 function(hpx_check_for_cxx11_std_initializer_list)
   add_hpx_config_test(HPX_WITH_CXX11_STD_INITIALIZER_LIST
     SOURCE cmake/tests/cxx11_std_initializer_list.cpp

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -98,6 +98,9 @@ function(hpx_perform_cxx_feature_tests)
   hpx_check_for_cxx11_std_exception_ptr(
     REQUIRED "HPX needs support for C++11 std::exception_ptr")
 
+  hpx_check_for_cxx11_std_forward_list(
+    REQUIRED "HPX needs support for C++11 std::forward_list")
+
   hpx_check_for_cxx11_std_initializer_list(
     REQUIRED "HPX needs support for C++11 std::initializer_list")
 

--- a/cmake/tests/cxx11_std_forward_list.cpp
+++ b/cmake/tests/cxx11_std_forward_list.cpp
@@ -1,0 +1,11 @@
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <forward_list>
+
+int main()
+{
+    std::forward_list<int> l;
+}

--- a/hpx/runtime/threads/thread_data.hpp
+++ b/hpx/runtime/threads/thread_data.hpp
@@ -33,6 +33,7 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <forward_list>
 #include <stack>
 #include <string>
 #include <utility>
@@ -718,8 +719,7 @@ namespace hpx { namespace threads
         bool ran_exit_funcs_;
 
         // Singly linked list (heap-allocated)
-        // FIXME: replace with forward_list eventually.
-        std::deque<util::function_nonser<void()> > exit_funcs_;
+        std::forward_list<util::function_nonser<void()> > exit_funcs_;
 
         // reference to scheduler which created/manages this thread
         policies::scheduler_base* scheduler_base_;

--- a/src/runtime/threads/thread_data.cpp
+++ b/src/runtime/threads/thread_data.cpp
@@ -45,10 +45,10 @@ namespace hpx { namespace threads
         {
             {
                 hpx::util::unlock_guard<mutex_type::scoped_lock> ul(l);
-                if(!exit_funcs_.back().empty())
-                    exit_funcs_.back()();
+                if(!exit_funcs_.front().empty())
+                    exit_funcs_.front()();
             }
-            exit_funcs_.pop_back();
+            exit_funcs_.pop_front();
         }
         ran_exit_funcs_ = true;
     }
@@ -63,7 +63,7 @@ namespace hpx { namespace threads
             return false;
         }
 
-        exit_funcs_.push_back(f);
+        exit_funcs_.push_front(f);
 
         return true;
     }


### PR DESCRIPTION
- flyby: add feature test for std::forward_list

