### PR TITLE
More constrained bound constructors

### DIFF
--- a/hpx/util/bind.hpp
+++ b/hpx/util/bind.hpp
@@ -199,7 +199,7 @@ namespace hpx { namespace util
 
             template <typename F_, typename ...Ts_, typename =
                 typename std::enable_if<
-                    !std::is_same<typename std::decay<F_>::type, bound>::value
+                    std::is_constructible<F, F_>::value
                 >::type>
             HPX_CONSTEXPR explicit bound(F_&& f, Ts_&&... vs)
               : base_type{

--- a/hpx/util/bind_back.hpp
+++ b/hpx/util/bind_back.hpp
@@ -109,7 +109,7 @@ namespace hpx { namespace util
 
             template <typename F_, typename ...Ts_, typename =
                 typename std::enable_if<
-                    !std::is_same<typename std::decay<F_>::type, bound_back>::value
+                    std::is_constructible<F, F_>::value
                 >::type>
             HPX_CONSTEXPR explicit bound_back(F_&& f, Ts_&&... vs)
               : base_type{

--- a/hpx/util/bind_front.hpp
+++ b/hpx/util/bind_front.hpp
@@ -109,7 +109,7 @@ namespace hpx { namespace util
 
             template <typename F_, typename ...Ts_, typename =
                 typename std::enable_if<
-                    !std::is_same<typename std::decay<F_>::type, bound_front>::value
+                    std::is_constructible<F, F_>::value
                 >::type>
             HPX_CONSTEXPR explicit bound_front(F_&& f, Ts_&&... vs)
               : base_type{

--- a/hpx/util/deferred_call.hpp
+++ b/hpx/util/deferred_call.hpp
@@ -109,7 +109,7 @@ namespace hpx { namespace util
 
             template <typename F_, typename ...Ts_, typename =
                 typename std::enable_if<
-                    !std::is_same<typename std::decay<F_>::type, deferred>::value
+                    std::is_constructible<F, F_>::value
                 >::type>
             explicit HPX_HOST_DEVICE deferred(F_&& f, Ts_&&... vs)
               : base_type{

--- a/hpx/util/one_shot.hpp
+++ b/hpx/util/one_shot.hpp
@@ -33,12 +33,12 @@ namespace hpx { namespace util
               : _called(false)
             {}
 
-            HPX_CONSTEXPR explicit one_shot_wrapper(F const& f)
-              : _f(f)
-              , _called(false)
-            {}
-            HPX_CONSTEXPR explicit one_shot_wrapper(F&& f)
-              : _f(std::move(f))
+            template <typename F_, typename =
+                typename std::enable_if<
+                    std::is_constructible<F, F_>::value
+                >::type>
+            HPX_CONSTEXPR explicit one_shot_wrapper(F_&& f)
+              : _f(std::forward<F_>(f))
               , _called(false)
             {}
 
@@ -60,11 +60,12 @@ namespace hpx { namespace util
             HPX_CONSTEXPR one_shot_wrapper()
             {}
 
-            HPX_CONSTEXPR explicit one_shot_wrapper(F const& f)
-              : _f(f)
-            {}
-            HPX_CONSTEXPR explicit one_shot_wrapper(F&& f)
-              : _f(std::move(f))
+            template <typename F_, typename =
+                typename std::enable_if<
+                    std::is_constructible<F, F_>::value
+                >::type>
+            HPX_CONSTEXPR explicit one_shot_wrapper(F_&& f)
+              : _f(std::forward<F_>(f))
             {}
 
             HPX_CONSTEXPR one_shot_wrapper(one_shot_wrapper&& other)


### PR DESCRIPTION
Workaround for old libstdc++ single element `std::tuple` bug.

Fixes #3731 