### PR TITLE
Use https for CDash submissions

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -12,7 +12,7 @@
 set(CTEST_PROJECT_NAME "HPX")
 set(CTEST_NIGHTLY_START_TIME "00:00:00 GMT")
 
-set(CTEST_DROP_METHOD "http")
+set(CTEST_DROP_METHOD "https")
 set(CTEST_DROP_SITE "cdash.cscs.ch")
 set(CTEST_DROP_LOCATION "/submit.php?project=HPX")
 set(CTEST_DROP_SITE_CDASH TRUE)


### PR DESCRIPTION
Required after CDash upgrade. Fixes missing submissions on dashboard.
