### PR TITLE
Fix a couple of test failures

### DIFF
--- a/hpx/runtime/threads/detail/set_thread_state.hpp
+++ b/hpx/runtime/threads/detail/set_thread_state.hpp
@@ -225,7 +225,11 @@ namespace hpx { namespace threads { namespace detail
                 << ")";
         } while (true);
 
-        if (new_state == pending) {
+        thread_state_enum previous_state_val = previous_state.state();
+        if (!(previous_state_val == pending ||
+                previous_state_val == pending_boost) &&
+            (new_state == pending || new_state == pending_boost))
+        {
             // REVIEW: Passing a specific target thread may interfere with the
             // round robin queuing.
 

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -187,7 +187,7 @@ namespace hpx { namespace threads
 
     char const* get_thread_state_name(thread_state_enum state)
     {
-        if (state < unknown || state > staged)
+        if (state < unknown || state > pending_boost)
             return "unknown";
         return strings::thread_state_names[state];
     }

--- a/tests/unit/threads/thread.cpp
+++ b/tests/unit/threads/thread.cpp
@@ -126,7 +126,10 @@ void interruption_point_thread(hpx::lcos::local::barrier* b,
     hpx::lcos::local::spinlock* m, bool* failed)
 {
     try {
-        std::lock_guard<hpx::lcos::local::spinlock> lk(*m);
+        std::unique_lock<hpx::lcos::local::spinlock> lk(*m);
+        hpx::util::ignore_while_checking<
+            std::unique_lock<hpx::lcos::local::spinlock>>
+            il(&lk);
         hpx::this_thread::interruption_point();
         *failed = true;
     }


### PR DESCRIPTION
- Handles `pending` and `pending_boost` states correctly in `set_thread_state`. When going from `pending` to `pending_boost` or vice versa the thread should not be scheduled again. This would sometimes cause this assert to fire: https://github.com/STEllAR-GROUP/hpx/blob/0c77050a7d402b771850ab876fff08daec37f9db/hpx/runtime/threads/policies/thread_queue.hpp#L495
- Ignore registered locks while calling `interruption_point` in `thread` test
- Flyby: fix check for valid states in `get_thread_state_name`