### PR TITLE
minor fix: option HPX_WITH_TEST was not working correctly

### DIFF
--- a/libs/_example/tests/CMakeLists.txt
+++ b/libs/_example/tests/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
+if (NOT HPX_WITH_TESTS)
   return()
 endif()
 if (NOT HPX__EXAMPLE_WITH_TESTS)

--- a/libs/create_library_skeleton.py
+++ b/libs/create_library_skeleton.py
@@ -87,7 +87,7 @@ endif()
 '''
 
 tests_cmakelists_template = cmake_header + f'''
-if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
+if (NOT HPX_WITH_TESTS)
   return()
 endif()
 if (NOT HPX_{lib_name_upper}_WITH_TESTS)

--- a/libs/preprocessor/tests/CMakeLists.txt
+++ b/libs/preprocessor/tests/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
+if (NOT HPX_WITH_TESTS)
   return()
 endif()
 if (NOT HPX_PREPROCESSOR_WITH_TESTS)


### PR DESCRIPTION
## Proposed Changes
CMake option HPX_WITH_TEST now disables all specialized test