### PR TITLE
Fix CUDA compilation

### DIFF
--- a/hpx/compute/cuda/allocator.hpp
+++ b/hpx/compute/cuda/allocator.hpp
@@ -172,7 +172,7 @@ namespace hpx { namespace compute { namespace cuda
         template <typename ... Args>
         HPX_HOST_DEVICE void bulk_construct(pointer p, std::size_t count, Args &&... args)
         {
-#if defined(HPX_COMPUTE_DEVICE_CODE)
+#if defined(HPX_COMPUTE_CODE)
             int threads_per_block = (hpx::util::min)(1024, int(count));
             int num_blocks =
                 int((count + threads_per_block - 1) / threads_per_block);
@@ -189,8 +189,6 @@ namespace hpx { namespace compute { namespace cuda
                 },
                 p.device_ptr(), count, std::forward<Args>(args)...);
             target_.synchronize();
-#else
-            HPX_ASSERT(false);
 #endif
         }
 
@@ -199,7 +197,7 @@ namespace hpx { namespace compute { namespace cuda
         template <typename ... Args>
         HPX_HOST_DEVICE void construct(pointer p, Args &&... args)
         {
-#if defined(HPX_COMPUTE_DEVICE_CODE)
+#if defined(HPX_COMPUTE_HOST_CODE) || defined(HPX_COMPUTE_DEVICE_CODE)
             detail::launch(
                 target_, 1, 1,
                 [] HPX_DEVICE (T* p, Args const&... args)
@@ -208,15 +206,13 @@ namespace hpx { namespace compute { namespace cuda
                 },
                 p.device_ptr(), std::forward<Args>(args)...);
             target_.synchronize();
-#else
-            HPX_ASSERT(false);
 #endif
         }
 
         // Calls the destructor of count objects pointed to by p
         HPX_HOST_DEVICE void bulk_destroy(pointer p, std::size_t count)
         {
-#if defined(HPX_COMPUTE_HOST_CODE)
+#if defined(HPX_COMPUTE_HOST_CODE) || defined(HPX_COMPUTE_DEVICE_CODE)
             int threads_per_block = (hpx::util::min)(1024, int(count));
             int num_blocks =
                 int((count + threads_per_block) / threads_per_block) - 1;
@@ -233,8 +229,6 @@ namespace hpx { namespace compute { namespace cuda
                 },
                 p.device_ptr(), count);
             target_.synchronize();
-#else
-            HPX_ASSERT(false);
 #endif
         }
 

--- a/hpx/util/detail/basic_function.hpp
+++ b/hpx/util/detail/basic_function.hpp
@@ -38,7 +38,7 @@ namespace hpx { namespace util { namespace detail
         using vtable = function_base_vtable;
 
     public:
-        HPX_CONSTEXPR function_base(
+        HPX_CONSTEXPR explicit function_base(
             function_base_vtable const* empty_vptr) noexcept
           : vptr(empty_vptr)
           , object(nullptr)

--- a/hpx/util/detail/empty_function.hpp
+++ b/hpx/util/detail/empty_function.hpp
@@ -30,7 +30,10 @@ namespace hpx { namespace util { namespace detail
     template <typename Sig, bool Copyable>
     struct function_vtable;
 
-#if defined(HPX_HAVE_CXX11_CONSTEXPR)
+// NOTE: nvcc (at least CUDA 9.2 and 10.1) fails with an internal compiler error
+// ("there was an error in verifying the lgenfe output!") with this enabled, so
+// we explicitly use the fallback.
+#if defined(HPX_HAVE_CXX11_CONSTEXPR) && !defined(HPX_HAVE_CUDA)
     template <typename Sig>
     HPX_CONSTEXPR function_vtable<Sig, true> const*
     get_empty_function_vtable() noexcept

--- a/libs/config/include/hpx/config/compiler_specific.hpp
+++ b/libs/config/include/hpx/config/compiler_specific.hpp
@@ -96,6 +96,7 @@
 // Detecting CUDA compilation mode
 // Detecting NVCC
 #if defined(__NVCC__) || defined(__CUDACC__)
+#define HPX_COMPUTE_CODE
 # if defined(__CUDA_ARCH__)
 // nvcc compiling CUDA code, device mode.
 #  define HPX_COMPUTE_DEVICE_CODE
@@ -105,6 +106,7 @@
 # endif
 // Detecting NVCC
 #elif defined(__clang__) && defined(__CUDA__)
+#define HPX_COMPUTE_CODE
 # if defined(__CUDA_ARCH__)
 // clang compiling CUDA code, device mode.
 #   define HPX_COMPUTE_DEVICE_CODE

--- a/tests/unit/computeapi/host/CMakeLists.txt
+++ b/tests/unit/computeapi/host/CMakeLists.txt
@@ -7,14 +7,9 @@ set(tests
     block_allocator
    )
 
-include_directories(${CUDA_INCLUDE_DIRS})
-
 foreach(test ${tests})
   set(sources
       ${test}.cpp)
-
-  set(${test}_FLAGS
-    DEPENDENCIES ${CUDA_LIBRARIES} ${CUDA_CUBLAS_LIBRARIES})
 
   source_group("Source Files" FILES ${sources})
 

--- a/tests/unit/computeapi/host/block_allocator.cpp
+++ b/tests/unit/computeapi/host/block_allocator.cpp
@@ -4,7 +4,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/compute.hpp>
+#include <hpx/compute/host.hpp>
 #include <hpx/testing.hpp>
 
 #include <atomic>


### PR DESCRIPTION
Fixes CUDA compilation.

1. `function_base` constructor was `constexpr` which `nvcc` didn't like. This was causing the `there was an error in verifying the lgenfe output!` errors. I couldn't figure out if this is a known bug or not. @K-ballo was the `constexpr` critical for performance?
2. `construct`/`bulk_construct`/`bulk_destroy` didn't instantiate `detail::launch` in device code which meant that kernel launches would fail.