### PR TITLE
Making sure HPX_IDLE_BACKOFF_TIME_MAX is always defined (even if its unused)

### DIFF
--- a/libs/config/include/hpx/config.hpp
+++ b/libs/config/include/hpx/config.hpp
@@ -421,11 +421,10 @@
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-// Maximum sleep time for idle backoff in milliseconds.
-#if defined(HPX_HAVE_THREAD_MANAGER_IDLE_BACKOFF)
-#  if !defined(HPX_IDLE_BACKOFF_TIME_MAX)
-#    define HPX_IDLE_BACKOFF_TIME_MAX 1000
-#  endif
+// Maximum sleep time for idle backoff in milliseconds (used only if
+// HPX_HAVE_THREAD_MANAGER_IDLE_BACKOFF is defined).
+#if !defined(HPX_IDLE_BACKOFF_TIME_MAX)
+#  define HPX_IDLE_BACKOFF_TIME_MAX 1000
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #4056
