### PR TITLE
Add instructions on getting HPX to documentation

### DIFF
--- a/docs/sphinx/manual.rst
+++ b/docs/sphinx/manual.rst
@@ -16,6 +16,7 @@ information on how to build and use |hpx| in different scenarios.
 .. toctree::
    :maxdepth: 2
 
+   manual/getting_hpx
    manual/building_hpx
    manual/creating_hpx_projects
    manual/starting_the_hpx_runtime

--- a/docs/sphinx/manual/building_hpx.rst
+++ b/docs/sphinx/manual/building_hpx.rst
@@ -1250,6 +1250,12 @@ crucial for getting decent performance on the Xeon Phi.
 How to install |hpx| on Fedora distributions
 --------------------------------------------
 
+.. important::
+
+   There are official |hpx| packages for Fedora. Unless you want to customize
+   your build you may want to start off with the official packages. Instructions
+   can be found on the |stellar_hpx_download|_ page.
+
 .. note::
 
    This section of the manual is based off of our collaborators Patrick Diehl's
@@ -1302,7 +1308,13 @@ How to install |hpx| on Fedora distributions
 How to install |hpx| on Arch distributions
 ------------------------------------------
 
-* Install all packages for minimal installation:
+.. important::
+
+   There are |hpx| packages for Arch in the AUR. Unless you want to customize
+   your build you may want to start off with those. Instructions can be found on
+   the |stellar_hpx_download|_ page.
+
+* Install all packages for a minimal installation:
 
   .. code-block:: bash
 

--- a/docs/sphinx/manual/building_hpx.rst
+++ b/docs/sphinx/manual/building_hpx.rst
@@ -1319,6 +1319,33 @@ How to install |hpx| on Arch distributions
 The rest of the installation steps are same as provided with Fedora
 or Unix variants.
 
+How to install |hpx| on Debian-based distributions
+--------------------------------------------------
+
+* Install all packages for a minimal installation:
+
+  .. code-block:: bash
+
+     sudo apt install cmake libboost-all-dev hwloc libgoogle-perftools-dev
+
+* For building the documentation you will need to further install the following:
+
+  .. code-block:: bash
+
+     sudo apt install doxygen python-pip
+
+     pip install --user sphinx sphinx_rtd_theme breathe
+
+  or the following if you prefer to get Python packages from the Debian
+  repositories:
+
+  .. code-block:: bash
+
+     sudo apt install doxygen python-sphinx python-sphinx-rtd-theme python-breathe
+
+The rest of the installation steps are same as provided with Fedora
+or Unix variants.
+
 .. include:: ../../generated/cmake_toolchains.rst
 
 .. include:: ../../generated/cmake_variables.rst

--- a/docs/sphinx/manual/getting_hpx.rst
+++ b/docs/sphinx/manual/getting_hpx.rst
@@ -1,0 +1,27 @@
+..
+    Copyright (c) 2019 Mikael Simberg
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+.. _getting_hpx:
+
+=============
+Getting |hpx|
+=============
+
+There are |hpx| packages available for a few Linux distributions. The easiest
+way to get started with |hpx| is to use those packages. We keep an up-to-date
+list with instructions on the |stellar_hpx_download|_ page. If you use one of
+the available packages you can skip the next section, :ref:`hpx_build_system`,
+but we still recommend that you look through it as it contains useful
+information on how you can customize |hpx| at compile-time.
+
+If there isn't a package available for your platform you should either clone our
+repository:
+
+.. code-block: bash
+
+   git clone https://github.com/STEllAR-GROUP/hpx.git
+
+or download a package with the source files from |stellar_hpx_download|_.


### PR DESCRIPTION
## Proposed Changes

- Add instructions on which packages are needed on Debian to build HPX
- Add notes to documentation about distribution packages
- Add "Getting HPX" section to manual

Replaces #3543.