### PR TITLE
Helper functions that are useful in numa binding and testing of allocator

### DIFF
--- a/hpx/parallel/util/numa_binding_allocator.hpp
+++ b/hpx/parallel/util/numa_binding_allocator.hpp
@@ -33,7 +33,7 @@
 
 // Can be used to enable debugging of the allocator page mapping
 //#define NUMA_BINDING_ALLOCATOR_INIT_MEMORY
-// #define NUMA_BINDING_ALLOCATOR_DEBUG_PAGE_BINDING
+//#define NUMA_BINDING_ALLOCATOR_DEBUG_PAGE_BINDING
 
 #if defined(NUMA_BINDING_ALLOCATOR_DEBUG_PAGE_BINDING) && !defined(HPX_MSVC)
 #include <plugins/parcelport/parcelport_logging.hpp>
@@ -630,9 +630,16 @@ namespace hpx { namespace compute { namespace host {
         }
 
     public:
+        // return the binding helper cast to a specific type
+        template <typename Binder>
+        std::shared_ptr<Binder> get_binding_helper_cast() const
+        {
+            return std::dynamic_pointer_cast<Binder>(binding_helper_);
+        }
+
         std::shared_ptr<numa_binding_helper<T>> binding_helper_;
-        threads::hpx_hwloc_membind_policy policy_;
-        unsigned int flags_;
+        threads::hpx_hwloc_membind_policy       policy_;
+        unsigned int                            flags_;
 
     private:
         mutable std::mutex init_mutex;

--- a/hpx/runtime/resource/detail/partitioner.hpp
+++ b/hpx/runtime/resource/detail/partitioner.hpp
@@ -15,7 +15,7 @@
 #include <hpx/runtime/threads/topology.hpp>
 #include <hpx/util/command_line_handling.hpp>
 #include <hpx/util/tuple.hpp>
-
+#include <hpx/util/assert.hpp>
 #include <boost/program_options.hpp>
 
 #include <atomic>
@@ -127,6 +127,15 @@ namespace hpx { namespace resource { namespace detail
         // resource partitioner called in hpx_init
         void configure_pools();
 
+        // returns the number of threads(pus) requested
+        // by the user at startup.
+        // This should not be called before the RP has parsed the config and
+        // assigned affinity data
+        std::size_t threads_needed() {
+            HPX_ASSERT(pus_needed_ != std::size_t(-1));
+            return pus_needed_;
+        }
+
         ////////////////////////////////////////////////////////////////////////
         scheduling_policy which_scheduler(std::string const& pool_name);
         threads::topology &get_topology() const;
@@ -224,7 +233,7 @@ namespace hpx { namespace resource { namespace detail
         // holds all of the command line switches
         util::command_line_handling cfg_;
         std::size_t first_core_;
-        std::size_t cores_needed_;
+        std::size_t pus_needed_;
 
         // contains the basic characteristics of the thread pool partitioning ...
         // that will be passed to the runtime

--- a/hpx/runtime/resource/partitioner.hpp
+++ b/hpx/runtime/resource/partitioner.hpp
@@ -259,6 +259,13 @@ namespace hpx { namespace resource
         // Access all available NUMA domains
         HPX_EXPORT std::vector<numa_domain> const& numa_domains() const;
 
+        // Returns the threads requested at startup --hpx:threads=cores
+        // for example will return the number actually created
+        HPX_EXPORT std::size_t get_number_requested_threads();
+
+        // return the topology object managed by the internal partitioner
+        HPX_EXPORT hpx::threads::topology const &get_topology() const;
+
     private:
         detail::partitioner& partitioner_;
     };

--- a/src/runtime/resource/detail/detail_partitioner.cpp
+++ b/src/runtime/resource/detail/detail_partitioner.cpp
@@ -216,7 +216,7 @@ namespace hpx { namespace resource { namespace detail
     ////////////////////////////////////////////////////////////////////////
     partitioner::partitioner()
       : first_core_(std::size_t(-1))
-      , cores_needed_(std::size_t(-1))
+      , pus_needed_(std::size_t(-1))
       , mode_(mode_default)
       , topo_(threads::create_topology())
     {
@@ -361,8 +361,8 @@ namespace hpx { namespace resource { namespace detail
         }
 
         // should have been initialized by now
-        HPX_ASSERT(cores_needed_ != std::size_t(-1));
-        return cores_needed_;
+        HPX_ASSERT(pus_needed_ != std::size_t(-1));
+        return pus_needed_;
     }
 
     // This function is called in hpx_init, before the instantiation of the
@@ -916,7 +916,7 @@ namespace hpx { namespace resource { namespace detail
         cfg_.parse_result_ = cfg_.call(desc_cmdline, argc, argv);
 
         // set all parameters related to affinity data
-        cores_needed_ = affinity_data_.init(cfg_);
+        pus_needed_ = affinity_data_.init(cfg_);
 
         if (fill_internal_topology)
         {

--- a/src/runtime/resource/partitioner.cpp
+++ b/src/runtime/resource/partitioner.cpp
@@ -303,4 +303,15 @@ namespace hpx { namespace resource
     {
         return partitioner_.numa_domains();
     }
+
+    hpx::threads::topology const &partitioner::get_topology() const
+    {
+        return partitioner_.get_topology();
+    }
+
+    std::size_t partitioner::get_number_requested_threads()
+    {
+        return partitioner_.threads_needed();
+    }
+
 }}    // namespace hpx


### PR DESCRIPTION
This is a commit that was left off the original branch but is useful for other tests
Adds methods to query number of threads user requested on start (useful when creating custom pools and deciding how many to put in each), a utility function to access the topology from the RP.
Also adds a cast function to the allocator to convert the binder to a user type.
If this could go into the next release, it would be very useful.