### PR TITLE
Fixing component migration

### DIFF
--- a/hpx/components/component_storage/server/migrate_from_storage.hpp
+++ b/hpx/components/component_storage/server/migrate_from_storage.hpp
@@ -71,9 +71,12 @@ namespace hpx { namespace components { namespace server
             using hpx::components::runtime_support;
             return runtime_support::migrate_component_async<Component>(
                         target_locality, ptr, to_resurrect)
-                .then(util::bind_back(
-                    &detail::migrate_component_cleanup<Component>,
-                    ptr, to_resurrect));
+                .then(launch::sync,
+                    [ptr, to_resurrect](future<id_type> && f)
+                    {
+                        ptr->mark_as_migrated();
+                        return f.get();
+                    });
         }
 
         template <typename Component>
@@ -147,7 +150,7 @@ namespace hpx { namespace components { namespace server
             return make_ready_future(naming::invalid_id);
         }
 
-        auto r = agas::begin_migration(to_resurrect);
+        auto r = agas::begin_migration(to_resurrect).get();
 
         // retrieve the data from the given storage
         typedef typename server::component_storage::migrate_from_here_action
@@ -155,12 +158,13 @@ namespace hpx { namespace components { namespace server
         return async<action_type>(r.first, to_resurrect.get_gid())
             .then(util::bind_back(
                 &detail::migrate_from_storage_here<Component>,
-                to_resurrect, r.second, target_locality)).then(
-                    [to_resurrect](future<naming::id_type> && f) -> naming::id_type
-                    {
-                        agas::end_migration(to_resurrect);
-                        return f.get();
-                    });
+                to_resurrect, r.second, target_locality))
+            .then(
+                [to_resurrect](future<naming::id_type> && f) -> naming::id_type
+                {
+                    agas::end_migration(to_resurrect);
+                    return f.get();
+                });
     }
 
     template <typename Component>

--- a/hpx/error.hpp
+++ b/hpx/error.hpp
@@ -139,6 +139,9 @@ namespace hpx
         length_error = 55,
         ///< Equivalent to std::length_error
 
+        migration_needs_retry = 56,     ///< migration failed because of global
+                                        ///< race, retry
+
         /// \cond NOINTERNAL
         last_error,
 
@@ -206,6 +209,7 @@ namespace hpx
         /* 53 */ "task_block_not_active",
         /* 54 */ "out_of_range",
         /* 55 */ "length_error",
+        /* 56 */ "migration_needs_retry",
 
         /*    */ ""
     };

--- a/hpx/runtime/agas/addressing_service.hpp
+++ b/hpx/runtime/agas/addressing_service.hpp
@@ -48,8 +48,6 @@
 
 namespace hpx { namespace agas
 {
-struct request;
-struct response;
 HPX_EXPORT void destroy_big_boot_barrier();
 
 struct HPX_EXPORT addressing_service
@@ -1376,7 +1374,7 @@ public:
     /// start/stop migration of an object
     ///
     /// \returns Current locality and address of the object to migrate
-    std::pair<naming::id_type, naming::address>
+    hpx::future<std::pair<naming::id_type, naming::address>>
         begin_migration(naming::id_type const& id);
     bool end_migration(naming::id_type const& id);
 
@@ -1389,7 +1387,8 @@ public:
     /// Delay migration until the object is unpinned otherwise.
     hpx::future<void> mark_as_migrated(naming::gid_type const& gid,
         util::unique_function_nonser<
-            std::pair<bool, hpx::future<void> >()> && f);
+            std::pair<bool, hpx::future<void> >()> && f,
+        bool expect_to_be_marked_as_migrating);
 
     /// Remove the given object from the table of migrated objects
     void unmark_as_migrated(naming::gid_type const& gid);

--- a/hpx/runtime/agas/interface.hpp
+++ b/hpx/runtime/agas/interface.hpp
@@ -300,14 +300,15 @@ HPX_API_EXPORT hpx::future<hpx::id_type> on_symbol_namespace_event(
     std::string const& name, bool call_for_past_events);
 
 ///////////////////////////////////////////////////////////////////////////////
-HPX_API_EXPORT std::pair<naming::id_type, naming::address>
+HPX_API_EXPORT hpx::future<std::pair<naming::id_type, naming::address>>
     begin_migration(naming::id_type const& id);
 HPX_API_EXPORT bool end_migration(naming::id_type const& id);
 
 HPX_API_EXPORT hpx::future<void>
     mark_as_migrated(naming::gid_type const& gid,
         util::unique_function_nonser<
-            std::pair<bool, hpx::future<void> >()> && f);
+            std::pair<bool, hpx::future<void> >()> && f,
+        bool expect_to_be_marked_as_migrating);
 
 HPX_API_EXPORT std::pair<bool, components::pinned_ptr>
     was_object_migrated(naming::gid_type const& gid,

--- a/hpx/runtime/agas/primary_namespace.hpp
+++ b/hpx/runtime/agas/primary_namespace.hpp
@@ -55,8 +55,8 @@ struct HPX_EXPORT primary_namespace
     naming::address addr() const;
     naming::id_type gid() const;
 
-    std::pair<naming::id_type, naming::address>
-    begin_migration(naming::gid_type id);
+    hpx::future<std::pair<naming::id_type, naming::address>>
+        begin_migration(naming::gid_type id);
     bool end_migration(naming::gid_type id);
 
     bool bind_gid(gva g, naming::gid_type id, naming::gid_type locality);

--- a/hpx/runtime/agas/server/primary_namespace.hpp
+++ b/hpx/runtime/agas/server/primary_namespace.hpp
@@ -370,6 +370,7 @@ struct HPX_EXPORT primary_namespace
     HPX_DEFINE_COMPONENT_ACTION(primary_namespace, allocate);
     HPX_DEFINE_COMPONENT_ACTION(primary_namespace, bind_gid);
     HPX_DEFINE_COMPONENT_ACTION(primary_namespace, colocate);
+    HPX_DEFINE_COMPONENT_ACTION(primary_namespace, begin_migration);
     HPX_DEFINE_COMPONENT_ACTION(primary_namespace, end_migration);
     HPX_DEFINE_COMPONENT_ACTION(primary_namespace, decrement_credit);
     HPX_DEFINE_COMPONENT_ACTION(primary_namespace, increment_credit);
@@ -404,6 +405,13 @@ HPX_ACTION_USES_MEDIUM_STACK(
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::agas::server::primary_namespace::bind_gid_action,
     primary_namespace_bind_gid_action)
+
+HPX_ACTION_USES_MEDIUM_STACK(
+    hpx::agas::server::primary_namespace::begin_migration_action)
+
+HPX_REGISTER_ACTION_DECLARATION(
+    hpx::agas::server::primary_namespace::begin_migration_action,
+    primary_namespace_begin_migration_action)
 
 HPX_ACTION_USES_MEDIUM_STACK(
     hpx::agas::server::primary_namespace::end_migration_action)

--- a/hpx/runtime/components/server/migrate_component.hpp
+++ b/hpx/runtime/components/server/migrate_component.hpp
@@ -14,7 +14,6 @@
 #include <hpx/runtime/naming/name.hpp>
 #include <hpx/traits/component_supports_migration.hpp>
 #include <hpx/traits/is_component.hpp>
-#include <hpx/util/bind_back.hpp>
 
 #include <cstdint>
 #include <memory>
@@ -115,17 +114,6 @@ namespace hpx { namespace components { namespace server
     // to be migrated
     namespace detail
     {
-        // clean up (source) memory of migrated object
-        template <typename Component>
-        id_type migrate_component_cleanup(
-            future<id_type> && f,
-            std::shared_ptr<Component> ptr,
-            id_type const& to_migrate)
-        {
-            ptr->mark_as_migrated();
-            return f.get();
-        }
-
         // trigger the actual migration
         template <typename Component, typename DistPolicy>
         future<id_type> migrate_component_postproc(
@@ -138,27 +126,38 @@ namespace hpx { namespace components { namespace server
 
             if (pin_count == ~0x0u)
             {
+                agas::unmark_as_migrated(to_migrate.get_gid());
+
                 return hpx::make_exceptional_future<id_type>(
                     HPX_GET_EXCEPTION(invalid_status,
                         "hpx::components::server::migrate_component",
                         "attempting to migrate an instance of a component "
-                        "which was already migrated"));
+                        "that was already migrated"));
             }
 
             if (pin_count > 1)
             {
+                agas::unmark_as_migrated(to_migrate.get_gid());
+
                 return hpx::make_exceptional_future<id_type>(
                     HPX_GET_EXCEPTION(invalid_status,
                         "hpx::components::server::migrate_component",
                         "attempting to migrate an instance of a component "
-                        "which is currently pinned"));
+                        "that is currently pinned"));
             }
 
             return runtime_support::migrate_component_async<Component>(
                         policy, ptr, to_migrate)
-                .then(util::bind_back(
-                    &detail::migrate_component_cleanup<Component>,
-                    ptr, to_migrate));
+                .then(launch::sync,
+                    [ptr, to_migrate](future<id_type> && f)
+                    {
+                        ptr->mark_as_migrated();
+                        if (f.has_exception())
+                        {
+                            agas::unmark_as_migrated(to_migrate.get_gid());
+                        }
+                        return f.get();
+                    });
         }
     }
 
@@ -175,10 +174,12 @@ namespace hpx { namespace components { namespace server
 
         if (!traits::component_supports_migration<Component>::call())
         {
+            agas::unmark_as_migrated(to_migrate.get_gid());
+
             return hpx::make_exceptional_future<hpx::id_type>(
                 HPX_GET_EXCEPTION(invalid_status,
                     "hpx::components::server::migrate_component",
-                    "attempting to migrate an instance of a component which "
+                    "attempting to migrate an instance of a component that "
                     "does not support migration"));
         }
 
@@ -206,15 +207,16 @@ namespace hpx { namespace components { namespace server
     // This is executed on the locality responsible for managing the address
     // resolution for the given object.
     template <typename Component, typename DistPolicy>
-    future<id_type> trigger_migrate_component(
-        id_type const& to_migrate, DistPolicy const& policy)
+    future<id_type> trigger_migrate_component(id_type const& to_migrate,
+        DistPolicy const& policy, naming::id_type const& id,
+        naming::address const& addr)
     {
         if (!traits::component_supports_migration<Component>::call())
         {
             return hpx::make_exceptional_future<id_type>(
                 HPX_GET_EXCEPTION(invalid_status,
                     "hpx::components::server::trigger_migrate_component",
-                    "attempting to migrate an instance of a component which "
+                    "attempting to migrate an instance of a component that "
                     "does not support migration"));
         }
 
@@ -227,12 +229,13 @@ namespace hpx { namespace components { namespace server
                     "responsible for managing the address of the given object"));
         }
 
-        auto r = agas::begin_migration(to_migrate);
-
         // perform actual object migration
         typedef migrate_component_action<Component, DistPolicy> action_type;
-        return async<action_type>(r.first, to_migrate, r.second, policy)
-            .then(
+
+        // force unwrapping outer future
+        future<id_type> f = async<action_type>(id, to_migrate, addr, policy);
+
+        return f.then(launch::sync,
                 [to_migrate](future<id_type> && f) -> id_type
                 {
                     agas::end_migration(to_migrate);
@@ -243,7 +246,8 @@ namespace hpx { namespace components { namespace server
     template <typename Component, typename DistPolicy>
     struct trigger_migrate_component_action
       : ::hpx::actions::action<
-            future<id_type> (*)(id_type const&, DistPolicy const&)
+            future<id_type> (*)(id_type const&, DistPolicy const&,
+                naming::id_type const&, naming::address const&)
           , &trigger_migrate_component<Component, DistPolicy>
           , trigger_migrate_component_action<Component, DistPolicy> >
     {};
@@ -262,38 +266,52 @@ namespace hpx { namespace components { namespace server
             return hpx::make_exceptional_future<id_type>(
                 HPX_GET_EXCEPTION(invalid_status,
                     "hpx::components::server::perform_migrate_component",
-                    "attempting to migrate an instance of a component which "
+                    "attempting to migrate an instance of a component that "
                     "does not support migration"));
         }
 
         // retrieve pointer to object (must be local)
         return hpx::get_ptr<Component>(to_migrate)
-            .then(
+            .then(launch::sync,
                 [=](future<std::shared_ptr<Component> > && f) -> future<id_type>
                 {
-                    future<void> trigger_migration;
+                    std::shared_ptr<Component> ptr = f.get();
 
+                    using bm_result = std::pair<naming::id_type, naming::address>;
+
+                    // mark object in AGAS as being migrated first
+                    return agas::begin_migration(to_migrate).then(
+                        launch::sync,
+                        [HPX_CAPTURE_MOVE(ptr), to_migrate, policy](
+                            hpx::future<bm_result> && bmf) mutable
+                        -> future<id_type>
                     {
-                        std::shared_ptr<Component> ptr = f.get();
+                        auto r = bmf.get();     // propagate exceptions
 
                         // Delay the start of the migration operation until no
                         // more actions (threads) are pending or currently
                         // running for the given object (until the object is
                         // unpinned).
-                        trigger_migration = ptr->mark_as_migrated(to_migrate);
+                        future<void> trigger_migration =
+                            ptr->mark_as_migrated(to_migrate);
 
                         // Unpin the object, will trigger migration if this is
                         // the only pin-count.
-                    }
+                        ptr = std::shared_ptr<Component>{};
 
-                    // Once the migration is possible (object is not pinned
-                    // anymore trigger the necessary actions)
-                    return trigger_migration
-                        .then(
+                        // Once the migration is possible (object is not pinned
+                        // anymore trigger the necessary actions)
+                        return trigger_migration.then(
                             launch::async,  // run on separate thread
                             [=](future<void> && f) -> future<id_type>
                             {
-                                f.get();        // rethrow exceptions
+                                // end migration operation in case of error
+                                if (f.has_exception())
+                                {
+                                    agas::end_migration(to_migrate);
+                                }
+
+                                f.get();        // rethrow exception
 
                                 // now trigger 2nd step of migration
                                 typedef trigger_migrate_component_action<
@@ -302,8 +320,9 @@ namespace hpx { namespace components { namespace server
 
                                 return async<action_type>(
                                     naming::get_locality_from_id(to_migrate),
-                                    to_migrate, policy);
+                                    to_migrate, policy, r.first, r.second);
                             });
+                    });
                 });
     }
 

--- a/hpx/runtime/components/server/migration_support.hpp
+++ b/hpx/runtime/components/server/migration_support.hpp
@@ -86,9 +86,9 @@ namespace hpx { namespace components
             // more than once
             {
                 std::unique_lock<mutex_type> l(mtx_);
-                if (this->pin_count_ != ~0x0u && this->pin_count_ > 1)
+                if (pin_count_ != ~0x0u && pin_count_ > 1)
                 {
-                    --this->pin_count_;
+                    --pin_count_;
                     return false;
                 }
             }
@@ -123,7 +123,7 @@ namespace hpx { namespace components
                         }
                     }
                     return std::make_pair(false, make_ready_future());
-                }).get();
+                }, true).get();
 
             return was_migrated;
         }
@@ -173,7 +173,7 @@ namespace hpx { namespace components
 
                     l.unlock();
                     return std::make_pair(true, std::move(f));
-                });
+                }, false);
         }
 
         /// This hook is invoked on the newly created object after the migration

--- a/src/runtime/agas/interface.cpp
+++ b/src/runtime/agas/interface.cpp
@@ -501,7 +501,7 @@ hpx::future<hpx::id_type> on_symbol_namespace_event(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-std::pair<naming::id_type, naming::address>
+hpx::future<std::pair<naming::id_type, naming::address>>
     begin_migration(naming::id_type const& id)
 {
     naming::resolver_client& resolver = naming::get_agas_client();
@@ -515,10 +515,12 @@ bool end_migration(naming::id_type const& id)
 }
 
 hpx::future<void> mark_as_migrated(naming::gid_type const& gid,
-    util::unique_function_nonser<std::pair<bool, hpx::future<void> >()> && f)
+    util::unique_function_nonser<std::pair<bool, hpx::future<void> >()> && f,
+    bool expect_to_be_marked_as_migrating)
 {
     naming::resolver_client& resolver = naming::get_agas_client();
-    return resolver.mark_as_migrated(gid, std::move(f));
+    return resolver.mark_as_migrated(
+        gid, std::move(f), expect_to_be_marked_as_migrating);
 }
 
 std::pair<bool, components::pinned_ptr>

--- a/src/runtime/agas/server/primary_namespace_server.cpp
+++ b/src/runtime/agas/server/primary_namespace_server.cpp
@@ -280,13 +280,18 @@ bool primary_namespace::end_migration(naming::gid_type id)
     using hpx::util::get;
 
     migration_table_type::iterator it = migrating_objects_.find(id);
-    if (it == migrating_objects_.end() || !get<0>(it->second))
-        return false;
+    HPX_ASSERT(it != migrating_objects_.end() && get<0>(it->second));
 
     // flag this id as not being migrated anymore
     get<0>(it->second) = false;
-
-    get<2>(it->second).notify_all(std::move(l), hpx::throws);
+    if (get<1>(it->second) != 0)
+    {
+        get<2>(it->second).notify_all(std::move(l), hpx::throws);
+    }
+    else
+    {
+        migrating_objects_.erase(it);
+    }
 
     return true;
 }
@@ -302,15 +307,23 @@ void primary_namespace::wait_for_migration_locked(
     using hpx::util::get;
 
     migration_table_type::iterator it = migrating_objects_.find(id);
-    if (it != migrating_objects_.end() && get<0>(it->second))
+    if (it != migrating_objects_.end())
     {
-        ++get<1>(it->second);
+        if (get<0>(it->second))
+        {
+            ++get<1>(it->second);
 
-        get<2>(it->second).wait(l, ec);
+            get<2>(it->second).wait(l, ec);
 
-        HPX_ASSERT(hpx::util::get<0>(it->second) == false);
-        if (--get<1>(it->second) == 0)
+            HPX_ASSERT(!get<0>(it->second));
+            if (--get<1>(it->second) == 0)
+                migrating_objects_.erase(it);
+        }
+        else
+        {
+            HPX_ASSERT(get<1>(it->second) == 0);
             migrating_objects_.erase(it);
+        }
     }
 }
 

--- a/src/runtime/agas/server/primary_namespace_server.cpp
+++ b/src/runtime/agas/server/primary_namespace_server.cpp
@@ -315,7 +315,6 @@ void primary_namespace::wait_for_migration_locked(
 
             get<2>(it->second).wait(l, ec);
 
-            HPX_ASSERT(!get<0>(it->second));
             if (--get<1>(it->second) == 0)
                 migrating_objects_.erase(it);
         }

--- a/src/runtime/agas/server/route.cpp
+++ b/src/runtime/agas/server/route.cpp
@@ -96,6 +96,7 @@ namespace hpx { namespace agas { namespace server
         }
 
         naming::id_type source = p.source_id();
+
         // either send the parcel on its way or execute actions locally
         if (addr.locality_ == get_locality())
         {

--- a/tests/unit/component/migrate_component.cpp
+++ b/tests/unit/component/migrate_component.cpp
@@ -50,8 +50,9 @@ struct test_server
         auto f = hpx::make_ready_future_after(std::chrono::seconds(1));
 
         return f.then(
-            [this](hpx::future<void> && f)
+            [this](hpx::future<void> && f) -> void
             {
+                HPX_TEST(pin_count() != 0);
                 f.get();
                 HPX_TEST(pin_count() != 0);
             });
@@ -67,14 +68,15 @@ struct test_server
     {
         HPX_TEST(pin_count() != 0);
 
-        auto f =
-            hpx::make_ready_future(/*_after(std::chrono::seconds(1), */data_);
+        auto f = hpx::make_ready_future(data_);
 
         return f.then(
-            [this](hpx::future<int> && f)
+            [this](hpx::future<int> && f) -> int
             {
                 HPX_TEST(pin_count() != 0);
-                return f.get();
+                auto result = f.get();
+                HPX_TEST(pin_count() != 0);
+                return result;
             });
     }
 
@@ -117,7 +119,7 @@ private:
     int data_;
 };
 
-typedef hpx::components::simple_component<test_server> server_type;
+typedef hpx::components::component<test_server> server_type;
 HPX_REGISTER_COMPONENT(server_type, test_server);
 
 typedef test_server::call_action call_action;


### PR DESCRIPTION
Fixes the migration test that is failing intermittently.

This PR fixes several issues with component migration:

- one of the continuations involved was attached to the outer future of a `future<future<id_type>>` instead of the inner one
- in case of exceptions the interrupted migration operation is now cleaned up properly
- the migration operation is now (silently) retried if a global race is detected (see commit message below for an explanation)