### PR TITLE
Threading refactoring

### DIFF
--- a/examples/resource_partitioner/shared_priority_queue_scheduler.hpp
+++ b/examples/resource_partitioner/shared_priority_queue_scheduler.hpp
@@ -767,8 +767,10 @@ namespace hpx { namespace threads { namespace policies { namespace example {
             {
                 // Create thread on this worker thread if possible
                 LOG_CUSTOM_VAR(msg = msgs[0]);
-                std::size_t global_thread_num = hpx::get_worker_thread_num();
-                thread_num = this->global_to_local_thread_index(global_thread_num);
+                std::size_t global_thread_num =
+                    threads::detail::get_thread_num_tss();
+                thread_num =
+                    this->global_to_local_thread_index(global_thread_num);
                 if (thread_num>=num_workers_) {
                     // This is a task being injected from a thread on another pool.
                     // Reset thread_num to first queue.
@@ -797,8 +799,10 @@ namespace hpx { namespace threads { namespace policies { namespace example {
                 domain_num = data.schedulehint.hint % num_domains_;
                 // if the thread creating the new task is on the domain
                 // assigned to the new task - try to reuse the core as well
-                std::size_t global_thread_num = hpx::get_worker_thread_num();
-                thread_num = this->global_to_local_thread_index(global_thread_num);
+                std::size_t global_thread_num =
+                    threads::detail::get_thread_num_tss();
+                thread_num =
+                    this->global_to_local_thread_index(global_thread_num);
                 if (d_lookup_[thread_num] == domain_num) {
                     q_index = q_lookup_[thread_num];
                 }
@@ -966,8 +970,10 @@ namespace hpx { namespace threads { namespace policies { namespace example {
             {
                 // Create thread on this worker thread if possible
                 LOG_CUSTOM_VAR(msg = msgs[0]);
-                std::size_t global_thread_num = hpx::get_worker_thread_num();
-                thread_num = this->global_to_local_thread_index(global_thread_num);
+                std::size_t global_thread_num =
+                    threads::detail::get_thread_num_tss();
+                thread_num =
+                    this->global_to_local_thread_index(global_thread_num);
                 if (thread_num>=num_workers_) {
                     // This is a task being injected from a thread on another pool.
                     // Reset thread_num to first queue.
@@ -997,8 +1003,10 @@ namespace hpx { namespace threads { namespace policies { namespace example {
                 domain_num = schedulehint.hint % num_domains_;
                 // if the thread creating the new task is on the domain
                 // assigned to the new task - try to reuse the core as well
-                std::size_t global_thread_num = hpx::get_worker_thread_num();
-                thread_num = this->global_to_local_thread_index(global_thread_num);
+                std::size_t global_thread_num =
+                    threads::detail::get_thread_num_tss();
+                thread_num =
+                    this->global_to_local_thread_index(global_thread_num);
                 if (d_lookup_[thread_num] == domain_num) {
                     q_index = q_lookup_[thread_num];
                 }
@@ -1066,8 +1074,10 @@ namespace hpx { namespace threads { namespace policies { namespace example {
             {
                 // Create thread on this worker thread if possible
                 LOG_CUSTOM_VAR(msg = msgs[0]);
-                std::size_t global_thread_num = hpx::get_worker_thread_num();
-                thread_num = this->global_to_local_thread_index(global_thread_num);
+                std::size_t global_thread_num =
+                    threads::detail::get_thread_num_tss();
+                thread_num =
+                    this->global_to_local_thread_index(global_thread_num);
                 if (thread_num>=num_workers_) {
                     // This is a task being injected from a thread on another pool.
                     // Reset thread_num to first queue.
@@ -1097,8 +1107,10 @@ namespace hpx { namespace threads { namespace policies { namespace example {
                 domain_num = schedulehint.hint % num_domains_;
                 // if the thread creating the new task is on the domain
                 // assigned to the new task - try to reuse the core as well
-                std::size_t global_thread_num = hpx::get_worker_thread_num();
-                thread_num = this->global_to_local_thread_index(global_thread_num);
+                std::size_t global_thread_num =
+                    threads::detail::get_thread_num_tss();
+                thread_num =
+                    this->global_to_local_thread_index(global_thread_num);
                 if (d_lookup_[thread_num] == domain_num) {
                     q_index = q_lookup_[thread_num];
                 }

--- a/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
@@ -26,8 +26,6 @@
 #include <hpx/runtime/threads/policies/schedulers.hpp>
 #include <hpx/runtime/threads/thread_data.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
-#include <hpx/runtime/threads/threadmanager.hpp>
-#include <hpx/thread_support/unlock_guard.hpp>
 #include <hpx/topology/topology.hpp>
 #include <hpx/state.hpp>
 #include <hpx/functional/deferred_call.hpp>

--- a/hpx/runtime/threads/policies/shared_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/shared_priority_queue_scheduler.hpp
@@ -8,7 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assertion.hpp>
-#include <hpx/runtime/get_worker_thread_num.hpp>
+#include <hpx/runtime/threads/detail/thread_num_tss.hpp>
 #include <hpx/runtime/threads/policies/lockfree_queue_backends.hpp>
 #include <hpx/runtime/threads/policies/queue_helpers.hpp>
 #include <hpx/runtime/threads/policies/scheduler_base.hpp>
@@ -631,8 +631,10 @@ namespace hpx { namespace threads { namespace policies {
             case thread_schedule_hint_mode::thread_schedule_hint_mode_none:
             {
                 // Create thread on this worker thread if possible
-                std::size_t global_thread_num = hpx::get_worker_thread_num();
-                thread_num = this->global_to_local_thread_index(global_thread_num);
+                std::size_t global_thread_num =
+                    threads::detail::get_thread_num_tss();
+                thread_num =
+                    this->global_to_local_thread_index(global_thread_num);
                 if (thread_num>=num_workers_) {
                     // This is a task being injected from a thread on another pool.
                     // Reset thread_num to first queue.
@@ -659,8 +661,10 @@ namespace hpx { namespace threads { namespace policies {
                 domain_num = data.schedulehint.hint % num_domains_;
                 // if the thread creating the new task is on the domain
                 // assigned to the new task - try to reuse the core as well
-                std::size_t global_thread_num = hpx::get_worker_thread_num();
-                thread_num = this->global_to_local_thread_index(global_thread_num);
+                std::size_t global_thread_num =
+                    threads::detail::get_thread_num_tss();
+                thread_num =
+                    this->global_to_local_thread_index(global_thread_num);
                 if (d_lookup_[thread_num] == domain_num) {
                     q_index = q_lookup_[thread_num];
                 }
@@ -793,8 +797,10 @@ namespace hpx { namespace threads { namespace policies {
             case thread_schedule_hint_mode::thread_schedule_hint_mode_none:
             {
                 // Create thread on this worker thread if possible
-                std::size_t global_thread_num = hpx::get_worker_thread_num();
-                thread_num = this->global_to_local_thread_index(global_thread_num);
+                std::size_t global_thread_num =
+                    threads::detail::get_thread_num_tss();
+                thread_num =
+                    this->global_to_local_thread_index(global_thread_num);
                 if (thread_num>=num_workers_) {
                     // This is a task being injected from a thread on another pool.
                     // Reset thread_num to first queue.
@@ -822,8 +828,10 @@ namespace hpx { namespace threads { namespace policies {
                 domain_num = schedulehint.hint % num_domains_;
                 // if the thread creating the new task is on the domain
                 // assigned to the new task - try to reuse the core as well
-                std::size_t global_thread_num = hpx::get_worker_thread_num();
-                thread_num = this->global_to_local_thread_index(global_thread_num);
+                std::size_t global_thread_num =
+                    threads::detail::get_thread_num_tss();
+                thread_num =
+                    this->global_to_local_thread_index(global_thread_num);
                 if (d_lookup_[thread_num] == domain_num) {
                     q_index = q_lookup_[thread_num];
                 }
@@ -881,8 +889,10 @@ namespace hpx { namespace threads { namespace policies {
             case thread_schedule_hint_mode::thread_schedule_hint_mode_none:
             {
                 // Create thread on this worker thread if possible
-                std::size_t global_thread_num = hpx::get_worker_thread_num();
-                thread_num = this->global_to_local_thread_index(global_thread_num);
+                std::size_t global_thread_num =
+                    threads::detail::get_thread_num_tss();
+                thread_num =
+                    this->global_to_local_thread_index(global_thread_num);
                 if (thread_num>=num_workers_) {
                     // This is a task being injected from a thread on another pool.
                     // Reset thread_num to first queue.
@@ -910,8 +920,10 @@ namespace hpx { namespace threads { namespace policies {
                 domain_num = schedulehint.hint % num_domains_;
                 // if the thread creating the new task is on the domain
                 // assigned to the new task - try to reuse the core as well
-                std::size_t global_thread_num = hpx::get_worker_thread_num();
-                thread_num = this->global_to_local_thread_index(global_thread_num);
+                std::size_t global_thread_num =
+                    threads::detail::get_thread_num_tss();
+                thread_num =
+                    this->global_to_local_thread_index(global_thread_num);
                 if (d_lookup_[thread_num] == domain_num) {
                     q_index = q_lookup_[thread_num];
                 }

--- a/hpx/runtime/threads/thread.hpp
+++ b/hpx/runtime/threads/thread.hpp
@@ -7,12 +7,14 @@
 #define HPX_RUNTIME_THREADS_THREAD_HPP
 
 #include <hpx/config.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/errors.hpp>
 #include <hpx/lcos/local/spinlock.hpp>
 #include <hpx/lcos_fwd.hpp>
-#include <hpx/runtime/threads/thread_data_fwd.hpp>
-#include <hpx/runtime_fwd.hpp>
 #include <hpx/functional/deferred_call.hpp>
+#include <hpx/runtime/threads/policies/scheduler_base.hpp>
+#include <hpx/runtime/threads/thread_data.hpp>
+#include <hpx/runtime/threads/thread_pool_base.hpp>
 #include <hpx/timing/steady_clock.hpp>
 #include <hpx/util_fwd.hpp>
 
@@ -28,6 +30,10 @@
 namespace hpx
 {
     ///////////////////////////////////////////////////////////////////////////
+    using thread_termination_handler_type =
+        std::function<void(std::exception_ptr const& e)>;
+    void set_thread_termination_handler(thread_termination_handler_type f);
+
     class thread
     {
         typedef lcos::local::spinlock mutex_type;
@@ -44,14 +50,34 @@ namespace hpx
                 thread>::value>::type>
         explicit thread(F&& f)
         {
-            start_thread(util::deferred_call(std::forward<F>(f)));
+            HPX_ASSERT(threads::get_self_ptr());
+            start_thread(
+                threads::get_self_id()->get_scheduler_base()->get_parent_pool(),
+                util::deferred_call(std::forward<F>(f)));
         }
 
-        template <typename F, typename ...Ts>
+        template <typename F, typename... Ts>
         explicit thread(F&& f, Ts&&... vs)
         {
-            start_thread(util::deferred_call(
-                std::forward<F>(f), std::forward<Ts>(vs)...));
+            HPX_ASSERT(threads::get_self_ptr());
+            start_thread(
+                threads::get_self_id()->get_scheduler_base()->get_parent_pool(),
+                util::deferred_call(
+                    std::forward<F>(f), std::forward<Ts>(vs)...));
+        }
+
+        template <typename F>
+        thread(threads::thread_pool_base* pool, F&& f)
+        {
+            start_thread(pool, util::deferred_call(std::forward<F>(f)));
+        }
+
+        template <typename F, typename... Ts>
+        thread(threads::thread_pool_base* pool, F&& f, Ts&&... vs)
+        {
+            start_thread(pool,
+                util::deferred_call(
+                    std::forward<F>(f), std::forward<Ts>(vs)...));
         }
 
         ~thread();
@@ -104,7 +130,8 @@ namespace hpx
         {
             id_ = threads::invalid_thread_id;
         }
-        void start_thread(util::unique_function_nonser<void()>&& func);
+        void start_thread(threads::thread_pool_base* pool,
+            util::unique_function_nonser<void()>&& func);
         static threads::thread_result_type thread_function_nullary(
             util::unique_function_nonser<void()> const& func);
 

--- a/hpx/runtime/threads/thread.hpp
+++ b/hpx/runtime/threads/thread.hpp
@@ -19,6 +19,7 @@
 #include <hpx/util_fwd.hpp>
 
 #include <cstddef>
+#include <exception>
 #include <iosfwd>
 #include <mutex>
 #include <utility>

--- a/hpx/runtime_handlers.hpp
+++ b/hpx/runtime_handlers.hpp
@@ -1,0 +1,23 @@
+//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c)      2017 Shoshana Jakobovits
+//  Copyright (c) 2010-2011 Phillip LeBlanc, Dylan Stark
+//  Copyright (c)      2011 Bryce Lelbach
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/assertion.hpp>
+
+#include <string>
+
+namespace hpx { namespace detail {
+    HPX_NORETURN void assertion_handler(
+        hpx::assertion::source_location const& loc, const char* expr,
+        std::string const& msg);
+    void test_failure_handler();
+#if defined(HPX_HAVE_VERIFY_LOCKS)
+    void registered_locks_error_handler();
+    bool register_locks_predicate();
+#endif
+}}    // namespace hpx::detail

--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -657,6 +657,8 @@ namespace hpx
             hpx::util::set_test_failure_handler(&detail::test_failure_handler);
             hpx::set_custom_exception_info_handler(&detail::custom_exception_info);
             hpx::set_pre_exception_handler(&detail::pre_exception_handler);
+            hpx::set_thread_termination_handler(
+                [](std::exception_ptr const& e) { report_error(e); });
 #if defined(HPX_HAVE_VERIFY_LOCKS)
             hpx::util::set_registered_locks_error_handler(
                 &detail::registered_locks_error_handler);

--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -30,6 +30,7 @@
 #include <hpx/runtime/shutdown_function.hpp>
 #include <hpx/runtime/startup_function.hpp>
 #include <hpx/runtime/threads/policies/schedulers.hpp>
+#include <hpx/runtime_handlers.hpp>
 #include <hpx/runtime_impl.hpp>
 #include <hpx/testing.hpp>
 #include <hpx/util/apex.hpp>
@@ -310,84 +311,8 @@ namespace hpx
     extern void termination_handler(int signum);
 #endif
 
-    extern void new_handler();
-
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
-    {
-        HPX_NORETURN void assertion_handler(
-            hpx::assertion::source_location const& loc, const char* expr,
-            std::string const& msg)
-        {
-            hpx::util::may_attach_debugger("exception");
-
-            std::ostringstream strm;
-            strm << "Assertion '" << expr << "' failed";
-            if (!msg.empty())
-            {
-                strm << " (" << msg << ")";
-            }
-
-            hpx::exception e(hpx::assertion_failure, strm.str());
-            std::cerr << hpx::diagnostic_information(
-                             hpx::detail::get_exception(e, loc.function_name,
-                                 loc.file_name, loc.line_number))
-                      << std::endl;
-            std::abort();
-        }
-
-        void test_failure_handler()
-        {
-            hpx::util::may_attach_debugger("test-failure");
-        }
-
-#if defined(HPX_HAVE_VERIFY_LOCKS)
-        void registered_locks_error_handler()
-        {
-            std::string back_trace = hpx::util::trace(std::size_t(128));
-
-            // throw or log, depending on config options
-            if (get_config_entry("hpx.throw_on_held_lock", "1") == "0")
-            {
-                if (back_trace.empty())
-                {
-                    LERR_(debug)
-                        << "suspending thread while at least one lock is "
-                           "being held (stack backtrace was disabled at "
-                           "compile time)";
-                }
-                else
-                {
-                    LERR_(debug)
-                        << "suspending thread while at least one lock is "
-                        << "being held, stack backtrace: " << back_trace;
-                }
-            }
-            else
-            {
-                if (back_trace.empty())
-                {
-                    HPX_THROW_EXCEPTION(invalid_status, "verify_no_locks",
-                        "suspending thread while at least one lock is "
-                        "being held (stack backtrace was disabled at "
-                        "compile time)");
-                }
-                else
-                {
-                    HPX_THROW_EXCEPTION(invalid_status, "verify_no_locks",
-                        "suspending thread while at least one lock is "
-                        "being held, stack backtrace: " +
-                            back_trace);
-                }
-            }
-        }
-
-        bool register_locks_predicate()
-        {
-            return threads::get_self_ptr() != nullptr;
-        }
-#endif
-
+    namespace detail {
         ///////////////////////////////////////////////////////////////////////
         struct dump_config
         {

--- a/src/runtime/threads/executors/current_executor.cpp
+++ b/src/runtime/threads/executors/current_executor.cpp
@@ -9,7 +9,7 @@
 #include <hpx/concurrency/register_locks.hpp>
 #include <hpx/errors.hpp>
 #include <hpx/functional/bind.hpp>
-#include <hpx/runtime/get_worker_thread_num.hpp>
+#include <hpx/runtime/threads/detail/thread_num_tss.hpp>
 #include <hpx/runtime/threads/detail/create_thread.hpp>
 #include <hpx/runtime/threads/detail/set_thread_state.hpp>
 #include <hpx/runtime/threads/policies/scheduler_base.hpp>
@@ -147,7 +147,8 @@ namespace hpx { namespace threads { namespace executors { namespace detail
 
     hpx::state current_executor::get_state() const
     {
-        return scheduler_base_->get_state(hpx::get_worker_thread_num());
+        return scheduler_base_->get_state(
+            threads::detail::get_thread_num_tss());
     }
 
     void current_executor::set_scheduler_mode(

--- a/src/runtime/threads/executors/this_thread_executors.cpp
+++ b/src/runtime/threads/executors/this_thread_executors.cpp
@@ -15,7 +15,6 @@
 #endif
 
 #include <hpx/assertion.hpp>
-#include <hpx/runtime/get_worker_thread_num.hpp>
 #include <hpx/runtime/threads/detail/create_thread.hpp>
 #include <hpx/runtime/threads/detail/scheduling_loop.hpp>
 #include <hpx/runtime/threads/detail/set_thread_state.hpp>
@@ -434,7 +433,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         HPX_ASSERT(std::size_t(-1) == orig_thread_num_);
 
         thread_num_ = thread_num;
-        orig_thread_num_ = hpx::get_worker_thread_num();
+        orig_thread_num_ = threads::detail::get_thread_num_tss();
 
         std::atomic<hpx::state>& state = scheduler_.get_state(0);
         hpx::state expected = state_initialized;

--- a/src/runtime/threads/thread.cpp
+++ b/src/runtime/threads/thread.cpp
@@ -3,9 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/lcos/future.hpp>
-#include <hpx/runtime/threads/thread.hpp>
-
 #include <hpx/assertion.hpp>
 #include <hpx/concurrency/register_locks.hpp>
 #include <hpx/errors.hpp>
@@ -14,11 +11,12 @@
 #include <hpx/concurrency/register_locks.hpp>
 #include <hpx/functional/unique_function.hpp>
 #include <hpx/lcos/detail/future_data.hpp>
+#include <hpx/lcos/future.hpp>
+#include <hpx/runtime/threads/thread.hpp>
 #include <hpx/runtime/threads/thread_data_fwd.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
 #include <hpx/runtime/threads/thread_init_data.hpp>
-#include <hpx/runtime/threads/threadmanager.hpp>
-#include <hpx/runtime_fwd.hpp>
+#include <hpx/runtime/threads/thread_pool_base.hpp>
 #include <hpx/thread_support/unlock_guard.hpp>
 #include <hpx/timing/steady_clock.hpp>
 
@@ -26,6 +24,7 @@
 
 #include <cstddef>
 #include <exception>
+#include <functional>
 #include <mutex>
 #include <utility>
 
@@ -33,27 +32,20 @@
 #include <cpu-features.h>
 #endif
 
-namespace hpx
-{
-    void thread::terminate(const char* function, const char* reason) const
-    {
-        try {
-            // free all registered exit-callback functions
-            threads::free_thread_exit_callbacks(id_);
-
-            // report the error globally
-            HPX_THROW_EXCEPTION(invalid_status, function, reason);
-        }
-        catch(...) {
-            hpx::report_error(std::current_exception());
-            /* nothing else we can do */;
-        }
+namespace hpx {
+    namespace detail {
+        static thread_termination_handler_type thread_termination_handler;
     }
 
-    ///////////////////////////////////////////////////////////////////////////
+    void set_thread_termination_handler(thread_termination_handler_type f)
+    {
+        detail::thread_termination_handler = f;
+    }
+
     thread::thread() noexcept
       : id_(hpx::threads::invalid_thread_id)
-    {}
+    {
+    }
 
     thread::thread(thread&& rhs) noexcept
     {
@@ -64,12 +56,14 @@ namespace hpx
 
     thread& thread::operator=(thread&& rhs) noexcept
     {
-        std::lock_guard<mutex_type> l(mtx_);
-        std::lock_guard<mutex_type> l2(rhs.mtx_);
-        // If our current thread is joinable, terminate
+        std::unique_lock<mutex_type> l(mtx_);
+        std::unique_lock<mutex_type> l2(rhs.mtx_);
         if (joinable_locked())
         {
-            terminate("thread::operator=", "destroying running thread");
+            l2.unlock();
+            l.unlock();
+            HPX_THROW_EXCEPTION(invalid_status,
+                "thread::operator=", "destroying running thread");
         }
         id_ = rhs.id_;
         rhs.id_ = threads::invalid_thread_id;
@@ -78,11 +72,24 @@ namespace hpx
 
     thread::~thread()
     {
-        // If the thread is still running, we terminate the whole application
-        // as we have no chance of reporting this error (we can't throw)
         if (joinable())
         {
-            terminate("thread::~thread", "destroying running thread");
+            if (detail::thread_termination_handler)
+            {
+                try
+                {
+                    HPX_THROW_EXCEPTION(invalid_status, "thread::~thread",
+                        "destroying running thread");
+                }
+                catch (...)
+                {
+                    detail::thread_termination_handler(std::current_exception());
+                }
+            }
+            else
+            {
+                std::terminate();
+            }
         }
 
         HPX_ASSERT(id_ == threads::invalid_thread_id);
@@ -98,9 +105,9 @@ namespace hpx
     static void run_thread_exit_callbacks()
     {
         threads::thread_id_type id = threads::get_self_id();
-        if (id == threads::invalid_thread_id) {
-            HPX_THROW_EXCEPTION(null_thread_id,
-                "run_thread_exit_callbacks",
+        if (id == threads::invalid_thread_id)
+        {
+            HPX_THROW_EXCEPTION(null_thread_id, "run_thread_exit_callbacks",
                 "null thread id encountered");
         }
         threads::run_thread_exit_callbacks(id);
@@ -109,14 +116,17 @@ namespace hpx
     threads::thread_result_type thread::thread_function_nullary(
         util::unique_function_nonser<void()> const& func)
     {
-        try {
+        try
+        {
             // Now notify our calling thread that we started execution.
             func();
         }
-        catch (hpx::thread_interrupted const&) { //-V565
+        catch (hpx::thread_interrupted const&)
+        {    //-V565
             /* swallow this exception */
         }
-        catch (hpx::exception const&) {
+        catch (hpx::exception const&)
+        {
             // Verify that there are no more registered locks for this
             // OS-thread. This will throw if there are still any locks
             // held.
@@ -136,8 +146,8 @@ namespace hpx
         // run all callbacks attached to the exit event for this thread
         run_thread_exit_callbacks();
 
-        return threads::thread_result_type(threads::terminated,
-            threads::invalid_thread_id);
+        return threads::thread_result_type(
+            threads::terminated, threads::invalid_thread_id);
     }
 
     thread::id thread::get_id() const noexcept
@@ -150,19 +160,22 @@ namespace hpx
         return hpx::threads::hardware_concurrency();
     }
 
-    void thread::start_thread(util::unique_function_nonser<void()>&& func)
+    void thread::start_thread(threads::thread_pool_base* pool,
+        util::unique_function_nonser<void()>&& func)
     {
+        HPX_ASSERT(pool);
+
         threads::thread_init_data data(
-            util::one_shot(util::bind(&thread::thread_function_nullary,
-                std::move(func))),
+            util::one_shot(
+                util::bind(&thread::thread_function_nullary, std::move(func))),
             "thread::thread_function_nullary");
 
         // create the new thread, note that id_ is guaranteed to be valid
         // before the thread function is executed
         error_code ec(lightweight);
-        threads::get_thread_manager().register_thread(
-            data, id_, threads::pending, true, ec);
-        if (ec) {
+        pool->create_thread(data, id_, threads::pending, true, ec);
+        if (ec)
+        {
             HPX_THROW_EXCEPTION(thread_resource_error, "thread::start_thread",
                 "Could not create thread");
             return;
@@ -178,31 +191,33 @@ namespace hpx
     {
         std::unique_lock<mutex_type> l(mtx_);
 
-        if(!joinable_locked())
+        if (!joinable_locked())
         {
-            terminate("thread::join", "trying to join a non joinable thread");
+            l.unlock();
+            HPX_THROW_EXCEPTION(invalid_status, "thread::join",
+                "trying to join a non joinable thread");
         }
 
         native_handle_type this_id = threads::get_self_id();
         if (this_id == id_)
         {
+            l.unlock();
             HPX_THROW_EXCEPTION(thread_resource_error, "thread::join",
                 "hpx::thread: trying joining itself");
             return;
         }
         this_thread::interruption_point();
 
-
         // register callback function to be called when thread exits
-        if (threads::add_thread_exit_callback(id_,
-                util::bind_front(&resume_thread, this_id)))
+        if (threads::add_thread_exit_callback(
+                id_, util::bind_front(&resume_thread, this_id)))
         {
             // wait for thread to be terminated
-            util::unlock_guard<std::unique_lock<mutex_type> > ul(l);
+            util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
             this_thread::suspend(threads::suspended, "thread::join");
         }
 
-        detach_locked();   // invalidate this object
+        detach_locked();    // invalidate this object
     }
 
     // extensions
@@ -231,10 +246,8 @@ namespace hpx
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
-    {
-        struct thread_task_base
-          : lcos::detail::future_data<void>
+    namespace detail {
+        struct thread_task_base : lcos::detail::future_data<void>
         {
         private:
             typedef lcos::detail::future_data<void>::mutex_type mutex_type;
@@ -247,7 +260,8 @@ namespace hpx
             thread_task_base(threads::thread_id_type const& id)
             {
                 if (threads::add_thread_exit_callback(id,
-                        util::bind_front(&thread_task_base::thread_exit_function,
+                        util::bind_front(
+                            &thread_task_base::thread_exit_function,
                             future_base_type(this))))
                 {
                     id_ = id;
@@ -268,11 +282,11 @@ namespace hpx
             void cancel()
             {
                 std::lock_guard<mutex_type> l(this->mtx_);
-                if (!this->is_ready()) {
+                if (!this->is_ready())
+                {
                     threads::interrupt_thread(id_);
                     this->set_error(thread_cancelled,
-                        "thread_task_base::cancel",
-                        "future has been canceled");
+                        "thread_task_base::cancel", "future has been canceled");
                     id_ = threads::invalid_thread_id;
                 }
             }
@@ -290,7 +304,7 @@ namespace hpx
         private:
             threads::thread_id_type id_;
         };
-    }
+    }    // namespace detail
 
     lcos::future<void> thread::get_future(error_code& ec)
     {
@@ -302,24 +316,24 @@ namespace hpx
         }
 
         detail::thread_task_base* p = new detail::thread_task_base(id_);
-        boost::intrusive_ptr<lcos::detail::future_data<void> > base(p);
-        if (!p->valid()) {
+        boost::intrusive_ptr<lcos::detail::future_data<void>> base(p);
+        if (!p->valid())
+        {
             HPX_THROWS_IF(ec, thread_resource_error, "thread::get_future",
                 "Could not create future as thread has been terminated.");
             return lcos::future<void>();
         }
 
         using traits::future_access;
-        return future_access<lcos::future<void> >::create(std::move(base));
+        return future_access<lcos::future<void>>::create(std::move(base));
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace this_thread
-    {
+    namespace this_thread {
         void yield_to(thread::id id) noexcept
         {
-            this_thread::suspend(threads::pending, id.native_handle(),
-                "this_thread::yield_to");
+            this_thread::suspend(
+                threads::pending, id.native_handle(), "this_thread::yield_to");
         }
 
         void yield() noexcept
@@ -350,12 +364,14 @@ namespace hpx
 
         bool interruption_enabled()
         {
-            return threads::get_thread_interruption_enabled(threads::get_self_id());
+            return threads::get_thread_interruption_enabled(
+                threads::get_self_id());
         }
 
         bool interruption_requested()
         {
-            return threads::get_thread_interruption_requested(threads::get_self_id());
+            return threads::get_thread_interruption_requested(
+                threads::get_self_id());
         }
 
         void interrupt()
@@ -383,7 +399,8 @@ namespace hpx
         disable_interruption::disable_interruption()
           : interruption_was_enabled_(interruption_enabled())
         {
-            if (interruption_was_enabled_) {
+            if (interruption_was_enabled_)
+            {
                 interruption_was_enabled_ =
                     threads::set_thread_interruption_enabled(
                         threads::get_self_id(), false);
@@ -393,7 +410,8 @@ namespace hpx
         disable_interruption::~disable_interruption()
         {
             threads::thread_self* p = threads::get_self_ptr();
-            if (p) {
+            if (p)
+            {
                 threads::set_thread_interruption_enabled(
                     threads::get_self_id(), interruption_was_enabled_);
             }
@@ -414,11 +432,11 @@ namespace hpx
         restore_interruption::~restore_interruption()
         {
             threads::thread_self* p = threads::get_self_ptr();
-            if (p) {
+            if (p)
+            {
                 threads::set_thread_interruption_enabled(
                     threads::get_self_id(), interruption_was_enabled_);
             }
         }
-    }
-}
-
+    }    // namespace this_thread
+}    // namespace hpx

--- a/src/runtime_handlers.cpp
+++ b/src/runtime_handlers.cpp
@@ -1,0 +1,95 @@
+//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c)      2017 Shoshana Jakobovits
+//  Copyright (c) 2010-2011 Phillip LeBlanc, Dylan Stark
+//  Copyright (c)      2011 Bryce Lelbach
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/assertion.hpp>
+#include <hpx/custom_exception_info.hpp>
+#include <hpx/errors.hpp>
+#include <hpx/logging.hpp>
+#include <hpx/runtime/config_entry.hpp>
+#include <hpx/runtime/threads/thread_data.hpp>
+#include <hpx/runtime_handlers.hpp>
+#include <hpx/util/backtrace.hpp>
+#include <hpx/util/debugging.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace hpx { namespace detail {
+    HPX_NORETURN void assertion_handler(
+        hpx::assertion::source_location const& loc, const char* expr,
+        std::string const& msg)
+    {
+        hpx::util::may_attach_debugger("exception");
+
+        std::ostringstream strm;
+        strm << "Assertion '" << expr << "' failed";
+        if (!msg.empty())
+        {
+            strm << " (" << msg << ")";
+        }
+
+        hpx::exception e(hpx::assertion_failure, strm.str());
+        std::cerr << hpx::diagnostic_information(hpx::detail::get_exception(
+                         e, loc.function_name, loc.file_name, loc.line_number))
+                  << std::endl;
+        std::abort();
+    }
+
+    void test_failure_handler()
+    {
+        hpx::util::may_attach_debugger("test-failure");
+    }
+
+#if defined(HPX_HAVE_VERIFY_LOCKS)
+    void registered_locks_error_handler()
+    {
+        std::string back_trace = hpx::util::trace(std::size_t(128));
+
+        // throw or log, depending on config options
+        if (get_config_entry("hpx.throw_on_held_lock", "1") == "0")
+        {
+            if (back_trace.empty())
+            {
+                LERR_(debug) << "suspending thread while at least one lock is "
+                                "being held (stack backtrace was disabled at "
+                                "compile time)";
+            }
+            else
+            {
+                LERR_(debug) << "suspending thread while at least one lock is "
+                             << "being held, stack backtrace: " << back_trace;
+            }
+        }
+        else
+        {
+            if (back_trace.empty())
+            {
+                HPX_THROW_EXCEPTION(invalid_status, "verify_no_locks",
+                    "suspending thread while at least one lock is "
+                    "being held (stack backtrace was disabled at "
+                    "compile time)");
+            }
+            else
+            {
+                HPX_THROW_EXCEPTION(invalid_status, "verify_no_locks",
+                    "suspending thread while at least one lock is "
+                    "being held, stack backtrace: " +
+                        back_trace);
+            }
+        }
+    }
+
+    bool register_locks_predicate()
+    {
+        return threads::get_self_ptr() != nullptr;
+    }
+#endif
+}}    // namespace hpx::detail


### PR DESCRIPTION
Minor threading refactoring to remove a few more dependencies.

- Use `hpx::threads::detail::get_thread_num_tss` instead of `hpx::get_worker_thread_num` to get thread number in schedulers etc.
- Pass thread pool into `hpx::thread` constructor. Old constructors remain, but don't fall back to the default thread pool if not on an HPX thread.
- Remove some leftover includes.