### PR TITLE
Add back private m_desc member variable in program_options module

### DIFF
--- a/libs/program_options/include/hpx/program_options/parsers.hpp
+++ b/libs/program_options/include/hpx/program_options/parsers.hpp
@@ -194,6 +194,9 @@ namespace hpx { namespace program_options {
         using detail::cmdline::style_parser;
 
         basic_command_line_parser& extra_style_parser(style_parser s);
+
+    private:
+        const options_description* m_desc;
     };
 
     using command_line_parser = basic_command_line_parser<char>;


### PR DESCRIPTION
Fixes compilation with `HPX_PROGRAM_OPTIONS_WITH_BOOST_PROGRAM_OPTIONS_COMPATIBILITY=OFF`.

@hkaiser would you happen to remember if the warning was about an unused variable? Can we ignore the check on that line somehow?