### PR TITLE
fixed number of tasks and number of threads for heterogeneous slurm environments

### DIFF
--- a/hpx/util/batch_environments/slurm_environment.hpp
+++ b/hpx/util/batch_environments/slurm_environment.hpp
@@ -48,6 +48,7 @@ namespace hpx { namespace util { namespace batch_environments {
         bool valid_;
 
         HPX_EXPORT void retrieve_number_of_localities(bool debug);
+        HPX_EXPORT void retrieve_number_of_tasks(bool debug);
         HPX_EXPORT void retrieve_nodelist(std::vector<std::string> & nodes,
             bool debug);
         HPX_EXPORT void retrieve_number_of_threads();

--- a/src/util/batch_environments/slurm_environment.cpp
+++ b/src/util/batch_environments/slurm_environment.cpp
@@ -72,7 +72,8 @@ namespace hpx { namespace util { namespace batch_environments
         else
         {
             if (debug) {
-                std::cerr << "SLURM_STEP_NUM_TASKS not found: set num_localities to 1" << std::endl;
+                std::cerr << "SLURM_STEP_NUM_TASKS not found: set num_localities to 1"
+                          << std::endl;
             }
             num_localities_ = 1;
         }
@@ -83,8 +84,8 @@ namespace hpx { namespace util { namespace batch_environments
         char *slurm_step_tasks_per_node = std::getenv("SLURM_STEP_TASKS_PER_NODE");
         if(slurm_step_tasks_per_node)
         {
-            std::vector<std::string> slurm_step_tasks_per_node_tokens;
-            boost::split(slurm_step_tasks_per_node_tokens, slurm_step_tasks_per_node, boost::is_any_of(","));
+            std::vector<std::string> tokens;
+            boost::split(tokens, slurm_step_tasks_per_node, boost::is_any_of(","));
 
             char *slurm_node_id = std::getenv("SLURM_NODEID");
             HPX_ASSERT(slurm_node_id != nullptr);
@@ -92,16 +93,18 @@ namespace hpx { namespace util { namespace batch_environments
             {
                 std::size_t node_id = safe_lexical_cast<std::size_t>(slurm_node_id);
                 std::size_t task_count = 0;
-                for( auto& slurm_step_tasks_per_node_token : slurm_step_tasks_per_node_tokens )
+                for( auto& token : tokens )
                 {
-                    std::size_t paren_pos = slurm_step_tasks_per_node_token.find_first_of('(');
+                    std::size_t paren_pos = token.find_first_of('(');
                     if(paren_pos != std::string::npos)
                     {
-                        HPX_ASSERT(slurm_step_tasks_per_node_token[paren_pos + 1] == 'x');
-                        HPX_ASSERT(slurm_step_tasks_per_node_token[slurm_step_tasks_per_node_token.size() - 1] == ')');
+                        HPX_ASSERT(token[paren_pos + 1] == 'x');
+                        HPX_ASSERT(token[token.size() - 1] == ')');
                         std::size_t begin = paren_pos + 2;
-                        std::size_t end = slurm_step_tasks_per_node_token.size() - 1;
-                        task_count += safe_lexical_cast<std::size_t>(slurm_step_tasks_per_node_token.substr(paren_pos + 2, end - begin));
+                        std::size_t end = token.size() - 1;
+                        task_count +=
+                              safe_lexical_cast<std::size_t>(
+                                 token.substr(paren_pos + 2, end - begin));
                     }
                     else
                     {
@@ -110,7 +113,8 @@ namespace hpx { namespace util { namespace batch_environments
 
                     if( task_count > node_id )
                     {
-                       num_tasks_ = safe_lexical_cast<std::size_t>(slurm_step_tasks_per_node_token.substr(0, paren_pos));
+                       num_tasks_ =
+                             safe_lexical_cast<std::size_t>(token.substr(0, paren_pos));
                        break;
                     }
                 }
@@ -120,7 +124,8 @@ namespace hpx { namespace util { namespace batch_environments
         else
         {
             if (debug) {
-                std::cerr << "SLURM_STEP_TASKS_PER_NODE not found: set num_tasks to 1" << std::endl;
+                std::cerr << "SLURM_STEP_TASKS_PER_NODE not found: set num_tasks to 1"
+                          << std::endl;
             }
             num_tasks_ = 1;
         }
@@ -321,8 +326,8 @@ namespace hpx { namespace util { namespace batch_environments
             HPX_ASSERT(slurm_job_cpus_on_node != nullptr);
             if(slurm_job_cpus_on_node)
             {
-                std::vector<std::string> slurm_job_cpus_on_node_tokens;
-                boost::split(slurm_job_cpus_on_node_tokens, slurm_job_cpus_on_node, boost::is_any_of(","));
+                std::vector<std::string> tokens;
+                boost::split(tokens, slurm_job_cpus_on_node, boost::is_any_of(","));
 
                 char *slurm_node_id = std::getenv("SLURM_NODEID");
                 HPX_ASSERT(slurm_node_id != nullptr);
@@ -330,16 +335,18 @@ namespace hpx { namespace util { namespace batch_environments
                 {
                     std::size_t node_id = safe_lexical_cast<std::size_t>(slurm_node_id);
                     std::size_t task_count = 0;
-                    for( auto& slurm_job_cpus_on_node_token : slurm_job_cpus_on_node_tokens )
+                    for( auto& token : tokens )
                     {
-                        std::size_t paren_pos = slurm_job_cpus_on_node_token.find_first_of('(');
+                        std::size_t paren_pos = token.find_first_of('(');
                         if(paren_pos != std::string::npos)
                         {
-                            HPX_ASSERT(slurm_job_cpus_on_node_token[paren_pos + 1] == 'x');
-                            HPX_ASSERT(slurm_job_cpus_on_node_token[slurm_job_cpus_on_node_token.size() - 1] == ')');
+                            HPX_ASSERT(token[paren_pos + 1] == 'x');
+                            HPX_ASSERT(token[token.size() - 1] == ')');
                             std::size_t begin = paren_pos + 2;
-                            std::size_t end = slurm_job_cpus_on_node_token.size() - 1;
-                            task_count += safe_lexical_cast<std::size_t>(slurm_job_cpus_on_node_token.substr(paren_pos + 2, end - begin));
+                            std::size_t end = token.size() - 1;
+                            task_count +=
+                                  safe_lexical_cast<std::size_t>(
+                                     token.substr(paren_pos + 2, end - begin));
                         }
                         else
                         {
@@ -347,7 +354,9 @@ namespace hpx { namespace util { namespace batch_environments
                         }
                         if( task_count > node_id )
                         {
-                           num_threads_ = safe_lexical_cast<std::size_t>(slurm_job_cpus_on_node_token.substr(0, paren_pos)) / num_tasks_;
+                           num_threads_ =
+                                 safe_lexical_cast<std::size_t>(
+                                    token.substr(0, paren_pos)) / num_tasks_;
                            break;
                         }
                     }

--- a/tests/unit/util/parse_slurm_environment.cpp
+++ b/tests/unit/util/parse_slurm_environment.cpp
@@ -5,6 +5,9 @@
 
 #include <hpx/util/lightweight_test.hpp>
 #include <hpx/util/batch_environments/slurm_environment.hpp>
+#include <vector>
+#include <utility>
+#include <string>
 
 static constexpr bool enable_debug = false;
 

--- a/tests/unit/util/parse_slurm_environment.cpp
+++ b/tests/unit/util/parse_slurm_environment.cpp
@@ -1,0 +1,150 @@
+//  Copyright (c) 2019 Marco Diers
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/util/lightweight_test.hpp>
+#include <hpx/util/batch_environments/slurm_environment.hpp>
+
+static constexpr bool enable_debug = false;
+
+
+// example values in slurm conf
+//   SelectTypeParameters=CR_Socket
+//   NodeName=anode1 CPUs=48 Sockets=4 CoresPerSocket=6 ThreadsPerCore=2
+//   NodeName=anode2 CPUs=16 Sockets=1 CoresPerSocket=8 ThreadsPerCore=2
+//   NodeName=inode[7,14,20] CPUs=8 Sockets=1 CoresPerSocket=4 ThreadsPerCore=2
+//   NodeName=inode11 CPUs=4 Sockets=1 CoresPerSocket=4 ThreadsPerCore=1
+
+
+static auto run_in_slurm_env( std::vector<std::pair<const char*, const char*>>&& environment,
+                              std::vector<std::size_t>&& num_threads ) -> void
+{
+    static const std::vector<std::string> hpx_nodelist { "anode1", "anode2", "inode7", "inode11", "inode14", "inode20" };
+    static constexpr std::array<const char*, 13u> procids { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12" };
+    static constexpr std::array<const char*, 13u> nodeids { "0", "0", "0", "1", "1", "2", "2", "3", "3", "4", "4", "5", "5" };
+
+    for( auto& procid : procids )
+    {
+        auto index( static_cast<std::size_t>( std::atoi( procid ) ) );
+        std::vector<std::pair<const char*, const char*>> defaultenvironment
+        {
+           { "SLURM_STEP_NUM_TASKS", "13" },
+           { "SLURM_STEP_NODELIST", "anode[1-2],inode[7,11,14,20]" },
+           { "SLURM_STEP_TASKS_PER_NODE", "3,2(x5)" },
+           { "SLURM_PROCID", procid },
+           { "SLURM_NODEID", nodeids[index] }
+        };
+        std::copy( std::begin( environment ), std::end( environment ), std::back_inserter( defaultenvironment ) );
+        for( auto& env : defaultenvironment )
+        {
+            ::setenv( env.first, env.second, 1 );
+        }
+
+        std::vector<std::string> nodelist;
+        hpx::util::batch_environments::slurm_environment env( nodelist, enable_debug );
+        HPX_TEST_EQ( env.valid(), true );
+        HPX_TEST_EQ( nodelist == hpx_nodelist, true );
+        HPX_TEST_EQ( env.node_num(), index );
+        HPX_TEST_EQ( env.num_threads(), num_threads[index] );
+        HPX_TEST_EQ( env.num_localities(), 13u );
+
+        for( auto& env : defaultenvironment )
+        {
+            ::unsetenv( env.first );
+        }
+    }
+    return;
+}
+
+
+// srun
+//    use the defaults
+static auto default_test() -> void
+{
+    run_in_slurm_env(
+    {
+        { "SLURM_JOB_CPUS_PER_NODE", "12,16,8,4,8(x2)" }
+    }, { 4u, 4u, 4u, 8u, 8u, 4u, 4u, 2u, 2u, 4u, 4u, 4u, 4u } );
+    return;
+}
+
+
+// srun --exclusive
+//    affected environment variable SLURM_JOB_CPUS_PER_NODE
+static auto exclusive_test() -> void
+{
+    run_in_slurm_env(
+    {
+        { "SLURM_JOB_CPUS_PER_NODE", "48,16,8,4,8(x2)" }
+    }, { 16u, 16u, 16, 8u, 8u, 4u, 4u, 2u, 2u, 4u, 4u, 4u, 4u } );
+    return;
+}
+
+
+// srun --cpus-per-task=1
+//    set environment variable SLURM_CPUS_PER_TASK=1
+static auto cpuspertask_test() -> void
+{
+    run_in_slurm_env(
+    {
+        { "SLURM_CPUS_PER_TASK", "1" },
+        { "SLURM_JOB_CPUS_PER_NODE", "12,16,8,4,8(x2)" }
+    }, { 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u } );
+    return;
+}
+
+
+// srun --exclusive --cpus-per-task=1
+//    set environment variable SLURM_CPUS_PER_TASK=1
+//    affected environment variable SLURM_JOB_CPUS_PER_NODE
+static auto cpuspertask_exclusive_test() -> void
+{
+    run_in_slurm_env(
+    {
+        { "SLURM_CPUS_PER_TASK", "1" },
+        { "SLURM_JOB_CPUS_PER_NODE", "48,16,8,4,8(x2)" }
+    }, { 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u } );
+    return;
+}
+
+
+// srun --threads-per-core=1
+//    affected environment variable SLURM_JOB_CPUS_PER_NODE
+static auto threadspercore_test() -> void
+{
+    run_in_slurm_env(
+    {
+        { "SLURM_JOB_CPUS_PER_NODE", "12,16,8,4,8(x2)" }
+    }, { 4u, 4u, 4u, 8u, 8u, 4u, 4u, 2u, 2u, 4u, 4u, 4u, 4u } );
+    return;
+}
+
+
+// srun --exclusive --threads-per-core=1
+//    affected environment variable SLURM_JOB_CPUS_PER_NODE
+static auto threadspercore_exclusive_test() -> void
+{
+    run_in_slurm_env(
+    {
+        { "SLURM_JOB_CPUS_PER_NODE", "24,8,4(x4)" }
+    }, { 8u, 8u, 8u, 4u, 4u, 2u, 2u, 2u, 2u, 2u, 2u, 2u, 2u } );
+    return;
+}
+
+
+int main()
+{
+    // disabled for run in slurm environment
+    if( std::getenv( "SLURM_PROCID" ) )
+    {
+        return 0;
+    }
+    default_test();
+    exclusive_test();
+    cpuspertask_test();
+    cpuspertask_exclusive_test();
+    threadspercore_test();
+    threadspercore_exclusive_test();
+    return 0;
+}

--- a/tests/unit/util/parse_slurm_environment.cpp
+++ b/tests/unit/util/parse_slurm_environment.cpp
@@ -17,12 +17,16 @@ static constexpr bool enable_debug = false;
 //   NodeName=inode11 CPUs=4 Sockets=1 CoresPerSocket=4 ThreadsPerCore=1
 
 
-static auto run_in_slurm_env( std::vector<std::pair<const char*, const char*>>&& environment,
-                              std::vector<std::size_t>&& num_threads ) -> void
+static auto run_in_slurm_env(
+      std::vector<std::pair<const char*, const char*>>&& environment,
+      std::vector<std::size_t>&& num_threads ) -> void
 {
-    static const std::vector<std::string> hpx_nodelist { "anode1", "anode2", "inode7", "inode11", "inode14", "inode20" };
-    static constexpr std::array<const char*, 13u> procids { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12" };
-    static constexpr std::array<const char*, 13u> nodeids { "0", "0", "0", "1", "1", "2", "2", "3", "3", "4", "4", "5", "5" };
+    static const std::vector<std::string> hpx_nodelist
+        { "anode1", "anode2", "inode7", "inode11", "inode14", "inode20" };
+    static constexpr std::array<const char*, 13u> procids
+        { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12" };
+    static constexpr std::array<const char*, 13u> nodeids
+        { "0", "0", "0", "1", "1", "2", "2", "3", "3", "4", "4", "5", "5" };
 
     for( auto& procid : procids )
     {
@@ -35,7 +39,8 @@ static auto run_in_slurm_env( std::vector<std::pair<const char*, const char*>>&&
            { "SLURM_PROCID", procid },
            { "SLURM_NODEID", nodeids[index] }
         };
-        std::copy( std::begin( environment ), std::end( environment ), std::back_inserter( defaultenvironment ) );
+        std::copy( std::begin( environment ), std::end( environment ),
+                   std::back_inserter( defaultenvironment ) );
         for( auto& env : defaultenvironment )
         {
             ::setenv( env.first, env.second, 1 );

--- a/tests/unit/util/parse_slurm_environment.cpp
+++ b/tests/unit/util/parse_slurm_environment.cpp
@@ -8,6 +8,8 @@
 #include <vector>
 #include <utility>
 #include <string>
+#include <cstddef>
+#include <array>
 
 static constexpr bool enable_debug = false;
 


### PR DESCRIPTION
Fixed for heterogeneous slurm environments
- number of tasks determination
- number of threads determination

Added test to show the slurm environment with its variables.

Changed the behavior with hyperthreading. Before it was determined by hpx::topology, now it depends on the slurm argument --threads-per-core, which is intended for this purpose, according to the approach `2019-03-18 14:23 <hkaiser> mdiers_: all depends on the environment`.

Some more informations about it: http://irclog.cct.lsu.edu/ste~b~~b~ar/2019-03-18