### PR TITLE
Fix problem export modules when HPX_WITH_APEX ON

### DIFF
--- a/cmake/HPX_AddModule.cmake
+++ b/cmake/HPX_AddModule.cmake
@@ -6,7 +6,7 @@
 function(add_hpx_module name)
   # Retrieve arguments
   set(options DEPRECATION_WARNINGS)
-  set(one_value_args COMPATIBILITY_HEADERS GLOBAL_HEADER_GEN FORCE_LINKING_GEN INSTALL_BINARIES)
+  set(one_value_args COMPATIBILITY_HEADERS GLOBAL_HEADER_GEN FORCE_LINKING_GEN INSTALL_BINARIES EXPORT)
   set(multi_value_args SOURCES HEADERS COMPAT_HEADERS DEPENDENCIES CMAKE_SUBDIRS)
   cmake_parse_arguments(${name} "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
 

--- a/libs/assertion/CMakeLists.txt
+++ b/libs/assertion/CMakeLists.txt
@@ -28,13 +28,18 @@ set(assertion_sources
   source_location.cpp
 )
 
+# Apex depends on hpx_assertion, need to export it
+if(HPX_WITH_APEX)
+  set(_export_module INSTALL_BINARIES ON EXPORT ON)
+endif()
+
 include(HPX_AddModule)
 add_hpx_module(assertion
     DEPRECATION_WARNINGS
     COMPATIBILITY_HEADERS ON    # Added in 1.4.0
     GLOBAL_HEADER_GEN OFF
-    INSTALL_BINARIES OFF
     FORCE_LINKING_GEN OFF
+    ${_export_module}
     SOURCES ${assertion_sources}
     HEADERS ${assertion_headers}
     COMPAT_HEADERS ${assertion_compat_headers}

--- a/libs/cache/CMakeLists.txt
+++ b/libs/cache/CMakeLists.txt
@@ -41,12 +41,17 @@ set(cache_compat_headers
 set(cache_sources
 )
 
+# Apex depends on hpx_cache, need to export it
+if(HPX_WITH_APEX)
+  set(_export_module INSTALL_BINARIES ON EXPORT ON)
+endif()
+
 include(HPX_AddModule)
 add_hpx_module(cache
     DEPRECATION_WARNINGS
     COMPATIBILITY_HEADERS ON    # Added in 1.4.0
-    INSTALL_BINARIES OFF
     FORCE_LINKING_GEN ON
+    ${_export_module}           # Necessary for apex
     SOURCES ${cache_sources}
     HEADERS ${cache_headers}
     COMPAT_HEADERS ${cache_compat_headers}

--- a/libs/config/CMakeLists.txt
+++ b/libs/config/CMakeLists.txt
@@ -37,12 +37,17 @@ set(config_sources
   version.cpp
 )
 
+# Apex depends on hpx_config, need to export it
+if(HPX_WITH_APEX)
+  set(_export_module INSTALL_BINARIES ON EXPORT ON)
+endif()
+
 include(HPX_AddModule)
 add_hpx_module(config
     COMPATIBILITY_HEADERS OFF
     GLOBAL_HEADER_GEN OFF
-    INSTALL_BINARIES OFF
     FORCE_LINKING_GEN OFF
+    ${_export_module}           # Necessary for apex
     SOURCES ${config_sources}
     HEADERS ${config_headers}
     DEPENDENCIES hpx_preprocessor

--- a/libs/preprocessor/CMakeLists.txt
+++ b/libs/preprocessor/CMakeLists.txt
@@ -31,12 +31,17 @@ set(preprocessor_compat_headers
 set(preprocessor_sources
 )
 
+# Apex depends on hpx_preprocessor, need to export it
+if(HPX_WITH_APEX)
+  set(_export_module INSTALL_BINARIES ON EXPORT ON)
+endif()
+
 include(HPX_AddModule)
 add_hpx_module(preprocessor
     DEPRECATION_WARNINGS
     COMPATIBILITY_HEADERS OFF
-    INSTALL_BINARIES OFF
     FORCE_LINKING_GEN ON
+    ${_export_module}           # Necessary for apex
     SOURCES ${preprocessor_sources}
     HEADERS ${preprocessor_headers}
     COMPAT_HEADERS ${preprocessor_compat_headers}


### PR DESCRIPTION
Needs the addition of hpx_assertion as a dependency in apex project (open PR).
- Export modules when HPX_WITH_APEX = ON
- Add the missing EXPORT option in `add_hpx_module` function