### PR TITLE
Document known broken OpenMPI builds

### DIFF
--- a/docs/sphinx/manual/building_hpx.rst
+++ b/docs/sphinx/manual/building_hpx.rst
@@ -331,6 +331,12 @@ listed below.
      * Can be used as a highspeed communication library backend for the
        parcelport.
 
+.. note::
+
+   When using OpenMPI please note that Ubuntu (notably 18.04 LTS) and older
+   Debian ship an OpenMPI 2.x built with ``--enable-heterogeneous`` which may
+   cause communication failures at runtime and should not be used.
+
 .. list-table:: Optional software prerequisites for |hpx| on Linux systems
 
    * * Name


### PR DESCRIPTION
OpenMPI's `--enable-heterogeneous` build flag is considered deprecated and broken according to OpenMPI:s README and is documented to cause problems on Ubuntu's and debian's bug trackers:

https://bugs.launchpad.net/ubuntu/+source/openmpi/+bug/1731938
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=886336
https://github.com/open-mpi/ompi/issues/171

This PR adds a documentation note to warn about this mentioning distributions which build with this flag.

Feedback on wording very welcome.