### PR TITLE
Add inline keyword to invalid_thread_id definition for nvcc

### DIFF
--- a/hpx/runtime/threads/thread_id_type.hpp
+++ b/hpx/runtime/threads/thread_id_type.hpp
@@ -130,7 +130,7 @@ namespace threads {
         thread_data* thrd_;
     };
 
-    HPX_CONSTEXPR_OR_CONST thread_id_type invalid_thread_id;
+    HPX_CONSTEXPR_OR_CONST inline thread_id_type invalid_thread_id;
 }
 }
 


### PR DESCRIPTION
Add `inline` keyword to `invalid_thread_id` to replace the removed `constexpr` after #3606. 
