### PR TITLE
Adding option allowing to force using Boost.FileSystem

### DIFF
--- a/libs/filesystem/CMakeLists.txt
+++ b/libs/filesystem/CMakeLists.txt
@@ -5,17 +5,40 @@
 
 cmake_minimum_required(VERSION 3.3.2 FATAL_ERROR)
 
+set(__filesystem_compatibility_default ON)
+if(HPX_WITH_CXX17_FILESYSTEM)
+  set(__filesystem_compatibility_default OFF)
+endif()
+
+# Compatibility with using Boost.FileSystem, introduced in V1.4.0
+hpx_option(HPX_FILESYSTEM_WITH_BOOST_FILESYSTEM_COMPATIBILITY
+  BOOL "Enable Boost.FileSystem compatibility. (default: ${__filesystem_compatibility_default})"
+  ON ADVANCED CATEGORY "Modules")
+
 set(__boost_filesystem)
-if(NOT HPX_WITH_CXX17_FILESYSTEM)
+if(HPX_FILESYSTEM_WITH_BOOST_FILESYSTEM_COMPATIBILITY)
+
+  hpx_add_config_define_namespace(
+    DEFINE HPX_FILESYSTEM_HAVE_BOOST_FILESYSTEM_COMPATIBILITY
+    NAMESPACE FILESYSTEM)
+
   find_package(Boost ${Boost_MINIMUM_VERSION}
     QUIET MODULE
     COMPONENTS filesystem)
   if(Boost_FILESYSTEM_FOUND)
     set(__boost_filesystem ${Boost_LIBRARIES})
   else()
-    hpx_error("Could not find Boost.Filesystem. Provide a boost installation including the filesystem library or use a compiler with support for the C++17 filesystem library")
+    hpx_error("Could not find Boost.Filesystem. Provide a boost installation "
+      "including the filesystem library or use a compiler with support for the "
+      "C++17 filesystem library")
   endif()
   hpx_libraries(${Boost_LIBRARIES})
+else()
+  if(NOT HPX_WITH_CXX17_FILESYSTEM)
+    hpx_error("Could not find std::filesystem. Use a compiler with support for "
+      "the C++17 filesystem library or enable Boost.FileSystem compatibility "
+      "(set HPX_FILESYSTEM_WITH_BOOST_FILESYSTEM_COMPATIBILITY to ON)")
+  endif()
 endif()
 
 set(filesystem_headers "hpx/filesystem.hpp")
@@ -25,6 +48,12 @@ add_hpx_module(filesystem
   FORCE_LINKING_GEN
   GLOBAL_HEADER_GEN OFF
   HEADERS ${filesystem_headers}
-  DEPENDENCIES hpx_config ${__boost_filesystem}
+  DEPENDENCIES
+    hpx_config
+    ${__boost_filesystem}
   CMAKE_SUBDIRS examples tests
 )
+
+if(HPX_FILESYSTEM_WITH_BOOST_FILESYSTEM_COMPATIBILITY)
+  hpx_info("    Boost library found: filesystem")
+endif()

--- a/libs/filesystem/include/hpx/filesystem.hpp
+++ b/libs/filesystem/include/hpx/filesystem.hpp
@@ -16,8 +16,9 @@
 #define HPX_FILESYSTEM_HPP
 
 #include <hpx/config.hpp>
+#include <hpx/filesystem/config/defines.hpp>
 
-#if defined(HPX_HAVE_CXX17_FILESYSTEM)
+#if !defined(HPX_FILESYSTEM_HAVE_BOOST_FILESYSTEM_COMPATIBILITY)
 #include <filesystem>
 #include <system_error>
 

--- a/src/util/parse_command_line.cpp
+++ b/src/util/parse_command_line.cpp
@@ -285,13 +285,13 @@ namespace hpx { namespace util
                 // here. Boost filesystem returns an empty path for
                 // "/".parent_path() whereas C++17 filesystem will keep
                 // returning "/".
-#if defined(HPX_HAVE_CXX17_FILESYSTEM)
+#if !defined(HPX_FILESYSTEM_HAVE_BOOST_FILESYSTEM_COMPATIBILITY)
                 auto dir_prev = dir;
-#endif
                 dir = dir.parent_path();    // chop off last directory part
-#if defined(HPX_HAVE_CXX17_FILESYSTEM)
                 if (dir_prev == dir)
                     break;
+#else
+                dir = dir.parent_path();    // chop off last directory part
 #endif
             }
         }


### PR DESCRIPTION
- this is useful in situations where other parts of an application rely on Boost.FileSystem
