### PR TITLE
Adding support for gitlab runner

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,8 @@
+# Copyright (c) 2019 Thomas Heller
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 Checks: '-*,modernize-use-nullptr,misc-use-after-move,misc-virtual-near-miss,misc-multiple-statement-macro,misc-move-constructor-init,misc-move-forwarding-reference,misc-assert-side-effect,misc-dangling-handle,misc-non-copyable-objects,misc-forwarding-reference-overload,misc-unused-raii'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*hpx.*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,8 @@
+Checks: '-*,modernize-use-nullptr,misc-use-after-move,misc-virtual-near-miss,misc-multiple-statement-macro,misc-move-constructor-init,misc-move-forwarding-reference,misc-assert-side-effect,misc-dangling-handle,misc-non-copyable-objects,misc-forwarding-reference-overload,misc-unused-raii'
+WarningsAsErrors: '*'
+HeaderFilterRegex: '.*hpx.*'
+CheckOptions:
+  - key: misc-assert-side-effect.CheckFunctionCalls
+    value: 1
+  - key: misc-assert-side-effect.AssertMacros
+    value: 'HPX_ASSERT'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,41 @@
+#  Copyright (c) 2018 Thomas Heller
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+variables:
+    GIT_STRATEGY: none
+
+# The configuration of the build is split over multiple files to more clearly
+# arrange the different configurations. The included files are supposed to
+# expose hidden keys that can be extended.
+# NOTE: gitlab doesn't support recursive includes yet, so we flatten everything
+# here
+
+checkout:
+    image: stellargroup/build_env:ubuntu
+    stage: checkout
+    variables:
+        GIT_STRATEGY: fetch
+        GIT_DEPTH: "1"
+    script:
+        # Moving checked out files to seperate directory ...
+        - cd ..
+        - mv hpx tmp
+        - mkdir hpx
+        - mv tmp hpx/source;
+        - cp hpx/source/.clang-tidy hpx/
+    artifacts:
+        paths:
+            - source
+
+include:
+    - .gitlab-ci/stages.yml
+    - .gitlab-ci/cmake.yml
+    - .gitlab-ci/inspect.yml
+    - .gitlab-ci/core.yml
+    - .gitlab-ci/test.yml
+    - .gitlab-ci/docker.yml
+    - .gitlab-ci/linux/x86/clang-7.0.1/boost-1.65.1/debug.yml
+    - .gitlab-ci/linux/x86/clang-7.0.1/boost-1.65.1/release.yml
+    - .gitlab-ci/docs.yml

--- a/.gitlab-ci/cmake.yml
+++ b/.gitlab-ci/cmake.yml
@@ -1,0 +1,38 @@
+#  Copyright (c) 2018 Thomas Heller
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# The cmake configure step. This should be reused for the different configurations
+# Environment variables affecting the build:
+#  - CMAKE_BUILD_TYPE: Set the CMAKE_BUILD_TYPE
+#  - CMAKE_EXTRA_FLAGS: Extra flags passed to cmake (for example to enable clang-tidy checks)
+#
+#  TODO: add more options
+.cmake:
+    image: stellargroup/build_env:ubuntu
+    stage: cmake
+    script:
+        - mkdir -p build
+        - cd build
+        - cmake --version
+        - cmake ../source -G "Ninja"
+            -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE
+            -DHPX_WITH_MALLOC=system
+            -DHPX_WITH_GIT_COMMIT=${CI_COMMIT_SHA}
+            -DHPX_WITH_GIT_BRANCH="${CI_COMMIT_REF_NAME}"
+            -DHPX_WITH_GIT_TAG="${CI_COMMIT_TAG}"
+            -DHPX_WITH_TOOLS=On
+            -DCMAKE_CXX_FLAGS="-fcolor-diagnostics"
+            -DHPX_WITH_TESTS_HEADERS=On
+            -DHPX_WITH_DEPRECATION_WARNINGS=Off
+            -DHPX_WITH_THREAD_LOCAL_STORAGE=On
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=On
+            -DHPX_WITH_DOCUMENTATION=On
+            ${CMAKE_EXTRA_FLAGS}
+    except:
+        - gh-pages
+    artifacts:
+        paths:
+            - build
+

--- a/.gitlab-ci/core.yml
+++ b/.gitlab-ci/core.yml
@@ -1,0 +1,17 @@
+#  Copyright (c) 2018 Thomas Heller
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+.core:
+    image: stellargroup/build_env:ubuntu
+    stage: build
+    script:
+      - cd build
+      - ninja core
+    except:
+        - gh-pages
+    artifacts:
+        paths:
+            - build
+

--- a/.gitlab-ci/docker.yml
+++ b/.gitlab-ci/docker.yml
@@ -1,0 +1,34 @@
+#  Copyright (c) 2018 Thomas Heller
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# The docker step builds the Docker image for the corresponding build.
+# The target image can be set via the TARGET_IMAGE_NAME variable
+.docker:
+    image: stellargroup/build_env:ubuntu
+    stage: deploy
+    script:
+        - cp source/tools/docker/Dockerfile /usr/local/
+        - cd build
+        - cmake . -DHPX_WITH_DOCUMENTATION=Off
+        - ninja install
+        - curl -L -o /tmp/docker.tgz https://download.docker.com/linux/static/stable/x86_64/docker-18.03.0-ce.tgz
+        - tar -xz -C /tmp -f /tmp/docker.tgz
+        - mv /tmp/docker/* /usr/bin
+        - cd /usr/local
+        - docker build -t ${TARGET_IMAGE_NAME} .
+        - docker create -v /hpx --name sources-${CI_JOB_ID} stellargroup/hpx:dev /bin/true
+        - docker cp /builds/stellar-group/hpx/source/examples/quickstart/hello_world.cpp sources-${CI_JOB_ID}:/hpx
+        - docker run --volumes-from sources-${CI_JOB_ID} -w /hpx ${TARGET_IMAGE_NAME}
+            hpxcxx --exe=hello_world_test_build
+            hello_world.cpp -g -lhpx_iostreamsd
+        - docker run --volumes-from sources-${CI_JOB_ID} -w /hpx ${TARGET_IMAGE_NAME}
+            ./hello_world_test_build --hpx:bind=none
+        - docker run --volumes-from sources-${CI_JOB_ID} -w /hpx ${TARGET_IMAGE_NAME}
+            hpxrun.py -l 2 -t 2 ./hello_world_test_build -- --hpx:bind=none
+    after_script:
+        - docker rm sources-${CI_JOB_ID}
+    except:
+        - gh-pages
+

--- a/.gitlab-ci/docs.yml
+++ b/.gitlab-ci/docs.yml
@@ -1,0 +1,28 @@
+#  Copyright (c) 2018 Thomas Heller
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# These are the doc steps. They are factored out, but merely depend on
+# one single build.
+
+build docs:
+    image: stellargroup/build_env:ubuntu
+    stage: build
+    script:
+        - cd build
+        - ninja docs
+    except:
+        - gh-pages
+    artifacts:
+        when: on_success
+        paths:
+            - build
+    dependencies:
+        - checkout
+        - cmake Debug x86
+    tags:
+        - linux
+        - x86
+        - clang-7.0.1
+        - boost-1.65.1

--- a/.gitlab-ci/inspect.yml
+++ b/.gitlab-ci/inspect.yml
@@ -1,0 +1,26 @@
+#  Copyright (c) 2018 Thomas Heller
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# Run inspect on a given source tree
+.inspect:
+    image: stellargroup/build_env:ubuntu
+    stage: build
+    script:
+        - cd build
+        - ninja inspect
+        - touch hpx-no-inspect
+        - cd ../source
+        - ../build/bin/inspect --all --output=../hpx_inspect_report.html .
+    after_script:
+        - ./source/tools/inspect/inspect_to_junit.py ./hpx_inspect_report.html ./hpx_inspect.xml
+    artifacts:
+        when: on_failure
+        paths:
+            - hpx_inspect_report.html
+            - build
+        reports:
+            junit: hpx_inspect.xml
+    except:
+        - gh-pages

--- a/.gitlab-ci/linux/x86/clang-7.0.1/boost-1.65.1/debug.yml
+++ b/.gitlab-ci/linux/x86/clang-7.0.1/boost-1.65.1/debug.yml
@@ -1,0 +1,104 @@
+#  Copyright (c) 2018 Thomas Heller
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+.debug-x86: &debug-x86
+    variables:
+        CMAKE_BUILD_TYPE: "Debug"
+        CMAKE_EXTRA_FLAGS: "-DCMAKE_CXX_CLANG_TIDY=clang-tidy"
+        TARGET_IMAGE_NAME: stellargroup/hpx:dev
+    tags:
+        - linux
+        - x86
+        - clang-7.0.1
+        - boost-1.65.1
+
+cmake Debug x86:
+    <<: *debug-x86
+    extends: .cmake
+
+inspect Debug x86:
+    <<: *debug-x86
+    extends: .inspect
+    dependencies:
+        - checkout
+        - cmake Debug x86
+
+core Debug x86:
+    <<: *debug-x86
+    extends: .core
+    dependencies:
+        - checkout
+        - cmake Debug x86
+
+examples Debug x86:
+    <<: *debug-x86
+    variables:
+        TESTS: "examples"
+    extends: .test
+    dependencies:
+        - checkout
+        - core Debug x86
+        - get conv.xsl
+        - get junit2html
+    artifacts:
+        paths:
+            - build
+
+tests.unit Debug x86:
+    <<: *debug-x86
+    variables:
+        TESTS: "tests.unit"
+    extends: .test
+    dependencies:
+        - checkout
+        - core Debug x86
+        - get conv.xsl
+        - get junit2html
+
+tests.regressions Debug x86:
+    <<: *debug-x86
+    variables:
+        TESTS: "tests.regressions"
+    extends: .test
+    dependencies:
+        - checkout
+        - core Debug x86
+        - get conv.xsl
+        - get junit2html
+
+tests.performance Debug x86:
+    <<: *debug-x86
+    variables:
+        TESTS: "tests.performance"
+    extends: .test
+    dependencies:
+        - checkout
+        - core Debug x86
+        - get conv.xsl
+        - get junit2html
+
+tests.headers Debug x86:
+    <<: *debug-x86
+    variables:
+        TESTS: "tests.headers"
+    extends: .test
+    dependencies:
+        - checkout
+        - core Debug x86
+        - get conv.xsl
+        - get junit2html
+
+docker Debug x86:
+    <<: *debug-x86
+    extends: .docker
+    environment:
+        name: dev/docker_images
+        url: https://hub.docker.com/r/stellargroup/hpx/tags
+    dependencies:
+        - checkout
+        - core Debug x86
+        - inspect Debug x86
+        - examples Debug x86
+        - build docs

--- a/.gitlab-ci/linux/x86/clang-7.0.1/boost-1.65.1/release.yml
+++ b/.gitlab-ci/linux/x86/clang-7.0.1/boost-1.65.1/release.yml
@@ -1,0 +1,79 @@
+#  Copyright (c) 2018 Thomas Heller
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+.release-x86: &release-x86
+    variables:
+        CMAKE_BUILD_TYPE: "Release"
+        CMAKE_EXTRA_FLAGS: "-DCMAKE_CXX_CLANG_TIDY=clang-tidy"
+    tags:
+        - linux
+        - x86
+        - clang-7.0.1
+        - boost-1.65.1
+
+cmake Release x86:
+    <<: *release-x86
+    extends: .cmake
+
+core Release x86:
+    <<: *release-x86
+    extends: .core
+    dependencies:
+        - checkout
+        - cmake Release x86
+
+examples Release x86:
+    <<: *release-x86
+    variables:
+        TESTS: "examples"
+    extends: .test
+    dependencies:
+        - checkout
+        - core Release x86
+        - get conv.xsl
+        - get junit2html
+
+tests.unit Release x86:
+    <<: *release-x86
+    variables:
+        TESTS: "tests.unit"
+    extends: .test
+    dependencies:
+        - checkout
+        - core Release x86
+        - get conv.xsl
+        - get junit2html
+
+tests.regressions Release x86:
+    <<: *release-x86
+    variables:
+        TESTS: "tests.regressions"
+    extends: .test
+    dependencies:
+        - checkout
+        - core Release x86
+        - get conv.xsl
+        - get junit2html
+
+tests.performance Release x86:
+    <<: *release-x86
+    variables:
+        TESTS: "tests.performance"
+    extends: .test
+    dependencies:
+        - checkout
+        - core Release x86
+        - get conv.xsl
+        - get junit2html
+
+tests.headers Release x86:
+    <<: *release-x86
+    variables:
+        TESTS: "tests.headers"
+    extends: .test
+    dependencies:
+        - checkout
+        - core Release x86
+        - get conv.xsl

--- a/.gitlab-ci/stages.yml
+++ b/.gitlab-ci/stages.yml
@@ -1,0 +1,11 @@
+#  Copyright (c) 2018 Thomas Heller
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+stages:
+    - checkout
+    - cmake
+    - build
+    - test
+    - deploy

--- a/.gitlab-ci/test.yml
+++ b/.gitlab-ci/test.yml
@@ -1,0 +1,44 @@
+#  Copyright (c) 2018 Thomas Heller
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+get conv.xsl:
+    image: stellargroup/build_env:ubuntu
+    stage: checkout
+    script:
+        - curl
+            https://raw.githubusercontent.com/Kitware/CDash/master/tests/circle/conv.xsl
+            -o conv.xsl
+    artifacts:
+        paths:
+            - conv.xsl
+
+get junit2html:
+    image: stellargroup/build_env:ubuntu
+    stage: checkout
+    script:
+        - git clone https://github.com/inorton/junit2html.git
+    artifacts:
+        paths:
+            - junit2html
+
+.test:
+    image: stellargroup/build_env:ubuntu
+    stage: test
+    script:
+      - cd build
+      - ninja ${TESTS}
+      - ctest -T test --no-compress-output --output-on-failure -R ${TESTS}
+    after_script:
+      - xsltproc conv.xsl build/Testing/`head -n 1 < build/Testing/TAG`/Test.xml > ${TESTS}.xml
+      - ./junit2html/junit2html ./${TESTS}.xml ./${TESTS}.html
+    artifacts:
+        when: always
+        reports:
+            junit: ${TESTS}.xml
+        paths:
+            - ${TESTS}.xml
+            - ${TESTS}.html
+    except:
+        - gh-pages

--- a/hpx/config/autolink.hpp
+++ b/hpx/config/autolink.hpp
@@ -5,15 +5,15 @@
 
 #include <hpx/config.hpp>
 
-#ifndef HPX_AUTOLINK_LIB_NAME
-#error "Macro HPX_AUTOLINK_LIB_NAME not set (internal error)"
-#endif
-
 // enable auto-linking for supported platforms
 #if defined(HPX_MSVC) \
     || defined(__BORLANDC__) \
     || (defined(__MWERKS__) && defined(_WIN32) && (__MWERKS__ >= 0x3000)) \
     || (defined(__ICL) && defined(_MSC_EXTENSIONS) && (HPX_MSVC >= 1200))
+
+#ifndef HPX_AUTOLINK_LIB_NAME
+#error "Macro HPX_AUTOLINK_LIB_NAME not set (internal error)"
+#endif
 
 #if defined(HPX_DEBUG)
 #pragma comment(lib, HPX_AUTOLINK_LIB_NAME "d" ".lib")

--- a/hpx/plugins/binary_filter_factory.hpp
+++ b/hpx/plugins/binary_filter_factory.hpp
@@ -67,7 +67,7 @@ namespace hpx { namespace plugins
         {
             if (isenabled_)
                 return new BinaryFilter(compress, next_filter);
-            return 0;
+            return nullptr;
         }
 
     protected:

--- a/hpx/runtime/threads/coroutines/detail/context_base.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_base.hpp
@@ -102,22 +102,27 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         typedef hpx::threads::thread_id_type thread_id_type;
 
         template <typename Derived>
-        context_base(Derived& derived, std::ptrdiff_t stack_size, thread_id_type id)
-          : default_context_impl(derived, stack_size),
-            m_caller(),
-            m_state(ctx_ready),
-            m_exit_state(ctx_exit_not_requested),
-            m_exit_status(ctx_not_exited),
+        context_base(
+            Derived& derived, std::ptrdiff_t stack_size, thread_id_type id)
+          : default_context_impl(derived, stack_size)
+          , m_caller()
+          , m_state(ctx_ready)
+          , m_exit_state(ctx_exit_not_requested)
+          , m_exit_status(ctx_not_exited)
 #if defined(HPX_HAVE_THREAD_PHASE_INFORMATION)
-            m_phase(0),
+          , m_phase(0)
 #endif
-            m_thread_data(0),
+#if defined(HPX_HAVE_THREAD_LOCAL_STORAGE)
+          , m_thread_data(nullptr)
+#else
+          , m_thread_data(0)
+#endif
 #if defined(HPX_HAVE_APEX)
-            m_apex_data(nullptr),
+          , m_apex_data(nullptr)
 #endif
-            m_type_info(),
-            m_thread_id(id),
-            continuation_recursion_count_(0)
+          , m_type_info()
+          , m_thread_id(id)
+          , continuation_recursion_count_(0)
         {}
 
         void reset()
@@ -347,7 +352,11 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 #if defined(HPX_HAVE_THREAD_PHASE_INFORMATION)
             HPX_ASSERT(m_phase == 0);
 #endif
+#if defined(HPX_HAVE_THREAD_LOCAL_STORAGE)
+            HPX_ASSERT(m_thread_data == nullptr);
+#else
             HPX_ASSERT(m_thread_data == 0);
+#endif
 #if defined(HPX_HAVE_APEX)
             m_apex_data = rebind_base_apex(id);
 #endif

--- a/hpx/util/debug/demangle_helper.hpp
+++ b/hpx/util/debug/demangle_helper.hpp
@@ -43,8 +43,12 @@ namespace hpx { namespace util { namespace debug
     class cxxabi_demangle_helper
     {
     public:
-        cxxabi_demangle_helper() :
-            demangled_ {abi::__cxa_demangle(typeid(T).name(), 0, 0, 0), std::free} {}
+        cxxabi_demangle_helper()
+          : demangled_{abi::__cxa_demangle(
+                           typeid(T).name(), nullptr, nullptr, nullptr),
+                std::free}
+        {
+        }
 
         char const* type_id() const
         {

--- a/hpx/util/memory_chunk.hpp
+++ b/hpx/util/memory_chunk.hpp
@@ -49,7 +49,7 @@ namespace hpx { namespace util
         explicit memory_chunk(std::size_t chunk_size)
           : chunk_size_(chunk_size)
           , allocated_(0)
-          , current_(0)
+          , current_(nullptr)
         {}
 
         void charge()
@@ -163,7 +163,7 @@ namespace hpx { namespace util
 
             if(!data_) charge();
 
-            iterator result = 0;
+            iterator result = nullptr;
 
             HPX_ASSERT(size <= chunk_size_);
 
@@ -204,7 +204,7 @@ namespace hpx { namespace util
                 return result;
             }
             check_invariants_locked(0, size);
-            return 0;
+            return nullptr;
         }
 
         bool deallocate(char * p, size_type size)

--- a/src/runtime/threads/coroutines/detail/tss.cpp
+++ b/src/runtime/threads/coroutines/detail/tss.cpp
@@ -52,7 +52,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
     {
 #ifdef HPX_HAVE_THREAD_LOCAL_STORAGE
         delete storage;
-        storage = 0;
+        storage = nullptr;
 #endif
     }
 
@@ -70,8 +70,8 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
         if (nullptr == tss_map)
             return 0;
 
-        tss_data_node* node = tss_map->find(0);
-        if (0 == node)
+        tss_data_node* node = tss_map->find(nullptr);
+        if (nullptr == node)
             return 0;
 
         return node->get_data<std::size_t>();
@@ -100,10 +100,10 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
             return 0;
         }
 
-        tss_data_node* node = tss_map->find(0);
-        if (0 == node)
+        tss_data_node* node = tss_map->find(nullptr);
+        if (nullptr == node)
         {
-            tss_map->insert(0, new std::size_t(data)); //-V508
+            tss_map->insert(nullptr, new std::size_t(data));    //-V508
             return 0;
         }
 
@@ -197,12 +197,12 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 #ifdef HPX_HAVE_THREAD_LOCAL_STORAGE
         if (tss_data_node* const current_node = find_tss_data(key))
         {
-            if (func || (tss_data != 0))
+            if (func || (tss_data != nullptr))
                 current_node->reinit(func, tss_data, cleanup_existing);
             else
                 erase_tss_node(key, cleanup_existing);
         }
-        else if(func || (tss_data != 0))
+        else if (func || (tss_data != nullptr))
         {
             add_new_tss_node(key, func, tss_data);
         }

--- a/src/util/register_locks_globally.cpp
+++ b/src/util/register_locks_globally.cpp
@@ -82,8 +82,8 @@ namespace hpx { namespace util
     {
         using detail::register_locks_globally;
 
-        if (register_locks_globally::lock_detection_enabled_
-            && 0 != threads::get_self_ptr())
+        if (register_locks_globally::lock_detection_enabled_ &&
+            nullptr != threads::get_self_ptr())
         {
             register_locks_globally::held_locks_map& held_locks =
                 register_locks_globally::get_lock_map();
@@ -109,8 +109,8 @@ namespace hpx { namespace util
     {
         using detail::register_locks_globally;
 
-        if (register_locks_globally::lock_detection_enabled_
-            && 0 != threads::get_self_ptr())
+        if (register_locks_globally::lock_detection_enabled_ &&
+            nullptr != threads::get_self_ptr())
         {
             register_locks_globally::held_locks_map& held_locks =
                 register_locks_globally::get_lock_map();

--- a/tests/unit/threads/tss.cpp
+++ b/tests/unit/threads/tss.cpp
@@ -148,7 +148,7 @@ struct dummy_class_tracks_deletions
 unsigned dummy_class_tracks_deletions::deletions = 0;
 
 hpx::threads::thread_specific_ptr<dummy_class_tracks_deletions>
-    tss_with_null_cleanup(0);
+    tss_with_null_cleanup(nullptr);
 
 void tss_thread_with_null_cleanup(dummy_class_tracks_deletions* delete_tracker)
 {
@@ -198,7 +198,7 @@ void test_tss_cleanup_not_called_for_null_pointer()
     local_tss.reset(new Dummy);
 
     tss_cleanup_called = false;
-    local_tss.reset(0);
+    local_tss.reset(nullptr);
     HPX_TEST(tss_cleanup_called);
 
     tss_cleanup_called = false;


### PR DESCRIPTION
This adds support for gitlab runners and enables a (semi modular) setup to add new configurations. This will allow for a basis to add more PR based tests for more configurations. The whole workflow was slightly changed:
 - The tests are split up between unit, regression, performance and examples. Due to the enhanced infrastructure, we don't need to split them anymore
 - Checking the code with clang-tidy is enabled by default. A .clang-tidy file has been added for the clang-tidy configuration
 - We build both, a debug and release version.

This can be seen as a first step to add more and unified testing using the packet.net infrastructure to our codebase. The tests are run via a gitlab mirror which starts gitlab runners