### PR TITLE
Add nvcc to exclude constexpress since is it not supported by nvcc

### DIFF
--- a/hpx/config/constexpr.hpp
+++ b/hpx/config/constexpr.hpp
@@ -9,7 +9,7 @@
 
 #include <hpx/config/defines.hpp>
 
-#if defined(HPX_HAVE_CXX11_CONSTEXPR) && !defined(HPX_MSVC_NVCC)
+#if defined(HPX_HAVE_CXX11_CONSTEXPR) && !defined(HPX_MSVC_NVCC) && !defined(__NVCC__)
 #   define HPX_CONSTEXPR constexpr
 #   define HPX_CONSTEXPR_OR_CONST constexpr
 #else


### PR DESCRIPTION
Fixes constexpress defines for nvcc compiler 

## Proposed Changes

  - Add nvcc compiler to this check https://github.com/STEllAR-GROUP/hpx/blob/master/hpx/config/constexpr.hpp#L12


## Any background context you want to provide?

Since we have `!defined(HPX_MSVC_NVCC)` we should add NVdida's nvcc compiler too.