### PR TITLE
Add this to lambda capture list

### DIFF
--- a/hpx/lcos/local/channel.hpp
+++ b/hpx/lcos/local/channel.hpp
@@ -266,7 +266,7 @@ namespace hpx { namespace lcos { namespace local
             }
             local::packaged_task<T()> pop_pt()
             {
-                return local::packaged_task<T()>([=, this]() -> T { return get(); });
+                return local::packaged_task<T()>([this]() -> T { return get(); });
             }
 
         public:

--- a/hpx/lcos/local/channel.hpp
+++ b/hpx/lcos/local/channel.hpp
@@ -266,7 +266,7 @@ namespace hpx { namespace lcos { namespace local
             }
             local::packaged_task<T()> pop_pt()
             {
-                return local::packaged_task<T()>([=]() -> T { return get(); });
+                return local::packaged_task<T()>([=, this]() -> T { return get(); });
             }
 
         public:

--- a/hpx/runtime/parcelset/parcelhandler.hpp
+++ b/hpx/runtime/parcelset/parcelhandler.hpp
@@ -194,11 +194,10 @@ namespace hpx { namespace parcelset
         ///                 id (if not already set).
         HPX_FORCEINLINE void put_parcel(parcel p)
         {
-            auto f =
-                [=, this](boost::system::error_code const& ec, parcel const& p) -> void
-                {
-                    invoke_write_handler(ec, p);
-                };
+            auto f = [this](boost::system::error_code const& ec,
+                         parcel const& p) -> void {
+                invoke_write_handler(ec, p);
+            };
 
             put_parcel(std::move(p), std::move(f));
         }
@@ -235,10 +234,9 @@ namespace hpx { namespace parcelset
         ///                 id (if not already set).
         void put_parcels(std::vector<parcel> parcels)
         {
-            std::vector<write_handler_type> handlers(parcels.size(), [=, this](
-                boost::system::error_code const& ec, parcel const & p) -> void {
-                    return invoke_write_handler(ec, p);
-                });
+            std::vector<write_handler_type> handlers(parcels.size(),
+                [this](boost::system::error_code const& ec, parcel const& p)
+                    -> void { return invoke_write_handler(ec, p); });
 
             put_parcels(std::move(parcels), std::move(handlers));
         }

--- a/hpx/runtime/parcelset/parcelhandler.hpp
+++ b/hpx/runtime/parcelset/parcelhandler.hpp
@@ -195,7 +195,7 @@ namespace hpx { namespace parcelset
         HPX_FORCEINLINE void put_parcel(parcel p)
         {
             auto f =
-                [=](boost::system::error_code const& ec, parcel const& p) -> void
+                [=, this](boost::system::error_code const& ec, parcel const& p) -> void
                 {
                     invoke_write_handler(ec, p);
                 };
@@ -235,7 +235,7 @@ namespace hpx { namespace parcelset
         ///                 id (if not already set).
         void put_parcels(std::vector<parcel> parcels)
         {
-            std::vector<write_handler_type> handlers(parcels.size(), [=](
+            std::vector<write_handler_type> handlers(parcels.size(), [=, this](
                 boost::system::error_code const& ec, parcel const & p) -> void {
                     return invoke_write_handler(ec, p);
                 });


### PR DESCRIPTION
The implicit capture of 'this' by default by-value capture is deprecated in C++20.  This revision is intended to address this change (and to eliminate numerous warnings when building code).
