### PR TITLE
Fixing migration for components that have actions returning a client

### DIFF
--- a/hpx/runtime/actions/component_action.hpp
+++ b/hpx/runtime/actions/component_action.hpp
@@ -157,9 +157,13 @@ namespace hpx { namespace actions
             basic_action<Component const, R(Ps...), derived_type>::
                 increment_invocation_count();
 
-            using is_future = typename traits::is_future<R>::type;
-            return detail::component_invoke<Component const, R>(is_future{},
-                lva, comptype, F, std::forward<Ts>(vs)...);
+            using is_future_or_client = typename std::integral_constant<bool,
+                traits::is_future<R>::value ||
+                    traits::is_client<R>::value>::type;
+
+            return detail::component_invoke<Component const, R>(
+                is_future_or_client{}, lva, comptype, F,
+                std::forward<Ts>(vs)...);
         }
     };
 

--- a/hpx/runtime/components/server/migrate_component.hpp
+++ b/hpx/runtime/components/server/migrate_component.hpp
@@ -169,6 +169,7 @@ namespace hpx { namespace components { namespace server
         // 'migration' to same locality as before is a no-op
         if (policy.get_next_target() == hpx::find_here())
         {
+            agas::unmark_as_migrated(to_migrate.get_gid());
             return make_ready_future(to_migrate);
         }
 

--- a/tests/unit/component/migrate_component.cpp
+++ b/tests/unit/component/migrate_component.cpp
@@ -18,6 +18,41 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
+struct dummy_server : hpx::components::component_base<dummy_server>
+{
+    dummy_server() = default;
+
+    hpx::id_type call() const { return hpx::find_here(); }
+
+    HPX_DEFINE_COMPONENT_ACTION(dummy_server, call);
+};
+
+typedef hpx::components::component<dummy_server> dummy_server_type;
+HPX_REGISTER_COMPONENT(dummy_server_type, dummy_server);
+
+typedef dummy_server::call_action dummy_action;
+HPX_REGISTER_ACTION(dummy_action);
+
+struct dummy_client : hpx::components::client_base<dummy_client, dummy_server>
+{
+    typedef hpx::components::client_base<dummy_client, dummy_server> base_type;
+
+    dummy_client() = default;
+
+    dummy_client(hpx::id_type const& id)
+      : base_type(id)
+    {}
+    dummy_client(hpx::future<hpx::id_type> && id)
+      : base_type(std::move(id))
+    {}
+
+    hpx::id_type call() const
+    {
+        return hpx::async<dummy_action>(this->get_id()).get();
+    }
+};
+
+///////////////////////////////////////////////////////////////////////////////
 struct test_server
   : hpx::components::migration_support<
         hpx::components::component_base<test_server>
@@ -80,6 +115,22 @@ struct test_server
             });
     }
 
+    dummy_client lazy_get_client(hpx::id_type there) const
+    {
+        HPX_TEST(pin_count() != 0);
+
+        auto f = dummy_client(hpx::new_<dummy_server>(there));
+
+        return f.then(
+            [this](dummy_client && f) -> hpx::id_type
+            {
+                HPX_TEST(pin_count() != 0);
+                auto result = f.get();
+                HPX_TEST(pin_count() != 0);
+                return result;
+            });
+    }
+
     // Components which should be migrated using hpx::migrate<> need to
     // be Serializable and CopyConstructable. Components can be
     // MoveConstructable in which case the serialized data is moved into the
@@ -105,9 +156,13 @@ struct test_server
 
     HPX_DEFINE_COMPONENT_ACTION(test_server, call, call_action);
     HPX_DEFINE_COMPONENT_ACTION(test_server, busy_work, busy_work_action);
-    HPX_DEFINE_COMPONENT_ACTION(test_server, lazy_busy_work, lazy_busy_work_action);
+    HPX_DEFINE_COMPONENT_ACTION(
+        test_server, lazy_busy_work, lazy_busy_work_action);
+
     HPX_DEFINE_COMPONENT_ACTION(test_server, get_data, get_data_action);
     HPX_DEFINE_COMPONENT_ACTION(test_server, lazy_get_data, lazy_get_data_action);
+    HPX_DEFINE_COMPONENT_ACTION(
+        test_server, lazy_get_client, lazy_get_client_action);
 
     template <typename Archive>
     void serialize(Archive& ar, unsigned version)
@@ -142,6 +197,10 @@ typedef test_server::lazy_get_data_action lazy_get_data_action;
 HPX_REGISTER_ACTION_DECLARATION(lazy_get_data_action);
 HPX_REGISTER_ACTION(lazy_get_data_action);
 
+typedef test_server::lazy_get_client_action lazy_get_client_action;
+HPX_REGISTER_ACTION_DECLARATION(lazy_get_client_action);
+HPX_REGISTER_ACTION(lazy_get_client_action);
+
 struct test_client
   : hpx::components::client_base<test_client, test_server>
 {
@@ -175,6 +234,11 @@ struct test_client
     int lazy_get_data() const
     {
         return lazy_get_data_action()(this->get_id()).get();
+    }
+
+    dummy_client lazy_get_client(hpx::id_type there) const
+    {
+        return lazy_get_client_action()(this->get_id(), there);
     }
 };
 
@@ -234,6 +298,39 @@ bool test_migrate_lazy_component(hpx::id_type source, hpx::id_type target)
         // the migrated object should live on the target now
         HPX_TEST_EQ(t2.call(), target);
         HPX_TEST_EQ(t2.lazy_get_data(), 42);
+    }
+    catch (hpx::exception const& e) {
+        hpx::cout << hpx::get_error_what(e) << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+bool test_migrate_lazy_component_client(
+    hpx::id_type source, hpx::id_type target)
+{
+    // create component on given locality
+    test_client t1 = hpx::new_<test_client>(source, 42);
+    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+
+    // the new object should live on the source locality
+    HPX_TEST_EQ(t1.call(), source);
+    HPX_TEST_EQ(t1.lazy_get_client(target).call(), target);
+
+    try {
+        // migrate t1 to the target
+        test_client t2(hpx::components::migrate(t1, target));
+
+        // wait for migration to be done
+        HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+
+        // the migrated object should have the same id as before
+        HPX_TEST_EQ(t1.get_id(), t2.get_id());
+
+        // the migrated object should live on the target now
+        HPX_TEST_EQ(t2.call(), target);
+        HPX_TEST_EQ(t2.lazy_get_client(source).call(), source);
     }
     catch (hpx::exception const& e) {
         hpx::cout << hpx::get_error_what(e) << std::endl;
@@ -325,6 +422,48 @@ bool test_migrate_lazy_busy_component(hpx::id_type source, hpx::id_type target)
     return true;
 }
 
+bool test_migrate_lazy_busy_component_client(
+    hpx::id_type source, hpx::id_type target)
+{
+    // create component on given locality
+    test_client t1 = hpx::new_<test_client>(source, 42);
+    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+
+    // the new object should live on the source locality
+    HPX_TEST_EQ(t1.call(), source);
+    HPX_TEST_EQ(t1.lazy_get_client(target).call(), target);
+
+    // add some concurrent busy work
+    hpx::future<void> lazy_busy_work = t1.lazy_busy_work();
+
+    try {
+        // migrate t1 to the target
+        test_client t2(hpx::components::migrate(t1, target));
+
+        HPX_TEST_EQ(t1.lazy_get_client(target).call(), target);
+
+        // wait for migration to be done
+        HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+
+        // the migrated object should have the same id as before
+        HPX_TEST_EQ(t1.get_id(), t2.get_id());
+
+        // the migrated object should live on the target now
+        HPX_TEST_EQ(t2.call(), target);
+        HPX_TEST_EQ(t2.lazy_get_client(source).call(), source);
+    }
+    catch (hpx::exception const& e) {
+        hpx::cout << hpx::get_error_what(e) << std::endl;
+        return false;
+    }
+
+    // the busy work should be finished by now, wait anyways
+    lazy_busy_work.wait();
+
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 bool test_migrate_component2(hpx::id_type source, hpx::id_type target)
 {
     test_client t1 = hpx::new_<test_client>(source, 42);
@@ -417,6 +556,53 @@ bool test_migrate_lazy_component2(hpx::id_type source, hpx::id_type target)
     return true;
 }
 
+bool test_migrate_lazy_component_client2(hpx::id_type source, hpx::id_type target)
+{
+    test_client t1 = hpx::new_<test_client>(source, 42);
+    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+
+    // the new object should live on the source locality
+    HPX_TEST_EQ(t1.call(), source);
+    HPX_TEST_EQ(t1.lazy_get_client(target).call(), target);
+
+    std::size_t N = 100;
+
+    try {
+        // migrate an object back and forth between 2 localities a couple of
+        // times
+        for(std::size_t i = 0; i < N; ++i)
+        {
+            // migrate t1 to the target (loc2)
+            test_client t2(hpx::components::migrate(t1, target));
+
+            HPX_TEST_EQ(t1.lazy_get_client(target).call(), target);
+
+            // wait for migration to be done
+            HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+
+            // the migrated object should have the same id as before
+            HPX_TEST_EQ(t1.get_id(), t2.get_id());
+
+            // the migrated object should live on the target now
+            HPX_TEST_EQ(t2.call(), target);
+            HPX_TEST_EQ(t2.lazy_get_data(), 42);
+            HPX_TEST_EQ(t2.lazy_get_client(source).call(), source);
+
+            hpx::cout << "." << std::flush;
+
+            std::swap(source, target);
+        }
+
+        hpx::cout << std::endl;
+    }
+    catch (hpx::exception const& e) {
+        hpx::cout << hpx::get_error_what(e) << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
 bool test_migrate_busy_component2(hpx::id_type source, hpx::id_type target)
 {
     test_client t1 = hpx::new_<test_client>(source, 42);
@@ -485,6 +671,8 @@ bool test_migrate_busy_component2(hpx::id_type source, hpx::id_type target)
         hpx::cout << hpx::get_error_what(e) << std::endl;
         return false;
     }
+
+    hpx::cout << std::endl;
 
     return true;
 }
@@ -558,6 +746,83 @@ bool test_migrate_lazy_busy_component2(hpx::id_type source, hpx::id_type target)
         return false;
     }
 
+    hpx::cout << std::endl;
+
+    return true;
+}
+
+bool test_migrate_lazy_busy_component_client2(
+    hpx::id_type source, hpx::id_type target)
+{
+    test_client t1 = hpx::new_<test_client>(source, 42);
+    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+
+    // the new object should live on the source locality
+    HPX_TEST_EQ(t1.call(), source);
+    HPX_TEST_EQ(t1.get_data(), 42);
+
+    std::size_t N = 100;
+
+    // First, spawn a thread (locally) that will migrate the object between
+    // source and target a few times
+    hpx::future<void> migrate_future = hpx::async(
+        [source, target, t1, N]() mutable
+        {
+            for(std::size_t i = 0; i < N; ++i)
+            {
+                // migrate t1 to the target (loc2)
+                test_client t2(hpx::components::migrate(t1, target));
+
+                HPX_TEST_EQ(t1.lazy_get_client(target).call(), target);
+
+                // wait for migration to be done
+                HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+
+                // the migrated object should have the same id as before
+                HPX_TEST_EQ(t1.get_id(), t2.get_id());
+
+                // the migrated object should live on the target now
+                HPX_TEST_EQ(t2.call(), target);
+                HPX_TEST_EQ(t2.lazy_get_client(source).call(), source);
+
+                hpx::cout << "." << std::flush;
+
+                std::swap(source, target);
+            }
+
+            hpx::cout << std::endl;
+        }
+    );
+
+    // Second, we generate tons of work which should automatically follow
+    // the migration.
+    hpx::future<void> create_work = hpx::async(
+        [t1, N, target]()
+        {
+            for(std::size_t i = 0; i < 2*N; ++i)
+            {
+                hpx::cout
+                    << hpx::naming::get_locality_id_from_id(t1.call())
+                    << std::flush;
+                HPX_TEST_EQ(t1.lazy_get_client(target).call(), target);
+            }
+        }
+    );
+
+    hpx::wait_all(migrate_future, create_work);
+
+    // rethrow exceptions
+    try {
+        migrate_future.get();
+        create_work.get();
+    }
+    catch (hpx::exception const& e) {
+        hpx::cout << hpx::get_error_what(e) << std::endl;
+        return false;
+    }
+
+    hpx::cout << std::endl;
+
     return true;
 }
 
@@ -577,6 +842,11 @@ int main()
         HPX_TEST(test_migrate_lazy_component(hpx::find_here(), id));
         hpx::cout << "test_migrate_lazy_component: <-" << id << std::endl;
         HPX_TEST(test_migrate_lazy_component(id, hpx::find_here()));
+
+        hpx::cout << "test_migrate_lazy_component_client: ->" << id << std::endl;
+        HPX_TEST(test_migrate_lazy_component_client(hpx::find_here(), id));
+        hpx::cout << "test_migrate_lazy_component_client: <-" << id << std::endl;
+        HPX_TEST(test_migrate_lazy_component_client(id, hpx::find_here()));
     }
 
     for (hpx::id_type const& id : localities)
@@ -590,6 +860,13 @@ int main()
         HPX_TEST(test_migrate_lazy_busy_component(hpx::find_here(), id));
         hpx::cout << "test_migrate_lazy_busy_component: <-" << id << std::endl;
         HPX_TEST(test_migrate_lazy_busy_component(id, hpx::find_here()));
+
+        hpx::cout << "test_migrate_lazy_busy_component_client: ->" << id
+                  << std::endl;
+        HPX_TEST(test_migrate_lazy_busy_component_client(hpx::find_here(), id));
+        hpx::cout << "test_migrate_lazy_busy_component_client: <-" << id
+                  << std::endl;
+        HPX_TEST(test_migrate_lazy_busy_component_client(id, hpx::find_here()));
     }
 
     for (hpx::id_type const& id : localities)
@@ -603,6 +880,11 @@ int main()
         HPX_TEST(test_migrate_lazy_component2(hpx::find_here(), id));
         hpx::cout << "test_migrate_lazy_component2: <-" << id << std::endl;
         HPX_TEST(test_migrate_lazy_component2(id, hpx::find_here()));
+
+        hpx::cout << "test_migrate_lazy_component_client2: ->" << id << std::endl;
+        HPX_TEST(test_migrate_lazy_component_client2(hpx::find_here(), id));
+        hpx::cout << "test_migrate_lazy_component_client2: <-" << id << std::endl;
+        HPX_TEST(test_migrate_lazy_component_client2(id, hpx::find_here()));
     }
 
     for (hpx::id_type const& id : localities)
@@ -616,6 +898,15 @@ int main()
         HPX_TEST(test_migrate_lazy_busy_component2(hpx::find_here(), id));
         hpx::cout << "test_migrate_lazy_busy_component2: <-" << id << std::endl;
         HPX_TEST(test_migrate_lazy_busy_component2(id, hpx::find_here()));
+
+        hpx::cout << "test_migrate_lazy_busy_component_client2: ->" << id
+                  << std::endl;
+        HPX_TEST(
+            test_migrate_lazy_busy_component_client2(hpx::find_here(), id));
+        hpx::cout << "test_migrate_lazy_busy_component_client2: <-" << id
+                  << std::endl;
+        HPX_TEST(
+            test_migrate_lazy_busy_component_client2(id, hpx::find_here()));
     }
 
     return hpx::util::report_errors();


### PR DESCRIPTION
- flyby: properly unmark as migrated component that do not need to be migrated as target locality is the same as current locality
- flyby: adding missing functions to `gather_here`/`gather_there`

@parsa this should fix the hang in your application, please re-check