### PR TITLE
use std::round for guaranteed rounding without errors

### DIFF
--- a/src/runtime/threads/policies/parse_affinity_options.cpp
+++ b/src/runtime/threads/policies/parse_affinity_options.cpp
@@ -42,6 +42,7 @@ BOOST_FUSION_ADAPT_STRUCT(
     (hpx::threads::detail::spec_type::type, type_)
 )
 
+
 namespace hpx { namespace threads { namespace detail
 {
     static char const* const type_names[] =
@@ -1037,9 +1038,8 @@ namespace hpx { namespace threads { namespace detail
         std::size_t pus_t2 = 0;
         for (std::size_t n = 0; n < num_numas; ++n)
         {
-            std::size_t temp = static_cast<std::size_t>(std::floor(0.5 +
-                static_cast<double>(num_threads) * num_pus_numa[n] /
-                    pus_t));
+            std::size_t temp = static_cast<std::size_t>(std::round(
+                static_cast<double>(num_threads * num_pus_numa[n]) / pus_t));
 
             // due to rounding up, we might have too many threads
             if ((pus_t2 + temp) > num_threads)
@@ -1129,6 +1129,7 @@ namespace hpx { namespace threads { namespace detail
             }
             core_offset += num_cores_numa[n];
         }
+
     }
 
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #4105 
