### PR TITLE
Fix and update modules documentation

### DIFF
--- a/cmake/templates/conf.py.in
+++ b/cmake/templates/conf.py.in
@@ -89,7 +89,7 @@ for subdir_full, dirs, files in os.walk(hpx_libs_dir):
         for f in files:
             if not file_regex.match(f) is None:
                 skip = False
-                for line in file(subdir_full + '/' + f):
+                for line in open(subdir_full + '/' + f):
                     if '// sphinx:undocumented' in line:
                         skip = True
                         break
@@ -130,11 +130,11 @@ for lib in breathe_projects_source:
     if not os.path.exists(basedir):
         os.makedirs(basedir)
     lib_api_ref = open(basedir + '/api.rst', 'w')
-    lib_name = lib.upper() if len(lib) == 2 else lib.capitalize()
-    lib_api_ref.write(api_ref_header.format(lib_name))
+    lib_api_ref.write(api_ref_header.format(lib))
     for source in lib_sources[1]:
         header = source[len('include/'):]
         lib_api_ref.write(api_ref_file.format(header, lib))
+    lib_api_ref.close()
     api_refs += '   /libs/' + lib + '/api.rst\n'
     print('Generated ' + basedir + '/api.rst')
 

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -334,7 +334,11 @@ endforeach()
 file(GLOB_RECURSE sphinx_libs_source_files LIST_DIRECTORIES false RELATIVE
     "${CMAKE_SOURCE_DIR}/libs" "${CMAKE_SOURCE_DIR}/libs/*/docs/*")
 
-set(sphinx_libs_source_files "index.rst" ${sphinx_libs_source_files})
+set(sphinx_libs_source_files
+    "all_modules.rst"
+    "index.rst"
+    "overview.rst"
+    ${sphinx_libs_source_files})
 
 foreach(sphinx_source_file ${sphinx_libs_source_files})
   add_custom_command(

--- a/docs/sphinx/api.rst
+++ b/docs/sphinx/api.rst
@@ -8,10 +8,15 @@
 API reference
 =============
 
+Main |hpx| library reference
+============================
+
+.. doxygenindex::
+
+Modules reference
+=================
+
 .. toctree::
    :maxdepth: 1
 
 {}
-
-.. doxygenindex::
-

--- a/docs/sphinx/contributing/documentation.rst
+++ b/docs/sphinx/contributing/documentation.rst
@@ -23,7 +23,9 @@ Please see the :ref:`documentation prerequisites <documentation_prerequisites>`
 section for details on what you need in order to build the |hpx| documentation.
 Enable building of the documentation by setting ``HPX_WITH_DOCUMENTATION=ON``
 during |cmake|_ configuration. To build the documentation build the ``docs``
-target using your build tool.
+target using your build tool. The default output format is HTML documentation.
+You can choose alternative output formats (single-page HTML, PDF, and man) with
+the ``HPX_WITH_DOCUMENTATION_OUTPUT_FORMATS`` |cmake|_ option.
 
 .. note::
 

--- a/docs/sphinx/examples/hello_world.rst
+++ b/docs/sphinx/examples/hello_world.rst
@@ -120,7 +120,7 @@ OS-thread prints out the statement, the future is marked as ready, and
 executing on the correct OS-thread, it returns a value of -1, which causes
 ``hello_world_foreman()`` to leave the OS-thread id in ``attendance``.
 
-.. literalinclude:: ../../examples/quickstart/hello_world_distributed_distributed.cpp
+.. literalinclude:: ../../examples/quickstart/hello_world_distributed.cpp
    :lines: 37-61
 
 Because |hpx| features work stealing task schedulers, there is no way to

--- a/docs/sphinx/manual/building_hpx.rst
+++ b/docs/sphinx/manual/building_hpx.rst
@@ -1299,7 +1299,7 @@ How to install |hpx| on Fedora distributions
      sudo echo /opt/hpx/lib > /etc/ld.so.conf.d/hpx.conf
      sudo ldconfig
 
-.. _arch_installation
+.. _arch_installation:
 
 How to install |hpx| on Arch distributions
 ------------------------------------------

--- a/libs/README.rst
+++ b/libs/README.rst
@@ -11,25 +11,41 @@ The tool ```create_library_skeleton.py`` can be used to generate a basic
 skeleton. The structure of this skeleton should be as follows:
 
 * ``<lib_name>/``
+
   * ``README.rst``
   * ``CMakeLists.txt``
   * ``cmake``
   * ``docs/``
+
     * ``index.rst``
+
   * ``examples/``
+
     * ``CMakeLists.txt``
+
   * ``include/``
+
     * ``hpx/``
+
       * ``<lib_name>``
+
   * ``src/``
+
     * ``CMakeLists.txt``
+
   * ``tests/``
+
     * ``CMakeLists.txt``
     * ``unit/``
+
       * ``CMakeLists.txt``
+
     * ``regressions/``
+
       * ``CMakeLists.txt``
+
     * ``performance/``
+
       * ``CMakeLists.txt``
 
 A ``README.rst`` should be always included which explains the basic purpose of

--- a/libs/_example/docs/index.rst
+++ b/libs/_example/docs/index.rst
@@ -6,12 +6,11 @@
 
 .. _libs__example:
 
-===========
-HPX Modules
-===========
+==============
+Example module
+==============
 
-|hpx| itself is organized into different sub-libraries. Those libraries can be
-seen as independent modules, with clear dependencies and no cycles.
+This is an example module used to explain the structure of an |hpx| module.
 
 The tool `create_library_skeleton.py
 <https://github.com/STEllAR-GROUP/hpx/blob/master/libs/create_library_skeleton.py>`_
@@ -19,25 +18,41 @@ can be used to generate a basic skeleton. The structure of this skeleton is as
 follows:
 
 * ``<lib_name>/``
+
   * ``README.rst``
   * ``CMakeLists.txt``
   * ``cmake``
   * ``docs/``
+
     * ``index.rst``
+
   * ``examples/``
+
     * ``CMakeLists.txt``
+
   * ``include/``
+
     * ``hpx/``
+
       * ``<lib_name>``
+
   * ``src/``
+
     * ``CMakeLists.txt``
+
   * ``tests/``
+
     * ``CMakeLists.txt``
     * ``unit/``
+
       * ``CMakeLists.txt``
+
     * ``regressions/``
+
       * ``CMakeLists.txt``
+
     * ``performance/``
+
       * ``CMakeLists.txt``
 
 A ``README.rst`` should be always included which explains the basic purpose of

--- a/libs/all_modules.rst
+++ b/libs/all_modules.rst
@@ -4,9 +4,14 @@
    Distributed under the Boost Software License, Version 1.0. (See accompanying
    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+.. _all_modules:
+
+===========
+All modules
+===========
+
 .. toctree::
-   :caption: Modules
    :maxdepth: 2
 
-   /libs/overview.rst
-   /libs/all_modules.rst
+   /libs/_example/docs/index.rst
+   /libs/preprocessor/docs/index.rst

--- a/libs/create_library_skeleton.py
+++ b/libs/create_library_skeleton.py
@@ -195,7 +195,6 @@ libs = sorted([ lib for lib in os.listdir(cwd) if os.path.isdir(lib) ])
 # Adapting top level CMakeLists.txt
 libs_cmakelists = cmake_header + f'''
 # This file is auto generated. Please do not edit manually.
-
 '''
 
 libs_cmakelists += '''
@@ -204,7 +203,7 @@ set(HPX_LIBS
 for lib in libs:
     if not lib.startswith('_'):
         libs_cmakelists += f'  {lib}\n'
-libs_cmakelists += ')\n'
+libs_cmakelists += '  CACHE INTERNAL "" FORCE\n)\n'
 
 libs_cmakelists += '''
 foreach(lib ${HPX_LIBS})
@@ -215,23 +214,28 @@ endforeach()
 f = open(os.path.join(cwd, 'CMakeLists.txt'), 'w')
 f.write(libs_cmakelists)
 
-# Adapting top level index.rst
-index_rst = f'''..
+# Adapting all_modules.rst
+all_modules_rst = f'''..
    Copyright (c) 2018-2019 The STE||AR-Group
 
    Distributed under the Boost Software License, Version 1.0. (See accompanying
    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+.. _all_modules:
+
+===========
+All modules
+===========
+
 .. toctree::
-   :caption: Libraries
    :maxdepth: 2
 
 '''
 for lib in libs:
-    index_rst += f'   /libs/{lib}/docs/index.rst\n'
+    all_modules_rst += f'   /libs/{lib}/docs/index.rst\n'
 
-f = open(os.path.join(cwd, 'index.rst'), 'w')
-f.write(index_rst)
+f = open(os.path.join(cwd, 'all_modules.rst'), 'w')
+f.write(all_modules_rst)
 
 ################################################################################
 

--- a/libs/overview.rst
+++ b/libs/overview.rst
@@ -1,0 +1,18 @@
+..
+   Copyright (c) 2019 The STE||AR-Group
+
+   Distributed under the Boost Software License, Version 1.0. (See accompanying
+   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+.. _modules_overview:
+
+========
+Overview
+========
+
+|hpx| is organized into different sub-libraries. Those libraries can be seen as
+independent modules, with clear dependencies and no cycles. As an end-user, the
+use of these modules is completely transparent. If you use e.g.
+``add_hpx_executable`` to create a target in your project you will automatically
+get all modules as dependencies. See :ref:`all_modules` for a list of the
+available modules.

--- a/libs/preprocessor/docs/index.rst
+++ b/libs/preprocessor/docs/index.rst
@@ -6,9 +6,9 @@
 
 .. _libs_preprocessor:
 
-===
+============
 preprocessor
-===
+============
 
 This library contains useful preprocessor macros:
 


### PR DESCRIPTION
- Make sure API docs show up for modules
- Fix links to `HPX_PP_X` macro docs
- Slightly restructure modules documentation
  - Add headings to API reference
  - Move list of all modules to subsection
- Minor formatting and link fixes in docs