### PR TITLE
Fixing #3792

### DIFF
--- a/hpx/lcos/barrier.hpp
+++ b/hpx/lcos/barrier.hpp
@@ -18,6 +18,7 @@
 #include <cstddef>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <hpx/config/warnings_prefix.hpp>
 
@@ -69,6 +70,18 @@ namespace hpx { namespace lcos {
         /// A barrier \a base_name is created. It expects that
         /// \a num participate and the local rank is \a rank.
         barrier(std::string const&  base_name, std::size_t num, std::size_t rank);
+
+        /// Creates a barrier with a vector of ranks
+        ///
+        /// \param base_name The name of the barrier
+        /// \param ranks Gives a list of participating ranks (this could be derived
+        ///              from a list of locality ids
+        /// \param rank The rank of the calling site for this invocation
+        ///
+        /// A barrier \a base_name is created. It expects that ranks.size()
+        /// and the local rank is \a rank (must be contained in \a ranks).
+        barrier(std::string const& base_name,
+            std::vector<std::size_t> const& ranks, std::size_t rank);
 
         /// \cond NOINTERNAL
         barrier(barrier&& other);

--- a/src/lcos/barrier.cpp
+++ b/src/lcos/barrier.cpp
@@ -21,6 +21,7 @@
 #include <cstddef>
 #include <string>
 #include <utility>
+#include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx
@@ -56,7 +57,26 @@ namespace hpx { namespace lcos {
     {
         if ((*node_)->num_ >= (*node_)->cut_off_ || (*node_)->rank_ == 0)
             register_with_basename(
-                base_name, node_->get_unmanaged_id(), (*node_)->rank_).get();
+                base_name, node_->get_unmanaged_id(), (*node_)->rank_)
+                .get();
+    }
+
+    barrier::barrier(std::string const& base_name,
+        std::vector<std::size_t> const& ranks, std::size_t rank)
+    {
+        auto rank_it = std::find(ranks.begin(), ranks.end(), rank);
+        HPX_ASSERT(rank_it != ranks.end());
+
+        std::size_t barrier_rank = std::distance(ranks.begin(), rank_it);
+        node_.reset(
+            new (hpx::components::component_heap<wrapping_type>().alloc())
+                wrapping_type(
+                    new wrapped_type(base_name, ranks.size(), barrier_rank)));
+
+        if ((*node_)->num_ >= (*node_)->cut_off_ || (*node_)->rank_ == 0)
+            register_with_basename(
+                base_name, node_->get_unmanaged_id(), (*node_)->rank_)
+                .get();
     }
 
     barrier::barrier()

--- a/tests/regressions/lcos/CMakeLists.txt
+++ b/tests/regressions/lcos/CMakeLists.txt
@@ -11,6 +11,7 @@ set(tests
     async_callback_non_deduced_context
     async_unwrap_1037
     barrier_hang
+    barrier_3792
     broadcast_unwrap_future_2885
     broadcast_wait_for_2822
     call_promise_get_gid_more_than_once
@@ -64,6 +65,7 @@ set(after_588_PARAMETERS LOCALITIES 2)
 set(async_action_1813_PARAMETERS LOCALITIES 2)
 set(async_callback_with_bound_callback_PARAMETERS LOCALITIES 2)
 set(async_callback_non_deduced_context_PARAMETERS THREADS_PER_LOCALITY 4)
+set(barrier_3792_PARAMETERS LOCALITIES 3 THREADS_PER_LOCALITY 1)
 set(broadcast_unwrap_future_2885_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 4)
 set(broadcast_wait_for_2822_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 4)
 set(channel_2916_FLAGS DEPENDENCIES iostreams_component)

--- a/tests/regressions/lcos/barrier_3792.cpp
+++ b/tests/regressions/lcos/barrier_3792.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2019 Weile Wei
+// Copyright (c) 2019 Maxwell Reeser
+// Copyright (c) 2019 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/bind.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+void run_barrier_test1(std::vector<size_t> locs)
+{
+    auto loc_it = std::find(locs.begin(), locs.end(), hpx::get_locality_id());
+    if (loc_it == locs.end())
+        return;
+
+    std::size_t barrier_rank = std::distance(locs.begin(), loc_it);
+
+    std::string barrier_name =
+        "/loc_list/barrier" + std::to_string(locs[0]) + std::to_string(locs[1]);
+    hpx::lcos::barrier b(barrier_name, locs.size(), barrier_rank);
+    b.wait();
+}
+
+void run_barrier_test2(std::vector<size_t> locs)
+{
+    auto loc_it = std::find(locs.begin(), locs.end(), hpx::get_locality_id());
+    if (loc_it == locs.end())
+        return;
+
+    std::string barrier_name =
+        "/loc_list/barrier" + std::to_string(locs[0]) + std::to_string(locs[1]);
+    hpx::lcos::barrier b(barrier_name, locs, hpx::get_locality_id());
+    b.wait();
+}
+
+int hpx_main()
+{
+    std::cout << "Hello world from locality " << hpx::get_locality_id()
+              << std::endl;
+    std::vector<size_t> locs_0{0, 1};
+    run_barrier_test1(locs_0);
+    run_barrier_test2(locs_0);
+    std::vector<size_t> locs_1{0, 2};
+    run_barrier_test1(locs_1);
+    run_barrier_test2(locs_1);
+    std::vector<size_t> locs_2{1, 2};
+    run_barrier_test1(locs_2);
+    run_barrier_test2(locs_2);
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // We force hpx_main to run on all processes
+    std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
+    return hpx::init(argc, argv, cfg);
+}


### PR DESCRIPTION
This fixes the problems reported in #3792. The main issue lies within an
implementation detail of the barrier. The rank of a barrier is
completely decoupled from the locality id. For that reason, the barrier
root is always rank 0. If no barrier with rank 0 is given, we get the
reported hang. The added test shows both a workaround to that issue and
adds an additional barrier constructor that takes a vector of ranks, and
the rank of the given barrier instantiation.
