### PR TITLE
Add 'inline' to definition of checkpoint stream operators to fix link error

### DIFF
--- a/hpx/util/checkpoint.hpp
+++ b/hpx/util/checkpoint.hpp
@@ -153,7 +153,7 @@ namespace util {
     ///
     /// \returns Operator<< returns the ostream object.
     ///
-    std::ostream& operator<<(std::ostream& ost, checkpoint const& ckp)
+    inline std::ostream& operator<<(std::ostream& ost, checkpoint const& ckp)
     {
         // Write the size of the checkpoint to the file
         int64_t size = ckp.size();
@@ -184,7 +184,7 @@ namespace util {
     ///
     /// \returns Operator>> returns the ostream object.
     ///
-    std::istream& operator>>(std::istream& ist, checkpoint& ckp)
+    inline std::istream& operator>>(std::istream& ist, checkpoint& ckp)
     {
         // Read in the size of the next checkpoint
         int64_t length;


### PR DESCRIPTION
The functions std::ostream& operator<<(std::ostream& ost, checkpoint const& ckp) and std::istream& operator>>(std::istream& ost, checkpoint const& ckp) are both defined in the header file hpx/util/checkpoint.hpp

As a result, including the header file within multiple translation units will result in a linker error due to multiple definitions of these functions.  Therefore, these functions either need to be prefaced with 'inline' or otherwise have their definitions placed in a .cpp file.  Since there is currently no file src/util/checkpoint.cpp, rather than adding this as a new file and moving the definitions there, this fix addresses the problem with the inline keyword instead.


## Proposed Changes

  - add inline keyword to function definitions for operator<< and operator>> 
