### PR TITLE
Fix CMake configuration with examples off and tests on

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,47 @@ jobs:
           paths:
             - ./build
 
+  configure_test_combinations:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /hpx
+      - run:
+          name: Running CMake with tests on and examples off
+          command: |
+            cmake \
+                /hpx/source \
+                -G "Ninja" \
+                -DHPX_WITH_MALLOC=system \
+                -DHPX_WITH_TESTS=On \
+                -DHPX_WITH_EXAMPLES=Off
+            rm -rf *
+      - run:
+          name: Running CMake with tests off and examples on
+          command: |
+            cmake \
+                /hpx/source \
+                -G "Ninja" \
+                -DHPX_WITH_MALLOC=system \
+                -DHPX_WITH_TESTS=Off \
+                -DHPX_WITH_EXAMPLES=On
+            rm -rf *
+      - run:
+          name: Running CMake with APEX on
+          command: |
+            cmake \
+                /hpx/source \
+                -G "Ninja" \
+                -DHPX_WITH_MALLOC=system \
+                -DHPX_WITH_APEX=On \
+                -DHPX_WITH_TESTS=On \
+                -DHPX_WITH_EXAMPLES=On
+            rm -rf *
+      - persist_to_workspace:
+          root: /hpx
+          paths:
+            - ./build
+
   clang_tidy:
     <<: *defaults
     steps:
@@ -1178,6 +1219,10 @@ workflows:
       - checkout_code:
           <<: *gh_pages_filter
       - configure:
+          requires:
+            - checkout_code
+          <<: *gh_pages_filter
+      - configure_test_combinations:
           requires:
             - checkout_code
           <<: *gh_pages_filter

--- a/libs/cache/examples/CMakeLists.txt
+++ b/libs/cache/examples/CMakeLists.txt
@@ -3,8 +3,12 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-if (HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
-  add_hpx_pseudo_target(tests.examples.modules.cache)
-  add_hpx_pseudo_dependencies(tests.examples.modules tests.examples.modules.cache)
+if (HPX_WITH_EXAMPLES)
+  add_hpx_pseudo_target(examples.modules.cache)
+  add_hpx_pseudo_dependencies(examples.modules examples.modules.cache)
+  if (HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES AND HPX_CACHE_WITH_TESTS)
+    add_hpx_pseudo_target(tests.examples.modules.cache)
+    add_hpx_pseudo_dependencies(tests.examples.modules tests.examples.modules.cache)
+  endif()
 endif()
 

--- a/libs/collectives/examples/CMakeLists.txt
+++ b/libs/collectives/examples/CMakeLists.txt
@@ -3,9 +3,12 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-if (HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
-  add_hpx_pseudo_target(tests.examples.modules.collectives)
-  add_hpx_pseudo_dependencies(tests.examples.modules
-    tests.examples.modules.collectives)
+if (HPX_WITH_EXAMPLES)
+  add_hpx_pseudo_target(examples.modules.collectives)
+  add_hpx_pseudo_dependencies(examples.modules examples.modules.collectives)
+  if (HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES AND HPX_COLLECTIVES_WITH_TESTS)
+    add_hpx_pseudo_target(tests.examples.modules.collectives)
+    add_hpx_pseudo_dependencies(tests.examples.modules tests.examples.modules.collectives)
+  endif()
 endif()
 

--- a/libs/config/examples/CMakeLists.txt
+++ b/libs/config/examples/CMakeLists.txt
@@ -3,8 +3,12 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-if (HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
-  add_hpx_pseudo_target(tests.examples.modules.config)
-  add_hpx_pseudo_dependencies(tests.examples.modules tests.examples.modules.config)
+if (HPX_WITH_EXAMPLES)
+  add_hpx_pseudo_target(examples.modules.config)
+  add_hpx_pseudo_dependencies(examples.modules examples.modules.config)
+  if (HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES AND HPX_CONFIG_WITH_TESTS)
+    add_hpx_pseudo_target(tests.examples.modules.config)
+    add_hpx_pseudo_dependencies(tests.examples.modules tests.examples.modules.config)
+  endif()
 endif()
 

--- a/libs/create_library_skeleton.py
+++ b/libs/create_library_skeleton.py
@@ -83,11 +83,14 @@ add_hpx_module(cache
 '''
 
 examples_cmakelists_template = cmake_header + f'''
-if (HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
-  add_hpx_pseudo_target(tests.examples.module.{lib_name})
-  add_hpx_pseudo_dependencies(tests.examples.module tests.examples.module.{lib_name})
+if (HPX_WITH_EXAMPLES)
+  add_hpx_pseudo_target(examples.modules.{lib_name})
+  add_hpx_pseudo_dependencies(examples.modules examples.modules.{lib_name})
+  if (HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES AND HPX_{lib_name_upper}_WITH_TESTS)
+    add_hpx_pseudo_target(tests.examples.modules.{lib_name})
+    add_hpx_pseudo_dependencies(tests.examples.modules tests.examples.modules.{lib_name})
+  endif()
 endif()
-
 '''
 
 tests_cmakelists_template = cmake_header + f'''
@@ -103,20 +106,20 @@ if (NOT HPX_{lib_name_upper}_WITH_TESTS)
 endif()
 
 if (HPX_WITH_TESTS_UNIT)
-  add_hpx_pseudo_target(tests.unit.module.{lib_name})
-  add_hpx_pseudo_dependencies(tests.unit.module tests.unit.module.{lib_name})
+  add_hpx_pseudo_target(tests.unit.modules.{lib_name})
+  add_hpx_pseudo_dependencies(tests.unit.modules tests.unit.modules.{lib_name})
   add_subdirectory(unit)
 endif()
 
 if (HPX_WITH_TESTS_REGRESSIONS)
-  add_hpx_pseudo_target(tests.regressions.module.{lib_name})
-  add_hpx_pseudo_dependencies(tests.regressions.module tests.regressions.module.{lib_name})
+  add_hpx_pseudo_target(tests.regressions.modules.{lib_name})
+  add_hpx_pseudo_dependencies(tests.regressions.modules tests.regressions.modules.{lib_name})
   add_subdirectory(regressions)
 endif()
 
 if (HPX_WITH_TESTS_BENCHMARKS)
-  add_hpx_pseudo_target(tests.performance.module.{lib_name})
-  add_hpx_pseudo_dependencies(tests.performance.module tests.performance.module.{lib_name})
+  add_hpx_pseudo_target(tests.performance.modules.{lib_name})
+  add_hpx_pseudo_dependencies(tests.performance.modules tests.performance.modules.{lib_name})
   add_subdirectory(performance)
 endif()
 


### PR DESCRIPTION
Fixes #3953.

Also adds a few CircleCI steps which simply configure HPX with different combinations of options. For now only:
- tests on, examples off
- tests off, examples on
- apex on (and tests on, examples on)

If someone can think of other combinations that we've had troubles with I'll happily add them.