### PR TITLE
Link with libsupc++ if needed for thread_local

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1243,6 +1243,10 @@ if(NOT WIN32)
     endif()
   endif()
 
+  if(HPX_HAVE_LIBSUPCPP)
+    hpx_libraries(supc++)
+  endif()
+
   if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
     hpx_libraries(dl)
   endif()

--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -566,8 +566,29 @@ endfunction()
 function(hpx_check_for_cxx11_thread_local)
   add_hpx_config_test(HPX_WITH_CXX11_THREAD_LOCAL
     SOURCE cmake/tests/cxx11_thread_local.cpp
-    FILE ${ARGN}
-    CMAKECXXFEATURE cxx_thread_local)
+    FILE ${ARGN})
+endfunction()
+
+function(hpx_check_for_cxx11_thread_local)
+  add_hpx_config_test(HPX_WITH_CXX11_THREAD_LOCAL
+    SOURCE cmake/tests/cxx11_thread_local.cpp
+    FILE ${ARGN})
+
+  if(NOT HPX_WITH_CXX11_THREAD_LOCAL)
+    unset(HPX_HAVE_LIBSUPCPP CACHE)
+
+    # Clang version < 4 may require libsupc++
+    check_library_exists(supc++ __cxa_thread_atexit "" HPX_HAVE_LIBSUPCPP)
+    if(HPX_HAVE_LIBSUPCPP)
+      set(HPX_CXX11_THREAD_LOCAL_LIBRARIES supc++)
+
+      unset(HPX_WITH_CXX11_THREAD_LOCAL CACHE)
+      add_hpx_config_test(HPX_WITH_CXX11_THREAD_LOCAL
+        SOURCE cmake/tests/cxx11_thread_local.cpp
+        LIBRARIES ${HPX_CXX11_THREAD_LOCAL_LIBRARIES}
+        FILE ${ARGN})
+    endif()
+  endif()
 endfunction()
 
 ###############################################################################

--- a/cmake/tests/cxx11_thread_local.cpp
+++ b/cmake/tests/cxx11_thread_local.cpp
@@ -5,7 +5,12 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ////////////////////////////////////////////////////////////////////////////////
 
-thread_local int dummy = 0;
+struct dummy_type
+{
+    ~dummy_type(){};
+};
+
+thread_local dummy_type dummy;
 
 int main()
 {


### PR DESCRIPTION
Attempt to fix [these](http://rostam.cct.lsu.edu/builders/hpx_clang_3_9_boost_1_62_centos_x86_64_release/builds/214/steps/build_core/logs/stdio) errors occuring with clang < 4.
