### PR TITLE
Decouple serialization from function vtables

### DIFF
--- a/hpx/util/detail/basic_function.hpp
+++ b/hpx/util/detail/basic_function.hpp
@@ -305,7 +305,7 @@ namespace hpx { namespace util { namespace detail
         template <typename T>
         static serializable_vtable const* get_serializable_vtable() noexcept
         {
-            return detail::get_vtable<serializable_vtable, T>();
+            return detail::get_serializable_vtable<VTable, T>();
         }
 
     protected:

--- a/hpx/util/detail/vtable/vtable.hpp
+++ b/hpx/util/detail/vtable/vtable.hpp
@@ -25,14 +25,15 @@ namespace hpx { namespace util { namespace detail
     template <typename VTable, typename T>
     struct vtables
     {
-        static VTable const instance;
+        static HPX_CONSTEXPR_OR_CONST VTable instance =
+            detail::construct_vtable<T>();
     };
 
     template <typename VTable, typename T>
-    VTable const vtables<VTable, T>::instance = construct_vtable<T>();
+    HPX_CONSTEXPR_OR_CONST VTable vtables<VTable, T>::instance;
 
     template <typename VTable, typename T>
-    HPX_CONSTEXPR inline VTable const* get_vtable() noexcept
+    HPX_CONSTEXPR VTable const* get_vtable() noexcept
     {
         static_assert(
             !std::is_reference<T>::value,

--- a/hpx/util/function.hpp
+++ b/hpx/util/function.hpp
@@ -33,16 +33,12 @@ namespace hpx { namespace util
 
     template <typename R, typename ...Ts, bool Serializable>
     class function<R(Ts...), Serializable>
-      : public detail::basic_function<
-            detail::function_vtable<R(Ts...)>
-          , R(Ts...), Serializable
-        >
+      : public detail::basic_function<R(Ts...), true, Serializable>
     {
-        typedef detail::function_vtable<R(Ts...)> vtable;
-        typedef detail::basic_function<vtable, R(Ts...), Serializable> base_type;
+        using base_type = detail::basic_function<R(Ts...), true, Serializable>;
 
     public:
-        typedef typename base_type::result_type result_type;
+        typedef R result_type;
 
         function() noexcept
           : base_type()

--- a/hpx/util/function.hpp
+++ b/hpx/util/function.hpp
@@ -61,6 +61,7 @@ namespace hpx { namespace util
                 this->object = this->vptr->copy(
                     this->storage, detail::function_storage_size, other.object);
             }
+            this->copy_serializable_vptr(other);
         }
 
         function(function&& other) noexcept
@@ -92,6 +93,7 @@ namespace hpx { namespace util
                     this->vptr->destruct(this->object);
                     this->object = this->vptr->copy(
                         this->object, -1, other.object);
+                    this->copy_serializable_vptr(other);
                 }
             } else {
                 reset();
@@ -101,6 +103,7 @@ namespace hpx { namespace util
                 {
                     this->object = this->vptr->copy(
                         this->storage, detail::function_storage_size, other.object);
+                    this->copy_serializable_vptr(other);
                 } else {
                     this->object = nullptr;
                 }

--- a/hpx/util/unique_function.hpp
+++ b/hpx/util/unique_function.hpp
@@ -31,16 +31,12 @@ namespace hpx { namespace util
 
     template <typename R, typename ...Ts, bool Serializable>
     class unique_function<R(Ts...), Serializable>
-      : public detail::basic_function<
-            detail::unique_function_vtable<R(Ts...)>
-          , R(Ts...), Serializable
-        >
+      : public detail::basic_function<R(Ts...), false, Serializable>
     {
-        typedef detail::unique_function_vtable<R(Ts...)> vtable;
-        typedef detail::basic_function<vtable, R(Ts...), Serializable> base_type;
+        using base_type = detail::basic_function<R(Ts...), false, Serializable>;
 
     public:
-        typedef typename base_type::result_type result_type;
+        typedef R result_type;
 
         unique_function() noexcept
           : base_type()

--- a/hpx/util/unique_function.hpp
+++ b/hpx/util/unique_function.hpp
@@ -38,17 +38,11 @@ namespace hpx { namespace util
     public:
         typedef R result_type;
 
-        unique_function() noexcept
-          : base_type()
+        unique_function(std::nullptr_t = nullptr) noexcept
         {}
 
-        unique_function(std::nullptr_t) noexcept
-          : base_type()
-        {}
-
-        unique_function(unique_function&& other) noexcept
-          : base_type(static_cast<base_type&&>(other))
-        {}
+        unique_function(unique_function&&) noexcept = default;
+        unique_function& operator=(unique_function&&) noexcept = default;
 
         template <typename F, typename FD = typename std::decay<F>::type,
             typename Enable = typename std::enable_if<
@@ -56,15 +50,8 @@ namespace hpx { namespace util
              && traits::is_invocable_r<R, FD&, Ts...>::value
             >::type>
         unique_function(F&& f)
-          : base_type()
         {
             assign(std::forward<F>(f));
-        }
-
-        unique_function& operator=(unique_function&& other) noexcept
-        {
-            base_type::operator=(static_cast<base_type&&>(other));
-            return *this;
         }
 
         template <typename F, typename FD = typename std::decay<F>::type,

--- a/tests/unit/parcelset/set_parcel_write_handler.cpp
+++ b/tests/unit/parcelset/set_parcel_write_handler.cpp
@@ -43,7 +43,7 @@ int main()
 
     // test that handler is called for every parcel
     hpx::parcel_write_handler_type f1 = hpx::set_parcel_write_handler(wh);
-    HPX_TEST(!hpx::util::is_empty_function(f1));
+    HPX_TEST(!f1.empty());
 
     std::vector<hpx::id_type> localities = hpx::find_remote_localities();
 


### PR DESCRIPTION
Separating the serialization logic from the function vtables allows:
- making function vtable instances constexpr objects,
- reusing function instantiations for serializable/non-serializable versions,
- various function simplifications (2+1 vtables vs 2*2 vtables),

...at the cost of an extra vtable pointer for the serializable functions.