### PR TITLE
Introduced cache_aligned_data and cache_line_data helper structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1439,6 +1439,12 @@ if(HPX_WITH_COMPILER_WARNINGS)
     hpx_add_compile_flag_if_available(-Wformat=2)
     hpx_add_compile_flag_if_available(-Wno-format-nonliteral)
 
+    # enable C++17 style alignment on allocations for pre=C++17
+    hpx_add_compile_flag_if_available(-faligned-new)
+
+    # prevent warnings about over-aligned types for pre-C++17
+    hpx_add_compile_flag_if_available(-Wno-aligned-new)
+
     # Self initialization is dangerous
     hpx_add_compile_flag_if_available(-Winit-self)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -519,8 +519,8 @@ hpx_option(HPX_WITH_THREAD_STACK_MMAP BOOL
   CATEGORY "Thread Manager" ADVANCED)
 
 hpx_option(HPX_WITH_THREAD_MANAGER_IDLE_BACKOFF BOOL
-  "HPX scheduler threads do exponential backoff on idle queues (default: ON)"
-  ON
+  "HPX scheduler threads do exponential backoff on idle queues (default: OFF)"
+  OFF
   CATEGORY "Thread Manager" ADVANCED)
 
 hpx_option(HPX_WITH_STACKTRACES BOOL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -600,8 +600,8 @@ if(HPX_WITH_THREAD_CUMULATIVE_COUNTS)
 endif()
 
 hpx_option(HPX_WITH_THREAD_STEALING_COUNTS BOOL
-  "Enable keeping track of counts of thread stealing incidents in the schedulers (default: ON)"
-  ON CATEGORY "Thread Manager" ADVANCED)
+  "Enable keeping track of counts of thread stealing incidents in the schedulers (default: OFF)"
+  OFF CATEGORY "Thread Manager" ADVANCED)
 
 if(HPX_WITH_THREAD_STEALING_COUNTS)
   hpx_add_config_define(HPX_HAVE_THREAD_STEALING_COUNTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1383,13 +1383,17 @@ if(HPX_WITH_COMPILER_WARNINGS)
     hpx_add_compile_flag(-W3 LANGUAGES C CXX)
     # According to the ifort Windows manual, W3 isn't supported
     hpx_add_compile_flag(-W1 LANGUAGES Fortran)
-    # Boost.Lockfree triggers 'warning C4307: '+' : integral constant overflow'
-    # which is benign
-    hpx_add_compile_flag(-wd4307)
 
     # MSVC2012/2013 are overeager to report 'qualifier applied to function type
     # has no meaning; ignored'
     hpx_add_compile_flag(-wd4180)
+
+    # Boost.Lockfree triggers 'warning C4307: '+' : integral constant overflow'
+    # which is benign
+    hpx_add_compile_flag(-wd4307)
+
+    # object allocated on the heap may not be aligned
+    hpx_add_compile_flag(-wd4316)
 
     # max symbol length exceeded
     hpx_add_compile_flag(-wd4503)

--- a/examples/resource_partitioner/shared_priority_queue_scheduler.hpp
+++ b/examples/resource_partitioner/shared_priority_queue_scheduler.hpp
@@ -1310,8 +1310,8 @@ namespace example {
                 // set the preferred queue for this domain, if applicable
                 std::size_t q_index = q_lookup_[thread_num];
                 // get next task, steal if from another domain
-                result = hp_queues_[dom].wait_or_add_new(q_index, running,
-                    idle_loop_count, added);
+                result =
+                    hp_queues_[dom].wait_or_add_new(q_index, running, added);
                 if (0 != added) return result;
             }
 
@@ -1322,8 +1322,8 @@ namespace example {
                     // set the preferred queue for this domain, if applicable
                     std::size_t q_index = q_lookup_[thread_num];
                     // get next task, steal if from another domain
-                    result = np_queues_[dom].wait_or_add_new(q_index, running,
-                        idle_loop_count, added);
+                    result = np_queues_[dom].wait_or_add_new(
+                        q_index, running, added);
                     if (0 != added) return result;
                 }
             }
@@ -1339,14 +1339,14 @@ namespace example {
                         lp_lookup_[(counters_[dom]++ %
                                     lp_queues_[dom].num_cores)];
 
-                    result = lp_queues_[dom].wait_or_add_new(q_index, running,
-                        idle_loop_count, added);
+                    result = lp_queues_[dom].wait_or_add_new(
+                        q_index, running, added);
                     if (0 != added) return result;
                 }
 #else
                 // no cross domain stealing for LP queues
-                result = lp_queues_[domain_num].wait_or_add_new(0, running,
-                    idle_loop_count, added);
+                result =
+                    lp_queues_[domain_num].wait_or_add_new(0, running, added);
                 if (0 != added) return result;
 #endif
             }

--- a/hpx/lcos/local/barrier.hpp
+++ b/hpx/lcos/local/barrier.hpp
@@ -46,9 +46,11 @@ namespace hpx { namespace lcos { namespace local
         /// releasing all waiting threads as soon as the last \a thread
         /// entered this function.
         void wait();
+
         /// The function \a count_up will increase the number of \a threads
         /// to be waited in \a wait function.
         void count_up();
+
         /// The function \a reset will reset the number of \a threads
         /// as given by the function parameter \a number_of_threads.
         /// the newer coming \a threads executing the function
@@ -59,7 +61,7 @@ namespace hpx { namespace lcos { namespace local
         /// The function \a reset can be executed while previous \a threads
         /// executing waiting after they have been waken up.
         /// Thus \a total_ can not be reset to \a barrier_flag which
-        /// will break the comparision condition under the function \a wait.
+        /// will break the comparison condition under the function \a wait.
         void reset(std::size_t number_of_threads);
 
     private:

--- a/hpx/lcos/local/condition_variable.hpp
+++ b/hpx/lcos/local/condition_variable.hpp
@@ -14,6 +14,7 @@
 #include <hpx/lcos/local/spinlock.hpp>
 #include <hpx/runtime/threads/thread_enums.hpp>
 #include <hpx/util/assert_owns_lock.hpp>
+#include <hpx/util/cache_aligned_data.hpp>
 #include <hpx/util/register_locks.hpp>
 #include <hpx/util/steady_clock.hpp>
 #include <hpx/util/unlock_guard.hpp>
@@ -37,34 +38,34 @@ namespace hpx { namespace lcos { namespace local
     public:
         void notify_one(error_code& ec = throws)
         {
-            std::unique_lock<mutex_type> l(mtx_);
-            cond_.notify_one(std::move(l), ec);
+            std::unique_lock<mutex_type> l(mtx_.data_);
+            cond_.data_.notify_one(std::move(l), ec);
         }
 
         void notify_all(error_code& ec = throws)
         {
-            std::unique_lock<mutex_type> l(mtx_);
-            cond_.notify_all(std::move(l), ec);
+            std::unique_lock<mutex_type> l(mtx_.data_);
+            cond_.data_.notify_all(std::move(l), ec);
         }
 
         void wait(std::unique_lock<mutex>& lock, error_code& ec = throws)
         {
             HPX_ASSERT_OWNS_LOCK(lock);
             util::ignore_while_checking<std::unique_lock<mutex> > il(&lock);
-            std::unique_lock<mutex_type> l(mtx_);
+            std::unique_lock<mutex_type> l(mtx_.data_);
             util::unlock_guard<std::unique_lock<mutex> > unlock(lock);
             //The following ensures that the inner lock will be unlocked
             //before the outer to avoid deadlock (fixes issue #3608)
             std::lock_guard<std::unique_lock<mutex_type> > unlock_next(
                 l, std::adopt_lock);
 
-            cond_.wait(l, ec);
+            cond_.data_.wait(l, ec);
 
             // We need to ignore our internal mutex for the user provided lock
             // being able to be reacquired without a lock held during suspension
             // error. We can't use RAII here since the guard object would get
             // destructed before the unlock_guard.
-            hpx::util::ignore_lock(&mtx_);
+            hpx::util::ignore_lock(&mtx_.data_);
         }
 
         template <class Predicate>
@@ -86,7 +87,7 @@ namespace hpx { namespace lcos { namespace local
             HPX_ASSERT_OWNS_LOCK(lock);
 
             util::ignore_while_checking<std::unique_lock<mutex> > il(&lock);
-            std::unique_lock<mutex_type> l(mtx_);
+            std::unique_lock<mutex_type> l(mtx_.data_);
             util::unlock_guard<std::unique_lock<mutex> > unlock(lock);
             //The following ensures that the inner lock will be unlocked
             //before the outer to avoid deadlock (fixes issue #3608)
@@ -94,13 +95,13 @@ namespace hpx { namespace lcos { namespace local
                 l, std::adopt_lock);
 
             threads::thread_state_ex_enum const reason =
-                cond_.wait_until(l, abs_time, ec);
+                cond_.data_.wait_until(l, abs_time, ec);
 
             // We need to ignore our internal mutex for the user provided lock
             // being able to be reacquired without a lock held during suspension
             // error. We can't use RAII here since the guard object would get
             // destructed before the unlock_guard.
-            hpx::util::ignore_lock(&mtx_);
+            hpx::util::ignore_lock(&mtx_.data_);
 
             if (ec) return cv_status::error;
 
@@ -140,8 +141,8 @@ namespace hpx { namespace lcos { namespace local
         }
 
     private:
-        mutable mutex_type mtx_;
-        detail::condition_variable cond_;
+        mutable util::cache_line_data<mutex_type> mtx_;
+        util::cache_line_data<detail::condition_variable> cond_;
     };
 
     class condition_variable_any
@@ -152,14 +153,14 @@ namespace hpx { namespace lcos { namespace local
     public:
         void notify_one(error_code& ec = throws)
         {
-            std::unique_lock<mutex_type> l(mtx_);
-            cond_.notify_one(std::move(l), ec);
+            std::unique_lock<mutex_type> l(mtx_.data_);
+            cond_.data_.notify_one(std::move(l), ec);
         }
 
         void notify_all(error_code& ec = throws)
         {
-            std::unique_lock<mutex_type> l(mtx_);
-            cond_.notify_all(std::move(l), ec);
+            std::unique_lock<mutex_type> l(mtx_.data_);
+            cond_.data_.notify_all(std::move(l), ec);
         }
 
         template <class Lock>
@@ -168,20 +169,20 @@ namespace hpx { namespace lcos { namespace local
             HPX_ASSERT_OWNS_LOCK(lock);
 
             util::ignore_all_while_checking ignore_lock;
-            std::unique_lock<mutex_type> l(mtx_);
+            std::unique_lock<mutex_type> l(mtx_.data_);
             util::unlock_guard<Lock> unlock(lock);
             //The following ensures that the inner lock will be unlocked
             //before the outer to avoid deadlock (fixes issue #3608)
             std::lock_guard<std::unique_lock<mutex_type> > unlock_next(
                 l, std::adopt_lock);
 
-            cond_.wait(l, ec);
+            cond_.data_.wait(l, ec);
 
             // We need to ignore our internal mutex for the user provided lock
             // being able to be reacquired without a lock held during suspension
             // error. We can't use RAII here since the guard object would get
             // destructed before the unlock_guard.
-            hpx::util::ignore_lock(&mtx_);
+            hpx::util::ignore_lock(&mtx_.data_);
         }
 
         template <class Lock, class Predicate>
@@ -203,7 +204,7 @@ namespace hpx { namespace lcos { namespace local
             HPX_ASSERT_OWNS_LOCK(lock);
 
             util::ignore_all_while_checking ignore_lock;
-            std::unique_lock<mutex_type> l(mtx_);
+            std::unique_lock<mutex_type> l(mtx_.data_);
             util::unlock_guard<Lock> unlock(lock);
             //The following ensures that the inner lock will be unlocked
             //before the outer to avoid deadlock (fixes issue #3608)
@@ -211,13 +212,13 @@ namespace hpx { namespace lcos { namespace local
                 l, std::adopt_lock);
 
             threads::thread_state_ex_enum const reason =
-                cond_.wait_until(l, abs_time, ec);
+                cond_.data_.wait_until(l, abs_time, ec);
 
             // We need to ignore our internal mutex for the user provided lock
             // being able to be reacquired without a lock held during suspension
             // error. We can't use RAII here since the guard object would get
             // destructed before the unlock_guard.
-            hpx::util::ignore_lock(&mtx_);
+            hpx::util::ignore_lock(&mtx_.data_);
 
             if (ec) return cv_status::error;
 
@@ -256,8 +257,8 @@ namespace hpx { namespace lcos { namespace local
         }
 
     private:
-        mutable mutex_type mtx_;
-        detail::condition_variable cond_;
+        mutable util::cache_line_data<mutex_type> mtx_;
+        util::cache_line_data<detail::condition_variable> cond_;
     };
 }}}
 

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -1022,14 +1022,13 @@ namespace hpx { namespace threads { namespace policies
             {
                 this_high_priority_queue =
                     high_priority_queues_[num_thread].data_;
-                result = this_high_priority_queue->wait_or_add_new(running,
-                            idle_loop_count, added)
-                        && result;
+                result =
+                    this_high_priority_queue->wait_or_add_new(running, added) &&
+                    result;
                 if (0 != added) return result;
             }
 
-            result = this_queue->wait_or_add_new(
-                running, idle_loop_count, added) && result;
+            result = this_queue->wait_or_add_new(running, added) && result;
             if (0 != added) return result;
 
             // Check if we have been disabled
@@ -1046,9 +1045,9 @@ namespace hpx { namespace threads { namespace policies
                     num_thread < num_high_priority_queues_)
                 {
                     thread_queue_type* q = high_priority_queues_[idx].data_;
-                    result = this_high_priority_queue->
-                        wait_or_add_new(true, idle_loop_count, added, q)
-                        && result;
+                    result = this_high_priority_queue->wait_or_add_new(
+                                 true, added, q) &&
+                        result;
 
                     if (0 != added)
                     {
@@ -1059,9 +1058,9 @@ namespace hpx { namespace threads { namespace policies
                     }
                 }
 
-                result = this_queue->wait_or_add_new(true, idle_loop_count,
-                             added, queues_[idx].data_)
-                    && result;
+                result = this_queue->wait_or_add_new(
+                             true, added, queues_[idx].data_) &&
+                    result;
 
                 if (0 != added)
                 {
@@ -1099,8 +1098,8 @@ namespace hpx { namespace threads { namespace policies
             }
 #endif
 
-            result = low_priority_queue_.wait_or_add_new(running,
-                idle_loop_count, added) && result;
+            result =
+                low_priority_queue_.wait_or_add_new(running, added) && result;
 
             return result;
         }

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2019 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -17,6 +17,7 @@
 #include <hpx/runtime/threads_fwd.hpp>
 #include <hpx/throw_exception.hpp>
 #include <hpx/util/assert.hpp>
+#include <hpx/util/cache_aligned_data.hpp>
 #include <hpx/util/logging.hpp>
 #include <hpx/util_fwd.hpp>
 
@@ -123,44 +124,50 @@ namespace hpx { namespace threads { namespace policies
                 bool deferred_initialization = true)
           : scheduler_base(init.num_queues_, init.description_),
             max_queue_thread_count_(init.max_queue_thread_count_),
-            queues_(init.num_queues_),
-            high_priority_queues_(init.num_high_priority_queues_),
-            low_priority_queue_(init.max_queue_thread_count_),
             curr_queue_(0),
             numa_sensitive_(init.numa_sensitive_),
-            rp_(resource::get_partitioner())
+            rp_(resource::get_partitioner()),
+            num_queues_(init.num_queues_),
+            num_high_priority_queues_(init.num_high_priority_queues_),
+            low_priority_queue_(init.max_queue_thread_count_),
+            queues_(num_queues_),
+            high_priority_queues_(num_queues_),
+            victim_threads_(num_queues_)
         {
-            victim_threads_.clear();
-            victim_threads_.resize(init.num_queues_);
-
             if (!deferred_initialization)
             {
-#if defined(HPX_MSVC)
-#pragma warning(push)
-#pragma warning(disable: 4316) // object allocated on the heap may not be aligned 16
-#endif
-                HPX_ASSERT(init.num_queues_ != 0);
-                for (std::size_t i = 0; i < init.num_queues_; ++i)
-                    queues_[i] = new thread_queue_type(init.max_queue_thread_count_);
-
-                HPX_ASSERT(init.num_high_priority_queues_ != 0);
-                HPX_ASSERT(init.num_high_priority_queues_ <= init.num_queues_);
-                for (std::size_t i = 0; i < init.num_high_priority_queues_; ++i) {
-                    high_priority_queues_[i] =
+                HPX_ASSERT(num_queues_ != 0);
+                for (std::size_t i = 0; i != num_queues_; ++i)
+                {
+                    queues_[i].data_ =
                         new thread_queue_type(init.max_queue_thread_count_);
                 }
-#if defined(HPX_MSVC)
-#pragma warning(pop)
-#endif
+
+                HPX_ASSERT(num_high_priority_queues_ != 0);
+                HPX_ASSERT(num_high_priority_queues_ <= num_queues_);
+                for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
+                {
+                    high_priority_queues_[i].data_ =
+                        new thread_queue_type(init.max_queue_thread_count_);
+                }
+                for (std::size_t i = num_high_priority_queues_;
+                     i != num_queues_; ++i)
+                {
+                    high_priority_queues_[i].data_ = nullptr;
+                }
             }
         }
 
         virtual ~local_priority_queue_scheduler()
         {
-            for (std::size_t i = 0; i != queues_.size(); ++i)
-                delete queues_[i];
-            for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
-                delete high_priority_queues_[i];
+            for (std::size_t i = 0; i != num_queues_; ++i)
+            {
+                delete queues_[i].data_;
+            }
+            for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
+            {
+                delete high_priority_queues_[i].data_;
+            }
         }
 
         bool numa_sensitive() const override { return numa_sensitive_ != 0; }
@@ -176,14 +183,17 @@ namespace hpx { namespace threads { namespace policies
         {
             std::uint64_t time = 0;
 
-            for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
-                time += high_priority_queues_[i]->get_creation_time(reset);
+            for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
+            {
+                time += high_priority_queues_[i].data_->get_creation_time(reset);
+            }
 
             time += low_priority_queue_.get_creation_time(reset);
 
-            for (std::size_t i = 0; i != queues_.size(); ++i)
-                time += queues_[i]->get_creation_time(reset);
-
+            for (std::size_t i = 0; i != num_queues_; ++i)
+            {
+                time += queues_[i].data_->get_creation_time(reset);
+            }
             return time;
         }
 
@@ -191,15 +201,17 @@ namespace hpx { namespace threads { namespace policies
         {
             std::uint64_t time = 0;
 
-            for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
-                time += high_priority_queues_[i]->
-                    get_cleanup_time(reset);
+            for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
+            {
+                time += high_priority_queues_[i].data_->get_cleanup_time(reset);
+            }
 
             time += low_priority_queue_.get_cleanup_time(reset);
 
-            for (std::size_t i = 0; i != queues_.size(); ++i)
-                time += queues_[i]->get_cleanup_time(reset);
-
+            for (std::size_t i = 0; i != num_queues_; ++i)
+            {
+                time += queues_[i].data_->get_cleanup_time(reset);
+            }
             return time;
         }
 #endif
@@ -211,26 +223,28 @@ namespace hpx { namespace threads { namespace policies
             std::int64_t num_pending_misses = 0;
             if (num_thread == std::size_t(-1))
             {
-                for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
-                    num_pending_misses += high_priority_queues_[i]->
+                for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
+                {
+                    num_pending_misses += high_priority_queues_[i].data_->
                         get_num_pending_misses(reset);
-
-                for (std::size_t i = 0; i != queues_.size(); ++i)
-                    num_pending_misses += queues_[i]->
-                        get_num_pending_misses(reset);
-
+                }
+                for (std::size_t i = 0; i != num_queues_; ++i)
+                {
+                    num_pending_misses +=
+                        queues_[i].data_->get_num_pending_misses(reset);
+                }
                 num_pending_misses += low_priority_queue_.
                     get_num_pending_misses(reset);
 
                 return num_pending_misses;
             }
 
-            num_pending_misses += queues_[num_thread]->
+            num_pending_misses += queues_[num_thread].data_->
                 get_num_pending_misses(reset);
 
-            if (num_thread < high_priority_queues_.size())
+            if (num_thread < num_high_priority_queues_)
             {
-                num_pending_misses += high_priority_queues_[num_thread]->
+                num_pending_misses += high_priority_queues_[num_thread].data_->
                     get_num_pending_misses(reset);
             }
             if (num_thread == 0)
@@ -247,26 +261,28 @@ namespace hpx { namespace threads { namespace policies
             std::int64_t num_pending_accesses = 0;
             if (num_thread == std::size_t(-1))
             {
-                for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
-                    num_pending_accesses += high_priority_queues_[i]->
+                for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
+                {
+                    num_pending_accesses += high_priority_queues_[i].data_->
                         get_num_pending_accesses(reset);
-
-                for (std::size_t i = 0; i != queues_.size(); ++i)
-                    num_pending_accesses += queues_[i]->
+                }
+                for (std::size_t i = 0; i != num_queues_; ++i)
+                {
+                    num_pending_accesses += queues_[i].data_->
                         get_num_pending_accesses(reset);
-
+                }
                 num_pending_accesses += low_priority_queue_.
                     get_num_pending_accesses(reset);
 
                 return num_pending_accesses;
             }
 
-            num_pending_accesses += queues_[num_thread]->
+            num_pending_accesses += queues_[num_thread].data_->
                 get_num_pending_accesses(reset);
 
-            if (num_thread < high_priority_queues_.size())
+            if (num_thread < num_high_priority_queues_)
             {
-                num_pending_accesses += high_priority_queues_[num_thread]->
+                num_pending_accesses += high_priority_queues_[num_thread].data_->
                     get_num_pending_accesses(reset);
             }
             if (num_thread == 0)
@@ -283,26 +299,28 @@ namespace hpx { namespace threads { namespace policies
             std::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
             {
-                for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
-                    num_stolen_threads += high_priority_queues_[i]->
+                for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
+                {
+                    num_stolen_threads += high_priority_queues_[i].data_->
                         get_num_stolen_from_pending(reset);
-
-                for (std::size_t i = 0; i != queues_.size(); ++i)
-                    num_stolen_threads += queues_[i]->
+                }
+                for (std::size_t i = 0; i != num_queues_; ++i)
+                {
+                    num_stolen_threads += queues_[i].data_->
                         get_num_stolen_from_pending(reset);
-
+                }
                 num_stolen_threads += low_priority_queue_.
                     get_num_stolen_from_pending(reset);
 
                 return num_stolen_threads;
             }
 
-            num_stolen_threads += queues_[num_thread]->
+            num_stolen_threads += queues_[num_thread].data_->
                 get_num_stolen_from_pending(reset);
 
-            if (num_thread < high_priority_queues_.size())
+            if (num_thread < num_high_priority_queues_)
             {
-                num_stolen_threads += high_priority_queues_[num_thread]->
+                num_stolen_threads += high_priority_queues_[num_thread].data_->
                     get_num_stolen_from_pending(reset);
             }
             if (num_thread == 0)
@@ -319,26 +337,28 @@ namespace hpx { namespace threads { namespace policies
             std::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
             {
-                for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
-                    num_stolen_threads += high_priority_queues_[i]->
+                for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
+                {
+                    num_stolen_threads += high_priority_queues_[i].data_->
                         get_num_stolen_to_pending(reset);
-
-                for (std::size_t i = 0; i != queues_.size(); ++i)
-                    num_stolen_threads += queues_[i]->
+                }
+                for (std::size_t i = 0; i != num_queues_; ++i)
+                {
+                    num_stolen_threads += queues_[i].data_->
                         get_num_stolen_to_pending(reset);
-
+                }
                 num_stolen_threads += low_priority_queue_.
                     get_num_stolen_to_pending(reset);
 
                 return num_stolen_threads;
             }
 
-            num_stolen_threads += queues_[num_thread]->
+            num_stolen_threads += queues_[num_thread].data_->
                 get_num_stolen_to_pending(reset);
 
-            if (num_thread < high_priority_queues_.size())
+            if (num_thread < num_high_priority_queues_)
             {
-                num_stolen_threads += high_priority_queues_[num_thread]->
+                num_stolen_threads += high_priority_queues_[num_thread].data_->
                     get_num_stolen_to_pending(reset);
             }
             if (num_thread == 0)
@@ -355,26 +375,29 @@ namespace hpx { namespace threads { namespace policies
             std::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
             {
-                for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
-                    num_stolen_threads += high_priority_queues_[i]->
+                for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
+                {
+                    num_stolen_threads += high_priority_queues_[i].data_->
                         get_num_stolen_from_staged(reset);
+                }
 
-                for (std::size_t i = 0; i != queues_.size(); ++i)
-                    num_stolen_threads += queues_[i]->
+                for (std::size_t i = 0; i != num_queues_; ++i)
+                {
+                    num_stolen_threads += queues_[i].data_->
                         get_num_stolen_from_staged(reset);
-
+                }
                 num_stolen_threads += low_priority_queue_.
                     get_num_stolen_from_staged(reset);
 
                 return num_stolen_threads;
             }
 
-            num_stolen_threads += queues_[num_thread]->
+            num_stolen_threads += queues_[num_thread].data_->
                 get_num_stolen_from_staged(reset);
 
-            if (num_thread < high_priority_queues_.size())
+            if (num_thread < num_high_priority_queues_)
             {
-                num_stolen_threads += high_priority_queues_[num_thread]->
+                num_stolen_threads += high_priority_queues_[num_thread].data_->
                     get_num_stolen_from_staged(reset);
             }
             if (num_thread == 0)
@@ -391,26 +414,28 @@ namespace hpx { namespace threads { namespace policies
             std::int64_t num_stolen_threads = 0;
             if (num_thread == std::size_t(-1))
             {
-                for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
-                    num_stolen_threads += high_priority_queues_[i]->
+                for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
+                {
+                    num_stolen_threads += high_priority_queues_[i].data_->
                         get_num_stolen_to_staged(reset);
-
-                for (std::size_t i = 0; i != queues_.size(); ++i)
-                    num_stolen_threads += queues_[i]->
+                }
+                for (std::size_t i = 0; i != num_queues_; ++i)
+                {
+                    num_stolen_threads += queues_[i].data_->
                         get_num_stolen_to_staged(reset);
-
+                }
                 num_stolen_threads += low_priority_queue_.
                     get_num_stolen_to_staged(reset);
 
                 return num_stolen_threads;
             }
 
-            num_stolen_threads += queues_[num_thread]->
+            num_stolen_threads += queues_[num_thread].data_->
                 get_num_stolen_to_staged(reset);
 
-            if (num_thread < high_priority_queues_.size())
+            if (num_thread < num_high_priority_queues_)
             {
-                num_stolen_threads += high_priority_queues_[num_thread]->
+                num_stolen_threads += high_priority_queues_[num_thread].data_->
                     get_num_stolen_to_staged(reset);
             }
             if (num_thread == 0)
@@ -425,12 +450,13 @@ namespace hpx { namespace threads { namespace policies
         ///////////////////////////////////////////////////////////////////////
         void abort_all_suspended_threads() override
         {
-            for (std::size_t i = 0; i != queues_.size(); ++i)
-                queues_[i]->abort_all_suspended_threads();
+            for (std::size_t i = 0; i != num_queues_; ++i)
+                queues_[i].data_->abort_all_suspended_threads();
 
-            for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
-                high_priority_queues_[i]->abort_all_suspended_threads();
-
+            for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
+            {
+                high_priority_queues_[i].data_->abort_all_suspended_threads();
+            }
             low_priority_queue_.abort_all_suspended_threads();
         }
 
@@ -439,15 +465,19 @@ namespace hpx { namespace threads { namespace policies
         {
             bool empty = true;
 
-            for (std::size_t i = 0; i != queues_.size(); ++i)
-                empty = queues_[i]->cleanup_terminated(delete_all) && empty;
+            for (std::size_t i = 0; i != num_queues_; ++i)
+            {
+                empty = queues_[i].data_->
+                    cleanup_terminated(delete_all) && empty;
+            }
             if (!delete_all)
                 return empty;
 
-            for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
-                empty = high_priority_queues_[i]->
+            for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
+            {
+                empty = high_priority_queues_[i].data_->
                     cleanup_terminated(delete_all) && empty;
-
+            }
             empty = low_priority_queue_.cleanup_terminated(delete_all) && empty;
 
             return empty;
@@ -457,14 +487,15 @@ namespace hpx { namespace threads { namespace policies
         {
             bool empty = true;
 
-            empty = queues_[num_thread]->cleanup_terminated(delete_all);
+            empty = queues_[num_thread].data_->cleanup_terminated(delete_all);
             if (!delete_all)
                 return empty;
 
-            if (num_thread < high_priority_queues_.size())
-                empty = high_priority_queues_[num_thread]->
+            if (num_thread < num_high_priority_queues_)
+            {
+                empty = high_priority_queues_[num_thread].data_->
                     cleanup_terminated(delete_all) && empty;
-
+            }
             return empty;
         }
 
@@ -488,15 +519,13 @@ namespace hpx { namespace threads { namespace policies
 //                 }
 //             }
 #endif
-            std::size_t queue_size = queues_.size();
-
             if (std::size_t(-1) == num_thread)
             {
-                num_thread = curr_queue_++ % queue_size;
+                num_thread = curr_queue_++ % num_queues_;
             }
-            else if (num_thread >= queue_size)
+            else if (num_thread >= num_queues_)
             {
-                num_thread %= queue_size;
+                num_thread %= num_queues_;
             }
 
             std::unique_lock<pu_mutex_type> l;
@@ -511,10 +540,10 @@ namespace hpx { namespace threads { namespace policies
                 {
                     data.priority = thread_priority_normal;
                 }
-                std::size_t num = num_thread % high_priority_queues_.size();
+                std::size_t num = num_thread % num_high_priority_queues_;
 
-                high_priority_queues_[num]->create_thread(data, id,
-                    initial_state, run_now, ec);
+                high_priority_queues_[num].data_->create_thread(
+                        data, id,initial_state, run_now, ec);
                 return;
             }
 
@@ -525,9 +554,9 @@ namespace hpx { namespace threads { namespace policies
                 return;
             }
 
-            HPX_ASSERT(num_thread < queue_size);
-            queues_[num_thread]->create_thread(data, id, initial_state,
-                run_now, ec);
+            HPX_ASSERT(num_thread < num_queues_);
+            queues_[num_thread].data_->
+                create_thread(data, id, initial_state, run_now, ec);
         }
 
         /// Return the next thread to be executed, return false if none is
@@ -535,16 +564,14 @@ namespace hpx { namespace threads { namespace policies
         bool get_next_thread(std::size_t num_thread, bool running,
             std::int64_t& idle_loop_count, threads::thread_data*& thrd) override
         {
-            std::size_t queues_size = queues_.size();
-            std::size_t high_priority_queues = high_priority_queues_.size();
-
-            HPX_ASSERT(num_thread < queues_size);
+            HPX_ASSERT(num_thread < num_queues_);
             thread_queue_type* this_high_priority_queue = nullptr;
-            thread_queue_type* this_queue = queues_[num_thread];
+            thread_queue_type* this_queue = queues_[num_thread].data_;
 
-            if (num_thread < high_priority_queues)
+            if (num_thread < num_high_priority_queues_)
             {
-                this_high_priority_queue = high_priority_queues_[num_thread];
+                this_high_priority_queue =
+                    high_priority_queues_[num_thread].data_;
                 bool result =
                     this_high_priority_queue->get_next_thread(thrd);
 
@@ -575,14 +602,14 @@ namespace hpx { namespace threads { namespace policies
                 return false;
             }
 
-            for (std::size_t idx: victim_threads_[num_thread])
+            for (std::size_t idx : victim_threads_[num_thread].data_)
             {
                 HPX_ASSERT(idx != num_thread);
 
-                if (idx < high_priority_queues &&
-                    num_thread < high_priority_queues)
+                if (idx < num_high_priority_queues_ &&
+                    num_thread < num_high_priority_queues_)
                 {
-                    thread_queue_type* q = high_priority_queues_[idx];
+                    thread_queue_type* q = high_priority_queues_[idx].data_;
                     if (q->get_next_thread(thrd, running))
                     {
                         q->increment_num_stolen_from_pending();
@@ -592,9 +619,9 @@ namespace hpx { namespace threads { namespace policies
                     }
                 }
 
-                if (queues_[idx]->get_next_thread(thrd, running))
+                if (queues_[idx].data_->get_next_thread(thrd, running))
                 {
-                    queues_[idx]->increment_num_stolen_from_pending();
+                    queues_[idx].data_->increment_num_stolen_from_pending();
                     this_queue->increment_num_stolen_to_pending();
                     return true;
                 }
@@ -620,15 +647,13 @@ namespace hpx { namespace threads { namespace policies
                 allow_fallback = false;
             }
 
-            std::size_t queue_size = queues_.size();
-
             if (std::size_t(-1) == num_thread)
             {
-                num_thread = curr_queue_++ % queue_size;
+                num_thread = curr_queue_++ % num_queues_;
             }
-            else if (num_thread >= queue_size)
+            else if (num_thread >= num_queues_)
             {
-                num_thread %= queue_size;
+                num_thread %= num_queues_;
             }
 
             std::unique_lock<pu_mutex_type> l;
@@ -638,8 +663,8 @@ namespace hpx { namespace threads { namespace policies
                 priority == thread_priority_high ||
                 priority == thread_priority_boost)
             {
-                std::size_t num = num_thread % high_priority_queues_.size();
-                high_priority_queues_[num]->schedule_thread(thrd);
+                std::size_t num = num_thread % num_high_priority_queues_;
+                high_priority_queues_[num].data_->schedule_thread(thrd);
             }
             else if (priority == thread_priority_low)
             {
@@ -647,8 +672,8 @@ namespace hpx { namespace threads { namespace policies
             }
             else
             {
-                HPX_ASSERT(num_thread < queues_.size());
-                queues_[num_thread]->schedule_thread(thrd);
+                HPX_ASSERT(num_thread < num_queues_);
+                queues_[num_thread].data_->schedule_thread(thrd);
             }
         }
 
@@ -668,15 +693,13 @@ namespace hpx { namespace threads { namespace policies
                 allow_fallback = false;
             }
 
-            std::size_t queue_size = queues_.size();
-
             if (std::size_t(-1) == num_thread)
             {
-                num_thread = curr_queue_++ % queue_size;
+                num_thread = curr_queue_++ % num_queues_;
             }
-            else if (num_thread >= queue_size)
+            else if (num_thread >= num_queues_)
             {
-                num_thread %= queue_size;
+                num_thread %= num_queues_;
             }
 
             std::unique_lock<pu_mutex_type> l;
@@ -686,8 +709,8 @@ namespace hpx { namespace threads { namespace policies
                 priority == thread_priority_high ||
                 priority == thread_priority_boost)
             {
-                std::size_t num = num_thread % high_priority_queues_.size();
-                high_priority_queues_[num]->schedule_thread(thrd, true);
+                std::size_t num = num_thread % num_high_priority_queues_;
+                high_priority_queues_[num].data_->schedule_thread(thrd, true);
             }
             else if (priority == thread_priority_low)
             {
@@ -695,8 +718,8 @@ namespace hpx { namespace threads { namespace policies
             }
             else
             {
-                HPX_ASSERT(num_thread < queues_.size());
-                queues_[num_thread]->schedule_thread(thrd, true);
+                HPX_ASSERT(num_thread < num_queues_);
+                queues_[num_thread].data_->schedule_thread(thrd, true);
             }
         }
 
@@ -716,25 +739,28 @@ namespace hpx { namespace threads { namespace policies
             // Return queue length of one specific queue.
             std::int64_t count = 0;
             if (std::size_t(-1) != num_thread) {
-                HPX_ASSERT(num_thread < queues_.size());
+                HPX_ASSERT(num_thread < num_queues_);
 
-                if (num_thread < high_priority_queues_.size())
-                    count = high_priority_queues_[num_thread]->get_queue_length();
-
-                if (num_thread == queues_.size()-1)
+                if (num_thread < num_high_priority_queues_)
+                {
+                    count = high_priority_queues_[num_thread].data_->
+                        get_queue_length();
+                }
+                if (num_thread == num_queues_-1)
                     count += low_priority_queue_.get_queue_length();
 
-                return count + queues_[num_thread]->get_queue_length();
+                return count + queues_[num_thread].data_->get_queue_length();
             }
 
             // Cumulative queue lengths of all queues.
-            for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
-                count += high_priority_queues_[i]->get_queue_length();
-
+            for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
+            {
+                count += high_priority_queues_[i].data_->get_queue_length();
+            }
             count += low_priority_queue_.get_queue_length();
 
-            for (std::size_t i = 0; i != queues_.size(); ++i)
-                count += queues_[i]->get_queue_length();
+            for (std::size_t i = 0; i != num_queues_; ++i)
+                count += queues_[i].data_->get_queue_length();
 
             return count;
         }
@@ -750,38 +776,42 @@ namespace hpx { namespace threads { namespace policies
             std::int64_t count = 0;
             if (std::size_t(-1) != num_thread)
             {
-                HPX_ASSERT(num_thread < queues_.size());
+                HPX_ASSERT(num_thread < num_queues_);
 
                 switch (priority) {
                 case thread_priority_default:
                     {
-                        if (num_thread < high_priority_queues_.size())
-                            count = high_priority_queues_[num_thread]->
+                        if (num_thread < num_high_priority_queues_)
+                        {
+                            count = high_priority_queues_[num_thread].data_->
                                 get_thread_count(state);
-
-                        if (queues_.size()-1 == num_thread)
+                        }
+                        if (num_queues_-1 == num_thread)
                             count += low_priority_queue_.get_thread_count(state);
 
-                        return count + queues_[num_thread]->get_thread_count(state);
+                        return count + queues_[num_thread].data_->
+                            get_thread_count(state);
                     }
 
                 case thread_priority_low:
                     {
-                        if (queues_.size()-1 == num_thread)
+                        if (num_queues_-1 == num_thread)
                             return low_priority_queue_.get_thread_count(state);
                         break;
                     }
 
                 case thread_priority_normal:
-                    return queues_[num_thread]->get_thread_count(state);
+                    return queues_[num_thread].data_->get_thread_count(state);
 
                 case thread_priority_boost:
                 case thread_priority_high:
                 case thread_priority_high_recursive:
                     {
-                        if (num_thread < high_priority_queues_.size())
-                            return high_priority_queues_[num_thread]->
+                        if (num_thread < num_high_priority_queues_)
+                        {
+                            return high_priority_queues_[num_thread].data_->
                                 get_thread_count(state);
+                        }
                         break;
                     }
 
@@ -801,14 +831,17 @@ namespace hpx { namespace threads { namespace policies
             switch (priority) {
             case thread_priority_default:
                 {
-                    for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
-                        count += high_priority_queues_[i]->get_thread_count(state);
-
+                    for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
+                    {
+                        count += high_priority_queues_[i].data_->
+                            get_thread_count(state);
+                    }
                     count += low_priority_queue_.get_thread_count(state);
 
-                    for (std::size_t i = 0; i != queues_.size(); ++i)
-                        count += queues_[i]->get_thread_count(state);
-
+                    for (std::size_t i = 0; i != num_queues_; ++i)
+                    {
+                        count += queues_[i].data_->get_thread_count(state);
+                    }
                     break;
                 }
 
@@ -817,8 +850,10 @@ namespace hpx { namespace threads { namespace policies
 
             case thread_priority_normal:
                 {
-                    for (std::size_t i = 0; i != queues_.size(); ++i)
-                        count += queues_[i]->get_thread_count(state);
+                    for (std::size_t i = 0; i != num_queues_; ++i)
+                    {
+                        count += queues_[i].data_->get_thread_count(state);
+                    }
                     break;
                 }
 
@@ -826,8 +861,11 @@ namespace hpx { namespace threads { namespace policies
             case thread_priority_high:
             case thread_priority_high_recursive:
                 {
-                    for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
-                        count += high_priority_queues_[i]->get_thread_count(state);
+                    for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
+                    {
+                        count += high_priority_queues_[i].data_->
+                            get_thread_count(state);
+                    }
                     break;
                 }
 
@@ -850,17 +888,17 @@ namespace hpx { namespace threads { namespace policies
             thread_state_enum state = unknown) const override
         {
             bool result = true;
-            for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
+            for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
             {
-                result = result &&
-                    high_priority_queues_[i]->enumerate_threads(f, state);
+                result = result && high_priority_queues_[i].data_->
+                    enumerate_threads(f, state);
             }
 
             result = result && low_priority_queue_.enumerate_threads(f, state);
 
-            for (std::size_t i = 0; i != queues_.size(); ++i)
+            for (std::size_t i = 0; i != num_queues_; ++i)
             {
-                result = result && queues_[i]->enumerate_threads(f, state);
+                result = result && queues_[i].data_->enumerate_threads(f, state);
             }
             return result;
         }
@@ -876,38 +914,40 @@ namespace hpx { namespace threads { namespace policies
             std::uint64_t count = 0;
             if (std::size_t(-1) != num_thread)
             {
-                HPX_ASSERT(num_thread < queues_.size());
+                HPX_ASSERT(num_thread < num_queues_);
 
-                if (num_thread < high_priority_queues_.size())
+                if (num_thread < num_high_priority_queues_)
                 {
-                    wait_time = high_priority_queues_[num_thread]->
+                    wait_time = high_priority_queues_[num_thread].data_->
                         get_average_thread_wait_time();
                     ++count;
                 }
 
-                if (queues_.size()-1 == num_thread)
+                if (num_queues_-1 == num_thread)
                 {
                     wait_time += low_priority_queue_.
                         get_average_thread_wait_time();
                     ++count;
                 }
 
-                wait_time += queues_[num_thread]->get_average_thread_wait_time();
+                wait_time += queues_[num_thread].data_->
+                    get_average_thread_wait_time();
                 return wait_time / (count + 1);
             }
 
             // Return the cumulative average thread wait time for all queues.
-            for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
+            for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
             {
-                wait_time += high_priority_queues_[i]->get_average_thread_wait_time();
+                wait_time += high_priority_queues_[i].data_->
+                    get_average_thread_wait_time();
                 ++count;
             }
 
             wait_time += low_priority_queue_.get_average_thread_wait_time();
 
-            for (std::size_t i = 0; i != queues_.size(); ++i)
+            for (std::size_t i = 0; i != num_queues_; ++i)
             {
-                wait_time += queues_[i]->get_average_thread_wait_time();
+                wait_time += queues_[i].data_->get_average_thread_wait_time();
                 ++count;
             }
 
@@ -924,39 +964,40 @@ namespace hpx { namespace threads { namespace policies
             std::uint64_t count = 0;
             if (std::size_t(-1) != num_thread)
             {
-                HPX_ASSERT(num_thread < queues_.size());
+                HPX_ASSERT(num_thread < num_queues_);
 
-                if (num_thread < high_priority_queues_.size())
+                if (num_thread < num_high_priority_queues_)
                 {
-                    wait_time = high_priority_queues_[num_thread]->
+                    wait_time = high_priority_queues_[num_thread].data_->
                         get_average_task_wait_time();
                     ++count;
                 }
 
-                if (queues_.size()-1 == num_thread)
+                if (num_queues_-1 == num_thread)
                 {
                     wait_time += low_priority_queue_.
                         get_average_task_wait_time();
                     ++count;
                 }
 
-                wait_time += queues_[num_thread]->get_average_task_wait_time();
+                wait_time += queues_[num_thread].data_->
+                    get_average_task_wait_time();
                 return wait_time / (count + 1);
             }
 
             // Return the cumulative average task wait time for all queues.
-            for (std::size_t i = 0; i != high_priority_queues_.size(); ++i)
+            for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
             {
-                wait_time += high_priority_queues_[i]->
+                wait_time += high_priority_queues_[i].data_->
                     get_average_task_wait_time();
                 ++count;
             }
 
             wait_time += low_priority_queue_.get_average_task_wait_time();
 
-            for (std::size_t i = 0; i != queues_.size(); ++i)
+            for (std::size_t i = 0; i != num_queues_; ++i)
             {
-                wait_time += queues_[i]->get_average_task_wait_time();
+                wait_time += queues_[i].data_->get_average_task_wait_time();
                 ++count;
             }
 
@@ -974,13 +1015,13 @@ namespace hpx { namespace threads { namespace policies
             std::size_t added = 0;
             bool result = true;
 
-            std::size_t high_priority_queues = high_priority_queues_.size();
             thread_queue_type* this_high_priority_queue = nullptr;
-            thread_queue_type* this_queue = queues_[num_thread];
+            thread_queue_type* this_queue = queues_[num_thread].data_;
 
-            if (num_thread < high_priority_queues)
+            if (num_thread < num_high_priority_queues_)
             {
-                this_high_priority_queue = high_priority_queues_[num_thread];
+                this_high_priority_queue =
+                    high_priority_queues_[num_thread].data_;
                 result = this_high_priority_queue->wait_or_add_new(running,
                             idle_loop_count, added)
                         && result;
@@ -997,18 +1038,17 @@ namespace hpx { namespace threads { namespace policies
                 return true;
             }
 
-            for (std::size_t idx: victim_threads_[num_thread])
+            for (std::size_t idx : victim_threads_[num_thread].data_)
             {
                 HPX_ASSERT(idx != num_thread);
 
-                if (idx < high_priority_queues &&
-                    num_thread < high_priority_queues)
+                if (idx < num_high_priority_queues_ &&
+                    num_thread < num_high_priority_queues_)
                 {
-                    thread_queue_type* q =  high_priority_queues_[idx];
+                    thread_queue_type* q = high_priority_queues_[idx].data_;
                     result = this_high_priority_queue->
-                        wait_or_add_new(running, idle_loop_count,
-                            added, q)
-                      && result;
+                        wait_or_add_new(true, idle_loop_count, added, q)
+                        && result;
 
                     if (0 != added)
                     {
@@ -1019,11 +1059,13 @@ namespace hpx { namespace threads { namespace policies
                     }
                 }
 
-                result = this_queue->wait_or_add_new(running,
-                    idle_loop_count, added, queues_[idx]) && result;
+                result = this_queue->wait_or_add_new(true, idle_loop_count,
+                             added, queues_[idx].data_)
+                    && result;
+
                 if (0 != added)
                 {
-                    queues_[idx]->increment_num_stolen_from_staged(added);
+                    queues_[idx].data_->increment_num_stolen_from_staged(added);
                     this_queue->increment_num_stolen_to_staged(added);
                     return result;
                 }
@@ -1035,9 +1077,10 @@ namespace hpx { namespace threads { namespace policies
             {
                 bool suspended_only = true;
 
-                for (std::size_t i = 0; suspended_only && i != queues_.size(); ++i) {
-                    suspended_only = queues_[i]->dump_suspended_threads(
-                        i, idle_loop_count, running);
+                for (std::size_t i = 0; suspended_only && i != num_queues_; ++i)
+                {
+                    suspended_only = queues_[i].data_->
+                        dump_suspended_threads(i, idle_loop_count, running);
                 }
 
                 if (HPX_UNLIKELY(suspended_only)) {
@@ -1065,37 +1108,34 @@ namespace hpx { namespace threads { namespace policies
         ///////////////////////////////////////////////////////////////////////
         void on_start_thread(std::size_t num_thread) override
         {
-            if (nullptr == queues_[num_thread])
+            if (nullptr == queues_[num_thread].data_)
             {
-#if defined(HPX_MSVC)
-#pragma warning(push)
-#pragma warning(disable: 4316) // object allocated on the heap may not be aligned 16
-#endif
-                queues_[num_thread] =
+                queues_[num_thread].data_ =
                     new thread_queue_type(max_queue_thread_count_);
 
-                if (num_thread < high_priority_queues_.size())
+                if (num_thread < num_high_priority_queues_)
                 {
-                    high_priority_queues_[num_thread] =
+                    high_priority_queues_[num_thread].data_ =
                         new thread_queue_type(max_queue_thread_count_);
                 }
-#if defined(HPX_MSVC)
-#pragma warning(pop)
-#endif
             }
 
             // forward this call to all queues etc.
-            if (num_thread < high_priority_queues_.size())
-                high_priority_queues_[num_thread]->on_start_thread(num_thread);
-            if (num_thread == queues_.size()-1)
+            if (num_thread < num_high_priority_queues_)
+            {
+                high_priority_queues_[num_thread].data_->
+                    on_start_thread(num_thread);
+            }
+
+            if (num_thread == num_queues_-1)
                 low_priority_queue_.on_start_thread(num_thread);
 
-            queues_[num_thread]->on_start_thread(num_thread);
+            queues_[num_thread].data_->on_start_thread(num_thread);
 
-            std::size_t num_threads = queues_.size();
+            std::size_t num_threads = num_queues_;
             auto const& topo = rp_.get_topology();
 
-            // get numa domain masks of all queues...
+            // get NUMA domain masks of all queues...
             std::vector<mask_type> numa_masks(num_threads);
             std::vector<mask_type> core_masks(num_threads);
             for (std::size_t i = 0; i != num_threads; ++i)
@@ -1108,7 +1148,7 @@ namespace hpx { namespace threads { namespace policies
             // iterate over the number of threads again to determine where to
             // steal from
             std::ptrdiff_t radius = std::lround(num_threads / 2.0);
-            victim_threads_[num_thread].reserve(num_threads);
+            victim_threads_[num_thread].data_.reserve(num_threads);
 
             std::size_t num_pu = rp_.get_affinity_data().get_pu_num(num_thread);
             mask_cref_type pu_mask = topo.get_thread_affinity_mask(num_pu);
@@ -1140,14 +1180,14 @@ namespace hpx { namespace threads { namespace policies
 
                     if (f(std::size_t(left)))
                     {
-                        victim_threads_[num_thread].push_back(
+                        victim_threads_[num_thread].data_.push_back(
                             static_cast<std::size_t>(left));
                     }
 
                     std::size_t right = (num_thread + i) % num_threads;
                     if (f(right))
                     {
-                        victim_threads_[num_thread].push_back(right);
+                        victim_threads_[num_thread].data_.push_back(right);
                     }
                 }
                 if ((num_threads % 2) == 0)
@@ -1155,7 +1195,7 @@ namespace hpx { namespace threads { namespace policies
                     std::size_t right = (num_thread + i) % num_threads;
                     if (f(right))
                     {
-                        victim_threads_[num_thread].push_back(right);
+                        victim_threads_[num_thread].data_.push_back(right);
                     }
                 }
             };
@@ -1168,7 +1208,7 @@ namespace hpx { namespace threads { namespace policies
                 }
             );
 
-            // check for threads which share the same numa domain...
+            // check for threads which share the same NUMA domain...
             iterate(
                 [&](std::size_t other_num_thread)
                 {
@@ -1178,7 +1218,7 @@ namespace hpx { namespace threads { namespace policies
                 }
             );
 
-            // check for the rest and if we are numa aware
+            // check for the rest and if we are NUMA aware
             if (numa_sensitive_ != 2 && any(first_mask & pu_mask))
             {
                 iterate(
@@ -1192,22 +1232,27 @@ namespace hpx { namespace threads { namespace policies
 
         void on_stop_thread(std::size_t num_thread) override
         {
-            if (num_thread < high_priority_queues_.size())
-                high_priority_queues_[num_thread]->on_stop_thread(num_thread);
-            if (num_thread == queues_.size()-1)
+            if (num_thread < num_high_priority_queues_)
+            {
+                high_priority_queues_[num_thread].data_->
+                    on_stop_thread(num_thread);
+            }
+            if (num_thread == num_queues_-1)
                 low_priority_queue_.on_stop_thread(num_thread);
 
-            queues_[num_thread]->on_stop_thread(num_thread);
+            queues_[num_thread].data_->on_stop_thread(num_thread);
         }
 
         void on_error(std::size_t num_thread, std::exception_ptr const& e) override
         {
-            if (num_thread < high_priority_queues_.size())
-                high_priority_queues_[num_thread]->on_error(num_thread, e);
-            if (num_thread == queues_.size()-1)
+            if (num_thread < num_high_priority_queues_)
+            {
+                high_priority_queues_[num_thread].data_->on_error(num_thread, e);
+            }
+            if (num_thread == num_queues_-1)
                 low_priority_queue_.on_error(num_thread, e);
 
-            queues_[num_thread]->on_error(num_thread, e);
+            queues_[num_thread].data_->on_error(num_thread, e);
         }
 
         void reset_thread_distribution() override
@@ -1217,15 +1262,21 @@ namespace hpx { namespace threads { namespace policies
 
     protected:
         std::size_t max_queue_thread_count_;
-        std::vector<thread_queue_type*> queues_;
-        std::vector<thread_queue_type*> high_priority_queues_;
-        thread_queue_type low_priority_queue_;
         std::atomic<std::size_t> curr_queue_;
         std::size_t numa_sensitive_;
 
-        std::vector<std::vector<std::size_t> > victim_threads_;
-
         resource::detail::partitioner& rp_;
+
+        std::size_t num_queues_;
+        std::size_t num_high_priority_queues_;
+
+        thread_queue_type low_priority_queue_;
+
+        std::vector<util::cache_line_data<thread_queue_type*>> queues_;
+        std::vector<util::cache_line_data<thread_queue_type*>>
+            high_priority_queues_;
+        std::vector<util::cache_line_data<std::vector<std::size_t>>>
+            victim_threads_;
     };
 }}}
 

--- a/hpx/runtime/threads/policies/local_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_queue_scheduler.hpp
@@ -700,8 +700,8 @@ namespace hpx { namespace threads { namespace policies
             std::size_t added = 0;
             bool result = true;
 
-            result = queues_[num_thread]->wait_or_add_new(running,
-                idle_loop_count, added) && result;
+            result =
+                queues_[num_thread]->wait_or_add_new(running, added) && result;
             if (0 != added) return result;
 
             // Check if we have been disabled
@@ -738,8 +738,9 @@ namespace hpx { namespace threads { namespace policies
                             continue;
                         }
 
-                        result = queues_[num_thread]->wait_or_add_new(running,
-                            idle_loop_count, added, queues_[idx]) && result;
+                        result = queues_[num_thread]->wait_or_add_new(
+                                     running, added, queues_[idx]) &&
+                            result;
                         if (0 != added)
                         {
                             queues_[idx]->increment_num_stolen_from_staged(added);
@@ -772,7 +773,7 @@ namespace hpx { namespace threads { namespace policies
                         }
 
                         result = queues_[num_thread]->wait_or_add_new(running,
-                            idle_loop_count, added, queues_[idx]) && result;
+                            added, queues_[idx]) && result;
                         if (0 != added)
                         {
                             queues_[idx]->increment_num_stolen_from_staged(added);
@@ -794,7 +795,7 @@ namespace hpx { namespace threads { namespace policies
                     HPX_ASSERT(idx != num_thread);
 
                     result = queues_[num_thread]->wait_or_add_new(running,
-                        idle_loop_count, added, queues_[idx]) && result;
+                        added, queues_[idx]) && result;
                     if (0 != added)
                     {
                         queues_[idx]->increment_num_stolen_from_staged(added);

--- a/hpx/runtime/threads/policies/queue_helpers.hpp
+++ b/hpx/runtime/threads/policies/queue_helpers.hpp
@@ -85,7 +85,7 @@ namespace hpx { namespace threads { namespace policies
 
         // ----------------------------------------------------------------
         inline bool wait_or_add_new(std::size_t id, bool running,
-           std::int64_t& idle_loop_count, std::size_t& added)
+           std::size_t& added)
         {
             // loop over all queues and take one task,
             // starting with the requested queue
@@ -93,8 +93,7 @@ namespace hpx { namespace threads { namespace policies
             bool result = true;
             for (std::size_t i=0; i<num_queues; ++i) {
                 std::size_t q = (id + i) % num_queues;
-                result = queues_[q]->wait_or_add_new(running, idle_loop_count,
-                    added) && result;
+                result = queues_[q]->wait_or_add_new(running, added) && result;
                 if (0 != added) return result;
             }
             return result;

--- a/hpx/runtime/threads/policies/shared_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/shared_priority_queue_scheduler.hpp
@@ -1098,8 +1098,8 @@ namespace policies {
                 // set the preferred queue for this domain, if applicable
                 std::size_t q_index = q_lookup_[thread_num];
                 // get next task, steal if from another domain
-                result = hp_queues_[dom].wait_or_add_new(q_index, running,
-                    idle_loop_count, added);
+                result =
+                    hp_queues_[dom].wait_or_add_new(q_index, running, added);
                 if (0 != added) return result;
             }
 
@@ -1110,8 +1110,8 @@ namespace policies {
                     // set the preferred queue for this domain, if applicable
                     std::size_t q_index = q_lookup_[thread_num];
                     // get next task, steal if from another domain
-                    result = np_queues_[dom].wait_or_add_new(q_index, running,
-                        idle_loop_count, added);
+                    result = np_queues_[dom].wait_or_add_new(
+                        q_index, running, added);
                     if (0 != added) return result;
                 }
             }
@@ -1127,14 +1127,14 @@ namespace policies {
                         lp_lookup_[(counters_[dom]++ %
                             lp_queues_[dom].num_cores)];
 
-                    result = lp_queues_[dom].wait_or_add_new(q_index, running,
-                        idle_loop_count, added);
+                    result = lp_queues_[dom].wait_or_add_new(
+                        q_index, running, added);
                     if (0 != added) return result;
                 }
 #else
                 // no cross domain stealing for LP queues
-                result = lp_queues_[domain_num].wait_or_add_new(0, running,
-                    idle_loop_count, added);
+                result =
+                    lp_queues_[domain_num].wait_or_add_new(0, running, added);
                 if (0 != added) return result;
 #endif
             }

--- a/hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp
@@ -120,12 +120,13 @@ namespace hpx { namespace threads { namespace policies
             if (num_thread < this->num_high_priority_queues_)
             {
                 result = this->high_priority_queues_[num_thread].data_->
-                    wait_or_add_new(running, idle_loop_count, added) && result;
+                    wait_or_add_new(running, added) && result;
                 if (0 != added) return result;
             }
 
             result = this->queues_[num_thread].data_->wait_or_add_new(
-                running, idle_loop_count, added) && result;
+                         running, added) &&
+                result;
             if (0 != added) return result;
 
             // Check if we have been disabled
@@ -162,8 +163,9 @@ namespace hpx { namespace threads { namespace policies
             }
 #endif
 
-            result = this->low_priority_queue_.wait_or_add_new(running,
-                idle_loop_count, added) && result;
+            result =
+                this->low_priority_queue_.wait_or_add_new(running, added) &&
+                result;
             if (0 != added) return result;
 
             return result;

--- a/hpx/runtime/threads/policies/static_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/static_queue_scheduler.hpp
@@ -109,8 +109,9 @@ namespace hpx { namespace threads { namespace policies
             std::size_t added = 0;
             bool result = true;
 
-            result = this->queues_[num_thread]->wait_or_add_new(running,
-                idle_loop_count, added) && result;
+            result =
+                this->queues_[num_thread]->wait_or_add_new(running, added) &&
+                result;
             if (0 != added) return result;
 
             // Check if we have been disabled

--- a/hpx/runtime/threads/policies/thread_queue.hpp
+++ b/hpx/runtime/threads/policies/thread_queue.hpp
@@ -547,7 +547,6 @@ namespace hpx { namespace threads { namespace policies
             max_terminated_threads(detail::get_max_terminated_threads()),
             thread_map_count_(0),
             work_items_(128, queue_num),
-            work_items_count_(0),
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
             work_items_wait_(0),
             work_items_wait_count_(0),
@@ -581,6 +580,7 @@ namespace hpx { namespace threads { namespace policies
             add_new_logger_("thread_queue::add_new")
         {
             new_tasks_count_.data_ = 0;
+            work_items_count_.data_ = 0;
         }
 
         static void deallocate(threads::thread_data* p)
@@ -626,13 +626,13 @@ namespace hpx { namespace threads { namespace policies
         // This returns the current length of the queues (work items and new items)
         std::int64_t get_queue_length() const
         {
-            return work_items_count_ + new_tasks_count_.data_;
+            return work_items_count_.data_ + new_tasks_count_.data_;
         }
 
         // This returns the current length of the pending queue
         std::int64_t get_pending_queue_length() const
         {
-            return work_items_count_;
+            return work_items_count_.data_;
         }
 
         // This returns the current length of the staged queue
@@ -819,7 +819,7 @@ namespace hpx { namespace threads { namespace policies
             thread_description* trd;
             while (src->work_items_.pop(trd))
             {
-                --src->work_items_count_;
+                --src->work_items_count_.data_;
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
                 if (maintain_queue_wait_times) {
@@ -830,7 +830,7 @@ namespace hpx { namespace threads { namespace policies
                 }
 #endif
 
-                bool finished = count == ++work_items_count_;
+                bool finished = count == ++work_items_count_.data_;
                 work_items_.push(trd);
                 if (finished)
                     break;
@@ -876,7 +876,7 @@ namespace hpx { namespace threads { namespace policies
             bool allow_stealing = false, bool steal = false) HPX_HOT
         {
             std::int64_t work_items_count =
-                work_items_count_.load(std::memory_order_relaxed);
+                work_items_count_.data_.load(std::memory_order_relaxed);
 
             if (allow_stealing && min_tasks_to_steal_pending > work_items_count)
             {
@@ -887,7 +887,7 @@ namespace hpx { namespace threads { namespace policies
             thread_description* tdesc;
             if (0 != work_items_count && work_items_.pop(tdesc, steal))
             {
-                --work_items_count_;
+                --work_items_count_.data_;
 
                 if (maintain_queue_wait_times) {
                     work_items_wait_ += util::high_resolution_clock::now() -
@@ -903,7 +903,7 @@ namespace hpx { namespace threads { namespace policies
 #else
             if (0 != work_items_count && work_items_.pop(thrd, steal))
             {
-                --work_items_count_;
+                --work_items_count_.data_;
                 return true;
             }
 #endif
@@ -913,7 +913,7 @@ namespace hpx { namespace threads { namespace policies
         /// Schedule the passed thread
         void schedule_thread(threads::thread_data* thrd, bool other_end = false)
         {
-            ++work_items_count_;
+            ++work_items_count_.data_;
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
             work_items_.push(new thread_description(
                 thrd, util::high_resolution_clock::now()), other_end);
@@ -1037,34 +1037,46 @@ namespace hpx { namespace threads { namespace policies
         /// manager to allow for maintenance tasks to be executed in the
         /// scheduler. Returns true if the OS thread calling this function
         /// has to be terminated (i.e. no more work has to be done).
-        inline bool wait_or_add_new(bool running,
-            std::int64_t& idle_loop_count, std::size_t& added,
-            thread_queue* addfrom = nullptr, bool steal = false) HPX_HOT
+        inline bool wait_or_add_new(bool, std::size_t& added) HPX_HOT
+        {
+            if (0 == new_tasks_count_.data_.load(std::memory_order_relaxed))
+            {
+                return false;
+            }
+
+            // No obvious work has to be done, so a lock won't hurt too much.
+            //
+            // We prefer to exit this function (some kind of very short
+            // busy waiting) to blocking on this lock. Locking fails either
+            // when a thread is currently doing thread maintenance, which
+            // means there might be new work, or the thread owning the lock
+            // just falls through to the cleanup work below (no work is available)
+            // in which case the current thread (which failed to acquire
+            // the lock) will just retry to enter this loop.
+            std::unique_lock<mutex_type> lk(mtx_, std::try_to_lock);
+            if (!lk.owns_lock())
+                return false;            // avoid long wait on lock
+
+            // stop running after all HPX threads have been terminated
+            return add_new_always(added, this, lk);
+        }
+
+        inline bool wait_or_add_new(bool running, std::size_t& added,
+            thread_queue* addfrom, bool steal = false) HPX_HOT
         {
             // try to generate new threads from task lists, but only if our
             // own list of threads is empty
-            if (0 == work_items_count_.load(std::memory_order_relaxed))
+            if (0 == work_items_count_.data_.load(std::memory_order_relaxed))
             {
                 // see if we can avoid grabbing the lock below
-                if (addfrom)
+
+                // don't try to steal if there are only a few tasks left on
+                // this queue
+                if (running && min_tasks_to_steal_staged >
+                        addfrom->new_tasks_count_.data_.load(
+                            std::memory_order_relaxed))
                 {
-                    // don't try to steal if there are only a few tasks left on
-                    // this queue
-                    if (running && min_tasks_to_steal_staged >
-                            addfrom->new_tasks_count_.data_.load(
-                                std::memory_order_relaxed))
-                    {
-                        return false;
-                    }
-                }
-                else
-                {
-                    if (running && 0 == new_tasks_count_.data_.load(
-                                std::memory_order_relaxed))
-                    {
-                        return false;
-                    }
-                    addfrom = this;
+                    return false;
                 }
 
                 // No obvious work has to be done, so a lock won't hurt too much.
@@ -1112,8 +1124,8 @@ namespace hpx { namespace threads { namespace policies
         }
 
         ///////////////////////////////////////////////////////////////////////
-        bool dump_suspended_threads(std::size_t num_thread
-          , std::int64_t& idle_loop_count, bool running)
+        bool dump_suspended_threads(
+            std::size_t num_thread, std::int64_t& idle_loop_count, bool running)
         {
 #ifndef HPX_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION
             return false;
@@ -1139,7 +1151,6 @@ namespace hpx { namespace threads { namespace policies
         std::atomic<std::int64_t> thread_map_count_; // overall count of work items
 
         work_items_type work_items_;        // list of active work items
-        std::atomic<std::int64_t> work_items_count_; // count of active work items
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
         std::atomic<std::int64_t> work_items_wait_; // overall wait time of work items
@@ -1189,6 +1200,9 @@ namespace hpx { namespace threads { namespace policies
         // count of new tasks to run, separate to new cache line to avoid false
         // sharing
         util::cache_line_data<std::atomic<std::int64_t>> new_tasks_count_;
+
+        // count of active work items
+        util::cache_line_data<std::atomic<std::int64_t>> work_items_count_;
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/hpx/util/cache_aligned_data.hpp
+++ b/hpx/util/cache_aligned_data.hpp
@@ -14,7 +14,7 @@ namespace hpx { namespace util
 {
     ///////////////////////////////////////////////////////////////////////////
     // special struct to ensure cache line alignment of a data type
-#if defined(HPX_HAVE_CXX11_ALIGNAS)
+#if defined(HPX_HAVE_CXX11_ALIGNAS) && !defined(__NVCC__)
     template <typename Data>
     struct alignas(threads::get_cache_line_size()) cache_aligned_data
     {
@@ -36,7 +36,7 @@ namespace hpx { namespace util
     ///////////////////////////////////////////////////////////////////////////
     // special struct to data type is cache line aligned and fully occupies a
     // cache line
-#if defined(HPX_HAVE_CXX11_ALIGNAS)
+#if defined(HPX_HAVE_CXX11_ALIGNAS) && !defined(__NVCC__)
     template <typename Data>
     struct alignas(threads::get_cache_line_size()) cache_line_data
     {

--- a/hpx/util/cache_aligned_data.hpp
+++ b/hpx/util/cache_aligned_data.hpp
@@ -1,0 +1,63 @@
+//  Copyright (c) 2019 Hartmut Kaiser
+//  Copyright (c) 2019 Thomas Heller
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_UTIL_CACHE_ALIGNED_DATA_MAR_17_2019_1103AM)
+#define HPX_UTIL_CACHE_ALIGNED_DATA_MAR_17_2019_1103AM
+
+#include <hpx/config.hpp>
+#include <hpx/runtime/threads/topology.hpp>
+
+namespace hpx { namespace util
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // special struct to ensure cache line alignment of a data type
+#if defined(HPX_HAVE_CXX11_ALIGNAS)
+    template <typename Data>
+    struct alignas(threads::get_cache_line_size()) cache_aligned_data
+    {
+        Data data_;
+    };
+#else
+    template <typename Data>
+    struct cache_aligned_data
+    {
+        static_assert(threads::get_cache_line_size() >= sizeof(Data),
+            "threads::get_cache_line_size() >= sizeof(Data)");
+
+        // pad to cache line size bytes
+        Data data_;
+        char cacheline_pad[threads::get_cache_line_size() - sizeof(Data)];
+    };
+#endif
+
+    ///////////////////////////////////////////////////////////////////////////
+    // special struct to data type is cache line aligned and fully occupies a
+    // cache line
+#if defined(HPX_HAVE_CXX11_ALIGNAS)
+    template <typename Data>
+    struct alignas(threads::get_cache_line_size()) cache_line_data
+    {
+        static_assert(threads::get_cache_line_size() >= sizeof(Data),
+            "threads::get_cache_line_size() >= sizeof(Data)");
+
+        Data data_;
+        char cacheline_pad[threads::get_cache_line_size() - sizeof(Data)];
+    };
+#else
+    template <typename Data>
+    struct cache_line_data
+    {
+        static_assert(threads::get_cache_line_size() >= sizeof(Data),
+            "threads::get_cache_line_size() >= sizeof(Data)");
+
+        // pad to cache line size bytes
+        Data data_;
+        char cacheline_pad[threads::get_cache_line_size() - sizeof(Data)];
+    };
+#endif
+}}
+
+#endif

--- a/tests/unit/lcos/local_latch.cpp
+++ b/tests/unit/lcos/local_latch.cpp
@@ -123,7 +123,7 @@ int hpx_main()
     {
         num_threads.store(0);
 
-        hpx::lcos::local::latch l(1);
+        hpx::lcos::local::latch l(0);
         l.reset(NUM_THREADS+1);
         HPX_TEST(!l.is_ready());
 


### PR DESCRIPTION
- reduce false sharing in local priority scheduler and thread_queue 
- reduce false sharing in latch and condition_variable
- disabled thread stealing counters by default (to reduce overheads)

The changes result in an overall performance improvement by 30% (for_each benchmark).

Working towards #3744