### PR TITLE
More fixes to make sure that std::flush really flushes all output

### DIFF
--- a/examples/quickstart/component_with_custom_heap.cpp
+++ b/examples/quickstart/component_with_custom_heap.cpp
@@ -79,14 +79,13 @@ namespace allocator
         alloc_block& operator=(alloc_block const&) = delete;
         alloc_block& operator=(alloc_block&&) = delete;
 
-        HPX_CONSTEXPR HPX_FORCEINLINE alloc_block* operator[](
-            std::size_t i) noexcept
+        HPX_FORCEINLINE alloc_block* operator[](std::size_t i) noexcept
         {
             return reinterpret_cast<alloc_block*>(
                 reinterpret_cast<char*>(this) + i * allocation_size);
         }
-        HPX_CONSTEXPR HPX_FORCEINLINE alloc_block const* operator[](
-            std::size_t i) const noexcept
+        HPX_FORCEINLINE alloc_block const* operator[](std::size_t i) const
+            noexcept
         {
             return reinterpret_cast<alloc_block const*>(
                 reinterpret_cast<char const*>(this) + i * allocation_size);
@@ -153,7 +152,7 @@ namespace allocator
         alloc_page& operator=(alloc_page &&) = delete;
 
         template <typename T>
-        HPX_CONSTEXPR HPX_FORCEINLINE alloc_block<T>* get_block() noexcept
+        HPX_FORCEINLINE alloc_block<T>* get_block() noexcept
         {
             static_assert(page_size >= alloc_block<T>::allocation_size,
                 "size of objects is larger than configured page size");
@@ -164,8 +163,8 @@ namespace allocator
             return reinterpret_cast<alloc_block<T>*>(&data);
         }
         template <typename T>
-        HPX_CONSTEXPR HPX_FORCEINLINE alloc_block<T> const* get_block() const
-            noexcept
+        HPX_FORCEINLINE alloc_block<T> const* get_block()
+            const noexcept
         {
             static_assert(page_size >= alloc_block<T>::allocation_size,
                 "size of objects is larger than configured page size");
@@ -177,7 +176,7 @@ namespace allocator
         }
 
         template <typename T>
-        HPX_CONSTEXPR HPX_FORCEINLINE T& get(std::size_t i) noexcept
+        HPX_FORCEINLINE T& get(std::size_t i) noexcept
         {
             static_assert(page_size >= alloc_block<T>::allocation_size,
                 "size of objects is larger than configured page size");
@@ -189,8 +188,7 @@ namespace allocator
                 static_cast<alloc_block_header*>((*get_block<T>())[i]) + 1));
         }
         template <typename T>
-        HPX_CONSTEXPR HPX_FORCEINLINE T const& get(std::size_t i) const
-            noexcept
+        HPX_FORCEINLINE T const& get(std::size_t i) const noexcept
         {
             static_assert(page_size >= alloc_block<T>::allocation_size,
                 "size of objects is larger than configured page size");
@@ -216,13 +214,13 @@ namespace allocator
     };
 
     template <typename T>
-    HPX_CONSTEXPR HPX_FORCEINLINE T& get(
+    HPX_CXX14_CONSTEXPR HPX_FORCEINLINE T& get(
         alloc_page* page, std::size_t i) noexcept
     {
         return page->template get<T>(i);
     }
     template <typename T>
-    HPX_CONSTEXPR HPX_FORCEINLINE T const& get(
+    HPX_CXX14_CONSTEXPR HPX_FORCEINLINE T const& get(
         alloc_page const* page, std::size_t i) noexcept
     {
         return page->template get<T>(i);

--- a/examples/quickstart/potpourri.cpp
+++ b/examples/quickstart/potpourri.cpp
@@ -17,6 +17,13 @@ void final_task(hpx::future<hpx::util::tuple<hpx::future<double>, hpx::future<vo
     hpx::cout << "in final_task" << hpx::endl;
 }
 
+// Avoid ABI incompatibilities between C++11/C++17 as std::rand has exception
+// specification in libstdc++.
+int rand_wrapper()
+{
+    return std::rand();
+}
+
 int main(int, char**)
 {
     // A function can be launched asynchronously. The program will not block
@@ -49,7 +56,7 @@ int main(int, char**)
 
     // We fill the vector synchronously and sequentially.
     hpx::parallel::generate(hpx::parallel::execution::seq,
-                  std::begin(v), std::end(v), &std::rand);
+                  std::begin(v), std::end(v), &rand_wrapper);
 
     // We can launch the sort in parallel and asynchronously.
     hpx::future<void> done_sorting =

--- a/hpx/components/iostreams/server/buffer.hpp
+++ b/hpx/components/iostreams/server/buffer.hpp
@@ -100,8 +100,9 @@ namespace hpx { namespace iostreams { namespace detail
         void write(write_function_type const& f, Mutex& mtx)
         {
             std::unique_lock<mutex_type> l(*mtx_);
-            if (data_.get() && !data_->empty())
+            if (data_.get())
             {
+                // execute even for empty buffers as this will flush the output
                 std::shared_ptr<std::vector<char> > data(data_);
                 data_.reset();
                 l.unlock();

--- a/hpx/components/iostreams/server/order_output.hpp
+++ b/hpx/components/iostreams/server/order_output.hpp
@@ -36,7 +36,6 @@ namespace hpx { namespace iostreams { namespace detail
             if (count == data.first)
             {
                 // this is the next expected output line
-                if (!in.empty())
                 {
                     // output the line as requested
                     util::unlock_guard<std::unique_lock<Mutex> > ul(l);
@@ -49,7 +48,6 @@ namespace hpx { namespace iostreams { namespace detail
                 while (next != data.second.end())
                 {
                     buffer next_in = (*next).second;
-                    if (!next_in.empty())
                     {
                         // output the next line
                         util::unlock_guard<std::unique_lock<Mutex> > ul(l);


### PR DESCRIPTION
This is in addition to #3728 as we have missed some spots there.