### PR TITLE
Numa binding allocator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -739,7 +739,9 @@ jobs:
           when: always
           command: |
               ulimit -c unlimited
-              ctest -T test --no-compress-output --output-on-failure -R tests.unit.topology
+              ctest -T test --no-compress-output --output-on-failure \
+                  -R tests.unit.topology \
+                  -E tests.unit.topology.numa_allocator
       - run:
           <<: *convert_xml
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -725,6 +725,32 @@ jobs:
       - store_artifacts:
           path: tests.unit.threads
 
+  tests.unit.topology:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /hpx
+      - run:
+          name: Building Unit Tests
+          command: |
+              ninja -j2 -k 0 tests.unit.topology
+      - run:
+          name: Running Unit Tests
+          when: always
+          command: |
+              ulimit -c unlimited
+              ctest -T test --no-compress-output --output-on-failure -R tests.unit.topology
+      - run:
+          <<: *convert_xml
+      - run:
+          <<: *move_core_dump
+      - run:
+          <<: *move_debug_log
+      - store_test_results:
+          path: tests.unit.topology
+      - store_artifacts:
+          path: tests.unit.topology
+
   tests.unit.traits:
     <<: *defaults
     steps:
@@ -1205,6 +1231,8 @@ workflows:
           <<: *core_dependency
       - tests.unit.threads:
           <<: *core_dependency
+      - tests.unit.topology:
+          <<: *core_dependency
       - tests.unit.traits:
           <<: *core_dependency
       - tests.unit.util:
@@ -1273,6 +1301,7 @@ workflows:
             - tests.unit.resource
             - tests.unit.serialization
             - tests.unit.threads
+            - tests.unit.topology
             - tests.unit.traits
             - tests.unit.util
             - tests.unit.libs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -482,7 +482,7 @@ if(HPX_WITH_MAX_CPU_COUNT)
   hpx_add_config_define(HPX_HAVE_MAX_CPU_COUNT ${HPX_WITH_MAX_CPU_COUNT})
 endif()
 
-set(HPX_MAX_NUMA_DOMAIN_COUNT_DEFAULT "4")
+set(HPX_MAX_NUMA_DOMAIN_COUNT_DEFAULT "8")
 hpx_option(HPX_WITH_MAX_NUMA_DOMAIN_COUNT STRING
   "HPX applications will not run on machines with more NUMA domains (default: ${HPX_MAX_NUMA_DOMAIN_COUNT_DEFAULT})"
   ${HPX_MAX_NUMA_DOMAIN_COUNT_DEFAULT}

--- a/examples/transpose/transpose_block_numa.cpp
+++ b/examples/transpose/transpose_block_numa.cpp
@@ -575,7 +575,7 @@ int main(int argc, char* argv[])
     std::size_t numa_nodes = get_num_numa_nodes(topo, vm);
     std::pair<std::size_t, std::size_t> pus =
         get_num_numa_pus(topo, numa_nodes, vm);
-    std::size_t num_cores = topo.get_number_of_numa_node_cores(0);
+    //std::size_t num_cores = topo.get_number_of_numa_node_cores(0);
 
     // Initialize and run HPX, this example requires to run hpx_main on all
     // localities

--- a/examples/transpose/transpose_block_numa.cpp
+++ b/examples/transpose/transpose_block_numa.cpp
@@ -583,8 +583,8 @@ int main(int argc, char* argv[])
         "hpx.run_hpx_main!=1",
         "hpx.numa_sensitive=2",  // no-cross NUMA stealing
         // block all cores of requested number of NUMA-domains
-        hpx::util::format("hpx.cores={}", numa_nodes * num_cores),
-        hpx::util::format("hpx.os_threads={}", numa_nodes * pus.second)
+//        hpx::util::format("hpx.cores={}", numa_nodes * num_cores),
+//        hpx::util::format("hpx.os_threads={}", numa_nodes * pus.second)
     };
 
     std::string node_name("numanode");
@@ -605,8 +605,9 @@ int main(int argc, char* argv[])
             pus.second-1                             // core:0-%d
         );
     }
-    cfg.push_back(bind_desc);
+//    cfg.push_back(bind_desc);
 
+//    return hpx::init();
     return hpx::init(desc_commandline, argc, argv, cfg);
 }
 

--- a/hpx/parallel/util/numa_binding_allocator.hpp
+++ b/hpx/parallel/util/numa_binding_allocator.hpp
@@ -164,7 +164,7 @@ namespace hpx { namespace compute { namespace host {
         using numa_binding_helper_ptr = std::shared_ptr<numa_binding_helper<T>>;
 
         // default constructor produces an unusable allocator
-        numa_binding_allocator() {}
+        numa_binding_allocator() = default;
 
         // construct without a memory binder function
         // only first touch or interleave policies are valid
@@ -209,7 +209,7 @@ namespace hpx { namespace compute { namespace host {
             LOG_NUMA_MSG("numa_binding_allocator : Copy allocator rebind");
         }
 
-        // Move assignment
+        // Move constructor
         numa_binding_allocator(numa_binding_allocator&& rhs)
           : binding_helper_(std::move(rhs.binding_helper_))
           , policy_(rhs.policy_)

--- a/hpx/parallel/util/numa_binding_allocator.hpp
+++ b/hpx/parallel/util/numa_binding_allocator.hpp
@@ -9,9 +9,9 @@
 #include <hpx/config.hpp>
 
 #include <hpx/parallel/execution_policy.hpp>
-#include <hpx/runtime/threads/topology.hpp>
-#include <hpx/runtime/threads/executors/pool_executor.hpp>
 #include <hpx/runtime/threads/executors/guided_pool_executor.hpp>
+#include <hpx/runtime/threads/executors/pool_executor.hpp>
+#include <hpx/runtime/threads/topology.hpp>
 #include <hpx/util/assert.hpp>
 
 #include <sstream>
@@ -19,15 +19,15 @@
 #include <vector>
 
 #include <cstddef>
-#include <type_traits>
-#include <utility>
 #include <iostream>
 #include <memory>
+#include <type_traits>
+#include <utility>
 
 #if defined(__linux) || defined(linux) || defined(__linux__)
-# include <linux/unistd.h>
-# include <sys/mman.h>
-# define NUMA_ALLOCATOR_LINUX
+#include <linux/unistd.h>
+#include <sys/mman.h>
+#define NUMA_ALLOCATOR_LINUX
 #endif
 
 // Can be used to enable debugging of the allocator page mapping
@@ -35,32 +35,34 @@
 // #define NUMA_BINDING_ALLOCATOR_DEBUG_PAGE_BINDING
 
 #if defined(NUMA_BINDING_ALLOCATOR_DEBUG_PAGE_BINDING) && !defined(HPX_MSVC)
-# include <plugins/parcelport/parcelport_logging.hpp>
-# define LOG_NUMA_MSG(x)                                   \
-    std::cout << "<NUMA> " << THREAD_ID << ' ' << x << "\n"
+#include <plugins/parcelport/parcelport_logging.hpp>
+#define LOG_NUMA_MSG(x) std::cout << "<NUMA> " << THREAD_ID << ' ' << x << "\n"
 #else
-# define LOG_NUMA_MSG(x)
+#define LOG_NUMA_MSG(x)
 #endif
 
-namespace hpx { namespace threads { namespace executors
-{
-    struct numa_binding_allocator_tag {};
+namespace hpx { namespace threads { namespace executors {
+    struct numa_binding_allocator_tag
+    {
+    };
 
     template <>
-    struct HPX_EXPORT pool_numa_hint<numa_binding_allocator_tag> {
-      // The call operator () must return an int type
-      // The arguments must be const ref versions of the equivalent task arguments
-      int operator()(const std::size_t& domain) const {
-          LOG_NUMA_MSG("allocator pool_numa_hint returns domain " << domain);
-          return domain;
-      }
+    struct HPX_EXPORT pool_numa_hint<numa_binding_allocator_tag>
+    {
+        // The call operator () must return an int type
+        // The arguments must be const ref versions of the equivalent task arguments
+        int operator()(const std::size_t& domain) const
+        {
+            LOG_NUMA_MSG("allocator pool_numa_hint returns domain " << domain);
+            return domain;
+        }
     };
 }}}
 
-namespace hpx { namespace compute { namespace host
-{
+namespace hpx { namespace compute { namespace host {
     template <typename T>
-    struct numa_binding_helper {
+    struct numa_binding_helper
+    {
         // After memory has been allocated, this operator will be called
         // for every page of memory in the allocation by one thread in each
         // numa domain (implying that this function will be called for each page
@@ -68,9 +70,8 @@ namespace hpx { namespace compute { namespace host
         // The return from this function should be the domain number that
         // should touch this page. The thread with the matching domain will
         // perform a memory read/write on the page.
-        virtual std::size_t operator ()(
-            const T * const   /*base_ptr*/,
-            const T * const   /*page_ptr*/,
+        virtual std::size_t operator()(const T* const /*base_ptr*/,
+            const T* const /*page_ptr*/,
             const std::size_t /*page_size*/,
             const std::size_t /*domains*/) const
         {
@@ -82,36 +83,55 @@ namespace hpx { namespace compute { namespace host
         // The allocator uses the pool name to get numa bitmap masks needed by
         // the allocation function. The "default" pool is assumed
         // @TODO use an executor to retrieve the pool name
-        virtual const std::string &pool_name() const { return pool_name_; }
+        virtual const std::string& pool_name() const
+        {
+            return pool_name_;
+        }
 
         // Return the total memory consumption in bytes
-        virtual std::size_t memory_bytes() const { return 0; }
+        virtual std::size_t memory_bytes() const
+        {
+            return 0;
+        }
 
-//#ifdef NUMA_BINDING_ALLOCATOR_DEBUG_PAGE_BINDING
+        //#ifdef NUMA_BINDING_ALLOCATOR_DEBUG_PAGE_BINDING
         // Using how many dimensions should this data be displayed
         // This function is only required for debug purposes
-        virtual std::size_t array_rank() const { return 1; }
+        virtual std::size_t array_rank() const
+        {
+            return 1;
+        }
 
         // The number of elements along dimension x=0,y=1,z=2,...
         // This function is only required for debug purposes
-        virtual std::size_t array_size(std::size_t axis) const {
-            return memory_bytes()/sizeof(T);
+        virtual std::size_t array_size(std::size_t axis) const
+        {
+            return memory_bytes() / sizeof(T);
         };
 
         // When counting along elements in a given dimension,
         // how large a step should be taken in units of elements.
         // This should include padding along an axis
         // This function is only required for debug purposes
-        virtual std::size_t memory_step(std::size_t axis) const { return 1; };
+        virtual std::size_t memory_step(std::size_t axis) const
+        {
+            return 1;
+        };
 
         // When displaying the data, what step size should be used
         // This function is only required for debug purposes
-        virtual std::size_t display_step(std::size_t axis) const { return 1; };
+        virtual std::size_t display_step(std::size_t axis) const
+        {
+            return 1;
+        };
 
         // This is for debug/information purposes only and anything may
         // be returned that helps illuminate the mapping of pages->indices
-        virtual std::string description() const { return ""; };
-//#endif
+        virtual std::string description() const
+        {
+            return "";
+        };
+        //#endif
 
         std::string pool_name_ = "default";
     };
@@ -124,15 +144,15 @@ namespace hpx { namespace compute { namespace host
     /// This allocator can be used to request data that is bound
     /// to one or more numa domains via the bitmap mask supplied
 
-    template <typename T >
+    template <typename T>
     struct numa_binding_allocator
     {
-        typedef T              value_type;
-        typedef T*             pointer;
-        typedef const T*       const_pointer;
-        typedef T&             reference;
-        typedef T const&       const_reference;
-        typedef std::size_t    size_type;
+        typedef T value_type;
+        typedef T* pointer;
+        typedef const T* const_pointer;
+        typedef T& reference;
+        typedef T const& const_reference;
+        typedef std::size_t size_type;
         typedef std::ptrdiff_t difference_type;
         //
         template <typename U>
@@ -149,31 +169,32 @@ namespace hpx { namespace compute { namespace host
         // construct without a memory binder function
         // only first touch or interleave policies are valid
         numa_binding_allocator(threads::hpx_hwloc_membind_policy policy,
-                       unsigned int flags)
-            : policy_(policy)
-            , flags_(flags)
+            unsigned int flags)
+          : policy_(policy)
+          , flags_(flags)
         {
             LOG_NUMA_MSG("numa_binding_allocator : no binder function");
-            HPX_ASSERT(policy_ != threads::hpx_hwloc_membind_policy::membind_user);
+            HPX_ASSERT(
+                policy_ != threads::hpx_hwloc_membind_policy::membind_user);
         }
 
         // construct using a memory binder function for placing pages
         // according to a user defined pattern using first touch policy
         numa_binding_allocator(numa_binding_helper_ptr bind_func,
-                       threads::hpx_hwloc_membind_policy policy,
-                       unsigned int flags)
-            : binding_helper_(bind_func)
-            , policy_(policy)
-            , flags_(flags)
+            threads::hpx_hwloc_membind_policy policy,
+            unsigned int flags)
+          : binding_helper_(bind_func)
+          , policy_(policy)
+          , flags_(flags)
         {
             LOG_NUMA_MSG("numa_binding_allocator : allocator");
         }
 
         // copy constructor
         numa_binding_allocator(numa_binding_allocator const& rhs)
-            : binding_helper_(rhs.binding_helper_)
-            , policy_(rhs.policy_)
-            , flags_(rhs.flags_)
+          : binding_helper_(rhs.binding_helper_)
+          , policy_(rhs.policy_)
+          , flags_(rhs.flags_)
         {
             LOG_NUMA_MSG("numa_binding_allocator : Copy allocator");
         }
@@ -181,9 +202,9 @@ namespace hpx { namespace compute { namespace host
         // copy constructor using rebind type
         template <typename U>
         numa_binding_allocator(numa_binding_allocator<U> const& rhs)
-            : binding_helper_(rhs.binding_helper_)
-            , policy_(rhs.policy_)
-            , flags_(rhs.flags_)
+          : binding_helper_(rhs.binding_helper_)
+          , policy_(rhs.policy_)
+          , flags_(rhs.flags_)
         {
             LOG_NUMA_MSG("numa_binding_allocator : Copy allocator rebind");
         }
@@ -192,19 +213,19 @@ namespace hpx { namespace compute { namespace host
         numa_binding_allocator& operator=(numa_binding_allocator const& rhs)
         {
             binding_helper_ = rhs.binding_helper_;
-            policy_         = rhs.policy_;
-            flags_          = rhs.flags_;
+            policy_ = rhs.policy_;
+            flags_ = rhs.flags_;
 
             LOG_NUMA_MSG("numa_binding_allocator : Assignment operator");
             return *this;
         }
 
         // Move assignment
-        numa_binding_allocator& operator=(numa_binding_allocator && rhs)
+        numa_binding_allocator& operator=(numa_binding_allocator&& rhs)
         {
             binding_helper_ = rhs.binding_helper_;
-            policy_         = rhs.policy_;
-            flags_          = rhs.flags_;
+            policy_ = rhs.policy_;
+            flags_ = rhs.flags_;
 
             LOG_NUMA_MSG("numa_binding_allocator : Move assignment");
             return *this;
@@ -230,47 +251,50 @@ namespace hpx { namespace compute { namespace host
         {
             pointer result = nullptr;
 
-            if (policy_==threads::hpx_hwloc_membind_policy::membind_firsttouch)
+            if (policy_ ==
+                threads::hpx_hwloc_membind_policy::membind_firsttouch)
             {
                 threads::hwloc_bitmap_ptr bitmap =
                     threads::get_thread_manager().get_pool_numa_bitmap(
-                            binding_helper_->pool_name());
+                        binding_helper_->pool_name());
                 //
                 result = reinterpret_cast<pointer>(
                     threads::topology().allocate_membind(
                         n * sizeof(T), bitmap, policy_, 0));
             }
-            else if (policy_==threads::hpx_hwloc_membind_policy::membind_interleave)
+            else if (policy_ ==
+                threads::hpx_hwloc_membind_policy::membind_interleave)
             {
                 threads::hwloc_bitmap_ptr bitmap =
                     threads::get_thread_manager().get_pool_numa_bitmap(
-                            binding_helper_->pool_name());
+                        binding_helper_->pool_name());
                 //
                 result = reinterpret_cast<pointer>(
                     threads::topology().allocate_membind(
                         n * sizeof(T), bitmap, policy_, 0));
             }
-            else if (policy_==threads::hpx_hwloc_membind_policy::membind_user)
+            else if (policy_ == threads::hpx_hwloc_membind_policy::membind_user)
             {
                 result = reinterpret_cast<pointer>(
                     threads::topology().allocate(n * sizeof(T)));
                 threads::hwloc_bitmap_ptr bitmap =
                     threads::get_thread_manager().get_pool_numa_bitmap(
-                            binding_helper_->pool_name());
+                        binding_helper_->pool_name());
                 //
                 result = reinterpret_cast<pointer>(
-                    threads::topology().allocate_membind(
-                        n * sizeof(T), bitmap,
-                        threads::hpx_hwloc_membind_policy::membind_firsttouch, 0));
+                    threads::topology().allocate_membind(n * sizeof(T), bitmap,
+                        threads::hpx_hwloc_membind_policy::membind_firsttouch,
+                        0));
 #if defined(NUMA_ALLOCATOR_LINUX)
                 // if Transparent Huge Pages (THP) are enabled, this prevents
                 // pages from being merged into a single numa bound block
                 int ret = madvise(result, n * sizeof(T), MADV_NOHUGEPAGE);
                 // a return of -1 probably means there are no transparent huge pages
                 // so they can't be disabled, we can ignore it
-                if ((ret != 0) && (ret !=-1))
+                if ((ret != 0) && (ret != -1))
                 {
-                    std::cout << "ERROR: MADVISE " << strerror(ret) << std::endl;
+                    std::cout << "ERROR: MADVISE " << strerror(ret)
+                              << std::endl;
                 }
 #endif
                 initialize_pages(result, n);
@@ -285,7 +309,7 @@ namespace hpx { namespace compute { namespace host
         void deallocate(pointer p, size_type n)
         {
             LOG_NUMA_MSG("Calling deallocate membind for size (bytes) "
-                      << std::hex << (n * sizeof(T)));
+                << std::hex << (n * sizeof(T)));
 #ifdef NUMA_BINDING_ALLOCATOR_DEBUG_PAGE_BINDING
             display_binding(p, binding_helper_);
 #endif
@@ -302,8 +326,8 @@ namespace hpx { namespace compute { namespace host
 
         // Constructs an object of type T in allocated uninitialized storage
         // pointed to by p, using placement-new
-        template <class U, class ...A>
-        void construct(U* const p, A&& ...args)
+        template <class U, class... A>
+        void construct(U* const p, A&&... args)
         {
             new (p) U(std::forward<A>(args)...);
         }
@@ -316,15 +340,18 @@ namespace hpx { namespace compute { namespace host
 
         // a utility function that is slightly faster than the hwloc provided one
         // @TODO, move this into hpx::topology for cleanliness
-        int get_numa_domain(void *page)
+        int get_numa_domain(void* page)
         {
-            HPX_ASSERT( (std::size_t(page) & 4095) == 0 );
+            HPX_ASSERT((std::size_t(page) & 4095) == 0);
 #if defined(NUMA_ALLOCATOR_LINUX)
             // This is an optimized version of the hwloc equivalent
-            void *pages[1] = { page };
-            int  status[1] = { -1 };
-            if (syscall(__NR_move_pages, 0, 1, pages, nullptr, status, 0) == 0) {
-                if (status[0]>=0 && status[0]<=HPX_HAVE_MAX_NUMA_DOMAIN_COUNT) {
+            void* pages[1] = {page};
+            int status[1] = {-1};
+            if (syscall(__NR_move_pages, 0, 1, pages, nullptr, status, 0) == 0)
+            {
+                if (status[0] >= 0 &&
+                    status[0] <= HPX_HAVE_MAX_NUMA_DOMAIN_COUNT)
+                {
                     return status[0];
                 }
                 // if (status[0]<0) std::cout << "." << decnumber(status[0]) << ".";
@@ -338,22 +365,23 @@ namespace hpx { namespace compute { namespace host
 #endif
         }
 
-        std::string get_page_numa_domains(void *addr, std::size_t len) const
+        std::string get_page_numa_domains(void* addr, std::size_t len) const
         {
 #if defined(NUMA_ALLOCATOR_LINUX)
             // @TODO replace with topology::page_size
             int pagesize = 4096;
-            HPX_ASSERT( (std::size_t(addr) & (pagesize-1)) == 0 );
+            HPX_ASSERT((std::size_t(addr) & (pagesize - 1)) == 0);
 
-            std::size_t count = (len + pagesize-1)/pagesize;
+            std::size_t count = (len + pagesize - 1) / pagesize;
             std::vector<void*> pages(count, nullptr);
-            std::vector<int>  status(count, 0);
+            std::vector<int> status(count, 0);
 
-            for (std::size_t i=0; i<count; i++)
-                pages[i] = ((char*)addr) + i*pagesize;
+            for (std::size_t i = 0; i < count; i++)
+                pages[i] = ((char*) addr) + i * pagesize;
 
-            if (syscall(__NR_move_pages, 0,
-                        count, pages.data(), nullptr, status.data(), 0) < 0) {
+            if (syscall(__NR_move_pages, 0, count, pages.data(), nullptr,
+                    status.data(), 0) < 0)
+            {
                 HPX_THROW_EXCEPTION(kernel_error,
                     "get_page_numa_domains",
                     "Error getting numa domains with syscall");
@@ -361,9 +389,12 @@ namespace hpx { namespace compute { namespace host
 
             std::stringstream temp;
             temp << "Numa page binding for page count " << count << "\n";
-            for (std::size_t i=0; i<count; i++) {
-                if (status[i] >= 0) temp << status[i];
-                else temp << "-";
+            for (std::size_t i = 0; i < count; i++)
+            {
+                if (status[i] >= 0)
+                    temp << status[i];
+                else
+                    temp << "-";
             }
             return temp.str();
 #endif
@@ -376,11 +407,13 @@ namespace hpx { namespace compute { namespace host
             //
             threads::hwloc_bitmap_ptr bitmap =
                 threads::get_thread_manager().get_pool_numa_bitmap(
-                        binding_helper_->pool_name());
-            std::vector<threads::hwloc_bitmap_ptr> nodesets = create_nodesets(bitmap);
+                    binding_helper_->pool_name());
+            std::vector<threads::hwloc_bitmap_ptr> nodesets =
+                create_nodesets(bitmap);
             //
             using namespace threads::executors;
-            using allocator_hint_type = pool_numa_hint<numa_binding_allocator_tag>;
+            using allocator_hint_type =
+                pool_numa_hint<numa_binding_allocator_tag>;
             //
             // Warning :low priority tasks are used here, because the scheduler does
             // not steal across numa domains for those tasks, so they are sure
@@ -392,23 +425,21 @@ namespace hpx { namespace compute { namespace host
             // for each numa domain, we must launch a task to 'touch' the memory
             // that should be bound to the domain
             std::vector<hpx::future<void>> tasks;
-            for (size_type i=0; i<nodesets.size(); ++i) {
+            for (size_type i = 0; i < nodesets.size(); ++i)
+            {
 #ifdef NUMA_BINDING_ALLOCATOR_DEBUG_PAGE_BINDING
                 size_type i1 = hwloc_bitmap_first(nodesets[i]->get_bmp());
                 size_type i2 = hwloc_bitmap_last(nodesets[i]->get_bmp());
-                HPX_ASSERT(i1==i2);
+                HPX_ASSERT(i1 == i2);
 #endif
                 size_type domain = hwloc_bitmap_first(nodesets[i]->get_bmp());
-                LOG_NUMA_MSG("Launching First-Touch task for domain " << domain
-                          << " " << nodesets[i]);
+                LOG_NUMA_MSG("Launching First-Touch task for domain "
+                    << domain << " " << nodesets[i]);
                 // if (domain==7 || domain==3)
-                tasks.push_back(
-                    hpx::async(numa_executor,
-                        util::bind(&numa_binding_allocator::touch_pages,
-                            this, p, n, binding_helper_,
-                            util::placeholders::_1, nodesets), domain
-                    )
-                );
+                tasks.push_back(hpx::async(numa_executor,
+                    util::bind(&numa_binding_allocator::touch_pages, this, p, n,
+                        binding_helper_, util::placeholders::_1, nodesets),
+                    domain));
             }
             wait_all(tasks);
             LOG_NUMA_MSG("Done First-Touch tasks");
@@ -424,36 +455,49 @@ namespace hpx { namespace compute { namespace host
             display << helper->description() << "\n";
             std::size_t pagesize = threads::get_memory_page_size();
             pointer p2 = p;
-            if (N==2) {
+            if (N == 2)
+            {
                 std::size_t Nc = helper->array_size(0);
                 std::size_t Nr = helper->array_size(1);
-                std::size_t xinc = (std::min)(helper->display_step(0), pagesize);
-                std::size_t yinc = (std::min)(helper->display_step(1), pagesize);
+                std::size_t xinc =
+                    (std::min)(helper->display_step(0), pagesize);
+                std::size_t yinc =
+                    (std::min)(helper->display_step(1), pagesize);
                 std::size_t xoff = helper->memory_step(0);
                 std::size_t yoff = helper->memory_step(1);
                 std::size_t m = helper->memory_bytes();
 #ifdef numa_binding_allocator_PRETTY_DISPLAY
                 display << ' ';
-                for (std::size_t c=0; c<Nc; c += xinc) {
-                    if (c%(xinc*8)==0) display << '|';
-                    else display << '.';
+                for (std::size_t c = 0; c < Nc; c += xinc)
+                {
+                    if (c % (xinc * 8) == 0)
+                        display << '|';
+                    else
+                        display << '.';
                 }
 #endif
                 display << '\n';
-                for (std::size_t r=0; r<Nr; r += yinc) {
+                for (std::size_t r = 0; r < Nr; r += yinc)
+                {
 #ifdef numa_binding_allocator_PRETTY_DISPLAY
-                    if (r%(xinc*8)==0) display << '-';
-                    else display << '.';
+                    if (r % (xinc * 8) == 0)
+                        display << '-';
+                    else
+                        display << '.';
 #endif
                     //
-                    for (std::size_t c=0; c<Nc; c += xinc) {
-                        p2 = p + (c*xoff) + (r*yoff);
-                        if (p2 >= (p + m)) {
+                    for (std::size_t c = 0; c < Nc; c += xinc)
+                    {
+                        p2 = p + (c * xoff) + (r * yoff);
+                        if (p2 >= (p + m))
+                        {
                             display << '*';
                         }
-                        else {
+                        else
+                        {
                             size_type dom = get_numa_domain(p2);
-                            if (dom == size_type(-1)) {
+                            if (dom == size_type(-1))
+                            {
                                 display << '-';
                             }
                             else
@@ -463,98 +507,110 @@ namespace hpx { namespace compute { namespace host
                     display << "\n";
                 }
             }
-            else {
-                display << "Not yet implemented output for non 2D arrays" << "\n";
+            else
+            {
+                display << "Not yet implemented output for non 2D arrays"
+                        << "\n";
             }
             return display.str();
         }
 #endif
 
     protected:
-
-        std::vector<threads::hwloc_bitmap_ptr>
-        create_nodesets(threads::hwloc_bitmap_ptr bitmap) const
+        std::vector<threads::hwloc_bitmap_ptr> create_nodesets(
+            threads::hwloc_bitmap_ptr bitmap) const
         {
             // for each numa domain, we need a nodeset object
             threads::mask_type numa_mask =
-                dynamic_cast<const threads::topology*>
-                    (&threads::get_topology())->
-                        bitmap_to_mask(bitmap->get_bmp(), HWLOC_OBJ_NUMANODE);
+                dynamic_cast<const threads::topology*>(&threads::get_topology())
+                    ->bitmap_to_mask(bitmap->get_bmp(), HWLOC_OBJ_NUMANODE);
 
             LOG_NUMA_MSG("Pool numa mask is " << numa_mask);
 
             std::vector<threads::hwloc_bitmap_ptr> nodesets;
-            for (size_type i=0; i<threads::mask_size(numa_mask); ++i) {
-                if (threads::test(numa_mask, i)) {
+            for (size_type i = 0; i < threads::mask_size(numa_mask); ++i)
+            {
+                if (threads::test(numa_mask, i))
+                {
                     hwloc_bitmap_t bitmap = hwloc_bitmap_alloc();
                     hwloc_bitmap_zero(bitmap);
                     hwloc_bitmap_set(bitmap, i);
                     nodesets.push_back(
-                        std::make_shared<threads::hpx_hwloc_bitmap_wrapper>(bitmap));
-                    LOG_NUMA_MSG("Node mask " << i << " is " << nodesets.back());
+                        std::make_shared<threads::hpx_hwloc_bitmap_wrapper>(
+                            bitmap));
+                    LOG_NUMA_MSG(
+                        "Node mask " << i << " is " << nodesets.back());
                 }
             }
             return nodesets;
         }
 
-        void touch_pages(pointer p, size_t n,
-                         numa_binding_helper_ptr helper, size_type numa_domain,
-                         const std::vector<threads::hwloc_bitmap_ptr> &nodesets) const
+        void touch_pages(pointer p, size_t n, numa_binding_helper_ptr helper,
+            size_type numa_domain,
+            const std::vector<threads::hwloc_bitmap_ptr>& nodesets) const
         {
-            const size_type pagesize  = threads::get_memory_page_size();
-            const size_type pageN     = pagesize/sizeof(T);
-            const size_type num_pages = (n*sizeof(T) + pagesize - 1) / pagesize;
+            const size_type pagesize = threads::get_memory_page_size();
+            const size_type pageN = pagesize / sizeof(T);
+            const size_type num_pages =
+                (n * sizeof(T) + pagesize - 1) / pagesize;
             pointer page_ptr = p;
             std::intptr_t memory = reinterpret_cast<std::intptr_t>(p);
             HPX_ASSERT(memory % pagesize == 0);
 
             LOG_NUMA_MSG("touch pages for numa " << numa_domain);
-            for (size_type i=0; i<num_pages; ++i) {
+            for (size_type i = 0; i < num_pages; ++i)
+            {
                 // we pass the base pointer and current page pointer
                 size_type dom =
                     helper->operator()(p, page_ptr, pagesize, nodesets.size());
-                if (dom==numa_domain) {
-                    HPX_ASSERT( (std::size_t(page_ptr) & 4095) ==0 );
+                if (dom == numa_domain)
+                {
+                    HPX_ASSERT((std::size_t(page_ptr) & 4095) == 0);
                     // trigger a memory read and rewrite without changing contents
                     volatile T* vaddr = const_cast<volatile T*>(page_ptr);
                     *vaddr = *vaddr;
 #ifdef NUMA_BINDING_ALLOCATOR_INIT_MEMORY
 #if defined(NUMA_ALLOCATOR_LINUX)
-                    int Vmem = sched_getcpu(); // show which cpu is actually being used
+                    int Vmem =
+                        sched_getcpu();    // show which cpu is actually being used
 #else
-                    int Vmem = numa_domain;    // show just the domain we think we're on
+                    int Vmem =
+                        numa_domain;    // show just the domain we think we're on
 #endif
-                     pointer elem_ptr = page_ptr;
-                     for (size_type j=0; j<pageN; ++j) {
-                         *elem_ptr++ = T(Vmem);
-                     }
- #endif
+                    pointer elem_ptr = page_ptr;
+                    for (size_type j = 0; j < pageN; ++j)
+                    {
+                        *elem_ptr++ = T(Vmem);
+                    }
+#endif
                 }
                 page_ptr += pageN;
             }
         }
 
         // This is obsolete but kept for possible future use
-        void bind_pages(pointer p, size_t n,
-                        numa_binding_helper_ptr helper, size_type numa_domain,
-                        const std::vector<threads::hwloc_bitmap_ptr> &nodesets) const
+        void bind_pages(pointer p, size_t n, numa_binding_helper_ptr helper,
+            size_type numa_domain,
+            const std::vector<threads::hwloc_bitmap_ptr>& nodesets) const
         {
-            const size_type pagesize  = threads::get_memory_page_size();
-            const size_type pageN     = pagesize/sizeof(T);
-            const size_type num_pages = (n*sizeof(T) + pagesize - 1) / pagesize;
+            const size_type pagesize = threads::get_memory_page_size();
+            const size_type pageN = pagesize / sizeof(T);
+            const size_type num_pages =
+                (n * sizeof(T) + pagesize - 1) / pagesize;
             pointer page_ptr = p;
             std::intptr_t memory = reinterpret_cast<std::intptr_t>(p);
             HPX_ASSERT(memory % pagesize == 0);
 
             LOG_NUMA_MSG("bind pages for numa " << numa_domain);
-            for (size_type i=0; i<num_pages; ++i) {
+            for (size_type i = 0; i < num_pages; ++i)
+            {
                 // we pass the base pointer and current page pointer
                 size_type dom =
                     helper->operator()(p, page_ptr, pagesize, nodesets.size());
-                if (dom==numa_domain) {
-                    threads::topology().
-                        set_area_membind_nodeset(page_ptr, pagesize,
-                                                 nodesets[dom]->get_bmp());
+                if (dom == numa_domain)
+                {
+                    threads::topology().set_area_membind_nodeset(
+                        page_ptr, pagesize, nodesets[dom]->get_bmp());
                 }
                 page_ptr += pageN;
             }
@@ -562,12 +618,12 @@ namespace hpx { namespace compute { namespace host
 
     private:
         hpx::lcos::local::spinlock display_mutex;
-        mutable std::mutex         init_mutex;
+        mutable std::mutex init_mutex;
 
     public:
         std::shared_ptr<numa_binding_helper<T>> binding_helper_;
-        threads::hpx_hwloc_membind_policy       policy_;
-        unsigned int                            flags_;
+        threads::hpx_hwloc_membind_policy policy_;
+        unsigned int flags_;
     };
 }}}
 

--- a/hpx/parallel/util/numa_binding_allocator.hpp
+++ b/hpx/parallel/util/numa_binding_allocator.hpp
@@ -11,6 +11,7 @@
 #include <hpx/parallel/execution_policy.hpp>
 #include <hpx/runtime/threads/executors/guided_pool_executor.hpp>
 #include <hpx/runtime/threads/executors/pool_executor.hpp>
+#include <hpx/runtime/threads/threadmanager.hpp>
 #include <hpx/runtime/threads/topology.hpp>
 #include <hpx/util/assert.hpp>
 

--- a/hpx/parallel/util/numa_binding_allocator.hpp
+++ b/hpx/parallel/util/numa_binding_allocator.hpp
@@ -302,7 +302,7 @@ namespace hpx { namespace compute { namespace host {
                 // so they can't be disabled, we can ignore it
                 if ((ret != 0) && (ret != -1))
                 {
-                    std::cout << "ERROR: MADVISE " << strerror(ret)
+                    std::cerr << "ERROR: MADVISE " << strerror(ret)
                               << std::endl;
                 }
 #endif

--- a/hpx/parallel/util/numa_binding_allocator.hpp
+++ b/hpx/parallel/util/numa_binding_allocator.hpp
@@ -1,0 +1,569 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright (c) 2017-2019 John Biddiscombe
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef HPX_COMPUTE_HOST_NUMA_BINDING_ALLOCATOR_HPP
+#define HPX_COMPUTE_HOST_NUMA_BINDING_ALLOCATOR_HPP
+
+#include <hpx/config.hpp>
+
+#include <hpx/parallel/execution_policy.hpp>
+#include <hpx/runtime/threads/topology.hpp>
+
+#include <hpx/runtime/threads/executors/pool_executor.hpp>
+#include <hpx/runtime/threads/executors/guided_pool_executor.hpp>
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+#include <iostream>
+#include <memory>
+
+#if defined(__linux) || defined(linux) || defined(__linux__)
+# include <linux/unistd.h>
+# include <sys/mman.h>
+# define NUMA_ALLOCATOR_LINUX
+#endif
+
+// Can be used to enable debugging of the allocator page mapping
+//#define NUMA_BINDING_ALLOCATOR_INIT_MEMORY
+// #define NUMA_BINDING_ALLOCATOR_DEBUG_PAGE_BINDING
+
+#if defined(NUMA_BINDING_ALLOCATOR_DEBUG_PAGE_BINDING) && !defined(HPX_MSVC)
+# include <plugins/parcelport/parcelport_logging.hpp>
+# define LOG_NUMA_MSG(x)                                   \
+    std::cout << "<NUMA> " << THREAD_ID << ' ' << x << "\n"
+#else
+# define LOG_NUMA_MSG(x)
+#endif
+
+namespace hpx { namespace threads { namespace executors
+{
+    struct numa_binding_allocator_tag {};
+
+    template <>
+    struct HPX_EXPORT pool_numa_hint<numa_binding_allocator_tag> {
+      // The call operator () must return an int type
+      // The arguments must be const ref versions of the equivalent task arguments
+      int operator()(const std::size_t& domain) const {
+          LOG_NUMA_MSG("allocator pool_numa_hint returns domain " << domain);
+          return domain;
+      }
+    };
+}}}
+
+namespace hpx { namespace compute { namespace host
+{
+    template <typename T>
+    struct numa_binding_helper {
+        // After memory has been allocated, this operator will be called
+        // for every page of memory in the allocation by one thread in each
+        // numa domain (implying that this function will be called for each page
+        // by N threads, where N = number of domains.
+        // The return from this function should be the domain number that
+        // should touch this page. The thread with the matching domain will
+        // perform a memory read/write on the page.
+        virtual std::size_t operator ()(
+            const T * const   /*base_ptr*/,
+            const T * const   /*page_ptr*/,
+            const std::size_t /*page_size*/,
+            const std::size_t /*domains*/) const
+        {
+            return 0;
+        }
+        // virtual destructor to quiet compiler warnings
+        virtual ~numa_binding_helper() {}
+
+        // The allocator uses the pool name to get numa bitmap masks needed by
+        // the allocation function. The "default" pool is assumed
+        // @TODO use an executor to retrieve the pool name
+        virtual const std::string &pool_name() const { return pool_name_; }
+
+        // Return the total memory consumption in bytes
+        virtual std::size_t memory_bytes() const { return 0; }
+
+//#ifdef NUMA_BINDING_ALLOCATOR_DEBUG_PAGE_BINDING
+        // Using how many dimensions should this data be displayed
+        // This function is only required for debug purposes
+        virtual std::size_t array_rank() const { return 1; }
+
+        // The number of elements along dimension x=0,y=1,z=2,...
+        // This function is only required for debug purposes
+        virtual std::size_t array_size(std::size_t axis) const {
+            return memory_bytes()/sizeof(T);
+        };
+
+        // When counting along elements in a given dimension,
+        // how large a step should be taken in units of elements.
+        // This should include padding along an axis
+        // This function is only required for debug purposes
+        virtual std::size_t memory_step(std::size_t axis) const { return 1; };
+
+        // When displaying the data, what step size should be used
+        // This function is only required for debug purposes
+        virtual std::size_t display_step(std::size_t axis) const { return 1; };
+
+        // This is for debug/information purposes only and anything may
+        // be returned that helps illuminate the mapping of pages->indices
+        virtual std::string description() const { return ""; };
+//#endif
+
+        std::string pool_name_ = "default";
+    };
+
+    template <typename T>
+    using numa_binding_helper_ptr = std::shared_ptr<numa_binding_helper<T>>;
+
+    /// The numa_binding_allocator allocates memory using a policy based on
+    /// hwloc flags for memory binding.
+    /// This allocator can be used to request data that is bound
+    /// to one or more numa domains via the bitmap mask supplied
+
+    template <typename T >
+    struct numa_binding_allocator
+    {
+        typedef T              value_type;
+        typedef T*             pointer;
+        typedef const T*       const_pointer;
+        typedef T&             reference;
+        typedef T const&       const_reference;
+        typedef std::size_t    size_type;
+        typedef std::ptrdiff_t difference_type;
+        //
+        template <typename U>
+        struct rebind
+        {
+            typedef numa_binding_allocator<U> other;
+        };
+
+        using numa_binding_helper_ptr = std::shared_ptr<numa_binding_helper<T>>;
+
+        // default constructor produces an unusable allocator
+        numa_binding_allocator() {}
+
+        // construct without a memory binder function
+        // only first touch or interleave policies are valid
+        numa_binding_allocator(threads::hpx_hwloc_membind_policy policy,
+                       unsigned int flags)
+            : policy_(policy)
+            , flags_(flags)
+        {
+            LOG_NUMA_MSG("numa_binding_allocator : no binder function");
+            HPX_ASSERT(policy_ != threads::hpx_hwloc_membind_policy::membind_user);
+        }
+
+        // construct using a memory binder function for placing pages
+        // according to a user defined pattern using first touch policy
+        numa_binding_allocator(numa_binding_helper_ptr bind_func,
+                       threads::hpx_hwloc_membind_policy policy,
+                       unsigned int flags)
+            : binding_helper_(bind_func)
+            , policy_(policy)
+            , flags_(flags)
+        {
+            LOG_NUMA_MSG("numa_binding_allocator : allocator");
+        }
+
+        // copy constructor
+        numa_binding_allocator(numa_binding_allocator const& rhs)
+            : binding_helper_(rhs.binding_helper_)
+            , policy_(rhs.policy_)
+            , flags_(rhs.flags_)
+        {
+            LOG_NUMA_MSG("numa_binding_allocator : Copy allocator");
+        }
+
+        // copy constructor using rebind type
+        template <typename U>
+        numa_binding_allocator(numa_binding_allocator<U> const& rhs)
+            : binding_helper_(rhs.binding_helper_)
+            , policy_(rhs.policy_)
+            , flags_(rhs.flags_)
+        {
+            LOG_NUMA_MSG("numa_binding_allocator : Copy allocator rebind");
+        }
+
+        // Assignment operator
+        numa_binding_allocator& operator=(numa_binding_allocator const& rhs)
+        {
+            binding_helper_ = rhs.binding_helper_;
+            policy_         = rhs.policy_;
+            flags_          = rhs.flags_;
+
+            LOG_NUMA_MSG("numa_binding_allocator : Assignment operator");
+            return *this;
+        }
+
+        // Move assignment
+        numa_binding_allocator& operator=(numa_binding_allocator && rhs)
+        {
+            binding_helper_ = rhs.binding_helper_;
+            policy_         = rhs.policy_;
+            flags_          = rhs.flags_;
+
+            LOG_NUMA_MSG("numa_binding_allocator : Move assignment");
+            return *this;
+        }
+
+        // Returns the actual address of x even in presence of overloaded
+        // operator&
+        pointer address(reference x) const noexcept
+        {
+            return &x;
+        }
+
+        // Returns the actual address of x even in presence of overloaded
+        // operator&
+        const_pointer address(const_reference x) const noexcept
+        {
+            return &x;
+        }
+
+        // Allocates n * sizeof(T) bytes of uninitialized storage and
+        // then spawns threads to touch memory if membind_user is selected
+        pointer allocate(size_type n)
+        {
+            pointer result = nullptr;
+
+            if (policy_==threads::hpx_hwloc_membind_policy::membind_firsttouch)
+            {
+                threads::hwloc_bitmap_ptr bitmap =
+                    threads::get_thread_manager().get_pool_numa_bitmap(
+                            binding_helper_->pool_name());
+                //
+                result = reinterpret_cast<pointer>(
+                    threads::topology().allocate_membind(
+                        n * sizeof(T), bitmap, policy_, 0));
+            }
+            else if (policy_==threads::hpx_hwloc_membind_policy::membind_interleave)
+            {
+                threads::hwloc_bitmap_ptr bitmap =
+                    threads::get_thread_manager().get_pool_numa_bitmap(
+                            binding_helper_->pool_name());
+                //
+                result = reinterpret_cast<pointer>(
+                    threads::topology().allocate_membind(
+                        n * sizeof(T), bitmap, policy_, 0));
+            }
+            else if (policy_==threads::hpx_hwloc_membind_policy::membind_user)
+            {
+                result = reinterpret_cast<pointer>(
+                    threads::topology().allocate(n * sizeof(T)));
+                threads::hwloc_bitmap_ptr bitmap =
+                    threads::get_thread_manager().get_pool_numa_bitmap(
+                            binding_helper_->pool_name());
+                //
+                result = reinterpret_cast<pointer>(
+                    threads::topology().allocate_membind(
+                        n * sizeof(T), bitmap,
+                        threads::hpx_hwloc_membind_policy::membind_firsttouch, 0));
+#if defined(NUMA_ALLOCATOR_LINUX)
+                // if Transparent Huge Pages (THP) are enabled, this prevents
+                // pages from being merged into a single numa bound block
+                int ret = madvise(result, n * sizeof(T), MADV_NOHUGEPAGE);
+                // a return of -1 probably means there are no transparent huge pages
+                // so they can't be disabled, we can ignore it
+                if ((ret != 0) && (ret !=-1))
+                {
+                    std::cout << "ERROR: MADVISE " << strerror(ret) << std::endl;
+                }
+#endif
+                initialize_pages(result, n);
+            }
+            return result;
+        }
+
+        // Deallocates the storage referenced by the pointer p, which must be a
+        // pointer obtained by an earlier call to allocate(). The argument n
+        // must be equal to the first argument of the call to allocate() that
+        // originally produced p; otherwise, the behavior is undefined.
+        void deallocate(pointer p, size_type n)
+        {
+            LOG_NUMA_MSG("Calling deallocate membind for size (bytes) "
+                      << std::hex << (n * sizeof(T)));
+#ifdef NUMA_BINDING_ALLOCATOR_DEBUG_PAGE_BINDING
+            display_binding(p, binding_helper_);
+#endif
+            threads::topology().deallocate(p, n * sizeof(T));
+        }
+
+        // Returns the maximum theoretically possible value of n, for which the
+        // call allocate(n, 0) could succeed. In most implementations, this
+        // returns std::numeric_limits<size_type>::max() / sizeof(value_type).
+        size_type max_size() const noexcept
+        {
+            return (std::numeric_limits<size_type>::max)();
+        }
+
+        // Constructs an object of type T in allocated uninitialized storage
+        // pointed to by p, using placement-new
+        template <class U, class ...A>
+        void construct(U* const p, A&& ...args)
+        {
+            new (p) U(std::forward<A>(args)...);
+        }
+
+        template <class U>
+        void destroy(U* const p)
+        {
+            p->~U();
+        }
+
+        // a utility function that is slightly faster than the hwloc provided one
+        // @TODO, move this into hpx::topology for cleanliness
+        int get_numa_domain(void *page)
+        {
+            HPX_ASSERT( (std::size_t(page) & 4095) == 0 );
+#if defined(NUMA_ALLOCATOR_LINUX)
+            // This is an optimized version of the hwloc equivalent
+            void *pages[1] = { page };
+            int  status[1] = { -1 };
+            if (syscall(__NR_move_pages, 0, 1, pages, nullptr, status, 0) == 0) {
+                if (status[0]>=0 && status[0]<=HPX_HAVE_MAX_NUMA_DOMAIN_COUNT) {
+                    return status[0];
+                }
+                // if (status[0]<0) std::cout << "." << decnumber(status[0]) << ".";
+                return -1;
+            }
+            HPX_THROW_EXCEPTION(kernel_error,
+                "get_numa_domain",
+                "Error getting numa domain with syscall");
+#else
+            return threads::get_topology().get_numa_domain(page);
+#endif
+        }
+
+        std::string get_page_numa_domains(void *addr, std::size_t len) const
+        {
+#if defined(NUMA_ALLOCATOR_LINUX)
+            // @TODO replace with topology::page_size
+            int pagesize = 4096;
+            HPX_ASSERT( (std::size_t(addr) & (pagesize-1)) == 0 );
+
+            std::size_t count = (len + pagesize-1)/pagesize;
+            std::vector<void*> pages(count, nullptr);
+            std::vector<int>  status(count, 0);
+
+            for (std::size_t i=0; i<count; i++)
+                pages[i] = ((char*)addr) + i*pagesize;
+
+            if (syscall(__NR_move_pages, 0,
+                        count, pages.data(), nullptr, status.data(), 0) < 0) {
+                HPX_THROW_EXCEPTION(kernel_error,
+                    "get_page_numa_domains",
+                    "Error getting numa domains with syscall");
+            }
+
+            std::stringstream temp;
+            temp << "Numa page binding for page count " << count << "\n";
+            for (std::size_t i=0; i<count; i++) {
+                if (status[i] >= 0) temp << status[i];
+                else temp << "-";
+            }
+            return temp.str();
+#endif
+            return "";
+        }
+
+        void initialize_pages(pointer p, size_t n) const
+        {
+            std::unique_lock<std::mutex> lk(init_mutex);
+            //
+            threads::hwloc_bitmap_ptr bitmap =
+                threads::get_thread_manager().get_pool_numa_bitmap(binding_helper_->pool_name());
+            std::vector<threads::hwloc_bitmap_ptr> nodesets = create_nodesets(bitmap);
+            //
+            using namespace threads::executors;
+            using allocator_hint_type = pool_numa_hint<numa_binding_allocator_tag>;
+            //
+            // Warning :low priority tasks are used here, because the scheduler does
+            // not steal across numa domains for those tasks, so they are sure
+            // to remain on the right queue and be executed on the right domain.
+            guided_pool_executor<allocator_hint_type> numa_executor(
+                binding_helper_->pool_name(), threads::thread_priority_low);
+
+            LOG_NUMA_MSG("Launching First-Touch tasks");
+            // for each numa domain, we must launch a task to 'touch' the memory
+            // that should be bound to the domain
+            std::vector<hpx::future<void>> tasks;
+            for (size_type i=0; i<nodesets.size(); ++i) {
+#ifdef NUMA_BINDING_ALLOCATOR_DEBUG_PAGE_BINDING
+                size_type i1 = hwloc_bitmap_first(nodesets[i]->get_bmp());
+                size_type i2 = hwloc_bitmap_last(nodesets[i]->get_bmp());
+                HPX_ASSERT(i1==i2);
+#endif
+                size_type domain = hwloc_bitmap_first(nodesets[i]->get_bmp());
+                LOG_NUMA_MSG("Launching First-Touch task for domain " << domain
+                          << " " << nodesets[i]);
+                // if (domain==7 || domain==3)
+                tasks.push_back(
+                    hpx::async(numa_executor,
+                        util::bind(&numa_binding_allocator::touch_pages,
+                            this, p, n, binding_helper_,
+                            util::placeholders::_1, nodesets), domain
+                    )
+                );
+            }
+            wait_all(tasks);
+            LOG_NUMA_MSG("Done First-Touch tasks");
+        }
+
+#ifdef NUMA_BINDING_ALLOCATOR_DEBUG_PAGE_BINDING
+        std::string display_binding(pointer p, numa_binding_helper_ptr helper)
+        {
+            std::unique_lock<std::mutex> lk(init_mutex);
+            //
+            std::ostringstream display;
+            auto N = helper->array_rank();
+            display << helper->description() << "\n";
+            std::size_t pagesize = sysconf(_SC_PAGE_SIZE)/sizeof(T);
+            pointer p2 = p;
+            if (N==2) {
+                std::size_t Nc = helper->array_size(0);
+                std::size_t Nr = helper->array_size(1);
+                std::size_t xinc = std::min(helper->display_step(0), pagesize);
+                std::size_t yinc = std::min(helper->display_step(1), pagesize);
+                std::size_t xoff = helper->memory_step(0);
+                std::size_t yoff = helper->memory_step(1);
+                std::size_t m = helper->memory_bytes();
+#ifdef numa_binding_allocator_PRETTY_DISPLAY
+                display << ' ';
+                for (std::size_t c=0; c<Nc; c += xinc) {
+                    if (c%(xinc*8)==0) display << '|';
+                    else display << '.';
+                }
+#endif
+                display << '\n';
+                for (std::size_t r=0; r<Nr; r += yinc) {
+#ifdef numa_binding_allocator_PRETTY_DISPLAY
+                    if (r%(xinc*8)==0) display << '-';
+                    else display << '.';
+#endif
+                    //
+                    for (std::size_t c=0; c<Nc; c += xinc) {
+                        p2 = p + (c*xoff) + (r*yoff);
+                        if (p2 >= (p + m)) {
+                            display << '*';
+                        }
+                        else {
+                            size_type dom = get_numa_domain(p2);
+                            if (dom == size_type(-1)) {
+                                display << '-';
+                            }
+                            else
+                                display << std::hex << dom;
+                        }
+                    }
+                    display << "\n";
+                }
+            }
+            else {
+                display << "Not yet implemented output for non 2D arrays" << "\n";
+            }
+            return display.str();
+        }
+#endif
+
+    protected:
+
+        std::vector<threads::hwloc_bitmap_ptr>
+        create_nodesets(threads::hwloc_bitmap_ptr bitmap) const
+        {
+            // for each numa domain, we need a nodeset object
+            threads::mask_type numa_mask =
+                dynamic_cast<const threads::topology*>
+                    (&threads::get_topology())->
+                        bitmap_to_mask(bitmap->get_bmp(), HWLOC_OBJ_NUMANODE);
+
+            LOG_NUMA_MSG("Pool numa mask is " << numa_mask);
+
+            std::vector<threads::hwloc_bitmap_ptr> nodesets;
+            for (size_type i=0; i<threads::mask_size(numa_mask); ++i) {
+                if (threads::test(numa_mask, i)) {
+                    hwloc_bitmap_t bitmap = hwloc_bitmap_alloc();
+                    hwloc_bitmap_zero(bitmap);
+                    hwloc_bitmap_set(bitmap, i);
+                    nodesets.push_back(
+                        std::make_shared<threads::hpx_hwloc_bitmap_wrapper>(bitmap));
+                    LOG_NUMA_MSG("Node mask " << i << " is " << nodesets.back());
+                }
+            }
+            return nodesets;
+        }
+
+        void touch_pages(pointer p, size_t n,
+                         numa_binding_helper_ptr helper, size_type numa_domain,
+                         const std::vector<threads::hwloc_bitmap_ptr> &nodesets) const
+        {
+            const size_type pagesize  = sysconf(_SC_PAGE_SIZE);
+            const size_type pageN     = pagesize/sizeof(T);
+            const size_type num_pages = (n*sizeof(T) + pagesize - 1) / pagesize;
+            pointer page_ptr = p;
+            std::intptr_t memory = reinterpret_cast<std::intptr_t>(p);
+            HPX_ASSERT(memory % pagesize == 0);
+
+            LOG_NUMA_MSG("touch pages for numa " << numa_domain);
+            for (size_type i=0; i<num_pages; ++i) {
+                // we pass the base pointer and current page pointer
+                size_type dom = helper->operator()(p, page_ptr, pagesize, nodesets.size());
+                if (dom==numa_domain) {
+                    HPX_ASSERT( (std::size_t(page_ptr) & 4095) ==0 );
+                    // trigger a memory read and rewrite without changing contents
+                    volatile T* vaddr = const_cast<volatile T*>(page_ptr);
+                    *vaddr = *vaddr;
+#ifdef NUMA_BINDING_ALLOCATOR_INIT_MEMORY
+#if defined(NUMA_ALLOCATOR_LINUX)
+                    int Vmem = sched_getcpu(); // show which cpu is actually being used
+#else
+                    int Vmem = numa_domain;    // show just the domain we think we're on
+#endif
+                     pointer elem_ptr = page_ptr;
+                     for (size_type j=0; j<pageN; ++j) {
+                         *elem_ptr++ = T(Vmem);
+                     }
+ #endif
+                }
+                page_ptr += pageN;
+            }
+        }
+
+        // This is obsolete but kept for possible future use
+        void bind_pages(pointer p, size_t n,
+                        numa_binding_helper_ptr helper, size_type numa_domain,
+                        const std::vector<threads::hwloc_bitmap_ptr> &nodesets) const
+        {
+            const size_type pagesize  = sysconf(_SC_PAGE_SIZE);
+            const size_type pageN     = pagesize/sizeof(T);
+            const size_type num_pages = (n*sizeof(T) + pagesize - 1) / pagesize;
+            pointer page_ptr = p;
+            std::intptr_t memory = reinterpret_cast<std::intptr_t>(p);
+            HPX_ASSERT(memory % pagesize == 0);
+
+            LOG_NUMA_MSG("bind pages for numa " << numa_domain);
+            for (size_type i=0; i<num_pages; ++i) {
+                // we pass the base pointer and current page pointer
+                size_type dom = helper->operator()(p, page_ptr, pagesize, nodesets.size());
+                if (dom==numa_domain) {
+                    threads::topology().
+                        set_area_membind_nodeset(page_ptr, pagesize,
+                                                 nodesets[dom]->get_bmp());
+                }
+                page_ptr += pageN;
+            }
+        }
+
+    private:
+        hpx::lcos::local::spinlock display_mutex;
+        mutable std::mutex         init_mutex;
+
+    public:
+        std::shared_ptr<numa_binding_helper<T>> binding_helper_;
+        threads::hpx_hwloc_membind_policy       policy_;
+        unsigned int                            flags_;
+    };
+}}}
+
+#endif

--- a/hpx/parallel/util/numa_binding_allocator.hpp
+++ b/hpx/parallel/util/numa_binding_allocator.hpp
@@ -1,9 +1,7 @@
-///////////////////////////////////////////////////////////////////////////////
 //  Copyright (c) 2017-2019 John Biddiscombe
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-///////////////////////////////////////////////////////////////////////////////
 
 #ifndef HPX_COMPUTE_HOST_NUMA_BINDING_ALLOCATOR_HPP
 #define HPX_COMPUTE_HOST_NUMA_BINDING_ALLOCATOR_HPP
@@ -424,7 +422,7 @@ namespace hpx { namespace compute { namespace host
             std::ostringstream display;
             auto N = helper->array_rank();
             display << helper->description() << "\n";
-            std::size_t pagesize = sysconf(_SC_PAGE_SIZE)/sizeof(T);
+            std::size_t pagesize = threads::get_memory_page_size();
             pointer p2 = p;
             if (N==2) {
                 std::size_t Nc = helper->array_size(0);
@@ -503,7 +501,7 @@ namespace hpx { namespace compute { namespace host
                          numa_binding_helper_ptr helper, size_type numa_domain,
                          const std::vector<threads::hwloc_bitmap_ptr> &nodesets) const
         {
-            const size_type pagesize  = sysconf(_SC_PAGE_SIZE);
+            const size_type pagesize  = threads::get_memory_page_size();
             const size_type pageN     = pagesize/sizeof(T);
             const size_type num_pages = (n*sizeof(T) + pagesize - 1) / pagesize;
             pointer page_ptr = p;
@@ -541,7 +539,7 @@ namespace hpx { namespace compute { namespace host
                         numa_binding_helper_ptr helper, size_type numa_domain,
                         const std::vector<threads::hwloc_bitmap_ptr> &nodesets) const
         {
-            const size_type pagesize  = sysconf(_SC_PAGE_SIZE);
+            const size_type pagesize  = threads::get_memory_page_size();
             const size_type pageN     = pagesize/sizeof(T);
             const size_type num_pages = (n*sizeof(T) + pagesize - 1) / pagesize;
             pointer page_ptr = p;

--- a/hpx/parallel/util/numa_binding_allocator.hpp
+++ b/hpx/parallel/util/numa_binding_allocator.hpp
@@ -12,9 +12,13 @@
 
 #include <hpx/parallel/execution_policy.hpp>
 #include <hpx/runtime/threads/topology.hpp>
-
 #include <hpx/runtime/threads/executors/pool_executor.hpp>
 #include <hpx/runtime/threads/executors/guided_pool_executor.hpp>
+#include <hpx/util/assert.hpp>
+
+#include <sstream>
+#include <string>
+#include <vector>
 
 #include <cstddef>
 #include <type_traits>
@@ -373,7 +377,8 @@ namespace hpx { namespace compute { namespace host
             std::unique_lock<std::mutex> lk(init_mutex);
             //
             threads::hwloc_bitmap_ptr bitmap =
-                threads::get_thread_manager().get_pool_numa_bitmap(binding_helper_->pool_name());
+                threads::get_thread_manager().get_pool_numa_bitmap(
+                        binding_helper_->pool_name());
             std::vector<threads::hwloc_bitmap_ptr> nodesets = create_nodesets(bitmap);
             //
             using namespace threads::executors;
@@ -424,8 +429,8 @@ namespace hpx { namespace compute { namespace host
             if (N==2) {
                 std::size_t Nc = helper->array_size(0);
                 std::size_t Nr = helper->array_size(1);
-                std::size_t xinc = std::min(helper->display_step(0), pagesize);
-                std::size_t yinc = std::min(helper->display_step(1), pagesize);
+                std::size_t xinc = (std::min)(helper->display_step(0), pagesize);
+                std::size_t yinc = (std::min)(helper->display_step(1), pagesize);
                 std::size_t xoff = helper->memory_step(0);
                 std::size_t yoff = helper->memory_step(1);
                 std::size_t m = helper->memory_bytes();
@@ -508,7 +513,8 @@ namespace hpx { namespace compute { namespace host
             LOG_NUMA_MSG("touch pages for numa " << numa_domain);
             for (size_type i=0; i<num_pages; ++i) {
                 // we pass the base pointer and current page pointer
-                size_type dom = helper->operator()(p, page_ptr, pagesize, nodesets.size());
+                size_type dom =
+                    helper->operator()(p, page_ptr, pagesize, nodesets.size());
                 if (dom==numa_domain) {
                     HPX_ASSERT( (std::size_t(page_ptr) & 4095) ==0 );
                     // trigger a memory read and rewrite without changing contents
@@ -545,7 +551,8 @@ namespace hpx { namespace compute { namespace host
             LOG_NUMA_MSG("bind pages for numa " << numa_domain);
             for (size_type i=0; i<num_pages; ++i) {
                 // we pass the base pointer and current page pointer
-                size_type dom = helper->operator()(p, page_ptr, pagesize, nodesets.size());
+                size_type dom =
+                    helper->operator()(p, page_ptr, pagesize, nodesets.size());
                 if (dom==numa_domain) {
                     threads::topology().
                         set_area_membind_nodeset(page_ptr, pagesize,

--- a/hpx/parallel/util/numa_binding_allocator.hpp
+++ b/hpx/parallel/util/numa_binding_allocator.hpp
@@ -378,7 +378,7 @@ namespace hpx { namespace compute { namespace host {
         {
 #if defined(NUMA_ALLOCATOR_LINUX)
             // @TODO replace with topology::page_size
-            int pagesize = 4096;
+            int pagesize = threads::get_memory_page_size();
             HPX_ASSERT((std::size_t(addr) & (pagesize - 1)) == 0);
 
             std::size_t count = (len + pagesize - 1) / pagesize;
@@ -574,7 +574,8 @@ namespace hpx { namespace compute { namespace host {
                     helper->operator()(p, page_ptr, pagesize, nodesets.size());
                 if (dom == numa_domain)
                 {
-                    HPX_ASSERT((std::size_t(page_ptr) & 4095) == 0);
+                    HPX_ASSERT((std::size_t(page_ptr) &
+                                (threads::get_memory_page_size()-1)) == 0);
                     // trigger a memory read and rewrite without changing contents
                     volatile T* vaddr = const_cast<volatile T*>(page_ptr);
                     *vaddr = *vaddr;

--- a/hpx/parallel/util/numa_binding_allocator.hpp
+++ b/hpx/parallel/util/numa_binding_allocator.hpp
@@ -172,6 +172,7 @@ namespace hpx { namespace compute { namespace host {
             unsigned int flags)
           : policy_(policy)
           , flags_(flags)
+          , init_mutex()
         {
             LOG_NUMA_MSG("numa_binding_allocator : no binder function");
             HPX_ASSERT(
@@ -186,6 +187,7 @@ namespace hpx { namespace compute { namespace host {
           : binding_helper_(bind_func)
           , policy_(policy)
           , flags_(flags)
+          , init_mutex()
         {
             LOG_NUMA_MSG("numa_binding_allocator : allocator");
         }
@@ -195,6 +197,7 @@ namespace hpx { namespace compute { namespace host {
           : binding_helper_(rhs.binding_helper_)
           , policy_(rhs.policy_)
           , flags_(rhs.flags_)
+          , init_mutex()
         {
             LOG_NUMA_MSG("numa_binding_allocator : Copy allocator");
         }
@@ -205,6 +208,7 @@ namespace hpx { namespace compute { namespace host {
           : binding_helper_(rhs.binding_helper_)
           , policy_(rhs.policy_)
           , flags_(rhs.flags_)
+          , init_mutex()
         {
             LOG_NUMA_MSG("numa_binding_allocator : Copy allocator rebind");
         }
@@ -214,6 +218,7 @@ namespace hpx { namespace compute { namespace host {
           : binding_helper_(std::move(rhs.binding_helper_))
           , policy_(rhs.policy_)
           , flags_(rhs.flags_)
+          , init_mutex()
         {
             LOG_NUMA_MSG("numa_binding_allocator : Move constructor");
         }
@@ -284,8 +289,6 @@ namespace hpx { namespace compute { namespace host {
             }
             else if (policy_ == threads::hpx_hwloc_membind_policy::membind_user)
             {
-                result = reinterpret_cast<pointer>(
-                    threads::topology().allocate(n * sizeof(T)));
                 threads::hwloc_bitmap_ptr bitmap =
                     threads::get_thread_manager().get_pool_numa_bitmap(
                         binding_helper_->pool_name());
@@ -626,13 +629,13 @@ namespace hpx { namespace compute { namespace host {
             }
         }
 
-    private:
-        mutable std::mutex init_mutex;
-
     public:
         std::shared_ptr<numa_binding_helper<T>> binding_helper_;
         threads::hpx_hwloc_membind_policy policy_;
         unsigned int flags_;
+
+    private:
+        mutable std::mutex init_mutex;
     };
 }}}
 

--- a/hpx/parallel/util/numa_binding_allocator.hpp
+++ b/hpx/parallel/util/numa_binding_allocator.hpp
@@ -51,7 +51,7 @@ namespace hpx { namespace threads { namespace executors {
     {
         // The call operator () must return an int type
         // The arguments must be const ref versions of the equivalent task arguments
-        int operator()(const std::size_t& domain) const
+        int operator()(const int& domain) const
         {
             LOG_NUMA_MSG("allocator pool_numa_hint returns domain " << domain);
             return domain;
@@ -78,7 +78,7 @@ namespace hpx { namespace compute { namespace host {
             return 0;
         }
         // virtual destructor to quiet compiler warnings
-        virtual ~numa_binding_helper() {}
+        virtual ~numa_binding_helper() = default;
 
         // The allocator uses the pool name to get numa bitmap masks needed by
         // the allocation function. The "default" pool is assumed
@@ -94,9 +94,8 @@ namespace hpx { namespace compute { namespace host {
             return 0;
         }
 
-        //#ifdef NUMA_BINDING_ALLOCATOR_DEBUG_PAGE_BINDING
         // Using how many dimensions should this data be displayed
-        // This function is only required for debug purposes
+        // (This function is only required/used) for debug purposes
         virtual std::size_t array_rank() const
         {
             return 1;
@@ -207,6 +206,15 @@ namespace hpx { namespace compute { namespace host {
           , flags_(rhs.flags_)
         {
             LOG_NUMA_MSG("numa_binding_allocator : Copy allocator rebind");
+        }
+
+        // Move assignment
+        numa_binding_allocator(numa_binding_allocator&& rhs)
+          : binding_helper_(std::move(rhs.binding_helper_))
+          , policy_(rhs.policy_)
+          , flags_(rhs.flags_)
+        {
+            LOG_NUMA_MSG("numa_binding_allocator : Move constructor");
         }
 
         // Assignment operator
@@ -617,7 +625,6 @@ namespace hpx { namespace compute { namespace host {
         }
 
     private:
-        hpx::lcos::local::spinlock display_mutex;
         mutable std::mutex init_mutex;
 
     public:

--- a/hpx/runtime/threads/topology.hpp
+++ b/hpx/runtime/threads/topology.hpp
@@ -35,6 +35,7 @@
 
 namespace hpx { namespace threads
 {
+
     struct hpx_hwloc_bitmap_wrapper
     {
         HPX_NON_COPYABLE(hpx_hwloc_bitmap_wrapper);
@@ -321,6 +322,8 @@ namespace hpx { namespace threads
 
     private:
         static mask_type empty_mask;
+        static std::size_t memory_page_size_;
+        friend std::size_t get_memory_page_size();
 
         std::size_t init_node_number(
             std::size_t num_thread, hwloc_obj_type_t type
@@ -448,6 +451,14 @@ namespace hpx { namespace threads
 #else
         return 64;      // assume 64 byte cache-line size
 #endif
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // abstract away memory page size, calls to system functions are
+    // expensive, so return a value initializaed at startup
+    inline std::size_t get_memory_page_size()
+    {
+        return hpx::threads::topology::memory_page_size_;
     }
 }}
 

--- a/src/runtime/threads/topology.cpp
+++ b/src/runtime/threads/topology.cpp
@@ -50,6 +50,10 @@
 #include <sys/resource.h>
 #endif
 
+#if defined(HPX_HAVE_UNISTD_H)
+#include <unistd.h>
+#endif
+
 namespace hpx { namespace threads { namespace detail
 {
     std::size_t hwloc_hardware_concurrency()
@@ -124,7 +128,26 @@ namespace hpx { namespace threads { namespace detail
 #endif
         return node;
     }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // abstract away memory page size
+    std::size_t get_memory_page_size_impl()
+    {
+#if defined(HPX_HAVE_UNISTD_H)
+        return sysconf(_SC_PAGE_SIZE);
+#elif defined(HPX_WINDOWS)
+        SYSTEM_INFO systemInfo;
+        GetSystemInfo(&systemInfo);
+        return systemInfo.dwPageSize;
+#else
+        return 4096;
+#endif
+    }
+
 }}}
+
+std::size_t hpx::threads::topology::memory_page_size_ =
+        hpx::threads::detail::get_memory_page_size_impl();
 
 namespace hpx { namespace threads
 {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -17,6 +17,7 @@ set(subdirs
     resource
     serialization
     threads
+    topology
     traits
     util
    )

--- a/tests/unit/topology/CMakeLists.txt
+++ b/tests/unit/topology/CMakeLists.txt
@@ -3,16 +3,17 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests
+if (HPX_WITH_SHARED_PRIORITY_SCHEDULER AND HPX_WITH_CXX14_RETURN_TYPE_DEDUCTION)
+  set(tests ${tests}
     numa_allocator
-)
+  )
 
-###############################################################################
-# NB. threads = -2 = threads = 'cores'
-# NB. threads = -1 = threads = 'all'
-set(numa_allocator_PARAMETERS
+  # NB. threads = -2 = threads = 'cores'
+  # NB. threads = -1 = threads = 'all'
+  set(numa_allocator_PARAMETERS
     THREADS_PER_LOCALITY -2
     ARGS --size=1024 --nb=512 --tiles-per-domain=2 --col-proc=1 --row-proc=1)
+endif()
 
 ###############################################################################
 foreach(test ${tests})

--- a/tests/unit/topology/CMakeLists.txt
+++ b/tests/unit/topology/CMakeLists.txt
@@ -30,7 +30,7 @@ foreach(test ${tests})
                      HPX_PREFIX ${HPX_BUILD_PREFIX}
                      FOLDER "Tests/Unit/Topology/")
 
-  add_hpx_unit_test("util" ${test} ${${test}_PARAMETERS})
+  add_hpx_unit_test("topology" ${test} ${${test}_PARAMETERS})
 
   # add a custom target for this example
   add_hpx_pseudo_target(tests.unit.topology.${test})

--- a/tests/unit/topology/CMakeLists.txt
+++ b/tests/unit/topology/CMakeLists.txt
@@ -1,0 +1,44 @@
+# Copyright (c) 2019 John Biddiscombe
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests
+    numa_allocator
+)
+
+###############################################################################
+# NB. threads = -2 = threads = 'cores'
+# NB. threads = -1 = threads = 'all'
+set(numa_allocator_PARAMETERS
+    THREADS_PER_LOCALITY -2
+    ARGS --size=1024 --nb=512 --tiles-per-domain=2 --col-proc=1 --row-proc=1)
+
+###############################################################################
+foreach(test ${tests})
+  set(sources
+      ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  # add example executable
+  add_hpx_executable(${test}_test
+                     SOURCES ${sources}
+                     ${${test}_FLAGS}
+                     EXCLUDE_FROM_ALL
+                     HPX_PREFIX ${HPX_BUILD_PREFIX}
+                     FOLDER "Tests/Unit/Topology/")
+
+  add_hpx_unit_test("util" ${test} ${${test}_PARAMETERS})
+
+  # add a custom target for this example
+  add_hpx_pseudo_target(tests.unit.topology.${test})
+
+  # make pseudo-targets depend on master pseudo-target
+  add_hpx_pseudo_dependencies(tests.unit.topology
+                              tests.unit.topology.${test})
+
+  # add dependencies to pseudo-target
+  add_hpx_pseudo_dependencies(tests.unit.topology.${test}
+                              ${test}_test)
+endforeach()

--- a/tests/unit/topology/CMakeLists.txt
+++ b/tests/unit/topology/CMakeLists.txt
@@ -12,7 +12,7 @@ if (HPX_WITH_SHARED_PRIORITY_SCHEDULER AND HPX_WITH_CXX14_RETURN_TYPE_DEDUCTION)
   # NB. threads = -1 = threads = 'all'
   set(numa_allocator_PARAMETERS
     THREADS_PER_LOCALITY -2
-    ARGS --size=1024 --nb=512 --tiles-per-domain=2 --col-proc=1 --row-proc=1)
+    ARGS --size=128 --nb=512 --tiles-per-domain=2 --col-proc=1 --row-proc=1)
 endif()
 
 ###############################################################################

--- a/tests/unit/topology/allocator_binder_linear.hpp
+++ b/tests/unit/topology/allocator_binder_linear.hpp
@@ -1,0 +1,83 @@
+#ifndef ALLOCATOR_BINDER_LINEAR_HPP
+#define ALLOCATOR_BINDER_LINEAR_HPP
+
+#include <hpx/parallel/util/numa_binding_allocator.hpp>
+
+// ------------------------------------------------------------------------
+// Example of an allocator binder for 1D arrays.
+// This simply binds pages according to a linear sequence
+// with increasing numa domain number modulo the total domains available
+// ------------------------------------------------------------------------
+template <typename T>
+struct linear_numa_binder : hpx::compute::host::numa_binding_helper<T>
+{
+    linear_numa_binder(std::size_t num_pages) :
+        hpx::compute::host::numa_binding_helper<T>()
+    {
+        const std::size_t CACHE_LINE_SIZE = sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
+        const std::size_t PAGE_SIZE       = sysconf(_SC_PAGE_SIZE);
+        const std::size_t ALIGNMENT       = std::max(PAGE_SIZE, CACHE_LINE_SIZE);
+        elements_page_            = (ALIGNMENT/sizeof(T));
+        N_                        = num_pages*elements_page_;
+    }
+
+    // return the domain that a given page should be bound to
+    virtual std::size_t operator ()(
+            const T * const base_ptr,
+            const T * const page_ptr,
+            const std::size_t pagesize,
+            const std::size_t domains) const override
+    {
+        std::intptr_t offset = page_ptr - base_ptr;
+        std::size_t   index  = (offset / elements_page_);
+        return index % domains;
+    }
+
+    // This is for debug purposes
+    virtual std::string description() const override
+    {
+        std::ostringstream temp;
+        temp << "Linear "           << std::dec
+             << " N "               << N_
+             << " elements_page_ "  << elements_page_;
+        return temp.str();
+    }
+
+    // Total memory consumption in bytes
+    virtual std::size_t memory_bytes() const override
+    {
+        return sizeof(T) * N_;
+    }
+
+    // Using how many dimensions should this data be displayed
+    virtual std::size_t array_rank() const override
+    {
+        return 1;
+    }
+
+    // The number of elements along dimension x=0,y=1,z=2,...
+    virtual std::size_t array_size(std::size_t axis) const override
+    {
+        if (axis==0) return N_;
+        return 1;
+    }
+
+    // When counting along elements in a given dimension,
+    // how large a step should be taken in units of elements.
+    // This should include padding along an axis
+    virtual std::size_t memory_step(std::size_t axis) const override
+    {
+        return 1;
+    }
+
+    // When displaying the data, what step size should be used
+    virtual std::size_t display_step(std::size_t axis) const override
+    {
+        return elements_page_;
+    }
+    //
+    std::size_t N_;
+    std::size_t elements_page_;
+};
+
+#endif // ALLOCATOR_BINDER_LINEAR_HPP

--- a/tests/unit/topology/allocator_binder_linear.hpp
+++ b/tests/unit/topology/allocator_binder_linear.hpp
@@ -20,7 +20,7 @@
 template <typename T>
 struct linear_numa_binder : hpx::compute::host::numa_binding_helper<T>
 {
-    linear_numa_binder(std::size_t num_pages)
+    explicit linear_numa_binder(std::size_t num_pages)
       : hpx::compute::host::numa_binding_helper<T>()
     {
         const std::size_t CACHE_LINE_SIZE = hpx::threads::get_cache_line_size();

--- a/tests/unit/topology/allocator_binder_linear.hpp
+++ b/tests/unit/topology/allocator_binder_linear.hpp
@@ -20,8 +20,8 @@
 template <typename T>
 struct linear_numa_binder : hpx::compute::host::numa_binding_helper<T>
 {
-    linear_numa_binder(std::size_t num_pages) :
-        hpx::compute::host::numa_binding_helper<T>()
+    linear_numa_binder(std::size_t num_pages)
+      : hpx::compute::host::numa_binding_helper<T>()
     {
         const std::size_t CACHE_LINE_SIZE = hpx::threads::get_cache_line_size();
         const std::size_t PAGE_SIZE       = hpx::threads::get_memory_page_size();
@@ -31,14 +31,13 @@ struct linear_numa_binder : hpx::compute::host::numa_binding_helper<T>
     }
 
     // return the domain that a given page should be bound to
-    virtual std::size_t operator ()(
-            const T * const base_ptr,
-            const T * const page_ptr,
-            const std::size_t pagesize,
-            const std::size_t domains) const override
+    virtual std::size_t operator()(const T* const base_ptr,
+        const T* const page_ptr,
+        const std::size_t pagesize,
+        const std::size_t domains) const override
     {
         std::intptr_t offset = page_ptr - base_ptr;
-        std::size_t   index  = (offset / elements_page_);
+        std::size_t index = (offset / elements_page_);
         return index % domains;
     }
 
@@ -46,9 +45,8 @@ struct linear_numa_binder : hpx::compute::host::numa_binding_helper<T>
     virtual std::string description() const override
     {
         std::ostringstream temp;
-        temp << "Linear "           << std::dec
-             << " N "               << N_
-             << " elements_page_ "  << elements_page_;
+        temp << "Linear " << std::dec << " N " << N_ << " elements_page_ "
+             << elements_page_;
         return temp.str();
     }
 
@@ -67,7 +65,8 @@ struct linear_numa_binder : hpx::compute::host::numa_binding_helper<T>
     // The number of elements along dimension x=0,y=1,z=2,...
     virtual std::size_t array_size(std::size_t axis) const override
     {
-        if (axis==0) return N_;
+        if (axis == 0)
+            return N_;
         return 1;
     }
 
@@ -89,4 +88,4 @@ struct linear_numa_binder : hpx::compute::host::numa_binding_helper<T>
     std::size_t elements_page_;
 };
 
-#endif // ALLOCATOR_BINDER_LINEAR_HPP
+#endif    // ALLOCATOR_BINDER_LINEAR_HPP

--- a/tests/unit/topology/allocator_binder_linear.hpp
+++ b/tests/unit/topology/allocator_binder_linear.hpp
@@ -1,3 +1,8 @@
+//  Copyright (c) 2019 John Biddiscombe
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #ifndef ALLOCATOR_BINDER_LINEAR_HPP
 #define ALLOCATOR_BINDER_LINEAR_HPP
 
@@ -18,8 +23,8 @@ struct linear_numa_binder : hpx::compute::host::numa_binding_helper<T>
     linear_numa_binder(std::size_t num_pages) :
         hpx::compute::host::numa_binding_helper<T>()
     {
-        const std::size_t CACHE_LINE_SIZE = sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
-        const std::size_t PAGE_SIZE       = sysconf(_SC_PAGE_SIZE);
+        const std::size_t CACHE_LINE_SIZE = hpx::threads::get_cache_line_size();
+        const std::size_t PAGE_SIZE       = hpx::threads::get_memory_page_size();
         const std::size_t ALIGNMENT       = (std::max)(PAGE_SIZE, CACHE_LINE_SIZE);
         elements_page_ = (ALIGNMENT / sizeof(T));
         N_ = num_pages * elements_page_;

--- a/tests/unit/topology/allocator_binder_linear.hpp
+++ b/tests/unit/topology/allocator_binder_linear.hpp
@@ -2,6 +2,10 @@
 #define ALLOCATOR_BINDER_LINEAR_HPP
 
 #include <hpx/parallel/util/numa_binding_allocator.hpp>
+//
+#include <cstddef>
+#include <sstream>
+#include <string>
 
 // ------------------------------------------------------------------------
 // Example of an allocator binder for 1D arrays.
@@ -16,9 +20,9 @@ struct linear_numa_binder : hpx::compute::host::numa_binding_helper<T>
     {
         const std::size_t CACHE_LINE_SIZE = sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
         const std::size_t PAGE_SIZE       = sysconf(_SC_PAGE_SIZE);
-        const std::size_t ALIGNMENT       = std::max(PAGE_SIZE, CACHE_LINE_SIZE);
-        elements_page_            = (ALIGNMENT/sizeof(T));
-        N_                        = num_pages*elements_page_;
+        const std::size_t ALIGNMENT       = (std::max)(PAGE_SIZE, CACHE_LINE_SIZE);
+        elements_page_ = (ALIGNMENT / sizeof(T));
+        N_ = num_pages * elements_page_;
     }
 
     // return the domain that a given page should be bound to

--- a/tests/unit/topology/allocator_binder_matrix.hpp
+++ b/tests/unit/topology/allocator_binder_matrix.hpp
@@ -21,14 +21,16 @@
 template <typename T>
 struct matrix_numa_binder : hpx::compute::host::numa_binding_helper<T>
 {
-    matrix_numa_binder(std::size_t Ncols, std::size_t Nrows,
-                       std::size_t Ntile, std::size_t Ntiles_per_domain,
-                       std::size_t Ncolprocs=1, std::size_t Nrowprocs=1
-                       )
-        : hpx::compute::host::numa_binding_helper<T>()
-        , cols_(Ncols), rows_(Nrows)
-        , tile_size_(Ntile), tiles_per_domain_(Ntiles_per_domain)
-        ,  colprocs_(Ncolprocs), rowprocs_(Nrowprocs)
+    matrix_numa_binder(std::size_t Ncols, std::size_t Nrows, std::size_t Ntile,
+        std::size_t Ntiles_per_domain, std::size_t Ncolprocs = 1,
+        std::size_t Nrowprocs = 1)
+      : hpx::compute::host::numa_binding_helper<T>()
+      , cols_(Ncols)
+      , rows_(Nrows)
+      , tile_size_(Ntile)
+      , tiles_per_domain_(Ntiles_per_domain)
+      , colprocs_(Ncolprocs)
+      , rowprocs_(Nrowprocs)
     {
         const int CACHE_LINE_SIZE = hpx::threads::get_cache_line_size();
         const int PAGE_SIZE       = hpx::threads::get_memory_page_size();
@@ -40,16 +42,15 @@ struct matrix_numa_binder : hpx::compute::host::numa_binding_helper<T>
     }
 
     // return the domain that a given page should be bound to
-    virtual std::size_t operator ()(
-            const T * const base_ptr,
-            const T * const page_ptr,
-            const std::size_t pagesize,
-            const std::size_t domains) const override
+    virtual std::size_t operator()(const T* const base_ptr,
+        const T* const page_ptr,
+        const std::size_t pagesize,
+        const std::size_t domains) const override
     {
         std::intptr_t offset = page_ptr - base_ptr;
-        std::size_t   col    = (offset / leading_dim_);
-        std::size_t   row    = (offset % leading_dim_);
-        std::size_t   index = col/rows_page_;
+        std::size_t col = (offset / leading_dim_);
+        std::size_t row = (offset % leading_dim_);
+        std::size_t index = col / rows_page_;
         index += (row / rows_page_);
         return index % domains;
     }
@@ -58,23 +59,20 @@ struct matrix_numa_binder : hpx::compute::host::numa_binding_helper<T>
     virtual std::string description() const override
     {
         std::ostringstream temp;
-        temp << "Matrix "             << std::dec
-             << " columns "           << cols_
-             << " rows "              << rows_
-             << " tile_size "         << tile_size_
-             << " leading_dim "       << leading_dim_
-             << " tiles_per_domain "  << tiles_per_domain_
-             << " colprocs "          << colprocs_
-             << " rowprocs "          << rowprocs_
-             << " rows_page "         << rows_page_ << " domains(col) " << rows_/rows_page_
-             << " display_step ("     << display_step(0) << ',' << display_step(1) << ')';
+        temp << "Matrix " << std::dec << " columns " << cols_ << " rows "
+             << rows_ << " tile_size " << tile_size_ << " leading_dim "
+             << leading_dim_ << " tiles_per_domain " << tiles_per_domain_
+             << " colprocs " << colprocs_ << " rowprocs " << rowprocs_
+             << " rows_page " << rows_page_ << " domains(col) "
+             << rows_ / rows_page_ << " display_step (" << display_step(0)
+             << ',' << display_step(1) << ')';
         return temp.str();
     }
 
     // Total memory consumption in bytes
     virtual std::size_t memory_bytes() const override
     {
-        return sizeof(T) * (cols_/colprocs_) * (leading_dim_/rowprocs_);
+        return sizeof(T) * (cols_ / colprocs_) * (leading_dim_ / rowprocs_);
     }
 
     // Using how many dimensions should this data be displayed
@@ -86,8 +84,9 @@ struct matrix_numa_binder : hpx::compute::host::numa_binding_helper<T>
     // The number of elements along dimension x=0,y=1,z=2,...
     virtual std::size_t array_size(std::size_t axis) const override
     {
-        if (axis==0) return cols_/colprocs_;
-        return rows_/rowprocs_;
+        if (axis == 0)
+            return cols_ / colprocs_;
+        return rows_ / rowprocs_;
     }
 
     // When counting along elements in a given dimension,
@@ -95,14 +94,16 @@ struct matrix_numa_binder : hpx::compute::host::numa_binding_helper<T>
     // This should include padding along an axis
     virtual std::size_t memory_step(std::size_t axis) const override
     {
-        if (axis==0) return leading_dim_/rowprocs_;
+        if (axis == 0)
+            return leading_dim_ / rowprocs_;
         return 1;
     }
 
     // When displaying the data, what step size should be used
     virtual std::size_t display_step(std::size_t axis) const override
     {
-        if (axis==0) return rows_page_;
+        if (axis == 0)
+            return rows_page_;
         return rows_page_;
     }
     //
@@ -116,4 +117,4 @@ struct matrix_numa_binder : hpx::compute::host::numa_binding_helper<T>
     std::size_t rows_page_;
 };
 
-#endif // ALLOCATOR_BINDER_MATRIX_HPP
+#endif    // ALLOCATOR_BINDER_MATRIX_HPP

--- a/tests/unit/topology/allocator_binder_matrix.hpp
+++ b/tests/unit/topology/allocator_binder_matrix.hpp
@@ -1,0 +1,110 @@
+#ifndef ALLOCATOR_BINDER_MATRIX_HPP
+#define ALLOCATOR_BINDER_MATRIX_HPP
+
+#include <hpx/parallel/util/numa_binding_allocator.hpp>
+
+// ------------------------------------------------------------------------
+// Example of an allocator binder for 2D matrices that are tiled.
+// Data is stored in column major order and columns are padded
+// to align with a page boundary.
+// Note: Column major ordering flips offsets (caution)
+// ------------------------------------------------------------------------
+template <typename T>
+struct matrix_numa_binder : hpx::compute::host::numa_binding_helper<T>
+{
+    matrix_numa_binder(std::size_t Ncols, std::size_t Nrows,
+                       std::size_t Ntile, std::size_t Ntiles_per_domain,
+                       std::size_t Ncolprocs=1, std::size_t Nrowprocs=1
+                       )
+        : hpx::compute::host::numa_binding_helper<T>()
+        , cols_(Ncols), rows_(Nrows)
+        , tile_size_(Ntile), tiles_per_domain_(Ntiles_per_domain)
+        ,  colprocs_(Ncolprocs), rowprocs_(Nrowprocs)
+    {
+        const int CACHE_LINE_SIZE = sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
+        const int PAGE_SIZE       = sysconf(_SC_PAGE_SIZE);
+        const int ALIGNMENT       = std::max(PAGE_SIZE, CACHE_LINE_SIZE);
+        const int ELEMS_ALIGN     = (ALIGNMENT/sizeof(T));
+        rows_page_   = ELEMS_ALIGN;
+        leading_dim_ = ELEMS_ALIGN*((rows_*sizeof(T) + ALIGNMENT-1)/ALIGNMENT);
+        // @TODO : put tiles_per_domain_ back in
+    }
+
+    // return the domain that a given page should be bound to
+    virtual std::size_t operator ()(
+            const T * const base_ptr,
+            const T * const page_ptr,
+            const std::size_t pagesize,
+            const std::size_t domains) const override
+    {
+        std::intptr_t offset = page_ptr - base_ptr;
+        std::size_t   col    = (offset / leading_dim_);
+        std::size_t   row    = (offset % leading_dim_);
+        std::size_t   index = col/rows_page_;
+        index += (row / rows_page_);
+        return index % domains;
+    }
+
+    // for debug purposes
+    virtual std::string description() const override
+    {
+        std::ostringstream temp;
+        temp << "Matrix "             << std::dec
+             << " columns "           << cols_
+             << " rows "              << rows_
+             << " tile_size "         << tile_size_
+             << " leading_dim "       << leading_dim_
+             << " tiles_per_domain "  << tiles_per_domain_
+             << " colprocs "          << colprocs_
+             << " rowprocs "          << rowprocs_
+             << " rows_page "         << rows_page_ << " domains(col) " << rows_/rows_page_
+             << " display_step ("     << display_step(0) << ',' << display_step(1) << ')';
+        return temp.str();
+    }
+
+    // Total memory consumption in bytes
+    virtual std::size_t memory_bytes() const override
+    {
+        return sizeof(T) * (cols_/colprocs_) * (leading_dim_/rowprocs_);
+    }
+
+    // Using how many dimensions should this data be displayed
+    virtual std::size_t array_rank() const override
+    {
+        return 2;
+    }
+
+    // The number of elements along dimension x=0,y=1,z=2,...
+    virtual std::size_t array_size(std::size_t axis) const override
+    {
+        if (axis==0) return cols_/colprocs_;
+        return rows_/rowprocs_;
+    }
+
+    // When counting along elements in a given dimension,
+    // how large a step should be taken in units of elements.
+    // This should include padding along an axis
+    virtual std::size_t memory_step(std::size_t axis) const override
+    {
+        if (axis==0) return leading_dim_/rowprocs_;
+        return 1;
+    }
+
+    // When displaying the data, what step size should be used
+    virtual std::size_t display_step(std::size_t axis) const override
+    {
+        if (axis==0) return rows_page_;
+        return rows_page_;
+    }
+    //
+    std::size_t cols_;
+    std::size_t rows_;
+    std::size_t tile_size_;
+    std::size_t leading_dim_;
+    std::size_t tiles_per_domain_;
+    std::size_t colprocs_;
+    std::size_t rowprocs_;
+    std::size_t rows_page_;
+};
+
+#endif // ALLOCATOR_BINDER_MATRIX_HPP

--- a/tests/unit/topology/allocator_binder_matrix.hpp
+++ b/tests/unit/topology/allocator_binder_matrix.hpp
@@ -2,6 +2,10 @@
 #define ALLOCATOR_BINDER_MATRIX_HPP
 
 #include <hpx/parallel/util/numa_binding_allocator.hpp>
+//
+#include <cstddef>
+#include <sstream>
+#include <string>
 
 // ------------------------------------------------------------------------
 // Example of an allocator binder for 2D matrices that are tiled.
@@ -23,7 +27,7 @@ struct matrix_numa_binder : hpx::compute::host::numa_binding_helper<T>
     {
         const int CACHE_LINE_SIZE = sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
         const int PAGE_SIZE       = sysconf(_SC_PAGE_SIZE);
-        const int ALIGNMENT       = std::max(PAGE_SIZE, CACHE_LINE_SIZE);
+        const int ALIGNMENT       = (std::max)(PAGE_SIZE, CACHE_LINE_SIZE);
         const int ELEMS_ALIGN     = (ALIGNMENT/sizeof(T));
         rows_page_   = ELEMS_ALIGN;
         leading_dim_ = ELEMS_ALIGN*((rows_*sizeof(T) + ALIGNMENT-1)/ALIGNMENT);

--- a/tests/unit/topology/allocator_binder_matrix.hpp
+++ b/tests/unit/topology/allocator_binder_matrix.hpp
@@ -1,3 +1,8 @@
+//  Copyright (c) 2019 John Biddiscombe
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #ifndef ALLOCATOR_BINDER_MATRIX_HPP
 #define ALLOCATOR_BINDER_MATRIX_HPP
 
@@ -25,8 +30,8 @@ struct matrix_numa_binder : hpx::compute::host::numa_binding_helper<T>
         , tile_size_(Ntile), tiles_per_domain_(Ntiles_per_domain)
         ,  colprocs_(Ncolprocs), rowprocs_(Nrowprocs)
     {
-        const int CACHE_LINE_SIZE = sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
-        const int PAGE_SIZE       = sysconf(_SC_PAGE_SIZE);
+        const int CACHE_LINE_SIZE = hpx::threads::get_cache_line_size();
+        const int PAGE_SIZE       = hpx::threads::get_memory_page_size();
         const int ALIGNMENT       = (std::max)(PAGE_SIZE, CACHE_LINE_SIZE);
         const int ELEMS_ALIGN     = (ALIGNMENT/sizeof(T));
         rows_page_   = ELEMS_ALIGN;

--- a/tests/unit/topology/numa_allocator.cpp
+++ b/tests/unit/topology/numa_allocator.cpp
@@ -82,7 +82,8 @@ void test_binding(std::shared_ptr<Binder<T>> numa_binder, Allocator &allocator)
     temp << "Numa page binding for page count " << num_pages << "\n";
     for (std::size_t i=0; i<num_pages; ++i) {
         // we pass the base pointer and current page pointer
-        std::size_t dom = numa_binder->operator()(M, page_ptr, pagesize, num_numa_domains);
+        std::size_t dom =
+                numa_binder->operator()(M, page_ptr, pagesize, num_numa_domains);
         temp << dom;
         page_ptr += pageN;
     }
@@ -97,7 +98,8 @@ void test_binding(std::shared_ptr<Binder<T>> numa_binder, Allocator &allocator)
     std::cout << "get_numa_domain() " << num_numa_domains << " Domain Numa pattern\n";
     for (unsigned int j=0; j<ysize; j+=ystep) {
         for (unsigned int i=0; i<xsize; i+=xstep) {
-            T *page_ptr = &M[i*numa_binder->memory_step(0) + j*numa_binder->memory_step(1)];
+            T *page_ptr =
+                    &M[i*numa_binder->memory_step(0) + j*numa_binder->memory_step(1)];
             int dom = allocator.get_numa_domain(page_ptr);
             if (dom == -1) {
                 std::cout << '-';
@@ -114,7 +116,8 @@ void test_binding(std::shared_ptr<Binder<T>> numa_binder, Allocator &allocator)
         std::cout << "Contents of memory locations\n";
         for (unsigned int j=0; j<ysize; j+=ystep) {
             for (unsigned int i=0; i<xsize; i+=xstep) {
-                T *page_ptr = &M[i*numa_binder->memory_step(0) + j*numa_binder->memory_step(1)];
+                T *page_ptr =
+                    &M[i*numa_binder->memory_step(0) + j*numa_binder->memory_step(1)];
                 std::cout << *page_ptr << " ";
             }
             std::cout << "\n";
@@ -126,7 +129,8 @@ void test_binding(std::shared_ptr<Binder<T>> numa_binder, Allocator &allocator)
     std::cout << "Expected " << num_numa_domains << " Domain Numa pattern\n";
     for (unsigned int j=0; j<ysize; j+=ystep) {
         for (unsigned int i=0; i<xsize; i+=xstep) {
-            T *page_ptr = &M[i*numa_binder->memory_step(0) + j*numa_binder->memory_step(1)];
+            T *page_ptr =
+                &M[i*numa_binder->memory_step(0) + j*numa_binder->memory_step(1)];
             int d = numa_binder->operator()(M, page_ptr, 4096, num_numa_domains);
             std::cout << std::hex << d;
         }

--- a/tests/unit/topology/numa_allocator.cpp
+++ b/tests/unit/topology/numa_allocator.cpp
@@ -73,7 +73,7 @@ void test_binding(std::shared_ptr<Binder<T>> numa_binder, Allocator &allocator)
     std::string domain_string = allocator.get_page_numa_domains(M, num_bytes);
 
     // now generate the 'correct' string of numa domains per page
-    const std::size_t pagesize  = sysconf(_SC_PAGE_SIZE);
+    const std::size_t pagesize  = hpx::threads::get_memory_page_size();
     const std::size_t pageN     = pagesize/sizeof(T);
     const std::size_t num_pages = (num_bytes + pagesize - 1) / pagesize;
     T* page_ptr = M;

--- a/tests/unit/topology/numa_allocator.cpp
+++ b/tests/unit/topology/numa_allocator.cpp
@@ -145,7 +145,7 @@ void test_binding(std::shared_ptr<Binder<T>> numa_binder, Allocator& allocator)
             T* page_ptr = &M[i * numa_binder->memory_step(0) +
                 j * numa_binder->memory_step(1)];
             int d =
-                numa_binder->operator()(M, page_ptr, 4096, num_numa_domains);
+                numa_binder->operator()(M, page_ptr, pagesize, num_numa_domains);
             std::cout << std::hex << d;
         }
         std::cout << "\n";

--- a/tests/unit/topology/numa_allocator.cpp
+++ b/tests/unit/topology/numa_allocator.cpp
@@ -217,7 +217,7 @@ int main(int argc, char* argv[])
     // clang-format off
     desc_cmdline.add_options()
         ("size,n",
-         boost::program_options::value<int>()->default_value(4096),
+         boost::program_options::value<int>()->default_value(1024),
          "Matrix size.")
         ("tiles-per-domain,t",
          boost::program_options::value<int>()->default_value(1),

--- a/tests/unit/topology/numa_allocator.cpp
+++ b/tests/unit/topology/numa_allocator.cpp
@@ -1,0 +1,262 @@
+//  Copyright (c) 2017-2018 John Biddiscombe
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+//
+#include <hpx/parallel/algorithms/for_loop.hpp>
+#include <hpx/parallel/executors.hpp>
+//
+#include <hpx/runtime/resource/partitioner.hpp>
+#include <hpx/runtime/threads/cpu_mask.hpp>
+#include <hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp>
+#include <hpx/runtime/threads/executors/pool_executor.hpp>
+#include <hpx/runtime/threads/executors/guided_pool_executor.hpp>
+//
+#include <hpx/include/iostreams.hpp>
+#include <hpx/include/runtime.hpp>
+//
+#include <hpx/util/lightweight_test.hpp>
+//
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+// The allocator that binds pages to numa domains
+#include <hpx/parallel/util/numa_binding_allocator.hpp>
+// Example binder functions for different page binding mappings
+#include "allocator_binder_linear.hpp"
+#include "allocator_binder_matrix.hpp"
+// Scheduler that honours numa placement hints for tasks
+#include "examples/resource_partitioner/shared_priority_queue_scheduler.hpp"
+
+// ------------------------------------------------------------------------
+// allocator maker for this test
+template <template<typename> class Binder, typename T>
+auto get_allocator(std::shared_ptr<Binder<T>> numa_binder, int allocator_mode)
+{
+    using namespace hpx::compute::host;
+    if (allocator_mode==0) {
+        return numa_binding_allocator<T>(numa_binder,
+            hpx::threads::hpx_hwloc_membind_policy::membind_firsttouch, 0);
+    }
+    else if (allocator_mode==1) {
+        return numa_binding_allocator<T>(numa_binder,
+            hpx::threads::hpx_hwloc_membind_policy::membind_interleave, 0);
+    }
+    else /*if (allocator_mode==2)*/ {
+        return numa_binding_allocator<T>(numa_binder,
+            hpx::threads::hpx_hwloc_membind_policy::membind_user, 0);
+    }
+}
+
+// ------------------------------------------------------------------------
+template <template<typename> class Binder, typename T, typename Allocator>
+void test_binding(std::shared_ptr<Binder<T>> numa_binder, Allocator &allocator)
+{
+    // num_numa_domains is only correct when using the default pool
+    int num_numa_domains = hpx::resource::get_partitioner().numa_domains().size();
+
+    // create a container
+    std::vector<T, Allocator> data(allocator);
+
+    // resize it and trigger a page touch function for each page
+    std::size_t num_bytes = numa_binder->memory_bytes();
+    data.reserve(num_bytes/sizeof(T));
+    T *M = data.data();
+    // this is a debugging function that returns a string of numa bindings
+    std::string domain_string = allocator.get_page_numa_domains(M, num_bytes);
+
+    // now generate the 'correct' string of numa domains per page
+    const std::size_t pagesize  = sysconf(_SC_PAGE_SIZE);
+    const std::size_t pageN     = pagesize/sizeof(T);
+    const std::size_t num_pages = (num_bytes + pagesize - 1) / pagesize;
+    T* page_ptr = M;
+
+    std::stringstream temp;
+    temp << "Numa page binding for page count " << num_pages << "\n";
+    for (std::size_t i=0; i<num_pages; ++i) {
+        // we pass the base pointer and current page pointer
+        std::size_t dom = numa_binder->operator()(M, page_ptr, pagesize, num_numa_domains);
+        temp << dom;
+        page_ptr += pageN;
+    }
+    HPX_TEST_EQ(domain_string, temp.str());
+
+    std::size_t xsize = numa_binder->array_size(0);
+    std::size_t ysize = numa_binder->array_size(1);
+    std::size_t xstep = numa_binder->display_step(0);
+    std::size_t ystep = numa_binder->display_step(1);
+
+    std::cout << "============================\n";
+    std::cout << "get_numa_domain() " << num_numa_domains << " Domain Numa pattern\n";
+    for (unsigned int j=0; j<ysize; j+=ystep) {
+        for (unsigned int i=0; i<xsize; i+=xstep) {
+            T *page_ptr = &M[i*numa_binder->memory_step(0) + j*numa_binder->memory_step(1)];
+            int dom = allocator.get_numa_domain(page_ptr);
+            if (dom == -1) {
+                std::cout << '-';
+            }
+            else
+                std::cout << std::hex << dom;
+        }
+        std::cout << "\n";
+    }
+    std::cout << "============================\n\n";
+
+#ifdef NUMA_BINDING_ALLOCATOR_INIT_MEMORY
+        std::cout << "============================\n";
+        std::cout << "Contents of memory locations\n";
+        for (unsigned int j=0; j<ysize; j+=ystep) {
+            for (unsigned int i=0; i<xsize; i+=xstep) {
+                T *page_ptr = &M[i*numa_binder->memory_step(0) + j*numa_binder->memory_step(1)];
+                std::cout << *page_ptr << " ";
+            }
+            std::cout << "\n";
+        }
+        std::cout << "============================\n\n";
+#endif
+
+    std::cout << "============================\n";
+    std::cout << "Expected " << num_numa_domains << " Domain Numa pattern\n";
+    for (unsigned int j=0; j<ysize; j+=ystep) {
+        for (unsigned int i=0; i<xsize; i+=xstep) {
+            T *page_ptr = &M[i*numa_binder->memory_step(0) + j*numa_binder->memory_step(1)];
+            int d = numa_binder->operator()(M, page_ptr, 4096, num_numa_domains);
+            std::cout << std::hex << d;
+        }
+        std::cout << "\n";
+    }
+    std::cout << "============================\n\n";
+
+#ifdef NUMA_BINDING_ALLOCATOR_DEBUG_PAGE_BINDING
+    std::cout << allocator.display_binding(M, numa_binder) << std::endl;
+#endif
+}
+
+// ------------------------------------------------------------------------
+// this is called on an hpx thread after the runtime starts up
+// ------------------------------------------------------------------------
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    int Nc = vm["size"].as<int>();
+    int Nr = vm["size"].as<int>();
+    int Nt = vm["nb"].as<int>();
+    int Nd = vm["tiles-per-domain"].as<int>();
+    int p = vm["col-proc"].as<int>();
+    int q = vm["row-proc"].as<int>();
+
+    std::size_t num_threads = hpx::get_num_worker_threads();
+    std::cout << "HPX using threads = " << num_threads << std::endl;
+
+    // ---------------------------------
+    using namespace hpx::compute::host;
+    using matrix_elem = double;
+    int allocator_mode = 2;
+
+    // ---------------------------------
+    // test linear 1D array
+    std::cout << "Test 1D" << std::endl << std::endl;
+    using binder_type_1D = linear_numa_binder<matrix_elem>;
+    std::shared_ptr<binder_type_1D> numa_binder_1D =
+            std::make_shared<binder_type_1D>(Nc);
+
+    auto allocator_1D = get_allocator(numa_binder_1D, allocator_mode);
+    test_binding(numa_binder_1D, allocator_1D);
+
+    // ---------------------------------
+    // test 2D matrix : todo add tiles per page etc
+    std::cout << "Test 2D" << std::endl << std::endl;
+    using binder_type_2D = matrix_numa_binder<matrix_elem>;
+    std::shared_ptr<binder_type_2D> numa_binder_2D =
+            std::make_shared<binder_type_2D>(10*Nc, 10*Nr, Nt, Nd, p, q);
+
+    auto allocator_2D = numa_binding_allocator<matrix_elem>(numa_binder_2D,
+        hpx::threads::hpx_hwloc_membind_policy::membind_user, 0);
+    test_binding(numa_binder_2D, allocator_2D);
+
+    return hpx::finalize();
+}
+
+// ------------------------------------------------------------------------
+// scheduler type needed for numa bound tasks
+// ------------------------------------------------------------------------
+using high_priority_sched =
+    hpx::threads::policies::example::shared_priority_queue_scheduler<>;
+using hpx::threads::policies::scheduler_mode;
+
+// the normal int main function that is called at startup and runs on an OS thread
+// the user must call hpx::init to start the hpx runtime which will execute hpx_main
+// on an hpx thread
+int main(int argc, char* argv[])
+{
+    boost::program_options::options_description desc_cmdline("Test options");
+    // clang-format off
+    desc_cmdline.add_options()
+        ("size,n",
+         boost::program_options::value<int>()->default_value(4096),
+         "Matrix size.")
+        ("tiles-per-domain,t",
+         boost::program_options::value<int>()->default_value(1),
+        "Number of Tiles per numa domain.")
+        ("nb",
+         boost::program_options::value<int>()->default_value(128),
+        "Block cyclic distribution size.")
+        ("row-proc,p",
+         boost::program_options::value<int>()->default_value(1),
+        "Number of row processes in the 2D communicator.")
+        ("col-proc,q",
+         boost::program_options::value<int>()->default_value(1),
+        "Number of column processes in the 2D communicator.")
+        ("no-check",
+         "Disable result checking")
+    // clang-format on
+    ;
+
+    // HPX uses a boost program options variable map, but we need it before
+    // hpx-main, so we will create another one here and throw it away after use
+    boost::program_options::variables_map vm;
+    boost::program_options::store(
+        boost::program_options::command_line_parser(argc, argv)
+            .allow_unregistered()
+            .options(desc_cmdline)
+            .run(),
+        vm);
+
+    // Create the resource partitioner
+    hpx::resource::partitioner rp(desc_cmdline, argc, argv);
+
+    using numa_scheduler =
+        hpx::threads::policies::example::shared_priority_queue_scheduler<>;
+    using hpx::threads::policies::scheduler_mode;
+    // setup the default pool with a numa aware scheduler
+    rp.create_thread_pool(
+        "default",
+        [](hpx::threads::policies::callback_notifier& notifier, std::size_t num_threads,
+          std::size_t thread_offset, std::size_t pool_index,
+          std::string const& pool_name) -> std::unique_ptr<hpx::threads::thread_pool_base>
+          {
+            std::unique_ptr<numa_scheduler> scheduler(new numa_scheduler(
+                num_threads, {2, 3, 64}, "shared-priority-scheduler"));
+
+            scheduler_mode mode = scheduler_mode(
+                scheduler_mode::do_background_work |
+                scheduler_mode::delay_exit);
+
+            std::unique_ptr<hpx::threads::thread_pool_base> pool(
+              new hpx::threads::detail::scheduled_thread_pool<high_priority_sched>(
+                  std::move(scheduler), notifier, pool_index, pool_name,
+                  mode, thread_offset)
+            );
+            return pool;
+          }
+    );
+
+    hpx::init();
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
## Proposed Changes
This introduces a numa_allocator that can provide memory with interleaved/first touch or user defined numa binding per page of memory.
The allocator uses a 'binder' object that defines the way pages are bound and users can supply their own binders. A 1D and 2D example (unit test) are provided that mimic the way we bind memory in our matrix allocation