### PR TITLE
Fixed unusable behavior of the clang code analyzer.

### DIFF
--- a/hpx/traits/brace_initializable_traits.hpp
+++ b/hpx/traits/brace_initializable_traits.hpp
@@ -85,7 +85,8 @@ namespace hpx { namespace traits
 
     template <typename T, std::size_t N>
     constexpr auto is_paren_constructible()
-    -> detail::is_paren_constructible<T, std::make_index_sequence<N>>
+    -> decltype(detail::is_paren_constructible(
+            static_cast<T*>(nullptr), std::make_index_sequence<N>{}))
     {
         return {};
     }


### PR DESCRIPTION
Fixed an unusable behaviour of the the clang code analyzer.
The clangbackend of the qtcreator 4.8.1 aborts with the code analysis at runtime internally.
I couldn't find out exactly what it is, but the following fix helped.
is_brace_constructible() 20 lines above served as template for the fix.
