### PR TITLE
Fix a couple of bugs in the thread test

### DIFF
--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -730,7 +730,7 @@ namespace detail
 
             // start new thread at given point in time
             threads::set_thread_state(id, abs_time, threads::pending,
-                threads::wait_timeout, threads::thread_priority_boost, ec);
+                threads::wait_timeout, threads::thread_priority_boost, true, ec);
             if (ec) {
                 // thread scheduling failed, report error to the new future
                 this->base_type::set_exception(hpx::detail::access_exception(ec));

--- a/hpx/runtime/parcelset/parcelport_impl.hpp
+++ b/hpx/runtime/parcelset/parcelport_impl.hpp
@@ -356,9 +356,9 @@ namespace hpx { namespace parcelset
                     ec);
             if (ec) return;
 
-            threads::set_thread_state(id,
-                std::chrono::milliseconds(100), threads::pending,
-                threads::wait_signaled, threads::thread_priority_boost, ec);
+            threads::set_thread_state(id, std::chrono::milliseconds(100),
+                threads::pending, threads::wait_signaled,
+                threads::thread_priority_boost, true, ec);
         }
 
         /// Return the name of this locality

--- a/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
@@ -715,7 +715,7 @@ namespace hpx { namespace threads { namespace detail
             new_state_ex, priority,
             thread_schedule_hint(
                 static_cast<std::int16_t>(get_worker_thread_num())),
-            ec);
+            true, ec);
     }
 
     template <typename Scheduler>
@@ -728,7 +728,7 @@ namespace hpx { namespace threads { namespace detail
             newstate_ex, priority,
             thread_schedule_hint(
                 static_cast<std::int16_t>(get_worker_thread_num())),
-            nullptr, ec);
+            nullptr, true, ec);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/threads/detail/set_thread_state.hpp
+++ b/hpx/runtime/threads/detail/set_thread_state.hpp
@@ -39,6 +39,7 @@ namespace hpx { namespace threads { namespace detail
         thread_id_type const& id, thread_state_enum new_state,
         thread_state_ex_enum new_state_ex, thread_priority priority,
         thread_schedule_hint schedulehint = thread_schedule_hint(),
+        bool retry_on_active = true,
         error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -74,16 +75,16 @@ namespace hpx { namespace threads { namespace detail
         // just retry, set_state will create new thread if target is still active
         error_code ec(lightweight);      // do not throw
         detail::set_thread_state(thrd, newstate, newstate_ex, priority,
-            thread_schedule_hint(), ec);
+            thread_schedule_hint(), true, ec);
 
         return thread_result_type(terminated, invalid_thread_id);
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    inline thread_state set_thread_state(
-        thread_id_type const& thrd, thread_state_enum new_state,
-        thread_state_ex_enum new_state_ex, thread_priority priority,
-        thread_schedule_hint schedulehint, error_code& ec)
+    inline thread_state set_thread_state(thread_id_type const& thrd,
+        thread_state_enum new_state, thread_state_ex_enum new_state_ex,
+        thread_priority priority, thread_schedule_hint schedulehint,
+        bool retry_on_active, error_code& ec)
     {
         if (HPX_UNLIKELY(!thrd)) {
             HPX_THROWS_IF(ec, null_thread_id, "threads::detail::set_thread_state",
@@ -134,23 +135,38 @@ namespace hpx { namespace threads { namespace detail
             switch (previous_state_val) {
             case active:
                 {
-                    // schedule a new thread to set the state
-                    LTM_(warning)
-                        << "set_thread_state: thread is currently active, scheduling "
-                            "new thread, thread(" << thrd << "), description("
-                        << thrd->get_description() << "), new state("
-                        << get_thread_state_name(new_state) << ")";
+                    if (retry_on_active)
+                    {
+                        // schedule a new thread to set the state
+                        LTM_(warning)
+                            << "set_thread_state: thread is currently active, "
+                               "scheduling new thread, thread("
+                            << thrd << "), description("
+                            << thrd->get_description() << "), new state("
+                            << get_thread_state_name(new_state) << ")";
 
-                    thread_init_data data(
-                        util::bind(&set_active_state,
-                            thrd, new_state, new_state_ex,
-                            priority, previous_state),
-                        "set state for active thread", 0, priority);
+                        thread_init_data data(
+                            util::bind(&set_active_state, thrd, new_state,
+                                new_state_ex, priority, previous_state),
+                            "set state for active thread", 0, priority);
 
-                    create_work(thrd->get_scheduler_base(), data, pending, ec);
+                        create_work(
+                            thrd->get_scheduler_base(), data, pending, ec);
 
-                    if (&ec != &throws)
+                        if (&ec != &throws)
+                            ec = make_success_code();
+                    }
+                    else
+                    {
+                        LTM_(warning)
+                            << "set_thread_state: thread is currently active, "
+                               "but not scheduling new thread because "
+                               "retry_on_active = false, thread("
+                            << thrd << "), description("
+                            << thrd->get_description() << "), new state("
+                            << get_thread_state_name(new_state) << ")";
                         ec = make_success_code();
+                    }
 
                     return previous_state;     // done
                 }
@@ -255,12 +271,11 @@ namespace hpx { namespace threads { namespace detail
     ///////////////////////////////////////////////////////////////////////////
     /// This thread function is used by the at_timer thread below to trigger
     /// the required action.
-    inline thread_result_type wake_timer_thread(
-        thread_id_type const& thrd, thread_state_enum newstate,
-        thread_state_ex_enum newstate_ex, thread_priority priority,
-        thread_id_type const& timer_id,
-        std::shared_ptr<std::atomic<bool> > const& triggered,
-        thread_state_ex_enum my_statex)
+    inline thread_result_type wake_timer_thread(thread_id_type const& thrd,
+        thread_state_enum newstate, thread_state_ex_enum newstate_ex,
+        thread_priority priority, thread_id_type const& timer_id,
+        std::shared_ptr<std::atomic<bool>> const& triggered,
+        bool retry_on_active, thread_state_ex_enum my_statex)
     {
         if (HPX_UNLIKELY(!thrd)) {
             HPX_THROW_EXCEPTION(null_thread_id,
@@ -281,7 +296,8 @@ namespace hpx { namespace threads { namespace detail
         {
             error_code ec(lightweight);    // do not throw
             detail::set_thread_state(timer_id, pending, my_statex,
-                thread_priority_boost, thread_schedule_hint(), ec);
+                thread_priority_boost, thread_schedule_hint(), retry_on_active,
+                ec);
         }
 
         return thread_result_type(terminated, invalid_thread_id);
@@ -294,7 +310,7 @@ namespace hpx { namespace threads { namespace detail
         util::steady_clock::time_point& abs_time,
         thread_id_type const& thrd, thread_state_enum newstate,
         thread_state_ex_enum newstate_ex, thread_priority priority,
-        std::atomic<bool>* started)
+        std::atomic<bool>* started, bool retry_on_active)
     {
         if (HPX_UNLIKELY(!thrd)) {
             HPX_THROW_EXCEPTION(null_thread_id,
@@ -314,7 +330,7 @@ namespace hpx { namespace threads { namespace detail
         thread_init_data data(
             util::bind_front(&wake_timer_thread,
                 thrd, newstate, newstate_ex, priority,
-                self_id, triggered),
+                self_id, triggered, retry_on_active),
             "wake_timer", 0, priority);
 
         thread_id_type wake_id = invalid_thread_id;
@@ -328,20 +344,19 @@ namespace hpx { namespace threads { namespace detail
             get_thread_pool("timer-pool")->get_io_service(), abs_time);
 
         // let the timer invoke the set_state on the new (suspended) thread
-        t.async_wait(
-            [wake_id, priority](const boost::system::error_code& ec)
+        t.async_wait([wake_id, priority, retry_on_active](
+                         const boost::system::error_code& ec) {
+            if (ec.value() == boost::system::errc::operation_canceled)
             {
-                if (ec.value() == boost::system::errc::operation_canceled)
-                {
-                    detail::set_thread_state(wake_id, pending, wait_abort,
-                        priority, thread_schedule_hint(), throws);
-                }
-                else
-                {
-                    detail::set_thread_state(wake_id, pending, wait_timeout,
-                        priority, thread_schedule_hint(), throws);
-                }
-            });
+                detail::set_thread_state(wake_id, pending, wait_abort, priority,
+                    thread_schedule_hint(), retry_on_active, throws);
+            }
+            else
+            {
+                detail::set_thread_state(wake_id, pending, wait_timeout,
+                    priority, thread_schedule_hint(), retry_on_active, throws);
+            }
+        });
 
         if (started != nullptr)
             started->store(true);
@@ -375,7 +390,7 @@ namespace hpx { namespace threads { namespace detail
         util::steady_time_point const& abs_time, thread_id_type const& thrd,
         thread_state_enum newstate, thread_state_ex_enum newstate_ex,
         thread_priority priority, thread_schedule_hint schedulehint,
-        std::atomic<bool>* started, error_code& ec)
+        std::atomic<bool>* started, bool retry_on_active, error_code& ec)
     {
         if (HPX_UNLIKELY(!thrd)) {
             HPX_THROWS_IF(ec, null_thread_id,
@@ -389,7 +404,7 @@ namespace hpx { namespace threads { namespace detail
         thread_init_data data(
             util::bind(&at_timer<SchedulingPolicy>,
                 std::ref(scheduler), abs_time.value(), thrd, newstate, newstate_ex,
-                priority, started),
+                priority, started, retry_on_active),
                 "at_timer (expire at)", 0, priority, schedulehint);
 
         thread_id_type newid = invalid_thread_id;
@@ -400,11 +415,11 @@ namespace hpx { namespace threads { namespace detail
     template <typename SchedulingPolicy>
     thread_id_type set_thread_state_timed(SchedulingPolicy& scheduler,
         util::steady_time_point const& abs_time, thread_id_type const& id,
-        std::atomic<bool>* started, error_code& ec)
+        std::atomic<bool>* started, bool retry_on_active, error_code& ec)
     {
         return set_thread_state_timed(scheduler, abs_time, id, pending,
-            wait_timeout, thread_priority_normal,
-            thread_schedule_hint(), started, ec);
+            wait_timeout, thread_priority_normal, thread_schedule_hint(),
+            started, retry_on_active, ec);
     }
 
     /// Set a timer to set the state of the given \a thread to the given
@@ -414,20 +429,21 @@ namespace hpx { namespace threads { namespace detail
         util::steady_duration const& rel_time, thread_id_type const& thrd,
         thread_state_enum newstate, thread_state_ex_enum newstate_ex,
         thread_priority priority, thread_schedule_hint schedulehint,
-        std::atomic<bool>& started, error_code& ec)
+        std::atomic<bool>& started, bool retry_on_active, error_code& ec)
     {
         return set_thread_state_timed(scheduler, rel_time.from_now(), thrd,
-            newstate, newstate_ex, priority, schedulehint, started, ec);
+            newstate, newstate_ex, priority, schedulehint, started,
+            retry_on_active, ec);
     }
 
     template <typename SchedulingPolicy>
     thread_id_type set_thread_state_timed(SchedulingPolicy& scheduler,
         util::steady_duration const& rel_time, thread_id_type const& thrd,
-        std::atomic<bool>* started, error_code& ec)
+        std::atomic<bool>* started, bool retry_on_active, error_code& ec)
     {
         return set_thread_state_timed(scheduler, rel_time.from_now(), thrd,
             pending, wait_timeout, thread_priority_normal,
-            thread_schedule_hint(), started, ec);
+            thread_schedule_hint(), started, retry_on_active, ec);
     }
 }}}
 

--- a/hpx/runtime/threads/thread_helpers.hpp
+++ b/hpx/runtime/threads/thread_helpers.hpp
@@ -74,6 +74,7 @@ namespace hpx { namespace threads
         thread_state_enum state = pending,
         thread_state_ex_enum stateex = wait_signaled,
         thread_priority priority = thread_priority_normal,
+        bool retry_on_active = true,
         hpx::error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////
@@ -111,6 +112,7 @@ namespace hpx { namespace threads
         thread_state_enum state = pending,
         thread_state_ex_enum stateex = wait_timeout,
         thread_priority priority = thread_priority_normal,
+        bool retry_on_active = true,
         error_code& ec = throws);
 
     inline thread_id_type set_thread_state(thread_id_type const& id,
@@ -118,10 +120,11 @@ namespace hpx { namespace threads
         thread_state_enum state = pending,
         thread_state_ex_enum stateex = wait_timeout,
         thread_priority priority = thread_priority_normal,
+        bool retry_on_active = true,
         error_code& /*ec*/ = throws)
     {
-        return set_thread_state(id, abs_time, nullptr, state, stateex,
-            priority, throws);
+        return set_thread_state(id, abs_time, nullptr, state, stateex, priority,
+            retry_on_active, throws);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -156,10 +159,11 @@ namespace hpx { namespace threads
         thread_state_enum state = pending,
         thread_state_ex_enum stateex = wait_timeout,
         thread_priority priority = thread_priority_normal,
+        bool retry_on_active = true,
         error_code& ec = throws)
     {
         return set_thread_state(id, rel_time.from_now(), state, stateex,
-            priority, ec);
+            priority, retry_on_active, ec);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/lcos/local/detail/condition_variable.cpp
+++ b/src/lcos/local/detail/condition_variable.cpp
@@ -89,8 +89,8 @@ namespace hpx { namespace lcos { namespace local { namespace detail
             bool not_empty = !queue_.empty();
             lock.unlock();
 
-            threads::set_thread_state(id,
-                threads::pending, threads::wait_signaled, priority, ec);
+            threads::set_thread_state(id, threads::pending,
+                threads::wait_signaled, priority, true, ec);
 
             return not_empty;
         }
@@ -138,8 +138,8 @@ namespace hpx { namespace lcos { namespace local { namespace detail
                 error_code local_ec;
                 {
                     util::ignore_while_checking<std::unique_lock<mutex_type> > il(&lock);
-                    threads::set_thread_state(id,
-                        threads::pending, threads::wait_signaled, priority, local_ec);
+                    threads::set_thread_state(id, threads::pending,
+                        threads::wait_signaled, priority, true, local_ec);
                 }
 
                 if (local_ec)
@@ -264,9 +264,9 @@ namespace hpx { namespace lcos { namespace local { namespace detail
 
                 // forcefully abort thread, do not throw
                 error_code ec(lightweight);
-                threads::set_thread_state(id,
-                    threads::pending, threads::wait_abort,
-                    threads::thread_priority_default, ec);
+                threads::set_thread_state(id, threads::pending,
+                    threads::wait_abort, threads::thread_priority_default, true,
+                    ec);
                 if (ec)
                 {
                     LERR_(fatal)

--- a/src/runtime/threads/executors/current_executor.cpp
+++ b/src/runtime/threads/executors/current_executor.cpp
@@ -93,7 +93,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
 
         // now schedule new thread for execution
         threads::detail::set_thread_state_timed(
-            *scheduler_base_, abs_time, id, nullptr, ec);
+            *scheduler_base_, abs_time, id, nullptr, true, ec);
         if (ec) return;
 
         if (&ec != &throws)

--- a/src/runtime/threads/executors/this_thread_executors.cpp
+++ b/src/runtime/threads/executors/this_thread_executors.cpp
@@ -200,9 +200,10 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         ++tasks_scheduled_;
 
         // now schedule new thread for execution
-        threads::detail::set_thread_state_timed(scheduler_, abs_time, id,
-            nullptr, ec);
-        if (ec) {
+        threads::detail::set_thread_state_timed(
+            scheduler_, abs_time, id, nullptr, true, ec);
+        if (ec)
+        {
             --tasks_scheduled_;
             return;
         }

--- a/src/runtime/threads/executors/thread_pool_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_executors.cpp
@@ -207,9 +207,10 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         ++tasks_scheduled_;
 
         // now schedule new thread for execution
-        threads::detail::set_thread_state_timed(scheduler_, abs_time, id,
-            nullptr, ec);
-        if (ec) {
+        threads::detail::set_thread_state_timed(
+            scheduler_, abs_time, id, nullptr, true, ec);
+        if (ec)
+        {
             --tasks_scheduled_;
             return;
         }

--- a/src/util/interval_timer.cpp
+++ b/src/util/interval_timer.cpp
@@ -124,9 +124,10 @@ namespace hpx { namespace util { namespace detail
             is_started_ = false;
 
             if (id_) {
-                error_code ec(lightweight);       // avoid throwing on error
+                error_code ec(lightweight);    // avoid throwing on error
                 threads::set_thread_state(id_, threads::pending,
-                    threads::wait_abort, threads::thread_priority_boost, ec);
+                    threads::wait_abort, threads::thread_priority_boost, true,
+                    ec);
                 id_.reset();
             }
             return true;
@@ -258,10 +259,9 @@ namespace hpx { namespace util { namespace detail
         }
 
         // schedule this thread to be run after the given amount of seconds
-        threads::set_thread_state(id,
-            std::chrono::microseconds(microsecs_),
+        threads::set_thread_state(id, std::chrono::microseconds(microsecs_),
             threads::pending, threads::wait_signaled,
-            threads::thread_priority_boost, ec);
+            threads::thread_priority_boost, true, ec);
 
         if (ec) {
             is_terminated_ = true;
@@ -269,7 +269,7 @@ namespace hpx { namespace util { namespace detail
 
             // abort the newly created thread
             threads::set_thread_state(id, threads::pending, threads::wait_abort,
-                threads::thread_priority_boost, ec);
+                threads::thread_priority_boost, true, ec);
 
             return;
         }


### PR DESCRIPTION
## Proposed Changes

- Add option to not retry setting state when target thread is active
- Don't retry setting state when interrupting a thread
- Remove some barriers from parts of the thread test to avoid rare hang

More details in commit messages.