### PR TITLE
Store debug logs and core dumps on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,17 @@ convert_xml: &convert_xml
     name: Converting XML
     when: always
     command: |
-        mkdir ${CIRCLE_JOB}
+        mkdir -p ${CIRCLE_JOB}
         xsltproc \
           /hpx/conv.xsl Testing/`head -n 1 < Testing/TAG`/Test.xml \
           > ${CIRCLE_JOB}/Test.xml
+
+move_debug_log: &move_debug_log
+    name: Moving debug logs
+    when: always
+    command: |
+        mkdir -p ${CIRCLE_JOB}
+        cp debug-log.txt ${CIRCLE_JOB} || true
 
 gh_pages_filter: &gh_pages_filter
     filters:
@@ -91,6 +98,8 @@ jobs:
                 -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=On \
                 -DHPX_WITH_DEPRECATION_WARNINGS=Off \
                 -DHPX_WITH_THREAD_LOCAL_STORAGE=On \
+                -DHPX_WITH_TESTS_DEBUG_LOG=On \
+                -DHPX_WITH_TESTS_DEBUG_LOG_DESTINATION=/hpx/build/debug-log.txt \
                 -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
                 -DHPX_WITH_DOCUMENTATION=On
       - persist_to_workspace:
@@ -197,6 +206,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.examples
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_debug_log
       - store_test_results:
           path: tests.examples
       - store_artifacts:
@@ -218,6 +229,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.actions
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_debug_log
       - store_test_results:
           path: tests.unit.actions
       - store_artifacts:
@@ -239,6 +252,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.agas
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_debug_log
       - store_test_results:
           path: tests.unit.agas
       - store_artifacts:
@@ -260,6 +275,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.build
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_debug_log
       - store_test_results:
           path: tests.unit.build
       - store_artifacts:
@@ -281,6 +298,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.component
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_debug_log
       - store_test_results:
           path: tests.unit.component
       - store_artifacts:
@@ -302,6 +321,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.computeapi
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_debug_log
       - store_test_results:
           path: tests.unit.computeabi
       - store_artifacts:
@@ -323,6 +344,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.diagnostics
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_debug_log
       - store_test_results:
           path: tests.unit.diagnostics
       - store_artifacts:
@@ -344,6 +367,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.lcos
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_debug_log
       - store_test_results:
           path: tests.unit.lcos
       - store_artifacts:
@@ -365,6 +390,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.parallel.algorithms
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_debug_log
       - store_test_results:
           path: tests.unit.parallel.algorithms
       - store_artifacts:
@@ -386,6 +413,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.parallel.block
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_debug_log
       - store_test_results:
           path: tests.unit.parallel.block
       - store_artifacts:
@@ -407,6 +436,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.parallel.container_algorithms
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_debug_log
       - store_test_results:
           path: tests.unit.parallel.container_algorithms
       - store_artifacts:
@@ -428,6 +459,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.parallel.datapar_algorithms
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_debug_log
       - store_test_results:
           path: tests.unit.parallel.datapar_algorithms
       - store_artifacts:
@@ -449,6 +482,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.parallel.executors
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_debug_log
       - store_test_results:
           path: tests.unit.parallel.executors
       - store_artifacts:
@@ -472,6 +507,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.parallel.segmented_algorithms
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_debug_log
       - store_test_results:
           path: tests.unit.parallel.segmented_algorithms
       - store_artifacts:
@@ -493,6 +530,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.parcelset
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_debug_log
       - store_test_results:
           path: tests.unit.parcelset
       - store_artifacts:
@@ -514,6 +553,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.performance_counter
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_debug_log
       - store_test_results:
           path: tests.unit.performance_counter
       - store_artifacts:
@@ -535,6 +576,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.resource
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_debug_log
       - store_test_results:
           path: tests.unit.resource
       - store_artifacts:
@@ -556,6 +599,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.serialization
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_debug_log
       - store_test_results:
           path: tests.unit.serialization
       - store_artifacts:
@@ -577,6 +622,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.threads
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_debug_log
       - store_test_results:
           path: tests.unit.threads
       - store_artifacts:
@@ -598,6 +645,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.traits
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_debug_log
       - store_test_results:
           path: tests.unit.traits
       - store_artifacts:
@@ -619,6 +668,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.util
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_debug_log
       - store_test_results:
           path: tests.unit.util
       - store_artifacts:
@@ -640,6 +691,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.regressions
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_debug_log
       - store_test_results:
           path: tests.regressions
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,17 @@ convert_xml: &convert_xml
           /hpx/conv.xsl Testing/`head -n 1 < Testing/TAG`/Test.xml \
           > ${CIRCLE_JOB}/Test.xml
 
+move_core_dump: &move_core_dump
+    name: Moving core dumps
+    when: on_fail
+    command: |
+        mkdir -p ${CIRCLE_JOB}
+        # Ignore errors if there are no core dumps
+        cp core.* ${CIRCLE_JOB} || true
+
 move_debug_log: &move_debug_log
     name: Moving debug logs
-    when: always
+    when: on_fail
     command: |
         mkdir -p ${CIRCLE_JOB}
         cp debug-log.txt ${CIRCLE_JOB} || true
@@ -203,9 +211,12 @@ jobs:
           name: Running Unit Tests
           when: always
           command: |
+              ulimit -c unlimited
               ctest -T test --no-compress-output --output-on-failure -R tests.examples
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_core_dump
       - run:
           <<: *move_debug_log
       - store_test_results:
@@ -226,9 +237,12 @@ jobs:
           name: Running Unit Tests
           when: always
           command: |
+              ulimit -c unlimited
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.actions
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_core_dump
       - run:
           <<: *move_debug_log
       - store_test_results:
@@ -249,9 +263,12 @@ jobs:
           name: Running Unit Tests
           when: always
           command: |
+              ulimit -c unlimited
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.agas
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_core_dump
       - run:
           <<: *move_debug_log
       - store_test_results:
@@ -272,9 +289,12 @@ jobs:
           name: Running Unit Tests
           when: always
           command: |
+              ulimit -c unlimited
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.build
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_core_dump
       - run:
           <<: *move_debug_log
       - store_test_results:
@@ -295,9 +315,12 @@ jobs:
           name: Running Unit Tests
           when: always
           command: |
+              ulimit -c unlimited
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.component
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_core_dump
       - run:
           <<: *move_debug_log
       - store_test_results:
@@ -318,9 +341,12 @@ jobs:
           name: Running Unit Tests
           when: always
           command: |
+              ulimit -c unlimited
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.computeapi
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_core_dump
       - run:
           <<: *move_debug_log
       - store_test_results:
@@ -341,9 +367,12 @@ jobs:
           name: Running Unit Tests
           when: always
           command: |
+              ulimit -c unlimited
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.diagnostics
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_core_dump
       - run:
           <<: *move_debug_log
       - store_test_results:
@@ -364,9 +393,12 @@ jobs:
           name: Running Unit Tests
           when: always
           command: |
+              ulimit -c unlimited
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.lcos
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_core_dump
       - run:
           <<: *move_debug_log
       - store_test_results:
@@ -387,9 +419,12 @@ jobs:
           name: Running Unit Tests
           when: always
           command: |
+              ulimit -c unlimited
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.parallel.algorithms
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_core_dump
       - run:
           <<: *move_debug_log
       - store_test_results:
@@ -410,9 +445,12 @@ jobs:
           name: Running Unit Tests
           when: always
           command: |
+              ulimit -c unlimited
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.parallel.block
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_core_dump
       - run:
           <<: *move_debug_log
       - store_test_results:
@@ -433,9 +471,12 @@ jobs:
           name: Running Unit Tests
           when: always
           command: |
+              ulimit -c unlimited
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.parallel.container_algorithms
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_core_dump
       - run:
           <<: *move_debug_log
       - store_test_results:
@@ -456,9 +497,12 @@ jobs:
           name: Running Unit Tests
           when: always
           command: |
+              ulimit -c unlimited
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.parallel.datapar_algorithms
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_core_dump
       - run:
           <<: *move_debug_log
       - store_test_results:
@@ -479,9 +523,12 @@ jobs:
           name: Running Unit Tests
           when: always
           command: |
+              ulimit -c unlimited
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.parallel.executors
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_core_dump
       - run:
           <<: *move_debug_log
       - store_test_results:
@@ -504,9 +551,12 @@ jobs:
           name: Running Unit Tests
           when: always
           command: |
+              ulimit -c unlimited
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.parallel.segmented_algorithms
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_core_dump
       - run:
           <<: *move_debug_log
       - store_test_results:
@@ -527,9 +577,12 @@ jobs:
           name: Running Unit Tests
           when: always
           command: |
+              ulimit -c unlimited
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.parcelset
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_core_dump
       - run:
           <<: *move_debug_log
       - store_test_results:
@@ -550,9 +603,12 @@ jobs:
           name: Running Unit Tests
           when: always
           command: |
+              ulimit -c unlimited
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.performance_counter
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_core_dump
       - run:
           <<: *move_debug_log
       - store_test_results:
@@ -573,9 +629,12 @@ jobs:
           name: Running Unit Tests
           when: always
           command: |
+              ulimit -c unlimited
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.resource
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_core_dump
       - run:
           <<: *move_debug_log
       - store_test_results:
@@ -596,9 +655,12 @@ jobs:
           name: Running Unit Tests
           when: always
           command: |
+              ulimit -c unlimited
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.serialization
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_core_dump
       - run:
           <<: *move_debug_log
       - store_test_results:
@@ -619,9 +681,12 @@ jobs:
           name: Running Unit Tests
           when: always
           command: |
+              ulimit -c unlimited
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.threads
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_core_dump
       - run:
           <<: *move_debug_log
       - store_test_results:
@@ -642,9 +707,12 @@ jobs:
           name: Running Unit Tests
           when: always
           command: |
+              ulimit -c unlimited
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.traits
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_core_dump
       - run:
           <<: *move_debug_log
       - store_test_results:
@@ -665,9 +733,12 @@ jobs:
           name: Running Unit Tests
           when: always
           command: |
+              ulimit -c unlimited
               ctest -T test --no-compress-output --output-on-failure -R tests.unit.util
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_core_dump
       - run:
           <<: *move_debug_log
       - store_test_results:
@@ -691,6 +762,8 @@ jobs:
               ctest -T test --no-compress-output --output-on-failure -R tests.regressions
       - run:
           <<: *convert_xml
+      - run:
+          <<: *move_core_dump
       - run:
           <<: *move_debug_log
       - store_test_results:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -883,6 +883,16 @@ if(HPX_WITH_ATTACH_DEBUGGER_ON_TEST_FAILURE)
   hpx_add_config_define(HPX_HAVE_ATTACH_DEBUGGER_ON_TEST_FAILURE)
 endif()
 
+hpx_option(HPX_WITH_TESTS_DEBUG_LOG BOOL
+  "Turn on debug logs (--hpx:debug-hpx-log) for tests (default: OFF)"
+  OFF
+  CATEGORY "Debugging" ADVANCED)
+
+hpx_option(HPX_WITH_TESTS_DEBUG_LOG_DESTINATION STRING
+  "Destination for test debug logs (default: cout)"
+  "cout"
+  CATEGORY "Debugging" ADVANCED)
+
 # If APEX is defined, the action timers need thread debug info.
 if(HPX_WITH_APEX)
     hpx_add_config_define(HPX_HAVE_THREAD_DESCRIPTION)

--- a/cmake/HPX_AddTest.cmake
+++ b/cmake/HPX_AddTest.cmake
@@ -41,6 +41,9 @@ function(add_hpx_test category name)
     set(args ${args} "${arg}")
   endforeach()
   set(args "-v" "--" ${args})
+  if(${HPX_WITH_TESTS_DEBUG_LOG})
+    set(args ${args} "--hpx:debug-hpx-log=${HPX_WITH_TESTS_DEBUG_LOG_DESTINATION}")
+  endif()
 
   set(cmd "${PYTHON_EXECUTABLE}"
           "${CMAKE_BINARY_DIR}/bin/hpxrun.py"


### PR DESCRIPTION
## Proposed Changes

- Add CMake option `HPX_WITH_TESTS_DEBUG_LOG` which when enabled will add the command line argument `--hpx:debug-hpx-log` to tests. `HPX_WITH_TESTS_DEBUG_LOG_DESTINATION` sets the output destination.
- Enable `HPX_WITH_TESTS_DEBUG_LOG` on CircleCI and store output as artifacts.
- Enable core dumps on CircleCI and store output as artifacts.

## Any background context you want to provide?

Trying to get more information about timeouts and failures in our tests.