### PR TITLE
Restructuring counter data in scheduler to reduce false sharing

### DIFF
--- a/hpx/runtime/threads/detail/scheduled_thread_pool.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2017 Shoshana Jakobovits
+//  Copyright (c) 2007-2019 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -48,102 +49,107 @@ namespace hpx { namespace threads { namespace detail
             std::size_t thread_offset = 0);
         virtual ~scheduled_thread_pool();
 
-        void print_pool(std::ostream& os);
+        void print_pool(std::ostream& os) override;
 
-        threads::policies::scheduler_base* get_scheduler() const
+        threads::policies::scheduler_base* get_scheduler() const override
         {
             return sched_.get();
         }
 
         ///////////////////////////////////////////////////////////////////
-        hpx::state get_state() const;
-        hpx::state get_state(std::size_t num_thread) const;
+        hpx::state get_state() const override;
+        hpx::state get_state(std::size_t num_thread) const override;
 
-        bool has_reached_state(hpx::state s) const
+        bool has_reached_state(hpx::state s) const override
         {
             return sched_->Scheduler::has_reached_state(s);
         }
 
         ///////////////////////////////////////////////////////////////////
-        void do_some_work(std::size_t num_thread)
+        void do_some_work(std::size_t num_thread) override
         {
             sched_->Scheduler::do_some_work(num_thread);
         }
 
         void create_thread(thread_init_data& data, thread_id_type& id,
-            thread_state_enum initial_state, bool run_now, error_code& ec);
+            thread_state_enum initial_state, bool run_now, error_code& ec) override;
 
         void create_work(thread_init_data& data,
-            thread_state_enum initial_state, error_code& ec);
+            thread_state_enum initial_state, error_code& ec) override;
 
         thread_state set_state(thread_id_type const& id,
             thread_state_enum new_state, thread_state_ex_enum new_state_ex,
-            thread_priority priority, error_code& ec);
+            thread_priority priority, error_code& ec) override;
 
         thread_id_type set_state(
             util::steady_time_point const& abs_time, thread_id_type const& id,
             thread_state_enum newstate, thread_state_ex_enum newstate_ex,
-            thread_priority priority, error_code& ec);
+            thread_priority priority, error_code& ec) override;
 
-        void report_error(std::size_t num, std::exception_ptr const& e);
+        void report_error(std::size_t num, std::exception_ptr const& e) override;
 
-        void abort_all_suspended_threads()
+        void abort_all_suspended_threads() override
         {
             sched_->Scheduler::abort_all_suspended_threads();
         }
 
-        bool cleanup_terminated(bool delete_all)
+        bool cleanup_terminated(bool delete_all) override
         {
             return sched_->Scheduler::cleanup_terminated(delete_all);
         }
 
         std::int64_t get_thread_count(thread_state_enum state,
-            thread_priority priority, std::size_t num, bool reset)
+            thread_priority priority, std::size_t num, bool reset) override
         {
             return sched_->Scheduler::get_thread_count(
                 state, priority, num, reset);
         }
 
-        std::int64_t get_background_thread_count()
+        std::int64_t get_background_thread_count() override
         {
             return sched_->Scheduler::get_background_thread_count();
         }
 
         bool enumerate_threads(
             util::function_nonser<bool(thread_id_type)> const& f,
-            thread_state_enum state) const
+            thread_state_enum state) const override
         {
             return sched_->Scheduler::enumerate_threads(f, state);
         }
 
-        void reset_thread_distribution()
+        void reset_thread_distribution() override
         {
             return sched_->Scheduler::reset_thread_distribution();
         }
 
-        void set_scheduler_mode(threads::policies::scheduler_mode mode)
+        void set_scheduler_mode(threads::policies::scheduler_mode mode) override
         {
             mode_ = mode;
             return sched_->Scheduler::set_scheduler_mode(mode);
         }
 
         ///////////////////////////////////////////////////////////////////
-        bool run(std::unique_lock<compat::mutex>& l, std::size_t pool_threads);
+        bool run(std::unique_lock<compat::mutex>& l,
+            std::size_t pool_threads) override;
 
         template <typename Lock>
         void stop_locked(Lock& l, bool blocking = true);
-        void stop(std::unique_lock<compat::mutex>& l, bool blocking = true);
+        void stop(
+            std::unique_lock<compat::mutex>& l, bool blocking = true) override;
 
-        hpx::future<void> suspend();
-        void suspend_cb(std::function<void(void)> callback, error_code& ec = throws);
-        void suspend_direct(error_code& ec = throws);
+        hpx::future<void> suspend() override;
+        void suspend_cb(std::function<void(void)> callback,
+            error_code& ec = throws) override;
+        void suspend_direct(error_code& ec = throws) override;
 
-        hpx::future<void> resume();
-        void resume_cb(std::function<void(void)> callback, error_code& ec = throws);
-        void resume_direct(error_code& ec = throws);
+        hpx::future<void> resume() override;
+        void resume_cb(std::function<void(void)> callback,
+            error_code& ec = throws) override;
+        void resume_direct(error_code& ec = throws) override;
 
         ///////////////////////////////////////////////////////////////////
-        compat::thread& get_os_thread_handle(std::size_t global_thread_num)
+        compat::thread& get_os_thread_handle(
+            std::size_t global_thread_num) override
         {
             std::size_t num_thread_local =
                 global_thread_num - this->thread_offset_;
@@ -154,12 +160,12 @@ namespace hpx { namespace threads { namespace detail
         void thread_func(std::size_t thread_num, std::size_t global_thread_num,
             std::shared_ptr<compat::barrier> startup);
 
-        std::size_t get_os_thread_count() const
+        std::size_t get_os_thread_count() const override
         {
             return thread_count_;
         }
 
-        std::size_t get_active_os_thread_count() const
+        std::size_t get_active_os_thread_count() const override
         {
             std::size_t active_os_thread_count = 0;
             for (std::size_t thread_num = 0; thread_num < threads_.size();
@@ -176,50 +182,57 @@ namespace hpx { namespace threads { namespace detail
         }
 
 #ifdef HPX_HAVE_THREAD_STEALING_COUNTS
-        std::int64_t get_num_pending_misses(std::size_t num, bool reset)
+        std::int64_t get_num_pending_misses(
+            std::size_t num, bool reset) override
         {
             return sched_->Scheduler::get_num_pending_misses(num, reset);
         }
 
-        std::int64_t get_num_pending_accesses(std::size_t num, bool reset)
+        std::int64_t get_num_pending_accesses(
+            std::size_t num, bool reset) override
         {
             return sched_->Scheduler::get_num_pending_accesses(num, reset);
         }
 
-        std::int64_t get_num_stolen_from_pending(std::size_t num, bool reset)
+        std::int64_t get_num_stolen_from_pending(
+            std::size_t num, bool reset) override
         {
             return sched_->Scheduler::get_num_stolen_from_pending(num, reset);
         }
 
-        std::int64_t get_num_stolen_to_pending(std::size_t num, bool reset)
+        std::int64_t get_num_stolen_to_pending(
+            std::size_t num, bool reset) override
         {
             return sched_->Scheduler::get_num_stolen_to_pending(num, reset);
         }
 
-        std::int64_t get_num_stolen_from_staged(std::size_t num, bool reset)
+        std::int64_t get_num_stolen_from_staged(
+            std::size_t num, bool reset) override
         {
             return sched_->Scheduler::get_num_stolen_from_staged(num, reset);
         }
 
-        std::int64_t get_num_stolen_to_staged(std::size_t num, bool reset)
+        std::int64_t get_num_stolen_to_staged(
+            std::size_t num, bool reset) override
         {
             return sched_->Scheduler::get_num_stolen_to_staged(num, reset);
         }
 #endif
-        std::int64_t get_queue_length(std::size_t num_thread, bool reset)
+        std::int64_t get_queue_length(
+            std::size_t num_thread, bool reset) override
         {
             return sched_->Scheduler::get_queue_length(num_thread);
         }
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
         std::int64_t get_average_thread_wait_time(
-            std::size_t num_thread, bool reset)
+            std::size_t num_thread, bool reset) override
         {
             return sched_->Scheduler::get_average_thread_wait_time(num_thread);
         }
 
         std::int64_t get_average_task_wait_time(
-            std::size_t num_thread, bool reset)
+            std::size_t num_thread, bool reset) override
         {
             return sched_->Scheduler::get_average_task_wait_time(num_thread);
         }
@@ -228,65 +241,66 @@ namespace hpx { namespace threads { namespace detail
         std::int64_t get_executed_threads() const;
 
 #if defined(HPX_HAVE_THREAD_CUMULATIVE_COUNTS)
-        std::int64_t get_executed_threads(std::size_t, bool);
-        std::int64_t get_executed_thread_phases(std::size_t, bool);
+        std::int64_t get_executed_threads(std::size_t, bool) override;
+        std::int64_t get_executed_thread_phases(std::size_t, bool) override;
 #if defined(HPX_HAVE_THREAD_IDLE_RATES)
-        std::int64_t get_thread_phase_duration(std::size_t, bool);
-        std::int64_t get_thread_duration(std::size_t, bool);
-        std::int64_t get_thread_phase_overhead(std::size_t, bool);
-        std::int64_t get_thread_overhead(std::size_t, bool);
-        std::int64_t get_cumulative_thread_duration(std::size_t, bool);
-        std::int64_t get_cumulative_thread_overhead(std::size_t, bool);
+        std::int64_t get_thread_phase_duration(std::size_t, bool) override;
+        std::int64_t get_thread_duration(std::size_t, bool) override;
+        std::int64_t get_thread_phase_overhead(std::size_t, bool) override;
+        std::int64_t get_thread_overhead(std::size_t, bool) override;
+        std::int64_t get_cumulative_thread_duration(std::size_t, bool) override;
+        std::int64_t get_cumulative_thread_overhead(std::size_t, bool) override;
 #endif
 #endif
 
-        std::int64_t get_cumulative_duration(std::size_t, bool);
+        std::int64_t get_cumulative_duration(std::size_t, bool) override;
 
 #if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
-        std::int64_t get_background_work_duration(std::size_t, bool);
-        std::int64_t get_background_overhead(std::size_t, bool);
+        std::int64_t get_background_work_duration(std::size_t, bool) override;
+        std::int64_t get_background_overhead(std::size_t, bool) override;
 #endif    // HPX_HAVE_BACKGROUND_THREAD_COUNTERS
 
 #if defined(HPX_HAVE_THREAD_IDLE_RATES)
-        std::int64_t avg_idle_rate_all(bool reset);
-        std::int64_t avg_idle_rate(std::size_t, bool);
+        std::int64_t avg_idle_rate_all(bool reset) override;
+        std::int64_t avg_idle_rate(std::size_t, bool) override;
 
 #if defined(HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES)
-        std::int64_t avg_creation_idle_rate(std::size_t, bool);
-        std::int64_t avg_cleanup_idle_rate(std::size_t, bool);
+        std::int64_t avg_creation_idle_rate(std::size_t, bool) override;
+        std::int64_t avg_cleanup_idle_rate(std::size_t, bool) override;
 #endif
 #endif
 
-        std::int64_t get_idle_loop_count(std::size_t num, bool reset);
-        std::int64_t get_busy_loop_count(std::size_t num, bool reset);
-        std::int64_t get_scheduler_utilization() const;
+        std::int64_t get_idle_loop_count(std::size_t num, bool reset) override;
+        std::int64_t get_busy_loop_count(std::size_t num, bool reset) override;
+        std::int64_t get_scheduler_utilization() const override;
 
         ///////////////////////////////////////////////////////////////////////
         // detail::manage_executor implementation
 
         // Return the requested policy element
-        std::size_t get_policy_element(executor_parameter p, error_code&) const;
+        std::size_t get_policy_element(
+            executor_parameter p, error_code&) const override;
 
         // Return statistics collected by this scheduler
-        void get_statistics(executor_statistics& s, error_code&) const;
+        void get_statistics(executor_statistics& s, error_code&) const override;
 
         // Provide the given processing unit to the scheduler.
         void add_processing_unit(std::size_t virt_core,
-            std::size_t thread_num, error_code&  = hpx::throws);
+            std::size_t thread_num, error_code&  = hpx::throws) override;
 
         // Remove the given processing unit from the scheduler.
         void remove_processing_unit(
-            std::size_t virt_core, error_code& = hpx::throws);
+            std::size_t virt_core, error_code& = hpx::throws) override;
 
         // Suspend the given processing unit on the scheduler.
-        hpx::future<void> suspend_processing_unit(std::size_t virt_core);
+        hpx::future<void> suspend_processing_unit(std::size_t virt_core) override;
         void suspend_processing_unit_cb(std::function<void(void)> callback,
-            std::size_t virt_core, error_code& = hpx::throws);
+            std::size_t virt_core, error_code& = hpx::throws) override;
 
         // Resume the given processing unit on the scheduler.
-        hpx::future<void> resume_processing_unit(std::size_t virt_core);
+        hpx::future<void> resume_processing_unit(std::size_t virt_core) override;
         void resume_processing_unit_cb(std::function<void(void)> callback,
-            std::size_t virt_core, error_code& = hpx::throws);
+            std::size_t virt_core, error_code& = hpx::throws) override;
 
     protected:
         friend struct init_tss_helper<Scheduler>;
@@ -315,66 +329,74 @@ namespace hpx { namespace threads { namespace detail
         void init_perf_counter_data(std::size_t pool_threads);
 
     private:
-        // count number of executed HPX-threads and thread phases (invocations)
-        std::vector<std::int64_t> executed_threads_;
-        std::vector<std::int64_t> executed_thread_phases_;
-
-        // scheduler utilization data
-        std::vector<std::uint8_t> tasks_active_;
+        // store data for the various thread-specific counters together to
+        // reduce false sharing
+        struct scheduling_counter_data
+        {
+            // count number of executed HPX-threads and thread phases (invocations)
+            std::int64_t executed_threads_;
+            std::int64_t executed_thread_phases_;
 
 #if defined(HPX_HAVE_THREAD_CUMULATIVE_COUNTS)
-        // timestamps/values of last reset operation for various performance
-        // counters
-        std::vector<std::int64_t> reset_executed_threads_;
-        std::vector<std::int64_t> reset_executed_thread_phases_;
+            // timestamps/values of last reset operation for various performance
+            // counters
+            std::int64_t reset_executed_threads_;
+            std::int64_t reset_executed_thread_phases_;
 
 #if defined(HPX_HAVE_THREAD_IDLE_RATES)
-        std::vector<std::int64_t> reset_thread_duration_;
-        std::vector<std::uint64_t> reset_thread_duration_times_;
+            std::int64_t reset_thread_duration_;
+            std::int64_t reset_thread_duration_times_;
 
-        std::vector<std::int64_t> reset_thread_overhead_;
-        std::vector<std::uint64_t> reset_thread_overhead_times_;
-        std::vector<std::uint64_t> reset_thread_overhead_times_total_;
+            std::int64_t reset_thread_overhead_;
+            std::int64_t reset_thread_overhead_times_;
+            std::int64_t reset_thread_overhead_times_total_;
 
-        std::vector<std::int64_t> reset_thread_phase_duration_;
-        std::vector<std::uint64_t> reset_thread_phase_duration_times_;
+            std::int64_t reset_thread_phase_duration_;
+            std::int64_t reset_thread_phase_duration_times_;
 
-        std::vector<std::int64_t> reset_thread_phase_overhead_;
-        std::vector<std::uint64_t> reset_thread_phase_overhead_times_;
-        std::vector<std::uint64_t> reset_thread_phase_overhead_times_total_;
+            std::int64_t reset_thread_phase_overhead_;
+            std::int64_t reset_thread_phase_overhead_times_;
+            std::int64_t reset_thread_phase_overhead_times_total_;
 
-        std::vector<std::uint64_t> reset_cumulative_thread_duration_;
+            std::int64_t reset_cumulative_thread_duration_;
 
-        std::vector<std::uint64_t> reset_cumulative_thread_overhead_;
-        std::vector<std::uint64_t> reset_cumulative_thread_overhead_total_;
+            std::int64_t reset_cumulative_thread_overhead_;
+            std::int64_t reset_cumulative_thread_overhead_total_;
 #endif
 #endif
 
 #if defined(HPX_HAVE_THREAD_IDLE_RATES)
-        std::vector<std::uint64_t> reset_idle_rate_time_;
-        std::vector<std::uint64_t> reset_idle_rate_time_total_;
+            std::int64_t reset_idle_rate_time_;
+            std::int64_t reset_idle_rate_time_total_;
 
 #if defined(HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES)
-        std::vector<std::uint64_t> reset_creation_idle_rate_time_;
-        std::vector<std::uint64_t> reset_creation_idle_rate_time_total_;
+            std::int64_t reset_creation_idle_rate_time_;
+            std::int64_t reset_creation_idle_rate_time_total_;
 
-        std::vector<std::uint64_t> reset_cleanup_idle_rate_time_;
-        std::vector<std::uint64_t> reset_cleanup_idle_rate_time_total_;
+            std::int64_t reset_cleanup_idle_rate_time_;
+            std::int64_t reset_cleanup_idle_rate_time_total_;
 #endif
 #endif
-
-        // tfunc_impl timers
-        std::vector<std::uint64_t> exec_times_, tfunc_times_;
-        std::vector<std::uint64_t> reset_tfunc_times_;
+            // tfunc_impl timers
+            std::int64_t exec_times_;
+            std::int64_t tfunc_times_;
+            std::int64_t reset_tfunc_times_;
 
 #if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
-        std::vector<std::uint64_t> background_duration_;
-        std::vector<std::uint64_t> reset_background_duration_;
-        std::vector<std::uint64_t> reset_background_tfunc_times_;
-        std::vector<std::uint64_t> reset_background_overhead_;
+            std::int64_t background_duration_;
+            std::int64_t reset_background_duration_;
+            std::int64_t reset_background_tfunc_times_;
+            std::int64_t reset_background_overhead_;
 #endif    // HPX_HAVE_BACKGROUND_THREAD_COUNTERS
 
-        std::vector<std::int64_t> idle_loop_counts_, busy_loop_counts_;
+            std::int64_t idle_loop_counts_;
+            std::int64_t busy_loop_counts_;
+
+            // scheduler utilization data
+            bool tasks_active_;
+        };
+
+        std::vector<scheduling_counter_data> counter_data_;
 
         // support detail::manage_executor interface
         std::atomic<long> thread_count_;

--- a/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2017 Shoshana Jakobovits
+//  Copyright (c) 2007-2019 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -31,6 +32,7 @@
 #include <hpx/runtime/threads/topology.hpp>
 #include <hpx/throw_exception.hpp>
 #include <hpx/util/assert.hpp>
+#include <hpx/util/invoke.hpp>
 #include <hpx/util/unlock_guard.hpp>
 #include <hpx/util/yield_while.hpp>
 
@@ -46,6 +48,7 @@
 #include <iosfwd>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -565,18 +568,21 @@ namespace hpx { namespace threads { namespace detail
                 hpx::threads::coroutines::prepare_main_thread main_thread;
 
                 // run main Scheduler loop until terminated
+                scheduling_counter_data& counter_data =
+                    counter_data_[thread_num];
+
                 detail::scheduling_counters counters(
-                    executed_threads_[thread_num],
-                    executed_thread_phases_[thread_num],
-                    tfunc_times_[thread_num],
-                    exec_times_[thread_num],
-                    idle_loop_counts_[thread_num],
-                    busy_loop_counts_[thread_num],
+                    counter_data.executed_threads_,
+                    counter_data.executed_thread_phases_,
+                    counter_data.tfunc_times_,
+                    counter_data.exec_times_,
+                    counter_data.idle_loop_counts_,
+                    counter_data.busy_loop_counts_,
 #if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
-                    tasks_active_[thread_num],
-                    background_duration_[thread_num]);
+                    counter_data.tasks_active_,
+                    counter_data.background_duration_);
 #else
-                    tasks_active_[thread_num]);
+                    counter_data.tasks_active_);
 #endif // HPX_HAVE_BACKGROUND_THREAD_COUNTERS
 
                 detail::scheduling_callbacks callbacks(
@@ -648,9 +654,9 @@ namespace hpx { namespace threads { namespace detail
         LTM_(info)    //-V128
             << "thread_func: " << id_.name()
             << " thread_num: " << global_thread_num
-            << " : ending OS thread, "    //-V128
-                "executed "
-            << executed_threads_[global_thread_num] << " HPX threads";
+            << " , ending OS thread, executed "    //-V128
+            << counter_data_[global_thread_num].executed_threads_
+            << " HPX threads";
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -725,6 +731,28 @@ namespace hpx { namespace threads { namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
     // performance counters
+    template <typename InIter, typename OutIter, typename ProjSrc,
+        typename ProjDest>
+    OutIter copy_projected(InIter first, InIter last, OutIter dest,
+        ProjSrc&& srcproj, ProjDest&& destproj)
+    {
+        while (first != last)
+        {
+            util::invoke(destproj, *dest++) = util::invoke(srcproj, *first++);
+        }
+        return dest;
+    }
+
+    template <typename InIter, typename T, typename Proj>
+    T accumulate_projected(InIter first, InIter last, T init, Proj && proj)
+    {
+        while (first != last)
+        {
+            init = std::move(init) + util::invoke(proj, *first++);
+        }
+        return init;
+    }
+
 #if defined(HPX_HAVE_THREAD_CUMULATIVE_COUNTS)
     template <typename Scheduler>
     std::int64_t scheduled_thread_pool<Scheduler>::get_executed_threads(
@@ -735,24 +763,27 @@ namespace hpx { namespace threads { namespace detail
 
         if (num != std::size_t(-1))
         {
-            executed_threads = executed_threads_[num];
-            reset_executed_threads = reset_executed_threads_[num];
+            executed_threads = counter_data_[num].executed_threads_;
+            reset_executed_threads = counter_data_[num].reset_executed_threads_;
 
             if (reset)
-                reset_executed_threads_[num] = executed_threads;
+                counter_data_[num].reset_executed_threads_ = executed_threads;
         }
         else
         {
-            executed_threads = std::accumulate(executed_threads_.begin(),
-                executed_threads_.end(), std::int64_t(0));
-            reset_executed_threads =
-                std::accumulate(reset_executed_threads_.begin(),
-                    reset_executed_threads_.end(), std::int64_t(0));
+            executed_threads = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::executed_threads_);
+            reset_executed_threads = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::reset_executed_threads_);
 
             if (reset)
             {
-                std::copy(executed_threads_.begin(), executed_threads_.end(),
-                          reset_executed_threads_.begin());
+                copy_projected(counter_data_.begin(), counter_data_.end(),
+                    counter_data_.begin(),
+                    &scheduling_counter_data::executed_threads_,
+                    &scheduling_counter_data::reset_executed_threads_);
             }
         }
 
@@ -766,13 +797,13 @@ namespace hpx { namespace threads { namespace detail
     std::int64_t scheduled_thread_pool<Scheduler>::get_executed_threads() const
     {
         std::int64_t executed_threads =
-            std::accumulate(executed_threads_.begin(), executed_threads_.end(),
-            std::int64_t(0));
+            accumulate_projected(counter_data_.begin(), counter_data_.end(),
+                std::int64_t(0), &scheduling_counter_data::executed_threads_);
 
 #if defined(HPX_HAVE_THREAD_CUMULATIVE_COUNTS)
-        std::int64_t reset_executed_threads =
-            std::accumulate(reset_executed_threads_.begin(),
-                reset_executed_threads_.end(), std::int64_t(0));
+        std::int64_t reset_executed_threads = accumulate_projected(
+            counter_data_.begin(), counter_data_.end(), std::int64_t(0),
+            &scheduling_counter_data::reset_executed_threads_);
 
         HPX_ASSERT(executed_threads >= reset_executed_threads);
         return executed_threads - reset_executed_threads;
@@ -791,25 +822,29 @@ namespace hpx { namespace threads { namespace detail
 
         if (num != std::size_t(-1))
         {
-            executed_phases = executed_thread_phases_[num];
-            reset_executed_phases = reset_executed_thread_phases_[num];
+            executed_phases = counter_data_[num].executed_thread_phases_;
+            reset_executed_phases =
+                counter_data_[num].reset_executed_thread_phases_;
 
             if (reset)
-                reset_executed_thread_phases_[num] = executed_phases;
+                counter_data_[num].reset_executed_thread_phases_ =
+                    executed_phases;
         }
         else
         {
-            executed_phases = std::accumulate(executed_thread_phases_.begin(),
-                executed_thread_phases_.end(), std::int64_t(0));
-            reset_executed_phases = std::accumulate(
-                reset_executed_thread_phases_.begin(),
-                reset_executed_thread_phases_.end(), std::int64_t(0));
+            executed_phases = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::executed_thread_phases_);
+            reset_executed_phases = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::reset_executed_thread_phases_);
 
             if (reset)
             {
-                std::copy(executed_thread_phases_.begin(),
-                    executed_thread_phases_.end(),
-                    reset_executed_thread_phases_.begin());
+                copy_projected(counter_data_.begin(), counter_data_.end(),
+                    counter_data_.begin(),
+                    &scheduling_counter_data::executed_thread_phases_,
+                    &scheduling_counter_data::reset_executed_thread_phases_);
             }
         }
 
@@ -824,46 +859,53 @@ namespace hpx { namespace threads { namespace detail
     std::int64_t scheduled_thread_pool<Scheduler>::get_thread_phase_duration(
         std::size_t num, bool reset)
     {
-        std::uint64_t exec_total = 0ul;
-        std::int64_t num_phases = 0l;
-        std::uint64_t reset_exec_total = 0ul;
-        std::int64_t reset_num_phases = 0l;
+        std::int64_t exec_total = 0;
+        std::int64_t num_phases = 0;
+        std::int64_t reset_exec_total = 0;
+        std::int64_t reset_num_phases = 0;
 
         if (num != std::size_t(-1))
         {
-            exec_total = exec_times_[num];
-            num_phases = executed_thread_phases_[num];
+            exec_total = counter_data_[num].exec_times_;
+            num_phases = counter_data_[num].executed_thread_phases_;
 
-            reset_exec_total = reset_thread_phase_duration_times_[num];
-            reset_num_phases = reset_thread_phase_duration_[num];
+            reset_exec_total =
+                counter_data_[num].reset_thread_phase_duration_times_;
+            reset_num_phases = counter_data_[num].reset_thread_phase_duration_;
 
             if (reset)
             {
-                reset_thread_phase_duration_[num] = num_phases;
-                reset_thread_phase_duration_times_[num] = exec_total;
+                counter_data_[num].reset_thread_phase_duration_ = num_phases;
+                counter_data_[num].reset_thread_phase_duration_times_ =
+                    exec_total;
             }
         }
         else
         {
-            exec_total = std::accumulate(exec_times_.begin(),
-                exec_times_.end(), std::uint64_t(0));
-            num_phases = std::accumulate(executed_thread_phases_.begin(),
-                executed_thread_phases_.end(), std::int64_t(0));
+            exec_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::exec_times_);
+            num_phases = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::executed_thread_phases_);
 
-            reset_exec_total = std::accumulate(
-                reset_thread_phase_duration_times_.begin(),
-                reset_thread_phase_duration_times_.end(), std::uint64_t(0));
-            reset_num_phases = std::accumulate(
-                reset_thread_phase_duration_.begin(),
-                reset_thread_phase_duration_.end(), std::int64_t(0));
+            reset_exec_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::reset_thread_phase_duration_times_);
+            reset_num_phases = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::reset_thread_phase_duration_);
 
             if (reset)
             {
-                std::copy(exec_times_.begin(), exec_times_.end(),
-                    reset_thread_phase_duration_times_.begin());
-                std::copy(executed_thread_phases_.begin(),
-                    executed_thread_phases_.end(),
-                    reset_thread_phase_duration_.begin());
+                copy_projected(counter_data_.begin(), counter_data_.end(),
+                    counter_data_.begin(),
+                    &scheduling_counter_data::exec_times_,
+                    &scheduling_counter_data::reset_thread_phase_duration_times_);
+                copy_projected(counter_data_.begin(), counter_data_.end(),
+                    counter_data_.begin(),
+                    &scheduling_counter_data::executed_thread_phases_,
+                    &scheduling_counter_data::reset_thread_phase_duration_);
             }
         }
 
@@ -873,7 +915,7 @@ namespace hpx { namespace threads { namespace detail
         exec_total -= reset_exec_total;
         num_phases -= reset_num_phases;
 
-        return std::uint64_t(
+        return std::int64_t(
                 (double(exec_total) * timestamp_scale_) / double(num_phases)
             );
     }
@@ -882,47 +924,51 @@ namespace hpx { namespace threads { namespace detail
     std::int64_t scheduled_thread_pool<Scheduler>::get_thread_duration(
         std::size_t num, bool reset)
     {
-        std::uint64_t exec_total = 0ul;
-        std::int64_t num_threads = 0l;
-        std::uint64_t reset_exec_total = 0ul;
-        std::int64_t reset_num_threads = 0l;
+        std::int64_t exec_total = 0;
+        std::int64_t num_threads = 0;
+        std::int64_t reset_exec_total = 0;
+        std::int64_t reset_num_threads = 0;
 
         if (num != std::size_t(-1))
         {
-            exec_total = exec_times_[num];
-            num_threads = executed_threads_[num];
+            exec_total = counter_data_[num].exec_times_;
+            num_threads = counter_data_[num].executed_threads_;
 
-            reset_exec_total = reset_thread_duration_times_[num];
-            reset_num_threads = reset_thread_duration_[num];
+            reset_exec_total = counter_data_[num].reset_thread_duration_times_;
+            reset_num_threads = counter_data_[num].reset_thread_duration_;
 
             if (reset)
             {
-                reset_thread_duration_[num] = num_threads;
-                reset_thread_duration_times_[num] = exec_total;
+                counter_data_[num].reset_thread_duration_ = num_threads;
+                counter_data_[num].reset_thread_duration_times_ = exec_total;
             }
         }
         else
         {
-            exec_total = std::accumulate(
-                exec_times_.begin(), exec_times_.end(), std::uint64_t(0));
-            num_threads = std::accumulate(executed_threads_.begin(),
-                executed_threads_.end(), std::int64_t(0));
+            exec_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::exec_times_);
+            num_threads = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::executed_threads_);
 
-            reset_exec_total =
-                std::accumulate(reset_thread_duration_times_.begin(),
-                    reset_thread_duration_times_.end(),
-                    std::uint64_t(0));
-            reset_num_threads = std::accumulate(reset_thread_duration_.begin(),
-                reset_thread_duration_.end(),
-                std::int64_t(0));
+            reset_exec_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::reset_thread_duration_times_);
+            reset_num_threads = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::reset_thread_duration_);
 
             if (reset)
             {
-                std::copy(exec_times_.begin(), exec_times_.end(),
-                    reset_thread_duration_times_.begin());
-                std::copy(executed_threads_.begin(),
-                    executed_threads_.end(),
-                    reset_thread_duration_.begin());
+                copy_projected(counter_data_.begin(), counter_data_.end(),
+                    counter_data_.begin(),
+                    &scheduling_counter_data::exec_times_,
+                    &scheduling_counter_data::reset_thread_duration_times_);
+                copy_projected(counter_data_.begin(), counter_data_.end(),
+                    counter_data_.begin(),
+                    &scheduling_counter_data::executed_threads_,
+                    &scheduling_counter_data::reset_thread_duration_);
             }
         }
 
@@ -932,7 +978,7 @@ namespace hpx { namespace threads { namespace detail
         exec_total -= reset_exec_total;
         num_threads -= reset_num_threads;
 
-        return std::uint64_t(
+        return std::int64_t(
             (double(exec_total) * timestamp_scale_) / double(num_threads));
     }
 
@@ -940,60 +986,74 @@ namespace hpx { namespace threads { namespace detail
     std::int64_t scheduled_thread_pool<Scheduler>::get_thread_phase_overhead(
         std::size_t num, bool reset)
     {
-        std::uint64_t exec_total = 0;
-        std::uint64_t tfunc_total = 0;
+        std::int64_t exec_total = 0;
+        std::int64_t tfunc_total = 0;
         std::int64_t num_phases = 0;
 
-        std::uint64_t reset_exec_total = 0;
-        std::uint64_t reset_tfunc_total = 0;
+        std::int64_t reset_exec_total = 0;
+        std::int64_t reset_tfunc_total = 0;
         std::int64_t reset_num_phases = 0;
 
         if (num != std::size_t(-1))
         {
-            exec_total = exec_times_[num];
-            tfunc_total = tfunc_times_[num];
-            num_phases = executed_thread_phases_[num];
+            exec_total = counter_data_[num].exec_times_;
+            tfunc_total = counter_data_[num].tfunc_times_;
+            num_phases = counter_data_[num].executed_thread_phases_;
 
-            reset_exec_total = reset_thread_phase_overhead_times_[num];
-            reset_tfunc_total = reset_thread_phase_overhead_times_total_[num];
-            reset_num_phases = reset_thread_phase_overhead_[num];
+            reset_exec_total =
+                counter_data_[num].reset_thread_phase_overhead_times_;
+            reset_tfunc_total =
+                counter_data_[num].reset_thread_phase_overhead_times_total_;
+            reset_num_phases = counter_data_[num].reset_thread_phase_overhead_;
 
             if (reset)
             {
-                reset_thread_phase_overhead_times_[num] = exec_total;
-                reset_thread_phase_overhead_times_total_[num] = tfunc_total;
-                reset_thread_phase_overhead_[num] = num_phases;
+                counter_data_[num].reset_thread_phase_overhead_times_ =
+                    exec_total;
+                counter_data_[num].reset_thread_phase_overhead_times_total_ =
+                    tfunc_total;
+                counter_data_[num].reset_thread_phase_overhead_ = num_phases;
             }
         }
         else
         {
-            exec_total = std::accumulate(
-                exec_times_.begin(), exec_times_.end(), std::uint64_t(0));
-            tfunc_total = std::accumulate(
-                tfunc_times_.begin(), tfunc_times_.end(), std::uint64_t(0));
-            num_phases = std::accumulate(executed_thread_phases_.begin(),
-                executed_thread_phases_.end(), std::int64_t(0));
+            exec_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::exec_times_);
+            tfunc_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::tfunc_times_);
+            num_phases = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::executed_thread_phases_);
 
-            reset_exec_total =
-                std::accumulate(reset_thread_phase_overhead_times_.begin(),
-                    reset_thread_phase_overhead_times_.end(), std::uint64_t(0));
-            reset_tfunc_total = std::accumulate(
-                reset_thread_phase_overhead_times_total_.begin(),
-                reset_thread_phase_overhead_times_total_.end(),
-                std::uint64_t(0));
-            reset_num_phases =
-                std::accumulate(reset_thread_phase_overhead_.begin(),
-                    reset_thread_phase_overhead_.end(), std::int64_t(0));
+            reset_exec_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::reset_thread_phase_overhead_times_);
+            reset_tfunc_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::
+                    reset_thread_phase_overhead_times_total_);
+            reset_num_phases = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::reset_thread_phase_overhead_);
 
             if (reset)
             {
-                std::copy(exec_times_.begin(), exec_times_.end(),
-                    reset_thread_phase_overhead_times_.begin());
-                std::copy(tfunc_times_.begin(), tfunc_times_.end(),
-                    reset_thread_phase_overhead_times_total_.begin());
-                std::copy(executed_thread_phases_.begin(),
-                    executed_thread_phases_.end(),
-                    reset_thread_phase_overhead_.begin());
+                copy_projected(counter_data_.begin(), counter_data_.end(),
+                    counter_data_.begin(),
+                    &scheduling_counter_data::exec_times_,
+                    &scheduling_counter_data::
+                        reset_thread_phase_overhead_times_);
+                copy_projected(counter_data_.begin(), counter_data_.end(),
+                    counter_data_.begin(),
+                    &scheduling_counter_data::tfunc_times_,
+                    &scheduling_counter_data::
+                        reset_thread_phase_overhead_times_total_);
+                copy_projected(counter_data_.begin(), counter_data_.end(),
+                    counter_data_.begin(),
+                    &scheduling_counter_data::executed_thread_phases_,
+                    &scheduling_counter_data::reset_thread_phase_overhead_);
             }
         }
 
@@ -1010,7 +1070,7 @@ namespace hpx { namespace threads { namespace detail
 
         HPX_ASSERT(tfunc_total >= exec_total);
 
-        return std::uint64_t(
+        return std::int64_t(
             double((tfunc_total - exec_total) * timestamp_scale_) /
             double(num_phases));
     }
@@ -1019,59 +1079,70 @@ namespace hpx { namespace threads { namespace detail
     std::int64_t scheduled_thread_pool<Scheduler>::get_thread_overhead(
         std::size_t num, bool reset)
     {
-        std::uint64_t exec_total = 0;
-        std::uint64_t tfunc_total = 0;
+        std::int64_t exec_total = 0;
+        std::int64_t tfunc_total = 0;
         std::int64_t num_threads = 0;
 
-        std::uint64_t reset_exec_total = 0;
-        std::uint64_t reset_tfunc_total = 0;
+        std::int64_t reset_exec_total = 0;
+        std::int64_t reset_tfunc_total = 0;
         std::int64_t reset_num_threads = 0;
 
         if (num != std::size_t(-1))
         {
-            exec_total = exec_times_[num];
-            tfunc_total = tfunc_times_[num];
-            num_threads = executed_threads_[num];
+            exec_total = counter_data_[num].exec_times_;
+            tfunc_total = counter_data_[num].tfunc_times_;
+            num_threads = counter_data_[num].executed_threads_;
 
-            reset_exec_total = reset_thread_overhead_times_[num];
-            reset_tfunc_total = reset_thread_overhead_times_total_[num];
-            reset_num_threads = reset_thread_overhead_[num];
+            reset_exec_total = counter_data_[num].reset_thread_overhead_times_;
+            reset_tfunc_total =
+                counter_data_[num].reset_thread_overhead_times_total_;
+            reset_num_threads = counter_data_[num].reset_thread_overhead_;
 
             if (reset)
             {
-                reset_thread_overhead_times_[num] = exec_total;
-                reset_thread_overhead_times_total_[num] = tfunc_total;
-                reset_thread_overhead_[num] = num_threads;
+                counter_data_[num].reset_thread_overhead_times_ = exec_total;
+                counter_data_[num].reset_thread_overhead_times_total_ =
+                    tfunc_total;
+                counter_data_[num].reset_thread_overhead_ = num_threads;
             }
         }
         else
         {
-            exec_total = std::accumulate(
-                exec_times_.begin(), exec_times_.end(), std::uint64_t(0));
-            tfunc_total = std::accumulate(
-                tfunc_times_.begin(), tfunc_times_.end(), std::uint64_t(0));
-            num_threads = std::accumulate(executed_threads_.begin(),
-                executed_threads_.end(), std::int64_t(0));
+            exec_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::exec_times_);
+            tfunc_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::tfunc_times_);
+            num_threads = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::executed_threads_);
 
-            reset_exec_total =
-                std::accumulate(reset_thread_overhead_times_.begin(),
-                    reset_thread_overhead_times_.end(), std::uint64_t(0));
-            reset_tfunc_total =
-                std::accumulate(reset_thread_overhead_times_total_.begin(),
-                    reset_thread_overhead_times_total_.end(),
-                    std::uint64_t(0));
-            reset_num_threads = std::accumulate(reset_thread_overhead_.begin(),
-                reset_thread_overhead_.end(), std::int64_t(0));
+            reset_exec_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::reset_thread_overhead_times_);
+            reset_tfunc_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::reset_thread_overhead_times_total_);
+            reset_num_threads = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::reset_thread_overhead_);
 
             if (reset)
             {
-                std::copy(exec_times_.begin(), exec_times_.end(),
-                    reset_thread_overhead_times_.begin());
-                std::copy(tfunc_times_.begin(), tfunc_times_.end(),
-                    reset_thread_overhead_times_total_.begin());
-                std::copy(executed_threads_.begin(),
-                    executed_threads_.end(),
-                    reset_thread_overhead_.begin());
+                copy_projected(counter_data_.begin(), counter_data_.end(),
+                    counter_data_.begin(),
+                    &scheduling_counter_data::exec_times_,
+                    &scheduling_counter_data::reset_thread_overhead_times_);
+                copy_projected(counter_data_.begin(), counter_data_.end(),
+                    counter_data_.begin(),
+                    &scheduling_counter_data::tfunc_times_,
+                    &scheduling_counter_data::
+                        reset_thread_overhead_times_total_);
+                copy_projected(counter_data_.begin(), counter_data_.end(),
+                    counter_data_.begin(),
+                    &scheduling_counter_data::executed_thread_phases_,
+                    &scheduling_counter_data::reset_thread_overhead_);
             }
         }
 
@@ -1088,39 +1159,46 @@ namespace hpx { namespace threads { namespace detail
 
         HPX_ASSERT(tfunc_total >= exec_total);
 
-        return std::uint64_t(
+        return std::int64_t(
             double((tfunc_total - exec_total) * timestamp_scale_) /
             double(num_threads));
     }
 
     template <typename Scheduler>
-    std::int64_t scheduled_thread_pool<Scheduler>::get_cumulative_thread_duration(
+    std::int64_t
+    scheduled_thread_pool<Scheduler>::get_cumulative_thread_duration(
         std::size_t num, bool reset)
     {
-        std::uint64_t exec_total = 0ul;
-        std::uint64_t reset_exec_total = 0ul;
+        std::int64_t exec_total = 0;
+        std::int64_t reset_exec_total = 0;
 
         if (num != std::size_t(-1))
         {
-            exec_total = exec_times_[num];
-            reset_exec_total = reset_cumulative_thread_duration_[num];
-
-            if (reset)
-                reset_cumulative_thread_duration_[num] = exec_total;
-        }
-        else
-        {
-            exec_total = std::accumulate(
-                exec_times_.begin(), exec_times_.end(), std::uint64_t(0));
+            exec_total = counter_data_[num].exec_times_;
             reset_exec_total =
-                std::accumulate(reset_cumulative_thread_duration_.begin(),
-                    reset_cumulative_thread_duration_.end(),
-                    std::uint64_t(0));
+                counter_data_[num].reset_cumulative_thread_duration_;
 
             if (reset)
             {
-                std::copy(exec_times_.begin(), exec_times_.end(),
-                    reset_cumulative_thread_duration_.begin());
+                counter_data_[num].reset_cumulative_thread_duration_ =
+                    exec_total;
+            }
+        }
+        else
+        {
+            exec_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::exec_times_);
+            reset_exec_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::reset_cumulative_thread_duration_);
+
+            if (reset)
+            {
+                copy_projected(counter_data_.begin(), counter_data_.end(),
+                    counter_data_.begin(),
+                    &scheduling_counter_data::exec_times_,
+                    &scheduling_counter_data::reset_cumulative_thread_duration_);
             }
         }
 
@@ -1128,7 +1206,7 @@ namespace hpx { namespace threads { namespace detail
 
         exec_total -= reset_exec_total;
 
-        return std::uint64_t(double(exec_total) * timestamp_scale_);
+        return std::int64_t(double(exec_total) * timestamp_scale_);
     }
 
     template <typename Scheduler>
@@ -1136,47 +1214,57 @@ namespace hpx { namespace threads { namespace detail
     scheduled_thread_pool<Scheduler>::get_cumulative_thread_overhead(
         std::size_t num, bool reset)
     {
-        std::uint64_t exec_total = 0ul;
-        std::uint64_t reset_exec_total = 0ul;
-        std::uint64_t tfunc_total = 0ul;
-        std::uint64_t reset_tfunc_total = 0ul;
+        std::int64_t exec_total = 0;
+        std::int64_t reset_exec_total = 0;
+        std::int64_t tfunc_total = 0;
+        std::int64_t reset_tfunc_total = 0;
 
         if (num != std::size_t(-1))
         {
-            exec_total = exec_times_[num];
-            tfunc_total = tfunc_times_[num];
+            exec_total = counter_data_[num].exec_times_;
+            tfunc_total = counter_data_[num].tfunc_times_;
 
-            reset_exec_total = reset_cumulative_thread_overhead_[num];
-            reset_tfunc_total = reset_cumulative_thread_overhead_total_[num];
+            reset_exec_total =
+                counter_data_[num].reset_cumulative_thread_overhead_;
+            reset_tfunc_total =
+                counter_data_[num].reset_cumulative_thread_overhead_total_;
 
             if (reset)
             {
-                reset_cumulative_thread_overhead_[num] = exec_total;
-                reset_cumulative_thread_overhead_total_[num] = tfunc_total;
+                counter_data_[num].reset_cumulative_thread_overhead_ =
+                    exec_total;
+                counter_data_[num].reset_cumulative_thread_overhead_total_ =
+                    tfunc_total;
             }
         }
         else
         {
-            exec_total = std::accumulate(
-                exec_times_.begin(), exec_times_.end(), std::uint64_t(0));
-            reset_exec_total =
-                std::accumulate(reset_cumulative_thread_overhead_.begin(),
-                    reset_cumulative_thread_overhead_.end(),
-                    std::uint64_t(0));
+            exec_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::exec_times_);
+            reset_exec_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::reset_cumulative_thread_overhead_);
 
-            tfunc_total = std::accumulate(
-                tfunc_times_.begin(), tfunc_times_.end(), std::uint64_t(0));
-            reset_tfunc_total =
-                std::accumulate(reset_cumulative_thread_overhead_total_.begin(),
-                    reset_cumulative_thread_overhead_total_.end(),
-                    std::uint64_t(0));
+            tfunc_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::tfunc_times_);
+            reset_tfunc_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::
+                    reset_cumulative_thread_overhead_total_);
 
             if (reset)
             {
-                std::copy(exec_times_.begin(), exec_times_.end(),
-                    reset_cumulative_thread_overhead_.begin());
-                std::copy(tfunc_times_.begin(), tfunc_times_.end(),
-                    reset_cumulative_thread_overhead_total_.begin());
+                copy_projected(counter_data_.begin(), counter_data_.end(),
+                    counter_data_.begin(),
+                    &scheduling_counter_data::exec_times_,
+                    &scheduling_counter_data::reset_cumulative_thread_overhead_);
+                copy_projected(counter_data_.begin(), counter_data_.end(),
+                    counter_data_.begin(),
+                    &scheduling_counter_data::tfunc_times_,
+                    &scheduling_counter_data::
+                        reset_cumulative_thread_overhead_total_);
             }
         }
 
@@ -1186,7 +1274,7 @@ namespace hpx { namespace threads { namespace detail
         exec_total -= reset_exec_total;
         tfunc_total -= reset_tfunc_total;
 
-        return std::uint64_t(
+        return std::int64_t(
             (double(tfunc_total) - double(exec_total)) * timestamp_scale_);
     }
 #endif
@@ -1198,46 +1286,51 @@ namespace hpx { namespace threads { namespace detail
     std::int64_t scheduled_thread_pool<Scheduler>::get_background_overhead(
         std::size_t num, bool reset)
     {
-        std::uint64_t bg_total = 0ul;
-        std::uint64_t reset_bg_total = 0ul;
-        std::uint64_t tfunc_total = 0ul;
-        std::uint64_t reset_tfunc_total = 0ul;
+        std::int64_t bg_total = 0;
+        std::int64_t reset_bg_total = 0;
+        std::int64_t tfunc_total = 0;
+        std::int64_t reset_tfunc_total = 0;
 
         if (num != std::size_t(-1))
         {
-            tfunc_total = tfunc_times_[num];
-            reset_tfunc_total = reset_background_tfunc_times_[num];
+            tfunc_total = counter_data_[num].tfunc_times_;
+            reset_tfunc_total = counter_data_[num].reset_background_tfunc_times_;
 
-            bg_total = background_duration_[num];
-            reset_bg_total = reset_background_overhead_[num];
+            bg_total = counter_data_[num].background_duration_;
+            reset_bg_total = counter_data_[num].reset_background_overhead_;
 
             if (reset)
             {
-                reset_background_overhead_[num] = bg_total;
-                reset_background_tfunc_times_[num] = tfunc_total;
+                counter_data_[num].reset_background_overhead_ = bg_total;
+                counter_data_[num].reset_background_tfunc_times_ = tfunc_total;
             }
         }
         else
         {
-            tfunc_total = std::accumulate(
-                tfunc_times_.begin(), tfunc_times_.end(), std::uint64_t(0));
-            reset_tfunc_total =
-                std::accumulate(reset_background_tfunc_times_.begin(),
-                    reset_background_tfunc_times_.end(), std::uint64_t(0));
+            tfunc_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::tfunc_times_);
+            reset_tfunc_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::reset_background_tfunc_times_);
 
-            bg_total = std::accumulate(background_duration_.begin(),
-                background_duration_.end(), std::uint64_t(0));
-            reset_bg_total = std::accumulate(reset_background_overhead_.begin(),
-                reset_background_overhead_.end(), std::uint64_t(0));
+            bg_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::background_duration_);
+            reset_bg_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::reset_background_overhead_);
 
             if (reset)
             {
-                std::copy(tfunc_times_.begin(), tfunc_times_.end(),
-                    reset_background_tfunc_times_.begin());
-
-                std::copy(background_duration_.begin(),
-                    background_duration_.end(),
-                    reset_background_overhead_.begin());
+                copy_projected(counter_data_.begin(), counter_data_.end(),
+                    counter_data_.begin(),
+                    &scheduling_counter_data::tfunc_times_,
+                    &scheduling_counter_data::reset_background_tfunc_times_);
+                copy_projected(counter_data_.begin(), counter_data_.end(),
+                    counter_data_.begin(),
+                    &scheduling_counter_data::background_duration_,
+                    &scheduling_counter_data::reset_background_overhead_);
             }
         }
 
@@ -1249,76 +1342,83 @@ namespace hpx { namespace threads { namespace detail
 
         tfunc_total -= reset_tfunc_total;
         bg_total -= reset_bg_total;
+
         // this is now a 0.1 %
-        return std::uint64_t((double(bg_total) / tfunc_total) * 1000);
+        return std::int64_t((double(bg_total) / tfunc_total) * 1000);
     }
 
     template <typename Scheduler>
     std::int64_t scheduled_thread_pool<Scheduler>::get_background_work_duration(
         std::size_t num, bool reset)
     {
-        std::uint64_t bg_total = 0ul;
-        std::uint64_t reset_bg_total = 0ul;
+        std::int64_t bg_total = 0;
+        std::int64_t reset_bg_total = 0;
 
         if (num != std::size_t(-1))
         {
-            bg_total = background_duration_[num];
-            reset_bg_total = reset_background_duration_[num];
+            bg_total = counter_data_[num].background_duration_;
+            reset_bg_total = counter_data_[num].reset_background_duration_;
 
             if (reset)
             {
-                reset_background_duration_[num] = bg_total;
+                counter_data_[num].reset_background_duration_ = bg_total;
             }
         }
         else
         {
-            bg_total = std::accumulate(background_duration_.begin(),
-                background_duration_.end(), std::uint64_t(0));
-            reset_bg_total = std::accumulate(reset_background_duration_.begin(),
-                reset_background_duration_.end(), std::uint64_t(0));
+            bg_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::background_duration_);
+            reset_bg_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::reset_background_duration_);
 
             if (reset)
             {
-                std::copy(background_duration_.begin(),
-                    background_duration_.end(),
-                    reset_background_duration_.begin());
+                copy_projected(counter_data_.begin(), counter_data_.end(),
+                    counter_data_.begin(),
+                    &scheduling_counter_data::background_duration_,
+                    &scheduling_counter_data::reset_background_duration_);
             }
         }
 
         HPX_ASSERT(bg_total >= reset_bg_total);
         bg_total -= reset_bg_total;
-        return std::uint64_t(double(bg_total) * timestamp_scale_);
+        return std::int64_t(double(bg_total) * timestamp_scale_);
     }
-
 #endif    // HPX_HAVE_BACKGROUND_THREAD_COUNTERS
-          //////////////////////////////////////////////////////////////////////
 
+    ///////////////////////////////////////////////////////////////////////////
     template <typename Scheduler>
     std::int64_t scheduled_thread_pool<Scheduler>::get_cumulative_duration(
         std::size_t num, bool reset)
     {
-        std::uint64_t tfunc_total = 0ul;
-        std::uint64_t reset_tfunc_total = 0ul;
+        std::int64_t tfunc_total = 0;
+        std::int64_t reset_tfunc_total = 0;
 
         if (num != std::size_t(-1))
         {
-            tfunc_total = tfunc_times_[num];
-            reset_tfunc_total = reset_tfunc_times_[num];
+            tfunc_total = counter_data_[num].tfunc_times_;
+            reset_tfunc_total = counter_data_[num].reset_tfunc_times_;
 
             if (reset)
-                reset_tfunc_times_[num] = tfunc_total;
+                counter_data_[num].reset_tfunc_times_ = tfunc_total;
         }
         else
         {
-            tfunc_total = std::accumulate(
-                tfunc_times_.begin(), tfunc_times_.end(), std::uint64_t(0));
-            reset_tfunc_total = std::accumulate(reset_tfunc_times_.begin(),
-                reset_tfunc_times_.end(), std::uint64_t(0));
+            tfunc_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::tfunc_times_);
+            reset_tfunc_total = accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::reset_tfunc_times_);
 
             if (reset)
             {
-                std::copy(tfunc_times_.begin(), tfunc_times_.end(),
-                    reset_tfunc_times_.begin());
+                copy_projected(counter_data_.begin(), counter_data_.end(),
+                    counter_data_.begin(),
+                    &scheduling_counter_data::tfunc_times_,
+                    &scheduling_counter_data::reset_tfunc_times_);
             }
         }
 
@@ -1326,7 +1426,7 @@ namespace hpx { namespace threads { namespace detail
 
         tfunc_total -= reset_tfunc_total;
 
-        return std::uint64_t(double(tfunc_total) * timestamp_scale_);
+        return std::int64_t(double(tfunc_total) * timestamp_scale_);
     }
 
 #if defined(HPX_HAVE_THREAD_IDLE_RATES)
@@ -1338,24 +1438,30 @@ namespace hpx { namespace threads { namespace detail
         double const creation_total =
             static_cast<double>(sched_->Scheduler::get_creation_time(reset));
 
-        std::uint64_t exec_total = std::accumulate(
-            exec_times_.begin(), exec_times_.end(), std::uint64_t(0));
-        std::uint64_t tfunc_total = std::accumulate(
-            tfunc_times_.begin(), tfunc_times_.end(), std::uint64_t(0));
-        std::uint64_t reset_exec_total =
-            std::accumulate(reset_creation_idle_rate_time_.begin(),
-                reset_creation_idle_rate_time_.end(), std::uint64_t(0));
-        std::uint64_t reset_tfunc_total =
-            std::accumulate(reset_creation_idle_rate_time_total_.begin(),
-                reset_creation_idle_rate_time_total_.end(),
-                std::uint64_t(0));
+        std::int64_t exec_total = accumulate_projected(counter_data_.begin(),
+            counter_data_.end(), std::int64_t(0),
+            &scheduling_counter_data::exec_times_);
+        std::int64_t tfunc_total = accumulate_projected(counter_data_.begin(),
+            counter_data_.end(), std::int64_t(0),
+            &scheduling_counter_data::tfunc_times_);
+
+        std::int64_t reset_exec_total = accumulate_projected(
+            counter_data_.begin(), counter_data_.end(), std::int64_t(0),
+            &scheduling_counter_data::reset_creation_idle_rate_time_);
+        std::int64_t reset_tfunc_total = accumulate_projected(
+            counter_data_.begin(), counter_data_.end(), std::int64_t(0),
+            &scheduling_counter_data::reset_creation_idle_rate_time_total_);
 
         if (reset)
         {
-            std::copy(exec_times_.begin(), exec_times_.end(),
-                reset_creation_idle_rate_time_.begin());
-            std::copy(tfunc_times_.begin(), tfunc_times_.end(),
-                reset_creation_idle_rate_time_.begin());
+            copy_projected(counter_data_.begin(), counter_data_.end(),
+                counter_data_.begin(),
+                &scheduling_counter_data::exec_times_,
+                &scheduling_counter_data::reset_creation_idle_rate_time_);
+            copy_projected(counter_data_.begin(), counter_data_.end(),
+                counter_data_.begin(),
+                &scheduling_counter_data::tfunc_times_,
+                &scheduling_counter_data::reset_creation_idle_rate_time_);
         }
 
         HPX_ASSERT(exec_total >= reset_exec_total);
@@ -1381,24 +1487,30 @@ namespace hpx { namespace threads { namespace detail
         double const cleanup_total =
             static_cast<double>(sched_->Scheduler::get_cleanup_time(reset));
 
-        std::uint64_t exec_total = std::accumulate(
-            exec_times_.begin(), exec_times_.end(), std::uint64_t(0));
-        std::uint64_t tfunc_total = std::accumulate(
-            tfunc_times_.begin(), tfunc_times_.end(), std::uint64_t(0));
-        std::uint64_t reset_exec_total =
-            std::accumulate(reset_cleanup_idle_rate_time_.begin(),
-                reset_cleanup_idle_rate_time_.end(), std::uint64_t(0));
-        std::uint64_t reset_tfunc_total =
-            std::accumulate(reset_cleanup_idle_rate_time_total_.begin(),
-                reset_cleanup_idle_rate_time_total_.end(),
-                std::uint64_t(0));
+        std::int64_t exec_total = accumulate_projected(counter_data_.begin(),
+            counter_data_.end(), std::int64_t(0),
+            &scheduling_counter_data::exec_times_);
+        std::int64_t tfunc_total = accumulate_projected(counter_data_.begin(),
+            counter_data_.end(), std::int64_t(0),
+            &scheduling_counter_data::tfunc_times_);
+
+        std::int64_t reset_exec_total = accumulate_projected(
+            counter_data_.begin(), counter_data_.end(), std::int64_t(0),
+            &scheduling_counter_data::reset_cleanup_idle_rate_time_);
+        std::int64_t reset_tfunc_total = accumulate_projected(
+            counter_data_.begin(), counter_data_.end(), std::int64_t(0),
+            &scheduling_counter_data::reset_cleanup_idle_rate_time_total_);
 
         if (reset)
         {
-            std::copy(exec_times_.begin(), exec_times_.end(),
-                reset_cleanup_idle_rate_time_.begin());
-            std::copy(tfunc_times_.begin(), tfunc_times_.end(),
-                reset_cleanup_idle_rate_time_.begin());
+            copy_projected(counter_data_.begin(), counter_data_.end(),
+                counter_data_.begin(),
+                &scheduling_counter_data::exec_times_,
+                &scheduling_counter_data::reset_cleanup_idle_rate_time_);
+            copy_projected(counter_data_.begin(), counter_data_.end(),
+                counter_data_.begin(),
+                &scheduling_counter_data::tfunc_times_,
+                &scheduling_counter_data::reset_cleanup_idle_rate_time_);
         }
 
         HPX_ASSERT(exec_total >= reset_exec_total);
@@ -1421,23 +1533,30 @@ namespace hpx { namespace threads { namespace detail
     template <typename Scheduler>
     std::int64_t scheduled_thread_pool<Scheduler>::avg_idle_rate_all(bool reset)
     {
-        std::uint64_t exec_total = std::accumulate(
-            exec_times_.begin(), exec_times_.end(), std::uint64_t(0));
-        std::uint64_t tfunc_total = std::accumulate(
-            tfunc_times_.begin(), tfunc_times_.end(), std::uint64_t(0));
-        std::uint64_t reset_exec_total =
-            std::accumulate(reset_idle_rate_time_.begin(),
-                reset_idle_rate_time_.end(), std::uint64_t(0));
-        std::uint64_t reset_tfunc_total =
-            std::accumulate(reset_idle_rate_time_total_.begin(),
-                reset_idle_rate_time_total_.end(), std::uint64_t(0));
+        std::int64_t exec_total = accumulate_projected(counter_data_.begin(),
+            counter_data_.end(), std::int64_t(0),
+            &scheduling_counter_data::exec_times_);
+        std::int64_t tfunc_total = accumulate_projected(counter_data_.begin(),
+            counter_data_.end(), std::int64_t(0),
+            &scheduling_counter_data::tfunc_times_);
+
+        std::int64_t reset_exec_total = accumulate_projected(
+            counter_data_.begin(), counter_data_.end(), std::int64_t(0),
+            &scheduling_counter_data::reset_idle_rate_time_);
+        std::int64_t reset_tfunc_total = accumulate_projected(
+            counter_data_.begin(), counter_data_.end(), std::int64_t(0),
+            &scheduling_counter_data::reset_idle_rate_time_total_);
 
         if (reset)
         {
-            std::copy(exec_times_.begin(), exec_times_.end(),
-                reset_idle_rate_time_.begin());
-            std::copy(tfunc_times_.begin(), tfunc_times_.end(),
-                reset_idle_rate_time_total_.begin());
+            copy_projected(counter_data_.begin(), counter_data_.end(),
+                counter_data_.begin(),
+                &scheduling_counter_data::exec_times_,
+                &scheduling_counter_data::reset_idle_rate_time_);
+            copy_projected(counter_data_.begin(), counter_data_.end(),
+                counter_data_.begin(),
+                &scheduling_counter_data::tfunc_times_,
+                &scheduling_counter_data::reset_idle_rate_time_total_);
         }
 
         HPX_ASSERT(exec_total >= reset_exec_total);
@@ -1458,21 +1577,22 @@ namespace hpx { namespace threads { namespace detail
 
     template <typename Scheduler>
     std::int64_t scheduled_thread_pool<Scheduler>::avg_idle_rate(
-        std::size_t num_thread, bool reset)
+        std::size_t num, bool reset)
     {
-        if (num_thread == std::size_t(-1))
+        if (num == std::size_t(-1))
             return avg_idle_rate_all(reset);
 
-        std::uint64_t exec_time = exec_times_[num_thread];
-        std::uint64_t tfunc_time = tfunc_times_[num_thread];
-        std::uint64_t reset_exec_time = reset_idle_rate_time_[num_thread];
-        std::uint64_t reset_tfunc_time =
-            reset_idle_rate_time_total_[num_thread];
+        std::int64_t exec_time = counter_data_[num].exec_times_;
+        std::int64_t tfunc_time = counter_data_[num].tfunc_times_;
+        std::int64_t reset_exec_time =
+            counter_data_[num].reset_idle_rate_time_;
+        std::int64_t reset_tfunc_time =
+            counter_data_[num].reset_idle_rate_time_total_;
 
         if (reset)
         {
-            reset_idle_rate_time_[num_thread] = exec_time;
-            reset_idle_rate_time_total_[num_thread] = tfunc_time;
+            counter_data_[num].reset_idle_rate_time_ = exec_time;
+            counter_data_[num].reset_idle_rate_time_total_ = tfunc_time;
         }
 
         HPX_ASSERT(exec_time >= reset_exec_time);
@@ -1498,10 +1618,11 @@ namespace hpx { namespace threads { namespace detail
     {
         if (num == std::size_t(-1))
         {
-            return std::accumulate(
-                idle_loop_counts_.begin(), idle_loop_counts_.end(), 0ll);
+            return accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::idle_loop_counts_);
         }
-        return idle_loop_counts_[num];
+        return counter_data_[num].idle_loop_counts_;
     }
 
     template <typename Scheduler>
@@ -1510,18 +1631,21 @@ namespace hpx { namespace threads { namespace detail
     {
         if (num == std::size_t(-1))
         {
-            return std::accumulate(
-                busy_loop_counts_.begin(), busy_loop_counts_.end(), 0ll);
+            return accumulate_projected(counter_data_.begin(),
+                counter_data_.end(), std::int64_t(0),
+                &scheduling_counter_data::busy_loop_counts_);
         }
-        return busy_loop_counts_[num];
+        return counter_data_[num].busy_loop_counts_;
     }
 
     template <typename Scheduler>
     std::int64_t scheduled_thread_pool<Scheduler>::get_scheduler_utilization()
         const
     {
-        return (std::accumulate(tasks_active_.begin(), tasks_active_.end(),
-            std::int64_t(0)) * 100) / thread_count_.load();
+        return (accumulate_projected(counter_data_.begin(), counter_data_.end(),
+                    std::int64_t(0), &scheduling_counter_data::tasks_active_) *
+                   100) /
+            thread_count_.load();
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1529,68 +1653,7 @@ namespace hpx { namespace threads { namespace detail
     void scheduled_thread_pool<Scheduler>::init_perf_counter_data(
         std::size_t pool_threads)
     {
-        executed_threads_.resize(pool_threads);
-        executed_thread_phases_.resize(pool_threads);
-
-        tfunc_times_.resize(pool_threads);
-        exec_times_.resize(pool_threads);
-
-        idle_loop_counts_.resize(pool_threads);
-        busy_loop_counts_.resize(pool_threads);
-
-        reset_tfunc_times_.resize(pool_threads);
-
-        tasks_active_.resize(pool_threads);
-
-#if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
-        background_duration_.resize(pool_threads);
-        reset_background_duration_.resize(pool_threads);
-        reset_background_tfunc_times_.resize(pool_threads);
-        reset_background_overhead_.resize(pool_threads);
-#endif    // HPX_HAVE_BACKGROUND_THREAD_COUNTERS
-
-#if defined(HPX_HAVE_THREAD_CUMULATIVE_COUNTS)
-        // timestamps/values of last reset operation for various
-        // performance counters
-        reset_executed_threads_.resize(pool_threads);
-        reset_executed_thread_phases_.resize(pool_threads);
-
-#if defined(HPX_HAVE_THREAD_IDLE_RATES)
-        // timestamps/values of last reset operation for various
-        // performance counters
-        reset_thread_duration_.resize(pool_threads);
-        reset_thread_duration_times_.resize(pool_threads);
-
-        reset_thread_overhead_.resize(pool_threads);
-        reset_thread_overhead_times_.resize(pool_threads);
-        reset_thread_overhead_times_total_.resize(pool_threads);
-
-        reset_thread_phase_duration_.resize(pool_threads);
-        reset_thread_phase_duration_times_.resize(pool_threads);
-
-        reset_thread_phase_overhead_.resize(pool_threads);
-        reset_thread_phase_overhead_times_.resize(pool_threads);
-        reset_thread_phase_overhead_times_total_.resize(pool_threads);
-
-        reset_cumulative_thread_duration_.resize(pool_threads);
-
-        reset_cumulative_thread_overhead_.resize(pool_threads);
-        reset_cumulative_thread_overhead_total_.resize(pool_threads);
-#endif
-#endif
-
-#if defined(HPX_HAVE_THREAD_IDLE_RATES)
-        reset_idle_rate_time_.resize(pool_threads);
-        reset_idle_rate_time_total_.resize(pool_threads);
-
-#if defined(HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES)
-        reset_creation_idle_rate_time_.resize(pool_threads);
-        reset_creation_idle_rate_time_total_.resize(pool_threads);
-
-        reset_cleanup_idle_rate_time_.resize(pool_threads);
-        reset_cleanup_idle_rate_time_total_.resize(pool_threads);
-#endif
-#endif
+        counter_data_.resize(pool_threads);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2019 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -203,19 +203,19 @@ namespace hpx { namespace threads { namespace detail
 #ifdef HPX_HAVE_THREAD_IDLE_RATES
     struct idle_collect_rate
     {
-        idle_collect_rate(std::uint64_t& tfunc_time, std::uint64_t& exec_time)
+        idle_collect_rate(std::int64_t& tfunc_time, std::int64_t& exec_time)
           : start_timestamp_(util::hardware::timestamp())
           , tfunc_time_(tfunc_time)
           , exec_time_(exec_time)
         {}
 
-        void collect_exec_time(std::uint64_t timestamp)
+        void collect_exec_time(std::int64_t timestamp)
         {
             exec_time_ += util::hardware::timestamp() - timestamp;
         }
         void take_snapshot()
         {
-            if (tfunc_time_ == std::uint64_t(-1))
+            if (tfunc_time_ == std::int64_t(-1))
             {
                 start_timestamp_ = util::hardware::timestamp();
                 tfunc_time_ = 0;
@@ -227,10 +227,10 @@ namespace hpx { namespace threads { namespace detail
             }
         }
 
-        std::uint64_t start_timestamp_;
+        std::int64_t start_timestamp_;
 
-        std::uint64_t& tfunc_time_;
-        std::uint64_t& exec_time_;
+        std::int64_t& tfunc_time_;
+        std::int64_t& exec_time_;
     };
 
     struct exec_time_wrapper
@@ -244,7 +244,7 @@ namespace hpx { namespace threads { namespace detail
             idle_rate_.collect_exec_time(timestamp_);
         }
 
-        std::uint64_t timestamp_;
+        std::int64_t timestamp_;
         idle_collect_rate& idle_rate_;
     };
 
@@ -264,7 +264,7 @@ namespace hpx { namespace threads { namespace detail
 #else
     struct idle_collect_rate
     {
-        idle_collect_rate(std::uint64_t&, std::uint64_t&) {}
+        idle_collect_rate(std::int64_t&, std::int64_t&) {}
     };
 
     struct exec_time_wrapper
@@ -280,20 +280,19 @@ namespace hpx { namespace threads { namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
 #if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
-
     struct background_work_duration_counter
     {
-        background_work_duration_counter(std::uint64_t& background_exec_time)
+        background_work_duration_counter(std::int64_t& background_exec_time)
           : background_exec_time_(background_exec_time)
         {
         }
 
-        void collect_background_exec_time(std::uint64_t timestamp)
+        void collect_background_exec_time(std::int64_t timestamp)
         {
             background_exec_time_ += util::hardware::timestamp() - timestamp;
         }
 
-        std::uint64_t& background_exec_time_;
+        std::int64_t& background_exec_time_;
     };
 
     struct background_exec_time_wrapper
@@ -310,7 +309,7 @@ namespace hpx { namespace threads { namespace detail
             background_work_duration_.collect_background_exec_time(timestamp_);
         }
 
-        std::uint64_t timestamp_;
+        std::int64_t timestamp_;
         background_work_duration_counter& background_work_duration_;
     };
 #endif    // HPX_HAVE_BACKGROUND_THREAD_COUNTERS
@@ -318,17 +317,17 @@ namespace hpx { namespace threads { namespace detail
     ///////////////////////////////////////////////////////////////////////////
     struct is_active_wrapper
     {
-        is_active_wrapper(std::uint8_t& is_active)
+        is_active_wrapper(bool& is_active)
           : is_active_(is_active)
         {
-            is_active = 1;
+            is_active = true;
         }
         ~is_active_wrapper()
         {
-            is_active_ = 0;
+            is_active_ = false;
         }
 
-        std::uint8_t& is_active_;
+        bool& is_active_;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -337,36 +336,36 @@ namespace hpx { namespace threads { namespace detail
     {
         scheduling_counters(std::int64_t& executed_threads,
                 std::int64_t& executed_thread_phases,
-                std::uint64_t& tfunc_time, std::uint64_t& exec_time,
+                std::int64_t& tfunc_time, std::int64_t& exec_time,
                 std::int64_t& idle_loop_count, std::int64_t& busy_loop_count,
-                std::uint8_t& is_active, std::uint64_t& background_work_duration)
+                bool& is_active, std::int64_t& background_work_duration)
           : executed_threads_(executed_threads),
             executed_thread_phases_(executed_thread_phases),
             tfunc_time_(tfunc_time),
             exec_time_(exec_time),
             idle_loop_count_(idle_loop_count),
             busy_loop_count_(busy_loop_count),
-            is_active_(is_active),
-            background_work_duration_(background_work_duration)
+            background_work_duration_(background_work_duration),
+            is_active_(is_active)
         {}
 
         std::int64_t& executed_threads_;
         std::int64_t& executed_thread_phases_;
-        std::uint64_t& tfunc_time_;
-        std::uint64_t& exec_time_;
+        std::int64_t& tfunc_time_;
+        std::int64_t& exec_time_;
         std::int64_t& idle_loop_count_;
         std::int64_t& busy_loop_count_;
-        std::uint8_t& is_active_;
-        std::uint64_t& background_work_duration_;
+        std::int64_t& background_work_duration_;
+        bool& is_active_;
     };
 #else
     struct scheduling_counters
     {
         scheduling_counters(std::int64_t& executed_threads,
                 std::int64_t& executed_thread_phases,
-                std::uint64_t& tfunc_time, std::uint64_t& exec_time,
+                std::int64_t& tfunc_time, std::int64_t& exec_time,
                 std::int64_t& idle_loop_count, std::int64_t& busy_loop_count,
-                std::uint8_t& is_active)
+                bool& is_active)
           : executed_threads_(executed_threads),
             executed_thread_phases_(executed_thread_phases),
             tfunc_time_(tfunc_time),
@@ -378,11 +377,11 @@ namespace hpx { namespace threads { namespace detail
 
         std::int64_t& executed_threads_;
         std::int64_t& executed_thread_phases_;
-        std::uint64_t& tfunc_time_;
-        std::uint64_t& exec_time_;
+        std::int64_t& tfunc_time_;
+        std::int64_t& exec_time_;
         std::int64_t& idle_loop_count_;
         std::int64_t& busy_loop_count_;
-        std::uint8_t& is_active_;
+        bool& is_active_;
     };
 
 #endif // HPX_HAVE_BACKGROUND_THREAD_COUNTERS
@@ -477,7 +476,7 @@ namespace hpx { namespace threads { namespace detail
 #if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
     bool call_background_thread(thread_id_type& background_thread,
         thread_data*& next_thrd, SchedulingPolicy& scheduler, std::size_t num_thread,
-        bool running, std::uint64_t& background_work_exec_time_init)
+        bool running, std::int64_t& background_work_exec_time_init)
 #else
     bool call_background_thread(thread_id_type& background_thread,
         thread_data*& next_thrd, SchedulingPolicy& scheduler, std::size_t num_thread,
@@ -574,7 +573,7 @@ namespace hpx { namespace threads { namespace detail
         std::int64_t& busy_loop_count = counters.busy_loop_count_;
 
 #if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
-        std::uint64_t& bg_work_exec_time_init = counters.background_work_duration_;
+        std::int64_t& bg_work_exec_time_init = counters.background_work_duration_;
 #endif    // HPX_HAVE_BACKGROUND_THREAD_COUNTERS
 
         idle_collect_rate idle_rate(counters.tfunc_time_, counters.exec_time_);

--- a/src/runtime/threads/executors/this_thread_executors.cpp
+++ b/src/runtime/threads/executors/this_thread_executors.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2019 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -345,12 +345,12 @@ namespace hpx { namespace threads { namespace executors { namespace detail
 
             // FIXME: turn these values into performance counters
             std::int64_t executed_threads = 0, executed_thread_phases = 0;
-            std::uint64_t overall_times = 0, thread_times = 0;
+            std::int64_t overall_times = 0, thread_times = 0;
             std::int64_t idle_loop_count = 0, busy_loop_count = 0;
-            std::uint8_t task_active = 0;
+            bool task_active = false;
 
 #if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
-            std::uint64_t bg_work = 0;
+            std::int64_t bg_work = 0;
             threads::detail::scheduling_counters counters(
                 executed_threads, executed_thread_phases,
                 overall_times, thread_times, idle_loop_count, busy_loop_count,

--- a/src/runtime/threads/executors/thread_pool_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_executors.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2019 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -341,12 +341,12 @@ namespace hpx { namespace threads { namespace executors { namespace detail
 
             // FIXME: turn these values into performance counters
             std::int64_t executed_threads = 0, executed_thread_phases = 0;
-            std::uint64_t overall_times = 0, thread_times = 0;
+            std::int64_t overall_times = 0, thread_times = 0;
             std::int64_t idle_loop_count = 0, busy_loop_count = 0;
-            std::uint8_t task_active = 0;
+            bool task_active = false;
 
 #if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
-            std::uint64_t bg_work = 0;
+            std::int64_t bg_work = 0;
             threads::detail::scheduling_counters counters(
                 executed_threads, executed_thread_phases,
                 overall_times, thread_times, idle_loop_count, busy_loop_count,


### PR DESCRIPTION
Fixes #3612

While this change did not show any significant overall performance improvements for the test applications I ran, I have seen in VTune that the amount of time spent in the scheduling_loop goes down significantly (almost a factor of 100). Therefor I'd suggest to merge this anyhow.