### PR TITLE
Add tests for libs header tests

### DIFF
--- a/cmake/HPX_AddCompileTest.cmake
+++ b/cmake/HPX_AddCompileTest.cmake
@@ -83,6 +83,13 @@ function(add_hpx_lib_header_tests lib)
       add_library(tests.headers.${lib}.${test_name} ${CMAKE_CURRENT_BINARY_DIR}/${full_test_file})
       target_link_libraries(tests.headers.${lib}.${test_name} hpx_${lib})
       add_dependencies(tests.headers.${lib} tests.headers.${lib}.${test_name})
+
+      add_test(NAME "tests.headers.${lib}.${test_name}"
+        COMMAND ${CMAKE_COMMAND}
+        --build ${CMAKE_BINARY_DIR}
+          --target tests.headers.${lib}.${test_name}
+          --config $<CONFIGURATION>
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
     endif()
   endforeach()
 
@@ -97,4 +104,11 @@ function(add_hpx_lib_header_tests lib)
   add_library(tests.headers.${lib}.${test_name} "${CMAKE_CURRENT_BINARY_DIR}/${test_name}.cpp")
   target_link_libraries(tests.headers.${lib}.${test_name} hpx_${lib})
   add_dependencies(tests.headers.${lib} tests.headers.${lib}.${test_name})
+
+  add_test(NAME "tests.headers.${lib}.${test_name}"
+    COMMAND ${CMAKE_COMMAND}
+    --build ${CMAKE_BINARY_DIR}
+      --target tests.headers.${lib}.${test_name}
+      --config $<CONFIGURATION>
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 endfunction()


### PR DESCRIPTION
Previously only build targets were created, but no tests. This adds the tests.
