### PR TITLE
Making sure symbols are properly exported from modules (needed for Windows/MacOS)

### DIFF
--- a/cmake/templates/config_version.hpp.in
+++ b/cmake/templates/config_version.hpp.in
@@ -70,9 +70,11 @@ namespace hpx
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-#if !defined(HPX_EXPORTS) && !defined(HPX_NO_VERSION_CHECK)
-    // This is instantiated for each translation unit outside of the HPX core
-    // library, forcing to resolve the variable HPX_CHECK_VERSION.
+#if !defined(HPX_EXPORTS) && !defined(HPX_MODULE_EXPORTS) &&                   \
+    !defined(HPX_NO_VERSION_CHECK)
+
+// This is instantiated for each translation unit outside of the HPX core
+// library, forcing to resolve the variable HPX_CHECK_VERSION.
     namespace
     {
         // Note: this function is never executed.

--- a/libs/cache/CMakeLists.txt
+++ b/libs/cache/CMakeLists.txt
@@ -91,9 +91,10 @@ if(HPX_CACHE_WITH_COMPATIBILITY_HEADERS)
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include_compatibility>)
 endif()
 
-target_compile_definitions(hpx_cache PUBLIC
+target_compile_definitions(hpx_cache PRIVATE
   $<$<CONFIG:Debug>:DEBUG>
   $<$<CONFIG:Debug>:_DEBUG>
+  HPX_MODULE_EXPORTS
 )
 
 include(HPX_AddSourceGroup)

--- a/libs/config/CMakeLists.txt
+++ b/libs/config/CMakeLists.txt
@@ -53,9 +53,10 @@ target_include_directories(hpx_config PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>)
 
-target_compile_definitions(hpx_config PUBLIC
+target_compile_definitions(hpx_config PRIVATE
   $<$<CONFIG:Debug>:DEBUG>
   $<$<CONFIG:Debug>:_DEBUG>
+  HPX_MODULE_EXPORTS
 )
 
 include(HPX_AddSourceGroup)

--- a/libs/config/include/hpx/config/export_definitions.hpp
+++ b/libs/config/include/hpx/config/export_definitions.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2012 Hartmut Kaiser
+//  Copyright (c) 2007-2019 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -52,7 +52,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 // define the export/import helper macros used by the runtime module
-#if defined(HPX_EXPORTS)
+#if defined(HPX_EXPORTS) || defined(HPX_MODULE_EXPORTS)
 # define  HPX_EXPORT             HPX_SYMBOL_EXPORT
 # define  HPX_EXCEPTION_EXPORT   HPX_SYMBOL_EXPORT
 # define  HPX_API_EXPORT         HPX_APISYMBOL_EXPORT
@@ -83,7 +83,7 @@
 // components
 #if defined(HPX_EXPORTS) || defined(HPX_COMPONENT_EXPORTS) || \
     defined(HPX_APPLICATION_EXPORTS) || defined(HPX_SERIALIZATION_EXPORTS) || \
-    defined(HPX_LIBRARY_EXPORTS)
+    defined(HPX_LIBRARY_EXPORTS) || defined(HPX_MODULE_EXPORTS)
 # define HPX_ALWAYS_EXPORT       HPX_SYMBOL_EXPORT
 # define HPX_ALWAYS_IMPORT       HPX_SYMBOL_IMPORT
 #else

--- a/libs/config/src/version.cpp
+++ b/libs/config/src/version.cpp
@@ -1,18 +1,9 @@
 ////////////////////////////////////////////////////////////////////////////////
-//  Copyright (c) 2011 Bryce Lelbach
-//  Copyright (c) 2011-2017 Hartmut Kaiser
+//  Copyright (c) 2019 STE||AR Group
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <hpx/config/version.hpp>
-#include <hpx/preprocessor/stringize.hpp>
-
-///////////////////////////////////////////////////////////////////////////////
-namespace hpx
-{
-    char const HPX_CHECK_VERSION[] = HPX_PP_STRINGIZE(HPX_CHECK_VERSION);
-    char const HPX_CHECK_BOOST_VERSION[] = HPX_PP_STRINGIZE(HPX_CHECK_BOOST_VERSION);
-}
-
+// This file was intentionally left empty. It is used as a dummy to force cmake
+// into generating a separate Visual Studio project for this module.

--- a/libs/preprocessor/CMakeLists.txt
+++ b/libs/preprocessor/CMakeLists.txt
@@ -75,6 +75,12 @@ if(HPX_PREPROCESSOR_WITH_COMPATIBILITY_HEADERS)
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include_compatibility>)
 endif()
 
+target_compile_definitions(hpx_preprocessor PRIVATE
+  $<$<CONFIG:Debug>:DEBUG>
+  $<$<CONFIG:Debug>:_DEBUG>
+  HPX_MODULE_EXPORTS
+)
+
 include(HPX_AddSourceGroup)
 add_hpx_source_group(
   NAME hpx_preprocessor


### PR DESCRIPTION
- flyby: removed definition of symbols from config module as those are part of the main library
- flyby: made COMPILE_DEFINITIONS in modules PRIVATE

@msimberg, @aurianer please note the addition of the `HPX_MODULE_EXPORTS` compile definition. I believe we should add that to all of our modules. Also, once modules start actually implementing things we'll have to come up with a way to force linking of the symbols that are implemented in a module to the main library.