### PR TITLE
Overload for start without entry point/argv.

### DIFF
--- a/hpx/hpx_init.hpp
+++ b/hpx/hpx_init.hpp
@@ -735,6 +735,44 @@ namespace hpx
         int argc, char** argv, std::vector<std::string> const& cfg,
         hpx::runtime_mode mode = hpx::runtime_mode_default);
 
+    /// \brief Main entry point for launching the HPX runtime system.
+    ///
+    /// This is a simplified main entry point, which can be used to set up the
+    /// runtime for an HPX application (the runtime system will be set up in
+    /// console mode or worker mode depending on the command line settings). It
+    /// will schedule the function given by \p f as a HPX thread. This overload
+    /// will not call `hpx_main`.
+    ///
+    /// \param f            [in] The function to be scheduled as an HPX
+    ///                     thread. Usually this function represents the main
+    ///                     entry point of any HPX application. If \p f is
+    ///                     `nullptr` the HPX runtime environment will be started
+    ///                     without invoking \p f.
+    /// \param cfg          A list of configuration settings which will be added
+    ///                     to the system configuration before the runtime
+    ///                     instance is run. Each of the entries in this list
+    ///                     must have the format of a fully defined key/value
+    ///                     pair from an ini-file (for instance
+    ///                     'hpx.component.enabled=1')
+    /// \param mode         [in] The mode the created runtime environment
+    ///                     should be initialized in. There has to be exactly
+    ///                     one locality in each HPX application which is
+    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     all other localities have to be run in worker mode
+    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     set up automatically, but sometimes it is necessary
+    ///                     to explicitly specify the mode.
+    ///
+    /// \returns            The function returns the value, which has been
+    ///                     returned from the user supplied function \p f.
+    ///
+    /// \note               The created runtime system instance will be
+    ///                     executed in console or worker mode depending on the
+    ///                     configuration passed in `cfg`.
+    inline int init(util::function_nonser<int(int, char**)> const& f,
+        std::vector<std::string> const& cfg,
+        hpx::runtime_mode mode = hpx::runtime_mode_default);
+
 /// \cond NOINTERNAL
     inline int init(std::nullptr_t f, std::string const& app_name, int argc,
         char** argv, hpx::runtime_mode mode = hpx::runtime_mode_default);

--- a/hpx/hpx_init.hpp
+++ b/hpx/hpx_init.hpp
@@ -745,6 +745,9 @@ namespace hpx
     inline int init(std::nullptr_t f, int argc, char** argv,
         std::vector<std::string> const& cfg,
         hpx::runtime_mode mode = hpx::runtime_mode_default);
+
+    inline int init(std::nullptr_t f, std::vector<std::string> const& cfg,
+        hpx::runtime_mode mode = hpx::runtime_mode_default);
 /// \endcond
 }
 

--- a/hpx/hpx_init_impl.hpp
+++ b/hpx/hpx_init_impl.hpp
@@ -327,6 +327,16 @@ namespace hpx
     }
 
     inline int
+        init(util::function_nonser<int(int, char**)> const& f,
+        std::vector<std::string> const& cfg,
+        hpx::runtime_mode mode)
+    {
+        char *dummy_argv[2] = { const_cast<char*>(HPX_APPLICATION_STRING), nullptr };
+
+        return init(f, 1, dummy_argv, cfg, mode);
+    }
+
+    inline int
     init(std::nullptr_t, std::string const& app_name, int argc, char** argv,
         hpx::runtime_mode mode)
     {

--- a/hpx/hpx_init_impl.hpp
+++ b/hpx/hpx_init_impl.hpp
@@ -372,6 +372,15 @@ namespace hpx
         return init(main_f, desc_commandline, argc, argv, cfg,
             startup_function_type(), shutdown_function_type(), mode);
     }
+
+    inline int
+    init(std::nullptr_t, std::vector<std::string> const& cfg,
+         hpx::runtime_mode mode)
+    {
+      char *dummy_argv[2] = { const_cast<char*>(HPX_APPLICATION_STRING), nullptr };
+
+      return init(nullptr, 1, dummy_argv, cfg, mode);
+    }
 }
 
 #endif /*HPX_HPX_INIT_IMPL_HPP*/

--- a/hpx/hpx_start.hpp
+++ b/hpx/hpx_start.hpp
@@ -770,6 +770,9 @@ namespace hpx
     inline bool start(std::nullptr_t f,
         int argc, char** argv, std::vector<std::string> const& cfg,
         hpx::runtime_mode mode = hpx::runtime_mode_default);
+
+    inline bool start(std::nullptr_t f, std::vector<std::string> const& cfg,
+        hpx::runtime_mode mode = hpx::runtime_mode_default);
 /// \endcond
 }
 

--- a/hpx/hpx_start.hpp
+++ b/hpx/hpx_start.hpp
@@ -759,6 +759,47 @@ namespace hpx
         int argc, char** argv, std::vector<std::string> const& cfg,
         hpx::runtime_mode mode = hpx::runtime_mode_default);
 
+    /// \brief Main non-blocking entry point for launching the HPX runtime system.
+    ///
+    /// This is a simplified main, non-blocking entry point, which can be used
+    /// to set up the runtime for an HPX application (the runtime system will
+    /// be set up in console mode or worker mode depending on the command line
+    /// settings). It will return immediately after that. Use `hpx::wait` and
+    /// `hpx::stop` to synchronize with the runtime system's execution. This
+    /// overload will schedule the function given by \p f as a HPX thread. It
+    /// will not call `hpx_main`.
+    ///
+    /// \param f            [in] The function to be scheduled as an HPX
+    ///                     thread. Usually this function represents the main
+    ///                     entry point of any HPX application. If \p f is
+    ///                     `nullptr` the HPX runtime environment will be started
+    ///                     without invoking \p f.
+    /// \param cfg          A list of configuration settings which will be added
+    ///                     to the system configuration before the runtime
+    ///                     instance is run. Each of the entries in this list
+    ///                     must have the format of a fully defined key/value
+    ///                     pair from an ini-file (for instance
+    ///                     'hpx.component.enabled=1')
+    /// \param mode         [in] The mode the created runtime environment
+    ///                     should be initialized in. There has to be exactly
+    ///                     one locality in each HPX application which is
+    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     all other localities have to be run in worker mode
+    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     set up automatically, but sometimes it is necessary
+    ///                     to explicitly specify the mode.
+    ///
+    /// \returns            The function returns \a true if command line processing
+    ///                     succeeded and the runtime system was started successfully.
+    ///                     It will return \a false otherwise.
+    ///
+    /// \note               The created runtime system instance will be
+    ///                     executed in console or worker mode depending on the
+    ///                     configuration passed in `cfg`.
+    inline bool start(util::function_nonser<int(int, char**)> const& f,
+        std::vector<std::string> const& cfg,
+        hpx::runtime_mode mode = hpx::runtime_mode_default);
+
 /// \cond NOINTERNAL
     inline bool start(std::nullptr_t f,
         std::string const& app_name, int argc, char** argv,

--- a/hpx/hpx_start_impl.hpp
+++ b/hpx/hpx_start_impl.hpp
@@ -321,6 +321,15 @@ namespace hpx
             startup_function_type(), shutdown_function_type(), mode);
     }
 
+    inline bool start(util::function_nonser<int(int, char**)> const& f,
+        std::vector<std::string> const& cfg,
+        hpx::runtime_mode mode)
+    {
+        char *dummy_argv[2] = { const_cast<char*>(HPX_APPLICATION_STRING), nullptr };
+
+        return start(f, 1, dummy_argv, cfg, mode);
+    }
+
     inline bool start(std::nullptr_t f, std::string const& app_name, int argc,
         char** argv, hpx::runtime_mode mode)
     {

--- a/hpx/hpx_start_impl.hpp
+++ b/hpx/hpx_start_impl.hpp
@@ -363,6 +363,14 @@ namespace hpx
         return start(main_f, desc_commandline, argc, argv, cfg,
             startup_function_type(), shutdown_function_type(), mode);
     }
+
+    inline bool start(std::nullptr_t f, std::vector<std::string> const& cfg,
+        hpx::runtime_mode mode)
+    {
+      char *dummy_argv[2] = { const_cast<char*>(HPX_APPLICATION_STRING), nullptr };
+
+      return start(nullptr, 1, dummy_argv, cfg, mode);
+    }
 }
 
 #endif /*HPX_HPX_START_IMPL_HPP*/


### PR DESCRIPTION
Fixes #4107.

This overload allows starting the runtime while providing no entry point
and no command line arguments to parse. 
