### PR TITLE
This fixes the launch_process/launched_process pair of tests

### DIFF
--- a/tests/unit/component/launched_process.cpp
+++ b/tests/unit/component/launched_process.cpp
@@ -75,7 +75,10 @@ int main(int argc, char* argv[])
 
         // This explicitly enables the component we depend on (it is disabled by
         // default to avoid being loaded outside of this test).
-        "hpx.components.launch_process_test_server.enabled!=1"
+        "hpx.components.launch_process_test_server.enabled!=1",
+
+        // Make sure networking will not be disabled
+        "hpx.expect_connecting_localities!=1"
     };
 
     // Note: this uses runtime_mode_connect to instruct this locality to


### PR DESCRIPTION
- we have to make sure networking stays enabled for both parts of the test
