### PR TITLE
Disable transpose_block_numa example on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,7 +232,12 @@ jobs:
           when: always
           command: |
               ulimit -c unlimited
-              ctest -T test --no-compress-output --output-on-failure -R tests.examples
+              # NOTE: transpose_block_numa is disabled because
+              # hwloc_get_area_membind_nodeset (which is used by the
+              # numa_allocator) fails with EPERM.
+              ctest -T test --no-compress-output --output-on-failure \
+                  -R tests.examples \
+                  -E tests.examples.transpose.transpose_block_numa
       - run:
           <<: *convert_xml
       - run:


### PR DESCRIPTION
## Any background context you want to provide?

This call to hwloc: https://github.com/STEllAR-GROUP/hpx/blob/8a8cec8dee6f0dc12200c124b6cb3bf43264bc27/src/runtime/threads/topology.cpp#L522-L528 returns `-1` and sets `errno = EPERM` (i.e. permission denied) on CircleCI. My guess is that this hasn't come up before because of recent changes to exception handling (#3662, #3814), or CircleCI launching containers differently. Since we have pycicle running as well without containers I think we can safely disable the example on CircleCI.