### PR TITLE
making clang-tidy work properly again

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,11 +3,19 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-Checks: '-*,modernize-use-nullptr,misc-use-after-move,misc-virtual-near-miss,misc-multiple-statement-macro,misc-move-constructor-init,misc-move-forwarding-reference,misc-assert-side-effect,misc-dangling-handle,misc-non-copyable-objects,misc-forwarding-reference-overload,misc-unused-raii'
+Checks: >
+    -*,
+    bugprone-*,
+    -bugprone-assert-side-effect,
+    -bugprone-exception-escape,
+    -bugprone-forward-declaration-namespace,
+    -bugprone-macro-parentheses,
+    modernize-use-nullptr,
+    misc-non-copyable-objects
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*hpx.*'
 CheckOptions:
-  - key: misc-assert-side-effect.CheckFunctionCalls
+  - key: bugprone-assert-side-effect.CheckFunctionCalls
     value: 1
-  - key: misc-assert-side-effect.AssertMacros
+  - key: bugprone-assert-side-effect.AssertMacros
     value: 'HPX_ASSERT'

--- a/hpx/exception_fwd.hpp
+++ b/hpx/exception_fwd.hpp
@@ -12,13 +12,6 @@
 #include <hpx/config.hpp>
 #include <hpx/error.hpp>
 
-/// \cond NOINTERNAL
-namespace boost
-{
-    class exception_ptr;
-}
-/// \endcond
-
 namespace hpx
 {
     /// \cond NOINTERNAL

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -881,7 +881,7 @@ namespace hpx { namespace lcos { namespace detail
     unwrap_impl(Future && future, error_code& ec)
     {
         return unwrap_impl_alloc(
-            util::internal_allocator<>{}, std::move(future), ec);
+            util::internal_allocator<>{}, std::forward<Future>(future), ec);
     }
 
 //     template <typename R>

--- a/hpx/lcos/local/recursive_mutex.hpp
+++ b/hpx/lcos/local/recursive_mutex.hpp
@@ -28,7 +28,7 @@ namespace hpx { namespace lcos { namespace local
         {
             typedef std::size_t thread_id_type;
 
-            static thread_id_type invalid_id() { return thread_id_type(~0u); }
+            static thread_id_type invalid_id() { return ~0u; }
 
             static thread_id_type call()
             {
@@ -45,7 +45,7 @@ namespace hpx { namespace lcos { namespace local
         {
             typedef std::size_t thread_id_type;
 
-            static thread_id_type invalid_id() { return thread_id_type(~0u); }
+            static thread_id_type invalid_id() { return ~0u; }
 
             static thread_id_type call()
             {

--- a/hpx/parallel/executors/execution_parameters.hpp
+++ b/hpx/parallel/executors/execution_parameters.hpp
@@ -559,9 +559,8 @@ namespace hpx { namespace parallel { namespace execution
         template <typename T>
         struct base_member_helper
         {
-            template <typename U>
-            explicit base_member_helper(U&& t)
-              : member_(std::forward<U>(t))
+            explicit base_member_helper(T t)
+              : member_(t)
             {}
 
             T member_;

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -23,6 +23,7 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <cmath>
 #include <exception>
 #include <memory>
 #include <string>
@@ -1106,8 +1107,7 @@ namespace hpx { namespace threads { namespace policies
 
             // iterate over the number of threads again to determine where to
             // steal from
-            std::ptrdiff_t radius =
-                static_cast<std::ptrdiff_t>((num_threads / 2.0) + 0.5);
+            std::ptrdiff_t radius = std::lround(num_threads / 2.0);
             victim_threads_[num_thread].reserve(num_threads);
 
             std::size_t num_pu = rp_.get_affinity_data().get_pu_num(num_thread);

--- a/hpx/runtime/threads/policies/queue_helpers.hpp
+++ b/hpx/runtime/threads/policies/queue_helpers.hpp
@@ -15,6 +15,7 @@
 #include <hpx/util/logging.hpp>
 #include <hpx/util/unused.hpp>
 
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <vector>
@@ -66,7 +67,7 @@ namespace hpx { namespace threads { namespace policies
         // ----------------------------------------------------------------
         inline std::size_t get_queue_index(std::size_t id) const
         {
-            return static_cast<std::size_t>(0.5 + id*scale);;
+            return std::lround(id*scale);
         }
 
         // ----------------------------------------------------------------

--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -559,7 +559,7 @@ namespace hpx
             start(*rt, cfg.hpx_main_f_, cfg.vm_, cfg.rtcfg_.mode_, std::move(startup),
                 std::move(shutdown));
 
-            rt.release();          // pointer to runtime is stored in TLS
+            (void)rt.release();          // pointer to runtime is stored in TLS
             return 0;
         }
 

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -2890,7 +2890,7 @@ namespace hpx
                 "no basename specified");
         }
 
-        if (sequence_nr == std::size_t(~0U))
+        if (sequence_nr == ~0U)
         {
             sequence_nr =
                 std::size_t(naming::get_locality_id_from_id(find_here()));
@@ -2910,7 +2910,7 @@ namespace hpx
                 "no basename specified");
         }
 
-        if (sequence_nr == std::size_t(~0U))
+        if (sequence_nr == ~0U)
         {
             sequence_nr =
                 std::size_t(naming::get_locality_id_from_id(find_here()));
@@ -2944,7 +2944,7 @@ namespace hpx
                 "no basename specified");
         }
 
-        if (sequence_nr == std::size_t(~0U))
+        if (sequence_nr == ~0U)
         {
             sequence_nr =
                 std::size_t(naming::get_locality_id_from_id(find_here()));

--- a/src/util/runtime_configuration.cpp
+++ b/src/util/runtime_configuration.cpp
@@ -133,7 +133,7 @@ namespace hpx { namespace util
             "[hpx]",
             "location = ${HPX_LOCATION:$[system.prefix]}",
             "component_paths = ${HPX_COMPONENT_PATHS}",
-            "component_base_paths = $[hpx.location]"
+            "component_base_paths = $[hpx.location]" // NOLINT
                 HPX_INI_PATH_DELIMITER "$[system.executable_prefix]",
             "component_path_suffixes = /lib/hpx" HPX_INI_PATH_DELIMITER
                                       "/bin/hpx",

--- a/tests/performance/parallel_algorithms/local/benchmark_remove_if.cpp
+++ b/tests/performance/parallel_algorithms/local/benchmark_remove_if.cpp
@@ -99,7 +99,7 @@ double run_remove_if_benchmark_std(int test_count,
             org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
-        std::remove_if(first, last, pred);
+        (void)std::remove_if(first, last, pred);
         time += hpx::util::high_resolution_clock::now() - elapsed;
     }
 

--- a/tests/unit/parallel/algorithms/sort_tests.hpp
+++ b/tests/unit/parallel/algorithms/sort_tests.hpp
@@ -85,7 +85,7 @@ void rnd_strings(std::vector<std::string> &V)
 // --------------------------------------------------------------------
 // check that the array is sorted correctly
 template <class IA, typename Compare>
-int verify_(const std::vector <IA> &A, Compare comp, std::uint64_t elapsed,
+int verify_(const std::vector <IA> &A, Compare comp, double elapsed,
     bool print)
 {
     if (A.size()<2) {

--- a/tests/unit/serialization/serialization_list.cpp
+++ b/tests/unit/serialization/serialization_list.cpp
@@ -36,7 +36,7 @@ struct A
 struct B
 {
     const int a;
-    double b;
+    short b;
 
 public:
     B() = delete;

--- a/tests/unit/util/any.cpp
+++ b/tests/unit/util/any.cpp
@@ -132,7 +132,7 @@ int hpx_main(variables_map& vm)
             HPX_TEST(!any1.empty());
             any any2(std::move(any1));
             HPX_TEST(!any2.empty());
-            HPX_TEST(any1.empty());
+            HPX_TEST(any1.empty()); // NOLINT
         }
 
         {
@@ -143,7 +143,7 @@ int hpx_main(variables_map& vm)
 
             any2 = std::move(any1);
             HPX_TEST(!any2.empty());
-            HPX_TEST(any1.empty());
+            HPX_TEST(any1.empty()); // NOLINT
         }
     }
     // non serializable version
@@ -219,7 +219,7 @@ int hpx_main(variables_map& vm)
             HPX_TEST(!any1.empty());
             any_nonser any2(std::move(any1));
             HPX_TEST(!any2.empty());
-            HPX_TEST(any1.empty());
+            HPX_TEST(any1.empty()); // NOLINT
         }
 
         {
@@ -230,7 +230,7 @@ int hpx_main(variables_map& vm)
 
             any2 = std::move(any1);
             HPX_TEST(!any2.empty());
-            HPX_TEST(any1.empty());
+            HPX_TEST(any1.empty()); // NOLINT
         }
     }
 

--- a/tests/unit/util/iterator/iterator_facade.cpp
+++ b/tests/unit/util/iterator/iterator_facade.cpp
@@ -104,9 +104,12 @@ struct wrapper
 {
     T m_x;
 
-    template <typename T_>
-    explicit wrapper(T_ && x)
-        : m_x(std::forward<T_>(x))
+    template <typename T_,
+        typename TD = typename std::decay<T_>::type,
+        typename Enable =
+            typename std::enable_if<!std::is_same<TD, wrapper<T>>::value>::type>
+    explicit wrapper(T_&& x)
+      : m_x(std::forward<T_>(x))
     {}
 
     template <typename U>


### PR DESCRIPTION
This PR makes sure that the code is properly checked with the below enabled checks:
   
     - All of bugprone except:
        - bugprone-assert-side-effect
        - bugprone-exception-escape
        - bugprone-forward-declaration-namespace
        - bugprone-macro-parentheses
     - Removing removed tests

This PR includes the fixes that appeared.