### PR TITLE
Casting MPI tag value

### DIFF
--- a/hpx/plugins/parcelport/mpi/sender.hpp
+++ b/hpx/plugins/parcelport/mpi/sender.hpp
@@ -37,7 +37,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
         using mutex_type = hpx::lcos::local::spinlock;
 
         sender()
-          : next_free_tag_request_(-1)
+          : next_free_tag_request_((MPI_Request)(-1))
           , next_free_tag_(-1)
         {
         }


### PR DESCRIPTION
GCC 7.3 and openmpi 4 was complaining about this assignment, added a cast to make it happy.  

Fixes #4151

## Proposed Changes

  - minor change to cast a variable assignment

