### PR TITLE
Converted typedefs in actions submodule to using directives

### DIFF
--- a/hpx/runtime/actions/action_priority.hpp
+++ b/hpx/runtime/actions/action_priority.hpp
@@ -17,7 +17,7 @@ namespace hpx { namespace actions
     template <typename Action>
     threads::thread_priority action_priority()
     {
-        typedef typename hpx::traits::extract_action<Action>::type action_type_;
+        using action_type_ = typename hpx::traits::extract_action<Action>::type;
         threads::thread_priority priority =
             static_cast<threads::thread_priority>(
                 traits::action_priority<action_type_>::value);

--- a/hpx/runtime/actions/action_support.hpp
+++ b/hpx/runtime/actions/action_support.hpp
@@ -44,7 +44,7 @@ namespace hpx { namespace traits
         template <>
         struct action_remote_result_customization_point<void>
         {
-            typedef util::unused_type type;
+            using type = util::unused_type;
         };
     }
 }}

--- a/hpx/runtime/actions/basic_action.hpp
+++ b/hpx/runtime/actions/basic_action.hpp
@@ -234,32 +234,32 @@ namespace hpx { namespace actions
             >::value,
             "Using non-const references as arguments for actions is not supported.");
 
-        typedef Component component_type;
-        typedef Derived derived_type;
+        using component_type = Component;
+        using derived_type = Derived;
 
         // result_type represents the type returned when invoking operator()
-        typedef typename traits::promise_local_result<R>::type result_type;
+        using result_type = typename traits::promise_local_result<R>::type;
 
         // The remote_result_type is the remote type for the type_continuation
-        typedef typename traits::action_remote_result<R>::type remote_result_type;
+        using remote_result_type = typename traits::action_remote_result<R>::type;
 
         // The local_result_type is the local type for the type_continuation
-        typedef
+        using local_result_type =
             typename traits::promise_local_result<
                 remote_result_type
-            >::type local_result_type;
+            >::type;
 
-        typedef
+        using continuation_type =
             hpx::actions::typed_continuation<
                 local_result_type,
                 remote_result_type
-            > continuation_type;
+            >;
 
-        typedef R internal_result_type;
+        using internal_result_type = R;
         static const std::size_t arity = sizeof...(Args);
-        typedef util::tuple<typename std::decay<Args>::type...> arguments_type;
+        using arguments_type = util::tuple<typename std::decay<Args>::type...>;
 
-        typedef void action_tag;
+        using action_tag = void;
 
         ///////////////////////////////////////////////////////////////////////
         static std::string get_action_name(naming::address::address_type /*lva*/)
@@ -462,7 +462,7 @@ namespace hpx { namespace actions
             return static_cast<int>(components::get_component_type<Component>());
         }
 
-        typedef std::false_type direct_execution;
+        using direct_execution = std::false_type;
 
         /// The function \a get_action_type returns whether this action needs
         /// to be executed in a new thread or directly.
@@ -514,13 +514,13 @@ namespace hpx { namespace actions
         template <typename Action, typename Derived>
         struct action_type
         {
-            typedef Derived type;
+            using type = Derived;
         };
 
         template <typename Action>
         struct action_type<Action, this_type>
         {
-            typedef Action type;
+            using type = Action;
         };
     }
 
@@ -537,11 +537,11 @@ namespace hpx { namespace actions
                 Derived
             >::type>
     {
-        typedef typename detail::action_type<
+        using derived_type = typename detail::action_type<
             direct_action, Derived
-        >::type derived_type;
+        >::type;
 
-        typedef std::true_type direct_execution;
+        using direct_execution = std::true_type;
 
         /// The function \a get_action_type returns whether this action needs
         /// to be executed in a new thread or directly.
@@ -557,20 +557,17 @@ namespace hpx { namespace actions
     // supported function pointer.
     template <typename TF, TF F, typename Derived = detail::this_type,
         typename Direct = std::false_type>
-    struct make_action;
-
-    template <typename TF, TF F, typename Derived>
-    struct make_action<TF, F, Derived, std::false_type>
+    struct make_action
       : action<TF, F, Derived>
     {
-        typedef action<TF, F, Derived> type;
+        using type = action<TF, F, Derived>;
     };
 
     template <typename TF, TF F, typename Derived>
     struct make_action<TF, F, Derived, std::true_type>
       : direct_action<TF, F, Derived>
     {
-        typedef direct_action<TF, F, Derived> type;
+        using type = direct_action<TF, F, Derived>;
     };
 
     template <typename TF, TF F, typename Derived = detail::this_type>

--- a/hpx/runtime/actions/component_action.hpp
+++ b/hpx/runtime/actions/component_action.hpp
@@ -12,7 +12,7 @@
 #include <hpx/preprocessor/cat.hpp>
 #include <hpx/preprocessor/expand.hpp>
 #include <hpx/preprocessor/nargs.hpp>
-#include <hpx/runtime/actions/basic_action.hpp>
+#include <hpx/runtime/actions/plain_action.hpp>
 #include <hpx/runtime/components/pinned_ptr.hpp>
 #include <hpx/runtime/naming/address.hpp>
 #include <hpx/traits/is_future.hpp>
@@ -97,9 +97,8 @@ namespace hpx { namespace actions
         >
     {
     public:
-        typedef typename detail::action_type<
-            action, Derived
-        >::type derived_type;
+        using derived_type =
+            typename detail::action_type<action, Derived>::type;
 
         static std::string get_action_name(naming::address::address_type lva)
         {
@@ -138,9 +137,8 @@ namespace hpx { namespace actions
         >
     {
     public:
-        typedef typename detail::action_type<
-            action, Derived
-        >::type derived_type;
+        using derived_type =
+            typename detail::action_type<action, Derived>::type;
 
         static std::string get_action_name(naming::address::address_type lva)
         {
@@ -243,7 +241,7 @@ namespace hpx { namespace actions
 
 #define HPX_DEFINE_COMPONENT_ACTION_3(component, func, name)                  \
     struct name : hpx::actions::make_action<                                  \
-        decltype(&component::func), &component::func, name>::type {}          \
+        decltype(&component::func), &component::func>::type {}                \
     /**/
 #define HPX_DEFINE_COMPONENT_ACTION_2(component, func)                        \
     HPX_DEFINE_COMPONENT_ACTION_3(component, func,                            \
@@ -265,7 +263,7 @@ namespace hpx { namespace actions
 
 #define HPX_DEFINE_COMPONENT_DIRECT_ACTION_3(component, func, name)           \
     struct name : hpx::actions::make_direct_action<                           \
-        decltype(&component::func), &component::func, name>::type {}          \
+        decltype(&component::func), &component::func>::type {}                \
     /**/
 
 #define HPX_DEFINE_COMPONENT_DIRECT_ACTION_2(component, func)                 \

--- a/hpx/runtime/actions/detail/action_factory.hpp
+++ b/hpx/runtime/actions/detail/action_factory.hpp
@@ -25,10 +25,10 @@ namespace hpx { namespace actions { namespace detail
         HPX_NON_COPYABLE(action_registry);
 
     public:
-        typedef base_action* (*ctor_t)(bool);
-        typedef std::unordered_map<std::string, ctor_t> typename_to_ctor_t;
-        typedef std::unordered_map<std::string, std::uint32_t> typename_to_id_t;
-        typedef std::vector<ctor_t> cache_t;
+        using ctor_t = base_action* (*)(bool);
+        using typename_to_ctor_t = std::unordered_map<std::string, ctor_t>;
+        using typename_to_id_t = std::unordered_map<std::string, std::uint32_t>;
+        using cache_t = std::vector<ctor_t>;
 
         HPX_STATIC_CONSTEXPR std::uint32_t invalid_id = ~0;
 

--- a/hpx/runtime/actions/detail/invocation_count_registry.hpp
+++ b/hpx/runtime/actions/detail/invocation_count_registry.hpp
@@ -26,10 +26,10 @@ namespace hpx { namespace actions { namespace detail
         HPX_NON_COPYABLE(invocation_count_registry);
 
     public:
-        typedef std::int64_t (*get_invocation_count_type)(bool);
-        typedef std::unordered_map<
+        using get_invocation_count_type = std::int64_t (*)(bool);
+        using map_type = std::unordered_map<
                 std::string, get_invocation_count_type, hpx::util::jenkins_hash
-            > map_type;
+            >;
 
         invocation_count_registry() {}
 

--- a/hpx/runtime/actions/plain_action.hpp
+++ b/hpx/runtime/actions/plain_action.hpp
@@ -74,9 +74,8 @@ namespace hpx { namespace actions
         >
     {
     public:
-        typedef typename detail::action_type<
-            action, Derived
-        >::type derived_type;
+        using derived_type =
+            typename detail::action_type<action, Derived>::type;
 
         static std::string get_action_name(naming::address::address_type /*lva*/)
         {
@@ -179,12 +178,11 @@ namespace hpx { namespace traits
     struct name : hpx::actions::make_action<                                  \
         typename std::add_pointer<                                            \
             typename std::remove_pointer<decltype(&func)>::type               \
-        >::type, &func, name>::type {}                                        \
+        >::type, &func>::type {}                                              \
     /**/
 #else
 #define HPX_DEFINE_PLAIN_ACTION_2(func, name)                                 \
-    struct name : hpx::actions::make_action<                                  \
-        decltype(&func), &func, name>::type {}                                \
+    struct name : hpx::actions::make_action<decltype(&func), &func>::type {}  \
     /**/
 #endif
 
@@ -193,8 +191,8 @@ namespace hpx { namespace traits
     /**/
 
 #define HPX_DEFINE_PLAIN_DIRECT_ACTION_2(func, name)                          \
-    struct name : hpx::actions::make_direct_action<                           \
-        decltype(&func), &func, name>::type {}                                \
+    struct name                                                               \
+      : hpx::actions::make_direct_action<decltype(&func), &func>::type {}     \
     /**/
 
 /// \endcond

--- a/hpx/runtime/actions/transfer_action.hpp
+++ b/hpx/runtime/actions/transfer_action.hpp
@@ -38,7 +38,7 @@ namespace hpx { namespace actions
     public:
         HPX_NON_COPYABLE(transfer_action);
 
-        typedef transfer_base_action<Action> base_type;
+        using base_type = transfer_base_action<Action>;
 
     public:
         // construct an empty transfer_action to avoid serialization overhead

--- a/hpx/runtime/actions/transfer_base_action.hpp
+++ b/hpx/runtime/actions/transfer_base_action.hpp
@@ -145,16 +145,16 @@ namespace hpx { namespace actions
         HPX_NON_COPYABLE(transfer_base_action);
 
     public:
-        typedef typename Action::component_type component_type;
-        typedef typename Action::derived_type derived_type;
-        typedef typename Action::result_type result_type;
-        typedef typename Action::arguments_type arguments_base_type;
-        typedef typename std::conditional<
+        using component_type = typename Action::component_type;
+        using derived_type = typename Action::derived_type;
+        using result_type = typename Action::result_type;
+        using arguments_base_type = typename Action::arguments_type;
+        using arguments_type = typename std::conditional<
                 std::is_constructible<arguments_base_type>::value,
                     arguments_base_type,
                     detail::argument_holder<arguments_base_type>
-            >::type arguments_type;
-        typedef typename Action::continuation_type continuation_type;
+            >::type;
+        using continuation_type = typename Action::continuation_type;
 
         // This is the priority value this action has been instantiated with
         // (statically). This value might be different from the priority member
@@ -168,7 +168,7 @@ namespace hpx { namespace actions
         HPX_STATIC_CONSTEXPR std::uint32_t stacksize_value =
             traits::action_stacksize<Action>::value;
 
-        typedef typename Action::direct_execution direct_execution;
+        using direct_execution = typename Action::direct_execution;
 
         // construct an empty transfer_action to avoid serialization overhead
         transfer_base_action() = default;

--- a/hpx/runtime/actions/transfer_continuation_action.hpp
+++ b/hpx/runtime/actions/transfer_continuation_action.hpp
@@ -39,8 +39,8 @@ namespace hpx { namespace actions
     public:
         HPX_NON_COPYABLE(transfer_continuation_action);
 
-        typedef transfer_base_action<Action> base_type;
-        typedef typename base_type::continuation_type continuation_type;
+        using base_type = transfer_base_action<Action>;
+        using continuation_type = typename base_type::continuation_type;
 
     public:
         // construct an empty transfer_continuation_action to avoid serialization

--- a/hpx/traits/extract_action.hpp
+++ b/hpx/traits/extract_action.hpp
@@ -17,10 +17,10 @@ namespace hpx { namespace traits
     template <typename Action, typename Enable = void>
     struct extract_action
     {
-        typedef typename Action::derived_type type;
-        typedef typename type::result_type result_type;
-        typedef typename type::local_result_type local_result_type;
-        typedef typename type::remote_result_type remote_result_type;
+        using type = typename Action::derived_type;
+        using result_type = typename type::result_type;
+        using local_result_type = typename type::local_result_type;
+        using remote_result_type = typename type::remote_result_type;
     };
 
     template <typename Action>

--- a/hpx/util/internal_allocator.hpp
+++ b/hpx/util/internal_allocator.hpp
@@ -65,8 +65,7 @@ namespace hpx { namespace util
             return &x;
         }
 
-        pointer allocate(size_type n,
-            std::allocator<void>::const_pointer hint = nullptr)
+        pointer allocate(size_type n, void* hint = nullptr)
         {
             return reinterpret_cast<pointer>(
                 HPX_PP_CAT(HPX_HAVE_JEMALLOC_PREFIX, malloc)(n * sizeof(T)));


### PR DESCRIPTION
- flyby: fixed MSVC warning in internal allocator

