### PR TITLE
Fixing problems with lcos::barrier and iostreams

### DIFF
--- a/hpx/components/iostreams/ostream.hpp
+++ b/hpx/components/iostreams/ostream.hpp
@@ -132,14 +132,14 @@ namespace hpx { namespace iostreams
                 detail::get_outstream(tag));
         }
 
-//         ///////////////////////////////////////////////////////////////////////
-//         void release_ostream(char const* name, naming::id_type const& id);
-//
-//         template <typename Tag>
-//         void release_ostream(Tag tag, naming::id_type const& id)
-//         {
-//             release_ostream(get_outstream_name(tag), id);
-//         }
+        ///////////////////////////////////////////////////////////////////////
+        HPX_EXPORT void release_ostream(char const* name, naming::id_type const& id);
+
+        template <typename Tag>
+        void release_ostream(Tag tag, naming::id_type const& id)
+        {
+            release_ostream(get_outstream_name(tag), id);
+        }
 
         ///////////////////////////////////////////////////////////////////////
         void register_ostreams();
@@ -281,7 +281,7 @@ namespace hpx { namespace iostreams
             }
 
             // FIXME: find a later spot to invoke this
-//             detail::release_ostream(tag, this->get_id());
+            detail::release_ostream(tag, this->get_id());
             this->base_type::free();
         }
 

--- a/hpx/lcos/detail/barrier_node.hpp
+++ b/hpx/lcos/detail/barrier_node.hpp
@@ -48,6 +48,7 @@ namespace hpx { namespace lcos { namespace detail {
 
         barrier_node();
         barrier_node(std::string base_name, std::size_t num, std::size_t rank);
+
         void set_event();
         hpx::future<void> gather();
 

--- a/src/components/iostreams/standard_streams.cpp
+++ b/src/components/iostreams/standard_streams.cpp
@@ -61,17 +61,17 @@ namespace hpx { namespace iostreams { namespace detail
     }
 
     ///////////////////////////////////////////////////////////////////////////
-//     void release_ostream(char const* name, naming::id_type const& id)
-//     {
-//         LRT_(info) << "detail::release_ostream: destroying '"
-//                    << name << "' stream object";
-//
-//         if (agas::is_console())
-//         {
-//             // now unregister the object from AGAS
-//             agas::unregister_name(launch::sync, name);
-//         }
-//     }
+    void release_ostream(char const* name, naming::id_type const& id)
+    {
+        LRT_(info) << "detail::release_ostream: destroying '"
+                   << name << "' stream object";
+
+        if (agas::is_console())
+        {
+            // now unregister the object from AGAS
+            agas::unregister_name(launch::sync, name);
+        }
+    }
 }}}
 
 namespace hpx { namespace iostreams

--- a/src/lcos/barrier.cpp
+++ b/src/lcos/barrier.cpp
@@ -103,8 +103,7 @@ namespace hpx { namespace lcos {
                 // make sure this runs as an HPX thread
                 if (hpx::threads::get_self_ptr() == nullptr)
                 {
-                    return hpx::threads::run_as_hpx_thread(
-                        &barrier::release, this);
+                    hpx::threads::run_as_hpx_thread(&barrier::release, this);
                 }
 
                 hpx::future<void> f;
@@ -126,6 +125,7 @@ namespace hpx { namespace lcos {
                     }
                 ).get();
             }
+            intrusive_ptr_release(node_->get());
             node_.reset();
         }
     }
@@ -142,6 +142,7 @@ namespace hpx { namespace lcos {
                     hpx::unregister_with_basename(
                         (*node_)->base_name_, (*node_)->rank_);
             }
+            intrusive_ptr_release(node_->get());
             node_.reset();
         }
     }


### PR DESCRIPTION
 - Fixing memory leak with hpx::cout and friends during shutdown
 - Fixing potential memory corruption with lcos barrier
