### PR TITLE
Fix CMake configuration with PAPI on

### DIFF
--- a/components/performance_counters/papi/CMakeLists.txt
+++ b/components/performance_counters/papi/CMakeLists.txt
@@ -36,6 +36,7 @@ if(HPX_WITH_PAPI)
     PREPEND_SOURCE_ROOT
     SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/src"
     SOURCES ${papi_counters_sources}
+    DEPENDENCIES ${PAPI_LIBRARIES}
     ${_exclude_from_all_flag})
 
   add_hpx_pseudo_dependencies(components.performance_counters.papi papi_counters_component)

--- a/components/performance_counters/papi/CMakeLists.txt
+++ b/components/performance_counters/papi/CMakeLists.txt
@@ -22,6 +22,7 @@ if(HPX_WITH_PAPI)
   )
 
   set(papi_counters_sources
+    papi_startup.cpp
     server/papi.cpp
     util/papi.cpp
   )

--- a/components/performance_counters/papi/CMakeLists.txt
+++ b/components/performance_counters/papi/CMakeLists.txt
@@ -38,7 +38,7 @@ if(HPX_WITH_PAPI)
     SOURCES ${papi_counters_sources}
     ${_exclude_from_all_flag})
 
-  add_hpx_pseudo_dependencies(components.performance_counters.papi_counters papi_counters_component)
+  add_hpx_pseudo_dependencies(components.performance_counters.papi papi_counters_component)
 
   add_subdirectory(tests)
   add_subdirectory(examples)

--- a/components/performance_counters/papi/tests/regressions/CMakeLists.txt
+++ b/components/performance_counters/papi/tests/regressions/CMakeLists.txt
@@ -24,16 +24,5 @@ foreach(test ${tests})
                      FOLDER "Tests/Regressions/Components")
 
   add_hpx_regression_test("components.papi_counters" ${test} ${${test}_PARAMETERS})
-
-  # add a custom target for this example
-  add_hpx_pseudo_target(tests.regressions.components.papi_counters.${test})
-
-  # make pseudo-targets depend on master pseudo-target
-  add_hpx_pseudo_dependencies(tests.regressions.components.papi_counters
-                              tests.regressions.components.papi_counters.${test})
-
-  # add dependencies to pseudo-target
-  add_hpx_pseudo_dependencies(tests.regressions.components.papi_counters.${test}
-                              ${test}_test)
 endforeach()
 

--- a/tests/regressions/performance_counters/CMakeLists.txt
+++ b/tests/regressions/performance_counters/CMakeLists.txt
@@ -9,13 +9,6 @@ set(tests
     statistics_2666
     uptime_1737)
 
-if(HPX_WITH_PAPI)
-  set(tests ${tests}
-    papi_counters_active_interface
-    papi_counters_basic_functions
-    papi_counters_segfault_1890)
-endif()
-
 foreach(test ${tests})
   set(sources
       ${test}.cpp)


### PR DESCRIPTION
Fixes master. I broke configuration with PAPI turned on with #3954. This attempts to fix it. There's a build running on rostam here: http://rostam.cct.lsu.edu/builders/hpx_gcc_6_boost_1_64_centos_x86_64_debug/builds/373.