### PR TITLE
Function tests

### DIFF
--- a/libs/functional/include/hpx/functional/function_ref.hpp
+++ b/libs/functional/include/hpx/functional/function_ref.hpp
@@ -17,6 +17,7 @@
 
 #include <cstddef>
 #include <cstring>
+#include <functional>
 #include <memory>
 #include <string>
 #include <type_traits>
@@ -114,6 +115,17 @@ namespace hpx { namespace util {
             vptr = get_vtable<T>()->invoke;
 #endif
             object = reinterpret_cast<void*>(std::addressof(f));
+        }
+
+        template <typename T>
+        void assign(std::reference_wrapper<T> f_ref) noexcept
+        {
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+            vptr = get_vtable<T>();
+#else
+            vptr = get_vtable<T>()->invoke;
+#endif
+            object = reinterpret_cast<void*>(std::addressof(f_ref.get()));
         }
 
         template <typename T>

--- a/libs/functional/tests/unit/CMakeLists.txt
+++ b/libs/functional/tests/unit/CMakeLists.txt
@@ -18,7 +18,7 @@ set(function_tests
   stateless_test
   sum_avg
 )
-    
+
 add_hpx_pseudo_target(tests.unit.modules.functional.function)
 
 foreach(test ${function_tests})

--- a/libs/functional/tests/unit/CMakeLists.txt
+++ b/libs/functional/tests/unit/CMakeLists.txt
@@ -2,3 +2,38 @@
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# Function tests
+set(function_tests
+    #allocator_test
+  contains_test
+  function_args
+  function_arith
+  function_bind_test
+  function_ref
+  function_ref_wrapper
+  function_target
+  function_test
+  nothrow_swap
+  stateless_test
+  sum_avg
+)
+    
+add_hpx_pseudo_target(tests.unit.modules.functional.function)
+
+foreach(test ${function_tests})
+  set(sources function/${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  add_hpx_executable(${test}_test
+                     SOURCES ${sources}
+                     NOLIBS
+                     DEPENDENCIES hpx_functional hpx_testing
+                     EXCLUDE_FROM_ALL
+                     FOLDER "Tests/Unit/Modules/Functional/Function")
+
+  add_hpx_unit_test("modules.functional.function" ${test})
+
+endforeach()
+add_hpx_pseudo_dependencies(tests.unit.modules.functional tests.unit.modules.functional.function)

--- a/libs/functional/tests/unit/function/allocator_test.cpp
+++ b/libs/functional/tests/unit/function/allocator_test.cpp
@@ -10,7 +10,6 @@
 
 // For more information, see http://www.boost.org
 
-#include <hpx/hpx_init.hpp>
 #include <hpx/testing.hpp>
 #include <hpx/functional/function.hpp>
 
@@ -75,8 +74,7 @@ struct DoNothing: base
 
 static void do_nothing() {}
 
-int
-    test_main(int, char*[])
+int main(int, char*[])
 {
     hpx::util::function_nonser<int(int, int)> f;
     f.assign( plus_int<disable_small_object_optimization>(), counting_allocator<int>() );
@@ -136,5 +134,5 @@ int
     fv.assign(&do_nothing, std::allocator<int>() );
     fv2.assign(fv, std::allocator<int>() );
 
-    return 0;
+    return hpx::util::report_errors();
 }

--- a/libs/functional/tests/unit/function/contains_test.cpp
+++ b/libs/functional/tests/unit/function/contains_test.cpp
@@ -8,8 +8,7 @@
 //  1.0. (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/hpx_main.hpp>
-#include <hpx/include/util.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/testing.hpp>
 
 #include <functional>

--- a/libs/functional/tests/unit/function/function_args.cpp
+++ b/libs/functional/tests/unit/function/function_args.cpp
@@ -7,8 +7,7 @@
 
 // For more information, see http://www.boost.org
 
-#include <hpx/hpx_main.hpp>
-#include <hpx/include/util.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/testing.hpp>
 
 #include <iostream>

--- a/libs/functional/tests/unit/function/function_arith.cpp
+++ b/libs/functional/tests/unit/function/function_arith.cpp
@@ -10,8 +10,7 @@
 
 // For more information, see http://www.boost.org/
 
-#include <hpx/hpx_main.hpp>
-#include <hpx/include/util.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/testing.hpp>
 
 float mul_ints(int x, int y) { return ((float)x) * y; }

--- a/libs/functional/tests/unit/function/function_bind_test.cpp
+++ b/libs/functional/tests/unit/function/function_bind_test.cpp
@@ -10,8 +10,8 @@
 
 // For more information, see http://www.boost.org
 
-#include <hpx/hpx_main.hpp>
-#include <hpx/include/util.hpp>
+#include <hpx/functional/function.hpp>
+#include <hpx/functional/bind.hpp>
 #include <hpx/testing.hpp>
 
 #include <cstdlib>

--- a/libs/functional/tests/unit/function/function_ref.cpp
+++ b/libs/functional/tests/unit/function/function_ref.cpp
@@ -11,8 +11,6 @@
 
 // For more information, see http://www.boost.org
 
-#include <hpx/hpx.hpp>
-#include <hpx/hpx_init.hpp>
 #include <hpx/functional/function_ref.hpp>
 #include <hpx/testing.hpp>
 

--- a/libs/functional/tests/unit/function/function_ref_wrapper.cpp
+++ b/libs/functional/tests/unit/function/function_ref_wrapper.cpp
@@ -10,8 +10,7 @@
 
 // For more information, see http://www.boost.org/
 
-#include <hpx/hpx_main.hpp>
-#include <hpx/include/util.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/testing.hpp>
 
 #include <functional>

--- a/libs/functional/tests/unit/function/function_target.cpp
+++ b/libs/functional/tests/unit/function/function_target.cpp
@@ -3,7 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/hpx.hpp>
 #include <hpx/functional/function.hpp>
 #include <hpx/testing.hpp>
 
@@ -18,13 +17,13 @@ struct foo
 int main()
 {
     {
-        hpx::util::function<int()> fun = foo();
+        hpx::util::function_nonser<int()> fun = foo();
 
         HPX_TEST(fun.target<foo>() != nullptr);
     }
 
     {
-        hpx::util::function<int()> fun = foo();
+        hpx::util::function_nonser<int()> fun = foo();
 
         HPX_TEST(fun.target<foo const>() != nullptr);
     }

--- a/libs/functional/tests/unit/function/function_test.cpp
+++ b/libs/functional/tests/unit/function/function_test.cpp
@@ -20,8 +20,7 @@
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wdouble-promotion"
 #endif
-#include <hpx/hpx_main.hpp>
-#include <hpx/include/util.hpp>
+#include <hpx/functional/function.hpp>
 #if defined(__clang__)
 #  pragma clang diagnostic pop
 #elif defined(__GNUC__)

--- a/libs/functional/tests/unit/function/nothrow_swap.cpp
+++ b/libs/functional/tests/unit/function/nothrow_swap.cpp
@@ -11,8 +11,7 @@
 
 // For more information, see http://www.boost.org
 
-#include <hpx/hpx_main.hpp>
-#include <hpx/include/util.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/testing.hpp>
 
 struct tried_to_copy {};

--- a/libs/functional/tests/unit/function/stateless_test.cpp
+++ b/libs/functional/tests/unit/function/stateless_test.cpp
@@ -10,8 +10,7 @@
 
 // For more information, see http://www.boost.org
 
-#include <hpx/hpx_main.hpp>
-#include <hpx/include/util.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/testing.hpp>
 
 #include <cstddef>

--- a/libs/functional/tests/unit/function/sum_avg.cpp
+++ b/libs/functional/tests/unit/function/sum_avg.cpp
@@ -10,8 +10,7 @@
 
 // For more information, see http://www.boost.org/
 
-#include <hpx/hpx_main.hpp>
-#include <hpx/include/util.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/testing.hpp>
 
 void do_sum_avg(int values[], int n, int& sum, float& avg)

--- a/tests/unit/util/function/CMakeLists.txt
+++ b/tests/unit/util/function/CMakeLists.txt
@@ -4,18 +4,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
-    function_bind_test
-    contains_test
-    function_arith
-    function_args
     function_object_size
-    function_ref
-    function_ref_wrapper
-    function_target
-    function_test
-    nothrow_swap
-    stateless_test
-    sum_avg
    )
 
 foreach(test ${tests})


### PR DESCRIPTION
This PR moves some of the tests related to `hpx::util::function_nonser` to the functional module.

Flyby: function_ref now properly handles `std::reference_wrapper`
