### PR TITLE
Fix git_external fetching of tags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -680,6 +680,8 @@ if(HPX_WITH_HPXMP)
     OR ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")))
     hpx_option(HPX_WITH_HPXMP_NO_UPDATE BOOL
       "Do not update code from remote hpxMP repository." OFF CATEGORY "OpenMP")
+    hpx_option(HPX_WITH_HPXMP_TAG STRING
+      "hpxMP repository tag or branch" "v0.2.0" CATEGORY "OpenMP")
   else()
     hpx_warn("hpxMP can be used only when compiling with clang or gcc")
     set(HPX_WITH_HPXMP OFF)
@@ -1637,11 +1639,6 @@ if(HPX_WITH_APEX)
   if(HPX_WITH_APEX_NO_UPDATE)
     set(_hpx_apex_no_update NO_UPDATE)
   endif()
-  set(_hpx_apex_tag "v2.1.4")
-  if(HPX_WITH_APEX_TAG)
-    message("Overriding APEX git tag ${_hpx_apex_tag} with ${HPX_WITH_APEX_TAG}")
-    set(_hpx_apex_tag ${HPX_WITH_APEX_TAG})
-  endif()
 
   # We want to track parent dependencies
   hpx_add_config_define(HPX_HAVE_THREAD_PARENT_REFERENCE)
@@ -1649,7 +1646,7 @@ if(HPX_WITH_APEX)
   include(GitExternal)
   git_external(apex
     https://github.com/khuck/xpress-apex.git
-    ${_hpx_apex_tag}
+    ${HPX_WITH_APEX_TAG}
     ${_hpx_apex_no_update}
     VERBOSE)
 
@@ -1701,17 +1698,12 @@ if(HPX_WITH_HPXMP)
   if(HPX_WITH_HPXMP_NO_UPDATE)
     set(_hpxmp_no_update NO_UPDATE)
   endif()
-  set(_hpx_hpxmp_tag "v0.2.0")
-  if(HPX_WITH_HPXMP_TAG)
-    message("Overriding hpxMP git tag ${_hpx_hpxmp_tag} with ${HPX_WITH_HPXMP_TAG}")
-    set(_hpx_hpxmp_tag ${HPX_WITH_HPXMP_TAG})
-  endif()
 
   # handle hpxMP library
   include(GitExternal)
   git_external(hpxmp
     https://github.com/STEllAR-GROUP/hpxMP.git
-    ${_hpx_hpxmp_tag}
+    ${HPX_WITH_HPXMP_TAG}
     ${_hpxmp_no_update}
     VERBOSE)
 

--- a/cmake/GitExternal.cmake
+++ b/cmake/GitExternal.cmake
@@ -19,12 +19,12 @@
 #
 # [optional] Flags which control behaviour
 #  NO_UPDATE
-#    When set, GitExternal will not change a repo that has already been checked out. 
-#    The purpose of this is to allow one to set a default branch to be checked out, 
-#    but stop GitExternal from changing back to that branch if the user has checked 
+#    When set, GitExternal will not change a repo that has already been checked out.
+#    The purpose of this is to allow one to set a default branch to be checked out,
+#    but stop GitExternal from changing back to that branch if the user has checked
 #    out and is working on another.
-#  VERBOSE 
-#    When set, displays information about git commands that are executed  
+#  VERBOSE
+#    When set, displays information about git commands that are executed
 #
 
 find_package(Git)
@@ -55,17 +55,21 @@ function(GIT_EXTERNAL DIR REPO TAG)
     if(nok)
       message(FATAL_ERROR "${DIR} git clone failed: ${error}\n")
     endif()
-  endif()
 
-  if(IS_DIRECTORY "${DIR}/.git")
+    # checkout requested tag
+    GIT_EXTERNAL_MESSAGE("git checkout -q ${TAG}")
+    execute_process(
+      COMMAND "${GIT_EXECUTABLE}" checkout -q "${TAG}"
+      RESULT_VARIABLE nok ERROR_VARIABLE error
+      WORKING_DIRECTORY "${DIR}"
+      )
+    if(nok)
+      message(STATUS "${DIR} git checkout ${TAG} failed: ${error}\n")
+    endif()
+  elseif(IS_DIRECTORY "${DIR}/.git")
     if (${GIT_EXTERNAL_NO_UPDATE})
       GIT_EXTERNAL_MESSAGE("Update branch disabled by user")
     else()
-      GIT_EXTERNAL_MESSAGE("current ref is \"${currentref}\" and tag is \"${TAG}\"")
-      if(currentref STREQUAL TAG) # nothing to do
-        return()
-      endif()
-
       # reset generated files
       foreach(GIT_EXTERNAL_RESET_FILE ${GIT_EXTERNAL_RESET})
         GIT_EXTERNAL_MESSAGE("git reset -q ${GIT_EXTERNAL_RESET_FILE}")
@@ -100,15 +104,24 @@ function(GIT_EXTERNAL DIR REPO TAG)
         message(STATUS "${DIR} git checkout ${TAG} failed: ${error}\n")
       endif()
 
-      # update tag
-      GIT_EXTERNAL_MESSAGE("git rebase FETCH_HEAD")
-      execute_process(COMMAND ${GIT_EXECUTABLE} rebase FETCH_HEAD
-        RESULT_VARIABLE RESULT OUTPUT_VARIABLE OUTPUT ERROR_VARIABLE OUTPUT
+      # check if this is a branch
+      GIT_EXTERNAL_MESSAGE("git symbolic-ref -q HEAD")
+      execute_process(COMMAND "${GIT_EXECUTABLE}" symbolic-ref -q HEAD
+        RESULT_VARIABLE nok ERROR_VARIABLE error
         WORKING_DIRECTORY "${DIR}")
-      if(RESULT)
-        message(STATUS "git rebase failed, aborting ${DIR} merge")
-        execute_process(COMMAND ${GIT_EXECUTABLE} rebase --abort
+      if(nok)
+        message(STATUS "${TAG} is not a branch")
+      else()
+        # update tag
+        GIT_EXTERNAL_MESSAGE("git rebase FETCH_HEAD")
+        execute_process(COMMAND ${GIT_EXECUTABLE} rebase FETCH_HEAD
+          RESULT_VARIABLE RESULT OUTPUT_VARIABLE OUTPUT ERROR_VARIABLE OUTPUT
           WORKING_DIRECTORY "${DIR}")
+        if(RESULT)
+          message(STATUS "git rebase failed, aborting ${DIR} merge")
+          execute_process(COMMAND ${GIT_EXECUTABLE} rebase --abort
+            WORKING_DIRECTORY "${DIR}")
+        endif()
       endif()
     endif()
   else()


### PR DESCRIPTION
Fixes handling of tags for APEX and hpxMP. The old behaviour was to incorrectly do a `git rebase FETCH_HEAD` after checking out a tag, which would always end up on the latest `develop` commit. This PR skips the rebase if `HPX_WITH_X_TAG` is not a branch (with the assumption that tags never change).

@khuck I noticed that you've already had to fix this in APEX (you're using the same `GitExternal.cmake` script). Not sure how general my solution is but you might want to have a look at it.