### PR TITLE
Add ccls cache directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@
 apex
 packages
 .vscode
-
+.ccls-cache


### PR DESCRIPTION
Ignore cache directory produced by [ccls](https://github.com/MaskRay/ccls).