### PR TITLE
Change current_function_helper back to non-constexpr

### DIFF
--- a/libs/assertion/include/hpx/assertion/current_function.hpp
+++ b/libs/assertion/include/hpx/assertion/current_function.hpp
@@ -12,9 +12,11 @@
 //
 //  Adapted to HPX naming scheme
 
+#include <hpx/config.hpp>
+
 namespace hpx { namespace assertion { namespace detail {
 
-    constexpr void current_function_helper()
+    HPX_CXX14_CONSTEXPR inline void current_function_helper()
     {
 #if defined(__GNUC__) || (defined(__MWERKS__) && (__MWERKS__ >= 0x3000)) ||    \
     (defined(__ICC) && (__ICC >= 600)) || defined(__ghs__) ||                  \


### PR DESCRIPTION
void constexpr functions not supported in C++11 (https://cdash.cscs.ch/viewBuildError.php?buildid=59491).