### PR TITLE
Refactoring thread queue configuration options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -624,16 +624,16 @@ hpx_option(HPX_WITH_SPINLOCK_POOL_NUM STRING
 
 hpx_add_config_define(HPX_HAVE_SPINLOCK_POOL_NUM ${HPX_WITH_SPINLOCK_POOL_NUM})
 
-# Count number of terminated threads before forcefully cleaning up all of
-# them. Note: terminated threads are cleaned up either when this number is
-# reached for a particular thread queue or if the HPX_BUSY_LOOP_COUNT_MAX is
-# reached, which will clean up the terminated threads for _all_ thread queues.
+# Deprecated in 1.4.0
 hpx_option(HPX_SCHEDULER_MAX_TERMINATED_THREADS STRING
-  "Maximum number of terminated threads collected before those are cleaned up (default: 100)"
-  "100" CATEGORY "Thread Manager" ADVANCED)
+  "[Deprecated] Maximum number of terminated threads collected before those are cleaned up (default: 100)"
+  "0" CATEGORY "Thread Manager" ADVANCED)
 
-hpx_add_config_define(HPX_SCHEDULER_MAX_TERMINATED_THREADS
-  ${HPX_SCHEDULER_MAX_TERMINATED_THREADS})
+if(HPX_SCHEDULER_MAX_TERMINATED_THREADS GREATER 0)
+  hpx_warn("HPX_SCHEDULER_MAX_TERMINATED_THREADS is deprecated and will be removed in a future release. Use the configuration option hpx.thread_queue.max_terminated_threads instead to set the value.")
+  hpx_add_config_define(HPX_THREAD_QUEUE_MAX_TERMINATED_THREADS
+    ${HPX_SCHEDULER_MAX_TERMINATED_THREADS})
+endif()
 
 hpx_option(HPX_WITH_SWAP_CONTEXT_EMULATION BOOL
   "Emulate SwapContext API for coroutines (default: OFF)"

--- a/examples/resource_partitioner/async_customization.cpp
+++ b/examples/resource_partitioner/async_customization.cpp
@@ -503,12 +503,15 @@ int main(int argc, char** argv)
     using hpx::threads::policies::scheduler_mode;
     // setup the default pool with our custom priority scheduler
     rp.create_thread_pool("custom",
-        [](hpx::threads::thread_pool_init_parameters init)
+        [](hpx::threads::thread_pool_init_parameters init,
+            hpx::threads::policies::thread_queue_init_parameters
+                thread_queue_init)
             -> std::unique_ptr<hpx::threads::thread_pool_base> {
-            std::cout << "User defined scheduler creation callback " << std::endl;
+            high_priority_sched::init_parameter_type scheduler_init(
+                init.num_threads_, {6, 6, 64}, init.affinity_data_,
+                thread_queue_init, "shared-priority-scheduler");
             std::unique_ptr<high_priority_sched> scheduler(
-                new high_priority_sched(init.num_threads_, {6, 6, 64},
-                    "shared-priority-scheduler", init.affinity_data_));
+                new high_priority_sched(scheduler_init));
 
             init.mode_ = scheduler_mode(scheduler_mode::do_background_work |
                 scheduler_mode::delay_exit);

--- a/examples/resource_partitioner/guided_pool_test.cpp
+++ b/examples/resource_partitioner/guided_pool_test.cpp
@@ -260,13 +260,18 @@ int main(int argc, char* argv[])
     // create a thread pool and supply a lambda that returns a new pool with
     // a user supplied scheduler attached
     rp.create_thread_pool(CUSTOM_POOL_NAME,
-        [](hpx::threads::thread_pool_init_parameters init)
+        [](hpx::threads::thread_pool_init_parameters init,
+            hpx::threads::policies::thread_queue_init_parameters
+                thread_queue_init)
             -> std::unique_ptr<hpx::threads::thread_pool_base> {
             std::cout << "User defined scheduler creation callback "
                       << std::endl;
+
+            high_priority_sched::init_parameter_type scheduler_init(
+                init.num_threads_, {6, 6, 64}, init.affinity_data_,
+                thread_queue_init, "shared-priority-scheduler");
             std::unique_ptr<high_priority_sched> scheduler(
-                new high_priority_sched(init.num_threads_, {6, 6, 64},
-                    "shared-priority-scheduler", init.affinity_data_));
+                new high_priority_sched(scheduler_init));
 
             init.mode_ = scheduler_mode(scheduler_mode::delay_exit);
 

--- a/examples/resource_partitioner/oversubscribing_resource_partitioner.cpp
+++ b/examples/resource_partitioner/oversubscribing_resource_partitioner.cpp
@@ -277,15 +277,18 @@ int main(int argc, char* argv[])
     // create a thread pool and supply a lambda that returns a new pool with
     // the a user supplied scheduler attached
     rp.create_thread_pool("default",
-        [](hpx::threads::thread_pool_init_parameters init)
+        [](hpx::threads::thread_pool_init_parameters init,
+            hpx::threads::policies::thread_queue_init_parameters
+                thread_queue_init)
             -> std::unique_ptr<hpx::threads::thread_pool_base> {
             std::cout << "User defined scheduler creation callback "
                       << std::endl;
 
+            high_priority_sched::init_parameter_type scheduler_init(
+                init.num_threads_, {4, 4, 64}, init.affinity_data_,
+                thread_queue_init, "shared-priority-scheduler");
             std::unique_ptr<high_priority_sched> scheduler(
-                new high_priority_sched(init.num_threads_,
-                    hpx::threads::policies::core_ratios(4, 4, 64),
-                    "shared-priority-scheduler", init.affinity_data_));
+                new high_priority_sched(scheduler_init));
 
             init.mode_ = scheduler_mode(scheduler_mode::do_background_work |
                 scheduler_mode::delay_exit);
@@ -308,14 +311,18 @@ int main(int argc, char* argv[])
         // create a thread pool and supply a lambda that returns a new pool with
         // the a user supplied scheduler attached
         rp.create_thread_pool("mpi",
-            [](hpx::threads::thread_pool_init_parameters init)
+            [](hpx::threads::thread_pool_init_parameters init,
+                hpx::threads::policies::thread_queue_init_parameters
+                    thread_queue_init)
                 -> std::unique_ptr<hpx::threads::thread_pool_base> {
                 std::cout << "User defined scheduler creation callback "
                           << std::endl;
+
+                high_priority_sched::init_parameter_type scheduler_init(
+                    init.num_threads_, {4, 4, 64}, init.affinity_data_,
+                    thread_queue_init, "shared-priority-scheduler");
                 std::unique_ptr<high_priority_sched> scheduler(
-                    new high_priority_sched(init.num_threads_,
-                        hpx::threads::policies::core_ratios(4, 4, 64),
-                        "shared-priority-scheduler", init.affinity_data_));
+                    new high_priority_sched(scheduler_init));
 
                 init.mode_ = scheduler_mode(scheduler_mode::delay_exit);
 

--- a/examples/resource_partitioner/shared_priority_queue_scheduler.hpp
+++ b/examples/resource_partitioner/shared_priority_queue_scheduler.hpp
@@ -187,18 +187,6 @@ namespace hpx { namespace threads { namespace policies { namespace example {
             default_shared_priority_queue_scheduler_terminated_queue>
     class shared_priority_queue_scheduler : public scheduler_base
     {
-    protected:
-        // The maximum number of active threads this thread manager should
-        // create. This number will be a constraint only as long as the work
-        // items queue is not empty. Otherwise the number of active threads
-        // will be incremented in steps equal to the \a min_add_new_count
-        // specified above.
-        // FIXME: this is specified both here, and in thread_queue.
-        enum
-        {
-            max_thread_count = 1000
-        };
-
     public:
         typedef std::false_type has_periodic_maintenance;
 
@@ -206,24 +194,55 @@ namespace hpx { namespace threads { namespace policies { namespace example {
             TerminatedQueuing>
             thread_queue_type;
 
-        shared_priority_queue_scheduler(std::size_t num_worker_threads,
-            core_ratios cores_per_queue,
-            char const* description,
-            detail::affinity_data const& affinity_data,
-            int max_tasks = max_thread_count)
-          : scheduler_base(num_worker_threads, description)
-          , cores_per_queue_(cores_per_queue)
-          , max_queue_thread_count_(max_tasks)
-          , num_workers_(num_worker_threads)
+        struct init_parameter
+        {
+            init_parameter(std::size_t num_worker_threads,
+                core_ratios cores_per_queue,
+                detail::affinity_data const& affinity_data,
+                thread_queue_init_parameters thread_queue_init = {},
+                char const* description = "shared_priority_queue_scheduler")
+              : num_worker_threads_(num_worker_threads)
+              , cores_per_queue_(cores_per_queue)
+              , thread_queue_init_(thread_queue_init)
+              , affinity_data_(affinity_data)
+              , description_(description)
+            {
+            }
+
+            init_parameter(std::size_t num_worker_threads,
+                core_ratios cores_per_queue,
+                detail::affinity_data const& affinity_data,
+                char const* description)
+              : num_worker_threads_(num_worker_threads)
+              , cores_per_queue_(cores_per_queue)
+              , thread_queue_init_()
+              , affinity_data_(affinity_data)
+              , description_(description)
+            {
+            }
+
+            std::size_t num_worker_threads_;
+            core_ratios cores_per_queue_;
+            thread_queue_init_parameters thread_queue_init_;
+            detail::affinity_data const& affinity_data_;
+            char const* description_;
+        };
+        typedef init_parameter init_parameter_type;
+
+        explicit shared_priority_queue_scheduler(init_parameter const& init)
+          : scheduler_base(init.num_worker_threads_, init.description_,
+                init.thread_queue_init_)
+          , cores_per_queue_(init.cores_per_queue_)
+          , num_workers_(init.num_worker_threads_)
           , num_domains_(1)
-          , affinity_data_(affinity_data)
+          , affinity_data_(init.affinity_data_)
           , initialized_(false)
         {
             LOG_CUSTOM_MSG(
                 "Constructing shared_priority_queue_scheduler with num threads "
                 << decnumber(num_worker_threads));
             //
-            HPX_ASSERT(num_worker_threads != 0);
+            HPX_ASSERT(num_workers_ != 0);
         }
 
         virtual ~shared_priority_queue_scheduler()
@@ -1415,7 +1434,7 @@ namespace hpx { namespace threads { namespace policies { namespace example {
                         q_counts_[i] / cores_per_queue_.high_priority,
                         std::size_t(1));
                     hp_queues_[i].init(
-                        q_counts_[i], queues, max_queue_thread_count_);
+                        q_counts_[i], queues, thread_queue_init_);
                     LOG_CUSTOM_MSG2("Created HP queue for numa " << i
                                     << " cores " << q_counts_[i]
                                     << " queues " << queues);
@@ -1423,7 +1442,7 @@ namespace hpx { namespace threads { namespace policies { namespace example {
                     queues = (std::max)(q_counts_[i] / cores_per_queue_.normal_priority,
                         std::size_t(1));
                     np_queues_[i].init(
-                        q_counts_[i], queues, max_queue_thread_count_);
+                        q_counts_[i], queues, thread_queue_init_);
                     LOG_CUSTOM_MSG2("Created NP queue for numa " << i
                                     << " cores " << q_counts_[i]
                                     << " queues " << queues);
@@ -1431,7 +1450,7 @@ namespace hpx { namespace threads { namespace policies { namespace example {
                     queues = (std::max)(q_counts_[i] / cores_per_queue_.low_priority,
                         std::size_t(1));
                     lp_queues_[i].init(
-                        q_counts_[i], queues, max_queue_thread_count_);
+                        q_counts_[i], queues, thread_queue_init_);
                     LOG_CUSTOM_MSG2("Created LP queue for numa " << i
                                     << " cores " << q_counts_[i]
                                     << " queues " << queues);
@@ -1550,9 +1569,6 @@ namespace hpx { namespace threads { namespace policies { namespace example {
 
         // number of cores per queue for HP, NP, LP queues
         core_ratios cores_per_queue_;
-
-        // max storage size of any queue
-        std::size_t max_queue_thread_count_;
 
         // number of worker threads assigned to this pool
         std::size_t num_workers_;

--- a/examples/resource_partitioner/simple_resource_partitioner.cpp
+++ b/examples/resource_partitioner/simple_resource_partitioner.cpp
@@ -266,15 +266,18 @@ int main(int argc, char* argv[])
     // create a thread pool and supply a lambda that returns a new pool with
     // the a user supplied scheduler attached
     rp.create_thread_pool("default",
-        [](hpx::threads::thread_pool_init_parameters init)
+        [](hpx::threads::thread_pool_init_parameters init,
+            hpx::threads::policies::thread_queue_init_parameters
+                thread_queue_init)
             -> std::unique_ptr<hpx::threads::thread_pool_base> {
             std::cout << "User defined scheduler creation callback "
                       << std::endl;
 
+            high_priority_sched::init_parameter_type scheduler_init(
+                init.num_threads_, {4, 4, 64}, init.affinity_data_,
+                thread_queue_init, "shared-priority-scheduler");
             std::unique_ptr<high_priority_sched> scheduler(
-                new high_priority_sched(init.num_threads_,
-                    hpx::threads::policies::core_ratios(4, 4, 64),
-                    "shared-priority-scheduler", init.affinity_data_));
+                new high_priority_sched(scheduler_init));
 
             init.mode_ = scheduler_mode(scheduler_mode::do_background_work |
                 scheduler_mode::delay_exit);
@@ -295,14 +298,18 @@ int main(int argc, char* argv[])
         // create a thread pool and supply a lambda that returns a new pool with
         // the a user supplied scheduler attached
         rp.create_thread_pool("mpi",
-            [](hpx::threads::thread_pool_init_parameters init)
+            [](hpx::threads::thread_pool_init_parameters init,
+                hpx::threads::policies::thread_queue_init_parameters
+                    thread_queue_init)
                 -> std::unique_ptr<hpx::threads::thread_pool_base> {
                 std::cout << "User defined scheduler creation callback "
                           << std::endl;
+
+                high_priority_sched::init_parameter_type scheduler_init(
+                    init.num_threads_, {4, 4, 64}, init.affinity_data_,
+                    thread_queue_init, "shared-priority-scheduler");
                 std::unique_ptr<high_priority_sched> scheduler(
-                    new high_priority_sched(init.num_threads_,
-                        hpx::threads::policies::core_ratios(4, 4, 64),
-                        "shared-priority-scheduler", init.affinity_data_));
+                    new high_priority_sched(scheduler_init));
 
                 init.mode_ = scheduler_mode(scheduler_mode::delay_exit);
 

--- a/hpx/plugins/parcelport_factory_base.hpp
+++ b/hpx/plugins/parcelport_factory_base.hpp
@@ -8,7 +8,7 @@
 #define HPX_PLUGINS_PARCELPORT_FACTORY_BASE_HPP
 
 #include <hpx/config.hpp>
-#include <hpx/runtime/threads_fwd.hpp>
+#include <hpx/runtime/threads/policies/callback_notifier.hpp>
 #include <hpx/util_fwd.hpp>
 
 #include <cstddef>

--- a/hpx/runtime/resource/detail/partitioner.hpp
+++ b/hpx/runtime/resource/detail/partitioner.hpp
@@ -12,6 +12,7 @@
 #include <hpx/runtime/runtime_mode.hpp>
 #include <hpx/topology/cpu_mask.hpp>
 #include <hpx/runtime/threads/policies/affinity_data.hpp>
+#include <hpx/runtime/threads/policies/scheduler_mode.hpp>
 #include <hpx/topology/topology.hpp>
 #include <hpx/util/command_line_handling.hpp>
 #include <hpx/datastructures/tuple.hpp>
@@ -52,12 +53,11 @@ namespace hpx { namespace resource { namespace detail
         static std::size_t num_threads_overall;
 
     private:
-        init_pool_data(const std::string &name,
-            scheduling_policy = scheduling_policy::unspecified,
-            hpx::threads::policies::scheduler_mode =
-                hpx::threads::policies::scheduler_mode::default_mode);
+        init_pool_data(const std::string& name, scheduling_policy policy,
+            hpx::threads::policies::scheduler_mode mode);
 
-        init_pool_data(std::string const& name, scheduler_function create_func);
+        init_pool_data(std::string const& name, scheduler_function create_func,
+            hpx::threads::policies::scheduler_mode mode);
 
         std::string pool_name_;
         scheduling_policy scheduling_policy_;
@@ -253,6 +253,8 @@ namespace hpx { namespace resource { namespace detail
 
         // topology information
         threads::topology& topo_;
+
+        threads::policies::scheduler_mode default_scheduler_mode_;
     };
 }}}
 

--- a/hpx/runtime/resource/partitioner_fwd.hpp
+++ b/hpx/runtime/resource/partitioner_fwd.hpp
@@ -8,7 +8,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/runtime/threads/detail/network_background_callback.hpp>
-#include <hpx/runtime/threads_fwd.hpp>
+#include <hpx/runtime/threads/policies/thread_queue_init_parameters.hpp>
+#include <hpx/runtime/threads/thread_pool_base.hpp>
 #include <hpx/util/function.hpp>
 
 #include <cstddef>
@@ -54,7 +55,8 @@ namespace hpx
 
         using scheduler_function = util::function_nonser<
             std::unique_ptr<hpx::threads::thread_pool_base>(
-                hpx::threads::thread_pool_init_parameters)>;
+                hpx::threads::thread_pool_init_parameters,
+                hpx::threads::policies::thread_queue_init_parameters)>;
 
         // Choose same names as in command-line options except with _ instead of
         // -.

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -390,9 +390,9 @@ namespace hpx { namespace threads { namespace detail
         thread_id_type background_thread;
         background_running.reset(new bool(true));
         thread_init_data background_init(
-            [&, background_running](thread_state_ex_enum) -> thread_result_type
-            {
-                while(*background_running)
+            [&, background_running](
+                thread_state_ex_enum) -> thread_result_type {
+                while (*background_running)
                 {
                     if (callbacks.background_())
                     {
@@ -402,17 +402,15 @@ namespace hpx { namespace threads { namespace detail
                         if (*background_running)
                             idle_loop_count = callbacks.max_idle_loop_count_;
                     }
-                    hpx::this_thread::suspend(hpx::threads::pending,
-                        "background_work");
+                    hpx::this_thread::suspend(
+                        hpx::threads::pending, "background_work");
                 }
 
                 return thread_result_type(terminated, invalid_thread_id);
             },
             hpx::util::thread_description("background_work"),
-            thread_priority_high_recursive,
-            schedulehint,
-            get_stack_size(thread_stacksize_large),
-            &scheduler);
+            thread_priority_high_recursive, schedulehint,
+            scheduler.get_stack_size(thread_stacksize_large), &scheduler);
 
         // Create in suspended to prevent the thread from being scheduled
         // directly...

--- a/hpx/runtime/threads/executors/thread_pool_os_executors.hpp
+++ b/hpx/runtime/threads/executors/thread_pool_os_executors.hpp
@@ -7,6 +7,7 @@
 #define HPX_RUNTIME_THREADS_EXECUTORS_THREAD_POOL_OS_EXECUTORS_HPP
 
 #include <hpx/config.hpp>
+#include <hpx/datastructures/optional.hpp>
 #include <hpx/runtime/resource/detail/partitioner.hpp>
 #include <hpx/runtime/threads/detail/scheduled_thread_pool.hpp>
 #include <hpx/runtime/threads/policies/affinity_data.hpp>
@@ -27,10 +28,8 @@
 
 #include <hpx/config/warnings_prefix.hpp>
 
-namespace hpx { namespace threads { namespace executors
-{
-    namespace detail
-    {
+namespace hpx { namespace threads { namespace executors {
+    namespace detail {
         //////////////////////////////////////////////////////////////////////
         template <typename Scheduler>
         class HPX_EXPORT thread_pool_os_executor
@@ -38,13 +37,15 @@ namespace hpx { namespace threads { namespace executors
         {
         public:
             thread_pool_os_executor(std::size_t num_threads,
-                policies::detail::affinity_data const& affinity_data);
+                policies::detail::affinity_data const& affinity_data,
+                util::optional<policies::callback_notifier> notifier =
+                    util::nullopt);
             ~thread_pool_os_executor();
 
             // Schedule the specified function for execution in this executor.
             // Depending on the subclass implementation, this may block in some
             // situations.
-            void add(closure_type && f,
+            void add(closure_type&& f,
                 util::thread_description const& description,
                 threads::thread_state_enum initial_state, bool run_now,
                 threads::thread_stacksize stacksize,
@@ -54,17 +55,15 @@ namespace hpx { namespace threads { namespace executors
             // Schedule given function for execution in this executor no sooner
             // than time abs_time. This call never blocks, and may violate
             // bounds on the executor's queue size.
-            void add_at(
-                util::steady_clock::time_point const& abs_time,
-                closure_type && f, util::thread_description const& description,
+            void add_at(util::steady_clock::time_point const& abs_time,
+                closure_type&& f, util::thread_description const& description,
                 threads::thread_stacksize stacksize, error_code& ec) override;
 
             // Schedule given function for execution in this executor no sooner
             // than time rel_time from now. This call never blocks, and may
             // violate bounds on the executor's queue size.
-            void add_after(
-                util::steady_clock::duration const& rel_time,
-                closure_type && f, util::thread_description const& description,
+            void add_after(util::steady_clock::duration const& rel_time,
+                closure_type&& f, util::thread_description const& description,
                 threads::thread_stacksize stacksize, error_code& ec) override;
 
             // Return an estimate of the number of waiting tasks.
@@ -99,7 +98,7 @@ namespace hpx { namespace threads { namespace executors
 
         private:
             // the scheduler used by this executor
-            Scheduler *scheduler_;
+            Scheduler* scheduler_;
             std::string executor_name_;
             threads::policies::callback_notifier notifier_;
             std::unique_ptr<threads::detail::scheduled_thread_pool<Scheduler>>
@@ -116,14 +115,16 @@ namespace hpx { namespace threads { namespace executors
             typedef std::mutex mutex_type;
             mutable mutex_type mtx_;
         };
-    }
+    }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
 #if defined(HPX_HAVE_LOCAL_SCHEDULER)
     struct HPX_EXPORT local_queue_os_executor : public scheduled_executor
     {
         local_queue_os_executor(std::size_t num_threads,
-            policies::detail::affinity_data const& affinity_data);
+            policies::detail::affinity_data const& affinity_data,
+            util::optional<policies::callback_notifier> notifier =
+                util::nullopt);
     };
 #endif
 
@@ -131,7 +132,9 @@ namespace hpx { namespace threads { namespace executors
     struct HPX_EXPORT static_queue_os_executor : public scheduled_executor
     {
         static_queue_os_executor(std::size_t num_threads,
-            policies::detail::affinity_data const& affinity_data);
+            policies::detail::affinity_data const& affinity_data,
+            util::optional<policies::callback_notifier> notifier =
+                util::nullopt);
     };
 #endif
 
@@ -139,7 +142,9 @@ namespace hpx { namespace threads { namespace executors
       : public scheduled_executor
     {
         local_priority_queue_os_executor(std::size_t num_threads,
-            policies::detail::affinity_data const& affinity_data);
+            policies::detail::affinity_data const& affinity_data,
+            util::optional<policies::callback_notifier> notifier =
+                util::nullopt);
     };
 
 #if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
@@ -147,10 +152,12 @@ namespace hpx { namespace threads { namespace executors
       : public scheduled_executor
     {
         static_priority_queue_os_executor(std::size_t num_threads,
-            policies::detail::affinity_data const& affinity_data);
+            policies::detail::affinity_data const& affinity_data,
+            util::optional<policies::callback_notifier> notifier =
+                util::nullopt);
     };
 #endif
-}}}
+}}}    // namespace hpx::threads::executors
 
 #include <hpx/config/warnings_suffix.hpp>
 

--- a/hpx/runtime/threads/policies/callback_notifier.hpp
+++ b/hpx/runtime/threads/policies/callback_notifier.hpp
@@ -7,7 +7,6 @@
 #define HPX_THREADMANAGER_POLICIES_CALLBACK_NOTIFIER_JUN_18_2009_1132AM
 
 #include <hpx/config.hpp>
-#include <hpx/runtime/threads_fwd.hpp>
 #include <hpx/util/function.hpp>
 
 #include <cstddef>
@@ -18,7 +17,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace threads { namespace policies {
-    class callback_notifier
+    class HPX_EXPORT callback_notifier
     {
     public:
         typedef util::function_nonser<void(

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -4,7 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(HPX_THREADMANAGER_SCHEDULING_LOCAL_PRIORITY_QUEUE_MAR_15_2011_0926AM)
+#if !defined(                                                                  \
+    HPX_THREADMANAGER_SCHEDULING_LOCAL_PRIORITY_QUEUE_MAR_15_2011_0926AM)
 #define HPX_THREADMANAGER_SCHEDULING_LOCAL_PRIORITY_QUEUE_MAR_15_2011_0926AM
 
 #include <hpx/config.hpp>
@@ -16,8 +17,8 @@
 #include <hpx/runtime/threads/policies/lockfree_queue_backends.hpp>
 #include <hpx/runtime/threads/policies/scheduler_base.hpp>
 #include <hpx/runtime/threads/policies/thread_queue.hpp>
+#include <hpx/runtime/threads/policies/thread_queue_init_parameters.hpp>
 #include <hpx/runtime/threads/thread_data.hpp>
-#include <hpx/runtime/threads_fwd.hpp>
 #include <hpx/topology/topology.hpp>
 #include <hpx/util_fwd.hpp>
 
@@ -37,8 +38,7 @@
 // TODO: add branch prediction and function heat
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace threads { namespace policies
-{
+namespace hpx { namespace threads { namespace policies {
 #ifdef HPX_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION
     ///////////////////////////////////////////////////////////////////////////
     // We globally control whether to do minimal deadlock detection using this
@@ -71,21 +71,12 @@ namespace hpx { namespace threads { namespace policies
             default_local_priority_queue_scheduler_terminated_queue>
     class HPX_EXPORT local_priority_queue_scheduler : public scheduler_base
     {
-    protected:
-        // The maximum number of active threads this thread manager should
-        // create. This number will be a constraint only as long as the work
-        // items queue is not empty. Otherwise the number of active threads
-        // will be incremented in steps equal to the \a min_add_new_count
-        // specified above.
-        // FIXME: this is specified both here, and in thread_queue.
-        enum { max_thread_count = 1000 };
-
     public:
         typedef std::false_type has_periodic_maintenance;
 
-        typedef thread_queue<
-            Mutex, PendingQueuing, StagedQueuing, TerminatedQueuing
-        > thread_queue_type;
+        typedef thread_queue<Mutex, PendingQueuing, StagedQueuing,
+            TerminatedQueuing>
+            thread_queue_type;
 
         // the scheduler type takes two initialization parameters:
         //    the number of queues
@@ -96,52 +87,55 @@ namespace hpx { namespace threads { namespace policies
             init_parameter(std::size_t num_queues,
                 detail::affinity_data const& affinity_data,
                 std::size_t num_high_priority_queues = std::size_t(-1),
-                std::size_t max_queue_thread_count = max_thread_count,
                 std::size_t numa_sensitive = 0,
+                thread_queue_init_parameters thread_queue_init = {},
                 char const* description = "local_priority_queue_scheduler")
               : num_queues_(num_queues)
               , num_high_priority_queues_(
                     num_high_priority_queues == std::size_t(-1) ?
                         num_queues :
                         num_high_priority_queues)
-              , max_queue_thread_count_(max_queue_thread_count)
               , numa_sensitive_(numa_sensitive)
+              , thread_queue_init_(thread_queue_init)
               , affinity_data_(affinity_data)
               , description_(description)
-            {}
+            {
+            }
 
             init_parameter(std::size_t num_queues,
-                detail::affinity_data const& affinity_data, char const* description)
+                detail::affinity_data const& affinity_data,
+                char const* description)
               : num_queues_(num_queues)
               , num_high_priority_queues_(num_queues)
-              , max_queue_thread_count_(max_thread_count)
               , numa_sensitive_(false)
+              , thread_queue_init_()
               , affinity_data_(affinity_data)
               , description_(description)
-            {}
+            {
+            }
 
             std::size_t num_queues_;
             std::size_t num_high_priority_queues_;
-            std::size_t max_queue_thread_count_;
             std::size_t numa_sensitive_;
+            thread_queue_init_parameters thread_queue_init_;
             detail::affinity_data const& affinity_data_;
             char const* description_;
         };
         typedef init_parameter init_parameter_type;
 
         local_priority_queue_scheduler(init_parameter_type const& init,
-                bool deferred_initialization = true)
-          : scheduler_base(init.num_queues_, init.description_),
-            max_queue_thread_count_(init.max_queue_thread_count_),
-            curr_queue_(0),
-            numa_sensitive_(init.numa_sensitive_),
-            affinity_data_(init.affinity_data_),
-            num_queues_(init.num_queues_),
-            num_high_priority_queues_(init.num_high_priority_queues_),
-            low_priority_queue_(init.max_queue_thread_count_),
-            queues_(num_queues_),
-            high_priority_queues_(num_queues_),
-            victim_threads_(num_queues_)
+            bool deferred_initialization = true)
+          : scheduler_base(
+                init.num_queues_, init.description_, init.thread_queue_init_)
+          , curr_queue_(0)
+          , numa_sensitive_(init.numa_sensitive_)
+          , affinity_data_(init.affinity_data_)
+          , num_queues_(init.num_queues_)
+          , num_high_priority_queues_(init.num_high_priority_queues_)
+          , low_priority_queue_(0, thread_queue_init_)
+          , queues_(num_queues_)
+          , high_priority_queues_(num_queues_)
+          , victim_threads_(num_queues_)
         {
             if (!deferred_initialization)
             {
@@ -149,7 +143,7 @@ namespace hpx { namespace threads { namespace policies
                 for (std::size_t i = 0; i != num_queues_; ++i)
                 {
                     queues_[i].data_ =
-                        new thread_queue_type(init.max_queue_thread_count_);
+                        new thread_queue_type(i, thread_queue_init_);
                 }
 
                 HPX_ASSERT(num_high_priority_queues_ != 0);
@@ -157,7 +151,7 @@ namespace hpx { namespace threads { namespace policies
                 for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
                 {
                     high_priority_queues_[i].data_ =
-                        new thread_queue_type(init.max_queue_thread_count_);
+                        new thread_queue_type(i, thread_queue_init_);
                 }
                 for (std::size_t i = num_high_priority_queues_;
                      i != num_queues_; ++i)
@@ -180,7 +174,10 @@ namespace hpx { namespace threads { namespace policies
             }
         }
 
-        bool numa_sensitive() const override { return numa_sensitive_ != 0; }
+        bool numa_sensitive() const override
+        {
+            return numa_sensitive_ != 0;
+        }
 
         static std::string get_scheduler_name()
         {
@@ -194,7 +191,8 @@ namespace hpx { namespace threads { namespace policies
 
             for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
             {
-                time += high_priority_queues_[i].data_->get_creation_time(reset);
+                time +=
+                    high_priority_queues_[i].data_->get_creation_time(reset);
             }
 
             time += low_priority_queue_.get_creation_time(reset);
@@ -234,32 +232,33 @@ namespace hpx { namespace threads { namespace policies
             {
                 for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
                 {
-                    num_pending_misses += high_priority_queues_[i].data_->
-                        get_num_pending_misses(reset);
+                    num_pending_misses +=
+                        high_priority_queues_[i].data_->get_num_pending_misses(
+                            reset);
                 }
                 for (std::size_t i = 0; i != num_queues_; ++i)
                 {
                     num_pending_misses +=
                         queues_[i].data_->get_num_pending_misses(reset);
                 }
-                num_pending_misses += low_priority_queue_.
-                    get_num_pending_misses(reset);
+                num_pending_misses +=
+                    low_priority_queue_.get_num_pending_misses(reset);
 
                 return num_pending_misses;
             }
 
-            num_pending_misses += queues_[num_thread].data_->
-                get_num_pending_misses(reset);
+            num_pending_misses +=
+                queues_[num_thread].data_->get_num_pending_misses(reset);
 
             if (num_thread < num_high_priority_queues_)
             {
-                num_pending_misses += high_priority_queues_[num_thread].data_->
-                    get_num_pending_misses(reset);
+                num_pending_misses += high_priority_queues_[num_thread]
+                                          .data_->get_num_pending_misses(reset);
             }
-            if (num_thread == num_queues_-1)
+            if (num_thread == num_queues_ - 1)
             {
-                num_pending_misses += low_priority_queue_.
-                    get_num_pending_misses(reset);
+                num_pending_misses +=
+                    low_priority_queue_.get_num_pending_misses(reset);
             }
             return num_pending_misses;
         }
@@ -272,32 +271,34 @@ namespace hpx { namespace threads { namespace policies
             {
                 for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
                 {
-                    num_pending_accesses += high_priority_queues_[i].data_->
-                        get_num_pending_accesses(reset);
+                    num_pending_accesses +=
+                        high_priority_queues_[i]
+                            .data_->get_num_pending_accesses(reset);
                 }
                 for (std::size_t i = 0; i != num_queues_; ++i)
                 {
-                    num_pending_accesses += queues_[i].data_->
-                        get_num_pending_accesses(reset);
+                    num_pending_accesses +=
+                        queues_[i].data_->get_num_pending_accesses(reset);
                 }
-                num_pending_accesses += low_priority_queue_.
-                    get_num_pending_accesses(reset);
+                num_pending_accesses +=
+                    low_priority_queue_.get_num_pending_accesses(reset);
 
                 return num_pending_accesses;
             }
 
-            num_pending_accesses += queues_[num_thread].data_->
-                get_num_pending_accesses(reset);
+            num_pending_accesses +=
+                queues_[num_thread].data_->get_num_pending_accesses(reset);
 
             if (num_thread < num_high_priority_queues_)
             {
-                num_pending_accesses += high_priority_queues_[num_thread].data_->
-                    get_num_pending_accesses(reset);
+                num_pending_accesses +=
+                    high_priority_queues_[num_thread]
+                        .data_->get_num_pending_accesses(reset);
             }
-            if (num_thread == num_queues_-1)
+            if (num_thread == num_queues_ - 1)
             {
-                num_pending_accesses += low_priority_queue_.
-                    get_num_pending_accesses(reset);
+                num_pending_accesses +=
+                    low_priority_queue_.get_num_pending_accesses(reset);
             }
             return num_pending_accesses;
         }
@@ -310,32 +311,34 @@ namespace hpx { namespace threads { namespace policies
             {
                 for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
                 {
-                    num_stolen_threads += high_priority_queues_[i].data_->
-                        get_num_stolen_from_pending(reset);
+                    num_stolen_threads +=
+                        high_priority_queues_[i]
+                            .data_->get_num_stolen_from_pending(reset);
                 }
                 for (std::size_t i = 0; i != num_queues_; ++i)
                 {
-                    num_stolen_threads += queues_[i].data_->
-                        get_num_stolen_from_pending(reset);
+                    num_stolen_threads +=
+                        queues_[i].data_->get_num_stolen_from_pending(reset);
                 }
-                num_stolen_threads += low_priority_queue_.
-                    get_num_stolen_from_pending(reset);
+                num_stolen_threads +=
+                    low_priority_queue_.get_num_stolen_from_pending(reset);
 
                 return num_stolen_threads;
             }
 
-            num_stolen_threads += queues_[num_thread].data_->
-                get_num_stolen_from_pending(reset);
+            num_stolen_threads +=
+                queues_[num_thread].data_->get_num_stolen_from_pending(reset);
 
             if (num_thread < num_high_priority_queues_)
             {
-                num_stolen_threads += high_priority_queues_[num_thread].data_->
-                    get_num_stolen_from_pending(reset);
+                num_stolen_threads +=
+                    high_priority_queues_[num_thread]
+                        .data_->get_num_stolen_from_pending(reset);
             }
-            if (num_thread == num_queues_-1)
+            if (num_thread == num_queues_ - 1)
             {
-                num_stolen_threads += low_priority_queue_.
-                    get_num_stolen_from_pending(reset);
+                num_stolen_threads +=
+                    low_priority_queue_.get_num_stolen_from_pending(reset);
             }
             return num_stolen_threads;
         }
@@ -348,32 +351,34 @@ namespace hpx { namespace threads { namespace policies
             {
                 for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
                 {
-                    num_stolen_threads += high_priority_queues_[i].data_->
-                        get_num_stolen_to_pending(reset);
+                    num_stolen_threads +=
+                        high_priority_queues_[i]
+                            .data_->get_num_stolen_to_pending(reset);
                 }
                 for (std::size_t i = 0; i != num_queues_; ++i)
                 {
-                    num_stolen_threads += queues_[i].data_->
-                        get_num_stolen_to_pending(reset);
+                    num_stolen_threads +=
+                        queues_[i].data_->get_num_stolen_to_pending(reset);
                 }
-                num_stolen_threads += low_priority_queue_.
-                    get_num_stolen_to_pending(reset);
+                num_stolen_threads +=
+                    low_priority_queue_.get_num_stolen_to_pending(reset);
 
                 return num_stolen_threads;
             }
 
-            num_stolen_threads += queues_[num_thread].data_->
-                get_num_stolen_to_pending(reset);
+            num_stolen_threads +=
+                queues_[num_thread].data_->get_num_stolen_to_pending(reset);
 
             if (num_thread < num_high_priority_queues_)
             {
-                num_stolen_threads += high_priority_queues_[num_thread].data_->
-                    get_num_stolen_to_pending(reset);
+                num_stolen_threads +=
+                    high_priority_queues_[num_thread]
+                        .data_->get_num_stolen_to_pending(reset);
             }
-            if (num_thread == num_queues_-1)
+            if (num_thread == num_queues_ - 1)
             {
-                num_stolen_threads += low_priority_queue_.
-                    get_num_stolen_to_pending(reset);
+                num_stolen_threads +=
+                    low_priority_queue_.get_num_stolen_to_pending(reset);
             }
             return num_stolen_threads;
         }
@@ -386,33 +391,35 @@ namespace hpx { namespace threads { namespace policies
             {
                 for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
                 {
-                    num_stolen_threads += high_priority_queues_[i].data_->
-                        get_num_stolen_from_staged(reset);
+                    num_stolen_threads +=
+                        high_priority_queues_[i]
+                            .data_->get_num_stolen_from_staged(reset);
                 }
 
                 for (std::size_t i = 0; i != num_queues_; ++i)
                 {
-                    num_stolen_threads += queues_[i].data_->
-                        get_num_stolen_from_staged(reset);
+                    num_stolen_threads +=
+                        queues_[i].data_->get_num_stolen_from_staged(reset);
                 }
-                num_stolen_threads += low_priority_queue_.
-                    get_num_stolen_from_staged(reset);
+                num_stolen_threads +=
+                    low_priority_queue_.get_num_stolen_from_staged(reset);
 
                 return num_stolen_threads;
             }
 
-            num_stolen_threads += queues_[num_thread].data_->
-                get_num_stolen_from_staged(reset);
+            num_stolen_threads +=
+                queues_[num_thread].data_->get_num_stolen_from_staged(reset);
 
             if (num_thread < num_high_priority_queues_)
             {
-                num_stolen_threads += high_priority_queues_[num_thread].data_->
-                    get_num_stolen_from_staged(reset);
+                num_stolen_threads +=
+                    high_priority_queues_[num_thread]
+                        .data_->get_num_stolen_from_staged(reset);
             }
-            if (num_thread == num_queues_-1)
+            if (num_thread == num_queues_ - 1)
             {
-                num_stolen_threads += low_priority_queue_.
-                    get_num_stolen_from_staged(reset);
+                num_stolen_threads +=
+                    low_priority_queue_.get_num_stolen_from_staged(reset);
             }
             return num_stolen_threads;
         }
@@ -425,32 +432,34 @@ namespace hpx { namespace threads { namespace policies
             {
                 for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
                 {
-                    num_stolen_threads += high_priority_queues_[i].data_->
-                        get_num_stolen_to_staged(reset);
+                    num_stolen_threads +=
+                        high_priority_queues_[i]
+                            .data_->get_num_stolen_to_staged(reset);
                 }
                 for (std::size_t i = 0; i != num_queues_; ++i)
                 {
-                    num_stolen_threads += queues_[i].data_->
-                        get_num_stolen_to_staged(reset);
+                    num_stolen_threads +=
+                        queues_[i].data_->get_num_stolen_to_staged(reset);
                 }
-                num_stolen_threads += low_priority_queue_.
-                    get_num_stolen_to_staged(reset);
+                num_stolen_threads +=
+                    low_priority_queue_.get_num_stolen_to_staged(reset);
 
                 return num_stolen_threads;
             }
 
-            num_stolen_threads += queues_[num_thread].data_->
-                get_num_stolen_to_staged(reset);
+            num_stolen_threads +=
+                queues_[num_thread].data_->get_num_stolen_to_staged(reset);
 
             if (num_thread < num_high_priority_queues_)
             {
-                num_stolen_threads += high_priority_queues_[num_thread].data_->
-                    get_num_stolen_to_staged(reset);
+                num_stolen_threads +=
+                    high_priority_queues_[num_thread]
+                        .data_->get_num_stolen_to_staged(reset);
             }
-            if (num_thread == num_queues_-1)
+            if (num_thread == num_queues_ - 1)
             {
-                num_stolen_threads += low_priority_queue_.
-                    get_num_stolen_to_staged(reset);
+                num_stolen_threads +=
+                    low_priority_queue_.get_num_stolen_to_staged(reset);
             }
             return num_stolen_threads;
         }
@@ -476,23 +485,25 @@ namespace hpx { namespace threads { namespace policies
 
             for (std::size_t i = 0; i != num_queues_; ++i)
             {
-                empty = queues_[i].data_->
-                    cleanup_terminated(delete_all) && empty;
+                empty =
+                    queues_[i].data_->cleanup_terminated(delete_all) && empty;
             }
             if (!delete_all)
                 return empty;
 
             for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
             {
-                empty = high_priority_queues_[i].data_->
-                    cleanup_terminated(delete_all) && empty;
+                empty = high_priority_queues_[i].data_->cleanup_terminated(
+                            delete_all) &&
+                    empty;
             }
             empty = low_priority_queue_.cleanup_terminated(delete_all) && empty;
 
             return empty;
         }
 
-        bool cleanup_terminated(std::size_t num_thread, bool delete_all) override
+        bool cleanup_terminated(
+            std::size_t num_thread, bool delete_all) override
         {
             bool empty = true;
 
@@ -502,8 +513,10 @@ namespace hpx { namespace threads { namespace policies
 
             if (num_thread < num_high_priority_queues_)
             {
-                empty = high_priority_queues_[num_thread].data_->
-                    cleanup_terminated(delete_all) && empty;
+                empty =
+                    high_priority_queues_[num_thread].data_->cleanup_terminated(
+                        delete_all) &&
+                    empty;
             }
             return empty;
         }
@@ -518,7 +531,8 @@ namespace hpx { namespace threads { namespace policies
             // NOTE: This scheduler ignores NUMA hints.
             std::size_t num_thread =
                 data.schedulehint.mode == thread_schedule_hint_mode_thread ?
-                data.schedulehint.hint : std::size_t(-1);
+                data.schedulehint.hint :
+                std::size_t(-1);
 
             if (std::size_t(-1) == num_thread)
             {
@@ -547,20 +561,20 @@ namespace hpx { namespace threads { namespace policies
                 std::size_t num = num_thread % num_high_priority_queues_;
 
                 high_priority_queues_[num].data_->create_thread(
-                        data, id,initial_state, run_now, ec);
+                    data, id, initial_state, run_now, ec);
                 return;
             }
 
             if (data.priority == thread_priority_low)
             {
-                low_priority_queue_.create_thread(data, id, initial_state,
-                    run_now, ec);
+                low_priority_queue_.create_thread(
+                    data, id, initial_state, run_now, ec);
                 return;
             }
 
             HPX_ASSERT(num_thread < num_queues_);
-            queues_[num_thread].data_->
-                create_thread(data, id, initial_state, run_now, ec);
+            queues_[num_thread].data_->create_thread(
+                data, id, initial_state, run_now, ec);
         }
 
         /// Return the next thread to be executed, return false if none is
@@ -576,8 +590,7 @@ namespace hpx { namespace threads { namespace policies
             {
                 this_high_priority_queue =
                     high_priority_queues_[num_thread].data_;
-                bool result =
-                    this_high_priority_queue->get_next_thread(thrd);
+                bool result = this_high_priority_queue->get_next_thread(thrd);
 
                 this_high_priority_queue->increment_num_pending_accesses();
                 if (result)
@@ -593,8 +606,8 @@ namespace hpx { namespace threads { namespace policies
                     return true;
                 this_queue->increment_num_pending_misses();
 
-                bool have_staged = this_queue->
-                    get_staged_queue_length(std::memory_order_relaxed) != 0;
+                bool have_staged = this_queue->get_staged_queue_length(
+                                       std::memory_order_relaxed) != 0;
 
                 // Give up, we should have work to convert.
                 if (have_staged)
@@ -619,8 +632,8 @@ namespace hpx { namespace threads { namespace policies
                         if (q->get_next_thread(thrd, running))
                         {
                             q->increment_num_stolen_from_pending();
-                            this_high_priority_queue->
-                                increment_num_stolen_to_pending();
+                            this_high_priority_queue
+                                ->increment_num_stolen_to_pending();
                             return true;
                         }
                     }
@@ -735,7 +748,8 @@ namespace hpx { namespace threads { namespace policies
             threads::thread_data* thrd, std::int64_t& busy_count) override
         {
             HPX_ASSERT(thrd->get_scheduler_base() == this);
-            thrd->get_queue<thread_queue_type>().destroy_thread(thrd, busy_count);
+            thrd->get_queue<thread_queue_type>().destroy_thread(
+                thrd, busy_count);
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -745,15 +759,16 @@ namespace hpx { namespace threads { namespace policies
         {
             // Return queue length of one specific queue.
             std::int64_t count = 0;
-            if (std::size_t(-1) != num_thread) {
+            if (std::size_t(-1) != num_thread)
+            {
                 HPX_ASSERT(num_thread < num_queues_);
 
                 if (num_thread < num_high_priority_queues_)
                 {
-                    count = high_priority_queues_[num_thread].data_->
-                        get_queue_length();
+                    count = high_priority_queues_[num_thread]
+                                .data_->get_queue_length();
                 }
-                if (num_thread == num_queues_-1)
+                if (num_thread == num_queues_ - 1)
                     count += low_priority_queue_.get_queue_length();
 
                 return count + queues_[num_thread].data_->get_queue_length();
@@ -785,27 +800,28 @@ namespace hpx { namespace threads { namespace policies
             {
                 HPX_ASSERT(num_thread < num_queues_);
 
-                switch (priority) {
+                switch (priority)
+                {
                 case thread_priority_default:
+                {
+                    if (num_thread < num_high_priority_queues_)
                     {
-                        if (num_thread < num_high_priority_queues_)
-                        {
-                            count = high_priority_queues_[num_thread].data_->
-                                get_thread_count(state);
-                        }
-                        if (num_queues_-1 == num_thread)
-                            count += low_priority_queue_.get_thread_count(state);
-
-                        return count + queues_[num_thread].data_->
-                            get_thread_count(state);
+                        count = high_priority_queues_[num_thread]
+                                    .data_->get_thread_count(state);
                     }
+                    if (num_queues_ - 1 == num_thread)
+                        count += low_priority_queue_.get_thread_count(state);
+
+                    return count +
+                        queues_[num_thread].data_->get_thread_count(state);
+                }
 
                 case thread_priority_low:
-                    {
-                        if (num_queues_-1 == num_thread)
-                            return low_priority_queue_.get_thread_count(state);
-                        break;
-                    }
+                {
+                    if (num_queues_ - 1 == num_thread)
+                        return low_priority_queue_.get_thread_count(state);
+                    break;
+                }
 
                 case thread_priority_normal:
                     return queues_[num_thread].data_->get_thread_count(state);
@@ -813,77 +829,81 @@ namespace hpx { namespace threads { namespace policies
                 case thread_priority_boost:
                 case thread_priority_high:
                 case thread_priority_high_recursive:
+                {
+                    if (num_thread < num_high_priority_queues_)
                     {
-                        if (num_thread < num_high_priority_queues_)
-                        {
-                            return high_priority_queues_[num_thread].data_->
-                                get_thread_count(state);
-                        }
-                        break;
+                        return high_priority_queues_[num_thread]
+                            .data_->get_thread_count(state);
                     }
+                    break;
+                }
 
                 default:
                 case thread_priority_unknown:
-                    {
-                        HPX_THROW_EXCEPTION(bad_parameter,
-                            "local_priority_queue_scheduler::get_thread_count",
-                            "unknown thread priority value (thread_priority_unknown)");
-                        return 0;
-                    }
+                {
+                    HPX_THROW_EXCEPTION(bad_parameter,
+                        "local_priority_queue_scheduler::get_thread_"
+                        "count",
+                        "unknown thread priority value "
+                        "(thread_priority_unknown)");
+                    return 0;
+                }
                 }
                 return 0;
             }
 
             // Return the cumulative count for all queues.
-            switch (priority) {
+            switch (priority)
+            {
             case thread_priority_default:
+            {
+                for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
                 {
-                    for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
-                    {
-                        count += high_priority_queues_[i].data_->
-                            get_thread_count(state);
-                    }
-                    count += low_priority_queue_.get_thread_count(state);
-
-                    for (std::size_t i = 0; i != num_queues_; ++i)
-                    {
-                        count += queues_[i].data_->get_thread_count(state);
-                    }
-                    break;
+                    count +=
+                        high_priority_queues_[i].data_->get_thread_count(state);
                 }
+                count += low_priority_queue_.get_thread_count(state);
+
+                for (std::size_t i = 0; i != num_queues_; ++i)
+                {
+                    count += queues_[i].data_->get_thread_count(state);
+                }
+                break;
+            }
 
             case thread_priority_low:
                 return low_priority_queue_.get_thread_count(state);
 
             case thread_priority_normal:
+            {
+                for (std::size_t i = 0; i != num_queues_; ++i)
                 {
-                    for (std::size_t i = 0; i != num_queues_; ++i)
-                    {
-                        count += queues_[i].data_->get_thread_count(state);
-                    }
-                    break;
+                    count += queues_[i].data_->get_thread_count(state);
                 }
+                break;
+            }
 
             case thread_priority_boost:
             case thread_priority_high:
             case thread_priority_high_recursive:
+            {
+                for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
                 {
-                    for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
-                    {
-                        count += high_priority_queues_[i].data_->
-                            get_thread_count(state);
-                    }
-                    break;
+                    count +=
+                        high_priority_queues_[i].data_->get_thread_count(state);
                 }
+                break;
+            }
 
             default:
             case thread_priority_unknown:
-                {
-                    HPX_THROW_EXCEPTION(bad_parameter,
-                        "local_priority_queue_scheduler::get_thread_count",
-                        "unknown thread priority value (thread_priority_unknown)");
-                    return 0;
-                }
+            {
+                HPX_THROW_EXCEPTION(bad_parameter,
+                    "local_priority_queue_scheduler::get_thread_count",
+                    "unknown thread priority value "
+                    "(thread_priority_unknown)");
+                return 0;
+            }
             }
             return count;
         }
@@ -897,15 +917,16 @@ namespace hpx { namespace threads { namespace policies
             bool result = true;
             for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
             {
-                result = result && high_priority_queues_[i].data_->
-                    enumerate_threads(f, state);
+                result = result &&
+                    high_priority_queues_[i].data_->enumerate_threads(f, state);
             }
 
             result = result && low_priority_queue_.enumerate_threads(f, state);
 
             for (std::size_t i = 0; i != num_queues_; ++i)
             {
-                result = result && queues_[i].data_->enumerate_threads(f, state);
+                result =
+                    result && queues_[i].data_->enumerate_threads(f, state);
             }
             return result;
         }
@@ -925,28 +946,28 @@ namespace hpx { namespace threads { namespace policies
 
                 if (num_thread < num_high_priority_queues_)
                 {
-                    wait_time = high_priority_queues_[num_thread].data_->
-                        get_average_thread_wait_time();
+                    wait_time = high_priority_queues_[num_thread]
+                                    .data_->get_average_thread_wait_time();
                     ++count;
                 }
 
-                if (num_queues_-1 == num_thread)
+                if (num_queues_ - 1 == num_thread)
                 {
-                    wait_time += low_priority_queue_.
-                        get_average_thread_wait_time();
+                    wait_time +=
+                        low_priority_queue_.get_average_thread_wait_time();
                     ++count;
                 }
 
-                wait_time += queues_[num_thread].data_->
-                    get_average_thread_wait_time();
+                wait_time +=
+                    queues_[num_thread].data_->get_average_thread_wait_time();
                 return wait_time / (count + 1);
             }
 
             // Return the cumulative average thread wait time for all queues.
             for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
             {
-                wait_time += high_priority_queues_[i].data_->
-                    get_average_thread_wait_time();
+                wait_time += high_priority_queues_[i]
+                                 .data_->get_average_thread_wait_time();
                 ++count;
             }
 
@@ -975,28 +996,28 @@ namespace hpx { namespace threads { namespace policies
 
                 if (num_thread < num_high_priority_queues_)
                 {
-                    wait_time = high_priority_queues_[num_thread].data_->
-                        get_average_task_wait_time();
+                    wait_time = high_priority_queues_[num_thread]
+                                    .data_->get_average_task_wait_time();
                     ++count;
                 }
 
-                if (num_queues_-1 == num_thread)
+                if (num_queues_ - 1 == num_thread)
                 {
-                    wait_time += low_priority_queue_.
-                        get_average_task_wait_time();
+                    wait_time +=
+                        low_priority_queue_.get_average_task_wait_time();
                     ++count;
                 }
 
-                wait_time += queues_[num_thread].data_->
-                    get_average_task_wait_time();
+                wait_time +=
+                    queues_[num_thread].data_->get_average_task_wait_time();
                 return wait_time / (count + 1);
             }
 
             // Return the cumulative average task wait time for all queues.
             for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
             {
-                wait_time += high_priority_queues_[i].data_->
-                    get_average_task_wait_time();
+                wait_time += high_priority_queues_[i]
+                                 .data_->get_average_task_wait_time();
                 ++count;
             }
 
@@ -1034,11 +1055,13 @@ namespace hpx { namespace threads { namespace policies
                 result =
                     this_high_priority_queue->wait_or_add_new(running, added) &&
                     result;
-                if (0 != added) return result;
+                if (0 != added)
+                    return result;
             }
 
             result = this_queue->wait_or_add_new(running, added) && result;
-            if (0 != added) return result;
+            if (0 != added)
+                return result;
 
             // Check if we have been disabled
             if (!running)
@@ -1057,20 +1080,20 @@ namespace hpx { namespace threads { namespace policies
                     {
                         thread_queue_type* q = high_priority_queues_[idx].data_;
                         result = this_high_priority_queue->wait_or_add_new(
-                            true, added, q) &&
+                                     true, added, q) &&
                             result;
 
                         if (0 != added)
                         {
                             q->increment_num_stolen_from_staged(added);
-                            this_high_priority_queue->
-                                increment_num_stolen_to_staged(added);
+                            this_high_priority_queue
+                                ->increment_num_stolen_to_staged(added);
                             return result;
                         }
                     }
 
                     result = this_queue->wait_or_add_new(
-                        true, added, queues_[idx].data_) &&
+                                 true, added, queues_[idx].data_) &&
                         result;
 
                     if (0 != added)
@@ -1091,27 +1114,33 @@ namespace hpx { namespace threads { namespace policies
 
                 for (std::size_t i = 0; suspended_only && i != num_queues_; ++i)
                 {
-                    suspended_only = queues_[i].data_->
-                        dump_suspended_threads(i, idle_loop_count, running);
+                    suspended_only = queues_[i].data_->dump_suspended_threads(
+                        i, idle_loop_count, running);
                 }
 
-                if (HPX_UNLIKELY(suspended_only)) {
-                    if (running) {
-                        LTM_(error) //-V128
+                if (HPX_UNLIKELY(suspended_only))
+                {
+                    if (running)
+                    {
+                        LTM_(error)    //-V128
                             << "queue(" << num_thread << "): "
-                            << "no new work available, are we deadlocked?";
+                            << "no new work available, are we "
+                               "deadlocked?";
                     }
-                    else {
-                        LHPX_CONSOLE_(hpx::util::logging::level::error) //-V128
-                              << "  [TM] " //-V128
-                              << "queue(" << num_thread << "): "
-                              << "no new work available, are we deadlocked?\n";
+                    else
+                    {
+                        LHPX_CONSOLE_(
+                            hpx::util::logging::level::error)    //-V128
+                            << "  [TM] "                         //-V128
+                            << "queue(" << num_thread << "): "
+                            << "no new work available, are we "
+                               "deadlocked?\n";
                     }
                 }
             }
 #endif
 
-            if (num_thread == num_queues_-1)
+            if (num_thread == num_queues_ - 1)
             {
                 result = low_priority_queue_.wait_or_add_new(running, added) &&
                     result;
@@ -1126,23 +1155,23 @@ namespace hpx { namespace threads { namespace policies
             if (nullptr == queues_[num_thread].data_)
             {
                 queues_[num_thread].data_ =
-                    new thread_queue_type(max_queue_thread_count_);
+                    new thread_queue_type(num_thread, thread_queue_init_);
 
                 if (num_thread < num_high_priority_queues_)
                 {
                     high_priority_queues_[num_thread].data_ =
-                        new thread_queue_type(max_queue_thread_count_);
+                        new thread_queue_type(num_thread, thread_queue_init_);
                 }
             }
 
             // forward this call to all queues etc.
             if (num_thread < num_high_priority_queues_)
             {
-                high_priority_queues_[num_thread].data_->
-                    on_start_thread(num_thread);
+                high_priority_queues_[num_thread].data_->on_start_thread(
+                    num_thread);
             }
 
-            if (num_thread == num_queues_-1)
+            if (num_thread == num_queues_ - 1)
                 low_priority_queue_.on_start_thread(num_thread);
 
             queues_[num_thread].data_->on_start_thread(num_thread);
@@ -1180,68 +1209,58 @@ namespace hpx { namespace threads { namespace policies
             else
                 first_mask = pu_mask;
 
-            auto iterate = [&](hpx::util::function_nonser<bool(std::size_t)> f)
-            {
-                // check our neighbors in a radial fashion (left and right
-                // alternating, increasing distance each iteration)
-                int i = 1;
-                for (/**/; i < radius; ++i)
-                {
-                    std::ptrdiff_t left =
-                        (static_cast<std::ptrdiff_t>(num_thread) - i) %
+            auto iterate =
+                [&](hpx::util::function_nonser<bool(std::size_t)> f) {
+                    // check our neighbors in a radial fashion (left and right
+                    // alternating, increasing distance each iteration)
+                    int i = 1;
+                    for (/**/; i < radius; ++i)
+                    {
+                        std::ptrdiff_t left =
+                            (static_cast<std::ptrdiff_t>(num_thread) - i) %
                             static_cast<std::ptrdiff_t>(num_threads);
-                    if (left < 0)
-                        left = num_threads + left;
+                        if (left < 0)
+                            left = num_threads + left;
 
-                    if (f(std::size_t(left)))
-                    {
-                        victim_threads_[num_thread].data_.push_back(
-                            static_cast<std::size_t>(left));
-                    }
+                        if (f(std::size_t(left)))
+                        {
+                            victim_threads_[num_thread].data_.push_back(
+                                static_cast<std::size_t>(left));
+                        }
 
-                    std::size_t right = (num_thread + i) % num_threads;
-                    if (f(right))
-                    {
-                        victim_threads_[num_thread].data_.push_back(right);
+                        std::size_t right = (num_thread + i) % num_threads;
+                        if (f(right))
+                        {
+                            victim_threads_[num_thread].data_.push_back(right);
+                        }
                     }
-                }
-                if ((num_threads % 2) == 0)
-                {
-                    std::size_t right = (num_thread + i) % num_threads;
-                    if (f(right))
+                    if ((num_threads % 2) == 0)
                     {
-                        victim_threads_[num_thread].data_.push_back(right);
+                        std::size_t right = (num_thread + i) % num_threads;
+                        if (f(right))
+                        {
+                            victim_threads_[num_thread].data_.push_back(right);
+                        }
                     }
-                }
-            };
+                };
 
             // check for threads which share the same core...
-            iterate(
-                [&](std::size_t other_num_thread)
-                {
-                    return any(core_mask & core_masks[other_num_thread]);
-                }
-            );
+            iterate([&](std::size_t other_num_thread) {
+                return any(core_mask & core_masks[other_num_thread]);
+            });
 
             // check for threads which share the same NUMA domain...
-            iterate(
-                [&](std::size_t other_num_thread)
-                {
-                    return
-                        !any(core_mask & core_masks[other_num_thread])
-                        && any(numa_mask & numa_masks[other_num_thread]);
-                }
-            );
+            iterate([&](std::size_t other_num_thread) {
+                return !any(core_mask & core_masks[other_num_thread]) &&
+                    any(numa_mask & numa_masks[other_num_thread]);
+            });
 
             // check for the rest and if we are NUMA aware
             if (numa_sensitive_ != 2 && any(first_mask & pu_mask))
             {
-                iterate(
-                    [&](std::size_t other_num_thread)
-                    {
-                        return !any(numa_mask & numa_masks[other_num_thread]);
-                    }
-                );
+                iterate([&](std::size_t other_num_thread) {
+                    return !any(numa_mask & numa_masks[other_num_thread]);
+                });
             }
         }
 
@@ -1249,22 +1268,24 @@ namespace hpx { namespace threads { namespace policies
         {
             if (num_thread < num_high_priority_queues_)
             {
-                high_priority_queues_[num_thread].data_->
-                    on_stop_thread(num_thread);
+                high_priority_queues_[num_thread].data_->on_stop_thread(
+                    num_thread);
             }
-            if (num_thread == num_queues_-1)
+            if (num_thread == num_queues_ - 1)
                 low_priority_queue_.on_stop_thread(num_thread);
 
             queues_[num_thread].data_->on_stop_thread(num_thread);
         }
 
-        void on_error(std::size_t num_thread, std::exception_ptr const& e) override
+        void on_error(
+            std::size_t num_thread, std::exception_ptr const& e) override
         {
             if (num_thread < num_high_priority_queues_)
             {
-                high_priority_queues_[num_thread].data_->on_error(num_thread, e);
+                high_priority_queues_[num_thread].data_->on_error(
+                    num_thread, e);
             }
-            if (num_thread == num_queues_-1)
+            if (num_thread == num_queues_ - 1)
                 low_priority_queue_.on_error(num_thread, e);
 
             queues_[num_thread].data_->on_error(num_thread, e);
@@ -1276,7 +1297,6 @@ namespace hpx { namespace threads { namespace policies
         }
 
     protected:
-        std::size_t max_queue_thread_count_;
         std::atomic<std::size_t> curr_queue_;
         std::size_t numa_sensitive_;
 
@@ -1293,9 +1313,8 @@ namespace hpx { namespace threads { namespace policies
         std::vector<util::cache_line_data<std::vector<std::size_t>>>
             victim_threads_;
     };
-}}}
+}}}    // namespace hpx::threads::policies
 
 #include <hpx/config/warnings_suffix.hpp>
 
 #endif
-

--- a/hpx/runtime/threads/policies/queue_helpers.hpp
+++ b/hpx/runtime/threads/policies/queue_helpers.hpp
@@ -12,6 +12,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/logging.hpp>
+#include <hpx/runtime/threads/policies/thread_queue_init_parameters.hpp>
 #include <hpx/runtime/threads/thread_data.hpp>
 #include <hpx/type_support/unused.hpp>
 
@@ -22,15 +23,17 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace threads { namespace policies
-{
+namespace hpx { namespace threads { namespace policies {
     // Holds core/queue ratios used by schedulers.
     struct core_ratios
     {
         core_ratios(std::size_t high_priority, std::size_t normal_priority,
             std::size_t low_priority)
-          : high_priority(high_priority), normal_priority(normal_priority),
-            low_priority(low_priority) {}
+          : high_priority(high_priority)
+          , normal_priority(normal_priority)
+          , low_priority(low_priority)
+        {
+        }
 
         std::size_t high_priority;
         std::size_t normal_priority;
@@ -43,32 +46,34 @@ namespace hpx { namespace threads { namespace policies
     template <typename QueueType>
     struct queue_holder
     {
-        void init(std::size_t cores,
-                  std::size_t queues,
-                  std::size_t max_tasks)
+        void init(std::size_t cores, std::size_t queues,
+            thread_queue_init_parameters thread_queue_init)
         {
-            num_cores  = cores;
+            num_cores = cores;
             num_queues = queues;
-            scale      = num_cores==1 ? 0
-                         : static_cast<double>(num_queues-1)/(num_cores-1);
+            scale = num_cores == 1 ?
+                0 :
+                static_cast<double>(num_queues - 1) / (num_cores - 1);
             //
             queues_.resize(num_queues);
-            for (std::size_t i = 0; i < num_queues; ++i) {
-                queues_[i] = new QueueType(max_tasks);
+            for (std::size_t i = 0; i < num_queues; ++i)
+            {
+                queues_[i] = new QueueType(i, thread_queue_init);
             }
         }
 
         // ----------------------------------------------------------------
         ~queue_holder()
         {
-            for(auto &q : queues_) delete q;
+            for (auto& q : queues_)
+                delete q;
             queues_.clear();
         }
 
         // ----------------------------------------------------------------
         inline std::size_t get_queue_index(std::size_t id) const
         {
-            return std::lround(id*scale);
+            return std::lround(id * scale);
         }
 
         // ----------------------------------------------------------------
@@ -77,25 +82,29 @@ namespace hpx { namespace threads { namespace policies
             // loop over all queues and take one task,
             // starting with the requested queue
             // then stealing from any other one in the container
-            for (std::size_t i=0; i<num_queues; ++i) {
+            for (std::size_t i = 0; i < num_queues; ++i)
+            {
                 std::size_t q = (id + i) % num_queues;
-                if (queues_[q]->get_next_thread(thrd)) return true;
+                if (queues_[q]->get_next_thread(thrd))
+                    return true;
             }
             return false;
         }
 
         // ----------------------------------------------------------------
-        inline bool wait_or_add_new(std::size_t id, bool running,
-           std::size_t& added)
+        inline bool wait_or_add_new(
+            std::size_t id, bool running, std::size_t& added)
         {
             // loop over all queues and take one task,
             // starting with the requested queue
             // then stealing from any other one in the container
             bool result = true;
-            for (std::size_t i=0; i<num_queues; ++i) {
+            for (std::size_t i = 0; i < num_queues; ++i)
+            {
                 std::size_t q = (id + i) % num_queues;
                 result = queues_[q]->wait_or_add_new(running, added) && result;
-                if (0 != added) return result;
+                if (0 != added)
+                    return result;
             }
             return result;
         }
@@ -104,40 +113,48 @@ namespace hpx { namespace threads { namespace policies
         inline std::size_t get_queue_length() const
         {
             std::size_t len = 0;
-            for (auto &q : queues_) len += q->get_queue_length();
+            for (auto& q : queues_)
+                len += q->get_queue_length();
             return len;
         }
 
         // ----------------------------------------------------------------
-        inline std::size_t get_thread_count(thread_state_enum state = unknown) const
+        inline std::size_t get_thread_count(
+            thread_state_enum state = unknown) const
         {
             std::size_t len = 0;
-            for (auto &q : queues_) len += q->get_thread_count(state);
+            for (auto& q : queues_)
+                len += q->get_thread_count(state);
             return len;
         }
 
         // ----------------------------------------------------------------
-        bool enumerate_threads(util::function_nonser<bool(thread_id_type)> const& f,
+        bool enumerate_threads(
+            util::function_nonser<bool(thread_id_type)> const& f,
             thread_state_enum state = unknown) const
         {
             bool result = true;
-            for (auto &q : queues_) result = result && q->enumerate_threads(f, state);
+            for (auto& q : queues_)
+                result = result && q->enumerate_threads(f, state);
             return result;
         }
 
         // ----------------------------------------------------------------
-        inline std::size_t size() const {
+        inline std::size_t size() const
+        {
             return num_queues;
         }
 
         // ----------------------------------------------------------------
-        std::size_t             num_cores;
-        std::size_t             num_queues;
-        double                  scale;
+        std::size_t num_cores;
+        std::size_t num_queues;
+        double scale;
         std::vector<QueueType*> queues_;
     };
 
-    struct add_new_tag {};
+    struct add_new_tag
+    {
+    };
 
 #ifdef HPX_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION
     ///////////////////////////////////////////////////////////////////////////
@@ -147,124 +164,133 @@ namespace hpx { namespace threads { namespace policies
     extern bool minimal_deadlock_detection;
 #endif
 
-///////////////////////////////////////////////////////////////////////////////
-namespace detail
-{
-    ///////////////////////////////////////////////////////////////////////////
-    // debug helper function, logs all suspended threads
-    // this returns true if all threads in the map are currently suspended
-    template <typename Map>
-    bool dump_suspended_threads(std::size_t num_thread,
-        Map& tm, std::int64_t& idle_loop_count, bool running) HPX_COLD;
+    ///////////////////////////////////////////////////////////////////////////////
+    namespace detail {
+        ///////////////////////////////////////////////////////////////////////////
+        // debug helper function, logs all suspended threads
+        // this returns true if all threads in the map are currently suspended
+        template <typename Map>
+        bool dump_suspended_threads(std::size_t num_thread, Map& tm,
+            std::int64_t& idle_loop_count, bool running) HPX_COLD;
 
-    template <typename Map>
-    bool dump_suspended_threads(std::size_t num_thread,
-        Map& tm, std::int64_t& idle_loop_count, bool running)
-    {
-#ifndef HPX_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION
-        HPX_UNUSED(tm);
-        HPX_UNUSED(idle_loop_count);
-        HPX_UNUSED(running); //-V601
-        return false;
-#else
-        if (!minimal_deadlock_detection)
-            return false;
-
-        // attempt to output possibly deadlocked threads occasionally only
-        if (HPX_LIKELY((idle_loop_count++ % HPX_IDLE_LOOP_COUNT_MAX) != 0))
-            return false;
-
-        bool result = false;
-        bool collect_suspended = true;
-
-        bool logged_headline = false;
-        typename Map::const_iterator end = tm.end();
-        for (typename Map::const_iterator it = tm.begin(); it != end; ++it)
+        template <typename Map>
+        bool dump_suspended_threads(std::size_t num_thread, Map& tm,
+            std::int64_t& idle_loop_count, bool running)
         {
-            threads::thread_data const* thrd = it->get();
-            threads::thread_state_enum state = thrd->get_state().state();
-            threads::thread_state_enum marked_state = thrd->get_marked_state();
+#ifndef HPX_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION
+            HPX_UNUSED(tm);
+            HPX_UNUSED(idle_loop_count);
+            HPX_UNUSED(running);    //-V601
+            return false;
+#else
+            if (!minimal_deadlock_detection)
+                return false;
 
-            if (state != marked_state) {
-                // log each thread only once
-                if (!logged_headline) {
-                    if (running) {
-                        LTM_(error) //-V128
-                            << "Listing suspended threads while queue ("
-                            << num_thread << ") is empty:";
+            // attempt to output possibly deadlocked threads occasionally only
+            if (HPX_LIKELY((idle_loop_count++ % HPX_IDLE_LOOP_COUNT_MAX) != 0))
+                return false;
+
+            bool result = false;
+            bool collect_suspended = true;
+
+            bool logged_headline = false;
+            typename Map::const_iterator end = tm.end();
+            for (typename Map::const_iterator it = tm.begin(); it != end; ++it)
+            {
+                threads::thread_data const* thrd = it->get();
+                threads::thread_state_enum state = thrd->get_state().state();
+                threads::thread_state_enum marked_state =
+                    thrd->get_marked_state();
+
+                if (state != marked_state)
+                {
+                    // log each thread only once
+                    if (!logged_headline)
+                    {
+                        if (running)
+                        {
+                            LTM_(error)    //-V128
+                                << "Listing suspended threads while queue ("
+                                << num_thread << ") is empty:";
+                        }
+                        else
+                        {
+                            LHPX_CONSOLE_(
+                                hpx::util::logging::level::error)    //-V128
+                                << "  [TM] Listing suspended threads while "
+                                   "queue ("
+                                << num_thread << ") is empty:\n";
+                        }
+                        logged_headline = true;
                     }
-                    else {
-                        LHPX_CONSOLE_(hpx::util::logging::level::error) //-V128
-                            << "  [TM] Listing suspended threads while queue ("
-                            << num_thread << ") is empty:\n";
+
+                    if (running)
+                    {
+                        LTM_(error)
+                            << "queue(" << num_thread << "): "    //-V128
+                            << get_thread_state_name(state) << "(" << std::hex
+                            << std::setw(8) << std::setfill('0') << (*it) << "."
+                            << std::hex << std::setw(2) << std::setfill('0')
+                            << thrd->get_thread_phase() << "/" << std::hex
+                            << std::setw(8) << std::setfill('0')
+                            << thrd->get_component_id() << ")"
+#ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
+                            << " P" << std::hex << std::setw(8)
+                            << std::setfill('0') << thrd->get_parent_thread_id()
+#endif
+                            << ": " << thrd->get_description() << ": "
+                            << thrd->get_lco_description();
                     }
-                    logged_headline = true;
-                }
-
-                if (running) {
-                    LTM_(error) << "queue(" << num_thread << "): " //-V128
-                                << get_thread_state_name(state)
-                                << "(" << std::hex << std::setw(8)
-                                    << std::setfill('0') << (*it)
-                                << "." << std::hex << std::setw(2)
-                                    << std::setfill('0') << thrd->get_thread_phase()
-                                << "/" << std::hex << std::setw(8)
-                                    << std::setfill('0') << thrd->get_component_id()
-                                << ")"
+                    else
+                    {
+                        LHPX_CONSOLE_(hpx::util::logging::level::error)
+                            << "  [TM] "    //-V128
+                            << "queue(" << num_thread
+                            << "): " << get_thread_state_name(state) << "("
+                            << std::hex << std::setw(8) << std::setfill('0')
+                            << (*it) << "." << std::hex << std::setw(2)
+                            << std::setfill('0') << thrd->get_thread_phase()
+                            << "/" << std::hex << std::setw(8)
+                            << std::setfill('0') << thrd->get_component_id()
+                            << ")"
 #ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
-                                << " P" << std::hex << std::setw(8)
-                                    << std::setfill('0') << thrd->get_parent_thread_id()
+                            << " P" << std::hex << std::setw(8)
+                            << std::setfill('0') << thrd->get_parent_thread_id()
 #endif
-                                << ": " << thrd->get_description()
-                                << ": " << thrd->get_lco_description();
-                }
-                else {
-                    LHPX_CONSOLE_(hpx::util::logging::level::error) << "  [TM] " //-V128
-                                << "queue(" << num_thread << "): "
-                                << get_thread_state_name(state)
-                                << "(" << std::hex << std::setw(8)
-                                    << std::setfill('0') << (*it)
-                                << "." << std::hex << std::setw(2)
-                                    << std::setfill('0') << thrd->get_thread_phase()
-                                << "/" << std::hex << std::setw(8)
-                                    << std::setfill('0') << thrd->get_component_id()
-                                << ")"
-#ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
-                                << " P" << std::hex << std::setw(8)
-                                    << std::setfill('0') << thrd->get_parent_thread_id()
-#endif
-                                << ": " << thrd->get_description()
-                                << ": " << thrd->get_lco_description() << "\n";
-                }
-                thrd->set_marked_state(state);
+                            << ": " << thrd->get_description() << ": "
+                            << thrd->get_lco_description() << "\n";
+                    }
+                    thrd->set_marked_state(state);
 
-                // result should be true if we found only suspended threads
-                if (collect_suspended) {
-                    switch(state) {
-                    case threads::suspended:
-                        result = true;    // at least one is suspended
-                        break;
+                    // result should be true if we found only suspended threads
+                    if (collect_suspended)
+                    {
+                        switch (state)
+                        {
+                        case threads::suspended:
+                            result = true;    // at least one is suspended
+                            break;
 
-                    case threads::pending:
-                    case threads::active:
-                        result = false;   // one is active, no deadlock (yet)
-                        collect_suspended = false;
-                        break;
+                        case threads::pending:
+                        case threads::active:
+                            result =
+                                false;    // one is active, no deadlock (yet)
+                            collect_suspended = false;
+                            break;
 
-                    default:
-                        // If the thread is terminated we don't care too much
-                        // anymore.
-                        break;
+                        default:
+                            // If the thread is terminated we don't care too much
+                            // anymore.
+                            break;
+                        }
                     }
                 }
             }
-        }
-        return result;
+            return result;
 #endif
-    }
-}
+        }
+    }    // namespace detail
 
-}}}
+}}}    // namespace hpx::threads::policies
 
-#endif // HPX_F0153C92_99B1_4F31_8FA9_4208DB2F26CE
-
+#endif    // HPX_F0153C92_99B1_4F31_8FA9_4208DB2F26CE

--- a/hpx/runtime/threads/policies/scheduler_base.hpp
+++ b/hpx/runtime/threads/policies/scheduler_base.hpp
@@ -9,9 +9,10 @@
 #include <hpx/config.hpp>
 #include <hpx/assertion.hpp>
 #include <hpx/concurrency/cache_line_data.hpp>
+#include <hpx/format.hpp>
 #include <hpx/runtime/resource/detail/partitioner.hpp>
 #include <hpx/runtime/threads/policies/scheduler_mode.hpp>
-#include <hpx/runtime/threads/scoped_background_timer.hpp>
+#include <hpx/runtime/threads/policies/thread_queue_init_parameters.hpp>
 #include <hpx/runtime/threads/thread_init_data.hpp>
 #include <hpx/runtime/threads/thread_pool_base.hpp>
 #include <hpx/state.hpp>
@@ -33,8 +34,7 @@
 #include <hpx/config/warnings_prefix.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace threads { namespace policies
-{
+namespace hpx { namespace threads { namespace policies {
     ///////////////////////////////////////////////////////////////////////////
     /// The scheduler_base defines the interface to be implemented by all
     /// scheduler policies
@@ -46,19 +46,19 @@ namespace hpx { namespace threads { namespace policies
     public:
         typedef std::mutex pu_mutex_type;
 
-        scheduler_base(std::size_t num_threads,
-            char const* description = "",
+        scheduler_base(std::size_t num_threads, char const* description = "",
+            thread_queue_init_parameters thread_queue_init = {},
             scheduler_mode mode = nothing_special);
 
         virtual ~scheduler_base() = default;
 
-        threads::thread_pool_base *get_parent_pool()
+        threads::thread_pool_base* get_parent_pool()
         {
             HPX_ASSERT(parent_pool_ != nullptr);
             return parent_pool_;
         }
 
-        void set_parent_pool(threads::thread_pool_base *p)
+        void set_parent_pool(threads::thread_pool_base* p)
         {
             HPX_ASSERT(parent_pool_ == nullptr);
             parent_pool_ = p;
@@ -74,7 +74,10 @@ namespace hpx { namespace threads { namespace policies
             return n + parent_pool_->get_thread_offset();
         }
 
-        char const* get_description() const { return description_; }
+        char const* get_description() const
+        {
+            return description_;
+        }
 
         void idle_callback(std::size_t num_thread);
 
@@ -119,7 +122,10 @@ namespace hpx { namespace threads { namespace policies
         }
 
         ///////////////////////////////////////////////////////////////////////
-        virtual bool numa_sensitive() const { return false; }
+        virtual bool numa_sensitive() const
+        {
+            return false;
+        }
 
         virtual bool has_thread_stealing(std::size_t num_thread) const;
 
@@ -131,8 +137,8 @@ namespace hpx { namespace threads { namespace policies
 
         // either threads in same domain, or not in same domain
         // depending on the predicate
-        std::vector<std::size_t> domain_threads(
-            std::size_t local_id, const std::vector<std::size_t> &ts,
+        std::vector<std::size_t> domain_threads(std::size_t local_id,
+            const std::vector<std::size_t>& ts,
             std::function<bool(std::size_t, std::size_t)> pred);
 
 #ifdef HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES
@@ -141,26 +147,25 @@ namespace hpx { namespace threads { namespace policies
 #endif
 
 #ifdef HPX_HAVE_THREAD_STEALING_COUNTS
-        virtual std::int64_t get_num_pending_misses(std::size_t num_thread,
-            bool reset) = 0;
-        virtual std::int64_t get_num_pending_accesses(std::size_t num_thread,
-            bool reset) = 0;
+        virtual std::int64_t get_num_pending_misses(
+            std::size_t num_thread, bool reset) = 0;
+        virtual std::int64_t get_num_pending_accesses(
+            std::size_t num_thread, bool reset) = 0;
 
-        virtual std::int64_t get_num_stolen_from_pending(std::size_t num_thread,
-            bool reset) = 0;
-        virtual std::int64_t get_num_stolen_to_pending(std::size_t num_thread,
-            bool reset) = 0;
-        virtual std::int64_t get_num_stolen_from_staged(std::size_t num_thread,
-            bool reset) = 0;
-        virtual std::int64_t get_num_stolen_to_staged(std::size_t num_thread,
-            bool reset) = 0;
+        virtual std::int64_t get_num_stolen_from_pending(
+            std::size_t num_thread, bool reset) = 0;
+        virtual std::int64_t get_num_stolen_to_pending(
+            std::size_t num_thread, bool reset) = 0;
+        virtual std::int64_t get_num_stolen_from_staged(
+            std::size_t num_thread, bool reset) = 0;
+        virtual std::int64_t get_num_stolen_to_staged(
+            std::size_t num_thread, bool reset) = 0;
 #endif
 
         virtual std::int64_t get_queue_length(
             std::size_t num_thread = std::size_t(-1)) const = 0;
 
-        virtual std::int64_t get_thread_count(
-            thread_state_enum state = unknown,
+        virtual std::int64_t get_thread_count(thread_state_enum state = unknown,
             thread_priority priority = thread_priority_default,
             std::size_t num_thread = std::size_t(-1),
             bool reset = false) const = 0;
@@ -178,7 +183,8 @@ namespace hpx { namespace threads { namespace policies
         virtual void abort_all_suspended_threads() = 0;
 
         virtual bool cleanup_terminated(bool delete_all) = 0;
-        virtual bool cleanup_terminated(std::size_t num_thread, bool delete_all) = 0;
+        virtual bool cleanup_terminated(
+            std::size_t num_thread, bool delete_all) = 0;
 
         virtual void create_thread(thread_init_data& data, thread_id_type* id,
             thread_state_enum initial_state, bool run_now, error_code& ec) = 0;
@@ -196,8 +202,8 @@ namespace hpx { namespace threads { namespace policies
             bool allow_fallback = false,
             thread_priority priority = thread_priority_normal) = 0;
 
-        virtual void destroy_thread(threads::thread_data* thrd,
-            std::int64_t& busy_count) = 0;
+        virtual void destroy_thread(
+            threads::thread_data* thrd, std::int64_t& busy_count) = 0;
 
         virtual bool wait_or_add_new(std::size_t num_thread, bool running,
             std::int64_t& idle_loop_count, bool enable_stealing,
@@ -205,8 +211,8 @@ namespace hpx { namespace threads { namespace policies
 
         virtual void on_start_thread(std::size_t num_thread) = 0;
         virtual void on_stop_thread(std::size_t num_thread) = 0;
-        virtual void on_error(std::size_t num_thread,
-            std::exception_ptr const& e) = 0;
+        virtual void on_error(
+            std::size_t num_thread, std::exception_ptr const& e) = 0;
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
         virtual std::int64_t get_average_thread_wait_time(
@@ -216,6 +222,32 @@ namespace hpx { namespace threads { namespace policies
 #endif
 
         virtual void reset_thread_distribution() {}
+
+        std::ptrdiff_t get_stack_size(threads::thread_stacksize stacksize) const
+        {
+            switch (stacksize)
+            {
+            case thread_stacksize_small:
+                return thread_queue_init_.small_stacksize_;
+                break;
+
+            case thread_stacksize_medium:
+                return thread_queue_init_.medium_stacksize_;
+
+            case thread_stacksize_large:
+                return thread_queue_init_.large_stacksize_;
+
+            case thread_stacksize_huge:
+                return thread_queue_init_.huge_stacksize_;
+
+            default:
+                HPX_ASSERT_MSG(
+                    false, util::format("Invalid stack size {1}", stacksize));
+                break;
+            }
+
+            return thread_queue_init_.small_stacksize_;
+        }
 
     protected:
         // the scheduler mode is simply replicated across the cores to
@@ -241,11 +273,13 @@ namespace hpx { namespace threads { namespace policies
 
         std::vector<pu_mutex_type> pu_mtxs_;
 
-        std::vector<std::atomic<hpx::state> > states_;
+        std::vector<std::atomic<hpx::state>> states_;
         char const* description_;
 
+        thread_queue_init_parameters thread_queue_init_;
+
         // the pool that owns this scheduler
-        threads::thread_pool_base *parent_pool_;
+        threads::thread_pool_base* parent_pool_;
 
         std::atomic<std::int64_t> background_thread_count_;
 
@@ -254,19 +288,21 @@ namespace hpx { namespace threads { namespace policies
         // manage scheduler-local data
         coroutines::detail::tss_data_node* find_tss_data(void const* key);
         void add_new_tss_node(void const* key,
-            std::shared_ptr<coroutines::detail::tss_cleanup_function>
-            const& func, void* tss_data);
+            std::shared_ptr<coroutines::detail::tss_cleanup_function> const&
+                func,
+            void* tss_data);
         void erase_tss_node(void const* key, bool cleanup_existing);
         void* get_tss_data(void const* key);
         void set_tss_data(void const* key,
-            std::shared_ptr<coroutines::detail::tss_cleanup_function>
-            const& func, void* tss_data, bool cleanup_existing);
+            std::shared_ptr<coroutines::detail::tss_cleanup_function> const&
+                func,
+            void* tss_data, bool cleanup_existing);
 
     protected:
         std::shared_ptr<coroutines::detail::tss_storage> thread_data_;
 #endif
     };
-}}}
+}}}    // namespace hpx::threads::policies
 
 #include <hpx/config/warnings_suffix.hpp>
 

--- a/hpx/runtime/threads/policies/thread_queue.hpp
+++ b/hpx/runtime/threads/policies/thread_queue.hpp
@@ -13,9 +13,10 @@
 #include <hpx/concurrency/cache_line_data.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/errors.hpp>
-#include <hpx/runtime/config_entry.hpp>
+#include <hpx/format.hpp>
 #include <hpx/runtime/threads/policies/lockfree_queue_backends.hpp>
 #include <hpx/runtime/threads/policies/queue_helpers.hpp>
+#include <hpx/runtime/threads/policies/thread_queue_init_parameters.hpp>
 #include <hpx/runtime/threads/thread_data.hpp>
 #include <hpx/thread_support/unlock_guard.hpp>
 #include <hpx/timing/high_resolution_clock.hpp>
@@ -23,7 +24,7 @@
 #include <hpx/util/get_and_reset_value.hpp>
 
 #ifdef HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES
-#   include <hpx/util/tick_counter.hpp>
+#include <hpx/util/tick_counter.hpp>
 #endif
 
 #include <boost/lexical_cast.hpp>
@@ -43,8 +44,7 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace threads { namespace policies
-{
+namespace hpx { namespace threads { namespace policies {
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
     ///////////////////////////////////////////////////////////////////////////
     // We control whether to collect queue wait times using this global bool.
@@ -59,58 +59,6 @@ namespace hpx { namespace threads { namespace policies
     // startup code
     extern bool minimal_deadlock_detection;
 #endif
-
-    namespace detail
-    {
-        inline int get_min_tasks_to_steal_pending()
-        {
-            static int min_tasks_to_steal_pending =
-                boost::lexical_cast<int>(hpx::get_config_entry(
-                    "hpx.thread_queue.min_tasks_to_steal_pending", "0"));
-            return min_tasks_to_steal_pending;
-        }
-
-        inline int get_min_tasks_to_steal_staged()
-        {
-            static int min_tasks_to_steal_staged =
-                boost::lexical_cast<int>(hpx::get_config_entry(
-                    "hpx.thread_queue.min_tasks_to_steal_staged", "10"));
-            return min_tasks_to_steal_staged;
-        }
-
-        inline int get_min_add_new_count()
-        {
-            static int min_add_new_count =
-                boost::lexical_cast<int>(hpx::get_config_entry(
-                    "hpx.thread_queue.min_add_new_count", "10"));
-            return min_add_new_count;
-        }
-
-        inline int get_max_add_new_count()
-        {
-            static int max_add_new_count =
-                boost::lexical_cast<int>(hpx::get_config_entry(
-                    "hpx.thread_queue.max_add_new_count", "10"));
-            return max_add_new_count;
-        }
-
-        inline int get_max_delete_count()
-        {
-            static int max_delete_count =
-                boost::lexical_cast<int>(hpx::get_config_entry(
-                    "hpx.thread_queue.max_delete_count", "1000"));
-            return max_delete_count;
-        }
-
-        inline int get_max_terminated_threads()
-        {
-            static int max_terminated_threads =
-                boost::lexical_cast<int>(hpx::get_config_entry(
-                    "hpx.thread_queue.max_terminated_threads",
-                    std::to_string(HPX_SCHEDULER_MAX_TERMINATED_THREADS)));
-            return max_terminated_threads;
-        }
-    }
 
     ///////////////////////////////////////////////////////////////////////////
     // // Queue back-end interface:
@@ -152,22 +100,6 @@ namespace hpx { namespace threads { namespace policies
         // we use a simple mutex to protect the data members for now
         typedef Mutex mutex_type;
 
-        // don't steal if less than this amount of tasks are left
-        int const min_tasks_to_steal_pending;
-        int const min_tasks_to_steal_staged;
-
-        // create at least this amount of threads from tasks
-        int const min_add_new_count;
-
-        // create not more than this amount of threads from tasks
-        int const max_add_new_count;
-
-        // number of terminated threads to discard
-        int const max_delete_count;
-
-        // number of terminated threads to collect before cleaning them up
-        int const max_terminated_threads;
-
         // this is the type of a map holding all threads (except depleted ones)
         using thread_map_type = std::unordered_set<thread_id_type,
             std::hash<thread_id_type>, std::equal_to<thread_id_type>,
@@ -177,11 +109,11 @@ namespace hpx { namespace threads { namespace policies
             std::list<thread_id_type, util::internal_allocator<thread_id_type>>;
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
-        typedef
-            util::tuple<thread_init_data, thread_state_enum, std::uint64_t>
-        task_description;
+        typedef util::tuple<thread_init_data, thread_state_enum, std::uint64_t>
+            task_description;
 #else
-        typedef util::tuple<thread_init_data, thread_state_enum> task_description;
+        typedef util::tuple<thread_init_data, thread_state_enum>
+            task_description;
 #endif
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
@@ -190,14 +122,15 @@ namespace hpx { namespace threads { namespace policies
         typedef thread_data thread_description;
 #endif
 
-        typedef typename PendingQueuing::template
-            apply<thread_description*>::type work_items_type;
+        typedef
+            typename PendingQueuing::template apply<thread_description*>::type
+                work_items_type;
 
-        typedef typename StagedQueuing::template
-            apply<task_description*>::type task_items_type;
+        typedef typename StagedQueuing::template apply<task_description*>::type
+            task_items_type;
 
-        typedef typename TerminatedQueuing::template
-            apply<thread_data*>::type terminated_items_type;
+        typedef typename TerminatedQueuing::template apply<thread_data*>::type
+            terminated_items_type;
 
     protected:
         template <typename Lock>
@@ -205,49 +138,27 @@ namespace hpx { namespace threads { namespace policies
             threads::thread_init_data& data, thread_state_enum state, Lock& lk)
         {
             HPX_ASSERT(lk.owns_lock());
-            HPX_ASSERT(data.stacksize != 0);
+            HPX_ASSERT(data.stacksize > 0);
 
             std::ptrdiff_t stacksize = data.stacksize;
 
             thread_heap_type* heap = nullptr;
 
-            if (stacksize == get_stack_size(thread_stacksize_small))
+            if (stacksize == parameters_.small_stacksize_)
             {
                 heap = &thread_heap_small_;
             }
-            else if (stacksize == get_stack_size(thread_stacksize_medium))
+            else if (stacksize == parameters_.medium_stacksize_)
             {
                 heap = &thread_heap_medium_;
             }
-            else if (stacksize == get_stack_size(thread_stacksize_large))
+            else if (stacksize == parameters_.large_stacksize_)
             {
                 heap = &thread_heap_large_;
             }
-            else if (stacksize == get_stack_size(thread_stacksize_huge))
+            else if (stacksize == parameters_.huge_stacksize_)
             {
                 heap = &thread_heap_huge_;
-            }
-            else {
-                switch(stacksize) {
-                case thread_stacksize_small:
-                    heap = &thread_heap_small_;
-                    break;
-
-                case thread_stacksize_medium:
-                    heap = &thread_heap_medium_;
-                    break;
-
-                case thread_stacksize_large:
-                    heap = &thread_heap_large_;
-                    break;
-
-                case thread_stacksize_huge:
-                    heap = &thread_heap_huge_;
-                    break;
-
-                default:
-                    break;
-                }
             }
             HPX_ASSERT(heap);
 
@@ -276,12 +187,13 @@ namespace hpx { namespace threads { namespace policies
         }
 
         static util::internal_allocator<threads::thread_data> thread_alloc_;
-        static util::internal_allocator<task_description> task_description_alloc_;
+        static util::internal_allocator<task_description>
+            task_description_alloc_;
 
         ///////////////////////////////////////////////////////////////////////
         // add new threads if there is some amount of work available
         std::size_t add_new(std::int64_t add_count, thread_queue* addfrom,
-            std::unique_lock<mutex_type> &lk, bool steal = false)
+            std::unique_lock<mutex_type>& lk, bool steal = false)
         {
             HPX_ASSERT(lk.owns_lock());
 
@@ -293,9 +205,11 @@ namespace hpx { namespace threads { namespace policies
             while (add_count-- && addfrom->new_tasks_.pop(task, steal))
             {
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
-                if (maintain_queue_wait_times) {
+                if (maintain_queue_wait_times)
+                {
                     addfrom->new_tasks_wait_ +=
-                        util::high_resolution_clock::now() - util::get<2>(*task);
+                        util::high_resolution_clock::now() -
+                        util::get<2>(*task);
                     ++addfrom->new_tasks_wait_count_;
                 }
 #endif
@@ -313,7 +227,8 @@ namespace hpx { namespace threads { namespace policies
                 std::pair<thread_map_type::iterator, bool> p =
                     thread_map_.insert(thrd);
 
-                if (HPX_UNLIKELY(!p.second)) {
+                if (HPX_UNLIKELY(!p.second))
+                {
                     --addfrom->new_tasks_count_.data_;
                     lk.unlock();
                     HPX_THROW_EXCEPTION(hpx::out_of_memory,
@@ -329,7 +244,8 @@ namespace hpx { namespace threads { namespace policies
 
                 // only insert the thread into the work-items queue if it is in
                 // pending state
-                if (state == pending) {
+                if (state == pending)
+                {
                     // pushing the new thread into the pending queue of the
                     // specified thread_queue
                     ++added;
@@ -341,15 +257,17 @@ namespace hpx { namespace threads { namespace policies
                 HPX_ASSERT(&thrd->get_queue<thread_queue>() == this);
             }
 
-            if (added) {
-                LTM_(debug) << "add_new: added " << added << " tasks to queues"; //-V128
+            if (added)
+            {
+                LTM_(debug) << "add_new: added " << added
+                            << " tasks to queues";    //-V128
             }
             return added;
         }
 
         ///////////////////////////////////////////////////////////////////////
         bool add_new_always(std::size_t& added, thread_queue* addfrom,
-            std::unique_lock<mutex_type> &lk, bool steal = false)
+            std::unique_lock<mutex_type>& lk, bool steal = false)
         {
             HPX_ASSERT(lk.owns_lock());
 
@@ -358,28 +276,37 @@ namespace hpx { namespace threads { namespace policies
 #endif
 
             // create new threads from pending tasks (if appropriate)
-            std::int64_t add_count = -1;            // default is no constraint
+            std::int64_t add_count = -1;    // default is no constraint
 
             // if we are desperate (no work in the queues), add some even if the
-            // map holds more than max_count
-            if (HPX_LIKELY(max_count_)) {
-                std::size_t count = thread_map_.size();
-                if (max_count_ >= count + min_add_new_count) { //-V104
-                    HPX_ASSERT(max_count_ - count <
-                        static_cast<std::size_t>(
-                            (std::numeric_limits<std::int64_t>::max)()
-                        ));
-                    add_count = static_cast<std::int64_t>(max_count_ - count);
-                    if (add_count < min_add_new_count)
-                        add_count = min_add_new_count;
-                    if (add_count > max_add_new_count)
-                        add_count = max_add_new_count;
+            // map holds more than max_thread_count
+            if (HPX_LIKELY(parameters_.max_thread_count_))
+            {
+                std::int64_t count =
+                    static_cast<std::int64_t>(thread_map_.size());
+                if (parameters_.max_thread_count_ >=
+                    count + parameters_.min_add_new_count_)
+                {    //-V104
+                    HPX_ASSERT(parameters_.max_thread_count_ - count <
+                        (std::numeric_limits<std::int64_t>::max)());
+                    add_count = static_cast<std::int64_t>(
+                        parameters_.max_thread_count_ - count);
+                    if (add_count < parameters_.min_add_new_count_)
+                        add_count = parameters_.min_add_new_count_;
+                    if (add_count > parameters_.max_add_new_count_)
+                        add_count = parameters_.max_add_new_count_;
                 }
-                else if (work_items_.empty()) {
-                    add_count = min_add_new_count;    // add this number of threads
-                    max_count_ += min_add_new_count;  // increase max_count //-V101
+                else if (work_items_.empty())
+                {
+                    add_count =
+                        parameters_
+                            .min_add_new_count_;    // add this number of threads
+                    parameters_.max_thread_count_ +=
+                        parameters_
+                            .min_add_new_count_;    // increase max_thread_count //-V101
                 }
-                else {
+                else
+                {
                     return false;
                 }
             }
@@ -393,45 +320,26 @@ namespace hpx { namespace threads { namespace policies
         {
             std::ptrdiff_t stacksize = thrd->get_stack_size();
 
-            if (stacksize == get_stack_size(thread_stacksize_small))
+            if (stacksize == parameters_.small_stacksize_)
             {
                 thread_heap_small_.push_front(thrd);
             }
-            else if (stacksize == get_stack_size(thread_stacksize_medium))
+            else if (stacksize == parameters_.medium_stacksize_)
             {
                 thread_heap_medium_.push_front(thrd);
             }
-            else if (stacksize == get_stack_size(thread_stacksize_large))
+            else if (stacksize == parameters_.large_stacksize_)
             {
                 thread_heap_large_.push_front(thrd);
             }
-            else if (stacksize == get_stack_size(thread_stacksize_huge))
+            else if (stacksize == parameters_.huge_stacksize_)
             {
                 thread_heap_huge_.push_front(thrd);
             }
             else
             {
-                switch(stacksize) {
-                case thread_stacksize_small:
-                    thread_heap_small_.push_front(thrd);
-                    break;
-
-                case thread_stacksize_medium:
-                    thread_heap_medium_.push_front(thrd);
-                    break;
-
-                case thread_stacksize_large:
-                    thread_heap_large_.push_front(thrd);
-                    break;
-
-                case thread_stacksize_huge:
-                    thread_heap_huge_.push_front(thrd);
-                    break;
-
-                default:
-                    HPX_ASSERT(false);
-                    break;
-                }
+                HPX_ASSERT_MSG(
+                    false, util::format("Invalid stack size {1}", stacksize));
             }
         }
 
@@ -450,7 +358,8 @@ namespace hpx { namespace threads { namespace policies
             if (terminated_items_count_ == 0)
                 return true;
 
-            if (delete_all) {
+            if (delete_all)
+            {
                 // delete all threads
                 thread_data* todelete;
                 while (terminated_items_.pop(todelete))
@@ -463,19 +372,24 @@ namespace hpx { namespace threads { namespace policies
 
                     bool deleted = thread_map_.erase(tid) != 0;
                     HPX_ASSERT(deleted);
-                    if (deleted) {
+                    if (deleted)
+                    {
                         deallocate(todelete);
                         --thread_map_count_;
                         HPX_ASSERT(thread_map_count_ >= 0);
                     }
                 }
             }
-            else {
+            else
+            {
                 // delete only this many threads
-                std::int64_t delete_count =
-                    (std::max)(
-                        static_cast<std::int64_t>(terminated_items_count_ / 10),
-                        static_cast<std::int64_t>(max_delete_count));
+                std::int64_t delete_count = (std::min)(
+                    static_cast<std::int64_t>(terminated_items_count_ / 10),
+                    static_cast<std::int64_t>(parameters_.max_delete_count_));
+
+                // delete at least this many threads
+                delete_count = (std::max)(delete_count,
+                    static_cast<std::int64_t>(parameters_.min_delete_count_));
 
                 thread_data* todelete;
                 while (delete_count && terminated_items_.pop(todelete))
@@ -506,7 +420,8 @@ namespace hpx { namespace threads { namespace policies
             if (terminated_items_count_ == 0)
                 return true;
 
-            if (delete_all) {
+            if (delete_all)
+            {
                 // do not lock mutex while deleting all threads, do it piece-wise
                 while (true)
                 {
@@ -523,21 +438,9 @@ namespace hpx { namespace threads { namespace policies
             return cleanup_terminated_locked(false);
         }
 
-        // The maximum number of active threads this thread manager should
-        // create. This number will be a constraint only as long as the work
-        // items queue is not empty. Otherwise the number of active threads
-        // will be incremented in steps equal to the \a min_add_new_count
-        // specified above.
-        enum { max_thread_count = 1000 };
-
         thread_queue(std::size_t queue_num = std::size_t(-1),
-            std::size_t max_count = max_thread_count)
-          : min_tasks_to_steal_pending(detail::get_min_tasks_to_steal_pending())
-          , min_tasks_to_steal_staged(detail::get_min_tasks_to_steal_staged())
-          , min_add_new_count(detail::get_min_add_new_count())
-          , max_add_new_count(detail::get_max_add_new_count())
-          , max_delete_count(detail::get_max_delete_count())
-          , max_terminated_threads(detail::get_max_terminated_threads())
+            thread_queue_init_parameters parameters = {})
+          : parameters_(parameters)
           , thread_map_count_(0)
           , work_items_(128, queue_num)
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
@@ -546,9 +449,6 @@ namespace hpx { namespace threads { namespace policies
 #endif
           , terminated_items_(128)
           , terminated_items_count_(0)
-          , max_count_((0 == max_count) ?
-                    static_cast<std::size_t>(max_thread_count) :
-                    max_count)
           , new_tasks_(128)
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
           , new_tasks_wait_(0)
@@ -584,22 +484,17 @@ namespace hpx { namespace threads { namespace policies
 
         ~thread_queue()
         {
-            for(auto t: thread_heap_small_)
+            for (auto t : thread_heap_small_)
                 deallocate(t.get());
 
-            for(auto t: thread_heap_medium_)
+            for (auto t : thread_heap_medium_)
                 deallocate(t.get());
 
-            for(auto t: thread_heap_large_)
+            for (auto t : thread_heap_large_)
                 deallocate(t.get());
 
-            for(auto t: thread_heap_huge_)
+            for (auto t : thread_heap_huge_)
                 deallocate(t.get());
-        }
-
-        void set_max_count(std::size_t max_count = max_thread_count)
-        {
-            max_count_ = (0 == max_count) ? max_thread_count : max_count; //-V105
         }
 
 #ifdef HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES
@@ -746,7 +641,8 @@ namespace hpx { namespace threads { namespace policies
             thread_state_enum initial_state, bool run_now, error_code& ec)
         {
             // thread has not been created yet
-            if (id) *id = invalid_thread_id;
+            if (id)
+                *id = invalid_thread_id;
 
             if (run_now)
             {
@@ -764,7 +660,8 @@ namespace hpx { namespace threads { namespace policies
                     std::pair<thread_map_type::iterator, bool> p =
                         thread_map_.insert(thrd);
 
-                    if (HPX_UNLIKELY(!p.second)) {
+                    if (HPX_UNLIKELY(!p.second))
+                    {
                         lk.unlock();
                         HPX_THROWS_IF(ec, hpx::out_of_memory,
                             "threadmanager::register_thread",
@@ -782,7 +679,8 @@ namespace hpx { namespace threads { namespace policies
                         schedule_thread(thrd.get());
 
                     // return the thread_id of the newly created thread
-                    if (id) *id = thrd;
+                    if (id)
+                        *id = thrd;
 
                     if (&ec != &throws)
                         ec = make_success_code();
@@ -799,14 +697,15 @@ namespace hpx { namespace threads { namespace policies
             new (td) task_description(std::move(data), initial_state,
                 util::high_resolution_clock::now());
 #else
-            new (td) task_description(std::move(data), initial_state); //-V106
+            new (td)
+                task_description(std::move(data), initial_state);    //-V106
 #endif
             new_tasks_.push(td);
             if (&ec != &throws)
                 ec = make_success_code();
         }
 
-        void move_work_items_from(thread_queue *src, std::int64_t count)
+        void move_work_items_from(thread_queue* src, std::int64_t count)
         {
             thread_description* trd;
             while (src->work_items_.pop(trd))
@@ -814,7 +713,8 @@ namespace hpx { namespace threads { namespace policies
                 --src->work_items_count_.data_;
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
-                if (maintain_queue_wait_times) {
+                if (maintain_queue_wait_times)
+                {
                     std::uint64_t now = util::high_resolution_clock::now();
                     src->work_items_wait_ += now - util::get<1>(*trd);
                     ++src->work_items_wait_count_;
@@ -829,14 +729,14 @@ namespace hpx { namespace threads { namespace policies
             }
         }
 
-        void move_task_items_from(thread_queue *src,
-            std::int64_t count)
+        void move_task_items_from(thread_queue* src, std::int64_t count)
         {
             task_description* task;
             while (src->new_tasks_.pop(task))
             {
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
-                if (maintain_queue_wait_times) {
+                if (maintain_queue_wait_times)
+                {
                     std::int64_t now = util::high_resolution_clock::now();
                     src->new_tasks_wait_ += now - util::get<2>(*task);
                     ++src->new_tasks_wait_count_;
@@ -870,7 +770,8 @@ namespace hpx { namespace threads { namespace policies
             std::int64_t work_items_count =
                 work_items_count_.data_.load(std::memory_order_relaxed);
 
-            if (allow_stealing && min_tasks_to_steal_pending > work_items_count)
+            if (allow_stealing &&
+                parameters_.min_tasks_to_steal_pending_ > work_items_count)
             {
                 return false;
             }
@@ -881,7 +782,8 @@ namespace hpx { namespace threads { namespace policies
             {
                 --work_items_count_.data_;
 
-                if (maintain_queue_wait_times) {
+                if (maintain_queue_wait_times)
+                {
                     work_items_wait_ += util::high_resolution_clock::now() -
                         util::get<1>(*tdesc);
                     ++work_items_wait_count_;
@@ -908,22 +810,24 @@ namespace hpx { namespace threads { namespace policies
             ++work_items_count_.data_;
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
             work_items_.push(new thread_description(
-                thrd, util::high_resolution_clock::now()), other_end);
+                                 thrd, util::high_resolution_clock::now()),
+                other_end);
 #else
             work_items_.push(thrd, other_end);
 #endif
         }
 
         /// Destroy the passed thread as it has been terminated
-        void destroy_thread(threads::thread_data* thrd, std::int64_t& busy_count)
+        void destroy_thread(
+            threads::thread_data* thrd, std::int64_t& busy_count)
         {
             HPX_ASSERT(&thrd->get_queue<thread_queue>() == this);
             terminated_items_.push(thrd);
 
             std::int64_t count = ++terminated_items_count_;
-            if (count > max_terminated_threads)
+            if (count > parameters_.max_terminated_threads_)
             {
-                cleanup_terminated(true);   // clean up all terminated threads
+                cleanup_terminated(true);    // clean up all terminated threads
             }
         }
 
@@ -961,9 +865,9 @@ namespace hpx { namespace threads { namespace policies
         void abort_all_suspended_threads()
         {
             std::lock_guard<mutex_type> lk(mtx_);
-            thread_map_type::iterator end =  thread_map_.end();
-            for (thread_map_type::iterator it = thread_map_.begin();
-                 it != end; ++it)
+            thread_map_type::iterator end = thread_map_.end();
+            for (thread_map_type::iterator it = thread_map_.begin(); it != end;
+                 ++it)
             {
                 if ((*it)->get_state().state() == suspended)
                 {
@@ -996,7 +900,7 @@ namespace hpx { namespace threads { namespace policies
             if (state == unknown)
             {
                 std::lock_guard<mutex_type> lk(mtx_);
-                thread_map_type::const_iterator end =  thread_map_.end();
+                thread_map_type::const_iterator end = thread_map_.end();
                 for (thread_map_type::const_iterator it = thread_map_.begin();
                      it != end; ++it)
                 {
@@ -1006,7 +910,7 @@ namespace hpx { namespace threads { namespace policies
             else
             {
                 std::lock_guard<mutex_type> lk(mtx_);
-                thread_map_type::const_iterator end =  thread_map_.end();
+                thread_map_type::const_iterator end = thread_map_.end();
                 for (thread_map_type::const_iterator it = thread_map_.begin();
                      it != end; ++it)
                 {
@@ -1019,7 +923,7 @@ namespace hpx { namespace threads { namespace policies
             for (thread_id_type const& id : ids)
             {
                 if (!f(id))
-                    return false;       // stop iteration
+                    return false;    // stop iteration
             }
 
             return true;
@@ -1047,7 +951,7 @@ namespace hpx { namespace threads { namespace policies
             // the lock) will just retry to enter this loop.
             std::unique_lock<mutex_type> lk(mtx_, std::try_to_lock);
             if (!lk.owns_lock())
-                return false;            // avoid long wait on lock
+                return false;    // avoid long wait on lock
 
             // stop running after all HPX threads have been terminated
             return add_new_always(added, this, lk);
@@ -1064,7 +968,8 @@ namespace hpx { namespace threads { namespace policies
 
                 // don't try to steal if there are only a few tasks left on
                 // this queue
-                if (running && min_tasks_to_steal_staged >
+                if (running &&
+                    parameters_.min_tasks_to_steal_staged_ >
                         addfrom->new_tasks_count_.data_.load(
                             std::memory_order_relaxed))
                 {
@@ -1082,19 +987,21 @@ namespace hpx { namespace threads { namespace policies
                 // the lock) will just retry to enter this loop.
                 std::unique_lock<mutex_type> lk(mtx_, std::try_to_lock);
                 if (!lk.owns_lock())
-                    return false;            // avoid long wait on lock
+                    return false;    // avoid long wait on lock
 
                 // stop running after all HPX threads have been terminated
                 bool added_new = add_new_always(added, addfrom, lk, steal);
-                if (!added_new) {
+                if (!added_new)
+                {
                     // Before exiting each of the OS threads deletes the
                     // remaining terminated HPX threads
                     // REVIEW: Should we be doing this if we are stealing?
                     bool canexit = cleanup_terminated_locked(true);
-                    if (!running && canexit) {
+                    if (!running && canexit)
+                    {
                         // we don't have any registered work items anymore
                         //do_some_work();       // notify possibly waiting threads
-                        return true;            // terminate scheduling loop
+                        return true;    // terminate scheduling loop
                     }
                     return false;
                 }
@@ -1109,7 +1016,7 @@ namespace hpx { namespace threads { namespace policies
             if (!running && canexit)
             {
                 // we don't have any registered work items anymore
-                return true; // terminate scheduling loop
+                return true;    // terminate scheduling loop
             }
 
             return false;
@@ -1122,10 +1029,11 @@ namespace hpx { namespace threads { namespace policies
 #ifndef HPX_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION
             return false;
 #else
-            if (minimal_deadlock_detection) {
+            if (minimal_deadlock_detection)
+            {
                 std::lock_guard<mutex_type> lk(mtx_);
-                return detail::dump_suspended_threads(num_thread, thread_map_
-                  , idle_loop_count, running);
+                return detail::dump_suspended_threads(
+                    num_thread, thread_map_, idle_loop_count, running);
             }
             return false;
 #endif
@@ -1137,27 +1045,35 @@ namespace hpx { namespace threads { namespace policies
         void on_error(std::size_t num_thread, std::exception_ptr const& e) {}
 
     private:
-        mutable mutex_type mtx_;            // mutex protecting the members
+        thread_queue_init_parameters parameters_;
 
-        thread_map_type thread_map_;        // mapping of thread id's to HPX-threads
-        std::atomic<std::int64_t> thread_map_count_; // overall count of work items
+        mutable mutex_type mtx_;    // mutex protecting the members
 
-        work_items_type work_items_;        // list of active work items
+        thread_map_type thread_map_;    // mapping of thread id's to HPX-threads
+        std::atomic<std::int64_t>
+            thread_map_count_;    // overall count of work items
+
+        work_items_type work_items_;    // list of active work items
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
-        std::atomic<std::int64_t> work_items_wait_; // overall wait time of work items
-        std::atomic<std::int64_t> work_items_wait_count_; // overall number of
-                                                          // work items in queue
+        std::atomic<std::int64_t>
+            work_items_wait_;    // overall wait time of work items
+        std::atomic<std::int64_t>
+            work_items_wait_count_;    // overall number of
+                                       // work items in queue
 #endif
-        terminated_items_type terminated_items_;    // list of terminated threads
-        std::atomic<std::int64_t> terminated_items_count_; // count of terminated items
+        terminated_items_type
+            terminated_items_;    // list of terminated threads
+        std::atomic<std::int64_t>
+            terminated_items_count_;    // count of terminated items
 
-        std::size_t max_count_;     // maximum number of existing HPX-threads
-        task_items_type new_tasks_; // list of new tasks to run
+        task_items_type new_tasks_;    // list of new tasks to run
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
-        std::atomic<std::int64_t> new_tasks_wait_;  // overall wait time of new tasks
-        std::atomic<std::int64_t> new_tasks_wait_count_; // overall number tasks waited
+        std::atomic<std::int64_t>
+            new_tasks_wait_;    // overall wait time of new tasks
+        std::atomic<std::int64_t>
+            new_tasks_wait_count_;    // overall number tasks waited
 #endif
 
         thread_heap_type thread_heap_small_;
@@ -1203,10 +1119,9 @@ namespace hpx { namespace threads { namespace policies
     template <typename Mutex, typename PendingQueuing, typename StagedQueuing,
         typename TerminatedQueuing>
     util::internal_allocator<typename thread_queue<Mutex, PendingQueuing,
-            StagedQueuing, TerminatedQueuing>::task_description>
+        StagedQueuing, TerminatedQueuing>::task_description>
         thread_queue<Mutex, PendingQueuing, StagedQueuing,
             TerminatedQueuing>::task_description_alloc_;
-}}}
+}}}    // namespace hpx::threads::policies
 
 #endif
-

--- a/hpx/runtime/threads/policies/thread_queue_init_parameters.hpp
+++ b/hpx/runtime/threads/policies/thread_queue_init_parameters.hpp
@@ -1,0 +1,72 @@
+//  Copyright (c) 2019 Mikael Simberg
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_RUNTIME_THREADS_POLICIES_THREAD_QUEUE_INIT_PARAMETER_HPP)
+#define HPX_RUNTIME_THREADS_POLICIES_THREAD_QUEUE_INIT_PARAMETER_HPP
+
+#include <hpx/config.hpp>
+
+#include <cstddef>
+#include <cstdint>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace threads { namespace policies {
+    struct thread_queue_init_parameters
+    {
+        thread_queue_init_parameters(
+            std::int64_t max_thread_count = std::int64_t(
+                HPX_THREAD_QUEUE_MAX_THREAD_COUNT),
+            std::int64_t min_tasks_to_steal_pending = std::int64_t(
+                HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_PENDING),
+            std::int64_t min_tasks_to_steal_staged = std::int64_t(
+                HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_STAGED),
+            std::int64_t min_add_new_count = std::int64_t(
+                HPX_THREAD_QUEUE_MIN_ADD_NEW_COUNT),
+            std::int64_t max_add_new_count = std::int64_t(
+                HPX_THREAD_QUEUE_MAX_ADD_NEW_COUNT),
+            std::int64_t min_delete_count = std::int64_t(
+                HPX_THREAD_QUEUE_MIN_DELETE_COUNT),
+            std::int64_t max_delete_count = std::int64_t(
+                HPX_THREAD_QUEUE_MAX_DELETE_COUNT),
+            std::int64_t max_terminated_threads = std::int64_t(
+                HPX_THREAD_QUEUE_MAX_TERMINATED_THREADS),
+            double max_idle_backoff_time = double(HPX_IDLE_BACKOFF_TIME_MAX),
+            std::ptrdiff_t small_stacksize = HPX_SMALL_STACK_SIZE,
+            std::ptrdiff_t medium_stacksize = HPX_MEDIUM_STACK_SIZE,
+            std::ptrdiff_t large_stacksize = HPX_LARGE_STACK_SIZE,
+            std::ptrdiff_t huge_stacksize = HPX_HUGE_STACK_SIZE)
+          : max_thread_count_(max_thread_count)
+          , min_tasks_to_steal_pending_(min_tasks_to_steal_pending)
+          , min_tasks_to_steal_staged_(min_tasks_to_steal_staged)
+          , min_add_new_count_(min_add_new_count)
+          , max_add_new_count_(max_add_new_count)
+          , min_delete_count_(min_delete_count)
+          , max_delete_count_(max_delete_count)
+          , max_terminated_threads_(max_terminated_threads)
+          , max_idle_backoff_time_(max_idle_backoff_time)
+          , small_stacksize_(small_stacksize)
+          , medium_stacksize_(medium_stacksize)
+          , large_stacksize_(large_stacksize)
+          , huge_stacksize_(huge_stacksize)
+        {
+        }
+
+        std::int64_t max_thread_count_;
+        std::int64_t min_tasks_to_steal_pending_;
+        std::int64_t min_tasks_to_steal_staged_;
+        std::int64_t min_add_new_count_;
+        std::int64_t max_add_new_count_;
+        std::int64_t min_delete_count_;
+        std::int64_t max_delete_count_;
+        std::int64_t max_terminated_threads_;
+        double max_idle_backoff_time_;
+        std::ptrdiff_t small_stacksize_;
+        std::ptrdiff_t medium_stacksize_;
+        std::ptrdiff_t large_stacksize_;
+        std::ptrdiff_t huge_stacksize_;
+    };
+}}}    // namespace hpx::threads::policies
+
+#endif

--- a/hpx/runtime/threads/policies/thread_queue_mc.hpp
+++ b/hpx/runtime/threads/policies/thread_queue_mc.hpp
@@ -13,10 +13,10 @@
 #include <hpx/concurrency/cache_line_data.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/errors.hpp>
-#include <hpx/runtime/config_entry.hpp>
 #include <hpx/runtime/threads/policies/lockfree_queue_backends.hpp>
 #include <hpx/runtime/threads/policies/queue_helpers.hpp>
 #include <hpx/runtime/threads/policies/thread_queue.hpp>
+#include <hpx/runtime/threads/policies/thread_queue_init_parameters.hpp>
 #include <hpx/runtime/threads/thread_data.hpp>
 #include <hpx/thread_support/unlock_guard.hpp>
 #include <hpx/timing/high_resolution_clock.hpp>
@@ -25,7 +25,7 @@
 #include <hpx/util/get_and_reset_value.hpp>
 
 #ifdef HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES
-#   include <hpx/util/tick_counter.hpp>
+#include <hpx/util/tick_counter.hpp>
 #endif
 
 #include <boost/lexical_cast.hpp>
@@ -45,8 +45,7 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace threads { namespace policies
-{
+namespace hpx { namespace threads { namespace policies {
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
     ///////////////////////////////////////////////////////////////////////////
     // We control whether to collect queue wait times using this global bool.
@@ -104,22 +103,6 @@ namespace hpx { namespace threads { namespace policies
         // we use a simple mutex to protect the data members for now
         typedef Mutex mutex_type;
 
-        // don't steal if less than this amount of tasks are left
-        int const min_tasks_to_steal_pending;
-        int const min_tasks_to_steal_staged;
-
-        // create at least this amount of threads from tasks
-        int const min_add_new_count;
-
-        // create not more than this amount of threads from tasks
-        int const max_add_new_count;
-
-        // number of terminated threads to discard
-        int const max_delete_count;
-
-        // number of terminated threads to collect before cleaning them up
-        int const max_terminated_threads;
-
         // this is the type of a map holding all threads (except depleted ones)
         using thread_map_type = std::unordered_set<thread_id_type,
             std::hash<thread_id_type>, std::equal_to<thread_id_type>,
@@ -129,11 +112,11 @@ namespace hpx { namespace threads { namespace policies
             std::list<thread_id_type, util::internal_allocator<thread_id_type>>;
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
-        typedef
-            util::tuple<thread_init_data, thread_state_enum, std::uint64_t>
-        task_description;
+        typedef util::tuple<thread_init_data, thread_state_enum, std::uint64_t>
+            task_description;
 #else
-        typedef util::tuple<thread_init_data, thread_state_enum> task_description;
+        typedef util::tuple<thread_init_data, thread_state_enum>
+            task_description;
 #endif
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
@@ -142,14 +125,15 @@ namespace hpx { namespace threads { namespace policies
         typedef thread_data thread_description;
 #endif
 
-        typedef typename PendingQueuing::template
-            apply<thread_description*>::type work_items_type;
+        typedef
+            typename PendingQueuing::template apply<thread_description*>::type
+                work_items_type;
 
-        typedef concurrentqueue_fifo::
-            apply<task_description>::type task_items_type;
+        typedef concurrentqueue_fifo::apply<task_description>::type
+            task_items_type;
 
-        typedef typename TerminatedQueuing::template
-            apply<thread_data*>::type terminated_items_type;
+        typedef typename TerminatedQueuing::template apply<thread_data*>::type
+            terminated_items_type;
 
     protected:
         template <typename Lock>
@@ -163,43 +147,21 @@ namespace hpx { namespace threads { namespace policies
 
             thread_heap_type* heap = nullptr;
 
-            if (stacksize == get_stack_size(thread_stacksize_small))
+            if (stacksize == parameters_.small_stacksize_)
             {
                 heap = &thread_heap_small_;
             }
-            else if (stacksize == get_stack_size(thread_stacksize_medium))
+            else if (stacksize == parameters_.medium_stacksize_)
             {
                 heap = &thread_heap_medium_;
             }
-            else if (stacksize == get_stack_size(thread_stacksize_large))
+            else if (stacksize == parameters_.large_stacksize_)
             {
                 heap = &thread_heap_large_;
             }
-            else if (stacksize == get_stack_size(thread_stacksize_huge))
+            else if (stacksize == parameters_.huge_stacksize_)
             {
                 heap = &thread_heap_huge_;
-            }
-            else {
-                switch(stacksize) {
-                case thread_stacksize_small:
-                    heap = &thread_heap_small_;
-                    break;
-
-                case thread_stacksize_medium:
-                    heap = &thread_heap_medium_;
-                    break;
-
-                case thread_stacksize_large:
-                    heap = &thread_heap_large_;
-                    break;
-
-                case thread_stacksize_huge:
-                    heap = &thread_heap_huge_;
-                    break;
-
-                default:
-                    break;
-                }
             }
             HPX_ASSERT(heap);
 
@@ -232,7 +194,7 @@ namespace hpx { namespace threads { namespace policies
         ///////////////////////////////////////////////////////////////////////
         // add new threads if there is some amount of work available
         std::size_t add_new(std::int64_t add_count, thread_queue_mc* addfrom,
-            std::unique_lock<mutex_type> &lk, bool steal = false)
+            std::unique_lock<mutex_type>& lk, bool steal = false)
         {
             HPX_ASSERT(lk.owns_lock());
 
@@ -244,7 +206,8 @@ namespace hpx { namespace threads { namespace policies
             while (add_count-- && addfrom->new_tasks_.pop(task, steal))
             {
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
-                if (maintain_queue_wait_times) {
+                if (maintain_queue_wait_times)
+                {
                     addfrom->new_tasks_wait_ +=
                         util::high_resolution_clock::now() - util::get<2>(task);
                     ++addfrom->new_tasks_wait_count_;
@@ -262,7 +225,8 @@ namespace hpx { namespace threads { namespace policies
                 std::pair<thread_map_type::iterator, bool> p =
                     thread_map_.insert(thrd);
 
-                if (HPX_UNLIKELY(!p.second)) {
+                if (HPX_UNLIKELY(!p.second))
+                {
                     --addfrom->new_tasks_count_.data_;
                     lk.unlock();
                     HPX_THROW_EXCEPTION(hpx::out_of_memory,
@@ -278,7 +242,8 @@ namespace hpx { namespace threads { namespace policies
 
                 // only insert the thread into the work-items queue if it is in
                 // pending state
-                if (state == pending) {
+                if (state == pending)
+                {
                     // pushing the new thread into the pending queue of the
                     // specified thread_queue
                     ++added;
@@ -290,15 +255,17 @@ namespace hpx { namespace threads { namespace policies
                 HPX_ASSERT(&thrd->get_queue<thread_queue_mc>() == this);
             }
 
-            if (added) {
-                LTM_(debug) << "add_new: added " << added << " tasks to queues"; //-V128
+            if (added)
+            {
+                LTM_(debug) << "add_new: added " << added
+                            << " tasks to queues";    //-V128
             }
             return added;
         }
 
         ///////////////////////////////////////////////////////////////////////
         bool add_new_always(std::size_t& added, thread_queue_mc* addfrom,
-            std::unique_lock<mutex_type> &lk, bool steal = false)
+            std::unique_lock<mutex_type>& lk, bool steal = false)
         {
             HPX_ASSERT(lk.owns_lock());
 
@@ -307,28 +274,37 @@ namespace hpx { namespace threads { namespace policies
 #endif
 
             // create new threads from pending tasks (if appropriate)
-            std::int64_t add_count = -1;            // default is no constraint
+            std::int64_t add_count = -1;    // default is no constraint
 
             // if we are desperate (no work in the queues), add some even if the
-            // map holds more than max_count
-            if (HPX_LIKELY(max_count_)) {
-                std::size_t count = thread_map_.size();
-                if (max_count_ >= count + min_add_new_count) { //-V104
-                    HPX_ASSERT(max_count_ - count <
-                        static_cast<std::size_t>(
-                            (std::numeric_limits<std::int64_t>::max)()
-                        ));
-                    add_count = static_cast<std::int64_t>(max_count_ - count);
-                    if (add_count < min_add_new_count)
-                        add_count = min_add_new_count;
-                    if (add_count > max_add_new_count)
-                        add_count = max_add_new_count;
+            // map holds more than max_thread_count
+            if (HPX_LIKELY(parameters_.max_thread_count_))
+            {
+                std::int64_t count =
+                    static_cast<std::int64_t>(thread_map_.size());
+                if (parameters_.max_thread_count_ >=
+                    count + parameters_.min_add_new_count_)
+                {    //-V104
+                    HPX_ASSERT(parameters_.max_thread_count_ - count <
+                        (std::numeric_limits<std::int64_t>::max)());
+                    add_count = static_cast<std::int64_t>(
+                        parameters_.max_thread_count_ - count);
+                    if (add_count < parameters_.min_add_new_count_)
+                        add_count = parameters_.min_add_new_count_;
+                    if (add_count > parameters_.max_add_new_count_)
+                        add_count = parameters_.max_add_new_count_;
                 }
-                else if (work_items_.empty()) {
-                    add_count = min_add_new_count;    // add this number of threads
-                    max_count_ += min_add_new_count;  // increase max_count //-V101
+                else if (work_items_.empty())
+                {
+                    add_count =
+                        parameters_
+                            .min_add_new_count_;    // add this number of threads
+                    parameters_.max_thread_count_ +=
+                        parameters_
+                            .min_add_new_count_;    // increase max_thread_count //-V101
                 }
-                else {
+                else
+                {
                     return false;
                 }
             }
@@ -342,45 +318,26 @@ namespace hpx { namespace threads { namespace policies
         {
             std::ptrdiff_t stacksize = thrd->get_stack_size();
 
-            if (stacksize == get_stack_size(thread_stacksize_small))
+            if (stacksize == parameters_.small_stacksize_)
             {
                 thread_heap_small_.push_front(thrd);
             }
-            else if (stacksize == get_stack_size(thread_stacksize_medium))
+            else if (stacksize == parameters_.medium_stacksize_)
             {
                 thread_heap_medium_.push_front(thrd);
             }
-            else if (stacksize == get_stack_size(thread_stacksize_large))
+            else if (stacksize == parameters_.large_stacksize_)
             {
                 thread_heap_large_.push_front(thrd);
             }
-            else if (stacksize == get_stack_size(thread_stacksize_huge))
+            else if (stacksize == parameters_.huge_stacksize_)
             {
                 thread_heap_huge_.push_front(thrd);
             }
             else
             {
-                switch(stacksize) {
-                case thread_stacksize_small:
-                    thread_heap_small_.push_front(thrd);
-                    break;
-
-                case thread_stacksize_medium:
-                    thread_heap_medium_.push_front(thrd);
-                    break;
-
-                case thread_stacksize_large:
-                    thread_heap_large_.push_front(thrd);
-                    break;
-
-                case thread_stacksize_huge:
-                    thread_heap_huge_.push_front(thrd);
-                    break;
-
-                default:
-                    HPX_ASSERT(false);
-                    break;
-                }
+                HPX_ASSERT_MSG(
+                    false, util::format("Invalid stack size {1}", stacksize));
             }
         }
 
@@ -399,7 +356,8 @@ namespace hpx { namespace threads { namespace policies
             if (terminated_items_count_ == 0)
                 return true;
 
-            if (delete_all) {
+            if (delete_all)
+            {
                 // delete all threads
                 thread_data* todelete;
                 while (terminated_items_.pop(todelete))
@@ -412,19 +370,24 @@ namespace hpx { namespace threads { namespace policies
 
                     bool deleted = thread_map_.erase(tid) != 0;
                     HPX_ASSERT(deleted);
-                    if (deleted) {
+                    if (deleted)
+                    {
                         deallocate(todelete);
                         --thread_map_count_;
                         HPX_ASSERT(thread_map_count_ >= 0);
                     }
                 }
             }
-            else {
+            else
+            {
                 // delete only this many threads
-                std::int64_t delete_count =
-                    (std::max)(
-                        static_cast<std::int64_t>(terminated_items_count_ / 10),
-                        static_cast<std::int64_t>(max_delete_count));
+                std::int64_t delete_count = (std::min)(
+                    static_cast<std::int64_t>(terminated_items_count_ / 10),
+                    static_cast<std::int64_t>(parameters_.max_delete_count_));
+
+                // delete at least this many threads
+                delete_count = (std::max)(delete_count,
+                    static_cast<std::int64_t>(parameters_.min_delete_count_));
 
                 thread_data* todelete;
                 while (delete_count && terminated_items_.pop(todelete))
@@ -455,7 +418,8 @@ namespace hpx { namespace threads { namespace policies
             if (terminated_items_count_ == 0)
                 return true;
 
-            if (delete_all) {
+            if (delete_all)
+            {
                 // do not lock mutex while deleting all threads, do it piece-wise
                 while (true)
                 {
@@ -472,52 +436,37 @@ namespace hpx { namespace threads { namespace policies
             return cleanup_terminated_locked(false);
         }
 
-        // The maximum number of active threads this thread manager should
-        // create. This number will be a constraint only as long as the work
-        // items queue is not empty. Otherwise the number of active threads
-        // will be incremented in steps equal to the \a min_add_new_count
-        // specified above.
-        enum { max_thread_count = 1000 };
-
         thread_queue_mc(std::size_t queue_num = std::size_t(-1),
-                std::size_t max_count = max_thread_count)
-          : min_tasks_to_steal_pending(detail::get_min_tasks_to_steal_pending()),
-            min_tasks_to_steal_staged(detail::get_min_tasks_to_steal_staged()),
-            min_add_new_count(detail::get_min_add_new_count()),
-            max_add_new_count(detail::get_max_add_new_count()),
-            max_delete_count(detail::get_max_delete_count()),
-            max_terminated_threads(detail::get_max_terminated_threads()),
-            thread_map_count_(0),
-            work_items_(128, queue_num)
+            thread_queue_init_parameters parameters = {})
+          : parameters_(parameters)
+          , thread_map_count_(0)
+          , work_items_(128, queue_num)
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
-           ,work_items_wait_(0),
-            work_items_wait_count_(0)
+          , work_items_wait_(0)
+          , work_items_wait_count_(0)
 #endif
-           ,terminated_items_(128),
-            terminated_items_count_(0),
-            max_count_((0 == max_count)
-                      ? static_cast<std::size_t>(max_thread_count)
-                      : max_count),
-            new_tasks_(128)
+          , terminated_items_(128)
+          , terminated_items_count_(0)
+          , new_tasks_(128)
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
-           ,new_tasks_wait_(0),
-            new_tasks_wait_count_(0)
+          , new_tasks_wait_(0)
+          , new_tasks_wait_count_(0)
 #endif
-           ,thread_heap_small_(),
-            thread_heap_medium_(),
-            thread_heap_large_(),
-            thread_heap_huge_()
+          , thread_heap_small_()
+          , thread_heap_medium_()
+          , thread_heap_large_()
+          , thread_heap_huge_()
 #ifdef HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES
-           ,add_new_time_(0),
-            cleanup_terminated_time_(0)
+          , add_new_time_(0)
+          , cleanup_terminated_time_(0)
 #endif
 #ifdef HPX_HAVE_THREAD_STEALING_COUNTS
-           ,pending_misses_(0),
-            pending_accesses_(0),
-            stolen_from_pending_(0),
-            stolen_from_staged_(0),
-            stolen_to_pending_(0),
-            stolen_to_staged_(0)
+          , pending_misses_(0)
+          , pending_accesses_(0)
+          , stolen_from_pending_(0)
+          , stolen_from_staged_(0)
+          , stolen_to_pending_(0)
+          , stolen_to_staged_(0)
 #endif
         {
             new_tasks_count_.data_ = 0;
@@ -533,22 +482,17 @@ namespace hpx { namespace threads { namespace policies
 
         ~thread_queue_mc()
         {
-            for(auto t: thread_heap_small_)
+            for (auto t : thread_heap_small_)
                 deallocate(t.get());
 
-            for(auto t: thread_heap_medium_)
+            for (auto t : thread_heap_medium_)
                 deallocate(t.get());
 
-            for(auto t: thread_heap_large_)
+            for (auto t : thread_heap_large_)
                 deallocate(t.get());
 
-            for(auto t: thread_heap_huge_)
+            for (auto t : thread_heap_huge_)
                 deallocate(t.get());
-        }
-
-        void set_max_count(std::size_t max_count = max_thread_count)
-        {
-            max_count_ = (0 == max_count) ? max_thread_count : max_count; //-V105
         }
 
 #ifdef HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES
@@ -695,7 +639,8 @@ namespace hpx { namespace threads { namespace policies
             thread_state_enum initial_state, bool run_now, error_code& ec)
         {
             // thread has not been created yet
-            if (id) *id = invalid_thread_id;
+            if (id)
+                *id = invalid_thread_id;
 
             if (run_now)
             {
@@ -713,7 +658,8 @@ namespace hpx { namespace threads { namespace policies
                     std::pair<thread_map_type::iterator, bool> p =
                         thread_map_.insert(thrd);
 
-                    if (HPX_UNLIKELY(!p.second)) {
+                    if (HPX_UNLIKELY(!p.second))
+                    {
                         lk.unlock();
                         HPX_THROWS_IF(ec, hpx::out_of_memory,
                             "threadmanager::register_thread",
@@ -731,7 +677,8 @@ namespace hpx { namespace threads { namespace policies
                         schedule_thread(thrd.get());
 
                     // return the thread_id of the newly created thread
-                    if (id) *id = thrd;
+                    if (id)
+                        *id = thrd;
 
                     if (&ec != &throws)
                         ec = make_success_code();
@@ -747,13 +694,14 @@ namespace hpx { namespace threads { namespace policies
             new_tasks_.push(task_description(std::move(data), initial_state,
                 util::high_resolution_clock::now()));
 #else
-            new_tasks_.push(task_description(std::move(data), initial_state)); //-V106
+            new_tasks_.push(
+                task_description(std::move(data), initial_state));    //-V106
 #endif
             if (&ec != &throws)
                 ec = make_success_code();
         }
 
-        void move_work_items_from(thread_queue_mc *src, std::int64_t count)
+        void move_work_items_from(thread_queue_mc* src, std::int64_t count)
         {
             thread_description* trd;
             while (src->work_items_.pop(trd))
@@ -761,7 +709,8 @@ namespace hpx { namespace threads { namespace policies
                 --src->work_items_count_.data_;
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
-                if (maintain_queue_wait_times) {
+                if (maintain_queue_wait_times)
+                {
                     std::uint64_t now = util::high_resolution_clock::now();
                     src->work_items_wait_ += now - util::get<1>(*trd);
                     ++src->work_items_wait_count_;
@@ -776,14 +725,14 @@ namespace hpx { namespace threads { namespace policies
             }
         }
 
-        void move_task_items_from(thread_queue_mc *src,
-            std::int64_t count)
+        void move_task_items_from(thread_queue_mc* src, std::int64_t count)
         {
             task_description task;
             while (src->new_tasks_.pop(task))
             {
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
-                if (maintain_queue_wait_times) {
+                if (maintain_queue_wait_times)
+                {
                     std::int64_t now = util::high_resolution_clock::now();
                     src->new_tasks_wait_ += now - util::get<2>(*task);
                     ++src->new_tasks_wait_count_;
@@ -817,7 +766,8 @@ namespace hpx { namespace threads { namespace policies
             std::int64_t work_items_count =
                 work_items_count_.data_.load(std::memory_order_relaxed);
 
-            if (allow_stealing && min_tasks_to_steal_pending > work_items_count)
+            if (allow_stealing &&
+                parameters_.min_tasks_to_steal_pending_ > work_items_count)
             {
                 return false;
             }
@@ -828,7 +778,8 @@ namespace hpx { namespace threads { namespace policies
             {
                 --work_items_count_.data_;
 
-                if (maintain_queue_wait_times) {
+                if (maintain_queue_wait_times)
+                {
                     work_items_wait_ += util::high_resolution_clock::now() -
                         util::get<1>(*tdesc);
                     ++work_items_wait_count_;
@@ -855,22 +806,24 @@ namespace hpx { namespace threads { namespace policies
             ++work_items_count_.data_;
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
             work_items_.push(new thread_description(
-                thrd, util::high_resolution_clock::now()), other_end);
+                                 thrd, util::high_resolution_clock::now()),
+                other_end);
 #else
             work_items_.push(thrd, other_end);
 #endif
         }
 
         /// Destroy the passed thread as it has been terminated
-        void destroy_thread(threads::thread_data* thrd, std::int64_t& busy_count)
+        void destroy_thread(
+            threads::thread_data* thrd, std::int64_t& busy_count)
         {
             HPX_ASSERT(&thrd->get_queue<thread_queue_mc>() == this);
             terminated_items_.push(thrd);
 
             std::int64_t count = ++terminated_items_count_;
-            if (count > max_terminated_threads)
+            if (count > parameters_.max_terminated_threads_)
             {
-                cleanup_terminated(true);   // clean up all terminated threads
+                cleanup_terminated(true);    // clean up all terminated threads
             }
         }
 
@@ -908,9 +861,9 @@ namespace hpx { namespace threads { namespace policies
         void abort_all_suspended_threads()
         {
             std::lock_guard<mutex_type> lk(mtx_);
-            thread_map_type::iterator end =  thread_map_.end();
-            for (thread_map_type::iterator it = thread_map_.begin();
-                 it != end; ++it)
+            thread_map_type::iterator end = thread_map_.end();
+            for (thread_map_type::iterator it = thread_map_.begin(); it != end;
+                 ++it)
             {
                 if ((*it)->get_state().state() == suspended)
                 {
@@ -943,7 +896,7 @@ namespace hpx { namespace threads { namespace policies
             if (state == unknown)
             {
                 std::lock_guard<mutex_type> lk(mtx_);
-                thread_map_type::const_iterator end =  thread_map_.end();
+                thread_map_type::const_iterator end = thread_map_.end();
                 for (thread_map_type::const_iterator it = thread_map_.begin();
                      it != end; ++it)
                 {
@@ -953,7 +906,7 @@ namespace hpx { namespace threads { namespace policies
             else
             {
                 std::lock_guard<mutex_type> lk(mtx_);
-                thread_map_type::const_iterator end =  thread_map_.end();
+                thread_map_type::const_iterator end = thread_map_.end();
                 for (thread_map_type::const_iterator it = thread_map_.begin();
                      it != end; ++it)
                 {
@@ -966,7 +919,7 @@ namespace hpx { namespace threads { namespace policies
             for (thread_id_type const& id : ids)
             {
                 if (!f(id))
-                    return false;       // stop iteration
+                    return false;    // stop iteration
             }
 
             return true;
@@ -994,7 +947,7 @@ namespace hpx { namespace threads { namespace policies
             // the lock) will just retry to enter this loop.
             std::unique_lock<mutex_type> lk(mtx_, std::try_to_lock);
             if (!lk.owns_lock())
-                return false;            // avoid long wait on lock
+                return false;    // avoid long wait on lock
 
             // stop running after all HPX threads have been terminated
             return add_new_always(added, this, lk);
@@ -1011,7 +964,8 @@ namespace hpx { namespace threads { namespace policies
 
                 // don't try to steal if there are only a few tasks left on
                 // this queue
-                if (running && min_tasks_to_steal_staged >
+                if (running &&
+                    parameters_.min_tasks_to_steal_staged_ >
                         addfrom->new_tasks_count_.data_.load(
                             std::memory_order_relaxed))
                 {
@@ -1029,19 +983,21 @@ namespace hpx { namespace threads { namespace policies
                 // the lock) will just retry to enter this loop.
                 std::unique_lock<mutex_type> lk(mtx_, std::try_to_lock);
                 if (!lk.owns_lock())
-                    return false;            // avoid long wait on lock
+                    return false;    // avoid long wait on lock
 
                 // stop running after all HPX threads have been terminated
                 bool added_new = add_new_always(added, addfrom, lk, steal);
-                if (!added_new) {
+                if (!added_new)
+                {
                     // Before exiting each of the OS threads deletes the
                     // remaining terminated HPX threads
                     // REVIEW: Should we be doing this if we are stealing?
                     bool canexit = cleanup_terminated_locked(true);
-                    if (!running && canexit) {
+                    if (!running && canexit)
+                    {
                         // we don't have any registered work items anymore
                         //do_some_work();       // notify possibly waiting threads
-                        return true;            // terminate scheduling loop
+                        return true;    // terminate scheduling loop
                     }
                     return false;
                 }
@@ -1056,7 +1012,7 @@ namespace hpx { namespace threads { namespace policies
             if (!running && canexit)
             {
                 // we don't have any registered work items anymore
-                return true; // terminate scheduling loop
+                return true;    // terminate scheduling loop
             }
 
             return false;
@@ -1069,10 +1025,11 @@ namespace hpx { namespace threads { namespace policies
 #ifndef HPX_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION
             return false;
 #else
-            if (minimal_deadlock_detection) {
+            if (minimal_deadlock_detection)
+            {
                 std::lock_guard<mutex_type> lk(mtx_);
-                return detail::dump_suspended_threads(num_thread, thread_map_
-                  , idle_loop_count, running);
+                return detail::dump_suspended_threads(
+                    num_thread, thread_map_, idle_loop_count, running);
             }
             return false;
 #endif
@@ -1084,27 +1041,35 @@ namespace hpx { namespace threads { namespace policies
         void on_error(std::size_t num_thread, std::exception_ptr const& e) {}
 
     private:
-        mutable mutex_type mtx_;            // mutex protecting the members
+        thread_queue_init_parameters parameters_;
 
-        thread_map_type thread_map_;        // mapping of thread id's to HPX-threads
-        std::atomic<std::int64_t> thread_map_count_; // overall count of work items
+        mutable mutex_type mtx_;    // mutex protecting the members
 
-        work_items_type work_items_;        // list of active work items
+        thread_map_type thread_map_;    // mapping of thread id's to HPX-threads
+        std::atomic<std::int64_t>
+            thread_map_count_;    // overall count of work items
+
+        work_items_type work_items_;    // list of active work items
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
-        std::atomic<std::int64_t> work_items_wait_; // overall wait time of work items
-        std::atomic<std::int64_t> work_items_wait_count_; // overall number of
-                                                          // work items in queue
+        std::atomic<std::int64_t>
+            work_items_wait_;    // overall wait time of work items
+        std::atomic<std::int64_t>
+            work_items_wait_count_;    // overall number of
+                                       // work items in queue
 #endif
-        terminated_items_type terminated_items_;    // list of terminated threads
-        std::atomic<std::int64_t> terminated_items_count_; // count of terminated items
+        terminated_items_type
+            terminated_items_;    // list of terminated threads
+        std::atomic<std::int64_t>
+            terminated_items_count_;    // count of terminated items
 
-        std::size_t max_count_;     // maximum number of existing HPX-threads
-        task_items_type new_tasks_; // list of new tasks to run
+        task_items_type new_tasks_;    // list of new tasks to run
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
-        std::atomic<std::int64_t> new_tasks_wait_;  // overall wait time of new tasks
-        std::atomic<std::int64_t> new_tasks_wait_count_; // overall number tasks waited
+        std::atomic<std::int64_t>
+            new_tasks_wait_;    // overall wait time of new tasks
+        std::atomic<std::int64_t>
+            new_tasks_wait_count_;    // overall number tasks waited
 #endif
 
         thread_heap_type thread_heap_small_;
@@ -1147,7 +1112,6 @@ namespace hpx { namespace threads { namespace policies
         typename TerminatedQueuing>
     util::internal_allocator<threads::thread_data> thread_queue_mc<Mutex,
         PendingQueuing, StagedQueuing, TerminatedQueuing>::thread_alloc_;
-}}}
+}}}    // namespace hpx::threads::policies
 
 #endif
-

--- a/hpx/runtime/threads/thread_init_data.hpp
+++ b/hpx/runtime/threads/thread_init_data.hpp
@@ -43,7 +43,7 @@ namespace hpx { namespace threads
 #endif
             priority(thread_priority_normal),
             schedulehint(),
-            stacksize(get_default_stack_size()),
+            stacksize(HPX_SMALL_STACK_SIZE),
             scheduler_base(nullptr)
         {}
 
@@ -89,14 +89,14 @@ namespace hpx { namespace threads
             scheduler_base(rhs.scheduler_base)
         {
             if (stacksize == 0)
-                stacksize = get_default_stack_size();
+                stacksize = HPX_SMALL_STACK_SIZE;
         }
 
         template <typename F>
         thread_init_data(F && f, util::thread_description const& desc,
                 thread_priority priority_ = thread_priority_normal,
                 thread_schedule_hint os_thread = thread_schedule_hint(),
-                std::ptrdiff_t stacksize_ = std::ptrdiff_t(-1),
+                std::ptrdiff_t stacksize_ = HPX_SMALL_STACK_SIZE,
                 policies::scheduler_base* scheduler_base_ = nullptr)
           : func(std::forward<F>(f)),
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
@@ -111,12 +111,11 @@ namespace hpx { namespace threads
             apex_data(apex_new_task(description,parent_locality_id,parent_id)),
 #endif
             priority(priority_), schedulehint(os_thread),
-            stacksize(stacksize_ == std::ptrdiff_t(-1) ?
-                get_default_stack_size() : stacksize_),
+            stacksize(stacksize_),
             scheduler_base(scheduler_base_)
         {
             if (stacksize == 0)
-                stacksize = get_default_stack_size();
+                stacksize = HPX_SMALL_STACK_SIZE;
         }
 
         threads::thread_function_type func;

--- a/hpx/runtime/threads_fwd.hpp
+++ b/hpx/runtime/threads_fwd.hpp
@@ -18,7 +18,6 @@ namespace hpx
         namespace policies
         {
             struct scheduler_base;
-            class HPX_EXPORT callback_notifier;
             namespace detail {
                 struct HPX_EXPORT affinity_data;
             }

--- a/libs/config/include/hpx/config.hpp
+++ b/libs/config/include/hpx/config.hpp
@@ -371,6 +371,56 @@
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
+// Maximum number of threads to create in the thread queue, except when there is
+// no work to do, in which case the count will be increased in steps of
+// HPX_THREAD_QUEUE_MIN_ADD_NEW_COUNT.
+#if !defined(HPX_THREAD_QUEUE_MAX_THREAD_COUNT)
+#  define HPX_THREAD_QUEUE_MAX_THREAD_COUNT 1000
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+// Minimum number of pending tasks required to steal tasks.
+#if !defined(HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_PENDING)
+#  define HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_PENDING 0
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+// Minimum number of staged tasks required to steal tasks.
+#if !defined(HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_STAGED)
+#  define HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_STAGED 10
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+// Minimum number of staged tasks to add to work items queue.
+#if !defined(HPX_THREAD_QUEUE_MIN_ADD_NEW_COUNT)
+#  define HPX_THREAD_QUEUE_MIN_ADD_NEW_COUNT 10
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+// Maximum number of staged tasks to add to work items queue.
+#if !defined(HPX_THREAD_QUEUE_MAX_ADD_NEW_COUNT)
+#  define HPX_THREAD_QUEUE_MAX_ADD_NEW_COUNT 10
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+// Minimum number of terminated threads to delete in one go.
+#if !defined(HPX_THREAD_QUEUE_MIN_DELETE_COUNT)
+#  define HPX_THREAD_QUEUE_MIN_DELETE_COUNT 10
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+// Maximum number of terminated threads to delete in one go.
+#if !defined(HPX_THREAD_QUEUE_MAX_DELETE_COUNT)
+#  define HPX_THREAD_QUEUE_MAX_DELETE_COUNT 1000
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+// Maximum number of terminated threads to keep before cleaning them up.
+#if !defined(HPX_THREAD_QUEUE_MAX_TERMINATED_THREADS)
+#  define HPX_THREAD_QUEUE_MAX_TERMINATED_THREADS 100
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
 // Maximum sleep time for idle backoff in milliseconds.
 #if defined(HPX_HAVE_THREAD_MANAGER_IDLE_BACKOFF)
 #  if !defined(HPX_IDLE_BACKOFF_TIME_MAX)

--- a/libs/parallel_executors/include/hpx/parallel/executors/thread_execution.hpp
+++ b/libs/parallel_executors/include/hpx/parallel/executors/thread_execution.hpp
@@ -12,20 +12,22 @@
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/lcos/dataflow.hpp>
 #endif
+#include <hpx/datastructures/detail/pack.hpp>
+#include <hpx/datastructures/tuple.hpp>
+#include <hpx/iterator_support/range.hpp>
 #include <hpx/lcos/future.hpp>
 #include <hpx/lcos/local/futures_factory.hpp>
+#include <hpx/parallel/executors/execution.hpp>
+#include <hpx/parallel/executors/fused_bulk_execute.hpp>
+#include <hpx/runtime/threads/executors/current_executor.hpp>
 #include <hpx/runtime/threads/thread_executor.hpp>
+#include <hpx/runtime/threads/thread_helpers.hpp>
 #include <hpx/traits/future_access.hpp>
 #include <hpx/traits/is_launch_policy.hpp>
 #include <hpx/util/bind.hpp>
 #include <hpx/util/bind_back.hpp>
 #include <hpx/util/deferred_call.hpp>
-#include <hpx/datastructures/detail/pack.hpp>
-#include <hpx/iterator_support/range.hpp>
-#include <hpx/datastructures/tuple.hpp>
 #include <hpx/util/unwrap.hpp>
-
-#include <hpx/parallel/executors/execution.hpp>
 
 #include <algorithm>
 #include <type_traits>
@@ -34,19 +36,15 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 // define customization point specializations for thread executors
-namespace hpx { namespace threads
-{
+namespace hpx { namespace threads {
     ///////////////////////////////////////////////////////////////////////////
     // async_execute()
-    template <typename Executor, typename F, typename ... Ts>
-    HPX_FORCEINLINE
-    typename std::enable_if<
+    template <typename Executor, typename F, typename... Ts>
+    HPX_FORCEINLINE typename std::enable_if<
         hpx::traits::is_threads_executor<Executor>::value,
-        hpx::lcos::future<
-            typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
-        >
-    >::type
-    async_execute(Executor && exec, F && f, Ts &&... ts)
+        hpx::lcos::future<typename hpx::util::detail::invoke_deferred_result<F,
+            Ts...>::type>>::type
+    async_execute(Executor&& exec, F&& f, Ts&&... ts)
     {
         typedef typename util::detail::invoke_deferred_result<F, Ts...>::type
             result_type;
@@ -60,108 +58,83 @@ namespace hpx { namespace threads
 
     ///////////////////////////////////////////////////////////////////////////
     // sync_execute()
-    template <typename Executor, typename F, typename ... Ts>
-    HPX_FORCEINLINE
-    typename std::enable_if<
+    template <typename Executor, typename F, typename... Ts>
+    HPX_FORCEINLINE typename std::enable_if<
         hpx::traits::is_threads_executor<Executor>::value,
-        typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
-    >::type
-    sync_execute(Executor && exec, F && f, Ts &&... ts)
+        typename hpx::util::detail::invoke_deferred_result<F,
+            Ts...>::type>::type
+    sync_execute(Executor&& exec, F&& f, Ts&&... ts)
     {
-        return async_execute(std::forward<Executor>(exec),
-            std::forward<F>(f), std::forward<Ts>(ts)...).get();
+        return async_execute(std::forward<Executor>(exec), std::forward<F>(f),
+            std::forward<Ts>(ts)...)
+            .get();
     }
 
     ///////////////////////////////////////////////////////////////////////////
     // then_execute()
-    template <typename Executor, typename F, typename Future, typename ... Ts>
-    HPX_FORCEINLINE
-    typename std::enable_if<
+    template <typename Executor, typename F, typename Future, typename... Ts>
+    HPX_FORCEINLINE typename std::enable_if<
         hpx::traits::is_threads_executor<Executor>::value,
-        hpx::lcos::future<
-            typename hpx::util::detail::invoke_deferred_result<
-                F, Future, Ts...
-            >::type
-        >
-    >::type
-    then_execute(Executor && exec, F && f, Future&& predecessor, Ts &&... ts)
+        hpx::lcos::future<typename hpx::util::detail::invoke_deferred_result<F,
+            Future, Ts...>::type>>::type
+    then_execute(Executor&& exec, F&& f, Future&& predecessor, Ts&&... ts)
     {
-        typedef typename hpx::util::detail::invoke_deferred_result<
-                F, Future, Ts...
-            >::type result_type;
+        typedef typename hpx::util::detail::invoke_deferred_result<F, Future,
+            Ts...>::type result_type;
 
-        auto func = hpx::util::one_shot(hpx::util::bind_back(
-            std::forward<F>(f), std::forward<Ts>(ts)...));
+        auto func = hpx::util::one_shot(
+            hpx::util::bind_back(std::forward<F>(f), std::forward<Ts>(ts)...));
 
         typename hpx::traits::detail::shared_state_ptr<result_type>::type p =
             hpx::lcos::detail::make_continuation_exec<result_type>(
                 std::forward<Future>(predecessor), std::forward<Executor>(exec),
                 std::move(func));
 
-        return hpx::traits::future_access<hpx::lcos::future<result_type> >::
-            create(std::move(p));
+        return hpx::traits::future_access<
+            hpx::lcos::future<result_type>>::create(std::move(p));
     }
 
     ///////////////////////////////////////////////////////////////////////////
     // post()
-    template <typename Executor, typename F, typename ... Ts>
-    HPX_FORCEINLINE
-    typename std::enable_if<
-        hpx::traits::is_threads_executor<Executor>::value
-    >::type
-    post(Executor && exec, F && f, Ts &&... ts)
+    template <typename Executor, typename F, typename... Ts>
+    HPX_FORCEINLINE typename std::enable_if<
+        hpx::traits::is_threads_executor<Executor>::value>::type
+    post(Executor&& exec, F&& f, Ts&&... ts)
     {
         exec.add(
             util::deferred_call(std::forward<F>(f), std::forward<Ts>(ts)...),
-            "hpx::parallel::execution::post",
-            threads::pending,
-            true,
-            exec.get_stacksize(),
-            threads::thread_schedule_hint(),
-            throws);
+            "hpx::parallel::execution::post", threads::pending, true,
+            exec.get_stacksize(), threads::thread_schedule_hint(), throws);
     }
     ///////////////////////////////////////////////////////////////////////////
     // post()
-    template <typename Executor, typename F, typename Hint, typename ... Ts>
-    HPX_FORCEINLINE
-    typename std::enable_if<
+    template <typename Executor, typename F, typename Hint, typename... Ts>
+    HPX_FORCEINLINE typename std::enable_if<
         hpx::traits::is_threads_executor<Executor>::value &&
         std::is_same<typename hpx::util::decay<Hint>::type,
-            hpx::threads::thread_schedule_hint>::value
-    >::type
-    post(Executor && exec, F && f, Hint && hint, Ts &&... ts)
+            hpx::threads::thread_schedule_hint>::value>::type
+    post(Executor&& exec, F&& f, Hint&& hint, Ts&&... ts)
     {
         exec.add(
             util::deferred_call(std::forward<F>(f), std::forward<Ts>(ts)...),
-            "hpx::parallel::execution::post",
-            threads::pending,
-            true,
-            exec.get_stacksize(),
-            std::forward<Hint>(hint),
-            throws);
+            "hpx::parallel::execution::post", threads::pending, true,
+            exec.get_stacksize(), std::forward<Hint>(hint), throws);
     }
 
     ///////////////////////////////////////////////////////////////////////////
     // bulk_async_execute()
-    template <typename Executor, typename F, typename Shape, typename ... Ts>
-        typename std::enable_if<
-        hpx::traits::is_threads_executor<Executor>::value,
-        std::vector<hpx::lcos::future<
-            typename parallel::execution::detail::bulk_function_result<
-                F, Shape, Ts...
-            >::type
-        > >
-    >::type
-    bulk_async_execute(Executor && exec, F && f, Shape const& shape, Ts &&... ts)
+    template <typename Executor, typename F, typename Shape, typename... Ts>
+    typename std::enable_if<hpx::traits::is_threads_executor<Executor>::value,
+        std::vector<hpx::lcos::future<typename parallel::execution::detail::
+                bulk_function_result<F, Shape, Ts...>::type>>>::type
+    bulk_async_execute(Executor&& exec, F&& f, Shape const& shape, Ts&&... ts)
     {
-        std::vector<hpx::future<
-                typename parallel::execution::detail::bulk_function_result<
-                    F, Shape, Ts...
-                >::type
-            > > results;
+        std::vector<hpx::future<typename parallel::execution::detail::
+                bulk_function_result<F, Shape, Ts...>::type>>
+            results;
         results.reserve(util::size(shape));
 
-        for (auto const& elem: shape)
+        for (auto const& elem : shape)
         {
             results.push_back(
                 async_execute(exec, std::forward<F>(f), elem, ts...));
@@ -172,23 +145,18 @@ namespace hpx { namespace threads
 
     ///////////////////////////////////////////////////////////////////////////
     // bulk_sync_execute()
-    template <typename Executor, typename F, typename Shape, typename ... Ts>
-    typename std::enable_if<
-        hpx::traits::is_threads_executor<Executor>::value,
-        typename parallel::execution::detail::bulk_execute_result<
-            F, Shape, Ts...
-        >::type
-    >::type
-    bulk_sync_execute(Executor && exec, F && f, Shape const& shape, Ts &&... ts)
+    template <typename Executor, typename F, typename Shape, typename... Ts>
+    typename std::enable_if<hpx::traits::is_threads_executor<Executor>::value,
+        typename parallel::execution::detail::bulk_execute_result<F, Shape,
+            Ts...>::type>::type
+    bulk_sync_execute(Executor&& exec, F&& f, Shape const& shape, Ts&&... ts)
     {
-        std::vector<hpx::future<
-                typename parallel::execution::detail::bulk_function_result<
-                    F, Shape, Ts...
-                >::type
-            > > results;
+        std::vector<hpx::future<typename parallel::execution::detail::
+                bulk_function_result<F, Shape, Ts...>::type>>
+            results;
         results.reserve(util::size(shape));
 
-        for (auto const& elem: shape)
+        for (auto const& elem : shape)
         {
             results.push_back(
                 async_execute(exec, std::forward<F>(f), elem, ts...));
@@ -200,18 +168,13 @@ namespace hpx { namespace threads
     ///////////////////////////////////////////////////////////////////////////
     // bulk_then_execute()
     template <typename Executor, typename F, typename Shape, typename Future,
-        typename ... Ts>
-    HPX_FORCEINLINE
-    typename std::enable_if<
+        typename... Ts>
+    HPX_FORCEINLINE typename std::enable_if<
         hpx::traits::is_threads_executor<Executor>::value,
-        hpx::future<
-            typename parallel::execution::detail::bulk_then_execute_result<
-                F, Shape, Future, Ts...
-            >::type
-        >
-    >::type
-    bulk_then_execute(Executor && exec, F && f, Shape const& shape,
-        Future&& predecessor, Ts &&... ts)
+        hpx::future<typename parallel::execution::detail::
+                bulk_then_execute_result<F, Shape, Future, Ts...>::type>>::type
+    bulk_then_execute(Executor&& exec, F&& f, Shape const& shape,
+        Future&& predecessor, Ts&&... ts)
     {
         typedef typename parallel::execution::detail::then_bulk_function_result<
                 F, Shape, Future, Ts...
@@ -238,14 +201,16 @@ namespace hpx { namespace threads
 
         typedef typename std::decay<Future>::type future_type;
 
+        thread_id_type id = hpx::threads::get_self_id();
+        executors::current_executor exec_current =
+            hpx::threads::get_executor(id);
+
         shared_state_type p =
             lcos::detail::make_continuation_exec<result_future_type>(
-                std::forward<Future>(predecessor),
-                std::forward<Executor>(exec),
-                [HPX_CAPTURE_MOVE(func)](future_type&& predecessor) mutable
-                ->  result_future_type
-                {
-                    return hpx::dataflow(
+                std::forward<Future>(predecessor), std::forward<Executor>(exec),
+                [HPX_CAPTURE_MOVE(func), HPX_CAPTURE_MOVE(exec_current)](
+                    future_type&& predecessor) mutable -> result_future_type {
+                    return hpx::dataflow(exec_current,
                         hpx::util::functional::unwrap{},
                         func(std::move(predecessor)));
                 });
@@ -253,7 +218,6 @@ namespace hpx { namespace threads
         return hpx::traits::future_access<result_future_type>::create(
             std::move(p));
     }
-}}
+}}    // namespace hpx::threads
 
 #endif
-

--- a/libs/parallel_executors/tests/unit/CMakeLists.txt
+++ b/libs/parallel_executors/tests/unit/CMakeLists.txt
@@ -26,6 +26,7 @@ set(tests
     timed_parallel_executor
     timed_this_thread_executors
     timed_thread_pool_executors
+    standalone_thread_pool_os_executors
    )
 
 if(HPX_WITH_DATAPAR_VC OR HPX_WITH_DATAPAR_BOOST_SIMD)

--- a/libs/parallel_executors/tests/unit/service_executors.cpp
+++ b/libs/parallel_executors/tests/unit/service_executors.cpp
@@ -39,14 +39,14 @@ void test_async(Executor& exec)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::thread::id test_f(hpx::future<void> f, int passed_through)
+std::thread::id test_f(hpx::future<void> f, int passed_through)
 {
     HPX_TEST(f.is_ready());   // make sure, future is ready
 
     f.get();                    // propagate exceptions
 
     HPX_TEST_EQ(passed_through, 42);
-    return hpx::this_thread::get_id();
+    return std::this_thread::get_id();
 }
 
 template <typename Executor>
@@ -55,7 +55,7 @@ void test_then(Executor& exec)
     hpx::future<void> f = hpx::make_ready_future();
 
     HPX_TEST(
-        hpx::parallel::execution::async_execute(exec, &test, 42).get() !=
+        hpx::parallel::execution::then_execute(exec, &test_f, f, 42).get() !=
         std::this_thread::get_id());
 }
 

--- a/libs/parallel_executors/tests/unit/standalone_thread_pool_os_executors.cpp
+++ b/libs/parallel_executors/tests/unit/standalone_thread_pool_os_executors.cpp
@@ -1,0 +1,195 @@
+//  Copyright (c)      2019 Mikael Simberg
+//  Copyright (c) 2007-2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/include/apply.hpp>
+#include <hpx/include/async.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/parallel_executors.hpp>
+#include <hpx/testing.hpp>
+#include <hpx/util/yield_while.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdlib>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+hpx::thread::id test(int passed_through)
+{
+    HPX_TEST_EQ(passed_through, 42);
+    return hpx::this_thread::get_id();
+}
+
+template <typename Executor>
+void test_sync(Executor& exec)
+{
+    HPX_TEST(hpx::parallel::execution::sync_execute(exec, &test, 42) !=
+        hpx::this_thread::get_id());
+}
+
+template <typename Executor>
+void test_async(Executor& exec)
+{
+    HPX_TEST(hpx::parallel::execution::async_execute(exec, &test, 42).get() !=
+        hpx::this_thread::get_id());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+hpx::thread::id test_f(hpx::future<void> f, int passed_through)
+{
+    HPX_TEST(f.is_ready());    // make sure, future is ready
+
+    f.get();    // propagate exceptions
+
+    HPX_TEST_EQ(passed_through, 42);
+    return hpx::this_thread::get_id();
+}
+
+template <typename Executor>
+void test_then(Executor& exec)
+{
+    hpx::future<void> f = hpx::make_ready_future();
+
+    HPX_TEST(
+        hpx::parallel::execution::then_execute(exec, &test_f, f, 42).get() !=
+        hpx::this_thread::get_id());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void bulk_test(int value, hpx::thread::id tid, int passed_through)    //-V813
+{
+    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_EQ(passed_through, 42);
+}
+
+template <typename Executor>
+void test_bulk_sync(Executor& exec)
+{
+    hpx::thread::id tid = hpx::this_thread::get_id();
+
+    std::vector<int> v(107);
+    std::iota(std::begin(v), std::end(v), std::rand());
+
+    using hpx::util::placeholders::_1;
+    using hpx::util::placeholders::_2;
+
+    hpx::parallel::execution::bulk_sync_execute(
+        exec, hpx::util::bind(&bulk_test, _1, tid, _2), v, 42);
+    hpx::parallel::execution::bulk_sync_execute(exec, &bulk_test, v, tid, 42);
+}
+
+template <typename Executor>
+void test_bulk_async(Executor& exec)
+{
+    hpx::thread::id tid = hpx::this_thread::get_id();
+
+    std::vector<int> v(107);
+    std::iota(std::begin(v), std::end(v), std::rand());
+
+    using hpx::util::placeholders::_1;
+    using hpx::util::placeholders::_2;
+
+    hpx::when_all(hpx::parallel::execution::bulk_async_execute(
+                      exec, hpx::util::bind(&bulk_test, _1, tid, _2), v, 42))
+        .get();
+    hpx::when_all(hpx::parallel::execution::bulk_async_execute(
+                      exec, &bulk_test, v, tid, 42))
+        .get();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void bulk_test_f(int value, hpx::shared_future<void> f, hpx::thread::id tid,
+    int passed_through)    //-V813
+{
+    HPX_TEST(f.is_ready());    // make sure, future is ready
+
+    f.get();    // propagate exceptions
+
+    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_EQ(passed_through, 42);
+}
+
+template <typename Executor>
+void test_bulk_then(Executor& exec)
+{
+    hpx::thread::id tid = hpx::this_thread::get_id();
+
+    std::vector<int> v(107);
+    std::iota(std::begin(v), std::end(v), std::rand());
+
+    using hpx::util::placeholders::_1;
+    using hpx::util::placeholders::_2;
+    using hpx::util::placeholders::_3;
+
+    hpx::shared_future<void> f = hpx::make_ready_future();
+
+    hpx::parallel::execution::bulk_then_execute(
+        exec, hpx::util::bind(&bulk_test_f, _1, _2, tid, _3), v, f, 42)
+        .get();
+    hpx::parallel::execution::bulk_then_execute(
+        exec, &bulk_test_f, v, f, tid, 42)
+        .get();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename Executor>
+void test_thread_pool_os_executor(Executor exec)
+{
+    test_sync(exec);
+    test_async(exec);
+    test_then(exec);
+    test_bulk_sync(exec);
+    test_bulk_async(exec);
+    test_bulk_then(exec);
+}
+
+template <typename Executor>
+void spawn_test()
+{
+    using namespace hpx::parallel;
+
+    std::size_t const num_threads = 4;
+    std::size_t const max_cores = num_threads;
+    hpx::threads::policies::detail::affinity_data ad{};
+    ad.init(num_threads, max_cores);
+    hpx::threads::policies::callback_notifier notifier{};
+
+    Executor exec(num_threads, ad, notifier);
+
+    // We can't wait for futures on the main thread, so we spawn a thread to
+    // run the tests for us.
+    hpx::apply(exec, &test_thread_pool_os_executor<Executor>, exec);
+
+    //  NOTE: This is currently required because the executor is reference
+    //  counted and copies may be created inside the spawned task, meaning the
+    //  destructor does not necessarily block at the end of the scope.
+    hpx::util::yield_while(
+        [exec]() { return exec.num_pending_closures() != 0; });
+}
+
+int main(int argc, char* argv[])
+{
+    using namespace hpx::parallel;
+
+#if defined(HPX_HAVE_LOCAL_SCHEDULER)
+    spawn_test<execution::local_queue_os_executor>();
+#endif
+
+    spawn_test<execution::local_priority_queue_os_executor>();
+
+#if defined(HPX_HAVE_STATIC_SCHEDULER)
+    spawn_test<execution::static_queue_os_executor>();
+#endif
+
+#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
+    spawn_test<execution::static_priority_queue_os_executor>();
+#endif
+
+    return hpx::util::report_errors();
+}

--- a/libs/parallel_executors/tests/unit/standalone_thread_pool_os_executors.cpp
+++ b/libs/parallel_executors/tests/unit/standalone_thread_pool_os_executors.cpp
@@ -4,6 +4,12 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// The thread_pool_os_executor is an executor that creates a new thread pool for
+// itself. This checks that the usual functions of an executor work with this
+// executor when used *without the HPX runtime*. This test fails if thread
+// pools, schedulers etc. assume that the global runtime (configuration, thread
+// manager, etc.) always exists.
+
 #include <hpx/include/apply.hpp>
 #include <hpx/include/async.hpp>
 #include <hpx/include/lcos.hpp>

--- a/src/runtime/resource/detail/detail_partitioner.cpp
+++ b/src/runtime/resource/detail/detail_partitioner.cpp
@@ -6,28 +6,28 @@
 #include <hpx/config.hpp>
 #include <hpx/assertion.hpp>
 #include <hpx/errors.hpp>
+#include <hpx/format.hpp>
 #include <hpx/runtime/config_entry.hpp>
 #include <hpx/runtime/resource/detail/partitioner.hpp>
 #include <hpx/runtime/resource/partitioner.hpp>
 #include <hpx/runtime/runtime_fwd.hpp>
 #include <hpx/runtime/threads/detail/scheduled_thread_pool.hpp>
+#include <hpx/runtime/threads/policies/scheduler_mode.hpp>
 #include <hpx/runtime/threads/thread_pool_base.hpp>
 #include <hpx/topology/topology.hpp>
-#include <hpx/format.hpp>
+#include <hpx/type_support/static.hpp>
 #include <hpx/util/command_line_handling.hpp>
 #include <hpx/util/function.hpp>
-#include <hpx/type_support/static.hpp>
 
 #include <atomic>
 #include <cstddef>
 #include <iosfwd>
 #include <stdexcept>
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
-namespace hpx { namespace resource { namespace detail
-{
+namespace hpx { namespace resource { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     HPX_NORETURN void throw_runtime_error(
         std::string const& func, std::string const& message)
@@ -58,34 +58,35 @@ namespace hpx { namespace resource { namespace detail
     ///////////////////////////////////////////////////////////////////////////
     std::size_t init_pool_data::num_threads_overall = 0;
 
-    init_pool_data::init_pool_data(
-            std::string const& name, scheduling_policy sched,
-            hpx::threads::policies::scheduler_mode mode)
-        : pool_name_(name)
-        , scheduling_policy_(sched)
-        , num_threads_(0)
-        , mode_(mode)
+    init_pool_data::init_pool_data(std::string const& name,
+        scheduling_policy sched, hpx::threads::policies::scheduler_mode mode)
+      : pool_name_(name)
+      , scheduling_policy_(sched)
+      , num_threads_(0)
+      , mode_(mode)
     {
         if (name.empty())
         {
             throw_invalid_argument("init_pool_data::init_pool_data",
-                "cannot instantiate a thread_pool with empty string as a name.");
+                "cannot instantiate a thread_pool with empty string as a "
+                "name.");
         }
     }
 
     init_pool_data::init_pool_data(std::string const& name,
-            scheduler_function create_func)
-        : pool_name_(name)
-        , scheduling_policy_(user_defined)
-        , num_threads_(0)
-        , mode_(hpx::threads::policies::scheduler_mode::default_mode)
-        , create_function_(std::move(create_func))
+        scheduler_function create_func,
+        hpx::threads::policies::scheduler_mode mode)
+      : pool_name_(name)
+      , scheduling_policy_(user_defined)
+      , num_threads_(0)
+      , mode_(mode)
+      , create_function_(std::move(create_func))
     {
         if (name.empty())
         {
             throw_invalid_argument("init_pool_data::init_pool_data",
-                    "cannot instantiate a thread_pool with empty string "
-                    "as a name.");
+                "cannot instantiate a thread_pool with empty string "
+                "as a name.");
         }
     }
 
@@ -98,9 +99,9 @@ namespace hpx { namespace resource { namespace detail
         if (pu_index >= hpx::threads::hardware_concurrency())
         {
             throw_invalid_argument("init_pool_data::add_resource",
-                    "init_pool_data::add_resource: processing unit index "
-                    "out of bounds. The total available number of "
-                    "processing units on this machine is " +
+                "init_pool_data::add_resource: processing unit index "
+                "out of bounds. The total available number of "
+                "processing units on this machine is " +
                     std::to_string(hpx::threads::hardware_concurrency()));
         }
 
@@ -118,8 +119,7 @@ namespace hpx { namespace resource { namespace detail
         {
             assigned_pus_.push_back(pu_mask);
             assigned_pu_nums_.push_back(
-                util::make_tuple(pu_index, exclusive, false)
-            );
+                util::make_tuple(pu_index, exclusive, false));
         }
     }
 
@@ -207,11 +207,11 @@ namespace hpx { namespace resource { namespace detail
     {
         for (std::size_t i = 0; i != num_threads_; ++i)
         {
-             std::size_t& pu_num = util::get<0>(assigned_pu_nums_[i]);
-             pu_num = (pu_num + first_core) % threads::hardware_concurrency();
+            std::size_t& pu_num = util::get<0>(assigned_pu_nums_[i]);
+            pu_num = (pu_num + first_core) % threads::hardware_concurrency();
 
-             threads::reset(assigned_pus_[i]);
-             threads::set(assigned_pus_[i], pu_num);
+            threads::reset(assigned_pus_[i]);
+            threads::set(assigned_pus_[i], pu_num);
         }
     }
 
@@ -221,6 +221,7 @@ namespace hpx { namespace resource { namespace detail
       , pus_needed_(std::size_t(-1))
       , mode_(mode_default)
       , topo_(threads::create_topology())
+      , default_scheduler_mode_(threads::policies::scheduler_mode::default_mode)
     {
         // allow only one partitioner instance
         if (++instance_number_counter_ > 1)
@@ -230,7 +231,7 @@ namespace hpx { namespace resource { namespace detail
         }
 
 #if defined(HPX_HAVE_MAX_CPU_COUNT)
-        if(HPX_HAVE_MAX_CPU_COUNT < topo_.get_number_of_pus())
+        if (HPX_HAVE_MAX_CPU_COUNT < topo_.get_number_of_pus())
         {
             throw_runtime_error("partitioner::partioner",
                 hpx::util::format(
@@ -243,8 +244,23 @@ namespace hpx { namespace resource { namespace detail
         }
 #endif
 
+        std::string default_scheduler_mode_str =
+            hpx::get_config_entry("hpx.default_scheduler_mode", std::string());
+        if (!default_scheduler_mode_str.empty())
+        {
+            default_scheduler_mode_ = threads::policies::scheduler_mode(
+                hpx::util::safe_lexical_cast<std::size_t>(
+                    default_scheduler_mode_str));
+            HPX_ASSERT_MSG(
+                (default_scheduler_mode_ &
+                    ~threads::policies::scheduler_mode::all_flags) == 0,
+                "hpx.default_scheduler_mode contains unknown scheduler "
+                "modes");
+        }
+
         // Create the default pool
-        initial_thread_pools_.push_back(init_pool_data("default"));
+        initial_thread_pools_.push_back(init_pool_data("default",
+            scheduling_policy::unspecified, default_scheduler_mode_));
     }
 
     partitioner::~partitioner()
@@ -260,7 +276,8 @@ namespace hpx { namespace resource { namespace detail
         threads::set(pu_mask, pu_num);
         threads::topology& topo = get_topology();
 
-        threads::mask_type comp = affinity_data_.get_used_pus_mask(topo, pu_num);
+        threads::mask_type comp =
+            affinity_data_.get_used_pus_mask(topo, pu_num);
         return threads::any(comp & pu_mask);
     }
 
@@ -277,8 +294,8 @@ namespace hpx { namespace resource { namespace detail
         // loop on the numa-domains
         for (std::size_t i = 0; i != num_numa_nodes; ++i)
         {
-            numa_domains_.emplace_back(i);    // add a numa domain
-            numa_domain &nd = numa_domains_.back();     // numa-domain just added
+            numa_domains_.emplace_back(i);             // add a numa domain
+            numa_domain& nd = numa_domains_.back();    // numa-domain just added
 
             std::size_t numa_node_cores = topo.get_number_of_numa_node_cores(i);
             nd.cores_.reserve(numa_node_cores);
@@ -289,7 +306,7 @@ namespace hpx { namespace resource { namespace detail
             for (std::size_t j = 0; j != numa_node_cores; ++j)
             {
                 nd.cores_.emplace_back(j, &nd);
-                core &c = nd.cores_.back();
+                core& c = nd.cores_.back();
 
                 std::size_t core_pus = topo.get_number_of_core_pus(j);
                 c.pus_.reserve(core_pus);
@@ -303,14 +320,14 @@ namespace hpx { namespace resource { namespace detail
                     {
                         c.pus_.emplace_back(pid, &c,
                             affinity_data_.get_thread_occupancy(topo, pid));
-                        pu &p = c.pus_.back();
+                        pu& p = c.pus_.back();
 
                         if (p.thread_occupancy_ == 0)
                         {
                             throw_runtime_error(
                                 "partitioner::fill_topology_vectors",
                                 "PU #" + std::to_string(pid) +
-                                " has thread occupancy 0");
+                                    " has thread occupancy 0");
                         }
                         core_contains_exposed_pus = true;
                     }
@@ -376,11 +393,11 @@ namespace hpx { namespace resource { namespace detail
     {
         // Assign all free resources to the default pool
         bool first = true;
-        for (hpx::resource::numa_domain &d : numa_domains_)
+        for (hpx::resource::numa_domain& d : numa_domains_)
         {
-            for (hpx::resource::core &c : d.cores_)
+            for (hpx::resource::core& c : d.cores_)
             {
-                for (hpx::resource::pu &p : c.pus_)
+                for (hpx::resource::pu& p : c.pus_)
                 {
                     if (p.thread_occupancy_count_ == 0)
                     {
@@ -403,9 +420,9 @@ namespace hpx { namespace resource { namespace detail
         {
             l.unlock();
             throw_runtime_error("partitioner::setup_pools",
-                "Default pool " + get_default_pool_name()
-                + " has no threads assigned. Please rerun with "
-                "--hpx:threads=X and check the pool thread assignment");
+                "Default pool " + get_default_pool_name() +
+                    " has no threads assigned. Please rerun with "
+                    "--hpx:threads=X and check the pool thread assignment");
         }
 
         // Check whether any of the pools defined up to now are empty
@@ -506,7 +523,7 @@ namespace hpx { namespace resource { namespace detail
         new_affinity_masks.reserve(initial_thread_pools_.size());
 
         {
-            for (auto &itp : initial_thread_pools_)
+            for (auto& itp : initial_thread_pools_)
             {
                 for (auto const& mask : itp.assigned_pus_)
                 {
@@ -550,8 +567,7 @@ namespace hpx { namespace resource { namespace detail
 
     // create a new thread_pool
     void partitioner::create_thread_pool(std::string const& pool_name,
-        scheduling_policy sched,
-        hpx::threads::policies::scheduler_mode mode)
+        scheduling_policy sched, hpx::threads::policies::scheduler_mode mode)
     {
         if (get_runtime_ptr() != nullptr)
         {
@@ -571,10 +587,10 @@ namespace hpx { namespace resource { namespace detail
 
         std::unique_lock<mutex_type> l(mtx_);
 
-        if (pool_name==get_default_pool_name())
+        if (pool_name == get_default_pool_name())
         {
-            initial_thread_pools_[0] = detail::init_pool_data(
-                get_default_pool_name(), sched, mode);
+            initial_thread_pools_[0] =
+                detail::init_pool_data(get_default_pool_name(), sched, mode);
             return;
         }
 
@@ -587,11 +603,13 @@ namespace hpx { namespace resource { namespace detail
                 l.unlock();
                 throw std::invalid_argument(
                     "partitioner::create_thread_pool: "
-                    "there already exists a pool named '" + pool_name + "'.\n");
+                    "there already exists a pool named '" +
+                    pool_name + "'.\n");
             }
         }
 
-        initial_thread_pools_.push_back(detail::init_pool_data(pool_name, sched, mode));
+        initial_thread_pools_.push_back(
+            detail::init_pool_data(pool_name, sched, mode));
     }
 
     // create a new thread_pool
@@ -616,10 +634,11 @@ namespace hpx { namespace resource { namespace detail
 
         std::unique_lock<mutex_type> l(mtx_);
 
-        if (pool_name==get_default_pool_name())
+        if (pool_name == get_default_pool_name())
         {
-            initial_thread_pools_[0] = detail::init_pool_data(
-                get_default_pool_name(), std::move(scheduler_creation));
+            initial_thread_pools_[0] =
+                detail::init_pool_data(get_default_pool_name(),
+                    std::move(scheduler_creation), default_scheduler_mode_);
             return;
         }
 
@@ -632,25 +651,24 @@ namespace hpx { namespace resource { namespace detail
                 l.unlock();
                 throw std::invalid_argument(
                     "partitioner::create_thread_pool: "
-                    "there already exists a pool named '" + pool_name + "'.\n");
+                    "there already exists a pool named '" +
+                    pool_name + "'.\n");
             }
         }
 
-        initial_thread_pools_.push_back(
-            detail::init_pool_data(pool_name, std::move(scheduler_creation)));
+        initial_thread_pools_.push_back(detail::init_pool_data(
+            pool_name, std::move(scheduler_creation), default_scheduler_mode_));
     }
 
     // ----------------------------------------------------------------------
     // Add processing units to pools via pu/core/domain api
     // ----------------------------------------------------------------------
-    void partitioner::add_resource(
-        pu const& p, std::string const& pool_name, bool exclusive,
-        std::size_t num_threads)
+    void partitioner::add_resource(pu const& p, std::string const& pool_name,
+        bool exclusive, std::size_t num_threads)
     {
         if (get_runtime_ptr() != nullptr)
         {
-            HPX_THROW_EXCEPTION(invalid_status,
-                "partitioner::add_resource",
+            HPX_THROW_EXCEPTION(invalid_status, "partitioner::add_resource",
                 "this function must be called before the runtime system has "
                 "been started");
         }
@@ -668,8 +686,8 @@ namespace hpx { namespace resource { namespace detail
         if (mode_ & mode_allow_oversubscription)
         {
             // increment occupancy counter
-            get_pool_data(l, pool_name).add_resource(
-                p.id_, exclusive, num_threads);
+            get_pool_data(l, pool_name)
+                .add_resource(p.id_, exclusive, num_threads);
             ++p.thread_occupancy_count_;
             return;
         }
@@ -677,8 +695,8 @@ namespace hpx { namespace resource { namespace detail
         // check occupancy counter and increment it
         if (p.thread_occupancy_count_ == 0)
         {
-            get_pool_data(l, pool_name).add_resource(
-                p.id_, exclusive, num_threads);
+            get_pool_data(l, pool_name)
+                .add_resource(p.id_, exclusive, num_threads);
             ++p.thread_occupancy_count_;
 
             // Make sure the total number of requested threads does not exceed
@@ -691,28 +709,30 @@ namespace hpx { namespace resource { namespace detail
                     // then it's all fine
                 } else {*/
                 l.unlock();
-                throw std::runtime_error(
-                    "partitioner::add_resource: " "Creation of " +
-                    std::to_string(detail::init_pool_data::num_threads_overall) +
-                        " threads requested by the resource partitioner, but "
-                        "only " +
+                throw std::runtime_error("partitioner::add_resource: "
+                                         "Creation of " +
+                    std::to_string(
+                        detail::init_pool_data::num_threads_overall) +
+                    " threads requested by the resource partitioner, but "
+                    "only " +
                     std::to_string(cfg_.num_threads_) +
-                        " provided on the command-line.");
+                    " provided on the command-line.");
                 //                }
             }
         }
         else
         {
             l.unlock();
-            throw std::runtime_error(
-                "partitioner::add_resource: " "PU #" + std::to_string(p.id_) +
-                " can be assigned only " + std::to_string(p.thread_occupancy_) +
+            throw std::runtime_error("partitioner::add_resource: "
+                                     "PU #" +
+                std::to_string(p.id_) + " can be assigned only " +
+                std::to_string(p.thread_occupancy_) +
                 " threads according to affinity bindings.");
         }
     }
 
-    void partitioner::add_resource(std::vector<pu> const& pv,
-        std::string const& pool_name, bool exclusive)
+    void partitioner::add_resource(
+        std::vector<pu> const& pv, std::string const& pool_name, bool exclusive)
     {
         for (pu const& p : pv)
         {
@@ -720,8 +740,8 @@ namespace hpx { namespace resource { namespace detail
         }
     }
 
-    void partitioner::add_resource(core const& c,
-        std::string const& pool_name, bool exclusive)
+    void partitioner::add_resource(
+        core const& c, std::string const& pool_name, bool exclusive)
     {
         add_resource(c.pus_, pool_name, exclusive);
     }
@@ -729,23 +749,22 @@ namespace hpx { namespace resource { namespace detail
     void partitioner::add_resource(std::vector<core> const& cv,
         std::string const& pool_name, bool exclusive)
     {
-        for (const core &c : cv)
+        for (const core& c : cv)
         {
             add_resource(c.pus_, pool_name, exclusive);
         }
     }
 
-    void partitioner::add_resource(numa_domain const& nd,
-        std::string const& pool_name, bool exclusive)
+    void partitioner::add_resource(
+        numa_domain const& nd, std::string const& pool_name, bool exclusive)
     {
         add_resource(nd.cores_, pool_name, exclusive);
     }
 
-    void partitioner::add_resource(
-        std::vector<numa_domain> const& ndv,
+    void partitioner::add_resource(std::vector<numa_domain> const& ndv,
         std::string const& pool_name, bool exclusive)
     {
-        for (const numa_domain &d : ndv)
+        for (const numa_domain& d : ndv)
         {
             add_resource(d, pool_name, exclusive);
         }
@@ -768,8 +787,7 @@ namespace hpx { namespace resource { namespace detail
     ////////////////////////////////////////////////////////////////////////
     // this function is called in the constructor of thread_pool
     // returns a scheduler (moved) that thread pool should have as a data member
-    scheduling_policy partitioner::which_scheduler(
-        std::string const& pool_name)
+    scheduling_policy partitioner::which_scheduler(std::string const& pool_name)
     {
         std::unique_lock<mutex_type> l(mtx_);
 
@@ -780,19 +798,18 @@ namespace hpx { namespace resource { namespace detail
         {
             l.unlock();
             throw std::invalid_argument(
-                "partitioner::which_scheduler: " "Thread pool " + pool_name +
+                "partitioner::which_scheduler: Thread pool " + pool_name +
                 " cannot be instantiated with unspecified scheduler type.");
         }
         return sched_type;
     }
 
-    threads::topology &partitioner::get_topology() const
+    threads::topology& partitioner::get_topology() const
     {
         return topo_;
     }
 
-    util::command_line_handling &
-    partitioner::get_command_line_switches()
+    util::command_line_handling& partitioner::get_command_line_switches()
     {
         return cfg_;
     }
@@ -829,54 +846,49 @@ namespace hpx { namespace resource { namespace detail
         return initial_thread_pools_.size();
     }
 
-    std::size_t partitioner::get_num_threads(
-        std::size_t pool_index) const
+    std::size_t partitioner::get_num_threads(std::size_t pool_index) const
     {
         std::unique_lock<mutex_type> l(mtx_);
         return get_pool_data(l, pool_index).num_threads_;
     }
 
-    std::size_t partitioner::get_num_threads(
-        const std::string &pool_name) const
+    std::size_t partitioner::get_num_threads(const std::string& pool_name) const
     {
         std::unique_lock<mutex_type> l(mtx_);
         return get_pool_data(l, pool_name).num_threads_;
     }
 
-    hpx::threads::policies::scheduler_mode
-    partitioner::get_scheduler_mode(std::size_t pool_index) const
+    hpx::threads::policies::scheduler_mode partitioner::get_scheduler_mode(
+        std::size_t pool_index) const
     {
         std::unique_lock<mutex_type> l(mtx_);
         return get_pool_data(l, pool_index).mode_;
     }
 
     detail::init_pool_data const& partitioner::get_pool_data(
-        std::unique_lock<mutex_type>&l, std::size_t pool_index) const
+        std::unique_lock<mutex_type>& l, std::size_t pool_index) const
     {
         if (pool_index >= initial_thread_pools_.size())
         {
             l.unlock();
-            throw_invalid_argument(
-                "partitioner::get_pool_data",
+            throw_invalid_argument("partitioner::get_pool_data",
                 "pool index " + std::to_string(pool_index) +
                     " too large: the resource partitioner owns only " +
-                std::to_string(initial_thread_pools_.size()) +
+                    std::to_string(initial_thread_pools_.size()) +
                     " thread pools.");
         }
         return initial_thread_pools_[pool_index];
     }
 
-    std::string const& partitioner::get_pool_name(
-        std::size_t index) const
+    std::string const& partitioner::get_pool_name(std::size_t index) const
     {
         if (index >= initial_thread_pools_.size())
         {
-            throw_invalid_argument(
-                "partitioner::get_pool_name: ",
+            throw_invalid_argument("partitioner::get_pool_name: ",
                 "pool " + std::to_string(index) +
-                " (zero-based index) requested out of bounds. The "
-                "partitioner owns only " +
-                std::to_string(initial_thread_pools_.size()) + " pools");
+                    " (zero-based index) requested out of bounds. The "
+                    "partitioner owns only " +
+                    std::to_string(initial_thread_pools_.size()) + " pools");
         }
         return initial_thread_pools_[index].pool_name_;
     }
@@ -898,11 +910,10 @@ namespace hpx { namespace resource { namespace detail
     }
 
     int partitioner::parse(
-        util::function_nonser<
-            int(boost::program_options::variables_map& vm)
-        > const& f,
+        util::function_nonser<int(
+            boost::program_options::variables_map& vm)> const& f,
         boost::program_options::options_description desc_cmdline, int argc,
-        char **argv, std::vector<std::string> ini_config,
+        char** argv, std::vector<std::string> ini_config,
         resource::partitioner_mode rpmode, runtime_mode mode,
         bool fill_internal_topology)
     {
@@ -937,8 +948,7 @@ namespace hpx { namespace resource { namespace detail
         return cfg_.parse_result_;
     }
 
-    scheduler_function partitioner::get_pool_creator(
-        std::size_t index) const
+    scheduler_function partitioner::get_pool_creator(std::size_t index) const
     {
         std::unique_lock<mutex_type> l(mtx_);
         if (index >= initial_thread_pools_.size())
@@ -972,15 +982,15 @@ namespace hpx { namespace resource { namespace detail
     {
         if (get_runtime_ptr() == nullptr)
         {
-            throw std::runtime_error("partitioner::create_thread_pool: "
+            throw std::runtime_error(
+                "partitioner::create_thread_pool: "
                 "this function must be called after the runtime system has "
                 "been started");
         }
 
         if (!(mode_ & mode_allow_dynamic_pools))
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
-                "partitioner::shrink_pool",
+            HPX_THROW_EXCEPTION(bad_parameter, "partitioner::shrink_pool",
                 "dynamic pools have not been enabled for the "
                 "partitioner");
         }
@@ -1009,10 +1019,10 @@ namespace hpx { namespace resource { namespace detail
 
         if (!has_non_exclusive_pus)
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
-                "partitioner::shrink_pool",
-                "pool '" + pool_name + "' has no non-exclusive pus "
-                "associated");
+            HPX_THROW_EXCEPTION(bad_parameter, "partitioner::shrink_pool",
+                "pool '" + pool_name +
+                    "' has no non-exclusive pus "
+                    "associated");
         }
 
         for (std::size_t pu_num : pu_nums_to_remove)
@@ -1028,15 +1038,15 @@ namespace hpx { namespace resource { namespace detail
     {
         if (get_runtime_ptr() == nullptr)
         {
-            throw std::runtime_error("partitioner::create_thread_pool: "
+            throw std::runtime_error(
+                "partitioner::create_thread_pool: "
                 "this function must be called after the runtime system has "
                 "been started");
         }
 
         if (!(mode_ & mode_allow_dynamic_pools))
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
-                "partitioner::expand_pool",
+            HPX_THROW_EXCEPTION(bad_parameter, "partitioner::expand_pool",
                 "dynamic pools have not been enabled for the "
                 "partitioner");
         }
@@ -1065,10 +1075,10 @@ namespace hpx { namespace resource { namespace detail
 
         if (!has_non_exclusive_pus)
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
-                "partitioner::expand_pool",
-                "pool '" + pool_name + "' has no non-exclusive pus "
-                "associated");
+            HPX_THROW_EXCEPTION(bad_parameter, "partitioner::expand_pool",
+                "pool '" + pool_name +
+                    "' has no non-exclusive pus "
+                    "associated");
         }
 
         for (std::size_t pu_num : pu_nums_to_add)
@@ -1080,12 +1090,12 @@ namespace hpx { namespace resource { namespace detail
     }
 
     ////////////////////////////////////////////////////////////////////////
-    std::size_t partitioner::get_pool_index(
-        std::string const& pool_name) const
+    std::size_t partitioner::get_pool_index(std::string const& pool_name) const
     {
         // the default pool is always index 0, it may be renamed
         // but the user can always ask for "default"
-        if (pool_name == "default") {
+        if (pool_name == "default")
+        {
             return 0;
         }
         {
@@ -1100,21 +1110,19 @@ namespace hpx { namespace resource { namespace detail
             }
         }
 
-        throw_invalid_argument(
-            "partitioner::get_pool_index",
+        throw_invalid_argument("partitioner::get_pool_index",
             "the resource partitioner does not own a thread pool named '" +
-            pool_name + "'");
+                pool_name + "'");
     }
 
     // has to be private bc pointers become invalid after data member
     // thread_pools_ is resized we don't want to allow the user to use it
     detail::init_pool_data const& partitioner::get_pool_data(
-        std::unique_lock<mutex_type>&l, std::string const& pool_name) const
+        std::unique_lock<mutex_type>& l, std::string const& pool_name) const
     {
-        auto pool = std::find_if(
-            initial_thread_pools_.begin(), initial_thread_pools_.end(),
-            [&pool_name](detail::init_pool_data const& itp) -> bool
-            {
+        auto pool = std::find_if(initial_thread_pools_.begin(),
+            initial_thread_pools_.end(),
+            [&pool_name](detail::init_pool_data const& itp) -> bool {
                 return (itp.pool_name_ == pool_name);
             });
 
@@ -1124,19 +1132,17 @@ namespace hpx { namespace resource { namespace detail
         }
 
         l.unlock();
-        throw_invalid_argument(
-            "partitioner::get_pool_data",
+        throw_invalid_argument("partitioner::get_pool_data",
             "the resource partitioner does not own a thread pool named '" +
-            pool_name + "'");
+                pool_name + "'");
     }
 
     detail::init_pool_data& partitioner::get_pool_data(
         std::unique_lock<mutex_type>& l, std::string const& pool_name)
     {
-        auto pool = std::find_if(
-            initial_thread_pools_.begin(), initial_thread_pools_.end(),
-            [&pool_name](detail::init_pool_data const& itp) -> bool
-            {
+        auto pool = std::find_if(initial_thread_pools_.begin(),
+            initial_thread_pools_.end(),
+            [&pool_name](detail::init_pool_data const& itp) -> bool {
                 return (itp.pool_name_ == pool_name);
             });
 
@@ -1146,10 +1152,9 @@ namespace hpx { namespace resource { namespace detail
         }
 
         l.unlock();
-        throw_invalid_argument(
-            "partitioner::get_pool_data",
+        throw_invalid_argument("partitioner::get_pool_data",
             "the resource partitioner does not own a thread pool named '" +
-            pool_name + "'");
+                pool_name + "'");
     }
 
     void partitioner::print_init_pool_data(std::ostream& os) const
@@ -1157,8 +1162,8 @@ namespace hpx { namespace resource { namespace detail
         std::lock_guard<mutex_type> l(mtx_);
 
         //! make this prettier
-        os << "the resource partitioner owns "
-            << initial_thread_pools_.size() << " pool(s) : \n";
+        os << "the resource partitioner owns " << initial_thread_pools_.size()
+           << " pool(s) : \n";
         for (auto itp : initial_thread_pools_)
         {
             itp.print_pool(os);
@@ -1167,4 +1172,4 @@ namespace hpx { namespace resource { namespace detail
 
     ////////////////////////////////////////////////////////////////////////
     std::atomic<int> partitioner::instance_number_counter_(-1);
-}}}
+}}}    // namespace hpx::resource::detail

--- a/src/runtime/threads/executors/current_executor.cpp
+++ b/src/runtime/threads/executors/current_executor.cpp
@@ -62,7 +62,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         thread_init_data data(util::one_shot(util::bind(
             &current_executor::thread_function_nullary,
             std::move(f))), desc);
-        data.stacksize = threads::get_stack_size(stacksize);
+        data.stacksize = scheduler_base_->get_stack_size(stacksize);
 
         threads::thread_id_type id = threads::invalid_thread_id;
         threads::detail::create_thread(scheduler_base_, data, id, //-V601
@@ -82,7 +82,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         thread_init_data data(util::one_shot(util::bind(
             &current_executor::thread_function_nullary,
             std::move(f))), desc);
-        data.stacksize = threads::get_stack_size(stacksize);
+        data.stacksize = scheduler_base_->get_stack_size(stacksize);
 
         threads::thread_id_type id = threads::invalid_thread_id;
         threads::detail::create_thread( //-V601

--- a/src/runtime/threads/executors/pool_executor.cpp
+++ b/src/runtime/threads/executors/pool_executor.cpp
@@ -82,8 +82,8 @@ namespace hpx { namespace threads { namespace executors
             if (stacksize == threads::thread_stacksize_default)
                 stacksize = stacksize_;
 
-            data.stacksize    = threads::get_stack_size(stacksize);
-            data.priority     = priority_;
+            data.stacksize = pool_.get_scheduler()->get_stack_size(stacksize);
+            data.priority = priority_;
             data.schedulehint = schedulehint;
 
             threads::thread_id_type id = threads::invalid_thread_id;
@@ -113,8 +113,10 @@ namespace hpx { namespace threads { namespace executors
                 desc);
 
             if (stacksize == threads::thread_stacksize_default)
+            {
                 stacksize = stacksize_;
-            data.stacksize = threads::get_stack_size(stacksize);
+            }
+            data.stacksize = pool_.get_scheduler()->get_stack_size(stacksize);
             data.priority = priority_;
 
             threads::thread_id_type id = threads::invalid_thread_id;

--- a/src/runtime/threads/executors/thread_pool_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_executors.cpp
@@ -170,7 +170,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         thread_init_data data(util::one_shot(util::bind(
             &thread_pool_executor::thread_function_nullary,
             this, std::move(f))), desc);
-        data.stacksize = threads::get_stack_size(stacksize);
+        data.stacksize = scheduler_.get_stack_size(stacksize);
 
         // update statistics
         ++tasks_scheduled_;
@@ -200,7 +200,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         thread_init_data data(util::one_shot(util::bind(
             &thread_pool_executor::thread_function_nullary,
             this, std::move(f))), desc);
-        data.stacksize = threads::get_stack_size(stacksize);
+        data.stacksize = scheduler_.get_stack_size(stacksize);
 
         threads::thread_id_type id = threads::invalid_thread_id;
         threads::detail::create_thread( //-V601

--- a/src/runtime/threads/thread_helpers.cpp
+++ b/src/runtime/threads/thread_helpers.cpp
@@ -88,7 +88,6 @@ namespace hpx { namespace threads
         return id ? id->get_priority() : thread_priority_unknown;
     }
 
-    /// The get_stack_size function is part of the thread related API. It
     std::ptrdiff_t get_stack_size(thread_id_type const& id, error_code& ec)
     {
         return id ? id->get_stack_size() :

--- a/src/util/runtime_configuration.cpp
+++ b/src/util/runtime_configuration.cpp
@@ -132,12 +132,12 @@ namespace hpx { namespace util
             "[hpx]",
             "location = ${HPX_LOCATION:$[system.prefix]}",
             "component_paths = ${HPX_COMPONENT_PATHS}",
-            "component_base_paths = $[hpx.location]" // NOLINT
-                HPX_INI_PATH_DELIMITER "$[system.executable_prefix]",
+            "component_base_paths = $[hpx.location]"    // NOLINT
+            HPX_INI_PATH_DELIMITER "$[system.executable_prefix]",
             "component_path_suffixes = /lib/hpx" HPX_INI_PATH_DELIMITER
-                                      "/bin/hpx",
+            "/bin/hpx",
             "master_ini_path = $[hpx.location]" HPX_INI_PATH_DELIMITER
-                              "$[system.executable_prefix]/",
+            "$[system.executable_prefix]/",
             "master_ini_path_suffixes = /share/" HPX_BASE_DIR_NAME
                 HPX_INI_PATH_DELIMITER "/../share/" HPX_BASE_DIR_NAME,
 #ifdef HPX_HAVE_ITTNOTIFY
@@ -169,14 +169,17 @@ namespace hpx { namespace util
 #endif
 #ifdef HPX_HAVE_SPINLOCK_DEADLOCK_DETECTION
 #ifdef HPX_DEBUG
-            "spinlock_deadlock_detection = ${HPX_SPINLOCK_DEADLOCK_DETECTION:1}",
+            "spinlock_deadlock_detection = "
+            "${HPX_SPINLOCK_DEADLOCK_DETECTION:1}",
 #else
-            "spinlock_deadlock_detection = ${HPX_SPINLOCK_DEADLOCK_DETECTION:0}",
+            "spinlock_deadlock_detection = "
+            "${HPX_SPINLOCK_DEADLOCK_DETECTION:0}",
 #endif
             "spinlock_deadlock_detection_limit = "
-                "${HPX_SPINLOCK_DEADLOCK_DETECTION_LIMIT:1000000}",
+            "${HPX_SPINLOCK_DEADLOCK_DETECTION_LIMIT:1000000}",
 #endif
-            "expect_connecting_localities = ${HPX_EXPECT_CONNECTING_LOCALITIES:0}",
+            "expect_connecting_localities = "
+            "${HPX_EXPECT_CONNECTING_LOCALITIES:0}",
 
             // add placeholders for keys to be added by command line handling
             "os_threads = cores",
@@ -190,15 +193,16 @@ namespace hpx { namespace util
             "pu_offset = 0",
             "numa_sensitive = 0",
             "max_background_threads = "
-                "${HPX_MAX_BACKGROUND_THREADS:$[hpx.os_threads]}",
+            "${HPX_MAX_BACKGROUND_THREADS:$[hpx.os_threads]}",
 
-            "max_idle_loop_count = ${HPX_MAX_IDLE_LOOP_COUNT:"
-                HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_IDLE_LOOP_COUNT_MAX)) "}",
-            "max_busy_loop_count = ${HPX_MAX_BUSY_LOOP_COUNT:"
-                HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_BUSY_LOOP_COUNT_MAX)) "}",
+            "max_idle_loop_count = ${HPX_MAX_IDLE_LOOP_COUNT:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_IDLE_LOOP_COUNT_MAX)) "}",
+            "max_busy_loop_count = ${HPX_MAX_BUSY_LOOP_COUNT:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_BUSY_LOOP_COUNT_MAX)) "}",
 #if defined(HPX_HAVE_THREAD_MANAGER_IDLE_BACKOFF)
-            "max_idle_backoff_time = ${HPX_MAX_IDLE_BACKOFF_TIME:"
-            HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_IDLE_BACKOFF_TIME_MAX)) "}",
+            "max_idle_backoff_time = "
+            "${HPX_MAX_IDLE_BACKOFF_TIME:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_IDLE_BACKOFF_TIME_MAX)) "}",
 #endif
             "default_scheduler_mode = ${HPX_DEFAULT_SCHEDULER_MODE}",
 
@@ -226,42 +230,59 @@ namespace hpx { namespace util
 #endif
 
             "[hpx.stacks]",
-            "small_size = ${HPX_SMALL_STACK_SIZE:"
-                HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_SMALL_STACK_SIZE)) "}",
-            "medium_size = ${HPX_MEDIUM_STACK_SIZE:"
-                HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_MEDIUM_STACK_SIZE)) "}",
-            "large_size = ${HPX_LARGE_STACK_SIZE:"
-                HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_LARGE_STACK_SIZE)) "}",
-            "huge_size = ${HPX_HUGE_STACK_SIZE:"
-                HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_HUGE_STACK_SIZE)) "}",
+            "small_size = ${HPX_SMALL_STACK_SIZE:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_SMALL_STACK_SIZE)) "}",
+            "medium_size = ${HPX_MEDIUM_STACK_SIZE:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_MEDIUM_STACK_SIZE)) "}",
+            "large_size = ${HPX_LARGE_STACK_SIZE:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_LARGE_STACK_SIZE)) "}",
+            "huge_size = ${HPX_HUGE_STACK_SIZE:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_HUGE_STACK_SIZE)) "}",
 #if defined(__linux) || defined(linux) || defined(__linux__) || defined(__FreeBSD__)
             "use_guard_pages = ${HPX_USE_GUARD_PAGES:1}",
 #endif
 
             "[hpx.threadpools]",
 #if defined(HPX_HAVE_IO_POOL)
-            "io_pool_size = ${HPX_NUM_IO_POOL_SIZE:"
-                HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_NUM_IO_POOL_SIZE)) "}",
+            "io_pool_size = ${HPX_NUM_IO_POOL_SIZE:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_NUM_IO_POOL_SIZE)) "}",
 #endif
 #if defined(HPX_HAVE_NETWORKING)
-            "parcel_pool_size = ${HPX_NUM_PARCEL_POOL_SIZE:"
-                HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_NUM_PARCEL_POOL_SIZE)) "}",
+            "parcel_pool_size = ${HPX_NUM_PARCEL_POOL_SIZE:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_NUM_PARCEL_POOL_SIZE)) "}",
 #endif
 #if defined(HPX_HAVE_TIMER_POOL)
-            "timer_pool_size = ${HPX_NUM_TIMER_POOL_SIZE:"
-                HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_NUM_TIMER_POOL_SIZE)) "}",
+            "timer_pool_size = ${HPX_NUM_TIMER_POOL_SIZE:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_NUM_TIMER_POOL_SIZE)) "}",
 #endif
 
             "[hpx.thread_queue]",
+            "max_count = ${HPX_THREAD_QUEUE_MAX_THREAD_COUNT:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_THREAD_QUEUE_MAX_THREAD_COUNT)) "}",
             "min_tasks_to_steal_pending = "
-                "${HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_PENDING:0}",
+            "${HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_PENDING:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_THREAD_QUEUE_MAX_THREAD_COUNT)) "}",
+            "max_tasks_to_steal_pending = "
+            "${HPX_THREAD_QUEUE_MAX_TASKS_TO_STEAL_PENDING:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_THREAD_QUEUE_MAX_THREAD_COUNT)) "}",
+            "min_tasks_to_steal_pending = "
+            "${HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_PENDING:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_THREAD_QUEUE_MAX_THREAD_COUNT)) "}",
             "min_tasks_to_steal_staged = "
-                "${HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_STAGED:10}",
-            "min_add_new_count = ${HPX_THREAD_QUEUE_MIN_ADD_NEW_COUNT:10}",
-            "max_add_new_count = ${HPX_THREAD_QUEUE_MAX_ADD_NEW_COUNT:10}",
-            "max_delete_count = ${HPX_THREAD_QUEUE_MAX_DELETE_COUNT:1000}",
-            "max_terminated_threads = ${HPX_SCHEDULER_MAX_TERMINATED_THREADS:"
-              HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_SCHEDULER_MAX_TERMINATED_THREADS)) "}",
+            "${HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_STAGED:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_THREAD_QUEUE_MAX_THREAD_COUNT)) "}",
+            "min_add_new_count = "
+            "${HPX_THREAD_QUEUE_MIN_ADD_NEW_COUNT:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_THREAD_QUEUE_MAX_THREAD_COUNT)) "}",
+            "max_add_new_count = "
+            "${HPX_THREAD_QUEUE_MAX_ADD_NEW_COUNT:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_THREAD_QUEUE_MAX_THREAD_COUNT)) "}",
+            "max_delete_count = "
+            "${HPX_THREAD_QUEUE_MAX_DELETE_COUNT:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_THREAD_QUEUE_MAX_THREAD_COUNT)) "}",
+            "max_terminated_threads = "
+            "${HPX_SCHEDULER_MAX_TERMINATED_THREADS:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_THREAD_QUEUE_MAX_TERMINATED_THREADS)) "}",
 
             "[hpx.commandline]",
             // enable aliasing
@@ -303,16 +324,15 @@ namespace hpx { namespace util
             // 'address' has deliberately no default, see
             // command_line_handling.cpp
             "address = ${HPX_AGAS_SERVER_ADDRESS}",
-            "port = ${HPX_AGAS_SERVER_PORT:"
-                HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_INITIAL_IP_PORT)) "}",
+            "port = ${HPX_AGAS_SERVER_PORT:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_INITIAL_IP_PORT)) "}",
             "max_pending_refcnt_requests = "
-                "${HPX_AGAS_MAX_PENDING_REFCNT_REQUESTS:"
-                HPX_PP_STRINGIZE(HPX_PP_EXPAND(
-                    HPX_INITIAL_AGAS_MAX_PENDING_REFCNT_REQUESTS))
-                "}",
+            "${HPX_AGAS_MAX_PENDING_REFCNT_REQUESTS:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(
+                    HPX_INITIAL_AGAS_MAX_PENDING_REFCNT_REQUESTS)) "}",
             "service_mode = hosted",
-            "local_cache_size = ${HPX_AGAS_LOCAL_CACHE_SIZE:"
-                HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_AGAS_LOCAL_CACHE_SIZE)) "}",
+            "local_cache_size = ${HPX_AGAS_LOCAL_CACHE_SIZE:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_AGAS_LOCAL_CACHE_SIZE)) "}",
             "use_range_caching = ${HPX_AGAS_USE_RANGE_CACHING:1}",
             "use_caching = ${HPX_AGAS_USE_CACHING:1}",
 

--- a/tests/unit/threads/schedule_last.cpp
+++ b/tests/unit/threads/schedule_last.cpp
@@ -43,10 +43,13 @@ void test_scheduler(int argc, char* argv[])
     hpx::resource::partitioner rp(argc, argv, std::move(cfg));
 
     rp.create_thread_pool("default",
-        [](hpx::threads::thread_pool_init_parameters thread_pool_init)
+        [](hpx::threads::thread_pool_init_parameters thread_pool_init,
+            hpx::threads::policies::thread_queue_init_parameters
+                thread_queue_init)
             -> std::unique_ptr<hpx::threads::thread_pool_base> {
             typename Scheduler::init_parameter_type init(
-                thread_pool_init.num_threads_, thread_pool_init.affinity_data_);
+                thread_pool_init.num_threads_, thread_pool_init.affinity_data_,
+                std::size_t(-1), 0, thread_queue_init);
             std::unique_ptr<Scheduler> scheduler(new Scheduler(init));
 
             thread_pool_init.mode_ = hpx::threads::policies::scheduler_mode(

--- a/tests/unit/topology/numa_allocator.cpp
+++ b/tests/unit/topology/numa_allocator.cpp
@@ -252,11 +252,15 @@ int main(int argc, char* argv[])
     using hpx::threads::policies::scheduler_mode;
     // setup the default pool with a numa aware scheduler
     rp.create_thread_pool("default",
-        [](hpx::threads::thread_pool_init_parameters init)
+        [](hpx::threads::thread_pool_init_parameters init,
+            hpx::threads::policies::thread_queue_init_parameters
+                thread_queue_init)
             -> std::unique_ptr<hpx::threads::thread_pool_base> {
+            numa_scheduler::init_parameter_type scheduler_init(
+                init.num_threads_, {2, 3, 64}, init.affinity_data_,
+                thread_queue_init, "shared-priority-scheduler");
             std::unique_ptr<numa_scheduler> scheduler(
-                new numa_scheduler(init.num_threads_, {2, 3, 64},
-                    "shared-priority-scheduler", init.affinity_data_));
+                new numa_scheduler(scheduler_init));
 
             scheduler_mode mode =
                 scheduler_mode(scheduler_mode::do_background_work |


### PR DESCRIPTION
Passes various thread queue related configuration options (miscellaneous min/max counts, stack sizes, max idle backoff time) explicitly into the thread queues instead of getting them from the configuration. The configuration values are extracted in the thread manager instead.

Also adds a test which creates a standalone `thread_pool_os_executor` without the runtime.

Flyby:
- Deprecate `HPX_SCHEDULER_MAX_TERMINATED_THREADS` CMake option in favor of setting it through configuration values.
- Remove hardcoded and duplicated max thread count values from thread queues and schedulers in favor of setting it through configuration values.
- Fix thread queue constructor arguments (`max_queue_thread_count_` passed as `queue_num`).
- clang format most of the touched files.

@biddisco this probably conflicts with your changes to `thread_queue_mc` and `shared_priority_queue_scheduler`. I'll revert my changes to those files if the conflicts are bad and rebase once you've got your PR up.