### PR TITLE
Add scripts to create releases and generate lists of PRs and issues

### DIFF
--- a/docs/sphinx/contributing/release_procedure.rst
+++ b/docs/sphinx/contributing/release_procedure.rst
@@ -32,8 +32,8 @@ are completed to avoid confusion.
 
 #. Write release notes in ``docs/sphinx/releases/whats_new_$VERSION.rst``. Keep
    adding merged PRs and closed issues to this until just before the release is
-   made. Add the new release notes to the table of contents in
-   ``docs/sphinx/releases.rst``.
+   made. Use ``tools/generate_pr_issue_list.sh`` to generate the lists. Add the
+   new release notes to the table of contents in ``docs/sphinx/releases.rst``.
 
 #. Build the docs, and proof-read them. Update any documentation that may have
    changed, and correct any typos. Pay special attention to:
@@ -111,13 +111,9 @@ are completed to avoid confusion.
    #. Change ``HPX_VERSION_TAG`` in ``CMakeLists.txt`` to ``-rcN``, where ``N``
       is the current iteration of this step. Start with ``-rc1``.
 
-   #. Tag a release candidate from the release branch, where tag name is the
-      version to be released with a ``-rcN`` suffix and description is "HPX
-      V$VERSION: The C++ Standards Library for Parallelism and Concurrency".
-
-      * ``git tag -a [tag name] -m '[description]'``
-      * ``git push origin [tag name]``
-      * Create a pre-release on GitHub
+   #. Tag and create a pre-release on GitHub using the script
+      ``tools/roll_release.sh``. The script requires that you have the |stellar|
+      Group signing key.
 
    #. This step is not necessary for patch releases. Notify
       ``hpx-users@stellar.cct.lsu.edu`` and ``stellar@cct.lsu.edu`` of the
@@ -146,42 +142,15 @@ are completed to avoid confusion.
    the docs, and change the value of ``HPX_VERSION_DATE`` in
    ``CMakeLists.txt``.
 
-#. Tag the release from the release branch, where tag name is the version to be
-   released and description is "HPX V$VERSION: The C++ Standards Library for
-   Parallelism and Concurrency". Sign the release tag with the
-   ``contact@stellar-group.org`` key by adding the ``-s`` flag to ``git tag``.
-   Make sure you change git to sign with the ``contact@stellar-group.org`` key,
-   rather than your own key if you use one. You also need to change the name and
-   email used for commits. Change them to ``STE||AR Group`` and
-   ``contact@stellar-group.org``, respectively. Finally, the
-   ``contact@stellar-group.org`` email address needs to be added to your GitHub
-   account for the tag to show up as verified.
-
-   * ``git tag -s -a [tag name] -m '[description]'``
-   * ``git push origin [tag name]``
-
-#. Create a release on GitHub
-
-   * Refer to the 'What's New' section in the documentation you uploaded in the
-     notes for the Github release (see previous releases for a hint).
-   * A DOI number using Zenodo is automatically assigned once the release is
-     created as such on github.
-   * Verify on Zenodo (https://zenodo.org/) that release was uploaded. Logging
-     into zenodo using the github credentials might be necessary to see the new
-     release as it usually takes a while for it to propagate to the search
-     engine used on zenodo.
+#. Tag and create a release on GitHub using the script
+   ``tools/roll_release.sh``. The script requires that you have the |stellar|
+   Group signing key.
 
 #. Update the websites (`stellar-group.org <https://stellar-group.org>`_ and
    `stellar.cct.lsu.edu <https://stellar.cct.lsu.edu>`_) with the following:
 
-   * Download links on the download page
-
-     * Run the script ``tools/roll_release.sh``. The script creates archives of
-       the release and prints HTML for the download pages. Upload the archives
-       to `stellar.cct.lsu.edu <https://stellar.cct.lsu.edu>`_, and add the
-       provided HTML to the downloads pages of both websites.
-     * Check that the download links work.
-
+   * Download links on the downloads pages. Use the direct link to the release
+     printed by the previous step.
    * Documentation links on the docs page (link to generated documentation on
      GitHub Pages). Follow the style of previous releases.
    * A new blog post announcing the release, which links to downloads and the

--- a/tools/generate_issue_pr_list.sh
+++ b/tools/generate_issue_pr_list.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019 Mikael Simberg
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file BOOST_LICENSE_1_0.rst or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# This script generates issue and PR lists for the current release. The output
+# is meant to be used in the release notes for each release. It relie on the hub
+# command line tool (https://hub.github.com/), jq, and sed.
+
+VERSION_MAJOR=$(sed -n 's/set(HPX_VERSION_MAJOR \(.*\))/\1/p' CMakeLists.txt)
+VERSION_MINOR=$(sed -n 's/set(HPX_VERSION_MINOR \(.*\))/\1/p' CMakeLists.txt)
+VERSION_SUBMINOR=$(sed -n 's/set(HPX_VERSION_SUBMINOR \(.*\))/\1/p' CMakeLists.txt)
+VERSION_FULL_NOTAG=$VERSION_MAJOR.$VERSION_MINOR.$VERSION_SUBMINOR
+
+# hub does not have a sub-command for milestones, but we can list milestones
+# using the hub api command instead (based on
+# https://github.com/github/hub/issues/2063#issuecomment-472181266)
+github_milestones() {
+  hub api --cache 3600 graphql -f query='
+    {
+      repository(owner: "{owner}", name: "{repo}") {
+        milestones(first: 100, states: OPEN, orderBy: {field:CREATED_AT, direction:DESC}) {
+          edges {
+            node {
+              title
+              number
+            }
+          }
+        }
+      }
+    }
+  ' | jq -r '.data.repository.milestones.edges[].node | [.number,.title] | @tsv'
+}
+
+milestone_id_from_version() {
+    github_milestones | grep "${1}" | cut -f1
+}
+
+VERSION_MILESTONE_ID=$(milestone_id_from_version "${VERSION_FULL_NOTAG}")
+
+# echo "Closed issues"
+# echo "============="
+
+# hub issue --state=closed --milestone="${VERSION_MILESTONE_ID}" --format="* :hpx-issue:\`%I\` - %t%n"
+
+echo ""
+echo "Closed pull requests"
+echo "===================="
+
+# The hub pr list command does not allow filtering by milestone like hub issue.
+# However, it lets us print the milestone for each PR. So we print every PR with
+# a milestone, filter out the unwanted PRs, and remove the printed milestone
+# from every PR instead.
+hub pr list --state=closed --format="[%Mn]* :hpx-pr:\`%I\` - %t%n" |
+    sed -n "s/^\[${VERSION_MILESTONE_ID}\]\(.*\)/\1/p"

--- a/tools/roll_release.sh
+++ b/tools/roll_release.sh
@@ -1,103 +1,73 @@
 #!/usr/bin/env bash
 #
+# Copyright (c)      2019 Mikael Simberg
 # Copyright (c) 2011-2012 Bryce Adelstein-Lelbach
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file BOOST_LICENSE_1_0.rst or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-VERSION_MAJOR=`sed -n 's/set(HPX_VERSION_MAJOR \(.*\))/\1/p' CMakeLists.txt`
-VERSION_MINOR=`sed -n 's/set(HPX_VERSION_MINOR \(.*\))/\1/p' CMakeLists.txt`
-VERSION_SUBMINOR=`sed -n 's/set(HPX_VERSION_SUBMINOR \(.*\))/\1/p' CMakeLists.txt`
-VERSION_TAG=`sed -n 's/set(HPX_VERSION_TAG "\(.*\)")/\1/p' CMakeLists.txt`
+# This script tags a release locally and creates a release on GitHub. It relies
+# on the hub command line tool (https://hub.github.com/).
 
-if [ ! -z "$VERSION_TAG" ]; then
-    echo "Warning: VERSION_TAG is not empty (\"$VERSION_TAG\")."
-    echo "If you intended to make a final release, remove the tag in hpx/config/version.hpp."
+set -o errexit
+
+VERSION_MAJOR=$(sed -n 's/set(HPX_VERSION_MAJOR \(.*\))/\1/p' CMakeLists.txt)
+VERSION_MINOR=$(sed -n 's/set(HPX_VERSION_MINOR \(.*\))/\1/p' CMakeLists.txt)
+VERSION_SUBMINOR=$(sed -n 's/set(HPX_VERSION_SUBMINOR \(.*\))/\1/p' CMakeLists.txt)
+VERSION_TAG=$(sed -n 's/set(HPX_VERSION_TAG "\(.*\)")/\1/p' CMakeLists.txt)
+VERSION_FULL_NOTAG=$VERSION_MAJOR.$VERSION_MINOR.$VERSION_SUBMINOR
+VERSION_FULL_TAG=$VERSION_MAJOR.$VERSION_MINOR.$VERSION_SUBMINOR$VERSION_TAG
+VERSION_DESCRIPTION="HPX V${VERSION_FULL_NOTAG}: The C++ Standards Library for Parallelism and Concurrency"
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+if [ "$CURRENT_BRANCH" != "release" ]; then
+    echo "Not on release branch. Not continuing to make release."
+    exit 1
 fi
 
-DOT_VERSION=$VERSION_MAJOR.$VERSION_MINOR.$VERSION_SUBMINOR$VERSION_TAG
-UNDERSCORE_VERSION=${VERSION_MAJOR}_${VERSION_MINOR}_$VERSION_SUBMINOR$VERSION_TAG
-
-DOCS_WEBSITE="https://stellar-group.github.io"
-SOURCE_WEBSITE="http://stellar.cct.lsu.edu"
-
-ZIP=hpx_$DOT_VERSION.zip
-TARGZ=hpx_$DOT_VERSION.tar.gz
-TARBZ2=hpx_$DOT_VERSION.tar.bz2
-SEVENZ=hpx_$DOT_VERSION.7z
-
-rm -rf packages
-mkdir -p packages/zip/hpx_$DOT_VERSION
-mkdir -p packages/tar.gz/hpx_$DOT_VERSION
-mkdir -p packages/tar.bz2/hpx_$DOT_VERSION
-mkdir -p packages/7z/hpx_$DOT_VERSION
-
-echo -n "Packaging $ZIP... "
-zip -q -x .git\* -x packages -x packages/\* -r packages/$ZIP .
-(cd packages/zip/hpx_$DOT_VERSION && unzip -qq ../../$ZIP)
-rm -f packages/$ZIP
-(cd packages/zip && zip -q -r ../$ZIP hpx_$DOT_VERSION)
-rm -rf packages/zip/hpx_$DOT_VERSION
-(cd packages/zip && unzip -qq ../$ZIP)
-echo "DONE"
-
-echo -n "Packaging $TARGZ... "
-tar --exclude=.git\* --exclude=packages --exclude=packages/\* -czf packages/$TARGZ .
-(cd packages/tar.gz/hpx_$DOT_VERSION && tar -xf ../../$TARGZ)
-rm -f packages/$TARGZ
-(cd packages/tar.gz && tar -czf ../$TARGZ hpx_$DOT_VERSION)
-rm -rf packages/tar.gz/hpx_$DOT_VERSION
-(cd packages/tar.gz && tar -xf ../$TARGZ)
-echo "DONE"
-
-echo -n "Packaging $TARBZ2... "
-tar --exclude=.git\* --exclude=packages --exclude=packages/\* -cjf packages/$TARBZ2 .
-(cd packages/tar.bz2/hpx_$DOT_VERSION && tar -xf ../../$TARBZ2)
-rm -f packages/$TARBZ2
-(cd packages/tar.bz2 && tar -cjf ../$TARBZ2 hpx_$DOT_VERSION)
-rm -rf packages/tar.bz2/hpx_$DOT_VERSION
-(cd packages/tar.bz2 && tar -xf ../$TARBZ2)
-echo "DONE"
-
-if type -t "7za" > /dev/null;
-then
-	SEVENZIP=7za
+if [ -z "$VERSION_TAG" ]; then
+    echo "You are about to tag and create a final release on GitHub."
 else
-	SEVENZIP=7zr
-fi
-echo -n "Packaging $SEVENZ... "
-$SEVENZIP a -xr\!.git -xr\!packages packages/$SEVENZ . > /dev/null
-(cd packages/7z/hpx_$DOT_VERSION && $SEVENZIP x ../../$SEVENZ > /dev/null)
-rm -f packages/$SEVENZ
-(cd packages/7z && $SEVENZIP a ../$SEVENZ hpx_$DOT_VERSION > /dev/null)
-rm -rf packages/7z/hpx_$DOT_VERSION
-(cd packages/7z && $SEVENZIP x ../$SEVENZ > /dev/null)
-echo "DONE"
-
-if [ ! -z "$VERSION_TAG" ]; then
-    echo "Not printing HTML for non-final release."
-    exit
+    echo "You are about to tag and create a pre-release on GitHub."
+    echo "If you intended to make a final release, remove the tag in the main CMakeLists.txt first."
 fi
 
-ZIP_MD5=`md5sum packages/$ZIP | awk {'print $1'}`
-TARGZ_MD5=`md5sum packages/$TARGZ | awk {'print $1'}`
-TARBZ2_MD5=`md5sum packages/$TARBZ2 | awk {'print $1'}`
-SEVENZ_MD5=`md5sum packages/$SEVENZ | awk {'print $1'}`
+echo ""
+echo "The version is \"${VERSION_FULL_TAG}\"."
+echo "The version description is:"
+echo "\"${VERSION_DESCRIPTION}\"."
+echo ""
 
-ZIP_SIZE=`ls -s -h packages/$ZIP | awk {'print $1'}`
-TARGZ_SIZE=`ls -s -h packages/$TARGZ | awk {'print $1'}`
-TARBZ2_SIZE=`ls -s -h packages/$TARBZ2 | awk {'print $1'}`
-SEVENZ_SIZE=`ls -s -h packages/$SEVENZ | awk {'print $1'}`
+echo "Do you want to continue?"
+select yn in "Yes" "No"; do
+    case $yn in
+        Yes ) break;;
+        No ) exit;;
+    esac
+done
 
-echo "<ul>"
-echo "  <li>HPX V$DOT_VERSION: <a title=\"HPX V$DOT_VERSION Release Notes\" href=\"$DOCS_WEBSITE/hpx/docs/sphinx/tags/$DOT_VERSION/html/releases/whats_new_$UNDERSCORE_VERSION.html\">release notes</a>"
-echo "  <table>"
-echo "    <tr><th>File</th><th>MD5 Hash</th></tr>"
-echo "    <tr><td><a title=\"HPX V$DOT_VERSION (zip)\" href=\"$SOURCE_WEBSITE/files/$ZIP\">zip ($ZIP_SIZE)</a></td><td><code>$ZIP_MD5</code></td></tr>"
-echo "    <tr><td><a title=\"HPX V$DOT_VERSION (gz)\" href=\"$SOURCE_WEBSITE/files/$TARGZ\">gz ($TARGZ_SIZE)</a></td><td><code>$TARGZ_MD5</code></td></tr>"
-echo "    <tr><td><a title=\"HPX V$DOT_VERSION (bz2)\" href=\"$SOURCE_WEBSITE/files/$TARBZ2\">bz2 ($TARBZ2_SIZE)</a></td><td><code>$TARBZ2_MD5</code></td></tr>"
-echo "    <tr><td><a title=\"HPX V$DOT_VERSION (7z)\" href=\"$SOURCE_WEBSITE/files/$SEVENZ\">7z ($SEVENZ_SIZE)</a></td><td><code>$SEVENZ_MD5</code></td></tr>"
-echo "  </table>"
-echo "  </li>"
-echo "</ul>"
+if [ -z "$VERSION_TAG" ]; then
+    PRERELEASE_FLAG=""
+else
+    PRERELEASE_FLAG="--prerelease"
+fi
 
+echo ""
+echo "Setting the signing key for signing the release. It is up to you to change it back to your own afterwards."
+git config user.signingkey E18AE35E86BB194F
+git config user.email "contact@stellar-group.org"
+git config user.name "STE||AR Group"
+
+echo ""
+echo "Tagging release."
+git tag -s -a "${VERSION_FULL_TAG}" -m "${VERSION_DESCRIPTION}"
+
+echo ""
+echo "Creating release."
+hub release create \
+    ${PRERELEASE_FLAG} \
+    --message "${VERSION_DESCRIPTION}" \
+    "${VERSION_FULL_TAG}"
+
+echo ""
+echo "Now add the above URL to the downloads pages on stellar.cct.lsu.edu and stellar-group.org."


### PR DESCRIPTION
Remove package generation from `tools/roll_release.sh`, and instead tag and create a release on GitHub with the `hub` tool. Also add a script to generate PR and issue lists using `hub`.

Not fully tested in real life for obvious reasons, but I'll amend these as needed when it's time for the next release.