### PR TITLE
Added CMake policy CMP0060 for HPX applications.

### DIFF
--- a/cmake/HPX_SetupTarget.cmake
+++ b/cmake/HPX_SetupTarget.cmake
@@ -9,6 +9,7 @@
 cmake_policy(PUSH)
 
 hpx_set_cmake_policy(CMP0054 NEW)
+hpx_set_cmake_policy(CMP0060 NEW)
 
 function(hpx_setup_target target)
   # retrieve arguments


### PR DESCRIPTION
While the policy CMP0060 is activated for building HPX itself, for HPX
applications #2396 can lead to errors during linking if the wrong Boost
installation is picked up by the CMake module.