### PR TITLE
Adding configuration key that allows to explicitly add a directory to the component search path 

### DIFF
--- a/hpx/util/ini.hpp
+++ b/hpx/util/ini.hpp
@@ -166,6 +166,7 @@ namespace hpx { namespace util
             return get_section(l, sec_name);
         }
 
+        section_map& get_sections() { return sections_; }
         section_map const& get_sections() const { return sections_; }
 
         void add_entry(std::string const& key, entry_type const& val)

--- a/hpx/util/runtime_configuration.hpp
+++ b/hpx/util/runtime_configuration.hpp
@@ -16,10 +16,13 @@
 #include <hpx/util/plugin/dll.hpp>
 #include <hpx/plugins/plugin_registry_base.hpp>
 
+#include <boost/filesystem.hpp>
+
 #include <cstddef>
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -149,6 +152,21 @@ namespace hpx { namespace util
             std::vector<std::string> const& cmdline_ini_defs);
 
         void reconfigure();
+
+        void load_component_paths(
+            std::vector<std::shared_ptr<plugins::plugin_registry_base>>&
+                plugin_registries,
+            std::string const& component_base_paths,
+            std::string const& component_path_suffixes,
+            std::set<std::string>& component_paths,
+            std::map<std::string, boost::filesystem::path>& basenames);
+
+        void load_component_path(
+            std::vector<std::shared_ptr<plugins::plugin_registry_base>>&
+                plugin_registries,
+            std::string const& path,
+            std::set<std::string>& component_paths,
+            std::map<std::string, boost::filesystem::path>& basenames);
 
     public:
         runtime_mode mode_;


### PR DESCRIPTION
The new key is `hpx.component_path`. 

The configuration key with the same name was used before as the base path for component searches and has been renamed to `hpx.component_base_paths`.

This is necessary for Phylanx to allow specifying additional plugin directories.
