### PR TITLE
Add troubleshooting section to manual

### DIFF
--- a/docs/sphinx/manual.rst
+++ b/docs/sphinx/manual.rst
@@ -28,3 +28,4 @@ information on how to build and use |hpx| in different scenarios.
    manual/optimizing_hpx_applications
    manual/hpx_runtime_and_resources
    manual/miscellaneous
+   manual/troubleshooting

--- a/docs/sphinx/manual/troubleshooting.rst
+++ b/docs/sphinx/manual/troubleshooting.rst
@@ -1,0 +1,51 @@
+..
+    Copyright (C) 2019 Mikael Simberg
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+.. _troubleshooting:
+
+===============
+Troubleshooting
+===============
+
+This section contains commonly encountered problems when compiling or using HPX.
+
+.. _troubleshooting_program_options:
+
+``Undefined reference to boost::program_options``
+=================================================
+
+Boost.ProgramOptions is not ABI compatible between all C++ versions and
+compilers. Because of this you may see linker errors similar to this:
+
+.. code-block:: text
+
+   ...: undefined reference to `boost::program_options::operator<<(std::ostream&, boost::program_options::options_description const&)'
+
+if you are not linking to a compatible version of Boost.ProgramOptions. We
+recommend that you use ``hpx::program_options``, which is part of |hpx|, as a
+replacement for ``boost::program_options`` (see :ref:`libs_program_options`).
+Until you have migrated to use ``hpx::program_options`` we recommend that you
+always build |boost|_ libraries and |hpx| with the same compiler and C++
+standard.
+
+.. _troubleshooting_iostreams:
+
+``Undefined reference to hpx::cout``
+====================================
+
+You may see an linker error message that looks a bit like this:
+
+.. code-block:: text
+
+   hello_world.cpp:(.text+0x5aa): undefined reference to `hpx::cout'
+   hello_world.cpp:(.text+0x5c3): undefined reference to `hpx::iostreams::flush'
+
+This usually happens if you are trying to use |hpx| iostreams functionality such
+as ``hpx::cout`` but are not linking against it. The iostreams functionality is
+not part of the core |hpx| library, and must be linked to explicitly. Typically
+this can be solved by adding ``COMPONENT_DEPENDENCIES iostreams`` to a call to
+``add_hpx_library/add_hpx_executable/hpx_setup_target`` if using |cmake|. See
+:ref:`creating_hpx_projects` for more details.


### PR DESCRIPTION
Adds a short troubleshooting section to the manual. Generally I think we should try to keep tips like these in their appropriate sections, but some things pop up frequently enough that I think it's worth having a separate section just for common problems. Doesn't contain much yet, but it'll hopefully expand over time.
