### PR TITLE
Stackless coroutines now can refer to themselves (through get_self() and friends)

### DIFF
--- a/libs/coroutines/include/hpx/coroutines/detail/coroutine_accessor.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/coroutine_accessor.hpp
@@ -31,20 +31,9 @@
 #define HPX_RUNTIME_THREADS_COROUTINES_DETAIL_COROUTINE_ACCESSOR_HPP
 
 namespace hpx { namespace threads { namespace coroutines { namespace detail {
+
     struct coroutine_accessor
     {
-        template <typename Coroutine>
-        static void acquire(Coroutine& x)
-        {
-            x.acquire();
-        }
-
-        template <typename Coroutine>
-        static void release(Coroutine& x)
-        {
-            x.release();
-        }
-
         template <typename Coroutine>
         static typename Coroutine::impl_ptr get_impl(Coroutine& x)
         {

--- a/libs/coroutines/include/hpx/coroutines/detail/coroutine_stackful_self.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/coroutine_stackful_self.hpp
@@ -1,0 +1,120 @@
+//  Copyright (c) 2019 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_RUNTIME_THREADS_COROUTINES_DETAIL_STACKFUL_SELF_HPP
+#define HPX_RUNTIME_THREADS_COROUTINES_DETAIL_STACKFUL_SELF_HPP
+
+#include <hpx/config.hpp>
+#include <hpx/assertion.hpp>
+#include <hpx/coroutines/detail/coroutine_impl.hpp>
+#include <hpx/coroutines/detail/coroutine_self.hpp>
+#include <hpx/coroutines/thread_enums.hpp>
+#include <hpx/coroutines/thread_id_type.hpp>
+#include <hpx/functional/function.hpp>
+
+#include <cstddef>
+#include <exception>
+#include <limits>
+#include <utility>
+
+namespace hpx { namespace threads { namespace coroutines { namespace detail {
+
+    class coroutine_stackful_self : public coroutine_self
+    {
+    public:
+        explicit coroutine_stackful_self(
+            impl_type* pimpl, coroutine_self* next_self = nullptr)
+          : coroutine_self(next_self)
+          , pimpl_(pimpl)
+        {
+        }
+
+        arg_type yield_impl(result_type arg) override
+        {
+            HPX_ASSERT(pimpl_);
+
+            this->pimpl_->bind_result(arg);
+
+            {
+                reset_self_on_exit on_exit(this);
+                this->pimpl_->yield();
+            }
+
+            return *pimpl_->args();
+        }
+
+        thread_id_type get_thread_id() const override
+        {
+            HPX_ASSERT(pimpl_);
+            return pimpl_->get_thread_id();
+        }
+
+        std::size_t get_thread_phase() const override
+        {
+#if defined(HPX_HAVE_THREAD_PHASE_INFORMATION)
+            HPX_ASSERT(pimpl_);
+            return pimpl_->get_thread_phase();
+#else
+            return 0;
+#endif
+        }
+
+        std::ptrdiff_t get_available_stack_space() override
+        {
+#if defined(HPX_HAVE_THREADS_GET_STACK_POINTER)
+            return pimpl_->get_available_stack_space();
+#else
+            return (std::numeric_limits<std::ptrdiff_t>::max)();
+#endif
+        }
+
+        std::size_t get_thread_data() const override
+        {
+            HPX_ASSERT(pimpl_);
+            return pimpl_->get_thread_data();
+        }
+        std::size_t set_thread_data(std::size_t data) override
+        {
+            HPX_ASSERT(pimpl_);
+            return pimpl_->set_thread_data(data);
+        }
+
+        tss_storage* get_thread_tss_data() override
+        {
+#if defined(HPX_HAVE_THREAD_LOCAL_STORAGE)
+            HPX_ASSERT(pimpl_);
+            return pimpl_->get_thread_tss_data(false);
+#else
+            return nullptr;
+#endif
+        }
+
+        tss_storage* get_or_create_thread_tss_data() override
+        {
+#if defined(HPX_HAVE_THREAD_LOCAL_STORAGE)
+            HPX_ASSERT(pimpl_);
+            return pimpl_->get_thread_tss_data(true);
+#else
+            return nullptr;
+#endif
+        }
+
+        std::size_t& get_continuation_recursion_count() override
+        {
+            HPX_ASSERT(pimpl_);
+            return pimpl_->get_continuation_recursion_count();
+        }
+
+    private:
+        coroutine_impl* get_impl() override
+        {
+            return pimpl_;
+        }
+        coroutine_impl* pimpl_;
+    };
+}}}}    // namespace hpx::threads::coroutines::detail
+
+#endif /*HPX_RUNTIME_THREADS_COROUTINES_DETAIL_SELF_HPP*/

--- a/libs/coroutines/include/hpx/coroutines/detail/coroutine_stackless_self.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/coroutine_stackless_self.hpp
@@ -1,0 +1,108 @@
+//  Copyright (c) 2019 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_RUNTIME_THREADS_COROUTINES_DETAIL_STACKLESS_SELF_HPP
+#define HPX_RUNTIME_THREADS_COROUTINES_DETAIL_STACKLESS_SELF_HPP
+
+#include <hpx/config.hpp>
+#include <hpx/assertion.hpp>
+#include <hpx/coroutines/detail/coroutine_self.hpp>
+#include <hpx/coroutines/thread_enums.hpp>
+#include <hpx/coroutines/thread_id_type.hpp>
+#include <hpx/functional/function.hpp>
+
+#include <cstddef>
+#include <exception>
+#include <limits>
+#include <utility>
+
+namespace hpx { namespace threads { namespace coroutines {
+
+    class stackless_coroutine;
+}}}    // namespace hpx::threads::coroutines
+
+namespace hpx { namespace threads { namespace coroutines { namespace detail {
+
+    class coroutine_stackless_self : public coroutine_self
+    {
+    public:
+        explicit coroutine_stackless_self(stackless_coroutine* pimpl)
+          : coroutine_self(nullptr)
+          , pimpl_(pimpl)
+        {
+        }
+
+        arg_type yield_impl(result_type arg) override
+        {
+            // stackless coroutines don't support suspension
+            HPX_ASSERT(false);
+            return threads::wait_abort;
+        }
+
+        thread_id_type get_thread_id() const override
+        {
+            HPX_ASSERT(pimpl_);
+            return pimpl_->get_thread_id();
+        }
+
+        std::size_t get_thread_phase() const override
+        {
+#if defined(HPX_HAVE_THREAD_PHASE_INFORMATION)
+            HPX_ASSERT(pimpl_);
+            return pimpl_->get_thread_phase();
+#else
+            return 0;
+#endif
+        }
+
+        std::ptrdiff_t get_available_stack_space() override
+        {
+            return (std::numeric_limits<std::ptrdiff_t>::max)();
+        }
+
+        std::size_t get_thread_data() const override
+        {
+            HPX_ASSERT(pimpl_);
+            return pimpl_->get_thread_data();
+        }
+        std::size_t set_thread_data(std::size_t data) override
+        {
+            HPX_ASSERT(pimpl_);
+            return pimpl_->set_thread_data(data);
+        }
+
+        tss_storage* get_thread_tss_data() override
+        {
+#if defined(HPX_HAVE_THREAD_LOCAL_STORAGE)
+            HPX_ASSERT(pimpl_);
+            return pimpl_->get_thread_tss_data(false);
+#else
+            return nullptr;
+#endif
+        }
+
+        tss_storage* get_or_create_thread_tss_data() override
+        {
+#if defined(HPX_HAVE_THREAD_LOCAL_STORAGE)
+            HPX_ASSERT(pimpl_);
+            return pimpl_->get_thread_tss_data(true);
+#else
+            return nullptr;
+#endif
+        }
+
+        std::size_t& get_continuation_recursion_count() override
+        {
+            HPX_ASSERT(pimpl_);
+            return pimpl_->get_continuation_recursion_count();
+        }
+
+    private:
+        stackless_coroutine* pimpl_;
+    };
+}}}}    // namespace hpx::threads::coroutines::detail
+
+#endif

--- a/libs/coroutines/src/detail/coroutine_impl.cpp
+++ b/libs/coroutines/src/detail/coroutine_impl.cpp
@@ -33,7 +33,7 @@
 #include <hpx/assertion.hpp>
 #include <hpx/coroutines/coroutine.hpp>
 #include <hpx/coroutines/detail/coroutine_impl.hpp>
-#include <hpx/coroutines/detail/coroutine_self.hpp>
+#include <hpx/coroutines/detail/coroutine_stackful_self.hpp>
 
 #include <cstddef>
 #include <exception>
@@ -41,24 +41,6 @@
 
 namespace hpx { namespace threads { namespace coroutines { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
-    namespace {
-        struct reset_self_on_exit
-        {
-            reset_self_on_exit(
-                coroutine_self* val, coroutine_self* old_val = nullptr)
-              : old_self(old_val)
-            {
-                coroutine_self::set_self(val);
-            }
-
-            ~reset_self_on_exit()
-            {
-                coroutine_self::set_self(old_self);
-            }
-
-            coroutine_self* old_self;
-        };
-    }    // namespace
 
 #if defined(HPX_DEBUG)
     coroutine_impl::~coroutine_impl()
@@ -85,7 +67,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
             std::exception_ptr tinfo;
             {
                 coroutine_self* old_self = coroutine_self::get_self();
-                coroutine_self self(this, old_self);
+                coroutine_stackful_self self(this, old_self);
                 reset_self_on_exit on_exit(&self, old_self);
                 try
                 {

--- a/src/runtime/threads/thread_data.cpp
+++ b/src/runtime/threads/thread_data.cpp
@@ -10,6 +10,7 @@
 
 #include <hpx/assertion.hpp>
 #include <hpx/concurrency/register_locks.hpp>
+#include <hpx/coroutines/detail/coroutine_accessor.hpp>
 #include <hpx/errors.hpp>
 #include <hpx/functional/function.hpp>
 #include <hpx/logging.hpp>

--- a/tests/regressions/threads/CMakeLists.txt
+++ b/tests/regressions/threads/CMakeLists.txt
@@ -10,6 +10,7 @@ set(tests
     resume_priority
     run_as_hpx_thread_exceptions_3304
     run_as_os_thread_lockup_2991
+    stackless_self_4155
     thread_data_1111
     thread_pool_executor_1112
     thread_rescheduling

--- a/tests/regressions/threads/stackless_self_4155.cpp
+++ b/tests/regressions/threads/stackless_self_4155.cpp
@@ -1,0 +1,21 @@
+// Copyright (C) 2019 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/threadmanager.hpp>
+#include <hpx/testing.hpp>
+
+void stackless_thread()
+{
+    HPX_TEST_NEQ(hpx::threads::get_self_id(), hpx::threads::invalid_thread_id);
+}
+
+int main(int argc, char* argv[])
+{
+    hpx::threads::register_non_suspendable_work_nullary(stackless_thread);
+    return hpx::util::report_errors();
+}
+


### PR DESCRIPTION
Fixes #4155
