### PR TITLE
Move version check to config module

### DIFF
--- a/cmake/templates/modules.cpp.in
+++ b/cmake/templates/modules.cpp.in
@@ -3,10 +3,14 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/cache/force_linking.hpp>
+#include <hpx/config/export_definitions.hpp>
 
+@MODULE_FORCE_LINKING_INCLUDES@
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace cache
+namespace hpx
 {
-    void force_linking() {}
-}}
+    // Enforce for this function to be linked into the main HPX library
+    HPX_EXPORT void force_linking()
+    {@MODULE_FORCE_LINKING_CALLS@
+    }
+}

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -16,7 +16,20 @@ set(HPX_LIBS
 
 hpx_info("Configuring modules:")
 
+set(MODULE_FORCE_LINKING_INCLUDES)
+set(MODULE_FORCE_LINKING_CALLS)
 foreach(lib ${HPX_LIBS})
   add_subdirectory(${lib})
+
+  set(MODULE_FORCE_LINKING_INCLUDES
+    "${MODULE_FORCE_LINKING_INCLUDES}#include <hpx/${lib}/force_linking.hpp>\n")
+
+  set(MODULE_FORCE_LINKING_CALLS
+    "${MODULE_FORCE_LINKING_CALLS}\n        ${lib}::force_linking();")
+
 endforeach()
 
+configure_file(
+    "${PROJECT_SOURCE_DIR}/cmake/templates/modules.cpp.in"
+    "${CMAKE_BINARY_DIR}/libs/modules.cpp"
+    @ONLY)

--- a/libs/cache/CMakeLists.txt
+++ b/libs/cache/CMakeLists.txt
@@ -9,6 +9,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # Default location is $HPX_ROOT/libs/cache/include
 set(cache_headers
+  hpx/cache/force_linking.hpp
   hpx/cache/local_cache.hpp
   hpx/cache/lru_cache.hpp
   hpx/cache/entries/entry.hpp

--- a/libs/cache/include/hpx/cache/force_linking.hpp
+++ b/libs/cache/include/hpx/cache/force_linking.hpp
@@ -1,12 +1,10 @@
-//  Copyright (c) 2019 STE||AR Group
+//  Copyright (c) 2019 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/cache/force_linking.hpp>
-
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace cache
 {
-    void force_linking() {}
+    void force_linking();
 }}

--- a/libs/cache/tests/unit/local_mru_cache.cpp
+++ b/libs/cache/tests/unit/local_mru_cache.cpp
@@ -3,10 +3,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/hpx_main.hpp>
 #include <hpx/cache/entries/lru_entry.hpp>
-#include <hpx/cache/statistics/local_statistics.hpp>
 #include <hpx/cache/local_cache.hpp>
+#include <hpx/cache/statistics/local_statistics.hpp>
+#include <hpx/hpx_main.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <string>

--- a/libs/cache/tests/unit/local_statistics.cpp
+++ b/libs/cache/tests/unit/local_statistics.cpp
@@ -3,10 +3,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/hpx_main.hpp>
 #include <hpx/cache/entries/lru_entry.hpp>
-#include <hpx/cache/statistics/local_statistics.hpp>
 #include <hpx/cache/local_cache.hpp>
+#include <hpx/cache/statistics/local_statistics.hpp>
+#include <hpx/hpx_main.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <string>

--- a/libs/config/CMakeLists.txt
+++ b/libs/config/CMakeLists.txt
@@ -22,6 +22,7 @@ set(config_headers
   hpx/config/emulate_deleted.hpp
   hpx/config/export_definitions.hpp
   hpx/config/forceinline.hpp
+  hpx/config/force_linking.hpp
   hpx/config/lambda_capture.hpp
   hpx/config/manual_profiling.hpp
   hpx/config/threads_stack.hpp

--- a/libs/config/include/hpx/config/force_linking.hpp
+++ b/libs/config/include/hpx/config/force_linking.hpp
@@ -1,12 +1,10 @@
-//  Copyright (c) 2019 STE||AR Group
+//  Copyright (c) 2019 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/cache/force_linking.hpp>
-
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace cache
+namespace hpx { namespace config
 {
-    void force_linking() {}
+    void force_linking();
 }}

--- a/libs/config/src/version.cpp
+++ b/libs/config/src/version.cpp
@@ -6,12 +6,21 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <hpx/config/export_definitions.hpp>
+#include <hpx/config/force_linking.hpp>
 #include <hpx/config/version.hpp>
 #include <hpx/preprocessor/stringize.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx
 {
-    char const HPX_CHECK_VERSION[] = HPX_PP_STRINGIZE(HPX_CHECK_VERSION);
-    char const HPX_CHECK_BOOST_VERSION[] = HPX_PP_STRINGIZE(HPX_CHECK_BOOST_VERSION);
+    HPX_EXPORT char const HPX_CHECK_VERSION[] =
+        HPX_PP_STRINGIZE(HPX_CHECK_VERSION);
+    HPX_EXPORT char const HPX_CHECK_BOOST_VERSION[] =
+        HPX_PP_STRINGIZE(HPX_CHECK_BOOST_VERSION);
+
+    namespace config
+    {
+        void force_linking() {}
+    }
 }

--- a/libs/config/src/version.cpp
+++ b/libs/config/src/version.cpp
@@ -1,9 +1,17 @@
 ////////////////////////////////////////////////////////////////////////////////
-//  Copyright (c) 2019 STE||AR Group
+//  Copyright (c) 2011 Bryce Lelbach
+//  Copyright (c) 2011-2017 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ////////////////////////////////////////////////////////////////////////////////
 
-// This file was intentionally left empty. It is used as a dummy to force cmake
-// into generating a separate Visual Studio project for this module.
+#include <hpx/config/version.hpp>
+#include <hpx/preprocessor/stringize.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx
+{
+    char const HPX_CHECK_VERSION[] = HPX_PP_STRINGIZE(HPX_CHECK_VERSION);
+    char const HPX_CHECK_BOOST_VERSION[] = HPX_PP_STRINGIZE(HPX_CHECK_BOOST_VERSION);
+}

--- a/libs/preprocessor/CMakeLists.txt
+++ b/libs/preprocessor/CMakeLists.txt
@@ -12,6 +12,7 @@ set(preprocessor_headers
   hpx/preprocessor/cat.hpp
   hpx/preprocessor/config.hpp
   hpx/preprocessor/expand.hpp
+  hpx/preprocessor/force_linking.hpp
   hpx/preprocessor/nargs.hpp
   hpx/preprocessor/stringize.hpp
   hpx/preprocessor/strip_parens.hpp

--- a/libs/preprocessor/CMakeLists.txt
+++ b/libs/preprocessor/CMakeLists.txt
@@ -19,16 +19,14 @@ set(preprocessor_headers
 )
 
 # Default location is $HPX_ROOT/libs/preprocessor/include_compatibility
-if(HPX_${upper_module_name}_WITH_COMPATIBILITY_HEADERS)
-  set(preprocessor_compat_headers
-    hpx/util/detail/pp/cat.hpp
-    hpx/util/detail/pp/config.hpp
-    hpx/util/detail/pp/expand.hpp
-    hpx/util/detail/pp/nargs.hpp
-    hpx/util/detail/pp/stringize.hpp
-    hpx/util/detail/pp/strip_parens.hpp
-  )
-endif()
+set(preprocessor_compat_headers
+  hpx/util/detail/pp/cat.hpp
+  hpx/util/detail/pp/config.hpp
+  hpx/util/detail/pp/expand.hpp
+  hpx/util/detail/pp/nargs.hpp
+  hpx/util/detail/pp/stringize.hpp
+  hpx/util/detail/pp/strip_parens.hpp
+)
 
 # Default location is $HPX_ROOT/libs/preprocessor/src
 set(preprocessor_sources

--- a/libs/preprocessor/include/hpx/preprocessor/force_linking.hpp
+++ b/libs/preprocessor/include/hpx/preprocessor/force_linking.hpp
@@ -1,12 +1,10 @@
-//  Copyright (c) 2019 STE||AR Group
+//  Copyright (c) 2019 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/cache/force_linking.hpp>
-
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace cache
+namespace hpx { namespace preprocessor
 {
-    void force_linking() {}
+    void force_linking();
 }}

--- a/libs/preprocessor/src/preprocessor.cpp
+++ b/libs/preprocessor/src/preprocessor.cpp
@@ -1,7 +1,12 @@
-//  Copyright (c) 2019 Hartmut Kaiser
+//  Copyright (c) 2019 STE||AR Group
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// This file was intentionally left empty. It is used as a dummy to force cmake
-// into generating a separate Visual Studio project for this module.
+#include <hpx/preprocessor/force_linking.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace preprocessor
+{
+    void force_linking() {}
+}}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,10 @@ add_hpx_library_sources(hpx
   GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/src/compat/*.cpp"
   APPEND)
 
+add_hpx_library_sources(hpx_generated
+  GLOB GLOBS "${CMAKE_BINARY_DIR}/libs/modules.cpp"
+  APPEND)
+
 # libhpx_wrap sources
 if(HPX_WITH_DYNAMIC_HPX_MAIN AND (("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux") OR (APPLE)))
   add_hpx_library_sources (hpx_wrap
@@ -160,6 +164,11 @@ add_hpx_source_group(
   TARGETS ${hpx_SOURCES})
 
 add_hpx_source_group(
+  NAME hpx_generated CLASS "Source Files"
+  ROOT "${CMAKE_BINARY_DIR}/libs"
+  TARGETS ${hpx_generated_SOURCES})
+
+add_hpx_source_group(
   NAME hpx CLASS "External Source Files"
   ROOT "${PROJECT_SOURCE_DIR}"
   TARGETS ${hpx_external_SOURCES})
@@ -224,23 +233,27 @@ endforeach()
 ################################################################################
 # libhpx
 if(HPX_WITH_STATIC_LINKING)
-  set(hpx_SOURCES ${hpx_SOURCES} ${hpx_init_SOURCES})
+  set(hpx_SOURCES ${hpx_SOURCES} ${hpx_init_SOURCES} ${hpx_generated_SOURCES})
 endif()
 if(HPX_WITH_DEFAULT_TARGETS)
   if(HPX_WITH_CUDA)
     cuda_add_library(hpx ${hpx_library_link_mode_core}
-      ${hpx_SOURCES} ${hpx_external_SOURCES} ${hpx_external_OBJECTS} ${hpx_HEADERS})
+      ${hpx_SOURCES} ${hpx_external_SOURCES} ${hpx_generated_SOURCES}
+      ${hpx_external_OBJECTS} ${hpx_HEADERS})
   else()
     add_library(hpx ${hpx_library_link_mode_core}
-      ${hpx_SOURCES} ${hpx_external_SOURCES} ${hpx_external_OBJECTS} ${hpx_HEADERS})
+      ${hpx_SOURCES} ${hpx_external_SOURCES} ${hpx_generated_SOURCES}
+      ${hpx_external_OBJECTS} ${hpx_HEADERS})
   endif()
 else()
   if(HPX_WITH_CUDA)
     cuda_add_library(hpx ${hpx_library_link_mode_core} EXCLUDE_FROM_ALL
-      ${hpx_SOURCES} ${hpx_external_SOURCES} ${hpx_external_OBJECTS} ${hpx_HEADERS})
+      ${hpx_SOURCES} ${hpx_external_SOURCES} ${hpx_generated_SOURCES}
+      ${hpx_external_OBJECTS} ${hpx_HEADERS})
   else()
     add_library(hpx ${hpx_library_link_mode_core} EXCLUDE_FROM_ALL
-      ${hpx_SOURCES} ${hpx_external_SOURCES} ${hpx_external_OBJECTS} ${hpx_HEADERS})
+      ${hpx_SOURCES} ${hpx_external_SOURCES} ${hpx_generated_SOURCES}
+      ${hpx_external_OBJECTS} ${hpx_HEADERS})
   endif()
 endif()
 

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -298,9 +298,5 @@ namespace hpx
 
         return strm.str();
     }
-
-    //////////////////////////////////////////////////////////////////////////
-    char const HPX_CHECK_VERSION[] = HPX_PP_STRINGIZE(HPX_CHECK_VERSION);
-    char const HPX_CHECK_BOOST_VERSION[] = HPX_PP_STRINGIZE(HPX_CHECK_BOOST_VERSION);
 }
 

--- a/tests/performance/local/agas_cache_timings.cpp
+++ b/tests/performance/local/agas_cache_timings.cpp
@@ -11,10 +11,10 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 
+#include <hpx/cache/entries/lfu_entry.hpp>
+#include <hpx/cache/local_cache.hpp>
+#include <hpx/cache/statistics/local_full_statistics.hpp>
 #include <hpx/preprocessor/stringize.hpp>
-#include <hpx/util/cache/entries/lfu_entry.hpp>
-#include <hpx/util/cache/local_cache.hpp>
-#include <hpx/util/cache/statistics/local_full_statistics.hpp>
 #include <hpx/util/histogram.hpp>
 #include <hpx/util/lightweight_test.hpp>
 


### PR DESCRIPTION
Move version check definitions to config module. They should've been defined there in the first place (instead of duplicated in the core library and config). Moving this to the config library means that using modules also have the version check. Should also fix the linker errors in the assertion PR.

Flyby: use non-compatibility headers from the cache module.