### PR TITLE
Attempt to tackle timeouts during startup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,7 @@ jobs:
                 -DHPX_WITH_THREAD_LOCAL_STORAGE=On \
                 -DHPX_WITH_TESTS_DEBUG_LOG=On \
                 -DHPX_WITH_TESTS_DEBUG_LOG_DESTINATION=/hpx/build/debug-log.txt \
+                -DHPX_WITH_SPINLOCK_DEADLOCK_DETECTION=On \
                 -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
                 -DHPX_WITH_DOCUMENTATION=On
       - persist_to_workspace:

--- a/.gitlab-ci/cmake.yml
+++ b/.gitlab-ci/cmake.yml
@@ -29,6 +29,7 @@
             -DHPX_WITH_THREAD_LOCAL_STORAGE=On
             -DCMAKE_EXPORT_COMPILE_COMMANDS=On
             -DHPX_WITH_DOCUMENTATION=On
+            -DHPX_WITH_SPINLOCK_DEADLOCK_DETECTION=On
             ${CMAKE_EXTRA_FLAGS}
     except:
         - gh-pages

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -1184,13 +1184,13 @@ namespace hpx { namespace components { namespace server
 
         plugin_map_type::const_iterator it = plugins_.find(message_handler_type);
         if (it == plugins_.end() || !(*it).second.first) {
+            l.unlock();
             if (ec.category() != hpx::get_lightweight_hpx_category())
             {
                 // we don't know anything about this component
                 std::ostringstream strm;
                 strm << "attempt to create message handler plugin instance of "
                         "invalid/unknown type: " << message_handler_type;
-                l.unlock();
                 HPX_THROWS_IF(ec, hpx::bad_plugin_type,
                     "runtime_support::create_message_handler",
                     strm.str());
@@ -1247,13 +1247,13 @@ namespace hpx { namespace components { namespace server
 
         plugin_map_type::const_iterator it = plugins_.find(message_handler_type);
         if (it == plugins_.end() || !(*it).second.first) {
+            l.unlock();
             if (ec.category() != hpx::get_lightweight_hpx_category())
             {
                 // we don't know anything about this component
                 std::ostringstream strm;
                 strm << "attempt to create message handler plugin instance of "
                         "invalid/unknown type: " << message_handler_type;
-                l.unlock();
                 HPX_THROWS_IF(ec, hpx::bad_plugin_type,
                     "runtime_support::create_message_handler",
                     strm.str());
@@ -1307,6 +1307,7 @@ namespace hpx { namespace components { namespace server
 
         plugin_map_type::const_iterator it = plugins_.find(binary_filter_type);
         if (it == plugins_.end() || !(*it).second.first) {
+            l.unlock();
             // we don't know anything about this component
             std::ostringstream strm;
             strm << "attempt to create binary filter plugin instance of "


### PR DESCRIPTION
This PR enables the deadlock detection for our spinlocks and unlocks the lock before throwing an exception during loading of components.
