### PR TITLE
Added architecture identification to cmake to be able to detect timestamp support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2007-2018 Hartmut Kaiser
+# Copyright (c) 2007-2019 Hartmut Kaiser
 # Copyright (c) 2011-2014 Thomas Heller
 # Copyright (c) 2007-2008 Chirag Dekate
 # Copyright (c)      2011 Bryce Lelbach
@@ -1446,6 +1446,12 @@ endif()
 if(MSVC)
   # Display full paths in diagnostics
   hpx_add_compile_flag(-FC LANGUAGES C CXX)
+  if(CMAKE_CL_64)
+    set(__target_arch "x86_64")
+  else()
+    set(__target_arch "x84")
+  endif()
+  hpx_info("Architecture detected: ${__target_arch}")
 else()
   # Show the flags that toggle each warning
   hpx_add_compile_flag_if_available(-fdiagnostics-show-option LANGUAGES CXX C Fortran)
@@ -1519,28 +1525,51 @@ else()
     hpx_add_compile_flag_if_available(-wd2536)
   endif()
 
+  set(__has_timestamp_support OFF)
+  include(TargetArch)
 
-  # rdtsc is an x86 instruction that reads the value of a CPU time stamp
-  # counter. rdtscp is an extension to rdtsc. The difference is that rdtscp is
-  # a serializing instruction.
-  hpx_cpuid("rdtsc" HPX_WITH_RDTSC
-    DEFINITIONS HPX_HAVE_RDTSC)
+  target_architecture(__target_arch)
+  if("${__target_arch}" STREQUAL "i386" OR
+     "${__target_arch}" STREQUAL "ix86" OR
+     "${__target_arch}" STREQUAL "x86_64" OR
+     "${__target_arch}" STREQUAL "ia64")
 
- # One can not assume if RDTSCP is available on the hardware
- # of the build infrastructure, that it will be available on
- # all potential target hardware, see Issue  #3575
- if(NOT ${HPX_WITH_BUILD_BINARY_PACKAGE})
+      # rdtsc is an x86 instruction that reads the value of a CPU time stamp
+      # counter. rdtscp is an extension to rdtsc. The difference is that rdtscp is
+      # a serializing instruction.
+      hpx_cpuid("rdtsc" HPX_WITH_RDTSC DEFINITIONS HPX_HAVE_RDTSC)
 
-  # XeonPhi's do not support RDTSCP
-  if(NOT ("${HPX_PLATFORM_UC}" STREQUAL "XEONPHI"))
-    hpx_cpuid("rdtscp" HPX_WITH_RDTSCP
-      DEFINITIONS HPX_HAVE_RDTSCP)
+      # One can not assume if RDTSCP is available on the hardware
+      # of the build infrastructure, that it will be available on
+      # all potential target hardware, see Issue  #3575
+      if(NOT ${HPX_WITH_BUILD_BINARY_PACKAGE})
+
+        # XeonPhi's do not support RDTSCP
+        if(NOT ("${HPX_PLATFORM_UC}" STREQUAL "XEONPHI"))
+          hpx_cpuid("rdtscp" HPX_WITH_RDTSCP DEFINITIONS HPX_HAVE_RDTSCP)
+        endif()
+
+      endif()
+      if(HPX_WITH_RDTSC OR HPX_WITH_RDTSCP)
+        set(__has_timestamp_support ON)
+      endif()
+  elseif("${__target_arch}" STREQUAL "arm" OR
+         "${__target_arch}" STREQUAL "armv5" OR
+         "${__target_arch}" STREQUAL "armv6" OR
+         "${__target_arch}" STREQUAL "armv7")
+    set(__has_timestamp_support ON)
+  elseif("${__target_arch}" STREQUAL "ppc" OR
+         "${__target_arch}" STREQUAL "ppc64")
+    set(__has_timestamp_support ON)
+  elseif("${__target_arch}" STREQUAL "bgq")
+    set(__has_timestamp_support ON)
+  elseif("${__target_arch}" STREQUAL "s390x")
+    set(__has_timestamp_support ON)
   endif()
 
- endif()
-
-  if(NOT HPX_WITH_RDTSC AND NOT HPX_WITH_RDTSCP)
-    hpx_warn("Neither rdtsc nor rdtscp is available; some performance counters may report incorrect results")
+  hpx_info("Architecture detected: ${__target_arch}")
+  if(NOT __has_timestamp_support)
+    hpx_warn("No timestamp support is available; some performance counters may report incorrect results")
   endif()
 endif()
 

--- a/cmake/TargetArch.cmake
+++ b/cmake/TargetArch.cmake
@@ -1,0 +1,149 @@
+# Copyright (c) 2019 Hartmut Kaiser
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# This file was adapted from:
+# https://github.com/axr/solar-cmake/blob/master/TargetArch.cmake
+
+# Based on the Qt 5 processor detection code, so should be very accurate
+# https://qt.gitorious.org/qt/qtbase/blobs/master/src/corelib/global/qprocessordetection.h
+# Currently handles arm (v5, v6, v7), x86 (32/64), ia64, ppc (32/64), s390x, and BGQ
+
+# Regarding POWER/PowerPC, just as is noted in the Qt source,
+# "There are many more known variants/revisions that we do not handle/detect."
+
+set(archdetect_c_code "
+    #if defined(__arm__) || defined(__TARGET_ARCH_ARM) || defined(__arm64__) || defined(__aarch64__)
+        #if defined(__ARM_ARCH_7__) \\
+            || defined(__ARM_ARCH_7A__) \\
+            || defined(__ARM_ARCH_7R__) \\
+            || defined(__ARM_ARCH_7M__) \\
+            || (defined(__TARGET_ARCH_ARM) && __TARGET_ARCH_ARM-0 >= 7)
+            #error cmake_ARCH armv7
+        #elif defined(__ARM_ARCH_6__) \\
+            || defined(__ARM_ARCH_6J__) \\
+            || defined(__ARM_ARCH_6T2__) \\
+            || defined(__ARM_ARCH_6Z__) \\
+            || defined(__ARM_ARCH_6K__) \\
+            || defined(__ARM_ARCH_6ZK__) \\
+            || defined(__ARM_ARCH_6M__) \\
+            || (defined(__TARGET_ARCH_ARM) && __TARGET_ARCH_ARM-0 >= 6)
+            #error cmake_ARCH armv6
+        #elif defined(__ARM_ARCH_5TEJ__) \\
+            || (defined(__TARGET_ARCH_ARM) && __TARGET_ARCH_ARM-0 >= 5)
+            #error cmake_ARCH armv5
+        #else
+            #error cmake_ARCH arm
+        #endif
+    #elif defined(__i386) || defined(__i386__) || defined(_M_IX86)
+        #error cmake_ARCH i386
+    #elif defined(__i486__) || defined(__i586__) || defined(__i686__)
+        #error cmake_ARCH ix86
+    #elif defined(__x86_64) || defined(__x86_64__) || defined(__amd64) || defined(__amd64__) || defined(_M_X64)
+        #error cmake_ARCH x86_64
+    #elif defined(__ia64) || defined(__ia64__) || defined(_M_IA64)
+        #error cmake_ARCH ia64
+    #elif defined(__ppc__) || defined(__ppc) || defined(__powerpc__) \\
+          || defined(_ARCH_COM) || defined(_ARCH_PWR) || defined(_ARCH_PPC)  \\
+          || defined(_M_MPPC) || defined(_M_PPC)
+        #if defined(__ppc64__) || defined(__powerpc64__) || defined(__64BIT__)
+            #error cmake_ARCH ppc64
+        #else
+            #error cmake_ARCH ppc
+        #endif
+    #elif defined(__bgq__)
+        #error cmake_ARCH bgq
+    #elif defined(__s390x__)
+        #error cmake_ARCH s390x
+    #endif
+
+    #error cmake_ARCH unknown
+")
+
+# Set ppc_support to TRUE before including this file or ppc and ppc64
+# will be treated as invalid architectures since they are no longer supported by Apple
+
+function(target_architecture output_var)
+    if(APPLE AND CMAKE_OSX_ARCHITECTURES)
+        # On OS X we use CMAKE_OSX_ARCHITECTURES *if* it was set
+        # First let's normalize the order of the values
+
+        # Note that it's not possible to compile PowerPC applications if you are using
+        # the OS X SDK version 10.6 or later - you'll need 10.4/10.5 for that, so we
+        # disable it by default
+        # See this page for more information:
+        # http://stackoverflow.com/questions/5333490/how-can-we-restore-ppc-ppc64-as-well-as-full-10-4-10-5-sdk-support-to-xcode-4
+
+        # Architecture defaults to i386 or ppc on OS X 10.5 and earlier, depending
+        # on the CPU type detected at runtime.
+        # On OS X 10.6+ the default is x86_64 if the CPU supports it, i386 otherwise.
+
+        foreach(osx_arch ${CMAKE_OSX_ARCHITECTURES})
+            if("${osx_arch}" STREQUAL "ppc" AND ppc_support)
+                set(osx_arch_ppc TRUE)
+            elseif("${osx_arch}" STREQUAL "i386")
+                set(osx_arch_i386 TRUE)
+            elseif("${osx_arch}" STREQUAL "x86_64")
+                set(osx_arch_x86_64 TRUE)
+            elseif("${osx_arch}" STREQUAL "ppc64" AND ppc_support)
+                set(osx_arch_ppc64 TRUE)
+            else()
+                message(FATAL_ERROR "Invalid OS X arch name: ${osx_arch}")
+            endif()
+        endforeach()
+
+        # Now add all the architectures in our normalized order
+        if(osx_arch_ppc)
+            list(APPEND ARCH ppc)
+        endif()
+
+        if(osx_arch_i386)
+            list(APPEND ARCH i386)
+        endif()
+
+        if(osx_arch_x86_64)
+            list(APPEND ARCH x86_64)
+        endif()
+
+        if(osx_arch_ppc64)
+            list(APPEND ARCH ppc64)
+        endif()
+    else()
+        file(WRITE "${CMAKE_BINARY_DIR}/arch.c" "${archdetect_c_code}")
+
+        enable_language(C)
+
+        # Detect the architecture in a rather creative way...
+        # This compiles a small C program which is a series of ifdefs that selects a
+        # particular #error preprocessor directive whose message string contains the
+        # target architecture. The program will always fail to compile (both because
+        # file is not a valid C program, and obviously because of the presence of the
+        # #error preprocessor directives... but by exploiting the preprocessor in this
+        # way, we can detect the correct target architecture even when cross-compiling,
+        # since the program itself never needs to be run (only the compiler/preprocessor)
+        try_run(
+            run_result_unused
+            compile_result_unused
+            "${CMAKE_BINARY_DIR}"
+            "${CMAKE_BINARY_DIR}/arch.c"
+            COMPILE_OUTPUT_VARIABLE ARCH
+            CMAKE_FLAGS CMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}
+        )
+
+        # Parse the architecture name from the compiler output
+        string(REGEX MATCH "cmake_ARCH ([a-zA-Z0-9_]+)" ARCH "${ARCH}")
+
+        # Get rid of the value marker leaving just the architecture name
+        string(REPLACE "cmake_ARCH " "" ARCH "${ARCH}")
+
+        # If we are compiling with an unknown architecture this variable should
+        # already be set to "unknown" but in the case that it's empty (i.e. due
+        # to a typo in the code), then set it to unknown
+        if (NOT ARCH)
+            set(ARCH unknown)
+        endif()
+    endif()
+
+    set(${output_var} "${ARCH}" PARENT_SCOPE)
+endfunction()

--- a/hpx/util/hardware/timestamp.hpp
+++ b/hpx/util/hardware/timestamp.hpp
@@ -12,18 +12,17 @@
 
 #if defined(HPX_MSVC)
   #include <hpx/util/hardware/timestamp/msvc.hpp>
-#elif defined(__amd64__) || defined(__amd64)    \
-   || defined(__x86_64__) || defined(__x86_64)  \
-   || defined(_M_X64)
+#elif defined(__amd64__) || defined(__amd64) || defined(__x86_64__) ||         \
+    defined(__x86_64) || defined(_M_X64)
     #if defined(HPX_HAVE_RDTSC) || defined(HPX_HAVE_RDTSCP)
         #include <hpx/util/hardware/timestamp/linux_x86_64.hpp>
     #else
         #include <hpx/util/hardware/timestamp/linux_generic.hpp>
     #endif
-#elif defined(i386) || defined(__i386__) || defined(__i486__)           \
-   || defined(__i586__) || defined(__i686__) || defined(__i386)         \
-   || defined(_M_IX86) || defined(__X86__) || defined(_X86_)            \
-   || defined(__THW_INTEL__) || defined(__I86__) || defined(__INTEL__)
+#elif defined(i386) || defined(__i386__) || defined(__i486__) ||               \
+    defined(__i586__) || defined(__i686__) || defined(__i386) ||               \
+    defined(_M_IX86) || defined(__X86__) || defined(_X86_) ||                  \
+    defined(__THW_INTEL__) || defined(__I86__) || defined(__INTEL__)
     #if defined(HPX_HAVE_RDTSC) || defined(HPX_HAVE_RDTSCP)
         #include <hpx/util/hardware/timestamp/linux_x86_32.hpp>
     #else
@@ -33,7 +32,7 @@
     #include <hpx/util/hardware/timestamp/linux_generic.hpp>
 #elif defined(__arm__) || defined(__arm64__) || defined(__aarch64__)
     #include <hpx/util/hardware/timestamp/linux_generic.hpp>
-#elif defined(__powerpc__)
+#elif defined(__ppc__) || defined(__ppc) || defined(__powerpc__)
     #include <hpx/util/hardware/timestamp/linux_generic.hpp>
 #elif defined(__bgq__)
     #include <hpx/util/hardware/timestamp/bgq.hpp>


### PR DESCRIPTION
- aligned cmake and code timestamp detection

This improves the error reporting for platforms for which we do not support extracting timestamps.

Fixes #3601
