### PR TITLE
Disable more code if networking is not available/not enabled

### DIFF
--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -1532,32 +1532,45 @@ namespace hpx { namespace parcelset
     parcelhandler::get_parcelport_factories()
     {
         static std::vector<plugins::parcelport_factory_base *> factories;
-        if(factories.empty())
+#if defined(HPX_HAVE_NETWORKING)
+        if(factories.empty() && hpx::is_networking_enabled())
         {
             init_static_parcelport_factories(factories);
         }
+#endif
         return factories;
     }
 
     void parcelhandler::add_parcelport_factory(
         plugins::parcelport_factory_base *factory)
     {
-        auto & factories = get_parcelport_factories();
-        if (std::find(factories.begin(), factories.end(), factory) !=
-            factories.end())
+#if defined(HPX_HAVE_NETWORKING)
+        if (hpx::is_networking_enabled())
         {
-            return;
+            auto & factories = get_parcelport_factories();
+            if (std::find(factories.begin(), factories.end(), factory) !=
+                factories.end())
+            {
+                return;
+            }
+            factories.push_back(factory);
         }
-        factories.push_back(factory);
+#endif
     }
 
     void parcelhandler::init(int *argc, char ***argv,
         util::command_line_handling &cfg)
     {
-        for (plugins::parcelport_factory_base* factory : get_parcelport_factories())
+#if defined(HPX_HAVE_NETWORKING)
+        if (hpx::is_networking_enabled())
         {
-            factory->init(argc, argv, cfg);
+            for (plugins::parcelport_factory_base* factory :
+                get_parcelport_factories())
+            {
+                factory->init(argc, argv, cfg);
+            }
         }
+#endif
     }
 
     std::vector<std::string> parcelhandler::load_runtime_configuration()


### PR DESCRIPTION
Fixes https://github.com/STEllAR-GROUP/phylanx/issues/892

## Proposed Changes

- this disables more startup code that does not need to run if networking is disabled or not available