### PR TITLE
Fix CircleCI config for modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -772,6 +772,31 @@ jobs:
       - store_artifacts:
           path: tests.unit.util
 
+  tests.unit.libs:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /hpx
+      - run:
+          name: Building Unit Tests
+          command: |
+              ninja -j2 -k 0 tests.unit.preprocessor
+      - run:
+          name: Running Unit Tests
+          when: always
+          command: |
+              ulimit -c unlimited
+              ctest -T test --no-compress-output --output-on-failure -R tests.unit.preprocessor
+      - run:
+          <<: *convert_xml
+      - run:
+          <<: *move_core_dump
+      - run:
+          <<: *move_debug_log
+      - store_test_results:
+          path: tests.unit.libs
+      - store_artifacts:
+          path: tests.unit.libs
   tests.regressions:
     <<: *defaults
     steps:
@@ -1179,6 +1204,8 @@ workflows:
           <<: *core_dependency
       - tests.unit.util:
           <<: *core_dependency
+      - tests.unit.libs:
+          <<: *core_dependency
       - tests.regressions:
           <<: *core_dependency
       - tests.performance:
@@ -1206,6 +1233,8 @@ workflows:
       - tests.headers.traits:
           <<: *core_dependency
       - tests.headers.util:
+          <<: *core_dependency
+      - tests.headers.libs:
           <<: *core_dependency
       - examples:
           <<: *core_dependency
@@ -1241,6 +1270,7 @@ workflows:
             - tests.unit.threads
             - tests.unit.traits
             - tests.unit.util
+            - tests.unit.libs
             - tests.headers.compat
             - tests.headers.components
             - tests.headers.compute
@@ -1253,6 +1283,7 @@ workflows:
             - tests.headers.runtime
             - tests.headers.traits
             - tests.headers.util
+            - tests.headers.libs
             - tests.performance
             - tests.regressions
             - examples

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1855,15 +1855,6 @@ set(HPX_DEBUG_POSTFIX "d")
 ################################################################################
 # Add libraries
 ################################################################################
-if(HPX_WITH_STATIC_LINKING)
-  if(MSVC)
-    # The MSVC linker can't handle a static library as large as we get when
-    # statically linking the main HPX library
-    set(hpx_libs_link_mode SHARED)
-  endif()
-else()
-  set(hpx_libs_link_mode ${hpx_library_link_mode})
-endif()
 add_subdirectory(libs)
 
 ################################################################################

--- a/libs/create_library_skeleton.py
+++ b/libs/create_library_skeleton.py
@@ -67,7 +67,14 @@ project(HPX.{lib_name} CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${{CMAKE_CURRENT_SOURCE_DIR}}/cmake")
 
-option(HPX_{lib_name_upper}_WITH_TESTS "Include tests for {lib_name}" On)
+include(HPX_AddDefinitions)
+include(HPX_Option)
+
+hpx_option(HPX_{lib_name_upper}_WITH_TESTS
+  BOOL
+  "Build HPX {lib_name} module tests. (default: ON)"
+  ON ADVANCED
+  CATEGORY "Modules")
 
 message(STATUS "{lib_name}: Configuring")
 

--- a/libs/preprocessor/CMakeLists.txt
+++ b/libs/preprocessor/CMakeLists.txt
@@ -9,10 +9,14 @@ project(HPX.preprocessor CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-option(HPX_PREPROCESSOR_WITH_TESTS "Include tests for preprocessor" On)
-
 include(HPX_AddDefinitions)
 include(HPX_Option)
+
+hpx_option(HPX_PREPROCESSOR_WITH_TESTS
+  BOOL
+  "Build HPX preprocessor module tests. (default: ON)"
+  ON ADVANCED
+  CATEGORY "Modules")
 
 hpx_option(HPX_PREPROCESSOR_WITH_DEPRECATION_WARNINGS
   BOOL

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -300,15 +300,14 @@ foreach(_plugin ${HPX_STATIC_PARCELPORT_PLUGINS})
 endforeach()
 
 # integrate the hpx modules with the main library
-set(_modules hpx_preprocessor)
-foreach(_module ${_modules})
+foreach(_module ${HPX_LIBS})
   # add module binaries as PRIVATE dependencies to the core hpx library to
   # avoid dependent applicatons have to link against those
-  target_link_libraries(hpx ${HPX_TLL_PRIVATE} ${_module})
+  target_link_libraries(hpx ${HPX_TLL_PRIVATE} hpx_${_module})
 
   # add module include directories as PUBLIC to core hpx library to enable
   # compilation against indirectly included headers
-  get_target_property(_module_includes ${_module} INTERFACE_INCLUDE_DIRECTORIES)
+  get_target_property(_module_includes hpx_${_module} INTERFACE_INCLUDE_DIRECTORIES)
   target_include_directories(hpx PUBLIC ${_module_includes})
 endforeach()
 
@@ -355,10 +354,10 @@ if(NOT HPX_WITH_STATIC_LINKING)
   endif()
   target_include_directories(hpx_init PRIVATE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>)
 
-  foreach(_module ${_modules})
+  foreach(_module ${HPX_LIBS})
     # add module include directories as PRIVATE to the hpx_init library to
     # enable its compilation against indirectly included headers
-    get_target_property(_module_includes ${_module} INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(_module_includes hpx_${_module} INTERFACE_INCLUDE_DIRECTORIES)
     target_include_directories(hpx_init PRIVATE ${_module_includes})
   endforeach()
 
@@ -402,10 +401,10 @@ if(HPX_WITH_DYNAMIC_HPX_MAIN AND (("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux") OR (
 
     target_include_directories(hpx_wrap PRIVATE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>)
 
-    foreach(_module ${_modules})
+    foreach(_module ${HPX_LIBS})
       # add module include directories as PRIVATE to the hpx_wrap library to
       # enable its compilation against indirectly included headers
-      get_target_property(_module_includes ${_module} INTERFACE_INCLUDE_DIRECTORIES)
+      get_target_property(_module_includes hpx_${_module} INTERFACE_INCLUDE_DIRECTORIES)
       target_include_directories(hpx_wrap PRIVATE ${_module_includes})
     endforeach()
 


### PR DESCRIPTION
Add libs tests to CircleCI config.

Flyby: use `hpx_option` for all options in modules.