### PR TITLE
Handle quick exit

### DIFF
--- a/hpx/hpx_init.hpp
+++ b/hpx/hpx_init.hpp
@@ -53,6 +53,12 @@ namespace hpx_startup
 /// \namespace hpx
 namespace hpx
 {
+    namespace detail
+    {
+        HPX_EXPORT void on_exit() noexcept;
+        HPX_EXPORT void on_abort(int signal) noexcept;
+    }
+
 #ifndef DOXYGEN
     typedef int (*hpx_main_type)(hpx::program_options::variables_map&);
     typedef int (*hpx_user_main_type)(int argc, char** argv);

--- a/hpx/hpx_init_impl.hpp
+++ b/hpx/hpx_init_impl.hpp
@@ -20,7 +20,9 @@
 #include <hpx/util/find_prefix.hpp>
 #include <hpx/functional/function.hpp>
 
+#include <csignal>
 #include <cstddef>
+#include <cstdlib>
 #include <string>
 #include <utility>
 #include <vector>
@@ -72,6 +74,11 @@ namespace hpx
 #if defined(__FreeBSD__)
         freebsd_environ = environ;
 #endif
+        // set a handler for std::abort
+        std::signal(SIGABRT, detail::on_abort);
+        std::at_quick_exit(detail::on_exit);
+        std::atexit(detail::on_exit);
+
         return detail::run_or_start(f, desc_cmdline, argc, argv,
             hpx_startup::user_main_config(cfg),
             std::move(startup), std::move(shutdown), mode, true);

--- a/hpx/hpx_start.hpp
+++ b/hpx/hpx_start.hpp
@@ -46,6 +46,12 @@ namespace hpx_startup
 /// \namespace hpx
 namespace hpx
 {
+    namespace detail
+    {
+        HPX_EXPORT void on_exit() noexcept;
+        HPX_EXPORT void on_abort(int signal) noexcept;
+    }
+
 #ifndef DOXYGEN
     typedef int (*hpx_main_type)(hpx::program_options::variables_map&);
 #endif

--- a/hpx/hpx_start_impl.hpp
+++ b/hpx/hpx_start_impl.hpp
@@ -19,7 +19,9 @@
 #include <hpx/util/find_prefix.hpp>
 #include <hpx/functional/function.hpp>
 
+#include <csignal>
 #include <cstddef>
+#include <cstdlib>
 #include <string>
 #include <utility>
 #include <vector>
@@ -73,6 +75,11 @@ namespace hpx
 #if defined(__FreeBSD__)
         freebsd_environ = environ;
 #endif
+        // set a handler for std::abort, std::at_quick_exit, and std::atexit
+        std::signal(SIGABRT, detail::on_abort);
+        std::at_quick_exit(detail::on_exit);
+        std::atexit(detail::on_exit);
+
         return 0 == detail::run_or_start(f, desc_cmdline, argc, argv,
             hpx_startup::user_main_config(cfg),
             std::move(startup), std::move(shutdown), mode, false);


### PR DESCRIPTION
Sometimes the HPX library gets simply unloaded as a result of some extreme error handling. Avoid hangs in the end by setting a flag.
