### PR TITLE
Switching the use of message(STATUS "...") to hpx_info

### DIFF
--- a/libs/algorithms/tests/CMakeLists.txt
+++ b/libs/algorithms/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_ALGORITHMS_WITH_TESTS)
-  message(STATUS "Tests for algorithms disabled")
+  hpx_info("    Tests for algorithms disabled")
   return()
 endif()
 

--- a/libs/allocator_support/tests/CMakeLists.txt
+++ b/libs/allocator_support/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_ALLOCATOR_SUPPORT_WITH_TESTS)
-  message(STATUS "Tests for allocator_support disabled")
+  hpx_info("    Tests for allocator_support disabled")
   return()
 endif()
 

--- a/libs/assertion/tests/CMakeLists.txt
+++ b/libs/assertion/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_ASSERTION_WITH_TESTS)
-  message(STATUS "Tests for assertion disabled")
+  hpx_info("    Tests for assertion disabled")
   return()
 endif()
 

--- a/libs/cache/tests/CMakeLists.txt
+++ b/libs/cache/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_CACHE_WITH_TESTS)
-  message(STATUS "Tests for cache disabled")
+  hpx_info("    Tests for cache disabled")
   return()
 endif()
 

--- a/libs/collectives/tests/CMakeLists.txt
+++ b/libs/collectives/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_COLLECTIVES_WITH_TESTS)
-  message(STATUS "Tests for collectives disabled")
+  hpx_info("    Tests for collectives disabled")
   return()
 endif()
 

--- a/libs/concepts/tests/CMakeLists.txt
+++ b/libs/concepts/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_CONCEPTS_WITH_TESTS)
-  message(STATUS "Tests for concepts disabled")
+  hpx_info("    Tests for concepts disabled")
   return()
 endif()
 

--- a/libs/concurrency/tests/CMakeLists.txt
+++ b/libs/concurrency/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_CONCURRENCY_WITH_TESTS)
-  message(STATUS "Tests for concurrency disabled")
+  hpx_info("    Tests for concurrency disabled")
   return()
 endif()
 

--- a/libs/config/tests/CMakeLists.txt
+++ b/libs/config/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_CONFIG_WITH_TESTS)
-  message(STATUS "Tests for config disabled")
+  hpx_info("    Tests for config disabled")
   return()
 endif()
 

--- a/libs/create_library_skeleton.py
+++ b/libs/create_library_skeleton.py
@@ -97,6 +97,7 @@ endif()
 '''
 
 tests_cmakelists_template = cmake_header + f'''
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -104,7 +105,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_{lib_name_upper}_WITH_TESTS)
-  message(STATUS "Tests for {lib_name} disabled")
+  hpx_info("    Tests for {lib_name} disabled")
   return()
 endif()
 

--- a/libs/datastructures/tests/CMakeLists.txt
+++ b/libs/datastructures/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_DATASTRUCTURES_WITH_TESTS)
-  message(STATUS "Tests for datastructures disabled")
+  hpx_info("    Tests for datastructures disabled")
   return()
 endif()
 

--- a/libs/errors/tests/CMakeLists.txt
+++ b/libs/errors/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_ERRORS_WITH_TESTS)
-  message(STATUS "Tests for errors disabled")
+  hpx_info("    Tests for errors disabled")
   return()
 endif()
 

--- a/libs/filesystem/tests/CMakeLists.txt
+++ b/libs/filesystem/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_FILESYSTEM_WITH_TESTS)
-  message(STATUS "Tests for filesystem disabled")
+  hpx_info("    Tests for filesystem disabled")
   return()
 endif()
 

--- a/libs/format/tests/CMakeLists.txt
+++ b/libs/format/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_FORMAT_WITH_TESTS)
-  message(STATUS "Tests for format disabled")
+  hpx_info("    Tests for format disabled")
   return()
 endif()
 

--- a/libs/hardware/tests/CMakeLists.txt
+++ b/libs/hardware/tests/CMakeLists.txt
@@ -3,12 +3,15 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
+include(HPX_Option)
+
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   hpx_set_option(HPX_HARDWARE_WITH_TESTS VALUE OFF FORCE)
   return()
 endif()
 if (NOT HPX_HARDWARE_WITH_TESTS)
-  message(STATUS "Tests for hardware disabled")
+  hpx_info("    Tests for hardware disabled")
   return()
 endif()
 

--- a/libs/hashing/tests/CMakeLists.txt
+++ b/libs/hashing/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_HASHING_WITH_TESTS)
-  message(STATUS "Tests for hashing disabled")
+  hpx_info("    Tests for hashing disabled")
   return()
 endif()
 

--- a/libs/iterator_support/tests/CMakeLists.txt
+++ b/libs/iterator_support/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_ITERATOR_SUPPORT_WITH_TESTS)
-  message(STATUS "Tests for iterator_support disabled")
+  hpx_info("    Tests for iterator_support disabled")
   return()
 endif()
 

--- a/libs/logging/tests/CMakeLists.txt
+++ b/libs/logging/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_LOGGING_WITH_TESTS)
-  message(STATUS "Tests for logging disabled")
+  hpx_info("    Tests for logging disabled")
   return()
 endif()
 

--- a/libs/parallel_executors/tests/CMakeLists.txt
+++ b/libs/parallel_executors/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_PARALLEL_EXECUTORS_WITH_TESTS)
-  message(STATUS "Tests for parallel_executors disabled")
+  hpx_info("    Tests for parallel_executors disabled")
   return()
 endif()
 

--- a/libs/preprocessor/tests/CMakeLists.txt
+++ b/libs/preprocessor/tests/CMakeLists.txt
@@ -3,12 +3,15 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
+include(HPX_Option)
+
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   hpx_set_option(HPX_PREPROCESSOR_WITH_TESTS VALUE OFF FORCE)
   return()
 endif()
 if (NOT HPX_PREPROCESSOR_WITH_TESTS)
-  message(STATUS "Tests for preprocessor disabled")
+  hpx_info("    Tests for preprocessor disabled")
   return()
 endif()
 

--- a/libs/program_options/tests/CMakeLists.txt
+++ b/libs/program_options/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_PROGRAM_OPTIONS_WITH_TESTS)
-  message(STATUS "Tests for program_options disabled")
+  hpx_info("    Tests for program_options disabled")
   return()
 endif()
 

--- a/libs/resiliency/tests/CMakeLists.txt
+++ b/libs/resiliency/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_RESILIENCY_WITH_TESTS)
-  message(STATUS "Tests for resiliency disabled")
+  hpx_info("    Tests for resiliency disabled")
   return()
 endif()
 

--- a/libs/segmented_algorithms/tests/CMakeLists.txt
+++ b/libs/segmented_algorithms/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_SEGMENTED_ALGORITHMS_WITH_TESTS)
-  message(STATUS "Tests for segmented_algorithms disabled")
+  hpx_info("    Tests for segmented_algorithms disabled")
   return()
 endif()
 

--- a/libs/statistics/tests/CMakeLists.txt
+++ b/libs/statistics/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_STATISTICS_WITH_TESTS)
-  message(STATUS "Tests for statistics disabled")
+  hpxInfo("    Tests for statistics disabled")
   return()
 endif()
 

--- a/libs/statistics/tests/CMakeLists.txt
+++ b/libs/statistics/tests/CMakeLists.txt
@@ -11,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_STATISTICS_WITH_TESTS)
-  hpxInfo("    Tests for statistics disabled")
+  hpx_info("    Tests for statistics disabled")
   return()
 endif()
 

--- a/libs/testing/tests/CMakeLists.txt
+++ b/libs/testing/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_TESTING_WITH_TESTS)
-  message(STATUS "Tests for test disabled")
+  hpx_info("    Tests for test disabled")
   return()
 endif()
 

--- a/libs/thread_support/tests/CMakeLists.txt
+++ b/libs/thread_support/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_THREAD_SUPPORT_WITH_TESTS)
-  message(STATUS "Tests for thread_support disabled")
+  hpx_info("    Tests for thread_support disabled")
   return()
 endif()
 

--- a/libs/timing/tests/CMakeLists.txt
+++ b/libs/timing/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_TIMING_WITH_TESTS)
-  message(STATUS "Tests for timing disabled")
+  hpx_info("    Tests for timing disabled")
   return()
 endif()
 

--- a/libs/topology/tests/CMakeLists.txt
+++ b/libs/topology/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_TOPOLOGY_WITH_TESTS)
-  message(STATUS "Tests for topology disabled")
+  hpx_info("    Tests for topology disabled")
   return()
 endif()
 

--- a/libs/type_support/tests/CMakeLists.txt
+++ b/libs/type_support/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_TYPE_SUPPORT_WITH_TESTS)
-  message(STATUS "Tests for type_support disabled")
+  hpx_info("    Tests for type_support disabled")
   return()
 endif()
 

--- a/libs/util/tests/CMakeLists.txt
+++ b/libs/util/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_Message)
 include(HPX_Option)
 
 if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
@@ -10,7 +11,7 @@ if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()
 endif()
 if (NOT HPX_UTIL_WITH_TESTS)
-  message(STATUS "Tests for util disabled")
+  hpx_info("    Tests for util disabled")
   return()
 endif()
 


### PR DESCRIPTION
- indenting cmake output generated from module configuration

This just cleans up the generated output from module configuration.
