### PR TITLE
Explicitly set number of jobs for all ninja invocations on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ jobs:
       - run:
           name: Building Sphinx Documentation
           command: |
-              ninja docs
+              ninja -j1 docs
           no_output_timeout: 45m
       - persist_to_workspace:
           root: /hpx
@@ -206,7 +206,7 @@ jobs:
       - run:
           name: Pushing Sphinx Documentation
           command: |
-              ninja git_docs
+              ninja -j1 git_docs
 
   core:
     <<: *defaults
@@ -306,7 +306,7 @@ jobs:
           command: |
               # Disable documentation just for this step
               cmake -DHPX_WITH_DOCUMENTATION=OFF .
-              ninja install
+              ninja -j1 install
       - run:
           name: Building Unit Tests
           command: |


### PR DESCRIPTION
`ninja` defaults to parallel builds `-j` isn't specified. This sets it explicitly on all invocations on CircleCI. In particular, it sets it to `1` for the docs build. This is most likely why the docs build has been failing on master.