### PR TITLE
Adding new performance counters

### DIFF
--- a/docs/sphinx/manual/optimizing_hpx_applications.rst
+++ b/docs/sphinx/manual/optimizing_hpx_applications.rst
@@ -2031,6 +2031,133 @@ system and application performance.
        ``HPX_WITH_THREAD_IDLE_RATES`` are set to ``ON`` (default: ``OFF``). The
        unit of measure displayed for this counter is 0.1%.
      * None
+   * * ``/threads/time/background-send-duration``
+     * ``locality#*/total`` or
+
+       ``locality#*/worker-thread#*``
+
+       where:
+
+       ``locality#*`` is defining the locality for which the overall time spent
+       performing background work related to sending parcels should be queried
+       for. The locality id (given by ``*``) is a (zero based) number
+       identifying the locality.
+
+       ``worker-thread#*`` is defining the worker thread for which the overall
+       time spent performing background work related to sending parcels should
+       be queried for. The worker thread number (given by the ``*``) is a (zero
+       based) number identifying the worker thread. The number of available
+       worker threads is usually specified on the command line for the
+       application using the option :option:`--hpx:threads`.
+
+     * Returns the overall time spent performing background work related to
+       sending parcels on the given locality since application start. If the
+       instance name is ``total`` the counter returns the overall time spent
+       performing background work for all worker threads (cores) on that
+       locality. If the instance name is ``worker-thread#*`` the counter will
+       return the overall time spent performing background work for all worker
+       threads separately. This counter is available only if the configuration
+       time constants ``HPX_WITH_BACKGROUND_THREAD_COUNTERS`` (default: ``OFF``)
+       and ``HPX_WITH_THREAD_IDLE_RATES`` are set to ``ON`` (default: ``OFF``).
+       The unit of measure for this counter is nanosecond [ns].
+
+       This counter will currently return meaningful values for the MPI
+       parcelport only.
+
+     * None
+   * * ``/threads/background-send-overhead``
+     * ``locality#*/total`` or
+
+       ``locality#*/worker-thread#*``
+
+       where:
+
+       ``locality#*`` is defining the locality for which the background overhead
+       related to sending parcels should be queried for. The locality id (given
+       by ``*``) is a (zero based) number identifying the locality.
+
+       ``worker-thread#*`` is defining the worker thread for which the
+       background overhead related to sending parcels should be queried for.
+       The worker thread number (given by the ``*``) is a (zero based) number
+       identifying the worker thread. The number of available worker threads is
+       usually specified on the command line for the application using the option
+       :option:`--hpx:threads`.
+     * Returns the background overhead related to sending parcels on the given
+       locality since application start. If the instance name is ``total`` the
+       counter returns the background overhead for all worker threads (cores) on
+       that locality. If the instance name is ``worker-thread#*`` the counter
+       will return background overhead for all worker threads separately. This
+       counter is available only if the configuration time constants
+       ``HPX_WITH_BACKGROUND_THREAD_COUNTERS`` (default: ``OFF``) and
+       ``HPX_WITH_THREAD_IDLE_RATES`` are set to ``ON`` (default: ``OFF``). The
+       unit of measure displayed for this counter is 0.1%.
+
+       This counter will currently return meaningful values for the MPI
+       parcelport only.
+     * None
+   * * ``/threads/time/background-receive-duration``
+     * ``locality#*/total`` or
+
+       ``locality#*/worker-thread#*``
+
+       where:
+
+       ``locality#*`` is defining the locality for which the overall time spent
+       performing background work related to receiving parcels should be queried
+       for. The locality id (given by ``*``) is a (zero based) number identifying
+       the locality.
+
+       ``worker-thread#*`` is defining the worker thread for which the overall
+       time spent performing background work related to receiving parcels should
+       be queried for. The worker thread number (given by the ``*``) is a (zero
+       based) number identifying the worker thread. The number of available
+       worker threads is usually specified on the command line for the
+       application using the option :option:`--hpx:threads`.
+
+     * Returns the overall time spent performing background work related to
+       receiving parcels on the given locality since application start. If the
+       instance name is ``total`` the counter returns the overall time spent
+       performing background work for all worker threads (cores) on that
+       locality. If the instance name is ``worker-thread#*`` the counter will
+       return the overall time spent performing background work for all worker
+       threads separately. This counter is available only if the configuration
+       time constants ``HPX_WITH_BACKGROUND_THREAD_COUNTERS`` (default: ``OFF``)
+       and ``HPX_WITH_THREAD_IDLE_RATES`` are set to ``ON`` (default: ``OFF``).
+       The unit of measure for this counter is nanosecond [ns].
+
+       This counter will currently return meaningful values for the MPI
+       parcelport only.
+     * None
+   * * ``/threads/background-receive-overhead``
+     * ``locality#*/total`` or
+
+       ``locality#*/worker-thread#*``
+
+       where:
+
+       ``locality#*`` is defining the locality for which the background overhead
+       related to receiving should be queried for. The locality id (given by
+       ``*``) is a (zero based) number identifying the locality.
+
+       ``worker-thread#*`` is defining the worker thread for which the
+       background overhead related to receiving parcels should be queried for.
+       The worker thread number (given by the ``*``) is a (zero based) number
+       identifying the worker thread. The number of available worker threads is
+       usually specified on the command line for the application using the option
+       :option:`--hpx:threads`.
+     * Returns the background overhead related to receiving parcels on the given
+       locality since application start. If the instance name is ``total`` the
+       counter returns the background overhead for all worker threads (cores) on
+       that locality. If the instance name is ``worker-thread#*`` the counter
+       will return background overhead for all worker threads separately. This
+       counter is available only if the configuration time constants
+       ``HPX_WITH_BACKGROUND_THREAD_COUNTERS`` (default: ``OFF``) and
+       ``HPX_WITH_THREAD_IDLE_RATES`` are set to ``ON`` (default: ``OFF``). The
+       unit of measure displayed for this counter is 0.1%.
+
+       This counter will currently return meaningful values for the MPI
+       parcelport only.
+     * None
 
 .. list-table:: General performance counters exposing characteristics of localities
 

--- a/hpx/runtime/parcelset/parcelhandler.hpp
+++ b/hpx/runtime/parcelset/parcelhandler.hpp
@@ -108,7 +108,8 @@ namespace hpx { namespace parcelset
         ///
         /// \returns Whether any work has been performed
         bool do_background_work(std::size_t num_thread = 0,
-            bool stop_buffering = false);
+            bool stop_buffering = false,
+            parcelport_background_mode mode = parcelport_background_mode_all);
 
         /// \brief Allow access to AGAS resolver instance.
         ///

--- a/hpx/runtime/parcelset/parcelport.hpp
+++ b/hpx/runtime/parcelset/parcelport.hpp
@@ -172,7 +172,8 @@ namespace hpx { namespace parcelset
         };
 
         // invoke pending background work
-        virtual bool do_background_work(std::size_t num_thread) = 0;
+        virtual bool do_background_work(
+            std::size_t num_thread, parcelport_background_mode mode) = 0;
 
         // retrieve performance counter value for given statistics type
         virtual std::int64_t get_connection_cache_statistics(

--- a/hpx/runtime/parcelset/parcelport_impl.hpp
+++ b/hpx/runtime/parcelset/parcelport_impl.hpp
@@ -299,10 +299,11 @@ namespace hpx { namespace parcelset
             return nullptr;
         }
 
-        bool do_background_work(std::size_t num_thread) override
+        bool do_background_work(
+            std::size_t num_thread, parcelport_background_mode mode) override
         {
             trigger_pending_work();
-            return do_background_work_impl<ConnectionHandler>(num_thread);
+            return do_background_work_impl<ConnectionHandler>(num_thread, mode);
         }
 
         /// support enable_shared_from_this
@@ -445,9 +446,10 @@ namespace hpx { namespace parcelset
             >::do_background_work::value,
             bool
         >::type
-        do_background_work_impl(std::size_t num_thread)
+        do_background_work_impl(std::size_t num_thread,
+            parcelport_background_mode mode)
         {
-            return connection_handler().background_work(num_thread);
+            return connection_handler().background_work(num_thread, mode);
         }
 
         template <typename ConnectionHandler_>
@@ -457,7 +459,7 @@ namespace hpx { namespace parcelset
             >::do_background_work::value,
             bool
         >::type
-        do_background_work_impl(std::size_t)
+        do_background_work_impl(std::size_t, parcelport_background_mode)
         {
             return false;
         }

--- a/hpx/runtime/parcelset_fwd.hpp
+++ b/hpx/runtime/parcelset_fwd.hpp
@@ -41,7 +41,22 @@ namespace hpx {
             std::size_t num, std::size_t interval, locality const& l,
             error_code& ec = throws);
 
-        HPX_API_EXPORT bool do_background_work(std::size_t num_thread = 0);
+        ////////////////////////////////////////////////////////////////////////
+        /// Type of background work to perform
+        enum parcelport_background_mode
+        {
+            /// perform buffer flush operations
+            parcelport_background_mode_flush_buffers = 0x01,
+            /// perform send operations (includes buffer flush)
+            parcelport_background_mode_send = 0x03,
+            /// perform receive operations
+            parcelport_background_mode_receive = 0x04,
+            /// perform all operations
+            parcelport_background_mode_all = 0x07
+        };
+
+        HPX_API_EXPORT bool do_background_work(std::size_t num_thread = 0,
+            parcelport_background_mode mode = parcelport_background_mode_all);
 
         typedef util::function_nonser<
             void(boost::system::error_code const&, parcel const&)

--- a/hpx/runtime/threads/detail/scheduled_thread_pool.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool.hpp
@@ -281,6 +281,12 @@ namespace hpx { namespace threads { namespace detail
 #if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
         std::int64_t get_background_work_duration(std::size_t, bool) override;
         std::int64_t get_background_overhead(std::size_t, bool) override;
+
+        std::int64_t get_background_send_duration(std::size_t, bool) override;
+        std::int64_t get_background_send_overhead(std::size_t, bool) override;
+
+        std::int64_t get_background_receive_duration(std::size_t, bool) override;
+        std::int64_t get_background_receive_overhead(std::size_t, bool) override;
 #endif    // HPX_HAVE_BACKGROUND_THREAD_COUNTERS
 
 #if defined(HPX_HAVE_THREAD_IDLE_RATES)
@@ -406,10 +412,23 @@ namespace hpx { namespace threads { namespace detail
             std::int64_t reset_tfunc_times_;
 
 #if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
+            // overall counters for background work
             std::int64_t background_duration_;
             std::int64_t reset_background_duration_;
             std::int64_t reset_background_tfunc_times_;
             std::int64_t reset_background_overhead_;
+
+            // counters for background work related to sending parcels
+            std::int64_t background_send_duration_;
+            std::int64_t reset_background_send_duration_;
+            std::int64_t reset_background_send_tfunc_times_;
+            std::int64_t reset_background_send_overhead_;
+
+            // counters for background work related to receiving parcels
+            std::int64_t background_receive_duration_;
+            std::int64_t reset_background_receive_duration_;
+            std::int64_t reset_background_receive_tfunc_times_;
+            std::int64_t reset_background_receive_overhead_;
 #endif    // HPX_HAVE_BACKGROUND_THREAD_COUNTERS
 
             std::int64_t idle_loop_counts_;

--- a/hpx/runtime/threads/policies/scheduler_base.hpp
+++ b/hpx/runtime/threads/policies/scheduler_base.hpp
@@ -11,6 +11,7 @@
 #include <hpx/compat/mutex.hpp>
 #include <hpx/runtime/resource/detail/partitioner.hpp>
 #include <hpx/runtime/threads/policies/scheduler_mode.hpp>
+#include <hpx/runtime/threads/scoped_background_timer.hpp>
 #include <hpx/runtime/threads/thread_init_data.hpp>
 #include <hpx/runtime/threads/thread_pool_base.hpp>
 #include <hpx/state.hpp>
@@ -78,7 +79,13 @@ namespace hpx { namespace threads { namespace policies
 
         void idle_callback(std::size_t num_thread);
 
+#if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
+        bool background_callback(std::size_t num_thread,
+            std::int64_t& background_work_exec_time_send,
+            std::int64_t& background_work_exec_time_receive);
+#else
         bool background_callback(std::size_t num_thread);
+#endif
 
         /// This function gets called by the thread-manager whenever new work
         /// has been added, allowing the scheduler to reactivate one or more of

--- a/hpx/runtime/threads/scoped_background_timer.hpp
+++ b/hpx/runtime/threads/scoped_background_timer.hpp
@@ -1,0 +1,60 @@
+//  Copyright (c) 2019 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_THREADS_SCOPED_BACKGROUND_TIMER_JUN_10_2019_0301PM)
+#define HPX_THREADS_SCOPED_BACKGROUND_TIMER_JUN_10_2019_0301PM
+
+#include <hpx/config.hpp>
+#include <hpx/util/hardware/timestamp.hpp>
+
+#include <cstdint>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace threads
+{
+#if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
+    ////////////////////////////////////////////////////////////////////////////
+    struct background_work_duration_counter
+    {
+        background_work_duration_counter(std::int64_t& background_exec_time)
+          : background_exec_time_(background_exec_time)
+        {
+        }
+
+        void collect_background_exec_time(std::int64_t timestamp)
+        {
+            if (background_exec_time_ != -1)
+            {
+                background_exec_time_ +=
+                    util::hardware::timestamp() - timestamp;
+            }
+        }
+
+        std::int64_t& background_exec_time_;
+    };
+
+    struct background_exec_time_wrapper
+    {
+        background_exec_time_wrapper(
+                background_work_duration_counter& background_work_duration)
+          : timestamp_(background_work_duration.background_exec_time_ != -1 ?
+                    util::hardware::timestamp() : -1)
+          , background_work_duration_(background_work_duration)
+        {
+        }
+
+        ~background_exec_time_wrapper()
+        {
+            background_work_duration_.collect_background_exec_time(timestamp_);
+        }
+
+        std::int64_t timestamp_;
+        background_work_duration_counter& background_work_duration_;
+    };
+#endif
+}}
+
+#endif
+

--- a/hpx/runtime/threads/thread_pool_base.hpp
+++ b/hpx/runtime/threads/thread_pool_base.hpp
@@ -237,6 +237,16 @@ namespace hpx { namespace threads
             std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
         virtual std::int64_t get_background_overhead(
             std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
+
+        virtual std::int64_t get_background_send_duration(
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
+        virtual std::int64_t get_background_send_overhead(
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
+
+        virtual std::int64_t get_background_receive_duration(
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
+        virtual std::int64_t get_background_receive_overhead(
+            std::size_t /*thread_num*/, bool /*reset*/) { return 0; }
 #endif    // HPX_HAVE_BACKGROUND_THREAD_COUNTERS
 
 #if defined(HPX_HAVE_THREAD_IDLE_RATES)

--- a/hpx/runtime/threads/threadmanager.hpp
+++ b/hpx/runtime/threads/threadmanager.hpp
@@ -367,6 +367,12 @@ namespace hpx { namespace threads
 #if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
         std::int64_t get_background_work_duration(bool reset);
         std::int64_t get_background_overhead(bool reset);
+
+        std::int64_t get_background_send_duration(bool reset);
+        std::int64_t get_background_send_overhead(bool reset);
+
+        std::int64_t get_background_receive_duration(bool reset);
+        std::int64_t get_background_receive_overhead(bool reset);
 #endif    //HPX_HAVE_BACKGROUND_THREAD_COUNTERS
 
         std::int64_t get_cumulative_duration(bool reset);

--- a/plugins/parcelport/libfabric/parcelport_libfabric.cpp
+++ b/plugins/parcelport/libfabric/parcelport_libfabric.cpp
@@ -425,7 +425,9 @@ namespace libfabric
     // This is called whenever the main thread scheduler is idling,
     // is used to poll for events, messages on the libfabric connection
     // --------------------------------------------------------------------
-    bool parcelport::background_work(std::size_t num_thread) {
+    bool parcelport::background_work(
+        std::size_t num_thread, parcelport_background_mode mode)
+    {
         if (stopped_ || hpx::is_stopped()) {
             return false;
         }

--- a/plugins/parcelport/libfabric/parcelport_libfabric.hpp
+++ b/plugins/parcelport/libfabric/parcelport_libfabric.hpp
@@ -204,7 +204,8 @@ namespace libfabric
         // This is called whenever the main thread scheduler is idling,
         // is used to poll for events, messages on the libfabric connection
         // --------------------------------------------------------------------
-        bool background_work(std::size_t num_thread);
+        bool background_work(
+            std::size_t num_thread, parcelport_background_mode mode);
         void io_service_work();
         bool background_work_OS_thread();
 

--- a/plugins/parcelport/mpi/parcelport_mpi.cpp
+++ b/plugins/parcelport/mpi/parcelport_mpi.cpp
@@ -144,10 +144,10 @@ namespace hpx { namespace parcelset
                 return true;
             }
 
-            /// Stop the handling of connectons.
+            /// Stop the handling of connections.
             void do_stop()
             {
-                while(do_background_work(0))
+                while(do_background_work(0, parcelport_background_mode_all))
                 {
                     if(threads::get_self_ptr())
                         hpx::this_thread::suspend(hpx::threads::pending,
@@ -158,7 +158,7 @@ namespace hpx { namespace parcelset
             }
 
             /// Return the name of this locality
-            std::string get_locality_name() const
+            std::string get_locality_name() const override
             {
                 return util::mpi_environment::get_processor_name();
             }
@@ -171,7 +171,7 @@ namespace hpx { namespace parcelset
             }
 
             parcelset::locality agas_locality(
-                util::runtime_configuration const & ini) const
+                util::runtime_configuration const & ini) const override
             {
                 return
                     parcelset::locality(
@@ -181,19 +181,26 @@ namespace hpx { namespace parcelset
                     );
             }
 
-            parcelset::locality create_locality() const
+            parcelset::locality create_locality() const override
             {
                 return parcelset::locality(locality());
             }
 
-            bool background_work(std::size_t num_thread)
+            bool background_work(
+                std::size_t num_thread, parcelport_background_mode mode)
             {
                 if (stopped_)
                     return false;
 
                 bool has_work = false;
-                has_work = sender_.background_work();
-                has_work = receiver_.background_work() || has_work;
+                if (mode & parcelport_background_mode_send)
+                {
+                    has_work = sender_.background_work();
+                }
+                if (mode & parcelport_background_mode_receive)
+                {
+                    has_work = receiver_.background_work() || has_work;
+                }
                 return has_work;
             }
 

--- a/plugins/parcelport/verbs/parcelport_verbs.cpp
+++ b/plugins/parcelport/verbs/parcelport_verbs.cpp
@@ -358,7 +358,7 @@ namespace verbs
             // We only execute work on the IO service while HPX is starting
             while (hpx::is_starting())
             {
-                background_work(0);
+                background_work(0, parcelport_background_mode_all);
             }
             LOG_DEBUG_MSG("io service task completed");
         }
@@ -1549,7 +1549,9 @@ namespace verbs
         // This is called whenever the main thread scheduler is idling,
         // is used to poll for events, messages on the verbs connection
         // --------------------------------------------------------------------
-        bool background_work(std::size_t num_thread) {
+        bool background_work(
+            std::size_t num_thread, parcelport_background_mode mode)
+        {
             if (stopped_ || hpx::is_stopped()) {
                 return false;
             }

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -1368,9 +1368,11 @@ namespace hpx { namespace naming
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace parcelset
 {
-    bool do_background_work(std::size_t num_thread)
+    bool do_background_work(
+        std::size_t num_thread, parcelport_background_mode mode)
     {
-        return get_runtime().get_parcel_handler().do_background_work(num_thread);
+        return get_runtime().get_parcel_handler().do_background_work(
+            num_thread, mode);
     }
 }}
 

--- a/src/runtime/threads/executors/this_thread_executors.cpp
+++ b/src/runtime/threads/executors/this_thread_executors.cpp
@@ -354,10 +354,12 @@ namespace hpx { namespace threads { namespace executors { namespace detail
 
 #if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
             std::int64_t bg_work = 0;
+            std::int64_t bg_send = 0;
+            std::int64_t bg_receive = 0;
             threads::detail::scheduling_counters counters(
                 executed_threads, executed_thread_phases,
                 overall_times, thread_times, idle_loop_count, busy_loop_count,
-                task_active, bg_work);
+                task_active, bg_work, bg_send, bg_receive);
 #else
             threads::detail::scheduling_counters counters(
                 executed_threads, executed_thread_phases,

--- a/src/runtime/threads/executors/thread_pool_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_executors.cpp
@@ -348,10 +348,12 @@ namespace hpx { namespace threads { namespace executors { namespace detail
 
 #if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
             std::int64_t bg_work = 0;
+            std::int64_t bg_send = 0;
+            std::int64_t bg_receive = 0;
             threads::detail::scheduling_counters counters(
                 executed_threads, executed_thread_phases,
                 overall_times, thread_times, idle_loop_count, busy_loop_count,
-                task_active, bg_work);
+                task_active, bg_work, bg_send, bg_receive);
 #else
             threads::detail::scheduling_counters counters(
                 executed_threads, executed_thread_phases,

--- a/src/runtime/threads/policies/scheduler_base.cpp
+++ b/src/runtime/threads/policies/scheduler_base.cpp
@@ -12,6 +12,7 @@
 #include <hpx/runtime/resource/detail/partitioner.hpp>
 #include <hpx/runtime/threads/policies/scheduler_base.hpp>
 #include <hpx/runtime/threads/policies/scheduler_mode.hpp>
+#include <hpx/runtime/threads/scoped_background_timer.hpp>
 #include <hpx/runtime/threads/thread_init_data.hpp>
 #include <hpx/runtime/threads/thread_pool_base.hpp>
 #include <hpx/state.hpp>
@@ -116,16 +117,58 @@ namespace hpx { namespace threads { namespace policies
 #endif
     }
 
-    bool scheduler_base::background_callback(std::size_t num_thread)
+    ///////////////////////////////////////////////////////////////////////////
+#if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) && defined(HPX_HAVE_THREAD_IDLE_RATES)
+    bool scheduler_base::background_callback(std::size_t num_thread,
+        std::int64_t& background_work_exec_time_send,
+        std::int64_t& background_work_exec_time_receive)
     {
         bool result = false;
-        if (hpx::parcelset::do_background_work(num_thread))
-            result = true;
+        // count background work duration
+        {
+            background_work_duration_counter bg_send_duration(
+                background_work_exec_time_send);
+            background_exec_time_wrapper bg_exec_time(bg_send_duration);
+
+            if (hpx::parcelset::do_background_work(
+                    num_thread, parcelset::parcelport_background_mode_send))
+            {
+                result = true;
+            }
+        }
+
+        {
+            background_work_duration_counter bg_receive_duration(
+                background_work_exec_time_receive);
+            background_exec_time_wrapper bg_exec_time(bg_receive_duration);
+
+            if (hpx::parcelset::do_background_work(
+                    num_thread, parcelset::parcelport_background_mode_receive))
+            {
+                result = true;
+            }
+        }
 
         if (0 == num_thread)
             hpx::agas::garbage_collect_non_blocking();
         return result;
     }
+#else
+    bool scheduler_base::background_callback(std::size_t num_thread)
+    {
+        bool result = false;
+
+        if (hpx::parcelset::do_background_work(
+                num_thread, parcelset::parcelport_background_mode_all))
+        {
+            result = true;
+        }
+
+        if (0 == num_thread)
+            hpx::agas::garbage_collect_non_blocking();
+        return result;
+    }
+#endif
 
     /// This function gets called by the thread-manager whenever new work
     /// has been added, allowing the scheduler to reactivate one or more of

--- a/src/runtime/threads/threadmanager.cpp
+++ b/src/runtime/threads/threadmanager.cpp
@@ -866,6 +866,40 @@ namespace hpx { namespace threads
             result += pool_iter->get_background_overhead(all_threads, reset);
         return result;
     }
+
+    std::int64_t threadmanager::get_background_send_duration(bool reset)
+    {
+        std::int64_t result = 0;
+        for (auto const& pool_iter : pools_)
+            result += pool_iter->get_background_send_duration(all_threads, reset);
+        return result;
+    }
+
+    std::int64_t threadmanager::get_background_send_overhead(bool reset)
+    {
+        std::int64_t result = 0;
+        for (auto const& pool_iter : pools_)
+            result += pool_iter->get_background_send_overhead(all_threads, reset);
+        return result;
+    }
+
+    std::int64_t threadmanager::get_background_receive_duration(bool reset)
+    {
+        std::int64_t result = 0;
+        for (auto const& pool_iter : pools_)
+            result +=
+                pool_iter->get_background_receive_duration(all_threads, reset);
+        return result;
+    }
+
+    std::int64_t threadmanager::get_background_receive_overhead(bool reset)
+    {
+        std::int64_t result = 0;
+        for (auto const& pool_iter : pools_)
+            result +=
+                pool_iter->get_background_receive_overhead(all_threads, reset);
+        return result;
+    }
 #endif    // HPX_HAVE_BACKGROUND_THREAD_COUNTERS
 
 #ifdef HPX_HAVE_THREAD_IDLE_RATES
@@ -1557,6 +1591,50 @@ namespace hpx { namespace threads
                     &threadmanager::locality_pool_thread_counter_creator, this,
                     &threadmanager::get_background_overhead,
                     &thread_pool_base::get_background_overhead),
+                &performance_counters::locality_pool_thread_counter_discoverer,
+                "0.1%"},
+            {"/threads/time/background-send-duration",
+                performance_counters::counter_raw,
+                "returns the overall time spent running background work "
+                    "related to sending parcels",
+                HPX_PERFORMANCE_COUNTER_V1,
+                util::bind_front(
+                    &threadmanager::locality_pool_thread_counter_creator, this,
+                    &threadmanager::get_background_send_duration,
+                    &thread_pool_base::get_background_send_duration),
+                &performance_counters::locality_pool_thread_counter_discoverer,
+                "ns"},
+            {"/threads/background-send-overhead",
+                performance_counters::counter_raw,
+                "returns the overall background overhead "
+                    "related to sending parcels",
+                HPX_PERFORMANCE_COUNTER_V1,
+                util::bind_front(
+                    &threadmanager::locality_pool_thread_counter_creator, this,
+                    &threadmanager::get_background_send_overhead,
+                    &thread_pool_base::get_background_send_overhead),
+                &performance_counters::locality_pool_thread_counter_discoverer,
+                "0.1%"},
+            {"/threads/time/background-receive-duration",
+                performance_counters::counter_raw,
+                "returns the overall time spent running background work "
+                    "related to receiving parcels",
+                HPX_PERFORMANCE_COUNTER_V1,
+                util::bind_front(
+                    &threadmanager::locality_pool_thread_counter_creator, this,
+                    &threadmanager::get_background_receive_duration,
+                    &thread_pool_base::get_background_receive_duration),
+                &performance_counters::locality_pool_thread_counter_discoverer,
+                "ns"},
+            {"/threads/background-receive-overhead",
+                performance_counters::counter_raw,
+                "returns the overall background overhead "
+                    "related to receiving parcels",
+                HPX_PERFORMANCE_COUNTER_V1,
+                util::bind_front(
+                    &threadmanager::locality_pool_thread_counter_creator, this,
+                    &threadmanager::get_background_receive_overhead,
+                    &thread_pool_base::get_background_receive_overhead),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 "0.1%"},
 #endif    // HPX_HAVE_BACKGROUND_THREAD_COUNTERS

--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -478,7 +478,7 @@ namespace hpx
         LRT_(warning) << "runtime_impl: about to stop services";
 
         // flush all parcel buffers, stop buffering parcels at this point
-        //parcel_handler_.do_background_work(true);
+        //parcel_handler_.do_background_work(true, parcelport_background_mode_all);
 
         // execute all on_exit functions whenever the first thread calls this
         this->runtime::stopping();

--- a/tests/performance/network/network_storage/network_storage.cpp
+++ b/tests/performance/network/network_storage/network_storage.cpp
@@ -426,7 +426,8 @@ int background_work()
 {
     while(FuturesActive)
     {
-        hpx::parcelset::do_background_work(0);
+        hpx::parcelset::do_background_work(
+            0, hpx::parcelset::parcelport_background_mode_all);
         hpx::this_thread::suspend(std::chrono::microseconds(10));
     }
     return 1;


### PR DESCRIPTION
- `/threads/time/background-send-duration`, `/threads/time/background-receive-duration`
- `/threads/time/background-send-overhead`, `/threads/time/background-receive-overhead`

These counters currently return meaningful values for the MPI parcelport only

@justwagle please verify whether the new counters provide you with the information you need