### PR TITLE
Check circular dependencies in a circle ci step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,7 @@ jobs:
           name: Check circular dependencies with cpp-dependencies
           command: |
               cpp-dependencies --dir /hpx/source/libs --graph-cycles /hpx/tools/cpp-dependencies/circular_deps.dot
+              dot /hpx/tools/cpp-dependencies/circular_deps.dot -Tsvg -o /hpx/tools/cpp-dependencies/circular_deps.svg
               if [[ $(wc -l /hpx/tools/cpp-dependencies/circular_deps.dot | awk '{print $1}') -gt 2 ]]; then exit 1; fi
 
   configure:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,18 @@ jobs:
             - ./source
             - ./conv.xsl
 
+  # Check circular dependencies with cpp-dependencies tool
+  check_circular_deps:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /hpx
+      - run:
+          name: Check circular dependencies with cpp-dependencies
+          command: |
+              cpp-dependencies --dir /hpx/source/libs --graph-cycles /hpx/tools/cpp-dependencies/circular_deps.dot
+              if [[ $(wc -l /hpx/tools/cpp-dependencies/circular_deps.dot | awk '{print $1}') -gt 2 ]]; then exit 1; fi
+
   configure:
     <<: *defaults
     steps:
@@ -990,6 +1002,10 @@ workflows:
   build-and-test:
     jobs:
       - checkout_code:
+          <<: *gh_pages_filter
+      - check_circular_deps:
+          requires:
+            - checkout_code
           <<: *gh_pages_filter
       - configure:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,9 +106,15 @@ jobs:
       - run:
           name: Check circular dependencies with cpp-dependencies
           command: |
-              cpp-dependencies --dir /hpx/source/libs --graph-cycles /hpx/tools/cpp-dependencies/circular_deps.dot
-              dot /hpx/tools/cpp-dependencies/circular_deps.dot -Tsvg -o /hpx/tools/cpp-dependencies/circular_deps.svg
-              if [[ $(wc -l /hpx/tools/cpp-dependencies/circular_deps.dot | awk '{print $1}') -gt 2 ]]; then exit 1; fi
+              cpp-dependencies --dir /hpx/source/libs --graph-cycles /tmp/circular_deps.dot
+              dot /tmp/circular_deps.dot -Tsvg -o /tmp/circular_deps.svg
+              if [[ $(wc -l /tmp/circular_deps.dot | awk '{print $1}') -gt 2 ]]; then exit 1; fi
+      - store_artifacts:
+          path: /tmp/circular_deps.dot
+          destination: /hpx/artifacts
+      - store_artifacts:
+          path: /tmp/circular_deps.svg
+          destination: /hpx/artifacts
 
   configure:
     <<: *defaults


### PR DESCRIPTION
Check for circular `#include` dependencies for the modules, the `cpp-dependencies` being installed in the Dockerfile from STE||AR-GROUP/docker_build_env
