### PR TITLE
Improve the error message for using to less MAX_CPU_COUNT

### DIFF
--- a/src/runtime/resource/detail/detail_partitioner.cpp
+++ b/src/runtime/resource/detail/detail_partitioner.cpp
@@ -226,6 +226,22 @@ namespace hpx { namespace resource { namespace detail
                 "Cannot instantiate more than one resource partitioner");
         }
 
+
+        if(HPX_HAVE_MAX_CPU_COUNT < topo_.get_number_of_pus())
+        {
+                throw_runtime_error(
+                   "partitioner::partioner",
+                   "Currently, HPX_HAVE_MAX_CPU_COUNT is set to " +
+                   std::to_string(HPX_HAVE_MAX_CPU_COUNT) +
+                   " while your system has " +
+                   std::to_string(topo_.get_number_of_pus()) +
+                   " processing units. Please reconfigure HPX with " +
+                   "-DHPX_WITH_MAX_CPU_COUNT=" +
+                   std::to_string(topo_.get_number_of_pus()) +
+                   " or higher) to increase the maximal CPU count."
+                   );
+        }
+
         // Create the default pool
         initial_thread_pools_.push_back(init_pool_data("default"));
     }


### PR DESCRIPTION
Fixes #3594 and #3482

## Proposed Changes

  - Setting a wrong value to `-DHPX_WITH_MAX_CPU_COUNT` results in an unspecific error message

```
[diehlpk@centaur build]$ ./bin/fibonacci
terminate called after throwing an instance of 'hpx::detail::exception_with_info<hpx::exception>'
  what():  The number of OS threads requested (20) does not match the number of threads to bind (12): HPX(bad_parameter)
```
This is misleading and we should improve the error handling here.

## Any background context you want to provide?

The PR shows this error message instead 

```
[diehlpk@centaur build]$ ./bin/fibonacci
terminate called after throwing an instance of 'std::runtime_error'
  what():  partitioner::partioner: HPX_HAVE_MAX_CPU_COUNT is set as 64 your system has 160. Please recompile HPX and increase the maximal CPU count!
Aborted (core dumped)
```


and no error message when the value is correct

```
[diehlpk@centaur build]$ ./bin/fibonacci
fibonacci(10) == 55
elapsed time: 0.002081 [s]
```




