### PR TITLE
Adding example demonstrating how to customize the memory management for a component

### DIFF
--- a/examples/quickstart/CMakeLists.txt
+++ b/examples/quickstart/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2007-2016 Hartmut Kaiser
+# Copyright (c) 2007-2019 Hartmut Kaiser
 # Copyright (c) 2011      Bryce Adelstein-Lelbach
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,6 +11,7 @@ set(example_programs
     component_ctors
     component_in_executable
     component_inheritance
+    component_with_custom_heap
     component_with_executor
     composable_guard
     customize_async
@@ -72,6 +73,7 @@ set(command_line_handling_FLAGS COMPONENT_DEPENDENCIES iostreams)
 set(component_in_executable_FLAGS COMPONENT_DEPENDENCIES iostreams)
 set(component_ctors_FLAGS COMPONENT_DEPENDENCIES iostreams)
 set(component_inheritance_FLAGS COMPONENT_DEPENDENCIES iostreams)
+set(component_with_custom_heap_FLAGS COMPONENT_DEPENDENCIES iostreams)
 set(component_with_executor_FLAGS COMPONENT_DEPENDENCIES iostreams)
 set(customize_async_FLAGS COMPONENT_DEPENDENCIES iostreams)
 set(enumerate_threads_FLAGS COMPONENT_DEPENDENCIES iostreams)

--- a/examples/quickstart/component_with_custom_heap.cpp
+++ b/examples/quickstart/component_with_custom_heap.cpp
@@ -1,0 +1,386 @@
+//  Copyright (c) 2019 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// The purpose of this example is to demonstrate how to control the memory
+// placement of newly created component instances. Here we use a simple
+// free-list allocator to make sure all created components are placed
+// consecutively in memory.
+// After creating 1000 component instances this example directly accesses those
+// in local memory without having to go through the AGAS address resolution.
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/actions.hpp>
+#include <hpx/include/components.hpp>
+#include <hpx/include/iostreams.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/util.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <mutex>
+#include <type_traits>
+
+///////////////////////////////////////////////////////////////////////////////
+// Implementation of a free_list allocator, this has no bearings on the example
+// component below.
+namespace free_list_allocator
+{
+    ///////////////////////////////////////////////////////////////////////////
+    HPX_CONSTEXPR std::size_t BLOCK_ALIGNMENT = 8;
+    HPX_CONSTEXPR std::size_t PAGE_SIZE = 16384;
+
+    template <typename T>
+    struct alloc_page;
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    struct alloc_block_header
+    {
+        HPX_CONSTEXPR HPX_FORCEINLINE alloc_block_header(
+                alloc_page<T>* p = nullptr) noexcept
+          : page(p)
+        {}
+
+        HPX_FORCEINLINE alloc_page<T>* get_ptr() noexcept
+        {
+            return page;
+        }
+
+        alloc_page<T>* page;
+    };
+
+    template <typename T>
+    struct alloc_block : alloc_block_header<T>
+    {
+        HPX_STATIC_CONSTEXPR std::size_t allocation_size =
+            ((sizeof(T) + BLOCK_ALIGNMENT - 1) & ~(BLOCK_ALIGNMENT - 1)) +
+            sizeof(alloc_block_header<T>);
+
+        HPX_CONSTEXPR HPX_FORCEINLINE alloc_block(
+                alloc_page<T>* page = nullptr) noexcept
+          : alloc_block_header<T>(page)
+          , next_free(nullptr)
+        {}
+
+        HPX_CONSTEXPR HPX_FORCEINLINE alloc_block<T>* operator[](
+            std::size_t i) noexcept
+        {
+            return reinterpret_cast<alloc_block<T>*>(
+                reinterpret_cast<char*>(this) + i * allocation_size);
+        }
+        HPX_CONSTEXPR HPX_FORCEINLINE alloc_block<T> const* operator[](
+            std::size_t i) const noexcept
+        {
+            return reinterpret_cast<alloc_block<T> const*>(
+                reinterpret_cast<char const*>(this) + i * allocation_size);
+        }
+
+        alloc_block<T>* next_free;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    class free_list_allocator
+    {
+        using mutex_type = hpx::lcos::local::spinlock;
+
+    public:
+        free_list_allocator()
+          : chain(nullptr)
+          , pages(nullptr)
+        {}
+
+        ~free_list_allocator() = default;
+
+        free_list_allocator(free_list_allocator const&) = delete;
+        free_list_allocator(free_list_allocator&&) = delete;
+
+        free_list_allocator& operator=(free_list_allocator const&) = delete;
+        free_list_allocator& operator=(free_list_allocator&&) = delete;
+
+        HPX_FORCEINLINE static free_list_allocator& get_allocator();
+
+        HPX_CONSTEXPR HPX_FORCEINLINE alloc_page<T> const* first_page() const
+        {
+            return pages;
+        }
+
+        void* alloc();
+        void free(void* addr);
+
+    private:
+
+        friend struct alloc_page<T>;
+
+        alloc_block<T>* chain;
+        alloc_page<T>* pages;
+        mutex_type mtx;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    struct alloc_page
+    {
+        HPX_CONSTEXPR HPX_FORCEINLINE alloc_page() noexcept
+          : next(nullptr)
+          , allocated_blocks(0)
+        {}
+
+        ~alloc_page()
+        {
+            // FIXME: loop over blocks and call destructor
+        }
+
+        alloc_page(alloc_page const&) = delete;
+        alloc_page& operator=(alloc_page const&) = delete;
+
+        alloc_page(alloc_page &&) = delete;
+        alloc_page& operator=(alloc_page &&) = delete;
+
+        HPX_CONSTEXPR HPX_FORCEINLINE alloc_block<T>* get_block() noexcept
+        {
+            return reinterpret_cast<alloc_block<T>*>(&data);
+        }
+        HPX_CONSTEXPR HPX_FORCEINLINE alloc_block<T> const* get_block() const noexcept
+        {
+            return reinterpret_cast<alloc_block<T> const*>(&data);
+        }
+
+        HPX_CONSTEXPR HPX_FORCEINLINE T& operator[](std::size_t i) noexcept
+        {
+            return *reinterpret_cast<T*>(static_cast<void*>(
+                static_cast<alloc_block_header<T>*>((*get_block())[i]) + 1));
+        }
+        HPX_CONSTEXPR HPX_FORCEINLINE T const& operator[](std::size_t i) const
+            noexcept
+        {
+            return *reinterpret_cast<T const*>(static_cast<void const*>(
+                static_cast<alloc_block_header<T> const*>((*get_block())[i]) + 1));
+        }
+
+        // for the available page size we account for the members of this
+        // class below
+        HPX_STATIC_CONSTEXPR std::size_t page_size =
+            PAGE_SIZE - 2 * sizeof(void*) - sizeof(std::size_t);
+
+        static_assert(page_size >= alloc_block<T>::allocation_size,
+            "size of objects is larger than configured page size");
+
+        typename std::aligned_storage<page_size>::type data;
+
+        alloc_page<T>* next;
+        std::size_t allocated_blocks;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    HPX_FORCEINLINE free_list_allocator<T>&
+        free_list_allocator<T>::get_allocator()
+    {
+        static free_list_allocator<T> ctx{};
+        return ctx;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    void* free_list_allocator<T>::alloc()
+    {
+        std::unique_lock<mutex_type> lk(mtx);
+
+        alloc_block<T>* blk = chain;
+        if (HPX_LIKELY(blk != nullptr))
+        {
+            chain = blk->next_free;
+            ++blk->page->allocated_blocks;
+            return reinterpret_cast<alloc_block_header<T>*>(blk) + 1;
+        }
+
+        alloc_page<T>* pg = nullptr;
+        alloc_block<T>* new_chain = nullptr;
+
+        {
+            hpx::util::unlock_guard<std::unique_lock<mutex_type>> ul(lk);
+
+            // allocate new page
+            pg = reinterpret_cast<alloc_page<T>*>(
+                std::malloc(sizeof(alloc_page<T>)));
+            if (nullptr == pg)
+            {
+                return nullptr;
+            }
+
+            new (pg) alloc_page<T>();
+
+            // FIXME: move block construction into alloc_page constructor
+            blk = new_chain = (*pg->get_block())[1];
+            new (blk) alloc_block<T>(pg);
+
+            std::size_t blocks =
+                (alloc_page<T>::page_size / alloc_block<T>::allocation_size) - 2;
+
+            do
+            {
+                alloc_block<T>* next = (*blk)[1];
+                new (next) alloc_block<T>(pg);
+
+                blk->next_free = next;
+                blk = next;
+            } while (--blocks != 0);
+
+            blk->next_free = nullptr;
+
+            blk = pg->get_block();
+            new (blk) alloc_block<T>(pg);
+
+            blk->next_free = nullptr;
+        }
+
+        pg->next = pages;
+        pages = pg;
+        chain = new_chain;
+
+        ++blk->page->allocated_blocks;
+
+        return reinterpret_cast<alloc_block_header<T>*>(blk) + 1;
+    }
+
+    template <typename T>
+    void free_list_allocator<T>::free(void* addr)
+    {
+        if (addr == nullptr)
+        {
+            return;     // ignore nullptr arguments
+        }
+
+        std::unique_lock<mutex_type> lk(mtx);
+
+        auto* blk = static_cast<alloc_block<T>*>(
+            reinterpret_cast<alloc_block_header<T>*>(addr) - 1);
+
+        alloc_page<T>* page = blk->get_ptr();
+
+        --page->allocated_blocks;
+
+        blk->next_free = chain;
+        chain = blk;
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// define component type
+struct hello_world_server
+  : hpx::components::component_base<hello_world_server>
+{
+    hello_world_server(std::size_t cnt = 0)
+      : count_(cnt)
+    {}
+
+    void print(std::size_t pagenum, std::size_t item) const
+    {
+        if (pagenum != std::size_t(-1))
+        {
+            hpx::cout << "hello world from page: " << pagenum
+                << ", item: " << item << ", number: " << count_ << "\n";
+        }
+        else
+        {
+            hpx::cout << "hello world from item: " << item
+                      << ", number: " << count_ << "\n";
+        }
+    }
+
+    HPX_DEFINE_COMPONENT_ACTION(hello_world_server, print, print_action);
+
+    std::size_t count_;
+};
+
+// special heap to use for placing components in free_list_heap
+template <typename Component>
+struct free_list_component_heap
+{
+    // alloc and free have to be exposed from a component heap
+    static void* alloc(std::size_t)
+    {
+        return free_list_allocator::free_list_allocator<Component>::
+            get_allocator().alloc();
+    }
+
+    static void free(void* p, std::size_t)
+    {
+        return free_list_allocator::free_list_allocator<Component>::
+            get_allocator().free(p);
+    }
+
+    // this is an additional function needed just for this example
+    static free_list_allocator::alloc_page<Component> const* get_first_page()
+    {
+        return free_list_allocator::free_list_allocator<Component>::
+            get_allocator().first_page();
+    }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// associate heap with component above
+namespace hpx { namespace traits
+{
+    template <>
+    struct component_heap_type<hello_world_server>
+    {
+        using type = free_list_component_heap<hello_world_server>;
+    };
+}}
+
+// the component macros must come after the component_heap_type specialization
+using server_type = hpx::components::component<hello_world_server>;
+HPX_REGISTER_COMPONENT(server_type, hello_world_server);
+
+using print_action = hello_world_server::print_action;
+HPX_REGISTER_ACTION_DECLARATION(print_action);
+HPX_REGISTER_ACTION(print_action);
+
+///////////////////////////////////////////////////////////////////////////////
+int main()
+{
+    // create 100 new component instances
+    std::vector<hpx::id_type> ids;
+    ids.reserve(1000);
+
+    for (std::size_t i = 0; i != 1000; ++i)
+    {
+        ids.push_back(hpx::local_new<hello_world_server>(hpx::launch::sync, i));
+    }
+
+    // Just for demonstration purposes we now access the components directly
+    // without having to go through AGAS to resolve their addresses. This
+    // obviously relies on internal knowledge of the used heap.
+
+    // Extract base pointer to the array (pages) managed by the heap above.
+    free_list_component_heap<hello_world_server>& heap =
+        hpx::components::component_heap<server_type>();
+
+    std::size_t pagenum = 0;
+    for (auto* page = heap.get_first_page(); page != nullptr;
+         page = page->next, ++pagenum)
+    {
+        auto blocks = page->allocated_blocks;
+        for (std::size_t i = 0; i != blocks; ++i)
+        {
+            (*page)[i].print(pagenum, i);
+        }
+    }
+
+    // now do the same but using AGAS
+    std::size_t i = 0;
+    for (auto const& id : ids)
+    {
+        print_action()(id, std::size_t(-1), i++);
+    }
+
+    return 0;
+}
+

--- a/hpx/include/traits.hpp
+++ b/hpx/include/traits.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2018 Hartmut Kaiser
+//  Copyright (c) 2007-2019 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -21,11 +21,13 @@
 #include <hpx/traits/action_stacksize.hpp>
 #include <hpx/traits/action_was_object_migrated.hpp>
 #include <hpx/traits/component_config_data.hpp>
+#include <hpx/traits/component_heap_type.hpp>
 #include <hpx/traits/component_pin_support.hpp>
 #include <hpx/traits/component_supports_migration.hpp>
 #include <hpx/traits/component_type_database.hpp>
 #include <hpx/traits/component_type_is_compatible.hpp>
 #include <hpx/traits/concepts.hpp>
+#include <hpx/traits/detail/wrap_int.hpp>
 #include <hpx/traits/extract_action.hpp>
 #include <hpx/traits/future_access.hpp>
 #include <hpx/traits/future_traits.hpp>
@@ -63,7 +65,6 @@
 #include <hpx/traits/promise_remote_result.hpp>
 #include <hpx/traits/segmented_iterator_traits.hpp>
 #include <hpx/traits/supports_streaming_with_any.hpp>
-#include <hpx/traits/detail/wrap_int.hpp>
 
 #endif
 

--- a/hpx/runtime/components/server/component.hpp
+++ b/hpx/runtime/components/server/component.hpp
@@ -11,13 +11,14 @@
 #include <hpx/config.hpp>
 #include <hpx/util/assert.hpp>
 #include <hpx/util/internal_allocator.hpp>
+#include <hpx/traits/component_heap_type.hpp>
 
 #include <cstddef>
 #include <new>
 #include <utility>
 
-namespace hpx { namespace components {
-
+namespace hpx { namespace components
+{
     namespace detail
     {
         ///////////////////////////////////////////////////////////////////////
@@ -41,7 +42,20 @@ namespace hpx { namespace components {
         template <typename Component>
         util::internal_allocator<Component> simple_heap<Component>::alloc_;
     }
+}}
 
+namespace hpx { namespace traits
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Component, typename Enable>
+    struct component_heap_type
+    {
+        using type = hpx::components::detail::simple_heap<Component>;
+    };
+}}
+
+namespace hpx { namespace components
+{
     ///////////////////////////////////////////////////////////////////////////
     template <typename Component>
     class component : public Component
@@ -50,7 +64,7 @@ namespace hpx { namespace components {
         typedef Component type_holder;
         typedef component<Component> component_type;
         typedef component_type derived_type;
-        typedef detail::simple_heap<Component> heap_type;
+        typedef typename traits::component_heap_type<Component>::type heap_type;
 
         /// \brief Construct a simple_component instance holding a new wrapped
         ///        instance

--- a/hpx/traits/component_heap_type.hpp
+++ b/hpx/traits/component_heap_type.hpp
@@ -1,0 +1,18 @@
+//  Copyright (c) 2019 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_TRAITS_COMPONENT_HEAP_TYPE_HPP
+#define HPX_TRAITS_COMPONENT_HEAP_TYPE_HPP
+
+#include <hpx/config.hpp>
+
+namespace hpx { namespace traits
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Component, typename Enable = void>
+    struct component_heap_type;
+}}
+
+#endif

--- a/src/runtime/components/server/component_base.cpp
+++ b/src/runtime/components/server/component_base.cpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2015 Thomas Heller
-//  Copyright (c) 2018 Hartmut Kaiser
+//  Copyright (c) 2018-2019 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -128,18 +128,8 @@ namespace hpx { namespace components { namespace detail
             gid_ = naming::replace_component_type(gid_, addr.type_);
             gid_ = naming::replace_locality_id(gid_, agas::get_locality_id());
 
-            if (!applier::bind_gid_local(gid_, addr))
-            {
-                std::ostringstream strm;
-                strm << "failed to bind id " << gid_
-                        << "to locality: " << hpx::get_locality();
-
-                gid_ = naming::invalid_gid;    // invalidate GID
-
-                HPX_THROW_EXCEPTION(duplicate_component_address,
-                    "component_base<Component>::get_base_gid",
-                    strm.str());
-            }
+            // there is no need to explicitly bind this id in AGAS as the id
+            // can be directly resolved to the address it contains.
         }
 
         std::unique_lock<naming::gid_type::mutex_type> l(gid_.get_mutex());

--- a/tests/unit/component/local_new.cpp
+++ b/tests/unit/component/local_new.cpp
@@ -60,6 +60,9 @@ void test_create_single_instance()
     hpx::id_type id = hpx::local_new<test_server>().get();
     HPX_TEST(hpx::async<call_action>(id).get() == hpx::find_here());
 
+    hpx::id_type id1 = hpx::local_new<test_server>(hpx::launch::sync);
+    HPX_TEST(hpx::async<call_action>(id1).get() == hpx::find_here());
+
     test_client t1 = hpx::local_new<test_client>();
     HPX_TEST(t1.call() == hpx::find_here());
 }
@@ -71,6 +74,9 @@ void test_create_single_instance_non_copyable_arg()
     hpx::id_type id = hpx::local_new<test_server>(a).get();
     HPX_TEST(hpx::async<call_action>(id).get() == hpx::find_here());
 
+    hpx::id_type id1 = hpx::local_new<test_server>(hpx::launch::sync, a);
+    HPX_TEST(hpx::async<call_action>(id1).get() == hpx::find_here());
+
     test_client t1 = hpx::local_new<test_client>(a);
     HPX_TEST(t1.call() == hpx::find_here());
 }
@@ -81,6 +87,17 @@ void test_create_multiple_instances()
     // make sure created objects live on locality they are supposed to be
     {
         std::vector<hpx::id_type> ids = hpx::local_new<test_server[]>(10).get();
+        HPX_TEST_EQ(ids.size(), std::size_t(10));
+
+        for (hpx::id_type const& id: ids)
+        {
+            HPX_TEST(hpx::async<call_action>(id).get() == hpx::find_here());
+        }
+    }
+
+    {
+        std::vector<hpx::id_type> ids =
+            hpx::local_new<test_server[]>(hpx::launch::sync, 10);
         HPX_TEST_EQ(ids.size(), std::size_t(10));
 
         for (hpx::id_type const& id: ids)


### PR DESCRIPTION
- adding traits::component_heap_type
- flyby: adding `local_new(launch::sync, ...)
- flyby: don't bind gids that hold lva

