### PR TITLE
Reduce functional utilities call depth

### DIFF
--- a/hpx/util/bind.hpp
+++ b/hpx/util/bind.hpp
@@ -135,7 +135,7 @@ namespace hpx { namespace util
             >::type operator()(Us&&... vs) &
             {
                 using invoke_impl = typename detail::dispatch_invoke<F&>::type;
-                return invoke_impl{_f}(detail::bind_eval<Ts&>::call(
+                return invoke_impl(_f)(detail::bind_eval<Ts&>::call(
                     util::get<Is>(_args),
                     util::forward_as_tuple(std::forward<Us>(vs)...))...);
             }
@@ -149,7 +149,7 @@ namespace hpx { namespace util
             >::type operator()(Us&&... vs) const&
             {
                 using invoke_impl = typename detail::dispatch_invoke<F const&>::type;
-                return invoke_impl{_f}(detail::bind_eval<Ts const&>::call(
+                return invoke_impl(_f)(detail::bind_eval<Ts const&>::call(
                     util::get<Is>(_args),
                     util::forward_as_tuple(std::forward<Us>(vs)...))...);
             }
@@ -163,7 +163,7 @@ namespace hpx { namespace util
             >::type operator()(Us&&... vs) &&
             {
                 using invoke_impl = typename detail::dispatch_invoke<F>::type;
-                return invoke_impl{std::move(_f)}(detail::bind_eval<Ts>::call(
+                return invoke_impl(std::move(_f))(detail::bind_eval<Ts>::call(
                     util::get<Is>(std::move(_args)),
                     util::forward_as_tuple(std::forward<Us>(vs)...))...);
             }
@@ -177,7 +177,7 @@ namespace hpx { namespace util
             >::type operator()(Us&&... vs) const&&
             {
                 using invoke_impl = typename detail::dispatch_invoke<F const>::type;
-                return invoke_impl{std::move(_f)}(detail::bind_eval<Ts const>::call(
+                return invoke_impl(std::move(_f))(detail::bind_eval<Ts const>::call(
                     util::get<Is>(std::move(_args)),
                     util::forward_as_tuple(std::forward<Us>(vs)...))...);
             }
@@ -199,7 +199,7 @@ namespace hpx { namespace util
             >;
 
         public:
-            bound() : base_type{} {} // needed for serialization
+            bound() {} // needed for serialization
 
             template <typename F_, typename ...Ts_, typename =
                 typename std::enable_if<

--- a/hpx/util/bind.hpp
+++ b/hpx/util/bind.hpp
@@ -134,8 +134,7 @@ namespace hpx { namespace util
                 util::tuple<Us&&...>
             >::type operator()(Us&&... vs) &
             {
-                using invoke_impl = typename detail::dispatch_invoke<F&>::type;
-                return invoke_impl(_f)(detail::bind_eval<Ts&>::call(
+                return HPX_INVOKE(_f, detail::bind_eval<Ts&>::call(
                     util::get<Is>(_args),
                     util::forward_as_tuple(std::forward<Us>(vs)...))...);
             }
@@ -148,8 +147,7 @@ namespace hpx { namespace util
                 util::tuple<Us&&...>
             >::type operator()(Us&&... vs) const&
             {
-                using invoke_impl = typename detail::dispatch_invoke<F const&>::type;
-                return invoke_impl(_f)(detail::bind_eval<Ts const&>::call(
+                return HPX_INVOKE(_f, detail::bind_eval<Ts const&>::call(
                     util::get<Is>(_args),
                     util::forward_as_tuple(std::forward<Us>(vs)...))...);
             }
@@ -162,8 +160,7 @@ namespace hpx { namespace util
                 util::tuple<Us&&...>
             >::type operator()(Us&&... vs) &&
             {
-                using invoke_impl = typename detail::dispatch_invoke<F>::type;
-                return invoke_impl(std::move(_f))(detail::bind_eval<Ts>::call(
+                return HPX_INVOKE(std::move(_f), detail::bind_eval<Ts>::call(
                     util::get<Is>(std::move(_args)),
                     util::forward_as_tuple(std::forward<Us>(vs)...))...);
             }
@@ -176,8 +173,7 @@ namespace hpx { namespace util
                 util::tuple<Us&&...>
             >::type operator()(Us&&... vs) const&&
             {
-                using invoke_impl = typename detail::dispatch_invoke<F const>::type;
-                return invoke_impl(std::move(_f))(detail::bind_eval<Ts const>::call(
+                return HPX_INVOKE(std::move(_f), detail::bind_eval<Ts const>::call(
                     util::get<Is>(std::move(_args)),
                     util::forward_as_tuple(std::forward<Us>(vs)...))...);
             }

--- a/hpx/util/bind.hpp
+++ b/hpx/util/bind.hpp
@@ -171,13 +171,14 @@ namespace hpx { namespace util
         {};
 
         ///////////////////////////////////////////////////////////////////////
-        template <typename F, typename Ts, typename Us, std::size_t ...Is>
+        template <std::size_t ...Is, typename F, typename Ts, typename Us>
         HPX_CONSTEXPR HPX_HOST_DEVICE
         typename invoke_bound_result<F&&, Ts&&, Us>::type
-        bound_impl(F&& f, Ts&& bound, Us&& unbound,
-            pack_c<std::size_t, Is...>)
+        bound_impl(pack_c<std::size_t, Is...>,
+            F&& f, Ts&& bound, Us&& unbound)
         {
-            return util::invoke(std::forward<F>(f),
+            using invoke_impl = typename detail::dispatch_invoke<F>::type;
+            return invoke_impl{std::forward<F>(f)}(
                 detail::bind_eval(
                     util::get<Is>(std::forward<Ts>(bound)),
                     std::forward<Us>(unbound))...);
@@ -223,9 +224,10 @@ namespace hpx { namespace util
                 util::tuple<Us&&...>
             >::type operator()(Us&&... vs) &
             {
-                return detail::bound_impl(_f, _args,
-                    util::forward_as_tuple(std::forward<Us>(vs)...),
-                    typename detail::make_index_pack<sizeof...(Ts)>::type());
+                using index_pack =
+                    typename detail::make_index_pack<sizeof...(Ts)>::type;
+                return detail::bound_impl(index_pack{},
+                    _f, _args, util::forward_as_tuple(std::forward<Us>(vs)...));
             }
 
             template <typename ...Us>
@@ -236,9 +238,10 @@ namespace hpx { namespace util
                 util::tuple<Us&&...>
             >::type operator()(Us&&... vs) const&
             {
-                return detail::bound_impl(_f, _args,
-                    util::forward_as_tuple(std::forward<Us>(vs)...),
-                    typename detail::make_index_pack<sizeof...(Ts)>::type());
+                using index_pack =
+                    typename detail::make_index_pack<sizeof...(Ts)>::type;
+                return detail::bound_impl(index_pack{},
+                    _f, _args, util::forward_as_tuple(std::forward<Us>(vs)...));
             }
 
             template <typename ...Us>
@@ -249,9 +252,11 @@ namespace hpx { namespace util
                 util::tuple<Us&&...>
             >::type operator()(Us&&... vs) &&
             {
-                return detail::bound_impl(std::move(_f), std::move(_args),
-                    util::forward_as_tuple(std::forward<Us>(vs)...),
-                    typename detail::make_index_pack<sizeof...(Ts)>::type());
+                using index_pack =
+                    typename detail::make_index_pack<sizeof...(Ts)>::type;
+                return detail::bound_impl(index_pack{},
+                    std::move(_f), std::move(_args),
+                    util::forward_as_tuple(std::forward<Us>(vs)...));
             }
 
             template <typename ...Us>
@@ -262,9 +267,11 @@ namespace hpx { namespace util
                 util::tuple<Us&&...>
             >::type operator()(Us&&... vs) const&&
             {
-                return detail::bound_impl(std::move(_f), std::move(_args),
-                    util::forward_as_tuple(std::forward<Us>(vs)...),
-                    typename detail::make_index_pack<sizeof...(Ts)>::type());
+                using index_pack =
+                    typename detail::make_index_pack<sizeof...(Ts)>::type;
+                return detail::bound_impl(index_pack{},
+                    std::move(_f), std::move(_args),
+                    util::forward_as_tuple(std::forward<Us>(vs)...));
             }
 
             template <typename Archive>

--- a/hpx/util/bind.hpp
+++ b/hpx/util/bind.hpp
@@ -57,146 +57,158 @@ namespace hpx { namespace util
     ///////////////////////////////////////////////////////////////////////////
     namespace detail
     {
-        template <
-            typename T, typename Us,
-            typename TD = typename std::decay<T>::type,
-            typename Enable = void
-        >
-        struct bind_eval_impl
+        template <std::size_t I>
+        struct bind_eval_placeholder
         {
-            typedef T&& type;
-
+            template <typename T, typename Us>
             static HPX_CONSTEXPR HPX_HOST_DEVICE
-            type call(T&& t, Us&& /*unbound*/)
-            {
-                return std::forward<T>(t);
-            }
-        };
-
-        template <
-            std::size_t I, typename Us,
-            typename Enable = void
-        >
-        struct bind_eval_placeholder_impl
-        {};
-
-        template <std::size_t I, typename Us>
-        struct bind_eval_placeholder_impl<I, Us,
-            typename std::enable_if<
-                (I < util::tuple_size<Us>::value)
-            >::type
-        >
-        {
-            typedef typename util::tuple_element<
-                I, typename std::decay<Us>::type
-            >::type&& type;
-
-            template <typename T>
-            static HPX_CONSTEXPR HPX_HOST_DEVICE
-            type call(T&& /*t*/, Us&& unbound)
+            typename util::tuple_element<
+                I, typename std::remove_reference<Us>::type
+            >::type&& call(T&& /*t*/, Us&& unbound)
             {
                 return util::get<I>(std::forward<Us>(unbound));
             }
         };
 
-        template <typename T, typename Us, typename TD>
-        struct bind_eval_impl<T, Us, TD,
+        template <
+            typename T, typename TD = typename std::decay<T>::type,
+            typename Enable = void>
+        struct bind_eval
+        {
+            template <typename Us>
+            static HPX_CONSTEXPR HPX_HOST_DEVICE
+            T&& call(T&& t, Us&& /*unbound*/)
+            {
+                return std::forward<T>(t);
+            }
+        };
+
+        template <typename T, typename TD>
+        struct bind_eval<T, TD,
             typename std::enable_if<
                 traits::is_placeholder<TD>::value != 0
             >::type
-        > : bind_eval_placeholder_impl<
-                (std::size_t)traits::is_placeholder<TD>::value - 1, Us
-            >
+        > : bind_eval_placeholder<
+                (std::size_t)traits::is_placeholder<TD>::value - 1>
         {};
 
-        template <typename T, typename Us, typename TD>
-        struct bind_eval_impl<T, Us, TD,
+        template <typename T, typename TD>
+        struct bind_eval<T, TD,
             typename std::enable_if<
                 traits::is_bind_expression<TD>::value
             >::type
         >
         {
-            typedef typename util::detail::invoke_fused_result<T, Us>::type type;
-
+            template <typename Us>
             static HPX_CONSTEXPR HPX_HOST_DEVICE
-            type call(T&& t, Us&& unbound)
+            typename util::detail::invoke_fused_result<T, Us>::type
+            call(T&& t, Us&& unbound)
             {
                 return util::invoke_fused(
                     std::forward<T>(t), std::forward<Us>(unbound));
             }
         };
 
-        template <typename T, typename Us>
-        HPX_CONSTEXPR HPX_HOST_DEVICE
-        typename bind_eval_impl<T, Us>::type
-        bind_eval(T&& t, Us&& unbound)
-        {
-            return bind_eval_impl<T, Us>::call(
-                std::forward<T>(t), std::forward<Us>(unbound));
-        }
-
-        ///////////////////////////////////////////////////////////////////////
-        template <typename F, typename Ts, typename Us>
-        struct invoke_bound_result_impl;
-
-        template <typename F, typename ...Ts, typename Us>
-        struct invoke_bound_result_impl<F, util::tuple<Ts...>, Us>
-          : util::invoke_result<
-                F, typename bind_eval_impl<Ts, Us>::type...
-            >
-        {};
-
         ///////////////////////////////////////////////////////////////////////
         template <typename F, typename Ts, typename Us>
         struct invoke_bound_result;
 
         template <typename F, typename ...Ts, typename Us>
-        struct invoke_bound_result<F&, util::tuple<Ts...>&, Us>
-          : invoke_bound_result_impl<F&, util::tuple<Ts&...>, Us>
-        {};
-
-        template <typename F, typename ...Ts, typename Us>
-        struct invoke_bound_result<F const&, util::tuple<Ts...> const&, Us>
-          : invoke_bound_result_impl<F const&, util::tuple<Ts const&...>, Us>
-        {};
-
-        template <typename F, typename ...Ts, typename Us>
-        struct invoke_bound_result<F&&, util::tuple<Ts...>&&, Us>
-          : invoke_bound_result_impl<F&&, util::tuple<Ts&&...>, Us>
-        {};
-
-        template <typename F, typename ...Ts, typename Us>
-        struct invoke_bound_result<F const&&, util::tuple<Ts...> const&&, Us>
-          : invoke_bound_result_impl<F const&&, util::tuple<Ts const&&...>, Us>
+        struct invoke_bound_result<F, util::tuple<Ts...>, Us>
+          : util::invoke_result<F, decltype(bind_eval<Ts>::call(
+                std::declval<Ts>(), std::declval<Us>()))...>
         {};
 
         ///////////////////////////////////////////////////////////////////////
-        template <std::size_t ...Is, typename F, typename Ts, typename Us>
-        HPX_CONSTEXPR HPX_HOST_DEVICE
-        typename invoke_bound_result<F&&, Ts&&, Us>::type
-        bound_impl(pack_c<std::size_t, Is...>,
-            F&& f, Ts&& bound, Us&& unbound)
+        template <typename F, typename Ts, typename Is>
+        struct bound_impl;
+
+        template <typename F, typename ...Ts, std::size_t ...Is>
+        struct bound_impl<F, util::tuple<Ts...>, pack_c<std::size_t, Is...>>
         {
-            using invoke_impl = typename detail::dispatch_invoke<F>::type;
-            return invoke_impl{std::forward<F>(f)}(
-                detail::bind_eval(
-                    util::get<Is>(std::forward<Ts>(bound)),
-                    std::forward<Us>(unbound))...);
-        }
+            template <typename ...Us>
+            HPX_CXX14_CONSTEXPR HPX_HOST_DEVICE
+            typename invoke_bound_result<
+                F&,
+                util::tuple<Ts&...>,
+                util::tuple<Us&&...>
+            >::type operator()(Us&&... vs) &
+            {
+                using invoke_impl = typename detail::dispatch_invoke<F&>::type;
+                return invoke_impl{_f}(detail::bind_eval<Ts&>::call(
+                    util::get<Is>(_args),
+                    util::forward_as_tuple(std::forward<Us>(vs)...))...);
+            }
+
+            template <typename ...Us>
+            HPX_CONSTEXPR HPX_HOST_DEVICE
+            typename invoke_bound_result<
+                F const&,
+                util::tuple<Ts const&...>,
+                util::tuple<Us&&...>
+            >::type operator()(Us&&... vs) const&
+            {
+                using invoke_impl = typename detail::dispatch_invoke<F const&>::type;
+                return invoke_impl{_f}(detail::bind_eval<Ts const&>::call(
+                    util::get<Is>(_args),
+                    util::forward_as_tuple(std::forward<Us>(vs)...))...);
+            }
+
+            template <typename ...Us>
+            HPX_CXX14_CONSTEXPR HPX_HOST_DEVICE
+            typename invoke_bound_result<
+                F&&,
+                util::tuple<Ts&&...>,
+                util::tuple<Us&&...>
+            >::type operator()(Us&&... vs) &&
+            {
+                using invoke_impl = typename detail::dispatch_invoke<F>::type;
+                return invoke_impl{std::move(_f)}(detail::bind_eval<Ts>::call(
+                    util::get<Is>(std::move(_args)),
+                    util::forward_as_tuple(std::forward<Us>(vs)...))...);
+            }
+
+            template <typename ...Us>
+            HPX_CONSTEXPR HPX_HOST_DEVICE
+            typename invoke_bound_result<
+                F const&&,
+                util::tuple<Ts const&&...>,
+                util::tuple<Us&&...>
+            >::type operator()(Us&&... vs) const&&
+            {
+                using invoke_impl = typename detail::dispatch_invoke<F const>::type;
+                return invoke_impl{std::move(_f)}(detail::bind_eval<Ts const>::call(
+                    util::get<Is>(std::move(_args)),
+                    util::forward_as_tuple(std::forward<Us>(vs)...))...);
+            }
+
+            F _f;
+            util::tuple<Ts...> _args;
+        };
 
         template <typename F, typename ...Ts>
         class bound
+          : private bound_impl<
+                F, util::tuple<typename util::decay_unwrap<Ts>::type...>,
+                typename detail::make_index_pack<sizeof...(Ts)>::type
+            >
         {
+            using base_type = detail::bound_impl<
+                F, util::tuple<typename util::decay_unwrap<Ts>::type...>,
+                typename detail::make_index_pack<sizeof...(Ts)>::type
+            >;
+
         public:
-            bound() {} // needed for serialization
+            bound() : base_type{} {} // needed for serialization
 
             template <typename F_, typename ...Ts_, typename =
                 typename std::enable_if<
                     !std::is_same<typename std::decay<F_>::type, bound>::value
                 >::type>
             HPX_CONSTEXPR explicit bound(F_&& f, Ts_&&... vs)
-              : _f(std::forward<F_>(f))
-              , _args(std::forward<Ts_>(vs)...)
+              : base_type{
+                    std::forward<F_>(f),
+                    util::forward_as_tuple(std::forward<Ts_>(vs)...)}
             {}
 
 #if !defined(__NVCC__) && !defined(__CUDACC__)
@@ -204,75 +216,17 @@ namespace hpx { namespace util
             bound(bound&&) = default;
 #else
             HPX_HOST_DEVICE bound(bound const& other)
-              : _f(other._f)
-              , _args(other._args)
+              : base_type{other}
             {}
 
             HPX_HOST_DEVICE bound(bound&& other)
-              : _f(std::move(other._f))
-              , _args(std::move(other._args))
+              : base_type{std::move(other)}
             {}
 #endif
 
             bound& operator=(bound const&) = delete;
 
-            template <typename ...Us>
-            HPX_CXX14_CONSTEXPR HPX_HOST_DEVICE
-            typename invoke_bound_result<
-                typename std::decay<F>::type&,
-                util::tuple<typename util::decay_unwrap<Ts>::type...>&,
-                util::tuple<Us&&...>
-            >::type operator()(Us&&... vs) &
-            {
-                using index_pack =
-                    typename detail::make_index_pack<sizeof...(Ts)>::type;
-                return detail::bound_impl(index_pack{},
-                    _f, _args, util::forward_as_tuple(std::forward<Us>(vs)...));
-            }
-
-            template <typename ...Us>
-            HPX_CONSTEXPR HPX_HOST_DEVICE
-            typename invoke_bound_result<
-                typename std::decay<F>::type const&,
-                util::tuple<typename util::decay_unwrap<Ts>::type...> const&,
-                util::tuple<Us&&...>
-            >::type operator()(Us&&... vs) const&
-            {
-                using index_pack =
-                    typename detail::make_index_pack<sizeof...(Ts)>::type;
-                return detail::bound_impl(index_pack{},
-                    _f, _args, util::forward_as_tuple(std::forward<Us>(vs)...));
-            }
-
-            template <typename ...Us>
-            HPX_CXX14_CONSTEXPR HPX_HOST_DEVICE
-            typename invoke_bound_result<
-                typename std::decay<F>::type&&,
-                util::tuple<typename util::decay_unwrap<Ts>::type...>&&,
-                util::tuple<Us&&...>
-            >::type operator()(Us&&... vs) &&
-            {
-                using index_pack =
-                    typename detail::make_index_pack<sizeof...(Ts)>::type;
-                return detail::bound_impl(index_pack{},
-                    std::move(_f), std::move(_args),
-                    util::forward_as_tuple(std::forward<Us>(vs)...));
-            }
-
-            template <typename ...Us>
-            HPX_CONSTEXPR HPX_HOST_DEVICE
-            typename invoke_bound_result<
-                typename std::decay<F>::type const&&,
-                util::tuple<typename util::decay_unwrap<Ts>::type...> const&&,
-                util::tuple<Us&&...>
-            >::type operator()(Us&&... vs) const&&
-            {
-                using index_pack =
-                    typename detail::make_index_pack<sizeof...(Ts)>::type;
-                return detail::bound_impl(index_pack{},
-                    std::move(_f), std::move(_args),
-                    util::forward_as_tuple(std::forward<Us>(vs)...));
-            }
+            using base_type::operator();
 
             template <typename Archive>
             void serialize(Archive& ar, unsigned int const /*version*/)
@@ -283,17 +237,13 @@ namespace hpx { namespace util
 
             std::size_t get_function_address() const
             {
-                return traits::get_function_address<
-                        typename std::decay<F>::type
-                    >::call(_f);
+                return traits::get_function_address<F>::call(_f);
             }
 
             char const* get_function_annotation() const
             {
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
-                return traits::get_function_annotation<
-                        typename std::decay<F>::type
-                    >::call(_f);
+                return traits::get_function_annotation<F>::call(_f);
 #else
                 return nullptr;
 #endif
@@ -303,9 +253,7 @@ namespace hpx { namespace util
             util::itt::string_handle get_function_annotation_itt() const
             {
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
-                return traits::get_function_annotation_itt<
-                        typename std::decay<F>::type
-                    >::call(_f);
+                return traits::get_function_annotation_itt<F>::call(_f);
 #else
                 static util::itt::string_handle sh("bound");
                 return sh;
@@ -314,8 +262,8 @@ namespace hpx { namespace util
 #endif
 
         private:
-            typename std::decay<F>::type _f;
-            util::tuple<typename util::decay_unwrap<Ts>::type...> _args;
+            using base_type::_f;
+            using base_type::_args;
         };
     }
 
@@ -326,8 +274,7 @@ namespace hpx { namespace util
       , detail::bound<
             typename std::decay<F>::type,
             typename std::decay<Ts>::type...>
-    >::type
-    bind(F&& f, Ts&&... vs)
+    >::type bind(F&& f, Ts&&... vs)
     {
         typedef detail::bound<
             typename std::decay<F>::type,

--- a/hpx/util/bind_action.hpp
+++ b/hpx/util/bind_action.hpp
@@ -40,7 +40,7 @@ namespace hpx { namespace util
             util::tuple<Ts...> const& bound, Us&& unbound)
         {
             return hpx::apply<Action>(
-                detail::bind_eval(
+                detail::bind_eval<Ts const&>::call(
                     util::get<Is>(bound),
                     std::forward<Us>(unbound))...);
         }
@@ -68,7 +68,7 @@ namespace hpx { namespace util
             util::tuple<Ts...> const& bound, Us&& unbound)
         {
             return hpx::apply_c<Action>(cont,
-                detail::bind_eval(
+                detail::bind_eval<Ts const&>::call(
                     util::get<Is>(bound),
                     std::forward<Us>(unbound))...);
         }
@@ -97,7 +97,7 @@ namespace hpx { namespace util
             util::tuple<Ts...> const& bound, Us&& unbound)
         {
             return hpx::apply<Action>(std::forward<Continuation>(cont),
-                detail::bind_eval(
+                detail::bind_eval<Ts const&>::call(
                     util::get<Is>(bound),
                     std::forward<Us>(unbound))...);
         }
@@ -130,7 +130,7 @@ namespace hpx { namespace util
             util::tuple<Ts...> const& bound, Us&& unbound)
         {
             return hpx::async<Action>(
-                detail::bind_eval(
+                detail::bind_eval<Ts const&>::call(
                     util::get<Is>(bound),
                     std::forward<Us>(unbound))...);
         }

--- a/hpx/util/bind_back.hpp
+++ b/hpx/util/bind_back.hpp
@@ -49,7 +49,7 @@ namespace hpx { namespace util
             >::type operator()(Us&&... vs) &
             {
                 using invoke_impl = typename detail::dispatch_invoke<F&>::type;
-                return invoke_impl{_f}(
+                return invoke_impl(_f)(
                     std::forward<Us>(vs)..., util::get<Is>(_args)...);
             }
 
@@ -62,7 +62,7 @@ namespace hpx { namespace util
             >::type operator()(Us&&... vs) const&
             {
                 using invoke_impl = typename detail::dispatch_invoke<F const&>::type;
-                return invoke_impl{_f}(
+                return invoke_impl(_f)(
                     std::forward<Us>(vs)..., util::get<Is>(_args)...);
             }
 
@@ -75,7 +75,7 @@ namespace hpx { namespace util
             >::type operator()(Us&&... vs) &&
             {
                 using invoke_impl = typename detail::dispatch_invoke<F>::type;
-                return invoke_impl{std::move(_f)}(
+                return invoke_impl(std::move(_f))(
                     std::forward<Us>(vs)..., util::get<Is>(std::move(_args))...);
             }
 
@@ -88,7 +88,7 @@ namespace hpx { namespace util
             >::type operator()(Us&&... vs) const&&
             {
                 using invoke_impl = typename detail::dispatch_invoke<F const>::type;
-                return invoke_impl{std::move(_f)}(
+                return invoke_impl(std::move(_f))(
                     std::forward<Us>(vs)..., util::get<Is>(std::move(_args))...);
             }
 
@@ -109,7 +109,7 @@ namespace hpx { namespace util
             >;
 
         public:
-            bound_back() : base_type{} {} // needed for serialization
+            bound_back() {} // needed for serialization
 
             template <typename F_, typename ...Ts_, typename =
                 typename std::enable_if<

--- a/hpx/util/bind_back.hpp
+++ b/hpx/util/bind_back.hpp
@@ -48,8 +48,7 @@ namespace hpx { namespace util
                 Us&&...
             >::type operator()(Us&&... vs) &
             {
-                using invoke_impl = typename detail::dispatch_invoke<F&>::type;
-                return invoke_impl(_f)(
+                return HPX_INVOKE(_f,
                     std::forward<Us>(vs)..., util::get<Is>(_args)...);
             }
 
@@ -61,8 +60,7 @@ namespace hpx { namespace util
                 Us&&...
             >::type operator()(Us&&... vs) const&
             {
-                using invoke_impl = typename detail::dispatch_invoke<F const&>::type;
-                return invoke_impl(_f)(
+                return HPX_INVOKE(_f,
                     std::forward<Us>(vs)..., util::get<Is>(_args)...);
             }
 
@@ -74,8 +72,7 @@ namespace hpx { namespace util
                 Us&&...
             >::type operator()(Us&&... vs) &&
             {
-                using invoke_impl = typename detail::dispatch_invoke<F>::type;
-                return invoke_impl(std::move(_f))(
+                return HPX_INVOKE(std::move(_f),
                     std::forward<Us>(vs)..., util::get<Is>(std::move(_args))...);
             }
 
@@ -87,8 +84,7 @@ namespace hpx { namespace util
                 Us&&...
             >::type operator()(Us&&... vs) const&&
             {
-                using invoke_impl = typename detail::dispatch_invoke<F const>::type;
-                return invoke_impl(std::move(_f))(
+                return HPX_INVOKE(std::move(_f),
                     std::forward<Us>(vs)..., util::get<Is>(std::move(_args))...);
             }
 

--- a/hpx/util/bind_back.hpp
+++ b/hpx/util/bind_back.hpp
@@ -29,51 +29,96 @@ namespace hpx { namespace util
         struct invoke_bound_back_result;
 
         template <typename F, typename ...Ts, typename ...Us>
-        struct invoke_bound_back_result<F&, util::tuple<Ts...>&, Us...>
-          : util::invoke_result<F&, Us..., Ts&...>
-        {};
-
-        template <typename F, typename ...Ts, typename ...Us>
-        struct invoke_bound_back_result<F const&, util::tuple<Ts...> const&, Us...>
-          : util::invoke_result<F const&, Us..., Ts const&...>
-        {};
-
-        template <typename F, typename ...Ts, typename ...Us>
-        struct invoke_bound_back_result<F&&, util::tuple<Ts...>&&, Us...>
+        struct invoke_bound_back_result<F, util::tuple<Ts...>, Us...>
           : util::invoke_result<F, Us..., Ts...>
         {};
 
-        template <typename F, typename ...Ts, typename ...Us>
-        struct invoke_bound_back_result<F const&&, util::tuple<Ts...> const&&, Us...>
-          : util::invoke_result<F const, Us..., Ts const...>
-        {};
-
-        template <std::size_t ...Is, typename F, typename Ts, typename ...Us>
-        HPX_CONSTEXPR HPX_HOST_DEVICE
-        typename invoke_bound_back_result<F&&, Ts&&, Us...>::type
-        bound_back_impl(pack_c<std::size_t, Is...>,
-            F&& f, Ts&& bound, Us&&... unbound)
-        {
-            using invoke_impl = typename detail::dispatch_invoke<F>::type;
-            return invoke_impl{std::forward<F>(f)}(
-                std::forward<Us>(unbound)...,
-                util::get<Is>(std::forward<Ts>(bound))...);
-        }
-
         ///////////////////////////////////////////////////////////////////////
-        template <typename F, typename ...Ts>
-        struct bound_back
+        template <typename F, typename Ts, typename Is>
+        struct bound_back_impl;
+
+        template <typename F, typename ...Ts, std::size_t ...Is>
+        struct bound_back_impl<F, util::tuple<Ts...>, pack_c<std::size_t, Is...>>
         {
+            template <typename ...Us>
+            HPX_CXX14_CONSTEXPR HPX_HOST_DEVICE
+            typename invoke_bound_back_result<
+                F&,
+                util::tuple<Ts&...>,
+                Us&&...
+            >::type operator()(Us&&... vs) &
+            {
+                using invoke_impl = typename detail::dispatch_invoke<F&>::type;
+                return invoke_impl{_f}(
+                    std::forward<Us>(vs)..., util::get<Is>(_args)...);
+            }
+
+            template <typename ...Us>
+            HPX_CONSTEXPR HPX_HOST_DEVICE
+            typename invoke_bound_back_result<
+                F const&,
+                util::tuple<Ts const&...>,
+                Us&&...
+            >::type operator()(Us&&... vs) const&
+            {
+                using invoke_impl = typename detail::dispatch_invoke<F const&>::type;
+                return invoke_impl{_f}(
+                    std::forward<Us>(vs)..., util::get<Is>(_args)...);
+            }
+
+            template <typename ...Us>
+            HPX_CXX14_CONSTEXPR HPX_HOST_DEVICE
+            typename invoke_bound_back_result<
+                F&&,
+                util::tuple<Ts&&...>,
+                Us&&...
+            >::type operator()(Us&&... vs) &&
+            {
+                using invoke_impl = typename detail::dispatch_invoke<F>::type;
+                return invoke_impl{std::move(_f)}(
+                    std::forward<Us>(vs)..., util::get<Is>(std::move(_args))...);
+            }
+
+            template <typename ...Us>
+            HPX_CONSTEXPR HPX_HOST_DEVICE
+            typename invoke_bound_back_result<
+                F const&&,
+                util::tuple<Ts const&&...>,
+                Us&&...
+            >::type operator()(Us&&... vs) const&&
+            {
+                using invoke_impl = typename detail::dispatch_invoke<F const>::type;
+                return invoke_impl{std::move(_f)}(
+                    std::forward<Us>(vs)..., util::get<Is>(std::move(_args))...);
+            }
+
+            F _f;
+            util::tuple<Ts...> _args;
+        };
+
+        template <typename F, typename ...Ts>
+        class bound_back
+          : private bound_back_impl<
+                F, util::tuple<Ts...>,
+                typename detail::make_index_pack<sizeof...(Ts)>::type
+            >
+        {
+            using base_type = detail::bound_back_impl<
+                F, util::tuple<Ts...>,
+                typename detail::make_index_pack<sizeof...(Ts)>::type
+            >;
+
         public:
-            bound_back() {} // needed for serialization
+            bound_back() : base_type{} {} // needed for serialization
 
             template <typename F_, typename ...Ts_, typename =
                 typename std::enable_if<
                     !std::is_same<typename std::decay<F_>::type, bound_back>::value
                 >::type>
             HPX_CONSTEXPR explicit bound_back(F_&& f, Ts_&&... vs)
-              : _f(std::forward<F_>(f))
-              , _args(std::forward<Ts_>(vs)...)
+              : base_type{
+                    std::forward<F_>(f),
+                    util::forward_as_tuple(std::forward<Ts_>(vs)...)}
             {}
 
 #if !defined(__NVCC__) && !defined(__CUDACC__)
@@ -81,73 +126,17 @@ namespace hpx { namespace util
             bound_back(bound_back&&) = default;
 #else
             HPX_CONSTEXPR HPX_HOST_DEVICE bound_back(bound_back const& other)
-              : _f(other._f)
-              , _args(other._args)
+              : base_type{other}
             {}
 
             HPX_CONSTEXPR HPX_HOST_DEVICE bound_back(bound_back&& other)
-              : _f(std::move(other._f))
-              , _args(std::move(other._args))
+              : base_type{std::move(other)}
             {}
 #endif
 
             bound_back& operator=(bound_back const&) = delete;
 
-            template <typename ...Us>
-            HPX_CXX14_CONSTEXPR HPX_HOST_DEVICE
-            typename invoke_bound_back_result<
-                typename std::decay<F>::type&,
-                util::tuple<typename util::decay_unwrap<Ts>::type...>&,
-                Us...
-            >::type operator()(Us&&... vs) &
-            {
-                using index_pack =
-                    typename detail::make_index_pack<sizeof...(Ts)>::type;
-                return detail::bound_back_impl(index_pack{},
-                    _f, _args, std::forward<Us>(vs)...);
-            }
-
-            template <typename ...Us>
-            HPX_CONSTEXPR HPX_HOST_DEVICE
-            typename invoke_bound_back_result<
-                typename std::decay<F>::type const&,
-                util::tuple<typename util::decay_unwrap<Ts>::type...> const&,
-                Us...
-            >::type operator()(Us&&... vs) const&
-            {
-                using index_pack =
-                    typename detail::make_index_pack<sizeof...(Ts)>::type;
-                return detail::bound_back_impl(index_pack{},
-                    _f, _args, std::forward<Us>(vs)...);
-            }
-
-            template <typename ...Us>
-            HPX_CXX14_CONSTEXPR HPX_HOST_DEVICE
-            typename invoke_bound_back_result<
-                typename std::decay<F>::type&&,
-                util::tuple<typename util::decay_unwrap<Ts>::type...>&&,
-                Us...
-            >::type operator()(Us&&... vs) &&
-            {
-                using index_pack =
-                    typename detail::make_index_pack<sizeof...(Ts)>::type;
-                return detail::bound_back_impl(index_pack{},
-                    std::move(_f), std::move(_args), std::forward<Us>(vs)...);
-            }
-
-            template <typename ...Us>
-            HPX_CONSTEXPR HPX_HOST_DEVICE
-            typename invoke_bound_back_result<
-                typename std::decay<F>::type const&&,
-                util::tuple<typename util::decay_unwrap<Ts>::type...> const&&,
-                Us...
-            >::type operator()(Us&&... vs) const&&
-            {
-                using index_pack =
-                    typename detail::make_index_pack<sizeof...(Ts)>::type;
-                return detail::bound_back_impl(index_pack{},
-                    std::move(_f), std::move(_args), std::forward<Us>(vs)...);
-            }
+            using base_type::operator();
 
             template <typename Archive>
             void serialize(Archive& ar, unsigned int const /*version*/)
@@ -158,17 +147,13 @@ namespace hpx { namespace util
 
             std::size_t get_function_address() const
             {
-                return traits::get_function_address<
-                        typename std::decay<F>::type
-                    >::call(_f);
+                return traits::get_function_address<F>::call(_f);
             }
 
             char const* get_function_annotation() const
             {
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
-                return traits::get_function_annotation<
-                        typename std::decay<F>::type
-                    >::call(_f);
+                return traits::get_function_annotation<F>::call(_f);
 #else
                 return nullptr;
 #endif
@@ -178,9 +163,7 @@ namespace hpx { namespace util
             util::itt::string_handle get_function_annotation_itt() const
             {
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
-                return traits::get_function_annotation_itt<
-                        typename std::decay<F>::type
-                    >::call(_f);
+                return traits::get_function_annotation_itt<F>::call(_f);
 #else
                 static util::itt::string_handle sh("bound_back");
                 return sh;
@@ -189,8 +172,8 @@ namespace hpx { namespace util
 #endif
 
         private:
-            typename std::decay<F>::type _f;
-            util::tuple<typename util::decay_unwrap<Ts>::type...> _args;
+            using base_type::_f;
+            using base_type::_args;
         };
     }
 

--- a/hpx/util/bind_back.hpp
+++ b/hpx/util/bind_back.hpp
@@ -48,13 +48,14 @@ namespace hpx { namespace util
           : util::invoke_result<F const, Us..., Ts const...>
         {};
 
-        template <typename F, std::size_t ...Is, typename Ts, typename ...Us>
+        template <std::size_t ...Is, typename F, typename Ts, typename ...Us>
         HPX_CONSTEXPR HPX_HOST_DEVICE
         typename invoke_bound_back_result<F&&, Ts&&, Us...>::type
-        bound_back_impl(F&& f, pack_c<std::size_t, Is...>, Ts&& bound,
-            Us&&... unbound)
+        bound_back_impl(pack_c<std::size_t, Is...>,
+            F&& f, Ts&& bound, Us&&... unbound)
         {
-            return util::invoke(std::forward<F>(f),
+            using invoke_impl = typename detail::dispatch_invoke<F>::type;
+            return invoke_impl{std::forward<F>(f)}(
                 std::forward<Us>(unbound)...,
                 util::get<Is>(std::forward<Ts>(bound))...);
         }
@@ -100,9 +101,10 @@ namespace hpx { namespace util
                 Us...
             >::type operator()(Us&&... vs) &
             {
-                return detail::bound_back_impl(_f,
-                    typename detail::make_index_pack<sizeof...(Ts)>::type(),
-                    _args, std::forward<Us>(vs)...);
+                using index_pack =
+                    typename detail::make_index_pack<sizeof...(Ts)>::type;
+                return detail::bound_back_impl(index_pack{},
+                    _f, _args, std::forward<Us>(vs)...);
             }
 
             template <typename ...Us>
@@ -113,9 +115,10 @@ namespace hpx { namespace util
                 Us...
             >::type operator()(Us&&... vs) const&
             {
-                return detail::bound_back_impl(_f,
-                    typename detail::make_index_pack<sizeof...(Ts)>::type(),
-                    _args, std::forward<Us>(vs)...);
+                using index_pack =
+                    typename detail::make_index_pack<sizeof...(Ts)>::type;
+                return detail::bound_back_impl(index_pack{},
+                    _f, _args, std::forward<Us>(vs)...);
             }
 
             template <typename ...Us>
@@ -126,9 +129,10 @@ namespace hpx { namespace util
                 Us...
             >::type operator()(Us&&... vs) &&
             {
-                return detail::bound_back_impl(std::move(_f),
-                    typename detail::make_index_pack<sizeof...(Ts)>::type(),
-                    std::move(_args), std::forward<Us>(vs)...);
+                using index_pack =
+                    typename detail::make_index_pack<sizeof...(Ts)>::type;
+                return detail::bound_back_impl(index_pack{},
+                    std::move(_f), std::move(_args), std::forward<Us>(vs)...);
             }
 
             template <typename ...Us>
@@ -139,9 +143,10 @@ namespace hpx { namespace util
                 Us...
             >::type operator()(Us&&... vs) const&&
             {
-                return detail::bound_back_impl(std::move(_f),
-                    typename detail::make_index_pack<sizeof...(Ts)>::type(),
-                    std::move(_args), std::forward<Us>(vs)...);
+                using index_pack =
+                    typename detail::make_index_pack<sizeof...(Ts)>::type;
+                return detail::bound_back_impl(index_pack{},
+                    std::move(_f), std::move(_args), std::forward<Us>(vs)...);
             }
 
             template <typename Archive>

--- a/hpx/util/bind_front.hpp
+++ b/hpx/util/bind_front.hpp
@@ -48,13 +48,14 @@ namespace hpx { namespace util
           : util::invoke_result<F const, Ts const..., Us...>
         {};
 
-        template <typename F, std::size_t ...Is, typename Ts, typename ...Us>
+        template <std::size_t ...Is, typename F, typename Ts, typename ...Us>
         HPX_CONSTEXPR HPX_HOST_DEVICE
         typename invoke_bound_front_result<F&&, Ts&&, Us...>::type
-        bound_front_impl(F&& f, pack_c<std::size_t, Is...>, Ts&& bound,
-            Us&&... unbound)
+        bound_front_impl(pack_c<std::size_t, Is...>,
+            F&& f, Ts&& bound, Us&&... unbound)
         {
-            return util::invoke(std::forward<F>(f),
+            using invoke_impl = typename detail::dispatch_invoke<F>::type;
+            return invoke_impl{std::forward<F>(f)}(
                 util::get<Is>(std::forward<Ts>(bound))...,
                 std::forward<Us>(unbound)...);
         }
@@ -100,9 +101,10 @@ namespace hpx { namespace util
                 Us...
             >::type operator()(Us&&... vs) &
             {
-                return detail::bound_front_impl(_f,
-                    typename detail::make_index_pack<sizeof...(Ts)>::type(),
-                    _args, std::forward<Us>(vs)...);
+                using index_pack =
+                    typename detail::make_index_pack<sizeof...(Ts)>::type;
+                return detail::bound_front_impl(index_pack{},
+                    _f, _args, std::forward<Us>(vs)...);
             }
 
             template <typename ...Us>
@@ -113,9 +115,10 @@ namespace hpx { namespace util
                 Us...
             >::type operator()(Us&&... vs) const&
             {
-                return detail::bound_front_impl(_f,
-                    typename detail::make_index_pack<sizeof...(Ts)>::type(),
-                    _args, std::forward<Us>(vs)...);
+                using index_pack =
+                    typename detail::make_index_pack<sizeof...(Ts)>::type;
+                return detail::bound_front_impl(index_pack{},
+                    _f, _args, std::forward<Us>(vs)...);
             }
 
             template <typename ...Us>
@@ -126,9 +129,10 @@ namespace hpx { namespace util
                 Us...
             >::type operator()(Us&&... vs) &&
             {
-                return detail::bound_front_impl(std::move(_f),
-                    typename detail::make_index_pack<sizeof...(Ts)>::type(),
-                    std::move(_args), std::forward<Us>(vs)...);
+                using index_pack =
+                    typename detail::make_index_pack<sizeof...(Ts)>::type;
+                return detail::bound_front_impl(index_pack{},
+                    std::move(_f), std::move(_args), std::forward<Us>(vs)...);
             }
 
             template <typename ...Us>
@@ -139,9 +143,10 @@ namespace hpx { namespace util
                 Us...
             >::type operator()(Us&&... vs) const&&
             {
-                return detail::bound_front_impl(std::move(_f),
-                    typename detail::make_index_pack<sizeof...(Ts)>::type(),
-                    std::move(_args), std::forward<Us>(vs)...);
+                using index_pack =
+                    typename detail::make_index_pack<sizeof...(Ts)>::type;
+                return detail::bound_front_impl(index_pack{},
+                    std::move(_f), std::move(_args), std::forward<Us>(vs)...);
             }
 
             template <typename Archive>

--- a/hpx/util/bind_front.hpp
+++ b/hpx/util/bind_front.hpp
@@ -48,8 +48,7 @@ namespace hpx { namespace util
                 Us&&...
             >::type operator()(Us&&... vs) &
             {
-                using invoke_impl = typename detail::dispatch_invoke<F&>::type;
-                return invoke_impl(_f)(
+                return HPX_INVOKE(_f,
                     util::get<Is>(_args)..., std::forward<Us>(vs)...);
             }
 
@@ -61,8 +60,7 @@ namespace hpx { namespace util
                 Us&&...
             >::type operator()(Us&&... vs) const&
             {
-                using invoke_impl = typename detail::dispatch_invoke<F const&>::type;
-                return invoke_impl(_f)(
+                return HPX_INVOKE(_f,
                     util::get<Is>(_args)..., std::forward<Us>(vs)...);
             }
 
@@ -74,8 +72,7 @@ namespace hpx { namespace util
                 Us&&...
             >::type operator()(Us&&... vs) &&
             {
-                using invoke_impl = typename detail::dispatch_invoke<F>::type;
-                return invoke_impl(std::move(_f))(
+                return HPX_INVOKE(std::move(_f),
                     util::get<Is>(std::move(_args))..., std::forward<Us>(vs)...);
             }
 
@@ -87,8 +84,7 @@ namespace hpx { namespace util
                 Us&&...
             >::type operator()(Us&&... vs) const&&
             {
-                using invoke_impl = typename detail::dispatch_invoke<F const>::type;
-                return invoke_impl(std::move(_f))(
+                return HPX_INVOKE(std::move(_f),
                     util::get<Is>(std::move(_args))..., std::forward<Us>(vs)...);
             }
 

--- a/hpx/util/bind_front.hpp
+++ b/hpx/util/bind_front.hpp
@@ -49,7 +49,7 @@ namespace hpx { namespace util
             >::type operator()(Us&&... vs) &
             {
                 using invoke_impl = typename detail::dispatch_invoke<F&>::type;
-                return invoke_impl{_f}(
+                return invoke_impl(_f)(
                     util::get<Is>(_args)..., std::forward<Us>(vs)...);
             }
 
@@ -62,7 +62,7 @@ namespace hpx { namespace util
             >::type operator()(Us&&... vs) const&
             {
                 using invoke_impl = typename detail::dispatch_invoke<F const&>::type;
-                return invoke_impl{_f}(
+                return invoke_impl(_f)(
                     util::get<Is>(_args)..., std::forward<Us>(vs)...);
             }
 
@@ -75,7 +75,7 @@ namespace hpx { namespace util
             >::type operator()(Us&&... vs) &&
             {
                 using invoke_impl = typename detail::dispatch_invoke<F>::type;
-                return invoke_impl{std::move(_f)}(
+                return invoke_impl(std::move(_f))(
                     util::get<Is>(std::move(_args))..., std::forward<Us>(vs)...);
             }
 
@@ -88,7 +88,7 @@ namespace hpx { namespace util
             >::type operator()(Us&&... vs) const&&
             {
                 using invoke_impl = typename detail::dispatch_invoke<F const>::type;
-                return invoke_impl{std::move(_f)}(
+                return invoke_impl(std::move(_f))(
                     util::get<Is>(std::move(_args))..., std::forward<Us>(vs)...);
             }
 
@@ -109,7 +109,7 @@ namespace hpx { namespace util
             >;
 
         public:
-            bound_front() : base_type{} {} // needed for serialization
+            bound_front() {} // needed for serialization
 
             template <typename F_, typename ...Ts_, typename =
                 typename std::enable_if<

--- a/hpx/util/deferred_call.hpp
+++ b/hpx/util/deferred_call.hpp
@@ -81,8 +81,7 @@ namespace hpx { namespace util
             typename util::invoke_result<F, Ts...>::type
             operator()()
             {
-                using invoke_impl = typename detail::dispatch_invoke<F>::type;
-                return invoke_impl(std::move(_f))(
+                return HPX_INVOKE(std::move(_f),
                     util::get<Is>(std::move(_args))...);
             }
 

--- a/hpx/util/deferred_call.hpp
+++ b/hpx/util/deferred_call.hpp
@@ -105,7 +105,10 @@ namespace hpx { namespace util
             typename invoke_deferred_result<F, Ts...>::type
             operator()()
             {
-                return util::invoke_fused(std::move(_f), std::move(_args));
+                using index_pack =
+                    typename make_index_pack<sizeof...(Ts)>::type;
+                return detail::invoke_fused_impl(index_pack{},
+                    std::move(_f), std::move(_args));
             }
 
             template <typename Archive>

--- a/hpx/util/deferred_call.hpp
+++ b/hpx/util/deferred_call.hpp
@@ -82,7 +82,7 @@ namespace hpx { namespace util
             operator()()
             {
                 using invoke_impl = typename detail::dispatch_invoke<F>::type;
-                return invoke_impl{std::move(_f)}(
+                return invoke_impl(std::move(_f))(
                     util::get<Is>(std::move(_args))...);
             }
 
@@ -106,7 +106,7 @@ namespace hpx { namespace util
             >;
 
         public:
-            deferred() : base_type{} {} // needed for serialization
+            deferred() {} // needed for serialization
 
             template <typename F_, typename ...Ts_, typename =
                 typename std::enable_if<

--- a/hpx/util/detail/vtable/callable_vtable.hpp
+++ b/hpx/util/detail/vtable/callable_vtable.hpp
@@ -30,9 +30,7 @@ namespace hpx { namespace util { namespace detail
         template <typename T>
         HPX_FORCEINLINE static R _invoke(void* f, Ts&&... vs)
         {
-            using invoke_impl = typename detail::dispatch_invoke<T&>::type;
-            return util::void_guard<R>(), invoke_impl(vtable::get<T>(f))(
-                    std::forward<Ts>(vs)...);
+            return HPX_INVOKE_R(R, vtable::get<T>(f), std::forward<Ts>(vs)...);
         }
         R (*invoke)(void*, Ts&&...);
 

--- a/hpx/util/detail/vtable/callable_vtable.hpp
+++ b/hpx/util/detail/vtable/callable_vtable.hpp
@@ -31,7 +31,7 @@ namespace hpx { namespace util { namespace detail
         HPX_FORCEINLINE static R _invoke(void* f, Ts&&... vs)
         {
             using invoke_impl = typename detail::dispatch_invoke<T&>::type;
-            return util::void_guard<R>(), invoke_impl{vtable::get<T>(f)}(
+            return util::void_guard<R>(), invoke_impl(vtable::get<T>(f))(
                     std::forward<Ts>(vs)...);
         }
         R (*invoke)(void*, Ts&&...);

--- a/hpx/util/detail/vtable/callable_vtable.hpp
+++ b/hpx/util/detail/vtable/callable_vtable.hpp
@@ -14,6 +14,7 @@
 #include <hpx/util/detail/empty_function.hpp>
 #include <hpx/util/detail/vtable/vtable.hpp>
 #include <hpx/util/invoke.hpp>
+#include <hpx/util/void_guard.hpp>
 
 #include <cstddef>
 #include <utility>
@@ -29,8 +30,9 @@ namespace hpx { namespace util { namespace detail
         template <typename T>
         HPX_FORCEINLINE static R _invoke(void* f, Ts&&... vs)
         {
-            return util::invoke_r<R>(
-                vtable::get<T>(f), std::forward<Ts>(vs)...);
+            using invoke_impl = typename detail::dispatch_invoke<T&>::type;
+            return util::void_guard<R>(), invoke_impl{vtable::get<T>(f)}(
+                    std::forward<Ts>(vs)...);
         }
         R (*invoke)(void*, Ts&&...);
 

--- a/hpx/util/invoke.hpp
+++ b/hpx/util/invoke.hpp
@@ -173,9 +173,9 @@ namespace hpx { namespace util
             template <typename F, typename... Ts>
             HPX_CONSTEXPR HPX_HOST_DEVICE
             typename util::invoke_result<F, Ts...>::type
-            operator()(F && f, Ts &&... vs)
+            operator()(F && f, Ts &&... vs) const
             {
-                return util::invoke(std::forward<F>(f),
+                return HPX_INVOKE(std::forward<F>(f),
                     std::forward<Ts>(vs)...);
             }
         };
@@ -185,9 +185,9 @@ namespace hpx { namespace util
         {
             template <typename F, typename... Ts>
             HPX_CONSTEXPR HPX_HOST_DEVICE
-            R operator()(F && f, Ts &&... vs)
+            R operator()(F && f, Ts &&... vs) const
             {
-                return util::invoke_r<R>(std::forward<F>(f),
+                return HPX_INVOKE_R(R, std::forward<F>(f),
                     std::forward<Ts>(vs)...);
             }
         };

--- a/hpx/util/invoke.hpp
+++ b/hpx/util/invoke.hpp
@@ -28,6 +28,11 @@ namespace hpx { namespace util
         {
             T C::*f;
 
+            HPX_CONSTEXPR HPX_HOST_DEVICE
+            invoke_mem_obj(T C::*mem_obj) noexcept
+              : f(mem_obj)
+            {}
+
             // t0.*f
             template <typename T0>
             HPX_CONSTEXPR HPX_HOST_DEVICE
@@ -57,6 +62,11 @@ namespace hpx { namespace util
         struct invoke_mem_fun
         {
             T C::*f;
+
+            HPX_CONSTEXPR HPX_HOST_DEVICE
+            invoke_mem_fun(T C::*mem_fun) noexcept
+              : f(mem_fun)
+            {}
 
             // (t0.*f)(t1, ..., tN)
             template <typename T0, typename ...Ts>
@@ -130,7 +140,7 @@ namespace hpx { namespace util
     invoke(F&& f, Ts&&... vs)
     {
         using invoke_impl = typename detail::dispatch_invoke<F>::type;
-        return invoke_impl{std::forward<F>(f)}(std::forward<Ts>(vs)...);
+        return invoke_impl(std::forward<F>(f))(std::forward<Ts>(vs)...);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -143,7 +153,7 @@ namespace hpx { namespace util
     R invoke_r(F&& f, Ts&&... vs)
     {
         using invoke_impl = typename detail::dispatch_invoke<F>::type;
-        return util::void_guard<R>(), invoke_impl{std::forward<F>(f)}(
+        return util::void_guard<R>(), invoke_impl(std::forward<F>(f))(
                 std::forward<Ts>(vs)...);
     }
 

--- a/hpx/util/invoke.hpp
+++ b/hpx/util/invoke.hpp
@@ -15,6 +15,7 @@
 
 #include <boost/ref.hpp>
 
+#include <functional>
 #include <type_traits>
 #include <utility>
 
@@ -108,6 +109,13 @@ namespace hpx { namespace util
                     invoke_mem_fun<T, C>,
                     invoke_mem_obj<T, C>
                 >::type;
+        };
+
+        // flatten std::[c]ref
+        template <typename F, typename X>
+        struct dispatch_invoke<F, ::std::reference_wrapper<X> >
+        {
+            using type = X&;
         };
 
         // support boost::[c]ref, which is not callable as std::[c]ref

--- a/hpx/util/invoke.hpp
+++ b/hpx/util/invoke.hpp
@@ -116,6 +116,17 @@ namespace hpx { namespace util
         {
             using type = X&;
         };
+
+        template <typename F>
+        using dispatch_invoke_t =
+            typename ::hpx::util::detail::dispatch_invoke<F>::type;
+
+        ///////////////////////////////////////////////////////////////////////
+#define HPX_INVOKE(F, ...)                                                     \
+        (::hpx::util::detail::dispatch_invoke_t<decltype((F))>(F)(__VA_ARGS__))
+
+#define HPX_INVOKE_R(R, F, ...)                                                \
+        (::hpx::util::void_guard<R>(), HPX_INVOKE(F, __VA_ARGS__))
     }
 
     /// Invokes the given callable object f with the content of
@@ -139,8 +150,7 @@ namespace hpx { namespace util
     typename util::invoke_result<F, Ts...>::type
     invoke(F&& f, Ts&&... vs)
     {
-        using invoke_impl = typename detail::dispatch_invoke<F>::type;
-        return invoke_impl(std::forward<F>(f))(std::forward<Ts>(vs)...);
+        return HPX_INVOKE(std::forward<F>(f), std::forward<Ts>(vs)...);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -152,9 +162,7 @@ namespace hpx { namespace util
     HPX_CONSTEXPR HPX_HOST_DEVICE
     R invoke_r(F&& f, Ts&&... vs)
     {
-        using invoke_impl = typename detail::dispatch_invoke<F>::type;
-        return util::void_guard<R>(), invoke_impl(std::forward<F>(f))(
-                std::forward<Ts>(vs)...);
+        return HPX_INVOKE_R(R, std::forward<F>(f), std::forward<Ts>(vs)...);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/hpx/util/invoke_fused.hpp
+++ b/hpx/util/invoke_fused.hpp
@@ -122,10 +122,11 @@ namespace hpx { namespace util
             template <typename F, typename Tuple>
             HPX_CONSTEXPR HPX_HOST_DEVICE
             typename util::detail::invoke_fused_result<F, Tuple>::type
-            operator()(F&& f, Tuple&& args) const
+            operator()(F&& f, Tuple&& t) const
             {
-                return util::invoke_fused(
-                    std::forward<F>(f), std::forward<Tuple>(args));
+                using index_pack = typename detail::fused_index_pack<Tuple>::type;
+                return detail::invoke_fused_impl(index_pack{},
+                    std::forward<F>(f), std::forward<Tuple>(t));
             }
         };
 
@@ -134,10 +135,11 @@ namespace hpx { namespace util
         {
             template <typename F, typename Tuple>
             HPX_CONSTEXPR HPX_HOST_DEVICE
-            R operator()(F&& f, Tuple&& args) const
+            R operator()(F&& f, Tuple&& t) const
             {
-                return util::invoke_fused_r<R>(
-                    std::forward<F>(f), std::forward<Tuple>(args));
+                using index_pack = typename detail::fused_index_pack<Tuple>::type;
+                return util::void_guard<R>(), detail::invoke_fused_impl(index_pack{},
+                    std::forward<F>(f), std::forward<Tuple>(t));
             }
         };
     }

--- a/hpx/util/invoke_fused.hpp
+++ b/hpx/util/invoke_fused.hpp
@@ -63,14 +63,14 @@ namespace hpx { namespace util
         {};
 
         ///////////////////////////////////////////////////////////////////////
-        template <typename F, typename Tuple, std::size_t ...Is>
+        template <std::size_t ...Is, typename F, typename Tuple>
         HPX_CONSTEXPR HPX_HOST_DEVICE
         typename invoke_fused_result<F, Tuple>::type
-        invoke_fused_impl(F&& f, Tuple&& t, pack_c<std::size_t, Is...>)
+        invoke_fused_impl(pack_c<std::size_t, Is...>, F&& f, Tuple&& t)
         {
-            using util::get;
-            return util::invoke(std::forward<F>(f),
-                get<Is>(std::forward<Tuple>(t))...);
+            using invoke_impl = typename detail::dispatch_invoke<F>::type;
+            return invoke_impl{std::forward<F>(f)}(
+                util::get<Is>(std::forward<Tuple>(t))...);
         }
     }
 
@@ -96,9 +96,9 @@ namespace hpx { namespace util
     typename detail::invoke_fused_result<F, Tuple>::type
     invoke_fused(F&& f, Tuple&& t)
     {
-        return detail::invoke_fused_impl(
-            std::forward<F>(f), std::forward<Tuple>(t),
-            typename detail::fused_index_pack<Tuple>::type());
+        using index_pack = typename detail::fused_index_pack<Tuple>::type;
+        return detail::invoke_fused_impl(index_pack{},
+            std::forward<F>(f), std::forward<Tuple>(t));
     }
 
     /// \copydoc invoke_fused
@@ -109,9 +109,9 @@ namespace hpx { namespace util
     HPX_CONSTEXPR HPX_HOST_DEVICE
     R invoke_fused_r(F&& f, Tuple&& t)
     {
-        return util::void_guard<R>(), detail::invoke_fused_impl(
-            std::forward<F>(f), std::forward<Tuple>(t),
-            typename detail::fused_index_pack<Tuple>::type());
+        using index_pack = typename detail::fused_index_pack<Tuple>::type;
+        return util::void_guard<R>(), detail::invoke_fused_impl(index_pack{},
+            std::forward<F>(f), std::forward<Tuple>(t));
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/hpx/util/invoke_fused.hpp
+++ b/hpx/util/invoke_fused.hpp
@@ -68,8 +68,7 @@ namespace hpx { namespace util
         typename invoke_fused_result<F, Tuple>::type
         invoke_fused_impl(pack_c<std::size_t, Is...>, F&& f, Tuple&& t)
         {
-            using invoke_impl = typename detail::dispatch_invoke<F>::type;
-            return invoke_impl(std::forward<F>(f))(
+            return HPX_INVOKE(std::forward<F>(f),
                 util::get<Is>(std::forward<Tuple>(t))...);
         }
     }

--- a/hpx/util/invoke_fused.hpp
+++ b/hpx/util/invoke_fused.hpp
@@ -69,7 +69,7 @@ namespace hpx { namespace util
         invoke_fused_impl(pack_c<std::size_t, Is...>, F&& f, Tuple&& t)
         {
             using invoke_impl = typename detail::dispatch_invoke<F>::type;
-            return invoke_impl{std::forward<F>(f)}(
+            return invoke_impl(std::forward<F>(f))(
                 util::get<Is>(std::forward<Tuple>(t))...);
         }
     }

--- a/hpx/util/one_shot.hpp
+++ b/hpx/util/one_shot.hpp
@@ -82,8 +82,7 @@ namespace hpx { namespace util
             {
                 check_call();
 
-                using invoke_impl = typename detail::dispatch_invoke<F>::type;
-                return invoke_impl(std::move(_f))(std::forward<Ts>(vs)...);
+                return HPX_INVOKE(std::move(_f), std::forward<Ts>(vs)...);
             }
 
             template <typename Archive>

--- a/hpx/util/one_shot.hpp
+++ b/hpx/util/one_shot.hpp
@@ -10,17 +10,9 @@
 #include <hpx/config.hpp>
 #include <hpx/traits/get_function_address.hpp>
 #include <hpx/traits/get_function_annotation.hpp>
-#include <hpx/traits/is_action.hpp>
-#include <hpx/traits/is_bind_expression.hpp>
-#include <hpx/traits/is_placeholder.hpp>
 #include <hpx/util/assert.hpp>
-#include <hpx/util/decay.hpp>
-#include <hpx/util/detail/pack.hpp>
 #include <hpx/util/invoke.hpp>
-#include <hpx/util/invoke_fused.hpp>
-#include <hpx/util/one_shot.hpp>
 #include <hpx/util/result_of.hpp>
-#include <hpx/util/tuple.hpp>
 
 #include <cstddef>
 #include <type_traits>
@@ -89,7 +81,9 @@ namespace hpx { namespace util
             operator()(Ts&&... vs)
             {
                 check_call();
-                return util::invoke(std::move(_f), std::forward<Ts>(vs)...);
+
+                using invoke_impl = typename detail::dispatch_invoke<F>::type;
+                return invoke_impl{std::move(_f)}(std::forward<Ts>(vs)...);
             }
 
             template <typename Archive>

--- a/hpx/util/one_shot.hpp
+++ b/hpx/util/one_shot.hpp
@@ -83,7 +83,7 @@ namespace hpx { namespace util
                 check_call();
 
                 using invoke_impl = typename detail::dispatch_invoke<F>::type;
-                return invoke_impl{std::move(_f)}(std::forward<Ts>(vs)...);
+                return invoke_impl(std::move(_f))(std::forward<Ts>(vs)...);
             }
 
             template <typename Archive>


### PR DESCRIPTION
Reduce the number of function calls necessary to invoke the target callable in the functional utilities.

This PR relays on reverting the workaround introduced in #2404, and instead fixes the underlying bug that is believed to have caused the original issue (for which there is no report and no tests).

Each "flatten" commit removes one frame from the call stack. Most changes result in code simplification, but two commits (titled "flatten ... some more") result in more complex code in order to embed index sequences into the wrappers.