### PR TITLE
Fix compilation on GCC 5

### DIFF
--- a/libs/plugin/include/hpx/plugin/export_plugin.hpp
+++ b/libs/plugin/include/hpx/plugin/export_plugin.hpp
@@ -108,7 +108,7 @@
                 std::transform(actname.begin(), actname.end(),                 \
                     actname.begin(), [](char c) { return std::tolower(c); });  \
                 HPX_PLUGIN_LIST_NAME_(prefix, name, classname)()->             \
-                    insert(std::make_pair(actname, w));                        \
+                    insert(std::make_pair(actname, hpx::util::any_nonser(w))); \
             }                                                                  \
         } HPX_PLUGIN_EXPORTER_INSTANCE_NAME_(                                  \
             prefix, name, actualname, classname);                              \


### PR DESCRIPTION
Fixes compilation on GCC 5 after #4050. It looks like our `any` constructor here: https://github.com/STEllAR-GROUP/hpx/blob/7305142684e4872f82a093c08d889c0f384f235e/libs/datastructures/include/hpx/datastructures/any.hpp#L457-L468 should not actually be explicit according to [cppreference](https://en.cppreference.com/w/cpp/utility/any/any). If that's the case I'll change the constructor instead of the construction. @hkaiser @K-ballo do you know what the correct thing to do here is?