### PR TITLE
Fix potential shutdown problems

### DIFF
--- a/hpx/components/iostreams/server/output_stream.hpp
+++ b/hpx/components/iostreams/server/output_stream.hpp
@@ -40,7 +40,7 @@ namespace hpx { namespace iostreams { namespace server
         // Executed in an io_pool thread to prevent io from blocking an HPX
         // shepherd thread.
         void call_write_async(std::uint32_t locality_id, std::uint64_t count,
-            detail::buffer const& in);
+            detail::buffer const& in, hpx::id_type /*this_id*/);
         void call_write_sync(std::uint32_t locality_id, std::uint64_t count,
             detail::buffer const& in, threads::thread_id_type caller);
 

--- a/hpx/runtime/parcelset/parcelport_impl.hpp
+++ b/hpx/runtime/parcelset/parcelport_impl.hpp
@@ -196,15 +196,19 @@ namespace hpx { namespace parcelset
         {
             flush_parcels();
 
-            io_service_pool_.stop();
             if (blocking) {
                 connection_cache_.shutdown();
                 connection_handler().do_stop();
+                io_service_pool_.wait();
+                io_service_pool_.stop();
                 io_service_pool_.join();
                 connection_cache_.clear();
                 io_service_pool_.clear();
             }
-
+            else
+            {
+                io_service_pool_.stop();
+            }
         }
 
     public:

--- a/src/components/iostreams/server/output_stream.cpp
+++ b/src/components/iostreams/server/output_stream.cpp
@@ -51,7 +51,7 @@ namespace hpx { namespace iostreams { namespace server
 {
     ///////////////////////////////////////////////////////////////////////////
     void output_stream::call_write_async(std::uint32_t locality_id,
-        std::uint64_t count, detail::buffer const& in)
+        std::uint64_t count, detail::buffer const& in, hpx::id_type /*this_id*/)
     { // {{{
         // Perform the IO operation.
         pending_output_.output(locality_id, count, in, write_f, mtx_);
@@ -62,9 +62,12 @@ namespace hpx { namespace iostreams { namespace server
     { // {{{
         // Perform the IO in another OS thread.
         detail::buffer in(buf_in);
+        // we need to capture the GID of the component to keep it alive long
+        // enough.
+        hpx::id_type this_id = this->get_id();
         hpx::get_thread_pool("io_pool")->get_io_service().post(
             util::bind_front(&output_stream::call_write_async, this,
-                locality_id, count, std::move(in)));
+                locality_id, count, std::move(in), std::move(this_id)));
     } // }}}
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -1828,16 +1828,6 @@ namespace hpx { namespace threads
             pool_iter->stop(lk, blocking);
         }
         deinit_tss();
-
-#ifdef HPX_HAVE_TIMER_POOL
-        LTM_(info) << "stop: stopping timer pool";
-        timer_pool_.stop();    // stop timer pool as well
-        if (blocking)
-        {
-            timer_pool_.join();
-            timer_pool_.clear();
-        }
-#endif
     }
 
     void threadmanager::suspend()

--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -515,6 +515,15 @@ namespace hpx
 
         // stop the rest of the system
         parcel_handler_.stop(blocking);     // stops parcel pools as well
+#ifdef HPX_HAVE_TIMER_POOL
+        LTM_(info) << "stop: stopping timer pool";
+        timer_pool_.stop();    // stop timer pool as well
+        if (blocking)
+        {
+            timer_pool_.join();
+            timer_pool_.clear();
+        }
+#endif
 #ifdef HPX_HAVE_IO_POOL
         io_pool_.stop();                    // stops io_pool_ as well
 #endif

--- a/src/util/io_service_pool.cpp
+++ b/src/util/io_service_pool.cpp
@@ -102,7 +102,7 @@ namespace hpx { namespace util
         }
     }
 
-            io_service_pool::~io_service_pool()
+    io_service_pool::~io_service_pool()
     {
         std::lock_guard<compat::mutex> l(mtx_);
         stop_locked();


### PR DESCRIPTION
## Proposed Changes

During shutdown, the lifetime of the different components needs to be taken care of in specific orders. This PR takes care of correct lifetime for the iostream components, the io_service pool, and the timer pool.