### PR TITLE
Fix default behaviour of paths in add_hpx_component

### DIFF
--- a/cmake/HPX_AddComponent.cmake
+++ b/cmake/HPX_AddComponent.cmake
@@ -6,7 +6,7 @@
 
 function(add_hpx_component name)
   # retrieve arguments
-  set(options EXCLUDE_FROM_ALL INSTALL_HEADERS NOEXPORT AUTOGLOB STATIC PLUGIN)
+  set(options EXCLUDE_FROM_ALL INSTALL_HEADERS NOEXPORT AUTOGLOB STATIC PLUGIN PREPEND_SOURCE_ROOT PREPEND_SOURCE_ROOT)
   set(one_value_args INI FOLDER SOURCE_ROOT HEADER_ROOT SOURCE_GLOB HEADER_GLOB OUTPUT_SUFFIX INSTALL_SUFFIX LANGUAGE)
   set(multi_value_args SOURCES HEADERS AUXILIARY DEPENDENCIES COMPONENT_DEPENDENCIES COMPILE_FLAGS LINK_FLAGS)
   cmake_parse_arguments(${name} "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
@@ -69,8 +69,12 @@ function(add_hpx_component name)
       TARGETS ${${name}_component_HEADERS})
   else()
     include(HPX_CMakeUtils)
-    prepend(${name}_SOURCES ${${name}_SOURCE_ROOT} ${${name}_SOURCES})
-    prepend(${name}_HEADERS ${${name}_HEADER_ROOT} ${${name}_HEADERS})
+    if(${name}_PREPEND_SOURCE_ROOT)
+      prepend(${name}_SOURCES ${${name}_SOURCE_ROOT} ${${name}_SOURCES})
+    endif()
+    if(${name}_PREPEND_HEADER_ROOT)
+      prepend(${name}_HEADERS ${${name}_HEADER_ROOT} ${${name}_HEADERS})
+    endif()
 
     add_hpx_library_sources_noglob(${name}_component
         SOURCES "${${name}_SOURCES}")

--- a/components/component_storage/CMakeLists.txt
+++ b/components/component_storage/CMakeLists.txt
@@ -27,8 +27,10 @@ set(component_storage_sources
 add_hpx_component(component_storage
   FOLDER "Core/Components/IO"
   INSTALL_HEADERS
+  PREPEND_HEADER_ROOT
   HEADER_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/include
   HEADERS ${component_storage_headers}
+  PREPEND_SOURCE_ROOT
   SOURCE_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/src
   SOURCES ${component_storage_sources}
   DEPENDENCIES unordered_component

--- a/components/containers/partitioned_vector/CMakeLists.txt
+++ b/components/containers/partitioned_vector/CMakeLists.txt
@@ -40,8 +40,10 @@ set(partitioned_vector_sources
 add_hpx_component(partitioned_vector
   FOLDER "Core/Components/Containers"
   INSTALL_HEADERS
+  PREPEND_HEADER_ROOT
   HEADER_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/include"
   HEADERS ${partitioned_vector_headers}
+  PREPEND_SOURE_ROOT
   SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/src"
   SOURCES ${partitioned_vector_sources}
   ${_exclude_from_all_flag})

--- a/components/containers/unordered/CMakeLists.txt
+++ b/components/containers/unordered/CMakeLists.txt
@@ -17,8 +17,10 @@ set(unordered_sources
 add_hpx_component(unordered
   FOLDER "Core/Components/Containers"
   INSTALL_HEADERS
+  PREPEND_HEADER_ROOT
   HEADER_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/include"
   HEADERS ${unordered_headers}
+  PREPEND_SOURCE_ROOT
   SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/src"
   SOURCES ${unordered_sources}
   ${_exclude_from_all_flag})

--- a/components/iostreams/CMakeLists.txt
+++ b/components/iostreams/CMakeLists.txt
@@ -30,8 +30,10 @@ set(iostreams_sources
 add_hpx_component(iostreams
   FOLDER "Core/Components/IO"
   INSTALL_HEADERS
+  PREPEND_HEADER_ROOT
   HEADER_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/include"
   HEADERS ${iostreams_headers}
+  PREPEND_SOURCE_ROOT
   SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/src"
   SOURCES ${iostreams_sources}
   ${_exclude_from_all_flag})

--- a/components/performance_counters/io/CMakeLists.txt
+++ b/components/performance_counters/io/CMakeLists.txt
@@ -20,8 +20,10 @@ if(HPX_WITH_IO_COUNTERS)
     FOLDER "Core/Components/Counters"
     INSTALL_HEADERS
     PLUGIN
+    PREPEND_HEADER_ROOT
     HEADER_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/include"
     HEADERS ${io_counters_headers}
+    PREPEND_SOURCE_ROOT
     SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/src"
     SOURCES ${io_counters_sources}
     ${_exclude_from_all_flag})

--- a/components/performance_counters/memory/CMakeLists.txt
+++ b/components/performance_counters/memory/CMakeLists.txt
@@ -22,8 +22,10 @@ add_hpx_component(memory
   FOLDER "Core/Components/Counters"
   INSTALL_HEADERS
   PLUGIN
+  PREPEND_HEADER_ROOT
   HEADER_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/include"
   HEADERS ${memory_headers}
+  PREPEND_SOURCE_ROOT
   SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/src"
   SOURCES ${memory_sources}
   ${_exclude_from_all_flag})

--- a/components/performance_counters/papi/CMakeLists.txt
+++ b/components/performance_counters/papi/CMakeLists.txt
@@ -30,8 +30,10 @@ if(HPX_WITH_PAPI)
     FOLDER "Core/Components/Counters"
     INSTALL_HEADERS
     PLUGIN
+    PREPEND_HEADER_ROOT
     HEADER_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/include"
     HEADERS ${papi_counters_headers}
+    PREPEND_SOURCE_ROOT
     SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/src"
     SOURCES ${papi_counters_sources}
     ${_exclude_from_all_flag})

--- a/components/process/CMakeLists.txt
+++ b/components/process/CMakeLists.txt
@@ -106,8 +106,10 @@ set(process_sources
 add_hpx_component(process
   FOLDER "Core/Components/Process"
   INSTALL_HEADERS
+  PREPEND_HEADER_ROOT
   HEADER_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/include"
   HEADERS ${process_headers}
+  PREPEND_SOURCE_ROOT
   SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/src"
   SOURCES ${process_sources}
   ${_exclude_from_all_flag})


### PR DESCRIPTION
Add option to explicitly prepend the root path to source and header files. Otherwise leave paths as they are (old behaviour).

@hkaiser does this work for phylanx?