### PR TITLE
Fix padding calculation in cache_aligned_data.hpp

### DIFF
--- a/hpx/runtime/threads/topology.hpp
+++ b/hpx/runtime/threads/topology.hpp
@@ -425,7 +425,7 @@ namespace hpx { namespace threads
 
     ///////////////////////////////////////////////////////////////////////////
     // abstract away cache-line size
-    HPX_STATIC_CONSTEXPR std::size_t get_cache_line_size()
+    constexpr std::size_t get_cache_line_size()
     {
 #if defined(HPX_HAVE_CXX17_HARDWARE_DESTRUCTIVE_INTERFERENCE_SIZE)
         return std::hardware_destructive_interference_size;

--- a/hpx/util/cache_aligned_data.hpp
+++ b/hpx/util/cache_aligned_data.hpp
@@ -10,8 +10,21 @@
 #include <hpx/config.hpp>
 #include <hpx/runtime/threads/topology.hpp>
 
-namespace hpx { namespace util
-{
+#include <cstddef>
+
+namespace hpx { namespace util {
+    namespace detail {
+        // Computes the padding required to fill up a full cache line after
+        // data_size bytes.
+        constexpr std::size_t get_cache_line_padding_size(
+            std::size_t data_size)
+        {
+            return (threads::get_cache_line_size() -
+                       (data_size % threads::get_cache_line_size())) %
+                threads::get_cache_line_size();
+        }
+    }    // namespace detail
+
     ///////////////////////////////////////////////////////////////////////////
     // special struct to ensure cache line alignment of a data type
 #if defined(HPX_HAVE_CXX11_ALIGNAS) && defined(HPX_HAVE_CXX17_ALIGNED_NEW) &&  \
@@ -27,8 +40,7 @@ namespace hpx { namespace util
     {
         // pad to cache line size bytes
         Data data_;
-        char cacheline_pad[threads::get_cache_line_size() -
-            (sizeof(Data) % threads::get_cache_line_size())];
+        char cacheline_pad[detail::get_cache_line_padding_size(sizeof(Data))];
     };
 #endif
 
@@ -41,9 +53,7 @@ namespace hpx { namespace util
     struct alignas(threads::get_cache_line_size()) cache_line_data
     {
         Data data_;
-        char cacheline_pad[threads::get_cache_line_size() -
-            (sizeof(Data) % threads::get_cache_line_size())];
-
+        char cacheline_pad[detail::get_cache_line_padding_size(sizeof(Data))];
     };
 #else
     template <typename Data>
@@ -51,10 +61,9 @@ namespace hpx { namespace util
     {
         // pad to cache line size bytes
         Data data_;
-        char cacheline_pad[threads::get_cache_line_size() -
-            (sizeof(Data) % threads::get_cache_line_size())];
+        char cacheline_pad[detail::get_cache_line_padding_size(sizeof(Data))];
     };
 #endif
-}}
+}}    // namespace hpx::util
 
 #endif

--- a/hpx/util/cache_aligned_data.hpp
+++ b/hpx/util/cache_aligned_data.hpp
@@ -40,6 +40,8 @@ namespace hpx { namespace util {
     {
         // pad to cache line size bytes
         Data data_;
+
+        //  cppcheck-suppress unusedVariable
         char cacheline_pad[detail::get_cache_line_padding_size(sizeof(Data))];
     };
 #endif
@@ -53,6 +55,8 @@ namespace hpx { namespace util {
     struct alignas(threads::get_cache_line_size()) cache_line_data
     {
         Data data_;
+
+        //  cppcheck-suppress unusedVariable
         char cacheline_pad[detail::get_cache_line_padding_size(sizeof(Data))];
     };
 #else
@@ -61,6 +65,8 @@ namespace hpx { namespace util {
     {
         // pad to cache line size bytes
         Data data_;
+
+        // cppcheck-suppress unusedVariable
         char cacheline_pad[detail::get_cache_line_padding_size(sizeof(Data))];
     };
 #endif


### PR DESCRIPTION
Correctly sets the padding to 0 when the size of the data is a multiple of the cache line size. If the calculation looks too cryptic I can change it to something a bit more explicit.

I've also made `get_cache_line_padding_size` and `get_cache_line_size` unconditionally `constexpr` since they have to be `constexpr`.