### PR TITLE
Enable support for compatibility headers for logging module

### DIFF
--- a/libs/logging/CMakeLists.txt
+++ b/libs/logging/CMakeLists.txt
@@ -89,7 +89,7 @@ set(logging_sources
 
 include(HPX_AddModule)
 add_hpx_module(logging
-    COMPATIBILITY_HEADERS OFF
+    COMPATIBILITY_HEADERS ON
     DEPRECATION_WARNINGS
     FORCE_LINKING_GEN
     GLOBAL_HEADER_GEN OFF


### PR DESCRIPTION
This makes sure that external modules can still use the old logging module headers 