### PR TITLE
Limiting executor

### DIFF
--- a/hpx/runtime/threads/executors/limiting_executor.hpp
+++ b/hpx/runtime/threads/executors/limiting_executor.hpp
@@ -1,0 +1,218 @@
+//  Copyright (c) 2017-2018 John Biddiscombe
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_RUNTIME_THREADS_LIMITING_EXECUTOR_HPP
+#define HPX_RUNTIME_THREADS_LIMITING_EXECUTOR_HPP
+
+#include <hpx/parallel/executors/execution_fwd.hpp>
+#include <hpx/runtime/threads/executors/default_executor.hpp>
+#include <hpx/runtime/threads/thread_executor.hpp>
+#include <hpx/runtime/threads/executors/pool_executor.hpp>
+#include <hpx/runtime/threads/thread_pool_base.hpp>
+#include <hpx/apply.hpp>
+#include <hpx/util/thread_description.hpp>
+#include <hpx/util/thread_specific_ptr.hpp>
+#include <hpx/util/deferred_call.hpp>
+#include <hpx/lcos/dataflow.hpp>
+#include <hpx/util/invoke.hpp>
+#include <hpx/util/pack_traversal.hpp>
+#include <hpx/util/yield_while.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <iostream>
+#include <type_traits>
+#include <utility>
+
+#include <hpx/config/warnings_prefix.hpp>
+
+// --------------------------------------------------------------------
+//
+// --------------------------------------------------------------------
+namespace hpx { namespace threads { namespace executors
+{
+    template <typename Executor>
+    struct limiting_executor
+    {
+        // --------------------------------------------------------------------
+        // For C++11 compatibility
+        template <bool B, typename T = void>
+        using enable_if_t = typename std::enable_if<B, T>::type;
+
+        // --------------------------------------------------------------------
+        //
+        // --------------------------------------------------------------------
+        limiting_executor(std::size_t lower, std::size_t upper,
+                          bool block_on_destruction=true)
+            : executor_(Executor())
+            , count_(0)
+            , lower_threshold_(lower)
+            , upper_threshold_(upper)
+            , block_(block_on_destruction) {}
+
+        limiting_executor(const Executor& ex, std::size_t lower, std::size_t upper,
+                            bool block_on_destruction=true)
+            : executor_(ex)
+            , count_(0)
+            , lower_threshold_(lower)
+            , upper_threshold_(upper)
+            , block_(block_on_destruction) {}
+
+        ~limiting_executor()
+        {
+            if (block_) {
+                set_and_wait(0,0);
+            }
+        }
+
+        void count_up()
+        {
+            if (++count_ > upper_threshold_) {
+                hpx::util::yield_while([&](){
+                    return (count_ > lower_threshold_);
+                });
+            }
+        }
+
+        void count_down()
+        {
+            --count_;
+        }
+
+        // --------------------------------------------------------------------
+        // post : for general apply()
+        // --------------------------------------------------------------------
+        template <typename F, typename ... Ts>
+        void
+        post(F && f, Ts &&... ts)
+        {
+            count_up();
+            parallel::execution::post(
+                executor_,
+                [this, f{std::move(f)},
+                    args = hpx::util::make_tuple(std::forward<Ts>(ts)...)]()
+                {
+                    hpx::util::invoke_fused(std::move(f), std::move(args));
+                    count_down();
+                }
+            );
+        }
+
+        // --------------------------------------------------------------------
+        // async execute specialized for simple arguments typical
+        // of a normal async call with arbitrary arguments
+        // --------------------------------------------------------------------
+        template <typename F, typename ... Ts>
+        future<typename util::invoke_result<F, Ts...>::type>
+        async_execute(F && f, Ts &&... ts)
+        {
+            typedef typename util::detail::invoke_deferred_result<
+                    F, Ts...>::type result_type;
+
+            count_up();
+            lcos::local::futures_factory<result_type()> p(
+                executor_,
+                [this, f{std::move(f)},
+                    args = hpx::util::make_tuple(std::forward<Ts>(ts)...)]()
+                {
+                    hpx::util::invoke_fused(std::move(f), std::move(args));
+                    count_down();
+                }
+            );
+
+            p.apply(
+                launch::async,
+                threads::thread_priority_default,
+                threads::thread_stacksize_default);
+
+            return p.get_future();
+        }
+
+        // --------------------------------------------------------------------
+        // .then() execute specialized for a future<P> predecessor argument
+        // note that future<> and shared_future<> are both supported
+        // --------------------------------------------------------------------
+        template <typename F,
+                  typename Future,
+                  typename ... Ts,
+                  typename = enable_if_t<traits::is_future<
+                    typename std::remove_reference<Future>::type>::value>>
+        auto
+        then_execute(F && f, Ts &&... ts)
+        ->  future<typename util::detail::invoke_deferred_result<
+            F, Future, Ts...>::type>
+        {
+            typedef typename util::detail::invoke_deferred_result<
+                    F, Future, Ts...>::type result_type;
+
+            count_up();
+            lcos::local::futures_factory<result_type()> p(
+                executor_,
+                [this, f{std::move(f)},
+                    args = hpx::util::make_tuple(std::forward<Ts>(ts)...)]()
+                {
+                    hpx::util::invoke_fused(std::move(f), std::move(args));
+                    count_down();
+                }
+            );
+
+            p.apply(
+                launch::async,
+                threads::thread_priority_default,
+                threads::thread_stacksize_default);
+
+            return p.get_future();
+        }
+
+        void set_and_wait(std::size_t lower, std::size_t upper)
+        {
+            set_threshold(lower, upper);
+            wait();
+        }
+
+        void set_threshold(std::size_t lower, std::size_t upper)
+        {
+            lower_threshold_ = lower;
+            upper_threshold_ = upper;
+        }
+
+        void wait()
+        {
+            hpx::util::yield_while([&](){
+                return (count_ > lower_threshold_);
+            });
+        }
+
+    private:
+        // --------------------------------------------------------------------
+        Executor                         executor_;
+        std::atomic<std::int64_t>        count_;
+        std::int64_t                     lower_threshold_;
+        std::int64_t                     upper_threshold_;
+        bool                             block_;
+    };
+
+}}}
+
+namespace hpx { namespace parallel { namespace execution
+{
+    template <typename Executor>
+    struct executor_execution_category<
+        threads::executors::limiting_executor<Executor> >
+    {
+        typedef parallel::execution::parallel_execution_tag type;
+    };
+
+    template <typename Executor>
+    struct is_two_way_executor<
+            threads::executors::limiting_executor<Executor> >
+      : std::true_type
+    {};
+}}}
+
+#include <hpx/config/warnings_suffix.hpp>
+
+#endif /*HPX_RUNTIME_THREADS_LIMITING_EXECUTOR_HPP*/

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -20,14 +20,14 @@
 #include <hpx/util/lightweight_test.hpp>
 #include <hpx/util/annotated_function.hpp>
 
-#include <cstddef>
-//
 #include <hpx/include/parallel_execution.hpp>
-#include <hpx/runtime/threads/executors/pool_executor.hpp>
-#include <hpx/runtime/threads/executors/limiting_executor.hpp>
-//
 #include <hpx/lcos/local/sliding_semaphore.hpp>
-//
+#include <hpx/runtime/threads/executors/limiting_executor.hpp>
+#include <hpx/runtime/threads/executors/pool_executor.hpp>
+
+#include <array>
+#include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <stdexcept>
 #include <vector>
@@ -53,7 +53,8 @@ using hpx::cout;
 using hpx::flush;
 
 ///////////////////////////////////////////////////////////////////////////////
-void print_stats(const char *title, const char *wait, const char *exec, std::int64_t count, double duration, bool csv)
+void print_stats(const char* title, const char* wait, const char* exec,
+    std::int64_t count, double duration, bool csv)
 {
     double us = 1e6*duration/count;
     if (csv)
@@ -62,16 +63,20 @@ void print_stats(const char *title, const char *wait, const char *exec, std::int
            count, title, duration, us) << flush;
     else
         hpx::util::format_to(cout,
-            "invoked {1}, futures {:10} {:15} {:20} in \t{5} seconds \t: {6} us per future \n",
+            "invoked {1}, futures {:10} {:15} {:20} in \t{5} seconds \t: "
+            "{6} us per future \n",
             count, title, wait, exec, duration, us) << flush;
+
     // CDash graph plotting
     //hpx::util::print_cdash_timing(title, duration);
 }
 
-const char *ExecName(const hpx::parallel::execution::parallel_executor &exec) {
+const char* ExecName(const hpx::parallel::execution::parallel_executor& exec)
+{
     return "parallel_executor";
 }
-const char *ExecName(const hpx::parallel::execution::default_executor &exec) {
+const char* ExecName(const hpx::parallel::execution::default_executor& exec)
+{
     return "default_executor";
 }
 
@@ -83,11 +88,14 @@ std::uint64_t num_iterations = 0;
 ///////////////////////////////////////////////////////////////////////////////
 double null_function()
 {
-    if (num_iterations>0) {
+    if (num_iterations > 0)
+    {
         const int array_size = 4096;
         std::array<double, array_size> dummy;
-        for (std::uint64_t i = 0; i < num_iterations; ++i) {
-            for (std::uint64_t j = 0; j < array_size; ++j) {
+        for (std::uint64_t i = 0; i < num_iterations; ++i)
+        {
+            for (std::uint64_t j = 0; j < array_size; ++j)
+            {
                 dummy[j] = 1.0 / (2.0 * i * j + 1.0);
             }
         }
@@ -144,7 +152,8 @@ void measure_action_futures_wait_all(std::uint64_t count, bool csv)
 
 // Time async execution using wait each on futures vector
 template <typename Executor>
-void measure_function_futures_wait_each(std::uint64_t count, bool csv, Executor &exec)
+void measure_function_futures_wait_each(
+    std::uint64_t count, bool csv, Executor& exec)
 {
     std::vector<future<double> > futures;
     futures.reserve(count);
@@ -161,7 +170,8 @@ void measure_function_futures_wait_each(std::uint64_t count, bool csv, Executor 
 }
 
 template <typename Executor>
-void measure_function_futures_wait_all(std::uint64_t count, bool csv, Executor &exec)
+void measure_function_futures_wait_all(
+    std::uint64_t count, bool csv, Executor& exec)
 {
     std::vector<future<double> > futures;
     futures.reserve(count);
@@ -177,13 +187,15 @@ void measure_function_futures_wait_all(std::uint64_t count, bool csv, Executor &
 }
 
 template <typename Executor>
-void measure_function_futures_thread_count(std::uint64_t count, bool csv, Executor &exec)
+void measure_function_futures_thread_count(
+    std::uint64_t count, bool csv, Executor& exec)
 {
     std::vector<future<double> > futures;
     futures.reserve(count);
 
     std::atomic<std::uint64_t> sanity_check(count);
     auto this_pool = hpx::this_thread::get_pool();
+
     // start the clock
     high_resolution_timer walltime;
     for (std::uint64_t i = 0; i < count; ++i) {
@@ -196,30 +208,28 @@ void measure_function_futures_thread_count(std::uint64_t count, bool csv, Execut
     }
 
     // Yield until there is only this and background threads left.
-    hpx::util::yield_while([this_pool, &sanity_check]()
+    hpx::util::yield_while(
+        [&sanity_check]()
         {
-            return (sanity_check>0);
-//        auto u = this_pool->get_thread_count_unknown(std::size_t(-1), false);
-//        auto b = this_pool->get_background_thread_count() + 1;
-////        std::cout << "Unknown " << u << " background " << b << std::endl;
-//        return u>b;
-//            return this_pool->get_thread_count_unknown(std::size_t(-1), false) >
-//                this_pool->get_background_thread_count() + 1;
+            return (sanity_check > 0);
         });
 
     // stop the clock
     const double duration = walltime.elapsed();
 
-    if (sanity_check!=0) {
+    if (sanity_check != 0)
+    {
         int count = this_pool->get_thread_count_unknown(std::size_t(-1), false);
-        throw std::runtime_error("This test is faulty " + std::to_string(count));
+        throw std::runtime_error(
+            "This test is faulty " + std::to_string(count));
     }
 
     print_stats("apply", "ThreadCount", ExecName(exec), count, duration, csv);
 }
 
 template <typename Executor>
-void measure_function_futures_limiting_executor(std::uint64_t count, bool csv, Executor exec)
+void measure_function_futures_limiting_executor(
+    std::uint64_t count, bool csv, Executor exec)
 {
     using namespace hpx::parallel::execution;
     std::uint64_t const num_threads = hpx::get_num_worker_threads();
@@ -229,7 +239,8 @@ void measure_function_futures_limiting_executor(std::uint64_t count, bool csv, E
     // start the clock
     high_resolution_timer walltime;
     {
-        hpx::threads::executors::limiting_executor<Executor> signal_exec(exec, tasks, tasks+1000);
+        hpx::threads::executors::limiting_executor<Executor> signal_exec(
+            exec, tasks, tasks + 1000);
         for (std::uint64_t i = 0; i < count; ++i) {
             hpx::apply(signal_exec, [&](){
                 null_function();
@@ -239,7 +250,8 @@ void measure_function_futures_limiting_executor(std::uint64_t count, bool csv, E
     }
 
     if (sanity_check!=0) {
-        throw std::runtime_error("This test is faulty " + std::to_string(sanity_check));
+        throw std::runtime_error(
+            "This test is faulty " + std::to_string(sanity_check));
     }
 
     // stop the clock
@@ -248,7 +260,8 @@ void measure_function_futures_limiting_executor(std::uint64_t count, bool csv, E
 }
 
 template <typename Executor>
-void measure_function_futures_sliding_semaphore(std::uint64_t count, bool csv, Executor &exec)
+void measure_function_futures_sliding_semaphore(
+    std::uint64_t count, bool csv, Executor& exec)
 {
     std::vector<future<double> > futures;
     futures.reserve(count);

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -18,8 +18,16 @@
 #include <hpx/include/threads.hpp>
 #include <hpx/util/yield_while.hpp>
 #include <hpx/util/lightweight_test.hpp>
+#include <hpx/util/annotated_function.hpp>
 
 #include <cstddef>
+//
+#include <hpx/include/parallel_execution.hpp>
+#include <hpx/runtime/threads/executors/pool_executor.hpp>
+#include <hpx/runtime/threads/executors/limiting_executor.hpp>
+//
+#include <hpx/lcos/local/sliding_semaphore.hpp>
+//
 #include <cstdint>
 #include <stdexcept>
 #include <vector>
@@ -45,6 +53,29 @@ using hpx::cout;
 using hpx::flush;
 
 ///////////////////////////////////////////////////////////////////////////////
+void print_stats(const char *title, const char *wait, const char *exec, std::int64_t count, double duration, bool csv)
+{
+    double us = 1e6*duration/count;
+    if (csv)
+        hpx::util::format_to(cout,
+            "{1},{2},{3},{4},{5},{6},\n",
+           count, title, duration, us) << flush;
+    else
+        hpx::util::format_to(cout,
+            "invoked {1}, futures {:10} {:15} {:20} in \t{5} seconds \t: {6} us per future \n",
+            count, title, wait, exec, duration, us) << flush;
+    // CDash graph plotting
+    //hpx::util::print_cdash_timing(title, duration);
+}
+
+const char *ExecName(const hpx::parallel::execution::parallel_executor &exec) {
+    return "parallel_executor";
+}
+const char *ExecName(const hpx::parallel::execution::default_executor &exec) {
+    return "default_executor";
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // we use globals here to prevent the delay from being optimized away
 double global_scratch = 0;
 std::uint64_t num_iterations = 0;
@@ -52,10 +83,17 @@ std::uint64_t num_iterations = 0;
 ///////////////////////////////////////////////////////////////////////////////
 double null_function()
 {
-    double d = 0.;
-    for (std::uint64_t i = 0; i < num_iterations; ++i)
-        d += 1. / (2. * i + 1.);
-    return d;
+    if (num_iterations>0) {
+        const int array_size = 4096;
+        std::array<double, array_size> dummy;
+        for (std::uint64_t i = 0; i < num_iterations; ++i) {
+            for (std::uint64_t j = 0; j < array_size; ++j) {
+                dummy[j] = 1.0 / (2.0 * i * j + 1.0);
+            }
+        }
+        return dummy[0];
+    }
+    return 0.0;
 }
 
 HPX_PLAIN_ACTION(null_function, null_action)
@@ -68,158 +106,202 @@ struct scratcher
     }
 };
 
-void measure_action_futures(std::uint64_t count, bool csv)
+// Time async action execution using wait each on futures vector
+void measure_action_futures_wait_each(std::uint64_t count, bool csv)
 {
     const id_type here = find_here();
-
     std::vector<future<double> > futures;
     futures.reserve(count);
 
     // start the clock
     high_resolution_timer walltime;
-
     for (std::uint64_t i = 0; i < count; ++i)
         futures.push_back(async<null_action>(here));
-
     wait_each(scratcher(), futures);
 
     // stop the clock
     const double duration = walltime.elapsed();
-
-    if (csv)
-        hpx::util::format_to(cout,
-            "{1},{2}\n",
-            count,
-            duration) << flush;
-    else
-        hpx::util::format_to(cout,
-            "invoked {1} futures (actions) in {2} seconds\n",
-            count,
-            duration) << flush;
-    // CDash graph plotting
-    hpx::util::print_cdash_timing("FutureOverheadActions", duration);
+    print_stats("Actions", "WaitEach", "no-executor", count, duration, csv);
 }
 
-void measure_function_futures_wait_each(std::uint64_t count, bool csv)
+// Time async action execution using wait each on futures vector
+void measure_action_futures_wait_all(std::uint64_t count, bool csv)
 {
+    const id_type here = find_here();
     std::vector<future<double> > futures;
-
     futures.reserve(count);
 
     // start the clock
     high_resolution_timer walltime;
-
     for (std::uint64_t i = 0; i < count; ++i)
-        futures.push_back(async(&null_function));
-
-    wait_each(scratcher(), futures);
-
-    // stop the clock
-    const double duration = walltime.elapsed();
-
-    if (csv)
-        hpx::util::format_to(cout,
-            "{1},{2}\n",
-            count,
-            duration) << flush;
-    else
-        hpx::util::format_to(cout,
-            "invoked {1} futures (functions, wait_each) in {2} seconds\n",
-            count,
-            duration) << flush;
-    // CDash graph plotting
-    hpx::util::print_cdash_timing("FutureOverheadWaitEach", duration);
-}
-
-void measure_function_futures_wait_all(std::uint64_t count, bool csv)
-{
-    std::vector<future<double> > futures;
-
-    futures.reserve(count);
-
-    // start the clock
-    high_resolution_timer walltime;
-
-    for (std::uint64_t i = 0; i < count; ++i)
-        futures.push_back(async(&null_function));
-
+        futures.push_back(async<null_action>(here));
     wait_all(futures);
 
     // stop the clock
     const double duration = walltime.elapsed();
-
-    if (csv)
-        hpx::util::format_to(cout,
-            "{1},{2}\n",
-           count,
-           duration) << flush;
-    else
-        hpx::util::format_to(cout,
-            "invoked {1} futures (functions, wait_all) in {2} seconds\n",
-            count,
-            duration) << flush;
-    // CDash graph plotting
-    hpx::util::print_cdash_timing("FutureOverheadFuturesWait", duration);
+    print_stats("Actions", "WaitAll", "no-executor", count, duration, csv);
 }
 
-void measure_function_futures_thread_count(std::uint64_t count, bool csv)
+// Time async execution using wait each on futures vector
+template <typename Executor>
+void measure_function_futures_wait_each(std::uint64_t count, bool csv, Executor &exec)
 {
     std::vector<future<double> > futures;
-
     futures.reserve(count);
 
     // start the clock
     high_resolution_timer walltime;
-
     for (std::uint64_t i = 0; i < count; ++i)
-        apply(&null_function);
+        futures.push_back(async(exec, &null_function));
+    wait_each(scratcher(), futures);
+
+    // stop the clock
+    const double duration = walltime.elapsed();
+    print_stats("async", "WaitEach", ExecName(exec), count, duration, csv);
+}
+
+template <typename Executor>
+void measure_function_futures_wait_all(std::uint64_t count, bool csv, Executor &exec)
+{
+    std::vector<future<double> > futures;
+    futures.reserve(count);
+
+    // start the clock
+    high_resolution_timer walltime;
+    for (std::uint64_t i = 0; i < count; ++i)
+        futures.push_back(async(exec, &null_function));
+    wait_all(futures);
+
+    const double duration = walltime.elapsed();
+    print_stats("async", "WaitAll", ExecName(exec), count, duration, csv);
+}
+
+template <typename Executor>
+void measure_function_futures_thread_count(std::uint64_t count, bool csv, Executor &exec)
+{
+    std::vector<future<double> > futures;
+    futures.reserve(count);
+
+    std::atomic<std::uint64_t> sanity_check(count);
+    auto this_pool = hpx::this_thread::get_pool();
+    // start the clock
+    high_resolution_timer walltime;
+    for (std::uint64_t i = 0; i < count; ++i) {
+        hpx::apply(exec,
+            [&sanity_check]() {
+               null_function();
+               sanity_check--;
+            }
+        );
+    }
 
     // Yield until there is only this and background threads left.
-    auto this_pool = hpx::this_thread::get_pool();
-    hpx::util::yield_while([this_pool]()
+    hpx::util::yield_while([this_pool, &sanity_check]()
         {
-            return this_pool->get_thread_count_unknown(std::size_t(-1), false) >
-                this_pool->get_background_thread_count() + 1;
+            return (sanity_check>0);
+//        auto u = this_pool->get_thread_count_unknown(std::size_t(-1), false);
+//        auto b = this_pool->get_background_thread_count() + 1;
+////        std::cout << "Unknown " << u << " background " << b << std::endl;
+//        return u>b;
+//            return this_pool->get_thread_count_unknown(std::size_t(-1), false) >
+//                this_pool->get_background_thread_count() + 1;
         });
 
     // stop the clock
     const double duration = walltime.elapsed();
 
-    if (csv)
-        hpx::util::format_to(cout,
-            "{1},{2}\n",
-            count,
-            duration) << flush;
-    else
-        hpx::util::format_to(cout,
-            "invoked {1} futures (functions, thread count) in {2} seconds\n",
-            count,
-            duration) << flush;
-    // CDash graph plotting
-    hpx::util::print_cdash_timing("FutureOverheadThreadCount", duration);
+    if (sanity_check!=0) {
+        int count = this_pool->get_thread_count_unknown(std::size_t(-1), false);
+        throw std::runtime_error("This test is faulty " + std::to_string(count));
+    }
+
+    print_stats("apply", "ThreadCount", ExecName(exec), count, duration, csv);
+}
+
+template <typename Executor>
+void measure_function_futures_limiting_executor(std::uint64_t count, bool csv, Executor exec)
+{
+    using namespace hpx::parallel::execution;
+    std::uint64_t const num_threads = hpx::get_num_worker_threads();
+    std::uint64_t const tasks = num_threads*2000;
+    std::atomic<std::uint64_t> sanity_check(count);
+
+    // start the clock
+    high_resolution_timer walltime;
+    {
+        hpx::threads::executors::limiting_executor<Executor> signal_exec(exec, tasks, tasks+1000);
+        for (std::uint64_t i = 0; i < count; ++i) {
+            hpx::apply(signal_exec, [&](){
+                null_function();
+                sanity_check--;
+            });
+        }
+    }
+
+    if (sanity_check!=0) {
+        throw std::runtime_error("This test is faulty " + std::to_string(sanity_check));
+    }
+
+    // stop the clock
+    const double duration = walltime.elapsed();
+    print_stats("apply", "limiting-Exec", ExecName(exec), count, duration, csv);
+}
+
+template <typename Executor>
+void measure_function_futures_sliding_semaphore(std::uint64_t count, bool csv, Executor &exec)
+{
+    std::vector<future<double> > futures;
+    futures.reserve(count);
+
+    // start the clock
+    high_resolution_timer walltime;
+    const int sem_count = 5000;
+    hpx::lcos::local::sliding_semaphore sem(sem_count);
+    for (std::uint64_t i = 0; i < count; ++i) {
+        hpx::async(exec, [i,&sem](){
+            null_function();
+            sem.signal(i);
+        });
+        sem.wait(i);
+    }
+    sem.wait(count);
+
+    // stop the clock
+    const double duration = walltime.elapsed();
+    print_stats("Apply", "Sliding-Sem", ExecName(exec), count, duration, csv);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-int hpx_main(
-    variables_map& vm
-    )
+int hpx_main(variables_map& vm)
 {
     {
         num_iterations = vm["delay-iterations"].as<std::uint64_t>();
 
         const std::uint64_t count = vm["futures"].as<std::uint64_t>();
-
+        bool csv = vm.count("csv") != 0;
         if (HPX_UNLIKELY(0 == count))
             throw std::logic_error("error: count of 0 futures specified\n");
+        const int nl = 1;
 
-        measure_action_futures(count, vm.count("csv") != 0);
-        measure_function_futures_wait_each(count, vm.count("csv") != 0);
-        measure_function_futures_wait_all(count, vm.count("csv") != 0);
-        measure_function_futures_thread_count(count, vm.count("csv") != 0);
+        hpx::parallel::execution::default_executor def;
+        hpx::parallel::execution::parallel_executor par;
+
+        for (int i=0; i<nl; i++) {
+            measure_action_futures_wait_each(count, csv);
+            measure_action_futures_wait_all(count, csv);
+            measure_function_futures_wait_each(count, csv, def);
+            measure_function_futures_wait_each(count, csv, par);
+            measure_function_futures_wait_all(count, csv, def);
+            measure_function_futures_wait_all(count, csv, par);
+            measure_function_futures_thread_count(count, csv, def);
+            measure_function_futures_thread_count(count, csv, par);
+            measure_function_futures_limiting_executor(count, csv, def);
+            measure_function_futures_limiting_executor(count, csv, par);
+            measure_function_futures_sliding_semaphore(count, csv, def);
+        }
     }
 
-    finalize();
-    return 0;
+    return hpx::finalize();
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This adds an executor that counts tasks and can be used to limit the number that go into the queues at any given time - and also to wait on them so that it is not necessary to wait on a vector of futures. It is similar to the aggregating executor and the recent changes to parallel algorithms to use a latch.

This executor can be used to replace sliding_semaphore and provides a much simpler and cleaner way of doing it.