### PR TITLE
Adding allocator imported target as a dependency of allocator module

### DIFF
--- a/libs/allocator_support/CMakeLists.txt
+++ b/libs/allocator_support/CMakeLists.txt
@@ -30,5 +30,6 @@ add_hpx_module(allocator_support
   DEPENDENCIES
     hpx_config
     hpx_preprocessor
+    hpx::allocator
   CMAKE_SUBDIRS examples tests
 )


### PR DESCRIPTION
Fixes master with jemalloc and `HPX_WITH_INTERNAL_ALLOCATOR`
