### PR TITLE
Replacing constexpr if in brace-serialization code

### DIFF
--- a/tests/unit/serialization/CMakeLists.txt
+++ b/tests/unit/serialization/CMakeLists.txt
@@ -25,7 +25,7 @@ set(tests
     zero_copy_serialization
 )
 
-if(HPX_WITH_CXX17_STRUCTURED_BINDINGS AND HPX_WITH_CXX17_IF_CONSTEXPR)
+if(HPX_WITH_CXX17_STRUCTURED_BINDINGS)
     set(tests ${tests}
         serialization_brace_initializable
 )

--- a/tests/unit/serialization/serialization_brace_initializable.cpp
+++ b/tests/unit/serialization/serialization_brace_initializable.cpp
@@ -3,6 +3,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_CXX17_STRUCTURED_BINDINGS)
 #include <hpx/include/serialization.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
@@ -90,3 +93,4 @@ int main()
 
     return hpx::util::report_errors();
 }
+#endif


### PR DESCRIPTION
- this is necessary as some compilers claim to support constexpr if but
  eventually refuse to compile our code
- flyby: guard brace initialization serialization test with the correct pp constant

Fixes https://github.com/STEllAR-GROUP/phylanx/issues/915
