### PR TITLE
Merging the executor-enabled overloads of shared_future<>::then

### DIFF
--- a/hpx/lcos/future.hpp
+++ b/hpx/lcos/future.hpp
@@ -1378,19 +1378,13 @@ namespace hpx { namespace lcos
                 std::forward<Policy>(policy), std::forward<F>(f), ec);
         }
 
-        template <typename F>
-        typename hpx::traits::future_then_result<shared_future, F>::type
-        then(threads::executor& sched, F && f, error_code& ec = throws) const
-        {
-            return base_type::then(shared_future(*this),
-                sched, std::forward<F>(f), ec);
-        }
-
         template <typename Executor, typename F>
         typename util::lazy_enable_if<
             hpx::traits::is_one_way_executor<
                 typename std::decay<Executor>::type>::value ||
             hpx::traits::is_two_way_executor<
+                typename std::decay<Executor>::type>::value ||
+            hpx::traits::is_threads_executor<
                 typename std::decay<Executor>::type>::value
           , hpx::traits::future_then_executor_result<Executor, shared_future, F>
         >::type

--- a/tests/regressions/lcos/CMakeLists.txt
+++ b/tests/regressions/lcos/CMakeLists.txt
@@ -48,6 +48,7 @@ set(tests
     shared_future_then_2166
     shared_mutex_1702
     shared_stated_leaked_1211
+    shared_future_then_with_executor_3634
     sliding_semaphore_2338
     split_future_2246
     wait_all_hang_1946

--- a/tests/regressions/lcos/shared_future_then_with_executor_3634.cpp
+++ b/tests/regressions/lcos/shared_future_then_with_executor_3634.cpp
@@ -1,0 +1,25 @@
+//  Copyright (c) 2019 Christopher Hinz
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This test case demonstrates the issue described in #3634:
+// The build fails if shared_future<>::then is called with a thread executor
+
+#include <hpx/hpx_main.hpp>
+
+#include <hpx/lcos/future.hpp>
+
+#include <hpx/parallel/executors.hpp> // Workaround for a missing header file
+#include <hpx/runtime/threads/executors/pool_executor.hpp>
+
+int main()
+{
+    hpx::threads::executors::pool_executor executor("default");
+
+    auto future = hpx::make_ready_future().share();
+
+    future.then(executor, [](hpx::shared_future<void> future) { future.get(); });
+
+    return 0;
+}


### PR DESCRIPTION
The separate overload for thread executors caused problems since
the implementation of `then` requires a `scheduled_executor` and not
just an `executor`.

The merged overload still does not test if the user-provided executor
does actually satisfy the requirements of a `scheduled_executor`.
Since future<>::then does exhibit the same issue, this should be
fixed in a separate PR.

This commit also adds a regression test demonstrating the issue.

This fixes issue #3634.
