### PR TITLE
Export handle_assert function

### DIFF
--- a/libs/assertion/include/hpx/assertion/evaluate_assert.hpp
+++ b/libs/assertion/include/hpx/assertion/evaluate_assert.hpp
@@ -8,7 +8,6 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_DEBUG)
 #include <hpx/assertion/source_location.hpp>
 
 #include <string>
@@ -32,5 +31,4 @@ namespace hpx { namespace assertion { namespace detail
     /// \endcond
 }}}
 
-#endif
 #endif

--- a/libs/assertion/include/hpx/assertion/force_linking.hpp
+++ b/libs/assertion/include/hpx/assertion/force_linking.hpp
@@ -16,10 +16,8 @@ namespace hpx { namespace assertion
 {
     struct force_linking_helper
     {
-#if defined(HPX_DEBUG)
         void (*handle_assert)(
             source_location const&, const char*, std::string const&);
-#endif
     };
 
     force_linking_helper& force_linking();

--- a/libs/assertion/src/assertion.cpp
+++ b/libs/assertion/src/assertion.cpp
@@ -3,6 +3,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/config.hpp>
 #include <hpx/assertion.hpp>
 
 #include <iostream>


### PR DESCRIPTION
Fixes GCC release builds. The function was not declared exported inside the assertion module, only for consumers of the module.

[Before](http://rostam.cct.lsu.edu/builders/hpx_gcc_8_boost_1_70_centos_x86_64_release/builds/85) and [after](http://rostam.cct.lsu.edu/builders/hpx_gcc_8_boost_1_70_centos_x86_64_release/builds/86).