### PR TITLE
Add HPX_WITH_BUILD_BINARY_PACKAGE to the compiler check (refs #3935)

### DIFF
--- a/cmake/templates/HPXMacros.cmake.in
+++ b/cmake/templates/HPXMacros.cmake.in
@@ -1,5 +1,6 @@
 # Copyright (c) 2014 Thomas Heller
 # Copyright (c) 2015 Andreas Schäfer
+# Copyright (c) 2019 Patrick Diehl
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -10,7 +11,7 @@ include(GNUInstallDirs)
 include(HPX_Utils)
 
 function(hpx_check_compiler_compatibility)
-  if(HPX_IGNORE_COMPILER_COMPATIBILITY)
+    if(HPX_IGNORE_COMPILER_COMPATIBILITY OR HPX_WITH_BUILD_BINARY_PACKAGE)
     return()
   endif()
 


### PR DESCRIPTION
Fixes #3935

Disable the strict compiler check when we build HPX as the distribution packages.

## Proposed Changes

  - We also use the option `HPX_WITH_BUILD_BINARY_PACKAGE` to disable certain features for building distribution packages. So we can reuse this option here.

## Any background context you want to provide?

On the Fedora build system, not all packages are recompiled if there is a minor update of the compiler. So we should disable the strict compiler check to not scare new users playing around with HPX. 
