### PR TITLE
Add set function for sliding_semaphore max_difference 

### DIFF
--- a/hpx/lcos/local/detail/sliding_semaphore.hpp
+++ b/hpx/lcos/local/detail/sliding_semaphore.hpp
@@ -35,6 +35,13 @@ namespace hpx { namespace lcos { namespace local { namespace detail
           : max_difference_(max_difference), lower_limit_(lower_limit), cond_()
         {}
 
+        void set_max_difference(std::int64_t max_difference,
+                                std::int64_t lower_limit)
+        {
+            max_difference_ = max_difference;
+            lower_limit_    = lower_limit;
+        }
+
         void wait(std::unique_lock<mutex_type>& l, std::int64_t upper_limit)
         {
             HPX_ASSERT_OWNS_LOCK(l);

--- a/hpx/lcos/local/detail/sliding_semaphore.hpp
+++ b/hpx/lcos/local/detail/sliding_semaphore.hpp
@@ -35,9 +35,12 @@ namespace hpx { namespace lcos { namespace local { namespace detail
           : max_difference_(max_difference), lower_limit_(lower_limit), cond_()
         {}
 
-        void set_max_difference(std::int64_t max_difference,
+        void set_max_difference(std::unique_lock<mutex_type> &l,
+                                std::int64_t max_difference,
                                 std::int64_t lower_limit)
         {
+            HPX_ASSERT_OWNS_LOCK(l);
+
             max_difference_ = max_difference;
             lower_limit_    = lower_limit;
         }

--- a/hpx/lcos/local/sliding_semaphore.hpp
+++ b/hpx/lcos/local/sliding_semaphore.hpp
@@ -62,6 +62,20 @@ namespace hpx { namespace lcos { namespace local
           : sem_(max_difference, lower_limit)
         {}
 
+        /// \brief Set/Change the difference that will cause the semaphore to trigger
+        ///
+        /// \param max_difference
+        ///                 [in] The max difference between the upper limit
+        ///                 (as set by wait()) and the lower limit (as set by
+        ///                 signal()) which is allowed without suspending any
+        ///                 thread calling wait().
+        /// \param lower_limit  [in] The initial lower limit.
+        void set_max_difference(std::int64_t max_difference,
+                std::int64_t lower_limit = 0)
+        {
+            sem_.set_max_difference(max_difference, lower_limit);
+        }
+
         /// \brief Wait for the semaphore to be signaled
         ///
         /// \param upper_limit [in] The new upper limit.

--- a/hpx/lcos/local/sliding_semaphore.hpp
+++ b/hpx/lcos/local/sliding_semaphore.hpp
@@ -73,7 +73,8 @@ namespace hpx { namespace lcos { namespace local
         void set_max_difference(std::int64_t max_difference,
                 std::int64_t lower_limit = 0)
         {
-            sem_.set_max_difference(max_difference, lower_limit);
+            std::unique_lock<mutex_type> l(mtx_);
+            sem_.set_max_difference(l, max_difference, lower_limit);
         }
 
         /// \brief Wait for the semaphore to be signaled


### PR DESCRIPTION
This allows the semaphore distance to be adjusted after initial use.

Largely obsolete now, due to the limiting_executor, but I have some code still using this.