### PR TITLE
Make counters in coroutines optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,7 +340,7 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
 endif()
 
 hpx_option(HPX_WITH_IO_COUNTERS BOOL
-  "Build HPX runtime (default: ${HPX_WITH_IO_COUNTERS_DEFAULT})"
+  "Enable IO counters (default: ${HPX_WITH_IO_COUNTERS_DEFAULT})"
   ${HPX_WITH_IO_COUNTERS_DEFAULT} ADVANCED CATEGORY "Build Targets")
 if(HPX_WITH_IO_COUNTERS)
   hpx_add_config_define(HPX_HAVE_IO_COUNTERS)
@@ -604,7 +604,7 @@ endif()
 
 hpx_option(HPX_WITH_COROUTINE_COUNTS BOOL
   "Enable keeping track of coroutine creation and rebind counts (default: OFF)"
-   ADVANCED CATEGORY "Thread Manager")
+   OFF CATEGORY "Thread Manager" ADVANCED)
 if(HPX_WITH_COROUTINE_COUNTS)
   hpx_add_config_define(HPX_HAVE_COROUTINE_COUNTS)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -602,11 +602,11 @@ if(HPX_WITH_THREAD_STEALING_COUNTS)
   hpx_add_config_define(HPX_HAVE_THREAD_STEALING_COUNTS)
 endif()
 
-hpx_option(HPX_WITH_COROUTINE_COUNTS BOOL
+hpx_option(HPX_WITH_COROUTINE_COUNTERS BOOL
   "Enable keeping track of coroutine creation and rebind counts (default: OFF)"
    OFF CATEGORY "Thread Manager" ADVANCED)
-if(HPX_WITH_COROUTINE_COUNTS)
-  hpx_add_config_define(HPX_HAVE_COROUTINE_COUNTS)
+if(HPX_WITH_COROUTINE_COUNTERS)
+  hpx_add_config_define(HPX_HAVE_COROUTINE_COUNTERS)
 endif()
 
 hpx_option(HPX_WITH_THREAD_LOCAL_STORAGE BOOL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -602,6 +602,13 @@ if(HPX_WITH_THREAD_STEALING_COUNTS)
   hpx_add_config_define(HPX_HAVE_THREAD_STEALING_COUNTS)
 endif()
 
+hpx_option(HPX_WITH_COROUTINE_COUNTS BOOL
+  "Enable keeping track of coroutine creation and rebind counts (default: OFF)"
+   ADVANCED CATEGORY "Thread Manager")
+if(HPX_WITH_COROUTINE_COUNTS)
+  hpx_add_config_define(HPX_HAVE_COROUTINE_COUNTS)
+endif()
+
 hpx_option(HPX_WITH_THREAD_LOCAL_STORAGE BOOL
   "Enable thread local storage for all HPX threads (default: OFF)"
   OFF CATEGORY "Thread Manager" ADVANCED)

--- a/hpx/runtime/threads/coroutines/detail/context_generic_context.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_generic_context.hpp
@@ -241,7 +241,7 @@ namespace hpx { namespace threads { namespace coroutines
                         static_cast<char*>(stack_pointer_) - stack_size_;
                     if (posix::reset_stack(limit, stack_size_))
                     {
-#if defined(HPX_HAVE_COROUTINE_COUNTS)
+#if defined(HPX_HAVE_COROUTINE_COUNTERS)
                         increment_stack_unbind_count();
 #endif
                     }
@@ -255,7 +255,7 @@ namespace hpx { namespace threads { namespace coroutines
             {
                 if (ctx_)
                 {
-#if defined(HPX_HAVE_COROUTINE_COUNTS)
+#if defined(HPX_HAVE_COROUTINE_COUNTERS)
                     increment_stack_recycle_count();
 #endif
                     ctx_ = boost::context::detail::make_fcontext(
@@ -263,7 +263,7 @@ namespace hpx { namespace threads { namespace coroutines
                 }
             }
 
-#if defined(HPX_HAVE_COROUTINE_COUNTS)
+#if defined(HPX_HAVE_COROUTINE_COUNTERS)
             typedef std::atomic<std::int64_t> counter_type;
 
         private:

--- a/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_linux_x86.hpp
@@ -323,7 +323,7 @@ namespace hpx { namespace threads { namespace coroutines
                 if (posix::reset_stack(
                     m_stack, static_cast<std::size_t>(m_stack_size)))
                 {
-#if defined(HPX_HAVE_COROUTINE_COUNTS)
+#if defined(HPX_HAVE_COROUTINE_COUNTERS)
                     increment_stack_unbind_count();
 #endif
                 }
@@ -332,7 +332,7 @@ namespace hpx { namespace threads { namespace coroutines
             void rebind_stack()
             {
                 HPX_ASSERT(m_stack);
-#if defined(HPX_HAVE_COROUTINE_COUNTS)
+#if defined(HPX_HAVE_COROUTINE_COUNTERS)
                 increment_stack_recycle_count();
 #endif
 
@@ -359,7 +359,7 @@ namespace hpx { namespace threads { namespace coroutines
 
             typedef std::atomic<std::int64_t> counter_type;
 
-#if defined(HPX_HAVE_COROUTINE_COUNTS)
+#if defined(HPX_HAVE_COROUTINE_COUNTERS)
         private:
             static counter_type& get_stack_unbind_counter()
             {

--- a/hpx/runtime/threads/coroutines/detail/context_posix.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_posix.hpp
@@ -351,7 +351,7 @@ namespace hpx { namespace threads { namespace coroutines
                     if (posix::reset_stack(
                         m_stack, static_cast<std::size_t>(m_stack_size)))
                     {
-#if defined(HPX_HAVE_COROUTINE_COUNTS)
+#if defined(HPX_HAVE_COROUTINE_COUNTERS)
                         increment_stack_unbind_count();
 #endif
                     }
@@ -364,7 +364,7 @@ namespace hpx { namespace threads { namespace coroutines
                 {
                     // just reset the context stack pointer to its initial value at
                     // the stack start
-#if defined(HPX_HAVE_COROUTINE_COUNTS)
+#if defined(HPX_HAVE_COROUTINE_COUNTERS)
                     increment_stack_recycle_count();
 #endif
                     int error = HPX_COROUTINE_MAKE_CONTEXT(
@@ -375,7 +375,7 @@ namespace hpx { namespace threads { namespace coroutines
             }
 
 
-#if defined(HPX_HAVE_COROUTINE_COUNTS)
+#if defined(HPX_HAVE_COROUTINE_COUNTERS)
             typedef std::atomic<std::int64_t> counter_type;
 
         private:

--- a/hpx/runtime/threads/coroutines/detail/context_windows_fibers.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_windows_fibers.hpp
@@ -237,26 +237,32 @@ namespace hpx { namespace threads { namespace coroutines
 
             void rebind_stack() noexcept
             {
+#if defined(HPX_HAVE_COROUTINE_COUNTS)
                 increment_stack_recycle_count();
+#endif
             }
 
+#if defined(HPX_HAVE_COROUTINE_COUNTS)
             typedef std::atomic<std::int64_t> counter_type;
 
+        private:
             static counter_type& get_stack_recycle_counter() noexcept
             {
                 static counter_type counter(0);
                 return counter;
             }
 
-            static std::uint64_t get_stack_recycle_count(bool reset) noexcept
-            {
-                return util::get_and_reset_value(get_stack_recycle_counter(), reset);
-            }
-
             static std::uint64_t increment_stack_recycle_count() noexcept
             {
                 return ++get_stack_recycle_counter();
             }
+
+        public:
+            static std::uint64_t get_stack_recycle_count(bool reset) noexcept
+            {
+                return util::get_and_reset_value(get_stack_recycle_counter(), reset);
+            }
+#endif
 
         private:
             std::ptrdiff_t stacksize_;

--- a/hpx/runtime/threads/coroutines/detail/context_windows_fibers.hpp
+++ b/hpx/runtime/threads/coroutines/detail/context_windows_fibers.hpp
@@ -237,12 +237,12 @@ namespace hpx { namespace threads { namespace coroutines
 
             void rebind_stack() noexcept
             {
-#if defined(HPX_HAVE_COROUTINE_COUNTS)
+#if defined(HPX_HAVE_COROUTINE_COUNTERS)
                 increment_stack_recycle_count();
 #endif
             }
 
-#if defined(HPX_HAVE_COROUTINE_COUNTS)
+#if defined(HPX_HAVE_COROUTINE_COUNTERS)
             typedef std::atomic<std::int64_t> counter_type;
 
         private:

--- a/src/runtime/threads/threadmanager_counters.cpp
+++ b/src/runtime/threads/threadmanager_counters.cpp
@@ -371,6 +371,7 @@ namespace hpx { namespace threads {
 
         ///////////////////////////////////////////////////////////////////////////
         // thread counts counter creation function
+#if defined(HPX_HAVE_COROUTINE_COUNTS)
         naming::gid_type thread_counts_counter_creator(
             performance_counters::counter_info const& info, error_code& ec)
         {
@@ -420,13 +421,16 @@ namespace hpx { namespace threads {
                 "invalid counter instance name: " + paths.instancename_);
             return naming::invalid_gid;
         }
+#endif
     }
 
     ///////////////////////////////////////////////////////////////////////////
     void register_counter_types(threadmanager& tm)
     {
+#if defined(HPX_HAVE_COROUTINE_COUNTS)
         performance_counters::create_counter_func counts_creator(
             util::bind_front(&detail::thread_counts_counter_creator));
+#endif
 
         performance_counters::generic_counter_type_data counter_types[] = {
             // length of thread queue(s)
@@ -699,6 +703,7 @@ namespace hpx { namespace threads {
                     &thread_pool_base::get_thread_count_staged),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 ""},
+#if defined(HPX_HAVE_COROUTINE_COUNTS)
             {"/threads/count/stack-recycles", performance_counters::counter_raw,
                 "returns the total number of HPX-thread recycling operations "
                 "performed for the referenced locality",
@@ -716,6 +721,7 @@ namespace hpx { namespace threads {
                 "the referenced locality",
                 HPX_PERFORMANCE_COUNTER_V1, counts_creator,
                 &detail::locality_allocator_counter_discoverer, ""},
+#endif
 #ifdef HPX_HAVE_THREAD_STEALING_COUNTS
             {"/threads/count/pending-misses", performance_counters::counter_raw,
                 "returns the number of times that the referenced worker-thread "

--- a/src/runtime/threads/threadmanager_counters.cpp
+++ b/src/runtime/threads/threadmanager_counters.cpp
@@ -371,7 +371,7 @@ namespace hpx { namespace threads {
 
         ///////////////////////////////////////////////////////////////////////////
         // thread counts counter creation function
-#if defined(HPX_HAVE_COROUTINE_COUNTS)
+#if defined(HPX_HAVE_COROUTINE_COUNTERS)
         naming::gid_type thread_counts_counter_creator(
             performance_counters::counter_info const& info, error_code& ec)
         {
@@ -427,7 +427,7 @@ namespace hpx { namespace threads {
     ///////////////////////////////////////////////////////////////////////////
     void register_counter_types(threadmanager& tm)
     {
-#if defined(HPX_HAVE_COROUTINE_COUNTS)
+#if defined(HPX_HAVE_COROUTINE_COUNTERS)
         performance_counters::create_counter_func counts_creator(
             util::bind_front(&detail::thread_counts_counter_creator));
 #endif
@@ -703,7 +703,7 @@ namespace hpx { namespace threads {
                     &thread_pool_base::get_thread_count_staged),
                 &performance_counters::locality_pool_thread_counter_discoverer,
                 ""},
-#if defined(HPX_HAVE_COROUTINE_COUNTS)
+#if defined(HPX_HAVE_COROUTINE_COUNTERS)
             {"/threads/count/stack-recycles", performance_counters::counter_raw,
                 "returns the total number of HPX-thread recycling operations "
                 "performed for the referenced locality",

--- a/tests/unit/performance_counter/all_counters.cpp
+++ b/tests/unit/performance_counter/all_counters.cpp
@@ -73,9 +73,11 @@ char const* const locality_pool_thread_no_total_counter_names[] =
 
 char const* const locality_counter_names[] =
 {
+#if defined(HPX_HAVE_COROUTINE_COUNTERS)
     "/threads/count/stack-recycles",
 #if !defined(HPX_WINDOWS) && !defined(HPX_HAVE_GENERIC_CONTEXT_COROUTINES)
     "/threads/count/stack-unbinds",
+#endif
 #endif
     "/scheduler/utilization/instantaneous",
     nullptr


### PR DESCRIPTION
Makes the counters optional and turns them off by default. Saves us some cache misses when creating and rebinding threads. It makes a small but noticeable difference in the `future_overheads` benchmark.