### PR TITLE
Include GNUInstallDirs earlier to have it available for subdirectories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 ################################################################################
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 
+include(GNUInstallDirs)
 include(HPX_Utils)
 
 # explicitly set certain policies
@@ -1730,8 +1731,6 @@ endif()
 ################################################################################
 # search path configuration
 ################################################################################
-include(GNUInstallDirs)
-
 if(HPX_WITH_FULL_RPATH)
   hpx_include(SetFullRPATH)
 endif()


### PR DESCRIPTION
Move the inclusion of `GNUInstallDirs` in the main `CMakeLists.txt` further up to have it available for subdirectories (like APEX).