### PR TITLE
Prevent MSVC from prematurely instantiating things

### DIFF
--- a/hpx/util/function.hpp
+++ b/hpx/util/function.hpp
@@ -44,20 +44,26 @@ namespace hpx { namespace util
         function& operator=(function const&) = default;
         function& operator=(function&&) noexcept = default;
 
+        // the split SFINAE prevents MSVC from eagerly instantiating things
         template <typename F, typename FD = typename std::decay<F>::type,
-            typename Enable = typename std::enable_if<
+            typename Enable1 = typename std::enable_if<
                 !std::is_same<FD, function>::value
-             && traits::is_invocable_r<R, FD&, Ts...>::value
+            >::type,
+            typename Enable2 = typename std::enable_if<
+                traits::is_invocable_r<R, FD&, Ts...>::value
             >::type>
         function(F&& f)
         {
             assign(std::forward<F>(f));
         }
 
+        // the split SFINAE prevents MSVC from eagerly instantiating things
         template <typename F, typename FD = typename std::decay<F>::type,
-            typename Enable = typename std::enable_if<
+            typename Enable1 = typename std::enable_if<
                 !std::is_same<FD, function>::value
-             && traits::is_invocable_r<R, FD&, Ts...>::value
+            >::type,
+            typename Enable2 = typename std::enable_if<
+                traits::is_invocable_r<R, FD&, Ts...>::value
             >::type>
         function& operator=(F&& f)
         {

--- a/hpx/util/unique_function.hpp
+++ b/hpx/util/unique_function.hpp
@@ -42,20 +42,26 @@ namespace hpx { namespace util
         unique_function(unique_function&&) noexcept = default;
         unique_function& operator=(unique_function&&) noexcept = default;
 
+        // the split SFINAE prevents MSVC from eagerly instantiating things
         template <typename F, typename FD = typename std::decay<F>::type,
-            typename Enable = typename std::enable_if<
+            typename Enable1 = typename std::enable_if<
                 !std::is_same<FD, unique_function>::value
-             && traits::is_invocable_r<R, FD&, Ts...>::value
+            >::type,
+            typename Enable2 = typename std::enable_if<
+                traits::is_invocable_r<R, FD&, Ts...>::value
             >::type>
         unique_function(F&& f)
         {
             assign(std::forward<F>(f));
         }
 
+        // the split SFINAE prevents MSVC from eagerly instantiating things
         template <typename F, typename FD = typename std::decay<F>::type,
-            typename Enable = typename std::enable_if<
+            typename Enable1 = typename std::enable_if<
                 !std::is_same<FD, unique_function>::value
-             && traits::is_invocable_r<R, FD&, Ts...>::value
+            >::type,
+            typename Enable2 = typename std::enable_if<
+                traits::is_invocable_r<R, FD&, Ts...>::value
             >::type>
         unique_function& operator=(F&& f)
         {


### PR DESCRIPTION
- this touches on `util::function`, `util::unique_function`, and `util::iterator_adaptor`

## Proposed Changes

  - splitting SFINAE on `util::function` and friends to prevent MSVC to over-eagerly instantiate non-needed functions
 - adding SFINAE to `util::iterator_adaptor` members to achieve similar effects