### PR TITLE
add header iomanip to tests and tool

### DIFF
--- a/examples/resource_partitioner/shared_priority_queue_scheduler.hpp
+++ b/examples/resource_partitioner/shared_priority_queue_scheduler.hpp
@@ -29,6 +29,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <exception>
+#include <iomanip>
 #include <iostream>
 #include <memory>
 #include <mutex>

--- a/libs/collectives/tests/performance/osu/osu_coll.hpp
+++ b/libs/collectives/tests/performance/osu/osu_coll.hpp
@@ -10,6 +10,7 @@
 #define ITERATIONS_LARGE 100
 
 #include <cstddef>
+#include <iomanip>
 #include <string>
 #include <utility>
 #include <vector>

--- a/libs/segmented_algorithms/tests/unit/partitioned_vector_exclusive_scan.cpp
+++ b/libs/segmented_algorithms/tests/unit/partitioned_vector_exclusive_scan.cpp
@@ -14,6 +14,7 @@
 #include "partitioned_vector_scan.hpp"
 
 #include <cstddef>
+#include <iomanip>
 #include <iostream>
 #include <type_traits>
 #include <vector>

--- a/libs/segmented_algorithms/tests/unit/partitioned_vector_exclusive_scan2.cpp
+++ b/libs/segmented_algorithms/tests/unit/partitioned_vector_exclusive_scan2.cpp
@@ -14,6 +14,7 @@
 #include "partitioned_vector_scan.hpp"
 
 #include <cstddef>
+#include <iomanip>
 #include <iostream>
 #include <type_traits>
 #include <vector>

--- a/libs/segmented_algorithms/tests/unit/partitioned_vector_inclusive_scan.cpp
+++ b/libs/segmented_algorithms/tests/unit/partitioned_vector_inclusive_scan.cpp
@@ -14,6 +14,7 @@
 #include "partitioned_vector_scan.hpp"
 
 #include <cstddef>
+#include <iomanip>
 #include <iostream>
 #include <type_traits>
 #include <vector>

--- a/libs/segmented_algorithms/tests/unit/partitioned_vector_inclusive_scan2.cpp
+++ b/libs/segmented_algorithms/tests/unit/partitioned_vector_inclusive_scan2.cpp
@@ -14,6 +14,7 @@
 #include "partitioned_vector_scan.hpp"
 
 #include <cstddef>
+#include <iomanip>
 #include <iostream>
 #include <type_traits>
 #include <vector>

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -62,6 +62,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <exception>
+#include <iomanip>
 #include <iostream>
 #include <map>
 #include <memory>

--- a/src/util/init_logging.cpp
+++ b/src/util/init_logging.cpp
@@ -28,6 +28,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <iomanip>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/tools/inspect/include_check.cpp
+++ b/tools/inspect/include_check.cpp
@@ -48,6 +48,8 @@ namespace boost
         {"(\\bstd\\s*::\\s*((i|o)?stringstream)\\b)", "std::\\2", "sstream"},
         {"(\\bstd\\s*::\\s*((i|o)?fstream)\\b)", "std::\\2", "fstream"},
         {"(\\bstd\\s*::\\s*(cin|cout|cerr|clog)\\b)", "std::\\2", "iostream"},
+        {"(\\bstd\\s*::\\s*setw\\b)", "std::setw", "iomanip"},
+        {"(\\bstd\\s*::\\s*setprecision\\b)", "std::setprecision", "iomanip"},
         // cstddef
         {"(\\bstd\\s*::\\s*size_t\\b)", "std::size_t", "cstddef"},
         {"(\\bstd\\s*::\\s*ptrdiff_t\\b)", "std::ptrdiff_t", "cstddef"},


### PR DESCRIPTION
## Proposed Changes

  - add header iomanip to those missing places and inspect tool

## Any background context you want to provide?
I have bugs when building tests: https://gist.github.com/weilewei/087b30fd5fe07ac885553c6709c18c34
for example:
```
/gpfs/alpine/proj-shared/cph102/weile/dev/src/hpx/libs/segmented_algorithms/tests/unit/partitioned_vector_exclusive_scan2.cpp:27:23: error: 'setw' is not a member of 'std'
     std::cout << std::setw(60) << a << std::setw(40) << b << std::setw(10)     \
```
