### PR TITLE
Make tuple serialization non-intrusive

### DIFF
--- a/hpx/include/serialization.hpp
+++ b/hpx/include/serialization.hpp
@@ -26,6 +26,7 @@
 #include <hpx/runtime/serialization/set.hpp>
 #include <hpx/runtime/serialization/shared_ptr.hpp>
 #include <hpx/runtime/serialization/string.hpp>
+#include <hpx/runtime/serialization/tuple.hpp>
 #include <hpx/runtime/serialization/unique_ptr.hpp>
 #include <hpx/runtime/serialization/unordered_map.hpp>
 #include <hpx/runtime/serialization/valarray.hpp>

--- a/hpx/runtime/actions/action_support.hpp
+++ b/hpx/runtime/actions/action_support.hpp
@@ -23,7 +23,6 @@
 #include <hpx/runtime/threads/thread_init_data.hpp>
 #include <hpx/traits/action_remote_result.hpp>
 #include <hpx/util/debug/demangle_helper.hpp>
-#include <hpx/util/tuple.hpp>
 #if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
 #include <hpx/util/itt_notify.hpp>
 #endif

--- a/hpx/runtime/actions/basic_action.hpp
+++ b/hpx/runtime/actions/basic_action.hpp
@@ -29,6 +29,7 @@
 #include <hpx/runtime/naming/address.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime/parcelset/detail/per_action_data_counter_registry.hpp>
+#include <hpx/runtime/serialization/tuple.hpp>
 #include <hpx/runtime/threads/thread_data_fwd.hpp>
 #include <hpx/runtime/threads/thread_enums.hpp>
 #include <hpx/runtime_fwd.hpp>

--- a/hpx/runtime/serialization/tuple.hpp
+++ b/hpx/runtime/serialization/tuple.hpp
@@ -1,0 +1,118 @@
+//  Copyright (c) 2011-2013 Thomas Heller
+//  Copyright (c) 2011-2013 Hartmut Kaiser
+//  Copyright (c) 2013-2015 Agustin Berge
+//  Copyright (c)      2019 Mikael Simberg
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_RUNTIME_SERIALIZATION_TUPLE_HPP)
+#define HPX_RUNTIME_SERIALIZATION_TUPLE_HPP
+
+#include <hpx/runtime/serialization/detail/non_default_constructible.hpp>
+#include <hpx/traits/is_bitwise_serializable.hpp>
+#include <hpx/util/detail/pack.hpp>
+#include <hpx/util/tuple.hpp>
+
+#include <cstddef>
+#include <type_traits>
+
+namespace hpx { namespace traits {
+    template <typename... Ts>
+    struct is_bitwise_serializable<::hpx::util::tuple<Ts...>>
+      : ::hpx::util::detail::all_of<hpx::traits::is_bitwise_serializable<
+            typename std::remove_const<Ts>::type>...>
+    {
+    };
+}}
+
+namespace hpx { namespace util { namespace detail {
+    template <typename Archive, typename Is, typename... Ts>
+    struct serialize_with_index_pack;
+
+    template <typename Archive, typename Is, typename... Ts>
+    struct load_construct_data_with_index_pack;
+
+    template <typename Archive, typename Is, typename... Ts>
+    struct save_construct_data_with_index_pack;
+
+    template <typename Archive, std::size_t... Is, typename... Ts>
+    struct serialize_with_index_pack<Archive,
+        hpx::util::detail::pack_c<std::size_t, Is...>, Ts...>
+    {
+        static void call(Archive& ar, hpx::util::tuple<Ts...>& t, unsigned int)
+        {
+            int const _sequencer[] = {((ar & hpx::util::get<Is>(t)), 0)...};
+            (void) _sequencer;
+        }
+    };
+
+    template <typename Archive, std::size_t... Is, typename... Ts>
+    struct load_construct_data_with_index_pack<Archive,
+        hpx::util::detail::pack_c<std::size_t, Is...>, Ts...>
+    {
+        static void call(
+            Archive& ar, hpx::util::tuple<Ts...>& t, unsigned int version)
+        {
+            using serialization::detail::load_construct_data;
+            int const _sequencer[] = {
+                (load_construct_data(ar, &hpx::util::get<Is>(t), version),
+                    0)...};
+            (void) _sequencer;
+        }
+    };
+
+    template <typename Archive, std::size_t... Is, typename... Ts>
+    struct save_construct_data_with_index_pack<Archive,
+        hpx::util::detail::pack_c<std::size_t, Is...>, Ts...>
+    {
+        static void call(
+            Archive& ar, hpx::util::tuple<Ts...> const& t, unsigned int version)
+        {
+            using serialization::detail::save_construct_data;
+            int const _sequencer[] = {
+                (save_construct_data(ar, &hpx::util::get<Is>(t), version),
+                    0)...};
+            (void) _sequencer;
+        }
+    };
+}}}
+
+namespace hpx { namespace serialization {
+    template <typename Archive, typename... Ts>
+    void serialize(
+        Archive& ar, hpx::util::tuple<Ts...>& t, unsigned int version)
+    {
+        using Is =
+            typename hpx::util::detail::make_index_pack<sizeof...(Ts)>::type;
+        hpx::util::detail::serialize_with_index_pack<Archive, Is, Ts...>::call(
+            ar, t, version);
+    }
+
+    template <typename Archive>
+    void serialize(Archive& ar, hpx::util::tuple<>&, unsigned)
+    {
+    }
+
+    template <typename Archive, typename... Ts>
+    void load_construct_data(
+        Archive& ar, hpx::util::tuple<Ts...>* t, unsigned int version)
+    {
+        using Is =
+            typename hpx::util::detail::make_index_pack<sizeof...(Ts)>::type;
+        hpx::util::detail::load_construct_data_with_index_pack<Archive, Is,
+            Ts...>::call(ar, *t, version);
+    }
+
+    template <typename Archive, typename... Ts>
+    void save_construct_data(
+        Archive& ar, hpx::util::tuple<Ts...> const* t, unsigned int version)
+    {
+        using Is =
+            typename hpx::util::detail::make_index_pack<sizeof...(Ts)>::type;
+        hpx::util::detail::save_construct_data_with_index_pack<Archive, Is,
+            Ts...>::call(ar, *t, version);
+    }
+}}
+
+#endif

--- a/hpx/util/tuple.hpp
+++ b/hpx/util/tuple.hpp
@@ -9,8 +9,6 @@
 #define HPX_UTIL_TUPLE_HPP
 
 #include <hpx/config.hpp>
-#include <hpx/runtime/serialization/detail/non_default_constructible.hpp>
-#include <hpx/traits/is_bitwise_serializable.hpp>
 #include <hpx/util/decay.hpp>
 #include <hpx/util/detail/pack.hpp>
 
@@ -304,37 +302,6 @@ namespace hpx { namespace util
                 return static_cast<tuple_member<
                         I, typename detail::at_index<I, Ts...>::type
                     > const&>(*this).value();
-            }
-
-            template <typename Archive>
-            void serialize(Archive& ar, unsigned int const)
-            {
-                int const _sequencer[] = {
-                    ((ar & this->get<Is>()), 0)...
-                };
-                (void)_sequencer;
-            }
-
-            template <typename Archive>
-            friend void load_construct_data(
-                Archive& ar, tuple_impl* t, unsigned int const version)
-            {
-                using serialization::detail::load_construct_data;
-                int const _sequencer[] = {
-                    (load_construct_data(ar, &t->get<Is>(), version), 0)...
-                };
-                (void)_sequencer;
-            }
-
-            template <typename Archive>
-            friend void save_construct_data(
-                Archive& ar, tuple_impl const* t, unsigned int const version)
-            {
-                using serialization::detail::save_construct_data;
-                int const _sequencer[] = {
-                    (save_construct_data(ar, &t->get<Is>(), version), 0)...
-                };
-                (void)_sequencer;
             }
         };
 
@@ -1055,64 +1022,6 @@ namespace hpx { namespace util
         x.swap(y);
     }
 #endif
-}}
-
-namespace hpx { namespace traits
-{
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename Is, typename ...Ts>
-    struct is_bitwise_serializable<
-        ::hpx::util::detail::tuple_impl<Is, Ts...>
-    > : ::hpx::util::detail::all_of<
-            hpx::traits::is_bitwise_serializable<
-                typename std::remove_const<Ts>::type
-            >...
-        >
-    {};
-}}
-
-namespace hpx { namespace serialization
-{
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename Archive, typename ...Ts>
-    HPX_FORCEINLINE
-    void serialize(
-        Archive& ar
-      , ::hpx::util::tuple<Ts...>& t
-      , unsigned int const /*version*/ = 0
-    )
-    {
-        ar & t._impl;
-    }
-
-    template <typename Archive>
-    HPX_FORCEINLINE
-    void serialize(
-        Archive& ar
-      , ::hpx::util::tuple<>& t
-      , unsigned int const version = 0
-    )
-    {}
-
-    template <typename Archive, typename ...Ts>
-    HPX_FORCEINLINE
-    void load_construct_data(
-        Archive& ar
-      , ::hpx::util::tuple<Ts...>* t
-      , unsigned int const version = 0)
-    {
-        load_construct_data(ar, &(t->_impl), version);
-    }
-
-    template <typename Archive, typename ...Ts>
-    HPX_FORCEINLINE
-    void save_construct_data(
-        Archive& ar
-      , ::hpx::util::tuple<Ts...> const* t
-      , unsigned int const version = 0)
-    {
-        save_construct_data(ar, &(t->_impl), version);
-    }
 }}
 
 #if defined(HPX_MSVC_WARNING_PRAGMA)

--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -32,6 +32,7 @@
 #include <hpx/util/function.hpp>
 #include <hpx/util/logging.hpp>
 #include <hpx/util/query_counters.hpp>
+#include <hpx/util/tuple.hpp>
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>


### PR DESCRIPTION
Remove the serialization implementation from the `tuple(_impl)` class so that the serialization functionality can be stored in a separate file. This lets parts of HPX that need `tuple` *not* depend on serialization (and transitively naming, AGAS details, etc.).