### PR TITLE
Add C++17 filesystem compatibility header

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -695,6 +695,13 @@ function(hpx_check_for_cxx17_aligned_new)
 endfunction()
 
 ###############################################################################
+function(hpx_check_for_cxx17_filesystem)
+  add_hpx_config_test(HPX_WITH_CXX17_FILESYSTEM
+    SOURCE cmake/tests/cxx17_filesystem.cpp
+    FILE ${ARGN})
+endfunction()
+
+###############################################################################
 function(hpx_check_for_cxx17_fold_expressions)
   add_hpx_config_test(HPX_WITH_CXX17_FOLD_EXPRESSIONS
     SOURCE cmake/tests/cxx17_fold_expressions.cpp

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -197,8 +197,11 @@ function(hpx_perform_cxx_feature_tests)
 
   if(HPX_WITH_CXX1Z OR HPX_WITH_CXX17 OR HPX_WITH_CXX2A)
     # Check the availability of certain C++17 language features
+    hpx_check_for_cxx17_filesystem(
+      DEFINITIONS HPX_HAVE_CXX17_FILESYSTEM)
+
     hpx_check_for_cxx17_fold_expressions(
-        DEFINITIONS HPX_HAVE_CXX17_FOLD_EXPRESSIONS)
+      DEFINITIONS HPX_HAVE_CXX17_FOLD_EXPRESSIONS)
 
     hpx_check_for_cxx17_fallthrough_attribute(
       DEFINITIONS HPX_HAVE_CXX17_FALLTHROUGH_ATTRIBUTE)

--- a/cmake/HPX_SetupBoost.cmake
+++ b/cmake/HPX_SetupBoost.cmake
@@ -26,6 +26,7 @@ set(Boost_ADDITIONAL_VERSIONS
     "1.59.0" "1.59"
     "1.58.0" "1.58"
     "1.57.0" "1.57")
+set(__boost_minimum_version "1.61")
 
 set(__boost_libraries)
 if(HPX_PARCELPORT_VERBS_WITH_LOGGING OR HPX_PARCELPORT_VERBS_WITH_DEV_MODE OR
@@ -60,12 +61,13 @@ endif()
 
 set(__boost_libraries
   ${__boost_libraries}
-  filesystem
   program_options
   system)
 
 set(Boost_NO_BOOST_CMAKE ON) # disable the search for boost-cmake
-find_package(Boost 1.61 MODULE REQUIRED COMPONENTS ${__boost_libraries})
+find_package(Boost ${__boost_minimum_version}
+  MODULE REQUIRED
+  COMPONENTS ${__boost_libraries})
 
 if(NOT Boost_FOUND)
   hpx_error("Could not find Boost. Please set BOOST_ROOT to point to your Boost installation.")
@@ -81,6 +83,18 @@ if(UNIX AND NOT CYGWIN)
 endif()
 
 set(Boost_TMP_LIBRARIES ${Boost_TMP_LIBRARIES} ${Boost_LIBRARIES})
+
+if(NOT HPX_WITH_CXX17_FILESYSTEM)
+  find_package(Boost ${__boost_minimum_version}
+    QUIET MODULE
+    COMPONENTS filesystem)
+  if(Boost_FILESYSTEM_FOUND)
+    hpx_info("  filesystem")
+  else()
+    hpx_error("Could not find Boost.Filesystem. Either use a compiler with support for C++17 filesystem or provide a boost installation including the filesystem library")
+  endif()
+  set(Boost_TMP_LIBRARIES ${Boost_TMP_LIBRARIES} ${Boost_LIBRARIES})
+endif()
 
 if(HPX_WITH_COMPRESSION_BZIP2 OR HPX_WITH_COMPRESSION_ZLIB)
   find_package(Boost 1.61 QUIET MODULE COMPONENTS iostreams)

--- a/cmake/tests/cxx17_filesystem.cpp
+++ b/cmake/tests/cxx17_filesystem.cpp
@@ -1,0 +1,15 @@
+////////////////////////////////////////////////////////////////////////////////
+//  Copyright (c) 2019 Mikael Simberg
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+////////////////////////////////////////////////////////////////////////////////
+
+#include <filesystem>
+
+int main()
+{
+    std::filesystem::path p = std::filesystem::current_path();
+
+    return 0;
+}

--- a/components/process/include/hpx/components/process/util/posix/initializers/run_exe.hpp
+++ b/components/process/include/hpx/components/process/util/posix/initializers/run_exe.hpp
@@ -14,9 +14,9 @@
 
 #if !defined(HPX_WINDOWS)
 #include <hpx/components/process/util/posix/initializers/initializer_base.hpp>
+#include <hpx/filesystem.hpp>
 #include <hpx/runtime/serialization/string.hpp>
 
-#include <boost/filesystem.hpp>
 #include <boost/shared_array.hpp>
 
 #include <string>
@@ -82,7 +82,7 @@ inline run_exe_ run_exe(const std::string &s)
     return run_exe_(s);
 }
 
-inline run_exe_ run_exe(const boost::filesystem::path &p)
+inline run_exe_ run_exe(const filesystem::path &p)
 {
     return run_exe_(p.string());
 }

--- a/components/process/include/hpx/components/process/util/posix/shell_path.hpp
+++ b/components/process/include/hpx/components/process/util/posix/shell_path.hpp
@@ -16,13 +16,12 @@
 #if !defined(HPX_WINDOWS)
 #include <hpx/components/process/export_definitions.hpp>
 #include <hpx/errors.hpp>
-
-#include <boost/filesystem/path.hpp>
+#include <hpx/filesystem.hpp>
 
 namespace hpx { namespace components { namespace process { namespace posix
 {
-    HPX_PROCESS_EXPORT boost::filesystem::path shell_path();
-    HPX_PROCESS_EXPORT boost::filesystem::path shell_path(hpx::error_code &ec);
+    HPX_PROCESS_EXPORT filesystem::path shell_path();
+    HPX_PROCESS_EXPORT filesystem::path shell_path(hpx::error_code &ec);
 }}}}
 
 #endif

--- a/components/process/include/hpx/components/process/util/windows/initializers/run_exe.hpp
+++ b/components/process/include/hpx/components/process/util/windows/initializers/run_exe.hpp
@@ -15,8 +15,9 @@
 
 #if defined(HPX_WINDOWS)
 #include <hpx/components/process/util/windows/initializers/initializer_base.hpp>
+#include <hpx/filesystem.hpp>
 #include <hpx/runtime/serialization/string.hpp>
-#include <boost/filesystem.hpp>
+
 #include <string>
 
 namespace hpx { namespace components { namespace process { namespace windows {
@@ -59,7 +60,7 @@ inline run_exe_<std::wstring> run_exe(const std::wstring &ws)
     return run_exe_<std::wstring>(ws);
 }
 
-inline run_exe_<std::wstring> run_exe(const boost::filesystem::path &p)
+inline run_exe_<std::wstring> run_exe(const filesystem::path &p)
 {
     return run_exe_<std::wstring>(p.wstring());
 }
@@ -74,7 +75,7 @@ inline run_exe_<std::string> run_exe(const std::string &s)
     return run_exe_<std::string>(s);
 }
 
-inline run_exe_<std::string> run_exe(const boost::filesystem::path &p)
+inline run_exe_<std::string> run_exe(const filesystem::path &p)
 {
     return run_exe_<std::string>(p.string());
 }

--- a/components/process/include/hpx/components/process/util/windows/initializers/start_in_dir.hpp
+++ b/components/process/include/hpx/components/process/util/windows/initializers/start_in_dir.hpp
@@ -15,8 +15,9 @@
 
 #if defined(HPX_WINDOWS)
 #include <hpx/components/process/util/windows/initializers/initializer_base.hpp>
+#include <hpx/filesystem.hpp>
 #include <hpx/runtime/serialization/serialization_fwd.hpp>
-#include <boost/filesystem/path.hpp>
+
 #include <string>
 
 namespace hpx { namespace components { namespace process { namespace windows {
@@ -60,7 +61,7 @@ inline start_in_dir_<std::wstring> start_in_dir(const std::wstring &ws)
     return start_in_dir_<std::wstring>(ws);
 }
 
-inline start_in_dir_<std::wstring> start_in_dir(const boost::filesystem::path &p)
+inline start_in_dir_<std::wstring> start_in_dir(const filesystem::path &p)
 {
     return start_in_dir_<std::wstring>(p.wstring());
 }
@@ -75,7 +76,7 @@ inline start_in_dir_<std::string> start_in_dir(const std::string &s)
     return start_in_dir_<std::string>(s);
 }
 
-inline start_in_dir_<std::string> start_in_dir(const boost::filesystem::path &p)
+inline start_in_dir_<std::string> start_in_dir(const filesystem::path &p)
 {
     return start_in_dir_<std::string>(p.string());
 }

--- a/components/process/include/hpx/components/process/util/windows/shell_path.hpp
+++ b/components/process/include/hpx/components/process/util/windows/shell_path.hpp
@@ -16,13 +16,12 @@
 #if defined(HPX_WINDOWS)
 #include <hpx/components/process/export_definitions.hpp>
 #include <hpx/errors.hpp>
-
-#include <boost/filesystem/path.hpp>
+#include <hpx/filesystem.hpp>
 
 namespace hpx { namespace components { namespace process { namespace windows
 {
-    HPX_PROCESS_EXPORT boost::filesystem::path shell_path();
-    HPX_PROCESS_EXPORT boost::filesystem::path shell_path(hpx::error_code &ec);
+    HPX_PROCESS_EXPORT filesystem::path shell_path();
+    HPX_PROCESS_EXPORT filesystem::path shell_path(hpx::error_code &ec);
 }}}}
 
 #endif

--- a/components/process/src/util/posix/search_path.cpp
+++ b/components/process/src/util/posix/search_path.cpp
@@ -11,15 +11,17 @@
 #include <hpx/config.hpp>
 
 #if !defined(HPX_WINDOWS)
-#include <hpx/errors.hpp>
 #include <hpx/components/process/util/search_path.hpp>
+#include <hpx/errors.hpp>
+#include <hpx/filesystem.hpp>
 
-#include <boost/filesystem.hpp>
 #include <boost/tokenizer.hpp>
+
+#include <unistd.h>
+
 #include <cstdlib>
 #include <stdexcept>
 #include <string>
-#include <unistd.h>
 
 namespace hpx { namespace components { namespace process { namespace posix
 {
@@ -42,7 +44,7 @@ namespace hpx { namespace components { namespace process { namespace posix
         tokenizer tok(path, sep);
         for (tokenizer::iterator it = tok.begin(); it != tok.end(); ++it)
         {
-            boost::filesystem::path p = *it;
+            filesystem::path p = *it;
             p /= filename;
             if (!::access(p.c_str(), X_OK))
             {

--- a/components/process/src/util/posix/shell_path.cpp
+++ b/components/process/src/util/posix/shell_path.cpp
@@ -11,19 +11,18 @@
 #include <hpx/config.hpp>
 
 #if !defined(HPX_WINDOWS)
-#include <hpx/errors.hpp>
 #include <hpx/components/process/util/shell_path.hpp>
-
-#include <boost/filesystem/path.hpp>
+#include <hpx/errors.hpp>
+#include <hpx/filesystem.hpp>
 
 namespace hpx { namespace components { namespace process { namespace posix
 {
-    boost::filesystem::path shell_path()
+    filesystem::path shell_path()
     {
         return "/bin/sh";
     }
 
-    boost::filesystem::path shell_path(hpx::error_code &ec)
+    filesystem::path shell_path(hpx::error_code &ec)
     {
         ec = hpx::make_success_code();
         return "/bin/sh";

--- a/components/process/src/util/windows/search_path.cpp
+++ b/components/process/src/util/windows/search_path.cpp
@@ -11,18 +11,19 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_WINDOWS)
-#include <hpx/errors.hpp>
 #include <hpx/components/process/util/windows/search_path.hpp>
+#include <hpx/errors.hpp>
+#include <hpx/filesystem.hpp>
 
-#include <boost/filesystem.hpp>
-#include <boost/tokenizer.hpp>
 #include <boost/system/error_code.hpp>
+#include <boost/tokenizer.hpp>
+
+#include <shellapi.h>
 
 #include <array>
 #include <cstdlib>
 #include <stdexcept>
 #include <string>
-#include <shellapi.h>
 
 namespace hpx { namespace components { namespace process { namespace windows
 {
@@ -46,17 +47,17 @@ namespace hpx { namespace components { namespace process { namespace windows
         tokenizer tok(path, sep);
         for (tokenizer::iterator it = tok.begin(); it != tok.end(); ++it)
         {
-            boost::filesystem::path p = *it;
+            filesystem::path p = *it;
             p /= filename;
             std::array<std::wstring, 4> extensions =
                 { L"", L".exe", L".com", L".bat" };
             for (std::array<std::wstring, 4>::iterator it2 = extensions.begin();
                 it2 != extensions.end(); ++it2)
             {
-                boost::filesystem::path p2 = p;
+                filesystem::path p2 = p;
                 p2 += *it2;
                 boost::system::error_code ec;
-                bool file = boost::filesystem::is_regular_file(p2, ec);
+                bool file = filesystem::is_regular_file(p2, ec);
                 if (!ec && file &&
                     SHGetFileInfoW(p2.c_str(), 0, 0, 0, SHGFI_EXETYPE))
                 {

--- a/components/process/src/util/windows/shell_path.cpp
+++ b/components/process/src/util/windows/shell_path.cpp
@@ -11,14 +11,13 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_WINDOWS)
-#include <hpx/errors.hpp>
 #include <hpx/components/process/util/windows/shell_path.hpp>
-
-#include <boost/filesystem/path.hpp>
+#include <hpx/errors.hpp>
+#include <hpx/filesystem.hpp>
 
 namespace hpx { namespace components { namespace process { namespace windows
 {
-    boost::filesystem::path shell_path()
+    filesystem::path shell_path()
     {
         TCHAR sysdir[MAX_PATH];
         UINT size = ::GetSystemDirectory(sysdir, sizeof(sysdir));
@@ -28,15 +27,15 @@ namespace hpx { namespace components { namespace process { namespace windows
                 "process::shell_path",
                 "GetSystemDirectory() failed");
         }
-        boost::filesystem::path p = sysdir;
+        filesystem::path p = sysdir;
         return p / "cmd.exe";
     }
 
-    boost::filesystem::path shell_path(hpx::error_code &ec)
+    filesystem::path shell_path(hpx::error_code &ec)
     {
         TCHAR sysdir[MAX_PATH];
         UINT size = ::GetSystemDirectory(sysdir, sizeof(sysdir));
-        boost::filesystem::path p;
+        filesystem::path p;
         if (!size)
         {
             HPX_THROWS_IF(ec, invalid_status,

--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -271,14 +271,14 @@ namespace hpx { namespace components { namespace server
 #if !defined(HPX_HAVE_STATIC_LINKING)
         bool load_component(hpx::util::plugin::dll& d,
             util::section& ini, std::string const& instance,
-            std::string const& component, boost::filesystem::path const& lib,
+            std::string const& component, filesystem::path const& lib,
             naming::gid_type const& prefix, naming::resolver_client& agas_client,
             bool isdefault, bool isenabled,
             boost::program_options::options_description& options,
             std::set<std::string>& startup_handled);
         bool load_component_dynamic(
             util::section& ini, std::string const& instance,
-            std::string const& component, boost::filesystem::path lib,
+            std::string const& component, filesystem::path lib,
             naming::gid_type const& prefix, naming::resolver_client& agas_client,
             bool isdefault, bool isenabled,
             boost::program_options::options_description& options,
@@ -293,7 +293,7 @@ namespace hpx { namespace components { namespace server
 
         bool load_component_static(
             util::section& ini, std::string const& instance,
-            std::string const& component, boost::filesystem::path const& lib,
+            std::string const& component, filesystem::path const& lib,
             naming::gid_type const& prefix, naming::resolver_client& agas_client,
             bool isdefault, bool isenabled,
             boost::program_options::options_description& options,
@@ -313,13 +313,13 @@ namespace hpx { namespace components { namespace server
 #if !defined(HPX_HAVE_STATIC_LINKING)
         bool load_plugin(hpx::util::plugin::dll& d,
             util::section& ini, std::string const& instance,
-            std::string const& component, boost::filesystem::path const& lib,
+            std::string const& component, filesystem::path const& lib,
             bool isenabled,
             boost::program_options::options_description& options,
             std::set<std::string>& startup_handled);
         bool load_plugin_dynamic(
             util::section& ini, std::string const& instance,
-            std::string const& component, boost::filesystem::path lib,
+            std::string const& component, filesystem::path lib,
             bool isenabled,
             boost::program_options::options_description& options,
             std::set<std::string>& startup_handled);

--- a/hpx/util/init_ini_data.hpp
+++ b/hpx/util/init_ini_data.hpp
@@ -7,13 +7,12 @@
 #if!defined(HPX_INIT_INI_DATA_SEP_26_2008_0344PM)
 #define HPX_INIT_INI_DATA_SEP_26_2008_0344PM
 
+#include <hpx/filesystem.hpp>
 #include <hpx/plugins/plugin_registry_base.hpp>
 #include <hpx/runtime/components/component_registry_base.hpp>
 #include <hpx/util/ini.hpp>
 #include <hpx/util/plugin/dll.hpp>
 #include <hpx/util/plugin/virtual_constructor.hpp>
-
-#include <boost/filesystem/path.hpp>
 
 #include <map>
 #include <memory>
@@ -51,7 +50,7 @@ namespace hpx { namespace util
     // default ini settings assuming all of those are components
     std::vector<std::shared_ptr<plugins::plugin_registry_base> >
     init_ini_data_default(std::string const& libs, section& ini,
-        std::map<std::string, boost::filesystem::path>& basenames,
+        std::map<std::string, filesystem::path>& basenames,
         std::map<std::string, hpx::util::plugin::dll>& modules);
 
 }}

--- a/hpx/util/plugin/detail/dll_dlopen.hpp
+++ b/hpx/util/plugin/detail/dll_dlopen.hpp
@@ -13,10 +13,9 @@
 #include <hpx/config.hpp>
 #include <hpx/assertion.hpp>
 #include <hpx/errors.hpp>
+#include <hpx/filesystem.hpp>
 #include <hpx/util/plugin/config.hpp>
 
-#include <boost/filesystem/convenience.hpp>
-#include <boost/filesystem/path.hpp>
 #include <boost/shared_ptr.hpp>
 
 #include <iostream>
@@ -148,13 +147,9 @@ namespace hpx { namespace util { namespace plugin {
           , mtx_(mutex_instance())
         {
             // map_name defaults to dll base name
-            namespace fs = boost::filesystem;
+            namespace fs = filesystem;
 
-#if BOOST_FILESYSTEM_VERSION == 2
-            fs::path dll_path(dll_name, fs::native);
-#else
             fs::path dll_path(dll_name);
-#endif
             map_name = fs::basename(dll_path);
         }
 
@@ -318,7 +313,7 @@ namespace hpx { namespace util { namespace plugin {
         std::string get_directory(error_code& ec = throws) const
         {
             // now find the full path of the loaded library
-            using boost::filesystem::path;
+            using filesystem::path;
             std::string result;
 
 #if !defined(__ANDROID__) && !defined(ANDROID) && !defined(__APPLE__)

--- a/hpx/util/plugin/detail/dll_windows.hpp
+++ b/hpx/util/plugin/detail/dll_windows.hpp
@@ -13,10 +13,9 @@
 #include <hpx/config.hpp>
 #include <hpx/assertion.hpp>
 #include <hpx/errors.hpp>
+#include <hpx/filesystem.hpp>
 #include <hpx/util/plugin/config.hpp>
 
-#include <boost/filesystem/convenience.hpp>
-#include <boost/filesystem/path.hpp>
 #include <boost/shared_ptr.hpp>
 
 #include <iostream>
@@ -68,13 +67,9 @@ namespace hpx { namespace util { namespace plugin {
         :   dll_name(libname), map_name(""), dll_handle(nullptr)
         {
             // map_name defaults to dll base name
-            namespace fs = boost::filesystem;
+            namespace fs = filesystem;
 
-#if BOOST_FILESYSTEM_VERSION == 2
-            fs::path dll_path(dll_name, fs::native);
-#else
             fs::path dll_path(dll_name);
-#endif
             map_name = fs::basename(dll_path);
         }
 

--- a/hpx/util/runtime_configuration.hpp
+++ b/hpx/util/runtime_configuration.hpp
@@ -8,6 +8,7 @@
 #define HPX_UTIL_RUNTIME_CONFIGURATION_HPP
 
 #include <hpx/config.hpp>
+#include <hpx/filesystem.hpp>
 #include <hpx/runtime/agas_fwd.hpp>
 #include <hpx/runtime/components/static_factory_data.hpp>
 #include <hpx/runtime/runtime_mode.hpp>
@@ -15,8 +16,6 @@
 #include <hpx/util/ini.hpp>
 #include <hpx/util/plugin/dll.hpp>
 #include <hpx/plugins/plugin_registry_base.hpp>
-
-#include <boost/filesystem.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -159,14 +158,14 @@ namespace hpx { namespace util
             std::string const& component_base_paths,
             std::string const& component_path_suffixes,
             std::set<std::string>& component_paths,
-            std::map<std::string, boost::filesystem::path>& basenames);
+            std::map<std::string, filesystem::path>& basenames);
 
         void load_component_path(
             std::vector<std::shared_ptr<plugins::plugin_registry_base>>&
                 plugin_registries,
             std::string const& path,
             std::set<std::string>& component_paths,
-            std::map<std::string, boost::filesystem::path>& basenames);
+            std::map<std::string, filesystem::path>& basenames);
 
     public:
         runtime_mode mode_;

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -20,6 +20,7 @@ set(HPX_LIBS
   config
   datastructures
   errors
+  filesystem
   format
   hardware
   hashing

--- a/libs/all_modules.rst
+++ b/libs/all_modules.rst
@@ -23,6 +23,7 @@ All modules
    /libs/config/docs/index.rst
    /libs/datastructures/docs/index.rst
    /libs/errors/docs/index.rst
+   /libs/filesystem/docs/index.rst
    /libs/format/docs/index.rst
    /libs/hardware/docs/index.rst
    /libs/hashing/docs/index.rst

--- a/libs/config/include/hpx/config.hpp
+++ b/libs/config/include/hpx/config.hpp
@@ -9,9 +9,9 @@
 
 // We need to detect if user code include boost/config.hpp before
 // including hpx/config.hpp
-// Everything else might lead to hard compile errors and possible very subtile bugs.
+// Everything else might lead to hard compile errors and possible very subtle bugs.
 #if defined(BOOST_CONFIG_HPP)
-#error Boost.Config was included before the hpx config header. This might lead to subtile failures and compile errors. Please include <hpx/config.hpp> before any other boost header
+#error Boost.Config was included before the hpx config header. This might lead to subtle failures and compile errors. Please include <hpx/config.hpp> before any other boost header
 #endif
 
 #include <hpx/config/attributes.hpp>

--- a/libs/create_library_skeleton.py
+++ b/libs/create_library_skeleton.py
@@ -180,10 +180,6 @@ if lib_name != '--recreate-index':
     f = open(os.path.join(lib_name, 'examples', 'CMakeLists.txt'), 'w')
     f.write(examples_cmakelists_template)
 
-    # Generate src/CMakeLists.txt
-    f = open(os.path.join(lib_name, 'src', 'CMakeLists.txt'), 'w')
-    f.write(cmake_header)
-
     # Generate tests/CMakeLists.txt
     f = open(os.path.join(lib_name, 'tests', 'CMakeLists.txt'), 'w')
     f.write(tests_cmakelists_template)

--- a/libs/errors/CMakeLists.txt
+++ b/libs/errors/CMakeLists.txt
@@ -48,6 +48,7 @@ add_hpx_module(errors
       hpx_assertion
       hpx_config
       hpx_datastructures
+      hpx_filesystem
       hpx_format
       hpx_logging
       hpx_thread_support

--- a/libs/errors/src/exception.cpp
+++ b/libs/errors/src/exception.cpp
@@ -13,8 +13,6 @@
 #include <hpx/format.hpp>
 #include <hpx/logging.hpp>
 
-#include <boost/filesystem/path.hpp>
-
 #if defined(HPX_WINDOWS)
 #include <process.h>
 #elif defined(HPX_HAVE_UNISTD_H)

--- a/libs/errors/src/throw_exception.cpp
+++ b/libs/errors/src/throw_exception.cpp
@@ -5,10 +5,10 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/filesystem.hpp>
 #include <hpx/errors/error.hpp>
 #include <hpx/errors/exception.hpp>
 
-#include <boost/filesystem/path.hpp>
 #include <boost/system/error_code.hpp>
 
 #include <exception>
@@ -18,7 +18,7 @@ namespace hpx { namespace detail {
     HPX_NORETURN void throw_exception(error errcode, std::string const& msg,
         std::string const& func, std::string const& file, long line)
     {
-        boost::filesystem::path p(file);
+        filesystem::path p(file);
         hpx::detail::throw_exception(
             hpx::exception(errcode, msg, hpx::plain), func, p.string(), line);
     }
@@ -35,7 +35,7 @@ namespace hpx { namespace detail {
         throwmode mode, std::string const& func, std::string const& file,
         long line, std::string const& auxinfo)
     {
-        boost::filesystem::path p(file);
+        filesystem::path p(file);
         return hpx::detail::get_exception(hpx::exception(errcode, msg, mode),
             p.string(), file, line, auxinfo);
     }

--- a/libs/filesystem/CMakeLists.txt
+++ b/libs/filesystem/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+cmake_minimum_required(VERSION 3.3.2 FATAL_ERROR)
+
+set(filesystem_headers "hpx/filesystem.hpp")
+
+include(HPX_AddModule)
+add_hpx_module(filesystem
+  FORCE_LINKING_GEN
+  GLOBAL_HEADER_GEN OFF
+  HEADERS ${filesystem_headers}
+  DEPENDENCIES hpx_config
+  CMAKE_SUBDIRS examples tests
+)

--- a/libs/filesystem/README.rst
+++ b/libs/filesystem/README.rst
@@ -1,0 +1,15 @@
+
+..
+   Copyright (c) 2019 The STE||AR-Group
+
+   Distributed under the Boost Software License, Version 1.0. (See accompanying
+   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+==========
+filesystem
+==========
+
+This library is part of HPX.
+
+Documentation can be found `here
+<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/filesystem/docs/index.html>`__.

--- a/libs/filesystem/docs/index.rst
+++ b/libs/filesystem/docs/index.rst
@@ -1,0 +1,16 @@
+..
+   Copyright (c) 2019 The STE||AR-Group
+
+   Distributed under the Boost Software License, Version 1.0. (See accompanying
+   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+.. _libs_filesystem:
+
+==========
+filesystem
+==========
+
+This module provides a compatibility layer for the C++17 filesystem library. If
+the filesystem library is available this module will simply forward its contents
+into the ``hpx::filesystem`` namespace. If the library is not available it will
+fall back to Boost.Filesystem instead.

--- a/libs/filesystem/examples/CMakeLists.txt
+++ b/libs/filesystem/examples/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if (HPX_WITH_EXAMPLES)
+  add_hpx_pseudo_target(examples.modules.filesystem)
+  add_hpx_pseudo_dependencies(examples.modules examples.modules.filesystem)
+  if (HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES AND HPX_FILESYSTEM_WITH_TESTS)
+    add_hpx_pseudo_target(tests.examples.modules.filesystem)
+    add_hpx_pseudo_dependencies(tests.examples.modules tests.examples.modules.filesystem)
+  endif()
+endif()

--- a/libs/filesystem/include/hpx/filesystem.hpp
+++ b/libs/filesystem/include/hpx/filesystem.hpp
@@ -1,0 +1,76 @@
+//  Copyright (c) 2019 Mikael Simberg
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file
+/// This file provides a compatibility layer using Boost.Filesystem for the
+/// C++17 filesystem library. It is *not* intended to be a complete
+/// compatibility layer. It only contains functions required by the HPX
+/// codebase. It also provides some functions only available in Boost.Filesystem
+/// when using C++17 filesystem.
+
+#if !defined(HPX_FILESYSTEM_HPP)
+#define HPX_FILESYSTEM_HPP
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_CXX17_FILESYSTEM)
+#include <filesystem>
+#include <system_error>
+
+namespace hpx { namespace filesystem {
+    using namespace std::filesystem;
+    using std::error_code;
+    using std::filesystem::canonical;
+
+    inline path initial_path()
+    {
+        static path ip = current_path();
+        return ip;
+    }
+
+    inline path basename(path const& p)
+    {
+        return p.stem();
+    }
+
+    inline path canonical(path const& p, path const& base)
+    {
+        if (p.is_relative())
+        {
+            return canonical(base / p);
+        }
+        else
+        {
+            return canonical(p);
+        }
+    }
+
+    inline path canonical(path const& p, path const& base, error_code& ec)
+    {
+        if (p.is_relative())
+        {
+            return canonical(base / p, ec);
+        }
+        else
+        {
+            return canonical(p, ec);
+        }
+    }
+
+}}    // namespace hpx::filesystem
+#else
+#include <boost/filesystem.hpp>
+
+static_assert(BOOST_FILESYSTEM_VERSION == 3,
+    "HPX requires Boost.Filesystem version 3 (or support for the C++17 "
+    "filesystem library)");
+
+namespace hpx { namespace filesystem {
+    using namespace boost::filesystem;
+    using boost::system::error_code;
+}}    // namespace hpx::filesystem
+#endif
+
+#endif

--- a/libs/filesystem/tests/CMakeLists.txt
+++ b/libs/filesystem/tests/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+include(HPX_Option)
+
+if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
+  hpx_set_option(HPX_FILESYSTEM_WITH_TESTS VALUE OFF FORCE)
+  return()
+endif()
+if (NOT HPX_FILESYSTEM_WITH_TESTS)
+  message(STATUS "Tests for filesystem disabled")
+  return()
+endif()
+
+if (HPX_WITH_TESTS_UNIT)
+  add_hpx_pseudo_target(tests.unit.modules.filesystem)
+  add_hpx_pseudo_dependencies(tests.unit.modules tests.unit.modules.filesystem)
+  add_subdirectory(unit)
+endif()
+
+if (HPX_WITH_TESTS_REGRESSIONS)
+  add_hpx_pseudo_target(tests.regressions.modules.filesystem)
+  add_hpx_pseudo_dependencies(tests.regressions.modules tests.regressions.modules.filesystem)
+  add_subdirectory(regressions)
+endif()
+
+if (HPX_WITH_TESTS_BENCHMARKS)
+  add_hpx_pseudo_target(tests.performance.modules.filesystem)
+  add_hpx_pseudo_dependencies(tests.performance.modules tests.performance.modules.filesystem)
+  add_subdirectory(performance)
+endif()
+
+if (HPX_WITH_TESTS_HEADERS)
+  add_hpx_header_tests(
+    modules.filesystem
+    HEADERS ${filesystem_headers}
+    HEADER_ROOT ${PROJECT_SOURCE_DIR}/include
+    NOLIBS
+    DEPENDENCIES hpx_filesystem)
+endif()

--- a/libs/filesystem/tests/performance/CMakeLists.txt
+++ b/libs/filesystem/tests/performance/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/filesystem/tests/regressions/CMakeLists.txt
+++ b/libs/filesystem/tests/regressions/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+

--- a/libs/filesystem/tests/unit/CMakeLists.txt
+++ b/libs/filesystem/tests/unit/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/logging/CMakeLists.txt
+++ b/libs/logging/CMakeLists.txt
@@ -96,6 +96,6 @@ add_hpx_module(logging
     SOURCES ${logging_sources}
     HEADERS ${logging_headers}
     COMPAT_HEADERS ${logging_compat_headers}
-    DEPENDENCIES hpx_assertion hpx_config
+    DEPENDENCIES hpx_assertion hpx_config hpx_filesystem
     CMAKE_SUBDIRS examples tests
 )

--- a/libs/logging/src/logging.cpp
+++ b/libs/logging/src/logging.cpp
@@ -7,12 +7,12 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_LOGGING)
+#include <hpx/filesystem.hpp>
 #include <hpx/logging.hpp>
 #include <hpx/logging/format/destination/defaults.hpp>
 #include <hpx/logging/format/named_write.hpp>
 
 #include <boost/config.hpp>
-#include <boost/filesystem/operations.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/version.hpp>
 

--- a/src/custom_exception_info.cpp
+++ b/src/custom_exception_info.cpp
@@ -24,8 +24,6 @@
 #include <hpx/version.hpp>
 #include <hpx/custom_exception_info.hpp>
 
-#include <boost/filesystem/path.hpp>
-
 #if defined(HPX_WINDOWS)
 #  include <process.h>
 #elif defined(HPX_HAVE_UNISTD_H)

--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -11,7 +11,13 @@
 #include <hpx/apply.hpp>
 #include <hpx/assertion.hpp>
 #include <hpx/async.hpp>
+#include <hpx/custom_exception_info.hpp>
+#include <hpx/datastructures/tuple.hpp>
+#include <hpx/errors.hpp>
+#include <hpx/filesystem.hpp>
+#include <hpx/format.hpp>
 #include <hpx/hpx_user_main_config.hpp>
+#include <hpx/logging.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/runtime/actions/plain_action.hpp>
 #include <hpx/runtime/agas/interface.hpp>
@@ -23,19 +29,14 @@
 #include <hpx/runtime/startup_function.hpp>
 #include <hpx/runtime/threads/policies/schedulers.hpp>
 #include <hpx/runtime_impl.hpp>
+#include <hpx/testing.hpp>
 #include <hpx/util/apex.hpp>
 #include <hpx/util/bind_action.hpp>
 #include <hpx/util/bind_front.hpp>
 #include <hpx/util/command_line_handling.hpp>
 #include <hpx/util/debugging.hpp>
-#include <hpx/errors.hpp>
-#include <hpx/custom_exception_info.hpp>
-#include <hpx/format.hpp>
-#include <hpx/testing.hpp>
 #include <hpx/util/function.hpp>
-#include <hpx/logging.hpp>
 #include <hpx/util/query_counters.hpp>
-#include <hpx/datastructures/tuple.hpp>
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
@@ -650,6 +651,8 @@ namespace hpx
             startup_function_type startup, shutdown_function_type shutdown,
             hpx::runtime_mode mode, bool blocking)
         {
+            HPX_UNUSED(hpx::filesystem::initial_path());
+
             hpx::assertion::set_assertion_handler(&detail::assertion_handler);
             hpx::util::set_test_failure_handler(&detail::test_failure_handler);
             hpx::set_custom_exception_info_handler(&detail::custom_exception_info);

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -5,10 +5,11 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/runtime.hpp>
-#include <hpx/errors.hpp>
 #include <hpx/apply.hpp>
+#include <hpx/errors.hpp>
+#include <hpx/filesystem.hpp>
 #include <hpx/logging.hpp>
+#include <hpx/runtime.hpp>
 #include <hpx/thread_support/unlock_guard.hpp>
 #include <hpx/util/find_prefix.hpp>
 #include <hpx/util/ini.hpp>
@@ -54,8 +55,6 @@
 
 #include <hpx/plugins/parcelport/mpi/mpi_environment.hpp>
 
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/convenience.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/tokenizer.hpp>
@@ -1441,7 +1440,7 @@ namespace hpx { namespace components { namespace server
     ///////////////////////////////////////////////////////////////////////////
     bool runtime_support::load_component_static(
         util::section& ini, std::string const& instance,
-        std::string const& component, boost::filesystem::path const& lib,
+        std::string const& component, filesystem::path const& lib,
         naming::gid_type const& prefix, naming::resolver_client& agas_client,
         bool isdefault, bool isenabled,
         boost::program_options::options_description& options,
@@ -1539,7 +1538,7 @@ namespace hpx { namespace components { namespace server
         iterator end = s.end();
         for (iterator i = s.begin (); i != end; ++i)
         {
-            namespace fs = boost::filesystem;
+            namespace fs = filesystem;
 
             // the section name is the instance name of the component
             util::section const& sect = i->second;
@@ -1581,7 +1580,7 @@ namespace hpx { namespace components { namespace server
                 typedef boost::tokenizer<boost::char_separator<char> > tokenizer;
                 boost::char_separator<char> sep(HPX_INI_PATH_DELIMITER);
                 tokenizer tokens(component_path, sep);
-                boost::system::error_code fsec;
+                fs::error_code fsec;
                 for(tokenizer::iterator it = tokens.begin(); it != tokens.end(); ++it)
                 {
                     lib = fs::path(*it);
@@ -1755,7 +1754,7 @@ namespace hpx { namespace components { namespace server
 #if !defined(HPX_HAVE_STATIC_LINKING)
     bool runtime_support::load_component_dynamic(
         util::section& ini, std::string const& instance,
-        std::string const& component, boost::filesystem::path lib,
+        std::string const& component, filesystem::path lib,
         naming::gid_type const& prefix, naming::resolver_client& agas_client,
         bool isdefault, bool isenabled,
         boost::program_options::options_description& options,
@@ -1777,7 +1776,7 @@ namespace hpx { namespace components { namespace server
         if (ec) {
             // build path to component to load
             std::string libname(HPX_MAKE_DLL_STRING(component));
-            lib /= boost::filesystem::path(libname);
+            lib /= filesystem::path(libname);
             d.load_library(ec);
             if (ec) {
                 LRT_(warning) << "dynamic loading failed: " << lib.string()
@@ -1890,7 +1889,7 @@ namespace hpx { namespace components { namespace server
     bool runtime_support::load_component(
         hpx::util::plugin::dll& d, util::section& ini,
         std::string const& instance, std::string const& component,
-        boost::filesystem::path const& lib, naming::gid_type const& prefix,
+        filesystem::path const& lib, naming::gid_type const& prefix,
         naming::resolver_client& agas_client, bool isdefault, bool isenabled,
         boost::program_options::options_description& options,
         std::set<std::string>& startup_handled)
@@ -1982,7 +1981,7 @@ namespace hpx { namespace components { namespace server
         iterator end = s.end();
         for (iterator i = s.begin (); i != end; ++i)
         {
-            namespace fs = boost::filesystem;
+            namespace fs = filesystem;
 
             // the section name is the instance name of the component
             util::section const& sect = i->second;
@@ -2015,7 +2014,7 @@ namespace hpx { namespace components { namespace server
                 typedef boost::tokenizer<boost::char_separator<char> > tokenizer;
                 boost::char_separator<char> sep(HPX_INI_PATH_DELIMITER);
                 tokenizer tokens(component_path, sep);
-                boost::system::error_code fsec;
+                fs::error_code fsec;
                 for(tokenizer::iterator it = tokens.begin(); it != tokens.end(); ++it)
                 {
                     lib = fs::path(*it);
@@ -2068,7 +2067,7 @@ namespace hpx { namespace components { namespace server
     bool runtime_support::load_plugin(hpx::util::plugin::dll& d,
         util::section& ini,
         std::string const& instance, std::string const& plugin,
-        boost::filesystem::path const& lib, bool isenabled,
+        filesystem::path const& lib, bool isenabled,
         boost::program_options::options_description& options,
         std::set<std::string>& startup_handled)
     {
@@ -2145,7 +2144,7 @@ namespace hpx { namespace components { namespace server
 
     bool runtime_support::load_plugin_dynamic(util::section& ini,
         std::string const& instance, std::string const& plugin,
-        boost::filesystem::path lib, bool isenabled,
+        filesystem::path lib, bool isenabled,
         boost::program_options::options_description& options,
         std::set<std::string>& startup_handled)
     {
@@ -2164,7 +2163,7 @@ namespace hpx { namespace components { namespace server
         if (ec) {
             // build path to component to load
             std::string libname(HPX_MAKE_DLL_STRING(plugin));
-            lib /= boost::filesystem::path(libname);
+            lib /= filesystem::path(libname);
             d.load_library(ec);
             if (ec) {
                 LRT_(warning) << "dynamic loading failed: " << lib.string()

--- a/src/runtime/parcelset/locality.cpp
+++ b/src/runtime/parcelset/locality.cpp
@@ -12,6 +12,8 @@
 #include <hpx/runtime/serialization/serialize.hpp>
 #include <hpx/runtime/serialization/string.hpp>
 
+#include <boost/io/ios_state.hpp>
+
 #include <string>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/util/find_prefix.cpp
+++ b/src/util/find_prefix.cpp
@@ -10,6 +10,7 @@
 #include <hpx/assertion.hpp>
 #include <hpx/errors.hpp>
 #include <hpx/util/find_prefix.hpp>
+#include <hpx/filesystem.hpp>
 
 #if defined(HPX_WINDOWS)
 #  include <windows.h>
@@ -31,7 +32,6 @@
 #include <hpx/util/plugin/dll.hpp>
 #include <hpx/type_support/unused.hpp>
 
-#include <boost/filesystem/path.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/tokenizer.hpp>
@@ -65,7 +65,7 @@ namespace hpx { namespace util
             dll.load_library(ec);
             if (ec) return hpx_prefix();
 
-            using boost::filesystem::path;
+            using hpx::filesystem::path;
 
             std::string const prefix =
                 path(dll.get_directory(ec)).parent_path().string();
@@ -117,7 +117,7 @@ namespace hpx { namespace util
     ///////////////////////////////////////////////////////////////////////////////
     std::string get_executable_prefix(char const* argv0)
     {
-        using boost::filesystem::path;
+        using hpx::filesystem::path;
         path p(get_executable_filename(argv0));
 
         return p.parent_path().parent_path().string();

--- a/src/util/init_ini_data.cpp
+++ b/src/util/init_ini_data.cpp
@@ -7,6 +7,7 @@
 #include <hpx/config.hpp>
 #include <hpx/assertion.hpp>
 #include <hpx/errors.hpp>
+#include <hpx/filesystem.hpp>
 #include <hpx/plugins/plugin_registry_base.hpp>
 #include <hpx/runtime/components/component_registry_base.hpp>
 #include <hpx/runtime/startup_function.hpp>
@@ -17,10 +18,6 @@
 #include <hpx/util/plugin.hpp>
 
 #include <boost/assign/std/vector.hpp>
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/exception.hpp>
-#include <boost/filesystem/convenience.hpp>
 #include <boost/tokenizer.hpp>
 
 #include <algorithm>
@@ -39,8 +36,8 @@ namespace hpx { namespace util
     bool handle_ini_file (section& ini, std::string const& loc)
     {
         try {
-            namespace fs = boost::filesystem;
-            boost::system::error_code ec;
+            namespace fs = filesystem;
+            fs::error_code ec;
             if (!fs::exists(loc, ec) || ec)
                 return false;       // avoid exception on missing file
             ini.read (loc);
@@ -57,7 +54,7 @@ namespace hpx { namespace util
     {
         char const* env = getenv(env_var);
         if (nullptr != env) {
-            namespace fs = boost::filesystem;
+            namespace fs = filesystem;
 
             fs::path inipath (env);
             if (nullptr != file_suffix)
@@ -79,7 +76,7 @@ namespace hpx { namespace util
     // successfully
     bool init_ini_data_base (section& ini, std::string& hpx_ini_file)
     {
-        namespace fs = boost::filesystem;
+        namespace fs = filesystem;
 
         // fall back: use compile time prefix
         std::string ini_paths(ini.get_entry("hpx.master_ini_path"));
@@ -141,8 +138,8 @@ namespace hpx { namespace util
         result = handle_ini_file_env(ini, "PWD", "/.hpx.ini") || result;
 
         if (!hpx_ini_file.empty()) {
-            namespace fs = boost::filesystem;
-            boost::system::error_code ec;
+            namespace fs = filesystem;
+            fs::error_code ec;
             if (!fs::exists(hpx_ini_file, ec) || ec) {
                 std::cerr << "hpx::init: command line warning: file specified using "
                              "--hpx::config does not exist ("
@@ -165,7 +162,7 @@ namespace hpx { namespace util
     // global function to read component ini information
     void merge_component_inis(section& ini)
     {
-        namespace fs = boost::filesystem;
+        namespace fs = filesystem;
 
         // now merge all information into one global structure
         std::string ini_path(ini.get_entry("hpx.ini_path", HPX_DEFAULT_INI_PATH));
@@ -189,24 +186,19 @@ namespace hpx { namespace util
                 fs::directory_iterator nodir;
                 fs::path this_path (*it);
 
-                boost::system::error_code ec;
+                fs::error_code ec;
                 if (!fs::exists(this_path, ec) || ec)
                     continue;
 
                 for (fs::directory_iterator dir(this_path); dir != nodir; ++dir)
                 {
-                    if (fs::extension(*dir) != ".ini")
+                    if ((*dir).path().extension() != ".ini")
                         continue;
 
                     // read and merge the ini file into the main ini hierarchy
                     try {
-#if BOOST_FILESYSTEM_VERSION == 3
                         ini.merge ((*dir).path().string());
                         LBT_(info) << "loaded configuration: " << (*dir).path().string();
-#else
-                        ini.merge ((*dir).string());
-                        LBT_(info) << "loaded configuration: " << (*dir).string();
-#endif
                     }
                     catch (hpx::exception const& /*e*/) {
                         ;
@@ -364,15 +356,15 @@ namespace hpx { namespace util
     namespace detail
     {
         inline bool cmppath_less(
-            std::pair<boost::filesystem::path, std::string> const& lhs,
-            std::pair<boost::filesystem::path, std::string> const& rhs)
+            std::pair<filesystem::path, std::string> const& lhs,
+            std::pair<filesystem::path, std::string> const& rhs)
         {
             return lhs.first < rhs.first;
         }
 
         inline bool cmppath_equal(
-            std::pair<boost::filesystem::path, std::string> const& lhs,
-            std::pair<boost::filesystem::path, std::string> const& rhs)
+            std::pair<filesystem::path, std::string> const& lhs,
+            std::pair<filesystem::path, std::string> const& rhs)
         {
             return lhs.first == rhs.first;
         }
@@ -381,10 +373,10 @@ namespace hpx { namespace util
     ///////////////////////////////////////////////////////////////////////////
     std::vector<std::shared_ptr<plugins::plugin_registry_base> >
     init_ini_data_default(std::string const& libs, util::section& ini,
-        std::map<std::string, boost::filesystem::path>& basenames,
+        std::map<std::string, filesystem::path>& basenames,
         std::map<std::string, hpx::util::plugin::dll>& modules)
     {
-        namespace fs = boost::filesystem;
+        namespace fs = filesystem;
 
         typedef std::vector<std::pair<fs::path, std::string> >::iterator
             iterator_type;
@@ -400,7 +392,7 @@ namespace hpx { namespace util
             fs::directory_iterator nodir;
             fs::path libs_path(libs);
 
-            boost::system::error_code ec;
+            fs::error_code ec;
             if (!fs::exists(libs_path, ec) || ec)
                 return plugin_registries;     // given directory doesn't exist
 
@@ -419,7 +411,7 @@ namespace hpx { namespace util
             for (fs::directory_iterator dir(libs_path); dir != nodir; ++dir)
             {
                 fs::path curr(*dir);
-                if (fs::extension(curr) != HPX_SHARED_LIB_EXTENSION)
+                if (curr.extension() != HPX_SHARED_LIB_EXTENSION)
                     continue;
 
                 // instance name and module name are the same
@@ -436,7 +428,7 @@ namespace hpx { namespace util
                     name.erase(i - 1, version.length() + 1); // - 1 for one more dot
 #endif
                 // ensure base directory, remove symlinks, etc.
-                boost::system::error_code fsec;
+                fs::error_code fsec;
                 fs::path canonical_curr =
                     fs::canonical(curr, fs::initial_path(), fsec);
                 if (fsec)

--- a/src/util/init_logging.cpp
+++ b/src/util/init_logging.cpp
@@ -23,7 +23,6 @@
 #include <boost/version.hpp>
 #include <boost/config.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/filesystem/operations.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/src/util/runtime_configuration.cpp
+++ b/src/util/runtime_configuration.cpp
@@ -8,6 +8,7 @@
 
 // TODO: move parcel ports into plugins
 #include <hpx/assertion.hpp>
+#include <hpx/filesystem.hpp>
 #include <hpx/preprocessor/expand.hpp>
 #include <hpx/preprocessor/stringize.hpp>
 #include <hpx/runtime/parcelset/parcelhandler.hpp>
@@ -20,7 +21,6 @@
 #include <hpx/util/safe_lexical_cast.hpp>
 #include <hpx/version.hpp>
 
-#include <boost/filesystem.hpp>
 #include <boost/predef/other/endian.h>
 #include <boost/spirit/include/qi_alternative.hpp>
 #include <boost/spirit/include/qi_numeric.hpp>
@@ -415,9 +415,9 @@ namespace hpx { namespace util
             plugin_registries,
         std::string const& path,
         std::set<std::string>& component_paths,
-        std::map<std::string, boost::filesystem::path>& basenames)
+        std::map<std::string, filesystem::path>& basenames)
     {
-        namespace fs = boost::filesystem;
+        namespace fs = filesystem;
 
         using plugin_list_type =
             std::vector<std::shared_ptr<plugins::plugin_registry_base>>;
@@ -425,7 +425,7 @@ namespace hpx { namespace util
         if (!path.empty())
         {
             fs::path this_p(path);
-            boost::system::error_code fsec;
+            fs::error_code fsec;
             fs::path canonical_p =
                 fs::canonical(this_p, fs::initial_path(), fsec);
             if (fsec)
@@ -457,9 +457,9 @@ namespace hpx { namespace util
         std::string const& component_base_paths,
         std::string const& component_path_suffixes,
         std::set<std::string>& component_paths,
-        std::map<std::string, boost::filesystem::path>& basenames)
+        std::map<std::string, filesystem::path>& basenames)
     {
-        namespace fs = boost::filesystem;
+        namespace fs = filesystem;
 
         // try to build default ini structure from shared libraries in default
         // installation location, this allows to install simple components
@@ -507,7 +507,7 @@ namespace hpx { namespace util
         std::set<std::string> component_paths;
 
         // list of base names avoiding to load a module more than once
-        std::map<std::string, boost::filesystem::path> basenames;
+        std::map<std::string, filesystem::path> basenames;
 
         // plugin registry object
         plugin_list_type plugin_registries;

--- a/tests/unit/component/launch_process.cpp
+++ b/tests/unit/component/launch_process.cpp
@@ -3,14 +3,13 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/filesystem.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/include/process.hpp>
 #include <hpx/testing.hpp>
 
 #include <tests/unit/component/components/launch_process_test_server.hpp>
-
-#include <boost/filesystem.hpp>
 
 #include <cstddef>
 #include <iostream>
@@ -48,7 +47,7 @@ std::vector<std::string> get_environment()
 int hpx_main(boost::program_options::variables_map &vm)
 {
     namespace process = hpx::components::process;
-    namespace fs = boost::filesystem;
+    namespace fs = hpx::filesystem;
 
     // find where the HPX core libraries are located
     fs::path base_dir = hpx::util::find_prefix();

--- a/tools/inspect/CMakeLists.txt
+++ b/tools/inspect/CMakeLists.txt
@@ -14,7 +14,8 @@ if(NOT Boost_REGEX_FOUND)
   hpx_error("HPX inspect tool requires Boost.Regex")
 endif()
 
-target_link_libraries(inspect PRIVATE ${Boost_LIBRARIES} hpx_config)
+target_link_libraries(inspect
+  PRIVATE ${Boost_LIBRARIES} hpx_config hpx_filesystem)
 
 # add dependencies to pseudo-target
 add_hpx_pseudo_dependencies(tools.inspect inspect)

--- a/tools/inspect/apple_macro_check.cpp
+++ b/tools/inspect/apple_macro_check.cpp
@@ -7,16 +7,16 @@
 //  (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config/defines.hpp>
+#include <hpx/config.hpp>
+#include <hpx/filesystem.hpp>
 
 #include "apple_macro_check.hpp"
 #include "function_hyper.hpp"
 #include <functional>
 #include <string>
 #include "boost/regex.hpp"
-#include "boost/filesystem/operations.hpp"
 
-namespace fs = boost::filesystem;
+namespace fs = hpx::filesystem;
 
 namespace
 {

--- a/tools/inspect/ascii_check.cpp
+++ b/tools/inspect/ascii_check.cpp
@@ -8,10 +8,12 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 //  √ -- this is a test.
 
-#include <hpx/config/defines.hpp>
+#include <hpx/config.hpp>
 
 #include "ascii_check.hpp"
 #include "function_hyper.hpp"
+
+#include <algorithm>
 #include <cstddef>
 
 namespace boost

--- a/tools/inspect/assert_macro_check.cpp
+++ b/tools/inspect/assert_macro_check.cpp
@@ -7,16 +7,17 @@
 //  (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config/defines.hpp>
+#include <hpx/config.hpp>
+#include <hpx/filesystem.hpp>
 
 #include "assert_macro_check.hpp"
-#include <functional>
 #include "function_hyper.hpp"
 #include "boost/regex.hpp"
 #include "boost/lexical_cast.hpp"
-#include "boost/filesystem/operations.hpp"
 
-namespace fs = boost::filesystem;
+#include <functional>
+
+namespace fs = hpx::filesystem;
 
 namespace
 {

--- a/tools/inspect/copyright_check.cpp
+++ b/tools/inspect/copyright_check.cpp
@@ -5,7 +5,7 @@
 //  (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config/defines.hpp>
+#include <hpx/config.hpp>
 
 #include "copyright_check.hpp"
 #include "function_hyper.hpp"

--- a/tools/inspect/crlf_check.cpp
+++ b/tools/inspect/crlf_check.cpp
@@ -8,7 +8,7 @@
 
 //  Contributed by Joerg Walter
 
-#include <hpx/config/defines.hpp>
+#include <hpx/config.hpp>
 
 #include "crlf_check.hpp"
 #include "function_hyper.hpp"
@@ -52,13 +52,13 @@ namespace boost
         }
       }
 
-      if (failed && full_path.leaf() != test_file_name)
+      if (failed && full_path.filename() != test_file_name)
       {
         ++m_files_with_errors;
         error( library_name, full_path, name() );
       }
 
-      if (!failed && full_path.leaf() == test_file_name)
+      if (!failed && full_path.filename() == test_file_name)
       {
         ++m_files_with_errors;
         error( library_name, full_path, loclink(full_path,

--- a/tools/inspect/deprecated_include_check.cpp
+++ b/tools/inspect/deprecated_include_check.cpp
@@ -8,7 +8,7 @@
 //  (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config/defines.hpp>
+#include <hpx/config.hpp>
 
 #include <algorithm>
 

--- a/tools/inspect/deprecated_macro_check.cpp
+++ b/tools/inspect/deprecated_macro_check.cpp
@@ -8,15 +8,15 @@
 //  (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config/defines.hpp>
+#include <hpx/config.hpp>
+#include <hpx/filesystem.hpp>
 
 #include "deprecated_macro_check.hpp"
 #include <functional>
 #include "function_hyper.hpp"
 #include "boost/regex.hpp"
-#include "boost/filesystem/operations.hpp"
 
-namespace fs = boost::filesystem;
+namespace fs = hpx::filesystem;
 
 namespace
 {

--- a/tools/inspect/deprecated_name_check.cpp
+++ b/tools/inspect/deprecated_name_check.cpp
@@ -8,7 +8,7 @@
 //  (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config/defines.hpp>
+#include <hpx/config.hpp>
 
 #include <algorithm>
 

--- a/tools/inspect/end_check.cpp
+++ b/tools/inspect/end_check.cpp
@@ -7,7 +7,7 @@
 //  (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config/defines.hpp>
+#include <hpx/config.hpp>
 
 #include "end_check.hpp"
 #include "function_hyper.hpp"

--- a/tools/inspect/endline_whitespace_check.cpp
+++ b/tools/inspect/endline_whitespace_check.cpp
@@ -6,7 +6,8 @@
 //  (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config/defines.hpp>
+#include <hpx/config.hpp>
+#include <hpx/filesystem.hpp>
 
 #include "endline_whitespace_check.hpp"
 #include "function_hyper.hpp"
@@ -16,11 +17,10 @@
 #include <boost/foreach.hpp>
 #include <boost/tokenizer.hpp>
 #include "boost/regex.hpp"
-#include "boost/filesystem/operations.hpp"
 
 
 using namespace std;
-namespace fs = boost::filesystem;
+namespace fs = hpx::filesystem;
 
 namespace boost
 {

--- a/tools/inspect/function_hyper.hpp
+++ b/tools/inspect/function_hyper.hpp
@@ -8,12 +8,14 @@
 #ifndef FUNCTION_HYPER_HPP
 #define FUNCTION_HYPER_HPP
 
+#include <hpx/config.hpp>
+#include <hpx/filesystem.hpp>
+
 #include "inspector.hpp"
-#include "boost/filesystem/path.hpp"
-#include <hpx/config/defines.hpp>
+
 #include <string>
 
-using boost::filesystem::path;
+using hpx::filesystem::path;
 
 // When you have a specific line and the line is the location of the link
 inline std::string linelink(path const& full_path, std::string const& linenumb)

--- a/tools/inspect/include_check.cpp
+++ b/tools/inspect/include_check.cpp
@@ -7,7 +7,7 @@
 //  (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config/defines.hpp>
+#include <hpx/config.hpp>
 
 #include <algorithm>
 

--- a/tools/inspect/inspect.cpp
+++ b/tools/inspect/inspect.cpp
@@ -21,7 +21,8 @@ const char* hpx_no_inspect = "hpx-" "no-inspect";
 //  Directories with a file name of the hpx_no_inspect value are not inspected.
 //  Files that contain the hpx_no_inspect value are not inspected.
 
-#include <hpx/config/defines.hpp>
+#include <hpx/config.hpp>
+#include <hpx/filesystem.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -34,8 +35,6 @@ const char* hpx_no_inspect = "hpx-" "no-inspect";
 #include <string>
 #include <vector>
 
-#include "boost/filesystem/operations.hpp"
-#include "boost/filesystem/fstream.hpp"
 #include "boost/program_options.hpp"
 #include "function_hyper.hpp"
 
@@ -82,7 +81,7 @@ const char* hpx_no_inspect = "hpx-" "no-inspect";
 #include "boost/test/included/prg_exec_monitor.hpp"
 #endif
 
-namespace fs = boost::filesystem;
+namespace fs = hpx::filesystem;
 
 using namespace boost::inspect;
 
@@ -237,7 +236,7 @@ namespace
   bool visit_predicate( const path & pth )
   {
     string local( boost::inspect::relative_to( pth, search_root_path() ) );
-    string leaf( pth.leaf().string() );
+    string leaf( pth.filename().string() );
     if (leaf[0] == '.')  // ignore hidden by convention directories such as
       return false;      //  .htaccess, .git, .svn, .bzr, .DS_Store, etc.
 
@@ -252,7 +251,7 @@ namespace
       && local.find("doc/xml") != 0
       && local.find("doc\\xml") != 0
       // ignore if tag file present
-      && !boost::filesystem::exists(pth / hpx_no_inspect)
+      && !hpx::filesystem::exists(pth / hpx_no_inspect)
       ;
   }
 
@@ -287,7 +286,7 @@ namespace
   bool find_signature( const path & file_path,
     const boost::inspect::string_set & signatures )
   {
-    string name( file_path.leaf().string() );
+    string name( file_path.filename().string() );
     if ( signatures.find( name ) == signatures.end() )
     {
       string::size_type pos( name.rfind( '.' ) );
@@ -306,7 +305,8 @@ namespace
 
     if ( !find_signature( file_path, content_signatures ) ) return;
 
-    fs::ifstream fin( file_path, std::ios_base::in|std::ios_base::binary );
+    std::ifstream fin( file_path.string(),
+        std::ios_base::in|std::ios_base::binary );
     if ( !fin )
       throw string( "could not open input file: " ) + file_path.string();
     std::getline( fin, target, '\0' ); // read the whole file
@@ -349,7 +349,7 @@ namespace
           visit_all<DirectoryIterator>( cur_lib, *itr, insps );
         }
       }
-      else if (itr->path().leaf().string()[0] != '.') // ignore if hidden
+      else if (itr->path().filename().string()[0] != '.') // ignore if hidden
       {
         ++file_count;
         string content;
@@ -467,7 +467,7 @@ namespace
             {
               out << "\n  " << this_rel_path.parent_path().string() << '/';
             }
-            out << "\n    " << this_rel_path.leaf() << ':';
+            out << "\n    " << this_rel_path.filename() << ':';
           }
         }
         if ( current.library != itr->library
@@ -905,13 +905,11 @@ int cpp_main( int argc_param, char * argv_param[] )
     if (vm.count("hpx:positional"))
     {
         for (auto const& s: vm["hpx:positional"].as<std::vector<std::string> >())
-            search_roots.push_back(fs::canonical(fs::absolute(s,
-                fs::initial_path())));
+            search_roots.push_back(fs::canonical(s, fs::initial_path()));
     }
     else
     {
-        search_roots.push_back(fs::canonical(fs::absolute(".",
-            fs::initial_path())));
+        search_roots.push_back(fs::canonical(fs::initial_path()));
     }
 
     if (vm.count("text"))
@@ -1010,7 +1008,7 @@ int cpp_main( int argc_param, char * argv_param[] )
     for(auto const& search_root: search_roots)
     {
         ::search_root = search_root;
-        visit_all<fs::directory_iterator>( search_root.leaf().string(),
+        visit_all<fs::directory_iterator>( search_root.filename().string(),
             search_root, inspectors );
     }
 

--- a/tools/inspect/inspector.hpp
+++ b/tools/inspect/inspector.hpp
@@ -11,16 +11,17 @@
 #ifndef BOOST_INSPECTOR_HPP
 #define BOOST_INSPECTOR_HPP
 
+#include <hpx/filesystem.hpp>
+
 #include <cstddef>
 #include <iostream>
 #include <ostream>
 #include <set>
 #include <string>
 
-#include "boost/filesystem/path.hpp"
 
 using std::string;
-using boost::filesystem::path;
+using hpx::filesystem::path;
 
 namespace boost
 {
@@ -96,7 +97,7 @@ namespace boost
     inline string relative_to( const path & src_arg, const path & base_arg )
     {
       path base( base_arg );
-      base.normalize();
+      base.lexically_normal();
       string::size_type pos( base.string().size() );
       string src_arg_s(src_arg.string());
       path src;
@@ -104,7 +105,7 @@ namespace boost
         src = path(src_arg.string().substr(pos));
       else
         src = path(src_arg_s);
-      src.normalize();
+      src.lexically_normal();
       return src.string();
     }
 

--- a/tools/inspect/length_check.cpp
+++ b/tools/inspect/length_check.cpp
@@ -6,21 +6,23 @@
 //  (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config/defines.hpp>
+#include <hpx/config.hpp>
+#include <hpx/filesystem.hpp>
 
 #include "length_check.hpp"
 #include "function_hyper.hpp"
+
+#include <boost/foreach.hpp>
+#include <boost/tokenizer.hpp>
+#include <boost/regex.hpp>
+
 #include <cstddef>
 #include <iostream>
 #include <functional>
 #include <string>
-#include <boost/foreach.hpp>
-#include <boost/tokenizer.hpp>
-#include "boost/regex.hpp"
-#include "boost/filesystem/operations.hpp"
 
 using namespace std;
-namespace fs = boost::filesystem;
+namespace fs = hpx::filesystem;
 
 namespace boost
 {

--- a/tools/inspect/license_check.cpp
+++ b/tools/inspect/license_check.cpp
@@ -5,7 +5,7 @@
 //  (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config/defines.hpp>
+#include <hpx/config.hpp>
 
 #include "boost/regex.hpp"
 #include "license_check.hpp"

--- a/tools/inspect/link_check.cpp
+++ b/tools/inspect/link_check.cpp
@@ -6,19 +6,19 @@
 //  (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config/defines.hpp>
+#include <hpx/config.hpp>
+#include <hpx/filesystem.hpp>
 
 #include "link_check.hpp"
 #include "function_hyper.hpp"
 #include "boost/regex.hpp"
-#include "boost/filesystem/operations.hpp"
 #include <boost/algorithm/string/case_conv.hpp>
 #include <cstdlib>
 #include <set>
 
 // #include <iostream>
 
-namespace fs = boost::filesystem;
+namespace fs = hpx::filesystem;
 
 namespace
 {

--- a/tools/inspect/minmax_check.cpp
+++ b/tools/inspect/minmax_check.cpp
@@ -7,7 +7,7 @@
 //  (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config/defines.hpp>
+#include <hpx/config.hpp>
 
 #include <algorithm>
 

--- a/tools/inspect/path_name_check.cpp
+++ b/tools/inspect/path_name_check.cpp
@@ -7,11 +7,11 @@
 //  (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config/defines.hpp>
+#include <hpx/config.hpp>
+#include <hpx/filesystem.hpp>
 
 #include "path_name_check.hpp"
 
-#include "boost/filesystem/operations.hpp"
 #include "boost/lexical_cast.hpp"
 #include "function_hyper.hpp"
 
@@ -43,7 +43,7 @@ namespace boost
       string::size_type pos;
 
       //  called for each file and directory, so only the leaf need be tested
-      string const leaf( full_path.leaf().string() );
+      string const leaf( full_path.filename().string() );
 
       //  includes only allowable characters
       if ( (pos = leaf.find_first_not_of( allowable )) != string::npos )
@@ -63,7 +63,7 @@ namespace boost
       }
 
       //  rules for dot characters differ slightly for directories and files
-      if ( filesystem::is_directory( full_path ) )
+      if ( hpx::filesystem::is_directory( full_path ) )
       {
         if ( std::strchr( leaf.c_str(), '.' ) )
         {

--- a/tools/inspect/tab_check.cpp
+++ b/tools/inspect/tab_check.cpp
@@ -6,7 +6,7 @@
 //  (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config/defines.hpp>
+#include <hpx/config.hpp>
 
 #include "tab_check.hpp"
 #include "function_hyper.hpp"

--- a/tools/inspect/unnamed_namespace_check.cpp
+++ b/tools/inspect/unnamed_namespace_check.cpp
@@ -6,7 +6,7 @@
 //  (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config/defines.hpp>
+#include <hpx/config.hpp>
 
 #include "boost/regex.hpp"
 #include "boost/lexical_cast.hpp"


### PR DESCRIPTION
Adds a basic compatibility layer for C++17 filesystem. Mostly just forwards `std::filesystem` to `hpx::filesystem` if it's available and otherwise forwards `boost::filesystem` instead. The appropriate `error_code` is introduced into the `hpx::filesystem` namespace.

~It's not 100% transparent because of `error_code`. I've so far put explicit ifdefs where needed. The other main difference is that `canonical` doesn't take a base path for relative paths. In some cases we set this to `initial_path` but I'm not sure we care about the difference between that and `current_path`. I could probably put together something that does the same with `std` features.~

Where no naming changes were required I've just assumed that the functions behave the same, but let's see first if the tests even pass.

If someone wants to try `std::filesystem` it requires GCC 9, or an older GCC and explicit linking to `stdc++fs`. I think it's not yet in any released `libc++` but it can be linked to explicitly with `c++fs` as well.

Part of #3440.