### PR TITLE
This adds a configuration file that will cause for stale issues to be automatically closed

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,27 @@
+# Copyright (c) 2019 Hartmut Kaiser
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 180
+
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 30
+
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - "tag: pinned"
+
+# Label to use when marking an issue as stale
+staleLabel: "tag: wontfix"
+
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed. Please re-open if necessary.


### PR DESCRIPTION

- The time frames currently set will consider a PR as stale after 180 and will
  close it after another month.

Marking issues with 'tag: pinned' keeps them open. If we decided to go for this we should first mark all issues that shouldn't be closed.