### PR TITLE
Updating the default order of priority for thread_description

### DIFF
--- a/hpx/util/thread_description.hpp
+++ b/hpx/util/thread_description.hpp
@@ -74,6 +74,7 @@ namespace hpx { namespace util
         }
 #endif
 
+        /* The priority of description is name, altname, address */
         template <typename F, typename =
             typename std::enable_if<
                 !std::is_same<F, thread_description>::value &&
@@ -84,6 +85,7 @@ namespace hpx { namespace util
           : type_(data_type_description)
         {
             char const* name = traits::get_function_annotation<F>::call(f);
+            // If a name exists, use it, not the altname.
             if (name != nullptr)
             {
                 altname = name;

--- a/src/util/thread_description.cpp
+++ b/src/util/thread_description.cpp
@@ -48,28 +48,36 @@ namespace hpx { namespace util
 #endif
     }
 
+    /* The priority of description is id::name, altname, id::address */
     void thread_description::init_from_alternative_name(char const* altname)
     {
 #if defined(HPX_HAVE_THREAD_DESCRIPTION) && !defined(HPX_HAVE_THREAD_DESCRIPTION_FULL)
-        type_ = data_type_description;
-        data_.desc_ = altname;
-        if (altname == nullptr)
+        hpx::threads::thread_id_type id = hpx::threads::get_self_id();
+        if (id)
         {
-            hpx::threads::thread_id_type id = hpx::threads::get_self_id();
-            if (id)
+            // get the current task description
+            thread_description desc = hpx::threads::get_thread_description(id);
+            type_ = desc.kind();
+            // if the current task has a description, use it.
+            if (type_ == data_type_description)
             {
-                thread_description desc = hpx::threads::get_thread_description(id);
-                type_ = desc.kind();
-                if (type_ == data_type_description)
-                {
-                    data_.desc_ = desc.get_description();
-                }
-                else
-                {
+                data_.desc_ = desc.get_description();
+            }
+            else
+            {
+                // if there is an alternate name passed in, use it.
+                if (altname != nullptr) {
+                    type_ = data_type_description;
+                    data_.desc_ = altname;
+                } else {
+                    // otherwise, use the address of the task.
                     HPX_ASSERT(type_ == data_type_address);
                     data_.addr_ = desc.get_address();
                 }
             }
+        } else {
+            type_ = data_type_description;
+            data_.desc_ = altname;
         }
 #endif
     }


### PR DESCRIPTION
The order is now:
1) current thread name
2) altname
3) current thread function address

This will correctly annotate the work associated with the new task with the current task description when there is one.  This can still be overridden with annotated_functions.
