### PR TITLE
Fix async_customization dataflow example and Clarify what's being tested

### DIFF
--- a/examples/resource_partitioner/async_customization.cpp
+++ b/examples/resource_partitioner/async_customization.cpp
@@ -478,19 +478,18 @@ namespace hpx { namespace threads { namespace executors
 
 int hpx_main()
 {
-    int val = 0;
 
     test_async_executor exec;
-    val = test("Testing async custom executor", exec);
+    test("Testing async custom executor", exec);
 
     typedef hpx::threads::executors::pool_numa_hint<dummy_tag> dummy_hint;
     hpx::threads::executors::guided_pool_executor<dummy_hint> exec2("default");
-    val = test("Testing guided_pool_executor<dummy_hint>", exec2);
+    test("Testing guided_pool_executor<dummy_hint>", exec2);
 
     hpx::threads::executors::guided_pool_executor_shim<dummy_hint> exec3(true, "default");
-    val = test("Testing guided_pool_executor_shim<dummy_hint>", exec3);
+    test("Testing guided_pool_executor_shim<dummy_hint>", exec3);
 
-    return hpx::finalize(val);
+    return hpx::finalize(0);
 }
 
 int main(int argc, char** argv)

--- a/examples/resource_partitioner/async_customization.cpp
+++ b/examples/resource_partitioner/async_customization.cpp
@@ -6,6 +6,7 @@
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/runtime/threads/executors/default_executor.hpp>
 #include <hpx/runtime/threads/executors/pool_executor.hpp>
+#define GUIDED_EXECUTOR_DEBUG 1
 #include <hpx/runtime/threads/executors/guided_pool_executor.hpp>
 #include <hpx/runtime/resource/partitioner.hpp>
 //#include <hpx/runtime/threads/cpu_mask.hpp>
@@ -237,27 +238,23 @@ struct test_async_executor
     }
 
     // --------------------------------------------------------------------
-    // .then() execute specialized for a dataflow dispatch
+    // execute specialized for a dataflow dispatch
     // dataflow unwraps the outer future for us but passes a dataflowframe
     // function type, result type and tuple of futures as arguments
     // --------------------------------------------------------------------
     template <typename F,
-              typename DataFlowFrame,
-              typename Result,
               typename ... InnerFutures,
               typename = enable_if_t<
-                  is_tuple_of_futures<util::tuple<InnerFutures...>>::value>
+                  traits::is_future_tuple<util::tuple<InnerFutures...>>::value>
               >
     auto
     async_execute(F && f,
-                  DataFlowFrame && df,
-                  Result && r,
                   util::tuple<InnerFutures... > && predecessor)
     ->  future<typename util::detail::invoke_deferred_result<
-        F, DataFlowFrame, Result, util::tuple<InnerFutures... >>::type>
+        F, util::tuple<InnerFutures... >>::type>
     {
         typedef typename util::detail::invoke_deferred_result<
-            F, DataFlowFrame, Result, util::tuple<InnerFutures... >>::type
+            F, util::tuple<InnerFutures... >>::type
                 result_type;
 
         auto unwrapped_futures_tuple = util::map_pack(
@@ -272,7 +269,7 @@ struct test_async_executor
         std::cout << "dataflow      : unwrapped   : "
                   << print_type<decltype(unwrapped_futures_tuple)>(" | ") << "\n";
         std::cout << "dataflow-frame: Result      : "
-                  << print_type<Result>() << "\n";
+                  << print_type<result_type>() << "\n";
 
         // invoke a function with the unwrapped tuple future types to demonstrate
         // that we can access them
@@ -282,12 +279,10 @@ struct test_async_executor
         }, unwrapped_futures_tuple);
 
         // forward the task execution on to the real internal executor
+        // forward the task execution on to the real internal executor
         lcos::local::futures_factory<result_type()> p(
-            executor_,
             util::deferred_call(
                 std::forward<F>(f),
-                std::forward<DataFlowFrame>(df),
-                std::forward<Result>(r),
                 std::forward<util::tuple<InnerFutures...>>(predecessor)
             )
         );
@@ -319,9 +314,11 @@ namespace hpx { namespace parallel { namespace execution
 // test various execution modes
 // --------------------------------------------------------------------
 template <typename Executor>
-int test(Executor &exec)
+int test(const std::string &message, Executor &exec)
 {
     // test 1
+    std::cout << "============================" << std::endl;
+    std::cout << message << std::endl;
     std::cout << "============================" << std::endl;
     std::cout << "Test 1 : async()" << std::endl;
     auto fa = async(exec, [](int a, double b, const char *c)
@@ -407,8 +404,8 @@ int test(Executor &exec)
     auto fd = dataflow(exec,
         [](future<std::uint16_t> && f1, future<double> && f2)
         {
-            auto cmplx =
-                std::complex<std::uint64_t>(double(f1.get()), f2.get());
+            auto cmplx = std::complex<std::uint64_t>(f1.get(),
+                            static_cast<std::uint64_t>(f2.get()));
             std::cout << "Inside dataflow : " << cmplx << std::endl;
             return cmplx;
         }
@@ -420,11 +417,11 @@ int test(Executor &exec)
     // test 4b
     std::cout << "============================" << std::endl;
     std::cout << "Test 4b : dataflow(shared)" << std::endl;
-    future<std::uint16_t>      fs1 = make_ready_future(std::uint16_t(255));
-    shared_future<double> fs2 = make_ready_future(127.890).share();
+    future<std::uint32_t>      fs1 = make_ready_future(std::uint32_t(65535));
+    shared_future<double> fs2 = make_ready_future(2.178).share();
     //
     auto fds = dataflow(exec,
-        [](future<std::uint16_t> && f1, shared_future<double> && f2)
+        [](future<std::uint32_t> && f1, shared_future<double> && f2)
         {
             auto cmplx =
                 std::complex<std::uint64_t>(double(f1.get()), f2.get());
@@ -434,9 +431,10 @@ int test(Executor &exec)
         , fs1, fs2
     );
     fds.get();
+
     std::cout << "============================" << std::endl;
     std::cout << "Complete" << std::endl;
-    std::cout << "============================" << std::endl;
+    std::cout << "============================" << std::endl << std::endl;
     return 0;
 }
 
@@ -449,23 +447,31 @@ namespace hpx { namespace threads { namespace executors
     {
       int operator()(const int, const double, const char *) const {
           std::cout << "Hint 1 \n";
-          return 0;
+          return 1;
       }
       int operator()(const int ) const {
           std::cout << "Hint 2 \n";
-          return 0;
+          return 2;
       }
-      int operator()(const std::uint16_t, const double) const {
-          std::cout << "Hint 3 \n";
-          return 0;
-      }
-      int operator()(const util::tuple<future<int>, future<double>> &) const {
-          return 0;
+      int operator()(const util::tuple<future<int>,
+                     future<double>> &) const
+      {
+          std::cout << "Hint 3(a) \n";
+          return 3;
       }
       int operator()(const util::tuple<future<std::uint64_t>,
                      shared_future<float>> &) const
       {
-          return 0;
+          std::cout << "Hint 3(b) \n";
+          return 3;
+      }
+      int operator()(const std::uint16_t, const double) const {
+          std::cout << "Hint 4(a) \n";
+          return 4;
+      }
+      int operator()(const std::uint32_t, const double&) const {
+          std::cout << "Hint 4(b) \n";
+          return 4;
       }
     };
 }}}
@@ -475,11 +481,14 @@ int hpx_main()
     int val = 0;
 
     test_async_executor exec;
-    val = test(exec);
+    val = test("Testing async custom executor", exec);
 
     typedef hpx::threads::executors::pool_numa_hint<dummy_tag> dummy_hint;
-    hpx::threads::executors::guided_pool_executor_shim<dummy_hint> exec2(true, "default");
-    val = test(exec2);
+    hpx::threads::executors::guided_pool_executor<dummy_hint> exec2("default");
+    val = test("Testing guided_pool_executor<dummy_hint>", exec2);
+
+    hpx::threads::executors::guided_pool_executor_shim<dummy_hint> exec3(true, "default");
+    val = test("Testing guided_pool_executor_shim<dummy_hint>", exec3);
 
     return hpx::finalize(val);
 }

--- a/hpx/runtime/threads/executors/guided_pool_executor.hpp
+++ b/hpx/runtime/threads/executors/guided_pool_executor.hpp
@@ -25,14 +25,14 @@
 #include <type_traits>
 #include <utility>
 
+//#define GUIDED_EXECUTOR_DEBUG 1
+//#define GUIDED_POOL_EXECUTOR_FAKE_NOOP
+
 #ifdef GUIDED_EXECUTOR_DEBUG
 #include <iostream>
 #endif
 
 #include <hpx/config/warnings_prefix.hpp>
-
-//#define GUIDED_EXECUTOR_DEBUG 1
-//#define GUIDED_POOL_EXECUTOR_FAKE_NOOP
 
 // --------------------------------------------------------------------
 // pool_numa_hint
@@ -431,7 +431,7 @@ namespace hpx { namespace threads { namespace executors
 #else
                          decltype(unwrapped_futures_tuple)>(" | ")
 #endif
-                      << "\n"
+                      << "\n";
 
             std::cout << "dataflow hint returning " << domain << "\n";
 #endif

--- a/plugins/parcelport/libfabric/parcelport_libfabric.cpp
+++ b/plugins/parcelport/libfabric/parcelport_libfabric.cpp
@@ -142,7 +142,7 @@ namespace libfabric
     {
         while (hpx::is_starting())
         {
-            background_work(0);
+            background_work(0, parcelport_background_mode_all);
         }
         LOG_DEBUG_MSG("io service task completed");
     }


### PR DESCRIPTION
This is a minor cleanup of the async_customization example that was incorrect when the guided_executor was fixed.