### PR TITLE
Add more variations to future_overhead test

### DIFF
--- a/hpx/runtime/threads/policies/thread_queue.hpp
+++ b/hpx/runtime/threads/policies/thread_queue.hpp
@@ -317,7 +317,7 @@ namespace hpx { namespace threads { namespace policies
                     --addfrom->new_tasks_count_.data_;
                     lk.unlock();
                     HPX_THROW_EXCEPTION(hpx::out_of_memory,
-                        "threadmanager::add_new",
+                        "thread_queue::add_new",
                         "Couldn't add new thread to the thread map");
                     return 0;
                 }
@@ -767,7 +767,7 @@ namespace hpx { namespace threads { namespace policies
                     if (HPX_UNLIKELY(!p.second)) {
                         lk.unlock();
                         HPX_THROWS_IF(ec, hpx::out_of_memory,
-                            "threadmanager::register_thread",
+                            "thread_queue::create_thread",
                             "Couldn't add new thread to the map of threads");
                         return;
                     }

--- a/hpx/runtime/threads/policies/thread_queue_mc.hpp
+++ b/hpx/runtime/threads/policies/thread_queue_mc.hpp
@@ -266,7 +266,7 @@ namespace hpx { namespace threads { namespace policies
                     --addfrom->new_tasks_count_.data_;
                     lk.unlock();
                     HPX_THROW_EXCEPTION(hpx::out_of_memory,
-                        "threadmanager::add_new",
+                        "thread_queue_mc::add_new",
                         "Couldn't add new thread to the thread map");
                     return 0;
                 }
@@ -716,7 +716,7 @@ namespace hpx { namespace threads { namespace policies
                     if (HPX_UNLIKELY(!p.second)) {
                         lk.unlock();
                         HPX_THROWS_IF(ec, hpx::out_of_memory,
-                            "threadmanager::register_thread",
+                            "thread_queue_mc::create_work",
                             "Couldn't add new thread to the map of threads");
                         return;
                     }

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -30,6 +30,7 @@
 #include <cstdint>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 using boost::program_options::options_description;

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -53,7 +53,7 @@ using hpx::cout;
 using hpx::flush;
 
 // global vars we stick here to make printouts easy for plotting
-static std::string queuing = "";
+static std::string queuing = "default";
 static std::size_t numa_sensitive = 0;
 static std::uint64_t num_threads = 1;
 static std::string info_string = "";
@@ -63,20 +63,22 @@ void print_stats(const char* title, const char* wait, const char* exec,
     std::int64_t count, double duration, bool csv)
 {
     double us = 1e6 * duration / count;
-    if (csv)
+    if (csv) {
         hpx::util::format_to(cout,
-            "{1}, {:10}, {:15}, {:20}, {:10}, {:10}, {:20}, {:4}, {:4}, "
+            "{1}, {:27}, {:15}, {:18}, {:8}, {:8}, {:20}, {:4}, {:4}, "
             "{:20}\n",
             count, title, wait, exec, duration, us, queuing, numa_sensitive,
             num_threads, info_string)
             << flush;
-    else
+    }
+    else {
         hpx::util::format_to(cout,
-            "invoked {1}, futures {:10} {:15} {:20} in \t{5} seconds \t: {6} "
-            "us/future, queue {7} numa {8}, threads {9}, info {10}\n",
+            "invoked {:1}, futures {:27} {:15} {:18} in {:8} seconds : {:8} "
+            "us/future, queue {:20}, numa {:4}, threads {:4}, info {:20}\n",
             count, title, wait, exec, duration, us, queuing, numa_sensitive,
             num_threads, info_string)
             << flush;
+    }
     // CDash graph plotting
     //hpx::util::print_cdash_timing(title, duration);
 }

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -512,7 +512,8 @@ int main(int argc, char* argv[])
 
         ("csv", "output results as csv (format: count,duration)")
         ("test-all", "run all benchmarks")
-        ("repetitions", value<int>()->default_value(1), "number of repetitions of the full benchmark")
+        ("repetitions", value<int>()->default_value(1),
+         "number of repetitions of the full benchmark")
 
         ("info", value<std::string>()->default_value("none"),
          "extra info for plot output (e.g. branch name)");

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -369,7 +369,7 @@ void measure_function_futures_create_thread_hierarchical_placement(
     {
         auto const hint = hpx::threads::thread_schedule_hint(t);
         auto spawn_func = [&thread_func, sched, hint, t, count, num_threads,
-                              desc, prio, stack_size]() {
+                              desc, stack_size]() {
             std::uint64_t const count_start = t * count / num_threads;
             std::uint64_t const count_end = (t + 1) * count / num_threads;
             hpx::error_code ec;

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -63,7 +63,8 @@ void print_stats(const char* title, const char* wait, const char* exec,
     std::int64_t count, double duration, bool csv)
 {
     double us = 1e6 * duration / count;
-    if (csv) {
+    if (csv)
+    {
         hpx::util::format_to(cout,
             "{1}, {:27}, {:15}, {:18}, {:8}, {:8}, {:20}, {:4}, {:4}, "
             "{:20}\n",
@@ -71,7 +72,8 @@ void print_stats(const char* title, const char* wait, const char* exec,
             num_threads, info_string)
             << flush;
     }
-    else {
+    else
+    {
         hpx::util::format_to(cout,
             "invoked {:1}, futures {:27} {:15} {:18} in {:8} seconds : {:8} "
             "us/future, queue {:20}, numa {:4}, threads {:4}, info {:20}\n",


### PR DESCRIPTION
Adds a few more variations to the `future_overhead` test:
- Spawn tasks directly using `register_work` (overhead of executors)
- Spawn tasks directly on scheduler using `create_thread` (overhead of dispatching through applier, thread manager, thread pool)
- Spawn tasks hierarchically using `create_thread` with task placement (spawn one task per core which spawns all tasks for that core)
- Spawn tasks hierarchically using `apply` with task placement

Timings on Piz Daint (sorry about the ugly tables):
```
invoked 100000, futures      apply   limiting-Exec     default_executor in      0.071536 seconds        : 0.715361 us/future, queue  numa 0, threads 1, info none                                                              
invoked 100000, futures      apply   limiting-Exec    parallel_executor in      0.069927 seconds        : 0.699275 us/future, queue  numa 0, threads 1, info none                                                              
invoked 100000, futures     action        WaitEach          no-executor in      0.112674 seconds        : 1.126738 us/future, queue  numa 0, threads 1, info none                                                              
invoked 100000, futures     action         WaitAll          no-executor in      0.100595 seconds        : 1.005946 us/future, queue  numa 0, threads 1, info none                                                              
invoked 100000, futures      async        WaitEach     default_executor in      0.151116 seconds        : 1.511162 us/future, queue  numa 0, threads 1, info none                                                              
invoked 100000, futures      async        WaitEach    parallel_executor in      0.103295 seconds        : 1.032946 us/future, queue  numa 0, threads 1, info none                                                              
invoked 100000, futures      async         WaitAll     default_executor in      0.138836 seconds        : 1.388364 us/future, queue  numa 0, threads 1, info none                                                              
invoked 100000, futures      async         WaitAll    parallel_executor in      0.092037 seconds        : 0.920370 us/future, queue  numa 0, threads 1, info none                                                              
invoked 100000, futures      apply     ThreadCount     default_executor in      0.102927 seconds        : 1.029267 us/future, queue  numa 0, threads 1, info none                                                              
invoked 100000, futures      apply     ThreadCount    parallel_executor in      0.070489 seconds        : 0.704887 us/future, queue  numa 0, threads 1, info none                                                              
invoked 100000, futures      apply     Sliding-Sem     default_executor in      0.087901 seconds        : 0.879014 us/future, queue  numa 0, threads 1, info none                                                              
invoked 100000, futures      apply     Sliding-Sem    parallel_executor in      0.085327 seconds        : 0.853271 us/future, queue  numa 0, threads 1, info none                                                              
invoked 100000, futures register_work           latch                 none in   0.068932 seconds        : 0.689317 us/future, queue  numa 0, threads 1, info none                                                              
invoked 100000, futures create_thread           latch                 none in   0.064157 seconds        : 0.641567 us/future, queue  numa 0, threads 1, info none                                                              
invoked 100000, futures create_thread_hierarchical           latch                 none in      0.062903 seconds        : 0.629033 us/future, queue  numa 0, threads 1, info none                                              
invoked 100000, futures apply_hierarchical           latch     default_executor in      0.098540 seconds        : 0.985404 us/future, queue  numa 0, threads 1, info none
```

```
invoked 100000, futures      apply   limiting-Exec     default_executor in      0.045695 seconds        : 0.456949 us/future, queue  numa 0, threads 18, info none                                                             
invoked 100000, futures      apply   limiting-Exec    parallel_executor in      0.041699 seconds        : 0.416986 us/future, queue  numa 0, threads 18, info none                                                             
invoked 100000, futures     action        WaitEach          no-executor in      0.081346 seconds        : 0.813458 us/future, queue  numa 0, threads 18, info none                                                             
invoked 100000, futures     action         WaitAll          no-executor in      0.074717 seconds        : 0.747170 us/future, queue  numa 0, threads 18, info none                                                             
invoked 100000, futures      async        WaitEach     default_executor in      0.248704 seconds        : 2.487037 us/future, queue  numa 0, threads 18, info none                                                             
invoked 100000, futures      async        WaitEach    parallel_executor in      0.070782 seconds        : 0.707821 us/future, queue  numa 0, threads 18, info none                                                             
invoked 100000, futures      async         WaitAll     default_executor in      0.233087 seconds        : 2.330867 us/future, queue  numa 0, threads 18, info none                                                             
invoked 100000, futures      async         WaitAll    parallel_executor in      0.064412 seconds        : 0.644124 us/future, queue  numa 0, threads 18, info none                                                             
invoked 100000, futures      apply     ThreadCount     default_executor in      0.222897 seconds        : 2.228965 us/future, queue  numa 0, threads 18, info none                                                             
invoked 100000, futures      apply     ThreadCount    parallel_executor in      0.053388 seconds        : 0.533877 us/future, queue  numa 0, threads 18, info none                                                             
invoked 100000, futures      apply     Sliding-Sem     default_executor in      0.240655 seconds        : 2.406546 us/future, queue  numa 0, threads 18, info none                                                             
invoked 100000, futures      apply     Sliding-Sem    parallel_executor in      0.071160 seconds        : 0.711599 us/future, queue  numa 0, threads 18, info none                                                             
invoked 100000, futures register_work           latch                 none in   0.051454 seconds        : 0.514539 us/future, queue  numa 0, threads 18, info none                                                             
invoked 100000, futures create_thread           latch                 none in   0.046436 seconds        : 0.464356 us/future, queue  numa 0, threads 18, info none                                                             
invoked 100000, futures create_thread_hierarchical           latch                 none in      0.011537 seconds        : 0.115373 us/future, queue  numa 0, threads 18, info none                                             
invoked 100000, futures apply_hierarchical           latch     default_executor in      0.051020 seconds        : 0.510204 us/future, queue  numa 0, threads 18, info none
```

```
invoked 100000, futures      apply   limiting-Exec     default_executor in      0.098857 seconds        : 0.988569 us/future, queue  numa 0, threads 36, info none                                                             
invoked 100000, futures      apply   limiting-Exec    parallel_executor in      0.057570 seconds        : 0.575702 us/future, queue  numa 0, threads 36, info none                                                             
invoked 100000, futures     action        WaitEach          no-executor in      0.122239 seconds        : 1.222391 us/future, queue  numa 0, threads 36, info none                                                             
invoked 100000, futures     action         WaitAll          no-executor in      0.112463 seconds        : 1.124633 us/future, queue  numa 0, threads 36, info none                                                             
invoked 100000, futures      async        WaitEach     default_executor in      0.328070 seconds        : 3.280703 us/future, queue  numa 0, threads 36, info none                                                             
invoked 100000, futures      async        WaitEach    parallel_executor in      0.104692 seconds        : 1.046923 us/future, queue  numa 0, threads 36, info none                                                             
invoked 100000, futures      async         WaitAll     default_executor in      0.322980 seconds        : 3.229801 us/future, queue  numa 0, threads 36, info none                                                             
invoked 100000, futures      async         WaitAll    parallel_executor in      0.096391 seconds        : 0.963910 us/future, queue  numa 0, threads 36, info none                                                             
invoked 100000, futures      apply     ThreadCount     default_executor in      0.306251 seconds        : 3.062511 us/future, queue  numa 0, threads 36, info none                                                             
invoked 100000, futures      apply     ThreadCount    parallel_executor in      0.092758 seconds        : 0.927580 us/future, queue  numa 0, threads 36, info none                                                             
invoked 100000, futures      apply     Sliding-Sem     default_executor in      0.330664 seconds        : 3.306644 us/future, queue  numa 0, threads 36, info none                                                             
invoked 100000, futures      apply     Sliding-Sem    parallel_executor in      0.118773 seconds        : 1.187730 us/future, queue  numa 0, threads 36, info none                                                             
invoked 100000, futures register_work           latch                 none in   0.087652 seconds        : 0.876517 us/future, queue  numa 0, threads 36, info none                                                             
invoked 100000, futures create_thread           latch                 none in   0.079041 seconds        : 0.790408 us/future, queue  numa 0, threads 36, info none                                                             
invoked 100000, futures create_thread_hierarchical           latch                 none in      0.011673 seconds        : 0.116727 us/future, queue  numa 0, threads 36, info none                                             
invoked 100000, futures apply_hierarchical           latch     default_executor in      0.052060 seconds        : 0.520596 us/future, queue  numa 0, threads 36, info none
```

```
invoked 100000, futures      apply   limiting-Exec     default_executor in      0.044927 seconds        : 0.449273 us/future, queue  numa 0, threads 72, info none                                                             
invoked 100000, futures      apply   limiting-Exec    parallel_executor in      0.054969 seconds        : 0.549692 us/future, queue  numa 0, threads 72, info none                                                             
invoked 100000, futures     action        WaitEach          no-executor in      0.149016 seconds        : 1.490159 us/future, queue  numa 0, threads 72, info none                                                             
invoked 100000, futures     action         WaitAll          no-executor in      0.138322 seconds        : 1.383223 us/future, queue  numa 0, threads 72, info none                                                             
invoked 100000, futures      async        WaitEach     default_executor in      0.350506 seconds        : 3.505057 us/future, queue  numa 0, threads 72, info none                                                             
invoked 100000, futures      async        WaitEach    parallel_executor in      0.126604 seconds        : 1.266038 us/future, queue  numa 0, threads 72, info none                                                             
invoked 100000, futures      async         WaitAll     default_executor in      0.337756 seconds        : 3.377564 us/future, queue  numa 0, threads 72, info none                                                             
invoked 100000, futures      async         WaitAll    parallel_executor in      0.118260 seconds        : 1.182605 us/future, queue  numa 0, threads 72, info none                                                             
invoked 100000, futures      apply     ThreadCount     default_executor in      0.307390 seconds        : 3.073903 us/future, queue  numa 0, threads 72, info none                                                             
invoked 100000, futures      apply     ThreadCount    parallel_executor in      0.105353 seconds        : 1.053530 us/future, queue  numa 0, threads 72, info none                                                             
invoked 100000, futures      apply     Sliding-Sem     default_executor in      0.348388 seconds        : 3.483885 us/future, queue  numa 0, threads 72, info none                                                             
invoked 100000, futures      apply     Sliding-Sem    parallel_executor in      0.141513 seconds        : 1.415133 us/future, queue  numa 0, threads 72, info none                                                             
invoked 100000, futures register_work           latch                 none in   0.097532 seconds        : 0.975321 us/future, queue  numa 0, threads 72, info none                                                             
invoked 100000, futures create_thread           latch                 none in   0.089086 seconds        : 0.890856 us/future, queue  numa 0, threads 72, info none                                                             
invoked 100000, futures create_thread_hierarchical           latch                 none in      0.010706 seconds        : 0.107059 us/future, queue  numa 0, threads 72, info none                                             
invoked 100000, futures apply_hierarchical           latch     default_executor in      0.128711 seconds        : 1.287111 us/future, queue  numa 0, threads 72, info none
```

We're throwing away a bit of performance in the executors, but the difference isn't that big. The surprising part is just how much faster the hierarchical spawn with `create_thread` is. It doesn't improve much after 18 threads, but it doesn't get *worse* unlike all the other variations. I'm having a hard time believing this so I'd appreciate a pair of eyes (or more) to check that I'm not cheating in that test. If true it's very encouraging in the sense that we have a lot of room to improve in the executors and the way we spawn work, rather than in the queue backends. The `parallel_executor` is very close to doing this but I don't think it gets any of the benefits because it's still doing round robin scheduling.