### PR TITLE
Fix callable vtable for GCC4.9

### DIFF
--- a/hpx/util/detail/empty_function.hpp
+++ b/hpx/util/detail/empty_function.hpp
@@ -18,6 +18,12 @@ namespace hpx { namespace util { namespace detail
 
     HPX_NORETURN HPX_EXPORT void throw_bad_function_call();
 
+    template <typename R>
+    HPX_NORETURN inline R throw_bad_function_call()
+    {
+        throw_bad_function_call();
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     // make sure the empty table instance is initialized in time, even
     // during early startup

--- a/hpx/util/detail/vtable/callable_vtable.hpp
+++ b/hpx/util/detail/vtable/callable_vtable.hpp
@@ -95,9 +95,9 @@ namespace hpx { namespace util { namespace detail
           : invoke(&callable_vtable::template _invoke<T>)
         {}
 
-        HPX_NORETURN static R _empty_invoke(void*, Ts&&...)
+        static R _empty_invoke(void*, Ts&&...)
         {
-            throw_bad_function_call();
+            return throw_bad_function_call<R>();
         }
 
         HPX_CONSTEXPR callable_vtable(construct_vtable<empty_function>) noexcept


### PR DESCRIPTION
Workaround for GCC regression when forming function pointers to [[noreturn]] functions in constant expressions