### PR TITLE
Fix initialization of global_num_tasks in parallel_executor

### DIFF
--- a/libs/collectives/CMakeLists.txt
+++ b/libs/collectives/CMakeLists.txt
@@ -63,6 +63,7 @@ add_hpx_module(collectives
       hpx_execution
       hpx_format
       hpx_functional
+      hpx_hardware
       hpx_hashing
       hpx_iterator_support
       hpx_logging


### PR DESCRIPTION
Fixes deadlocks typically seen in the `1d_stencil` example caused by yielding while initializing a static variable. Details in commit message.

Also initializes `global_num_tasks` in the `parallel_executor` based on the number of threads in the current pool (or default pool if not on an HPX thread).