### PR TITLE
Add schedule hint executor parameters

### DIFF
--- a/hpx/async_launch_policy_dispatch.hpp
+++ b/hpx/async_launch_policy_dispatch.hpp
@@ -66,15 +66,13 @@ namespace hpx { namespace detail
             !traits::is_action<Action>::value
         >::type>
     {
-        template <typename F, typename ...Ts>
-        HPX_FORCEINLINE static
-        typename std::enable_if<
+        template <typename F, typename... Ts>
+        HPX_FORCEINLINE static typename std::enable_if<
             traits::detail::is_deferred_invocable<F, Ts...>::value,
-            hpx::future<
-                typename util::detail::invoke_deferred_result<F, Ts...>::type
-            >
-        >::type
-        call(launch policy, F && f, Ts&&... ts)
+            hpx::future<typename util::detail::invoke_deferred_result<F,
+                Ts...>::type>>::type
+        call(launch policy, threads::thread_schedule_hint hint, F&& f,
+            Ts&&... ts)
         {
             typedef typename util::detail::invoke_deferred_result<F, Ts...>::type
                 result_type;
@@ -90,7 +88,8 @@ namespace hpx { namespace detail
                 util::deferred_call(std::forward<F>(f), std::forward<Ts>(ts)...));
             if (hpx::detail::has_async_policy(policy))
             {
-                threads::thread_id_type tid = p.apply(policy, policy.priority());
+                threads::thread_id_type tid = p.apply(policy, policy.priority(),
+                    threads::thread_stacksize_default, hint);
                 if (tid && policy == launch::fork)
                 {
                     // make sure this thread is executed last
@@ -102,15 +101,13 @@ namespace hpx { namespace detail
             return p.get_future();
         }
 
-        template <typename F, typename ...Ts>
-        HPX_FORCEINLINE static
-        typename std::enable_if<
+        template <typename F, typename... Ts>
+        HPX_FORCEINLINE static typename std::enable_if<
             traits::detail::is_deferred_invocable<F, Ts...>::value,
-            hpx::future<
-                typename util::detail::invoke_deferred_result<F, Ts...>::type
-            >
-        >::type
-        call(hpx::detail::sync_policy, F && f, Ts&&... ts)
+            hpx::future<typename util::detail::invoke_deferred_result<F,
+                Ts...>::type>>::type
+        call(hpx::detail::sync_policy, threads::thread_schedule_hint hint,
+            F&& f, Ts&&... ts)
         {
             typedef typename util::detail::invoke_deferred_result<F, Ts...>::type
                 result_type;
@@ -120,15 +117,13 @@ namespace hpx { namespace detail
                 std::forward<F>(f), std::forward<Ts>(ts)...);
         }
 
-        template <typename F, typename ...Ts>
-        HPX_FORCEINLINE static
-        typename std::enable_if<
+        template <typename F, typename... Ts>
+        HPX_FORCEINLINE static typename std::enable_if<
             traits::detail::is_deferred_invocable<F, Ts...>::value,
-            hpx::future<
-                typename util::detail::invoke_deferred_result<F, Ts...>::type
-            >
-        >::type
-        call(hpx::detail::async_policy policy, F && f, Ts&&... ts)
+            hpx::future<typename util::detail::invoke_deferred_result<F,
+                Ts...>::type>>::type
+        call(hpx::detail::async_policy policy,
+            threads::thread_schedule_hint hint, F&& f, Ts&&... ts)
         {
             typedef typename util::detail::invoke_deferred_result<F, Ts...>::type
                 result_type;
@@ -136,19 +131,18 @@ namespace hpx { namespace detail
             lcos::local::futures_factory<result_type()> p(
                 util::deferred_call(std::forward<F>(f), std::forward<Ts>(ts)...));
 
-            p.apply(policy, policy.priority());
+            p.apply(policy, policy.priority(),
+                threads::thread_stacksize_default, hint);
             return p.get_future();
         }
 
-        template <typename F, typename ...Ts>
-        HPX_FORCEINLINE static
-        typename std::enable_if<
+        template <typename F, typename... Ts>
+        HPX_FORCEINLINE static typename std::enable_if<
             traits::detail::is_deferred_invocable<F, Ts...>::value,
-            hpx::future<
-                typename util::detail::invoke_deferred_result<F, Ts...>::type
-            >
-        >::type
-        call(hpx::detail::fork_policy policy, F && f, Ts&&... ts)
+            hpx::future<typename util::detail::invoke_deferred_result<F,
+                Ts...>::type>>::type
+        call(hpx::detail::fork_policy policy,
+            threads::thread_schedule_hint hint, F&& f, Ts&&... ts)
         {
             typedef typename util::detail::invoke_deferred_result<F, Ts...>::type
                 result_type;
@@ -157,7 +151,8 @@ namespace hpx { namespace detail
                 util::deferred_call(std::forward<F>(f), std::forward<Ts>(ts)...));
 
             // make sure this thread is executed last
-            threads::thread_id_type tid = p.apply(policy, policy.priority());
+            threads::thread_id_type tid = p.apply(policy, policy.priority(),
+                threads::thread_stacksize_default, hint);
             if (tid)
             {
                 // yield_to
@@ -167,15 +162,13 @@ namespace hpx { namespace detail
             return p.get_future();
         }
 
-        template <typename F, typename ...Ts>
-        HPX_FORCEINLINE static
-        typename std::enable_if<
+        template <typename F, typename... Ts>
+        HPX_FORCEINLINE static typename std::enable_if<
             traits::detail::is_deferred_invocable<F, Ts...>::value,
-            hpx::future<
-                typename util::detail::invoke_deferred_result<F, Ts...>::type
-            >
-        >::type
-        call(hpx::detail::deferred_policy, F && f, Ts &&... ts)
+            hpx::future<typename util::detail::invoke_deferred_result<F,
+                Ts...>::type>>::type
+        call(hpx::detail::deferred_policy, threads::thread_schedule_hint hint,
+            F&& f, Ts&&... ts)
         {
             typedef typename util::detail::invoke_deferred_result<F, Ts...>::type
                 result_type;

--- a/hpx/include/parallel_executor_parameters.hpp
+++ b/hpx/include/parallel_executor_parameters.hpp
@@ -11,6 +11,7 @@
 #include <hpx/parallel/executors/auto_chunk_size.hpp>
 #include <hpx/parallel/executors/chunked_placement.hpp>
 #include <hpx/parallel/executors/default_placement.hpp>
+#include <hpx/parallel/executors/default_schedule.hpp>
 #include <hpx/parallel/executors/dynamic_chunk_size.hpp>
 #include <hpx/parallel/executors/guided_chunk_size.hpp>
 #include <hpx/parallel/executors/persistent_auto_chunk_size.hpp>

--- a/hpx/include/parallel_executor_parameters.hpp
+++ b/hpx/include/parallel_executor_parameters.hpp
@@ -9,9 +9,12 @@
 #include <hpx/parallel/executors/execution_parameters.hpp>
 
 #include <hpx/parallel/executors/auto_chunk_size.hpp>
+#include <hpx/parallel/executors/chunked_placement.hpp>
+#include <hpx/parallel/executors/default_placement.hpp>
 #include <hpx/parallel/executors/dynamic_chunk_size.hpp>
 #include <hpx/parallel/executors/guided_chunk_size.hpp>
 #include <hpx/parallel/executors/persistent_auto_chunk_size.hpp>
+#include <hpx/parallel/executors/round_robin_placement.hpp>
 #include <hpx/parallel/executors/static_chunk_size.hpp>
 
 #endif

--- a/hpx/lcos/async.hpp
+++ b/hpx/lcos/async.hpp
@@ -304,17 +304,18 @@ namespace hpx { namespace detail
             traits::is_launch_policy<Policy>::value
         >::type>
     {
-        template <typename Policy_, typename F, typename ...Ts>
-        HPX_FORCEINLINE static auto
-        call(Policy_ && launch_policy, F && f, Ts &&... ts)
-        ->  decltype(detail::async_launch_policy_dispatch<
-                typename util::decay<F>::type
-            >::call(std::forward<Policy_>(launch_policy), std::forward<F>(f),
-                std::forward<Ts>(ts)...))
+        template <typename Policy_, typename F, typename... Ts>
+        HPX_FORCEINLINE static auto call(
+            Policy_&& launch_policy, F&& f, Ts&&... ts)
+            -> decltype(
+                detail::async_launch_policy_dispatch<typename util::decay<
+                    F>::type>::call(std::forward<Policy_>(launch_policy),
+                    threads::thread_schedule_hint(), std::forward<F>(f),
+                    std::forward<Ts>(ts)...))
         {
-            return detail::async_launch_policy_dispatch<
-                typename util::decay<F>::type
-            >::call(std::forward<Policy_>(launch_policy), std::forward<F>(f),
+            return detail::async_launch_policy_dispatch<typename util::decay<
+                F>::type>::call(std::forward<Policy_>(launch_policy),
+                threads::thread_schedule_hint(), std::forward<F>(f),
                 std::forward<Ts>(ts)...);
         }
 

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -390,13 +390,12 @@ namespace hpx { namespace lcos { namespace detail
                 "hpx::parallel::execution::parallel_executor::post");
 
             parallel::execution::detail::post_policy_dispatch<
-                    hpx::launch::async_policy
-                >::call(desc, hpx::launch::async,
-                    [HPX_CAPTURE_MOVE(this_),
-                        HPX_CAPTURE_MOVE(f)
-                    ]() mutable -> threads::thread_result_type {
-                        return this_->async_impl(std::move(f));
-                    });
+                hpx::launch::async_policy>::call(desc, hpx::launch::async,
+                threads::thread_schedule_hint(),
+                [HPX_CAPTURE_MOVE(this_), HPX_CAPTURE_MOVE(f)]() mutable
+                -> threads::thread_result_type {
+                    return this_->async_impl(std::move(f));
+                });
 
             if (&ec != &throws)
                 ec = make_success_code();
@@ -436,13 +435,12 @@ namespace hpx { namespace lcos { namespace detail
                 "hpx::parallel::execution::parallel_executor::post");
 
             parallel::execution::detail::post_policy_dispatch<
-                    hpx::launch::async_policy
-                >::call(desc, hpx::launch::async,
-                    [HPX_CAPTURE_MOVE(this_),
-                        HPX_CAPTURE_MOVE(f)
-                    ]() mutable -> threads::thread_result_type {
-                        return this_->async_impl_nounwrap(std::move(f));
-                    });
+                hpx::launch::async_policy>::call(desc, hpx::launch::async,
+                threads::thread_schedule_hint(),
+                [HPX_CAPTURE_MOVE(this_), HPX_CAPTURE_MOVE(f)]() mutable
+                -> threads::thread_result_type {
+                    return this_->async_impl_nounwrap(std::move(f));
+                });
 
             if (&ec != &throws)
                 ec = make_success_code();

--- a/hpx/parallel/executor_parameters.hpp
+++ b/hpx/parallel/executor_parameters.hpp
@@ -11,6 +11,7 @@
 #include <hpx/parallel/executors/auto_chunk_size.hpp>
 #include <hpx/parallel/executors/chunked_placement.hpp>
 #include <hpx/parallel/executors/default_placement.hpp>
+#include <hpx/parallel/executors/default_schedule.hpp>
 #include <hpx/parallel/executors/dynamic_chunk_size.hpp>
 #include <hpx/parallel/executors/guided_chunk_size.hpp>
 #include <hpx/parallel/executors/persistent_auto_chunk_size.hpp>

--- a/hpx/parallel/executor_parameters.hpp
+++ b/hpx/parallel/executor_parameters.hpp
@@ -9,9 +9,12 @@
 #include <hpx/config.hpp>
 
 #include <hpx/parallel/executors/auto_chunk_size.hpp>
+#include <hpx/parallel/executors/chunked_placement.hpp>
+#include <hpx/parallel/executors/default_placement.hpp>
 #include <hpx/parallel/executors/dynamic_chunk_size.hpp>
 #include <hpx/parallel/executors/guided_chunk_size.hpp>
 #include <hpx/parallel/executors/persistent_auto_chunk_size.hpp>
+#include <hpx/parallel/executors/round_robin_placement.hpp>
 #include <hpx/parallel/executors/static_chunk_size.hpp>
 
 #endif

--- a/hpx/parallel/executors/chunked_placement.hpp
+++ b/hpx/parallel/executors/chunked_placement.hpp
@@ -1,0 +1,64 @@
+//  Copyright (c) 2019 Mikael Simberg
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_EXECUTORS_CHUNKED_PLACEMENT)
+#define HPX_PARALLEL_EXECUTORS_CHUNKED_PLACEMENT
+
+#include <hpx/config.hpp>
+#include <hpx/parallel/executors/execution_parameters_fwd.hpp>
+#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/runtime/threads/thread_enums.hpp>
+#include <hpx/traits/is_executor_parameters.hpp>
+
+#include <cstddef>
+#include <type_traits>
+
+namespace hpx { namespace parallel { namespace execution {
+    ///////////////////////////////////////////////////////////////////////////
+    /// Loop tasks are given thread hints in a chunked fashion. For example,
+    /// with 10 tasks and 3 threads the tasks would be placed as follows:
+    ///
+    /// - tasks 1, 2, 3: thread 1
+    /// - tasks 4, 5, 6: thread 2
+    /// - tasks 7, 8, 9, 10: thread 3
+    struct chunked_placement
+    {
+        /// Construct a \a chunked_placement executor parameters object
+        HPX_CONSTEXPR chunked_placement() {}
+
+        /// \cond NOINTERNAL
+        template <typename Executor>
+        hpx::threads::thread_schedule_hint get_schedule_hint(Executor&,
+            std::size_t task_idx, std::size_t num_tasks, std::size_t cores)
+        {
+            return hpx::threads::thread_schedule_hint(
+                hpx::threads::thread_schedule_hint_mode_thread,
+                task_idx * cores / num_tasks);
+        }
+        /// \endcond
+
+    private:
+        /// \cond NOINTERNAL
+        friend class hpx::serialization::access;
+
+        template <typename Archive>
+        void serialize(Archive& ar, const unsigned int version)
+        {
+        }
+        /// \endcond
+    };
+}}}
+
+namespace hpx { namespace parallel { namespace execution {
+    /// \cond NOINTERNAL
+    template <>
+    struct is_executor_parameters<parallel::execution::chunked_placement>
+      : std::true_type
+    {
+    };
+    /// \endcond
+}}}
+
+#endif

--- a/hpx/parallel/executors/default_placement.hpp
+++ b/hpx/parallel/executors/default_placement.hpp
@@ -1,0 +1,57 @@
+//  Copyright (c) 2019 Mikael Simberg
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_EXECUTORS_SCHEDULER_PLACEMENT)
+#define HPX_PARALLEL_EXECUTORS_SCHEDULER_PLACEMENT
+
+#include <hpx/config.hpp>
+#include <hpx/parallel/executors/execution_parameters_fwd.hpp>
+#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/runtime/threads/thread_enums.hpp>
+#include <hpx/traits/is_executor_parameters.hpp>
+
+#include <cstddef>
+#include <type_traits>
+
+namespace hpx { namespace parallel { namespace execution {
+    ///////////////////////////////////////////////////////////////////////////
+    /// Lets the scheduler decide the task placement during bulk execution.
+    struct scheduler_placement
+    {
+        /// Construct a \a scheduler_placement executor parameters object
+        HPX_CONSTEXPR scheduler_placement() {}
+
+        /// \cond NOINTERNAL
+        template <typename Executor>
+        hpx::threads::thread_schedule_hint get_schedule_hint(Executor&,
+            std::size_t task_idx, std::size_t num_tasks, std::size_t cores)
+        {
+            return hpx::threads::thread_schedule_hint();
+        }
+        /// \endcond
+
+    private:
+        /// \cond NOINTERNAL
+        friend class hpx::serialization::access;
+
+        template <typename Archive>
+        void serialize(Archive& ar, const unsigned int version)
+        {
+        }
+        /// \endcond
+    };
+}}}
+
+namespace hpx { namespace parallel { namespace execution {
+    /// \cond NOINTERNAL
+    template <>
+    struct is_executor_parameters<parallel::execution::scheduler_placement>
+      : std::true_type
+    {
+    };
+    /// \endcond
+}}}
+
+#endif

--- a/hpx/parallel/executors/default_schedule.hpp
+++ b/hpx/parallel/executors/default_schedule.hpp
@@ -1,0 +1,90 @@
+
+//  Copyright (c) 2019 Mikael Simberg
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_EXECUTORS_DEFAULT_SCHEDULE)
+#define HPX_PARALLEL_EXECUTORS_DEFAULT_SCHEDULE
+
+#include <hpx/config.hpp>
+#include <hpx/parallel/executors/chunked_placement.hpp>
+#include <hpx/parallel/executors/execution_parameters_fwd.hpp>
+#include <hpx/parallel/executors/static_chunk_size.hpp>
+#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/traits/is_executor_parameters.hpp>
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { namespace execution {
+    ///////////////////////////////////////////////////////////////////////////
+    /// This executor parameter represents the default loop schedule for bulk
+    /// execution. Loop scheduling means 1. the chunking and 2. the placement of
+    /// tasks. The default schedule uses static chunking and chunked placement
+    /// which groups tasks with similar index on the same cores or pus. Note
+    /// that this is *not* exactly the same as OpenMP's static schedule since
+    /// the underlying thread pool may have work-stealing enabled.
+    struct default_schedule
+    {
+        /// Construct a \a default_schedule executor parameters object.
+        HPX_CONSTEXPR default_schedule() {}
+
+        /// Construct a \a default_schedule executor parameters object.
+        ///
+        /// \param chunk_size   [in] The optional chunk size to use as the
+        ///                     number of loop iterations to run on a single
+        ///                     thread.
+        ///
+        HPX_CONSTEXPR explicit default_schedule(std::size_t chunk_size)
+          : chunker_(chunk_size)
+        {
+        }
+
+        /// \cond NOINTERNAL
+        template <typename Executor, typename F>
+        std::size_t get_chunk_size(
+            Executor& exec, F&& f, std::size_t cores, std::size_t num_tasks)
+        {
+            return chunker_.get_chunk_size(
+                exec, std::forward<F>(f), cores, num_tasks);
+        }
+
+        template <typename Executor>
+        hpx::threads::thread_schedule_hint get_schedule_hint(Executor& exec,
+            std::size_t task_idx, std::size_t num_tasks, std::size_t cores)
+        {
+            return schedule_.get_schedule_hint(
+                exec, task_idx, num_tasks, cores);
+        }
+        /// \endcond
+
+    private:
+        /// \cond NOINTERNAL
+        friend class hpx::serialization::access;
+
+        template <typename Archive>
+        void serialize(Archive& ar, const unsigned int version)
+        {
+            ar & schedule_;
+            ar & chunker_;
+        }
+
+        chunked_placement schedule_;
+        static_chunk_size chunker_;
+        /// \endcond
+    };
+}}}
+
+namespace hpx { namespace parallel { namespace execution {
+    /// \cond NOINTERNAL
+    template <>
+    struct is_executor_parameters<parallel::execution::default_schedule>
+      : std::true_type
+    {
+    };
+    /// \endcond
+}}}
+
+#endif

--- a/hpx/parallel/executors/parallel_executor.hpp
+++ b/hpx/parallel/executors/parallel_executor.hpp
@@ -14,9 +14,9 @@
 #include <hpx/lcos/future.hpp>
 #include <hpx/lcos/local/latch.hpp>
 #include <hpx/parallel/algorithms/detail/predicates.hpp>
+#include <hpx/parallel/executors/default_schedule.hpp>
 #include <hpx/parallel/executors/fused_bulk_execute.hpp>
 #include <hpx/parallel/executors/post_policy_dispatch.hpp>
-#include <hpx/parallel/executors/static_chunk_size.hpp>
 #include <hpx/runtime/get_worker_thread_num.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/runtime/serialization/serialize.hpp>
@@ -87,9 +87,9 @@ namespace hpx { namespace parallel { namespace execution
         /// with this executor.
         typedef parallel_execution_tag execution_category;
 
-        /// Associate the static_chunk_size executor parameters type as a default
+        /// Associate the default_schedule executor parameters type as a default
         /// with this executor.
-        typedef static_chunk_size executor_parameters_type;
+        typedef default_schedule executor_parameters_type;
 
         /// Create a new parallel executor
         HPX_CONSTEXPR explicit parallel_policy_executor(

--- a/hpx/parallel/executors/post_policy_dispatch.hpp
+++ b/hpx/parallel/executors/post_policy_dispatch.hpp
@@ -25,12 +25,13 @@ namespace hpx { namespace parallel { namespace execution { namespace detail
     {
         template <typename F, typename... Ts>
         static void call(hpx::util::thread_description const& desc,
-            Policy const& policy, F && f, Ts &&... ts)
+            Policy const& policy, threads::thread_schedule_hint hint, F&& f,
+            Ts&&... ts)
         {
             threads::register_thread_nullary(
                 hpx::util::deferred_call(
                     std::forward<F>(f), std::forward<Ts>(ts)...),
-                desc, threads::pending, false, policy.priority());
+                desc, threads::pending, false, policy.priority(), hint);
         }
     };
 
@@ -39,7 +40,8 @@ namespace hpx { namespace parallel { namespace execution { namespace detail
     {
         template <typename F, typename... Ts>
         static void call(hpx::util::thread_description const& desc,
-            launch::fork_policy const& policy, F && f, Ts &&... ts)
+            launch::fork_policy const& policy,
+            threads::thread_schedule_hint /* hint */, F&& f, Ts&&... ts)
         {
             threads::thread_id_type tid = threads::register_thread_nullary(
                 hpx::util::deferred_call(

--- a/hpx/parallel/executors/round_robin_placement.hpp
+++ b/hpx/parallel/executors/round_robin_placement.hpp
@@ -1,0 +1,65 @@
+//  Copyright (c) 2019 Mikael Simberg
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_EXECUTORS_ROUND_ROBIN_PLACEMENT)
+#define HPX_PARALLEL_EXECUTORS_ROUND_ROBIN_PLACEMENT
+
+#include <hpx/config.hpp>
+#include <hpx/parallel/executors/execution_parameters_fwd.hpp>
+#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/runtime/threads/thread_enums.hpp>
+#include <hpx/traits/is_executor_parameters.hpp>
+
+#include <cstddef>
+#include <type_traits>
+
+namespace hpx { namespace parallel { namespace execution {
+    ///////////////////////////////////////////////////////////////////////////
+    /// Loop tasks are given thread hints in a round-robin fashion. For example,
+    /// with 10 tasks and 3 threads the tasks would be placed as follows:
+    ///
+    /// - tasks 1, 4, 7, 10: thread 1
+    /// - tasks 2, 5, 8: thread 2
+    /// - tasks 3, 6, 9: thread 3
+    struct round_robin_placement
+    {
+        /// Construct a \a round_robin_placement executor parameters object
+        HPX_CONSTEXPR round_robin_placement() {}
+
+        /// \cond NOINTERNAL
+        template <typename Executor>
+        hpx::threads::thread_schedule_hint get_schedule_hint(Executor&,
+            std::size_t task_idx, std::size_t /* num_tasks */,
+            std::size_t cores)
+        {
+            return hpx::threads::thread_schedule_hint(
+                hpx::threads::thread_schedule_hint_mode_thread,
+                task_idx % cores);
+        }
+        /// \endcond
+
+    private:
+        /// \cond NOINTERNAL
+        friend class hpx::serialization::access;
+
+        template <typename Archive>
+        void serialize(Archive& ar, const unsigned int version)
+        {
+        }
+        /// \endcond
+    };
+}}}
+
+namespace hpx { namespace parallel { namespace execution {
+    /// \cond NOINTERNAL
+    template <>
+    struct is_executor_parameters<parallel::execution::round_robin_placement>
+      : std::true_type
+    {
+    };
+    /// \endcond
+}}}
+
+#endif

--- a/hpx/parallel/executors/sequenced_executor.hpp
+++ b/hpx/parallel/executors/sequenced_executor.hpp
@@ -74,7 +74,8 @@ namespace hpx { namespace parallel { namespace execution
         {
             return hpx::detail::async_launch_policy_dispatch<
                 launch::deferred_policy>::call(launch::deferred,
-                std::forward<F>(f), std::forward<Ts>(ts)...);
+                threads::thread_schedule_hint(), std::forward<F>(f),
+                std::forward<Ts>(ts)...);
         }
 
         // NonBlockingOneWayExecutor (adapted) interface

--- a/hpx/parallel/executors/static_chunk_size.hpp
+++ b/hpx/parallel/executors/static_chunk_size.hpp
@@ -58,10 +58,6 @@ namespace hpx { namespace parallel { namespace execution
             if (chunk_size_ != 0)
                 return chunk_size_;
 
-            // Make sure the internal round robin counter of the executor is
-            // reset
-            execution::reset_thread_distribution(*this, exec);
-
             // by default use static work distribution over number of
             // available compute resources, create four times the number of
             // chunks than we have cores

--- a/hpx/parallel/util/detail/schedule_hint_iterator.hpp
+++ b/hpx/parallel/util/detail/schedule_hint_iterator.hpp
@@ -1,0 +1,76 @@
+//  Copyright (c) 2019 Mikael Simberg
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_PARALLEL_UTIL_DETAIL_SCHEDULE_HINT_ITERATOR_HPP)
+#define HPX_PARALLEL_UTIL_DETAIL_SCHEDULE_HINT_ITERATOR_HPP
+
+#include <hpx/config.hpp>
+#include <hpx/runtime/threads/thread_enums.hpp>
+#include <hpx/util/assert.hpp>
+#include <hpx/util/function.hpp>
+#include <hpx/util/iterator_facade.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace parallel { namespace util { namespace detail {
+    ///////////////////////////////////////////////////////////////////////////
+    struct schedule_hint_iterator
+      : public hpx::util::iterator_facade<schedule_hint_iterator,
+            threads::thread_schedule_hint const,
+            std::input_iterator_tag,
+            threads::thread_schedule_hint>
+    {
+    private:
+        typedef hpx::util::iterator_facade<schedule_hint_iterator,
+            threads::thread_schedule_hint const,
+            std::input_iterator_tag,
+            threads::thread_schedule_hint>
+            base_type;
+
+    public:
+        using schedule_hint_fn_type =
+            hpx::util::function_nonser<threads::thread_schedule_hint(
+                std::size_t)>;
+        using reference = threads::thread_schedule_hint;
+
+        HPX_HOST_DEVICE
+        schedule_hint_iterator(std::size_t task_idx,
+            schedule_hint_fn_type schedule_hint_fn = schedule_hint_fn_type())
+          : task_idx_(task_idx)
+          , schedule_hint_fn_(schedule_hint_fn)
+        {
+        }
+
+    protected:
+        friend class hpx::util::iterator_core_access;
+
+        HPX_HOST_DEVICE bool equal(schedule_hint_iterator const& other) const
+        {
+            return task_idx_ == other.task_idx_;
+        }
+
+        HPX_HOST_DEVICE reference dereference() const
+        {
+            HPX_ASSERT_MSG(schedule_hint_fn_,
+                "The begin iterator for schedule_hint_iterator requires a "
+                "non-empty function");
+            return schedule_hint_fn_(task_idx_);
+        }
+
+        HPX_HOST_DEVICE void increment()
+        {
+            ++task_idx_;
+        }
+
+    private:
+        std::size_t task_idx_;
+        schedule_hint_fn_type schedule_hint_fn_;
+    };
+}}}}
+
+#endif

--- a/hpx/parallel/util/scan_partitioner.hpp
+++ b/hpx/parallel/util/scan_partitioner.hpp
@@ -129,8 +129,9 @@ namespace hpx { namespace parallel { namespace util
                     // partition to the left is ready.
                     for (auto const& elem : shape)
                     {
-                        FwdIter it = hpx::util::get<0>(elem);
-                        std::size_t size = hpx::util::get<1>(elem);
+                        auto chunk_elem = hpx::util::get<1>(elem);
+                        FwdIter it = hpx::util::get<0>(chunk_elem);
+                        std::size_t size = hpx::util::get<1>(chunk_elem);
 
                         hpx::shared_future<Result1> prev = workitems.back();
                         auto curr = execution::async_execute(
@@ -221,8 +222,9 @@ namespace hpx { namespace parallel { namespace util
                     // partition to the left is ready.
                     for (auto const& elem : shape)
                     {
-                        FwdIter it = hpx::util::get<0>(elem);
-                        std::size_t size = hpx::util::get<1>(elem);
+                        auto chunk_elem = hpx::util::get<1>(elem);
+                        FwdIter it = hpx::util::get<0>(chunk_elem);
+                        std::size_t size = hpx::util::get<1>(chunk_elem);
 
                         hpx::shared_future<Result1> prev = workitems.back();
                         auto curr = execution::async_execute(
@@ -247,8 +249,9 @@ namespace hpx { namespace parallel { namespace util
                     else
                     {
                         auto elem = *shape_iter++;
-                        FwdIter it = hpx::util::get<0>(elem);
-                        std::size_t size = hpx::util::get<1>(elem);
+                        auto chunk_elem = hpx::util::get<1>(elem);
+                        FwdIter it = hpx::util::get<0>(chunk_elem);
+                        std::size_t size = hpx::util::get<1>(chunk_elem);
 
                         finalitems.push_back(dataflow(hpx::launch::sync,
                             f3, it, size, workitems[0], workitems[1]));
@@ -262,9 +265,10 @@ namespace hpx { namespace parallel { namespace util
                          shape_iter != std::end(shape);
                          ++shape_iter, ++widx)
                     {
-                        auto elem = *shape_iter;
-                        FwdIter it = hpx::util::get<0>(elem);
-                        std::size_t size = hpx::util::get<1>(elem);
+                        auto elem = *shape_iter++;
+                        auto chunk_elem = hpx::util::get<1>(elem);
+                        FwdIter it = hpx::util::get<0>(chunk_elem);
+                        std::size_t size = hpx::util::get<1>(chunk_elem);
 
                         // Wait the completion of f3 on previous partition.
                         finalitems.back().wait();

--- a/tests/performance/local/CMakeLists.txt
+++ b/tests/performance/local/CMakeLists.txt
@@ -16,6 +16,7 @@ set(benchmarks
     parent_vs_child_stealing
     print_heterogeneous_payloads
     resume_suspend
+    schedule_hint_parameter_perf
     skynet
     timed_task_spawn
     wait_all_timings
@@ -85,6 +86,7 @@ set(hpx_heterogeneous_timed_task_spawn_FLAGS DEPENDENCIES iostreams_component)
 set(parent_vs_child_stealing_FLAGS DEPENDENCIES iostreams_component)
 set(skynet_FLAGS DEPENDENCIES iostreams_component)
 set(wait_all_timings_FLAGS DEPENDENCIES iostreams_component)
+set(schedule_hint_parameter_perf_FLAGS DEPENDENCIES iostreams_component)
 
 set(delay_baseline_FLAGS NOLIBS
     DEPENDENCIES ${boost_library_dependencies} hpx_config hpx_preprocessor)

--- a/tests/performance/local/schedule_hint_parameter_perf.cpp
+++ b/tests/performance/local/schedule_hint_parameter_perf.cpp
@@ -1,0 +1,118 @@
+//  Copyright (c) 2019 Mikael Simberg
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/iostreams.hpp>
+#include <hpx/include/parallel_algorithm.hpp>
+#include <hpx/include/parallel_executor_parameters.hpp>
+#include <hpx/util/high_resolution_clock.hpp>
+
+#include <memory>
+#include <string>
+#include <tuple>
+
+void print_header()
+{
+    hpx::cout << "schedule,chunk_size,num_elements,threads,min,avg,max"
+              << std::endl;
+}
+
+void print_result(std::string const& name, int chunk_size, int num_elements,
+    std::tuple<double, double, double> timings)
+{
+    hpx::cout << name << "," << chunk_size << "," << num_elements << ","
+              << hpx::get_num_worker_threads() << "," << std::get<0>(timings)
+              << "," << std::get<1>(timings) << "," << std::get<2>(timings)
+              << std::endl;
+}
+
+template <typename Policy>
+std::tuple<double, double, double> test_schedule(
+    Policy&& p, int num_warmups, int num_iterations, int num_elements)
+{
+    hpx::util::high_resolution_timer timer;
+
+    double t_min = (std::numeric_limits<double>::max)();
+    double t_max = (std::numeric_limits<double>::min)();
+    double t_avg = 0.0;
+
+    for (int r = 0; r < num_warmups + num_iterations; ++r)
+    {
+        double* a = new double[num_elements];
+
+        hpx::parallel::for_loop(
+            p, 0, num_elements, [&a](int i) { a[i] = double(i); });
+
+        timer.restart();
+        hpx::parallel::for_loop(
+            p, 0, num_elements, [&a](int i) { a[i] = a[i] * a[i]; });
+        double t = timer.elapsed();
+
+        delete[] a;
+
+        if (r >= num_warmups)
+        {
+            t_min = (std::min)(t, t_min);
+            t_max = (std::max)(t, t_max);
+            t_avg += t;
+        }
+    }
+
+    t_avg /= num_iterations;
+
+    return std::make_tuple(t_min, t_avg, t_max);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    int const num_warmups = vm["num_warmups"].as<int>();
+    int const num_iterations = vm["num_iterations"].as<int>();
+    int const num_elements = vm["num_elements"].as<int>();
+    int const chunk_size = vm["chunk_size"].as<int>();
+
+    print_header();
+
+    using namespace hpx::parallel::execution;
+
+    auto chunked_result = test_schedule(
+        par.with(chunked_placement(), static_chunk_size(chunk_size)),
+        num_warmups, num_iterations, num_elements);
+    print_result("chunked", chunk_size, num_elements, chunked_result);
+
+    auto round_robin_result = test_schedule(
+        par.with(round_robin_placement(), static_chunk_size(chunk_size)),
+        num_warmups, num_iterations, num_elements);
+    print_result("round_robin", chunk_size, num_elements, round_robin_result);
+
+    auto scheduler_result = test_schedule(
+        par.with(scheduler_placement(), static_chunk_size(chunk_size)),
+        num_warmups, num_iterations, num_elements);
+    print_result(
+        "scheduler_default", chunk_size, num_elements, scheduler_result);
+
+    return hpx::finalize();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char* argv[])
+{
+    boost::program_options::options_description cmdline(
+        "usage: " HPX_APPLICATION_STRING " [options]");
+
+    using boost::program_options::value;
+
+    cmdline.add_options()("num_warmups", value<int>()->default_value(10),
+        "number of warmup iterations")("num_iterations",
+        value<int>()->default_value(100),
+        "number of tests to be averaged")("num_elements",
+        value<int>()->default_value(1000000), "number of elements in vector")(
+        "chunk_size", value<int>()->default_value(0),
+        "number of elements to combine into a single task");
+
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+    hpx::init(cmdline, argc, argv, cfg);
+}

--- a/tests/unit/parallel/executors/CMakeLists.txt
+++ b/tests/unit/parallel/executors/CMakeLists.txt
@@ -16,6 +16,7 @@ set(tests
     parallel_fork_executor
     parallel_policy_executor
     persistent_executor_parameters
+    schedule_hint_parameter
     sequenced_executor
     service_executors
     shared_parallel_executor

--- a/tests/unit/parallel/executors/schedule_hint_parameter.cpp
+++ b/tests/unit/parallel/executors/schedule_hint_parameter.cpp
@@ -24,6 +24,7 @@ int hpx_main(int argc, char* argv[])
 {
     using hpx::parallel::for_loop;
     using hpx::parallel::execution::chunked_placement;
+    using hpx::parallel::execution::default_schedule;
     using hpx::parallel::execution::par;
     using hpx::parallel::execution::round_robin_placement;
     using hpx::parallel::execution::static_chunk_size;
@@ -57,6 +58,19 @@ int hpx_main(int argc, char* argv[])
             void* dummy_executor = nullptr;
             thread_schedule_hint const hint =
                 check_chunked_placement.get_schedule_hint(
+                    dummy_executor, i, num_tasks, num_threads);
+            std::size_t const expected_thread = hint.hint;
+            std::size_t const actual_thread = hpx::get_worker_thread_num();
+
+            HPX_TEST_EQ(expected_thread, actual_thread);
+        });
+
+    default_schedule check_default_schedule;
+    for_loop(par.with(default_schedule(1)), std::size_t(0),
+        num_tasks, [&check_default_schedule, num_threads](std::size_t i) {
+            void* dummy_executor = nullptr;
+            thread_schedule_hint const hint =
+                check_default_schedule.get_schedule_hint(
                     dummy_executor, i, num_tasks, num_threads);
             std::size_t const expected_thread = hint.hint;
             std::size_t const actual_thread = hpx::get_worker_thread_num();

--- a/tests/unit/parallel/executors/schedule_hint_parameter.cpp
+++ b/tests/unit/parallel/executors/schedule_hint_parameter.cpp
@@ -1,0 +1,77 @@
+//  Copyright (c) 2019 Mikael Simberg
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Simple test verifying basic resource_partitioner functionality.
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/iostreams.hpp>
+#include <hpx/include/parallel_executor_parameters.hpp>
+#include <hpx/include/parallel_for_loop.hpp>
+#include <hpx/runtime/threads/thread_enums.hpp>
+#include <hpx/util/high_resolution_clock.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+int hpx_main(int argc, char* argv[])
+{
+    using hpx::parallel::for_loop;
+    using hpx::parallel::execution::chunked_placement;
+    using hpx::parallel::execution::par;
+    using hpx::parallel::execution::round_robin_placement;
+    using hpx::parallel::execution::static_chunk_size;
+    using hpx::threads::thread_schedule_hint;
+
+    std::size_t const num_tasks = 10;
+    std::size_t const num_threads = hpx::get_num_worker_threads();
+
+    // Disable stealing to ensure that tasks stay where they are scheduled.
+    hpx::threads::remove_scheduler_mode(
+        hpx::threads::policies::enable_stealing);
+
+    round_robin_placement check_round_robin_placement;
+    for_loop(par.with(static_chunk_size(1), round_robin_placement()),
+        std::size_t(0), num_tasks,
+        [&check_round_robin_placement, num_threads](std::size_t i) {
+            void* dummy_executor = nullptr;
+            thread_schedule_hint const hint =
+                check_round_robin_placement.get_schedule_hint(
+                    dummy_executor, i, num_tasks, num_threads);
+            std::size_t const expected_thread = hint.hint;
+            std::size_t const actual_thread = hpx::get_worker_thread_num();
+
+            HPX_TEST_EQ(expected_thread, actual_thread);
+        });
+
+    chunked_placement check_chunked_placement;
+    for_loop(par.with(static_chunk_size(1), chunked_placement()),
+        std::size_t(0), num_tasks,
+        [&check_chunked_placement, num_threads](std::size_t i) {
+            void* dummy_executor = nullptr;
+            thread_schedule_hint const hint =
+                check_chunked_placement.get_schedule_hint(
+                    dummy_executor, i, num_tasks, num_threads);
+            std::size_t const expected_thread = hint.hint;
+            std::size_t const actual_thread = hpx::get_worker_thread_num();
+
+            HPX_TEST_EQ(expected_thread, actual_thread);
+        });
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = {"hpx.os_threads=4"};
+
+    HPX_TEST_EQ(hpx::init(argc, argv, cfg), 0);
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Adds task placement executor parameters to complement chunk size parameters.

Implements
- `chunked_placement`: places contiguous tasks close to each other
- `round_robin_placement`: places tasks round-robin...
- `scheduler_placement`: leaves the decision to the scheduler

I've also added a `default_schedule` which combines `static_chunk_size` and `chunked_placement`. It's also the default for `parallel_executor`. This is almost like OpenMP's static schedule except work stealing may make it not completely static. To do this properly we'd need to be able to create tasks that can't be stolen.

Most importantly this makes the "static schedule" that we had before with `static_chunk_size` as static as we can without unstealable tasks. Earlier hierarchical spawning would interfere with round robin scheduling.

I'll post some benchmark numbers soon, but on multiple NUMA domains the improvement can be 10's of %. On single NUMA domains the difference is negligible. I assumed that `chunked_placement` would be faster than `round_robin` but there's practically no difference. The biggest improvement seems  to come from deterministic scheduling.