### PR TITLE
Fix includes in partitioned vector tests

### DIFF
--- a/tests/unit/parallel/segmented_algorithms/partitioned_vector_adjacent_difference1.cpp
+++ b/tests/unit/parallel/segmented_algorithms/partitioned_vector_adjacent_difference1.cpp
@@ -7,7 +7,7 @@
 #include <hpx/include/parallel_adjacent_difference.hpp>
 #include <hpx/include/parallel_count.hpp>
 #include <hpx/include/parallel_scan.hpp>
-#include <hpx/include/partitioned_vector.hpp>
+#include <hpx/include/partitioned_vector_predef.hpp>
 
 #include <hpx/util/lightweight_test.hpp>
 

--- a/tests/unit/parallel/segmented_algorithms/partitioned_vector_adjacent_difference2.cpp
+++ b/tests/unit/parallel/segmented_algorithms/partitioned_vector_adjacent_difference2.cpp
@@ -7,7 +7,7 @@
 #include <hpx/include/parallel_adjacent_difference.hpp>
 #include <hpx/include/parallel_count.hpp>
 #include <hpx/include/parallel_scan.hpp>
-#include <hpx/include/partitioned_vector.hpp>
+#include <hpx/include/partitioned_vector_predef.hpp>
 
 #include <hpx/util/lightweight_test.hpp>
 

--- a/tests/unit/parallel/segmented_algorithms/partitioned_vector_adjacent_find1.cpp
+++ b/tests/unit/parallel/segmented_algorithms/partitioned_vector_adjacent_find1.cpp
@@ -5,7 +5,7 @@
 
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/parallel_adjacent_find.hpp>
-#include <hpx/include/partitioned_vector.hpp>
+#include <hpx/include/partitioned_vector_predef.hpp>
 
 #include <hpx/util/lightweight_test.hpp>
 

--- a/tests/unit/parallel/segmented_algorithms/partitioned_vector_adjacent_find2.cpp
+++ b/tests/unit/parallel/segmented_algorithms/partitioned_vector_adjacent_find2.cpp
@@ -5,7 +5,7 @@
 
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/parallel_adjacent_find.hpp>
-#include <hpx/include/partitioned_vector.hpp>
+#include <hpx/include/partitioned_vector_predef.hpp>
 
 #include <hpx/util/lightweight_test.hpp>
 


### PR DESCRIPTION
Fixes these errors in partitioned vector tests with clang:
```
{compiler}: Clang version 3.8.1 (http://llvm.org/git/clang.git 07a6361e0f32f699d47c124106e7911b584974d4) (http://llvm.org/git/llvm.git 051e787f26dbfdc26cf61a57bc82ca00dcb812e8)
{stdlib}: libc++ version 3800
{what}: Unknown typename: N3hpx6server18partitioned_vectorIiNSt3__16vectorIiNS2_9allocatorIiEEEEE16get_value_actionE
: HPX(serialization_error)

terminating with uncaught exception of type hpx::detail::exception_with_info<hpx::exception>: Unknown typename: N3hpx6server18partitioned_vectorIiNSt3__16vectorIiNS2_9allocatorIiEEEEE16get_value_actionE
: HPX(serialization_error)
```