### PR TITLE
Windows requires to handle symlinks to directories differently from those linking files

### DIFF
--- a/cmake/HPX_CreateSymbolicLink.cmake
+++ b/cmake/HPX_CreateSymbolicLink.cmake
@@ -10,9 +10,17 @@
 function(create_symbolic_link SYM_TARGET SYM_DESTINATION)
   if(WIN32)
     if(NOT EXISTS ${SYM_DESTINATION})
-      # Create a junction for windows links
-      execute_process(COMMAND cmd /C "${CMAKE_SOURCE_DIR}/cmake/scripts/create_symbolic_link.bat"
-                                     ${SYM_DESTINATION} ${SYM_TARGET})
+      if(IS_DIRECTORY ${SYM_TARGET})
+        # Create a directory junction
+        execute_process(COMMAND 
+          cmd /C "${CMAKE_SOURCE_DIR}/cmake/scripts/create_symbolic_link_directory.bat"
+            ${SYM_DESTINATION} ${SYM_TARGET})
+      else()
+        # Create a file link
+        execute_process(COMMAND 
+          cmd /C "${CMAKE_SOURCE_DIR}/cmake/scripts/create_symbolic_link_file.bat"
+            ${SYM_DESTINATION} ${SYM_TARGET})
+      endif()
     endif()
   else()
     # Only available on unix derivates

--- a/cmake/scripts/create_symbolic_link_directory.bat
+++ b/cmake/scripts/create_symbolic_link_directory.bat
@@ -1,0 +1,6 @@
+:: Copyright (c) 2017 Denis Blank
+::
+:: Distributed under the Boost Software License, Version 1.0. (See accompanying
+:: file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+::
+@mklink /D "%1" "%2" > NUL

--- a/cmake/scripts/create_symbolic_link_file.bat
+++ b/cmake/scripts/create_symbolic_link_file.bat
@@ -3,4 +3,4 @@
 :: Distributed under the Boost Software License, Version 1.0. (See accompanying
 :: file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ::
-@mklink /J "%1" "%2" > NUL
+@mklink "%1" "%2" > NUL


### PR DESCRIPTION
This makes sure symlinks to files are properly created on Windows

- this also enables deleting linked directories using 'cmake -E remove_directory ...' (which failed before)