### PR TITLE
Only disable constexpr with clang-cuda, not nvcc+gcc

### DIFF
--- a/hpx/config/constexpr.hpp
+++ b/hpx/config/constexpr.hpp
@@ -9,7 +9,8 @@
 
 #include <hpx/config/defines.hpp>
 
-#if defined(HPX_HAVE_CXX11_CONSTEXPR) && !defined(HPX_MSVC_NVCC) && !defined(__NVCC__)
+#if defined(HPX_HAVE_CXX11_CONSTEXPR) && !defined(HPX_MSVC_NVCC) &&            \
+    !(defined(__NVCC__) && defined(__clang__))
 #   define HPX_CONSTEXPR constexpr
 #   define HPX_CONSTEXPR_OR_CONST constexpr
 #else


### PR DESCRIPTION
Trying to fix some of the compilation errors occuring with nvcc+gcc. The combo nvcc++gcc *does* support constexpr so only disable it if using clang-cuda.