### PR TITLE
Fix compilation with GCC 9

### DIFF
--- a/hpx/parallel/exception_list.hpp
+++ b/hpx/parallel/exception_list.hpp
@@ -96,7 +96,11 @@ namespace hpx { namespace parallel { inline namespace v1
             {
                 HPX_ASSERT(f.has_exception());
                 // Intel complains if this is not explicitly moved
+#if defined(HPX_INTEL_VERSION)
                 return std::move(f);
+#else
+                return f;
+#endif
             }
 
             static future<Result> call(std::exception_ptr const& e)

--- a/hpx/parallel/executors/sequenced_executor.hpp
+++ b/hpx/parallel/executors/sequenced_executor.hpp
@@ -109,7 +109,7 @@ namespace hpx { namespace parallel { namespace execution
                 throw exception_list(std::current_exception());
             }
 
-            return std::move(results);
+            return results;
         }
 
         template <typename F, typename S, typename ... Ts>

--- a/tests/regressions/parallel/scan_different_inits.cpp
+++ b/tests/regressions/parallel/scan_different_inits.cpp
@@ -24,28 +24,22 @@ void test_zero()
     std::vector<int> b, c, d, e, f, g;
     auto policy = hpx::parallel::execution::par;
 
-    Iter i_inc_add =
-        hpx::parallel::inclusive_scan(policy, a.begin(), a.end(), b.begin(),
-        [](int bar, int baz){ return bar+baz; }, 100);
-    Iter i_inc_mult =
-        hpx::parallel::inclusive_scan(policy, a.begin(), a.end(), c.begin(),
-        [](int bar, int baz){ return bar*baz; }, 10);
-    Iter i_exc_add =
-        hpx::parallel::exclusive_scan(policy, a.begin(), a.end(), d.begin(), 100,
-        [](int bar, int baz){ return bar+baz; });
-    Iter i_exc_mult =
-        hpx::parallel::exclusive_scan(policy, a.begin(), a.end(), e.begin(), 10,
-        [](int bar, int baz){ return bar*baz; });
+    Iter i_inc_add = hpx::parallel::inclusive_scan(policy, a.begin(), a.end(),
+        b.begin(), [](int bar, int baz) { return bar + baz; }, 100);
+    Iter i_inc_mult = hpx::parallel::inclusive_scan(policy, a.begin(), a.end(),
+        c.begin(), [](int bar, int baz) { return bar * baz; }, 10);
+    Iter i_exc_add = hpx::parallel::exclusive_scan(policy, a.begin(), a.end(),
+        d.begin(), 100, [](int bar, int baz) { return bar + baz; });
+    Iter i_exc_mult = hpx::parallel::exclusive_scan(policy, a.begin(), a.end(),
+        e.begin(), 10, [](int bar, int baz) { return bar * baz; });
     Iter i_transform_inc =
-        hpx::parallel::transform_inclusive_scan(policy, a.begin(), a.end(), f.begin(),
-            [](int bar, int baz){ return 2*bar+2*baz; },
-            [](int foo){ return foo - 3; },
-            10);
+        hpx::parallel::transform_inclusive_scan(policy, a.begin(), a.end(),
+            f.begin(), [](int bar, int baz) { return 2 * bar + 2 * baz; },
+            [](int foo) { return foo - 3; }, 10);
     Iter i_transform_exc =
-        hpx::parallel::transform_exclusive_scan(policy, a.begin(), a.end(), g.begin(),
-            10,
-            [](int bar, int baz){ return 2*bar+2*baz; },
-            [](int foo){ return foo - 3; });
+        hpx::parallel::transform_exclusive_scan(policy, a.begin(), a.end(),
+            g.begin(), 10, [](int bar, int baz) { return 2 * bar + 2 * baz; },
+            [](int foo) { return foo - 3; });
 
     HPX_TEST(i_inc_add == b.begin());
     HPX_TEST(i_inc_mult == c.begin());
@@ -62,35 +56,22 @@ void test_async_zero()
     std::vector<int> b, c, d, e, f, g;
     auto policy = hpx::parallel::execution::par(hpx::parallel::execution::task);
 
-    Fut_Iter f_inc_add =
-        hpx::parallel::inclusive_scan(policy,
-            a.begin(), a.end(), b.begin(),
-            [](int bar, int baz){ return bar+baz; }, 100);
-    Fut_Iter f_inc_mult =
-        hpx::parallel::inclusive_scan(policy,
-            a.begin(), a.end(), c.begin(),
-            [](int bar, int baz){ return bar*baz; }, 10);
-    Fut_Iter f_exc_add =
-        hpx::parallel::exclusive_scan(policy,
-            a.begin(), a.end(), d.begin(), 100,
-            [](int bar, int baz){ return bar+baz; });
-    Fut_Iter f_exc_mult =
-        hpx::parallel::exclusive_scan(policy,
-            a.begin(), a.end(), e.begin(), 10,
-            [](int bar, int baz){ return bar*baz; });
+    Fut_Iter f_inc_add = hpx::parallel::inclusive_scan(policy, a.begin(),
+        a.end(), b.begin(), [](int bar, int baz) { return bar + baz; }, 100);
+    Fut_Iter f_inc_mult = hpx::parallel::inclusive_scan(policy, a.begin(),
+        a.end(), c.begin(), [](int bar, int baz) { return bar * baz; }, 10);
+    Fut_Iter f_exc_add = hpx::parallel::exclusive_scan(policy, a.begin(),
+        a.end(), d.begin(), 100, [](int bar, int baz) { return bar + baz; });
+    Fut_Iter f_exc_mult = hpx::parallel::exclusive_scan(policy, a.begin(),
+        a.end(), e.begin(), 10, [](int bar, int baz) { return bar * baz; });
     Fut_Iter f_transform_inc =
-        hpx::parallel::transform_inclusive_scan(policy,
-            a.begin(), a.end(), f.begin(),
-            [](int bar, int baz){ return 2*bar+2*baz; },
-            [](int foo){ return foo - 3; },
-            10);
+        hpx::parallel::transform_inclusive_scan(policy, a.begin(), a.end(),
+            f.begin(), [](int bar, int baz) { return 2 * bar + 2 * baz; },
+            [](int foo) { return foo - 3; }, 10);
     Fut_Iter f_transform_exc =
-        hpx::parallel::transform_exclusive_scan(policy,
-            a.begin(), a.end(), g.begin(),
-            10,
-            [](int bar, int baz){ return 2*bar+2*baz; },
-            [](int foo){ return foo - 3; });
-
+        hpx::parallel::transform_exclusive_scan(policy, a.begin(), a.end(),
+            g.begin(), 10, [](int bar, int baz) { return 2 * bar + 2 * baz; },
+            [](int foo) { return foo - 3; });
 
     HPX_TEST(f_inc_add.get() == b.begin());
     HPX_TEST(f_inc_mult.get() == c.begin());
@@ -108,25 +89,23 @@ void test_one(std::vector<int> a)
 
     //  fun_add and fun_mult must be mathematically associative functions otherwise
     //  output is non-deterministic
-    auto fun_add = [](int bar, int baz){ return bar+baz+1; };
-    auto fun_mult = [](int bar, int baz){ return 2*bar*baz; };
-    auto fun_conv = [](int foo){ return foo - 3; };
+    auto fun_add = [](int bar, int baz) { return bar + baz + 1; };
+    auto fun_mult = [](int bar, int baz) { return 2 * bar * baz; };
+    auto fun_conv = [](int foo) { return foo - 3; };
     auto policy = hpx::parallel::execution::par;
 
-    Iter f_inc_add =
-        hpx::parallel::inclusive_scan(policy, a.begin(), a.end(), b.begin(), fun_add, 10);
-    Iter f_inc_mult =
-        hpx::parallel::inclusive_scan(policy, a.begin(), a.end(), c.begin(), fun_mult, 10);
-    Iter f_exc_add =
-        hpx::parallel::exclusive_scan(policy, a.begin(), a.end(), d.begin(), 10, fun_add);
-    Iter f_exc_mult =
-        hpx::parallel::exclusive_scan(policy, a.begin(), a.end(), e.begin(), 10, fun_mult);
-    Iter f_transform_inc =
-        hpx::parallel::transform_inclusive_scan(policy, a.begin(), a.end(), f.begin(),
-        fun_add, fun_conv, 10);
-    Iter f_transform_exc =
-        hpx::parallel::transform_exclusive_scan(policy, a.begin(), a.end(), g.begin(),
-        10, fun_add, fun_conv);
+    Iter f_inc_add = hpx::parallel::inclusive_scan(
+        policy, a.begin(), a.end(), b.begin(), fun_add, 10);
+    Iter f_inc_mult = hpx::parallel::inclusive_scan(
+        policy, a.begin(), a.end(), c.begin(), fun_mult, 10);
+    Iter f_exc_add = hpx::parallel::exclusive_scan(
+        policy, a.begin(), a.end(), d.begin(), 10, fun_add);
+    Iter f_exc_mult = hpx::parallel::exclusive_scan(
+        policy, a.begin(), a.end(), e.begin(), 10, fun_mult);
+    Iter f_transform_inc = hpx::parallel::transform_inclusive_scan(
+        policy, a.begin(), a.end(), f.begin(), fun_add, fun_conv, 10);
+    Iter f_transform_exc = hpx::parallel::transform_exclusive_scan(
+        policy, a.begin(), a.end(), g.begin(), 10, fun_add, fun_conv);
 
     HPX_UNUSED(f_inc_add);
     HPX_UNUSED(f_inc_mult);
@@ -167,31 +146,23 @@ void test_async_one(std::vector<int> a)
 
     //  fun_add and fun_mult must be mathematically associative functions otherwise
     //  output is non-deterministic
-    auto fun_add = [](int bar, int baz){ return bar+baz+1; };
-    auto fun_mult = [](int bar, int baz){ return 2*bar*baz; };
-    auto fun_conv = [](int foo){ return foo - 3; };
+    auto fun_add = [](int bar, int baz) { return bar + baz + 1; };
+    auto fun_mult = [](int bar, int baz) { return 2 * bar * baz; };
+    auto fun_conv = [](int foo) { return foo - 3; };
     auto policy = hpx::parallel::execution::par(hpx::parallel::execution::task);
 
-    Fut_Iter f_inc_add =
-        hpx::parallel::inclusive_scan(policy,
-            a.begin(), a.end(), b.begin(), fun_add, 10);
-    Fut_Iter f_inc_mult =
-        hpx::parallel::inclusive_scan(policy,
-            a.begin(), a.end(), c.begin(), fun_mult, 10);
-    Fut_Iter f_exc_add =
-        hpx::parallel::exclusive_scan(policy,
-            a.begin(), a.end(), d.begin(), 10, fun_add);
-    Fut_Iter f_exc_mult =
-        hpx::parallel::exclusive_scan(policy,
-            a.begin(), a.end(), e.begin(), 10, fun_mult);
-    Fut_Iter f_transform_inc =
-        hpx::parallel::transform_inclusive_scan(policy,
-            a.begin(), a.end(), f.begin(),
-            fun_add, fun_conv, 10);
-    Fut_Iter f_transform_exc =
-        hpx::parallel::transform_exclusive_scan(policy,
-            a.begin(), a.end(), g.begin(),
-            10, fun_add, fun_conv);
+    Fut_Iter f_inc_add = hpx::parallel::inclusive_scan(
+        policy, a.begin(), a.end(), b.begin(), fun_add, 10);
+    Fut_Iter f_inc_mult = hpx::parallel::inclusive_scan(
+        policy, a.begin(), a.end(), c.begin(), fun_mult, 10);
+    Fut_Iter f_exc_add = hpx::parallel::exclusive_scan(
+        policy, a.begin(), a.end(), d.begin(), 10, fun_add);
+    Fut_Iter f_exc_mult = hpx::parallel::exclusive_scan(
+        policy, a.begin(), a.end(), e.begin(), 10, fun_mult);
+    Fut_Iter f_transform_inc = hpx::parallel::transform_inclusive_scan(
+        policy, a.begin(), a.end(), f.begin(), fun_add, fun_conv, 10);
+    Fut_Iter f_transform_exc = hpx::parallel::transform_exclusive_scan(
+        policy, a.begin(), a.end(), g.begin(), 10, fun_add, fun_conv);
 
     hpx::parallel::v1::detail::sequential_inclusive_scan(
         a.begin(), a.end(), b_ans.begin(), 10, fun_add);
@@ -223,7 +194,7 @@ void test_async_one(std::vector<int> a)
 
 int hpx_main(boost::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int)std::random_device{}();
+    unsigned int seed = (unsigned int) std::random_device{}();
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 
@@ -231,17 +202,20 @@ int hpx_main(boost::program_options::variables_map& vm)
     std::mt19937 gen(seed);
     std::uniform_int_distribution<> dis(0, 10);
 
-    auto get_next_num = [&dis, &gen](int& num){ num = dis(gen); };
+    auto get_next_num = [&dis, &gen](int& num) { num = dis(gen); };
 
-    std::vector<int> a1(8); std::for_each(a1.begin(), a1.end(), get_next_num);
+    std::vector<int> a1(8);
+    std::for_each(a1.begin(), a1.end(), get_next_num);
     test_one(a1);
     test_async_one(a1);
 
-    std::vector<int> a2(2); std::for_each(a2.begin(), a2.end(), get_next_num);
+    std::vector<int> a2(2);
+    std::for_each(a2.begin(), a2.end(), get_next_num);
     test_one(a2);
     test_async_one(a2);
 
-    std::vector<int> a3(1); std::for_each(a3.begin(), a3.end(), get_next_num);
+    std::vector<int> a3(1);
+    std::for_each(a3.begin(), a3.end(), get_next_num);
     test_one(a3);
     test_async_one(a3);
 
@@ -264,15 +238,11 @@ int main(int argc, char* argv[])
     options_description desc_commandline(
         "Usage: " HPX_APPLICATION_STRING " [options]");
 
-    desc_commandline.add_options()
-        ("seed,s", value<unsigned int>(),
-        "the random number generator seed to use for this run")
-        ;
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
 
     // By default this test should run on all available cores
-    std::vector<std::string> const cfg = {
-        "hpx.os_threads=all"
-    };
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
     HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,

--- a/tests/regressions/parallel/scan_different_inits.cpp
+++ b/tests/regressions/parallel/scan_different_inits.cpp
@@ -19,30 +19,30 @@
 #if !(defined(HPX_INTEL_VERSION) && HPX_INTEL_VERSION == 1500)
 void test_zero()
 {
-    using namespace hpx::parallel;
     typedef std::vector<int>::iterator Iter;
     std::vector<int> a;
     std::vector<int> b, c, d, e, f, g;
+    auto policy = hpx::parallel::execution::par;
 
     Iter i_inc_add =
-        inclusive_scan(execution::par, a.begin(), a.end(), b.begin(),
+        hpx::parallel::inclusive_scan(policy, a.begin(), a.end(), b.begin(),
         [](int bar, int baz){ return bar+baz; }, 100);
     Iter i_inc_mult =
-        inclusive_scan(execution::par, a.begin(), a.end(), c.begin(),
+        hpx::parallel::inclusive_scan(policy, a.begin(), a.end(), c.begin(),
         [](int bar, int baz){ return bar*baz; }, 10);
     Iter i_exc_add =
-        exclusive_scan(execution::par, a.begin(), a.end(), d.begin(), 100,
+        hpx::parallel::exclusive_scan(policy, a.begin(), a.end(), d.begin(), 100,
         [](int bar, int baz){ return bar+baz; });
     Iter i_exc_mult =
-        exclusive_scan(execution::par, a.begin(), a.end(), e.begin(), 10,
+        hpx::parallel::exclusive_scan(policy, a.begin(), a.end(), e.begin(), 10,
         [](int bar, int baz){ return bar*baz; });
     Iter i_transform_inc =
-        transform_inclusive_scan(execution::par, a.begin(), a.end(), f.begin(),
+        hpx::parallel::transform_inclusive_scan(policy, a.begin(), a.end(), f.begin(),
             [](int bar, int baz){ return 2*bar+2*baz; },
             [](int foo){ return foo - 3; },
             10);
     Iter i_transform_exc =
-        transform_exclusive_scan(execution::par, a.begin(), a.end(), g.begin(),
+        hpx::parallel::transform_exclusive_scan(policy, a.begin(), a.end(), g.begin(),
             10,
             [](int bar, int baz){ return 2*bar+2*baz; },
             [](int foo){ return foo - 3; });
@@ -56,36 +56,36 @@ void test_zero()
 }
 void test_async_zero()
 {
-    using namespace hpx::parallel;
     typedef std::vector<int>::iterator Iter;
     typedef hpx::future<Iter> Fut_Iter;
     std::vector<int> a;
     std::vector<int> b, c, d, e, f, g;
+    auto policy = hpx::parallel::execution::par(hpx::parallel::execution::task);
 
     Fut_Iter f_inc_add =
-        inclusive_scan(execution::par(execution::task),
+        hpx::parallel::inclusive_scan(policy,
             a.begin(), a.end(), b.begin(),
             [](int bar, int baz){ return bar+baz; }, 100);
     Fut_Iter f_inc_mult =
-        inclusive_scan(execution::par(execution::task),
+        hpx::parallel::inclusive_scan(policy,
             a.begin(), a.end(), c.begin(),
             [](int bar, int baz){ return bar*baz; }, 10);
     Fut_Iter f_exc_add =
-        exclusive_scan(execution::par(execution::task),
+        hpx::parallel::exclusive_scan(policy,
             a.begin(), a.end(), d.begin(), 100,
             [](int bar, int baz){ return bar+baz; });
     Fut_Iter f_exc_mult =
-        exclusive_scan(execution::par(execution::task),
+        hpx::parallel::exclusive_scan(policy,
             a.begin(), a.end(), e.begin(), 10,
             [](int bar, int baz){ return bar*baz; });
     Fut_Iter f_transform_inc =
-        transform_inclusive_scan(execution::par(execution::task),
+        hpx::parallel::transform_inclusive_scan(policy,
             a.begin(), a.end(), f.begin(),
             [](int bar, int baz){ return 2*bar+2*baz; },
             [](int foo){ return foo - 3; },
             10);
     Fut_Iter f_transform_exc =
-        transform_exclusive_scan(execution::par(execution::task),
+        hpx::parallel::transform_exclusive_scan(policy,
             a.begin(), a.end(), g.begin(),
             10,
             [](int bar, int baz){ return 2*bar+2*baz; },
@@ -101,7 +101,6 @@ void test_async_zero()
 }
 void test_one(std::vector<int> a)
 {
-    using namespace hpx::parallel;
     typedef std::vector<int>::iterator Iter;
     std::size_t n = a.size();
     std::vector<int> b(n), c(n), d(n), e(n), f(n), g(n);
@@ -112,20 +111,21 @@ void test_one(std::vector<int> a)
     auto fun_add = [](int bar, int baz){ return bar+baz+1; };
     auto fun_mult = [](int bar, int baz){ return 2*bar*baz; };
     auto fun_conv = [](int foo){ return foo - 3; };
+    auto policy = hpx::parallel::execution::par;
 
     Iter f_inc_add =
-        inclusive_scan(execution::par, a.begin(), a.end(), b.begin(), fun_add, 10);
+        hpx::parallel::inclusive_scan(policy, a.begin(), a.end(), b.begin(), fun_add, 10);
     Iter f_inc_mult =
-        inclusive_scan(execution::par, a.begin(), a.end(), c.begin(), fun_mult, 10);
+        hpx::parallel::inclusive_scan(policy, a.begin(), a.end(), c.begin(), fun_mult, 10);
     Iter f_exc_add =
-        exclusive_scan(execution::par, a.begin(), a.end(), d.begin(), 10, fun_add);
+        hpx::parallel::exclusive_scan(policy, a.begin(), a.end(), d.begin(), 10, fun_add);
     Iter f_exc_mult =
-        exclusive_scan(execution::par, a.begin(), a.end(), e.begin(), 10, fun_mult);
+        hpx::parallel::exclusive_scan(policy, a.begin(), a.end(), e.begin(), 10, fun_mult);
     Iter f_transform_inc =
-        transform_inclusive_scan(execution::par, a.begin(), a.end(), f.begin(),
+        hpx::parallel::transform_inclusive_scan(policy, a.begin(), a.end(), f.begin(),
         fun_add, fun_conv, 10);
     Iter f_transform_exc =
-        transform_exclusive_scan(execution::par, a.begin(), a.end(), g.begin(),
+        hpx::parallel::transform_exclusive_scan(policy, a.begin(), a.end(), g.begin(),
         10, fun_add, fun_conv);
 
     HPX_UNUSED(f_inc_add);
@@ -170,25 +170,26 @@ void test_async_one(std::vector<int> a)
     auto fun_add = [](int bar, int baz){ return bar+baz+1; };
     auto fun_mult = [](int bar, int baz){ return 2*bar*baz; };
     auto fun_conv = [](int foo){ return foo - 3; };
+    auto policy = hpx::parallel::execution::par(hpx::parallel::execution::task);
 
     Fut_Iter f_inc_add =
-        inclusive_scan(execution::par(execution::task),
+        hpx::parallel::inclusive_scan(policy,
             a.begin(), a.end(), b.begin(), fun_add, 10);
     Fut_Iter f_inc_mult =
-        inclusive_scan(execution::par(execution::task),
+        hpx::parallel::inclusive_scan(policy,
             a.begin(), a.end(), c.begin(), fun_mult, 10);
     Fut_Iter f_exc_add =
-        exclusive_scan(execution::par(execution::task),
+        hpx::parallel::exclusive_scan(policy,
             a.begin(), a.end(), d.begin(), 10, fun_add);
     Fut_Iter f_exc_mult =
-        exclusive_scan(execution::par(execution::task),
+        hpx::parallel::exclusive_scan(policy,
             a.begin(), a.end(), e.begin(), 10, fun_mult);
     Fut_Iter f_transform_inc =
-        transform_inclusive_scan(execution::par(execution::task),
+        hpx::parallel::transform_inclusive_scan(policy,
             a.begin(), a.end(), f.begin(),
             fun_add, fun_conv, 10);
     Fut_Iter f_transform_exc =
-        transform_exclusive_scan(execution::par(execution::task),
+        hpx::parallel::transform_exclusive_scan(policy,
             a.begin(), a.end(), g.begin(),
             10, fun_add, fun_conv);
 

--- a/tests/unit/lcos/condition_variable.cpp
+++ b/tests/unit/lcos/condition_variable.cpp
@@ -68,8 +68,6 @@ struct wait_for_flag
         {
             return flag;
         }
-    private:
-        void operator=(check_flag&);
     };
 
 
@@ -457,9 +455,6 @@ struct cond_predicate
 
     int& _var;
     int _val;
-private:
-    void operator=(cond_predicate&);
-
 };
 
 void condition_test_waits(condition_test_data* data)

--- a/tests/unit/util/iterator/iterator_tests.hpp
+++ b/tests/unit/util/iterator/iterator_tests.hpp
@@ -546,6 +546,12 @@ namespace tests
         typedef const T& reference;
         typedef const T* pointer;
         typedef std::ptrdiff_t difference_type;
+        input_iterator_archetype_no_proxy()
+        {
+        }
+        input_iterator_archetype_no_proxy(input_iterator_archetype_no_proxy const&)
+        {
+        }
         self& operator=(const self&)
         {
             return *this;
@@ -585,6 +591,9 @@ namespace tests
         typedef T const* pointer;
         typedef std::ptrdiff_t difference_type;
         forward_iterator_archetype()
+        {
+        }
+        forward_iterator_archetype(forward_iterator_archetype const&)
         {
         }
         self& operator=(const self&)


### PR DESCRIPTION
Fixes compilation warnings issued by GCC 9.

- Warnings about redundant moves
- Warnings about implicitly created copy constructors
- Clash with (parallel) standard library exclusive_scan overloads