### PR TITLE
Fix block_executor

### DIFF
--- a/tests/regressions/computeapi/CMakeLists.txt
+++ b/tests/regressions/computeapi/CMakeLists.txt
@@ -6,16 +6,14 @@
 
 set(tests
     for_each_value_proxy
+    parallel_fill_4132
    )
 
-include_directories(${CUDA_INCLUDE_DIRS})
+set(for_each_value_proxy_PARAMETERS THREADS_PER_LOCALITY 4)
+set(parallel_fill_4132_PARAMETERS THREADS_PER_LOCALITY 4)
 
 foreach(test ${tests})
-  set(sources
-      ${test}.cpp)
-
-  set(${test}_FLAGS
-    DEPENDENCIES ${CUDA_LIBRARIES} ${CUDA_CUBLAS_LIBRARIES})
+  set(sources ${test}.cpp)
 
   source_group("Source Files" FILES ${sources})
 
@@ -28,6 +26,5 @@ foreach(test ${tests})
                      FOLDER "Tests/Regressions/Compute")
 
   add_hpx_regression_test("computeapi" ${test} ${${test}_PARAMETERS})
-
 endforeach()
 

--- a/tests/regressions/computeapi/parallel_fill_4132.cpp
+++ b/tests/regressions/computeapi/parallel_fill_4132.cpp
@@ -1,0 +1,63 @@
+//  Copyright (c) 2019 Steven R. Brandt
+//  Copyright (c) 2019 Mikael Simberg
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/compute.hpp>
+#include <hpx/include/parallel_executors.hpp>
+#include <hpx/include/parallel_fill.hpp>
+#include <hpx/testing.hpp>
+
+#include <cstddef>
+#include <vector>
+
+int hpx_main()
+{
+    std::size_t const max_targets =
+        (std::min)(hpx::get_num_worker_threads(), std::size_t(10));
+    ;
+    auto targets = hpx::compute::host::get_local_targets();
+
+    std::size_t nondivisible = 0;
+    for (std::size_t num_targets = 1; num_targets < max_targets; ++num_targets)
+    {
+        for (std::size_t num_elems = 1; num_elems < 10; ++num_elems)
+        {
+            if (num_elems % num_targets != 0)
+            {
+                ++nondivisible;
+            }
+
+            auto local_targets = targets;
+            local_targets.resize((std::min)(targets.size(), num_targets));
+            hpx::compute::host::block_executor<> exec(local_targets);
+
+            std::vector<int> v(num_elems, 0);
+            // Force there to be as many chunks as elements
+            hpx::parallel::fill(
+                hpx::parallel::execution::par.on(exec).with(
+                    hpx::parallel::execution::static_chunk_size(1)),
+                v.begin(), v.end(), 1);
+
+            std::for_each(v.begin(), v.end(), [](int x) { HPX_TEST_EQ(x, 1); });
+        }
+    }
+
+    // We want at least one of the combinations to have
+    // num_elems % num_targets != 0
+    HPX_TEST_LT(std::size_t(0), nondivisible);
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(
+        hpx::init(argc, argv), 0, "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Fixes #4132. In general fixes the `block_executor` to make sure it forwards all chunks to the underlying executors.

@hkaiser this fixes the problem, but I'm unsure about my `std::advance`s. A forward iterator does not guarantee O(1) complexity for it, does it? I found the current version easier to read, but I'll obviously change it to do fewer `std::advance`s if needed.