### PR TITLE
Add process thread binding option

### DIFF
--- a/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
+++ b/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
@@ -1823,7 +1823,7 @@ Here is a full grammar describing the possible format of mappings:
 
 .. productionlist::
    mappings: `distribution` | `mapping` (";" `mapping`)*
-   distribution: "compact" | "scatter" | "balanced" | "numa-balanced"
+   distribution: "compact" | "scatter" | "balanced" | "numa-balanced" | "process"
    mapping: `thread_spec` "=" `pu_specs`
    thread_spec: "thread:" `range_specs`
    pu_specs: `pu_spec` ("." `pu_spec`)*
@@ -1869,20 +1869,31 @@ only their first processing unit ``pu:0`` should be used.
    where each bit in the bitmasks corresponds to a processing unit the listed
    worker thread will be bound to run on.
 
-The difference between the four possible predefined distribution schemes
-(``compact``, ``scatter``, ``balanced`` and ``numa-balanced``) is best explained
-with an example. Imagine that we have a system with 4 cores and 4 hardware
-threads per core on 2 sockets. If we place 8 threads the assignments produced by
-the ``compact``, ``scatter``, ``balanced`` and ``numa-balanced`` types are shown
-in the figure below. Notice that ``compact`` does not fully utilize all the
-cores in the system. For this reason it is recommended that applications are run
-using the ``scatter`` or ``balanced``/``numa-balanced`` options in most cases.
+The difference between the predefined distribution schemes (``compact``,
+``scatter``, ``balanced`` and ``numa-balanced``) is best explained with an
+example. Imagine that we have a system with 4 cores and 4 hardware threads per
+core on 2 sockets. If we place 8 threads the assignments produced by the
+``compact``, ``scatter``, ``balanced`` and ``numa-balanced`` types are shown in
+the figure below. Notice that ``compact`` does not fully utilize all the cores
+in the system. For this reason it is recommended that applications are run using
+the ``scatter`` or ``balanced``/``numa-balanced`` options in most cases.
 
 .. _commandline_affinities:
 
 .. figure:: ../_static/images/affinities.png
 
    Schematic of thread affinity type distributions.
+
+The ``process`` option is different from the other distributions in that it does
+not define an explicit distribution, but instead uses the implicit distribution
+set by the process affinity mask. This is usually the case when running |hpx|
+applications through |mpi|_ or a batch environment. If no process mask is set it
+is equivalent to the ``compact`` distribution. The number of threads will
+automatically be set to the number of processing units in the process mask, and
+one thread will be bound to each processing unit in the mask. Currently this is
+complementary to the explicit support in |hpx| for batch environments. If you
+want to use the ``process`` binding option, it is recommended that you use the
+command line option :option:`--hpx:ignore-batch-env` as well.
 
 .. [#] The phase of a |hpx|-thread counts how often this thread has been
        activated.

--- a/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
+++ b/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
@@ -1467,6 +1467,11 @@ The predefined command line options for any application using
    :option:`--hpx:affinity` options. Implies :option:`--hpx:numa-sensitive`
    (:option:`--hpx:bind`\ ``=none``) disables defining thread affinities).
 
+.. option:: --hpx:use-process-mask
+
+   use the process mask to restrict available hardware resources (implies
+   :option:`--hpx:ignore-batch-env`)
+
 .. option:: --hpx:print-bind
 
    print to the console the bit masks calculated from the arguments specified to
@@ -1823,7 +1828,7 @@ Here is a full grammar describing the possible format of mappings:
 
 .. productionlist::
    mappings: `distribution` | `mapping` (";" `mapping`)*
-   distribution: "compact" | "scatter" | "balanced" | "numa-balanced" | "process"
+   distribution: "compact" | "scatter" | "balanced" | "numa-balanced"
    mapping: `thread_spec` "=" `pu_specs`
    thread_spec: "thread:" `range_specs`
    pu_specs: `pu_spec` ("." `pu_spec`)*
@@ -1869,14 +1874,14 @@ only their first processing unit ``pu:0`` should be used.
    where each bit in the bitmasks corresponds to a processing unit the listed
    worker thread will be bound to run on.
 
-The difference between the predefined distribution schemes (``compact``,
-``scatter``, ``balanced`` and ``numa-balanced``) is best explained with an
-example. Imagine that we have a system with 4 cores and 4 hardware threads per
-core on 2 sockets. If we place 8 threads the assignments produced by the
-``compact``, ``scatter``, ``balanced`` and ``numa-balanced`` types are shown in
-the figure below. Notice that ``compact`` does not fully utilize all the cores
-in the system. For this reason it is recommended that applications are run using
-the ``scatter`` or ``balanced``/``numa-balanced`` options in most cases.
+The difference between the four possible predefined distribution schemes
+(``compact``, ``scatter``, ``balanced`` and ``numa-balanced``) is best explained
+with an example. Imagine that we have a system with 4 cores and 4 hardware
+threads per core on 2 sockets. If we place 8 threads the assignments produced by
+the ``compact``, ``scatter``, ``balanced`` and ``numa-balanced`` types are shown
+in the figure below. Notice that ``compact`` does not fully utilize all the
+cores in the system. For this reason it is recommended that applications are run
+using the ``scatter`` or ``balanced``/``numa-balanced`` options in most cases.
 
 .. _commandline_affinities:
 
@@ -1884,16 +1889,16 @@ the ``scatter`` or ``balanced``/``numa-balanced`` options in most cases.
 
    Schematic of thread affinity type distributions.
 
-The ``process`` option is different from the other distributions in that it does
-not define an explicit distribution, but instead uses the implicit distribution
-set by the process affinity mask. This is usually the case when running |hpx|
-applications through |mpi|_ or a batch environment. If no process mask is set it
-is equivalent to the ``compact`` distribution. The number of threads will
-automatically be set to the number of processing units in the process mask, and
-one thread will be bound to each processing unit in the mask. Currently this is
-complementary to the explicit support in |hpx| for batch environments. If you
-want to use the ``process`` binding option, it is recommended that you use the
-command line option :option:`--hpx:ignore-batch-env` as well.
+In addition to the predefined distributions it is possible to restrict the
+resources used by |hpx| to the process CPU mask. The CPU mask is typically set
+by e.g. |mpi|_ and batch environments. Using the command line option
+:option:`--hpx:use-process-mask` makes |hpx| act as if only the processing units
+in the CPU mask are available for use by |hpx|. The number of threads is
+automatically determined from the CPU mask. The number of threads can still be
+changed manually using this option, but only to a number less than or equal to
+the number of processing units in the CPU mask. The option
+:option:`--hpx:print-bind` is useful in conjunction with
+:option:`--hpx:use-process-mask` to make sure threads are placed as expected.
 
 .. [#] The phase of a |hpx|-thread counts how often this thread has been
        activated.

--- a/hpx/runtime/threads/policies/affinity_data.hpp
+++ b/hpx/runtime/threads/policies/affinity_data.hpp
@@ -89,6 +89,7 @@ namespace hpx { namespace threads { namespace policies { namespace detail
         std::vector<mask_type> affinity_masks_;
         std::vector<std::size_t> pu_nums_;
         mask_type no_affinity_;                             ///< mask of processing units which have no affinity
+        bool use_process_mask_; ///< use the process CPU mask to limit available PUs
         static std::atomic<int> instance_number_counter_;   ///< counter for instance numbers
     };
 }}}}

--- a/hpx/runtime/threads/policies/parse_affinity_options.hpp
+++ b/hpx/runtime/threads/policies/parse_affinity_options.hpp
@@ -33,7 +33,8 @@ namespace hpx { namespace threads { namespace detail
         compact       = 0x01,
         scatter       = 0x02,
         balanced      = 0x04,
-        numa_balanced = 0x08
+        numa_balanced = 0x08,
+        process       = 0x10
     };
 
     struct spec_type

--- a/hpx/runtime/threads/policies/parse_affinity_options.hpp
+++ b/hpx/runtime/threads/policies/parse_affinity_options.hpp
@@ -33,8 +33,7 @@ namespace hpx { namespace threads { namespace detail
         compact       = 0x01,
         scatter       = 0x02,
         balanced      = 0x04,
-        numa_balanced = 0x08,
-        process       = 0x10
+        numa_balanced = 0x08
     };
 
     struct spec_type

--- a/hpx/runtime/threads/topology.hpp
+++ b/hpx/runtime/threads/topology.hpp
@@ -431,6 +431,7 @@ namespace hpx { namespace threads
         std::size_t max_cores,
         std::size_t num_threads,
         std::vector<std::size_t>& num_pus,
+        bool use_process_mask,
         error_code& ec = throws);
 
     // backwards compatibility helper
@@ -439,7 +440,7 @@ namespace hpx { namespace threads
     {
         std::vector<std::size_t> num_pus;
         parse_affinity_options(spec, affinities, 1, 1, affinities.size(),
-            num_pus, ec);
+            num_pus, false, ec);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/hpx/util/command_line_handling.hpp
+++ b/hpx/util/command_line_handling.hpp
@@ -36,6 +36,7 @@ namespace hpx { namespace util
             pu_step_(1),
             pu_offset_(std::size_t(-1)),
             numa_sensitive_(0),
+            use_process_mask_(false),
             cmd_line_parsed_(false),
             info_printed_(false),
             version_printed_(false),
@@ -63,6 +64,7 @@ namespace hpx { namespace util
         std::string affinity_domain_;
         std::string affinity_bind_;
         std::size_t numa_sensitive_;
+        bool use_process_mask_;
         bool cmd_line_parsed_;
         bool info_printed_;
         bool version_printed_;

--- a/src/runtime/threads/policies/affinity_data.cpp
+++ b/src/runtime/threads/policies/affinity_data.cpp
@@ -87,6 +87,7 @@ namespace hpx { namespace threads { namespace policies { namespace detail
       , affinity_masks_()
       , pu_nums_()
       , no_affinity_()
+      , use_process_mask_(false)
     {
         // allow only one affinity-data instance
         if (instance_number_counter_++ >= 0)
@@ -106,6 +107,7 @@ namespace hpx { namespace threads { namespace policies { namespace detail
     std::size_t affinity_data::init(util::command_line_handling const& cfg_)
     {
         num_threads_ = cfg_.num_threads_;
+        use_process_mask_ = cfg_.use_process_mask_;
         std::size_t num_system_pus = hardware_concurrency();
 
         // initialize from command line
@@ -151,8 +153,8 @@ namespace hpx { namespace threads { namespace policies { namespace detail
             for (std::size_t i = 0; i != num_threads_; ++i)
                 threads::resize(affinity_masks_[i], num_system_pus);
 
-            parse_affinity_options(affinity_desc, affinity_masks_,
-                used_cores, max_cores, num_threads_, pu_nums_);
+            parse_affinity_options(affinity_desc, affinity_masks_, used_cores,
+                max_cores, num_threads_, pu_nums_, use_process_mask_);
 
             std::size_t num_initialized = count_initialized(affinity_masks_);
             if (num_initialized != num_threads_) {

--- a/src/runtime/threads/policies/parse_affinity_options.cpp
+++ b/src/runtime/threads/policies/parse_affinity_options.cpp
@@ -68,7 +68,6 @@ namespace hpx { namespace threads { namespace detail
     //        scatter
     //        balanced
     //        numa-balanced
-    //        process
     //
     //    mapping:
     //        thread-spec=pu-specs
@@ -119,7 +118,6 @@ namespace hpx { namespace threads { namespace detail
                 |   partlit("scatter") >> qi::attr(scatter)
                 |   partlit("balanced") >> qi::attr(balanced)
                 |   partlit("numa-balanced") >> qi::attr(numa_balanced)
-                |   partlit("process") >> qi::attr(process)
                 ;
 
             thread_spec =
@@ -718,23 +716,86 @@ namespace hpx { namespace threads { namespace detail
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    bool pu_in_process_mask(bool use_process_mask, topology& t,
+        std::size_t num_core, std::size_t num_pu)
+    {
+        if (!use_process_mask)
+        {
+            return true;
+        }
+
+        threads::mask_type proc_mask = t.get_cpubind_mask();
+        threads::mask_type pu_mask =
+            t.init_thread_affinity_mask(num_core, num_pu);
+
+        return threads::bit_and(proc_mask, pu_mask);
+    }
+
+    void check_num_threads(bool use_process_mask, topology& t,
+        std::size_t num_threads, error_code& ec)
+    {
+        if (use_process_mask)
+        {
+            threads::mask_type proc_mask = t.get_cpubind_mask();
+            std::size_t num_pus_proc_mask = threads::count(proc_mask);
+
+            if (num_threads > num_pus_proc_mask)
+            {
+                HPX_THROWS_IF(ec, bad_parameter, "check_num_threads",
+                    hpx::util::format("specified number of threads ({1}) is "
+                                      "larger than number of processing units "
+                                      "available in process mask ({2})",
+                        num_threads, num_pus_proc_mask));
+            }
+        }
+        else
+        {
+            std::size_t num_threads_available = threads::hardware_concurrency();
+
+            if (num_threads > num_threads_available)
+            {
+                HPX_THROWS_IF(ec, bad_parameter, "check_num_threads",
+                    hpx::util::format(
+                        "specified number of threads ({1}) is larger than "
+                        "number of available processing units ({2})",
+                        num_threads, num_threads_available));
+            }
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     void decode_compact_distribution(topology& t,
-        std::vector<mask_type>& affinities,
-        std::size_t used_cores, std::size_t max_cores,
-        std::vector<std::size_t>& num_pus, error_code& ec)
+        std::vector<mask_type>& affinities, std::size_t used_cores,
+        std::size_t max_cores, std::vector<std::size_t>& num_pus,
+        bool use_process_mask, error_code& ec)
     {
         std::size_t num_threads = affinities.size();
+
+        check_num_threads(use_process_mask, t, num_threads, ec);
+
+        if (use_process_mask)
+        {
+            used_cores = 0;
+            max_cores = t.get_number_of_cores();
+        }
+
         std::size_t num_cores = (std::min)(max_cores, t.get_number_of_cores());
         num_pus.resize(num_threads);
 
-        for (std::size_t num_thread = 0; num_thread != num_threads; /**/)
+        for (std::size_t num_thread = 0; num_thread < num_threads; /**/)
         {
-            for(std::size_t num_core = 0; num_core != num_cores; ++num_core)
+            for(std::size_t num_core = 0; num_core < num_cores; ++num_core)
             {
                 std::size_t num_core_pus
                     = t.get_number_of_core_pus(num_core + used_cores);
-                for(std::size_t num_pu = 0; num_pu != num_core_pus; ++num_pu)
+                for(std::size_t num_pu = 0; num_pu < num_core_pus; ++num_pu)
                 {
+                    if (!pu_in_process_mask(
+                            use_process_mask, t, num_core, num_pu))
+                    {
+                        continue;
+                    }
+
                     if (any(affinities[num_thread]))
                     {
                         HPX_THROWS_IF(ec, bad_parameter,
@@ -745,9 +806,11 @@ namespace hpx { namespace threads { namespace detail
                                 num_thread));
                         return;
                     }
+
+                    num_pus[num_thread] =
+                        t.get_pu_number(num_core + used_cores, num_pu);
                     affinities[num_thread] = t.init_thread_affinity_mask(
                         num_core + used_cores, num_pu);
-                    num_pus[num_thread] = num_thread;
 
                     if(++num_thread == num_threads)
                         return;
@@ -757,19 +820,28 @@ namespace hpx { namespace threads { namespace detail
     }
 
     void decode_scatter_distribution(topology& t,
-        std::vector<mask_type>& affinities,
-        std::size_t used_cores, std::size_t max_cores,
-        std::vector<std::size_t>& num_pus, error_code& ec)
+        std::vector<mask_type>& affinities, std::size_t used_cores,
+        std::size_t max_cores, std::vector<std::size_t>& num_pus,
+        bool use_process_mask, error_code& ec)
     {
         std::size_t num_threads = affinities.size();
+
+        check_num_threads(use_process_mask, t, num_threads, ec);
+
+        if (use_process_mask)
+        {
+            used_cores = 0;
+            max_cores = t.get_number_of_cores();
+        }
+
         std::size_t num_cores = (std::min)(max_cores, t.get_number_of_cores());
 
-        std::vector<std::size_t> num_pus_cores(num_cores, 0);
+        std::vector<std::size_t> next_pu_index(num_cores, 0);
         num_pus.resize(num_threads);
 
-        for (std::size_t num_thread = 0; num_thread != num_threads; /**/)
+        for (std::size_t num_thread = 0; num_thread < num_threads; /**/)
         {
-            for(std::size_t num_core = 0; num_core != num_cores; ++num_core)
+            for(std::size_t num_core = 0; num_core < num_cores; ++num_core)
             {
                 if (any(affinities[num_thread]))
                 {
@@ -782,10 +854,35 @@ namespace hpx { namespace threads { namespace detail
                     return;
                 }
 
+                std::size_t num_core_pus =
+                    t.get_number_of_core_pus(num_core);
+                std::size_t pu_index = next_pu_index[num_core];
+                bool use_pu = false;
+
+                // Find the next PU on this core which is in the process mask
+                while (pu_index < num_core_pus)
+                {
+                    use_pu = pu_in_process_mask(
+                        use_process_mask, t, num_core, pu_index);
+                    ++pu_index;
+
+                    if (use_pu)
+                    {
+                        break;
+                    }
+                }
+
+                next_pu_index[num_core] = pu_index;
+
+                if (!use_pu)
+                {
+                    continue;
+                }
+
                 num_pus[num_thread] = t.get_pu_number(num_core + used_cores,
-                    num_pus_cores[num_core]);
+                    next_pu_index[num_core] - 1);
                 affinities[num_thread] = t.init_thread_affinity_mask(
-                    num_core + used_cores, num_pus_cores[num_core]++);
+                    num_core + used_cores, next_pu_index[num_core] - 1);
 
                 if(++num_thread == num_threads)
                     return;
@@ -795,23 +892,61 @@ namespace hpx { namespace threads { namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
     void decode_balanced_distribution(topology& t,
-        std::vector<mask_type>& affinities,
-        std::size_t used_cores, std::size_t max_cores,
-        std::vector<std::size_t>& num_pus, error_code& ec)
+        std::vector<mask_type>& affinities, std::size_t used_cores,
+        std::size_t max_cores, std::vector<std::size_t>& num_pus,
+        bool use_process_mask, error_code& ec)
     {
         std::size_t num_threads = affinities.size();
+
+        check_num_threads(use_process_mask, t, num_threads, ec);
+
+        if (use_process_mask)
+        {
+            used_cores = 0;
+            max_cores = t.get_number_of_cores();
+        }
+
         std::size_t num_cores = (std::min)(max_cores, t.get_number_of_cores());
 
         std::vector<std::size_t> num_pus_cores(num_cores, 0);
+        std::vector<std::size_t> next_pu_index(num_cores, 0);
+        std::vector<std::vector<std::size_t>> pu_indexes(num_cores);
         num_pus.resize(num_threads);
 
         // At first, calculate the number of used pus per core.
         // This needs to be done to make sure that we occupy all the available
         // cores
-        for (std::size_t num_thread = 0; num_thread != num_threads; /**/)
+        for (std::size_t num_thread = 0; num_thread < num_threads; /**/)
         {
-            for(std::size_t num_core = 0; num_core != num_cores; ++num_core)
+            for(std::size_t num_core = 0; num_core < num_cores; ++num_core)
             {
+                std::size_t num_core_pus =
+                    t.get_number_of_core_pus(num_core);
+                std::size_t pu_index = next_pu_index[num_core];
+                bool use_pu = false;
+
+                // Find the next PU on this core which is in the process mask
+                while (pu_index < num_core_pus)
+                {
+                    use_pu = pu_in_process_mask(
+                        use_process_mask, t, num_core, pu_index);
+                    ++pu_index;
+
+                    if (use_pu)
+                    {
+                        break;
+                    }
+                }
+
+                next_pu_index[num_core] = pu_index;
+
+                if (!use_pu)
+                {
+                    continue;
+                }
+
+                pu_indexes[num_core].push_back(next_pu_index[num_core] - 1);
+
                 num_pus_cores[num_core]++;
                 if(++num_thread == num_threads)
                     break;
@@ -821,9 +956,9 @@ namespace hpx { namespace threads { namespace detail
         // Iterate over the cores and assigned pus per core. this additional
         // loop is needed so that we have consecutive worker thread numbers
         std::size_t num_thread = 0;
-        for (std::size_t num_core = 0; num_core != num_cores; ++num_core)
+        for (std::size_t num_core = 0; num_core < num_cores; ++num_core)
         {
-            for (std::size_t num_pu = 0; num_pu != num_pus_cores[num_core]; ++num_pu)
+            for (std::size_t num_pu = 0; num_pu < num_pus_cores[num_core]; ++num_pu)
             {
                 if (any(affinities[num_thread]))
                 {
@@ -835,9 +970,11 @@ namespace hpx { namespace threads { namespace detail
                             num_thread));
                     return;
                 }
-                num_pus[num_thread] = t.get_pu_number(num_core + used_cores, num_pu);
+
+                num_pus[num_thread] = t.get_pu_number(
+                    num_core + used_cores, pu_indexes[num_core][num_pu]);
                 affinities[num_thread] = t.init_thread_affinity_mask(
-                    num_core + used_cores, num_pu);
+                    num_core + used_cores, pu_indexes[num_core][num_pu]);
                 ++num_thread;
             }
         }
@@ -845,64 +982,130 @@ namespace hpx { namespace threads { namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
     void decode_numabalanced_distribution(topology& t,
-        std::vector<mask_type>& affinities,
-        std::size_t used_cores, std::size_t max_cores,
-        std::vector<std::size_t>& num_pus, error_code& ec)
+        std::vector<mask_type>& affinities, std::size_t used_cores,
+        std::size_t max_cores, std::vector<std::size_t>& num_pus,
+        bool use_process_mask, error_code& ec)
     {
         std::size_t num_threads = affinities.size();
+
+        check_num_threads(use_process_mask, t, num_threads, ec);
+
+        if (use_process_mask)
+        {
+            used_cores = 0;
+            max_cores = t.get_number_of_cores();
+        }
+
         num_pus.resize(num_threads);
 
         // numa nodes
         std::size_t num_numas =
             (std::max)(std::size_t(1), t.get_number_of_numa_nodes());
         std::vector<std::size_t> num_cores_numa(num_numas, 0);
+        std::vector<std::size_t> num_pus_numa(num_numas, 0);
         std::vector<std::size_t> num_threads_numa(num_numas, 0);
         std::size_t cores_t = 0;
-        for (std::size_t n = 0; n != num_numas; ++n)
+        for (std::size_t n = 0; n < num_numas; ++n)
         {
             num_cores_numa[n] = t.get_number_of_numa_node_cores(n);
             cores_t += num_cores_numa[n];
         }
 
+        std::size_t core_offset = 0;
+        std::size_t pus_t = 0;
+        for (std::size_t n = 0; n < num_numas; ++n)
+        {
+            for (std::size_t num_core = 0; num_core < num_cores_numa[n];
+                 ++num_core)
+            {
+                std::size_t num_pus =
+                    t.get_number_of_core_pus(num_core + core_offset);
+                for (std::size_t num_pu = 0; num_pu < num_pus; ++num_pu)
+                {
+                    if (pu_in_process_mask(use_process_mask, t,
+                            num_core + core_offset, num_pu))
+                    {
+                        ++num_pus_numa[n];
+                    }
+                }
+            }
+
+            pus_t += num_pus_numa[n];
+            core_offset += num_cores_numa[n];
+        }
+
         // how many threads should go on each domain
-        std::size_t cores_t2 = 0;
-        for (std::size_t n = 0; n != num_numas; ++n)
+        std::size_t pus_t2 = 0;
+        for (std::size_t n = 0; n < num_numas; ++n)
         {
             std::size_t temp = static_cast<std::size_t>(std::floor(0.5 +
-                static_cast<double>(num_threads) * num_cores_numa[n] /
-                    cores_t));
+                static_cast<double>(num_threads) * num_pus_numa[n] /
+                    pus_t));
 
             // due to rounding up, we might have too many threads
-            if ((cores_t2 + temp) > num_threads)
-                temp = num_threads - cores_t2;
-            cores_t2 += temp;
+            if ((pus_t2 + temp) > num_threads)
+                temp = num_threads - pus_t2;
+            pus_t2 += temp;
             num_threads_numa[n] = temp;
+
+            // HPX_ASSERT(num_threads_numa[n] <= num_pus_numa[n]);
         }
+
+        // HPX_ASSERT(num_threads <= pus_t2);
 
         // assign threads to cores on each numa domain
         std::size_t num_thread = 0;
-        std::size_t offset = 0;
-        for (std::size_t n = 0; n != num_numas; ++n)
+        core_offset = 0;
+        for (std::size_t n = 0; n < num_numas; ++n)
         {
             std::vector<std::size_t> num_pus_cores(num_cores_numa[n], 0);
+            std::vector<std::size_t> next_pu_index(num_cores_numa[n], 0);
+            std::vector<std::vector<std::size_t>> pu_indexes(num_cores_numa[n]);
 
             // iterate once and count pus/core
-            for (std::size_t thrd = 0; thrd != num_threads_numa[n]; /**/)
+            for (std::size_t num_thread_numa = 0; num_thread_numa < num_threads_numa[n]; /**/)
             {
-                for(std::size_t c = 0; c != num_cores_numa[n]; ++c)
+                for(std::size_t num_core = 0; num_core < num_cores_numa[n]; ++num_core)
                 {
-                    num_pus_cores[c]++;
-                    if (++thrd == num_threads_numa[n])
+                    std::size_t num_core_pus =
+                        t.get_number_of_core_pus(num_core);
+                    std::size_t pu_index = next_pu_index[num_core];
+                    bool use_pu = false;
+
+                    // Find the next PU on this core which is in the process mask
+                    while (pu_index < num_core_pus)
+                    {
+                        use_pu = pu_in_process_mask(
+                            use_process_mask, t, num_core + core_offset, pu_index);
+                        ++pu_index;
+
+                        if (use_pu)
+                        {
+                            break;
+                        }
+                    }
+
+                    next_pu_index[num_core] = pu_index;
+
+                    if (!use_pu)
+                    {
+                        continue;
+                    }
+
+                    pu_indexes[num_core].push_back(next_pu_index[num_core] - 1);
+
+                    num_pus_cores[num_core]++;
+                    if (++num_thread_numa == num_threads_numa[n])
                         break;
                 }
             }
 
             // Iterate over the cores and assigned pus per core. this additional
             // loop is needed so that we have consecutive worker thread numbers
-            for (std::size_t num_core = 0; num_core != num_cores_numa[n];
+            for (std::size_t num_core = 0; num_core < num_cores_numa[n];
                  ++num_core)
             {
-                for (std::size_t num_pu = 0; num_pu != num_pus_cores[num_core];
+                for (std::size_t num_pu = 0; num_pu < num_pus_cores[num_core];
                      ++num_pu)
                 {
                     if (any(affinities[num_thread]))
@@ -915,92 +1118,45 @@ namespace hpx { namespace threads { namespace detail
                                 num_thread));
                         return;
                     }
-                    num_pus[num_thread] =
-                        t.get_pu_number(num_core + used_cores, num_pu);
+                    num_pus[num_thread] = t.get_pu_number(
+                        num_core + used_cores, pu_indexes[num_core][num_pu]);
                     affinities[num_thread] = t.init_thread_affinity_mask(
-                        num_core + used_cores + offset, num_pu);
+                        num_core + used_cores + core_offset,
+                        pu_indexes[num_core][num_pu]);
                     ++num_thread;
                 }
             }
-            offset += num_cores_numa[n];
-        }
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    void decode_process_distribution(topology& t,
-        std::vector<mask_type>& affinities,
-        std::vector<std::size_t>& num_pus, error_code& ec)
-    {
-        threads::mask_type proc_mask = t.get_cpubind_mask();
-        std::size_t num_threads = affinities.size();
-        num_pus.resize(num_threads);
-        std::size_t num_cores = t.get_number_of_cores();
-
-        affinities.resize(num_threads);
-        num_pus.resize(num_threads);
-
-        for (std::size_t num_thread = 0; num_thread < num_threads; /**/)
-        {
-            for(std::size_t num_core = 0; num_core < num_cores; ++num_core)
-            {
-                std::size_t num_core_pus
-                    = t.get_number_of_core_pus(num_core);
-                for(std::size_t num_pu = 0; num_pu < num_core_pus; ++num_pu)
-                {
-                    threads::mask_type pu_mask = t.init_thread_affinity_mask(num_core, num_pu);
-                    if (!threads::bit_and(proc_mask, pu_mask)) continue;
-
-                    if (any(affinities[num_thread]))
-                    {
-                        HPX_THROWS_IF(ec, bad_parameter,
-                            "decode_process_distribution",
-                            hpx::util::format(
-                                "affinity mask for thread {1} has "
-                                "already been set",
-                                num_thread));
-                        return;
-                    }
-                    affinities[num_thread] =
-                        t.init_thread_affinity_mask(num_core, num_pu);
-                    num_pus[num_thread] = num_thread;
-
-                    if(++num_thread == num_threads)
-                        return;
-                }
-            }
+            core_offset += num_cores_numa[n];
         }
     }
 
     ///////////////////////////////////////////////////////////////////////////
     void decode_distribution(distribution_type d, topology& t,
-        std::vector<mask_type>& affinities,
-        std::size_t used_cores, std::size_t max_cores, std::size_t num_threads,
-        std::vector<std::size_t>& num_pus, error_code& ec)
+        std::vector<mask_type>& affinities, std::size_t used_cores,
+        std::size_t max_cores, std::size_t num_threads,
+        std::vector<std::size_t>& num_pus, bool use_process_mask,
+        error_code& ec)
     {
         affinities.resize(num_threads);
         switch (d) {
         case compact:
             decode_compact_distribution(t, affinities, used_cores, max_cores,
-                num_pus, ec);
+                num_pus, use_process_mask, ec);
             break;
 
         case scatter:
             decode_scatter_distribution(t, affinities, used_cores, max_cores,
-                num_pus, ec);
+                num_pus, use_process_mask, ec);
             break;
 
         case balanced:
             decode_balanced_distribution(t, affinities, used_cores, max_cores,
-                num_pus, ec);
+                num_pus, use_process_mask, ec);
             break;
 
         case numa_balanced:
             decode_numabalanced_distribution(t, affinities, used_cores, max_cores,
-                num_pus, ec);
-            break;
-
-        case process:
-            decode_process_distribution(t, affinities, num_pus, ec);
+                num_pus, use_process_mask, ec);
             break;
 
         default:
@@ -1013,9 +1169,10 @@ namespace hpx { namespace threads
 {
     ///////////////////////////////////////////////////////////////////////////
     void parse_affinity_options(std::string const& spec,
-        std::vector<mask_type>& affinities,
-        std::size_t used_cores, std::size_t max_cores, std::size_t num_threads,
-        std::vector<std::size_t>& num_pus, error_code& ec)
+        std::vector<mask_type>& affinities, std::size_t used_cores,
+        std::size_t max_cores, std::size_t num_threads,
+        std::vector<std::size_t>& num_pus, bool use_process_mask,
+        error_code& ec)
     {
         detail::mappings_type mappings;
         detail::parse_mappings(spec, mappings, ec);
@@ -1031,13 +1188,21 @@ namespace hpx { namespace threads
             {
                 detail::decode_distribution(
                     boost::get<detail::distribution_type>(mappings), t,
-                    affinities, used_cores, max_cores, num_threads, num_pus, ec);
-                if (ec) return;
+                    affinities, used_cores, max_cores, num_threads, num_pus,
+                    use_process_mask, ec);
+                if (ec)
+                    return;
             }
             break;
 
         case 1:
             {
+                if (use_process_mask)
+                {
+                    HPX_THROWS_IF(ec, bad_parameter, "parse_affinity_options",
+                        "can't use --hpx:use-process-mask with custom thread "
+                        "bindings");
+                }
                 detail::mappings_spec_type mappings_specs(
                     boost::get<detail::mappings_spec_type>(mappings));
 

--- a/src/runtime/threads/policies/parse_affinity_options.cpp
+++ b/src/runtime/threads/policies/parse_affinity_options.cpp
@@ -1063,7 +1063,9 @@ namespace hpx { namespace threads { namespace detail
             std::vector<std::vector<std::size_t>> pu_indexes(num_cores_numa[n]);
 
             // iterate once and count pus/core
-            for (std::size_t num_thread_numa = 0; num_thread_numa < num_threads_numa[n]; /**/)
+            for (std::size_t num_thread_numa = 0;
+                 num_thread_numa < num_threads_numa[n];
+                /**/)
             {
                 for(std::size_t num_core = 0; num_core < num_cores_numa[n]; ++num_core)
                 {

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -605,7 +605,6 @@ namespace hpx { namespace util
         }
 
         bool using_nodelist = false;
-        bool enable_batch_env = false;
 
         std::vector<std::string> nodelist;
 
@@ -649,8 +648,9 @@ namespace hpx { namespace util
             (cfgmap.get_value<int>("hpx.use_process_mask", 0) > 0) ||
             (vm.count("hpx:use-process-mask") > 0);
 
-        enable_batch_env = ((cfgmap.get_value<int>("hpx.ignore_batch_env", 0) +
-                                vm.count("hpx:ignore-batch-env")) == 0) &&
+        bool enable_batch_env =
+            ((cfgmap.get_value<int>("hpx.ignore_batch_env", 0) +
+                 vm.count("hpx:ignore-batch-env")) == 0) &&
             !use_process_mask_;
 
         util::batch_environment env(nodelist, rtcfg_, debug_clp, enable_batch_env);

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -362,7 +362,6 @@ namespace hpx { namespace util
                 env.retrieve_number_of_threads();
 
             std::size_t default_threads = init_threads;
-            std::size_t default_cores = init_cores;
 
             std::string threads_str =
                 cfgmap.get_value<std::string>("hpx.os_threads",

--- a/src/util/parse_command_line.cpp
+++ b/src/util/parse_command_line.cpp
@@ -403,7 +403,8 @@ namespace hpx { namespace util
                 ("hpx:node", value<std::size_t>(),
                   "number of the node this locality is run on "
                   "(must be unique, alternatively: -0, -1, ..., -9)")
-                ("hpx:ignore-batch-env", "ignore batch environment variables")
+                ("hpx:ignore-batch-env", "ignore batch environment variables "
+                 "(implied by --hpx:use-process-mask)")
                 ("hpx:expect-connecting-localities",
                   "this locality expects other localities to dynamically connect "
                   "(default: false if the number of localities is equal to one, "
@@ -432,6 +433,9 @@ namespace hpx { namespace util
                   "values. Do not use with --hpx:pu-step, --hpx:pu-offset, or "
                   "--hpx:affinity options. Implies --hpx:numa-sensitive=1"
                   "(--hpx:bind=none disables defining thread affinities).")
+                ("hpx:use-process-mask", "use the process mask to restrict"
+                 "available hardware resources (implies "
+                 "--hpx:ignore-batch-environment)")
                 ("hpx:print-bind",
                   "print to the console the bit masks calculated from the "
                   "arguments specified to all --hpx:bind options.")


### PR DESCRIPTION
Adds a new thread binding option `--hpx:bind=process` which looks at the CPU mask of the process to choose which PUs to use for worker threads. If threads is `"cores"` (default) or `"all"` it overrides the number of threads to the number of PUs in the CPU mask, and if an explicit number has been set it uses that.

This is useful for making thread bindings consistent with the behaviour of other applications in batch environments. If this works well it could even replace the batch environment support we have (assuming all of them use mpi).