### PR TITLE
Temporary fix to local_dataflow_boost_small_vector test

### DIFF
--- a/tests/unit/lcos/local_dataflow_boost_small_vector.cpp
+++ b/tests/unit/lcos/local_dataflow_boost_small_vector.cpp
@@ -25,8 +25,8 @@
 // #include <boost/range/begin.hpp>
 // #include <boost/range/end.hpp>
 
-template <typename T> //, typename Allocator = std::allocator<T>>
-using small_vector = boost::container::small_vector<T, 3>;
+template <typename T, typename Allocator = boost::container::new_allocator<T>>
+using small_vector = boost::container::small_vector<T, 3, Allocator>;
 
 ///////////////////////////////////////////////////////////////////////////////
 std::atomic<std::uint32_t> void_f_count;


### PR DESCRIPTION
"Fixes" #3808. This sets the allocator explicitly in the test to avoid problems with dataflow not knowing what to do with a `void` allocator.

@hkaiser I'd be happy with this as a solution for the release to not have to rush in a proper fix.

I'm also tempted to say that this isn't even our problem since standard containers don't support `void` as an allocator either, but you're a better judge than I am of how bad this is and what we can reasonably do to support it.