### PR TITLE
Bump minimum required versions for 1.3.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1039,8 +1039,8 @@ link_directories(${CMAKE_BINARY_DIR}/lib)
 
 # Check if the selected compiler versions are supposed to work with our codebase
 if(CMAKE_COMPILER_IS_GNUCXX AND HPX_WITH_GCC_VERSION_CHECK)
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
-    hpx_error("GCC 4.9 or higher is required. Specify HPX_GCC_VERSION_CHECK=OFF to ignore this error.")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
+    hpx_error("GCC 5.0 or higher is required. Specify HPX_GCC_VERSION_CHECK=OFF to ignore this error.")
   endif()
 endif()
 
@@ -1774,11 +1774,6 @@ if(HPX_WITH_GENERIC_CONTEXT_COROUTINES)
   # Check if we can use generic coroutine contexts without any problems
   if(NOT Boost_CONTEXT_FOUND)
     hpx_error("The usage of Boost.Context was selected but Boost.Context was not found.")
-  endif()
-  if("${HPX_PLATFORM_UC}" STREQUAL "BLUEGENEQ")
-    if(Boost_VERSION LESS 105600)
-      hpx_error("On BlueGene/Q, Boost.Context can only be used with a Boost >=1.56")
-    endif()
   endif()
   hpx_add_config_define(HPX_HAVE_GENERIC_CONTEXT_COROUTINES)
 endif()

--- a/cmake/HPX_SetupBoost.cmake
+++ b/cmake/HPX_SetupBoost.cmake
@@ -12,8 +12,12 @@ endif()
 # Add additional version to recognize
 set(Boost_ADDITIONAL_VERSIONS
     ${Boost_ADDITIONAL_VERSIONS}
+    "1.70.0" "1.70"
+    "1.69.0" "1.69"
+    "1.68.0" "1.68"
+    "1.67.0" "1.67"
     "1.66.0" "1.66"
-    "1.65.0" "1.65"
+    "1.65.0" "1.65" "1.65.1" "1.65.1"
     "1.64.0" "1.64"
     "1.63.0" "1.63"
     "1.62.0" "1.62"
@@ -44,7 +48,7 @@ set(__use_generic_coroutine_context OFF)
 if(APPLE)
   set(__use_generic_coroutine_context ON)
 endif()
-if(HPX_PLATFORM_UC STREQUAL "BLUEGENEQ" AND Boost_VERSION GREATER 105500)
+if(HPX_PLATFORM_UC STREQUAL "BLUEGENEQ")
   set(__use_generic_coroutine_context ON)
 endif()
 hpx_option(
@@ -68,7 +72,7 @@ set(__boost_libraries
   system)
 
 set(Boost_NO_BOOST_CMAKE ON) # disable the search for boost-cmake
-find_package(Boost 1.55 MODULE REQUIRED COMPONENTS ${__boost_libraries})
+find_package(Boost 1.61 MODULE REQUIRED COMPONENTS ${__boost_libraries})
 
 if(NOT Boost_FOUND)
   hpx_error("Could not find Boost. Please set BOOST_ROOT to point to your Boost installation.")
@@ -86,7 +90,7 @@ endif()
 set(Boost_TMP_LIBRARIES ${Boost_TMP_LIBRARIES} ${Boost_LIBRARIES})
 
 if(HPX_WITH_COMPRESSION_BZIP2 OR HPX_WITH_COMPRESSION_ZLIB)
-  find_package(Boost 1.55 QUIET MODULE COMPONENTS iostreams)
+  find_package(Boost 1.61 QUIET MODULE COMPONENTS iostreams)
   if(Boost_IOSTREAMS_FOUND)
     hpx_info("  iostreams")
   else()
@@ -96,7 +100,7 @@ if(HPX_WITH_COMPRESSION_BZIP2 OR HPX_WITH_COMPRESSION_ZLIB)
 endif()
 
 # attempt to load Boost.Regex (if available), it's needed for inspect
-find_package(Boost 1.55 QUIET MODULE COMPONENTS regex)
+find_package(Boost 1.61 QUIET MODULE COMPONENTS regex)
 if(Boost_REGEX_FOUND)
   hpx_info("  regex")
   set(Boost_TMP_LIBRARIES ${Boost_TMP_LIBRARIES} ${Boost_LIBRARIES})

--- a/cmake/HPX_SetupBoostSIMD.cmake
+++ b/cmake/HPX_SetupBoostSIMD.cmake
@@ -9,9 +9,6 @@
 if(NOT BOOST_SIMD_ROOT)
   hpx_error("Using Boost.SIMD requires to set the variable BOOST_SIMD_ROOT to the Boost.SIMD installation directory.")
 endif()
-if(Boost_VERSION LESS 106000)
-  hpx_error("Boost.SIMD requires using Boost V1.60 or above")
-endif()
 
 include_directories(SYSTEM ${BOOST_SIMD_ROOT}/include)
 

--- a/docs/sphinx/manual/building_hpx.rst
+++ b/docs/sphinx/manual/building_hpx.rst
@@ -166,7 +166,7 @@ Software and libraries
 
 In the simplest case, |hpx| depends on |boost|_ and |hwloc|_. So, before you
 read further, please make sure you have a recent version of |boost|_ installed
-on your target machine. |hpx| currently requires at least Boost V1.58.0 to work
+on your target machine. |hpx| currently requires at least Boost V1.61.0 to work
 properly. It may build and run with older versions, but we do not test |hpx|
 with those versions, so please be warned.
 
@@ -228,18 +228,13 @@ favorite compiler with |hpx| visit |hpx_buildbot|_.
      *
      *
    * * |boost_libraries|_
-     * 1.62.0 or newer
-     * 1.58.0
+     * 1.67.0 or newer
+     * 1.61.0
      *
    * * |hwloc|_
      * 1.11
      * 1.2 (Xeon Phi: 1.6)
      *
-
-.. note::
-
-   When compiling |hpx| using clang/libc++ on OSX platform it is advised not
-   to use Boost V1.58 or V1.60.
 
 .. note::
 
@@ -282,8 +277,8 @@ favorite compiler with |hpx| visit |hpx_buildbot|_.
      *
      *
    * * |boost|_
-     * 1.62.0 or newer
-     * 1.58.0
+     * 1.67.0 or newer
+     * 1.61.0
      *
    * * |hwloc|_
      * 1.11
@@ -292,7 +287,7 @@ favorite compiler with |hpx| visit |hpx_buildbot|_.
 
 .. note::
 
-   You need to build the following Boost libraries for |hpx|: 
+   You need to build the following Boost libraries for |hpx|:
    Boost.Filesystem, Boost.ProgramOptions, Boost.Regex, and Boost.System. The
    following are not needed by default, but are required in certain
    configurations: Boost.Chrono, Boost.DateTime, Boost.Log, Boost.LogSetup, and
@@ -859,10 +854,10 @@ required libraries via MacPorts:
 
    .. code-block:: bash
 
-      wget http://sourceforge.net/projects/boost/files/boost/1.54.0/boost_1_54_0.tar.bz2
-      tar xjf boost_1_54_0.tar.bz2
-      pushd boost_1_54_0
-      export BOOST_ROOT=$HOME/boost_1_54_0
+      wget https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.bz2
+      tar xjf boost_1_69_0.tar.bz2
+      pushd boost_1_69_0
+      export BOOST_ROOT=$HOME/boost_1_69_0
       ./bootstrap.sh --prefix=$BOOST_DIR
       ./b2 -j8
       ./b2 -j8 install
@@ -982,9 +977,8 @@ How to build HPX under Windows 10 x64 with Visual Studio 2015
 * Download the |hwloc|_ V1.11.0 (or latest version) from `here
   <http://www.open-mpi.org/software/hwloc/v1.11/downloads/hwloc-win64-build-1.11.0.zip>`__
   and unpack it.
-* Download |boost|_ libraries V1.60 (or latest version) from `here
-  <https://sourceforge.net/projects/boost/files/boost/1.60.0/>`__ and unpack
-  them.
+* Download the latest |boost|_ libraries from `here
+  <https://www.boost.org/users/download/>`__ and unpack them.
 * Build the boost DLLs and LIBs by using these commands from Command Line (or
   PowerShell). Open CMD/PowerShell inside the Boost dir and type in:
 

--- a/docs/sphinx/manual/optimizing_hpx_applications.rst
+++ b/docs/sphinx/manual/optimizing_hpx_applications.rst
@@ -2295,8 +2295,7 @@ system and application performance.
        queried at fixed time intervals as specified by the first parameter.
      * Returns the current standard deviation (stddev) value calculated based on
        the values queried from the underlying counter (the one specified as the
-       instance name). Note that this counter will be available only for Boost
-       V1.56 and newer.
+       instance name).
      * Any parameter will be interpreted as a list of up to two comma separated
        (integer) values, where the first is the time interval (in milliseconds)
        at which the underlying counter should be queried. If no value is

--- a/examples/resource_partitioner/CMakeLists.txt
+++ b/examples/resource_partitioner/CMakeLists.txt
@@ -14,15 +14,11 @@ if(HPX_WITH_MAX_CPU_COUNT AND HPX_WITH_SHARED_PRIORITY_SCHEDULER)
     simple_resource_partitioner
   )
 
-  if(CMAKE_COMPILER_IS_GNUCXX AND HPX_WITH_GCC_VERSION_CHECK)
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
-      if (HPX_WITH_CXX14_RETURN_TYPE_DEDUCTION)
-        set(example_programs ${example_programs}
-          async_customization
-          guided_pool_test
-        )
-      endif()
-    endif()
+  if (HPX_WITH_CXX14_RETURN_TYPE_DEDUCTION)
+    set(example_programs ${example_programs}
+      async_customization
+      guided_pool_test
+    )
   endif()
 endif()
 

--- a/examples/resource_partitioner/async_customization.cpp
+++ b/examples/resource_partitioner/async_customization.cpp
@@ -371,7 +371,7 @@ int test(Executor &exec)
         {
             auto tup = f.get();
             auto cmplx = std::complex<double>(
-                util::get<0>(tup).get(), util::get<1>(tup).get());
+                double(util::get<0>(tup).get()), util::get<1>(tup).get());
             std::cout << "Inside when_all : " << cmplx << std::endl;
             return std::string("when_all");
         }
@@ -389,8 +389,8 @@ int test(Executor &exec)
         [](future<util::tuple<future<std::uint64_t>, shared_future<float>>> && f)
         {
             auto tup = f.get();
-            auto cmplx = std::complex<double>(
-                util::get<0>(tup).get(), util::get<1>(tup).get());
+            auto cmplx = std::complex<double>(double(util::get<0>(tup).get()),
+                double(util::get<1>(tup).get()));
             std::cout << "Inside when_all(shared) : " << cmplx << std::endl;
             return cmplx;
         }
@@ -407,7 +407,8 @@ int test(Executor &exec)
     auto fd = dataflow(exec,
         [](future<std::uint16_t> && f1, future<double> && f2)
         {
-            auto cmplx = std::complex<std::uint64_t>(f1.get(), f2.get());
+            auto cmplx =
+                std::complex<std::uint64_t>(double(f1.get()), f2.get());
             std::cout << "Inside dataflow : " << cmplx << std::endl;
             return cmplx;
         }
@@ -425,7 +426,8 @@ int test(Executor &exec)
     auto fds = dataflow(exec,
         [](future<std::uint16_t> && f1, shared_future<double> && f2)
         {
-            auto cmplx = std::complex<std::uint64_t>(f1.get(), f2.get());
+            auto cmplx =
+                std::complex<std::uint64_t>(double(f1.get()), f2.get());
             std::cout << "Inside dataflow(shared) : " << cmplx << std::endl;
             return cmplx;
         }

--- a/hpx/config.hpp
+++ b/hpx/config.hpp
@@ -33,9 +33,9 @@
 
 #include <boost/version.hpp>
 
-#if BOOST_VERSION < 105800
+#if BOOST_VERSION < 106100
 // Please update your Boost installation (see www.boost.org for details).
-#error HPX cannot be compiled with a Boost version earlier than 1.58.0
+#error HPX cannot be compiled with a Boost version earlier than 1.61.0
 #endif
 
 #include <hpx/util/detail/pp/cat.hpp>

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -27,15 +27,8 @@
 #include <hpx/util/unique_function.hpp>
 #include <hpx/util/unused.hpp>
 
-#include <boost/intrusive_ptr.hpp>
-
-// NOTE: small_vector was introduced in 1.58 but seems to be buggy in that
-// version, so use only from 1.59 onwards.
-#if BOOST_VERSION < 105900
-#include <vector>
-#else
 #include <boost/container/small_vector.hpp>
-#endif
+#include <boost/intrusive_ptr.hpp>
 
 #include <atomic>
 #include <chrono>
@@ -77,13 +70,8 @@ namespace detail
     {
     public:
         typedef util::unique_function_nonser<void()> completed_callback_type;
-#if BOOST_VERSION < 105900
-        typedef std::vector<completed_callback_type>
-            completed_callback_vector_type;
-#else
         typedef boost::container::small_vector<completed_callback_type, 3>
             completed_callback_vector_type;
-#endif
 
         typedef void has_future_data_refcnt_base;
 


### PR DESCRIPTION
Bump minimum Boost version to 1.61 and GCC to 5.
