### PR TITLE
Adding a distributed object abstraction

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -144,6 +144,7 @@ set(doxygen_dependencies
     "${PROJECT_SOURCE_DIR}/hpx/runtime/threads/thread_pool_base.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/lcos/barrier.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/lcos/broadcast.hpp"
+    "${PROJECT_SOURCE_DIR}/hpx/lcos/distributed_object.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/lcos/fold.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/lcos/gather.hpp"
     "${PROJECT_SOURCE_DIR}/hpx/lcos/reduce.hpp"

--- a/examples/transpose/CMakeLists.txt
+++ b/examples/transpose/CMakeLists.txt
@@ -12,6 +12,7 @@ set(example_programs
   transpose_block
   transpose_block_numa
   transpose_serial_vector
+  transpose_distributed_object
 )
 
 if(HPX_WITH_AWAIT)

--- a/examples/transpose/transpose_distributed_object.cpp
+++ b/examples/transpose/transpose_distributed_object.cpp
@@ -1,0 +1,380 @@
+// Copyright (c) 2019 Weile Wei
+// Copyright (c) 2019 Maxwell Reeser
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+///////////////////////////////////////////////////////////////////////////
+/// This is an example of distributed matrix transposition using distributed_object.
+///
+/// A distributed object is a single logical object partitioned across
+/// a set of localities. (A locality is a single node in a cluster or a
+/// NUMA domain in a SMP machine.) Each locality constructs an instance of
+/// distributed_object<T>, where a value of type T represents the value of this
+/// this locality's instance value. Once distributed_object<T> is constrcuted, it
+/// has a universal name which can be used on any locality in the given
+/// localities to locate the resident instance.
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+
+#include <hpx/parallel/algorithms/for_each.hpp>
+#include <hpx/parallel/algorithms/transform_reduce.hpp>
+
+#include <boost/range/irange.hpp>
+
+#include <hpx/include/async.hpp>
+#include <hpx/include/dataflow.hpp>
+#include <hpx/lcos/barrier.hpp>
+#include <hpx/lcos/distributed_object.hpp>
+#include <hpx/lcos/when_all.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <vector>
+
+bool verbose = false;    // command line argument
+
+typedef double* sub_block;
+
+#define COL_SHIFT 1000.00    // Constant to shift column index
+#define ROW_SHIFT 0.01       // Constant to shift row index
+
+// Register type for template components
+REGISTER_DISTRIBUTED_OBJECT_PART(double);
+using myVectorDouble = std::vector<double>;
+REGISTER_DISTRIBUTED_OBJECT_PART(myVectorDouble);
+
+using hpx::lcos::distributed_object;
+
+///////////////////////////////////////////////////////////////////////////////
+// transpose matrix when the target matrix is in a remote node
+void transpose(hpx::future<std::vector<double>> Af, std::uint64_t A_offset,
+    distributed_object<std::vector<double>>& B_temp, std::uint64_t B_offset,
+    std::uint64_t block_size, std::uint64_t block_order,
+    std::uint64_t tile_size);
+
+///////////////////////////////////////////////////////////////////////////////
+// transpose matrix when the target and destination matrix are in a same node
+void transpose_local(distributed_object<std::vector<double>>& A_temp,
+    std::uint64_t A_offset, distributed_object<std::vector<double>>& B_temp,
+    std::uint64_t B_offset, std::uint64_t block_size, std::uint64_t block_order,
+    std::uint64_t tile_size);
+
+double test_results(std::uint64_t order, std::uint64_t block_order,
+    std::vector<distributed_object<std::vector<double>>>& trans,
+    std::uint64_t blocks_start, std::uint64_t blocks_end);
+
+///////////////////////////////////////////////////////////////////////////////
+void run_matrix_transposition(boost::program_options::variables_map& vm)
+{
+    hpx::id_type here = hpx::find_here();
+    bool root = here == hpx::find_root_locality();
+
+    std::uint64_t num_localities = hpx::get_num_localities().get();
+
+    std::uint64_t order = vm["matrix_size"].as<std::uint64_t>();
+    std::uint64_t iterations = vm["iterations"].as<std::uint64_t>();
+    std::uint64_t num_local_blocks = vm["num_blocks"].as<std::uint64_t>();
+    std::uint64_t tile_size = order;
+
+    if (vm.count("tile_size"))
+        tile_size = vm["tile_size"].as<std::uint64_t>();
+
+    verbose = vm.count("verbose") > 0 ? true : false;
+
+    std::uint64_t bytes =
+        static_cast<std::uint64_t>(2.0 * sizeof(double) * order * order);
+
+    std::uint64_t num_blocks = num_localities * num_local_blocks;
+
+    std::uint64_t block_order = order / num_blocks;
+    std::uint64_t col_block_size = order * block_order;
+
+    std::uint64_t id = hpx::get_locality_id();
+
+    std::vector<distributed_object<std::vector<double>>> A(num_blocks);
+    std::vector<distributed_object<std::vector<double>>> B(num_blocks);
+
+    std::uint64_t blocks_start = id * num_local_blocks;
+    std::uint64_t blocks_end = (id + 1) * num_local_blocks;
+
+    // First allocate and create our local blocks
+    for (std::uint64_t b = 0; b != num_local_blocks; ++b)
+    {
+        std::uint64_t block_idx = b + blocks_start;
+        A[block_idx] = distributed_object<std::vector<double>>(
+            "A", std::vector<double>(col_block_size));
+        B[block_idx] = distributed_object<std::vector<double>>(
+            "B", std::vector<double>(col_block_size));
+    }
+
+    using hpx::parallel::for_each;
+    using hpx::parallel::execution::par;
+
+    // Fill the original matrix, set transpose to known garbage value.
+    auto range = boost::irange(blocks_start, blocks_end);
+    hpx::parallel::for_each(
+        par, std::begin(range), std::end(range), [&](std::uint64_t b) {
+            for (std::uint64_t i = 0; i != order; ++i)
+            {
+                for (std::uint64_t j = 0; j != block_order; ++j)
+                {
+                    double col_val = COL_SHIFT * (b * block_order + j);
+                    (*A[b])[i * block_order + j] = col_val + ROW_SHIFT * i;
+                    (*B[b])[i * block_order + j] = -1.0;
+                }
+            }
+        });
+
+    // wait all matrix to be initialized
+    hpx::lcos::barrier b("wait_for_init", hpx::find_all_localities().size(),
+        hpx::get_locality_id());
+    b.wait();
+
+    if (root)
+    {
+        std::cout << "Serial Matrix transpose: B = A^T\n"
+                  << "Matrix order           = " << order << "\n"
+                  << "Matrix local columns   = " << block_order << "\n"
+                  << "Total number of blocks = " << num_blocks << "\n"
+                  << "Number of localities   = " << num_localities << "\n";
+        if (tile_size < order)
+            std::cout << "Tile size             = " << tile_size << "\n";
+        else
+            std::cout << "Untiled\n";
+        std::cout << "Number of iterations  = " << iterations << "\n";
+    }
+
+    double errsq = 0.0;
+    double avgtime = 0.0;
+    double maxtime = 0.0;
+    double mintime =
+        366.0 * 24.0 * 3600.0;    // set the minimum time to a large value;
+                                  // one leap year should be enough
+
+    // start of iter loop
+    for (std::uint64_t iter = 0; iter < iterations; ++iter)
+    {
+        // starts matrix transposition
+        std::vector<hpx::future<void>> block_futures;
+        block_futures.resize(num_local_blocks);
+        hpx::util::high_resolution_timer t;
+        for_each(par, std::begin(range), std::end(range), [&](std::uint64_t b) {
+            std::vector<hpx::future<void>> phase_futures;
+            phase_futures.reserve(num_blocks);
+
+            auto phase_range =
+                boost::irange(static_cast<std::uint64_t>(0), num_blocks);
+            for (std::uint64_t phase : phase_range)
+            {
+                const std::uint64_t block_size = block_order * block_order;
+                const std::uint64_t from_block = phase;
+                const std::uint64_t from_phase = b;
+                const std::uint64_t A_offset = from_phase * block_size;
+                const std::uint64_t B_offset = phase * block_size;
+                const std::uint64_t from_locality = from_block % num_localities;
+                // Perform matrix transposition locally
+                if (blocks_start <= phase && phase < blocks_end)
+                {
+                    phase_futures.push_back(hpx::async(&transpose_local,
+                        std::ref(A[from_block]), A_offset, std::ref(B[b]),
+                        B_offset, block_size, block_order, tile_size));
+                }
+                // fetch remote matrix and then transpose the matrix
+                else
+                {
+                    phase_futures.push_back(hpx::dataflow(&transpose,
+                        A[b].fetch(from_locality), A_offset, std::ref(B[b]),
+                        B_offset, block_size, block_order, tile_size));
+                }
+            }
+
+            block_futures[b - blocks_start] = hpx::when_all(phase_futures);
+        });
+
+        hpx::wait_all(block_futures);
+
+        double elapsed = t.elapsed();
+
+        if (iter > 0 || iterations == 1)    // Skip the first iteration
+        {
+            avgtime = avgtime + elapsed;
+            maxtime = (std::max)(maxtime, elapsed);
+            mintime = (std::min)(mintime, elapsed);
+        }
+
+        if (root)
+            errsq +=
+                test_results(order, block_order, B, blocks_start, blocks_end);
+    }    // end of iter loop
+
+    double epsilon = 1.e-8;
+    if (root)
+    {
+        if (errsq < epsilon)
+        {
+            std::cout << "Solution validates\n";
+            avgtime = avgtime /
+                static_cast<double>(
+                    (std::max)(iterations - 1, static_cast<std::uint64_t>(1)));
+            std::cout << "Rate (MB/s): " << 1.e-6 * bytes / mintime << ", "
+                      << "Avg time (s): " << avgtime << ", "
+                      << "Min time (s): " << mintime << ", "
+                      << "Max time (s): " << maxtime << "\n";
+
+            if (verbose)
+                std::cout << "Squared errors: " << errsq << "\n";
+        }
+        else
+        {
+            std::cout << "ERROR: Aggregate squared error " << errsq
+                      << " exceeds threshold " << epsilon << "\n";
+            hpx::terminate();
+        }
+    }
+}
+
+void transpose(hpx::future<std::vector<double>> Af, std::uint64_t A_offset,
+    distributed_object<std::vector<double>>& B_temp, std::uint64_t B_offset,
+    std::uint64_t block_size, std::uint64_t block_order,
+    std::uint64_t tile_size)
+{
+    std::vector<double> A_temp = Af.get();
+    const sub_block A(&(A_temp[A_offset]));
+    sub_block B(&((*B_temp)[B_offset]));
+
+    if (tile_size < block_order)
+    {
+        for (std::uint64_t i = 0; i < block_order; i += tile_size)
+        {
+            for (std::uint64_t j = 0; j < block_order; j += tile_size)
+            {
+                std::uint64_t max_i = (std::min)(block_order, i + tile_size);
+                std::uint64_t max_j = (std::min)(block_order, j + tile_size);
+
+                for (std::uint64_t it = i; it != max_i; ++it)
+                {
+                    for (std::uint64_t jt = j; jt != max_j; ++jt)
+                    {
+                        B[it + block_order * jt] = A[jt + block_order * it];
+                    }
+                }
+            }
+        }
+    }
+    else
+    {
+        for (std::uint64_t i = 0; i != block_order; ++i)
+        {
+            for (std::uint64_t j = 0; j != block_order; ++j)
+            {
+                B[i + block_order * j] = A[j + block_order * i];
+            }
+        }
+    }
+}
+
+void transpose_local(distributed_object<std::vector<double>>& A_temp,
+    std::uint64_t A_offset, distributed_object<std::vector<double>>& B_temp,
+    std::uint64_t B_offset, std::uint64_t block_size, std::uint64_t block_order,
+    std::uint64_t tile_size)
+{
+    const sub_block A(&((*A_temp)[A_offset]));
+    sub_block B(&((*B_temp)[B_offset]));
+
+    if (tile_size < block_order)
+    {
+        for (std::uint64_t i = 0; i < block_order; i += tile_size)
+        {
+            for (std::uint64_t j = 0; j < block_order; j += tile_size)
+            {
+                std::uint64_t max_i = (std::min)(block_order, i + tile_size);
+                std::uint64_t max_j = (std::min)(block_order, j + tile_size);
+
+                for (std::uint64_t it = i; it != max_i; ++it)
+                {
+                    for (std::uint64_t jt = j; jt != max_j; ++jt)
+                    {
+                        B[it + block_order * jt] = A[jt + block_order * it];
+                    }
+                }
+            }
+        }
+    }
+    else
+    {
+        for (std::uint64_t i = 0; i != block_order; ++i)
+        {
+            for (std::uint64_t j = 0; j != block_order; ++j)
+            {
+                B[i + block_order * j] = A[j + block_order * i];
+            }
+        }
+    }
+}
+
+double test_results(std::uint64_t order, std::uint64_t block_order,
+    std::vector<distributed_object<std::vector<double>>>& trans,
+    std::uint64_t blocks_start, std::uint64_t blocks_end)
+{
+    using hpx::parallel::transform_reduce;
+    using hpx::parallel::execution::par;
+
+    // Fill the original matrix, set transpose to known garbage value.
+    auto range = boost::irange(blocks_start, blocks_end);
+    double errsq = transform_reduce(
+        par, std::begin(range), std::end(range), 0.0,
+        [](double lhs, double rhs) { return lhs + rhs; },
+        [&](std::uint64_t b) -> double {
+            sub_block trans_block = &((*(trans[b]))[0]);
+            double errsq = 0.0;
+            for (std::uint64_t i = 0; i < order; ++i)
+            {
+                double col_val = COL_SHIFT * i;
+                for (std::uint64_t j = 0; j < block_order; ++j)
+                {
+                    double diff = trans_block[i * block_order + j] -
+                        (col_val + ROW_SHIFT * (b * block_order + j));
+                    errsq += diff * diff;
+                }
+            }
+            return errsq;
+        });
+    if (verbose)
+    {
+        std::cout << " Squared sum of differences: " << errsq << "\n";
+    }
+
+    return errsq;
+}
+
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    run_matrix_transposition(vm);
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    using namespace boost::program_options;
+
+    options_description desc_commandline;
+    desc_commandline.add_options()("matrix_size",
+        value<std::uint64_t>()->default_value(1024),
+        "Matrix Size")("iterations", value<std::uint64_t>()->default_value(1),
+        "# iterations")("tile_size", value<std::uint64_t>(),
+        "Number of tiles to divide the individual matrix blocks for improved "
+        "cache and TLB performance")("num_blocks",
+        value<std::uint64_t>()->default_value(1),
+        "Number of blocks to divide the individual matrix blocks for "
+        "improved cache and TLB performance")("verbose", "Verbose output");
+
+    // Initialize and run HPX, this example requires to run hpx_main on all
+    // localities
+    std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
+    return hpx::init(desc_commandline, argc, argv, cfg);
+}

--- a/hpx/include/distributed_object.hpp
+++ b/hpx/include/distributed_object.hpp
@@ -1,0 +1,11 @@
+//  Copyright (c) 2019 Weile Wei
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_DISTRIBUTED_OBJECT_APRIl_12_2019_0412PM)
+#define HPX_DISTRIBUTED_OBJECT_APRIl_12_2019_0412PM
+
+#include <hpx/lcos/distributed_object.hpp>
+
+#endif

--- a/hpx/lcos/distributed_object.hpp
+++ b/hpx/lcos/distributed_object.hpp
@@ -149,8 +149,8 @@ namespace hpx { namespace lcos { namespace server {
 namespace hpx { namespace lcos {
     enum class construction_type
     {
-        Meta_Object,
-        All_to_All
+        meta_object,
+        all_to_all
     };
 }}
 
@@ -205,7 +205,7 @@ typedef hpx::lcos::meta_object_server::registration_action
     register_with_meta_action;
 HPX_REGISTER_ACTION_DECLARATION(register_with_meta_action, register_mo_action);
 
-// Meta_object front end, decides whether it is the root locality, and thus
+// meta_object front end, decides whether it is the root locality, and thus
 // whether to register with the root locality's meta object only or to register
 // itself as the root locality's meta object as well
 namespace hpx { namespace lcos {
@@ -258,7 +258,7 @@ namespace hpx { namespace lcos {
     /// owns its local value. In other words, local data of the distributed
     /// object can be different, but they share access to one another's data
     /// globally.
-    template <typename T, construction_type C = construction_type::All_to_All>
+    template <typename T, construction_type C = construction_type::all_to_all>
     class distributed_object
       : hpx::components::client_base<distributed_object<T>,
             server::distributed_object_part<T>>
@@ -288,10 +288,10 @@ namespace hpx { namespace lcos {
         /// data, and a type and construction_type in the template parameters
         ///
         /// \param construction_type The construction_type in the template parameters
-        /// accepts either Meta_Object, and it is set to All_to_All by defalut
-        /// The Meta_Object option provides meta object registration in the root
+        /// accepts either meta_object, and it is set to all_to_all by defalut
+        /// The meta_object option provides meta object registration in the root
         /// locality and meta object is essentailly a table that can find the
-        /// instances of distributed_object in all localities. The All_to_All option only
+        /// instances of distributed_object in all localities. The all_to_all option only
         /// locally holds the client and server of the distributed_object.
         /// \param base_name The name of the distributed_object, which should be a unique
         /// string across the localities
@@ -302,13 +302,13 @@ namespace hpx { namespace lcos {
           , base_(base)
           , sub_localities_(std::move(sub_localities))
         {
-            HPX_ASSERT(C == construction_type::All_to_All ||
-                C == construction_type::Meta_Object);
+            HPX_ASSERT(C == construction_type::all_to_all ||
+                C == construction_type::meta_object);
             HPX_ASSERT(sub_localities_.size() > 0);
             ensure_ptr();
             std::sort(sub_localities_.begin(), sub_localities_.end());
 
-            if (C == construction_type::Meta_Object)
+            if (C == construction_type::meta_object)
             {
                 meta_object mo(
                     base, sub_localities_.size(), sub_localities_[0]);
@@ -337,7 +337,7 @@ namespace hpx { namespace lcos {
         }
         /// Creates a distributed_object in every locality with a given base_name string,
         /// data. The construction_type in the template parameter is set to
-        /// All_to_All option by default.
+        /// all_to_all option by default.
         ///
         /// \param base_name The name of the distributed_object, which should be a unique
         /// string across the localities
@@ -511,10 +511,10 @@ namespace hpx { namespace lcos {
         /// the local instance.
         ///
         /// \param construction_type The construction_type in the template parameters
-        /// accepts either Meta_Object, and it is set to All_to_All by defalut
-        /// The Meta_Object option provides meta object registration in the root
+        /// accepts either meta_object, and it is set to all_to_all by defalut
+        /// The meta_object option provides meta object registration in the root
         /// locality and meta object is essentailly a table that can find the
-        /// instances of distributed_object in all localities. The All_to_All option only
+        /// instances of distributed_object in all localities. The all_to_all option only
         /// locally holds the client and server of the distributed_object.
         /// \param base_name The name of the distributed_object, which should be a unique
         /// string across the localities
@@ -523,12 +523,12 @@ namespace hpx { namespace lcos {
           : base_type(create_server(data))
           , base_(base)
         {
-            HPX_ASSERT(C == construction_type::All_to_All ||
-                C == construction_type::Meta_Object);
+            HPX_ASSERT(C == construction_type::all_to_all ||
+                C == construction_type::meta_object);
             ensure_ptr();
             size_t localities = hpx::find_all_localities().size();
             init_sub_localities();
-            if (C == construction_type::Meta_Object)
+            if (C == construction_type::meta_object)
             {
                 meta_object mo(base, localities, 0);
                 locs = mo.registration(this->get_id());
@@ -547,13 +547,13 @@ namespace hpx { namespace lcos {
           , base_(base)
           , sub_localities_(std::move(sub_localities))
         {
-            HPX_ASSERT(C == construction_type::All_to_All ||
-                C == construction_type::Meta_Object);
+            HPX_ASSERT(C == construction_type::all_to_all ||
+                C == construction_type::meta_object);
             HPX_ASSERT(sub_localities_.size() > 0);
             ensure_ptr();
             std::sort(sub_localities_.begin(), sub_localities_.end());
 
-            if (C == construction_type::Meta_Object)
+            if (C == construction_type::meta_object)
             {
                 meta_object mo(
                     base, sub_localities_.size(), sub_localities_[0]);

--- a/hpx/lcos/distributed_object.hpp
+++ b/hpx/lcos/distributed_object.hpp
@@ -457,7 +457,7 @@ namespace hpx { namespace lcos {
         /// \cond NOINTERNAL
         /// force compilation error if serialization of client occurs
         template <typename Archive, typename Type>
-        HPX_FORCEINLINE void serialize(
+        void serialize(
             Archive& ar, base_type& f, unsigned version) = delete;
 
     private:
@@ -661,7 +661,7 @@ namespace hpx { namespace lcos {
         /// \cond NOINTERNAL
         /// force compilation error if serialization of client occurs
         template <typename Archive, typename Type>
-        HPX_FORCEINLINE void serialize(
+        void serialize(
             Archive& ar, base_type& f, unsigned version) = delete;
 
     private:

--- a/hpx/lcos/distributed_object.hpp
+++ b/hpx/lcos/distributed_object.hpp
@@ -13,7 +13,7 @@
 #include <hpx/include/components.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/lcos/barrier.hpp>
-#include <hpx/pp/cat.hpp>
+#include <hpx/preprocessor/cat.hpp>
 #include <hpx/runtime/actions/component_action.hpp>
 #include <hpx/runtime/serialization/unordered_map.hpp>
 #include <hpx/throw_exception.hpp>

--- a/hpx/lcos/distributed_object.hpp
+++ b/hpx/lcos/distributed_object.hpp
@@ -1,0 +1,702 @@
+// Copyright (c) 2019 Weile Wei
+// Copyright (c) 2019 Maxwell Reeser
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file lcos/distributed_object.hpp
+
+#ifndef HPX_LCOS_DISTRIBUTED_OBJECT_HPP
+#define HPX_LCOS_DISTRIBUTED_OBJECT_HPP
+
+#include <hpx/include/components.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/lcos/barrier.hpp>
+#include <hpx/pp/cat.hpp>
+#include <hpx/runtime/actions/component_action.hpp>
+#include <hpx/runtime/serialization/unordered_map.hpp>
+#include <hpx/throw_exception.hpp>
+#include <hpx/util/assert.hpp>
+#include <hpx/util/bind.hpp>
+#include <boost/iterator/counting_iterator.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+/// \cond NOINTERNAL
+namespace hpx { namespace lcos { namespace server {
+    template <typename T>
+    class distributed_object_part
+      : public hpx::components::locking_hook<
+            hpx::components::component_base<distributed_object_part<T>>>
+    {
+    public:
+        typedef T data_type;
+        distributed_object_part() {}
+
+        distributed_object_part(data_type const& data)
+          : data_(data)
+        {
+        }
+
+        distributed_object_part(data_type&& data)
+          : data_(std::move(data))
+        {
+        }
+
+        data_type& operator*()
+        {
+            return data_;
+        }
+
+        data_type const& operator*() const
+        {
+            return data_;
+        }
+
+        data_type const* operator->() const
+        {
+            return &data_;
+        }
+
+        data_type* operator->()
+        {
+            return &data_;
+        }
+
+        data_type fetch() const
+        {
+            return data_;
+        }
+
+        HPX_DEFINE_COMPONENT_ACTION(distributed_object_part, fetch);
+
+    private:
+        data_type data_;
+    };
+
+    template <typename T>
+    class distributed_object_part<T&>
+      : public hpx::components::locking_hook<
+            hpx::components::component_base<distributed_object_part<T&>>>
+    {
+    public:
+        typedef T& data_type;
+        distributed_object_part() {}
+
+        distributed_object_part(data_type data)
+          : data_(data)
+        {
+        }
+
+        data_type operator*()
+        {
+            return data_;
+        }
+
+        data_type operator*() const
+        {
+            return data_;
+        }
+
+        T const* operator->() const
+        {
+            return data_;
+        }
+
+        T* operator->()
+        {
+            return data_;
+        }
+
+        T fetch() const
+        {
+            return data_;
+        }
+
+        HPX_DEFINE_COMPONENT_ACTION(distributed_object_part, fetch);
+
+    private:
+        data_type data_;
+    };
+}}}
+
+#define REGISTER_DISTRIBUTED_OBJECT_PART_DECLARATION(type)                     \
+    HPX_REGISTER_ACTION_DECLARATION(                                           \
+        hpx::lcos::server::distributed_object_part<type>::fetch_action,        \
+        HPX_PP_CAT(__distributed_object_part_fetch_action_, type));
+
+/**/
+
+#define REGISTER_DISTRIBUTED_OBJECT_PART(type)                                 \
+    HPX_REGISTER_ACTION(                                                       \
+        hpx::lcos::server::distributed_object_part<type>::fetch_action,        \
+        HPX_PP_CAT(__distributed_object_part_fetch_action_, type));            \
+    typedef ::hpx::components::component<                                      \
+        hpx::lcos::server::distributed_object_part<type>>                      \
+        HPX_PP_CAT(__distributed_object_part_, type);                          \
+    HPX_REGISTER_COMPONENT(HPX_PP_CAT(__distributed_object_part_, type))       \
+    /**/
+
+namespace hpx { namespace lcos {
+    enum class construction_type
+    {
+        Meta_Object,
+        All_to_All
+    };
+}}
+
+namespace hpx { namespace lcos {
+    class meta_object_server
+      : public hpx::components::locking_hook<
+            hpx::components::component_base<meta_object_server>>
+    {
+    public:
+        meta_object_server()
+          : b(hpx::find_all_localities().size())
+        {
+            servers.resize(hpx::find_all_localities().size());
+        }
+
+        meta_object_server(std::size_t num_locs, std::size_t root)
+          : b(num_locs)
+        {
+            servers_ = std::unordered_map<std::size_t, hpx::id_type>();
+            retrieved = false;
+        }
+
+        std::unordered_map<std::size_t, hpx::id_type> get_server_list()
+        {
+            return servers_;
+        }
+
+        std::unordered_map<std::size_t, hpx::id_type> registration(
+            std::size_t source_loc, hpx::id_type id)
+        {
+            {
+                servers_[source_loc] = id;
+            }
+            b.wait();
+            return servers_;
+        }
+
+        HPX_DEFINE_COMPONENT_ACTION(meta_object_server, get_server_list);
+        HPX_DEFINE_COMPONENT_ACTION(meta_object_server, registration);
+
+    private:
+        hpx::lcos::local::barrier b;
+        std::vector<hpx::id_type> servers;
+        bool retrieved;
+        std::unordered_map<std::size_t, hpx::id_type> servers_;
+        std::vector<hpx::id_type> servers__;
+    };
+}}
+typedef hpx::lcos::meta_object_server::get_server_list_action get_list_action;
+HPX_REGISTER_ACTION_DECLARATION(get_list_action, get_server_list_mo_action);
+typedef hpx::lcos::meta_object_server::registration_action
+    register_with_meta_action;
+HPX_REGISTER_ACTION_DECLARATION(register_with_meta_action, register_mo_action);
+
+// Meta_object front end, decides whether it is the root locality, and thus
+// whether to register with the root locality's meta object only or to register
+// itself as the root locality's meta object as well
+namespace hpx { namespace lcos {
+    class meta_object
+      : hpx::components::client_base<meta_object, meta_object_server>
+    {
+    public:
+        typedef hpx::components::client_base<meta_object, meta_object_server>
+            base_type;
+        meta_object(
+            std::string basename, std::size_t num_locs, std::size_t root)
+          : base_type(
+                hpx::new_<meta_object_server>(hpx::find_here(), num_locs, root))
+        {
+            if (hpx::get_locality_id() == root)
+            {
+                hpx::register_with_basename(
+                    basename, this->get_id(), hpx::get_locality_id());
+            }
+            meta_object_0 = hpx::find_from_basename(basename, root).get();
+        }
+
+        std::unordered_map<std::size_t, hpx::id_type> get_server_list()
+        {
+            return hpx::async(get_list_action(), meta_object_0).get();
+        }
+
+        std::unordered_map<std::size_t, hpx::id_type> registration(
+            hpx::id_type id)
+        {
+            hpx::future<std::unordered_map<std::size_t, hpx::id_type>> ret =
+                hpx::async(register_with_meta_action(), meta_object_0,
+                    hpx::get_locality_id(), id);
+            std::unordered_map<std::size_t, hpx::id_type> ret_ = ret.get();
+            return ret_;
+        }
+
+    private:
+        hpx::id_type meta_object_0;
+    };
+}}
+/// \endcond
+// The front end for the distributed_object itself. Essentially wraps actions for
+// the server, and stores information locally about the localities/servers
+// that it needs to know about
+namespace hpx { namespace lcos {
+    /// The distributed_object is a single logical object partitioned over a set of
+    /// localities/nodes/machines, where every locality shares the same global
+    /// name locality for the distributed object (i.e. a universal name), but
+    /// owns its local value. In other words, local data of the distributed
+    /// object can be different, but they share access to one another's data
+    /// globally.
+    template <typename T, construction_type C = construction_type::All_to_All>
+    class distributed_object
+      : hpx::components::client_base<distributed_object<T>,
+            server::distributed_object_part<T>>
+    {
+        typedef hpx::components::client_base<distributed_object<T>,
+            server::distributed_object_part<T>>
+            base_type;
+
+        typedef
+            typename server::distributed_object_part<T>::data_type data_type;
+
+    private:
+        template <typename Arg>
+        static hpx::future<hpx::id_type> create_server(Arg&& value)
+        {
+            return hpx::local_new<server::distributed_object_part<T>>(
+                std::forward<Arg>(value));
+        }
+
+    public:
+        /// Creates a distributed_object in every locality
+        ///
+        /// A distributed_object \a base_name is created through default constructor.
+        distributed_object() = default;
+
+        /// Creates a distributed_object in every locality with a given base_name string,
+        /// data, and a type and construction_type in the template parameters
+        ///
+        /// \param construction_type The construction_type in the template parameters
+        /// accepts either Meta_Object, and it is set to All_to_All by defalut
+        /// The Meta_Object option provides meta object registration in the root
+        /// locality and meta object is essentailly a table that can find the
+        /// instances of distributed_object in all localities. The All_to_All option only
+        /// locally holds the client and server of the distributed_object.
+        /// \param base_name The name of the distributed_object, which should be a unique
+        /// string across the localities
+        /// \param data The data of the type T of the distributed_object
+        distributed_object(std::string base, data_type const& data,
+            std::vector<size_t> sub_localities = all_localities())
+          : base_type(create_server(data))
+          , base_(base)
+          , sub_localities_(std::move(sub_localities))
+        {
+            HPX_ASSERT(C == construction_type::All_to_All ||
+                C == construction_type::Meta_Object);
+            HPX_ASSERT(sub_localities_.size() > 0);
+            ensure_ptr();
+            std::sort(sub_localities_.begin(), sub_localities_.end());
+
+            if (C == construction_type::Meta_Object)
+            {
+                meta_object mo(
+                    base, sub_localities_.size(), sub_localities_[0]);
+                locs = mo.registration(this->get_id());
+                basename_registration_helper(base, sub_localities_.size());
+            }
+            else
+            {
+                if (std::find(sub_localities_.begin(), sub_localities_.end(),
+                        static_cast<size_t>(hpx::get_locality_id())) !=
+                    sub_localities_.end())
+                {
+                    basename_registration_helper(base, sub_localities_.size());
+                    hpx::lcos::barrier barrier("wait_for_all_constructors",
+                        hpx::find_all_localities().size(),
+                        hpx::get_locality_id());
+                    barrier.wait();
+                }
+                else
+                {
+                    HPX_THROW_EXCEPTION(hpx::no_success, "constructor error",
+                        "distributed object is not valid within the given "
+                        "sub-locality");
+                }
+            }
+        }
+        /// Creates a distributed_object in every locality with a given base_name string,
+        /// data. The construction_type in the template parameter is set to
+        /// All_to_All option by default.
+        ///
+        /// \param base_name The name of the distributed_object, which should be a unique
+        /// string across the localities
+        /// \param data The data of the type T of the distributed_object
+        distributed_object(std::string base, data_type&& data,
+            std::vector<size_t> sub_localities = all_localities())
+          : base_type(create_server(std::move(data)))
+          , base_(base)
+          , sub_localities_(std::move(sub_localities))
+        {
+            ensure_ptr();
+            basename_registration_helper(
+                base, hpx::find_all_localities().size());
+        }
+        /// \cond NOINTERNAL
+        /// generate boilerplate code for the client
+        distributed_object(hpx::future<hpx::id_type>&& id)
+          : base_type(std::move(id))
+        {
+        }
+        /// generate boilerplate code for the client
+        distributed_object(hpx::id_type&& id)
+          : base_type(std::move(id))
+        {
+        }
+        /// \endcond
+
+        /// Access the calling locality's value instance for this distributed_object
+        data_type const& operator*() const
+        {
+            HPX_ASSERT(this->get_id());
+            return **ptr;
+        }
+
+        /// Access the calling locality's value instance for this distributed_object
+        data_type& operator*()
+        {
+            HPX_ASSERT(this->get_id());
+            return **ptr;
+        }
+
+        /// Access the calling locality's value instance for this distributed_object
+        data_type const* operator->() const
+        {
+            HPX_ASSERT(this->get_id());
+            return &**ptr;
+        }
+
+        /// Access the calling locality's value instance for this distributed_object
+        data_type* operator->()
+        {
+            HPX_ASSERT(this->get_id());
+            return &**ptr;
+        }
+
+        /// Asynchronously returns a future of a copy of the instance of this
+        /// distributed_object associated with the given locality index. The locality
+        /// index must be a valid locality ID with this distributed_object.
+        // TODO: write exception description
+        hpx::future<data_type> fetch(int idx)
+        {
+            /// \cond NOINTERNAL
+            if (std::find(sub_localities_.begin(), sub_localities_.end(),
+                    static_cast<size_t>(hpx::get_locality_id())) !=
+                sub_localities_.end())
+            {
+                HPX_ASSERT(this->get_id());
+                hpx::id_type lookup = get_basename_helper(idx);
+                typedef
+                    typename server::distributed_object_part<T>::fetch_action
+                        action_type;
+                return hpx::async<action_type>(lookup);
+            }
+            else
+            {
+                HPX_THROW_EXCEPTION(hpx::no_success,
+                    "fetch error",
+                    "distributed object is not valid within the given "
+                    "locality");
+            }
+            /// \endcond
+        }
+        /// \cond NOINTERNAL
+        /// force compilation error if serialization of client occurs
+        template <typename Archive, typename Type>
+        HPX_FORCEINLINE void serialize(
+            Archive& ar, base_type& f, unsigned version) = delete;
+
+    private:
+        mutable std::shared_ptr<server::distributed_object_part<T>> ptr;
+        std::string base_;
+        std::vector<size_t> sub_localities_;
+        void ensure_ptr() const
+        {
+            ptr = hpx::get_ptr<server::distributed_object_part<T>>(
+                hpx::launch::sync, this->get_id());
+        }
+
+        // make sure sub_localities_ is initialized ranging from 0 to
+        // num of all localities when the constructor is called within
+        // the context that all localities are provided so that fetch
+        // function can identify the target locality that can be found
+        // from the sub_localities
+        static std::vector<size_t> all_localities()
+        {
+            std::vector<size_t> all_localities_tmp;
+            all_localities_tmp.resize(hpx::find_all_localities().size());
+            std::iota(all_localities_tmp.begin(), all_localities_tmp.end(), 0);
+            return all_localities_tmp;
+        }
+
+    private:
+        std::vector<hpx::id_type> basename_list;
+        std::unordered_map<std::size_t, hpx::id_type> locs;
+        hpx::id_type get_basename_helper(int idx)
+        {
+            if (!locs[idx])
+            {
+                locs[idx] =
+                    hpx::find_from_basename(base_ + std::to_string(idx), idx)
+                        .get();
+            }
+            return locs[idx];
+        }
+        void basename_registration_helper(
+            std::string base, size_t basename_list_size)
+        {
+            hpx::register_with_basename(
+                base + std::to_string(hpx::get_locality_id()), this->get_id(),
+                hpx::get_locality_id());
+            basename_list.resize(basename_list_size);
+        }
+        /// \endcond
+    };
+
+    /// The distributed_object is a single logical object partitioned over a set of
+    /// localities/nodes/machines, where every locality shares the same global
+    /// name locality for the distributed object (i.e. a universal name), but
+    /// owns its local value. In other words, local data of the distributed
+    /// object can be different, but they share access to one another's data
+    /// globally.
+    template <typename T, construction_type C>
+    class distributed_object<T&, C>
+      : hpx::components::client_base<distributed_object<T&>,
+            server::distributed_object_part<T&>>
+    {
+        /// \cond NOINTERNAL
+        typedef hpx::components::client_base<distributed_object<T&>,
+            server::distributed_object_part<T&>>
+            base_type;
+
+        typedef
+            typename server::distributed_object_part<T&>::data_type data_type;
+
+    private:
+        template <typename Arg>
+        static hpx::future<hpx::id_type> create_server(Arg& value)
+        {
+            return hpx::local_new<server::distributed_object_part<T&>>(value);
+        }
+        /// \endcond
+    public:
+        /// Creates a distributed_object in every locality
+        ///
+        /// A distributed_object \a base_name is created through default constructor.
+        distributed_object() = default;
+
+        /// Creates a distributed_object in every locality with a given base_name string,
+        /// data, and a construction_type. This constructor of the distributed_object
+        /// wraps an existing local instance and thus is internally referring to
+        /// the local instance.
+        ///
+        /// \param construction_type The construction_type in the template parameters
+        /// accepts either Meta_Object, and it is set to All_to_All by defalut
+        /// The Meta_Object option provides meta object registration in the root
+        /// locality and meta object is essentailly a table that can find the
+        /// instances of distributed_object in all localities. The All_to_All option only
+        /// locally holds the client and server of the distributed_object.
+        /// \param base_name The name of the distributed_object, which should be a unique
+        /// string across the localities
+        /// \param data The data of the type T of the distributed_object
+        /*       distributed_object(std::string base, data_type data)
+          : base_type(create_server(data))
+          , base_(base)
+        {
+            HPX_ASSERT(C == construction_type::All_to_All ||
+                C == construction_type::Meta_Object);
+            ensure_ptr();
+            size_t localities = hpx::find_all_localities().size();
+            init_sub_localities();
+            if (C == construction_type::Meta_Object)
+            {
+                meta_object mo(base, localities, 0);
+                locs = mo.registration(this->get_id());
+                basename_registration_helper(base, localities);
+            }
+            else
+            {
+                basename_registration_helper(base, localities);
+            }
+        }*/
+
+        // TODO: Doxgen doc
+        distributed_object(std::string base, data_type data,
+            std::vector<size_t> sub_localities = all_localities())
+          : base_type(create_server(data))
+          , base_(base)
+          , sub_localities_(std::move(sub_localities))
+        {
+            HPX_ASSERT(C == construction_type::All_to_All ||
+                C == construction_type::Meta_Object);
+            HPX_ASSERT(sub_localities_.size() > 0);
+            ensure_ptr();
+            std::sort(sub_localities_.begin(), sub_localities_.end());
+
+            if (C == construction_type::Meta_Object)
+            {
+                meta_object mo(
+                    base, sub_localities_.size(), sub_localities_[0]);
+                locs = mo.registration(this->get_id());
+                basename_registration_helper(base, sub_localities_.size());
+            }
+            else
+            {
+                if (std::find(sub_localities_.begin(), sub_localities_.end(),
+                        static_cast<size_t>(hpx::get_locality_id())) !=
+                    sub_localities_.end())
+                {
+                    basename_registration_helper(base, sub_localities_.size());
+                    hpx::lcos::barrier barrier("wait_for_all_constructors",
+                        hpx::find_all_localities().size(),
+                        hpx::get_locality_id());
+                    barrier.wait();
+                }
+                else
+                {
+                    HPX_THROW_EXCEPTION(hpx::no_success, "constructor error",
+                        "distributed object is not valid within the given "
+                        "sub-locality");
+                }
+            }
+        }
+
+        /// \cond NOINTERNAL
+        /// generate boilerplate code for the client
+        distributed_object(hpx::future<hpx::id_type>&& id)
+          : base_type(std::move(id))
+        {
+        }
+        /// generate boilerplate code for the client
+        distributed_object(hpx::id_type&& id)
+          : base_type(std::move(id))
+        {
+        }
+        /// \endcond
+
+        /// Access the calling locality's value instance for this distributed_object
+        data_type const operator*() const
+        {
+            HPX_ASSERT(this->get_id());
+            return **ptr;
+        }
+
+        /// Access the calling locality's value instance for this distributed_object
+        data_type operator*()
+        {
+            HPX_ASSERT(this->get_id());
+            return **ptr;
+        }
+
+        /// Access the calling locality's value instance for this distributed_object
+        T const* operator->() const
+        {
+            HPX_ASSERT(this->get_id());
+            return &**ptr;
+        }
+
+        /// Access the calling locality's value instance for this distributed_object
+        T* operator->()
+        {
+            HPX_ASSERT(this->get_id());
+            return &**ptr;
+        }
+
+        /// Asynchronously returns a future of a copy of the instance of this
+        /// distributed_object associated with the given locality index. The locality
+        /// index must be a valid locality ID with this distributed_object.
+        // TODO: write exception description
+        hpx::future<T> fetch(int idx)
+        {
+            if (std::find(sub_localities_.begin(), sub_localities_.end(),
+                    static_cast<size_t>(hpx::get_locality_id())) !=
+                sub_localities_.end())
+            {
+                HPX_ASSERT(this->get_id());
+                hpx::id_type lookup = get_basename_helper(idx);
+                typedef typename server::distributed_object_part<
+                    T&>::fetch_ref_action action_type;
+                return hpx::async<action_type>(lookup);
+            }
+            else
+            {
+                HPX_THROW_EXCEPTION(hpx::no_success, "fetch error",
+                    "distributed object is not valid within the given "
+                    "locality");
+            }
+        }
+        /// \cond NOINTERNAL
+        /// force compilation error if serialization of client occurs
+        template <typename Archive, typename Type>
+        HPX_FORCEINLINE void serialize(
+            Archive& ar, base_type& f, unsigned version) = delete;
+
+    private:
+        mutable std::shared_ptr<server::distributed_object_part<T&>> ptr;
+        std::string base_;
+        mutable std::vector<size_t> sub_localities_;
+
+        // make sure sub_localities_ is initialized ranging from 0 to
+        // num of all localities when the constructor is called within
+        // the context that all localities are provided so that fetch
+        // function can identify the target locality that can be found
+        // from the sub_localities
+        static std::vector<size_t> all_localities()
+        {
+            std::vector<size_t> all_localities_tmp;
+            all_localities_tmp.resize(hpx::find_all_localities().size());
+            std::iota(all_localities_tmp.begin(), all_localities_tmp.end(), 0);
+            return all_localities_tmp;
+        }
+
+        void ensure_ptr() const
+        {
+            ptr = hpx::get_ptr<server::distributed_object_part<T&>>(
+                hpx::launch::sync, this->get_id());
+        }
+
+    private:
+        std::vector<hpx::id_type> basename_list;
+        std::unordered_map<std::size_t, hpx::id_type> locs;
+        hpx::id_type get_basename_helper(int idx)
+        {
+            if (!locs[idx])
+            {
+                locs[idx] =
+                    hpx::find_from_basename(base_ + std::to_string(idx), idx)
+                        .get();
+            }
+            return locs[idx];
+        }
+        void basename_registration_helper(
+            std::string base, size_t basename_list_size)
+        {
+            hpx::register_with_basename(
+                base + std::to_string(hpx::get_locality_id()), this->get_id(),
+                hpx::get_locality_id());
+            basename_list.resize(basename_list_size);
+        }
+        /// \endcond
+    };
+}}
+#endif /*HPX_LCOS_DISTRIBUTED_OBJECT_HPP*/

--- a/src/lcos/distributed_object.cpp
+++ b/src/lcos/distributed_object.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2019 Weile Wei
+// Copyright (c) 2019 Maxwell Reeser
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include "hpx/lcos/distributed_object.hpp"
+#include <hpx/hpx.hpp>
+#include <hpx/runtime/components/component_factory.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+// Add factory registration functionality.
+
+typedef hpx::components::component<hpx::lcos::meta_object_server>
+    meta_object_type;
+
+HPX_REGISTER_COMPONENT(meta_object_type, meta_object);
+
+HPX_REGISTER_ACTION(meta_object_type::registration_action, register_mo_action);
+HPX_REGISTER_ACTION(meta_object_type::get_server_list_action,
+    get_server_list_mo_action);

--- a/tests/unit/lcos/CMakeLists.txt
+++ b/tests/unit/lcos/CMakeLists.txt
@@ -29,6 +29,7 @@ set(tests
     client_then
     condition_variable
     counting_semaphore
+    distributed_object
     fold
     future
     future_ref

--- a/tests/unit/lcos/distributed_object.cpp
+++ b/tests/unit/lcos/distributed_object.cpp
@@ -72,11 +72,11 @@ void test_distributed_object_int_reduce_to_locality_0()
     // register and retrive the distributed object.
     distributed_object<int> dist_int("a_unique_name_string", cur_locality);
 
-    // create a barrier and wait for the distributed object to be constructed in
-    // all localities
-    hpx::lcos::barrier wait_for_construction(
-        "wait_for_construction", num_localities, cur_locality);
-    wait_for_construction.wait();
+    //// create a barrier and wait for the distributed object to be constructed in
+    //// all localities
+    //hpx::lcos::barrier wait_for_construction(
+    //    "wait_for_construction", num_localities, cur_locality);
+    //wait_for_construction.wait();
 
     // If there exists more than 2 (and include) localities, we are able to
     // asychronously fetch a future of a copy of the instance of this
@@ -132,12 +132,12 @@ void test_distributed_object_vector_elem_wise_add()
     // testing * operator
     HPX_TEST((*LOCAL) == local);
 
-    // create a barrier and wait for the distributed object to be
-    // constructed in all localities
-    hpx::lcos::barrier b_dist_vector("wait_for_construction",
-        hpx::find_all_localities().size(),
-        hpx::get_locality_id());
-    b_dist_vector.wait();
+    //// create a barrier and wait for the distributed object to be
+    //// constructed in all localities
+    //hpx::lcos::barrier b_dist_vector("wait_for_construction",
+    //    hpx::find_all_localities().size(),
+    //    hpx::get_locality_id());
+    //b_dist_vector.wait();
 
     // perform element-wise addition between distributed_objects
     for (int i = 0; i < len; i++)
@@ -314,8 +314,8 @@ void test_distributed_object_ref()
     int val_update = 42;
     myVectorInt vec1(n, val);
     distributed_object<myVectorInt&> dist_vec("vec1", vec1);
-    hpx::lcos::barrier b("/meta/barrier", hpx::find_all_localities().size());
-    b.wait();
+    //hpx::lcos::barrier b("/meta/barrier", hpx::find_all_localities().size());
+    //b.wait();
     // The update/change to the exsiting/referring object
     // will reflect the change to the distributed object
     vec1[2] = val_update;
@@ -503,12 +503,12 @@ void test_dist_object_vector_mo_sub_localities_constructor()
         // testing * operator
         HPX_TEST((*LOCAL) == local);
 
-        // create a barrier and wait for the distributed object to be
-        // constructed in all localities
-        hpx::lcos::barrier b_dist_vector("wait_for_construction",
-            sub_localities.size(),
-            hpx::get_locality_id());
-        b_dist_vector.wait();
+        //// create a barrier and wait for the distributed object to be
+        //// constructed in all localities
+        //hpx::lcos::barrier b_dist_vector("wait_for_construction",
+        //    sub_localities.size(),
+        //    hpx::get_locality_id());
+        //b_dist_vector.wait();
 
         // perform element-wise addition between distributed_objects
         for (int i = 0; i < len; i++)
@@ -557,9 +557,9 @@ void test_distributed_object_sub_localities_constructor()
         distributed_object<std::vector<int>> vec1(
             "vec1", input, sub_localities);
     }
-    hpx::lcos::barrier b(
-        "wait_for_construction", hpx::find_all_localities().size());
-    b.wait();
+    //hpx::lcos::barrier b(
+    //    "wait_for_construction", hpx::find_all_localities().size());
+    //b.wait();
 }
 
 int hpx_main()

--- a/tests/unit/lcos/distributed_object.cpp
+++ b/tests/unit/lcos/distributed_object.cpp
@@ -1,0 +1,586 @@
+// Copyright (c) 2019 Weile Wei
+// Copyright (c) 2019 Maxwell Reeser
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+///////////////////////////////////////////////////////////////////////////
+/// This is a distributed_object example using HPX component.
+///
+/// A distributed object is a single logical object partitioned across
+/// a set of localities. (A locality is a single node in a cluster or a
+/// NUMA domian in a SMP machine.) Each locality constructs an instance of
+/// distributed_object<T>, where a value of type T represents the value of this
+/// this locality's instance value. Once distributed_object<T> is conctructed, it
+/// has a universal name which can be used on any locality in the given
+/// localities to locate the resident instance.
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/lcos/barrier.hpp>
+#include <hpx/parallel/algorithms/for_each.hpp>
+
+#include <hpx/lcos/async.hpp>
+#include <hpx/lcos/dataflow.hpp>
+#include <hpx/lcos/when_all.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <hpx/include/distributed_object.hpp>
+#include <boost/range/irange.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+REGISTER_DISTRIBUTED_OBJECT_PART(int);
+
+using myVectorInt = std::vector<int>;
+REGISTER_DISTRIBUTED_OBJECT_PART(myVectorInt);
+using myMatrixInt = std::vector<std::vector<int>>;
+REGISTER_DISTRIBUTED_OBJECT_PART(myMatrixInt);
+
+REGISTER_DISTRIBUTED_OBJECT_PART(double);
+using myVectorDouble = std::vector<double>;
+REGISTER_DISTRIBUTED_OBJECT_PART(myVectorDouble);
+using myMatrixDouble = std::vector<std::vector<double>>;
+REGISTER_DISTRIBUTED_OBJECT_PART(myMatrixDouble);
+using myVectorDoubleConst = std::vector<double> const;
+REGISTER_DISTRIBUTED_OBJECT_PART(myVectorDoubleConst);
+
+using intRef = int&;
+REGISTER_DISTRIBUTED_OBJECT_PART(intRef);
+using myVectorIntRef = std::vector<int>&;
+REGISTER_DISTRIBUTED_OBJECT_PART(myVectorIntRef);
+using myVectorDoubleConstRef = std::vector<double> const&;
+REGISTER_DISTRIBUTED_OBJECT_PART(myVectorDoubleConstRef);
+
+// addition/sum reduced to locality  for distributed_object
+void test_distributed_object_int_reduce_to_locality_0()
+{
+    using hpx::lcos::distributed_object;
+    int num_localities = hpx::find_all_localities().size();
+    int cur_locality = hpx::get_locality_id();
+    int expect_res = 0, target_res = 0;
+    // Construct a distrtibuted object of type int in all provided localities
+    // User needs to provide the distributed object with a unique basename
+    // and data for construction. The unique basename string enables HPX
+    // register and retrive the distributed object.
+    distributed_object<int> dist_int("a_unique_name_string", cur_locality);
+
+    // create a barrier and wait for the distributed object to be constructed in
+    // all localities
+    hpx::lcos::barrier wait_for_construction(
+        "wait_for_construction", num_localities, cur_locality);
+    wait_for_construction.wait();
+
+    // If there exists more than 2 (and include) localities, we are able to
+    // asychronously fetch a future of a copy of the instance of this
+    // distributed object associated with the given locality
+    if (hpx::get_locality_id() >= 2)
+    {
+        HPX_TEST_EQ(dist_int.fetch(1).get(), 1);
+    }
+
+    if (cur_locality == 0 && num_localities >= 2)
+    {
+        using hpx::parallel::for_each;
+        using hpx::parallel::execution::par;
+        auto range = boost::irange(1, num_localities);
+        // compute expect result in parallel
+        // locality 0 fetchs all values
+        for_each(par, std::begin(range), std::end(range),
+            [&](std::uint64_t b) { expect_res += dist_int.fetch(b).get(); });
+        hpx::wait_all();
+
+        // compute target result
+        // to verify the accumulation results
+        for (int i = 0; i < num_localities; i++)
+        {
+            target_res += i;
+        }
+
+        HPX_TEST_EQ(expect_res, target_res);
+    }
+}
+
+// element-wise addition for vector<int> for distributed_object
+void test_distributed_object_vector_elem_wise_add()
+{
+    using hpx::lcos::distributed_object;
+    int num_localities = hpx::find_all_localities().size();
+    int cur_locality = hpx::get_locality_id();
+
+    // define vector based on the locality that it is running
+    int here_ = 42 + static_cast<int>(hpx::get_locality_id());
+    int len = 10;
+
+    // prepare vector data
+    std::vector<int> local(len, here_);
+
+    // construct a distributed_object with vector<int> type
+    distributed_object<std::vector<int>> LOCAL("lhs_vec", local);
+
+    // testing -> operator
+    HPX_TEST_EQ(LOCAL->size(), static_cast<size_t>(len));
+
+    // testing dist_object and its vector underneath
+    // testing * operator
+    HPX_TEST((*LOCAL) == local);
+
+    // create a barrier and wait for the distributed object to be
+    // constructed in all localities
+    hpx::lcos::barrier b_dist_vector("wait_for_construction",
+        hpx::find_all_localities().size(),
+        hpx::get_locality_id());
+    b_dist_vector.wait();
+
+    // perform element-wise addition between distributed_objects
+    for (int i = 0; i < len; i++)
+    {
+        (*LOCAL)[i] += 1;
+    }
+
+    hpx::lcos::barrier wait_for_operation("wait_for_operation",
+        hpx::find_all_localities().size(),
+        hpx::get_locality_id());
+    wait_for_operation.wait();
+
+    if (cur_locality == 0 && num_localities >= 2)
+    {
+        using hpx::parallel::for_each;
+        using hpx::parallel::execution::par;
+        auto range = boost::irange(1, num_localities);
+
+        std::vector<std::vector<int>> res(num_localities);
+        // compute expect result in parallel
+        // locality 0 fetchs all values
+        for_each(par, std::begin(range), std::end(range), [&](std::uint64_t b) {
+            res[b] = LOCAL.fetch(b).get();
+            for (int i = 0; i < len; i++)
+            {
+                HPX_TEST_EQ(res[b][i], static_cast<int>((*LOCAL)[i] + b));
+            }
+        });
+        hpx::wait_all();
+    }
+}
+
+// element-wise addition for vector<vector<double>> for distributed_object
+void test_distributed_object_matrix()
+{
+    using hpx::lcos::distributed_object;
+    double val = 42.0 + static_cast<double>(hpx::get_locality_id());
+    int rows = 5, cols = 5;
+
+    myMatrixDouble lhs(rows, std::vector<double>(cols, val));
+    myMatrixDouble rhs(rows, std::vector<double>(cols, val));
+    myMatrixDouble res(rows, std::vector<double>(cols, 0));
+
+    distributed_object<myMatrixDouble> LHS("m1", lhs);
+    distributed_object<myMatrixDouble> RHS("m2", rhs);
+    distributed_object<myMatrixDouble> RES("m3", res);
+
+    for (int i = 0; i < rows; i++)
+    {
+        for (int j = 0; j < cols; j++)
+        {
+            (*RES)[i][j] = (*LHS)[i][j] + (*RHS)[i][j];
+            res[i][j] = lhs[i][j] + rhs[i][j];
+        }
+    }
+    HPX_TEST((*RES) == res);
+    HPX_TEST_EQ(RES->size(), static_cast<size_t>(rows));
+    hpx::lcos::barrier b_dist_matrix("b_dist_matrix",
+        hpx::find_all_localities().size(),
+        hpx::get_locality_id());
+    b_dist_matrix.wait();
+
+    // test fetch function when 2 or more localities provided
+    if (hpx::find_all_localities().size() > 1)
+    {
+        if (hpx::get_locality_id() == 0)
+        {
+            hpx::future<myMatrixDouble> RES_first = RES.fetch(1);
+            HPX_TEST_EQ(RES_first.get()[0][0], 86);
+        }
+        else
+        {
+            hpx::future<myMatrixDouble> RES_first = RES.fetch(0);
+            HPX_TEST_EQ(RES_first.get()[0][0], 84);
+        }
+    }
+}
+
+// test constructor in All_to_All option
+void test_distributed_object_matrix_all_to_all()
+{
+    using hpx::lcos::distributed_object;
+    double val = 42.0 + static_cast<double>(hpx::get_locality_id());
+    int rows = 5, cols = 5;
+
+    myMatrixDouble lhs(rows, std::vector<double>(cols, val));
+    myMatrixDouble rhs(rows, std::vector<double>(cols, val));
+    myMatrixDouble res(rows, std::vector<double>(cols, 0));
+
+    typedef hpx::lcos::construction_type c_t;
+
+    distributed_object<myMatrixDouble, c_t::All_to_All> LHS("m1", lhs);
+    distributed_object<myMatrixDouble, c_t::All_to_All> RHS("m2", rhs);
+    distributed_object<myMatrixDouble, c_t::All_to_All> RES("m3", res);
+
+    for (int i = 0; i < rows; i++)
+    {
+        for (int j = 0; j < cols; j++)
+        {
+            (*RES)[i][j] = (*LHS)[i][j] + (*RHS)[i][j];
+            res[i][j] = lhs[i][j] + rhs[i][j];
+        }
+    }
+    HPX_TEST((*RES) == res);
+    HPX_TEST_EQ(RES->size(), static_cast<size_t>(rows));
+
+    hpx::lcos::barrier b_dist_matrix_2("b_dist_matrix_2",
+        hpx::find_all_localities().size(),
+        hpx::get_locality_id());
+    b_dist_matrix_2.wait();
+
+    // test fetch function when 2 or more localities provided
+    if (hpx::find_all_localities().size() > 1)
+    {
+        if (hpx::get_locality_id() == 0)
+        {
+            hpx::future<myMatrixDouble> RES_first = RES.fetch(1);
+            HPX_TEST_EQ(RES_first.get()[0][0], 86);
+        }
+        else
+        {
+            hpx::future<myMatrixDouble> RES_first = RES.fetch(0);
+            HPX_TEST_EQ(RES_first.get()[0][0], 84);
+        }
+    }
+}
+
+// test constructor in Meta_Object option
+void test_distributed_object_matrix_mo()
+{
+    using hpx::lcos::distributed_object;
+    int val = 42 + static_cast<int>(hpx::get_locality_id());
+    int rows = 5, cols = 5;
+
+    myMatrixInt m1(rows, std::vector<int>(cols, val));
+    myMatrixInt m2(rows, std::vector<int>(cols, val));
+    myMatrixInt m3(rows, std::vector<int>(cols, 0));
+
+    typedef hpx::lcos::construction_type c_t;
+
+    distributed_object<myMatrixInt, c_t::Meta_Object> M1("M1_meta", m1);
+    distributed_object<myMatrixInt, c_t::Meta_Object> M2("M2_meta", m2);
+    distributed_object<myMatrixInt, c_t::Meta_Object> M3("M3_meta", m3);
+
+    for (int i = 0; i < rows; i++)
+    {
+        for (int j = 0; j < cols; j++)
+        {
+            (*M3)[i][j] = (*M1)[i][j] + (*M2)[i][j];
+        }
+    }
+
+    for (int i = 0; i < rows; i++)
+    {
+        for (int j = 0; j < cols; j++)
+        {
+            m3[i][j] = m1[i][j] + m2[i][j];
+        }
+    }
+    hpx::lcos::barrier b("/meta/barrier", hpx::find_all_localities().size());
+    b.wait();
+
+    HPX_TEST((*M3) == m3);
+    HPX_TEST_EQ(M3->size(), static_cast<size_t>(rows));
+}
+
+// test constructor option with reference to an existing object
+void test_distributed_object_ref()
+{
+    using hpx::lcos::distributed_object;
+    size_t n = 10;
+    int val = 2;
+
+    int val_update = 42;
+    myVectorInt vec1(n, val);
+    distributed_object<myVectorInt&> dist_vec("vec1", vec1);
+    hpx::lcos::barrier b("/meta/barrier", hpx::find_all_localities().size());
+    b.wait();
+    // The update/change to the exsiting/referring object
+    // will reflect the change to the distributed object
+    vec1[2] = val_update;
+
+    HPX_TEST_EQ((*dist_vec)[2], val_update);
+    HPX_TEST_EQ(dist_vec->size(), static_cast<size_t>(n));
+}
+
+// test constructor option with reference to a const existing object
+void test_distributed_object_const_ref()
+{
+    using hpx::lcos::distributed_object;
+    int n = 10;
+    double val = 42.0;
+
+    myVectorDoubleConst vec1(n, val);
+    distributed_object<myVectorDoubleConstRef> dist_vec("vec1", vec1);
+    hpx::lcos::barrier wait_for_operation("wait_for_operation",
+        hpx::find_all_localities().size(),
+        hpx::get_locality_id());
+    wait_for_operation.wait();
+}
+
+// simple matrix multiplication example
+void test_distributed_object_matrix_mul()
+{
+    using hpx::lcos::distributed_object;
+    size_t cols = 5;    // Decide how big the matrix should be
+
+    size_t num_locs = hpx::find_all_localities().size();
+    std::vector<std::pair<size_t, size_t>> ranges(num_locs);
+
+    // Create a list of row ranges for each partition
+    size_t start = 0;
+    size_t diff = (int) std::ceil((double) cols / ((double) num_locs));
+    for (size_t i = 0; i < num_locs; i++)
+    {
+        size_t second = (std::min)(cols, start + diff);
+        ranges[i] = std::make_pair(start, second);
+        start += diff;
+    }
+
+    // Create our data, stored in all_data's. This way we can check for validity
+    // without using anything distributed. The seed being a constant is needed
+    // in order for all nodes to generate the same data
+    size_t here = hpx::get_locality_id();
+    size_t local_rows = ranges[here].second - ranges[here].first;
+    std::vector<std::vector<std::vector<int>>> all_data_m1(
+        hpx::find_all_localities().size());
+
+    std::srand(123456);
+
+    for (size_t i = 0; i < all_data_m1.size(); i++)
+    {
+        size_t tmp_num_rows = ranges[i].second - ranges[i].first;
+        all_data_m1[i] = std::vector<std::vector<int>>(
+            tmp_num_rows, std::vector<int>(cols, 0));
+        for (size_t j = 0; j < tmp_num_rows; j++)
+        {
+            for (size_t k = 0; k < cols; k++)
+            {
+                all_data_m1[i][j][k] = std::rand();
+            }
+        }
+    }
+
+    std::vector<std::vector<std::vector<int>>> all_data_m2(
+        hpx::find_all_localities().size());
+
+    std::srand(7891011);
+
+    for (size_t i = 0; i < all_data_m2.size(); i++)
+    {
+        size_t tmp_num_rows = ranges[i].second - ranges[i].first;
+        all_data_m2[i] = std::vector<std::vector<int>>(
+            tmp_num_rows, std::vector<int>(cols, 0));
+        for (size_t j = 0; j < tmp_num_rows; j++)
+        {
+            for (size_t k = 0; k < cols; k++)
+            {
+                all_data_m2[i][j][k] = std::rand();
+            }
+        }
+    }
+
+    std::vector<std::vector<int>> here_data_m3(
+        local_rows, std::vector<int>(cols, 0));
+
+    typedef hpx::lcos::construction_type c_t;
+
+    distributed_object<myMatrixInt, c_t::Meta_Object> M1(
+        "M1_meta_mat_mul", all_data_m1[here]);
+    distributed_object<myMatrixInt, c_t::Meta_Object> M2(
+        "M2_meta_mat_mul", all_data_m2[here]);
+    distributed_object<myMatrixInt, c_t::Meta_Object> M3(
+        "M3_meta_mat_mul", here_data_m3);
+
+    // Actual matrix multiplication. For non-local values, get the data
+    // and then use it, for local, just use the local data without doing
+    // a fetch to get it
+    size_t num_before_me = here;
+    int other_val;
+    for (size_t p = 0; p < num_before_me; p++)
+    {
+        std::vector<std::vector<int>> non_local = M2.fetch(p).get();
+        if (p == 0)
+            other_val = non_local[0][0];
+        for (size_t i = 0; i < local_rows; i++)
+        {
+            for (size_t j = ranges[p].first; j < ranges[p].second; j++)
+            {
+                for (size_t k = 0; k < cols; k++)
+                {
+                    (*M3)[i][j] +=
+                        (*M1)[i][k] * non_local[j - ranges[p].first][k];
+                    here_data_m3[i][j] += all_data_m1[here][i][k] *
+                        all_data_m2[p][j - ranges[p].first][k];
+                }
+            }
+        }
+    }
+    for (size_t i = 0; i < local_rows; i++)
+    {
+        for (size_t j = ranges[here].first; j < ranges[here].second; j++)
+        {
+            for (size_t k = 0; k < cols; k++)
+            {
+                (*M3)[i][j] += (*M1)[i][k] * (*M2)[j - ranges[here].first][k];
+                here_data_m3[i][j] += all_data_m1[here][i][k] *
+                    all_data_m2[here][j - ranges[here].first][k];
+            }
+        }
+    }
+    for (size_t p = here + 1; p < num_locs; p++)
+    {
+        std::vector<std::vector<int>> non_local = M2.fetch(p).get();
+        if (p == here + 1)
+            other_val = non_local[0][0];
+        for (size_t i = 0; i < local_rows; i++)
+        {
+            for (size_t j = ranges[p].first; j < ranges[p].second; j++)
+            {
+                for (size_t k = 0; k < cols; k++)
+                {
+                    (*M3)[i][j] +=
+                        (*M1)[i][k] * non_local[j - ranges[p].first][k];
+                    here_data_m3[i][j] += all_data_m1[here][i][k] *
+                        all_data_m2[p][j - ranges[p].first][k];
+                }
+            }
+        }
+    }
+    std::vector<std::vector<int>> tmp = *M3;
+    HPX_TEST((*M3) == here_data_m3);
+}
+
+void test_dist_object_vector_mo_sub_localities_constructor()
+{
+    typedef hpx::lcos::construction_type c_t;
+    using hpx::lcos::distributed_object;
+    int num_localities = hpx::find_all_localities().size();
+    size_t cur_locality = static_cast<size_t>(hpx::get_locality_id());
+
+    // define vector based on the locality that it is running
+    int here_ = 42 + static_cast<int>(hpx::get_locality_id());
+    int len = 10;
+
+    // prepare vector data
+    std::vector<int> local(len, here_);
+    std::vector<size_t> sub_localities{0, 1};
+
+    if (num_localities >= 2 &&
+        std::find(sub_localities.begin(), sub_localities.end(),
+            static_cast<size_t>(cur_locality)) != sub_localities.end())
+    {
+        // construct a distributed_object with vector<int> type
+
+        distributed_object<std::vector<int>, c_t::Meta_Object> LOCAL(
+            "lhs_vec", local, sub_localities);
+
+        // testing -> operator
+        HPX_TEST_EQ(LOCAL->size(), static_cast<size_t>(len));
+
+        // testing dist_object and its vector underneath
+        // testing * operator
+        HPX_TEST((*LOCAL) == local);
+
+        // create a barrier and wait for the distributed object to be
+        // constructed in all localities
+        hpx::lcos::barrier b_dist_vector("wait_for_construction",
+            sub_localities.size(),
+            hpx::get_locality_id());
+        b_dist_vector.wait();
+
+        // perform element-wise addition between distributed_objects
+        for (int i = 0; i < len; i++)
+        {
+            (*LOCAL)[i] += 1;
+        }
+
+        hpx::lcos::barrier wait_for_operation("wait_for_operation",
+            sub_localities.size(),
+            hpx::get_locality_id());
+        wait_for_operation.wait();
+
+        std::sort(sub_localities.begin(), sub_localities.end());
+        if (cur_locality == sub_localities[0])
+        {
+            using hpx::parallel::for_each;
+            using hpx::parallel::execution::par;
+
+            std::vector<std::vector<int>> res(num_localities);
+            // compute expect result in parallel
+            // locality 0 fetchs all values
+            for_each(par, std::begin(sub_localities) + 1,
+                std::end(sub_localities), [&](std::uint64_t b) {
+                    res[b] = LOCAL.fetch(b).get();
+                    for (int i = 0; i < len; i++)
+                    {
+                        HPX_TEST_EQ(
+                            res[b][i], static_cast<int>((*LOCAL)[i] + b));
+                    }
+                });
+            hpx::wait_all();
+        }
+    }
+    hpx::lcos::barrier all_blocked_barrier(
+        "all_blocked_barrier", num_localities, hpx::get_locality_id());
+    all_blocked_barrier.wait();
+}
+
+void test_distributed_object_sub_localities_constructor()
+{
+    using hpx::lcos::distributed_object;
+    std::vector<int> input(10, 1);
+    std::vector<size_t> sub_localities{0};
+    if (hpx::get_locality_id() == 0)
+    {
+        distributed_object<std::vector<int>> vec1(
+            "vec1", input, sub_localities);
+    }
+    hpx::lcos::barrier b(
+        "wait_for_construction", hpx::find_all_localities().size());
+    b.wait();
+}
+
+int hpx_main()
+{
+    {
+        test_distributed_object_int_reduce_to_locality_0();
+        test_distributed_object_vector_elem_wise_add();
+        test_distributed_object_matrix();
+        test_distributed_object_matrix_all_to_all();
+        test_distributed_object_matrix_mo();
+        test_distributed_object_matrix_mul();
+        test_distributed_object_ref();
+        test_distributed_object_const_ref();
+        test_dist_object_vector_mo_sub_localities_constructor();
+        test_distributed_object_sub_localities_constructor();
+    }
+    hpx::finalize();
+    return hpx::util::report_errors();
+}
+
+int main(int argc, char* argv[])
+{
+    return hpx::init(argc, argv);
+}

--- a/tests/unit/lcos/distributed_object.cpp
+++ b/tests/unit/lcos/distributed_object.cpp
@@ -216,7 +216,7 @@ void test_distributed_object_matrix()
     }
 }
 
-// test constructor in All_to_All option
+// test constructor in all_to_all option
 void test_distributed_object_matrix_all_to_all()
 {
     using hpx::lcos::distributed_object;
@@ -229,9 +229,9 @@ void test_distributed_object_matrix_all_to_all()
 
     typedef hpx::lcos::construction_type c_t;
 
-    distributed_object<myMatrixDouble, c_t::All_to_All> LHS("m1", lhs);
-    distributed_object<myMatrixDouble, c_t::All_to_All> RHS("m2", rhs);
-    distributed_object<myMatrixDouble, c_t::All_to_All> RES("m3", res);
+    distributed_object<myMatrixDouble, c_t::all_to_all> LHS("m1", lhs);
+    distributed_object<myMatrixDouble, c_t::all_to_all> RHS("m2", rhs);
+    distributed_object<myMatrixDouble, c_t::all_to_all> RES("m3", res);
 
     for (int i = 0; i < rows; i++)
     {
@@ -265,7 +265,7 @@ void test_distributed_object_matrix_all_to_all()
     }
 }
 
-// test constructor in Meta_Object option
+// test constructor in meta_object option
 void test_distributed_object_matrix_mo()
 {
     using hpx::lcos::distributed_object;
@@ -278,9 +278,9 @@ void test_distributed_object_matrix_mo()
 
     typedef hpx::lcos::construction_type c_t;
 
-    distributed_object<myMatrixInt, c_t::Meta_Object> M1("M1_meta", m1);
-    distributed_object<myMatrixInt, c_t::Meta_Object> M2("M2_meta", m2);
-    distributed_object<myMatrixInt, c_t::Meta_Object> M3("M3_meta", m3);
+    distributed_object<myMatrixInt, c_t::meta_object> M1("M1_meta", m1);
+    distributed_object<myMatrixInt, c_t::meta_object> M2("M2_meta", m2);
+    distributed_object<myMatrixInt, c_t::meta_object> M3("M3_meta", m3);
 
     for (int i = 0; i < rows; i++)
     {
@@ -406,11 +406,11 @@ void test_distributed_object_matrix_mul()
 
     typedef hpx::lcos::construction_type c_t;
 
-    distributed_object<myMatrixInt, c_t::Meta_Object> M1(
+    distributed_object<myMatrixInt, c_t::meta_object> M1(
         "M1_meta_mat_mul", all_data_m1[here]);
-    distributed_object<myMatrixInt, c_t::Meta_Object> M2(
+    distributed_object<myMatrixInt, c_t::meta_object> M2(
         "M2_meta_mat_mul", all_data_m2[here]);
-    distributed_object<myMatrixInt, c_t::Meta_Object> M3(
+    distributed_object<myMatrixInt, c_t::meta_object> M3(
         "M3_meta_mat_mul", here_data_m3);
 
     // Actual matrix multiplication. For non-local values, get the data
@@ -493,7 +493,7 @@ void test_dist_object_vector_mo_sub_localities_constructor()
     {
         // construct a distributed_object with vector<int> type
 
-        distributed_object<std::vector<int>, c_t::Meta_Object> LOCAL(
+        distributed_object<std::vector<int>, c_t::meta_object> LOCAL(
             "lhs_vec", local, sub_localities);
 
         // testing -> operator


### PR DESCRIPTION
This PR aims at adding dist_object for HPX.

A distributed object is a single logical object partitioned across a set of localities. With this dist_object functionality, it provides a nice interface for programmers to write a distributed object. The users do not need to write much code in order to build a distributed component in HPX, and the code will be more readable and portable.

This PR contains dist_object itself, comments for Doxygen, many test cases, and one example (matrix transpose). Please review code when you have time, and I will revise accordingly. Thanks a lot!