### PR TITLE
Fix program_options test with older boost versions

### DIFF
--- a/libs/program_options/examples/config_file_types.cpp
+++ b/libs/program_options/examples/config_file_types.cpp
@@ -27,7 +27,8 @@ bool check_float(Double1 test, Double2 expected)
     double expected_d = double(expected);
 
     double seperation = expected_d * (1. + FLOAT_SEPERATION) / expected_d;
-    if ((test_d < expected_d + seperation) && (test_d > expected_d - seperation))
+    if ((test_d < expected_d + seperation) &&
+        (test_d > expected_d - seperation))
     {
         return true;
     }
@@ -90,6 +91,7 @@ stringstream make_file()
 po::options_description set_options()
 {
     po::options_description opts;
+    // clang-format off
     opts.add_options()
         ("global_string",po::value<string>())
 
@@ -144,6 +146,7 @@ po::options_description set_options()
         ("booleans.present_equal_true", po::bool_switch())
         ("booleans.present_no_equal_true", po::bool_switch())
         ;
+    // clang-format on
 
     return opts;
 }
@@ -188,9 +191,9 @@ void check_results(po::variables_map& vm, vector<string> unregistered)
 
     int expected_int_postitive = 41;
     int expected_int_negative = -42;
-//     int expected_int_hex = 0x43;
-//     int expected_int_oct = 044;
-//     int expected_int_bin = 0b101010;
+    //     int expected_int_hex = 0x43;
+    //     int expected_int_oct = 044;
+    //     int expected_int_bin = 0b101010;
 
     float expected_float_positive = 51.1f;
     float expected_float_negative = -52.1f;
@@ -214,7 +217,7 @@ void check_results(po::variables_map& vm, vector<string> unregistered)
     bool expected_onoff_true = true;
     bool expected_onoff_false = false;
     bool expected_present_equal_true = true;
-//     bool expected_present_no_equal_true = true;
+    //     bool expected_present_no_equal_true = true;
 
     VERIFY(vm["global_string"].as<string>() == expected_global_string);
 

--- a/libs/program_options/examples/custom_syntax.cpp
+++ b/libs/program_options/examples/custom_syntax.cpp
@@ -44,10 +44,12 @@ int main(int ac, char* av[])
     try
     {
         options_description desc("Allowed options");
+        // clang-format off
         desc.add_options()
             ("help","produce a help message")
             ("foo", value<string>(), "just an option")
             ;
+        // clang-format on
 
         variables_map vm;
         store(command_line_parser(ac, av)

--- a/libs/program_options/examples/env_options.cpp
+++ b/libs/program_options/examples/env_options.cpp
@@ -9,8 +9,8 @@
 #include <algorithm>
 #include <cctype>
 #include <functional>
-#include <string>
 #include <iostream>
+#include <string>
 
 namespace po = hpx::program_options;
 
@@ -31,11 +31,13 @@ std::string mapper(std::string env_var)
 void get_env_options()
 {
     po::options_description config("Configuration");
+    // clang-format off
     config.add_options()
         ("path", "the execution path")
         ("verbosity", po::value<std::string>()->default_value("INFO"),
          "set verbosity: DEBUG, INFO, WARN, ERROR, FATAL")
         ;
+    // clang-format on
 
     po::variables_map vm;
     store(po::parse_environment(

--- a/libs/program_options/examples/first.cpp
+++ b/libs/program_options/examples/first.cpp
@@ -16,12 +16,15 @@ using namespace std;
 
 int main(int ac, char* av[])
 {
-    try {
+    try
+    {
         po::options_description desc("Allowed options");
+        // clang-format off
         desc.add_options()
             ("help", "produce help message")
             ("compression", po::value<double>(), "set compression level")
         ;
+        // clang-format on
 
         po::variables_map vm;
         po::store(po::parse_command_line(ac, av, desc), vm);

--- a/libs/program_options/examples/multiple_sources.cpp
+++ b/libs/program_options/examples/multiple_sources.cpp
@@ -37,6 +37,7 @@ int main(int ac, char* av[])
         // Declare a group of options that will be
         // allowed only on command line
         po::options_description generic("Generic options");
+        // clang-format off
         generic.add_options()
             ("version,v","print version string")
             ("help", "produce help message")
@@ -45,24 +46,29 @@ int main(int ac, char* av[])
                     "multiple_sources.cfg"),
               "name of a file of a configuration.")
             ;
+        // clang-format on
 
         // Declare a group of options that will be
         // allowed both on command line and in
         // config file
         po::options_description config("Configuration");
+        // clang-format off
         config.add_options()
             ("optimization", po::value<int>(&opt)->default_value(10),
                 "optimization level")
             ("include-path,I", po::value<vector<string>>()->composing(),
                 "include path")
             ;
+        // clang-format on
 
         // Hidden options, will be allowed both on command line and
         // in config file, but will not be shown to the user.
         po::options_description hidden("Hidden options");
+        // clang-format off
         hidden.add_options()
             ("input-file", po::value<vector<string>>(), "input file")
             ;
+        // clang-format on
 
         po::options_description cmdline_options;
         cmdline_options.add(generic).add(config).add(hidden);

--- a/libs/program_options/examples/option_groups.cpp
+++ b/libs/program_options/examples/option_groups.cpp
@@ -26,8 +26,8 @@
 #include <iostream>
 #include <string>
 
-#include <boost/tokenizer.hpp>
 #include <boost/token_functions.hpp>
+#include <boost/tokenizer.hpp>
 
 using namespace boost;
 using namespace hpx::program_options;
@@ -39,22 +39,24 @@ int main(int ac, char* av[])
     {
         // Declare three groups of options.
         options_description general("General options");
+        // clang-format off
         general.add_options()
             ("help", "produce a help message")
             ("help-module", value<string>(),
                 "produce a help for a given module")
             ("version", "output the version number")
             ;
+        // clang-format on
 
         options_description gui("GUI options");
-        gui.add_options()
-            ("display", value<string>(), "display to use")
-            ;
+        gui.add_options()("display", value<string>(), "display to use");
 
         options_description backend("Backend options");
+        // clang-format off
         backend.add_options()
             ("num-threads", value<int>(), "the initial number of threads")
             ;
+        // clang-format on
 
         // Declare an options description instance which will include
         // all the options
@@ -99,7 +101,7 @@ int main(int ac, char* av[])
                  << vm["num-threads"].as<int>() << "\n";
         }
     }
-    catch(std::exception const& e)
+    catch (std::exception const& e)
     {
         cout << e.what() << "\n";
     }

--- a/libs/program_options/examples/options_description.cpp
+++ b/libs/program_options/examples/options_description.cpp
@@ -31,6 +31,7 @@ int main(int ac, char* av[])
         int opt;
         int portnum;
         po::options_description desc("Allowed options");
+        // clang-format off
         desc.add_options()
             ("help", "produce help message")
             ("optimization", po::value<int>(&opt)->default_value(10),
@@ -44,6 +45,7 @@ int main(int ac, char* av[])
                   "include path")
             ("input-file", po::value< vector<string> >(), "input file")
         ;
+        // clang-format on
 
         po::positional_options_description p;
         p.add("input-file", -1);

--- a/libs/program_options/examples/options_hierarchy.cpp
+++ b/libs/program_options/examples/options_hierarchy.cpp
@@ -24,8 +24,8 @@
 #include <hpx/program_options.hpp>
 
 #include <algorithm>
-#include <functional>
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <map>
 #include <stdexcept>
@@ -140,6 +140,7 @@ private:
 
     void SetCommandLineOptions()
     {
+        // clang-format off
         command_line_options.add_options()
             ("help,h", "display this help message")
             ("version,v", "show program version")
@@ -151,6 +152,7 @@ private:
             ("master-file", po::value<std::string>())
             ("file", po::value<std::vector<std::string>>())
             ;
+        // clang-format on
 
         positional_options.add("master-file", 1);
         positional_options.add("file", -1);
@@ -158,6 +160,7 @@ private:
 
     void SetCommonOptions()
     {
+        // clang-format off
         common_options.add_options()
             ("path", po::value<std::string>()->default_value(""),
                 "the execution path to use (imports from environment if not "
@@ -168,10 +171,12 @@ private:
                 "paths to search for include files")
             ("run-gui", po::bool_switch(), "start the GUI")
             ;
+        // clang-format on
     }
 
     void SetConfigOnlyOptions()
     {
+        // clang-format off
         config_only_options.add_options()
             ("log-dir", po::value<std::string>()->default_value("log"))
             ("gui.height", po::value<unsigned int>()->default_value(100))
@@ -179,13 +184,13 @@ private:
             ("network.ip", po::value<std::string>()->default_value("127.0.0.1"))
             ("network.port", po::value<unsigned short>()->default_value(12345))
             ;
+        // clang-format on
 
         // Run a parser here (with no command line options) to add these defaults into
         // results, this way they will be enabled even if no config files are parsed.
         char const* argv[] = {"options_hierarchy", nullptr};
-        store(po::command_line_parser(1, argv)
-                  .options(config_only_options)
-                  .run(),
+        store(
+            po::command_line_parser(1, argv).options(config_only_options).run(),
             results);
         notify(results);
     }
@@ -247,8 +252,8 @@ private:
     void ParseEnvironment()
     {
         store(po::parse_environment(common_options,
-            std::bind(&OptionsHeirarchy::EnvironmentMapper, this,
-                std::placeholders::_1)),
+                  std::bind(&OptionsHeirarchy::EnvironmentMapper, this,
+                      std::placeholders::_1)),
             results);
         notify(results);
     }
@@ -272,7 +277,7 @@ private:
         if (results.count("config"))
         {
             auto files = results["config"].as<std::vector<std::string>>();
-            for (auto & file : files)
+            for (auto& file : files)
             {
                 LoadAConfigFile(file);
             }
@@ -323,7 +328,7 @@ void PrintOptions(OptionsHeirarchy options)
     std::cout << "Verbosity: " << options.Verbosity() << std::endl;
     std::cout << "Include Path:\n";
     auto includePaths = options.IncludePath();
-    for (auto & includePath : includePaths)
+    for (auto& includePath : includePaths)
     {
         std::cout << "   " << includePath << std::endl;
     }
@@ -331,7 +336,7 @@ void PrintOptions(OptionsHeirarchy options)
     std::cout << "Master-File: " << options.MasterFile() << std::endl;
     std::cout << "Additional Files:\n";
     auto files = options.Files();
-    for (auto & file : files)
+    for (auto& file : files)
     {
         std::cout << "   " << file << std::endl;
     }

--- a/libs/program_options/examples/real.cpp
+++ b/libs/program_options/examples/real.cpp
@@ -57,6 +57,7 @@ int main(int argc, char* argv[])
         string root = ".";
 
         options_description desc("Allowed options");
+        // clang-format off
         desc.add_options()
         // First parameter describes option name/short name
         // The second is parameter to option
@@ -77,6 +78,7 @@ int main(int argc, char* argv[])
                 "write source package list to <pathname>")
             ("root,r", value(&root), "treat <dirname> as project root directory")
         ;
+        // clang-format on
 
         variables_map vm;
         store(parse_command_line(argc, argv, desc), vm);

--- a/libs/program_options/examples/regex.cpp
+++ b/libs/program_options/examples/regex.cpp
@@ -19,8 +19,8 @@
 //
 // and the second invocation should issue an error message.
 
-#include <hpx/hpx_main.hpp>
 #include <hpx/datastructures/any.hpp>
+#include <hpx/hpx_main.hpp>
 #include <hpx/program_options.hpp>
 
 #include <iostream>
@@ -55,8 +55,8 @@ bool operator==(magic_number const& lhs, magic_number const& rhs)
    This has no practical meaning, meant only to show how
    regex can be used to validate values.
 */
-void validate(any& v, const std::vector<std::string>& values,
-    magic_number*, int)
+void validate(
+    any& v, const std::vector<std::string>& values, magic_number*, int)
 {
     static regex r(R"(\d\d\d-(\d\d\d))");
 
@@ -85,12 +85,14 @@ int main(int ac, char* av[])
     try
     {
         options_description desc("Allowed options");
+        // clang-format off
         desc.add_options()
             ("help","produce a help screen")
             ("version,v", "print the version number")
             ("magic,m", value<magic_number>(),
                 "magic value (in NNN-NNN format)")
             ;
+        // clang-format on
 
         variables_map vm;
         store(parse_command_line(ac, av, desc), vm);

--- a/libs/program_options/examples/response_file.cpp
+++ b/libs/program_options/examples/response_file.cpp
@@ -18,8 +18,8 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/program_options.hpp>
 
-#include <boost/tokenizer.hpp>
 #include <boost/token_functions.hpp>
+#include <boost/tokenizer.hpp>
 
 #include <algorithm>
 #include <fstream>
@@ -35,7 +35,7 @@ using namespace std;
 
 // Additional command line parser which interprets '@something' as a
 // option "config-file" with the value "something"
-pair<string, string> at_option_parser(string const&s)
+pair<string, string> at_option_parser(string const& s)
 {
     if ('@' == s[0])
         return std::make_pair(string("response-file"), s.substr(1));
@@ -45,8 +45,10 @@ pair<string, string> at_option_parser(string const&s)
 
 int main(int ac, char* av[])
 {
-    try {
+    try
+    {
         options_description desc("Allowed options");
+        // clang-format off
         desc.add_options()
             ("help", "produce a help message")
             ("include-path,I", value< vector<string> >()->composing(),
@@ -55,10 +57,14 @@ int main(int ac, char* av[])
             ("response-file", value<string>(),
                  "can be specified with '@name', too")
         ;
+        // clang-format on
 
         variables_map vm;
-        store(command_line_parser(ac, av).options(desc)
-              .extra_parser(at_option_parser).run(), vm);
+        store(command_line_parser(ac, av)
+                  .options(desc)
+                  .extra_parser(at_option_parser)
+                  .run(),
+            vm);
 
         if (vm.count("help"))
         {
@@ -82,7 +88,7 @@ int main(int ac, char* av[])
             // Split the file content
             string sstr = ss.str();
             char_separator<char> sep(" \n\r");
-            tokenizer<char_separator<char> > tok(sstr, sep);
+            tokenizer<char_separator<char>> tok(sstr, sep);
 
             vector<string> args;
             copy(tok.begin(), tok.end(), back_inserter(args));
@@ -93,7 +99,7 @@ int main(int ac, char* av[])
 
         if (vm.count("include-path"))
         {
-            const vector<string>& s = vm["include-path"].as<vector< string> >();
+            const vector<string>& s = vm["include-path"].as<vector<string>>();
             cout << "Include paths: ";
             copy(s.begin(), s.end(), ostream_iterator<string>(cout, " "));
             cout << "\n";

--- a/libs/program_options/include/hpx/program_options/config.hpp
+++ b/libs/program_options/include/hpx/program_options/config.hpp
@@ -17,15 +17,16 @@
 // hpxinspect:nodeprecatedname:boost::optional
 // hpxinspect:nodeprecatedinclude:boost/program_options/config.hpp
 
-#include <boost/program_options/config.hpp>
 #include <boost/any.hpp>
 #include <boost/optional.hpp>
+#include <boost/program_options/config.hpp>
 
 namespace hpx { namespace program_options {
 
     using any = boost::any;
     using boost::any_cast;
-    template <typename T> using optional = boost::optional<T>;
+    template <typename T>
+    using optional = boost::optional<T>;
 
 #define PROGRAM_OPTIONS_DEPRECATED_MESSAGE                                     \
     "The Boost.ProgramOptions was replaced by an equivalent "                  \
@@ -35,7 +36,7 @@ namespace hpx { namespace program_options {
     "to #include <hpx/program_options/*> and the related types to the "        \
     "namespace hpx::program_options."
 
-}}
+}}    // namespace hpx::program_options
 #else
 #include <hpx/datastructures/any.hpp>
 #include <hpx/datastructures/optional.hpp>
@@ -44,9 +45,9 @@ namespace hpx { namespace program_options {
 
     using any = hpx::util::any_nonser;
     using hpx::util::any_cast;
-    template <typename T> using optional = hpx::util::optional<T>;
-}}
+    template <typename T>
+    using optional = hpx::util::optional<T>;
+}}    // namespace hpx::program_options
 #endif
 
-#endif // PROGRAM_OPTIONS_CONFIG_HK_2004_01_11
-
+#endif    // PROGRAM_OPTIONS_CONFIG_HK_2004_01_11

--- a/libs/program_options/include/hpx/program_options/detail/convert.hpp
+++ b/libs/program_options/include/hpx/program_options/detail/convert.hpp
@@ -16,11 +16,11 @@
 namespace hpx { namespace program_options {
 
     using boost::from_8_bit;
-    using boost::to_8_bit;
-    using boost::from_utf8;
-    using boost::to_utf8;
-    using boost::to_local_8_bit;
     using boost::from_local_8_bit;
+    using boost::from_utf8;
+    using boost::to_8_bit;
+    using boost::to_local_8_bit;
+    using boost::to_utf8;
     using boost::program_options::to_internal;
 
 }}    // namespace hpx::program_options

--- a/libs/program_options/include/hpx/program_options/detail/parsers.hpp
+++ b/libs/program_options/include/hpx/program_options/detail/parsers.hpp
@@ -15,15 +15,15 @@
 
 namespace hpx { namespace program_options {
 
-    using boost::program_options::parse_command_line;
     using boost::program_options::collect_unrecognized;
+    using boost::program_options::parse_command_line;
 
 }}    // namespace hpx::program_options
 
 #else
 
-#include <hpx/program_options/parsers.hpp>
 #include <hpx/program_options/detail/convert.hpp>
+#include <hpx/program_options/parsers.hpp>
 
 #include <algorithm>
 #include <iterator>

--- a/libs/program_options/include/hpx/program_options/detail/utf8_codecvt_facet.hpp
+++ b/libs/program_options/include/hpx/program_options/detail/utf8_codecvt_facet.hpp
@@ -90,7 +90,7 @@ namespace hpx { namespace program_options { namespace detail {
 
     using boost::program_options::detail::utf8_codecvt_facet;
 
-}}}
+}}}    // namespace hpx::program_options::detail
 
 #else
 

--- a/libs/program_options/include/hpx/program_options/detail/value_semantic.hpp
+++ b/libs/program_options/include/hpx/program_options/detail/value_semantic.hpp
@@ -22,9 +22,9 @@ namespace hpx { namespace program_options {
 
     namespace validators {
 
-        using boost::program_options::validators::get_single_string;
         using boost::program_options::validators::check_first_occurrence;
-    }
+        using boost::program_options::validators::get_single_string;
+    }    // namespace validators
 
     using namespace validators;
 

--- a/libs/program_options/include/hpx/program_options/environment_iterator.hpp
+++ b/libs/program_options/include/hpx/program_options/environment_iterator.hpp
@@ -65,7 +65,7 @@ namespace hpx { namespace program_options {
     private:
         char** m_environment;
     };
-}}    // namespace hpx::util
+}}    // namespace hpx::program_options
 
 #endif
 #endif

--- a/libs/program_options/include/hpx/program_options/errors.hpp
+++ b/libs/program_options/include/hpx/program_options/errors.hpp
@@ -15,23 +15,23 @@
 
 namespace hpx { namespace program_options {
 
-    using boost::program_options::error;
-    using boost::program_options::too_many_positional_options_error;
-    using boost::program_options::invalid_command_line_style;
-    using boost::program_options::reading_file;
-    using boost::program_options::error_with_option_name;
-    using boost::program_options::multiple_values;
-    using boost::program_options::multiple_occurrences;
-    using boost::program_options::required_option;
-    using boost::program_options::error_with_no_option_name;
-    using boost::program_options::unknown_option;
     using boost::program_options::ambiguous_option;
-    using boost::program_options::invalid_syntax;
-    using boost::program_options::invalid_config_file_syntax;
+    using boost::program_options::error;
+    using boost::program_options::error_with_no_option_name;
+    using boost::program_options::error_with_option_name;
+    using boost::program_options::invalid_command_line_style;
     using boost::program_options::invalid_command_line_syntax;
-    using boost::program_options::validation_error;
+    using boost::program_options::invalid_config_file_syntax;
     using boost::program_options::invalid_option_value;
-}}
+    using boost::program_options::invalid_syntax;
+    using boost::program_options::multiple_occurrences;
+    using boost::program_options::multiple_values;
+    using boost::program_options::reading_file;
+    using boost::program_options::required_option;
+    using boost::program_options::too_many_positional_options_error;
+    using boost::program_options::unknown_option;
+    using boost::program_options::validation_error;
+}}    // namespace hpx::program_options
 
 #else
 
@@ -230,8 +230,7 @@ namespace hpx { namespace program_options {
 
     /** Class thrown when there are several option values, but
         user called a method which cannot return them all. */
-    class HPX_ALWAYS_EXPORT multiple_values
-      : public error_with_option_name
+    class HPX_ALWAYS_EXPORT multiple_values : public error_with_option_name
     {
     public:
         multiple_values()
@@ -246,8 +245,7 @@ namespace hpx { namespace program_options {
     /** Class thrown when there are several occurrences of an
         option, but user called a method which cannot return
         them all. */
-    class HPX_ALWAYS_EXPORT multiple_occurrences
-      : public error_with_option_name
+    class HPX_ALWAYS_EXPORT multiple_occurrences : public error_with_option_name
     {
     public:
         multiple_occurrences()
@@ -260,8 +258,7 @@ namespace hpx { namespace program_options {
     };
 
     /** Class thrown when a required/mandatory option is missing */
-    class HPX_ALWAYS_EXPORT required_option
-      : public error_with_option_name
+    class HPX_ALWAYS_EXPORT required_option : public error_with_option_name
     {
     public:
         // option name is constructed by the option_descriptor and never on the fly
@@ -304,8 +301,7 @@ namespace hpx { namespace program_options {
     };
 
     /** Class thrown when option name is not recognized. */
-    class HPX_ALWAYS_EXPORT unknown_option
-      : public error_with_no_option_name
+    class HPX_ALWAYS_EXPORT unknown_option : public error_with_no_option_name
     {
     public:
         unknown_option(const std::string& original_token = "")
@@ -318,8 +314,7 @@ namespace hpx { namespace program_options {
     };
 
     /** Class thrown when there's ambiguity among several possible options. */
-    class HPX_ALWAYS_EXPORT ambiguous_option
-      : public error_with_no_option_name
+    class HPX_ALWAYS_EXPORT ambiguous_option : public error_with_no_option_name
     {
     public:
         ambiguous_option(const std::vector<std::string>& xalternatives)
@@ -390,8 +385,7 @@ namespace hpx { namespace program_options {
         kind_t m_kind;
     };
 
-    class HPX_ALWAYS_EXPORT invalid_config_file_syntax
-      : public invalid_syntax
+    class HPX_ALWAYS_EXPORT invalid_config_file_syntax : public invalid_syntax
     {
     public:
         invalid_config_file_syntax(const std::string& invalid_line, kind_t kind)
@@ -410,8 +404,7 @@ namespace hpx { namespace program_options {
     };
 
     /** Class thrown when there are syntax errors in given command line */
-    class HPX_ALWAYS_EXPORT invalid_command_line_syntax
-      : public invalid_syntax
+    class HPX_ALWAYS_EXPORT invalid_command_line_syntax : public invalid_syntax
     {
     public:
         invalid_command_line_syntax(kind_t kind,
@@ -459,8 +452,7 @@ namespace hpx { namespace program_options {
     };
 
     /** Class thrown if there is an invalid option value given */
-    class HPX_ALWAYS_EXPORT invalid_option_value
-      : public validation_error
+    class HPX_ALWAYS_EXPORT invalid_option_value : public validation_error
     {
     public:
         invalid_option_value(const std::string& value);
@@ -468,8 +460,7 @@ namespace hpx { namespace program_options {
     };
 
     /** Class thrown if there is an invalid bool value given */
-    class HPX_ALWAYS_EXPORT invalid_bool_value
-      : public validation_error
+    class HPX_ALWAYS_EXPORT invalid_bool_value : public validation_error
     {
     public:
         invalid_bool_value(const std::string& value);

--- a/libs/program_options/include/hpx/program_options/force_linking.hpp
+++ b/libs/program_options/include/hpx/program_options/force_linking.hpp
@@ -16,7 +16,7 @@ namespace hpx { namespace program_options {
     };
 
     force_linking_helper& force_linking();
-}}
+}}    // namespace hpx::program_options
 #else
 
 #include <hpx/program_options.hpp>
@@ -31,7 +31,8 @@ namespace hpx { namespace program_options {
     using parse_environment1_type = basic_parsed_options<char> (*)(
         options_description const&, char const*);
     using parse_environment2_type = basic_parsed_options<char> (*)(
-        options_description const&, std::function<std::string(std::string)> const&);
+        options_description const&,
+        std::function<std::string(std::string)> const&);
     using parse_environment3_type = basic_parsed_options<char> (*)(
         options_description const&, std::string const&);
 

--- a/libs/program_options/include/hpx/program_options/options_description.hpp
+++ b/libs/program_options/include/hpx/program_options/options_description.hpp
@@ -18,9 +18,9 @@
 
 namespace hpx { namespace program_options {
 
+    using boost::program_options::duplicate_option_error;
     using boost::program_options::option_description;
     using boost::program_options::options_description_easy_init;
-    using boost::program_options::duplicate_option_error;
 
     class options_description
       : public boost::program_options::options_description
@@ -31,23 +31,27 @@ namespace hpx { namespace program_options {
         options_description(unsigned line_length = m_default_line_length,
             unsigned min_description_length = m_default_line_length / 2)
           : base_type(line_length, min_description_length)
-        {}
+        {
+        }
 
         options_description(const std::string& caption,
             unsigned line_length = m_default_line_length,
             unsigned min_description_length = m_default_line_length / 2)
           : base_type(caption, line_length, min_description_length)
-        {}
+        {
+        }
 
         HPX_DEPRECATED(PROGRAM_OPTIONS_DEPRECATED_MESSAGE)
         options_description(base_type const& rhs)
           : base_type(rhs)
-        {}
+        {
+        }
 
         HPX_DEPRECATED(PROGRAM_OPTIONS_DEPRECATED_MESSAGE)
         options_description(base_type&& rhs) noexcept
           : base_type(std::move(rhs))
-        {}
+        {
+        }
     };
 }}    // namespace hpx::program_options
 
@@ -66,7 +70,7 @@ namespace hpx { namespace program_options {
 #include <utility>
 #include <vector>
 
-#include<hpx/config/warnings_prefix.hpp>
+#include <hpx/config/warnings_prefix.hpp>
 
 namespace hpx { namespace program_options {
 
@@ -323,7 +327,7 @@ namespace hpx { namespace program_options {
 
 }}    // namespace hpx::program_options
 
-#include<hpx/config/warnings_suffix.hpp>
+#include <hpx/config/warnings_suffix.hpp>
 
 #endif
 #endif

--- a/libs/program_options/include/hpx/program_options/parsers.hpp
+++ b/libs/program_options/include/hpx/program_options/parsers.hpp
@@ -12,8 +12,8 @@
 // hpxinspect:nodeprecatedinclude:boost/program_options/parsers.hpp
 // hpxinspect:nodeprecatedinclude:boost/program_options/options_description.hpp
 
-#include <boost/program_options/parsers.hpp>
 #include <boost/program_options/options_description.hpp>
+#include <boost/program_options/parsers.hpp>
 
 namespace hpx { namespace program_options {
 
@@ -30,11 +30,11 @@ namespace hpx { namespace program_options {
     using boost::program_options::command_line_parser;
     using boost::program_options::wcommand_line_parser;
 
+    using boost::program_options::collect_unrecognized;
+    using boost::program_options::exclude_positional;
+    using boost::program_options::include_positional;
     using boost::program_options::parse_command_line;
     using boost::program_options::parse_config_file;
-    using boost::program_options::include_positional;
-    using boost::program_options::exclude_positional;
-    using boost::program_options::collect_unrecognized;
     using boost::program_options::parse_environment;
     using boost::program_options::split_unix;
 #ifdef HPX_WINDOWS

--- a/libs/program_options/include/hpx/program_options/value_semantic.hpp
+++ b/libs/program_options/include/hpx/program_options/value_semantic.hpp
@@ -20,22 +20,22 @@ namespace hpx { namespace program_options {
     using value_semantic_codecvt_helper =
         boost::program_options::value_semantic_codecvt_helper<Char>;
 
-    using boost::program_options::untyped_value;
     using boost::program_options::typed_value_base;
+    using boost::program_options::untyped_value;
 
     template <typename T, typename Char = char>
     using typed_value = boost::program_options::typed_value<T, Char>;
 
+    using boost::program_options::bool_switch;
     using boost::program_options::value;
     using boost::program_options::wvalue;
-    using boost::program_options::bool_switch;
 
     using boost::program_options::arg;
 
     namespace validators {
 
-        using boost::program_options::validators::get_single_string;
         using boost::program_options::validators::check_first_occurrence;
+        using boost::program_options::validators::get_single_string;
 
     }    // namespace validators
 

--- a/libs/program_options/include/hpx/program_options/variables_map.hpp
+++ b/libs/program_options/include/hpx/program_options/variables_map.hpp
@@ -14,15 +14,15 @@
 // hpxinspect:nodeprecatedinclude:boost/program_options/value_semantic.hpp
 
 #include <boost/program_options/parsers.hpp>
-#include <boost/program_options/variables_map.hpp>
 #include <boost/program_options/value_semantic.hpp>
+#include <boost/program_options/variables_map.hpp>
 
 namespace hpx { namespace program_options {
 
-    using boost::program_options::store;
-    using boost::program_options::notify;
-    using boost::program_options::variable_value;
     using boost::program_options::abstract_variables_map;
+    using boost::program_options::notify;
+    using boost::program_options::store;
+    using boost::program_options::variable_value;
     using boost::program_options::variables_map;
 
 }}    // namespace hpx::program_options

--- a/libs/program_options/src/cmdline.cpp
+++ b/libs/program_options/src/cmdline.cpp
@@ -252,7 +252,7 @@ namespace hpx { namespace program_options { namespace detail {
                     // so that they can be added to next.back()'s values
                     // if appropriate.
                     finish_option(next.back(), args, style_parsers);
-                    for (const auto & j : next)
+                    for (const auto& j : next)
                         result.push_back(j);
                 }
 
@@ -344,7 +344,7 @@ namespace hpx { namespace program_options { namespace detail {
 
         // Assign position keys to positional options.
         int position_key = 0;
-        for (auto & i : result)
+        for (auto& i : result)
         {
             if (i.string_key.empty())
                 i.position_key = position_key++;
@@ -368,21 +368,18 @@ namespace hpx { namespace program_options { namespace detail {
         }
 
         // set case sensitive flag
-        for (auto & i : result)
+        for (auto& i : result)
         {
             if (i.string_key.size() > 2 ||
-                (i.string_key.size() > 1 &&
-                    i.string_key[0] != '-'))
+                (i.string_key.size() > 1 && i.string_key[0] != '-'))
             {
                 // it is a long option
-                i.case_insensitive =
-                    is_style_active(long_case_insensitive);
+                i.case_insensitive = is_style_active(long_case_insensitive);
             }
             else
             {
                 // it is a short option
-                i.case_insensitive =
-                    is_style_active(short_case_insensitive);
+                i.case_insensitive = is_style_active(short_case_insensitive);
             }
         }
 

--- a/libs/program_options/src/config_file.cpp
+++ b/libs/program_options/src/config_file.cpp
@@ -25,7 +25,7 @@ namespace hpx { namespace program_options { namespace detail {
       : allowed_options(allowed_options)
       , m_allow_unregistered(allow_unregistered)
     {
-        for (const auto & allowed_option : allowed_options)
+        for (const auto& allowed_option : allowed_options)
         {
             add_option(allowed_option.c_str());
         }

--- a/libs/program_options/src/convert.cpp
+++ b/libs/program_options/src/convert.cpp
@@ -83,8 +83,8 @@ namespace hpx { namespace program_options {
     {
         using namespace std::placeholders;
         return detail::convert<wchar_t>(s,
-            std::bind(&std::codecvt<wchar_t, char, std::mbstate_t>::in, &cvt, _1,
-                _2, _3, _4, _5, _6, _7));
+            std::bind(&std::codecvt<wchar_t, char, std::mbstate_t>::in, &cvt,
+                _1, _2, _3, _4, _5, _6, _7));
     }
 
     HPX_EXPORT std::string to_8_bit(const std::wstring& s,
@@ -92,8 +92,8 @@ namespace hpx { namespace program_options {
     {
         using namespace std::placeholders;
         return detail::convert<char>(s,
-            std::bind(&std::codecvt<wchar_t, char, std::mbstate_t>::out, &cvt, _1,
-                _2, _3, _4, _5, _6, _7));
+            std::bind(&std::codecvt<wchar_t, char, std::mbstate_t>::out, &cvt,
+                _1, _2, _3, _4, _5, _6, _7));
     }
 
     namespace {

--- a/libs/program_options/src/force_linking.cpp
+++ b/libs/program_options/src/force_linking.cpp
@@ -6,22 +6,17 @@
 #include <hpx/program_options.hpp>
 #include <hpx/program_options/force_linking.hpp>
 
-namespace hpx { namespace program_options
-{
+namespace hpx { namespace program_options {
     force_linking_helper& force_linking()
     {
-        static force_linking_helper helper{
+        static force_linking_helper helper
+        {
 #if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY)
-            &parse_environment,
-            &parse_environment,
-            &parse_environment,
-            &parse_config_file<char>,
-            &parse_config_file<char>,
-            &parse_config_file<wchar_t>,
-            &split_unix,
+            &parse_environment, &parse_environment, &parse_environment,
+                &parse_config_file<char>, &parse_config_file<char>,
+                &parse_config_file<wchar_t>, &split_unix,
 #endif
         };
         return helper;
     }
-}}
-
+}}    // namespace hpx::program_options

--- a/libs/program_options/src/options_description.cpp
+++ b/libs/program_options/src/options_description.cpp
@@ -317,7 +317,7 @@ namespace hpx { namespace program_options {
         std::shared_ptr<options_description> d(new options_description(desc));
         groups.push_back(d);
 
-        for (const auto & option : desc.m_options)
+        for (const auto& option : desc.m_options)
         {
             add(option);
             belong_to_group.back() = true;
@@ -359,7 +359,7 @@ namespace hpx { namespace program_options {
         // We use linear search because matching specified option
         // name with the declared option name need to take care about
         // case sensitivity and trailing '*' and so we can't use simple map.
-        for (const auto & option : m_options)
+        for (const auto& option : m_options)
         {
             option_description::match_result r = option->match(
                 name, approx, long_ignore_case, short_ignore_case);
@@ -642,7 +642,7 @@ namespace hpx { namespace program_options {
         }
 
         /* Get width of groups as well*/
-        for (const auto & group : groups)
+        for (const auto& group : groups)
             width = (std::max)(width, group->get_option_column_width());
 
         /* this is the column were description should start, if first
@@ -678,7 +678,7 @@ namespace hpx { namespace program_options {
             os << "\n";
         }
 
-        for (const auto & group : groups)
+        for (const auto& group : groups)
         {
             os << "\n";
             group->print(os, width);

--- a/libs/program_options/src/parsers.cpp
+++ b/libs/program_options/src/parsers.cpp
@@ -42,7 +42,7 @@
 // available on iOS. The right replacement is not known. See
 // https://svn.boost.org/trac/boost/ticket/5053
 extern "C" {
-    extern char*** _NSGetEnviron(void);
+extern char*** _NSGetEnviron(void);
 }
 #define environ (*_NSGetEnviron())
 #else

--- a/libs/program_options/src/split.cpp
+++ b/libs/program_options/src/split.cpp
@@ -46,16 +46,16 @@ namespace hpx { namespace program_options {
 
     // Take a command line string and splits in into tokens, according
     // to the given collection of separators chars.
-    HPX_EXPORT std::vector<std::string> split_unix(
-        const std::string& cmdline, const std::string& seperator,
-        const std::string& quote, const std::string& escape)
+    HPX_EXPORT std::vector<std::string> split_unix(const std::string& cmdline,
+        const std::string& seperator, const std::string& quote,
+        const std::string& escape)
     {
         return detail::split_unix<char>(cmdline, seperator, quote, escape);
     }
 
-    HPX_EXPORT std::vector<std::wstring> split_unix(
-        const std::wstring& cmdline, const std::wstring& seperator,
-        const std::wstring& quote, const std::wstring& escape)
+    HPX_EXPORT std::vector<std::wstring> split_unix(const std::wstring& cmdline,
+        const std::wstring& seperator, const std::wstring& quote,
+        const std::wstring& escape)
     {
         return detail::split_unix<wchar_t>(cmdline, seperator, quote, escape);
     }

--- a/libs/program_options/src/value_semantic.cpp
+++ b/libs/program_options/src/value_semantic.cpp
@@ -142,7 +142,7 @@ namespace hpx { namespace program_options {
         check_first_occurrence(v);
         string s(get_single_string(xs, true));
 
-        for (char & i : s)
+        for (char& i : s)
             i = char(std::tolower(i));
 
         if (s.empty() || s == "on" || s == "yes" || s == "1" || s == "true")
@@ -164,7 +164,7 @@ namespace hpx { namespace program_options {
         check_first_occurrence(v);
         wstring s(get_single_string(xs, true));
 
-        for (wchar_t & i : s)
+        for (wchar_t& i : s)
             i = wchar_t(tolower(i));
 
         if (s.empty() || s == L"on" || s == L"yes" || s == L"1" || s == L"true")
@@ -329,7 +329,7 @@ namespace hpx { namespace program_options {
         //  replace placeholder with values
         //  placeholder are denoted by surrounding '%'
         //
-        for (auto & substitution : substitutions)
+        for (auto& substitution : substitutions)
             replace_token('%' + substitution.first + '%', substitution.second);
     }
 

--- a/libs/program_options/src/variables_map.cpp
+++ b/libs/program_options/src/variables_map.cpp
@@ -229,7 +229,7 @@ namespace hpx { namespace program_options {
         }
 
         // Lastly, run notify actions.
-        for (auto & k : *this)
+        for (auto& k : *this)
         {
             /* Users might wish to use variables_map to store their own values
                that are not parsed, and therefore will not have value_semantics

--- a/libs/program_options/src/winmain.cpp
+++ b/libs/program_options/src/winmain.cpp
@@ -109,7 +109,7 @@ namespace hpx { namespace program_options {
     {
         std::vector<std::wstring> result;
         std::vector<std::string> aux = split_winmain(to_internal(cmdline));
-        for (const auto & i : aux)
+        for (const auto& i : aux)
             result.push_back(from_utf8(i));
         return result;
     }

--- a/libs/program_options/tests/regressions/CMakeLists.txt
+++ b/libs/program_options/tests/regressions/CMakeLists.txt
@@ -23,6 +23,7 @@ foreach(test ${tests})
   add_hpx_executable(${test}_test
                      SOURCES ${sources}
                      ${${test}_FLAGS}
+                     EXCLUDE_FROM_ALL
                      FOLDER ${folder_name})
 
   add_hpx_regression_test("modules.program_options" ${test} ${${test}_PARAMETERS})

--- a/libs/program_options/tests/regressions/command_line_arguments_706.cpp
+++ b/libs/program_options/tests/regressions/command_line_arguments_706.cpp
@@ -9,14 +9,9 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/testing.hpp>
 
-char const* argv[] =
-{
-    "command_line_argument_test",
+char const* argv[] = {"command_line_argument_test",
     // We need only one thread, this argument should be gone in hpx_main
-    "--hpx:threads=1",
-    "nx=1",
-    "ny=1=5"
-};
+    "--hpx:threads=1", "nx=1", "ny=1=5"};
 
 int hpx_main(int argc, char** argv_init)
 {
@@ -24,7 +19,7 @@ int hpx_main(int argc, char** argv_init)
     HPX_TEST_EQ(0, std::strcmp(argv[0], argv_init[0]));
     for (int i = 1; i < argc; ++i)
     {
-        HPX_TEST_EQ(0, std::strcmp(argv[i+1], argv_init[i]));
+        HPX_TEST_EQ(0, std::strcmp(argv[i + 1], argv_init[i]));
     }
 
     return hpx::finalize();

--- a/libs/program_options/tests/regressions/command_line_required_arguments_2990.cpp
+++ b/libs/program_options/tests/regressions/command_line_required_arguments_2990.cpp
@@ -3,8 +3,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
 
 #include <iostream>
 #include <string>
@@ -25,9 +25,7 @@ int hpx_main(variables_map& vm)
 
 int main(int argc, char* argv[])
 {
-    std::vector<std::string> cfg = {
-        "hpx.commandline.rethrow_errors!=1"
-    };
+    std::vector<std::string> cfg = {"hpx.commandline.rethrow_errors!=1"};
 
     char help_option[] = "--hpx:help";
 
@@ -41,10 +39,12 @@ int main(int argc, char* argv[])
 
     options_description op("Issue #2990\n\nUsage: issue2990 [options]");
 
+    // clang-format off
     op.add_options()
         ("reqopt1", value<int>()->required(), "Required option 1")
         ("reqopt2", value<double>()->required(), "Required option 2")
         ("reqopt3", value<std::string>()->required(), "Required option 3");
+    // clang-format on
 
     return hpx::init(op, argc + 1, newargv.data(), cfg);
 }

--- a/libs/program_options/tests/regressions/commandline_options_1437.cpp
+++ b/libs/program_options/tests/regressions/commandline_options_1437.cpp
@@ -11,7 +11,7 @@
 
 bool invoked_main = false;
 
-int my_hpx_main(int argc, char **argv)
+int my_hpx_main(int argc, char** argv)
 {
     // all HPX command line arguments should have been stripped here
     HPX_TEST(argc == 1);
@@ -20,7 +20,7 @@ int my_hpx_main(int argc, char **argv)
     return hpx::finalize();
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
     HPX_TEST(argc > 1);
 

--- a/libs/program_options/tests/unit/CMakeLists.txt
+++ b/libs/program_options/tests/unit/CMakeLists.txt
@@ -34,6 +34,7 @@ foreach(test ${tests})
   add_hpx_executable(${test}_test
                      SOURCES ${sources}
                      ${${test}_FLAGS}
+                     EXCLUDE_FROM_ALL
                      FOLDER ${folder_name})
 
   add_hpx_unit_test("modules.program_options" ${test} ${${test}_PARAMETERS})

--- a/libs/program_options/tests/unit/boost_program_options.cpp
+++ b/libs/program_options/tests/unit/boost_program_options.cpp
@@ -9,7 +9,7 @@
 // We use boost::program_options here, so surpress the deprecation warning.
 #if defined(__clang__)
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined (__GNUC__)
+#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
@@ -26,10 +26,12 @@ int hpx_main(po::variables_map& vm)
 int main(int argc, char* argv[])
 {
     po::options_description desc("Allowed options");
+    // clang-format off
     desc.add_options()
         ("help", "produce help message")
         ("compression", po::value<double>(), "set compression level")
     ;
+    // clang-format on
 
     return hpx::init(desc, argc, argv);
 }

--- a/libs/program_options/tests/unit/cmdline.cpp
+++ b/libs/program_options/tests/unit/cmdline.cpp
@@ -405,12 +405,20 @@ void test_additional_parser()
 {
     options_description desc;
     desc.add_options()("response-file", value<string>(), "response file")(
-        "foo", value<int>(), "foo")("bar,baz", value<int>(), "bar");
+        "foo", value<int>(), "foo");
+#if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY) ||  \
+    (defined(BOOST_VERSION) && BOOST_VERSION >= 106800)
+    desc.add_options()("bar,baz", value<int>(), "bar");
+#endif
 
     vector<string> input;
     input.emplace_back("@config");
     input.emplace_back("--foo=1");
+#if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY) ||  \
+    (defined(BOOST_VERSION) && BOOST_VERSION >= 106800)
+    // the long_names() API function was introduced in Boost V1.68
     input.emplace_back("--baz=11");
+#endif
 
     cmdline cmd(input);
     cmd.set_options_description(desc);
@@ -418,13 +426,23 @@ void test_additional_parser()
 
     vector<option> result = cmd.run();
 
+#if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY) ||  \
+    (defined(BOOST_VERSION) && BOOST_VERSION >= 106800)
+    // the long_names() API function was introduced in Boost V1.68
     HPX_TEST(result.size() == 3);
+#else
+    HPX_TEST(result.size() == 2);
+#endif
     HPX_TEST_EQ(result[0].string_key, "response-file");
     HPX_TEST_EQ(result[0].value[0], "config");
     HPX_TEST_EQ(result[1].string_key, "foo");
     HPX_TEST_EQ(result[1].value[0], "1");
+#if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY) ||  \
+    (defined(BOOST_VERSION) && BOOST_VERSION >= 106800)
+    // the long_names() API function was introduced in Boost V1.68
     HPX_TEST_EQ(result[2].string_key, "bar");
     HPX_TEST_EQ(result[2].value[0], "11");
+#endif
 
     // Test that invalid options returned by additional style
     // parser are detected.
@@ -560,8 +578,11 @@ void test_implicit_value()
     style = cmdline::style_t(allow_long | long_allow_adjacent);
 
     test_case test_cases1[] = {
+#if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY) ||  \
+    (defined(BOOST_VERSION) && BOOST_VERSION >= 106500)
         // 'bar' does not even look like option, so is consumed
         {"--foo bar", s_success, "foo:bar"},
+#endif
         // '--bar' looks like option, and such option exists, so we don't
         // consume this token
         {"--foo --bar", s_success, "foo: bar:"},

--- a/libs/program_options/tests/unit/cmdline.cpp
+++ b/libs/program_options/tests/unit/cmdline.cpp
@@ -3,8 +3,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/hpx_main.hpp>
 #include <hpx/assertion.hpp>
+#include <hpx/hpx_main.hpp>
 #include <hpx/testing.hpp>
 
 #include <hpx/program_options/cmdline.hpp>
@@ -404,8 +404,11 @@ pair<string, string> at_option_parser_broken(string const& s)
 void test_additional_parser()
 {
     options_description desc;
-    desc.add_options()("response-file", value<string>(), "response file")(
-        "foo", value<int>(), "foo");
+    // clang-format off
+    desc.add_options()
+        ("response-file", value<string>(), "response file")
+        ("foo", value<int>(), "foo");
+    // clang-format on
 #if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY) ||  \
     (defined(BOOST_VERSION) && BOOST_VERSION >= 106800)
     desc.add_options()("bar,baz", value<int>(), "bar");
@@ -455,7 +458,7 @@ void test_additional_parser()
     {
         cmd2.run();
     }
-    catch(unknown_option const&)
+    catch (unknown_option const&)
     {
         caught_exception = true;
     }

--- a/libs/program_options/tests/unit/optional.cpp
+++ b/libs/program_options/tests/unit/optional.cpp
@@ -25,6 +25,9 @@ std::vector<std::string> sv(const char* array[], unsigned size)
 
 void test_optional()
 {
+// Support for storing into optionals was added in 1.65.0
+#if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY) || \
+   (defined(BOOST_VERSION) && BOOST_VERSION > 106500)
     po::optional<int> foo, bar, baz;
 
     po::options_description desc;
@@ -49,6 +52,7 @@ void test_optional()
     HPX_TEST(*bar == 1);
 
     HPX_TEST(!baz);
+#endif
 }
 
 int main(int, char*[])

--- a/libs/program_options/tests/unit/optional.cpp
+++ b/libs/program_options/tests/unit/optional.cpp
@@ -26,16 +26,18 @@ std::vector<std::string> sv(const char* array[], unsigned size)
 void test_optional()
 {
 // Support for storing into optionals was added in 1.65.0
-#if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY) || \
-   (defined(BOOST_VERSION) && BOOST_VERSION > 106500)
+#if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY) ||  \
+    (defined(BOOST_VERSION) && BOOST_VERSION > 106500)
     po::optional<int> foo, bar, baz;
 
     po::options_description desc;
+    // clang-format off
     desc.add_options()
         ("foo,f", po::value(&foo), "")
         ("bar,b", po::value(&bar), "")
         ("baz,z", po::value(&baz), "")
         ;
+    // clang-format on
 
     const char* cmdline1_[] = {"--foo=12", "--bar", "1"};
     std::vector<std::string> cmdline1 =

--- a/libs/program_options/tests/unit/options_description.cpp
+++ b/libs/program_options/tests/unit/options_description.cpp
@@ -68,25 +68,20 @@ void test_approximation()
 
 void test_approximation_with_multiname_options()
 {
+#if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY) ||  \
+    (defined(BOOST_VERSION) && BOOST_VERSION >= 106800)
+    // the long_names() API function was introduced in Boost V1.68
     options_description desc;
-    desc.add_options()
-        ("foo", new untyped_value())
-        ("fee", new untyped_value())
-        ("fe,baz", new untyped_value())
-        ("chroots,all-chroots", new untyped_value())
-        ("sessions,all-sessions", new untyped_value())
-        ("everything,all", new untyped_value())
-        ("qux,fo", new untyped_value())
-        ;
+    desc.add_options()("foo", new untyped_value())("fee", new untyped_value())(
+        "fe,baz", new untyped_value())("chroots,all-chroots",
+        new untyped_value())("sessions,all-sessions", new untyped_value())(
+        "everything,all", new untyped_value())("qux,fo", new untyped_value());
 
     HPX_TEST_EQ(desc.find("fo", true).long_name(), "qux");
 
     HPX_TEST_EQ(desc.find("all", true).long_name(), "everything");
     HPX_TEST_EQ(desc.find("all-ch", true).long_name(), "chroots");
 
-#if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY) ||  \
-    (defined(BOOST_VERSION) && BOOST_VERSION >= 106800)
-    // the long_names() API function was introduced in Boost V1.68
     HPX_TEST_EQ(desc.find("foo", false, false, false).long_names().second,
         std::size_t(1));
     HPX_TEST_EQ(
@@ -197,14 +192,17 @@ void test_formatting()
 
 void test_multiname_option_formatting()
 {
+#if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY) ||  \
+    (defined(BOOST_VERSION) && BOOST_VERSION >= 106800)
+    // the long_names() API function was introduced in Boost V1.68
     options_description desc;
-    desc.add_options()
-      ("foo,bar", new untyped_value(), "a multiple-name option")
-    ;
+    desc.add_options()(
+        "foo,bar", new untyped_value(), "a multiple-name option");
 
     stringstream ss;
     ss << desc;
     HPX_TEST_EQ(ss.str(), "  --foo arg             a multiple-name option\n");
+#endif
 }
 
 

--- a/libs/program_options/tests/unit/options_description.cpp
+++ b/libs/program_options/tests/unit/options_description.cpp
@@ -11,9 +11,9 @@
 
 #include <cstddef>
 #include <functional>
-#include <utility>
-#include <string>
 #include <sstream>
+#include <string>
+#include <utility>
 
 using namespace hpx::program_options;
 using namespace std;
@@ -21,18 +21,20 @@ using namespace std;
 void test_type()
 {
     options_description desc;
+    // clang-format off
     desc.add_options()
         ("foo", value<int>(), "")
         ("bar", value<string>(), "")
         ;
+    //clang-format on
 
-    const typed_value_base* b = dynamic_cast<const typed_value_base*>
-        (desc.find("foo", false).semantic().get());
+    const typed_value_base* b = dynamic_cast<const typed_value_base*>(
+        desc.find("foo", false).semantic().get());
     HPX_TEST(b);
     HPX_TEST(b->value_type() == typeid(int));
 
-    const typed_value_base* b2 = dynamic_cast<const typed_value_base*>
-        (desc.find("bar", false).semantic().get());
+    const typed_value_base* b2 = dynamic_cast<const typed_value_base*>(
+        desc.find("bar", false).semantic().get());
     HPX_TEST(b2);
     HPX_TEST(b2->value_type() == typeid(string));
 }
@@ -40,6 +42,7 @@ void test_type()
 void test_approximation()
 {
     options_description desc;
+    // clang-format off
     desc.add_options()
         ("foo", new untyped_value())
         ("fee", new untyped_value())
@@ -48,6 +51,7 @@ void test_approximation()
         ("all-sessions", new untyped_value())
         ("all", new untyped_value())
         ;
+    // clang-format on
 
     HPX_TEST_EQ(desc.find("fo", true).long_name(), "foo");
 
@@ -55,15 +59,16 @@ void test_approximation()
     HPX_TEST_EQ(desc.find("all-ch", true).long_name(), "all-chroots");
 
     options_description desc2;
+    // clang-format off
     desc2.add_options()
         ("help", "display this message")
         ("config", value<string>(), "config file name")
         ("config-value", value<string>(), "single config value")
         ;
+    // clang-format on
 
     HPX_TEST_EQ(desc2.find("config", true).long_name(), "config");
-    HPX_TEST_EQ(desc2.find("config-value", true).long_name(),
-                      "config-value");
+    HPX_TEST_EQ(desc2.find("config-value", true).long_name(), "config-value");
 }
 
 void test_approximation_with_multiname_options()
@@ -72,10 +77,17 @@ void test_approximation_with_multiname_options()
     (defined(BOOST_VERSION) && BOOST_VERSION >= 106800)
     // the long_names() API function was introduced in Boost V1.68
     options_description desc;
-    desc.add_options()("foo", new untyped_value())("fee", new untyped_value())(
-        "fe,baz", new untyped_value())("chroots,all-chroots",
-        new untyped_value())("sessions,all-sessions", new untyped_value())(
-        "everything,all", new untyped_value())("qux,fo", new untyped_value());
+    // clang-format off
+    desc.add_options()
+        ("foo", new untyped_value())
+        ("fee", new untyped_value())
+        ("fe,baz", new untyped_value())
+        ("chroots,all-chroots", new untyped_value())
+        ("sessions,all-sessions", new untyped_value())
+        ("everything,all", new untyped_value())
+        ("qux,fo", new untyped_value())
+        ;
+    // clang-format on
 
     HPX_TEST_EQ(desc.find("fo", true).long_name(), "qux");
 
@@ -109,6 +121,7 @@ void test_long_names_for_option_description()
     (defined(BOOST_VERSION) && BOOST_VERSION >= 106800)
     // the long_names() API function was introduced in Boost V1.68
     options_description desc;
+    // clang-format off
     desc.add_options()
         ("foo", new untyped_value())
         ("fe,baz", new untyped_value())
@@ -117,6 +130,7 @@ void test_long_names_for_option_description()
         ("everything,all", new untyped_value())
         ("qux,fo,q", new untyped_value())
         ;
+    // clang-format on
 
     HPX_TEST_EQ(desc.find("foo", false, false, false).long_names().second,
         std::size_t(1));
@@ -143,6 +157,7 @@ void test_formatting()
 {
     // Long option descriptions used to crash on MSVC-8.0.
     options_description desc;
+    // clang-format off
     desc.add_options()("test", new untyped_value(),
         "foo foo foo foo foo foo foo foo foo foo foo foo foo foo"
         "foo foo foo foo foo foo foo foo foo foo foo foo foo foo"
@@ -187,7 +202,8 @@ void test_formatting()
 "                        \n"
 "                            This paragraph has a first line indent only, bla \n"
 "                        bla bla bla bla bla bla bla bla bla bla bla bla bla bla\n"
-   );
+    );
+    // clang-format on
 }
 
 void test_multiname_option_formatting()
@@ -205,18 +221,18 @@ void test_multiname_option_formatting()
 #endif
 }
 
-
 void test_formatting_description_length()
 {
     {
-        options_description desc("",
-                                 options_description::m_default_line_length,
-                                 options_description::m_default_line_length / 2U);
-        desc.add_options()("an-option-that-sets-the-max",
-            new untyped_value(),    // > 40 available for desc
+        options_description desc("", options_description::m_default_line_length,
+            options_description::m_default_line_length / 2U);
+        // clang-format off
+        desc.add_options()
+            // 40 available for desc
+            ("an-option-that-sets-the-max", new untyped_value(),
             "this description sits on the same line, but wrapping should still "
-            "work correctly")(
-            "a-long-option-that-would-leave-very-little-space-for-description",
+             "work correctly")
+            ("a-long-option-that-would-leave-very-little-space-for-description",
             new untyped_value(),
             "the description of the long opt, but placed on the next line\n"
             "    \talso ensure that the tabulation works correctly when a"
@@ -240,6 +256,7 @@ void test_formatting_description_length()
             "                                            works correctly when "
             "a description \n"
             "                                            size has been set\n");
+        // clang-format on
     }
     {
         // the default behavior reserves 23 (+1 space) characters for the
@@ -282,43 +299,43 @@ void test_long_default_value()
 
 void test_word_wrapping()
 {
-   options_description desc("Supported options");
-   desc.add_options()(
-       "help", "this is a sufficiently long text to require word-wrapping");
-   desc.add_options()("prefix",
-       value<string>()->default_value("/h/proj/tmp/dispatch"),
-       "root path of the dispatch installation");
-   desc.add_options()("opt1",
-       "this_is_a_sufficiently_long_text_to_require_word-wrapping_but_cannot_"
-       "be_wrapped");
-   desc.add_options()(
-       "opt2", "this_is_a_sufficiently long_text_to_require_word-wrapping");
-   desc.add_options()("opt3",
-       "this_is_a "
-       "sufficiently_long_text_to_require_word-wrapping_but_will_not_be_"
-       "wrapped");
+    options_description desc("Supported options");
+    desc.add_options()(
+        "help", "this is a sufficiently long text to require word-wrapping");
+    desc.add_options()("prefix",
+        value<string>()->default_value("/h/proj/tmp/dispatch"),
+        "root path of the dispatch installation");
+    desc.add_options()("opt1",
+        "this_is_a_sufficiently_long_text_to_require_word-wrapping_but_cannot_"
+        "be_wrapped");
+    desc.add_options()(
+        "opt2", "this_is_a_sufficiently long_text_to_require_word-wrapping");
+    desc.add_options()("opt3",
+        "this_is_a "
+        "sufficiently_long_text_to_require_word-wrapping_but_will_not_be_"
+        "wrapped");
 
-   stringstream ss;
-   ss << desc;
-   HPX_TEST_EQ(ss.str(),
-       "Supported options:\n"
-       "  --help                               this is a sufficiently long "
-       "text to \n"
-       "                                       require word-wrapping\n"
-       "  --prefix arg (=/h/proj/tmp/dispatch) root path of the dispatch "
-       "installation\n"
-       "  --opt1                               "
-       "this_is_a_sufficiently_long_text_to_requ\n"
-       "                                       "
-       "ire_word-wrapping_but_cannot_be_wrapped\n"
-       "  --opt2                               this_is_a_sufficiently \n"
-       "                                       "
-       "long_text_to_require_word-wrapping\n"
-       "  --opt3                               this_is_a "
-       "sufficiently_long_text_to_requ\n"
-       "                                       "
-       "ire_word-wrapping_but_will_not_be_wrappe\n"
-       "                                       d\n");
+    stringstream ss;
+    ss << desc;
+    HPX_TEST_EQ(ss.str(),
+        "Supported options:\n"
+        "  --help                               this is a sufficiently long "
+        "text to \n"
+        "                                       require word-wrapping\n"
+        "  --prefix arg (=/h/proj/tmp/dispatch) root path of the dispatch "
+        "installation\n"
+        "  --opt1                               "
+        "this_is_a_sufficiently_long_text_to_requ\n"
+        "                                       "
+        "ire_word-wrapping_but_cannot_be_wrapped\n"
+        "  --opt2                               this_is_a_sufficiently \n"
+        "                                       "
+        "long_text_to_require_word-wrapping\n"
+        "  --opt3                               this_is_a "
+        "sufficiently_long_text_to_requ\n"
+        "                                       "
+        "ire_word-wrapping_but_will_not_be_wrappe\n"
+        "                                       d\n");
 }
 
 void test_default_values()
@@ -346,7 +363,7 @@ void test_value_name()
         "  --include directory   Search for headers in 'directory'.\n");
 }
 
-int main(int, char* [])
+int main(int, char*[])
 {
     test_type();
     test_approximation();
@@ -361,4 +378,3 @@ int main(int, char* [])
 
     return hpx::util::report_errors();
 }
-

--- a/libs/program_options/tests/unit/options_exception.cpp
+++ b/libs/program_options/tests/unit/options_exception.cpp
@@ -74,6 +74,9 @@ void test_ambiguous_long()
 
 void test_ambiguous_multiple_long_names()
 {
+#if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY) ||  \
+    (defined(BOOST_VERSION) && BOOST_VERSION >= 106800)
+    // the long_names() API function was introduced in Boost V1.68
     options_description desc;
     desc.add_options()("cfgfile,foo,c", value<string>()->multitoken(),
         "the config file")("output,foo,o", value<string>(), "the output file");
@@ -94,6 +97,7 @@ void test_ambiguous_multiple_long_names()
         HPX_TEST_EQ(e.alternatives()[0], "cfgfile");
         HPX_TEST_EQ(e.alternatives()[1], "output");
     }
+#endif
 }
 
 void test_unknown_option()
@@ -176,6 +180,8 @@ void test_multiple_occurrences()
 
 void test_multiple_occurrences_with_different_names()
 {
+#if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY) ||  \
+    (defined(BOOST_VERSION) && BOOST_VERSION >= 106800)
     options_description desc;
     desc.add_options()(
         "cfgfile,config-file,c", value<string>(), "the configfile");
@@ -195,16 +201,18 @@ void test_multiple_occurrences_with_different_names()
     {
         HPX_TEST((e.get_option_name() == "--cfgfile") ||
             (e.get_option_name() == "--config-file"));
-        HPX_TEST(
-            (string(e.what()) ==
-                "option '--cfgfile' cannot be specified more than once") ||
+        HPX_TEST((string(e.what()) ==
+                     "option '--cfgfile' cannot be specified more than once") ||
             (string(e.what()) ==
                 "option '--config-file' cannot be specified more than once"));
     }
+#endif
 }
 
 void test_multiple_occurrences_with_non_key_names()
 {
+#if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY) ||  \
+    (defined(BOOST_VERSION) && BOOST_VERSION >= 106800)
     options_description desc;
     desc.add_options()(
         "cfgfile,config-file,c", value<string>(), "the configfile");
@@ -226,6 +234,7 @@ void test_multiple_occurrences_with_non_key_names()
         HPX_TEST_EQ(string(e.what()),
             "option '--cfgfile' cannot be specified more than once");
     }
+#endif
 }
 
 void test_missing_value()

--- a/libs/program_options/tests/unit/parsers.cpp
+++ b/libs/program_options/tests/unit/parsers.cpp
@@ -63,6 +63,9 @@ namespace command_line {
 
     void test_many_different_options()
     {
+#if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY) ||  \
+    (defined(BOOST_VERSION) && BOOST_VERSION >= 106800)
+        // the long_names() API function was introduced in Boost V1.68
         options_description desc;
         desc.add_options()("foo,f", new untyped_value(), "")("bar,b",
             value<std::string>(), "")("car,voiture", new untyped_value())(
@@ -100,6 +103,7 @@ namespace command_line {
         check_value(a4[4], "dog", "16");
         check_value(a4[5], "dog", "17");
         check_value(a4[6], "plug3", "10");
+#endif
     }
 
     void test_not_crashing_with_empty_string_values()
@@ -136,6 +140,9 @@ namespace command_line {
 
     void test_multitoken_and_multiname()
     {
+#if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY) ||  \
+    (defined(BOOST_VERSION) && BOOST_VERSION >= 106800)
+        // the long_names() API function was introduced in Boost V1.68
         const char* cmdline[] = {"program", "-fone", "-b", "two", "--foo",
             "three", "four", "-zfive", "--fee", "six"};
         options_description desc;
@@ -175,10 +182,14 @@ namespace command_line {
         HPX_TEST_EQ(parsed_options[2].value[1], "four");
         check_value(parsed_options[3], "fizbaz", "five");
         check_value(parsed_options[4], "foo", "six");
+#endif
     }
 
     void test_multitoken_vector_option()
     {
+#if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY) ||  \
+    (defined(BOOST_VERSION) && BOOST_VERSION >= 106800)
+        // the long_names() API function was introduced in Boost V1.68
         options_description desc4("");
         desc4.add_options()("multitoken,multi-token,m",
             value<std::vector<std::string>>()->multitoken(),
@@ -202,6 +213,7 @@ namespace command_line {
         HPX_TEST_EQ(a6[1].string_key, "file");
         HPX_TEST(a6[1].value.size() == 1);
         HPX_TEST_EQ(a6[1].value[0], "some_file");
+#endif
     }
 
 }    // namespace command_line
@@ -218,11 +230,15 @@ void test_command_line()
 
 void test_config_file(const char* config_file)
 {
+#if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY) ||  \
+    (defined(BOOST_VERSION) && BOOST_VERSION >= 106800)
+    // the long_names() API function was introduced in Boost V1.68
     options_description desc;
     desc.add_options()("gv1", new untyped_value)("gv2", new untyped_value)(
-        "empty_value", new untyped_value)("plug*", new untyped_value)(
-        "m1.v1", new untyped_value)("m1.v2", new untyped_value)(
-        "m1.v3,alias3", new untyped_value)("b", bool_switch());
+            "empty_value", new untyped_value)("plug*", new untyped_value)(
+            "m1.v1", new untyped_value)(
+            "m1.v2", new untyped_value) desc.add_options()("m1.v3,alias3",
+        new untyped_value)("b", bool_switch());
 
     const char content1[] = " gv1 = 0#asd\n"
                             "empty_value = \n"
@@ -255,6 +271,7 @@ void test_config_file(const char* config_file)
     check_value(a2[4], "m1.v1", "1");
     check_value(a2[5], "m1.v2", "2");
     check_value(a2[6], "m1.v3", "3");
+#endif
 }
 
 void test_environment()

--- a/libs/program_options/tests/unit/parsers.cpp
+++ b/libs/program_options/tests/unit/parsers.cpp
@@ -3,14 +3,14 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/hpx_main.hpp>
 #include <hpx/filesystem.hpp>
+#include <hpx/hpx_main.hpp>
 #include <hpx/testing.hpp>
 
 #include <hpx/program_options/option.hpp>
 #include <hpx/program_options/options_description.hpp>
-#include <hpx/program_options/positional_options.hpp>
 #include <hpx/program_options/parsers.hpp>
+#include <hpx/program_options/positional_options.hpp>
 #include <hpx/program_options/value_semantic.hpp>
 #include <hpx/program_options/variables_map.hpp>
 
@@ -114,7 +114,7 @@ namespace command_line {
         desc2.add_options()("open", value<string>());
         variables_map vm;
         store(parse_command_line(sizeof(cmdline4) / sizeof(const char*),
-                      const_cast<char**>(cmdline4), desc2),
+                  const_cast<char**>(cmdline4), desc2),
             vm);
     }
 
@@ -146,9 +146,8 @@ namespace command_line {
         const char* cmdline[] = {"program", "-fone", "-b", "two", "--foo",
             "three", "four", "-zfive", "--fee", "six"};
         options_description desc;
-        desc.add_options()("bar,b", value<string>())(
-            "foo,fee,f", value<string>()->multitoken())(
-            "fizbaz,baz,z", value<string>());
+        desc.add_options()("bar,b", value<string>())("foo,fee,f",
+            value<string>()->multitoken())("fizbaz,baz,z", value<string>());
 
         vector<option> parsed_options =
             parse_command_line(sizeof(cmdline) / sizeof(const char*),
@@ -235,10 +234,9 @@ void test_config_file(const char* config_file)
     // the long_names() API function was introduced in Boost V1.68
     options_description desc;
     desc.add_options()("gv1", new untyped_value)("gv2", new untyped_value)(
-            "empty_value", new untyped_value)("plug*", new untyped_value)(
-            "m1.v1", new untyped_value)(
-            "m1.v2", new untyped_value) desc.add_options()("m1.v3,alias3",
-        new untyped_value)("b", bool_switch());
+        "empty_value", new untyped_value)("plug*", new untyped_value)(
+        "m1.v1", new untyped_value)("m1.v2", new untyped_value)(
+        "m1.v3,alias3", new untyped_value)("b", bool_switch());
 
     const char content1[] = " gv1 = 0#asd\n"
                             "empty_value = \n"

--- a/libs/program_options/tests/unit/positional_options.cpp
+++ b/libs/program_options/tests/unit/positional_options.cpp
@@ -3,8 +3,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/hpx_main.hpp>
 #include <hpx/filesystem.hpp>
+#include <hpx/hpx_main.hpp>
 #include <hpx/testing.hpp>
 
 #include <hpx/program_options/errors.hpp>
@@ -47,12 +47,14 @@ void test_positional_options()
 void test_parsing()
 {
     options_description desc;
+    // clang-format off
     desc.add_options()
         ("first", value<int>())
         ("second", value<int>())
         ("input-file", value< vector<string> >())
         ("some-other", value<string>())
     ;
+    // clang-format on
 
     positional_options_description p;
     p.add("input-file", 2).add("some-other", 1);
@@ -78,16 +80,14 @@ void test_parsing()
     args.emplace_back("file4");
 
     // Check that excessive number of positional options is detected.
-    HPX_TEST_THROW(
-        command_line_parser(args).options(desc).positional(p).run(),
+    HPX_TEST_THROW(command_line_parser(args).options(desc).positional(p).run(),
         too_many_positional_options_error);
 }
 
-int main(int, char* [])
+int main(int, char*[])
 {
     test_positional_options();
     test_parsing();
 
     return hpx::util::report_errors();
 }
-

--- a/libs/program_options/tests/unit/required.cpp
+++ b/libs/program_options/tests/unit/required.cpp
@@ -3,8 +3,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/hpx_main.hpp>
 #include <hpx/filesystem.hpp>
+#include <hpx/hpx_main.hpp>
 #include <hpx/testing.hpp>
 
 #include <hpx/program_options.hpp>
@@ -20,9 +20,12 @@ using namespace std;
 void required_throw_test()
 {
     options_description opts;
-    opts.add_options()(
-        "cfgfile,c", value<string>()->required(), "the configfile")(
-        "fritz,f", value<string>()->required(), "the output file");
+    // clang-format off
+    opts.add_options()
+        ("cfgfile,c", value<string>()->required(), "the configfile")
+        ("fritz,f", value<string>()->required(), "the output file")
+        ;
+    // clang-format on
 
     variables_map vm;
     bool thrown = false;
@@ -66,10 +69,12 @@ void required_throw_test()
 void simple_required_test(const char* config_file)
 {
     options_description opts;
+    // clang-format off
     opts.add_options()
         ("cfgfile,c", value<string>()->required(), "the configfile")
         ("fritz,f", value<string>()->required(), "the output file")
         ;
+    // clang-format on
 
     variables_map vm;
     bool thrown = false;

--- a/libs/program_options/tests/unit/required.cpp
+++ b/libs/program_options/tests/unit/required.cpp
@@ -95,6 +95,9 @@ void simple_required_test(const char* config_file)
 
 void multiname_required_test()
 {
+#if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY) ||  \
+    (defined(BOOST_VERSION) && BOOST_VERSION >= 106800)
+    // the long_names() API function was introduced in Boost V1.68
     options_description opts;
     opts.add_options()("foo,bar", value<string>()->required(), "the foo");
 
@@ -117,6 +120,7 @@ void multiname_required_test()
         }
         HPX_TEST(!thrown);
     }
+#endif
 }
 
 constexpr char const* const config_file = "required_test.cfg";

--- a/libs/program_options/tests/unit/split.cpp
+++ b/libs/program_options/tests/unit/split.cpp
@@ -173,11 +173,13 @@ void split_defaults(const options_description& description)
 int main(int /*ac*/, char** /*av*/)
 {
     options_description desc;
+    // clang-format off
     desc.add_options()
         ("input,i", value<string>(),"the input file")
         ("optimization,O", value<unsigned>(), "optimization level")
         ("opt,o", value<string>(), "misc option")
         ;
+    // clang-format on
 
     split_whitespace(desc);
     split_equalsign(desc);

--- a/libs/program_options/tests/unit/unicode.cpp
+++ b/libs/program_options/tests/unit/unicode.cpp
@@ -106,19 +106,19 @@ void check_value(const woption& option, const char* name, const wchar_t* value)
 
 void test_command_line()
 {
+#if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY) ||  \
+    (defined(BOOST_VERSION) && BOOST_VERSION >= 106800)
+    // the long_names() API function was introduced in Boost V1.68
     options_description desc;
-    desc.add_options()
-        ("foo,f", new untyped_value(), "")
+    desc.add_options()("foo,f", new untyped_value(), "")
         // Explicit qualification is a workaround for vc6
-        ("bar,b", value<std::string>(), "")
-        ("baz", new untyped_value())
-        ("qux,plug*", new untyped_value())
-        ;
+        ("bar,b", value<std::string>(), "")("baz", new untyped_value())(
+            "qux,plug*", new untyped_value());
 
-    const wchar_t* cmdline4_[] = { L"--foo=1\u0FF52", L"-f4", L"--bar=11",
-                             L"-b4", L"--plug3=10"};
-    vector<wstring> cmdline4 = sv(cmdline4_,
-                                  sizeof(cmdline4_)/sizeof(cmdline4_[0]));
+    const wchar_t* cmdline4_[] = {
+        L"--foo=1\u0FF52", L"-f4", L"--bar=11", L"-b4", L"--plug3=10"};
+    vector<wstring> cmdline4 =
+        sv(cmdline4_, sizeof(cmdline4_) / sizeof(cmdline4_[0]));
     vector<woption> a4 =
         wcommand_line_parser(cmdline4).options(desc).run().options;
 
@@ -128,6 +128,7 @@ void test_command_line()
     check_value(a4[1], "foo", L"4");
     check_value(a4[2], "bar", L"11");
     check_value(a4[4], "qux", L"10");
+#endif
 }
 
 // Since we've already tested conversion between parser encoding and

--- a/libs/program_options/tests/unit/unicode.cpp
+++ b/libs/program_options/tests/unit/unicode.cpp
@@ -27,9 +27,7 @@ void test_unicode_to_unicode()
 {
     options_description desc;
 
-    desc.add_options()
-        ("foo", wvalue<wstring>(), "unicode option")
-        ;
+    desc.add_options()("foo", wvalue<wstring>(), "unicode option");
 
     vector<wstring> args;
     args.push_back(L"--foo=\x044F");
@@ -55,9 +53,7 @@ void test_unicode_to_native()
 
     options_description desc;
 
-    desc.add_options()
-        ("foo", value<string>(), "unicode option")
-        ;
+    desc.add_options()("foo", value<string>(), "unicode option");
 
     vector<wstring> args;
     args.push_back(L"--foo=\x044F");
@@ -76,9 +72,7 @@ void test_native_to_unicode()
 
     options_description desc;
 
-    desc.add_options()
-        ("foo", wvalue<wstring>(), "unicode option")
-        ;
+    desc.add_options()("foo", wvalue<wstring>(), "unicode option");
 
     vector<string> args;
     args.push_back("--foo=\xD1\x8F");
@@ -142,9 +136,7 @@ void test_config_file()
 
     options_description desc;
 
-    desc.add_options()
-        ("foo", value<string>(), "unicode option")
-        ;
+    desc.add_options()("foo", value<string>(), "unicode option");
 
     std::wstringstream stream(L"foo = \x044F");
 
@@ -154,7 +146,7 @@ void test_config_file()
     HPX_TEST(vm["foo"].as<string>() == "\xD1\x8F");
 }
 
-int main(int, char* [])
+int main(int, char*[])
 {
     test_unicode_to_unicode();
     test_unicode_to_native();
@@ -164,4 +156,3 @@ int main(int, char* [])
 
     return hpx::util::report_errors();
 }
-

--- a/libs/program_options/tests/unit/variable_map.cpp
+++ b/libs/program_options/tests/unit/variable_map.cpp
@@ -32,6 +32,7 @@ vector<string> sv(const char* array[], unsigned size)
 void test_variable_map()
 {
     options_description desc;
+    // clang-format off
     desc.add_options()
         ("foo,f", new untyped_value)
         ("bar,b", value<string>())
@@ -39,6 +40,7 @@ void test_variable_map()
         ("baz", new untyped_value())
         ("output,o", new untyped_value(), "")
         ;
+    // clang-format on
 
     const char* cmdline3_[] = {"--foo='12'", "--bar=11", "-z3", "-ofoo"};
     vector<string> cmdline3 =
@@ -56,11 +58,13 @@ void test_variable_map()
     HPX_TEST(vm["output"].as<string>() == "foo");
 
     int i;
+    // clang-format off
     desc.add_options()
         ("zee", bool_switch(), "")
         ("zak", value<int>(&i), "")
         ("opt", bool_switch(), "")
         ;
+    // clang-format on
 
     const char* cmdline4_[] = {"--zee", "--zak=13"};
     vector<string> cmdline4 =
@@ -77,11 +81,13 @@ void test_variable_map()
     HPX_TEST(i == 13);
 
     options_description desc2;
+    // clang-format off
     desc2.add_options()
         ("vee", value<string>()->default_value("42"))
         ("voo", value<string>())
         ("iii", value<int>()->default_value(123))
-    ;
+        ;
+    // clang-format on
 
     const char* cmdline5_[] = {"--voo=1"};
     vector<string> cmdline5 =
@@ -97,12 +103,14 @@ void test_variable_map()
     HPX_TEST(vm3["iii"].as<int>() == 123);
 
     options_description desc3;
+    // clang-format off
     desc3.add_options()
         ("imp", value<int>()->implicit_value(100))
         ("iim", value<int>()->implicit_value(200)->default_value(201))
         ("mmp,m", value<int>()->implicit_value(123)->default_value(124))
         ("foo", value<int>())
-    ;
+        ;
+    // clang-format on
 
     /* The -m option is implicit. It does not have value in inside the token,
        and we should not grab the next token.  */
@@ -130,6 +138,7 @@ void notifier(const vector<int>& v)
 void test_semantic_values()
 {
     options_description desc;
+    // clang-format off
     desc.add_options()
         ("foo", new untyped_value())
         ("bar", value<int>())
@@ -137,6 +146,7 @@ void test_semantic_values()
         ("baz", value< vector<string> >()->multitoken())
         ("int", value< vector<int> >()->notifier(&notifier))
     ;
+    // clang-format on
 
     parsed_options parsed(&desc);
     vector<option>& options = parsed.options;
@@ -155,11 +165,11 @@ void test_semantic_values()
     notify(vm);
     HPX_TEST(vm.count("biz") == 1);
     HPX_TEST(vm.count("baz") == 1);
-    const vector<string> av = vm["biz"].as< vector<string> >();
-    const vector<string> av2 = vm["baz"].as< vector<string> >();
-    string exp1[] = { "a", "b x" };
+    const vector<string> av = vm["biz"].as<vector<string>>();
+    const vector<string> av2 = vm["baz"].as<vector<string>>();
+    string exp1[] = {"a", "b x"};
     HPX_TEST(av == vector<string>(exp1, exp1 + 2));
-    string exp2[] = { "q", "q", "w" };
+    string exp2[] = {"q", "q", "w"};
     HPX_TEST(av2 == vector<string>(exp2, exp2 + 3));
 
     options.emplace_back(option("int", vector<string>(1, "13")));
@@ -168,7 +178,7 @@ void test_semantic_values()
     store(parsed, vm2);
     notify(vm2);
     HPX_TEST(vm2.count("int") == 1);
-    HPX_TEST(vm2["int"].as< vector<int> >() == vector<int>(1, 13));
+    HPX_TEST(vm2["int"].as<vector<int>>() == vector<int>(1, 13));
     HPX_TEST_EQ(stored_value, 13);
 
     vector<option> saved_options = options;
@@ -189,16 +199,15 @@ void test_priority()
 {
     options_description desc;
     desc.add_options()
-    // Value of this option will be specified in two sources,
-    // and only first one should be used.
-    ("first", value< vector<int > >())
-    // Value of this option will have default value in the first source,
-    // and explicit assignment in the second, so the second should be used.
-    ("second", value< vector<int > >()->default_value(vector<int>(1, 1), ""))
-    ("aux", value< vector<int > >())
-     // This will have values in both sources, and values should be combined
-    ("include", value< vector<int> >()->composing())
-    ;
+        // Value of this option will be specified in two sources,
+        // and only first one should be used.
+        ("first", value<vector<int>>())
+        // Value of this option will have default value in the first source,
+        // and explicit assignment in the second, so the second should be used.
+        ("second", value<vector<int>>()->default_value(vector<int>(1, 1), ""))(
+            "aux", value<vector<int>>())
+        // This will have values in both sources, and values should be combined
+        ("include", value<vector<int>>()->composing());
 
     const char* cmdline1_[] = {
         "--first=1", "--aux=10", "--first=3", "--include=1"};
@@ -217,31 +226,31 @@ void test_priority()
     store(p1, vm);
 
     HPX_TEST(vm.count("first") == 1);
-    HPX_TEST(vm["first"].as< vector<int> >().size() == 2);
-    HPX_TEST_EQ(vm["first"].as< vector<int> >()[0], 1);
-    HPX_TEST_EQ(vm["first"].as< vector<int> >()[1], 3);
+    HPX_TEST(vm["first"].as<vector<int>>().size() == 2);
+    HPX_TEST_EQ(vm["first"].as<vector<int>>()[0], 1);
+    HPX_TEST_EQ(vm["first"].as<vector<int>>()[1], 3);
 
     HPX_TEST(vm.count("second") == 1);
-    HPX_TEST(vm["second"].as< vector<int> >().size() == 1);
-    HPX_TEST_EQ(vm["second"].as< vector<int> >()[0], 1);
+    HPX_TEST(vm["second"].as<vector<int>>().size() == 1);
+    HPX_TEST_EQ(vm["second"].as<vector<int>>()[0], 1);
 
     store(p2, vm);
 
     // Value should not change.
     HPX_TEST(vm.count("first") == 1);
-    HPX_TEST(vm["first"].as< vector<int> >().size() == 2);
-    HPX_TEST_EQ(vm["first"].as< vector<int> >()[0], 1);
-    HPX_TEST_EQ(vm["first"].as< vector<int> >()[1], 3);
+    HPX_TEST(vm["first"].as<vector<int>>().size() == 2);
+    HPX_TEST_EQ(vm["first"].as<vector<int>>()[0], 1);
+    HPX_TEST_EQ(vm["first"].as<vector<int>>()[1], 3);
 
     // Value should change to 7
     HPX_TEST(vm.count("second") == 1);
-    HPX_TEST(vm["second"].as< vector<int> >().size() == 1);
-    HPX_TEST_EQ(vm["second"].as< vector<int> >()[0], 7);
+    HPX_TEST(vm["second"].as<vector<int>>().size() == 1);
+    HPX_TEST_EQ(vm["second"].as<vector<int>>()[0], 7);
 
     HPX_TEST(vm.count("include") == 1);
-    HPX_TEST(vm["include"].as< vector<int> >().size() == 2);
-    HPX_TEST_EQ(vm["include"].as< vector<int> >()[0], 1);
-    HPX_TEST_EQ(vm["include"].as< vector<int> >()[1], 7);
+    HPX_TEST(vm["include"].as<vector<int>>().size() == 2);
+    HPX_TEST_EQ(vm["include"].as<vector<int>>()[0], 1);
+    HPX_TEST_EQ(vm["include"].as<vector<int>>()[1], 7);
 }
 
 void test_multiple_assignments_with_different_option_description()
@@ -251,15 +260,12 @@ void test_multiple_assignments_with_different_option_description()
     // in the options description provided the second time, we don't crash.
 
     options_description desc1("");
-    desc1.add_options()
-        ("help,h", "")
-        ("includes", value< vector<string> >()->composing(), "");
-        ;
+    desc1.add_options()("help,h", "")(
+        "includes", value<vector<string>>()->composing(), "");
+    ;
 
     options_description desc2("");
-    desc2.add_options()
-        ("output,o", "")
-        ;
+    desc2.add_options()("output,o", "");
 
     vector<string> input1;
     input1.emplace_back("--help");
@@ -274,7 +280,6 @@ void test_multiple_assignments_with_different_option_description()
     input3.emplace_back("--includes=b");
     parsed_options p3 = command_line_parser(input3).options(desc1).run();
 
-
     variables_map vm;
     store(p1, vm);
     store(p2, vm);
@@ -282,17 +287,16 @@ void test_multiple_assignments_with_different_option_description()
 
     HPX_TEST(vm.count("help") == 1);
     HPX_TEST(vm.count("includes") == 1);
-    HPX_TEST_EQ(vm["includes"].as< vector<string> >()[0], "a");
-    HPX_TEST_EQ(vm["includes"].as< vector<string> >()[1], "b");
+    HPX_TEST_EQ(vm["includes"].as<vector<string>>()[0], "a");
+    HPX_TEST_EQ(vm["includes"].as<vector<string>>()[1], "b");
 }
 
-int main(int, char* [])
+int main(int, char*[])
 {
     test_variable_map();
     test_semantic_values();
     test_priority();
     test_multiple_assignments_with_different_option_description();
 
-    return  hpx::util::report_errors();
+    return hpx::util::report_errors();
 }
-

--- a/libs/program_options/tests/unit/winmain.cpp
+++ b/libs/program_options/tests/unit/winmain.cpp
@@ -6,10 +6,9 @@
 #include <hpx/hpx_main.hpp>
 
 #if defined(HPX_WINDOWS)
-#include <hpx/testing.hpp>
 #include <hpx/preprocessor/cat.hpp>
 #include <hpx/program_options/parsers.hpp>
-
+#include <hpx/testing.hpp>
 
 #include <cctype>
 #include <cstdlib>
@@ -20,7 +19,8 @@
 using namespace hpx::program_options;
 using namespace std;
 
-void check_equal(const std::vector<string>& actual, char const**expected, int n)
+void check_equal(
+    const std::vector<string>& actual, char const** expected, int n)
 {
     if (actual.size() != n)
     {
@@ -47,8 +47,7 @@ void check_equal(const std::vector<string>& actual, char const**expected, int n)
 
 void test_winmain()
 {
-
-// The following expectations were obtained in Win2000 shell:
+    // The following expectations were obtained in Win2000 shell:
     TEST("1 ", {"1"});
     TEST("1\"2\" ", {"12"});
     TEST("1\"2  ", {"12  "});


### PR DESCRIPTION
This just disables some more tests when using older versions of Boost that don't support the tested functionality. Flyby: disable building `program_options` tests as part of the `all` target.
