### PR TITLE
Add hpx_memory as a dependency of parcelport plugins

### DIFF
--- a/plugins/parcelport/libfabric/CMakeLists.txt
+++ b/plugins/parcelport/libfabric/CMakeLists.txt
@@ -78,6 +78,7 @@ if (HPX_WITH_PARCELPORT_LIBFABRIC)
       hpx_errors
       hpx_execution
       hpx_hardware
+      hpx_memory
       hpx_plugin
       hpx_program_options
       hpx_serialization

--- a/plugins/parcelport/mpi/CMakeLists.txt
+++ b/plugins/parcelport/mpi/CMakeLists.txt
@@ -36,6 +36,7 @@ if(HPX_WITH_PARCELPORT_MPI)
       hpx_execution
       hpx_filesystem
       hpx_hardware
+      hpx_memory
       hpx_plugin
       hpx_program_options
       hpx_serialization

--- a/plugins/parcelport/tcp/CMakeLists.txt
+++ b/plugins/parcelport/tcp/CMakeLists.txt
@@ -29,6 +29,7 @@ if(HPX_WITH_PARCELPORT_TCP)
       hpx_execution
       hpx_functional
       hpx_hardware
+      hpx_memory
       hpx_plugin
       hpx_program_options
       hpx_serialization


### PR DESCRIPTION
Fixes master, missing `hpx_memory` dependency
