### PR TITLE
Ini

### DIFF
--- a/hpx/runtime/threads/coroutines/detail/context_generic_context.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_generic_context.hpp
@@ -256,8 +256,8 @@ namespace hpx { namespace threads { namespace coroutines
             {
 #if defined(HPX_HAVE_THREADS_GET_STACK_POINTER)
                 return stack_size_ -
-                    (get_stack_ptr() -
-                        reinterpret_cast<std::size_t>(stack_pointer_));
+                    (reinterpret_cast<std::size_t>(stack_pointer_) -
+                        get_stack_ptr());
 #else
                 return (std::numeric_limits<std::ptrdiff_t>::max)();
 #endif

--- a/hpx/runtime/threads/coroutines/detail/get_stack_pointer.hpp
+++ b/hpx/runtime/threads/coroutines/detail/get_stack_pointer.hpp
@@ -8,10 +8,14 @@
 #define HPX_RUNTIME_THREADS_COROUTINES_DETAIL_GET_STACK_POINTER_HPP
 
 #if !defined(HPX_WINDOWS)
+#if defined(HPX_GCC_VERSION)
+#define HPX_HAVE_THREADS_GET_STACK_POINTER
+#else
 #if defined(__x86_64__) || defined(__amd64)                                    \
     || defined(__i386__) || defined(__i486__) || defined(__i586__) || defined(__i686__) \
     || defined(__powerpc__) || defined(__arm__)
 #define HPX_HAVE_THREADS_GET_STACK_POINTER
+#endif
 #endif
 
 #include <cstddef>
@@ -21,18 +25,22 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail
 {
     inline std::size_t get_stack_ptr()
     {
+#if defined(HPX_GCC_VERSION)
+        return std::size_t(__builtin_frame_address(0));
+#else
         std::size_t stack_ptr = (std::numeric_limits<std::size_t>::max)();
 #if defined(__x86_64__) || defined(__amd64)
         asm("movq %%rsp, %0" : "=r"(stack_ptr));
 #elif defined(__i386__) || defined(__i486__) || defined(__i586__) || defined(__i686__)
         asm("movl %%esp, %0" : "=r"(stack_ptr));
 #elif defined(__powerpc__)
-        std::size_t stack_ptr_p = (std::size_t)&stack_ptr;
+        void* stack_ptr_p = &stack_ptr;
         asm("stw %%r1, 0(%0)" : "=&r"(stack_ptr_p));
 #elif defined(__arm__)
         asm("mov %0, sp" : "=r"(stack_ptr));
 #endif
         return stack_ptr;
+#endif
     }
 }}}}
 

--- a/hpx/util/ini.hpp
+++ b/hpx/util/ini.hpp
@@ -72,7 +72,6 @@ namespace hpx { namespace util
         HPX_SERIALIZATION_SPLIT_MEMBER()
 
     protected:
-        bool regex_init();
         void line_msg(std::string msg, std::string const& file,
             int lnum = 0, std::string const& line = "");
 


### PR DESCRIPTION
 - Using gcc intrinsic to retrieve stack pointer
    
    This patch uses the gcc intrinsic (also available on clang) `__builtin_frame_address` to retreive the current stack pointer. This makes for a more reliable stack overflow detection.
    
    Flyby: Streamlining up related code

 - Replacing std::regex usage with simpler mechanism
    
    The ini parser segfaults while parsing the ini lines on some implementations
    due to reaching an infinite recursion (observed with gcc 7.3.0 on power8).
    
    This patch replaces the usage of regexes with simple string searches.
