### PR TITLE
Factoring out container remapping into a separate trait

### DIFF
--- a/hpx/traits/pack_traversal_rebind_container.hpp
+++ b/hpx/traits/pack_traversal_rebind_container.hpp
@@ -1,0 +1,56 @@
+//  Copyright (c) 2019 Hartmut Kaiser
+//  Copyright (c) 2017 Denis Blank
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_TRAITS_PACK_TRAVERSAL_REBIND_CONTAINER_JUN_10_2019_1020AM)
+#define HPX_TRAITS_PACK_TRAVERSAL_REBIND_CONTAINER_JUN_10_2019_1020AM
+
+#include <memory>
+#include <type_traits>
+
+namespace hpx { namespace traits
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename NewType, typename Base, typename Enable = void>
+    struct pack_traversal_rebind_container;
+
+    /// Specialization for a container with a single type T (no allocator support)
+    template <typename NewType, template <class> class Base, typename OldType>
+    struct pack_traversal_rebind_container<NewType, Base<OldType>>
+    {
+        static Base<NewType> call(Base<OldType> const& /*container*/)
+        {
+            return Base<NewType>();
+        }
+    };
+
+    /// Specialization for a container with a single type T and
+    /// a particular allocator, which is preserved across the remap.
+    /// -> We remap the allocator through std::allocator_traits.
+    template <typename NewType, template <class, class> class Base,
+        typename OldType,typename OldAllocator>
+    struct pack_traversal_rebind_container<NewType, Base<OldType, OldAllocator>,
+        typename std::enable_if<std::uses_allocator<
+                Base<OldType, OldAllocator>, OldAllocator>::value
+            >::type>
+    {
+        using NewAllocator = typename std::allocator_traits<OldAllocator>::
+            template rebind_alloc<NewType>;
+
+        // Check whether the second argument of the container was
+        // the used allocator.
+        static Base<NewType, NewAllocator> call(
+            Base<OldType, OldAllocator> const& container)
+        {
+            // Create a new version of the allocator, that is capable of
+            // allocating the mapped type.
+            return Base<NewType, NewAllocator>(
+                NewAllocator(container.get_allocator()));
+        }
+    };
+}}
+
+#endif
+

--- a/hpx/util/detail/pack_traversal_impl.hpp
+++ b/hpx/util/detail/pack_traversal_impl.hpp
@@ -9,6 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/traits/detail/reserve.hpp>
 #include <hpx/traits/is_callable.hpp>
+#include <hpx/traits/pack_traversal_rebind_container.hpp>
 #include <hpx/util/always_void.hpp>
 #include <hpx/util/detail/container_category.hpp>
 #include <hpx/util/detail/pack.hpp>
@@ -347,51 +348,11 @@ namespace util {
             };
 
             /// Specialization for a container with a single type T
-            template <typename NewType, template <class> class Base,
-                typename OldType>
-            auto rebind_container(Base<OldType> const & /*container*/)
-                -> Base<NewType>
+            template <typename NewType, typename Container>
+            auto rebind_container(Container const& container)
             {
-                return Base<NewType>();
-            }
-
-            /// Specialization for a container with a single type T and
-            /// a particular allocator,
-            /// which is preserved across the remap.
-            /// -> We remap the allocator through std::allocator_traits.
-            template <typename NewType, template <class, class> class Base,
-                typename OldType, typename OldAllocator,
-                // Check whether the second argument of the container was
-                // the used allocator.
-                typename std::enable_if<std::uses_allocator<
-                        Base<OldType, OldAllocator>, OldAllocator>::value
-                    >::type* = nullptr,
-                typename NewAllocator = typename std::allocator_traits<
-                    OldAllocator>::template rebind_alloc<NewType>>
-            auto rebind_container(
-                Base<OldType, OldAllocator> const& container)
-                -> Base<NewType, NewAllocator>
-            {
-                // Create a new version of the allocator, that is capable of
-                // allocating the mapped type.
-                return Base<NewType, NewAllocator>(
-                    NewAllocator(container.get_allocator()));
-            }
-
-            // support types like boost::container::small_vector
-            // Note: small_vector's allocator support is not 100% conforming
-            template <typename NewType,
-                template <class, std::size_t, class> class Base,
-                typename OldType, std::size_t Size, typename OldAllocator,
-                typename NewAllocator = typename std::allocator_traits<
-                    OldAllocator>::template rebind_alloc<NewType>>
-            auto rebind_container(
-                Base<OldType, Size, OldAllocator> const& container)
-                -> Base<NewType, Size, NewAllocator>
-            {
-                // Create a new version of the container with a new allocator
-                // instance
-                return Base<NewType, Size, NewAllocator>();
+                return traits::pack_traversal_rebind_container<
+                    NewType, Container>::call(container);
             }
 
             /// Returns the default iterators of the container in case
@@ -526,8 +487,7 @@ namespace util {
             template <typename M, typename T>
             auto remap_container(
                 container_mapping_tag<false, false>, M&& mapper, T&& container)
-                -> decltype(
-                    rebind_container<mapped_type_from_t<T, M>>(container))
+            -> decltype(rebind_container<mapped_type_from_t<T, M>>(container))
             {
                 static_assert(has_push_back<typename std::decay<T>::type,
                                   element_of_t<T>>::value,
@@ -535,7 +495,7 @@ namespace util {
                     "method!");
 
                 // Create the new container, which is capable of holding
-                // the re-mappped types.
+                // the re-mapped types.
                 auto remapped =
                     rebind_container<mapped_type_from_t<T, M>>(container);
 
@@ -624,7 +584,7 @@ namespace util {
             struct tuple_like_remapper;
 
             /// Specialization for std::tuple like types which contain
-            /// an arbitrary amount of heterogenous arguments.
+            /// an arbitrary amount of heterogeneous arguments.
             template <typename M, template <typename...> class Base,
                 typename... OldArgs>
             struct tuple_like_remapper<strategy_remap_tag, M, Base<OldArgs...>,

--- a/tests/unit/lcos/local_dataflow_boost_small_vector.cpp
+++ b/tests/unit/lcos/local_dataflow_boost_small_vector.cpp
@@ -17,16 +17,39 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
+///////////////////////////////////////////////////////////////////////////////
 #include <boost/container/small_vector.hpp>
-// #include <boost/range/begin.hpp>
-// #include <boost/range/end.hpp>
 
-template <typename T, typename Allocator = boost::container::new_allocator<T>>
-using small_vector = boost::container::small_vector<T, 3, Allocator>;
+namespace hpx { namespace traits
+{
+    // support unwrapping of boost::container::small_vector
+    // Note: small_vector's allocator support is not 100% conforming
+    template <typename NewType, typename OldType, std::size_t Size,
+        typename OldAllocator>
+    struct pack_traversal_rebind_container<NewType,
+        boost::container::small_vector<OldType, Size, OldAllocator>>
+    {
+        using NewAllocator = typename std::allocator_traits<OldAllocator>::
+            template rebind_alloc<NewType>;
+
+        static boost::container::small_vector<NewType, Size, NewAllocator> call(
+            boost::container::small_vector<OldType, Size, OldAllocator> const&)
+        {
+            // Create a new version of the container with a new allocator
+            // instance
+            return boost::container::small_vector<NewType, Size, NewAllocator>();
+        }
+    };
+}}
+
+template <typename T>
+using small_vector =
+    boost::container::small_vector<T, 3, boost::container::new_allocator<T>>;
 
 ///////////////////////////////////////////////////////////////////////////////
 std::atomic<std::uint32_t> void_f_count;


### PR DESCRIPTION
This removes the dependency of the unwrapping code on boost::small_vector

Fixes #3871