### PR TITLE
Rename PAGE_SIZE to PAGE_SIZE_ because AppleClang

### DIFF
--- a/examples/quickstart/component_with_custom_heap.cpp
+++ b/examples/quickstart/component_with_custom_heap.cpp
@@ -35,7 +35,7 @@ namespace allocator
 {
     ///////////////////////////////////////////////////////////////////////////
     HPX_CONSTEXPR std::size_t BLOCK_ALIGNMENT = 8;
-    HPX_CONSTEXPR std::size_t PAGE_SIZE = 16384;
+    HPX_CONSTEXPR std::size_t PAGE_SIZE_ = 16384;
 
     struct alloc_page;
 
@@ -204,7 +204,7 @@ namespace allocator
         // for the available page size we account for the members of this
         // class below
         HPX_STATIC_CONSTEXPR std::size_t page_size =
-            PAGE_SIZE - sizeof(void*) - 2*sizeof(std::size_t);
+            PAGE_SIZE_ - sizeof(void*) - 2*sizeof(std::size_t);
 
         typename std::aligned_storage<page_size>::type data;
 


### PR DESCRIPTION
`PAGE_SIZE` is a macro in Apple Clang.

## Proposed Changes

  - Rename the `PAGE_SIZE` constant in `examples/quickstart/component_with_custom_heap.cpp` to `PAGE_SIZE_`.

## Any background context you want to provide?
```
...
CompileC cmake-build-debug/examples/quickstart/HPX.build/Debug/component_with_custom_heap.build/Objects-normal/x86_64/component_with_custom_heap.o examples/quickstart/component_with_custom_heap.cpp normal x86_64 c++ com.apple.compilers.llvm.clang.1_0.compiler
    cd /Users/parsa/Repositories/hpx
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++ -arch x86_64 -fmessage-length=204 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit=0 -fcolor-diagnostics -Wno-trigraphs -fpascal-strings -O0 -Wno-missing-field-initializers -Wno-missing-prototypes -Wno-return-type -Wno-non-virtual-dtor -Wno-overloaded-virtual -Wno-exit-time-destructors -Wno-missing-braces -Wparentheses -Wswitch -Wno-unused-function -Wno-unused-label -Wno-unused-parameter -Wno-unused-variable -Wunused-value -Wno-empty-body -Wno-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wno-constant-conversion -Wno-int-conversion -Wno-bool-conversion -Wno-enum-conversion -Wno-float-conversion -Wno-non-literal-null-conversion -Wno-objc-literal-conversion -Wno-shorten-64-to-32 -Wno-newline-eof -Wno-c++11-extensions -DCMAKE_INTDIR=\"Debug\" -DHPX_APPLICATION_NAME=component_with_custom_heap -DHPX_APPLICATION_STRING=\"component_with_custom_heap\" -DHPX_PREFIX=\"/Users/parsa/Repositories/hpx/cmake-install-debug\" -DHPX_APPLICATION_EXPORTS -D_GNU_SOURCE -D_DEBUG -DDEBUG -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk -fasm-blocks -fstrict-aliasing -Wdeprecated-declarations -Winvalid-offsetof -mmacosx-version-min=10.14 -g -Wno-sign-conversion -Wno-infinite-recursion -Wno-move -Wno-comma -Wno-block-capture-autoreleasing -Wno-strict-prototypes -Wno-range-loop-analysis -Wno-semicolon-before-method-body -I/Users/parsa/Repositories/hpx/cmake-build-debug/bin/Debug/include -I/Users/parsa/Repositories/hpx -I/Users/parsa/Repositories/hpx/cmake-build-debug -I/Users/parsa/Repositories/hpx/tests -I/Users/parsa/Repositories/hpx/examples -isystem /usr/local/include -I/Users/parsa/Repositories/hpx/cmake-build-debug/examples/quickstart/HPX.build/Debug/component_with_custom_heap.build/DerivedSources-normal/x86_64 -I/Users/parsa/Repositories/hpx/cmake-build-debug/examples/quickstart/HPX.build/Debug/component_with_custom_heap.build/DerivedSources/x86_64 -I/Users/parsa/Repositories/hpx/cmake-build-debug/examples/quickstart/HPX.build/Debug/component_with_custom_heap.build/DerivedSources -Wmost -Wno-four-char-constants -Wno-unknown-pragmas -F/Users/parsa/Repositories/hpx/cmake-build-debug/bin/Debug -std=c++17 -pthread -ftemplate-depth=256 -Wall -Wextra -Wno-unused-local-typedefs -Wno-strict-aliasing -Wno-sign-promo -Wno-attributes -Wno-cast-align -Wno-unused-parameter -Wformat=2 -Wno-format-nonliteral -Winit-self -Wdouble-promotion -Wcast-qual -Wcast-align -Werror=parentheses -Werror=reorder -Werror=return-type -Werror=sequence-point -Werror=uninitialized -Werror=format -Werror=missing-braces -Werror=sign-compare -fdiagnostics-show-option -Werror=vla -MMD -MT dependencies -MF /Users/parsa/Repositories/hpx/cmake-build-debug/examples/quickstart/HPX.build/Debug/component_with_custom_heap.build/Objects-normal/x86_64/component_with_custom_heap.d --serialize-diagnostics /Users/parsa/Repositories/hpx/cmake-build-debug/examples/quickstart/HPX.build/Debug/component_with_custom_heap.build/Objects-normal/x86_64/component_with_custom_heap.dia -c /Users/parsa/Repositories/hpx/examples/quickstart/component_with_custom_heap.cpp -o /Users/parsa/Repositories/hpx/cmake-build-debug/examples/quickstart/HPX.build/Debug/component_with_custom_heap.build/Objects-normal/x86_64/component_with_custom_heap.o
/Users/parsa/Repositories/hpx/examples/quickstart/component_with_custom_heap.cpp:38:31: error: expected unqualified-id
    HPX_CONSTEXPR std::size_t PAGE_SIZE = 16384;
                              ^
In file included from /Users/parsa/Repositories/hpx/examples/quickstart/component_with_custom_heap.cpp:16:
In file included from /Users/parsa/Repositories/hpx/hpx/include/actions.hpp:14:
In file included from /Users/parsa/Repositories/hpx/hpx/runtime/actions/make_continuation.hpp:12:
In file included from /Users/parsa/Repositories/hpx/hpx/runtime/actions/continuation_impl.hpp:10:
In file included from /Users/parsa/Repositories/hpx/hpx/runtime/applier/apply.hpp:20:
In file included from /Users/parsa/Repositories/hpx/hpx/runtime/parcelset/put_parcel.hpp:9:
In file included from /Users/parsa/Repositories/hpx/hpx/runtime.hpp:26:
In file included from /Users/parsa/Repositories/hpx/hpx/util/runtime_configuration.hpp:16:
In file included from /Users/parsa/Repositories/hpx/hpx/util/plugin/dll.hpp:20:
In file included from /Users/parsa/Repositories/hpx/hpx/util/plugin/detail/dll_dlopen.hpp:37:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/include/mach-o/dyld.h:31:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/include/mach-o/loader.h:35:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/include/mach/machine.h:67:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/include/mach/machine/vm_types.h:33:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/include/mach/i386/vm_types.h:73:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/include/mach/i386/vm_param.h:98:33: note: expanded from macro 'PAGE_SIZE'
#define PAGE_SIZE               I386_PGBYTES
                                ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/include/mach/i386/vm_param.h:95:33: note: expanded from macro 'I386_PGBYTES'
#define I386_PGBYTES            4096            /* bytes per 80386 page */
                                ^
1 error generated.

** BUILD FAILED **
```