### PR TITLE
Update deprecated header in thread_queue_mc.hpp

### DIFF
--- a/hpx/runtime/threads/policies/thread_queue_mc.hpp
+++ b/hpx/runtime/threads/policies/thread_queue_mc.hpp
@@ -8,21 +8,20 @@
 #define HPX_THREADMANAGER_THREAD_QUEUE_MC
 
 #include <hpx/config.hpp>
+#include <hpx/allocator_support/internal_allocator.hpp>
 #include <hpx/assertion.hpp>
-#include <hpx/error_code.hpp>
+#include <hpx/datastructures/tuple.hpp>
+#include <hpx/errors.hpp>
 #include <hpx/runtime/config_entry.hpp>
 #include <hpx/runtime/threads/policies/lockfree_queue_backends.hpp>
 #include <hpx/runtime/threads/policies/queue_helpers.hpp>
-#include <hpx/runtime/threads/thread_data.hpp>
 #include <hpx/runtime/threads/policies/thread_queue.hpp>
-#include <hpx/throw_exception.hpp>
-#include <hpx/allocator_support/internal_allocator.hpp>
+#include <hpx/runtime/threads/thread_data.hpp>
+#include <hpx/thread_support/unlock_guard.hpp>
+#include <hpx/timing/high_resolution_clock.hpp>
 #include <hpx/util/cache_aligned_data.hpp>
 #include <hpx/util/function.hpp>
 #include <hpx/util/get_and_reset_value.hpp>
-#include <hpx/timing/high_resolution_clock.hpp>
-#include <hpx/thread_support/unlock_guard.hpp>
-#include <hpx/datastructures/tuple.hpp>
 
 #ifdef HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES
 #   include <hpx/util/tick_counter.hpp>


### PR DESCRIPTION
Fixes warnings (and errors on CircleCI) from using the old deprecated headers from the errors module.