### PR TITLE
Forward HPX_* cmake cache variables to external projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,7 +395,8 @@ endif()
 if(NOT HPX_WITH_DATAPAR_VC)
   hpx_info("No vectorization library configured")
 else()
-  set(HPX_WITH_DATAPAR ON)
+  hpx_option(HPX_WITH_DATAPAR BOOL
+    "Enable data parallel algorithm support (default: ON)" ON ADVANCED)
 endif()
 
 ################################################################################
@@ -2006,9 +2007,12 @@ foreach(_module ${HPX_LIBS})
 endforeach()
 
 ################################################################################
-# External build system support (FindHPX.cmake and pkg-config).
-################################################################################
+# store cache vars and their values in order for them to be forwarded to the
+# projects (needs to be before the HPX_GeneratePackage call)
+include(HPX_ForwardCacheVariables)
 
+################################################################################
+# External build system support (FindHPX.cmake and pkg-config).
 include(HPX_GeneratePackage)
 
 message("")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1607,6 +1607,32 @@ endif()
 set(HPX_WITH_TARGET_ARCHITECTURE ${__target_arch} CACHE INTERNAL "" FORCE)
 
 ################################################################################
+# Set configuration option to use Boost.Context or not. This depends on the
+# platform.
+set(__use_generic_coroutine_context OFF)
+if(APPLE)
+  set(__use_generic_coroutine_context ON)
+endif()
+if(HPX_PLATFORM_UC STREQUAL "BLUEGENEQ")
+  set(__use_generic_coroutine_context ON)
+endif()
+hpx_option(HPX_WITH_GENERIC_CONTEXT_COROUTINES BOOL
+  "Use Boost.Context as the underlying coroutines context switch implementation."
+  ${__use_generic_coroutine_context} ADVANCED)
+
+# Compatibility with using Boost.ProgramOptions, introduced in V1.4.0
+hpx_option(HPX_PROGRAM_OPTIONS_WITH_BOOST_PROGRAM_OPTIONS_COMPATIBILITY
+  BOOL "Enable Boost.ProgramOptions compatibility. (default: ON)"
+  ON ADVANCED CATEGORY "Modules")
+
+# Compatibility with using Boost.FileSystem, introduced in V1.4.0
+set(__filesystem_compatibility_default ON)
+if(HPX_WITH_CXX17_FILESYSTEM)
+  set(__filesystem_compatibility_default OFF)
+endif()
+hpx_option(HPX_FILESYSTEM_WITH_BOOST_FILESYSTEM_COMPATIBILITY
+  BOOL "Enable Boost.FileSystem compatibility. (default: ${__filesystem_compatibility_default})"
+  ${__filesystem_compatibility_default} ADVANCED CATEGORY "Modules")
 
 ################################################################################
 # Find Our dependencies:

--- a/cmake/HPX_ForwardCacheVariables.cmake
+++ b/cmake/HPX_ForwardCacheVariables.cmake
@@ -1,0 +1,44 @@
+# Copyright (c) 2019 Ste||ar Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# The goal is to store all HPX_* cache variables in a file, so that they would
+# be forwarded to projects using HPX (the file is included in the
+# HPXConfig.cmake)
+
+function(write_license_header filename)
+  file(WRITE ${filename}
+"# Copyright (c) 2019 Ste||ar Group\n\
+#\n\
+# SPDX-License-Identifier: BSL-1.0\n\
+# Distributed under the Boost Software License, Version 1.0. (See accompanying\n\
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)\n\n"
+    )
+endfunction(write_license_header)
+
+get_cmake_property(cache_vars CACHE_VARIABLES)
+
+# Keep only the HPX_* like variables
+list(FILTER cache_vars INCLUDE REGEX HPX_)
+list(FILTER cache_vars EXCLUDE REGEX "Category$")
+
+# Write the HPXCacheVariables.cmake in the BUILD directory
+set(_cache_var_file
+  ${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}/${HPX_PACKAGE_NAME}CacheVariables.cmake)
+write_license_header(${_cache_var_file})
+file(APPEND ${_cache_var_file} "# File to store the HPX_* cache variables\n")
+foreach(_var IN LISTS cache_vars)
+  file(APPEND ${_cache_var_file} "set(${_var} ${${_var}})\n")
+endforeach()
+file(INSTALL ${_cache_var_file}
+  DESTINATION ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY})
+
+# Install the HPXCacheVariables.cmake in the INSTALL directory
+install(
+  FILES ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${HPX_PACKAGE_NAME}CacheVariables.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}
+  COMPONENT cmake
+  )
+

--- a/cmake/HPX_SetupBoost.cmake
+++ b/cmake/HPX_SetupBoost.cmake
@@ -51,21 +51,6 @@ if(Boost_VERSION_STRING VERSION_LESS 1.70)
   set(__boost_libraries ${__boost_libraries} system)
 endif()
 
-# Set configuration option to use Boost.Context or not. This depends on the
-# platform.
-set(__use_generic_coroutine_context OFF)
-if(APPLE)
-  set(__use_generic_coroutine_context ON)
-endif()
-if(HPX_PLATFORM_UC STREQUAL "BLUEGENEQ")
-  set(__use_generic_coroutine_context ON)
-endif()
-hpx_option(
-  HPX_WITH_GENERIC_CONTEXT_COROUTINES
-  BOOL
-  "Use Boost.Context as the underlying coroutines context switch implementation."
-  ${__use_generic_coroutine_context} ADVANCED)
-
 if(NOT HPX_WITH_NATIVE_TLS)
   set(__boost_libraries ${__boost_libraries} thread)
 endif()

--- a/cmake/HPX_SetupBoostFilesystem.cmake
+++ b/cmake/HPX_SetupBoostFilesystem.cmake
@@ -4,17 +4,6 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(__filesystem_compatibility_default ON)
-if(HPX_WITH_CXX17_FILESYSTEM)
-  set(__filesystem_compatibility_default OFF)
-endif()
-
-include(HPX_Option)
-# Compatibility with using Boost.FileSystem, introduced in V1.4.0
-hpx_option(HPX_FILESYSTEM_WITH_BOOST_FILESYSTEM_COMPATIBILITY
-  BOOL "Enable Boost.FileSystem compatibility. (default: ${__filesystem_compatibility_default})"
-  ${__filesystem_compatibility_default} ADVANCED CATEGORY "Modules")
-
 # Creates imported hpx::boost::filesystem target
 if(HPX_FILESYSTEM_WITH_BOOST_FILESYSTEM_COMPATIBILITY)
 

--- a/cmake/HPX_SetupBoostProgramOptions.cmake
+++ b/cmake/HPX_SetupBoostProgramOptions.cmake
@@ -4,12 +4,6 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-include(HPX_Option)
-# Compatibility with using Boost.ProgramOptions, introduced in V1.4.0
-hpx_option(HPX_PROGRAM_OPTIONS_WITH_BOOST_PROGRAM_OPTIONS_COMPATIBILITY
-  BOOL "Enable Boost.ProgramOptions compatibility. (default: ON)"
-  ON ADVANCED CATEGORY "Modules")
-
 if(HPX_PROGRAM_OPTIONS_WITH_BOOST_PROGRAM_OPTIONS_COMPATIBILITY)
   set(__boost_program_options hpx::boost::program_options)
 endif()

--- a/cmake/templates/HPXConfig.cmake.in
+++ b/cmake/templates/HPXConfig.cmake.in
@@ -49,7 +49,6 @@ set(HPX_Fortran_COMPILER_VERSION "@CMAKE_Fortran_COMPILER_VERSION@" CACHE STRING
 # Setup the imported libraries (publicly linked) #
 
 # Boost
-# We could define it inside the HPXCacheVariables file
 set(HPX_BOOST_ROOT "@BOOST_ROOT@")
 # By default BOOST_ROOT is set to HPX_BOOST_ROOT (not necessary for PAPI or
 # HWLOC cause we are specifying HPX_<lib>_ROOT as an HINT to find_package)

--- a/cmake/templates/HPXConfig.cmake.in
+++ b/cmake/templates/HPXConfig.cmake.in
@@ -5,6 +5,9 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+# Forward HPX_* cache variables
+include("${CMAKE_CURRENT_LIST_DIR}/HPXCacheVariables.cmake")
+
 # include exported targets if not already defined
 if (NOT TARGET hpx_config)
   include("${CMAKE_CURRENT_LIST_DIR}/HPXModulesTargets.cmake")
@@ -46,14 +49,7 @@ set(HPX_Fortran_COMPILER_VERSION "@CMAKE_Fortran_COMPILER_VERSION@" CACHE STRING
 # Setup the imported libraries (publicly linked) #
 
 # Boost
-set(HPX_PROGRAM_OPTIONS_WITH_BOOST_PROGRAM_OPTIONS_COMPATIBILITY
-  @HPX_PROGRAM_OPTIONS_WITH_BOOST_PROGRAM_OPTIONS_COMPATIBILITY@
-  CACHE STRING "" FORCE)
-set(HPX_FILESYSTEM_WITH_BOOST_FILESYSTEM_COMPATIBILITY
-  @HPX_FILESYSTEM_WITH_BOOST_FILESYSTEM_COMPATIBILITY@
-  CACHE STRING "" FORCE)
-set(HPX_WITH_CXX17_FILESYSTEM @HPX_WITH_CXX17_FILESYSTEM@)
-set(HPX_WITH_NATIVE_TLS @HPX_WITH_NATIVE_TLS@)
+# We could define it inside the HPXCacheVariables file
 set(HPX_BOOST_ROOT "@BOOST_ROOT@")
 # By default BOOST_ROOT is set to HPX_BOOST_ROOT (not necessary for PAPI or
 # HWLOC cause we are specifying HPX_<lib>_ROOT as an HINT to find_package)
@@ -74,18 +70,7 @@ set(HPX_PAPI_ROOT "@PAPI_ROOT@")
 include(HPX_SetupPapi)
 ##################################################
 
-set(HPX_WITH_PSEUDO_DEPENDENCIES @HPX_WITH_PSEUDO_DEPENDENCIES@)
-set(HPX_WITH_STATIC_LINKING @HPX_WITH_STATIC_LINKING@)
 set(HPX_WITH_MALLOC_DEFAULT @HPX_WITH_MALLOC@)
-set(HPX_WITH_PARCELPORT_TCP @HPX_WITH_PARCELPORT_TCP@)
-set(HPX_WITH_PARCELPORT_MPI @HPX_WITH_PARCELPORT_MPI@)
-set(HPX_WITH_APEX @HPX_WITH_APEX@)
-if(MSVC)
-  set(HPX_WITH_VCPKG @HPX_WITH_VCPKG@)
-endif()
-set(HPX_WITH_DYNAMIC_HPX_MAIN @HPX_WITH_DYNAMIC_HPX_MAIN@)
-set(HPX_WITH_DATAPAR @HPX_WITH_DATAPAR@)
-set(HPX_WITH_DATAPAR_VC @HPX_WITH_DATAPAR_VC@)
 
 if(NOT HPX_CMAKE_LOGLEVEL)
   set(HPX_CMAKE_LOGLEVEL "WARN")
@@ -101,30 +86,23 @@ if(NOT DEFINED ${CMAKE_FIND_PACKAGE_NAME}_FOUND)
   set(${CMAKE_FIND_PACKAGE_NAME}_FOUND true)
 endif()
 
-# Set variables to enable cuda/nvcc or cuda/clang when using add_hpx_executable()
-set(HPX_WITH_CUDA @HPX_WITH_CUDA@)
-set(HPX_WITH_CUDA_CLANG @HPX_WITH_CUDA_CLANG@)
-set(HPX_CUDA_CLANG_FLAGS @HPX_CUDA_CLANG_FLAGS@)
-
 # Set variables used by nvcc
 if(HPX_WITH_CUDA)
-    find_package(CUDA REQUIRED)
-    set(HPX_WITH_CUDA_CLANG @HPX_WITH_CUDA_CLANG@)
-    set(CUDA_SEPARABLE_COMPILATION ON)
-    set(CUDA_NVCC_FLAGS @CUDA_NVCC_FLAGS@)
-    set(HPX_CUDA_CLANG_FLAGS @HPX_CUDA_CLANG_FLAGS@)
-    # The following is a workaround to make sure that target_link_libraries in
-    # cuda_add_executable/library is called with a link keyword, not with a
-    # plain signature. From CMake 3.9 onwards this can be done officially with
-    # the CUDA_LINK_LIBRARIES_KEYWORD. For older versions we can emulate this by
-    # prepending a link keyword to CUDA_LIBRARIES.
-    #
-    # See
-    # https://gitlab.kitware.com/cmake/cmake/commit/9f41bfd7b9e6e8a7545f741f872949d2ae801978
-    # and https://gitlab.kitware.com/cmake/cmake/issues/16602 for more details.
-    if(CMAKE_VERSION VERSION_LESS "3.9")
-      set(CUDA_LIBRARIES PUBLIC ${CUDA_LIBRARIES})
-    else()
-      set(CUDA_LINK_LIBRARIES_KEYWORD PUBLIC)
-    endif()
+  find_package(CUDA REQUIRED)
+  set(CUDA_SEPARABLE_COMPILATION ON)
+  set(CUDA_NVCC_FLAGS @CUDA_NVCC_FLAGS@)
+  # The following is a workaround to make sure that target_link_libraries in
+  # cuda_add_executable/library is called with a link keyword, not with a
+  # plain signature. From CMake 3.9 onwards this can be done officially with
+  # the CUDA_LINK_LIBRARIES_KEYWORD. For older versions we can emulate this by
+  # prepending a link keyword to CUDA_LIBRARIES.
+  #
+  # See
+  # https://gitlab.kitware.com/cmake/cmake/commit/9f41bfd7b9e6e8a7545f741f872949d2ae801978
+  # and https://gitlab.kitware.com/cmake/cmake/issues/16602 for more details.
+  if(CMAKE_VERSION VERSION_LESS "3.9")
+    set(CUDA_LIBRARIES PUBLIC ${CUDA_LIBRARIES})
+  else()
+    set(CUDA_LINK_LIBRARIES_KEYWORD PUBLIC)
+  endif()
 endif()


### PR DESCRIPTION
Generalises  #4159
Forward `HPX_*` like CMake Cache variables to hpx dependent projects