### PR TITLE
Disable barrier_3792 test when networking is disabled

### DIFF
--- a/tests/regressions/lcos/CMakeLists.txt
+++ b/tests/regressions/lcos/CMakeLists.txt
@@ -11,7 +11,6 @@ set(tests
     async_callback_non_deduced_context
     async_unwrap_1037
     barrier_hang
-    barrier_3792
     broadcast_unwrap_future_2885
     broadcast_wait_for_2822
     call_promise_get_gid_more_than_once
@@ -65,7 +64,6 @@ set(after_588_PARAMETERS LOCALITIES 2)
 set(async_action_1813_PARAMETERS LOCALITIES 2)
 set(async_callback_with_bound_callback_PARAMETERS LOCALITIES 2)
 set(async_callback_non_deduced_context_PARAMETERS THREADS_PER_LOCALITY 4)
-set(barrier_3792_PARAMETERS LOCALITIES 3 THREADS_PER_LOCALITY 1)
 set(broadcast_unwrap_future_2885_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 4)
 set(broadcast_wait_for_2822_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 4)
 set(channel_2916_FLAGS DEPENDENCIES iostreams_component)
@@ -87,6 +85,11 @@ set(sliding_semaphore_2338_PARAMETERS THREADS_PER_LOCALITY 2)
 set(wait_for_1751_PARAMETERS THREADS_PER_LOCALITY 4)
 set(wait_all_hang_1946_PARAMETERS THREADS_PER_LOCALITY 8)
 set(wait_all_hang_1946_FLAGS DEPENDENCIES iostreams_component)
+
+if(HPX_WITH_NETWORKING)
+  set(tests ${tests} barrier_3792)
+  set(barrier_3792_PARAMETERS LOCALITIES 3 THREADS_PER_LOCALITY 1)
+endif()
 
 # Create test cases
 foreach(test ${tests})


### PR DESCRIPTION
The test doesn't make much sense with only one locality (and it hangs) so we disable it.