### PR TITLE
Various optimizations

### DIFF
--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2018 Hartmut Kaiser
+//  Copyright (c) 2007-2019 Hartmut Kaiser
 //  Copyright (c) 2013 Agustin Berge
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -526,10 +526,15 @@ namespace hpx { namespace lcos { namespace detail
 //         typename future_unwrap_result<future<R>>::result_type>::type
 //     unwrap(future<R> && future, error_code& ec = throws);
 
+    template <typename Allocator, typename Future>
+    typename traits::detail::shared_state_ptr<
+        typename future_unwrap_result<Future>::result_type>::type
+    unwrap_alloc(Allocator const& a, Future&& future, error_code& ec = throws);
+
     template <typename Future>
     typename hpx::traits::detail::shared_state_ptr<
         typename future_unwrap_result<Future>::result_type>::type
-    unwrap(Future && future, error_code& ec = throws);
+    unwrap(Future&& future, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Future>

--- a/hpx/runtime/agas/addressing_service.hpp
+++ b/hpx/runtime/agas/addressing_service.hpp
@@ -1231,12 +1231,9 @@ public:
 
     bool register_name(
         std::string const& name
-      , naming::id_type const& id
-      , error_code& ec = throws
-        )
-    {
-        return register_name_async(name, id).get(ec);
-    }
+        , naming::id_type const& id
+        , error_code& ec = throws
+    );
 
     /// \brief Unregister a global name (release any existing association)
     ///

--- a/hpx/runtime/agas/interface.hpp
+++ b/hpx/runtime/agas/interface.hpp
@@ -114,6 +114,10 @@ inline std::uint32_t get_num_localities(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+HPX_API_EXPORT std::string get_component_type_name(
+    components::component_type type, error_code& ec = throws);
+
+///////////////////////////////////////////////////////////////////////////////
 HPX_API_EXPORT lcos::future<std::vector<std::uint32_t> > get_num_threads();
 
 HPX_API_EXPORT std::vector<std::uint32_t> get_num_threads(

--- a/hpx/runtime/agas/server/primary_namespace.hpp
+++ b/hpx/runtime/agas/server/primary_namespace.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
-//  Copyright (c) 2012-2016 Hartmut Kaiser
+//  Copyright (c) 2012-2019 Hartmut Kaiser
 //  Copyright (c) 2016 Thomas Heller
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -21,6 +21,7 @@
 #include <hpx/runtime/naming/name.hpp>
 #include <hpx/traits/action_message_handler.hpp>
 #include <hpx/traits/action_serialization_filter.hpp>
+#include <hpx/util/internal_allocator.hpp>
 #include <hpx/util/tuple.hpp>
 
 #include <atomic>
@@ -337,17 +338,21 @@ struct HPX_EXPORT primary_namespace
         naming::gid_type locality_;
     };
 
+    using free_entry_allocator_type = util::internal_allocator<free_entry>;
+    using free_entry_list_type =
+        std::list<free_entry, free_entry_allocator_type>;
+
     void resolve_free_list(
         std::unique_lock<mutex_type>& l
       , std::list<refcnt_table_type::iterator> const& free_list
-      , std::list<free_entry>& free_entry_list
+      , free_entry_list_type& free_entry_list
       , naming::gid_type const& lower
       , naming::gid_type const& upper
       , error_code& ec
         );
 
     void decrement_sweep(
-        std::list<free_entry>& free_list
+        free_entry_list_type& free_list
       , naming::gid_type const& lower
       , naming::gid_type const& upper
       , std::int64_t credits
@@ -355,7 +360,7 @@ struct HPX_EXPORT primary_namespace
         );
 
     void free_components_sync(
-        std::list<free_entry>& free_list
+        free_entry_list_type& free_list
       , naming::gid_type const& lower
       , naming::gid_type const& upper
       , error_code& ec

--- a/hpx/runtime/components/component_type.hpp
+++ b/hpx/runtime/components/component_type.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2018 Hartmut Kaiser
+//  Copyright (c) 2007-2019 Hartmut Kaiser
 //  Copyright (c)      2017 Thomas Heller
 //  Copyright (c)      2011 Bryce Lelbach
 //
@@ -14,11 +14,12 @@
 #include <hpx/util/assert.hpp>
 #include <hpx/util/atomic_count.hpp>
 #include <hpx/util/decay.hpp>
-#include <hpx/util/detail/pp/strip_parens.hpp>
 #include <hpx/util/detail/pp/cat.hpp>
 #include <hpx/util/detail/pp/expand.hpp>
 #include <hpx/util/detail/pp/nargs.hpp>
 #include <hpx/util/detail/pp/stringize.hpp>
+#include <hpx/util/detail/pp/strip_parens.hpp>
+#include <hpx/util_fwd.hpp>
 
 #include <cstdint>
 #include <string>
@@ -86,11 +87,15 @@ namespace hpx { namespace components
         factory_check    = 2
     };
 
+    // access data related to component instance counts
     HPX_EXPORT bool& enabled(component_type type);
     HPX_EXPORT util::atomic_count& instance_count(component_type type);
     typedef void(*component_deleter_type)(
         hpx::naming::gid_type const&, hpx::naming::address const&);
     HPX_EXPORT component_deleter_type& deleter(component_type type);
+
+    HPX_EXPORT bool enumerate_instance_counts(
+        util::unique_function_nonser<bool(component_type)> const& f);
 
     /// \brief Return the string representation for a given component type id
     HPX_EXPORT std::string const get_component_type_name(component_type type);

--- a/hpx/runtime/components/server/component.hpp
+++ b/hpx/runtime/components/server/component.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2019 Hartmut Kaiser
 //  Copyright (c) 2015-2017 Thomas Heller
 //  Copyright (c)      2011 Bryce Lelbach
 //
@@ -10,6 +10,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/util/assert.hpp>
+#include <hpx/util/internal_allocator.hpp>
 
 #include <cstddef>
 #include <new>
@@ -17,7 +18,8 @@
 
 namespace hpx { namespace components {
 
-    namespace detail {
+    namespace detail
+    {
         ///////////////////////////////////////////////////////////////////////
         template <typename Component>
         struct simple_heap
@@ -25,14 +27,19 @@ namespace hpx { namespace components {
             void* alloc(std::size_t count)
             {
                 HPX_ASSERT(1 == count);
-                return ::operator new(sizeof(Component));
+                return alloc_.allocate(count);
             }
             void free(void* p, std::size_t count)
             {
                 HPX_ASSERT(1 == count);
-                ::operator delete(p);
+                alloc_.deallocate(static_cast<Component*>(p), count);
             }
+
+            static util::internal_allocator<Component> alloc_;
         };
+
+        template <typename Component>
+        util::internal_allocator<Component> simple_heap<Component>::alloc_;
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/components/server/wrapper_heap.hpp
+++ b/hpx/runtime/components/server/wrapper_heap.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 1998-2017 Hartmut Kaiser
+//  Copyright (c) 1998-2019 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -13,6 +13,7 @@
 #include <hpx/runtime_fwd.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/generate_unique_ids.hpp>
+#include <hpx/util/internal_allocator.hpp>
 #include <hpx/util/itt_notify.hpp>
 #include <hpx/util/wrapper_heap_base.hpp>
 
@@ -31,12 +32,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace components { namespace detail
 {
-#if HPX_DEBUG_WRAPPER_HEAP != 0
-#  define HPX_WRAPPER_HEAP_INITIALIZED_MEMORY 1
-#else
-#  define HPX_WRAPPER_HEAP_INITIALIZED_MEMORY 0
-#endif
-
     ///////////////////////////////////////////////////////////////////////////
     namespace one_size_heap_allocators
     {
@@ -50,11 +45,11 @@ namespace hpx { namespace components { namespace detail
         {
             static void* alloc(std::size_t size)
             {
-                return ::malloc(size);
+                return alloc_.allocate(size);
             }
-            static void free(void* p)
+            static void free(void* p, std::size_t count)
             {
-                ::free(p);
+                alloc_.deallocate(static_cast<char*>(p), count);
             }
             static void* realloc(std::size_t &, void *)
             {
@@ -63,6 +58,8 @@ namespace hpx { namespace components { namespace detail
                 // return nullptr
                 return nullptr;
             }
+
+            HPX_EXPORT static util::internal_allocator<char> alloc_;
         };
     }
 
@@ -172,7 +169,5 @@ namespace hpx { namespace components { namespace detail
 }}} // namespace hpx::components::detail
 
 #include <hpx/config/warnings_suffix.hpp>
-
-#undef HPX_WRAPPER_HEAP_INITIALIZED_MEMORY
 
 #endif

--- a/hpx/runtime/naming/id_type.hpp
+++ b/hpx/runtime/naming/id_type.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2019 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/runtime/serialization/serialization_fwd.hpp>
+#include <hpx/util/internal_allocator.hpp>
 
 #include <boost/intrusive_ptr.hpp>
 
@@ -35,7 +36,7 @@ namespace hpx { namespace naming
     private:
         friend struct detail::id_type_impl;
 
-        id_type(detail::id_type_impl* p)
+        id_type(detail::id_type_impl* p) noexcept
           : gid_(p)
         {}
 
@@ -49,30 +50,33 @@ namespace hpx { namespace naming
                                     ///< credits when sent
         };
 
-        id_type() {}
+        id_type() = default;
 
         id_type(std::uint64_t lsb_id, management_type t);
         id_type(gid_type const& gid, management_type t);
         id_type(std::uint64_t msb_id, std::uint64_t lsb_id, management_type t);
 
-        id_type(id_type const & o) : gid_(o.gid_) {}
-        id_type(id_type && o)
+        id_type(id_type const& o) noexcept
+          : gid_(o.gid_)
+        {
+        }
+        id_type(id_type && o) noexcept
           : gid_(std::move(o.gid_))
         {
             o.gid_.reset();
         }
 
-        id_type & operator=(id_type const & o)
+        id_type & operator=(id_type const & o) noexcept
         {
             if (this != &o)
                 gid_ = o.gid_;
             return *this;
         }
-        id_type & operator=(id_type && o)
+        id_type & operator=(id_type && o) noexcept
         {
             if (this != &o)
             {
-                gid_ = o.gid_;
+                gid_ = std::move(o.gid_);
                 o.gid_.reset();
             }
             return *this;
@@ -88,7 +92,7 @@ namespace hpx { namespace naming
         id_type& operator++();
         id_type operator++(int);
 
-        explicit operator bool() const noexcept;
+        explicit operator bool() const;
 
         // comparison is required as well
         friend bool operator== (id_type const& lhs, id_type const& rhs);
@@ -111,21 +115,22 @@ namespace hpx { namespace naming
         // care, or better, don't use this at all.
         void make_unmanaged() const;
 
-    private:
-        friend HPX_API_EXPORT gid_type get_parcel_dest_gid(id_type const& id);
+        static void deallocate(detail::id_type_impl* p);
 
+    private:
         friend HPX_EXPORT std::ostream& operator<<(std::ostream& os,
             id_type const& id);
 
         friend class hpx::serialization::access;
 
         void save(serialization::output_archive& ar, unsigned int version) const;
-
         void load(serialization::input_archive& ar, unsigned int version);
 
         HPX_SERIALIZATION_SPLIT_MEMBER()
 
         boost::intrusive_ptr<detail::id_type_impl> gid_;
+
+        static util::internal_allocator<detail::id_type_impl> alloc_;
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/naming/id_type.hpp
+++ b/hpx/runtime/naming/id_type.hpp
@@ -9,7 +9,6 @@
 #include <hpx/config.hpp>
 #include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/runtime/serialization/serialization_fwd.hpp>
-#include <hpx/util/internal_allocator.hpp>
 
 #include <boost/intrusive_ptr.hpp>
 
@@ -36,10 +35,6 @@ namespace hpx { namespace naming
     private:
         friend struct detail::id_type_impl;
 
-        id_type(detail::id_type_impl* p) noexcept
-          : gid_(p)
-        {}
-
     public:
         enum management_type
         {
@@ -63,22 +58,16 @@ namespace hpx { namespace naming
         id_type(id_type && o) noexcept
           : gid_(std::move(o.gid_))
         {
-            o.gid_.reset();
         }
 
         id_type & operator=(id_type const & o) noexcept
         {
-            if (this != &o)
-                gid_ = o.gid_;
+            gid_ = o.gid_;
             return *this;
         }
         id_type & operator=(id_type && o) noexcept
         {
-            if (this != &o)
-            {
-                gid_ = std::move(o.gid_);
-                o.gid_.reset();
-            }
+            gid_ = std::move(o.gid_);
             return *this;
         }
 
@@ -115,8 +104,6 @@ namespace hpx { namespace naming
         // care, or better, don't use this at all.
         void make_unmanaged() const;
 
-        static void deallocate(detail::id_type_impl* p);
-
     private:
         friend HPX_EXPORT std::ostream& operator<<(std::ostream& os,
             id_type const& id);
@@ -129,8 +116,6 @@ namespace hpx { namespace naming
         HPX_SERIALIZATION_SPLIT_MEMBER()
 
         boost::intrusive_ptr<detail::id_type_impl> gid_;
-
-        static util::internal_allocator<detail::id_type_impl> alloc_;
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/naming/id_type_impl.hpp
+++ b/hpx/runtime/naming/id_type_impl.hpp
@@ -19,45 +19,29 @@
 namespace hpx { namespace naming
 {
     ///////////////////////////////////////////////////////////////////////////
-    inline void id_type::deallocate(detail::id_type_impl* p)
-    {
-        using detail::id_type_impl;
-        p->~id_type_impl();
-        alloc_.deallocate(p, 1);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
     // the local gid is actually just a wrapper around the real thing
     inline id_type::id_type(std::uint64_t lsb_id, management_type t)
-      : gid_(nullptr)
+      : gid_(new detail::id_type_impl(detail::id_type_impl::init_no_addref{}, 0,
+                 lsb_id, static_cast<detail::id_type_management>(t)),
+            false)
     {
-        detail::id_type_impl* p = alloc_.allocate(1);
-        new (p) detail::id_type_impl(
-            0, lsb_id, static_cast<detail::id_type_management>(t));
-        gid_.reset(p, false);
     }
 
     inline id_type::id_type(gid_type const& gid, management_type t)
-      : gid_(nullptr)
+      : gid_(new detail::id_type_impl(detail::id_type_impl::init_no_addref{},
+                 gid, static_cast<detail::id_type_management>(t)),
+            false)
     {
-        detail::id_type_impl* p = alloc_.allocate(1);
-        new (p) detail::id_type_impl(
-            gid, static_cast<detail::id_type_management>(t));
-        gid_.reset(p, false);
-
         if (t == unmanaged)
             detail::strip_internal_bits_except_dont_cache_from_gid(*gid_);
     }
 
-    inline id_type::id_type(std::uint64_t msb_id, std::uint64_t lsb_id,
-            management_type t)
-      : gid_(nullptr)
+    inline id_type::id_type(
+            std::uint64_t msb_id, std::uint64_t lsb_id, management_type t)
+      : gid_(new detail::id_type_impl(detail::id_type_impl::init_no_addref{},
+                 msb_id, lsb_id, static_cast<detail::id_type_management>(t)),
+            false)
     {
-        detail::id_type_impl* p = alloc_.allocate(1);
-        new (p) detail::id_type_impl(
-            msb_id, lsb_id, static_cast<detail::id_type_management>(t));
-        gid_.reset(p, false);
-
         if (t == unmanaged)
             detail::strip_internal_bits_except_dont_cache_from_gid(*gid_);
     }

--- a/hpx/runtime/naming/id_type_impl.hpp
+++ b/hpx/runtime/naming/id_type_impl.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2019 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime/naming/name.hpp>
+#include <hpx/util/internal_allocator.hpp>
 
 #include <cstdint>
 
@@ -18,25 +19,45 @@
 namespace hpx { namespace naming
 {
     ///////////////////////////////////////////////////////////////////////////
+    inline void id_type::deallocate(detail::id_type_impl* p)
+    {
+        using detail::id_type_impl;
+        p->~id_type_impl();
+        alloc_.deallocate(p, 1);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     // the local gid is actually just a wrapper around the real thing
     inline id_type::id_type(std::uint64_t lsb_id, management_type t)
-        : gid_(new detail::id_type_impl(0, lsb_id,
-            static_cast<detail::id_type_management>(t)))
-    {}
+      : gid_(nullptr)
+    {
+        detail::id_type_impl* p = alloc_.allocate(1);
+        new (p) detail::id_type_impl(
+            0, lsb_id, static_cast<detail::id_type_management>(t));
+        gid_.reset(p, false);
+    }
 
     inline id_type::id_type(gid_type const& gid, management_type t)
-        : gid_(new detail::id_type_impl(gid,
-            static_cast<detail::id_type_management>(t)))
+      : gid_(nullptr)
     {
+        detail::id_type_impl* p = alloc_.allocate(1);
+        new (p) detail::id_type_impl(
+            gid, static_cast<detail::id_type_management>(t));
+        gid_.reset(p, false);
+
         if (t == unmanaged)
             detail::strip_internal_bits_except_dont_cache_from_gid(*gid_);
     }
 
     inline id_type::id_type(std::uint64_t msb_id, std::uint64_t lsb_id,
             management_type t)
-        : gid_(new detail::id_type_impl(msb_id, lsb_id,
-            static_cast<detail::id_type_management>(t)))
+      : gid_(nullptr)
     {
+        detail::id_type_impl* p = alloc_.allocate(1);
+        new (p) detail::id_type_impl(
+            msb_id, lsb_id, static_cast<detail::id_type_management>(t));
+        gid_.reset(p, false);
+
         if (t == unmanaged)
             detail::strip_internal_bits_except_dont_cache_from_gid(*gid_);
     }
@@ -61,7 +82,7 @@ namespace hpx { namespace naming
         return id_type((*gid_)++, unmanaged);
     }
 
-    inline id_type::operator bool() const noexcept
+    inline id_type::operator bool() const
     {
         return gid_ && *gid_;
     }

--- a/hpx/runtime/naming/name.hpp
+++ b/hpx/runtime/naming/name.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2018 Hartmut Kaiser
+//  Copyright (c) 2007-2019 Hartmut Kaiser
 //  Copyright (c) 2011 Bryce Lelbach
 //  Copyright (c) 2007 Richard D. Guidry Jr.
 //
@@ -794,31 +794,37 @@ namespace hpx { namespace naming
 
         private:
             typedef void (*deleter_type)(detail::id_type_impl*);
-            static deleter_type get_deleter(id_type_management t);
+            static deleter_type get_deleter(id_type_management t) noexcept;
 
         public:
-            id_type_impl()
-              : count_(0), type_(unknown_deleter)
+            id_type_impl() noexcept
+              : count_(1), type_(unknown_deleter)
             {}
 
-            explicit id_type_impl (std::uint64_t lsb_id, id_type_management t)
-              : gid_type(0, lsb_id), count_(0), type_(t)
+            explicit id_type_impl(
+                    std::uint64_t lsb_id, id_type_management t) noexcept
+              : gid_type(0, lsb_id)
+              , count_(1)
+              , type_(t)
             {}
 
             explicit id_type_impl (std::uint64_t msb_id, std::uint64_t lsb_id,
-                    id_type_management t)
-              : gid_type(msb_id, lsb_id), count_(0), type_(t)
+                    id_type_management t) noexcept
+              : gid_type(msb_id, lsb_id), count_(1), type_(t)
             {}
 
-            explicit id_type_impl (gid_type const& gid, id_type_management t)
-              : gid_type(gid), count_(0), type_(t)
+            explicit id_type_impl(
+                    gid_type const& gid, id_type_management t) noexcept
+              : gid_type(gid)
+              , count_(1)
+              , type_(t)
             {}
 
-            id_type_management get_management_type() const
+            id_type_management get_management_type() const noexcept
             {
                 return type_;
             }
-            void set_management_type(id_type_management type)
+            void set_management_type(id_type_management type) noexcept
             {
                 type_ = type;
             }
@@ -843,9 +849,6 @@ namespace hpx { namespace naming
             id_type_management type_;
         };
     }
-
-    ///////////////////////////////////////////////////////////////////////////
-    HPX_API_EXPORT gid_type get_parcel_dest_gid(id_type const& id);
 }}
 
 #include <hpx/runtime/naming/id_type.hpp>

--- a/hpx/runtime/naming/name.hpp
+++ b/hpx/runtime/naming/name.hpp
@@ -20,6 +20,7 @@
 #include <hpx/util/assert.hpp>
 #include <hpx/util/atomic_count.hpp>
 #include <hpx/util/detail/yield_k.hpp>
+#include <hpx/util/internal_allocator.hpp>
 #include <hpx/util/itt_notify.hpp>
 #include <hpx/util/register_locks.hpp>
 
@@ -797,24 +798,32 @@ namespace hpx { namespace naming
             static deleter_type get_deleter(id_type_management t) noexcept;
 
         public:
+            // This is a tag type used to convey the information that the caller is
+            // _not_ going to addref the future_data instance
+            struct init_no_addref {};
+
+            // called by serialization, needs to start off with a reference
+            // count of zero
             id_type_impl() noexcept
-              : count_(1), type_(unknown_deleter)
+              : count_(0), type_(unknown_deleter)
             {}
 
-            explicit id_type_impl(
+            explicit id_type_impl(init_no_addref,
                     std::uint64_t lsb_id, id_type_management t) noexcept
               : gid_type(0, lsb_id)
               , count_(1)
               , type_(t)
             {}
 
-            explicit id_type_impl (std::uint64_t msb_id, std::uint64_t lsb_id,
-                    id_type_management t) noexcept
-              : gid_type(msb_id, lsb_id), count_(1), type_(t)
+            explicit id_type_impl(init_no_addref, std::uint64_t msb_id,
+                    std::uint64_t lsb_id, id_type_management t) noexcept
+              : gid_type(msb_id, lsb_id)
+              , count_(1)
+              , type_(t)
             {}
 
-            explicit id_type_impl(
-                    gid_type const& gid, id_type_management t) noexcept
+            explicit id_type_impl(init_no_addref, gid_type const& gid,
+                    id_type_management t) noexcept
               : gid_type(gid)
               , count_(1)
               , type_(t)
@@ -836,6 +845,31 @@ namespace hpx { namespace naming
 
             HPX_SERIALIZATION_SPLIT_MEMBER()
 
+            // custom allocator support
+            static void* operator new(std::size_t size)
+            {
+                if (size != sizeof(id_type_impl))
+                {
+                    return ::operator new (size);
+                }
+                return alloc_.allocate(1);
+            }
+
+            static void operator delete(void *p, std::size_t size)
+            {
+                if (p == nullptr)
+                {
+                    return;
+                }
+
+                if (size != sizeof(id_type_impl))
+                {
+                    return ::operator delete (p);
+                }
+
+                return alloc_.deallocate(static_cast<id_type_impl*>(p), 1);
+            }
+
         private:
             // credit management (called during serialization), this function
             // has to be 'const' as save() above has to be 'const'.
@@ -847,6 +881,8 @@ namespace hpx { namespace naming
 
             util::atomic_count count_;
             id_type_management type_;
+
+            static util::internal_allocator<id_type_impl> alloc_;
         };
     }
 }}

--- a/hpx/runtime/threads/policies/thread_queue.hpp
+++ b/hpx/runtime/threads/policies/thread_queue.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2019 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -20,6 +20,7 @@
 #include <hpx/util/function.hpp>
 #include <hpx/util/get_and_reset_value.hpp>
 #include <hpx/util/high_resolution_clock.hpp>
+#include <hpx/util/internal_allocator.hpp>
 #include <hpx/util/unlock_guard.hpp>
 
 #ifdef HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES
@@ -171,7 +172,12 @@ namespace hpx { namespace threads { namespace policies
         int const max_terminated_threads;
 
         // this is the type of a map holding all threads (except depleted ones)
-        typedef std::unordered_set<thread_id_type> thread_map_type;
+        using thread_map_type =
+            std::unordered_set<thread_id_type, std::hash<thread_id_type>,
+                std::equal_to<>, util::internal_allocator<thread_id_type>>;
+
+        using thread_heap_type =
+            std::list<thread_id_type, util::internal_allocator<thread_id_type>>;
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
         typedef
@@ -206,7 +212,7 @@ namespace hpx { namespace threads { namespace policies
 
             std::ptrdiff_t stacksize = data.stacksize;
 
-            std::list<thread_id_type>* heap = nullptr;
+            thread_heap_type* heap = nullptr;
 
             if (stacksize == get_stack_size(thread_stacksize_small))
             {
@@ -265,12 +271,15 @@ namespace hpx { namespace threads { namespace policies
             {
                 hpx::util::unlock_guard<Lock> ull(lk);
 
-
                 // Allocate a new thread object.
-                thrd = thread_id_type(
-                    new threads::thread_data(data, this, state));
+                threads::thread_data* p = thread_alloc_.allocate(1);
+                new (p) threads::thread_data(data, this, state);
+                thrd = thread_id_type(p);
             }
         }
+
+        static util::internal_allocator<threads::thread_data> thread_alloc_;
+        static util::internal_allocator<task_description> task_description_alloc_;
 
         ///////////////////////////////////////////////////////////////////////
         // add new threads if there is some amount of work available
@@ -293,8 +302,6 @@ namespace hpx { namespace threads { namespace policies
                     ++addfrom->new_tasks_wait_count_;
                 }
 #endif
-
-
                 // measure thread creation time
                 util::block_profiler_wrapper<add_new_tag> bp(add_new_logger_);
 
@@ -305,7 +312,8 @@ namespace hpx { namespace threads { namespace policies
 
                 create_thread_object(thrd, data, state, lk);
 
-                delete task;
+                task->~task_description();
+                task_description_alloc_.deallocate(task, 1);
 
                 // add the new entry to the map of all threads
                 std::pair<thread_map_type::iterator, bool> p =
@@ -462,7 +470,7 @@ namespace hpx { namespace threads { namespace policies
                     bool deleted = thread_map_.erase(tid) != 0;
                     HPX_ASSERT(deleted);
                     if (deleted) {
-                        delete todelete;
+                        deallocate(todelete);
                         --thread_map_count_;
                         HPX_ASSERT(thread_map_count_ >= 0);
                     }
@@ -573,19 +581,26 @@ namespace hpx { namespace threads { namespace policies
             add_new_logger_("thread_queue::add_new")
         {}
 
+        static void deallocate(threads::thread_data* p)
+        {
+            using threads::thread_data;
+            p->~thread_data();
+            thread_alloc_.deallocate(p, 1);
+        }
+
         ~thread_queue()
         {
             for(auto t: thread_heap_small_)
-                delete t.get();
+                deallocate(t.get());
 
             for(auto t: thread_heap_medium_)
-                delete t.get();
+                deallocate(t.get());
 
             for(auto t: thread_heap_large_)
-                delete t.get();
+                deallocate(t.get());
 
             for(auto t: thread_heap_huge_)
-                delete t.get();
+                deallocate(t.get());
         }
 
         void set_max_count(std::size_t max_count = max_thread_count)
@@ -767,15 +782,14 @@ namespace hpx { namespace threads { namespace policies
             // later thread creation
             ++new_tasks_count_;
 
+            task_description* td = task_description_alloc_.allocate(1);
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
-            new_tasks_.push(new task_description(
-                std::move(data), initial_state,
-                util::high_resolution_clock::now()
-            ));
+            new (td) task_description(std::move(data), initial_state,
+                util::high_resolution_clock::now());
 #else
-            new_tasks_.push(new task_description( //-V106
-                std::move(data), initial_state));
+            new (td) task_description(std::move(data), initial_state); //-V106
 #endif
+            new_tasks_.push(td);
             if (&ec != &throws)
                 ec = make_success_code();
         }
@@ -809,8 +823,6 @@ namespace hpx { namespace threads { namespace policies
             task_description* task;
             while (src->new_tasks_.pop(task))
             {
-
-
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
                 if (maintain_queue_wait_times) {
                     std::int64_t now = util::high_resolution_clock::now();
@@ -1097,46 +1109,35 @@ namespace hpx { namespace threads { namespace policies
         void on_error(std::size_t num_thread, std::exception_ptr const& e) {}
 
     private:
-        mutable mutex_type mtx_;                    ///< mutex protecting the members
+        mutable mutex_type mtx_;            // mutex protecting the members
 
-        thread_map_type thread_map_;
-        ///< mapping of thread id's to HPX-threads
-        std::atomic<std::int64_t> thread_map_count_;
-        ///< overall count of work items
+        thread_map_type thread_map_;        // mapping of thread id's to HPX-threads
+        std::atomic<std::int64_t> thread_map_count_; // overall count of work items
 
-        work_items_type work_items_;
-        ///< list of active work items
-        std::atomic<std::int64_t> work_items_count_;
-        ///< count of active work items
+        work_items_type work_items_;        // list of active work items
+        std::atomic<std::int64_t> work_items_count_; // count of active work items
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
-        std::atomic<std::int64_t> work_items_wait_;
-        ///< overall wait time of work items
-        std::atomic<std::int64_t> work_items_wait_count_;
-        ///< overall number of work items in queue
+        std::atomic<std::int64_t> work_items_wait_; // overall wait time of work items
+        std::atomic<std::int64_t> work_items_wait_count_; // overall number of
+                                                          // work items in queue
 #endif
-        terminated_items_type terminated_items_;     ///< list of terminated threads
-        std::atomic<std::int64_t> terminated_items_count_;
-        ///< count of terminated items
+        terminated_items_type terminated_items_;    // list of terminated threads
+        std::atomic<std::int64_t> terminated_items_count_; // count of terminated items
 
-        std::size_t max_count_;
-        ///< maximum number of existing HPX-threads
-        task_items_type new_tasks_;
-        ///< list of new tasks to run
+        std::size_t max_count_;     // maximum number of existing HPX-threads
+        task_items_type new_tasks_; // list of new tasks to run
 
-        std::atomic<std::int64_t> new_tasks_count_;
-        ///< count of new tasks to run
+        std::atomic<std::int64_t> new_tasks_count_; // count of new tasks to run
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
-        std::atomic<std::int64_t> new_tasks_wait_;
-        ///< overall wait time of new tasks
-        std::atomic<std::int64_t> new_tasks_wait_count_;
-        ///< overall number tasks waited
+        std::atomic<std::int64_t> new_tasks_wait_;  // overall wait time of new tasks
+        std::atomic<std::int64_t> new_tasks_wait_count_; // overall number tasks waited
 #endif
 
-        std::list<thread_id_type> thread_heap_small_;
-        std::list<thread_id_type> thread_heap_medium_;
-        std::list<thread_id_type> thread_heap_large_;
-        std::list<thread_id_type> thread_heap_huge_;
+        thread_heap_type thread_heap_small_;
+        thread_heap_type thread_heap_medium_;
+        thread_heap_type thread_heap_large_;
+        thread_heap_type thread_heap_huge_;
 
 #ifdef HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES
         std::uint64_t add_new_time_;
@@ -1150,18 +1151,31 @@ namespace hpx { namespace threads { namespace policies
         // # of times our associated worker-thread looked for work in work_items
         std::atomic<std::int64_t> pending_accesses_;
 
+        // count of work_items stolen from this queue
         std::atomic<std::int64_t> stolen_from_pending_;
-        ///< count of work_items stolen from this queue
+        // count of new_tasks stolen from this queue
         std::atomic<std::int64_t> stolen_from_staged_;
-        ///< count of new_tasks stolen from this queue
+        // count of work_items stolen to this queue from other queues
         std::atomic<std::int64_t> stolen_to_pending_;
-        ///< count of work_items stolen to this queue from other queues
+        // count of new_tasks stolen to this queue from other queues
         std::atomic<std::int64_t> stolen_to_staged_;
-        ///< count of new_tasks stolen to this queue from other queues
 #endif
 
         util::block_profiler<add_new_tag> add_new_logger_;
     };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Mutex, typename PendingQueuing, typename StagedQueuing,
+        typename TerminatedQueuing>
+    util::internal_allocator<threads::thread_data> thread_queue<Mutex,
+        PendingQueuing, StagedQueuing, TerminatedQueuing>::thread_alloc_;
+
+    template <typename Mutex, typename PendingQueuing, typename StagedQueuing,
+        typename TerminatedQueuing>
+    util::internal_allocator<typename thread_queue<Mutex, PendingQueuing,
+            StagedQueuing, TerminatedQueuing>::task_description>
+        thread_queue<Mutex, PendingQueuing, StagedQueuing,
+            TerminatedQueuing>::task_description_alloc_;
 }}}
 
 #endif

--- a/src/performance_counters/server/component_instance_counter.cpp
+++ b/src/performance_counters/server/component_instance_counter.cpp
@@ -1,16 +1,18 @@
-//  Copyright (c) 2007-2012 Hartmut Kaiser
+//  Copyright (c) 2007-2019 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/runtime/components/component_type.hpp>
-#include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>
+#include <hpx/performance_counters/counters.hpp>
 #include <hpx/runtime/agas/addressing_service.hpp>
+#include <hpx/runtime/agas/interface.hpp>
+#include <hpx/runtime/components/component_type.hpp>
 #include <hpx/util/function.hpp>
 
 #include <cstdint>
+#include <sstream>
 #include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -44,10 +46,23 @@ namespace hpx { namespace performance_counters { namespace detail
                 }
 
                 if (paths.parameters_.empty()) {
+                    std::stringstream strm;
+                    strm << "invalid instance counter parameter: must specify "
+                            "a component type\n"
+                            "known component types:\n";
+
+                    components::enumerate_instance_counts(
+                        [&strm](components::component_type type) -> bool
+                        {
+                            strm << "  "
+                                 << agas::get_component_type_name(type)
+                                 << "\n";
+                            return true;
+                        });
+
                     HPX_THROWS_IF(ec, bad_parameter,
-                        "component_instance_counter_creator",
-                        "invalid instance counter parameter: must specify "
-                        "a component type");
+                        "component_instance_counter_creator", strm.str());
+
                     return naming::invalid_gid;
                 }
 

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -1032,8 +1032,10 @@ namespace hpx
             return naming::invalid_id;
         }
 
-        return naming::id_type(hpx::applier::get_applier().get_raw_locality(ec),
+        static naming::id_type here(
+            hpx::applier::get_applier().get_raw_locality(ec),
             naming::id_type::unmanaged);
+        return here;
     }
 
     naming::id_type find_root_locality(error_code& ec)

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
-//  Copyright (c) 2011-2018 Hartmut Kaiser
+//  Copyright (c) 2011-2019 Hartmut Kaiser
 //  Copyright (c) 2016 Parsa Amini
 //  Copyright (c) 2016 Thomas Heller
 //
@@ -1012,8 +1012,8 @@ bool addressing_service::resolve_locally_known_addresses(
             addr.locality_ = dest;
             addr.type_ = hpx::components::component_agas_primary_namespace;
             // addr.address_ will be supplied on the target locality
-            return true;
         }
+        return true;
     }
 
     if (HPX_AGAS_SYMBOL_NS_LSB == lsb)
@@ -1030,7 +1030,6 @@ bool addressing_service::resolve_locally_known_addresses(
             addr.type_ = hpx::components::component_agas_symbol_namespace;
             // addr.address_ will be supplied on the target locality
         }
-
         return true;
     }
 

--- a/src/runtime/agas/interface.cpp
+++ b/src/runtime/agas/interface.cpp
@@ -48,6 +48,10 @@ bool register_name(
   , error_code& ec
     )
 {
+    if (&ec == &throws)
+    {
+        return register_name(launch::sync, name, id.get_gid());
+    }
     return register_name(name, id).get(ec);
 }
 

--- a/src/runtime/agas/interface.cpp
+++ b/src/runtime/agas/interface.cpp
@@ -50,7 +50,8 @@ bool register_name(
 {
     if (&ec == &throws)
     {
-        return register_name(launch::sync, name, id.get_gid());
+        naming::resolver_client& agas_ = naming::get_agas_client();
+        return agas_.register_name(name, id);
     }
     return register_name(name, id).get(ec);
 }

--- a/src/runtime/agas/interface.cpp
+++ b/src/runtime/agas/interface.cpp
@@ -168,6 +168,13 @@ std::uint32_t get_num_overall_threads(
     return agas_.get_num_overall_threads(ec);
 }
 
+std::string get_component_type_name(
+    components::component_type type, error_code& ec)
+{
+    naming::resolver_client& agas_ = naming::get_agas_client();
+    return agas_.get_component_type_name(type, ec);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // bool is_local_address(
 //     naming::gid_type const& gid

--- a/src/runtime/agas/server/primary_namespace_server.cpp
+++ b/src/runtime/agas/server/primary_namespace_server.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
-//  Copyright (c) 2012-2017 Hartmut Kaiser
+//  Copyright (c) 2012-2019 Hartmut Kaiser
 //  Copyright (c) 2016 Thomas Heller
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -684,7 +684,7 @@ std::vector<std::int64_t> primary_namespace::decrement_credit(
         // Decrement.
         if (credits < 0)
         {
-            std::list<free_entry> free_list;
+            free_entry_list_type free_list;
             decrement_sweep(free_list, lower, upper, -credits, hpx::throws);
 
             free_components_sync(free_list, lower, upper, hpx::throws);
@@ -887,7 +887,7 @@ void primary_namespace::increment(
 void primary_namespace::resolve_free_list(
     std::unique_lock<mutex_type>& l
   , std::list<refcnt_table_type::iterator> const& free_list
-  , std::list<free_entry>& free_entry_list
+  , free_entry_list_type& free_entry_list
   , naming::gid_type const& lower
   , naming::gid_type const& upper
   , error_code& ec
@@ -978,7 +978,7 @@ void primary_namespace::resolve_free_list(
 
 ///////////////////////////////////////////////////////////////////////////////
 void primary_namespace::decrement_sweep(
-    std::list<free_entry>& free_entry_list
+    free_entry_list_type& free_entry_list
   , naming::gid_type const& lower
   , naming::gid_type const& upper
   , std::int64_t credits
@@ -1102,7 +1102,7 @@ void primary_namespace::decrement_sweep(
 
 ///////////////////////////////////////////////////////////////////////////////
 void primary_namespace::free_components_sync(
-    std::list<free_entry>& free_list
+    free_entry_list_type& free_list
   , naming::gid_type const& lower
   , naming::gid_type const& upper
   , error_code& ec

--- a/src/runtime/components/component_type.cpp
+++ b/src/runtime/components/component_type.cpp
@@ -20,6 +20,7 @@
 #include <map>
 #include <mutex>
 #include <string>
+#include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace components

--- a/src/runtime/components/server/wrapper_heap.cpp
+++ b/src/runtime/components/server/wrapper_heap.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 1998-2017 Hartmut Kaiser
+//  Copyright (c) 1998-2019 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -31,6 +31,11 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace components { namespace detail
 {
+    namespace one_size_heap_allocators
+    {
+        util::internal_allocator<char> fixed_mallocator::alloc_;
+    }
+
 #if HPX_DEBUG_WRAPPER_HEAP != 0
 #define HPX_WRAPPER_HEAP_INITIALIZED_MEMORY 1
 
@@ -383,7 +388,9 @@ namespace hpx { namespace components { namespace detail
                     << " with " << size() << " allocated object(s)!";
             }
 
-            allocator_type::free(pool_);
+            std::size_t const total_num_bytes =
+                parameters_.capacity * parameters_.element_size;
+            allocator_type::free(pool_, total_num_bytes);
             pool_ = first_free_ = nullptr;
             free_size_ = 0;
         }

--- a/src/runtime/naming/name.cpp
+++ b/src/runtime/naming/name.cpp
@@ -116,7 +116,7 @@ HPX_IS_BITWISE_SERIALIZABLE(hpx::naming::detail::gid_serialization_data)
 namespace hpx { namespace naming
 {
     ///////////////////////////////////////////////////////////////////////////
-    util::internal_allocator<detail::id_type_impl> id_type::alloc_;
+    util::internal_allocator<detail::id_type_impl> detail::id_type_impl::alloc_;
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail
@@ -127,7 +127,7 @@ namespace hpx { namespace naming
             if (!get_runtime_ptr())
             {
                 // delete local gid representation in any case
-                id_type::deallocate(p);
+                delete p;
                 return;
             }
 
@@ -190,7 +190,7 @@ namespace hpx { namespace naming
                     }
                 }
             }
-            id_type::deallocate(p);   // delete local gid representation in any case
+            delete p;   // delete local gid representation in any case
         }
 
         // custom deleter for managed gid_types, will be called when the last
@@ -207,7 +207,7 @@ namespace hpx { namespace naming
             else
             {
                 // delete local gid representation if needed
-                id_type::deallocate(p);
+                delete p;
             }
         }
 
@@ -215,7 +215,7 @@ namespace hpx { namespace naming
         // copy of the corresponding naming::id_type goes out of scope
         void gid_unmanaged_deleter(id_type_impl* p)
         {
-            id_type::deallocate(p);   // delete local gid representation only
+            delete p;   // delete local gid representation only
         }
 
         ///////////////////////////////////////////////////////////////////////

--- a/src/runtime/naming/name.cpp
+++ b/src/runtime/naming/name.cpp
@@ -137,8 +137,8 @@ namespace hpx { namespace naming
             // resolved, which means we don't know anything about the component
             // type.
             naming::address addr;
-            if ((gid_was_split(*p) ||
-                !naming::get_agas_client().resolve_cached(*p, addr)))
+            if (gid_was_split(*p) ||
+                !naming::get_agas_client().resolve_cached(*p, addr))
             {
                 // guard for wait_abort and other shutdown issues
                 try
@@ -199,7 +199,7 @@ namespace hpx { namespace naming
         {
             // a credit of zero means the component is not (globally) reference
             // counted
-            if (!refers_to_local_lva(*p) && detail::has_credits(*p))
+            if (detail::has_credits(*p))
             {
                 // execute the deleter directly
                 decrement_refcnt(p);

--- a/src/runtime/parcelset/parcel.cpp
+++ b/src/runtime/parcelset/parcel.cpp
@@ -159,22 +159,17 @@ namespace hpx { namespace parcelset
     }
 #endif
 
-    parcel::parcel()
-    {}
+    parcel::parcel() {}
 
-    parcel::~parcel()
-    {}
+    parcel::~parcel() {}
 
-    parcel::parcel(
-        naming::gid_type&& dest,
-        naming::address&& addr,
-        std::unique_ptr<actions::base_action> act
-    )
-      : data_(std::move(dest), std::move(addr), act->has_continuation()),
-        action_(std::move(act)),
-        size_(0)
+    parcel::parcel(naming::gid_type&& dest, naming::address&& addr,
+            std::unique_ptr<actions::base_action> act)
+      : data_(std::move(dest), std::move(addr), act->has_continuation())
+      , action_(std::move(act))
+      , size_(0)
     {
-//             HPX_ASSERT(is_valid());
+//         HPX_ASSERT(is_valid());
     }
 
     parcel::parcel(parcel && other)

--- a/tools/VS/gid_type.natvis
+++ b/tools/VS/gid_type.natvis
@@ -21,6 +21,7 @@
       <Item Name="[is_locked]">(id_msb_ &amp; 0x20000000ull) ? true : false</Item>
       <Item Name="[dont_cache]">(id_msb_ &amp; 0x00800000ull) ? true : false</Item>
       <Item Name="[migratable]">(id_msb_ &amp; 0x00400000ull) ? true : false</Item>
+      <Item Name="[local]">(id_msb_ &amp; 0x00000001ull) ? false : true</Item>
       <Item Condition="((id_msb_ &gt;&gt; 32) &amp; 0xffffffffull) != 0" Name="[locality_id]">(unsigned int)((id_msb_ &gt;&gt; 32) &amp; 0xffffffffull) - 1</Item>
       <Item Condition="(id_msb_ &amp; 1ull) == 0" Name="[comptype]">(hpx::components::component_enum_type)((id_msb_ &gt;&gt; 1ull) &amp; 0xfffffull)</Item>
     </Expand>
@@ -40,6 +41,7 @@
       <Item Condition="gid_.px != 0" Name="[is_locked]">(gid_.px->id_msb_ &amp; 0x20000000ull) ? true : false</Item>
       <Item Condition="gid_.px != 0" Name="[dont_cache]">(gid_.px->id_msb_ &amp; 0x00800000ull) ? true : false</Item>
       <Item Condition="gid_.px != 0" Name="[migratable]">(gid_.px->id_msb_ &amp; 0x00400000ull) ? true : false</Item>
+      <Item Condition="gid_.px != 0" Name="[local]">(gid_.px->id_msb_ &amp; 0x00000001ull) ? false : true</Item>
       <Item Condition="gid_.px != 0 &amp;&amp; ((gid_.px->id_msb_ &gt;&gt; 32) &amp; 0xffffffffull) != 0" Name="[locality_id]">(unsigned int)((gid_.px->id_msb_ &gt;&gt; 32) &amp; 0xffffffffull) - 1</Item>
       <Item Condition="gid_.px != 0 &amp;&amp; (gid_.px->id_msb_ &amp; 1ull) == 0" Name="[comptype]">(hpx::components::component_enum_type)((gid_.px->id_msb_ &gt;&gt; 1ull) &amp; 0xfffffull)</Item>
       <Item Condition="gid_.px != 0" Name="[count]">gid_.px->count_.value_</Item>


### PR DESCRIPTION
Applying various (mostly minor) optimizations 
- avoid initial reference counting for id_type
- switch more allocations to use internal_allocator (mostly important for Windows)
- avoid memory allocations
- fix problem in AGAS resolve_gid
- avoid decref handling for purely local components

Improving error message 
- listing component types in error message of component type instance counter