### PR TITLE
Send even empty buffers on hpx::endl and hpx::flush

### DIFF
--- a/hpx/components/iostreams/ostream.hpp
+++ b/hpx/components/iostreams/ostream.hpp
@@ -213,25 +213,20 @@ namespace hpx { namespace iostreams
             // apply the subject to the local stream
             *static_cast<stream_base_type*>(this) << subject;
 
-            // If the buffer isn't empty, send it to the destination.
-            if (!this->detail::buffer::empty_locked())
-            {
-                // Create the next buffer, returns the previous buffer
-                buffer next = this->detail::buffer::init_locked();
+            // Send even empty buffer to flush the data buffered server-side.
 
-                // Unlock the mutex before we cleanup.
-                l.unlock();
+            // Create the next buffer, returns the previous buffer
+            buffer next = this->detail::buffer::init_locked();
 
-                // Perform the write operation, then destroy the old buffer and
-                // stream.
-                typedef server::output_stream::write_sync_action action_type;
-                hpx::async<action_type>(this->get_id(), hpx::get_locality_id(),
-                    generational_count_++, next).get();
-            }
-            else
-            {
-                l.unlock();     // must unlock in any case
-            }
+            // Unlock the mutex before we cleanup.
+            l.unlock();
+
+            // Perform the write operation, then destroy the old buffer and
+            // stream.
+            typedef server::output_stream::write_sync_action action_type;
+            hpx::async<action_type>(this->get_id(), hpx::get_locality_id(),
+                generational_count_++, next).get();
+
             return *this;
         } // }}}
 


### PR DESCRIPTION
- This forces to empty all data buffered server side
