### PR TITLE
Removal of the default intel config include

### DIFF
--- a/cmake/templates/config_defines.hpp.in
+++ b/cmake/templates/config_defines.hpp.in
@@ -8,10 +8,6 @@
 #if !defined(HPX_CONFIG_DEFINES_HPP)
 #define HPX_CONFIG_DEFINES_HPP
 
-#if defined(__INTEL_COMPILER) && !defined(BOOST_COMPILER_CONFIG)
-#define BOOST_COMPILER_CONFIG "hpx/config/boost/compiler/intel.hpp"
-#endif
-
 #if !defined(HPX_PREFIX)
 #define HPX_PREFIX "@HPX_DEFINES_PREFIX@"
 #endif


### PR DESCRIPTION
That was overlooked during introducing the config module.
Fixes compilations with intel 2019 update 4